### PR TITLE
[analytics] refactor: remove client-side cap on filter selections

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.ts
@@ -2,7 +2,7 @@ import type { GetConsumptionFacetsResponse } from "@app/lib/api/analytics/consum
 import { fetchConsumptionFacets } from "@app/lib/api/analytics/consumption/facets";
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionFacetsBodySchema,
+  ConsumptionBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -138,7 +138,7 @@ const app = workspaceApp();
 app.post(
   "/",
   ensureIsManager(),
-  validate("json", ConsumptionFacetsBodySchema),
+  validate("json", ConsumptionBodySchema),
   async (ctx): HandlerResult<GetConsumptionFacetsResponse> => {
     const auth = ctx.get("auth");
     const { filter, ...periodInput } = ctx.req.valid("json");

--- a/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
@@ -32,18 +32,19 @@ async function setupTest({
   return createPrivateApiMockRequest({ role });
 }
 
-function getOverviewRequest(wId: string, query: Record<string, string> = {}) {
-  const qs = new URLSearchParams(query).toString();
-  return honoApp.request(
-    `/api/w/${wId}/analytics/consumption/overview${qs ? `?${qs}` : ""}`
-  );
+function postOverviewRequest(wId: string, body: Record<string, unknown> = {}) {
+  return honoApp.request(`/api/w/${wId}/analytics/consumption/overview`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 }
 
-describe("GET /api/w/:wId/analytics/consumption/overview", () => {
+describe("POST /api/w/:wId/analytics/consumption/overview", () => {
   it("returns 403 for non-manager users", async () => {
     const { workspace } = await setupTest({ role: "user" });
 
-    const response = await getOverviewRequest(workspace.sId);
+    const response = await postOverviewRequest(workspace.sId);
 
     expect(response.status).toBe(403);
     expect(vi.mocked(fetchConsumptionOverview)).not.toHaveBeenCalled();
@@ -53,7 +54,7 @@ describe("GET /api/w/:wId/analytics/consumption/overview", () => {
     vi.mocked(fetchConsumptionOverview).mockResolvedValue(new Ok(OVERVIEW));
     const { workspace } = await setupTest({ role: "admin" });
 
-    const response = await getOverviewRequest(workspace.sId);
+    const response = await postOverviewRequest(workspace.sId);
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(OVERVIEW);
@@ -70,10 +71,10 @@ describe("GET /api/w/:wId/analytics/consumption/overview", () => {
     vi.mocked(fetchConsumptionOverview).mockResolvedValue(new Ok(OVERVIEW));
     const { workspace } = await setupTest();
 
-    const response = await getOverviewRequest(workspace.sId, {
+    const response = await postOverviewRequest(workspace.sId, {
       period: "days",
-      days: "7",
-      filter: JSON.stringify({ agents: ["a1"], users: ["u1", "u2"] }),
+      days: 7,
+      filter: { agents: ["a1"], users: ["u1", "u2"] },
     });
 
     expect(response.status).toBe(200);
@@ -89,8 +90,8 @@ describe("GET /api/w/:wId/analytics/consumption/overview", () => {
   it("returns 400 on an unknown filter dimension", async () => {
     const { workspace } = await setupTest();
 
-    const response = await getOverviewRequest(workspace.sId, {
-      filter: JSON.stringify({ nope: ["x"] }),
+    const response = await postOverviewRequest(workspace.sId, {
+      filter: { nope: ["x"] },
     });
 
     expect(response.status).toBe(400);
@@ -106,7 +107,7 @@ describe("GET /api/w/:wId/analytics/consumption/overview", () => {
     );
     const { workspace } = await setupTest();
 
-    const response = await getOverviewRequest(workspace.sId);
+    const response = await postOverviewRequest(workspace.sId);
 
     expect(response.status).toBe(500);
     expect(await response.json()).toMatchObject({

--- a/front-api/routes/w/[wId]/analytics/consumption/overview.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.ts
@@ -1,7 +1,7 @@
 import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
 import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/overview";
 import {
-  ConsumptionQuerySchema,
+  ConsumptionBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import logger from "@app/logger/logger";
@@ -14,17 +14,17 @@ import { validate } from "@front-api/middlewares/validator";
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", ConsumptionQuerySchema),
+  validate("json", ConsumptionBodySchema),
   async (ctx): HandlerResult<GetConsumptionOverviewResponse> => {
     const auth = ctx.get("auth");
-    const query = ctx.req.valid("query");
+    const body = ctx.req.valid("json");
 
     const result = await fetchConsumptionOverview(auth, {
-      periodInput: toConsumptionPeriodInput(query),
-      filter: query.filter,
+      periodInput: toConsumptionPeriodInput(body),
+      filter: body.filter,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/timeseries.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/timeseries.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionQuerySchema,
+  ConsumptionBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import {
@@ -22,7 +22,7 @@ import { z } from "zod";
 
 export type { GetConsumptionTimeseriesResponse };
 
-const QuerySchema = ConsumptionQuerySchema.extend({
+const BodySchema = ConsumptionBodySchema.extend({
   granularity: z.enum(["day", "week", "month"]).optional().default("day"),
   mode: z.enum(["daily", "cumulative"]).optional().default("daily"),
   metric: z
@@ -32,7 +32,7 @@ const QuerySchema = ConsumptionQuerySchema.extend({
   // Absent means a single total series. Every dimension the query can be
   // filtered on can also be broken down by.
   breakdownBy: z.enum(CONSUMPTION_SCOPE_DIMENSIONS).optional(),
-  breakdownCount: z.coerce
+  breakdownCount: z
     .number()
     .int()
     .positive()
@@ -45,10 +45,10 @@ const QuerySchema = ConsumptionQuerySchema.extend({
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", QuerySchema),
+  validate("json", BodySchema),
   async (ctx): HandlerResult<GetConsumptionTimeseriesResponse> => {
     const auth = ctx.get("auth");
     const {
@@ -59,7 +59,7 @@ app.get(
       breakdownCount,
       filter,
       ...periodQuery
-    } = ctx.req.valid("query");
+    } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,

--- a/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopQuerySchema,
+  ConsumptionTopBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
@@ -17,13 +17,13 @@ export type { GetConsumptionTopAgentsResponse };
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", ConsumptionTopQuerySchema),
+  validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopAgentsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, filter, ...periodQuery } = ctx.req.valid("query");
+    const { limit, filter, ...periodQuery } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,

--- a/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopQuerySchema,
+  ConsumptionTopBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
@@ -17,13 +17,13 @@ export type { GetConsumptionTopGroupsResponse };
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", ConsumptionTopQuerySchema),
+  validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopGroupsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, filter, ...periodQuery } = ctx.req.valid("query");
+    const { limit, filter, ...periodQuery } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,

--- a/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopQuerySchema,
+  ConsumptionTopBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
@@ -17,13 +17,13 @@ export type { GetConsumptionTopModelsResponse };
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", ConsumptionTopQuerySchema),
+  validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopModelsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, filter, ...periodQuery } = ctx.req.valid("query");
+    const { limit, filter, ...periodQuery } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,

--- a/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopQuerySchema,
+  ConsumptionTopBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";
@@ -17,13 +17,13 @@ export type { GetConsumptionTopSkillsResponse };
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", ConsumptionTopQuerySchema),
+  validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSkillsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, filter, ...periodQuery } = ctx.req.valid("query");
+    const { limit, filter, ...periodQuery } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,

--- a/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopQuerySchema,
+  ConsumptionTopBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopSourcesResponse } from "@app/lib/api/analytics/consumption/top_sources";
@@ -17,13 +17,13 @@ export type { GetConsumptionTopSourcesResponse };
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", ConsumptionTopQuerySchema),
+  validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSourcesResponse> => {
     const auth = ctx.get("auth");
-    const { limit, filter, ...periodQuery } = ctx.req.valid("query");
+    const { limit, filter, ...periodQuery } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,

--- a/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopQuerySchema,
+  ConsumptionTopBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopToolsResponse } from "@app/lib/api/analytics/consumption/top_tools";
@@ -17,13 +17,13 @@ export type { GetConsumptionTopToolsResponse };
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", ConsumptionTopQuerySchema),
+  validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopToolsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, filter, ...periodQuery } = ctx.req.valid("query");
+    const { limit, filter, ...periodQuery } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,

--- a/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
@@ -1,6 +1,6 @@
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionTopQuerySchema,
+  ConsumptionTopBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTopUsersResponse } from "@app/lib/api/analytics/consumption/top_users";
@@ -17,13 +17,13 @@ export type { GetConsumptionTopUsersResponse };
 const app = workspaceApp();
 
 /** @ignoreswagger */
-app.get(
+app.post(
   "/",
   ensureIsManager(),
-  validate("query", ConsumptionTopQuerySchema),
+  validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopUsersResponse> => {
     const auth = ctx.get("auth");
-    const { limit, filter, ...periodQuery } = ctx.req.valid("query");
+    const { limit, filter, ...periodQuery } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -261,18 +261,19 @@ async function setupTest({
   return createPrivateApiMockRequest({ role });
 }
 
-function getRankingRequest(
+function postRankingRequest(
   wId: string,
   path: string,
-  query: Record<string, string> = {}
+  body: Record<string, unknown> = {}
 ) {
-  const qs = new URLSearchParams(query).toString();
-  return honoApp.request(
-    `/api/w/${wId}/analytics/consumption/${path}${qs ? `?${qs}` : ""}`
-  );
+  return honoApp.request(`/api/w/${wId}/analytics/consumption/${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
 }
 
-describe("GET /api/w/:wId/analytics/consumption/top-*", () => {
+describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
   it.each(
     RANKINGS
   )("$path is mounted, returns the ranking and defaults its period and limit", async ({
@@ -284,7 +285,7 @@ describe("GET /api/w/:wId/analytics/consumption/top-*", () => {
     arrangeOk();
     const { workspace } = await setupTest({ role: "admin" });
 
-    const response = await getRankingRequest(workspace.sId, path);
+    const response = await postRankingRequest(workspace.sId, path);
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(body);
@@ -299,7 +300,7 @@ describe("GET /api/w/:wId/analytics/consumption/top-*", () => {
   it.each(RANKINGS)("$path is refused to non-managers", async ({ path }) => {
     const { workspace } = await setupTest({ role: "user" });
 
-    const response = await getRankingRequest(workspace.sId, path);
+    const response = await postRankingRequest(workspace.sId, path);
 
     expect(response.status).toBe(403);
   });
@@ -308,11 +309,11 @@ describe("GET /api/w/:wId/analytics/consumption/top-*", () => {
     vi.mocked(fetchConsumptionTopAgents).mockResolvedValue(new Ok(TOP_AGENTS));
     const { workspace } = await setupTest();
 
-    const response = await getRankingRequest(workspace.sId, "top-agents", {
-      limit: "5",
+    const response = await postRankingRequest(workspace.sId, "top-agents", {
+      limit: 5,
       period: "days",
-      days: "7",
-      filter: JSON.stringify({ sources: ["slack"] }),
+      days: 7,
+      filter: { sources: ["slack"] },
     });
 
     expect(response.status).toBe(200);
@@ -328,8 +329,8 @@ describe("GET /api/w/:wId/analytics/consumption/top-*", () => {
   it("returns 400 on a limit above the cap", async () => {
     const { workspace } = await setupTest();
 
-    const response = await getRankingRequest(workspace.sId, "top-agents", {
-      limit: "1000",
+    const response = await postRankingRequest(workspace.sId, "top-agents", {
+      limit: 1000,
     });
 
     expect(response.status).toBe(400);
@@ -344,7 +345,7 @@ describe("GET /api/w/:wId/analytics/consumption/top-*", () => {
     );
     const { workspace } = await setupTest();
 
-    const response = await getRankingRequest(workspace.sId, "top-tools");
+    const response = await postRankingRequest(workspace.sId, "top-tools");
 
     expect(response.status).toBe(500);
     expect(await response.json()).toMatchObject({

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -5,7 +5,6 @@ import type {
   UsageModelTier,
 } from "@app/components/workspace/analytics/usageFilter";
 import {
-  MAX_USAGE_FILTER_SELECTIONS,
   toConsumptionScopeFilter,
   USAGE_FILTER_CATEGORIES,
   USAGE_FILTER_CATEGORY_LABEL,
@@ -149,17 +148,8 @@ export function UsageFilterPanel({
   const enabledFilteredOptions = filteredOptions.filter(
     (option) => !option.disabled
   );
-  const draftSelectionCount = usageFilterSelectionCount(draftFilter);
-  const remainingSelectionCapacity = Math.max(
-    0,
-    MAX_USAGE_FILTER_SELECTIONS - draftSelectionCount
-  );
   const unselectedEnabledOptions = enabledFilteredOptions.filter(
     (option) => !selectedIdsForActiveCategory.has(option.id)
-  );
-  const bulkSelectableOptions = unselectedEnabledOptions.slice(
-    0,
-    remainingSelectionCapacity
   );
 
   const appliedSelectionCount = usageFilterSelectionCount(filter);
@@ -245,7 +235,6 @@ export function UsageFilterPanel({
                 onToggleModel={(model) => toggleOption("model", model)}
                 activeTier={activeTier}
                 onTierChange={setActiveTier}
-                isSelectionLimitReached={remainingSelectionCapacity === 0}
               />
             )}
             {activeCategory === "agent" && (
@@ -269,18 +258,10 @@ export function UsageFilterPanel({
                   toggleOption(activeCategory, option)
                 }
                 onSelectAll={() =>
-                  selectAllFiltered(activeCategory, bulkSelectableOptions)
+                  selectAllFiltered(activeCategory, unselectedEnabledOptions)
                 }
-                selectAllLabel={
-                  remainingSelectionCapacity === 0
-                    ? "Limit reached"
-                    : unselectedEnabledOptions.length >
-                        remainingSelectionCapacity
-                      ? `Select next ${remainingSelectionCapacity}`
-                      : "Select all"
-                }
-                hasSelectableOptions={bulkSelectableOptions.length > 0}
-                isSelectionLimitReached={remainingSelectionCapacity === 0}
+                selectAllLabel="Select all"
+                hasSelectableOptions={unselectedEnabledOptions.length > 0}
                 isLoading={isFacetsLoading}
                 isUpdating={isFacetsValidating}
               />

--- a/front/components/workspace/analytics/usageFilter.test.ts
+++ b/front/components/workspace/analytics/usageFilter.test.ts
@@ -1,10 +1,4 @@
-import type { UsageFilterSourceOption } from "@app/components/workspace/analytics/usageFilter";
-import {
-  MAX_USAGE_FILTER_SELECTIONS,
-  selectAllUsageFilterOptions,
-  toConsumptionScopeFilter,
-  toggleUsageFilterOption,
-} from "@app/components/workspace/analytics/usageFilter";
+import { toConsumptionScopeFilter } from "@app/components/workspace/analytics/usageFilter";
 import { describe, expect, it } from "vitest";
 
 describe("toConsumptionScopeFilter", () => {
@@ -72,28 +66,5 @@ describe("toConsumptionScopeFilter", () => {
 
   it("omits empty member and group selections", () => {
     expect(toConsumptionScopeFilter({ member: [], group: [] })).toEqual({});
-  });
-
-  it("bounds the total number of selections serialized into analytics URLs", () => {
-    const options: UsageFilterSourceOption[] = Array.from(
-      { length: MAX_USAGE_FILTER_SELECTIONS + 5 },
-      (_, index) => ({
-        id: `source-${index}`,
-        name: `Source ${index}`,
-        kind: "source",
-        connectorProvider: undefined,
-        documentCount: 1,
-        disabled: false,
-      })
-    );
-    const atLimit = selectAllUsageFilterOptions({}, "source", options);
-
-    expect(atLimit.source).toHaveLength(MAX_USAGE_FILTER_SELECTIONS);
-    expect(toggleUsageFilterOption(atLimit, "source", options.at(-1)!)).toBe(
-      atLimit
-    );
-    expect(
-      toggleUsageFilterOption(atLimit, "source", options[0]).source
-    ).toHaveLength(MAX_USAGE_FILTER_SELECTIONS - 1);
   });
 });

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -16,10 +16,6 @@ export const USAGE_FILTER_CATEGORIES = [
   "source",
 ] as const;
 
-// Consumption widgets currently serialize their filters into GET query
-// strings. Keep the total bounded until those reads move to POST bodies.
-export const MAX_USAGE_FILTER_SELECTIONS = 50;
-
 export type UsageFilterCategory = (typeof USAGE_FILTER_CATEGORIES)[number];
 
 export const USAGE_FILTER_CATEGORY_LABEL: Record<UsageFilterCategory, string> =
@@ -133,12 +129,6 @@ export function toggleUsageFilterOption<C extends UsageFilterCategory>(
 ): UsageFilter {
   const current = filter[category] ?? [];
   const isSelected = current.some((e) => e.id === option.id);
-  if (
-    !isSelected &&
-    usageFilterSelectionCount(filter) >= MAX_USAGE_FILTER_SELECTIONS
-  ) {
-    return filter;
-  }
   const next = isSelected
     ? current.filter((e) => e.id !== option.id)
     : [...current, option];
@@ -168,13 +158,7 @@ export function selectAllUsageFilterOptions<C extends UsageFilterCategory>(
 ): UsageFilter {
   const current = filter[category] ?? [];
   const currentIds = new Set(current.map((e) => e.id));
-  const remainingCapacity = Math.max(
-    0,
-    MAX_USAGE_FILTER_SELECTIONS - usageFilterSelectionCount(filter)
-  );
-  const additions = options
-    .filter((e) => !currentIds.has(e.id))
-    .slice(0, remainingCapacity);
+  const additions = options.filter((e) => !currentIds.has(e.id));
   if (additions.length === 0) {
     return filter;
   }

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -45,7 +45,6 @@ interface UsageFilterModelComplexityControlsProps {
   onToggleModel: (model: UsageFilterModelOption) => void;
   activeTier: UsageModelTier;
   onTierChange: (tier: UsageModelTier) => void;
-  isSelectionLimitReached: boolean;
 }
 
 function getModelSelectionStatus({
@@ -75,7 +74,6 @@ export function UsageFilterModelComplexityControls({
   onToggleModel,
   activeTier,
   onTierChange,
-  isSelectionLimitReached,
 }: UsageFilterModelComplexityControlsProps) {
   const { isDark } = useTheme();
   const [isMoreModelsOpen, setIsMoreModelsOpen] = useState(false);
@@ -109,8 +107,7 @@ export function UsageFilterModelComplexityControls({
     return labModels.length > 0 ? [{ lab, models: labModels }] : [];
   });
   const isModelSelectionDisabled = (model: UsageFilterModelOption) =>
-    (model.disabled || isSelectionLimitReached) &&
-    !selectedModelIds.has(model.id);
+    model.disabled && !selectedModelIds.has(model.id);
 
   return (
     <>

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList.tsx
@@ -24,7 +24,6 @@ interface UsageFilterOptionCheckboxListProps {
   onSelectAll: () => void;
   selectAllLabel: string;
   hasSelectableOptions: boolean;
-  isSelectionLimitReached: boolean;
   isLoadingMore?: boolean;
   isLoading?: boolean;
   isUpdating?: boolean;
@@ -39,7 +38,6 @@ export function UsageFilterOptionCheckboxList({
   onSelectAll,
   selectAllLabel,
   hasSelectableOptions,
-  isSelectionLimitReached,
   isLoadingMore = false,
   isLoading = false,
   isUpdating = false,
@@ -66,11 +64,6 @@ export function UsageFilterOptionCheckboxList({
             {isUpdating && (
               <span className="text-xs text-muted-foreground">Updating…</span>
             )}
-            {isSelectionLimitReached && !isUpdating && (
-              <span className="text-xs text-muted-foreground">
-                Selection limit reached
-              </span>
-            )}
             <Button
               label={selectAllLabel}
               size="xmini"
@@ -94,8 +87,7 @@ export function UsageFilterOptionCheckboxList({
           <>
             {displayedOptions.map((option) => {
               const checked = selectedIds.has(option.id);
-              const disabled =
-                (option.disabled || isSelectionLimitReached) && !checked;
+              const disabled = option.disabled && !checked;
               const checkboxId = `usage-filter-option-${category}-${option.id}`;
               const availabilityDescriptionId = option.disabled
                 ? `${checkboxId}-availability`

--- a/front/hooks/useConsumptionFacets.ts
+++ b/front/hooks/useConsumptionFacets.ts
@@ -10,16 +10,15 @@ import type {
   UsageFilterToolOption,
 } from "@app/components/workspace/analytics/usageFilter";
 import { usageModelTierFromModelsTierName } from "@app/components/workspace/analytics/usageFilter";
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionFacetsResponse } from "@app/lib/api/analytics/consumption/facets";
-import type { ConsumptionFacetsBody } from "@app/lib/api/analytics/consumption/schema";
+import type { ConsumptionBody } from "@app/lib/api/analytics/consumption/schema";
 import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
-import { CONSUMPTION_SCOPE_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { isConnectorProvider } from "@app/types/data_source";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useSWRConfig } from "swr";
+import { useMemo } from "react";
 
 export type ConsumptionFacetOptions = {
   [C in UsageFilterCategory]: UsageFilterOptionForCategory<C>[];
@@ -34,43 +33,6 @@ const EMPTY_FACET_OPTIONS: ConsumptionFacetOptions = {
   skill: [],
   source: [],
 };
-
-const FACET_FILTER_DEBOUNCE_MS = 300;
-
-function normalizedFilter(
-  filter: ConsumptionScopeFilter | undefined
-): ConsumptionScopeFilter | undefined {
-  if (!filter) {
-    return undefined;
-  }
-
-  const normalized: ConsumptionScopeFilter = {};
-  for (const key of CONSUMPTION_SCOPE_FILTER_KEYS) {
-    const values = filter[key];
-    if (values && values.length > 0) {
-      normalized[key] = [...values].sort();
-    }
-  }
-  return normalized;
-}
-
-function useDebouncedValue<T>(value: T, delay: number) {
-  const [debouncedValue, setDebouncedValue] = useState(value);
-
-  useEffect(() => {
-    if (Object.is(value, debouncedValue)) {
-      return;
-    }
-
-    const timeout = setTimeout(() => setDebouncedValue(value), delay);
-    return () => clearTimeout(timeout);
-  }, [debouncedValue, delay, value]);
-
-  return {
-    debouncedValue,
-    isDebouncing: !Object.is(value, debouncedValue),
-  };
-}
 
 function baseOption(facet: {
   value: string;
@@ -142,73 +104,18 @@ export function useConsumptionFacets({
   filter?: ConsumptionScopeFilter;
   disabled?: boolean;
 }) {
-  const { fetcherWithBody } = useFetcher();
-  const { cache } = useSWRConfig();
-  const requestControllerRef = useRef<AbortController | null>(null);
-  const previousCacheKeyRef = useRef<string | null>(null);
   const url = `/api/w/${workspaceId}/analytics/consumption/facets`;
-  const bodyKey = JSON.stringify({
+  const body: ConsumptionBody = {
     period: period.kind,
     days:
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
-    filter: normalizedFilter(filter),
-  } satisfies ConsumptionFacetsBody);
-  const { debouncedValue: debouncedBodyKey, isDebouncing } = useDebouncedValue(
-    bodyKey,
-    FACET_FILTER_DEBOUNCE_MS
-  );
-  const cacheKey = JSON.stringify([url, debouncedBodyKey]);
+    filter: normalizedConsumptionFilter(filter),
+  };
 
-  const fetchFacets =
-    useCallback(async (): Promise<GetConsumptionFacetsResponse> => {
-      requestControllerRef.current?.abort();
-      const controller = new AbortController();
-      requestControllerRef.current = controller;
-
-      try {
-        const body = JSON.parse(debouncedBodyKey) as ConsumptionFacetsBody;
-        return await fetcherWithBody([url, body, "POST"], {
-          signal: controller.signal,
-        });
-      } finally {
-        if (requestControllerRef.current === controller) {
-          requestControllerRef.current = null;
-        }
-      }
-    }, [debouncedBodyKey, fetcherWithBody, url]);
-
-  useEffect(() => {
-    if (disabled || isDebouncing) {
-      requestControllerRef.current?.abort();
-    }
-  }, [disabled, isDebouncing]);
-
-  useEffect(() => {
-    const previousCacheKey = previousCacheKeyRef.current;
-    if (previousCacheKey && previousCacheKey !== cacheKey) {
-      cache.delete(previousCacheKey);
-    }
-    previousCacheKeyRef.current = cacheKey;
-  }, [cache, cacheKey]);
-
-  useEffect(
-    () => () => {
-      requestControllerRef.current?.abort();
-    },
-    []
-  );
-
-  const { data, error, isValidating } = useSWRWithDefaults(
-    cacheKey,
-    fetchFacets,
-    {
-      disabled: disabled || isDebouncing,
-      errorRetryCount: 0,
-      keepPreviousData: true,
-      revalidateOnFocus: false,
-      revalidateOnReconnect: false,
-    }
-  );
+  const { data, error, isValidating } = useConsumptionQuery<
+    ConsumptionBody,
+    GetConsumptionFacetsResponse
+  >({ url, body, disabled });
 
   const options = useMemo(
     () => (data ? toFacetOptions(data) : EMPTY_FACET_OPTIONS),
@@ -219,6 +126,6 @@ export function useConsumptionFacets({
     options,
     isFacetsLoading: !error && !data && !disabled,
     isFacetsError: error,
-    isFacetsValidating: isValidating || isDebouncing,
+    isFacetsValidating: isValidating,
   };
 }

--- a/front/hooks/useConsumptionOverview.ts
+++ b/front/hooks/useConsumptionOverview.ts
@@ -1,9 +1,10 @@
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
+import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
+import type { ConsumptionBody } from "@app/lib/api/analytics/consumption/schema";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { Fetcher } from "swr";
 
 export function useConsumptionOverview({
   workspaceId,
@@ -16,14 +17,18 @@ export function useConsumptionOverview({
   filter?: ConsumptionScopeFilter;
   disabled?: boolean;
 }) {
-  const { fetcher } = useFetcher();
-  const overviewFetcher: Fetcher<GetConsumptionOverviewResponse> = fetcher;
+  const url = `/api/w/${workspaceId}/analytics/consumption/overview`;
+  const body: ConsumptionBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+  };
 
-  const { data, error, isValidating } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/analytics/consumption/overview?${consumptionQueryString(period, filter)}`,
-    overviewFetcher,
-    { disabled }
-  );
+  const { data, error, isValidating } = useConsumptionQuery<
+    ConsumptionBody,
+    GetConsumptionOverviewResponse
+  >({ url, body, disabled });
 
   return {
     overview: data ?? null,

--- a/front/hooks/useConsumptionQuery.ts
+++ b/front/hooks/useConsumptionQuery.ts
@@ -1,0 +1,102 @@
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useSWRConfig } from "swr";
+
+const CONSUMPTION_FILTER_DEBOUNCE_MS = 300;
+
+function useDebouncedValue<T>(value: T, delayMs: number) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    if (Object.is(value, debouncedValue)) {
+      return;
+    }
+
+    const timeout = setTimeout(() => setDebouncedValue(value), delayMs);
+    return () => clearTimeout(timeout);
+  }, [debouncedValue, delayMs, value]);
+
+  return {
+    debouncedValue,
+    isDebouncing: !Object.is(value, debouncedValue),
+  };
+}
+
+// Shared by every consumption analytics widget: the filter travels as a POST
+// body instead of a query string, since it can select more values than fit
+// in a URL. The filter changes on every checkbox toggle, so requests are
+// debounced and a superseded request is aborted before it can race a fresher
+// one into the cache.
+export function useConsumptionQuery<TBody extends object, TResponse>({
+  url,
+  body,
+  disabled,
+}: {
+  url: string;
+  body: TBody;
+  disabled?: boolean;
+}) {
+  const { fetcherWithBody } = useFetcher();
+  const { cache } = useSWRConfig();
+  const requestControllerRef = useRef<AbortController | null>(null);
+  const previousCacheKeyRef = useRef<string | null>(null);
+
+  const bodyKey = JSON.stringify(body);
+  const { debouncedValue: debouncedBodyKey, isDebouncing } = useDebouncedValue(
+    bodyKey,
+    CONSUMPTION_FILTER_DEBOUNCE_MS
+  );
+  const cacheKey = JSON.stringify([url, debouncedBodyKey]);
+
+  const fetchData = useCallback(async (): Promise<TResponse> => {
+    requestControllerRef.current?.abort();
+    const controller = new AbortController();
+    requestControllerRef.current = controller;
+
+    try {
+      return await fetcherWithBody(
+        [url, JSON.parse(debouncedBodyKey), "POST"],
+        { signal: controller.signal }
+      );
+    } finally {
+      if (requestControllerRef.current === controller) {
+        requestControllerRef.current = null;
+      }
+    }
+  }, [debouncedBodyKey, fetcherWithBody, url]);
+
+  useEffect(() => {
+    if (disabled || isDebouncing) {
+      requestControllerRef.current?.abort();
+    }
+  }, [disabled, isDebouncing]);
+
+  useEffect(() => {
+    const previousCacheKey = previousCacheKeyRef.current;
+    if (previousCacheKey && previousCacheKey !== cacheKey) {
+      cache.delete(previousCacheKey);
+    }
+    previousCacheKeyRef.current = cacheKey;
+  }, [cache, cacheKey]);
+
+  useEffect(
+    () => () => {
+      requestControllerRef.current?.abort();
+    },
+    []
+  );
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    cacheKey,
+    fetchData,
+    {
+      disabled: disabled || isDebouncing,
+      errorRetryCount: 0,
+      keepPreviousData: true,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
+
+  return { data, error, isValidating: isValidating || isDebouncing };
+}

--- a/front/hooks/useConsumptionQuery.ts
+++ b/front/hooks/useConsumptionQuery.ts
@@ -40,6 +40,9 @@ export function useConsumptionQuery<TBody extends object, TResponse>({
   const { cache } = useSWRConfig();
   const requestControllerRef = useRef<AbortController | null>(null);
   const previousCacheKeyRef = useRef<string | null>(null);
+  const unmountAbortTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
 
   const bodyKey = JSON.stringify(body);
   const { debouncedValue: debouncedBodyKey, isDebouncing } = useDebouncedValue(
@@ -79,12 +82,29 @@ export function useConsumptionQuery<TBody extends object, TResponse>({
     previousCacheKeyRef.current = cacheKey;
   }, [cache, cacheKey]);
 
-  useEffect(
-    () => () => {
-      requestControllerRef.current?.abort();
-    },
-    []
-  );
+  // Cancels the in-flight request on a real unmount, e.g. when the user
+  // switches period/filter fast enough to tear this widget down mid-request:
+  // without this, a slow response could still land after the fact and
+  // overwrite the cache with data for a view the user already left.
+  // Deferred so StrictMode's dev-only mount -> cleanup -> mount replay can
+  // cancel the timeout first instead of aborting the request before it
+  // reaches the network. Without this, local dev (StrictMode) breaks every
+  // request; prod is unaffected. Recreating the controller per-effect (as a
+  // plain fetch-in-effect would) isn't an option: SWR treats this request as
+  // already cached for the replay's second mount, so it would never fire a
+  // second one to replace the one we just aborted.
+  useEffect(() => {
+    if (unmountAbortTimeoutRef.current !== null) {
+      clearTimeout(unmountAbortTimeoutRef.current);
+      unmountAbortTimeoutRef.current = null;
+    }
+
+    return () => {
+      unmountAbortTimeoutRef.current = setTimeout(() => {
+        requestControllerRef.current?.abort();
+      }, 0);
+    };
+  }, []);
 
   const { data, error, isValidating } = useSWRWithDefaults(
     cacheKey,

--- a/front/hooks/useConsumptionTimeseries.ts
+++ b/front/hooks/useConsumptionTimeseries.ts
@@ -1,13 +1,20 @@
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
+import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionBody } from "@app/lib/api/analytics/consumption/schema";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type {
   ConsumptionBreakdownDimension,
   ConsumptionTimeseriesMode,
   GetConsumptionTimeseriesResponse,
 } from "@app/lib/api/analytics/consumption/timeseries";
-import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { Fetcher } from "swr";
+
+type ConsumptionTimeseriesBody = ConsumptionBody & {
+  mode: ConsumptionTimeseriesMode;
+  breakdownBy?: ConsumptionBreakdownDimension;
+  breakdownCount?: number;
+};
 
 export function useConsumptionTimeseries({
   workspaceId,
@@ -27,23 +34,21 @@ export function useConsumptionTimeseries({
   filter?: ConsumptionScopeFilter;
   disabled?: boolean;
 }) {
-  const { fetcher } = useFetcher();
-  const timeseriesFetcher: Fetcher<GetConsumptionTimeseriesResponse> = fetcher;
+  const url = `/api/w/${workspaceId}/analytics/consumption/timeseries`;
+  const body: ConsumptionTimeseriesBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+    mode,
+    breakdownBy,
+    breakdownCount,
+  };
 
-  const params = new URLSearchParams(consumptionQueryString(period, filter));
-  params.set("mode", mode);
-  if (breakdownBy) {
-    params.set("breakdownBy", breakdownBy);
-  }
-  if (breakdownCount !== undefined) {
-    params.set("breakdownCount", String(breakdownCount));
-  }
-
-  const { data, error, isValidating } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/analytics/consumption/timeseries?${params.toString()}`,
-    timeseriesFetcher,
-    { disabled }
-  );
+  const { data, error, isValidating } = useConsumptionQuery<
+    ConsumptionTimeseriesBody,
+    GetConsumptionTimeseriesResponse
+  >({ url, body, disabled });
 
   return {
     timeseries: data ?? null,

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -1,6 +1,9 @@
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
+import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionTopBody } from "@app/lib/api/analytics/consumption/schema";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
 import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
@@ -9,10 +12,9 @@ import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/con
 import type { GetConsumptionTopSourcesResponse } from "@app/lib/api/analytics/consumption/top_sources";
 import type { GetConsumptionTopToolsResponse } from "@app/lib/api/analytics/consumption/top_tools";
 import type { GetConsumptionTopUsersResponse } from "@app/lib/api/analytics/consumption/top_users";
-import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { emptyArray } from "@app/lib/swr/swr";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { useMemo } from "react";
-import type { Fetcher } from "swr";
 
 const CONSUMPTION_TOP_ENDPOINTS = {
   agent: "top-agents",
@@ -129,18 +131,19 @@ export function useConsumptionTop({
   filter?: ConsumptionScopeFilter;
   disabled?: boolean;
 }) {
-  const { fetcher } = useFetcher();
-  const topFetcher: Fetcher<ConsumptionTopResponse> = fetcher;
+  const url = `/api/w/${workspaceId}/analytics/consumption/${CONSUMPTION_TOP_ENDPOINTS[dimension]}`;
+  const body: ConsumptionTopBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+    limit,
+  };
 
-  const params = new URLSearchParams(consumptionQueryString(period, filter));
-  params.set("limit", String(limit));
-
-  const { data, error, isValidating } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/analytics/consumption/` +
-      `${CONSUMPTION_TOP_ENDPOINTS[dimension]}?${params.toString()}`,
-    topFetcher,
-    { disabled }
-  );
+  const { data, error, isValidating } = useConsumptionQuery<
+    ConsumptionTopBody,
+    ConsumptionTopResponse
+  >({ url, body, disabled });
 
   const rows = useMemo(
     () => (data ? toRows(data) : emptyArray<ConsumptionTopRow>()),

--- a/front/lib/analytics/consumption_period.ts
+++ b/front/lib/analytics/consumption_period.ts
@@ -55,7 +55,7 @@ export function consumptionPeriodFromKey(
 }
 
 // Sorted, empty-dimension-free filter, so the same selection always produces
-// the same request body — needed for the SWR cache key to stay stable.
+// the same request body, needed for the SWR cache key to stay stable.
 export function normalizedConsumptionFilter(
   filter: ConsumptionScopeFilter | undefined
 ): ConsumptionScopeFilter | undefined {

--- a/front/lib/analytics/consumption_period.ts
+++ b/front/lib/analytics/consumption_period.ts
@@ -1,4 +1,5 @@
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { CONSUMPTION_SCOPE_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 
 export const CONSUMPTION_PERIOD_DAY_OPTIONS = [7, 30, 90] as const;
 
@@ -53,21 +54,21 @@ export function consumptionPeriodFromKey(
   );
 }
 
-/**
- * Query string shared by every consumption endpoint. Kept in one place so the
- * SWR keys of the different widgets stay in sync — two widgets disagreeing on
- * the window would show numbers that do not add up.
- */
-export function consumptionQueryString(
-  selection: ConsumptionPeriodSelection,
-  filter?: ConsumptionScopeFilter
-): string {
-  const params = new URLSearchParams({ period: selection.kind });
-  if (selection.kind === "days") {
-    params.set("days", String(selection.days));
+// Sorted, empty-dimension-free filter, so the same selection always produces
+// the same request body — needed for the SWR cache key to stay stable.
+export function normalizedConsumptionFilter(
+  filter: ConsumptionScopeFilter | undefined
+): ConsumptionScopeFilter | undefined {
+  if (!filter) {
+    return undefined;
   }
-  if (filter && Object.keys(filter).length > 0) {
-    params.set("filter", JSON.stringify(filter));
+
+  const normalized: ConsumptionScopeFilter = {};
+  for (const key of CONSUMPTION_SCOPE_FILTER_KEYS) {
+    const values = filter[key];
+    if (values && values.length > 0) {
+      normalized[key] = [...values].sort();
+    }
   }
-  return params.toString();
+  return normalized;
 }

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -23,38 +23,20 @@ const ConsumptionPeriodSchema = z.object({
     .default(DEFAULT_CONSUMPTION_PERIOD_DAYS),
 });
 
-export const ConsumptionQuerySchema = ConsumptionPeriodSchema.extend({
-  // JSON-encoded, mirroring the existing analytics filter query param: the
-  // filter is a map of dimension to selected ids and does not flatten well
-  // into repeated query params.
-  filter: z
-    .string()
-    .optional()
-    .transform((value) => {
-      if (!value) {
-        return undefined;
-      }
-      try {
-        return JSON.parse(value);
-      } catch {
-        return value; // Return the original so validation fails below.
-      }
-    })
-    .pipe(ConsumptionFilterSchema.optional()),
-});
-
-export type ConsumptionQuery = z.infer<typeof ConsumptionQuerySchema>;
-
-export const ConsumptionFacetsBodySchema = ConsumptionPeriodSchema.extend({
+// Every consumption endpoint takes at least this body: the period and the
+// filter (a map of dimension to selected ids). All of them are POST so the
+// filter can travel in the JSON body instead of a URL, which would cap the
+// number of selectable filter values.
+export const ConsumptionBodySchema = ConsumptionPeriodSchema.extend({
   filter: ConsumptionFilterSchema.optional(),
 });
 
-export type ConsumptionFacetsBody = z.infer<typeof ConsumptionFacetsBodySchema>;
+export type ConsumptionBody = z.infer<typeof ConsumptionBodySchema>;
 
-// Every `top-*` endpoint takes the same query: the period and the filters of any
-// consumption endpoint, plus how many rows to rank.
-export const ConsumptionTopQuerySchema = ConsumptionQuerySchema.extend({
-  limit: z.coerce
+// Every `top-*` endpoint takes the same body as any other consumption
+// endpoint, plus how many rows to rank.
+export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
+  limit: z
     .number()
     .int()
     .positive()
@@ -63,9 +45,11 @@ export const ConsumptionTopQuerySchema = ConsumptionQuerySchema.extend({
     .default(DEFAULT_CONSUMPTION_TOP_LIMIT),
 });
 
+export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;
+
 export function toConsumptionPeriodInput({
   period,
   days,
-}: Pick<ConsumptionQuery, "period" | "days">): ConsumptionPeriodInput {
+}: Pick<ConsumptionBody, "period" | "days">): ConsumptionPeriodInput {
   return period === "cycle" ? { kind: "cycle" } : { kind: "days", days };
 }


### PR DESCRIPTION
## Description

This PR removes the client-side 50-selection limit from the analytics usage filter panel. It is a follow-up to [#30405](https://github.com/dust-tt/dust/pull/30405), which moves the consumption endpoints from GET query strings to POST JSON bodies and removes the URL-length constraint that the cap was designed to protect against.

Until now, the filter helpers rejected additional selections after 50 total values, truncated “Select all” operations to the remaining capacity, disabled unchecked options at the limit, and displayed “Selection limit reached”. This PR removes that cap and the related UI state so users can select any number of available values and “Select all” selects all unselected enabled options. Existing option availability and disabled-option behavior remain unchanged.

This is a client-side-only cleanup in the stacked analytics refactor. It does not change persisted data or consumption response and authorization behavior. The larger filter selections rely on the POST-based consumption endpoints from #30405.

## Tests

The existing `front/components/workspace/analytics/usageFilter.test.ts` coverage was updated to remove the obsolete selection-cap assertion.

## Risk

Low. The user-visible behavior changes for workspaces selecting more than 50 filter values: those selections are now allowed and sent through the POST request path. The main compatibility dependency is #30405; deploying this change without the POST migration would leave the old URL-length constraint in place for larger filters. No migration, backfill, or persisted-data change is included, and reverting this PR restores the previous client-side cap.

## Deploy Plan

Deploy this follow-up after or together with [#30405](https://github.com/dust-tt/dust/pull/30405) so consumption analytics requests use POST JSON bodies before the client-side cap is removed. No special deployment steps were identified from the supplied context.