### PR TITLE
add metadata to skills api

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -3630,6 +3630,10 @@
                       "users_and_agents"
                     ],
                     "description": "Optional availability to apply to imported or updated skills. editors is unpublished, workspace_users is published, and users_and_agents is discoverable. New skills default to editors and existing skills keep their current availability when omitted."
+                  },
+                  "metadata": {
+                    "type": "string",
+                    "description": "Optional client-owned labels, sent as a JSON-encoded string-to-string map (e.g. '{\"managedBy\":\"my-ci\"}'), stamped on each imported skill. Returned on GET as the skill's metadata field. Lets an external system tag skills it manages and reconcile them (list, then archive skills no longer in its desired state) without storing skill IDs. Sending metadata on re-import overwrites it; omitting it preserves the existing value."
                   }
                 }
               }
@@ -15005,6 +15009,17 @@
                 "$ref": "#/components/schemas/SkillSourceMetadata"
               }
             ]
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Client-owned key/value labels attached to the skill. Set at import and used by external systems to tag and reconcile the skills they manage.",
+            "example": {
+              "managedBy": "my-ci"
+            }
           },
           "reinforcement": {
             "type": "string",

--- a/front-api/routes/v1/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.test.ts
@@ -289,6 +289,55 @@ describe("GET /api/v1/w/[wId]/skills", () => {
     expect(editorsSkillNames).toEqual(["Unpublished Skill"]);
   });
 
+  it("exposes client-owned metadata so managed skills can be filtered", async () => {
+    const { auth, workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceFactory.defaults(adminAuth);
+    await GroupPermissionResource.setForEverybody(adminAuth, {
+      grantType: "create",
+      resourceType: "skill",
+    });
+
+    const managed = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({ name: "Managed Skill", instructions: "m" }),
+      ],
+      source: "api",
+      onConflict: "error",
+      metadata: { managedBy: "acme-ci" },
+    });
+    if (managed.isErr()) {
+      throw managed.error;
+    }
+    const unmanaged = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({ name: "Unmanaged Skill", instructions: "u" }),
+      ],
+      source: "api",
+      onConflict: "error",
+    });
+    if (unmanaged.isErr()) {
+      throw unmanaged.error;
+    }
+
+    // Imported skills default to editors (unpublished), so an admin key with the
+    // bypass is required to surface them — the reconcile loop the CI runs.
+    const response = await getSkills(workspace, key, {
+      bypassEditorVisibility: "true",
+    });
+    expect(response.status).toBe(200);
+    const skills = (await response.json()).skills as {
+      name: string;
+      metadata: Record<string, string> | null;
+    }[];
+    const mine = skills.filter((s) => s.metadata?.managedBy === "acme-ci");
+    expect(mine.map((s) => s.name)).toEqual(["Managed Skill"]);
+  });
+
   it("rejects bypassEditorVisibility for non-admin API keys", async () => {
     const { workspace, key } = await createPublicApiMockRequest();
     await SpaceFactory.defaults(
@@ -481,6 +530,95 @@ describe("POST /api/v1/w/[wId]/skills", () => {
         .map((email) => email.toLowerCase())
         .sort()
     );
+  });
+
+  it("persists client-owned metadata and overwrites it on re-import", async () => {
+    const { auth, workspace } = await createPublicApiMockRequest();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceFactory.defaults(adminAuth);
+    await GroupPermissionResource.setForEverybody(adminAuth, {
+      grantType: "create",
+      resourceType: "skill",
+    });
+
+    const first = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({ name: "Managed Skill", instructions: "v1" }),
+      ],
+      source: "api",
+      onConflict: "error",
+      metadata: { managedBy: "acme-ci", env: "prod" },
+    });
+    if (first.isErr()) {
+      throw first.error;
+    }
+    expect(first.value.imported[0]?.toJSON(auth).metadata).toEqual({
+      managedBy: "acme-ci",
+      env: "prod",
+    });
+
+    // Re-importing with metadata overwrites the previous value.
+    const second = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({ name: "Managed Skill", instructions: "v2" }),
+      ],
+      source: "api",
+      onConflict: "error",
+      metadata: { managedBy: "acme-ci", env: "staging" },
+    });
+    if (second.isErr()) {
+      throw second.error;
+    }
+    expect(second.value.updated[0]?.toJSON(auth).metadata).toEqual({
+      managedBy: "acme-ci",
+      env: "staging",
+    });
+
+    // Re-importing without metadata preserves the existing value.
+    const third = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({ name: "Managed Skill", instructions: "v3" }),
+      ],
+      source: "api",
+      onConflict: "error",
+    });
+    if (third.isErr()) {
+      throw third.error;
+    }
+    const refetched = await SkillResource.fetchById(
+      auth,
+      first.value.imported[0].sId
+    );
+    expect(refetched?.toJSON(auth).metadata).toEqual({
+      managedBy: "acme-ci",
+      env: "staging",
+    });
+  });
+
+  it("defaults metadata to null when none is provided at import", async () => {
+    const { auth, workspace } = await createPublicApiMockRequest();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceFactory.defaults(adminAuth);
+    await GroupPermissionResource.setForEverybody(adminAuth, {
+      grantType: "create",
+      resourceType: "skill",
+    });
+
+    const result = await importSkillsFromFiles(auth, {
+      uploadedFiles: [
+        await makeSkillZipFile({ name: "Unmanaged Skill", instructions: "v1" }),
+      ],
+      source: "api",
+      onConflict: "error",
+    });
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.imported[0]?.toJSON(auth).metadata).toBeNull();
   });
 
   it("rejects the import for a non-builder API key", async () => {

--- a/front-api/routes/v1/w/[wId]/skills/index.ts
+++ b/front-api/routes/v1/w/[wId]/skills/index.ts
@@ -5,8 +5,14 @@ import {
 import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/github/import_skills";
 import { MAX_ZIP_SIZE_BYTES } from "@app/lib/api/skills/detection/zip/detect_skills";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
-import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration";
+import type {
+  SkillMetadata,
+  SkillType,
+} from "@app/types/assistant/skill_configuration";
+import {
+  SKILL_AVAILABILITIES,
+  SkillMetadataSchema,
+} from "@app/types/assistant/skill_configuration";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { createHono } from "@front-api/lib/hono";
 import type { PublicApiCtx } from "@front-api/middlewares/ctx";
@@ -16,6 +22,7 @@ import { validate } from "@front-api/middlewares/validator";
 import type { HttpBindings } from "@hono/node-server";
 import formidable from "formidable";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import skill from "./[skillId]";
 
@@ -148,6 +155,9 @@ app.route("/:skillId", skill);
  *                 type: string
  *                 enum: [editors, workspace_users, users_and_agents]
  *                 description: Optional availability to apply to imported or updated skills. editors is unpublished, workspace_users is published, and users_and_agents is discoverable. New skills default to editors and existing skills keep their current availability when omitted.
+ *               metadata:
+ *                 type: string
+ *                 description: 'Optional client-owned labels, sent as a JSON-encoded string-to-string map (e.g. ''{"managedBy":"my-ci"}''), stamped on each imported skill. Returned on GET as the skill''s metadata field. Lets an external system tag skills it manages and reconcile them (list, then archive skills no longer in its desired state) without storing skill IDs. Sending metadata on re-import overwrites it; omitting it preserves the existing value.'
  *     responses:
  *       200:
  *         description: Skills import result.
@@ -309,6 +319,37 @@ app.post("/", async (ctx): HandlerResult<ImportSkillsResponseBody> => {
     });
   }
 
+  // Optional client-owned labels, sent as a JSON-encoded string→string map, that
+  // the caller stamps on imported skills to tag skills it manages.
+  let metadata: SkillMetadata | undefined;
+  const rawMetadata = fields.metadata?.[0];
+  if (rawMetadata !== undefined) {
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(rawMetadata);
+    } catch (err) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Invalid metadata: ${normalizeError(err).message}`,
+        },
+      });
+    }
+
+    const metadataValidation = SkillMetadataSchema.safeParse(parsedJson);
+    if (!metadataValidation.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `Invalid metadata: ${fromError(metadataValidation.error).toString()}`,
+        },
+      });
+    }
+    metadata = metadataValidation.data;
+  }
+
   const result = await importSkillsFromFiles(auth, {
     uploadedFiles,
     availability: availabilityValidation.data,
@@ -316,6 +357,7 @@ app.post("/", async (ctx): HandlerResult<ImportSkillsResponseBody> => {
     names,
     source: "api",
     onConflict,
+    metadata,
   });
   if (result.isErr()) {
     return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -712,6 +712,14 @@
  *           nullable: true
  *           allOf:
  *             - $ref: '#/components/schemas/SkillSourceMetadata'
+ *         metadata:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties:
+ *             type: string
+ *           description: Client-owned key/value labels attached to the skill. Set at import and used by external systems to tag and reconcile the skills they manage.
+ *           example:
+ *             managedBy: "my-ci"
  *         reinforcement:
  *           type: string
  *           enum: [auto, "on", "off"]

--- a/front/lib/api/skills/detection/files/import_skills.ts
+++ b/front/lib/api/skills/detection/files/import_skills.ts
@@ -16,6 +16,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type {
   SkillAvailability,
+  SkillMetadata,
   SkillSourceType,
 } from "@app/types/assistant/skill_configuration";
 import { DEFAULT_SKILL_AVAILABILITY } from "@app/types/assistant/skill_configuration";
@@ -66,6 +67,7 @@ export async function importSkillsFromFiles(
     availability,
     source = "local_file",
     onConflict = "skip",
+    metadata,
   }: {
     uploadedFiles: formidable.File[];
     names?: string[];
@@ -73,6 +75,7 @@ export async function importSkillsFromFiles(
     availability?: SkillAvailability;
     source?: FileImportSource;
     onConflict?: ImportConflictStrategyType;
+    metadata?: SkillMetadata;
   }
 ): Promise<Result<ImportSkillsResult, Error>> {
   const canCreateSkills = await auth.hasWorkspacePermission("create", "skill");
@@ -258,6 +261,7 @@ export async function importSkillsFromFiles(
         fileAttachments,
         source,
         sourceMetadata: { filePath: skill.skillMdPath },
+        metadata,
       });
 
       await FileResource.bulkSetUseCaseMetadata(auth, fileAttachments, {
@@ -305,6 +309,7 @@ export async function importSkillsFromFiles(
           icon,
           source,
           sourceMetadata: { filePath: skill.skillMdPath },
+          metadata: metadata ?? null,
           availability: availability ?? DEFAULT_SKILL_AVAILABILITY,
         },
         {

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -11,6 +11,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   SkillAvailability,
+  SkillMetadata,
   SkillReinforcementMode,
   SkillSourceMetadata,
   SkillSourceType,
@@ -71,6 +72,10 @@ const SKILL_MODEL_ATTRIBUTES = {
     type: DataTypes.JSONB,
     allowNull: true,
   },
+  metadata: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  },
   availability: {
     type: DataTypes.STRING,
     allowNull: false,
@@ -113,6 +118,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
 
   declare source: SkillSourceType | null;
   declare sourceMetadata: SkillSourceMetadata | null;
+  declare metadata: SkillMetadata | null;
   declare availability: CreationOptional<SkillAvailability>;
   declare favoriteCount: CreationOptional<number>;
 

--- a/front/lib/reinforcement/aggregate_suggestions.test.ts
+++ b/front/lib/reinforcement/aggregate_suggestions.test.ts
@@ -19,6 +19,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     icon: null,
     source: null,
     sourceMetadata: null,
+    metadata: null,
     reinforcement: "auto",
     selfImprovementLock: false,
     selfImprovementCostsCapMicroUsd: null,

--- a/front/lib/reinforcement/analyze_conversation.test.ts
+++ b/front/lib/reinforcement/analyze_conversation.test.ts
@@ -18,6 +18,7 @@ function makeSkill(overrides: Partial<SkillType> = {}): SkillType {
     icon: null,
     source: null,
     sourceMetadata: null,
+    metadata: null,
     reinforcement: "auto",
     selfImprovementLock: false,
     selfImprovementCostsCapMicroUsd: null,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -81,6 +81,7 @@ import type {
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type {
   SkillAvailability,
+  SkillMetadata,
   SkillReinforcementMode,
   SkillSourceMetadata,
   SkillSourceType,
@@ -2069,6 +2070,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         icon: def.icon,
         source: null,
         sourceMetadata: null,
+        metadata: null,
         availability: SystemSkillsRegistry.isSystemSkill(def.sId)
           ? "workspace_users"
           : "users_and_agents",
@@ -2371,6 +2373,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           requestedSpaceIds: versionModel.requestedSpaceIds,
           source: versionModel.source,
           sourceMetadata: versionModel.sourceMetadata,
+          metadata: versionModel.metadata,
           availability: versionModel.availability,
           favoriteCount: this.favoriteCount,
           reinforcement: "auto",
@@ -2933,6 +2936,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       requestedSpaceIds,
       source,
       sourceMetadata,
+      metadata,
       status,
       userFacingDescription,
     }: {
@@ -2949,6 +2953,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       requestedSpaceIds: ModelId[];
       source?: SkillSourceType;
       sourceMetadata?: SkillSourceMetadata;
+      metadata?: SkillMetadata;
       status?: SkillStatus;
       userFacingDescription: string;
     }
@@ -3013,6 +3018,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           ...(status ? { status } : {}),
           ...(source ? { source } : {}),
           ...(sourceMetadata ? { sourceMetadata } : {}),
+          ...(metadata ? { metadata } : {}),
           ...(availability !== undefined ? { availability } : {}),
           ...(reinforcement !== undefined ? { reinforcement } : {}),
         },
@@ -4205,6 +4211,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       selfImprovementCostsCapAwuCredits: this.selfImprovementCostsCapAwuCredits,
       source: this.source,
       sourceMetadata: this.sourceMetadata,
+      metadata: this.metadata,
       tools: this.mcpServerViews.map((view) => {
         const serializedView = view.toJSON();
         const server = serializedView.server;
@@ -4320,6 +4327,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         ),
         source: skill.source,
         sourceMetadata: skill.sourceMetadata,
+        metadata: skill.metadata,
         createdAt: skill.createdAt,
         updatedAt: skill.updatedAt,
         availability: skill.availability,

--- a/front/migrations/pre-deploy/20260812120000_add_metadata_to_skills.sql
+++ b/front/migrations/pre-deploy/20260812120000_add_metadata_to_skills.sql
@@ -1,0 +1,16 @@
+/*
+Add a nullable, client-owned `metadata` JSONB label map to skills and their versions.
+Nullable with no default, so no backfill is required.
+
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" ADD COLUMN "metadata" jsonb;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" ADD COLUMN "metadata" jsonb;

--- a/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
+++ b/front/tests/reinforcement-evals/lib/reinforcement-executor.ts
@@ -82,6 +82,7 @@ function makeSkillType(config: MockSkillConfig): SkillType {
     icon: null,
     source: null,
     sourceMetadata: null,
+    metadata: null,
     reinforcement: "auto",
     selfImprovementLock: false,
     selfImprovementCostsCapMicroUsd: null,

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -58,6 +58,13 @@ export const SkillSourceMetadataSchema = z.object({
 
 export type SkillSourceMetadata = z.infer<typeof SkillSourceMetadataSchema>;
 
+// Client-owned key/value labels attached to a skill (akin to Kubernetes labels
+// or cloud-resource tags). Dust does not prescribe the keys; external systems
+// use them to tag skills they manage and reconcile them without storing sIds.
+export const SkillMetadataSchema = z.record(z.string(), z.string());
+
+export type SkillMetadata = z.infer<typeof SkillMetadataSchema>;
+
 export const SkillWithoutInstructionsAndToolsSchema = z.object({
   id: z.number(),
   sId: z.string(),
@@ -71,6 +78,7 @@ export const SkillWithoutInstructionsAndToolsSchema = z.object({
   icon: z.string().nullable(),
   source: z.enum(SKILL_SOURCES).nullable(),
   sourceMetadata: SkillSourceMetadataSchema.nullable(),
+  metadata: SkillMetadataSchema.nullable(),
   reinforcement: z.enum(SKILL_REINFORCEMENT_MODES),
   lastReinforcementAnalysisAt: z.string().nullable().optional(),
   selfImprovementLock: z.boolean(),


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10025

Adds a first-class, client-owned `metadata` field (a `Record<string, string>` label map, like Kubernetes labels / cloud-resource tags) to skills. It's settable at import via the public API and returned on GET. 

Dust doesn't prescribe the keys, callers pick their own (e.g. `{ "managedBy": "acme-ci" }`).

**Semantics:** sending `metadata` on re-import overwrites it; omitting it preserves the existing value (matches `updateSkill`'s `...(x ? { x } : {})` guards).

## Tests

locally

## Risk

no breaking change: additive only

## Deploy Plan

`front/migrations/pre-deploy/20260812120000_add_metadata_to_skills.sql` 
then deploy front

(adds a nullable JSONB `metadata` column to `skill_configurations` and `skill_versions`. Nullable, no default, no backfill.)
