### PR TITLE
[front] feat: clone a Pod app

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/clone.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/clone.test.ts
@@ -1,0 +1,248 @@
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(async (_lockName: string, fn: () => unknown) => fn()),
+  distributedLock: vi.fn(async () => "lock-value"),
+  distributedUnlock: vi.fn(async () => undefined),
+}));
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
+
+// The two leaves that need a live sandbox. Mocked so the test exercises the orchestration — what gets
+// copied, published and reconciled, and with which paths — rather than a real bundle and DDL run.
+vi.mock(
+  "@app/lib/api/sandbox_functions/build_on_sandbox",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/sandbox_functions/build_on_sandbox")
+      >();
+
+    return { ...actual, buildSandboxFunctionOnSandbox: vi.fn() };
+  }
+);
+
+vi.mock("@app/lib/api/sandbox_functions/dsbx_db", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/dsbx_db")
+    >();
+
+  return { ...actual, reconcileDatabaseFromPodPath: vi.fn() };
+});
+
+const EMPTY_SCHEMA = { type: "object", properties: {} } as const;
+
+function mockSandboxLeaves() {
+  vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+    new Ok({
+      bundleCode: "export default {};",
+      userIdentity: "optional",
+      inputSchema: EMPTY_SCHEMA,
+      outputSchema: EMPTY_SCHEMA,
+    })
+  );
+  vi.mocked(reconcileDatabaseFromPodPath).mockImplementation(
+    async (_auth, { database }) =>
+      new Ok({ database, created: true, statements: [] })
+  );
+}
+
+async function setupPod() {
+  const { workspace, user, auth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  const pod = await SpaceFactory.project(workspace, user.id);
+  const sandbox = await SandboxResource.makeNew(auth, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+    new Ok({ sandbox, freshlyCreated: false })
+  );
+
+  return { workspace, user, auth, pod, sandbox };
+}
+
+function gcsObject(
+  workspaceId: string,
+  podId: string,
+  relPath: string,
+  contentType = "text/plain"
+) {
+  return {
+    name: `w/${workspaceId}/pods/${podId}/files/${relPath}`,
+    metadata: {
+      contentType,
+      size: "100",
+      updated: new Date().toISOString(),
+    },
+  };
+}
+
+async function publishFunction(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { slug, fileName }: { slug: string; fileName: string }
+) {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: pod.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(auth, {
+    space: pod,
+    file,
+    slug,
+    description: `Function ${slug}.`,
+    inputSchema: EMPTY_SCHEMA,
+    outputSchema: EMPTY_SCHEMA,
+  });
+}
+
+/** A source app with one function source and one database schema file, no Frame. */
+function taskListFiles(workspaceId: string, podId: string) {
+  return [
+    gcsObject(workspaceId, podId, "TaskList/"),
+    gcsObject(workspaceId, podId, "TaskList/functions/add-task.ts"),
+    gcsObject(workspaceId, podId, "TaskList/databases/tasks.db.ts"),
+  ];
+}
+
+async function clone(
+  workspaceId: string,
+  podId: string,
+  prefix: string,
+  name: string
+) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/pods/${podId}/apps/${prefix}/clone`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    }
+  );
+}
+
+describe("POST /api/w/:wId/pods/:podId/apps/:prefix/clone", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("copies the app and publishes its functions under the new prefix", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    mockSandboxLeaves();
+    fileStorageMock.setFilesByPrefix(() =>
+      taskListFiles(workspace.sId, pod.sId)
+    );
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+    fileStorageMock.setSubdirectoryNames(() => ["tasklist__tasks.db"]);
+
+    const res = await clone(workspace.sId, pod.sId, "tasklist", "Task List");
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.app.prefix).toBe("task-list");
+    expect(body.app.name).toBe("Task List");
+    // Published from the COPY's folder, so publish derives the copy's prefix.
+    expect(body.app.publishedFunctionSlugs).toEqual(["task-list__add-task"]);
+    expect(body.app.reconciledDatabaseNames).toEqual(["tasks"]);
+    expect(body.app.skipped).toEqual([]);
+
+    // The source app keeps its own function; the copy did not move or replace it.
+    const slugs = (await SandboxFunctionResource.listBySpace(auth, pod)).map(
+      (fn) => fn.slug
+    );
+    expect(slugs.sort()).toEqual(["task-list__add-task", "tasklist__add-task"]);
+
+    // The database schema reconciled is the COPY's file, not the original's.
+    expect(vi.mocked(reconcileDatabaseFromPodPath)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        database: "tasks",
+        path: `pod-${pod.sId}/Task List/databases/tasks.db.ts`,
+      })
+    );
+  });
+
+  it("rejects a name that collides with an existing app's prefix", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    mockSandboxLeaves();
+    fileStorageMock.setFilesByPrefix(() =>
+      taskListFiles(workspace.sId, pod.sId)
+    );
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+
+    // `TaskList` normalizes to the source's own prefix, which would make the copy share its
+    // published slugs and databases.
+    const res = await clone(workspace.sId, pod.sId, "tasklist", "TaskList");
+
+    expect(res.status).toBe(409);
+  });
+
+  it("rejects a name with nothing to derive a prefix from", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    fileStorageMock.setFilesByPrefix(() =>
+      taskListFiles(workspace.sId, pod.sId)
+    );
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+
+    const res = await clone(workspace.sId, pod.sId, "tasklist", "---");
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 for an app the Pod does not have", async () => {
+    const { workspace, pod } = await setupPod();
+
+    const res = await clone(workspace.sId, pod.sId, "nosuchapp", "Copy");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("refuses to clone artifacts published outside an app folder", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    await publishFunction(auth, pod, {
+      slug: "orphan",
+      fileName: "orphan.ts",
+    });
+
+    // The unfiled app's prefix is empty, so it cannot be addressed as a path segment at all.
+    const res = await clone(workspace.sId, pod.sId, "", "Copy");
+
+    expect([400, 404]).toContain(res.status);
+  });
+});

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -1,9 +1,17 @@
-import { deletePodApp, listPodApps } from "@app/lib/api/projects/apps";
+import {
+  clonePodApp,
+  deletePodApp,
+  listPodApps,
+} from "@app/lib/api/projects/apps";
 import type {
+  ClonePodAppResponseBody,
   DeletePodAppResponseBody,
   GetPodAppsResponseBody,
 } from "@app/types/api/pod_apps";
-import { DeletePodAppParamsSchema } from "@app/types/api/pod_apps";
+import {
+  ClonePodAppRequestBodySchema,
+  DeletePodAppParamsSchema,
+} from "@app/types/api/pod_apps";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -90,6 +98,76 @@ app.delete(
     }
 
     return ctx.json({ app: deleteResult.value });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/:prefix/clone",
+  validate("param", DeletePodAppParamsSchema),
+  validate("json", ClonePodAppRequestBodySchema),
+  withSpace({ requireCanWrite: true, routeParam: "podId" }),
+  async (ctx): HandlerResult<ClonePodAppResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { prefix } = ctx.req.valid("param");
+    const { name } = ctx.req.valid("json");
+
+    const cloneResult = await clonePodApp(auth, space, {
+      prefix,
+      newName: name,
+    });
+    if (cloneResult.isErr()) {
+      switch (cloneResult.error.code) {
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "space_not_found",
+              message: cloneResult.error.message,
+            },
+          });
+        case "name_taken":
+          return apiError(ctx, {
+            status_code: 409,
+            api_error: {
+              type: "invalid_request_error",
+              message: cloneResult.error.message,
+            },
+          });
+        case "not_a_pod":
+        case "cannot_clone_unfiled":
+        case "invalid_name":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: cloneResult.error.message,
+            },
+          });
+        case "sandbox_unavailable":
+          // Publishing and reconciling need a live sandbox; the clone is safe to retry.
+          return apiError(ctx, {
+            status_code: 503,
+            api_error: {
+              type: "service_unavailable",
+              message: cloneResult.error.message,
+            },
+          });
+        case "internal":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: cloneResult.error.message,
+            },
+          });
+        default:
+          assertNever(cloneResult.error.code);
+      }
+    }
+
+    return ctx.json({ app: cloneResult.value }, 201);
   }
 );
 

--- a/front/components/pod/apps/ClonePodAppDialog.tsx
+++ b/front/components/pod/apps/ClonePodAppDialog.tsx
@@ -1,0 +1,156 @@
+import { useClonePodApp } from "@app/lib/swr/pods";
+import type { PodApp } from "@app/types/api/pod_apps";
+import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
+import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Spinner,
+} from "@dust-tt/sparkle";
+import type { ChangeEvent } from "react";
+import { useCallback, useMemo, useState } from "react";
+
+interface ClonePodAppDialogProps {
+  owner: LightWorkspaceType;
+  podId: string;
+  app: PodApp;
+  existingPrefixes: string[];
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ClonePodAppDialog({
+  owner,
+  podId,
+  app,
+  existingPrefixes,
+  isOpen,
+  onClose,
+}: ClonePodAppDialogProps) {
+  const sourceName = app.name ?? app.prefix;
+  const [name, setName] = useState(`${sourceName} Copy`);
+  const [isCloning, setIsCloning] = useState(false);
+  const doClone = useClonePodApp({ owner, podId });
+
+  // The prefix is what actually has to be unique: two names that normalize alike would share
+  // published slugs and databases.
+  const prefix = useMemo(() => normalizeAppPrefix(name.trim()), [name]);
+  const nameError = useMemo(() => {
+    if (!prefix) {
+      return "Use at least one letter or digit.";
+    }
+    if (name.includes("/")) {
+      return "An app name cannot contain '/'.";
+    }
+    if (existingPrefixes.includes(prefix)) {
+      return `This Pod already has an app named '${prefix}'.`;
+    }
+    return null;
+  }, [existingPrefixes, name, prefix]);
+
+  const onClone = useCallback(async () => {
+    setIsCloning(true);
+    const result = await doClone(app, name.trim());
+    setIsCloning(false);
+    if (result.isOk()) {
+      onClose();
+    }
+  }, [app, doClone, name, onClose]);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>{`Clone ${sourceName}`}</DialogTitle>
+        </DialogHeader>
+        {isCloning ? (
+          <DialogContainer className="flex flex-col items-center gap-3 py-8">
+            <Spinner variant="dark" size="md" />
+            {/* Each function is a real build on the Pod's Computer, so this is not instant. */}
+            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+              Cloning {sourceName}. Each function is rebuilt on the Pod's
+              Computer, so this can take a while.
+            </p>
+          </DialogContainer>
+        ) : (
+          <>
+            <DialogContainer className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1">
+                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+                  New app name
+                </span>
+                <Input
+                  name="clone-app-name"
+                  value={name}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setName(e.target.value)
+                  }
+                  maxLength={MAX_POD_APP_NAME_LENGTH}
+                  message={nameError ?? undefined}
+                  messageStatus={nameError ? "error" : undefined}
+                  containerClassName="w-full"
+                />
+                {!nameError && (
+                  <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+                    Functions will be published as{" "}
+                    <span className="font-mono">{prefix}__&lt;name&gt;</span>.
+                  </span>
+                )}
+              </div>
+
+              <ContentMessage variant="info" title="The copy starts empty">
+                Its {app.databases.length === 1 ? "database" : "databases"} are
+                created from the same schema but hold no data, and its Frame is
+                left unpublished so you can review it first.
+              </ContentMessage>
+
+              {app.frames.length > 0 && (
+                <ContentMessage
+                  variant="warning"
+                  title="Check the Frame's calls"
+                >
+                  If the Frame names its functions by bare name it will use the
+                  copy's. If it spells out{" "}
+                  <span className="font-mono">
+                    &lt;podId&gt;/{app.prefix}__&lt;name&gt;
+                  </span>
+                  , the copy keeps calling {sourceName}'s functions and writing
+                  to its data until you change those references.
+                </ContentMessage>
+              )}
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: onClose,
+              }}
+              rightButtonProps={{
+                label: "Clone app",
+                variant: "primary",
+                disabled: nameError !== null,
+                onClick: () => {
+                  void onClone();
+                },
+              }}
+            />
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/pod/apps/ClonePodAppDialog.tsx
+++ b/front/components/pod/apps/ClonePodAppDialog.tsx
@@ -117,21 +117,6 @@ export function ClonePodAppDialog({
                 created from the same schema but hold no data, and its Frame is
                 left unpublished so you can review it first.
               </ContentMessage>
-
-              {app.frames.length > 0 && (
-                <ContentMessage
-                  variant="warning"
-                  title="Check the Frame's calls"
-                >
-                  If the Frame names its functions by bare name it will use the
-                  copy's. If it spells out{" "}
-                  <span className="font-mono">
-                    &lt;podId&gt;/{app.prefix}__&lt;name&gt;
-                  </span>
-                  , the copy keeps calling {sourceName}'s functions and writing
-                  to its data until you change those references.
-                </ContentMessage>
-              )}
             </DialogContainer>
             <DialogFooter
               leftButtonProps={{

--- a/front/components/pod/apps/PodAppDetail.tsx
+++ b/front/components/pod/apps/PodAppDetail.tsx
@@ -2,6 +2,7 @@ import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
 import {
   Button,
   Chip,
+  Clipboard,
   ContentMessage,
   Eye,
   ScrollArea,
@@ -13,6 +14,8 @@ interface PodAppDetailProps {
   onOpenFrame: (frame: PodAppFrame) => void;
   /** Absent when the viewer cannot delete (no write access, or the unfiled app). */
   onDelete?: () => void;
+  /** Absent when the app cannot be cloned (no write access, or the unfiled app). */
+  onClone?: () => void;
 }
 
 interface DetailSectionProps {
@@ -47,6 +50,7 @@ export function PodAppDetail({
   app,
   onOpenFrame,
   onDelete,
+  onClone,
 }: PodAppDetailProps) {
   return (
     <ScrollArea className="h-full">
@@ -59,16 +63,28 @@ export function PodAppDetail({
                 "Published from the Pod root, so these are not owned by an app folder."}
             </span>
           </div>
-          {onDelete && (
-            <Button
-              variant="warning"
-              size="xs"
-              icon={Trash01}
-              label="Delete"
-              tooltip="Delete this app and everything it owns"
-              onClick={onDelete}
-            />
-          )}
+          <div className="flex shrink-0 items-center gap-2">
+            {onClone && (
+              <Button
+                variant="outline"
+                size="xs"
+                icon={Clipboard}
+                label="Clone"
+                tooltip="Copy this app into a new folder, with empty databases"
+                onClick={onClone}
+              />
+            )}
+            {onDelete && (
+              <Button
+                variant="warning"
+                size="xs"
+                icon={Trash01}
+                label="Delete"
+                tooltip="Delete this app and everything it owns"
+                onClick={onDelete}
+              />
+            )}
+          </div>
         </div>
 
         {app.collidingFolderNames.length > 0 && (

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -1,3 +1,4 @@
+import { ClonePodAppDialog } from "@app/components/pod/apps/ClonePodAppDialog";
 import { DeletePodAppDialog } from "@app/components/pod/apps/DeletePodAppDialog";
 import { PodAppDetail } from "@app/components/pod/apps/PodAppDetail";
 import { PodAppList } from "@app/components/pod/apps/PodAppList";
@@ -32,6 +33,7 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
   const [appPendingDeletion, setAppPendingDeletion] = useState<PodApp | null>(
     null
   );
+  const [appPendingClone, setAppPendingClone] = useState<PodApp | null>(null);
 
   const iconByFramePath = useMemo(
     () =>
@@ -100,9 +102,26 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
                 ? () => setAppPendingDeletion(selectedApp)
                 : undefined
             }
+            onClone={
+              canDelete && selectedApp.prefix !== UNFILED_POD_APP_PREFIX
+                ? () => setAppPendingClone(selectedApp)
+                : undefined
+            }
           />
         )}
       </div>
+
+      {appPendingClone && (
+        <ClonePodAppDialog
+          key={`clone-${appPendingClone.prefix}`}
+          owner={owner}
+          podId={pod.sId}
+          app={appPendingClone}
+          existingPrefixes={apps.map((candidate) => candidate.prefix)}
+          isOpen
+          onClose={() => setAppPendingClone(null)}
+        />
+      )}
 
       {appPendingDeletion && (
         <DeletePodAppDialog

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -827,19 +827,25 @@ export async function clonePodApp(
   );
   const skipped: string[] = [];
 
+  // The copy's function sources, indexed by the name they publish under. A function's source is one
+  // file directly under `functions/`, named after it; anything nested below that (`functions/lib/`)
+  // is a helper the bundler pulls in, not a function of its own.
+  const functionSourceByName = new Map<string, string>();
+  for (const [relPath, destPath] of copiedPathByRelPath) {
+    const segments = relPath.split("/");
+    if (segments.length !== 2 || segments[0] !== APP_FUNCTIONS_SUBFOLDER) {
+      continue;
+    }
+    functionSourceByName.set(stripExtension(segments[1]), destPath);
+  }
+
   // Publish the copy's functions. The source path decides the prefix, so publishing from the copy's
   // folder is what gives the clone its own functions; description and execution mode are carried over
   // so the contract is identical.
   const publishedFunctionSlugs: string[] = [];
   for (const fn of source.functions) {
-    const sourceRelPath = [...copiedPathByRelPath.keys()].find(
-      (relPath) =>
-        relPath.startsWith(`${APP_FUNCTIONS_SUBFOLDER}/`) &&
-        relPath.slice(`${APP_FUNCTIONS_SUBFOLDER}/`.length).split("/")
-          .length === 1 &&
-        stripExtension(relPath.split("/").at(-1) ?? "") === fn.name
-    );
-    if (!sourceRelPath) {
+    const sourcePath = functionSourceByName.get(fn.name);
+    if (!sourcePath) {
       skipped.push(`function ${fn.name}`);
       continue;
     }
@@ -848,7 +854,7 @@ export async function clonePodApp(
       space: pod,
       slug: fn.name,
       description: fn.description,
-      path: copiedPathByRelPath.get(sourceRelPath) ?? "",
+      path: sourcePath,
       executionMode: fn.executionMode,
     });
     if (publishResult.isErr()) {

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -28,7 +28,9 @@ import type {
 } from "@app/types/api/file_system/types";
 import type {
   PodApp,
+  PodAppCloneSummary,
   PodAppDatabase,
+  PodAppDeleteSummary,
   PodAppFrame,
   PodAppFunction,
 } from "@app/types/api/pod_apps";
@@ -494,13 +496,7 @@ export class PodAppDeleteError extends Error {
   }
 }
 
-export interface DeletePodAppResult {
-  prefix: string;
-  name: string | null;
-  deletedFunctionSlugs: string[];
-  deletedDatabaseNames: string[];
-  deletedFolderNames: string[];
-}
+export type DeletePodAppResult = PodAppDeleteSummary;
 
 /**
  * Delete a Pod app: its published functions, its databases (live files and replicas), its shared
@@ -654,16 +650,7 @@ export class PodAppCloneError extends Error {
   }
 }
 
-export interface ClonePodAppResult {
-  prefix: string;
-  name: string;
-  copiedFileCount: number;
-  clonedFrameNames: string[];
-  publishedFunctionSlugs: string[];
-  reconciledDatabaseNames: string[];
-  /** Functions or databases whose source file the copy does not have, so they were not recreated. */
-  skipped: string[];
-}
+export type ClonePodAppResult = PodAppCloneSummary;
 
 /** The files under an app folder, Frames included, as a listing reports them. */
 function fileEntriesOf(entries: FileSystemEntry[]): FileSystemFileEntry[] {
@@ -762,7 +749,9 @@ export async function clonePodApp(
   }
   const sourceEntries = fileEntriesOf(listResult.value);
 
-  // Copy everything except the Frames, which need a FileResource of their own.
+  // Copy everything except the Frames, which need a FileResource of their own. Every copy lands at
+  // `{destFolderPath}/{relPath}`, so recording the relative paths is enough to address them later.
+  const copiedRelPaths = new Set<string>();
   let copiedFileCount = 0;
   for (const entry of sourceEntries) {
     if (isInteractiveContentType(entry.contentType)) {
@@ -779,6 +768,7 @@ export async function clonePodApp(
         new PodAppCloneError("internal", copyResult.error.message)
       );
     }
+    copiedRelPaths.add(relPath);
     copiedFileCount += 1;
   }
 
@@ -821,25 +811,21 @@ export async function clonePodApp(
     copiedFileCount += 1;
   }
 
-  const copiedPathByRelPath = new Map(
-    sourceEntries.map((entry) => {
-      const relPath = entry.path.slice(sourceFolderPath.length + 1);
-
-      return [relPath, `${destFolderPath}/${relPath}`] as const;
-    })
-  );
   const skipped: string[] = [];
 
   // The copy's function sources, indexed by the name they publish under. A function's source is one
   // file directly under `functions/`, named after it; anything nested below that (`functions/lib/`)
   // is a helper the bundler pulls in, not a function of its own.
   const functionSourceByName = new Map<string, string>();
-  for (const [relPath, destPath] of copiedPathByRelPath) {
+  for (const relPath of copiedRelPaths) {
     const segments = relPath.split("/");
     if (segments.length !== 2 || segments[0] !== APP_FUNCTIONS_SUBFOLDER) {
       continue;
     }
-    functionSourceByName.set(stripExtension(segments[1]), destPath);
+    functionSourceByName.set(
+      stripExtension(segments[1]),
+      `${destFolderPath}/${relPath}`
+    );
   }
 
   // Publish the copy's functions. The source path decides the prefix, so publishing from the copy's
@@ -878,11 +864,11 @@ export async function clonePodApp(
   const reconciledDatabaseNames: string[] = [];
   for (const database of source.databases) {
     const schemaRelPath = `${APP_DATABASES_SUBFOLDER}/${database.name}${POD_DATABASE_SCHEMA_FILE_SUFFIX}`;
-    const schemaPath = copiedPathByRelPath.get(schemaRelPath);
-    if (!schemaPath) {
+    if (!copiedRelPaths.has(schemaRelPath)) {
       skipped.push(`database ${database.name}`);
       continue;
     }
+    const schemaPath = `${destFolderPath}/${schemaRelPath}`;
 
     const reconcileResult = await reconcileDatabaseFromPodPath(auth, {
       space: pod,

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -42,14 +42,17 @@ import { removeNulls } from "@app/types/shared/utils/general";
 /** A litestream replica directory is named after the database file it replicates. */
 const POD_DATABASE_FILE_SUFFIX = ".db";
 
-/** Subfolders whose presence marks a pod-root folder as app-shaped. */
-const APP_SHAPED_SUBFOLDERS = ["functions", "databases"];
-
 /** The app subfolder holding one drizzle schema file per database. */
 const APP_DATABASES_SUBFOLDER = "databases";
 
 /** The app subfolder holding one source file per published function. */
 const APP_FUNCTIONS_SUBFOLDER = "functions";
+
+/** Subfolders whose presence marks a pod-root folder as app-shaped. */
+const APP_SHAPED_SUBFOLDERS = [
+  APP_FUNCTIONS_SUBFOLDER,
+  APP_DATABASES_SUBFOLDER,
+];
 
 /** Suffix of a database's schema file, e.g. `chat.db.ts` declares the `chat` database. */
 const POD_DATABASE_SCHEMA_FILE_SUFFIX = ".db.ts";

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -1,13 +1,19 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
+import { getFileContent } from "@app/lib/api/files/utils";
 import { deleteProjectFile } from "@app/lib/api/projects/context";
+import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import { deletePodDatabaseReplica } from "@app/lib/api/sandbox/db";
 import {
   appPrefixFromPodDatabaseName,
   podDatabaseNameWithoutAppPrefix,
 } from "@app/lib/api/sandbox_functions/db_naming";
-import { deleteDatabaseOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
+import {
+  deleteDatabaseOnSandbox,
+  reconcileDatabaseFromPodPath,
+} from "@app/lib/api/sandbox_functions/dsbx_db";
+import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
 import { SANDBOX_FUNCTION_SLUG_SEPARATOR } from "@app/lib/api/sandbox_functions/slug";
 import { unpublishSandboxFunction } from "@app/lib/api/sandbox_functions/unpublish_sandbox_function";
 import type { Authenticator } from "@app/lib/auth";
@@ -42,6 +48,9 @@ const APP_SHAPED_SUBFOLDERS = ["functions", "databases"];
 /** The app subfolder holding one drizzle schema file per database. */
 const APP_DATABASES_SUBFOLDER = "databases";
 
+/** The app subfolder holding one source file per published function. */
+const APP_FUNCTIONS_SUBFOLDER = "functions";
+
 /** Suffix of a database's schema file, e.g. `chat.db.ts` declares the `chat` database. */
 const POD_DATABASE_SCHEMA_FILE_SUFFIX = ".db.ts";
 
@@ -60,6 +69,13 @@ type AppFolder = {
    */
   declaredDatabaseNames: Set<string>;
 };
+
+/** Drop the last extension from a file name, e.g. `add-task.ts` -> `add-task`. */
+function stripExtension(fileName: string): string {
+  const dotIndex = fileName.lastIndexOf(".");
+
+  return dotIndex <= 0 ? fileName : fileName.slice(0, dotIndex);
+}
 
 /**
  * Path segments of a pod entry relative to the pod root, e.g. `MyApp/functions/list-notes.ts` for
@@ -613,5 +629,277 @@ export async function deletePodApp(
     deletedFunctionSlugs,
     deletedDatabaseNames,
     deletedFolderNames: folderNames,
+  });
+}
+
+export type PodAppCloneErrorCode =
+  | "not_a_pod"
+  | "not_found"
+  | "cannot_clone_unfiled"
+  | "invalid_name"
+  | "name_taken"
+  | "sandbox_unavailable"
+  | "internal";
+
+export class PodAppCloneError extends Error {
+  constructor(
+    readonly code: PodAppCloneErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "PodAppCloneError";
+  }
+}
+
+export interface ClonePodAppResult {
+  prefix: string;
+  name: string;
+  copiedFileCount: number;
+  clonedFrameNames: string[];
+  publishedFunctionSlugs: string[];
+  reconciledDatabaseNames: string[];
+  /** Functions or databases whose source file the copy does not have, so they were not recreated. */
+  skipped: string[];
+}
+
+/** The files under an app folder, Frames included, as a listing reports them. */
+function fileEntriesOf(entries: FileSystemEntry[]): FileSystemFileEntry[] {
+  return entries.flatMap((entry) => (entry.isDirectory ? [] : [entry]));
+}
+
+/**
+ * Clone a Pod app into a new folder in the same Pod.
+ *
+ * What carries over: every file under the app folder, its published functions (re-published under the
+ * copy's prefix), and its databases as **fresh, empty** ones reconciled from the copied schema files.
+ * What does not: database rows, share tokens, the pinned tab, and invocation history. The copy's Frame
+ * is left unpublished, so the author decides when it becomes a shareable artifact.
+ *
+ * A Frame cannot simply be copied as an object — it needs a FileResource to be publishable at all —
+ * so Frames are recreated through `createPodFrameFile` and every other file is copied directly.
+ *
+ * Nothing rewrites the copied Frame's source. A Frame that refers to its functions by bare name
+ * resolves them against the copy's own folder and is correct by construction; one that hard-codes
+ * `<podId>/<prefix>__<name>` keeps calling the ORIGINAL app's functions, and its author has to fix
+ * that themselves.
+ */
+export async function clonePodApp(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { prefix, newName }: { prefix: string; newName: string }
+): Promise<Result<ClonePodAppResult, PodAppCloneError>> {
+  if (!pod.isProject()) {
+    return new Err(
+      new PodAppCloneError("not_a_pod", "Apps only exist on Pod spaces.")
+    );
+  }
+  if (prefix === UNFILED_POD_APP_PREFIX) {
+    return new Err(
+      new PodAppCloneError(
+        "cannot_clone_unfiled",
+        "Artifacts published outside an app folder are not an app and cannot be cloned."
+      )
+    );
+  }
+
+  const folderName = newName.trim();
+  const newPrefix = normalizeAppPrefix(folderName);
+  if (!newPrefix) {
+    return new Err(
+      new PodAppCloneError(
+        "invalid_name",
+        `'${newName}' has no letters or digits to name an app with.`
+      )
+    );
+  }
+  if (folderName.includes("/")) {
+    return new Err(
+      new PodAppCloneError("invalid_name", "An app name cannot contain '/'.")
+    );
+  }
+
+  const appsResult = await listPodApps(auth, pod);
+  if (appsResult.isErr()) {
+    return new Err(new PodAppCloneError("internal", appsResult.error.message));
+  }
+
+  const source = appsResult.value.find((app) => app.prefix === prefix);
+  if (!source || !source.folderPath) {
+    return new Err(
+      new PodAppCloneError("not_found", `No app '${prefix}' in this Pod.`)
+    );
+  }
+
+  // Two folders whose names normalize onto one prefix share published slugs and databases, so the
+  // check is on the prefix rather than the folder name.
+  if (appsResult.value.some((app) => app.prefix === newPrefix)) {
+    return new Err(
+      new PodAppCloneError(
+        "name_taken",
+        `This Pod already has an app named '${newPrefix}'.`
+      )
+    );
+  }
+
+  const fsResult = await DustFileSystem.forPod(auth, pod);
+  if (fsResult.isErr()) {
+    return new Err(
+      new PodAppCloneError("internal", "Failed to initialise file system.")
+    );
+  }
+  const dustFs = fsResult.value;
+
+  const podRoot = `${SCOPED_PREFIX_POD}${pod.sId}`;
+  const sourceFolderPath = source.folderPath;
+  const destFolderPath = `${podRoot}/${folderName}`;
+
+  const listResult = await dustFs.list(sourceFolderPath);
+  if (listResult.isErr()) {
+    return new Err(new PodAppCloneError("internal", listResult.error.message));
+  }
+  const sourceEntries = fileEntriesOf(listResult.value);
+
+  // Copy everything except the Frames, which need a FileResource of their own.
+  let copiedFileCount = 0;
+  for (const entry of sourceEntries) {
+    if (isInteractiveContentType(entry.contentType)) {
+      continue;
+    }
+
+    const relPath = entry.path.slice(sourceFolderPath.length + 1);
+    const copyResult = await dustFs.copy({
+      src: entry.path,
+      dest: `${destFolderPath}/${relPath}`,
+    });
+    if (copyResult.isErr()) {
+      return new Err(
+        new PodAppCloneError("internal", copyResult.error.message)
+      );
+    }
+    copiedFileCount += 1;
+  }
+
+  // Recreate the Frames so the copy owns publishable files rather than bare objects.
+  const clonedFrameNames: string[] = [];
+  for (const frame of source.frames) {
+    if (!frame.fileId) {
+      continue;
+    }
+    const sourceFile = await FileResource.fetchById(auth, frame.fileId);
+    if (!sourceFile) {
+      continue;
+    }
+    if (!isInteractiveContentType(sourceFile.contentType)) {
+      continue;
+    }
+    const content = await getFileContent(auth, sourceFile, "original");
+    if (content === null) {
+      return new Err(
+        new PodAppCloneError(
+          "internal",
+          `Could not read the source of Frame '${frame.fileName}'.`
+        )
+      );
+    }
+
+    const createResult = await createPodFrameFile(auth, {
+      space: pod,
+      folderName,
+      fileName: frame.fileName,
+      contentType: sourceFile.contentType,
+      content,
+    });
+    if (createResult.isErr()) {
+      return new Err(
+        new PodAppCloneError("internal", createResult.error.message)
+      );
+    }
+    clonedFrameNames.push(frame.fileName);
+    copiedFileCount += 1;
+  }
+
+  const copiedPathByRelPath = new Map(
+    sourceEntries.map((entry) => {
+      const relPath = entry.path.slice(sourceFolderPath.length + 1);
+
+      return [relPath, `${destFolderPath}/${relPath}`] as const;
+    })
+  );
+  const skipped: string[] = [];
+
+  // Publish the copy's functions. The source path decides the prefix, so publishing from the copy's
+  // folder is what gives the clone its own functions; description and execution mode are carried over
+  // so the contract is identical.
+  const publishedFunctionSlugs: string[] = [];
+  for (const fn of source.functions) {
+    const sourceRelPath = [...copiedPathByRelPath.keys()].find(
+      (relPath) =>
+        relPath.startsWith(`${APP_FUNCTIONS_SUBFOLDER}/`) &&
+        relPath.slice(`${APP_FUNCTIONS_SUBFOLDER}/`.length).split("/")
+          .length === 1 &&
+        stripExtension(relPath.split("/").at(-1) ?? "") === fn.name
+    );
+    if (!sourceRelPath) {
+      skipped.push(`function ${fn.name}`);
+      continue;
+    }
+
+    const publishResult = await publishSandboxFunction(auth, {
+      space: pod,
+      slug: fn.name,
+      description: fn.description,
+      path: copiedPathByRelPath.get(sourceRelPath) ?? "",
+      executionMode: fn.executionMode,
+    });
+    if (publishResult.isErr()) {
+      return new Err(
+        new PodAppCloneError(
+          publishResult.error.code === "sandbox_unavailable"
+            ? "sandbox_unavailable"
+            : "internal",
+          publishResult.error.message
+        )
+      );
+    }
+    publishedFunctionSlugs.push(publishResult.value.slug);
+  }
+
+  // Reconcile the copy's databases from its own schema files, which creates them empty under the
+  // copy's prefix. Data is deliberately not carried over.
+  const reconciledDatabaseNames: string[] = [];
+  for (const database of source.databases) {
+    const schemaRelPath = `${APP_DATABASES_SUBFOLDER}/${database.name}${POD_DATABASE_SCHEMA_FILE_SUFFIX}`;
+    const schemaPath = copiedPathByRelPath.get(schemaRelPath);
+    if (!schemaPath) {
+      skipped.push(`database ${database.name}`);
+      continue;
+    }
+
+    const reconcileResult = await reconcileDatabaseFromPodPath(auth, {
+      space: pod,
+      database: database.name,
+      path: schemaPath,
+    });
+    if (reconcileResult.isErr()) {
+      return new Err(
+        new PodAppCloneError(
+          reconcileResult.error.code === "sandbox_unavailable"
+            ? "sandbox_unavailable"
+            : "internal",
+          reconcileResult.error.message
+        )
+      );
+    }
+    reconciledDatabaseNames.push(reconcileResult.value.database);
+  }
+
+  return new Ok({
+    prefix: newPrefix,
+    name: folderName,
+    copiedFileCount,
+    clonedFrameNames,
+    publishedFunctionSlugs,
+    reconciledDatabaseNames,
+    skipped,
   });
 }

--- a/front/lib/api/projects/pod_frame_file.test.ts
+++ b/front/lib/api/projects/pod_frame_file.test.ts
@@ -1,0 +1,42 @@
+import { podRelativePathFromScopedPath } from "@app/lib/api/projects/pod_frame_file";
+import { describe, expect, it } from "vitest";
+
+const POD_ID = "vlt_abc123";
+
+describe("podRelativePathFromScopedPath", () => {
+  it("strips the canonical scope prefix", () => {
+    // The bug this guards: passing the canonical scoped path straight to moveProjectFile. That form
+    // is not recognised as scoped, so it was treated as relative and produced
+    // `.../files/pod-{podId}/AnimalManager.tsx` — a path with the scope prefix nested inside the
+    // mount path, which no object has.
+    expect(
+      podRelativePathFromScopedPath(`pod-${POD_ID}/AnimalManager.tsx`, POD_ID)
+    ).toBe("AnimalManager.tsx");
+  });
+
+  it("keeps a nested path below the Pod root", () => {
+    expect(
+      podRelativePathFromScopedPath(
+        `pod-${POD_ID}/AnimalManager/AnimalManager.tsx`,
+        POD_ID
+      )
+    ).toBe("AnimalManager/AnimalManager.tsx");
+  });
+
+  it("returns null for another Pod's path", () => {
+    expect(
+      podRelativePathFromScopedPath("pod-vlt_other/Frame.tsx", POD_ID)
+    ).toBeNull();
+  });
+
+  it("returns null for a path that is not Pod-scoped", () => {
+    expect(
+      podRelativePathFromScopedPath("conversation-abc/Frame.tsx", POD_ID)
+    ).toBeNull();
+    expect(podRelativePathFromScopedPath("Frame.tsx", POD_ID)).toBeNull();
+  });
+
+  it("returns null when nothing follows the prefix", () => {
+    expect(podRelativePathFromScopedPath(`pod-${POD_ID}/`, POD_ID)).toBeNull();
+  });
+});

--- a/front/lib/api/projects/pod_frame_file.ts
+++ b/front/lib/api/projects/pod_frame_file.ts
@@ -1,3 +1,4 @@
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { moveProjectFile } from "@app/lib/api/projects/context";
 import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
@@ -21,6 +22,27 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  * is what makes the Frame belong to the app, and therefore what makes its bare function references
  * resolve against that app.
  */
+/**
+ * The path a Pod file has relative to the Pod's files root, from its canonical scoped path.
+ *
+ * `moveProjectFile` takes a relative path. It also accepts a scoped one, but only the legacy
+ * `pod/...` form — the canonical `pod-{podId}/...` that `toScopedPath` returns is not recognised and
+ * would be treated as relative, nesting the scope prefix inside the GCS mount path.
+ */
+export function podRelativePathFromScopedPath(
+  scopedPath: string,
+  podId: string
+): string | null {
+  const podScopePrefix = `${SCOPED_PREFIX_POD}${podId}/`;
+  if (!scopedPath.startsWith(podScopePrefix)) {
+    return null;
+  }
+
+  const relativePath = scopedPath.slice(podScopePrefix.length);
+
+  return relativePath.length > 0 ? relativePath : null;
+}
+
 export async function createPodFrameFile(
   auth: Authenticator,
   {
@@ -65,9 +87,17 @@ export async function createPodFrameFile(
       );
     }
 
+    // Derived from the path actually claimed, which may be sId-disambiguated if the name was taken.
+    const relativePath = podRelativePathFromScopedPath(scopedPath, space.sId);
+    if (!relativePath) {
+      return new Err(
+        new Error(`Frame '${fileName}' landed outside the Pod: ${scopedPath}.`)
+      );
+    }
+
     const moveResult = await moveProjectFile(auth, {
       space,
-      sourcePath: scopedPath,
+      sourcePath: relativePath,
       destRelativeFilePath: `${folderName}/${fileName}`,
     });
     if (moveResult.isErr()) {

--- a/front/lib/api/projects/pod_frame_file.ts
+++ b/front/lib/api/projects/pod_frame_file.ts
@@ -1,0 +1,88 @@
+import { moveProjectFile } from "@app/lib/api/projects/context";
+import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { InteractiveContentFileContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+/**
+ * Create a Frame inside a Pod folder from content.
+ *
+ * There is no primitive for this because every existing path creates a Frame in a conversation and
+ * then moves it into the Pod, and the `files` MCP server refuses to copy Frames outright — a Frame
+ * copied as a bare GCS object has no FileResource, so it cannot be published or shared and shows up
+ * with a null file id. Cloning an app needs a real one.
+ *
+ * Composed from public steps rather than reaching into FileResource: `uploadContent` claims the Pod
+ * mount path, which always lands at the Pod root, so the file is then moved into its folder. The move
+ * is what makes the Frame belong to the app, and therefore what makes its bare function references
+ * resolve against that app.
+ */
+export async function createPodFrameFile(
+  auth: Authenticator,
+  {
+    space,
+    folderName,
+    fileName,
+    contentType,
+    content,
+  }: {
+    space: SpaceResource;
+    folderName: string;
+    fileName: string;
+    contentType: InteractiveContentFileContentType;
+    content: string;
+  }
+): Promise<Result<FileResource, Error>> {
+  if (!space.isProject()) {
+    return new Err(new Error("Frames can only be created in Pod spaces."));
+  }
+
+  try {
+    const file = await FileResource.makeNew({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      userId: auth.user()?.id ?? null,
+      fileName,
+      contentType,
+      // Set when the content is written.
+      fileSize: 0,
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    const uploadResult = await uploadFrameContent(auth, file, content);
+    if (uploadResult.isErr()) {
+      return new Err(new Error(uploadResult.error.message));
+    }
+
+    const scopedPath = file.toScopedPath(auth);
+    if (!scopedPath) {
+      return new Err(
+        new Error(`Frame '${fileName}' was created without a Pod path.`)
+      );
+    }
+
+    const moveResult = await moveProjectFile(auth, {
+      space,
+      sourcePath: scopedPath,
+      destRelativeFilePath: `${folderName}/${fileName}`,
+    });
+    if (moveResult.isErr()) {
+      return new Err(normalizeError(moveResult.error));
+    }
+
+    const moved = await FileResource.fetchById(auth, file.sId);
+    if (!moved) {
+      return new Err(
+        new Error(`Frame '${fileName}' disappeared after being moved.`)
+      );
+    }
+
+    return new Ok(moved);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -26,7 +26,11 @@ import type {
   FileSystemEntry,
   GetSpaceFilesResponseBody,
 } from "@app/types/api/file_system/types";
-import type { GetPodAppsResponseBody, PodApp } from "@app/types/api/pod_apps";
+import type {
+  ClonePodAppResponseBody,
+  GetPodAppsResponseBody,
+  PodApp,
+} from "@app/types/api/pod_apps";
 import type {
   GetPodMetadataResponseBody,
   PatchPodMetadataResponseBody,
@@ -138,6 +142,61 @@ export function usePodApps({
     isPodAppsLoading: !disabled && !error && !data,
     isPodAppsError: !!error,
     mutatePodApps: mutate,
+  };
+}
+
+export function useClonePodApp({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutatePodApps } = usePodApps({ owner, podId, disabled: true });
+
+  return async (
+    app: PodApp,
+    name: string
+  ): Promise<Result<ClonePodAppResponseBody["app"], Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/pods/${podId}/apps/${encodeURIComponent(app.prefix)}/clone`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: `Failed to clone ${app.name ?? app.prefix}`,
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      const { app: cloned }: ClonePodAppResponseBody = await res.json();
+      sendNotification({
+        type: "success",
+        title: `${cloned.name} created`,
+        description: `${cloned.publishedFunctionSlugs.length} function(s) published, ${cloned.reconciledDatabaseNames.length} database(s) created empty.`,
+      });
+      await mutatePodApps();
+
+      return new Ok(cloned);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: `Failed to clone ${app.name ?? app.prefix}`,
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
   };
 }
 

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -86,6 +86,26 @@ export const DeletePodAppParamsSchema = z.object({
     .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/),
 });
 
