### PR TITLE
feat: add an analytics seed scenario for the consumption page

### DIFF
--- a/front/scripts/seed/README.md
+++ b/front/scripts/seed/README.md
@@ -16,6 +16,7 @@ DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/<folder>/seed.ts --execute
 
 ## Folders
 
+- `analytics/` - Creates members, teams, skills and agents, then fills the consumption index behind the "Analytics (new)" page
 - `basics/` - Creates a custom agent with skills and sample conversations
 - `byok/` - Setup workspace to test Bring your own key
 - `governance/` - Creates users and skills for testing admin governance

--- a/front/scripts/seed/analytics/assets/agents.json
+++ b/front/scripts/seed/analytics/assets/agents.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "PipelineWatch",
+    "description": "Reviews the sales pipeline and flags the deals at risk.",
+    "instructions": "You review sales pipelines. Follow the Pipeline Review skill for the structure of your answer.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
+  },
+  {
+    "name": "ReleaseScribe",
+    "description": "Writes customer-facing release notes from merged pull requests.",
+    "instructions": "You write release notes. Follow the Release Notes skill for the structure of your answer.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/github_avatar_full.png"
+  },
+  {
+    "name": "SupportTriager",
+    "description": "Triages inbound support tickets and drafts first responses.",
+    "instructions": "You triage support tickets. Follow the Support Triage skill for the structure of your answer.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/intercom_avatar_full.png"
+  },
+  {
+    "name": "MeetingRecap",
+    "description": "Summarizes meeting transcripts into decisions and action items.",
+    "instructions": "You summarize meeting transcripts. Always answer with a Decisions section and an Action items section, one owner per action item.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/notion_avatar_full.png"
+  },
+  {
+    "name": "DocFinder",
+    "description": "Finds and cites internal documentation.",
+    "instructions": "You answer questions from internal documentation. Always cite the documents you used.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/drive_avatar_full.png"
+  },
+  {
+    "name": "OnboardingBuddy",
+    "description": "Answers the questions of new joiners about tools and processes.",
+    "instructions": "You help new joiners. Be concise, and always point to the person or channel to ask next.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/helper_avatar_full.png"
+  },
+  {
+    "name": "DataAnalyst",
+    "description": "Writes and explains SQL queries over the warehouse.",
+    "instructions": "You write SQL. Always explain what the query returns before showing it.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/gpt4_avatar_full.png"
+  },
+  {
+    "name": "ContractReader",
+    "description": "Extracts key terms from contracts.",
+    "instructions": "You read contracts. Always report the term, the notice period, the liability cap and anything unusual.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/confluence_avatar_full.png"
+  },
+  {
+    "name": "TranslationDesk",
+    "description": "Translates product copy while keeping the tone.",
+    "instructions": "You translate product copy. Keep the tone of the source, and flag anything that does not translate well.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/mistral_avatar_full.png"
+  },
+  {
+    "name": "IncidentBuddy",
+    "description": "Keeps an incident channel organized and drafts the timeline.",
+    "instructions": "You assist during incidents. Always keep a timestamped timeline of what happened.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/gemini_avatar_full.png"
+  }
+]

--- a/front/scripts/seed/analytics/assets/skills.json
+++ b/front/scripts/seed/analytics/assets/skills.json
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "Pipeline Review",
+    "agentFacingDescription": "Guidelines to review a sales pipeline: stage hygiene, next steps and risks.",
+    "userFacingDescription": "Review a sales pipeline and surface the deals at risk.",
+    "instructions": "When reviewing a pipeline, always report: deals with no next step, deals stuck in the same stage for more than 30 days, and the three deals most at risk with the reason why.",
+    "instructionsHtml": "<p>When reviewing a pipeline, always report: deals with no next step, deals stuck in the same stage for more than 30 days, and the three deals most at risk with the reason why.</p>"
+  },
+  {
+    "name": "Release Notes",
+    "agentFacingDescription": "Turns a list of merged pull requests into customer-facing release notes.",
+    "userFacingDescription": "Write release notes from merged pull requests.",
+    "instructions": "Group the changes into Added, Improved and Fixed. One line per change, written for a customer, never mentioning internal module names.",
+    "instructionsHtml": "<p>Group the changes into Added, Improved and Fixed. One line per change, written for a customer, never mentioning internal module names.</p>"
+  },
+  {
+    "name": "Support Triage",
+    "agentFacingDescription": "Rules to triage an inbound support ticket: severity, owning team and first response.",
+    "userFacingDescription": "Triage a support ticket and draft the first response.",
+    "instructions": "Assign a severity from S1 to S4, name the owning team, and draft a first response that acknowledges the issue and states the next step.",
+    "instructionsHtml": "<p>Assign a severity from S1 to S4, name the owning team, and draft a first response that acknowledges the issue and states the next step.</p>"
+  }
+]

