### PR TITLE
Fix LLM runs failing on fractional usage costs

### DIFF
--- a/front/lib/api/llm/run_lifecycle.test.ts
+++ b/front/lib/api/llm/run_lifecycle.test.ts
@@ -7,7 +7,10 @@ import type { ModelResponseEvent } from "@app/lib/model_constructors/types/outpu
 import { RunResource } from "@app/lib/resources/run_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import {
+  GPT_5_6_LUNA_MODEL_CONFIG,
+  GPT_5_MINI_MODEL_CONFIG,
+} from "@app/types/assistant/models/openai";
 import { describe, expect, it } from "vitest";
 
 class ThrowingNoopStream extends DustNoopNoopGlobalNoopStream {
@@ -138,6 +141,32 @@ describe("LLMRunLifecycle", () => {
       },
     ]);
     expect(await run.listRunUsages(auth)).toHaveLength(1);
+  });
+
+  it("persists fractional micro-dollar token costs as integers", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const parameters = {
+      ...makeLifecycleParameters(),
+      modelId: GPT_5_6_LUNA_MODEL_CONFIG.modelId,
+      providerId: GPT_5_6_LUNA_MODEL_CONFIG.providerId,
+    };
+    const lifecycle = await LLMRunLifecycle.start(auth, parameters);
+
+    await lifecycle.recordTokenUsage({
+      inputTokens: 13_331,
+      totalOutputTokens: 36,
+      reasoningTokens: 22,
+      totalTokens: 13_367,
+      cachedTokens: 13_328,
+      cacheCreationTokens: 0,
+    });
+
+    const run = await RunResource.fetchByDustRunId(auth, {
+      dustRunId: parameters.dustRunId,
+    });
+    expect(await run?.listRunUsages(auth)).toMatchObject([
+      { costMicroUsd: 310 },
+    ]);
   });
 });
 

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -704,7 +704,9 @@ export class RunResource extends BaseResource<RunModel> {
       modelId: modelConfig.modelId,
       promptTokens: usage.inputTokens,
       providerId: modelConfig.providerId,
-      costMicroUsd: usageCostMicroUsd,
+      // Token pricing can produce fractional micro-dollar values. Run usage stores a BIGINT, so
+      // normalize explicitly instead of relying on coercion that differs between inserts and updates.
+      costMicroUsd: Math.round(usageCostMicroUsd),
       isBatch,
     };
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Sequelize love story below 😬⬇️ 

Some model prices produce fractional micro-dollar costs, while persisted run usage requires whole micro-dollars. The previous insert path implicitly converted these values (yeah `Sequelize#bulkCreate` coerce values), but the new pending usage update rejects them. This caused an otherwise successful model response to fail after streaming, triggering retries that repeatedly rewrote the output before eventually showing a task failure.

This PR explicitly rounds token-derived costs before persistence while preserving fractional precision for pricing calculations elsewhere. It includes a regression test using the exact Luna usage that reproduced the failure.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
