### PR TITLE
[front] fix: update analytics subtitle spacing

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -149,7 +149,18 @@ export function ConsumptionOverview({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-sm text-muted-foreground">{header.join("  |  ")}</p>
+      <p className="text-sm text-muted-foreground">
+        {header.map((item, index) => (
+          <span key={item}>
+            {index > 0 && (
+              <span className="mx-2" aria-hidden="true">
+                |
+              </span>
+            )}
+            {item}
+          </span>
+        ))}
+      </p>
       <ConsumptionSummary workspaceId={workspaceId} overview={overview} />
     </div>
   );


### PR DESCRIPTION
## Description

This PR fixes the subtitle on the new Analytics page, specifically the spacing around the pipes.

Before
<img width="459" height="160" alt="image" src="https://github.com/user-attachments/assets/ae969f8b-229b-420e-98ae-716cfc996af8" />

After
<img width="458" height="156" alt="image" src="https://github.com/user-attachments/assets/f6befcbb-a7a4-4ab1-af1a-c84ff1a99f73" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
