### PR TITLE
Limit concurrent project file listings

### DIFF
--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -4,6 +4,8 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { PROJECT_FILES_MAX_CONCURRENT_REQUESTS_PER_PROCESS } from ".";
+
 const getAllFilesByPrefixMock = vi.hoisted(() => vi.fn());
 const getSignedUrlMock = vi.hoisted(() => vi.fn());
 
@@ -162,5 +164,63 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
     const body = await response.json();
     expect(body.files).toHaveLength(1);
     expect(body.files[0].path).toBe(`pod-${space.sId}/a.txt`);
+  });
+
+  it("limits concurrent connector listings and releases slots", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+    });
+
+    const space = await SpaceFactory.project(workspace);
+    let releaseListings: (() => void) | undefined;
+    const listingsReleased = new Promise<{
+      files: never[];
+      pageFetchCount: number;
+    }>((resolve) => {
+      releaseListings = () => resolve({ files: [], pageFetchCount: 1 });
+    });
+    getAllFilesByPrefixMock.mockImplementation(() => listingsReleased);
+
+    const activeRequests = Array.from(
+      { length: PROJECT_FILES_MAX_CONCURRENT_REQUESTS_PER_PROCESS },
+      () => getProjectFiles(workspace, key, space.sId)
+    );
+
+    await vi.waitFor(() => {
+      expect(getAllFilesByPrefixMock).toHaveBeenCalledTimes(
+        PROJECT_FILES_MAX_CONCURRENT_REQUESTS_PER_PROCESS
+      );
+    });
+
+    const rejectedResponse = await getProjectFiles(workspace, key, space.sId);
+
+    expect(rejectedResponse.status).toBe(429);
+    expect(rejectedResponse.headers.get("Retry-After")).toBe("1");
+    expect(await rejectedResponse.json()).toEqual({
+      error: {
+        type: "rate_limit_error",
+        message: "Too many concurrent project file listings. Retry later.",
+      },
+    });
+
+    releaseListings?.();
+    const completedResponses = [];
+    for (const request of activeRequests) {
+      completedResponses.push(await request);
+    }
+    expect(
+      completedResponses.every((response) => response.status === 200)
+    ).toBe(true);
+
+    getAllFilesByPrefixMock.mockResolvedValue({
+      files: [],
+      pageFetchCount: 1,
+    });
+    const responseAfterRelease = await getProjectFiles(
+      workspace,
+      key,
+      space.sId
+    );
+    expect(responseAfterRelease.status).toBe(200);
   });
 });

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -23,6 +23,12 @@ const QuerySchema = z.object({
   updatedSince: z.string().optional(),
 });
 
+export const PROJECT_FILES_MAX_CONCURRENT_REQUESTS_PER_PROCESS = 2;
+
+// This system-key-only route is owned by the dust_project connector. Keep the
+// circuit breaker local to this route so unrelated front requests are unaffected.
+let activeProjectFilesRequests = 0;
+
 /**
  * @ignoreswagger
  * System API key only endpoint. Undocumented.
@@ -62,63 +68,83 @@ app.get(
       });
     }
 
-    const { updatedSince } = ctx.req.valid("query");
-    const updatedSinceMs =
-      updatedSince !== undefined ? parseInt(updatedSince, 10) : null;
-    const updatedSinceFilter =
-      updatedSinceMs !== null && !Number.isNaN(updatedSinceMs)
-        ? updatedSinceMs
-        : null;
-
-    const fsResult = await DustFileSystem.forPod(auth, space);
-    if (fsResult.isErr()) {
+    if (
+      activeProjectFilesRequests >=
+      PROJECT_FILES_MAX_CONCURRENT_REQUESTS_PER_PROCESS
+    ) {
+      ctx.header("Retry-After", "1");
       return apiError(ctx, {
-        status_code: 500,
+        status_code: 429,
         api_error: {
-          type: "internal_server_error",
-          message: "Failed to list project files.",
-        },
-      });
-    }
-    const dustFs = fsResult.value;
-
-    const listResult = await dustFs.list(`${SCOPED_PREFIX_POD}${space.sId}`);
-    if (listResult.isErr()) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Failed to list project files.",
+          type: "rate_limit_error",
+          message: "Too many concurrent project file listings. Retry later.",
         },
       });
     }
 
-    let entries = await enrichListWithFileResourceIds(
-      auth,
-      dustFs,
-      listResult.value
-    );
+    activeProjectFilesRequests += 1;
 
-    if (updatedSinceFilter !== null) {
-      entries = entries.filter((e) => e.lastModifiedMs >= updatedSinceFilter);
+    try {
+      const { updatedSince } = ctx.req.valid("query");
+      const updatedSinceMs =
+        updatedSince !== undefined ? parseInt(updatedSince, 10) : null;
+      const updatedSinceFilter =
+        updatedSinceMs !== null && !Number.isNaN(updatedSinceMs)
+          ? updatedSinceMs
+          : null;
+
+      const fsResult = await DustFileSystem.forPod(auth, space);
+      if (fsResult.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to list project files.",
+          },
+        });
+      }
+      const dustFs = fsResult.value;
+
+      const listResult = await dustFs.list(`${SCOPED_PREFIX_POD}${space.sId}`);
+      if (listResult.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to list project files.",
+          },
+        });
+      }
+
+      let entries = await enrichListWithFileResourceIds(
+        auth,
+        dustFs,
+        listResult.value
+      );
+
+      if (updatedSinceFilter !== null) {
+        entries = entries.filter((e) => e.lastModifiedMs >= updatedSinceFilter);
+      }
+
+      const filesWithSignedUrls = await concurrentExecutor(
+        entries,
+        async (entry) => {
+          if (entry.isDirectory) {
+            return entry;
+          }
+          const urlResult = await dustFs.getDownloadUrl(entry.path);
+          return {
+            ...entry,
+            signedDownloadUrl: urlResult.isOk() ? urlResult.value : null,
+          };
+        },
+        { concurrency: 8 }
+      );
+
+      return ctx.json({ files: filesWithSignedUrls });
+    } finally {
+      activeProjectFilesRequests -= 1;
     }
-
-    const filesWithSignedUrls = await concurrentExecutor(
-      entries,
-      async (entry) => {
-        if (entry.isDirectory) {
-          return entry;
-        }
-        const urlResult = await dustFs.getDownloadUrl(entry.path);
-        return {
-          ...entry,
-          signedDownloadUrl: urlResult.isOk() ? urlResult.value : null,
-        };
-      },
-      { concurrency: 8 }
-    );
-
-    return ctx.json({ files: filesWithSignedUrls });
   }
 );
 


### PR DESCRIPTION
## Description

Limit the internal `project_files` listing endpoint to two concurrent requests per front process. Requests above the limit return `429` with `Retry-After: 1`, while unrelated front endpoints remain unaffected.

This route is system-key-only and is currently owned by the `dust_project` connector.

## Tests

- Added a functional route test that holds both slots, verifies the next request is rejected, releases the slots, and verifies a later request succeeds.
- `NODE_ENV=test npm test -- --reporter=verbose --testTimeout=10000 routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts`
- `npm run tsgo -- --noEmit`
- Biome check on both changed files

## Risk

Connector listing activity can be throttled under contention and retried by Temporal. The change is isolated to the internal project file listing route and can be safely rolled back.

## Deploy Plan

Deploy front normally. Monitor `rate_limit_error` responses on the project file listing route and front pod memory/OOM events.