### PR TITLE
Isolate sandbox Datadog credentials from workload users

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -614,8 +614,8 @@ const config = {
       domain: EnvironmentConfig.getOptionalEnvVariable("E2B_DOMAIN"),
     };
   },
-  getDatadogApiKey: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable("DD_API_KEY");
+  getSandboxDatadogApiKey: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("SANDBOX_DD_API_KEY");
   },
   getSandboxDevFrontHostName: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable(

--- a/front/lib/api/sandbox/image/egress/dust-systemd1.conf
+++ b/front/lib/api/sandbox/image/egress/dust-systemd1.conf
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "https://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+  <!--
+    systemd exposes its manager environment over the system bus. Sandbox
+    workload accounts must not invoke any manager API, including
+    GetEnvironment, even if another unit accidentally stores a secret there.
+  -->
+  <policy user="agent">
+    <deny send_destination="org.freedesktop.systemd1"/>
+  </policy>
+  <policy user="agent-proxied">
+    <deny send_destination="org.freedesktop.systemd1"/>
+  </policy>
+</busconfig>

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -91,11 +91,25 @@ function getCommandPath(command: string): string {
 }
 
 describe("sandbox image registry", () => {
-  test("pins the current dust-base image tag", () => {
+  test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
       tag: "0.8.84",
     });
+    expect(getDustBaseImage().baseImage).toEqual({
+      type: "docker",
+      imageRef: "dust-sbx-bedrock:1.11.0",
+    });
+  });
+
+  test("loads Fluent Bit credentials from a root-only runtime file", () => {
+    const serviceUnit = getCopiedContent(
+      getCopyOperations(getDustBaseImageOperations()),
+      "/etc/systemd/system/fluent-bit.service"
+    );
+
+    expect(serviceUnit).toContain("EnvironmentFile=/run/dust/fluent-bit.env");
+    expect(serviceUnit).not.toContain("Environment=DD_API_KEY");
   });
 
   test("creates the dormant proxied user and shared-path permissions", () => {
@@ -267,6 +281,10 @@ describe("sandbox image registry", () => {
       copyOperations,
       "/etc/dbus-1/system.d/dust-resolve1.conf"
     );
+    const systemd1Policy = getCopiedContent(
+      copyOperations,
+      "/etc/dbus-1/system.d/dust-systemd1.conf"
+    );
     const resolvedIpcDropIn = getCopiedContent(
       copyOperations,
       "/etc/systemd/system/systemd-resolved.service.d/dust-ipc.conf"
@@ -325,6 +343,14 @@ describe("sandbox image registry", () => {
     expect(
       resolve1Policy.match(
         /<deny send_destination="org\.freedesktop\.resolve1"\/>/g
+      )
+    ).toHaveLength(2);
+    for (const user of ["agent", "agent-proxied"]) {
+      expect(systemd1Policy).toContain(`<policy user="${user}">`);
+    }
+    expect(
+      systemd1Policy.match(
+        /<deny send_destination="org\.freedesktop\.systemd1"\/>/g
       )
     ).toHaveLength(2);
     expect(resolvedIpcDropIn).toContain("[Service]");

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -25,7 +25,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import fs from "fs";
 import path from "path";
 
-const DUST_BEDROCK_IMAGE_VERSION = "1.10.0";
+const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
 const DUST_BASE_IMAGE_VERSION = "0.8.84";
 const DSBX_CLI_VERSION = "0.1.50";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
@@ -703,6 +703,11 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   .copy(
     getLocalContent(EGRESS_LOCAL_DIR, "dust-resolve1.conf"),
     "/etc/dbus-1/system.d/dust-resolve1.conf",
+    { user: "root" }
+  )
+  .copy(
+    getLocalContent(EGRESS_LOCAL_DIR, "dust-systemd1.conf"),
+    "/etc/dbus-1/system.d/dust-systemd1.conf",
     { user: "root" }
   )
   .copy(

--- a/front/lib/api/sandbox/image/telemetry/fluent-bit.service
+++ b/front/lib/api/sandbox/image/telemetry/fluent-bit.service
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=simple
+EnvironmentFile=/run/dust/fluent-bit.env
 ExecStart=/opt/fluent-bit/bin/fluent-bit -c /etc/fluent-bit/fluent-bit.conf
 Restart=on-failure
 RestartSec=5

--- a/front/lib/api/sandbox/telemetry/index.test.ts
+++ b/front/lib/api/sandbox/telemetry/index.test.ts
@@ -1,0 +1,124 @@
+import config from "@app/lib/api/config";
+import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
+import { startTelemetry } from "@app/lib/api/sandbox/telemetry";
+import type { Authenticator } from "@app/lib/auth";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("startTelemetry", () => {
+  let auth: Authenticator;
+  let sandbox: SandboxResource;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+
+    const testSetup = await createResourceTest({ role: "admin" });
+    auth = testSetup.authenticator;
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [new Date()],
+    });
+    sandbox = await SandboxFactory.create(auth, conversation);
+  });
+
+  it("atomically installs the dedicated key without using the systemd manager environment", async () => {
+    const datadogApiKey = "sandbox-datadog-api-key";
+    vi.spyOn(config, "getSandboxDatadogApiKey").mockReturnValue(datadogApiKey);
+    const execRoot = vi.spyOn(sandbox, "execRoot").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: "",
+        stderr: "",
+      })
+    );
+
+    const result = await startTelemetry(auth, sandbox, {
+      kind: "conversation",
+      conversationId: "conv_telemetry_test",
+      spaceId: null,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(execRoot).toHaveBeenCalledTimes(1);
+    const [, command, options] = execRoot.mock.calls[0];
+    const renderedCommand = renderRootCommand(command);
+    expect(renderedCommand).not.toContain("systemctl set-environment");
+    expect(renderedCommand).not.toContain("systemctl unset-environment");
+    expect(renderedCommand).toContain("umask 077");
+    expect(renderedCommand).toContain("/bin/chmod 600");
+    expect(renderedCommand).toContain("/bin/mv -f /run/dust/fluent-bit.env.");
+    expect(renderedCommand).toContain(
+      "/run/dust/fluent-bit.env && /usr/bin/systemctl restart fluent-bit"
+    );
+    expect(renderedCommand).not.toContain(datadogApiKey);
+    expect(options).not.toHaveProperty("stdin");
+    expect(options?.envVars).toEqual({
+      DD_HOST: "http-intake.logs.datadoghq.eu",
+      DD_API_KEY: datadogApiKey,
+      E2B_SANDBOX_ID: sandbox.providerId,
+      CONVERSATION_ID: "conv_telemetry_test",
+      WORKSPACE_ID: auth.getNonNullableWorkspace().sId,
+    });
+  });
+
+  it("fails closed when the dedicated sandbox key is missing", async () => {
+    vi.spyOn(config, "getSandboxDatadogApiKey").mockReturnValue(undefined);
+    const execRoot = vi.spyOn(sandbox, "execRoot");
+
+    const result = await startTelemetry(auth, sandbox, {
+      kind: "pod",
+      spaceId: "space_telemetry_test",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(execRoot).not.toHaveBeenCalled();
+    if (result.isErr()) {
+      expect(result.error.message).toContain("SANDBOX_DD_API_KEY");
+    }
+  });
+
+  it("rejects values that could inject another EnvironmentFile entry", async () => {
+    vi.spyOn(config, "getSandboxDatadogApiKey").mockReturnValue(
+      "sandbox-key\nSECOND_SECRET=exposed"
+    );
+    const execRoot = vi.spyOn(sandbox, "execRoot");
+
+    const result = await startTelemetry(auth, sandbox, {
+      kind: "pod",
+      spaceId: "space_telemetry_test",
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(execRoot).not.toHaveBeenCalled();
+  });
+
+  it("reports a non-zero service restart as an error", async () => {
+    vi.spyOn(config, "getSandboxDatadogApiKey").mockReturnValue(
+      "sandbox-datadog-api-key"
+    );
+    vi.spyOn(sandbox, "execRoot").mockResolvedValue(
+      new Ok({
+        exitCode: 1,
+        stdout: "",
+        stderr: "fluent-bit failed",
+      })
+    );
+
+    const result = await startTelemetry(auth, sandbox, {
+      kind: "pod",
+      spaceId: "space_telemetry_test",
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("fluent-bit failed");
+    }
+  });
+});

--- a/front/lib/api/sandbox/telemetry/index.ts
+++ b/front/lib/api/sandbox/telemetry/index.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import config from "@app/lib/api/config";
 import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
 import type { SandboxRuntimeOwner } from "@app/lib/api/sandbox/owner";
@@ -10,16 +11,35 @@ import type { Authenticator } from "@app/lib/auth";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const FLUENT_BIT_ENV_PATH = "/run/dust/fluent-bit.env";
+const DD_HOST = "http-intake.logs.datadoghq.eu";
+const TELEMETRY_ENV_VALUE_PATTERN = /^[A-Za-z0-9_./:@-]+$/;
+
+function validateTelemetryEnvVars(
+  envVars: Record<string, string>
+): Result<void, Error> {
+  for (const [name, value] of Object.entries(envVars)) {
+    if (!value || !TELEMETRY_ENV_VALUE_PATTERN.test(value)) {
+      return new Err(
+        new Error(`Invalid sandbox telemetry environment value for ${name}.`)
+      );
+    }
+  }
+
+  return new Ok(undefined);
+}
 
 /**
  * Start fluent-bit telemetry in a sandbox.
  *
- * Sets up systemd environment variables and starts the fluent-bit service.
+ * Writes a root-only EnvironmentFile and starts the fluent-bit service.
  * Designed to be called fire-and-forget after sandbox creation or wake.
  *
- * Environment variables are passed via envVars to avoid exposing sensitive
- * values (like DD_API_KEY) in journalctl command logs.
+ * The dedicated sandbox key is transported in the root process environment,
+ * never argv or the systemd manager environment. The service reads it from a
+ * root-owned mode-0600 file that unprivileged sandbox accounts cannot access.
  */
 export async function startTelemetry(
   auth: Authenticator,
@@ -28,9 +48,6 @@ export async function startTelemetry(
 ): Promise<Result<void, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const ownerEnvVars = getSandboxOwnerEnvVars(owner);
-  const ownerSystemdEnv = Object.keys(ownerEnvVars)
-    .map((name) => `${name}="$${name}"`)
-    .join(" ");
 
   const childLogger = logger.child({
     sandboxId: sandbox.sId,
@@ -38,23 +55,48 @@ export async function startTelemetry(
     ...getSandboxOwnerLogContext(owner),
   });
 
+  const datadogApiKey = config.getSandboxDatadogApiKey();
+  if (!datadogApiKey) {
+    const error = new Error("SANDBOX_DD_API_KEY is not configured.");
+    childLogger.error(
+      { err: error, panic: true },
+      "Refusing to start sandbox telemetry without a dedicated Datadog API key"
+    );
+    return new Err(error);
+  }
+
+  const envVars = {
+    DD_HOST,
+    DD_API_KEY: datadogApiKey,
+    E2B_SANDBOX_ID: sandbox.providerId,
+    ...ownerEnvVars,
+    WORKSPACE_ID: workspaceId,
+  };
+  const validation = validateTelemetryEnvVars(envVars);
+  if (validation.isErr()) {
+    childLogger.error(
+      { err: validation.error, panic: true },
+      "Refusing to start sandbox telemetry with invalid environment values"
+    );
+    return validation;
+  }
+
+  const tmpPath = `${FLUENT_BIT_ENV_PATH}.${randomBytes(8).toString("hex")}.tmp`;
+  const environmentLines = Object.keys(envVars)
+    .map((name) => `"${name}=$${name}"`)
+    .join(" ");
+
   // /!\ DD_API_KEY must never appear literally in the command string;
-  // journalctl logs argv. Always interpolate from the envVars below.
+  // journalctl logs argv. Bash expands it only inside the root process.
   const result = await traceSandboxStartupPhase("telemetry_start", () =>
     sandbox.execRoot(
       auth,
       rootCommand.unsafeShell(
-        `/usr/bin/systemctl set-environment DD_HOST="$DD_HOST" DD_API_KEY="$DD_API_KEY" E2B_SANDBOX_ID="$E2B_SANDBOX_ID" ${ownerSystemdEnv} WORKSPACE_ID="$WORKSPACE_ID" && /usr/bin/systemctl start fluent-bit`,
-        "systemctl environment command expands sandbox env vars without embedding secrets in the TypeScript command string"
+        `/usr/bin/install -d -o root -g root -m 755 /run/dust && umask 077 && builtin printf '%s\\n' ${environmentLines} > ${tmpPath} && /bin/chown root:root ${tmpPath} && /bin/chmod 600 ${tmpPath} && /bin/mv -f ${tmpPath} ${FLUENT_BIT_ENV_PATH} && /usr/bin/systemctl restart fluent-bit`,
+        "bash builtins atomically render validated environment values into a root-only Fluent Bit EnvironmentFile without embedding the key in argv"
       ),
       {
-        envVars: {
-          DD_HOST: "http-intake.logs.datadoghq.eu",
-          DD_API_KEY: config.getDatadogApiKey() ?? "",
-          E2B_SANDBOX_ID: sandbox.providerId,
-          ...ownerEnvVars,
-          WORKSPACE_ID: workspaceId,
-        },
+        envVars,
       }
     )
   );
@@ -62,6 +104,16 @@ export async function startTelemetry(
   if (result.isErr()) {
     childLogger.error({ err: result.error }, "Failed to start telemetry");
     return result;
+  }
+
+  if (result.value.exitCode !== 0) {
+    const error = new Error(
+      `Failed to start sandbox telemetry: ${
+        result.value.stderr || result.value.stdout || "unknown error"
+      }`
+    );
+    childLogger.error({ err: error }, "Failed to start telemetry");
+    return new Err(error);
   }
 
   childLogger.info({}, "Telemetry started successfully");

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -378,6 +378,58 @@ test "$(/usr/bin/stat -c '%U:%G %a' /var/empty)" = "root:root 755"
   }
 }
 
+async function checkTelemetrySecretBoundary(
+  provider: E2BSandboxProvider,
+  providerId: string
+): Promise<void> {
+  const envPath = "/run/dust/fluent-bit.env";
+  try {
+    const seed = await runRootBashScript(
+      provider,
+      providerId,
+      `
+set -euo pipefail
+/usr/bin/install -d -o root -g root -m 755 /run/dust
+printf '%s\n' 'DD_API_KEY=sandbox-security-sentinel' > ${envPath}
+/usr/bin/chown root:root ${envPath}
+/usr/bin/chmod 600 ${envPath}
+`
+    );
+    assertCommandSucceeded("telemetry secret boundary seed", seed);
+
+    for (const user of [AGENT_USER, AGENT_PROXIED_USER] as const) {
+      const denial = await runBashScript(
+        provider,
+        providerId,
+        `
+set -euo pipefail
+if /usr/bin/systemctl show-environment >/dev/null 2>&1; then
+  echo "CRITICAL: workload can read the systemd manager environment"
+  exit 1
+fi
+if /bin/cat ${envPath} >/dev/null 2>&1; then
+  echo "CRITICAL: workload can read the Fluent Bit environment file"
+  exit 1
+fi
+if /bin/cat /proc/1/environ >/dev/null 2>&1; then
+  echo "CRITICAL: workload can read a root process environment"
+  exit 1
+fi
+`,
+        { user }
+      );
+      assertCommandSucceeded(`${user} telemetry secret denials`, denial);
+    }
+  } finally {
+    const cleanup = await runRootBashScript(
+      provider,
+      providerId,
+      `/bin/rm -f ${envPath}`
+    );
+    assertCommandSucceeded("telemetry secret boundary cleanup", cleanup);
+  }
+}
+
 async function checkControlledUidEgress(
   provider: E2BSandboxProvider,
   providerId: string
@@ -1292,6 +1344,7 @@ async function checkImage(image: SandboxImage): Promise<void> {
     await checkPamEscalationPaths(provider, providerId);
     await checkBasicSandboxFunctionality(provider, providerId);
     await checkAgentServiceBoundary(provider, providerId);
+    await checkTelemetrySecretBoundary(provider, providerId);
     await checkTargetUserState(provider, providerId);
     await checkEquivalentAccountEscalation(provider, providerId);
     await checkSystemAccountAudit(provider, providerId);

--- a/front/scripts/sandbox_security_check.ts
+++ b/front/scripts/sandbox_security_check.ts
@@ -383,6 +383,7 @@ async function checkTelemetrySecretBoundary(
   providerId: string
 ): Promise<void> {
   const envPath = "/run/dust/fluent-bit.env";
+  const processPidPath = "/run/dust/telemetry-secret-probe.pid";
   try {
     const seed = await runRootBashScript(
       provider,
@@ -393,7 +394,14 @@ set -euo pipefail
 printf '%s\n' 'DD_API_KEY=sandbox-security-sentinel' > ${envPath}
 /usr/bin/chown root:root ${envPath}
 /usr/bin/chmod 600 ${envPath}
-`
+/usr/bin/nohup /usr/bin/sleep 300 >/dev/null 2>&1 &
+printf '%s\n' "$!" > ${processPidPath}
+/usr/bin/chown root:root ${processPidPath}
+/usr/bin/chmod 644 ${processPidPath}
+secret_pid=$(/bin/cat ${processPidPath})
+/usr/bin/test -r "/proc/$secret_pid/environ"
+`,
+      { envVars: { DUST_TELEMETRY_SECRET: "sandbox-security-sentinel" } }
     );
     assertCommandSucceeded("telemetry secret boundary seed", seed);
 
@@ -411,7 +419,8 @@ if /bin/cat ${envPath} >/dev/null 2>&1; then
   echo "CRITICAL: workload can read the Fluent Bit environment file"
   exit 1
 fi
-if /bin/cat /proc/1/environ >/dev/null 2>&1; then
+secret_pid=$(/bin/cat ${processPidPath})
+if /bin/cat "/proc/$secret_pid/environ" >/dev/null 2>&1; then
   echo "CRITICAL: workload can read a root process environment"
   exit 1
 fi
@@ -424,7 +433,8 @@ fi
     const cleanup = await runRootBashScript(
       provider,
       providerId,
-      `/bin/rm -f ${envPath}`
+      `if [ -f ${processPidPath} ]; then /usr/bin/kill "$(/bin/cat ${processPidPath})" >/dev/null 2>&1 || true; fi
+/bin/rm -f ${envPath} ${processPidPath}`
     );
     assertCommandSucceeded("telemetry secret boundary cleanup", cleanup);
   }


### PR DESCRIPTION
## Description

- Replace the shared `DD_API_KEY` lookup with a dedicated, required `SANDBOX_DD_API_KEY` for Fluent Bit.
- Stop writing telemetry values to the systemd manager environment. Write a validated, root-owned mode `0600` file atomically under `/run/dust` and load it only from `fluent-bit.service`.
- Deny `org.freedesktop.systemd1` on the system bus for both sandbox workload accounts.
- Add image-build regression checks for the D-Bus denial, root process environment boundary, and Fluent Bit file permissions.
- Bump `dust-sbx-bedrock` from `1.10.0` to `1.11.0` and `dust-base` from `0.8.83` to `0.8.84`.

The sandbox previously read the same `DD_API_KEY` used by the main application environment. This change deliberately removes that reuse and has no fallback to the main key.

Startup performance is preserved: telemetry still uses exactly one fire-and-forget root exec on create or wake, does not stream stdin or add provider round trips, and adds no work to the normal sandbox exec path.

## Tests

- `NODE_ENV=test npm test lib/api/sandbox/telemetry/index.test.ts lib/api/sandbox/image/registry.test.ts scripts/sandbox_security_check.test.ts` (38 tests)
- `NODE_OPTIONS="--max-old-space-size=8192" npx tsgo --noEmit`
- `xmllint --noout lib/api/sandbox/image/egress/dust-systemd1.conf lib/api/sandbox/image/egress/dust-resolve1.conf`
- `git diff --check`

## Risk

- `SANDBOX_DD_API_KEY` must be provisioned before Front is deployed. If absent or malformed, telemetry fails closed and emits a panic log; sandbox execution remains available because telemetry startup is fire-and-forget.
- Existing sandbox images are intentionally unsupported. The new Front bootstrap expects the `EnvironmentFile` baked into `dust-base:0.8.84`.
- Workload users lose access to all `org.freedesktop.systemd1` system-bus methods. Root-owned sandbox services continue to use systemd normally.

## Deploy Plan

1. Create a Datadog API key dedicated exclusively to sandbox log intake. Do not reuse the main `DD_API_KEY`. Use distinct values per production region if operationally practical.
2. Provision `SANDBOX_DD_API_KEY` for Front in EU and US before deploying this commit.
3. Rotate every non-sandbox consumer off the exposed main `DD_API_KEY`, then revoke the exposed value as part of this rollout.
4. Deploy Front. The deploy workflow must first build and pass the live security checks for `dust-base:0.8.84` in EU and US, using the already released `dust-sbx-bedrock:1.11.0` base.
5. Immediately use `/poke/kill` for `dust-base` sandboxes whose version differs from `0.8.84`. This is the compatibility migration; do not add an old-image runtime fallback.
6. Create fresh conversation and pod sandboxes in both regions. Verify `systemctl show-environment` fails for uids 1002 and 1003, `/run/dust/fluent-bit.env` is unreadable to both users, and sandbox logs still arrive in Datadog.
7. Confirm the revoked API key no longer validates and monitor telemetry-start panic/error logs and sandbox log volume during rollout.
