### PR TITLE
Reduce analytics parallelism

### DIFF
--- a/front/temporal/analytics_queue/worker.ts
+++ b/front/temporal/analytics_queue/worker.ts
@@ -14,7 +14,7 @@ import { QUEUE_NAME } from "./config";
 // Must match the deployment's terminationGracePeriodSeconds minus 10s buffer.
 const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
 
-const MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS = 32;
+const MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS = 24;
 
 export async function runAnalyticsWorker() {
   const { connection, namespace } = await getTemporalWorkerConnection();


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We noticed that current concurrency on analytics queue workers (32) leads to some `OOMKilled`. See in DD [here](https://app.datadoghq.eu/notebook/340275/temporal-analytics-queue-performance). This PR reduces it to 24.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
