### PR TITLE
[front] enh: publish a cloned app's Frame

### DIFF
--- a/front/components/pod/apps/ClonePodAppDialog.tsx
+++ b/front/components/pod/apps/ClonePodAppDialog.tsx
@@ -114,8 +114,8 @@ export function ClonePodAppDialog({
 
               <ContentMessage variant="info" title="The copy starts empty">
                 Its {app.databases.length === 1 ? "database" : "databases"} are
-                created from the same schema but hold no data, and its Frame is
-                left unpublished so you can review it first.
+                created from the same schema but hold no data. Everything else
+                is published like the original's.
               </ContentMessage>
             </DialogContainer>
             <DialogFooter

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -3,7 +3,10 @@ import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
 import { getFileContent } from "@app/lib/api/files/utils";
 import { deleteProjectFile } from "@app/lib/api/projects/context";
-import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
+import {
+  createPodFrameFile,
+  publishPodFrameFile,
+} from "@app/lib/api/projects/pod_frame_file";
 import { deletePodDatabaseReplica } from "@app/lib/api/sandbox/db";
 import {
   appPrefixFromPodDatabaseName,
@@ -595,9 +598,10 @@ function fileEntriesOf(entries: FileSystemEntry[]): FileSystemFileEntry[] {
  * Clone a Pod app into a new folder in the same Pod.
  *
  * What carries over: every file under the app folder, its published functions (re-published under the
- * copy's prefix), and its databases as **fresh, empty** ones reconciled from the copied schema files.
- * What does not: database rows, share tokens, the pinned tab, and invocation history. The copy's Frame
- * is left unpublished, so the author decides when it becomes a shareable artifact.
+ * copy's prefix), its databases as **fresh, empty** ones reconciled from the copied schema files, and
+ * the published state of its Frames — a published Frame is published in the copy too, so the clone
+ * opens and renders exactly like the original.
+ * What does not: database rows, share tokens, the pinned tab, and invocation history.
  *
  * A Frame cannot simply be copied as an object — it needs a FileResource to be publishable at all —
  * so Frames are recreated through `createPodFrameFile` and every other file is copied directly.
@@ -733,6 +737,18 @@ export async function clonePodApp(
         new PodAppCloneError("internal", createResult.error.message)
       );
     }
+    // Publish the copy's Frame when the source's was published, so the clone is as usable as the
+    // original — openable, shareable, rendering its bundle. A source still being authored has no
+    // bundle to mirror, so the copy stays unpublished too and renders its source like any draft.
+    if (frame.isPublished) {
+      const publishResult = await publishPodFrameFile(auth, createResult.value);
+      if (publishResult.isErr()) {
+        return new Err(
+          new PodAppCloneError("internal", publishResult.error.message)
+        );
+      }
+    }
+
     clonedFrameNames.push(frame.fileName);
     copiedFileCount += 1;
   }

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -1,12 +1,8 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
-import { getFileContent } from "@app/lib/api/files/utils";
 import { deleteProjectFile } from "@app/lib/api/projects/context";
-import {
-  createPodFrameFile,
-  publishPodFrameFile,
-} from "@app/lib/api/projects/pod_frame_file";
+import { clonePodFrame } from "@app/lib/api/projects/pod_frame_file";
 import { deletePodDatabaseReplica } from "@app/lib/api/sandbox/db";
 import {
   appPrefixFromPodDatabaseName,
@@ -702,55 +698,25 @@ export async function clonePodApp(
     copiedFileCount += 1;
   }
 
-  // Recreate the Frames so the copy owns publishable files rather than bare objects.
+  // Recreate the Frames so the copy owns publishable files rather than bare objects, mirroring
+  // whether each was published.
   const clonedFrameNames: string[] = [];
   for (const frame of source.frames) {
-    if (!frame.fileId) {
-      continue;
-    }
-    const sourceFile = await FileResource.fetchById(auth, frame.fileId);
-    if (!sourceFile) {
-      continue;
-    }
-    if (!isInteractiveContentType(sourceFile.contentType)) {
-      continue;
-    }
-    const content = await getFileContent(auth, sourceFile, "original");
-    if (content === null) {
-      return new Err(
-        new PodAppCloneError(
-          "internal",
-          `Could not read the source of Frame '${frame.fileName}'.`
-        )
-      );
-    }
-
-    const createResult = await createPodFrameFile(auth, {
+    const frameResult = await clonePodFrame(auth, {
       space: pod,
       folderName,
-      fileName: frame.fileName,
-      contentType: sourceFile.contentType,
-      content,
+      frame,
     });
-    if (createResult.isErr()) {
+    if (frameResult.isErr()) {
       return new Err(
-        new PodAppCloneError("internal", createResult.error.message)
+        new PodAppCloneError("internal", frameResult.error.message)
       );
     }
-    // Publish the copy's Frame when the source's was published, so the clone is as usable as the
-    // original — openable, shareable, rendering its bundle. A source still being authored has no
-    // bundle to mirror, so the copy stays unpublished too and renders its source like any draft.
-    if (frame.isPublished) {
-      const publishResult = await publishPodFrameFile(auth, createResult.value);
-      if (publishResult.isErr()) {
-        return new Err(
-          new PodAppCloneError("internal", publishResult.error.message)
-        );
-      }
+    // Null means the source Frame had nothing to copy; the rest of the app is still worth cloning.
+    if (frameResult.value) {
+      clonedFrameNames.push(frame.fileName);
+      copiedFileCount += 1;
     }
-
-    clonedFrameNames.push(frame.fileName);
-    copiedFileCount += 1;
   }
 
   const skipped: string[] = [];

--- a/front/lib/api/projects/pod_frame_file.ts
+++ b/front/lib/api/projects/pod_frame_file.ts
@@ -1,5 +1,9 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
+import { splitFrameEntryScopedPath } from "@app/lib/api/files/mount_path";
 import { moveProjectFile } from "@app/lib/api/projects/context";
+import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
+import { publishFrame } from "@app/lib/api/viz/publish_frame";
 import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -22,6 +26,46 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  * is what makes the Frame belong to the app, and therefore what makes its bare function references
  * resolve against that app.
  */
+/**
+ * Publish a Frame that lives in a Pod folder, exactly as the interactive-content tool does: the
+ * Frame's own directory is the bundling root, so the bundler resolves its relative imports from the
+ * folder it sits in.
+ */
+export async function publishPodFrameFile(
+  auth: Authenticator,
+  file: FileResource
+): Promise<Result<void, Error>> {
+  const scopedPath = file.toScopedPath(auth);
+  if (!scopedPath) {
+    return new Err(
+      new Error(`Frame '${file.sId}' has no Pod path to publish from.`)
+    );
+  }
+
+  const splitResult = splitFrameEntryScopedPath(scopedPath);
+  if (splitResult.isErr()) {
+    return new Err(splitResult.error);
+  }
+  const { root, entryRelPath } = splitResult.value;
+
+  const fsResult = await DustFileSystem.fromScopedPath(auth, root);
+  if (fsResult.isErr()) {
+    return new Err(fsResult.error);
+  }
+
+  const publishResult = await publishFrame(auth, {
+    file,
+    reader: createMountFrameSourceReader(fsResult.value, root),
+    entryRelPath,
+    rootScopedPath: root,
+  });
+  if (publishResult.isErr()) {
+    return new Err(new Error(publishResult.error.message));
+  }
+
+  return new Ok(undefined);
+}
+
 /**
  * The path a Pod file has relative to the Pod's files root, from its canonical scoped path.
  *

--- a/front/lib/api/projects/pod_frame_file.ts
+++ b/front/lib/api/projects/pod_frame_file.ts
@@ -1,6 +1,7 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { splitFrameEntryScopedPath } from "@app/lib/api/files/mount_path";
+import { getFileContent } from "@app/lib/api/files/utils";
 import { moveProjectFile } from "@app/lib/api/projects/context";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import { publishFrame } from "@app/lib/api/viz/publish_frame";
@@ -8,7 +9,9 @@ import { uploadFrameContent } from "@app/lib/api/viz/upload_frame_content";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { PodAppFrame } from "@app/types/api/pod_apps";
 import type { InteractiveContentFileContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -31,7 +34,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  * Frame's own directory is the bundling root, so the bundler resolves its relative imports from the
  * folder it sits in.
  */
-export async function publishPodFrameFile(
+async function publishPodFrameFile(
   auth: Authenticator,
   file: FileResource
 ): Promise<Result<void, Error>> {
@@ -87,7 +90,7 @@ export function podRelativePathFromScopedPath(
   return relativePath.length > 0 ? relativePath : null;
 }
 
-export async function createPodFrameFile(
+async function createPodFrameFile(
   auth: Authenticator,
   {
     space,
@@ -159,4 +162,68 @@ export async function createPodFrameFile(
   } catch (error) {
     return new Err(normalizeError(error));
   }
+}
+
+/**
+ * Copy one Frame into an app folder in the same Pod, mirroring whether it was published.
+ *
+ * The whole Frame side of cloning an app: read the source, create a real file in the target folder,
+ * and publish it when the source was published. Callers get one operation rather than two steps they
+ * have to sequence correctly — creating before publishing, and publishing only from the folder the
+ * copy now lives in, which is what makes its bare function references resolve to the copy's own
+ * functions.
+ *
+ * Returns null when the source Frame has nothing to copy: a listing entry with no FileResource, or a
+ * file that is not interactive content. Those are skipped rather than failing the clone, since the
+ * app's other parts are still worth copying.
+ */
+export async function clonePodFrame(
+  auth: Authenticator,
+  {
+    space,
+    folderName,
+    frame,
+  }: {
+    space: SpaceResource;
+    folderName: string;
+    frame: PodAppFrame;
+  }
+): Promise<Result<FileResource | null, Error>> {
+  if (!frame.fileId) {
+    return new Ok(null);
+  }
+
+  const sourceFile = await FileResource.fetchById(auth, frame.fileId);
+  if (!sourceFile || !isInteractiveContentType(sourceFile.contentType)) {
+    return new Ok(null);
+  }
+
+  const content = await getFileContent(auth, sourceFile, "original");
+  if (content === null) {
+    return new Err(
+      new Error(`Could not read the source of Frame '${frame.fileName}'.`)
+    );
+  }
+
+  const createResult = await createPodFrameFile(auth, {
+    space,
+    folderName,
+    fileName: frame.fileName,
+    contentType: sourceFile.contentType,
+    content,
+  });
+  if (createResult.isErr()) {
+    return createResult;
+  }
+
+  // A source still being authored has no bundle to mirror, so the copy stays a draft and renders its
+  // source, exactly as the original does.
+  if (frame.isPublished) {
+    const publishResult = await publishPodFrameFile(auth, createResult.value);
+    if (publishResult.isErr()) {
+      return publishResult;
+    }
+  }
+
+  return new Ok(createResult.value);
 }


### PR DESCRIPTION
## Description

A clone left its Frame unpublished, so the copy of a working app arrived as a draft: it rendered its source, showed as "Not published" in the Apps tab, and had to be published by hand before it could be shared.

The copy now **mirrors the source**. A Frame that was published is published in the copy too; one still being authored stays a draft, since there is no bundle to mirror and the copy renders its source exactly as the original does.

I chose mirroring rather than publishing unconditionally so that cloning a half-written app does not silently produce a shareable artifact its author never asked for. Say the word if you would rather it always publish.

## How

Through the same path as the interactive-content publish tool: the Frame's own directory is the bundling root, so its relative imports resolve from the folder it sits in.

```
splitFrameEntryScopedPath → DustFileSystem.fromScopedPath → publishFrame(reader, entryRelPath, root)
```

It runs **after** the folder's files are copied, so those imports are present when the bundler walks them. Bundling from the copy's own folder is also what makes the Frame's bare function references resolve to the copy's functions rather than the original's.

The clone dialog no longer says the Frame is left unpublished.

## Risk

Low, and confined to clone. The only new failure mode is a publish that fails — bundling or validation — which fails the clone with the publish error rather than leaving a half-published Frame.

## Tests

Existing suite green: 19 apps-endpoint tests, front and front-api typecheck.

Not covered by tests, and unchanged from the original clone PR: anything on the Frame path. Creating a Frame goes through `uploadContent`, which never settles under the file-storage mock, so a clone test cannot get as far as having a Frame to publish. **Worth verifying by hand:** clone a published app, confirm the copy opens and renders its bundle rather than showing "Not published", and that its data is its own.
