### PR TITLE
Fix unconsumed tool result attribution

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -35,7 +35,11 @@ const BILLED_CREDIT_AMOUNT_MICRO = 10_000_000;
 // footprints are deterministic in the assertions below.
 const TOKENS_PER_FOOTPRINT = 2;
 
-async function setupSettledMessageWithUsage() {
+async function setupSettledMessageWithUsage({
+  runCount = 1,
+}: {
+  runCount?: number;
+} = {}) {
   const {
     authenticator: auth,
     globalSpace,
@@ -50,17 +54,25 @@ async function setupSettledMessageWithUsage() {
     agentConfigurationId: agentConfiguration.sId,
     messagesCreatedAt: [],
   });
-  const { run } = await RunFactory.createWithUsage(auth, {
-    inputTokens: INPUT_TOKENS_COUNT,
-    outputTokens: OUTPUT_TOKENS_COUNT,
-    reasoningTokens: REASONING_TOKENS_COUNT,
-  });
+  const runs = [];
+  for (let index = 0; index < runCount; index++) {
+    const { run } = await RunFactory.createWithUsage(auth, {
+      inputTokens: INPUT_TOKENS_COUNT,
+      outputTokens: OUTPUT_TOKENS_COUNT,
+      reasoningTokens: REASONING_TOKENS_COUNT,
+    });
+    runs.push(run);
+  }
+  const run = runs[0];
+  if (!run) {
+    throw new Error("At least one run is required");
+  }
   // The default factory status is "created", which is a tracked status, so attribution runs.
   const { agentMessage } = await ConversationFactory.createAgentMessage(auth, {
     workspace,
     conversation,
     agentConfig: agentConfiguration,
-    runIds: [run.dustRunId],
+    runIds: runs.map(({ dustRunId }) => dustRunId),
   });
   await ConversationResource.updateAgentMessageCostCredits(auth, {
     agentMessageModelId: agentMessage.agentMessageId,
@@ -73,6 +85,7 @@ async function setupSettledMessageWithUsage() {
     workspace,
     conversation,
     run,
+    runs,
     conversationId: conversation.sId,
     agentMessageId: agentMessage.sId,
     agentMessageModelId: agentMessage.agentMessageId,
@@ -258,6 +271,124 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     expect(
       (outputItem?.outputTokensCount ?? 0) + (toolItem?.outputTokensCount ?? 0)
     ).toBe(OUTPUT_TOKENS_COUNT - REASONING_TOKENS_COUNT);
+  });
+
+  it("removes only the last run's tool result footprint when the message stops", async () => {
+    const {
+      auth,
+      workspace,
+      conversation,
+      runs,
+      conversationId,
+      agentMessageId,
+      agentMessageModelId,
+    } = await setupSettledMessageWithUsage({ runCount: 2 });
+    const firstRun = runs[0];
+    const lastRun = runs[1];
+    if (!firstRun || !lastRun) {
+      throw new Error("Expected two runs");
+    }
+
+    const actions = [];
+    for (const run of [firstRun, lastRun]) {
+      const { action } = await AgentMCPActionFactory.create(auth, {
+        workspace,
+        conversationModelId: conversation.id,
+        agentMessageModelId,
+        status: "succeeded",
+        dustRunId: run.dustRunId,
+      });
+      actions.push(action);
+    }
+    const consumedAction = actions[0];
+    const unconsumedAction = actions[1];
+    if (!consumedAction || !unconsumedAction) {
+      throw new Error("Expected two actions");
+    }
+
+    const getItems = async () => {
+      const items =
+        await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+          auth,
+          {
+            agentMessageModelIds: [agentMessageModelId],
+            maxAttributionVersion:
+              AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+          }
+        );
+      return {
+        items,
+        toolByActionModelId: new Map(
+          items
+            .filter((item) => item.itemType === "tool")
+            .map((item) => [item.agentMCPActionId, item])
+        ),
+      };
+    };
+
+    // A resumable pass records both result footprints because either can still reach a later run.
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+    const { toolByActionModelId: toolsBeforeStop } = await getItems();
+    const consumedToolBeforeStop = toolsBeforeStop.get(consumedAction.id);
+    const unconsumedToolBeforeStop = toolsBeforeStop.get(unconsumedAction.id);
+    expect(consumedToolBeforeStop?.inputTokensCount).toBe(TOKENS_PER_FOOTPRINT);
+    expect(unconsumedToolBeforeStop?.inputTokensCount).toBe(
+      TOKENS_PER_FOOTPRINT
+    );
+
+    await ConversationFactory.setAgentMessageStatus({
+      workspace,
+      agentMessageModelId,
+      status: "gracefully_stopped",
+    });
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+
+    const { items: itemsAfterStop, toolByActionModelId: toolsAfterStop } =
+      await getItems();
+    const consumedToolAfterStop = toolsAfterStop.get(consumedAction.id);
+    const unconsumedToolAfterStop = toolsAfterStop.get(unconsumedAction.id);
+
+    expect(consumedToolAfterStop).toMatchObject({
+      inputTokensCount: TOKENS_PER_FOOTPRINT,
+      grossAttributedCreditAmountMicro:
+        consumedToolBeforeStop?.grossAttributedCreditAmountMicro,
+      directCreditAmountMicro: consumedToolBeforeStop?.directCreditAmountMicro,
+    });
+    expect(unconsumedToolAfterStop).toMatchObject({
+      inputTokensCount: 0,
+      directCreditAmountMicro:
+        unconsumedToolBeforeStop?.directCreditAmountMicro,
+    });
+    expect(
+      unconsumedToolAfterStop?.grossAttributedCreditAmountMicro
+    ).toBeLessThan(
+      unconsumedToolBeforeStop?.grossAttributedCreditAmountMicro ?? 0
+    );
+    expect(
+      itemsAfterStop.reduce(
+        (total, item) => total + (item.reconciledCreditAmountMicro ?? 0),
+        0
+      )
+    ).toBe(BILLED_CREDIT_AMOUNT_MICRO);
+
+    // A retry cannot subtract the result twice or restore it from stale potential evidence.
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId,
+      conversationId,
+    });
+    expect(
+      (await getItems()).toolByActionModelId.get(unconsumedAction.id)
+    ).toMatchObject({
+      inputTokensCount: 0,
+      grossAttributedCreditAmountMicro:
+        unconsumedToolAfterStop?.grossAttributedCreditAmountMicro,
+    });
   });
 
   it("stores a sandbox child Frame call as direct-charge-only", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -22,8 +22,14 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import type { UserMessageOrigin } from "@app/types/assistant/conversation";
-import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversation";
+import type {
+  AgentMessageStatus,
+  UserMessageOrigin,
+} from "@app/types/assistant/conversation";
+import {
+  AGENT_MESSAGE_STATUSES_TO_TRACK,
+  isTerminalAgentMessageStatus,
+} from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import assert from "assert";
@@ -32,11 +38,13 @@ function selectRunUsagesNeedingEvidence({
   actionsByDustRunId,
   currentItems,
   dustRunIdByRunModelId,
+  runUsageModelIdsWithUnconsumedToolResults,
   usages,
 }: {
   actionsByDustRunId: ReadonlyMap<string, AgentMCPActionResource[]>;
   currentItems: AgentMessageConsumptionItemResource[];
   dustRunIdByRunModelId: ReadonlyMap<ModelId, string>;
+  runUsageModelIdsWithUnconsumedToolResults: ReadonlySet<ModelId>;
   usages: RunUsageWithRunKeyType[];
 }): RunUsageWithRunKeyType[] {
   const modelItemTypesByRunUsageModelId = new Map<ModelId, Set<string>>();
@@ -89,7 +97,10 @@ function selectRunUsagesNeedingEvidence({
       const item = toolItemByActionModelId.get(action.id);
       return (
         !item ||
-        (item.completedAt === null && isToolExecutionStatusFinal(action.status))
+        (item.completedAt === null &&
+          isToolExecutionStatusFinal(action.status)) ||
+        (runUsageModelIdsWithUnconsumedToolResults.has(usage.runUsageModelId) &&
+          (item.inputTokensCount ?? 0) > 0)
       );
     });
 
@@ -97,15 +108,64 @@ function selectRunUsagesNeedingEvidence({
   });
 }
 
+/**
+ * A tool result emitted by the last reported model run of a terminal message was never sent back
+ * to the model. Run IDs on the message are de-duplicated in SQL without an ordering guarantee, so
+ * use the durable Run chronology instead.
+ */
+function runUsageModelIdsWithUnconsumedToolResults({
+  runs,
+  status,
+  usages,
+}: {
+  runs: RunResource[];
+  status: AgentMessageStatus;
+  usages: RunUsageWithRunKeyType[];
+}): ReadonlySet<ModelId> {
+  if (!isTerminalAgentMessageStatus(status)) {
+    return new Set();
+  }
+
+  const runModelIdsWithReportedUsage = new Set(
+    usages.map((usage) => usage.runModelId)
+  );
+  let lastRun: RunResource | null = null;
+  for (const run of runs) {
+    if (!runModelIdsWithReportedUsage.has(run.id)) {
+      continue;
+    }
+    if (
+      lastRun === null ||
+      run.createdAt.getTime() > lastRun.createdAt.getTime() ||
+      (run.createdAt.getTime() === lastRun.createdAt.getTime() &&
+        run.id > lastRun.id)
+    ) {
+      lastRun = run;
+    }
+  }
+
+  if (lastRun === null) {
+    return new Set();
+  }
+
+  return new Set(
+    usages
+      .filter((usage) => usage.runModelId === lastRun.id)
+      .map((usage) => usage.runUsageModelId)
+  );
+}
+
 async function buildRunUsageConsumptionEvidence(
   auth: Authenticator,
   {
     enrichedActionByModelId,
+    includeToolResultFootprints,
     runActions,
     triggeringUserMessageOrigin,
     usage,
   }: {
     enrichedActionByModelId: ReadonlyMap<ModelId, AgentMCPActionWithOutputType>;
+    includeToolResultFootprints: boolean;
     runActions: AgentMCPActionResource[];
     triggeringUserMessageOrigin: UserMessageOrigin | null;
     usage: RunUsageWithRunKeyType;
@@ -237,7 +297,9 @@ async function buildRunUsageConsumptionEvidence(
     const toolAttribution = buildToolAttribution({
       usage,
       toolCall,
-      inputTokensCount: footprint.inputTokensCount,
+      inputTokensCount: includeToolResultFootprints
+        ? footprint.inputTokensCount
+        : 0,
       directCreditAmountMicro,
     });
     records.push({
@@ -319,9 +381,10 @@ async function persistMessageConsumptionAttribution(
     usages: RunUsageWithRunKeyType[];
   }
 ): Promise<boolean> {
-  // Store the immutable evidence first, then materialize the newest complete allocation against the
-  // authoritative bill in the same transaction. An incomplete version keeps its evidence with null
-  // reconciliation and can be completed by a later finalize.
+  // Store the evidence first, remove any terminal result footprint that never reached another model
+  // run, then materialize the newest complete allocation against the authoritative bill in the same
+  // transaction. An incomplete version keeps its evidence with null reconciliation and can be
+  // completed by a later finalize.
   return withTransaction(async (transaction) => {
     await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
       conversation,
@@ -385,7 +448,9 @@ async function persistMessageConsumptionAttribution(
  * charge it, so its tool row is written pending: only the output the model already spent emitting the
  * call, carved out of the assistant bucket like any other tool call. When a later finalize sees the
  * action final, that pending row is completed in place with the result footprint and direct charge,
- * rather than replaced (the row cannot be re-inserted past its idempotency key).
+ * rather than replaced (the row cannot be re-inserted past its idempotency key). If the message
+ * becomes terminal without another reported model run, that footprint is removed in place: the
+ * result was produced, but never consumed.
  */
 export async function computeAndStoreAgentMessageConsumptionAttribution(
   auth: Authenticator,
@@ -442,6 +507,8 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
   // Every usage is reached through this message's own runIds, so each one belongs to this message.
   const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
   const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
+  const unconsumedToolResultRunUsageModelIds =
+    runUsageModelIdsWithUnconsumedToolResults({ runs, status, usages });
 
   // Group the message's tool calls by the run that emitted them. Each action carries its emitting
   // step content, whose dustRunId identifies that run and is the same identifier the run usages are
@@ -479,6 +546,8 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     actionsByDustRunId,
     currentItems,
     dustRunIdByRunModelId,
+    runUsageModelIdsWithUnconsumedToolResults:
+      unconsumedToolResultRunUsageModelIds,
     usages,
   });
   const dustRunIdsToProcess = new Set(
@@ -513,6 +582,9 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
     const usageEvidence = await buildRunUsageConsumptionEvidence(auth, {
       enrichedActionByModelId,
+      includeToolResultFootprints: !unconsumedToolResultRunUsageModelIds.has(
+        usage.runUsageModelId
+      ),
       runActions,
       triggeringUserMessageOrigin,
       usage,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -7,7 +7,10 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import { GPT_5_MODEL_ID } from "@app/types/assistant/models/openai";
+import {
+  GPT_4_1_MODEL_CONFIG,
+  GPT_5_MODEL_ID,
+} from "@app/types/assistant/models/openai";
 import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -169,6 +172,20 @@ describe("measureToolCallFootprints", () => {
 
     expect(res.isErr()).toBe(true);
     expect(tokenCountForTexts).not.toHaveBeenCalled();
+  });
+
+  it("tokenizes historical runs whose model is no longer served", async () => {
+    const res = await measureToolCallFootprints(auth, {
+      modelId: GPT_4_1_MODEL_CONFIG.modelId,
+      toolCalls: [footprintInput(makeAction())],
+    });
+
+    expect(res.isOk()).toBe(true);
+    expect(tokenCountForTexts).toHaveBeenCalledWith(
+      expect.any(Array),
+      GPT_4_1_MODEL_CONFIG,
+      expect.anything()
+    );
   });
 
   it("measures the call and result footprint of each action, aligned by position", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -5,8 +5,19 @@ import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import {
+  GPT_4_1_MINI_MODEL_CONFIG,
+  GPT_4_1_MODEL_CONFIG,
+} from "@app/types/assistant/models/openai";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+
+// Consumption attribution also runs for historical messages. These models are no longer in the
+// serving registry, but their immutable tokenizer configurations remain valid for old run usage.
+const HISTORICAL_TOKENIZATION_MODEL_CONFIGS = [
+  GPT_4_1_MODEL_CONFIG,
+  GPT_4_1_MINI_MODEL_CONFIG,
+];
 
 /**
  * The two texts an MCP action contributes to the model's token budget: the tool call the model
@@ -77,7 +88,11 @@ export async function measureToolCallFootprints(
     return new Ok([]);
   }
 
-  const model = getModelConfigByModelId(modelId);
+  const model =
+    getModelConfigByModelId(modelId) ??
+    HISTORICAL_TOKENIZATION_MODEL_CONFIGS.find(
+      (configuration) => configuration.modelId === modelId
+    );
   if (!model) {
     return new Err(
       new Error(`Cannot tokenize tool footprints: unknown model ${modelId}.`)

--- a/front/lib/models/agent/agent_message_consumption_item.ts
+++ b/front/lib/models/agent/agent_message_consumption_item.ts
@@ -69,10 +69,12 @@ function validateConsumptionItemShape(
 }
 
 // Each row explains one component of an agent message's cost (a model token bucket or a tool call).
-// `grossAttributedCreditAmountMicro` is immutable cache-naive evidence and is not expected to sum
-// to the bill. `reconciledCreditAmountMicro` materializes the item's share of the authoritative
-// Metronome AWU charge. It remains null until a complete attribution version can be allocated.
-// See attribution_builder.ts and allocation.ts for the pricing and reconciliation rationale.
+// `grossAttributedCreditAmountMicro` is cache-naive evidence and is not expected to sum to the
+// bill. It is stable once complete except for one monotonic correction: terminal messages remove a
+// final tool result that never reached another model run. `reconciledCreditAmountMicro`
+// materializes the item's share of the authoritative Metronome AWU charge. It remains null until a
+// complete attribution version can be allocated. See attribution_builder.ts and allocation.ts for
+// the pricing and reconciliation rationale.
 export class AgentMessageConsumptionItemModel extends WorkspaceAwareModel<AgentMessageConsumptionItemModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;

--- a/front/lib/resources/agent_message_consumption_item_resource.ts
+++ b/front/lib/resources/agent_message_consumption_item_resource.ts
@@ -270,9 +270,9 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
   }
 
   /**
-   * Bulk-inserts final tools, then completes only conflicting rows that are still pending. The
-   * insert waits on concurrent writes to the unique action identity, so the following lookup sees
-   * the settled conflict state without requiring a lock or allowing a stale pending write to win.
+   * Bulk-inserts final tools, then resolves conflicts by completing pending rows or removing a
+   * terminal result footprint. The insert waits on concurrent writes to the unique action identity,
+   * so the following lookup sees settled state without a separate lock.
    *
    * // TODO(2026-08-01 flav): Revisit based on how often it happens.
    * A resumed approval pass resubmits facts from earlier passes. PostgreSQL allocates sequence
@@ -319,7 +319,7 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     );
 
     // PostgreSQL returns an ID only for rows inserted by ON CONFLICT DO NOTHING. Most passes create
-    // final tools directly, so they finish without the pending-row lookup below.
+    // final tools directly, so they finish without the conflict lookup below.
     if (insertedRows.every((row) => Boolean(row.id))) {
       return;
     }
@@ -327,53 +327,99 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
     const recordByActionModelId = new Map(
       records.map((record) => [record.action.id, record])
     );
-    const pendingRows = await this.model.findAll({
-      attributes: ["id", "agentMCPActionId"],
+    const existingRows = await this.model.findAll({
+      attributes: [
+        "id",
+        "agentMCPActionId",
+        "completedAt",
+        "directCreditAmountMicro",
+        "inputTokensCount",
+        "outputTokensCount",
+      ],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         agentMessageId: agentMessageModelId,
         attributionVersion,
         agentMCPActionId: { [Op.in]: [...recordByActionModelId.keys()] },
         itemType: "tool",
-        completedAt: { [Op.is]: null },
       },
       transaction,
     });
 
-    for (const pendingRow of pendingRows) {
-      const actionModelId = pendingRow.agentMCPActionId;
+    for (const existingRow of existingRows) {
+      const actionModelId = existingRow.agentMCPActionId;
       assert(
         actionModelId !== null,
-        "A pending tool row must reference an action"
+        "An existing tool row must reference an action"
       );
       const record = recordByActionModelId.get(actionModelId);
       assert(
         record,
-        "A pending tool row must have matching completion evidence"
+        "An existing tool row must have matching completion evidence"
       );
 
-      await this.model.update(
-        {
-          itemType: "tool",
-          agentMCPActionId: actionModelId,
-          inputTokensCount: record.inputTokensCount,
-          grossAttributedCreditAmountMicro:
-            record.grossAttributedCreditAmountMicro,
-          directCreditAmountMicro: record.directCreditAmountMicro,
-          completedAt: now,
-        },
-        {
-          where: {
-            id: pendingRow.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-            agentMessageId: agentMessageModelId,
-            attributionVersion,
+      if (existingRow.completedAt === null) {
+        await this.model.update(
+          {
             itemType: "tool",
-            completedAt: { [Op.is]: null },
+            agentMCPActionId: actionModelId,
+            inputTokensCount: record.inputTokensCount,
+            grossAttributedCreditAmountMicro:
+              record.grossAttributedCreditAmountMicro,
+            directCreditAmountMicro: record.directCreditAmountMicro,
+            completedAt: now,
           },
-          transaction,
-        }
-      );
+          {
+            where: {
+              id: existingRow.id,
+              workspaceId: auth.getNonNullableWorkspace().id,
+              agentMessageId: agentMessageModelId,
+              attributionVersion,
+              itemType: "tool",
+              completedAt: { [Op.is]: null },
+            },
+            transaction,
+          }
+        );
+        continue;
+      }
+
+      // A terminal pass may prove that a potential result never reached another model run. Permit
+      // only that one-way correction. Stale non-terminal passes cannot restore the footprint.
+      if (
+        record.inputTokensCount === 0 &&
+        (existingRow.inputTokensCount ?? 0) > 0
+      ) {
+        assert(
+          existingRow.outputTokensCount === record.outputTokensCount &&
+            existingRow.directCreditAmountMicro ===
+              record.directCreditAmountMicro,
+          "Removing a tool result cannot change its call or direct-charge evidence"
+        );
+        await this.model.update(
+          {
+            itemType: "tool",
+            agentMCPActionId: actionModelId,
+            inputTokensCount: 0,
+            outputTokensCount: record.outputTokensCount,
+            grossAttributedCreditAmountMicro:
+              record.grossAttributedCreditAmountMicro,
+            directCreditAmountMicro: record.directCreditAmountMicro,
+          },
+          {
+            where: {
+              id: existingRow.id,
+              workspaceId: auth.getNonNullableWorkspace().id,
+              agentMessageId: agentMessageModelId,
+              attributionVersion,
+              itemType: "tool",
+              completedAt: { [Op.ne]: null },
+              inputTokensCount: { [Op.gt]: 0 },
+            },
+            transaction,
+          }
+        );
+      }
     }
   }
 
@@ -382,11 +428,11 @@ export class AgentMessageConsumptionItemResource extends BaseResource<AgentMessa
    * Callers pass the whole desired set and this reconciles it in one transaction, so the materializer
    * never coordinates a read then separate inserts and updates.
    *
-   * Three write shapes, one per identity class:
-   * - Model buckets and already-final tools with no prior row are inserted, first write wins, so a
-   *   re-finalize with the same identity is a no-op.
+   * Four write shapes, one per lifecycle state:
+   * - Model buckets and already-final tools with no prior row are inserted.
    * - A final tool is upserted on its (message, version, itemKey) identity only while the existing
    *   row is pending. This completes an approval-spanning tool without changing a completed fact.
+   * - A terminal pass may remove a completed tool's result footprint. This transition is one-way.
    * - A still-blocked tool is inserted pending and never overwrites an existing row, so a completed
    *   row from a concurrent pass is not regressed to pending.
    */

--- a/front/temporal/analytics_queue/activities/consumption_attribution.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_attribution.test.ts
@@ -87,8 +87,17 @@ describe("storeAgentMessageConsumptionAnalyticsActivity", () => {
   });
 
   it("completes when indexing succeeds", async () => {
-    vi.mocked(indexAgentMessageConsumptionAnalytics).mockResolvedValue(
-      new Ok(undefined)
+    const calls: string[] = [];
+    vi.mocked(
+      computeAndStoreAgentMessageConsumptionAttribution
+    ).mockImplementation(async () => {
+      calls.push("attribution");
+    });
+    vi.mocked(indexAgentMessageConsumptionAnalytics).mockImplementation(
+      async () => {
+        calls.push("indexing");
+        return new Ok(undefined);
+      }
     );
 
     await expect(
@@ -96,6 +105,11 @@ describe("storeAgentMessageConsumptionAnalyticsActivity", () => {
         message,
       })
     ).resolves.toBeUndefined();
+
+    expect(
+      computeAndStoreAgentMessageConsumptionAttribution
+    ).toHaveBeenCalledWith(expect.anything(), message);
+    expect(calls).toEqual(["attribution", "indexing"]);
   });
 
   it("throws the Elasticsearch error so Temporal retries the activity", async () => {

--- a/front/temporal/analytics_queue/activities/consumption_attribution.ts
+++ b/front/temporal/analytics_queue/activities/consumption_attribution.ts
@@ -42,6 +42,12 @@ export async function storeAgentMessageConsumptionAnalyticsActivity(
   { message }: { message: AgentMessageRef }
 ): Promise<void> {
   const auth = await Authenticator.fromJSON(authType);
+
+  // This activity retries independently from the attribution activity that precedes it in the
+  // workflow. Refresh attribution on every attempt so a retry can observe facts committed after
+  // the preceding activity (and so already-retrying workflows can apply newer attribution logic).
+  await computeAndStoreAgentMessageConsumptionAttribution(auth, message);
+
   const result = await indexAgentMessageConsumptionAnalytics(auth, {
     agentMessageId: message.agentMessageId,
   });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Tool consumption rows include the token footprint of tool results, assuming those results are consumed by a subsequent LLM run.

This is wrong when a message stops after executing tools. For example, with `gracefully_stopped`, the final tool results are produced and the tools are billed, but no following LLM run consumes their results.

As this "early exit" case is pretty rare, I did not want to overfit data model or event around this and kept it as an exit door.

This can make attributed costs exceed the authoritative message bill and cause analytics attribution to fail.

We are slightly changing the current approach or terminal messages:
- Order reported runs using the persisted run chronology.
- Keep tool-result footprints for every run except the last one.
- Record the last run’s tool-result footprint as zero.
- Preserve tool-call output tokens and direct tool charges.

Existing completed rows can only transition from a potential result footprint to zero. The transition is one-way, so retries
or stale non-terminal passes cannot restore it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

No migration required to be run.