--- a/front/scripts/seed/analytics/assets/users.json
+++ b/front/scripts/seed/analytics/assets/users.json
@@ -1,0 +1,37 @@
+[
+  {
+    "sId": "SeedUserNora",
+    "username": "nora",
+    "email": "nora@example.com",
+    "firstName": "Nora",
+    "lastName": "Patel"
+  },
+  {
+    "sId": "SeedUserMilo",
+    "username": "milo",
+    "email": "milo@example.com",
+    "firstName": "Milo",
+    "lastName": "Fontaine"
+  },
+  {
+    "sId": "SeedUserInes",
+    "username": "ines",
+    "email": "ines@example.com",
+    "firstName": "Ines",
+    "lastName": "Duarte"
+  },
+  {
+    "sId": "SeedUserTheo",
+    "username": "theo",
+    "email": "theo@example.com",
+    "firstName": "Theo",
+    "lastName": "Brandt"
+  },
+  {
+    "sId": "SeedUserSacha",
+    "username": "sacha",
+    "email": "sacha@example.com",
+    "firstName": "Sacha",
+    "lastName": "Okafor"
+  }
+]

--- a/front/scripts/seed/analytics/hiddenAgent.ts
+++ b/front/scripts/seed/analytics/hiddenAgent.ts
@@ -1,0 +1,127 @@
+import { DROID_AVATAR_URLS } from "@app/components/agent_builder/settings/avatar_picker/types";
+import {
+  createAgentConfiguration,
+  searchAgentConfigurationsByName,
+} from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { CreatedAgent, SeedContext } from "@app/scripts/seed/factories";
+import { SPACE_GROUP_PREFIX } from "@app/types/groups";
+
+const AGENT_NAME = "SeedPrivateAgent";
+const SPACE_NAME = "Analytics Restricted Space";
+
+async function findOrCreateRestrictedSpace(
+  ctx: SeedContext,
+  internalAuth: Authenticator,
+  owner: UserResource
+): Promise<SpaceResource> {
+  const { workspace, logger } = ctx;
+
+  const existingSpaces = await SpaceResource.listWorkspaceSpaces(internalAuth);
+  const existingSpace = existingSpaces.find(
+    (space) => space.name === SPACE_NAME
+  );
+  if (existingSpace) {
+    return existingSpace;
+  }
+
+  const spaceGroup = await GroupResource.makeNew({
+    name: `${SPACE_GROUP_PREFIX} ${SPACE_NAME}`,
+    workspaceId: workspace.id,
+    kind: "regular_auto",
+  });
+  const space = await SpaceResource.makeNew(
+    { name: SPACE_NAME, kind: "regular", workspaceId: workspace.id },
+    { members: [spaceGroup] }
+  );
+  // Adding space members requires administrate rights, which the owner (role
+  // "user") does not have.
+  const addMembersResult = await space.addMembers(internalAuth, {
+    userIds: [owner.sId],
+  });
+  if (addMembersResult.isErr()) {
+    throw addMembersResult.error;
+  }
+
+  logger.info({ sId: space.sId, name: SPACE_NAME }, "Restricted space created");
+  return space;
+}
+
+/**
+ * Seeds an agent the workspace admin is not supposed to see anywhere else:
+ * `hidden` scope (so it is unpublished), owned by another user (so the admin is
+ * not an editor), and built on a restricted space the admin is not a member of
+ * (so space permissions filter it out too).
+ *
+ * Its consumption still has to show up on the analytics page, which is scoped to
+ * the workspace rather than to what the admin can access.
+ */
+export async function seedHiddenAgent(
+  ctx: SeedContext,
+  { owner }: { owner: UserResource | undefined }
+): Promise<CreatedAgent | null> {
+  const { workspace, execute, logger } = ctx;
+
+  if (!execute || !owner) {
+    return null;
+  }
+
+  // The admin's own authenticator cannot see, nor create in, a restricted space
+  // it is not a member of.
+  const internalAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+
+  const existingAgents = await searchAgentConfigurationsByName(
+    internalAuth,
+    AGENT_NAME
+  );
+  const existingAgent = existingAgents.find((a) => a.name === AGENT_NAME);
+  if (existingAgent) {
+    logger.info(
+      { sId: existingAgent.sId, name: AGENT_NAME },
+      "Hidden agent already exists, skipping"
+    );
+    return { sId: existingAgent.sId, name: AGENT_NAME };
+  }
+
+  const space = await findOrCreateRestrictedSpace(ctx, internalAuth, owner);
+
+  const agentResult = await createAgentConfiguration(internalAuth, {
+    name: AGENT_NAME,
+    description: "Seeded agent that only its owner should see.",
+    instructions: "You are a seeded agent used to test analytics visibility.",
+    instructionsHtml: null,
+    pictureUrl: DROID_AVATAR_URLS[0],
+    status: "active",
+    scope: "hidden",
+    model: {
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      temperature: 0.7,
+    },
+    templateId: null,
+    requestedSpaceIds: [space.id],
+    tags: [],
+    editors: [owner.toJSON()],
+    authorId: owner.id,
+  });
+  if (agentResult.isErr()) {
+    throw agentResult.error;
+  }
+
+  logger.info(
+    {
+      sId: agentResult.value.sId,
+      name: AGENT_NAME,
+      ownerEmail: owner.email,
+      space: SPACE_NAME,
+    },
+    "Hidden agent created in a restricted space"
+  );
+
+  return { sId: agentResult.value.sId, name: AGENT_NAME };
+}

