### PR TITLE
Rename consumption analytics teams to groups

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6203,7 +6203,7 @@
                           "type": "string"
                         }
                       },
-                      "teams": {
+                      "groups": {
                         "type": "array",
                         "items": {
                           "type": "string"
@@ -6279,7 +6279,7 @@
                       "required": [
                         "agent",
                         "user",
-                        "team",
+                        "group",
                         "model",
                         "tool",
                         "skill",
@@ -6298,7 +6298,7 @@
                             "$ref": "#/components/schemas/PrivateConsumptionFacet"
                           }
                         },
-                        "team": {
+                        "group": {
                           "type": "array",
                           "items": {
                             "$ref": "#/components/schemas/PrivateConsumptionFacet"

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
@@ -28,7 +28,7 @@ const RESPONSE: GetConsumptionFacetsResponse = {
       },
     ],
     user: [],
-    team: [],
+    group: [],
     model: [],
     tool: [],
     skill: [],

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.ts
@@ -55,7 +55,7 @@ const app = workspaceApp();
  *                     type: array
  *                     items:
  *                       type: string
- *                   teams:
+ *                   groups:
  *                     type: array
  *                     items:
  *                       type: string
@@ -98,7 +98,7 @@ const app = workspaceApp();
  *                       format: date-time
  *                 facets:
  *                   type: object
- *                   required: [agent, user, team, model, tool, skill, source]
+ *                   required: [agent, user, group, model, tool, skill, source]
  *                   properties:
  *                     agent:
  *                       type: array
@@ -108,7 +108,7 @@ const app = workspaceApp();
  *                       type: array
  *                       items:
  *                         $ref: '#/components/schemas/PrivateConsumptionFacet'
- *                     team:
+ *                     group:
  *                       type: array
  *                       items:
  *                         $ref: '#/components/schemas/PrivateConsumptionFacet'

--- a/front-api/routes/w/[wId]/analytics/consumption/index.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/index.ts
@@ -3,10 +3,10 @@ import facets from "./facets";
 import overview from "./overview";
 import timeseries from "./timeseries";
 import topAgents from "./top-agents";
+import topGroups from "./top-groups";
 import topModels from "./top-models";
 import topSkills from "./top-skills";
 import topSources from "./top-sources";
-import topTeams from "./top-teams";
 import topTools from "./top-tools";
 import topUsers from "./top-users";
 
@@ -19,7 +19,7 @@ app.route("/top-agents", topAgents);
 app.route("/top-models", topModels);
 app.route("/top-skills", topSkills);
 app.route("/top-sources", topSources);
-app.route("/top-teams", topTeams);
+app.route("/top-groups", topGroups);
 app.route("/top-tools", topTools);
 app.route("/top-users", topUsers);
 

--- a/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
@@ -3,17 +3,17 @@ import {
   ConsumptionTopQuerySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
-import type { GetConsumptionTopTeamsResponse } from "@app/lib/api/analytics/consumption/top_teams";
-import { fetchConsumptionTopTeams } from "@app/lib/api/analytics/consumption/top_teams";
+import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
+import { fetchConsumptionTopGroups } from "@app/lib/api/analytics/consumption/top_groups";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
-export type { GetConsumptionTopTeamsResponse };
+export type { GetConsumptionTopGroupsResponse };
 
-// Mounted at /api/w/:wId/analytics/consumption/top-teams.
+// Mounted at /api/w/:wId/analytics/consumption/top-groups.
 const app = workspaceApp();
 
 /** @ignoreswagger */
@@ -21,7 +21,7 @@ app.get(
   "/",
   ensureIsManager(),
   validate("query", ConsumptionTopQuerySchema),
-  async (ctx): HandlerResult<GetConsumptionTopTeamsResponse> => {
+  async (ctx): HandlerResult<GetConsumptionTopGroupsResponse> => {
     const auth = ctx.get("auth");
     const { limit, filter, ...periodQuery } = ctx.req.valid("query");
 
@@ -30,7 +30,7 @@ app.get(
       toConsumptionPeriodInput(periodQuery)
     );
 
-    const result = await fetchConsumptionTopTeams(auth, {
+    const result = await fetchConsumptionTopGroups(auth, {
       period,
       limit,
       filter,
@@ -41,13 +41,13 @@ app.get(
           workspaceId: auth.getNonNullableWorkspace().sId,
           err: result.error,
         },
-        "[ConsumptionAnalytics] Failed to retrieve top-teams."
+        "[ConsumptionAnalytics] Failed to retrieve top-groups."
       );
       return apiError(ctx, {
         status_code: 500,
         api_error: {
           type: "internal_server_error",
-          message: "Failed to retrieve top teams.",
+          message: "Failed to retrieve top groups.",
         },
       });
     }

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -4,6 +4,10 @@ import {
   type GetConsumptionTopAgentsResponse,
 } from "@app/lib/api/analytics/consumption/top_agents";
 import {
+  fetchConsumptionTopGroups,
+  type GetConsumptionTopGroupsResponse,
+} from "@app/lib/api/analytics/consumption/top_groups";
+import {
   fetchConsumptionTopModels,
   type GetConsumptionTopModelsResponse,
 } from "@app/lib/api/analytics/consumption/top_models";
@@ -15,10 +19,6 @@ import {
   fetchConsumptionTopSources,
   type GetConsumptionTopSourcesResponse,
 } from "@app/lib/api/analytics/consumption/top_sources";
-import {
-  fetchConsumptionTopTeams,
-  type GetConsumptionTopTeamsResponse,
-} from "@app/lib/api/analytics/consumption/top_teams";
 import {
   fetchConsumptionTopTools,
   type GetConsumptionTopToolsResponse,
@@ -63,10 +63,10 @@ vi.mock(
   }
 );
 vi.mock(
-  import("@app/lib/api/analytics/consumption/top_teams"),
+  import("@app/lib/api/analytics/consumption/top_groups"),
   async (orig) => {
     const mod = await orig();
-    return { ...mod, fetchConsumptionTopTeams: vi.fn() };
+    return { ...mod, fetchConsumptionTopGroups: vi.fn() };
   }
 );
 vi.mock(
@@ -147,12 +147,12 @@ const TOP_SOURCES: GetConsumptionTopSourcesResponse = {
   ],
 };
 
-const TOP_TEAMS: GetConsumptionTopTeamsResponse = {
+const TOP_GROUPS: GetConsumptionTopGroupsResponse = {
   period: PERIOD,
   totalCredits: 5000,
-  teams: [
+  groups: [
     {
-      teamId: "team1",
+      groupId: "group1",
       name: "Engineering",
       credits: 200,
       messageCount: 4,
@@ -227,11 +227,13 @@ const RANKINGS = [
     lastCall: () => vi.mocked(fetchConsumptionTopSources).mock.lastCall,
   },
   {
-    path: "top-teams",
-    body: TOP_TEAMS,
+    path: "top-groups",
+    body: TOP_GROUPS,
     arrangeOk: () =>
-      vi.mocked(fetchConsumptionTopTeams).mockResolvedValue(new Ok(TOP_TEAMS)),
-    lastCall: () => vi.mocked(fetchConsumptionTopTeams).mock.lastCall,
+      vi
+        .mocked(fetchConsumptionTopGroups)
+        .mockResolvedValue(new Ok(TOP_GROUPS)),
+    lastCall: () => vi.mocked(fetchConsumptionTopGroups).mock.lastCall,
   },
   {
     path: "top-tools",

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -8,7 +8,7 @@ export const DEFAULT_CONSUMPTION_DIMENSION: ConsumptionDimension = "agent";
 export const CONSUMPTION_DIMENSIONS: ConsumptionDimension[] = [
   "agent",
   "user",
-  "team",
+  "group",
   "model",
   "tool",
   "skill",
@@ -41,9 +41,9 @@ export const CONSUMPTION_DIMENSION_CONFIG: Record<
     hasAvatar: true,
     avgLabel: MESSAGE_AVG_LABEL,
   },
-  team: {
-    label: "Teams",
-    breakdownLabel: "team",
+  group: {
+    label: "Groups",
+    breakdownLabel: "group",
     hasAvatar: false,
     avgLabel: MESSAGE_AVG_LABEL,
   },

--- a/front/components/workspace/analytics/usageFilter.test.ts
+++ b/front/components/workspace/analytics/usageFilter.test.ts
@@ -21,11 +21,11 @@ describe("toConsumptionScopeFilter", () => {
             disabled: false,
           },
         ],
-        team: [
+        group: [
           {
-            id: "team-1",
+            id: "group-1",
             name: "Engineering",
-            kind: "team",
+            kind: "group",
             documentCount: 1,
             disabled: false,
           },
@@ -63,15 +63,15 @@ describe("toConsumptionScopeFilter", () => {
       })
     ).toEqual({
       users: ["member-1"],
-      teams: ["team-1"],
+      groups: ["group-1"],
       tools: ["tool-1"],
       skills: ["skill-1"],
       sources: ["slack"],
     });
   });
 
-  it("omits empty member and team selections", () => {
-    expect(toConsumptionScopeFilter({ member: [], team: [] })).toEqual({});
+  it("omits empty member and group selections", () => {
+    expect(toConsumptionScopeFilter({ member: [], group: [] })).toEqual({});
   });
 
   it("bounds the total number of selections serialized into analytics URLs", () => {

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -9,7 +9,7 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 export const USAGE_FILTER_CATEGORIES = [
   "agent",
   "member",
-  "team",
+  "group",
   "model",
   "tool",
   "skill",
@@ -26,7 +26,7 @@ export const USAGE_FILTER_CATEGORY_LABEL: Record<UsageFilterCategory, string> =
   {
     agent: "Agents",
     member: "Members",
-    team: "Teams",
+    group: "Groups",
     model: "Models",
     tool: "Tools",
     skill: "Skills",
@@ -69,8 +69,8 @@ export interface UsageFilterMemberOption extends UsageFilterOptionBase {
   image: string | null;
 }
 
-export interface UsageFilterTeamOption extends UsageFilterOptionBase {
-  kind: "team";
+export interface UsageFilterGroupOption extends UsageFilterOptionBase {
+  kind: "group";
 }
 
 export interface UsageFilterSourceOption extends UsageFilterOptionBase {
@@ -100,7 +100,7 @@ export interface UsageFilterSkillOption extends UsageFilterOptionBase {
 export type UsageFilterOption =
   | UsageFilterAgentOption
   | UsageFilterMemberOption
-  | UsageFilterTeamOption
+  | UsageFilterGroupOption
   | UsageFilterSourceOption
   | UsageFilterModelOption
   | UsageFilterToolOption

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon.tsx
@@ -48,7 +48,7 @@ export function UsageFilterOptionIcon({ option }: UsageFilterOptionIconProps) {
       ) : null;
     case "skill":
       return <Icon visual={getSkillIcon(option.icon)} size="sm" />;
-    case "team":
+    case "group":
       return null;
     default:
       assertNeverAndIgnore(option);

--- a/front/hooks/useConsumptionFacets.ts
+++ b/front/hooks/useConsumptionFacets.ts
@@ -1,12 +1,12 @@
 import type {
   UsageFilterAgentOption,
   UsageFilterCategory,
+  UsageFilterGroupOption,
   UsageFilterMemberOption,
   UsageFilterModelOption,
   UsageFilterOptionForCategory,
   UsageFilterSkillOption,
   UsageFilterSourceOption,
-  UsageFilterTeamOption,
   UsageFilterToolOption,
 } from "@app/components/workspace/analytics/usageFilter";
 import { usageModelTierFromModelsTierName } from "@app/components/workspace/analytics/usageFilter";
@@ -28,7 +28,7 @@ export type ConsumptionFacetOptions = {
 const EMPTY_FACET_OPTIONS: ConsumptionFacetOptions = {
   agent: [],
   member: [],
-  team: [],
+  group: [],
   model: [],
   tool: [],
   skill: [],
@@ -101,9 +101,9 @@ function toFacetOptions(
       kind: "member",
       image: facet.pictureUrl,
     })),
-    team: data.facets.team.map<UsageFilterTeamOption>((facet) => ({
+    group: data.facets.group.map<UsageFilterGroupOption>((facet) => ({
       ...baseOption(facet),
-      kind: "team",
+      kind: "group",
     })),
     model: data.facets.model.map<UsageFilterModelOption>((facet) => ({
       ...baseOption(facet),

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -3,10 +3,10 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { consumptionQueryString } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
+import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
 import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";
 import type { GetConsumptionTopSourcesResponse } from "@app/lib/api/analytics/consumption/top_sources";
-import type { GetConsumptionTopTeamsResponse } from "@app/lib/api/analytics/consumption/top_teams";
 import type { GetConsumptionTopToolsResponse } from "@app/lib/api/analytics/consumption/top_tools";
 import type { GetConsumptionTopUsersResponse } from "@app/lib/api/analytics/consumption/top_users";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -17,7 +17,7 @@ import type { Fetcher } from "swr";
 const CONSUMPTION_TOP_ENDPOINTS = {
   agent: "top-agents",
   user: "top-users",
-  team: "top-teams",
+  group: "top-groups",
   model: "top-models",
   tool: "top-tools",
   skill: "top-skills",
@@ -35,7 +35,7 @@ export type ConsumptionTopRow = {
 type ConsumptionTopResponse =
   | GetConsumptionTopAgentsResponse
   | GetConsumptionTopUsersResponse
-  | GetConsumptionTopTeamsResponse
+  | GetConsumptionTopGroupsResponse
   | GetConsumptionTopModelsResponse
   | GetConsumptionTopToolsResponse
   | GetConsumptionTopSkillsResponse
@@ -63,9 +63,9 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       avgCredits: row.avgCreditsPerMessage,
     }));
   }
-  if ("teams" in data) {
-    return data.teams.map((row) => ({
-      id: row.teamId,
+  if ("groups" in data) {
+    return data.groups.map((row) => ({
+      id: row.groupId,
       name: row.name,
       pictureUrl: null,
       modelMaker: null,

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -109,7 +109,7 @@ export async function listConsumptionFacetCatalog(
       label: member.fullName,
       pictureUrl: member.image,
     })),
-    team: groups.map((group) => ({
+    group: groups.map((group) => ({
       value: group.sId,
       label: group.name,
       pictureUrl: null,

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -84,7 +84,7 @@ describe("fetchConsumptionFacets", () => {
           pictureUrl: null,
         },
       ],
-      team: [],
+      group: [],
       model: [],
       tool: [],
       skill: [],

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -53,7 +53,7 @@ export type ConsumptionFacets = {
   facets: {
     agent: ConsumptionAgentFacet[];
     user: ConsumptionFacet[];
-    team: ConsumptionFacet[];
+    group: ConsumptionFacet[];
     model: ConsumptionModelFacet[];
     tool: ConsumptionFacet[];
     skill: ConsumptionFacet[];
@@ -266,11 +266,11 @@ export async function fetchConsumptionFacets(
     getFacetBuckets(bucketsByDimension, "user"),
     catalog.user
   );
-  const teamFacets = await resolveFacets(
+  const groupFacets = await resolveFacets(
     auth,
-    "team",
-    getFacetBuckets(bucketsByDimension, "team"),
-    catalog.team
+    "group",
+    getFacetBuckets(bucketsByDimension, "group"),
+    catalog.group
   );
   const modelFacets = await resolveFacets(
     auth,
@@ -302,7 +302,7 @@ export async function fetchConsumptionFacets(
     facets: {
       agent: agentFacets,
       user: userFacets,
-      team: teamFacets,
+      group: groupFacets,
       model: modelFacets,
       tool: toolFacets,
       skill: skillFacets,

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -109,17 +109,17 @@ describe("resolveDimensionLabels", () => {
     });
   });
 
-  it("labels teams with their group name", async () => {
+  it("labels groups with their group name", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
-    const team = await GroupFactory.regularManual(workspace, "Engineering");
+    const group = await GroupFactory.regularManual(workspace, "Engineering");
 
-    const labels = await resolveDimensionLabels(authenticator, "team", [
-      team.sId,
+    const labels = await resolveDimensionLabels(authenticator, "group", [
+      group.sId,
     ]);
 
-    expect(labels.get(team.sId)).toEqual({
+    expect(labels.get(group.sId)).toEqual({
       name: "Engineering",
       pictureUrl: null,
     });

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -18,7 +18,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
  * The expected mapping is:
  * - "agent": agent sIds
  * - "user": user sIds
- * - "team": group sIds
+ * - "group": group sIds
  * - "model": raw model ids
  * - "tool": MCP server names
  * - "skill": skill sIds
@@ -76,7 +76,7 @@ export async function resolveDimensionLabels(
       );
     }
 
-    case "team": {
+    case "group": {
       const groups = await GroupResource.listAllWorkspaceGroups(auth, {
         groupKinds: [...CAP_ELIGIBLE_GROUP_KINDS],
       });

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -40,7 +40,7 @@ describe("buildConsumptionScopeQuery", () => {
       filter: {
         agents: ["a1"],
         users: ["u1", "u2"],
-        teams: ["team1"],
+        groups: ["group1"],
         models: ["gpt-5.6-luna"],
         tools: ["web_search_&_browse"],
         skills: ["s1"],
@@ -53,7 +53,7 @@ describe("buildConsumptionScopeQuery", () => {
       expect.objectContaining({ range: expect.anything() }),
       { term: { "agent.id": "a1" } },
       { terms: { "user.id": ["u1", "u2"] } },
-      { term: { "user.group_ids": "team1" } },
+      { term: { "user.group_ids": "group1" } },
       { term: { "model.model_id": "gpt-5.6-luna" } },
       { term: { "tool.server_name": "web_search_&_browse" } },
       { term: { "tool.attributed_skill_ids": "s1" } },

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -9,7 +9,7 @@ export const AGENT_MESSAGE_ID_FIELD = "agent_message_id";
 export const CONSUMPTION_SCOPE_DIMENSIONS = [
   "agent",
   "user",
-  "team",
+  "group",
   "model",
   "tool",
   "skill",
@@ -25,8 +25,8 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
 > = {
   agent: "agent.id",
   user: "user.id",
-  // Multi-valued: a member can belong to several teams at once.
-  team: "user.group_ids",
+  // Multi-valued: a member can belong to several groups at once.
+  group: "user.group_ids",
   model: "model.model_id",
   tool: "tool.server_name",
   // Multi-valued: one tool call can be attributed to several skills at once.
@@ -37,7 +37,7 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
 export const CONSUMPTION_SCOPE_FILTER_KEYS = [
   "agents",
   "users",
-  "teams",
+  "groups",
   "models",
   "tools",
   "skills",
@@ -57,7 +57,7 @@ export const CONSUMPTION_DIMENSION_FILTER_KEYS: Record<
 > = {
   agent: "agents",
   user: "users",
-  team: "teams",
+  group: "groups",
   model: "models",
   tool: "tools",
   skill: "skills",

--- a/front/lib/api/analytics/consumption/timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/timeseries.test.ts
@@ -243,7 +243,7 @@ describe("fetchConsumptionTimeseries", () => {
     it.each([
       "agent",
       "user",
-      "team",
+      "group",
       "model",
       "tool",
       "skill",

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,10 +1,10 @@
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
+import { fetchConsumptionTopGroups } from "@app/lib/api/analytics/consumption/top_groups";
 import { fetchConsumptionTopModels } from "@app/lib/api/analytics/consumption/top_models";
 import { fetchConsumptionTopSkills } from "@app/lib/api/analytics/consumption/top_skills";
 import { fetchConsumptionTopSources } from "@app/lib/api/analytics/consumption/top_sources";
-import { fetchConsumptionTopTeams } from "@app/lib/api/analytics/consumption/top_teams";
 import { fetchConsumptionTopTools } from "@app/lib/api/analytics/consumption/top_tools";
 import { fetchConsumptionTopUsers } from "@app/lib/api/analytics/consumption/top_users";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
@@ -219,7 +219,7 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
-  it("ranks users, teams and models per message on their own key", async () => {
+  it("ranks users, groups and models per message on their own key", async () => {
     const { auth } = await setup();
     mockAggs({
       buckets: [
@@ -255,16 +255,16 @@ describe("consumption top rankings", () => {
     });
 
     mockLabels({ key1: "Engineering" });
-    const teams = await fetchConsumptionTopTeams(auth, {
+    const groups = await fetchConsumptionTopGroups(auth, {
       period: PERIOD,
       limit: 10,
     });
-    expect(teams.isOk()).toBe(true);
-    if (!teams.isOk()) {
+    expect(groups.isOk()).toBe(true);
+    if (!groups.isOk()) {
       return;
     }
-    expect(teams.value.teams[0]).toEqual({
-      teamId: "key1",
+    expect(groups.value.groups[0]).toEqual({
+      groupId: "key1",
       name: "Engineering",
       credits: 2,
       messageCount: 4,

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -3,7 +3,7 @@ import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/perio
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
   avgCreditsPerUnit,
-  fetchConsumptionTopGroups,
+  fetchConsumptionTopGroups as fetchConsumptionTopGroupBuckets,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -11,30 +11,30 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 
 /**
- * Teams ranked by the credits consumed by their members over the period,
- * averaged per message. A member can belong to several teams, in which case
- * their consumption is attributed to each team they belonged to when the
+ * Groups ranked by the credits consumed by their members over the period,
+ * averaged per message. A member can belong to several groups, in which case
+ * their consumption is attributed to each group they belonged to when the
  * message completed.
  */
 
-export type ConsumptionTopTeamRow = {
-  teamId: string;
+export type ConsumptionTopGroupRow = {
+  groupId: string;
   name: string;
   credits: number;
   messageCount: number;
   avgCreditsPerMessage: number;
 };
 
-export type ConsumptionTopTeams = {
+export type ConsumptionTopGroups = {
   period: ConsumptionPeriod;
   totalCredits: number;
   // Highest credits first.
-  teams: ConsumptionTopTeamRow[];
+  groups: ConsumptionTopGroupRow[];
 };
 
-export type GetConsumptionTopTeamsResponse = ConsumptionTopTeams;
+export type GetConsumptionTopGroupsResponse = ConsumptionTopGroups;
 
-export async function fetchConsumptionTopTeams(
+export async function fetchConsumptionTopGroups(
   auth: Authenticator,
   {
     period,
@@ -45,9 +45,9 @@ export async function fetchConsumptionTopTeams(
     limit: number;
     filter?: ConsumptionScopeFilter;
   }
-): Promise<Result<ConsumptionTopTeams, ElasticsearchError>> {
-  const result = await fetchConsumptionTopGroups(auth, {
-    dimension: "team",
+): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
+  const result = await fetchConsumptionTopGroupBuckets(auth, {
+    dimension: "group",
     unit: "message",
     period,
     limit,
@@ -60,15 +60,15 @@ export async function fetchConsumptionTopTeams(
 
   const labels = await resolveDimensionLabels(
     auth,
-    "team",
+    "group",
     groups.map((group) => group.key)
   );
 
   return new Ok({
     period,
     totalCredits,
-    teams: groups.map((group) => ({
-      teamId: group.key,
+    groups: groups.map((group) => ({
+      groupId: group.key,
       name: labels.get(group.key)?.name ?? group.key,
       credits: group.credits,
       messageCount: group.count,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR renames "teams" to "groups" in the new analytics view. It's a breaking change of the private API, but since we are the only users, looks mostly fine.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