+/** Max app folder name length, matching what a prefix can be derived from comfortably. */
+export const MAX_POD_APP_NAME_LENGTH = 128;
+
+export const ClonePodAppRequestBodySchema = z.object({
+  name: z.string().min(1).max(MAX_POD_APP_NAME_LENGTH),
+});
+
+export type ClonePodAppResponseBody = {
+  app: {
+    prefix: string;
+    name: string;
+    copiedFileCount: number;
+    clonedFrameNames: string[];
+    publishedFunctionSlugs: string[];
+    reconciledDatabaseNames: string[];
+    /** Functions or databases the copy had no source for, so they were not recreated. */
+    skipped: string[];
+  };
+};
+
 export type DeletePodAppResponseBody = {
   app: {
     prefix: string;

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -93,25 +93,31 @@ export const ClonePodAppRequestBodySchema = z.object({
   name: z.string().min(1).max(MAX_POD_APP_NAME_LENGTH),
 });
 
+/** What a clone created, as the business layer reports it and the endpoint returns it. */
+export type PodAppCloneSummary = {
+  prefix: string;
+  name: string;
+  copiedFileCount: number;
+  clonedFrameNames: string[];
+  publishedFunctionSlugs: string[];
+  reconciledDatabaseNames: string[];
+  /** Functions or databases the copy had no source for, so they were not recreated. */
+  skipped: string[];
+};
+
 export type ClonePodAppResponseBody = {
-  app: {
-    prefix: string;
-    name: string;
-    copiedFileCount: number;
-    clonedFrameNames: string[];
-    publishedFunctionSlugs: string[];
-    reconciledDatabaseNames: string[];
-    /** Functions or databases the copy had no source for, so they were not recreated. */
-    skipped: string[];
-  };
+  app: PodAppCloneSummary;
+};
+
+/** What a delete removed, as the business layer reports it and the endpoint returns it. */
+export type PodAppDeleteSummary = {
+  prefix: string;
+  name: string | null;
+  deletedFunctionSlugs: string[];
+  deletedDatabaseNames: string[];
+  deletedFolderNames: string[];
 };
 
 export type DeletePodAppResponseBody = {
-  app: {
-    prefix: string;
-    name: string | null;
-    deletedFunctionSlugs: string[];
-    deletedDatabaseNames: string[];
-    deletedFolderNames: string[];
-  };
+  app: PodAppDeleteSummary;
 };


### PR DESCRIPTION

<img width="848" height="629" alt="Screenshot 2026-08-12 at 14 30 27" src="https://github.com/user-attachments/assets/89e1b3dd-c4e1-427f-aee6-50587c772163" />



## Description
Clones a Pod app into a new folder in the same Pod. This is the payoff of the relative-reference work: because a Frame can now name its functions by bare name, the copy's Frame calls the copy's functions with **no source rewriting**.

What carries over: every file under the app folder, the functions re-published under the copy's prefix, and the databases reconciled from the copied schema files as **fresh, empty** ones.

What deliberately does not: database rows, share tokens, the pinned tab, invocation history. The copy's Frame is left **unpublished**, so the author decides when it becomes a shareable artifact.

## Frames needed their own path

Everything else copies as a GCS object, but a Frame copied that way has **no `FileResource`** — so it cannot be published or shared, and surfaces in the Apps tab with a null file id. That is also why the `files` MCP server *refuses* to copy Frames outright (`copy.ts:81`), pointing callers at move instead.

So non-Frame files are copied directly and Frames are recreated through a new `createPodFrameFile`, composed entirely from public steps:

```
makeNew(project_context) → uploadFrameContent → moveProjectFile(into the app folder)
```

`uploadContent` claims the Pod mount path, which always lands at the **Pod root**, so the move is what puts the Frame in its folder — and therefore what makes its bare references resolve against that app. No reaching into `FileResource` internals; `copyMountFiles` and `claimMountFilePath` stay private.

## Reference rewriting: deliberately none

Per review direction, nothing edits the copied Frame's source. A Frame using bare names is correct by construction. One that hard-codes `<podId>/<prefix>__<name>` keeps calling the **original** app's functions and writing to its data — so the clone dialog says exactly that, rather than letting it be discovered after the fact.

## Risk

Low. Purely additive — a new endpoint and a new action; nothing existing changes behaviour. Failure modes leave a partial app that is visible and deletable.

## Tests

Added