--- a/front/scripts/seed/analytics/seed.ts
+++ b/front/scripts/seed/analytics/seed.ts
@@ -1,0 +1,110 @@
+import { makeScript } from "@app/scripts/helpers";
+import { seedHiddenAgent } from "@app/scripts/seed/analytics/hiddenAgent";
+import type {
+  AgentAsset,
+  SkillAsset,
+  UserAsset,
+} from "@app/scripts/seed/factories";
+import {
+  createSeedContext,
+  seedAgents,
+  seedConsumptionAnalytics,
+  seedGroup,
+  seedSkill,
+  seedUsers,
+} from "@app/scripts/seed/factories";
+import { removeNulls } from "@app/types/shared/utils/general";
+import * as fs from "fs";
+import * as path from "path";
+
+interface Assets {
+  agents: AgentAsset[];
+  skills: SkillAsset[];
+  users: UserAsset[];
+}
+
+function loadAssets(): Assets {
+  const assetsDir = path.join(__dirname, "assets");
+  const read = (file: string) =>
+    JSON.parse(fs.readFileSync(path.join(assetsDir, file), "utf-8"));
+  return {
+    agents: read("agents.json"),
+    skills: read("skills.json"),
+    users: read("users.json"),
+  };
+}
+
+const ENGINEERING_GROUP_NAME = "Analytics Engineering";
+const SALES_GROUP_NAME = "Analytics Sales";
+// Owns the hidden agent, so it is attributed to someone the admin does not edit.
+const HIDDEN_AGENT_OWNER_ID = "SeedUserSacha";
+
+makeScript(
+  {
+    daysBack: {
+      type: "number",
+      default: 90,
+      description: "Size of the window the consumption is spread over",
+    },
+    messagesPerDay: {
+      type: "number",
+      default: 12,
+      description: "Base number of agent messages per day",
+    },
+  },
+  async ({ daysBack, messagesPerDay, execute }, logger) => {
+    const { agents, skills, users } = loadAssets();
+
+    const ctx = await createSeedContext({ execute, logger });
+
+    // 1. Members to attribute consumption to.
+    logger.info("Seeding users...");
+    const createdUsers = await seedUsers(ctx, users);
+    const usersById = (ids: string[]) =>
+      removeNulls(ids.map((id) => createdUsers.get(id)));
+
+    // 2. Two overlapping teams, so the Teams tab ranks more than one group and
+    // some members belong to both.
+    logger.info("Seeding groups...");
+    await seedGroup(ctx, {
+      name: ENGINEERING_GROUP_NAME,
+      kind: "provisioned",
+      members: [
+        ctx.user,
+        ...usersById(["SeedUserNora", "SeedUserMilo", "SeedUserTheo"]),
+      ],
+    });
+    await seedGroup(ctx, {
+      name: SALES_GROUP_NAME,
+      kind: "regular_manual",
+      members: usersById([
+        "SeedUserInes",
+        "SeedUserTheo",
+        HIDDEN_AGENT_OWNER_ID,
+      ]),
+    });
+
+    // 3. Skills, which tool consumption is attributed to.
+    logger.info("Seeding skills...");
+    const createdSkills = [];
+    for (const skill of skills) {
+      createdSkills.push(await seedSkill(ctx, skill));
+    }
+
+    // 4. Enough agents for the rankings to have a long tail and an "others"
+    // series in the chart.
+    logger.info("Seeding agents...");
+    await seedAgents(ctx, agents, { skills: removeNulls(createdSkills) });
+
+    logger.info("Seeding the hidden agent...");
+    await seedHiddenAgent(ctx, {
+      owner: createdUsers.get(HIDDEN_AGENT_OWNER_ID),
+    });
+
+    // 5. The consumption documents themselves.
+    logger.info("Seeding consumption analytics...");
+    await seedConsumptionAnalytics(ctx, { daysBack, messagesPerDay });
+
+    logger.info("Analytics seed completed");
+  }
+);

--- a/front/scripts/seed/factories/index.ts
+++ b/front/scripts/seed/factories/index.ts
@@ -1,6 +1,7 @@
 export * from "./seedAgent";
 export * from "./seedAgentSuggestions";
 export * from "./seedAnalytics";
+export * from "./seedConsumptionAnalytics";
 export * from "./seedContext";
 export * from "./seedConversations";
 export * from "./seedDataSources";

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -35,8 +35,7 @@ import type { SeedContext } from "./types";
  * panel offers are exactly the ones the seeded documents carry.
  */
 
-// Consumption keys are part of the document id, so a second run overwrites the
-// first run's dataset instead of doubling it.
+// Keeps a second run overwriting the first run's documents instead of doubling them.
 const SEED_CONSUMPTION_KEY_PREFIX = "seed-consumption";
 
 const DEFAULT_DAYS_BACK = 90;
@@ -48,12 +47,10 @@ const MS_PER_HOUR = 60 * 60 * 1000;
 const LLM_CREDIT_RANGE = { min: 0.2, max: 8 };
 const TOOL_DIRECT_CREDIT_RANGE = { min: 0.01, max: 0.4 };
 const TOOL_MODEL_CREDIT_RANGE = { min: 0.01, max: 0.2 };
