### PR TITLE
[front] fix: attribute a legacy Pod database only to the app that would open it

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
@@ -162,6 +162,46 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
     ]);
   });
 
+  it("does not attribute a legacy database to an app that has its own prefixed one", async () => {
+    const { workspace, pod } = await setupPod();
+
+    // The state a clone leaves behind: the copy inherits the schema file, so both apps declare
+    // `counter`, but each has its own prefixed database and neither opens the bare legacy file.
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "Counter/"),
+      gcsObject(workspace.sId, pod.sId, "Counter/databases/counter.db.ts"),
+      gcsObject(workspace.sId, pod.sId, "Counter Copy/"),
+      gcsObject(workspace.sId, pod.sId, "Counter Copy/databases/counter.db.ts"),
+    ]);
+    fileStorageMock.setSubdirectoryNames(() => [
+      "counter.db",
+      "counter__counter.db",
+      "counter_copy__counter.db",
+    ]);
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const byPrefix = new Map<string, { databases: { onDiskName: string }[] }>(
+      body.apps.map((app: { prefix: string }) => [app.prefix, app])
+    );
+
+    // Each app shows exactly the database it would open — not the orphan as well.
+    expect(
+      byPrefix.get("counter")?.databases.map((db) => db.onDiskName)
+    ).toEqual(["counter__counter"]);
+    expect(
+      byPrefix.get("counter-copy")?.databases.map((db) => db.onDiskName)
+    ).toEqual(["counter_copy__counter"]);
+    // The bare file belongs to neither, so it surfaces as unfiled rather than being double-counted.
+    expect(byPrefix.get("")?.databases.map((db) => db.onDiskName)).toEqual([
+      "counter",
+    ]);
+  });
+
   it("leaves an unprefixed database no app declares in the unfiled app", async () => {
     const { workspace, pod } = await setupPod();
 

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -6,6 +6,7 @@ import { deletePodDatabaseReplica } from "@app/lib/api/sandbox/db";
 import {
   appPrefixFromPodDatabaseName,
   podDatabaseNameWithoutAppPrefix,
+  podDatabasePrefixFromAppPrefix,
 } from "@app/lib/api/sandbox_functions/db_naming";
 import { deleteDatabaseOnSandbox } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { SANDBOX_FUNCTION_SLUG_SEPARATOR } from "@app/lib/api/sandbox_functions/slug";
@@ -247,15 +248,19 @@ async function listPodDatabaseOnDiskNames(
  * `resolvePodDatabaseName` resolves the same case at reconcile time, so the tab attributes a legacy
  * database to exactly the app that keeps writing to it.
  *
- * Two apps declaring the same bare name genuinely share that one database (the transitional case
- * `resolvePodDatabaseName` documents), so it is reported under both rather than arbitrarily assigned.
- * A bare database no app declares falls back to the unfiled app.
+ * Declaring the name is not enough on its own, because `resolvePodDatabaseName` prefers the prefixed
+ * file whenever it exists: an app that has one opens that, and the bare file is not its database at
+ * all. Cloning an app makes this ordinary rather than rare — the copy inherits the schema file, so
+ * both apps declare the name while each opens its own prefixed file, leaving the bare one an orphan.
+ * Attribution therefore follows resolution, and a bare database that no app would open falls back to
+ * the unfiled app.
  */
 function groupDatabasesByAppPrefix(
   onDiskNames: string[],
   foldersByPrefix: Map<string, AppFolder[]>
 ): Map<string, PodAppDatabase[]> {
   const byPrefix = new Map<string, PodAppDatabase[]>();
+  const allOnDiskNames = new Set(onDiskNames);
 
   const attribute = (prefix: string, database: PodAppDatabase) => {
     byPrefix.set(prefix, [...(byPrefix.get(prefix) ?? []), database]);
@@ -273,8 +278,25 @@ function groupDatabasesByAppPrefix(
       continue;
     }
 
-    const declaringPrefixes = [...foldersByPrefix].filter(([, folders]) =>
-      folders.some((folder) => folder.declaredDatabaseNames.has(onDiskName))
+    // Only apps that would actually open this file: they declare the name AND have no prefixed
+    // database of their own to take precedence over it.
+    const declaringPrefixes = [...foldersByPrefix].filter(
+      ([appPrefix, folders]) => {
+        if (
+          !folders.some((folder) =>
+            folder.declaredDatabaseNames.has(onDiskName)
+          )
+        ) {
+          return false;
+        }
+
+        const databasePrefix = podDatabasePrefixFromAppPrefix(appPrefix);
+
+        return (
+          databasePrefix === null ||
+          !allOnDiskNames.has(`${databasePrefix}${onDiskName}`)
+        );
+      }
     );
     if (declaringPrefixes.length === 0) {
       attribute(UNFILED_POD_APP_PREFIX, database);

--- a/front/lib/api/sandbox_functions/db_naming.ts
+++ b/front/lib/api/sandbox_functions/db_naming.ts
@@ -40,7 +40,7 @@ const POD_DATABASE_PREFIX_SEPARATOR = SANDBOX_FUNCTION_SLUG_SEPARATOR;
  * unprefixed database names, which is how every pod behaved before namespacing — deliberately not
  * an error, since refusing would leave the app unable to create any database at all.
  */
-function podDatabasePrefixFromAppPrefix(
+export function podDatabasePrefixFromAppPrefix(
   appPrefix: string | null
 ): string | null {
   if (appPrefix === null) {


### PR DESCRIPTION
## Description

The Apps tab could list the same database twice under one app, and list a database under an app that never touches it. Reproduced with a Pod holding:

```
counter.db                 ← created before app namespacing, so no prefix
counter__counter.db        ← the Counter app's
counter_copy__counter.db   ← Counter Copy's
```

Both apps showed **two** databases, both rendered `counter`, because the display name is the on-disk name with the app prefix stripped.

## Cause

A database created before app namespacing has a bare filename, so its name says nothing about which app owns it. Attribution fell back to the schema file that declares it — `<AppName>/databases/{name}.db.ts` — and credited **every** app declaring that name.

Declaring the name was never sufficient. `resolvePodDatabaseName` prefers the *prefixed* file whenever it exists, so an app that has one opens that, and the bare file is not its database at all.

That mattered little while a duplicate declaration was rare. It stops being rare as soon as apps can be copied — a copy inherits the schema file, so two apps declare the name while each opens its own prefixed file, leaving the bare one an orphan credited to both.

## Fix

Attribution now follows resolution: a bare database is credited to a declaring app only when that app has no prefixed database of the same name — exactly the precedence `resolvePodDatabaseName` applies at reconcile time. So the tab reports the database each app would actually open, which is what it should have reported all along.

| | Before | After |
|---|---|---|
| Counter | `counter__counter`, `counter` | `counter__counter` |
| Counter Copy | `counter_copy__counter`, `counter` | `counter_copy__counter` |
| Unfiled | — | `counter` |

A bare file no app would open now surfaces as **unfiled** rather than being double-counted, which is also more useful: it says there is a stray legacy database nobody reads.

`podDatabasePrefixFromAppPrefix` is exported from `db_naming.ts` so the check uses the same prefix-building authority as reconcile and invocation, rather than reconstructing the name.

## Scope

Read-only change to how the Apps tab attributes databases. Nothing is created, moved or deleted, and the underlying files are untouched — a mis-attributed database was only ever displayed in the wrong place.

Found while testing the app-clone PR, but it is a bug in the already-merged tab, so it ships on its own. Clone only made the rare case ordinary; landing this first means clone does not appear to introduce it.

## Tests

One regression test using the exact three-file layout above, asserting each app lists only the database it would open and that the orphan is unfiled. Existing suite green: 15 apps-endpoint tests, 20 `db_naming` tests.
