### PR TITLE
[front] enh: add attribution breakdowns in Analytics view

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -1,0 +1,131 @@
+import { CostShareBar } from "@app/components/workspace/analytics/creditsTableCells";
+import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
+import { Button, Spinner } from "@dust-tt/sparkle";
+import { useState } from "react";
+import type { ConsumptionDimension } from "./consumptionDimensions";
+
+const BREAKDOWN_LIMIT = 25;
+const BREAKDOWN_PREVIEW_LIMIT = 3;
+
+const BREAKDOWN_DIMENSIONS = ["model", "tool", "user"] as const;
+type BreakdownDimension = (typeof BREAKDOWN_DIMENSIONS)[number];
+
+const BREAKDOWN_LABELS: Record<BreakdownDimension, string> = {
+  model: "By model",
+  tool: "By tools",
+  user: "By members",
+};
+
+interface BreakdownColumnProps {
+  workspaceId: string;
+  dimension: BreakdownDimension;
+  period: ConsumptionPeriodSelection;
+  filter: ConsumptionScopeFilter;
+}
+
+function BreakdownColumn({
+  workspaceId,
+  dimension,
+  period,
+  filter,
+}: BreakdownColumnProps) {
+  const [showAll, setShowAll] = useState(false);
+  const { rows, totalCredits, isTopLoading, isTopError } = useConsumptionTop({
+    workspaceId,
+    dimension,
+    period,
+    limit: BREAKDOWN_LIMIT,
+    filter,
+  });
+  const visibleRows = showAll ? rows : rows.slice(0, BREAKDOWN_PREVIEW_LIMIT);
+
+  return (
+    <div className="min-w-0">
+      <div className="mb-2 flex h-6 items-center justify-between gap-2">
+        <h4 className="text-sm font-medium text-foreground">
+          {BREAKDOWN_LABELS[dimension]}
+        </h4>
+        {rows.length > BREAKDOWN_PREVIEW_LIMIT && (
+          <Button
+            label={showAll ? "Show less" : "View all"}
+            variant="highlight-ghost"
+            size="xs"
+            onClick={() => setShowAll((current) => !current)}
+          />
+        )}
+      </div>
+      {isTopLoading ? (
+        <div className="flex h-24 items-center justify-center">
+          <Spinner size="sm" />
+        </div>
+      ) : isTopError ? (
+        <div className="flex h-24 items-center text-xs text-muted-foreground">
+          Failed to load breakdown.
+        </div>
+      ) : visibleRows.length === 0 ? (
+        <div className="flex h-24 items-center text-xs text-muted-foreground">
+          No attributed consumption.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {visibleRows.map((row) => {
+            const share = totalCredits > 0 ? row.credits / totalCredits : 0;
+            const percentage = Math.round(Math.min(100, share * 100));
+
+            return (
+              <div key={row.id} className="min-w-0">
+                <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+                  <span className="truncate text-muted-foreground">
+                    {row.name}
+                  </span>
+                  <span className="shrink-0 text-muted-foreground tabular-nums">
+                    {percentage}%
+                  </span>
+                </div>
+                <CostShareBar className="w-full" percentage={percentage} />
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface ConsumptionAttributionBreakdownProps {
+  workspaceId: string;
+  selectedDimension: ConsumptionDimension;
+  selectedRowId: string;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+}
+
+export function ConsumptionAttributionBreakdown({
+  workspaceId,
+  selectedDimension,
+  selectedRowId,
+  period,
+  filter,
+}: ConsumptionAttributionBreakdownProps) {
+  const selectedFilter: ConsumptionScopeFilter = {
+    ...filter,
+    [CONSUMPTION_DIMENSION_FILTER_KEYS[selectedDimension]]: [selectedRowId],
+  };
+
+  return (
+    <div className="grid grid-cols-3 gap-8 border-b border-separator px-2 py-4">
+      {BREAKDOWN_DIMENSIONS.map((dimension) => (
+        <BreakdownColumn
+          key={dimension}
+          workspaceId={workspaceId}
+          dimension={dimension}
+          period={period}
+          filter={selectedFilter}
+        />
+      ))}
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -91,7 +91,7 @@ function BreakdownColumn({
 
             return (
               <div key={row.id} className="min-w-0">
-                <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+                <div className="mb-1 flex h-4 items-center justify-between gap-2 text-xs">
                   <span className="truncate text-muted-foreground">
                     {row.name}
                   </span>

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -3,7 +3,7 @@ import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
-import { Button, LoadingBlock } from "@dust-tt/sparkle";
+import { Button, cn, LoadingBlock } from "@dust-tt/sparkle";
 import { useState } from "react";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 
@@ -132,7 +132,14 @@ export function ConsumptionAttributionBreakdown({
   };
 
   return (
-    <div className="grid animate-in grid-cols-3 gap-20 border-b border-separator px-2 pb-6 pt-4 fade-in-0 slide-in-from-top-1 duration-enter ease-enter motion-reduce:animate-none">
+    <div
+      className={cn(
+        "grid animate-in grid-cols-3 gap-20",
+        "border-b border-separator px-2 pb-6 pt-4",
+        "fade-in-0 slide-in-from-top-1 duration-enter ease-enter",
+        "motion-reduce:animate-none"
+      )}
+    >
       {BREAKDOWN_DIMENSIONS.map((dimension) => (
         <BreakdownColumn
           key={dimension}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -17,20 +17,30 @@ const BREAKDOWN_LABELS: Record<BreakdownDimension, string> = {
   user: "By users",
 };
 
-const SKELETON_LABEL_WIDTHS = ["w-28", "w-20", "w-24"];
-
 function BreakdownColumnSkeleton() {
   return (
     <div className="flex flex-col gap-2">
-      {SKELETON_LABEL_WIDTHS.map((width) => (
-        <div key={width}>
-          <div className="mb-1 flex h-4 items-center justify-between">
-            <LoadingBlock className={`h-3 ${width}`} />
-            <LoadingBlock className="h-3 w-7" />
-          </div>
-          <LoadingBlock className="h-1.5 w-full rounded-full" />
+      <div>
+        <div className="mb-1 flex h-4 items-center justify-between">
+          <LoadingBlock className="h-3 w-28" />
+          <LoadingBlock className="h-3 w-7" />
         </div>
-      ))}
+        <LoadingBlock className="h-1.5 w-full rounded-full" />
+      </div>
+      <div>
+        <div className="mb-1 flex h-4 items-center justify-between">
+          <LoadingBlock className="h-3 w-20" />
+          <LoadingBlock className="h-3 w-7" />
+        </div>
+        <LoadingBlock className="h-1.5 w-full rounded-full" />
+      </div>
+      <div>
+        <div className="mb-1 flex h-4 items-center justify-between">
+          <LoadingBlock className="h-3 w-24" />
+          <LoadingBlock className="h-3 w-7" />
+        </div>
+        <LoadingBlock className="h-1.5 w-full rounded-full" />
+      </div>
     </div>
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -128,15 +128,19 @@ export function ConsumptionAttributionBreakdown({
     ...filter,
     [CONSUMPTION_DIMENSION_FILTER_KEYS[selectedDimension]]: [selectedRowId],
   };
+  const visibleDimensions = BREAKDOWN_DIMENSIONS.filter(
+    (dimension) => dimension !== selectedDimension
+  );
 
   return (
     <div
       className={cn(
-        "grid grid-cols-3 gap-20",
+        "grid gap-20",
+        visibleDimensions.length === 2 ? "grid-cols-2" : "grid-cols-3",
         "border-b border-separator px-2 pb-6 pt-4"
       )}
     >
-      {BREAKDOWN_DIMENSIONS.map((dimension) => (
+      {visibleDimensions.map((dimension) => (
         <BreakdownColumn
           key={dimension}
           workspaceId={workspaceId}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -3,7 +3,7 @@ import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
-import { Button, Spinner } from "@dust-tt/sparkle";
+import { Button, LoadingBlock } from "@dust-tt/sparkle";
 import { useState } from "react";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 
@@ -16,8 +16,26 @@ type BreakdownDimension = (typeof BREAKDOWN_DIMENSIONS)[number];
 const BREAKDOWN_LABELS: Record<BreakdownDimension, string> = {
   model: "By model",
   tool: "By tools",
-  user: "By members",
+  user: "By users",
 };
+
+const SKELETON_LABEL_WIDTHS = ["w-28", "w-20", "w-24"];
+
+function BreakdownColumnSkeleton() {
+  return (
+    <div className="flex flex-col gap-2">
+      {SKELETON_LABEL_WIDTHS.map((width) => (
+        <div key={width}>
+          <div className="mb-1 flex h-4 items-center justify-between">
+            <LoadingBlock className={`h-3 ${width}`} />
+            <LoadingBlock className="h-3 w-7" />
+          </div>
+          <LoadingBlock className="h-1.5 w-full rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
 
 interface BreakdownColumnProps {
   workspaceId: string;
@@ -45,7 +63,7 @@ function BreakdownColumn({
   return (
     <div className="min-w-0">
       <div className="mb-2 flex h-6 items-center justify-between gap-2">
-        <h4 className="text-sm font-medium text-foreground">
+        <h4 className="text-sm font-medium text-muted-foreground">
           {BREAKDOWN_LABELS[dimension]}
         </h4>
         {rows.length > BREAKDOWN_PREVIEW_LIMIT && (
@@ -58,9 +76,7 @@ function BreakdownColumn({
         )}
       </div>
       {isTopLoading ? (
-        <div className="flex h-24 items-center justify-center">
-          <Spinner size="sm" />
-        </div>
+        <BreakdownColumnSkeleton />
       ) : isTopError ? (
         <div className="flex h-24 items-center text-xs text-muted-foreground">
           Failed to load breakdown.
@@ -116,7 +132,7 @@ export function ConsumptionAttributionBreakdown({
   };
 
   return (
-    <div className="grid grid-cols-3 gap-8 border-b border-separator px-2 py-4">
+    <div className="grid animate-in grid-cols-3 gap-20 border-b border-separator px-2 pb-6 pt-4 fade-in-0 slide-in-from-top-1 duration-enter ease-enter motion-reduce:animate-none">
       {BREAKDOWN_DIMENSIONS.map((dimension) => (
         <BreakdownColumn
           key={dimension}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -132,10 +132,8 @@ export function ConsumptionAttributionBreakdown({
   return (
     <div
       className={cn(
-        "grid animate-in grid-cols-3 gap-20",
-        "border-b border-separator px-2 pb-6 pt-4",
-        "fade-in-0 slide-in-from-top-1 duration-enter ease-enter",
-        "motion-reduce:animate-none"
+        "grid grid-cols-3 gap-20",
+        "border-b border-separator px-2 pb-6 pt-4"
       )}
     >
       {BREAKDOWN_DIMENSIONS.map((dimension) => (

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -3,12 +3,10 @@ import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
-import { Button, cn, LoadingBlock } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { cn, LoadingBlock } from "@dust-tt/sparkle";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 
-const BREAKDOWN_LIMIT = 25;
-const BREAKDOWN_PREVIEW_LIMIT = 3;
+const BREAKDOWN_LIMIT = 3;
 
 const BREAKDOWN_DIMENSIONS = ["model", "tool", "user"] as const;
 type BreakdownDimension = (typeof BREAKDOWN_DIMENSIONS)[number];
@@ -50,7 +48,6 @@ function BreakdownColumn({
   period,
   filter,
 }: BreakdownColumnProps) {
-  const [showAll, setShowAll] = useState(false);
   const { rows, totalCredits, isTopLoading, isTopError } = useConsumptionTop({
     workspaceId,
     dimension,
@@ -58,22 +55,13 @@ function BreakdownColumn({
     limit: BREAKDOWN_LIMIT,
     filter,
   });
-  const visibleRows = showAll ? rows : rows.slice(0, BREAKDOWN_PREVIEW_LIMIT);
 
   return (
     <div className="min-w-0">
-      <div className="mb-2 flex h-6 items-center justify-between gap-2">
+      <div className="mb-2 flex h-6 items-center">
         <h4 className="text-sm font-medium text-muted-foreground">
           {BREAKDOWN_LABELS[dimension]}
         </h4>
-        {rows.length > BREAKDOWN_PREVIEW_LIMIT && (
-          <Button
-            label={showAll ? "Show less" : "View all"}
-            variant="highlight-ghost"
-            size="xs"
-            onClick={() => setShowAll((current) => !current)}
-          />
-        )}
       </div>
       {isTopLoading ? (
         <BreakdownColumnSkeleton />
@@ -81,13 +69,13 @@ function BreakdownColumn({
         <div className="flex h-24 items-center text-xs text-muted-foreground">
           Failed to load breakdown.
         </div>
-      ) : visibleRows.length === 0 ? (
+      ) : rows.length === 0 ? (
         <div className="flex h-24 items-center text-xs text-muted-foreground">
           No attributed consumption.
         </div>
       ) : (
         <div className="flex flex-col gap-2">
-          {visibleRows.map((row) => {
+          {rows.map((row) => {
             const share = totalCredits > 0 ? row.credits / totalCredits : 0;
             const percentage = Math.round(Math.min(100, share * 100));
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -114,7 +114,16 @@ export function ConsumptionAttributionRowsTable({
             <tr>
               <td className="max-w-0" colSpan={row.getVisibleCells().length}>
                 <Collapsible open={row.original.isExpanded}>
-                  <CollapsibleContent>
+                  <CollapsibleContent
+                    animated={false}
+                    className={cn(
+                      "transition-none ease-enter motion-reduce:animate-none",
+                      "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+                      "data-[state=open]:slide-in-from-top-1 data-[state=open]:duration-enter",
+                      "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+                      "data-[state=closed]:slide-out-to-top-1 data-[state=closed]:duration-exit"
+                    )}
+                  >
                     <ConsumptionAttributionBreakdown
                       workspaceId={workspaceId}
                       selectedDimension={dimension}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -112,7 +112,7 @@ export function ConsumptionAttributionRowsTable({
               ))}
             </DataTable.Row>
             <tr>
-              <td colSpan={row.getVisibleCells().length}>
+              <td className="max-w-0" colSpan={row.getVisibleCells().length}>
                 <Collapsible open={row.original.isExpanded}>
                   <CollapsibleContent>
                     <ConsumptionAttributionBreakdown

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -52,10 +52,10 @@ export function ConsumptionAttributionRowsTable({
   });
 
   return (
-    <DataTable.Root className="min-w-[800px]">
+    <DataTable.Root className="min-w-150">
       <DataTable.Header>
         {table.getHeaderGroups().map((headerGroup) => (
-          <DataTable.Row key={headerGroup.id} widthClassName="min-w-[800px]">
+          <DataTable.Row key={headerGroup.id} widthClassName="w-full">
             {headerGroup.headers.map((header) => (
               <DataTable.Head
                 column={header.column}
@@ -101,7 +101,7 @@ export function ConsumptionAttributionRowsTable({
         {table.getRowModel().rows.map((row) => (
           <Fragment key={row.id}>
             <DataTable.Row
-              widthClassName="min-w-[800px]"
+              widthClassName="w-full"
               onClick={row.original.onClick}
               rowData={row.original}
             >

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -1,0 +1,134 @@
+import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronSelectorVertical,
+  Collapsible,
+  CollapsibleContent,
+  cn,
+  DataTable,
+  Icon,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Fragment } from "react";
+import { ConsumptionAttributionBreakdown } from "./ConsumptionAttributionBreakdown";
+import type { ConsumptionDimension } from "./consumptionDimensions";
+
+export type AttributionRowData = ConsumptionTopRow & {
+  isExpanded: boolean;
+  onClick: () => void;
+};
+
+interface ConsumptionAttributionRowsTableProps {
+  data: AttributionRowData[];
+  columns: ColumnDef<AttributionRowData>[];
+  workspaceId: string;
+  dimension: ConsumptionDimension;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+}
+
+export function ConsumptionAttributionRowsTable({
+  data,
+  columns,
+  workspaceId,
+  dimension,
+  period,
+  filter,
+}: ConsumptionAttributionRowsTableProps) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <DataTable.Root className="min-w-[800px]">
+      <DataTable.Header>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <DataTable.Row key={headerGroup.id} widthClassName="min-w-[800px]">
+            {headerGroup.headers.map((header) => (
+              <DataTable.Head
+                column={header.column}
+                key={header.id}
+                onClick={
+                  header.column.getCanSort()
+                    ? header.column.getToggleSortingHandler()
+                    : undefined
+                }
+                className={cn(header.column.getCanSort() && "cursor-pointer")}
+              >
+                <div
+                  className={cn(
+                    "flex items-center space-x-1 whitespace-nowrap",
+                    header.column.columnDef.meta?.headerAlign === "right" &&
+                      "justify-end"
+                  )}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                  {header.column.getCanSort() && (
+                    <Icon
+                      visual={
+                        header.column.getIsSorted() === "asc"
+                          ? ArrowUp
+                          : header.column.getIsSorted() === "desc"
+                            ? ArrowDown
+                            : ChevronSelectorVertical
+                      }
+                      size="xs"
+                      className="ml-1"
+                    />
+                  )}
+                </div>
+              </DataTable.Head>
+            ))}
+          </DataTable.Row>
+        ))}
+      </DataTable.Header>
+      <DataTable.Body>
+        {table.getRowModel().rows.map((row) => (
+          <Fragment key={row.id}>
+            <DataTable.Row
+              widthClassName="min-w-[800px]"
+              onClick={row.original.onClick}
+              rowData={row.original}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <DataTable.Cell column={cell.column} key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </DataTable.Cell>
+              ))}
+            </DataTable.Row>
+            <tr>
+              <td colSpan={row.getVisibleCells().length}>
+                <Collapsible open={row.original.isExpanded}>
+                  <CollapsibleContent>
+                    <ConsumptionAttributionBreakdown
+                      workspaceId={workspaceId}
+                      selectedDimension={dimension}
+                      selectedRowId={row.original.id}
+                      period={period}
+                      filter={filter}
+                    />
+                  </CollapsibleContent>
+                </Collapsible>
+              </td>
+            </tr>
+          </Fragment>
+        ))}
+      </DataTable.Body>
+    </DataTable.Root>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -33,7 +33,9 @@ const BREAKDOWN_PREVIEW_LIMIT = 3;
 
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
 
-type BreakdownDimension = "model" | "tool" | "user";
+const BREAKDOWN_DIMENSIONS = ["model", "tool", "user"] as const;
+
+type BreakdownDimension = (typeof BREAKDOWN_DIMENSIONS)[number];
 
 const BREAKDOWN_LABELS: Record<BreakdownDimension, string> = {
   model: "By model",
@@ -42,7 +44,6 @@ const BREAKDOWN_LABELS: Record<BreakdownDimension, string> = {
 };
 
 type AttributionRowData = ConsumptionTopRow & {
-  breakdownId: string;
   isExpanded: boolean;
   onClick: () => void;
 };
@@ -54,8 +55,6 @@ function CostShareBar({
   percentage: number;
   className?: string;
 }) {
-  const clampedPercentage = Math.min(100, Math.max(0, percentage));
-
   return (
     <svg
       aria-hidden="true"
@@ -64,18 +63,13 @@ function CostShareBar({
       viewBox="0 0 100 6"
     >
       <rect className="fill-muted" height="6" rx="3" width="100" />
-      <rect
-        className="fill-primary"
-        height="6"
-        rx="3"
-        width={clampedPercentage}
-      />
+      <rect className="fill-primary" height="6" rx="3" width={percentage} />
     </svg>
   );
 }
 
 function CostShareCell({ share }: { share: number }) {
-  const percentage = Math.min(100, Math.max(0, share * 100));
+  const percentage = Math.min(100, share * 100);
   return (
     <div className="flex items-center gap-2">
       <CostShareBar className="w-24" percentage={percentage} />
@@ -154,7 +148,7 @@ function buildColumns({
     },
     {
       id: "details",
-      header: () => <span className="sr-only">Details</span>,
+      header: "",
       enableSorting: false,
       meta: { sizeRatio: 6, headerAlign: "right" },
       cell: (info) => {
@@ -165,10 +159,8 @@ function buildColumns({
               icon={row.isExpanded ? ChevronDown : ChevronRight}
               variant="ghost-secondary"
               size="xs"
-              className="h-11 w-11"
               aria-label={`${row.isExpanded ? "Collapse" : "Expand"} breakdown for ${row.name}`}
               aria-expanded={row.isExpanded}
-              aria-controls={row.breakdownId}
               onClick={(event) => {
                 event.stopPropagation();
                 row.onClick();
@@ -235,7 +227,7 @@ function BreakdownColumn({
         <div className="flex flex-col gap-2">
           {visibleRows.map((row) => {
             const share = totalCredits > 0 ? row.credits / totalCredits : 0;
-            const percentage = Math.min(100, Math.max(0, share * 100));
+            const percentage = Math.min(100, share * 100);
             return (
               <div key={row.id} className="min-w-0">
                 <div className="mb-1 flex items-center justify-between gap-2 text-xs">
@@ -257,7 +249,6 @@ function BreakdownColumn({
 }
 
 interface AttributionBreakdownProps {
-  id: string;
   workspaceId: string;
   selectedDimension: ConsumptionDimension;
   selectedRowId: string;
@@ -266,44 +257,28 @@ interface AttributionBreakdownProps {
 }
 
 function AttributionBreakdown({
-  id,
   workspaceId,
   selectedDimension,
   selectedRowId,
   period,
   filter,
 }: AttributionBreakdownProps) {
-  const selectedFilter = useMemo<ConsumptionScopeFilter>(
-    () => ({
-      ...filter,
-      [CONSUMPTION_DIMENSION_FILTER_KEYS[selectedDimension]]: [selectedRowId],
-    }),
-    [filter, selectedDimension, selectedRowId]
-  );
+  const selectedFilter: ConsumptionScopeFilter = {
+    ...filter,
+    [CONSUMPTION_DIMENSION_FILTER_KEYS[selectedDimension]]: [selectedRowId],
+  };
 
   return (
-    <div
-      id={id}
-      className="grid grid-cols-3 gap-8 border-b border-separator px-2 py-4"
-    >
-      <BreakdownColumn
-        workspaceId={workspaceId}
-        dimension="model"
-        period={period}
-        filter={selectedFilter}
-      />
-      <BreakdownColumn
-        workspaceId={workspaceId}
-        dimension="tool"
-        period={period}
-        filter={selectedFilter}
-      />
-      <BreakdownColumn
-        workspaceId={workspaceId}
-        dimension="user"
-        period={period}
-        filter={selectedFilter}
-      />
+    <div className="grid grid-cols-3 gap-8 border-b border-separator px-2 py-4">
+      {BREAKDOWN_DIMENSIONS.map((dimension) => (
+        <BreakdownColumn
+          key={dimension}
+          workspaceId={workspaceId}
+          dimension={dimension}
+          period={period}
+          filter={selectedFilter}
+        />
+      ))}
     </div>
   );
 }
@@ -324,10 +299,7 @@ function AttributionRows({
   search,
 }: AttributionRowsProps) {
   const { hasAvatar, avgLabel } = CONSUMPTION_DIMENSION_CONFIG[dimension];
-  const [expandedRow, setExpandedRow] = useState<{
-    dimension: ConsumptionDimension;
-    id: string;
-  } | null>(null);
+  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
 
   const {
     rows: allRows,
@@ -380,24 +352,12 @@ function AttributionRows({
     );
   }
 
-  const toggleRow = (rowId: string) => {
-    setExpandedRow((current) =>
-      current?.dimension === dimension && current.id === rowId
-        ? null
-        : { dimension, id: rowId }
-    );
-  };
-
-  const data: AttributionRowData[] = rows.map((row) => {
-    const isExpanded =
-      expandedRow?.dimension === dimension && expandedRow.id === row.id;
-    return {
-      ...row,
-      breakdownId: `consumption-breakdown-${dimension}-${row.id}`,
-      isExpanded,
-      onClick: () => toggleRow(row.id),
-    };
-  });
+  const data: AttributionRowData[] = rows.map((row) => ({
+    ...row,
+    isExpanded: expandedRowId === row.id,
+    onClick: () =>
+      setExpandedRowId((current) => (current === row.id ? null : row.id)),
+  }));
 
   return (
     <div className="overflow-x-auto">
@@ -405,20 +365,17 @@ function AttributionRows({
         data={data}
         columns={columns}
         widthClassName="min-w-[800px]"
-        getRowId={(row) => row.id}
-        renderSubComponent={(tableRow) => {
-          const row = tableRow.original;
-          return row.isExpanded ? (
+        renderSubComponent={(row) =>
+          row.isExpanded ? (
             <AttributionBreakdown
-              id={row.breakdownId}
               workspaceId={workspaceId}
               selectedDimension={dimension}
               selectedRowId={row.id}
               period={period}
               filter={filter}
             />
-          ) : null;
-        }}
+          ) : null
+        }
       />
     </div>
   );

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -11,7 +11,7 @@ import { formatCredits } from "@app/lib/client/credits";
 import {
   Button,
   ChevronDown,
-  ChevronRight,
+  ChevronUp,
   cn,
   DataTable,
   SearchInput,
@@ -115,7 +115,7 @@ function buildColumns({
         return (
           <DataTable.CellContent className="w-full justify-end">
             <Button
-              icon={row.isExpanded ? ChevronDown : ChevronRight}
+              icon={row.isExpanded ? ChevronUp : ChevronDown}
               variant="ghost-secondary"
               size="xs"
               aria-label={`${row.isExpanded ? "Collapse" : "Expand"} breakdown for ${row.name}`}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -109,7 +109,7 @@ function buildColumns({
       id: "details",
       header: "",
       enableSorting: false,
-      meta: { sizeRatio: 6, headerAlign: "right" },
+      meta: { className: "w-12", headerAlign: "right" },
       cell: (info) => {
         const row = info.row.original;
         return (

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -69,12 +69,12 @@ function CostShareBar({
 }
 
 function CostShareCell({ share }: { share: number }) {
-  const percentage = Math.min(100, share * 100);
+  const percentage = Math.round(Math.min(100, share * 100));
   return (
     <div className="flex items-center gap-2">
       <CostShareBar className="w-24" percentage={percentage} />
       <span className="w-8 text-right text-xs text-muted-foreground tabular-nums">
-        {Math.round(percentage)}%
+        {percentage}%
       </span>
     </div>
   );
@@ -227,7 +227,7 @@ function BreakdownColumn({
         <div className="flex flex-col gap-2">
           {visibleRows.map((row) => {
             const share = totalCredits > 0 ? row.credits / totalCredits : 0;
-            const percentage = Math.min(100, share * 100);
+            const percentage = Math.round(Math.min(100, share * 100));
             return (
               <div key={row.id} className="min-w-0">
                 <div className="mb-1 flex items-center justify-between gap-2 text-xs">
@@ -235,7 +235,7 @@ function BreakdownColumn({
                     {row.name}
                   </span>
                   <span className="shrink-0 text-muted-foreground tabular-nums">
-                    {Math.round(percentage)}%
+                    {percentage}%
                   </span>
                 </div>
                 <CostShareBar className="w-full" percentage={percentage} />

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -1,10 +1,12 @@
-import { AvatarNameCell } from "@app/components/workspace/analytics/creditsTableCells";
+import {
+  AvatarNameCell,
+  CostShareCell,
+} from "@app/components/workspace/analytics/creditsTableCells";
 import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
-import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import {
   Button,
@@ -20,6 +22,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
+import { ConsumptionAttributionBreakdown } from "./ConsumptionAttributionBreakdown";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 import {
   CONSUMPTION_DIMENSION_CONFIG,
@@ -29,56 +32,12 @@ import {
 
 const TOP_LIMIT = 25;
 
-const BREAKDOWN_PREVIEW_LIMIT = 3;
-
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
-
-const BREAKDOWN_DIMENSIONS = ["model", "tool", "user"] as const;
-
-type BreakdownDimension = (typeof BREAKDOWN_DIMENSIONS)[number];
-
-const BREAKDOWN_LABELS: Record<BreakdownDimension, string> = {
-  model: "By model",
-  tool: "By tools",
-  user: "By members",
-};
 
 type AttributionRowData = ConsumptionTopRow & {
   isExpanded: boolean;
   onClick: () => void;
 };
-
-function CostShareBar({
-  percentage,
-  className,
-}: {
-  percentage: number;
-  className?: string;
-}) {
-  return (
-    <svg
-      aria-hidden="true"
-      className={cn("h-1.5", className)}
-      preserveAspectRatio="none"
-      viewBox="0 0 100 6"
-    >
-      <rect className="fill-muted" height="6" rx="3" width="100" />
-      <rect className="fill-primary" height="6" rx="3" width={percentage} />
-    </svg>
-  );
-}
-
-function CostShareCell({ share }: { share: number }) {
-  const percentage = Math.round(Math.min(100, share * 100));
-  return (
-    <div className="flex items-center gap-2">
-      <CostShareBar className="w-24" percentage={percentage} />
-      <span className="w-8 text-right text-xs text-muted-foreground tabular-nums">
-        {percentage}%
-      </span>
-    </div>
-  );
-}
 
 function buildColumns({
   hasAvatar,
@@ -173,116 +132,6 @@ function buildColumns({
   ];
 }
 
-interface BreakdownColumnProps {
-  workspaceId: string;
-  dimension: BreakdownDimension;
-  period: ConsumptionPeriodSelection;
-  filter: ConsumptionScopeFilter;
-}
-
-function BreakdownColumn({
-  workspaceId,
-  dimension,
-  period,
-  filter,
-}: BreakdownColumnProps) {
-  const [showAll, setShowAll] = useState(false);
-  const { rows, totalCredits, isTopLoading, isTopError } = useConsumptionTop({
-    workspaceId,
-    dimension,
-    period,
-    limit: TOP_LIMIT,
-    filter,
-  });
-  const visibleRows = showAll ? rows : rows.slice(0, BREAKDOWN_PREVIEW_LIMIT);
-
-  return (
-    <div className="min-w-0">
-      <div className="mb-2 flex h-6 items-center justify-between gap-2">
-        <h4 className="text-sm font-medium text-foreground">
-          {BREAKDOWN_LABELS[dimension]}
-        </h4>
-        {rows.length > BREAKDOWN_PREVIEW_LIMIT && (
-          <Button
-            label={showAll ? "Show less" : "View all"}
-            variant="highlight-ghost"
-            size="xs"
-            onClick={() => setShowAll((current) => !current)}
-          />
-        )}
-      </div>
-      {isTopLoading ? (
-        <div className="flex h-24 items-center justify-center">
-          <Spinner size="sm" />
-        </div>
-      ) : isTopError ? (
-        <div className="flex h-24 items-center text-xs text-muted-foreground">
-          Failed to load breakdown.
-        </div>
-      ) : visibleRows.length === 0 ? (
-        <div className="flex h-24 items-center text-xs text-muted-foreground">
-          No attributed consumption.
-        </div>
-      ) : (
-        <div className="flex flex-col gap-2">
-          {visibleRows.map((row) => {
-            const share = totalCredits > 0 ? row.credits / totalCredits : 0;
-            const percentage = Math.round(Math.min(100, share * 100));
-            return (
-              <div key={row.id} className="min-w-0">
-                <div className="mb-1 flex items-center justify-between gap-2 text-xs">
-                  <span className="truncate text-muted-foreground">
-                    {row.name}
-                  </span>
-                  <span className="shrink-0 text-muted-foreground tabular-nums">
-                    {percentage}%
-                  </span>
-                </div>
-                <CostShareBar className="w-full" percentage={percentage} />
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface AttributionBreakdownProps {
-  workspaceId: string;
-  selectedDimension: ConsumptionDimension;
-  selectedRowId: string;
-  period: ConsumptionPeriodSelection;
-  filter?: ConsumptionScopeFilter;
-}
-
-function AttributionBreakdown({
-  workspaceId,
-  selectedDimension,
-  selectedRowId,
-  period,
-  filter,
-}: AttributionBreakdownProps) {
-  const selectedFilter: ConsumptionScopeFilter = {
-    ...filter,
-    [CONSUMPTION_DIMENSION_FILTER_KEYS[selectedDimension]]: [selectedRowId],
-  };
-
-  return (
-    <div className="grid grid-cols-3 gap-8 border-b border-separator px-2 py-4">
-      {BREAKDOWN_DIMENSIONS.map((dimension) => (
-        <BreakdownColumn
-          key={dimension}
-          workspaceId={workspaceId}
-          dimension={dimension}
-          period={period}
-          filter={selectedFilter}
-        />
-      ))}
-    </div>
-  );
-}
-
 interface AttributionRowsProps {
   workspaceId: string;
   dimension: ConsumptionDimension;
@@ -367,7 +216,7 @@ function AttributionRows({
         widthClassName="min-w-[800px]"
         renderSubComponent={(row) =>
           row.isExpanded ? (
-            <AttributionBreakdown
+            <ConsumptionAttributionBreakdown
               workspaceId={workspaceId}
               selectedDimension={dimension}
               selectedRowId={row.id}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -47,18 +47,40 @@ type AttributionRowData = ConsumptionTopRow & {
   onClick: () => void;
 };
 
+function CostShareBar({
+  percentage,
+  className,
+}: {
+  percentage: number;
+  className?: string;
+}) {
+  const clampedPercentage = Math.min(100, Math.max(0, percentage));
+
+  return (
+    <svg
+      aria-hidden="true"
+      className={cn("h-1.5", className)}
+      preserveAspectRatio="none"
+      viewBox="0 0 100 6"
+    >
+      <rect className="fill-muted" height="6" rx="3" width="100" />
+      <rect
+        className="fill-primary"
+        height="6"
+        rx="3"
+        width={clampedPercentage}
+      />
+    </svg>
+  );
+}
+
 function CostShareCell({ share }: { share: number }) {
-  const percent = Math.round(share * 100);
+  const percentage = Math.min(100, Math.max(0, share * 100));
   return (
     <div className="flex items-center gap-2">
-      <div className="h-1.5 w-24 overflow-hidden rounded-full bg-muted">
-        <div
-          className="h-full rounded-full bg-primary"
-          style={{ width: `${Math.min(100, share * 100)}%` }}
-        />
-      </div>
+      <CostShareBar className="w-24" percentage={percentage} />
       <span className="w-8 text-right text-xs text-muted-foreground tabular-nums">
-        {percent}%
+        {Math.round(percentage)}%
       </span>
     </div>
   );
@@ -213,7 +235,7 @@ function BreakdownColumn({
         <div className="flex flex-col gap-2">
           {visibleRows.map((row) => {
             const share = totalCredits > 0 ? row.credits / totalCredits : 0;
-            const percent = Math.round(share * 100);
+            const percentage = Math.min(100, Math.max(0, share * 100));
             return (
               <div key={row.id} className="min-w-0">
                 <div className="mb-1 flex items-center justify-between gap-2 text-xs">
@@ -221,15 +243,10 @@ function BreakdownColumn({
                     {row.name}
                   </span>
                   <span className="shrink-0 text-muted-foreground tabular-nums">
-                    {percent}%
+                    {Math.round(percentage)}%
                   </span>
                 </div>
-                <div className="h-1.5 overflow-hidden rounded-full bg-muted">
-                  <div
-                    className="h-full rounded-full bg-primary"
-                    style={{ width: `${Math.min(100, share * 100)}%` }}
-                  />
-                </div>
+                <CostShareBar className="w-full" percentage={percentage} />
               </div>
             );
           })}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -4,8 +4,13 @@ import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import {
+  Button,
+  ChevronDown,
+  ChevronRight,
+  cn,
   DataTable,
   SearchInput,
   Spinner,
@@ -14,7 +19,7 @@ import {
   TabsTrigger,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 import {
   CONSUMPTION_DIMENSION_CONFIG,
@@ -24,11 +29,22 @@ import {
 
 const TOP_LIMIT = 25;
 
+const BREAKDOWN_PREVIEW_LIMIT = 3;
+
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
 
+type BreakdownDimension = "model" | "tool" | "user";
+
+const BREAKDOWN_LABELS: Record<BreakdownDimension, string> = {
+  model: "By model",
+  tool: "By tools",
+  user: "By members",
+};
+
 type AttributionRowData = ConsumptionTopRow & {
-  onClick?: () => void;
-  onDoubleClick?: () => void;
+  breakdownId: string;
+  isExpanded: boolean;
+  onClick: () => void;
 };
 
 function CostShareCell({ share }: { share: number }) {
@@ -62,7 +78,7 @@ function buildColumns({
       id: "name",
       accessorKey: "name",
       header: "Name",
-      meta: { sizeRatio: 34, headerAlign: "left" },
+      meta: { sizeRatio: 32, headerAlign: "left" },
       cell: (info) => {
         const { name, pictureUrl } = info.row.original;
         return (
@@ -79,7 +95,7 @@ function buildColumns({
     {
       id: "costShare",
       header: "Cost share",
-      meta: { sizeRatio: 22, headerAlign: "left" },
+      meta: { sizeRatio: 20, headerAlign: "left" },
       cell: (info) => (
         <DataTable.CellContent className="w-full justify-start">
           <CostShareCell
@@ -94,7 +110,7 @@ function buildColumns({
       id: "credits",
       accessorKey: "credits",
       header: "Total credits",
-      meta: { sizeRatio: 22, headerAlign: "right" },
+      meta: { sizeRatio: 20, headerAlign: "right" },
       cell: (info) => (
         <DataTable.BasicCellContent
           className="justify-end text-right tabular-nums"
@@ -114,7 +130,165 @@ function buildColumns({
         />
       ),
     },
+    {
+      id: "details",
+      header: () => <span className="sr-only">Details</span>,
+      enableSorting: false,
+      meta: { sizeRatio: 6, headerAlign: "right" },
+      cell: (info) => {
+        const row = info.row.original;
+        return (
+          <DataTable.CellContent className="w-full justify-end">
+            <Button
+              icon={row.isExpanded ? ChevronDown : ChevronRight}
+              variant="ghost-secondary"
+              size="xs"
+              className="h-11 w-11"
+              aria-label={`${row.isExpanded ? "Collapse" : "Expand"} breakdown for ${row.name}`}
+              aria-expanded={row.isExpanded}
+              aria-controls={row.breakdownId}
+              onClick={(event) => {
+                event.stopPropagation();
+                row.onClick();
+              }}
+            />
+          </DataTable.CellContent>
+        );
+      },
+    },
   ];
+}
+
+interface BreakdownColumnProps {
+  workspaceId: string;
+  dimension: BreakdownDimension;
+  period: ConsumptionPeriodSelection;
+  filter: ConsumptionScopeFilter;
+}
+
+function BreakdownColumn({
+  workspaceId,
+  dimension,
+  period,
+  filter,
+}: BreakdownColumnProps) {
+  const [showAll, setShowAll] = useState(false);
+  const { rows, totalCredits, isTopLoading, isTopError } = useConsumptionTop({
+    workspaceId,
+    dimension,
+    period,
+    limit: TOP_LIMIT,
+    filter,
+  });
+  const visibleRows = showAll ? rows : rows.slice(0, BREAKDOWN_PREVIEW_LIMIT);
+
+  return (
+    <div className="min-w-0">
+      <div className="mb-2 flex h-6 items-center justify-between gap-2">
+        <h4 className="text-sm font-medium text-foreground">
+          {BREAKDOWN_LABELS[dimension]}
+        </h4>
+        {rows.length > BREAKDOWN_PREVIEW_LIMIT && (
+          <Button
+            label={showAll ? "Show less" : "View all"}
+            variant="highlight-ghost"
+            size="xs"
+            onClick={() => setShowAll((current) => !current)}
+          />
+        )}
+      </div>
+      {isTopLoading ? (
+        <div className="flex h-24 items-center justify-center">
+          <Spinner size="sm" />
+        </div>
+      ) : isTopError ? (
+        <div className="flex h-24 items-center text-xs text-muted-foreground">
+          Failed to load breakdown.
+        </div>
+      ) : visibleRows.length === 0 ? (
+        <div className="flex h-24 items-center text-xs text-muted-foreground">
+          No attributed consumption.
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {visibleRows.map((row) => {
+            const share = totalCredits > 0 ? row.credits / totalCredits : 0;
+            const percent = Math.round(share * 100);
+            return (
+              <div key={row.id} className="min-w-0">
+                <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+                  <span className="truncate text-muted-foreground">
+                    {row.name}
+                  </span>
+                  <span className="shrink-0 text-muted-foreground tabular-nums">
+                    {percent}%
+                  </span>
+                </div>
+                <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                  <div
+                    className="h-full rounded-full bg-primary"
+                    style={{ width: `${Math.min(100, share * 100)}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface AttributionBreakdownProps {
+  id: string;
+  workspaceId: string;
+  selectedDimension: ConsumptionDimension;
+  selectedRowId: string;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+}
+
+function AttributionBreakdown({
+  id,
+  workspaceId,
+  selectedDimension,
+  selectedRowId,
+  period,
+  filter,
+}: AttributionBreakdownProps) {
+  const selectedFilter = useMemo<ConsumptionScopeFilter>(
+    () => ({
+      ...filter,
+      [CONSUMPTION_DIMENSION_FILTER_KEYS[selectedDimension]]: [selectedRowId],
+    }),
+    [filter, selectedDimension, selectedRowId]
+  );
+
+  return (
+    <div
+      id={id}
+      className="grid grid-cols-3 gap-8 border-b border-separator px-2 py-4"
+    >
+      <BreakdownColumn
+        workspaceId={workspaceId}
+        dimension="model"
+        period={period}
+        filter={selectedFilter}
+      />
+      <BreakdownColumn
+        workspaceId={workspaceId}
+        dimension="tool"
+        period={period}
+        filter={selectedFilter}
+      />
+      <BreakdownColumn
+        workspaceId={workspaceId}
+        dimension="user"
+        period={period}
+        filter={selectedFilter}
+      />
+    </div>
+  );
 }
 
 interface AttributionRowsProps {
@@ -133,6 +307,10 @@ function AttributionRows({
   search,
 }: AttributionRowsProps) {
   const { hasAvatar, avgLabel } = CONSUMPTION_DIMENSION_CONFIG[dimension];
+  const [expandedRow, setExpandedRow] = useState<{
+    dimension: ConsumptionDimension;
+    id: string;
+  } | null>(null);
 
   const {
     rows: allRows,
@@ -185,7 +363,48 @@ function AttributionRows({
     );
   }
 
-  return <DataTable<AttributionRowData> data={rows} columns={columns} />;
+  const toggleRow = (rowId: string) => {
+    setExpandedRow((current) =>
+      current?.dimension === dimension && current.id === rowId
+        ? null
+        : { dimension, id: rowId }
+    );
+  };
+
+  const data: AttributionRowData[] = rows.map((row) => {
+    const isExpanded =
+      expandedRow?.dimension === dimension && expandedRow.id === row.id;
+    return {
+      ...row,
+      breakdownId: `consumption-breakdown-${dimension}-${row.id}`,
+      isExpanded,
+      onClick: () => toggleRow(row.id),
+    };
+  });
+
+  return (
+    <div className="overflow-x-auto">
+      <DataTable<AttributionRowData>
+        data={data}
+        columns={columns}
+        widthClassName="min-w-[800px]"
+        getRowId={(row) => row.id}
+        renderSubComponent={(tableRow) => {
+          const row = tableRow.original;
+          return row.isExpanded ? (
+            <AttributionBreakdown
+              id={row.breakdownId}
+              workspaceId={workspaceId}
+              selectedDimension={dimension}
+              selectedRowId={row.id}
+              period={period}
+              filter={filter}
+            />
+          ) : null;
+        }}
+      />
+    </div>
+  );
 }
 
 interface ConsumptionAttributionTableProps {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -2,7 +2,6 @@ import {
   AvatarNameCell,
   CostShareCell,
 } from "@app/components/workspace/analytics/creditsTableCells";
-import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
@@ -12,8 +11,6 @@ import {
   Button,
   ChevronDown,
   ChevronUp,
-  Collapsible,
-  CollapsibleContent,
   cn,
   DataTable,
   SearchInput,
@@ -24,7 +21,8 @@ import {
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
-import { ConsumptionAttributionBreakdown } from "./ConsumptionAttributionBreakdown";
+import type { AttributionRowData } from "./ConsumptionAttributionRowsTable";
+import { ConsumptionAttributionRowsTable } from "./ConsumptionAttributionRowsTable";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 import {
   CONSUMPTION_DIMENSION_CONFIG,
@@ -35,11 +33,6 @@ import {
 const TOP_LIMIT = 25;
 
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
-
-type AttributionRowData = ConsumptionTopRow & {
-  isExpanded: boolean;
-  onClick: () => void;
-};
 
 function buildColumns({
   hasAvatar,
@@ -212,23 +205,13 @@ function AttributionRows({
 
   return (
     <div className="overflow-x-auto">
-      <DataTable<AttributionRowData>
+      <ConsumptionAttributionRowsTable
         data={data}
         columns={columns}
-        widthClassName="min-w-[800px]"
-        renderSubComponent={(row) => (
-          <Collapsible open={row.isExpanded}>
-            <CollapsibleContent>
-              <ConsumptionAttributionBreakdown
-                workspaceId={workspaceId}
-                selectedDimension={dimension}
-                selectedRowId={row.id}
-                period={period}
-                filter={filter}
-              />
-            </CollapsibleContent>
-          </Collapsible>
-        )}
+        workspaceId={workspaceId}
+        dimension={dimension}
+        period={period}
+        filter={filter}
       />
     </div>
   );

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -11,7 +11,6 @@ import {
   Button,
   ChevronDown,
   ChevronUp,
-  cn,
   DataTable,
   SearchInput,
   Spinner,

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -12,6 +12,8 @@ import {
   Button,
   ChevronDown,
   ChevronUp,
+  Collapsible,
+  CollapsibleContent,
   cn,
   DataTable,
   SearchInput,
@@ -214,17 +216,19 @@ function AttributionRows({
         data={data}
         columns={columns}
         widthClassName="min-w-[800px]"
-        renderSubComponent={(row) =>
-          row.isExpanded ? (
-            <ConsumptionAttributionBreakdown
-              workspaceId={workspaceId}
-              selectedDimension={dimension}
-              selectedRowId={row.id}
-              period={period}
-              filter={filter}
-            />
-          ) : null
-        }
+        renderSubComponent={(row) => (
+          <Collapsible open={row.isExpanded}>
+            <CollapsibleContent>
+              <ConsumptionAttributionBreakdown
+                workspaceId={workspaceId}
+                selectedDimension={dimension}
+                selectedRowId={row.id}
+                period={period}
+                filter={filter}
+              />
+            </CollapsibleContent>
+          </Collapsible>
+        )}
       />
     </div>
   );

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -32,7 +32,7 @@ export function CostShareBar({
     <progress
       aria-hidden="true"
       className={cn(
-        "h-1.5 appearance-none overflow-hidden rounded-full bg-muted",
+        "block h-1.5 appearance-none overflow-hidden rounded-full bg-muted",
         "[&::-webkit-progress-bar]:bg-muted",
         "[&::-webkit-progress-value]:rounded-full",
         "[&::-webkit-progress-value]:bg-primary",

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -1,5 +1,5 @@
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
-import { Avatar, Tooltip } from "@dust-tt/sparkle";
+import { Avatar, cn, Tooltip } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
 function EmptyCell() {
@@ -17,6 +17,39 @@ export function AvatarNameCell({
     <div className="flex items-center gap-2">
       <Avatar name={name} visual={imageUrl ?? undefined} size="xs" isRounded />
       <span className="truncate text-sm">{name}</span>
+    </div>
+  );
+}
+
+export function CostShareBar({
+  percentage,
+  className,
+}: {
+  percentage: number;
+  className?: string;
+}) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={cn("h-1.5", className)}
+      preserveAspectRatio="none"
+      viewBox="0 0 100 6"
+    >
+      <rect className="fill-muted" height="6" rx="3" width="100" />
+      <rect className="fill-primary" height="6" rx="3" width={percentage} />
+    </svg>
+  );
+}
+
+export function CostShareCell({ share }: { share: number }) {
+  const percentage = Math.round(Math.min(100, share * 100));
+
+  return (
+    <div className="flex items-center gap-2">
+      <CostShareBar className="w-24" percentage={percentage} />
+      <span className="w-8 text-right text-xs text-muted-foreground tabular-nums">
+        {percentage}%
+      </span>
     </div>
   );
 }

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -33,8 +33,11 @@ export function CostShareBar({
       aria-hidden="true"
       className={cn(
         "h-1.5 appearance-none overflow-hidden rounded-full bg-muted",
-        "[&::-webkit-progress-bar]:bg-muted [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-primary",
-        "[&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-primary",
+        "[&::-webkit-progress-bar]:bg-muted",
+        "[&::-webkit-progress-value]:rounded-full",
+        "[&::-webkit-progress-value]:bg-primary",
+        "[&::-moz-progress-bar]:rounded-full",
+        "[&::-moz-progress-bar]:bg-primary",
         className
       )}
       max={100}

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -29,14 +29,14 @@ export function CostShareBar({
   className?: string;
 }) {
   return (
-    <svg
-      aria-hidden="true"
-      className={cn("h-1.5", className)}
-      preserveAspectRatio="none"
-      viewBox="0 0 100 6"
-    >
-      <rect className="fill-muted" height="6" rx="3" width="100" />
-      <rect className="fill-primary" height="6" rx="3" width={percentage} />
+    <svg aria-hidden="true" className={cn("h-1.5", className)}>
+      <rect className="fill-muted" height="100%" rx="3" width="100%" />
+      <rect
+        className="fill-primary"
+        height="100%"
+        rx="3"
+        width={`${percentage}%`}
+      />
     </svg>
   );
 }

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -29,15 +29,17 @@ export function CostShareBar({
   className?: string;
 }) {
   return (
-    <svg aria-hidden="true" className={cn("h-1.5", className)}>
-      <rect className="fill-muted" height="100%" rx="3" width="100%" />
-      <rect
-        className="fill-primary"
-        height="100%"
-        rx="3"
-        width={`${percentage}%`}
-      />
-    </svg>
+    <progress
+      aria-hidden="true"
+      className={cn(
+        "h-1.5 appearance-none overflow-hidden rounded-full bg-muted",
+        "[&::-webkit-progress-bar]:bg-muted [&::-webkit-progress-value]:rounded-full [&::-webkit-progress-value]:bg-primary",
+        "[&::-moz-progress-bar]:rounded-full [&::-moz-progress-bar]:bg-primary",
+        className
+      )}
+      max={100}
+      value={percentage}
+    />
   );
 }
 

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -21,13 +21,12 @@ export function AvatarNameCell({
   );
 }
 
-export function CostShareBar({
-  percentage,
-  className,
-}: {
+interface CostShareBarProps {
   percentage: number;
   className?: string;
-}) {
+}
+
+export function CostShareBar({ percentage, className }: CostShareBarProps) {
   return (
     <progress
       aria-hidden="true"

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -32,12 +32,7 @@ export function CostShareBar({
     <progress
       aria-hidden="true"
       className={cn(
-        "block h-1.5 appearance-none overflow-hidden rounded-full bg-muted",
-        "[&::-webkit-progress-bar]:bg-muted",
-        "[&::-webkit-progress-value]:rounded-full",
-        "[&::-webkit-progress-value]:bg-primary",
-        "[&::-moz-progress-bar]:rounded-full",
-        "[&::-moz-progress-bar]:bg-primary",
+        "block h-1.5 overflow-hidden rounded-full bg-muted accent-primary",
         className
       )}
       max={100}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -116,7 +116,7 @@ interface DataTableProps<TData extends TBaseData> {
   enableSortingRemoval?: boolean;
   /** Omit the default bottom divider on tbody rows (e.g. dense custom lists). */
   hideRowDivider?: boolean;
-  renderSubComponent?: (row: Row<TData>) => ReactNode;
+  renderSubComponent?: (row: TData) => ReactNode;
 }
 
 export function DataTable<TData extends TBaseData>({
@@ -294,47 +294,49 @@ export function DataTable<TData extends TBaseData>({
               }
               row.original.onClick?.();
             };
-            const subComponent = renderSubComponent?.(row);
-
-            return (
-              <React.Fragment key={row.id}>
-                <DataTable.Row
-                  widthClassName={widthClassName}
-                  hideBottomBorder={hideRowDivider}
-                  onClick={
-                    enableRowSelection ? handleRowClick : row.original.onClick
+            const renderedRow = (
+              <DataTable.Row
+                widthClassName={widthClassName}
+                key={row.id}
+                hideBottomBorder={hideRowDivider}
+                onClick={
+                  enableRowSelection ? handleRowClick : row.original.onClick
+                }
+                onDoubleClick={row.original.onDoubleClick}
+                rowData={row.original}
+                {...(enableRowSelection && {
+                  "data-selected": row.getIsSelected(),
+                })}
+              >
+                {row.getVisibleCells().map((cell) => {
+                  const breakpoint = columnsBreakpoints[cell.column.id];
+                  if (
+                    !windowSize.width ||
+                    !shouldRenderColumn(windowSize.width, breakpoint)
+                  ) {
+                    return null;
                   }
-                  onDoubleClick={row.original.onDoubleClick}
-                  rowData={row.original}
-                  {...(enableRowSelection && {
-                    "data-selected": row.getIsSelected(),
-                  })}
-                >
-                  {row.getVisibleCells().map((cell) => {
-                    const breakpoint = columnsBreakpoints[cell.column.id];
-                    if (
-                      !windowSize.width ||
-                      !shouldRenderColumn(windowSize.width, breakpoint)
-                    ) {
-                      return null;
-                    }
-                    return (
-                      <DataTable.Cell column={cell.column} key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )}
-                      </DataTable.Cell>
-                    );
-                  })}
-                </DataTable.Row>
-                {subComponent != null && (
-                  <tr>
-                    <td colSpan={row.getVisibleCells().length}>
-                      {subComponent}
-                    </td>
-                  </tr>
-                )}
+                  return (
+                    <DataTable.Cell column={cell.column} key={cell.id}>
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext()
+                      )}
+                    </DataTable.Cell>
+                  );
+                })}
+              </DataTable.Row>
+            );
+
+            const subComponent = renderSubComponent?.(row.original);
+            return subComponent == null ? (
+              renderedRow
+            ) : (
+              <React.Fragment key={row.id}>
+                {renderedRow}
+                <tr>
+                  <td colSpan={row.getVisibleCells().length}>{subComponent}</td>
+                </tr>
               </React.Fragment>
             );
           })}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -116,6 +116,7 @@ interface DataTableProps<TData extends TBaseData> {
   enableSortingRemoval?: boolean;
   /** Omit the default bottom divider on tbody rows (e.g. dense custom lists). */
   hideRowDivider?: boolean;
+  renderSubComponent?: (row: Row<TData>) => ReactNode;
 }
 
 export function DataTable<TData extends TBaseData>({
@@ -141,6 +142,7 @@ export function DataTable<TData extends TBaseData>({
   getRowId,
   enableSortingRemoval = true,
   hideRowDivider = false,
+  renderSubComponent,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -292,39 +294,48 @@ export function DataTable<TData extends TBaseData>({
               }
               row.original.onClick?.();
             };
+            const subComponent = renderSubComponent?.(row);
 
             return (
-              <DataTable.Row
-                widthClassName={widthClassName}
-                key={row.id}
-                hideBottomBorder={hideRowDivider}
-                onClick={
-                  enableRowSelection ? handleRowClick : row.original.onClick
-                }
-                onDoubleClick={row.original.onDoubleClick}
-                rowData={row.original}
-                {...(enableRowSelection && {
-                  "data-selected": row.getIsSelected(),
-                })}
-              >
-                {row.getVisibleCells().map((cell) => {
-                  const breakpoint = columnsBreakpoints[cell.column.id];
-                  if (
-                    !windowSize.width ||
-                    !shouldRenderColumn(windowSize.width, breakpoint)
-                  ) {
-                    return null;
+              <React.Fragment key={row.id}>
+                <DataTable.Row
+                  widthClassName={widthClassName}
+                  hideBottomBorder={hideRowDivider}
+                  onClick={
+                    enableRowSelection ? handleRowClick : row.original.onClick
                   }
-                  return (
-                    <DataTable.Cell column={cell.column} key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </DataTable.Cell>
-                  );
-                })}
-              </DataTable.Row>
+                  onDoubleClick={row.original.onDoubleClick}
+                  rowData={row.original}
+                  {...(enableRowSelection && {
+                    "data-selected": row.getIsSelected(),
+                  })}
+                >
+                  {row.getVisibleCells().map((cell) => {
+                    const breakpoint = columnsBreakpoints[cell.column.id];
+                    if (
+                      !windowSize.width ||
+                      !shouldRenderColumn(windowSize.width, breakpoint)
+                    ) {
+                      return null;
+                    }
+                    return (
+                      <DataTable.Cell column={cell.column} key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </DataTable.Cell>
+                    );
+                  })}
+                </DataTable.Row>
+                {subComponent != null && (
+                  <tr>
+                    <td colSpan={row.getVisibleCells().length}>
+                      {subComponent}
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
             );
           })}
         </DataTable.Body>
@@ -346,7 +357,7 @@ export function DataTable<TData extends TBaseData>({
 }
 
 export interface ScrollableDataTableProps<TData extends TBaseData>
-  extends DataTableProps<TData> {
+  extends Omit<DataTableProps<TData>, "renderSubComponent"> {
   maxHeight?: string | boolean;
   onLoadMore?: () => void;
   isLoading?: boolean;

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -116,7 +116,6 @@ interface DataTableProps<TData extends TBaseData> {
   enableSortingRemoval?: boolean;
   /** Omit the default bottom divider on tbody rows (e.g. dense custom lists). */
   hideRowDivider?: boolean;
-  renderSubComponent?: (row: TData) => ReactNode;
 }
 
 export function DataTable<TData extends TBaseData>({
@@ -142,7 +141,6 @@ export function DataTable<TData extends TBaseData>({
   getRowId,
   enableSortingRemoval = true,
   hideRowDivider = false,
-  renderSubComponent,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -294,7 +292,8 @@ export function DataTable<TData extends TBaseData>({
               }
               row.original.onClick?.();
             };
-            const renderedRow = (
+
+            return (
               <DataTable.Row
                 widthClassName={widthClassName}
                 key={row.id}
@@ -327,18 +326,6 @@ export function DataTable<TData extends TBaseData>({
                 })}
               </DataTable.Row>
             );
-
-            const subComponent = renderSubComponent?.(row.original);
-            return subComponent == null ? (
-              renderedRow
-            ) : (
-              <React.Fragment key={row.id}>
-                {renderedRow}
-                <tr>
-                  <td colSpan={row.getVisibleCells().length}>{subComponent}</td>
-                </tr>
-              </React.Fragment>
-            );
           })}
         </DataTable.Body>
       </DataTable.Root>
@@ -359,7 +346,7 @@ export function DataTable<TData extends TBaseData>({
 }
 
 export interface ScrollableDataTableProps<TData extends TBaseData>
-  extends Omit<DataTableProps<TData>, "renderSubComponent"> {
+  extends DataTableProps<TData> {
   maxHeight?: string | boolean;
   onLoadMore?: () => void;
   isLoading?: boolean;


### PR DESCRIPTION
## Description

Closes dust-tt/tasks#10023.

Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=12868-75569&m=dev)

In the Analytics view, attribution rows expand (on click) to show how a selected item breaks down across models, tools, and members.

The View all button that switches tabs will be added in the next PR.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
