### PR TITLE
[front] enh: clean up Pod app listing — namespaced databases only, no Unfiled app

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/clone.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/clone.test.ts
@@ -240,7 +240,7 @@ describe("POST /api/w/:wId/pods/:podId/apps/:prefix/clone", () => {
       fileName: "orphan.ts",
     });
 
-    // The unfiled app's prefix is empty, so it cannot be addressed as a path segment at all.
+    // A prefix-less function belongs to no app, so an empty path segment addresses nothing.
     const res = await clone(workspace.sId, pod.sId, "", "Copy");
 
     expect([400, 404]).toContain(res.status);

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
@@ -226,8 +226,8 @@ describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix", () => {
       fileName: "orphan.ts",
     });
 
-    // The unfiled app's prefix is empty, so it cannot even be addressed as a path segment; a bare
-    // prefix-less delete must not be mistaken for one.
+    // A prefix-less function belongs to no app, so there is nothing to address: an empty path segment
+    // must not be mistaken for a deletable app.
     const res = await honoApp.request(
       `/api/w/${workspace.sId}/pods/${pod.sId}/apps/`,
       { method: "DELETE" }

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
@@ -135,7 +135,7 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
     expect(app.fileCount).toBe(2);
   });
 
-  it("attributes a database created before app namespacing via its schema file", async () => {
+  it("does not list a database created before app namespacing", async () => {
     const { workspace, pod } = await setupPod();
 
     fileStorageMock.setFilesByPrefix(() => [
@@ -146,8 +146,13 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
         "ProductManager/databases/products.db.ts"
       ),
     ]);
-    // Bare filename, so the name alone cannot say which app owns it.
-    fileStorageMock.setSubdirectoryNames(() => ["products.db"]);
+    // A bare filename says nothing about which app owns it, and the schema file that declares it is
+    // not evidence either — a clone inherits that declaration while opening its own prefixed file.
+    // Rather than infer ownership, such a database is left out.
+    fileStorageMock.setSubdirectoryNames(() => [
+      "products.db",
+      "productmanager__stock.db",
+    ]);
 
     const res = await honoApp.request(
       `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
@@ -157,12 +162,13 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
     const body = await res.json();
     expect(body.apps).toHaveLength(1);
     expect(body.apps[0].prefix).toBe("productmanager");
+    // Only the namespaced one; the bare `products` appears nowhere, not even as unfiled.
     expect(body.apps[0].databases).toEqual([
-      { name: "products", onDiskName: "products" },
+      { name: "stock", onDiskName: "productmanager__stock" },
     ]);
   });
 
-  it("leaves an unprefixed database no app declares in the unfiled app", async () => {
+  it("does not create an unfiled app for unprefixed databases alone", async () => {
     const { workspace, pod } = await setupPod();
 
     fileStorageMock.setSubdirectoryNames(() => ["orphaned.db"]);
@@ -173,11 +179,8 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.apps).toHaveLength(1);
-    expect(body.apps[0].prefix).toBe("");
-    expect(body.apps[0].databases).toEqual([
-      { name: "orphaned", onDiskName: "orphaned" },
-    ]);
+    // The unfiled app exists for functions published at the Pod root, not for databases.
+    expect(body.apps).toEqual([]);
   });
 
   it("ignores a pod-root folder that is not app-shaped", async () => {

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
@@ -162,13 +162,13 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
     const body = await res.json();
     expect(body.apps).toHaveLength(1);
     expect(body.apps[0].prefix).toBe("productmanager");
-    // Only the namespaced one; the bare `products` appears nowhere, not even as unfiled.
+    // Only the namespaced one; the bare `products` appears nowhere at all.
     expect(body.apps[0].databases).toEqual([
       { name: "stock", onDiskName: "productmanager__stock" },
     ]);
   });
 
-  it("does not create an unfiled app for unprefixed databases alone", async () => {
+  it("lists nothing for a Pod holding only unprefixed databases", async () => {
     const { workspace, pod } = await setupPod();
 
     fileStorageMock.setSubdirectoryNames(() => ["orphaned.db"]);
@@ -179,7 +179,6 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    // The unfiled app exists for functions published at the Pod root, not for databases.
     expect(body.apps).toEqual([]);
   });
 
@@ -200,9 +199,11 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
     expect(body.apps).toEqual([]);
   });
 
-  it("collects artifacts published from the Pod root into the unfiled app", async () => {
+  it("does not list a function published outside an app folder", async () => {
     const { workspace, pod, auth } = await setupPod();
 
+    // A prefix-less slug belongs to no app. It stays published and callable; there is just no app for
+    // it to be listed under, so no synthetic one is invented to hold it.
     await publishFunction(auth, pod, {
       slug: "orphan",
       fileName: "orphan.ts",
@@ -214,12 +215,7 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
 
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.apps).toHaveLength(1);
-    expect(body.apps[0].prefix).toBe("");
-    expect(body.apps[0].name).toBeNull();
-    expect(
-      body.apps[0].functions.map((fn: { slug: string }) => fn.slug)
-    ).toEqual(["orphan"]);
+    expect(body.apps).toEqual([]);
   });
 
   it("reports folders that normalize onto the same app prefix as one colliding app", async () => {

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -67,7 +67,6 @@ app.delete(
             },
           });
         case "not_a_pod":
-        case "cannot_delete_unfiled":
           return apiError(ctx, {
             status_code: 400,
             api_error: {

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -135,7 +135,6 @@ app.post(
             },
           });
         case "not_a_pod":
-        case "cannot_clone_unfiled":
         case "invalid_name":
           return apiError(ctx, {
             status_code: 400,

--- a/front/components/pod/apps/PodAppDetail.tsx
+++ b/front/components/pod/apps/PodAppDetail.tsx
@@ -14,7 +14,7 @@ interface PodAppDetailProps {
   onOpenFrame: (frame: PodAppFrame) => void;
   /** Absent when the viewer cannot delete (no write access). */
   onDelete?: () => void;
-  /** Absent when the app cannot be cloned (no write access, or the unfiled app). */
+  /** Absent when the app cannot be cloned (no write access). */
   onClone?: () => void;
 }
 

--- a/front/components/pod/apps/PodAppDetail.tsx
+++ b/front/components/pod/apps/PodAppDetail.tsx
@@ -12,7 +12,7 @@ import {
 interface PodAppDetailProps {
   app: PodApp;
   onOpenFrame: (frame: PodAppFrame) => void;
-  /** Absent when the viewer cannot delete (no write access, or the unfiled app). */
+  /** Absent when the viewer cannot delete (no write access). */
   onDelete?: () => void;
   /** Absent when the app cannot be cloned (no write access, or the unfiled app). */
   onClone?: () => void;
@@ -56,12 +56,8 @@ export function PodAppDetail({
     <ScrollArea className="h-full">
       <div className="flex flex-col gap-6 px-6 py-5">
         <div className="flex items-start justify-between gap-4">
-          <div className="flex min-w-0 flex-col gap-1">
-            <h3 className="heading-lg">{app.name ?? "Unfiled"}</h3>
-            <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
-              {app.folderPath ??
-                "Published from the Pod root, so these are not owned by an app folder."}
-            </span>
+          <div className="min-w-0">
+            <h3 className="heading-lg">{app.name}</h3>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {onClone && (

--- a/front/components/pod/apps/PodAppList.tsx
+++ b/front/components/pod/apps/PodAppList.tsx
@@ -75,7 +75,7 @@ export function PodAppList({
                   size="sm"
                 />
                 <span className="grow truncate copy-sm font-semibold">
-                  {app.name ?? "Unfiled"}
+                  {app.name}
                 </span>
                 {app.functions.length === 0 && app.databases.length === 0 && (
                   <Chip size="xs" color="primary" label="Draft" />

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -6,7 +6,6 @@ import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
 import { usePodApps } from "@app/lib/swr/pods";
 import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
-import { UNFILED_POD_APP_PREFIX } from "@app/types/api/pod_apps";
 import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import type { PodType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
@@ -95,12 +94,8 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
           <PodAppDetail
             app={selectedApp}
             onOpenFrame={setFramePreview}
-            // The unfiled app is a presentation device, not a folder, so there is nothing
-            // coherent to delete.
             onDelete={
-              canDelete && selectedApp.prefix !== UNFILED_POD_APP_PREFIX
-                ? () => setAppPendingDeletion(selectedApp)
-                : undefined
+              canDelete ? () => setAppPendingDeletion(selectedApp) : undefined
             }
             onClone={
               canDelete && selectedApp.prefix !== UNFILED_POD_APP_PREFIX

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -98,9 +98,7 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
               canDelete ? () => setAppPendingDeletion(selectedApp) : undefined
             }
             onClone={
-              canDelete && selectedApp.prefix !== UNFILED_POD_APP_PREFIX
-                ? () => setAppPendingClone(selectedApp)
-                : undefined
+              canDelete ? () => setAppPendingClone(selectedApp) : undefined
             }
           />
         )}

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -318,8 +318,8 @@ function groupFunctionsByAppPrefix(
  * A folder qualifies as an app when it holds a `functions/` or `databases/` subfolder, or a Frame at
  * its top, or any published function or database under its prefix. A prefix that owns published
  * artifacts but has no folder left is still listed, since those artifacts are live and would
- * otherwise be invisible; so is anything published from the pod root, gathered into a synthetic
- * unfiled app.
+ * otherwise be invisible. Anything published at the pod root carries no prefix and so belongs to no
+ * app; it is left out rather than gathered into a synthetic one.
  */
 export async function listPodApps(
   auth: Authenticator,
@@ -569,7 +569,6 @@ export async function deletePodApp(
 export type PodAppCloneErrorCode =
   | "not_a_pod"
   | "not_found"
-  | "cannot_clone_unfiled"
   | "invalid_name"
   | "name_taken"
   | "sandbox_unavailable"
@@ -616,14 +615,6 @@ export async function clonePodApp(
   if (!pod.isProject()) {
     return new Err(
       new PodAppCloneError("not_a_pod", "Apps only exist on Pod spaces.")
-    );
-  }
-  if (prefix === UNFILED_POD_APP_PREFIX) {
-    return new Err(
-      new PodAppCloneError(
-        "cannot_clone_unfiled",
-        "Artifacts published outside an app folder are not an app and cannot be cloned."
-      )
     );
   }
 

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -34,12 +34,10 @@ import type {
   PodAppFrame,
   PodAppFunction,
 } from "@app/types/api/pod_apps";
-import { UNFILED_POD_APP_PREFIX } from "@app/types/api/pod_apps";
 import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { removeNulls } from "@app/types/shared/utils/general";
 
 /** A litestream replica directory is named after the database file it replicates. */
 const POD_DATABASE_FILE_SUFFIX = ".db";
@@ -94,8 +92,7 @@ function relativeSegments(entry: FileSystemEntry, podRoot: string): string[] {
 
 /**
  * Group a pod's recursive file listing by the folder each entry sits in at the pod root. Entries
- * directly at the root belong to no app, so they are skipped: anything published from there surfaces
- * under the unfiled app instead.
+ * directly at the root belong to no app, so they are skipped.
  */
 function collectAppFolders(
   entries: FileSystemEntry[],
@@ -279,7 +276,13 @@ function groupDatabasesByAppPrefix(
   return byPrefix;
 }
 
-/** The pod's published functions, grouped by the app prefix each one's slug carries. */
+/**
+ * The pod's published functions, grouped by the app prefix their slug carries.
+ *
+ * A function published from the pod root has no prefix and so belongs to no app. Like an unprefixed
+ * database, it is left out rather than gathered into a synthetic app: it is still callable, it simply
+ * has no app to be listed under.
+ */
 function groupFunctionsByAppPrefix(
   sandboxFunctions: SandboxFunctionResource[]
 ): Map<string, PodAppFunction[]> {
@@ -289,11 +292,11 @@ function groupFunctionsByAppPrefix(
     const separatorIndex = sandboxFunction.slug.indexOf(
       SANDBOX_FUNCTION_SLUG_SEPARATOR
     );
-    const prefix =
-      separatorIndex > 0
-        ? sandboxFunction.slug.slice(0, separatorIndex)
-        : UNFILED_POD_APP_PREFIX;
+    if (separatorIndex <= 0) {
+      continue;
+    }
 
+    const prefix = sandboxFunction.slug.slice(0, separatorIndex);
     byPrefix.set(prefix, [
       ...(byPrefix.get(prefix) ?? []),
       sandboxFunction.toPodAppJSON(),
@@ -382,7 +385,6 @@ export async function listPodApps(
     ...functionsByPrefix.keys(),
     ...databasesByPrefix.keys(),
   ]);
-  realPrefixes.delete(UNFILED_POD_APP_PREFIX);
 
   const apps: PodApp[] = [];
 
@@ -421,25 +423,7 @@ export async function listPodApps(
     });
   }
 
-  apps.sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
-
-  // Artifacts published from the pod root have no folder to be found under, so they get a synthetic
-  // app rather than disappearing from the listing. Appended after the sort so it always sits last.
-  // Only functions can be unfiled now: a database with no app prefix is not listed at all, and one
-  // with a prefix belongs to that app.
-  const unfiledFunctions = functionsByPrefix.get(UNFILED_POD_APP_PREFIX) ?? [];
-  if (unfiledFunctions.length > 0) {
-    apps.push({
-      prefix: UNFILED_POD_APP_PREFIX,
-      name: null,
-      folderPath: null,
-      frames: [],
-      functions: unfiledFunctions,
-      databases: [],
-      fileCount: 0,
-      collidingFolderNames: [],
-    });
-  }
+  apps.sort((a, b) => a.name.localeCompare(b.name));
 
   return new Ok(apps);
 }
@@ -447,7 +431,6 @@ export async function listPodApps(
 export type PodAppDeleteErrorCode =
   | "not_a_pod"
   | "not_found"
-  | "cannot_delete_unfiled"
   | "sandbox_unavailable"
   | "internal";
 
@@ -488,17 +471,6 @@ export async function deletePodApp(
   if (!pod.isProject()) {
     return new Err(
       new PodAppDeleteError("not_a_pod", "Apps only exist on Pod spaces.")
-    );
-  }
-
-  // The unfiled app is a presentation device, not a folder: its artifacts each belong to whoever
-  // published them at the pod root, so there is nothing coherent to delete.
-  if (prefix === UNFILED_POD_APP_PREFIX) {
-    return new Err(
-      new PodAppDeleteError(
-        "cannot_delete_unfiled",
-        "Artifacts published outside an app folder cannot be deleted as an app."
-      )
     );
   }
 
@@ -569,9 +541,7 @@ export async function deletePodApp(
   // which is what revokes the Frames' share tokens along with them. Colliding folders all normalize
   // onto this one prefix, so every one of them belongs to the app being deleted.
   const folderNames =
-    app.collidingFolderNames.length > 0
-      ? app.collidingFolderNames
-      : removeNulls([app.name]);
+    app.collidingFolderNames.length > 0 ? app.collidingFolderNames : [app.name];
   for (const folderName of folderNames) {
     const deleteFolderResult = await deleteProjectFile(auth, {
       space: pod,

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -68,11 +68,6 @@ type AppFolder = {
   fileCount: number;
   frameEntries: FileSystemFileEntry[];
   hasAppShapedSubfolder: boolean;
-  /**
-   * App-relative names of the databases this folder declares, one per `databases/{name}.db.ts`. Used
-   * to attribute databases whose on-disk name carries no app prefix.
-   */
-  declaredDatabaseNames: Set<string>;
 };
 
 /** Drop the last extension from a file name, e.g. `add-task.ts` -> `add-task`. */
@@ -120,7 +115,6 @@ function collectAppFolders(
       fileCount: 0,
       frameEntries: [],
       hasAppShapedSubfolder: false,
-      declaredDatabaseNames: new Set(),
     };
     folders.set(name, folder);
 
@@ -164,19 +158,6 @@ function collectAppFolders(
     // of how the app is laid out.
     if (segments.length === 2 && isInteractiveContentType(entry.contentType)) {
       folder.frameEntries.push(entry);
-    }
-
-    if (
-      segments.length === 3 &&
-      segments[1] === APP_DATABASES_SUBFOLDER &&
-      entry.fileName.endsWith(POD_DATABASE_SCHEMA_FILE_SUFFIX)
-    ) {
-      folder.declaredDatabaseNames.add(
-        entry.fileName.slice(
-          0,
-          entry.fileName.length - POD_DATABASE_SCHEMA_FILE_SUFFIX.length
-        )
-      );
     }
   }
 
@@ -260,51 +241,39 @@ async function listPodDatabaseOnDiskNames(
 }
 
 /**
- * Group the pod's databases by the app prefix that owns each one.
+ * Group the pod's databases by the app prefix their filename carries.
  *
- * A namespaced database carries its app in its filename, so its prefix decides. A database created
- * before app namespacing has a bare filename instead, and the only remaining evidence of ownership is
- * the schema file that declares it — `<AppName>/databases/{name}.db.ts`. This mirrors how
- * `resolvePodDatabaseName` resolves the same case at reconcile time, so the tab attributes a legacy
- * database to exactly the app that keeps writing to it.
+ * Only namespaced databases are listed. A database created before app namespacing has a bare
+ * filename, which says nothing about which app owns it — the only evidence left is the schema file
+ * that declares it, and that evidence stops being reliable as soon as apps can be copied, because a
+ * copy inherits the declaration while opening its own prefixed file. Rather than infer ownership,
+ * such a database is left out of the listing entirely.
  *
- * Two apps declaring the same bare name genuinely share that one database (the transitional case
- * `resolvePodDatabaseName` documents), so it is reported under both rather than arbitrarily assigned.
- * A bare database no app declares falls back to the unfiled app.
+ * Two consequences worth knowing, both accepted deliberately:
+ *
+ *  - An app whose only database predates namespacing shows none, even though `resolvePodDatabaseName`
+ *    step 2 still opens that bare file at run time.
+ *  - Deleting an app does not remove such a database, because `deletePodApp` works from this listing.
+ *    The file and its replica outlive the app.
+ *
+ * Both go away once bare databases are migrated to their prefixed names, which is also what lets the
+ * step 2 fallback be deleted from the runtime (see `resolvePodDatabaseName`).
  */
 function groupDatabasesByAppPrefix(
-  onDiskNames: string[],
-  foldersByPrefix: Map<string, AppFolder[]>
+  onDiskNames: string[]
 ): Map<string, PodAppDatabase[]> {
   const byPrefix = new Map<string, PodAppDatabase[]>();
 
-  const attribute = (prefix: string, database: PodAppDatabase) => {
-    byPrefix.set(prefix, [...(byPrefix.get(prefix) ?? []), database]);
-  };
-
   for (const onDiskName of onDiskNames) {
-    const database = {
-      name: podDatabaseNameWithoutAppPrefix(onDiskName),
-      onDiskName,
-    };
-
-    const prefixFromName = appPrefixFromPodDatabaseName(onDiskName);
-    if (prefixFromName !== null) {
-      attribute(prefixFromName, database);
+    const prefix = appPrefixFromPodDatabaseName(onDiskName);
+    if (prefix === null) {
       continue;
     }
 
-    const declaringPrefixes = [...foldersByPrefix].filter(([, folders]) =>
-      folders.some((folder) => folder.declaredDatabaseNames.has(onDiskName))
-    );
-    if (declaringPrefixes.length === 0) {
-      attribute(UNFILED_POD_APP_PREFIX, database);
-      continue;
-    }
-
-    for (const [prefix] of declaringPrefixes) {
-      attribute(prefix, database);
-    }
+    byPrefix.set(prefix, [
+      ...(byPrefix.get(prefix) ?? []),
+      { name: podDatabaseNameWithoutAppPrefix(onDiskName), onDiskName },
+    ]);
   }
 
   return byPrefix;
@@ -406,12 +375,7 @@ export async function listPodApps(
     ]);
   }
 
-  // Needs foldersByPrefix: a database created before app namespacing has no prefix in its filename,
-  // so only the schema file that declares it says which app owns it.
-  const databasesByPrefix = groupDatabasesByAppPrefix(
-    databaseOnDiskNames,
-    foldersByPrefix
-  );
+  const databasesByPrefix = groupDatabasesByAppPrefix(databaseOnDiskNames);
 
   const realPrefixes = new Set([
     ...foldersByPrefix.keys(),
@@ -461,16 +425,17 @@ export async function listPodApps(
 
   // Artifacts published from the pod root have no folder to be found under, so they get a synthetic
   // app rather than disappearing from the listing. Appended after the sort so it always sits last.
+  // Only functions can be unfiled now: a database with no app prefix is not listed at all, and one
+  // with a prefix belongs to that app.
   const unfiledFunctions = functionsByPrefix.get(UNFILED_POD_APP_PREFIX) ?? [];
-  const unfiledDatabases = databasesByPrefix.get(UNFILED_POD_APP_PREFIX) ?? [];
-  if (unfiledFunctions.length > 0 || unfiledDatabases.length > 0) {
+  if (unfiledFunctions.length > 0) {
     apps.push({
       prefix: UNFILED_POD_APP_PREFIX,
       name: null,
       folderPath: null,
       frames: [],
       functions: unfiledFunctions,
-      databases: unfiledDatabases,
+      databases: [],
       fileCount: 0,
       collidingFolderNames: [],
     });

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -8,14 +8,6 @@ import { z } from "zod";
  * and database filenames. So these types describe a view assembled at read time, never stored.
  */
 
-/**
- * The prefix of the synthetic app collecting everything published from the pod root, which has no app
- * folder. Empty so it can never collide with a real prefix, which `normalizeAppPrefix` guarantees is
- * non-empty. Lives here rather than in `lib/api` so components can branch on it without pulling
- * server-only modules into the browser bundle.
- */
-export const UNFILED_POD_APP_PREFIX = "";
-
 export type PodAppFrame = {
   /** sId of the Frame's FileResource, or null for a source file with no row yet. */
   fileId: string | null;
@@ -51,13 +43,12 @@ export type PodAppDatabase = {
 
 export type PodApp = {
   /**
-   * The normalized app prefix, which is this app's identifier — apps have no sId. Empty string for
-   * the synthetic "unfiled" app collecting artifacts published from the pod root.
+   * The normalized app prefix, which is this app's identifier — apps have no sId.
    */
   prefix: string;
-  /** The folder name as authored (`TaskList`), or null for the unfiled app. */
-  name: string | null;
-  /** Canonical scoped path of the app folder, or null for the unfiled app. */
+  /** The folder name as authored (`TaskList`), falling back to the prefix if the folder is gone. */
+  name: string;
+  /** Canonical scoped path of the app folder, or null when only published artifacts remain. */
   folderPath: string | null;
   frames: PodAppFrame[];
   functions: PodAppFunction[];
@@ -112,7 +103,7 @@ export type ClonePodAppResponseBody = {
 /** What a delete removed, as the business layer reports it and the endpoint returns it. */
 export type PodAppDeleteSummary = {
   prefix: string;
-  name: string | null;
+  name: string;
   deletedFunctionSlugs: string[];
   deletedDatabaseNames: string[];
   deletedFolderNames: string[];


### PR DESCRIPTION
## Description

A cleanup of the Apps tab listing, dropping two things that only existed to paper over ambiguity.

## 1. Only namespaced databases are listed

A database created before app namespacing has a bare filename, which says nothing about which app owns it. The tab inferred ownership from the schema file that declares it — `<AppName>/databases/{name}.db.ts`.

That inference stops being reliable as soon as apps can be copied: a copy inherits the declaration while opening its own prefixed file, so both apps declare the name and the bare file is credited to both. Cloning `Counter` into `Counter Copy` produced this:

```
counter.db                 ← from before namespacing
counter__counter.db        ← Counter's
counter_copy__counter.db   ← Counter Copy's
```

Both apps listed **two** databases, both rendered `counter`, since the display name strips the app prefix.

Rather than sharpen the inference, it's gone. Ownership is a property of the filename or it is unknown:

```ts
for (const onDiskName of onDiskNames) {
  const prefix = appPrefixFromPodDatabaseName(onDiskName);
  if (prefix === null) { continue; }
  attribute(prefix, { name: podDatabaseNameWithoutAppPrefix(onDiskName), onDiskName });
}
```

With it goes the declared-names `Set` on every app folder, the pass over `databases/*.db.ts` that populated it, and the schema-file suffix constant.

### Accepted consequences

Documented on `groupDatabasesByAppPrefix`, where the decision lives:

- An app whose only database predates namespacing shows none, even though `resolvePodDatabaseName` step 2 still opens that bare file at run time.
- Deleting such an app leaves the database and its replica behind, since `deletePodApp` works from this listing.

Both disappear once bare databases are migrated to their prefixed names — which is also the prerequisite for deleting the step 2 fallback from the runtime, as `db_naming.ts` already notes. This PR is deliberately the cheap half: stop the tab guessing, leave the migration as the thing that removes the legacy concept.

## 2. No more Unfiled app

The synthetic "unfiled" app existed so a function published at the Pod root had somewhere to appear. With unprefixed databases no longer listed, keeping it for functions alone was inconsistent — and it was never an app: no folder, not deletable, and every consumer had to special-case a prefix that is the empty string. A prefix-less function stays published and callable; there is simply no app to list it under.

Removing it lets **`PodApp.name` stop being nullable** — it was only nullable for that one synthetic entry. That cascade removes:

- the `?? "Unfiled"` fallbacks in both components
- the empty-prefix guard in `deletePodApp`, its `cannot_delete_unfiled` error code, and the endpoint case mapping it
- a `removeNulls` around a value that can no longer be null

## 3. No scoped path under the app name

The detail pane showed `pod-{podId}/AnimalManager` beneath the heading. The pod id isn't information the reader needs and the folder name is already the heading, so the line is gone.

## Risk

Low. Read-only change to what the tab lists — nothing is created, moved or deleted, and no database file is touched. The one behavioural loss is stated above under accepted consequences.

## Tests

Legacy-attribution and unfiled tests replaced by ones asserting the new contract: a bare database is not listed under the app that declares it while its namespaced sibling is, a Pod of only bare databases lists nothing, and a function published outside an app folder is not listed. 14 apps-endpoint tests green; front, front-api and front-spa typecheck.
