### PR TITLE
[analytics] add Explore section header and match cycle selector button sizing

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -92,7 +92,7 @@ export function AnalyticsConsumptionPage() {
         <LazyMotion features={domAnimation}>
           <div className="flex flex-col gap-4">
             <div className="flex flex-col">
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between gap-4">
                 <h2 className="text-lg font-semibold text-foreground">
                   Explore
                 </h2>

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -210,15 +210,6 @@ export function ConsumptionAttributionTable({
 
   return (
     <div className="rounded-lg border border-border bg-card p-4">
-      <div className="mb-3 flex justify-end">
-        <SearchInput
-          name="consumption-attribution-search"
-          placeholder="Search…"
-          value={inputValue}
-          onChange={setValue}
-          className="w-64"
-        />
-      </div>
       <Tabs
         value={dimension}
         onValueChange={(value) => {
@@ -237,6 +228,13 @@ export function ConsumptionAttributionTable({
           ))}
         </TabsList>
       </Tabs>
+      <SearchInput
+        name="consumption-attribution-search"
+        placeholder="Search…"
+        value={inputValue}
+        onChange={setValue}
+        className="mt-3 w-full"
+      />
       <div className="pt-3">
         <AttributionRows
           workspaceId={workspaceId}

--- a/front/components/workspace/analytics/consumption/ConsumptionPeriodSelector.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionPeriodSelector.tsx
@@ -28,7 +28,7 @@ export function ConsumptionPeriodSelector({
       <DropdownMenuTrigger asChild>
         <Button
           label={consumptionPeriodLabel(period)}
-          size="xs"
+          size="sm"
           variant="outline"
           isSelect
         />


### PR DESCRIPTION
## Description

Small UI adjustments to the Analytics consumption page to better match Figma:

- Add spacing between the **Explore** heading and period selector.
- Move the attribution search below the dimension tabs and make it full width.
- Increase the period selector button size from `xs` to `sm`.

Before:
<img width="1158" height="488" alt="Capture d’écran 2026-08-12 à 16 26 06" src="https://github.com/user-attachments/assets/8b5e1b38-3247-4ae2-bb71-44625a325f3c" />

After: 
<img width="1158" height="526" alt="Capture d’écran 2026-08-12 à 16 32 38" src="https://github.com/user-attachments/assets/e551894d-87e6-4e3e-a76f-240c8671677e" />

## Tests

Manual visual validation is included in the attached before/after screenshots.

## Risk

Low risk: presentational changes only; analytics behavior and data handling are unchanged.

## Deploy Plan

- Deploy front