-// Triggered messages are spread over that many fake triggers.
 const TRIGGER_COUNT = 3;
 const MAX_LLM_STEPS = 3;
 const MAX_TOOL_CALLS = 3;
-// Share of messages that delegate to a sub-agent, which consumes under its own
-// agent message at depth 1.
+// Share of messages that delegate to a sub-agent.
 const SUB_AGENT_RATE = 0.15;
 // Messages land between these hours, so the daily buckets of the chart are not
 // perfectly flat.
@@ -116,9 +113,8 @@ function pick<T>(random: Random, items: T[]): T {
   return items[randomInt(random, 0, items.length - 1)];
 }
 
-// Rank-weighted pick: the first items of the list are much more likely, so the
-// rankings have a couple of heavy hitters and a long tail (and therefore an
-// "others" series in the chart).
+// Weighted towards the head of the list: the rankings need heavy hitters and a
+// long tail, and the chart an "others" series.
 function pickByRank<T>(random: Random, items: T[]): T {
   const weights = items.map((_, index) => 1 / (index + 1));
   const total = weights.reduce((sum, weight) => sum + weight, 0);
@@ -156,10 +152,6 @@ type ConsumptionPools = {
   skillIds: string[];
 };
 
-/**
- * Reads the workspace's consumption facet catalog — the very list the filter
- * panel offers — and turns it into the pools the documents are sampled from.
- */
 async function loadConsumptionPools(
   ctx: SeedContext
 ): Promise<ConsumptionPools> {
@@ -167,9 +159,7 @@ async function loadConsumptionPools(
 
   const catalog = await listConsumptionFacetCatalog(auth);
 
-  // The `team` dimension reads `user.group_ids`, which production fills with the
-  // cap-eligible groups the member belonged to. Mirror the real memberships so
-  // the team rankings match the workspace.
+  // Real memberships, so the Teams tab matches the workspace.
   const groups = await GroupResource.listAllWorkspaceGroups(auth, {
     groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
   });
@@ -228,10 +218,6 @@ function makeAgent(
   };
 }
 
-/**
- * Plans the messages of one day: a top-level message per entry, plus a
- * sub-agent message for the share of them that delegates.
- */
 function planDayMessages(
   random: Random,
   pools: ConsumptionPools,
@@ -289,8 +275,7 @@ function planDayMessages(
   return messages;
 }
 
-// The fields both document types carry, mirroring `makeBaseDocument` of the
-// production pipeline.
+// Fields both document types carry.
 type SeedConsumptionBaseFields = Pick<
   AgentMessageConsumptionAnalyticsData,
   | "agent"
@@ -412,8 +397,6 @@ function makeToolDocument(
   const directCreditMicro = roundCreditsToMicroCredits(
     randomCredits(random, TOOL_DIRECT_CREDIT_RANGE)
   );
-  // The tool document also carries the model cost of emitting the call and of
-  // the result footprint, so it is always above its direct charge.
   const creditMicro =
     directCreditMicro +
     roundCreditsToMicroCredits(randomCredits(random, TOOL_MODEL_CREDIT_RANGE));
@@ -507,8 +490,7 @@ function planDocuments(
     const dayStartMs = todayStartMs - dayOffset * MS_PER_DAY;
     const dayOfWeek = new Date(dayStartMs).getUTCDay();
     const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
-    // Volume grows over the window and drops on weekends, so the timeseries has
-    // a trend and a weekly rhythm rather than noise around a flat line.
+    // A trend and a weekly rhythm, rather than noise around a flat line.
     const growth = 0.5 + (daysBack - dayOffset) / daysBack;
     const dayMessageCount = Math.max(
       1,
@@ -591,8 +573,7 @@ export async function seedConsumptionAnalytics(
     }
   }
 
-  // The production path leaves refreshing to Elasticsearch. Force it so the
-  // page shows the seeded data right away.
+  // Force a refresh so the page shows the seeded data right away.
   const refreshResult = await withEs((client) =>
     client.indices.refresh({ index: CONSUMPTION_ANALYTICS_ALIAS_NAME })
   );

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -1,0 +1,616 @@
+import { upsertAgentMessageConsumptionAnalyticsDocuments } from "@app/lib/analytics/agent_message_consumption/store";
+import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
+import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import {
+  CONSUMPTION_ANALYTICS_ALIAS_NAME,
+  withEs,
+} from "@app/lib/api/elasticsearch";
+import {
+  microCreditsToCredits,
+  roundCreditsToMicroCredits,
+} from "@app/lib/credits/units";
+import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type {
+  AgentMessageConsumptionAnalyticsAgent,
+  AgentMessageConsumptionAnalyticsData,
+  AgentMessageConsumptionAnalyticsLlmData,
+  AgentMessageConsumptionAnalyticsToolData,
+  AgentMessageConsumptionAnalyticsUser,
+} from "@app/types/assistant/analytics";
+import type { UserMessageOrigin } from "@app/types/assistant/conversation";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
+import { removeNulls } from "@app/types/shared/utils/general";
+
+import type { SeedContext } from "./types";
+
+/**
+ * Seeds the consumption index the "Analytics (new)" page reads, with the
+ * documents the attribution pipeline would have produced for billed LLM steps
+ * and tool calls.
+ *
+ * Every dimension of the page (agent, member, team, model, tool, skill, source)
+ * is filled from the workspace's own facet catalog, so the values the filter
+ * panel offers are exactly the ones the seeded documents carry.
+ */
+
+// Consumption keys are part of the document id, so a second run overwrites the
+// first run's dataset instead of doubling it.
+const SEED_CONSUMPTION_KEY_PREFIX = "seed-consumption";
+
+const DEFAULT_DAYS_BACK = 90;
+const DEFAULT_MESSAGES_PER_DAY = 12;
+const BULK_CHUNK_SIZE = 500;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+const LLM_CREDIT_RANGE = { min: 0.2, max: 8 };
+const TOOL_DIRECT_CREDIT_RANGE = { min: 0.01, max: 0.4 };
+const TOOL_MODEL_CREDIT_RANGE = { min: 0.01, max: 0.2 };
+// Triggered messages are spread over that many fake triggers.
+const TRIGGER_COUNT = 3;
+const MAX_LLM_STEPS = 3;
+const MAX_TOOL_CALLS = 3;
+// Share of messages that delegate to a sub-agent, which consumes under its own
+// agent message at depth 1.
+const SUB_AGENT_RATE = 0.15;
+// Messages land between these hours, so the daily buckets of the chart are not
+// perfectly flat.
+const FIRST_HOUR_UTC = 7;
+const LAST_HOUR_UTC = 20;
+
+const ORIGIN_WEIGHTS: { origin: UserMessageOrigin; weight: number }[] = [
+  { origin: "web", weight: 60 },
+  { origin: "slack", weight: 15 },
+  { origin: "api", weight: 8 },
+  { origin: "extension", weight: 6 },
+  { origin: "cli_programmatic", weight: 4 },
+  { origin: "triggered", weight: 4 },
+  { origin: "gsheet", weight: 2 },
+  { origin: "email", weight: 1 },
+];
+
+const PROGRAMMATIC_ORIGINS: UserMessageOrigin[] = [
+  "api",
+  "cli_programmatic",
+  "triggered_programmatic",
+];
+
+const TRIGGERED_ORIGINS: UserMessageOrigin[] = [
+  "triggered",
+  "triggered_programmatic",
+];
+
+export interface SeedConsumptionAnalyticsOptions {
+  daysBack?: number;
+  messagesPerDay?: number;
+}
+
+// Deterministic PRNG (mulberry32): the same workspace always gets the same
+// dataset, which keeps re-runs idempotent and screenshots comparable.
+function makeRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Random = () => number;
+
+function randomInt(random: Random, min: number, max: number): number {
+  return Math.floor(random() * (max - min + 1)) + min;
+}
+
+function randomCredits(
+  random: Random,
+  { min, max }: { min: number; max: number }
+): number {
+  return min + random() * (max - min);
+}
+
+function pick<T>(random: Random, items: T[]): T {
+  return items[randomInt(random, 0, items.length - 1)];
+}
+
+// Rank-weighted pick: the first items of the list are much more likely, so the
+// rankings have a couple of heavy hitters and a long tail (and therefore an
+// "others" series in the chart).
+function pickByRank<T>(random: Random, items: T[]): T {
+  const weights = items.map((_, index) => 1 / (index + 1));
+  const total = weights.reduce((sum, weight) => sum + weight, 0);
+  let target = random() * total;
+  for (const [index, weight] of weights.entries()) {
+    target -= weight;
+    if (target <= 0) {
+      return items[index];
+    }
+  }
+  return items[items.length - 1];
+}
+
+function pickOrigin(random: Random): UserMessageOrigin {
+  const total = ORIGIN_WEIGHTS.reduce((sum, { weight }) => sum + weight, 0);
+  let target = random() * total;
+  for (const { origin, weight } of ORIGIN_WEIGHTS) {
+    target -= weight;
+    if (target <= 0) {
+      return origin;
+    }
+  }
+  return "web";
+}
+
+function seedId(prefix: string, index: number): string {
+  return `${prefix}${index.toString().padStart(6, "0")}`;
+}
+
+type ConsumptionPools = {
+  agentIds: string[];
+  users: AgentMessageConsumptionAnalyticsUser[];
+  models: ModelConfigurationType[];
+  toolServerNames: string[];
+  skillIds: string[];
+};
+
+/**
+ * Reads the workspace's consumption facet catalog — the very list the filter
+ * panel offers — and turns it into the pools the documents are sampled from.
+ */
+async function loadConsumptionPools(
+  ctx: SeedContext
+): Promise<ConsumptionPools> {
+  const { auth } = ctx;
+
+  const catalog = await listConsumptionFacetCatalog(auth);
+
+  // The `team` dimension reads `user.group_ids`, which production fills with the
+  // cap-eligible groups the member belonged to. Mirror the real memberships so
+  // the team rankings match the workspace.
+  const groups = await GroupResource.listAllWorkspaceGroups(auth, {
+    groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+  });
+  const groupsWithMembers = await GroupResource.fetchJSONWithMembers(
+    auth,
+    groups
+  );
+  const groupIdsByUserId = new Map<string, string[]>();
+  for (const group of groupsWithMembers) {
+    for (const memberId of group.memberIds) {
+      groupIdsByUserId.set(memberId, [
+        ...(groupIdsByUserId.get(memberId) ?? []),
+        group.sId,
+      ]);
+    }
+  }
+
+  return {
+    agentIds: catalog.agent.map((entry) => entry.value),
+    users: catalog.user.map((entry) => ({
+      id: entry.value,
+      group_ids: [...(groupIdsByUserId.get(entry.value) ?? [])].sort(),
+    })),
+    models: removeNulls(
+      catalog.model.map((entry) => getModelConfigByModelId(entry.value) ?? null)
+    ),
+    toolServerNames: catalog.tool.map((entry) => entry.value),
+    skillIds: catalog.skill.map((entry) => entry.value),
+  };
+}
+
+type SeedMessage = {
+  agent: AgentMessageConsumptionAnalyticsAgent;
+  agentMessageId: string;
+  completedAt: Date;
+  conversationId: string;
+  llmStepCount: number;
+  model: ModelConfigurationType;
+  origin: UserMessageOrigin;
+  toolCallCount: number;
+  user: AgentMessageConsumptionAnalyticsUser;
+};
+
+function makeAgent(
+  agentId: string,
+  parentAgentId?: string
+): AgentMessageConsumptionAnalyticsAgent {
+  return {
+    id: agentId,
+    version: "0",
+    tag_ids: [],
+    parent_ids: parentAgentId ? [parentAgentId] : [],
+    direct_parent_id: parentAgentId ?? null,
+    root_id: parentAgentId ?? agentId,
+    depth: parentAgentId ? 1 : 0,
+  };
+}
+
+/**
+ * Plans the messages of one day: a top-level message per entry, plus a
+ * sub-agent message for the share of them that delegates.
+ */
+function planDayMessages(
+  random: Random,
+  pools: ConsumptionPools,
+  {
+    dayStartMs,
+    messageCount,
+    nowMs,
+    startIndex,
+  }: {
+    dayStartMs: number;
+    messageCount: number;
+    nowMs: number;
+    startIndex: number;
+  }
+): SeedMessage[] {
+  const messages: SeedMessage[] = [];
+
+  for (let i = 0; i < messageCount; i++) {
+    const index = startIndex + messages.length;
+    const completedAtMs = Math.min(
+      dayStartMs +
+        randomInt(random, FIRST_HOUR_UTC, LAST_HOUR_UTC) * MS_PER_HOUR +
+        randomInt(random, 0, 59) * 60 * 1000,
+      nowMs
+    );
+    const agentId = pickByRank(random, pools.agentIds);
+    const conversationId = seedId("seedconv", index);
+    const shared = {
+      completedAt: new Date(completedAtMs),
+      conversationId,
+      model: pickByRank(random, pools.models),
+      origin: pickOrigin(random),
+      user: pickByRank(random, pools.users),
+    };
+
+    messages.push({
+      ...shared,
+      agent: makeAgent(agentId),
+      agentMessageId: seedId("seedmsg", index),
+      llmStepCount: randomInt(random, 1, MAX_LLM_STEPS),
+      toolCallCount: randomInt(random, 0, MAX_TOOL_CALLS),
+    });
+
+    if (random() < SUB_AGENT_RATE && pools.agentIds.length > 1) {
+      messages.push({
+        ...shared,
+        agent: makeAgent(pick(random, pools.agentIds), agentId),
+        agentMessageId: seedId("seedsubmsg", index),
+        llmStepCount: randomInt(random, 1, 2),
+        toolCallCount: randomInt(random, 0, 2),
+      });
+    }
+  }
+
+  return messages;
+}
+
+// The fields both document types carry, mirroring `makeBaseDocument` of the
+// production pipeline.
+type SeedConsumptionBaseFields = Pick<
+  AgentMessageConsumptionAnalyticsData,
+  | "agent"
+  | "agent_message_id"
+  | "api_key_name"
+  | "attribution_version"
+  | "completed_at"
+  | "consumption_key"
+  | "context_origin"
+  | "conversation_id"
+  | "execution_time_ms"
+  | "message_version"
+  | "model"
+  | "run_usage_id"
+  | "space_id"
+  | "status"
+  | "step_index"
+  | "trigger_id"
+  | "usage_type"
+  | "user"
+  | "workspace_id"
+>;
+
+function makeBaseFields(
+  random: Random,
+  message: SeedMessage,
+  {
+    consumptionKey,
+    stepIndex,
+    workspaceId,
+  }: { consumptionKey: string; stepIndex: number; workspaceId: string }
+): SeedConsumptionBaseFields {
+  const isProgrammatic = PROGRAMMATIC_ORIGINS.includes(message.origin);
+
+  return {
+    agent: message.agent,
+    agent_message_id: message.agentMessageId,
+    api_key_name: isProgrammatic ? "Seed integration key" : null,
+    attribution_version: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    completed_at: message.completedAt.toISOString(),
+    consumption_key: consumptionKey,
+    context_origin: message.origin,
+    conversation_id: message.conversationId,
+    execution_time_ms: randomInt(random, 400, 25_000),
+    message_version: "0",
+    model: {
+      provider_id: message.model.providerId,
+      model_id: message.model.modelId,
+      reasoning_effort: message.model.defaultReasoningEffort,
+      resolution_method: "agent",
+    },
+    run_usage_id: consumptionKey,
+    space_id: null,
+    status: "succeeded",
+    step_index: stepIndex,
+    trigger_id: TRIGGERED_ORIGINS.includes(message.origin)
+      ? seedId("seedtrigger", randomInt(random, 0, TRIGGER_COUNT - 1))
+      : null,
+    usage_type: isProgrammatic ? "programmatic" : "user",
+    user: message.user,
+    workspace_id: workspaceId,
+  };
+}
+
+function makeLlmDocument(
+  random: Random,
+  message: SeedMessage,
+  { stepIndex, workspaceId }: { stepIndex: number; workspaceId: string }
+): AgentMessageConsumptionAnalyticsLlmData {
+  const creditMicro = roundCreditsToMicroCredits(
+    randomCredits(random, LLM_CREDIT_RANGE)
+  );
+  const systemCreditMicro = Math.floor(creditMicro * 0.05);
+  const outputCreditMicro = Math.floor(creditMicro * 0.35);
+  const reasoningCreditMicro = Math.floor(creditMicro * 0.1);
+
+  return {
+    ...makeBaseFields(random, message, {
+      consumptionKey: `${SEED_CONSUMPTION_KEY_PREFIX}:llm:${stepIndex}`,
+      stepIndex,
+      workspaceId,
+    }),
+    consumption_type: "llm",
+    credit_micro: creditMicro,
+    gross_credit_micro: {
+      system: systemCreditMicro,
+      input:
+        creditMicro -
+        systemCreditMicro -
+        outputCreditMicro -
+        reasoningCreditMicro,
+      result_footprint: null,
+      output: outputCreditMicro,
+      reasoning: reasoningCreditMicro,
+      direct: 0,
+      total: creditMicro,
+    },
+    tokens: {
+      system: randomInt(random, 200, 1500),
+      input: randomInt(random, 800, 90_000),
+      result_footprint: null,
+      output: randomInt(random, 50, 2000),
+      reasoning: randomInt(random, 0, 3000),
+    },
+    tool: null,
+  };
+}
+
+function makeToolDocument(
+  random: Random,
+  message: SeedMessage,
+  pools: ConsumptionPools,
+  {
+    stepIndex,
+    toolIndex,
+    workspaceId,
+  }: { stepIndex: number; toolIndex: number; workspaceId: string }
+): AgentMessageConsumptionAnalyticsToolData {
+  const directCreditMicro = roundCreditsToMicroCredits(
+    randomCredits(random, TOOL_DIRECT_CREDIT_RANGE)
+  );
+  // The tool document also carries the model cost of emitting the call and of
+  // the result footprint, so it is always above its direct charge.
+  const creditMicro =
+    directCreditMicro +
+    roundCreditsToMicroCredits(randomCredits(random, TOOL_MODEL_CREDIT_RANGE));
+  const serverName = pickByRank(random, pools.toolServerNames);
+
+  return {
+    ...makeBaseFields(random, message, {
+      consumptionKey: `${SEED_CONSUMPTION_KEY_PREFIX}:tool:${stepIndex}:${toolIndex}`,
+      stepIndex,
+      workspaceId,
+    }),
+    consumption_type: "tool",
+    credit_micro: creditMicro,
+    gross_credit_micro: {
+      system: 0,
+      input: null,
+      result_footprint: null,
+      output: null,
+      reasoning: 0,
+      direct: directCreditMicro,
+      total: creditMicro,
+    },
+    tokens: {
+      system: 0,
+      input: null,
+      result_footprint: randomInt(random, 200, 12_000),
+      output: randomInt(random, 20, 400),
+      reasoning: 0,
+    },
+    tool: {
+      // Tool names are not a dimension of the page, only server names are.
+      name: `${serverName}_seed_tool`,
+      server_name: serverName,
+      parent_server_name: "",
+      action_id: seedId("seedaction", toolIndex),
+      attributed_skill_ids:
+        pools.skillIds.length > 0 && random() < 0.6
+          ? [pickByRank(random, pools.skillIds)]
+          : [],
+    },
+  };
+}
+
+function makeMessageDocuments(
+  random: Random,
+  message: SeedMessage,
+  pools: ConsumptionPools,
+  workspaceId: string
+): AgentMessageConsumptionAnalyticsData[] {
+  const documents: AgentMessageConsumptionAnalyticsData[] = [];
+
+  for (let stepIndex = 0; stepIndex < message.llmStepCount; stepIndex++) {
+    documents.push(
+      makeLlmDocument(random, message, { stepIndex, workspaceId })
+    );
+  }
+
+  if (pools.toolServerNames.length === 0) {
+    return documents;
+  }
+
+  for (let toolIndex = 0; toolIndex < message.toolCallCount; toolIndex++) {
+    documents.push(
+      makeToolDocument(random, message, pools, {
+        // A tool call belongs to the step that emitted it.
+        stepIndex: toolIndex % message.llmStepCount,
+        toolIndex,
+        workspaceId,
+      })
+    );
+  }
+
+  return documents;
+}
+
+function planDocuments(
+  pools: ConsumptionPools,
+  {
+    daysBack,
+    messagesPerDay,
+    workspaceId,
+  }: { daysBack: number; messagesPerDay: number; workspaceId: string }
+): AgentMessageConsumptionAnalyticsData[] {
+  const random = makeRandom(daysBack * 1000 + messagesPerDay);
+  const nowMs = Date.now();
+  const todayStartMs = Math.floor(nowMs / MS_PER_DAY) * MS_PER_DAY;
+  const documents: AgentMessageConsumptionAnalyticsData[] = [];
+  let messageIndex = 0;
+
+  for (let dayOffset = daysBack - 1; dayOffset >= 0; dayOffset--) {
+    const dayStartMs = todayStartMs - dayOffset * MS_PER_DAY;
+    const dayOfWeek = new Date(dayStartMs).getUTCDay();
+    const isWeekend = dayOfWeek === 0 || dayOfWeek === 6;
+    // Volume grows over the window and drops on weekends, so the timeseries has
+    // a trend and a weekly rhythm rather than noise around a flat line.
+    const growth = 0.5 + (daysBack - dayOffset) / daysBack;
+    const dayMessageCount = Math.max(
+      1,
+      Math.round(messagesPerDay * growth * (isWeekend ? 0.25 : 1))
+    );
+
+    const messages = planDayMessages(random, pools, {
+      dayStartMs,
+      messageCount: dayMessageCount,
+      nowMs,
+      startIndex: messageIndex,
+    });
+    messageIndex += messages.length;
+
+    for (const message of messages) {
+      documents.push(
+        ...makeMessageDocuments(random, message, pools, workspaceId)
+      );
+    }
+  }
+
+  return documents;
+}
+
+export async function seedConsumptionAnalytics(
+  ctx: SeedContext,
+  {
+    daysBack = DEFAULT_DAYS_BACK,
+    messagesPerDay = DEFAULT_MESSAGES_PER_DAY,
+  }: SeedConsumptionAnalyticsOptions = {}
+): Promise<void> {
+  const { workspace, execute, logger } = ctx;
+
+  const pools = await loadConsumptionPools(ctx);
+  if (
+    pools.agentIds.length === 0 ||
+    pools.users.length === 0 ||
+    pools.models.length === 0
+  ) {
+    throw new Error(
+      "The workspace has no agent, member or model to attribute consumption to."
+    );
+  }
+  if (pools.toolServerNames.length === 0) {
+    logger.warn(
+      "No MCP server in the workspace: the Tools and Skills tabs will be empty."
+    );
+  }
+
+  const documents = planDocuments(pools, {
+    daysBack,
+    messagesPerDay,
+    workspaceId: workspace.sId,
+  });
+  const totalCredits = microCreditsToCredits(
+    documents.reduce((sum, document) => sum + document.credit_micro, 0)
+  );
+
+  if (!execute) {
+    logger.info(
+      {
+        agentCount: pools.agentIds.length,
+        daysBack,
+        documentCount: documents.length,
+        memberCount: pools.users.length,
+        sampleDocument: documents[0],
+        totalCredits,
+      },
+      "Dry run: would index consumption documents"
+    );
+    return;
+  }
+
+  for (let i = 0; i < documents.length; i += BULK_CHUNK_SIZE) {
+    const result = await upsertAgentMessageConsumptionAnalyticsDocuments(
+      documents.slice(i, i + BULK_CHUNK_SIZE)
+    );
+    if (result.isErr()) {
+      throw result.error;
+    }
+  }
+
+  // The production path leaves refreshing to Elasticsearch. Force it so the
+  // page shows the seeded data right away.
+  const refreshResult = await withEs((client) =>
+    client.indices.refresh({ index: CONSUMPTION_ANALYTICS_ALIAS_NAME })
+  );
+  if (refreshResult.isErr()) {
+    throw refreshResult.error;
+  }
+
+  logger.info(
+    {
+      agentCount: pools.agentIds.length,
+      daysBack,
+      documentCount: documents.length,
+      memberCount: pools.users.length,
+      modelCount: pools.models.length,
+      skillCount: pools.skillIds.length,
+      toolCount: pools.toolServerNames.length,
+      totalCredits,
+    },
+    "Indexed consumption documents"
+  );
+}


### PR DESCRIPTION
## Description

`dust-hive feed <env> analytics` now populates the consumption index behind the "Analytics (new)" page, so it has data to show locally.

It seeds members, two overlapping teams, skills and enough agents for the rankings to have a tail, then writes LLM and tool consumption documents over the last 90 days. Dimension values are sampled from the workspace's own facet catalog, so the filter panel options and the indexed documents always match. Includes a hidden agent in a restricted space, to check consumption shows up for agents the admin cannot otherwise see.

Re-runnable: entities are skipped by name, and the documents have deterministic ids so a second run overwrites the first.

## Tests

Ran it against a local hive, dry and with `--execute`, and checked the overview, chart and all seven attribution tabs.

## Risk

None, dev-only seed script.

## Deploy Plan

Nothing to do.