### PR TITLE
[analytics] Add download raw data to analytics consumption endpoint

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -126,7 +126,10 @@ function mockLabels(labels: Record<string, string>) {
       new Map(
         keys
           .filter((key) => key in labels)
-          .map((key) => [key, { name: labels[key], pictureUrl: null }])
+          .map((key) => [
+            key,
+            { name: labels[key], pictureUrl: null, description: null },
+          ])
       )
   );
 }

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
+// This directive makes them available in the test environment.
+
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import {
+  ElasticsearchError,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type {
+  AgentMessageConsumptionAnalyticsLlmData,
+  AgentMessageConsumptionAnalyticsToolData,
+} from "@app/types/assistant/analytics";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Err, Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import AdmZip from "adm-zip";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, resolveDimensionLabels: vi.fn() };
+});
+
+const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
+  workspace_id: "w1",
+  agent: {
+    id: "agent1",
+    version: "1",
+    tag_ids: ["tag1"],
+    parent_ids: [],
+    direct_parent_id: null,
+    root_id: "agent1",
+    depth: 0,
+  },
+  agent_message_id: "msg1",
+  api_key_name: null,
+  attribution_version: 1,
+  completed_at: "2026-08-01T00:00:00.000Z",
+  consumption_key: "run-usage:1",
+  context_origin: "api",
+  conversation_id: "conv1",
+  credit_micro: 1_000_000,
+  execution_time_ms: null,
+  message_version: "1",
+  model: {
+    provider_id: "anthropic",
+    model_id: "claude-sonnet-5",
+    reasoning_effort: "medium",
+    resolution_method: "auto",
+  },
+  run_usage_id: "123",
+  space_id: "space1",
+  status: "succeeded",
+  step_index: 0,
+  trigger_id: null,
+  usage_type: "user",
+  user: { id: "user1", group_ids: ["group1"] },
+  consumption_type: "llm",
+  gross_credit_micro: {
+    system: 100_000,
+    input: 200_000,
+    result_footprint: null,
+    output: 300_000,
+    reasoning: 400_000,
+    direct: 0,
+    total: 1_000_000,
+  },
+  tokens: {
+    system: 10,
+    input: 20,
+    result_footprint: null,
+    output: 30,
+    reasoning: 40,
+  },
+  tool: null,
+};
+
+const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
+  ...LLM_DOC,
+  consumption_key: "action:1",
+  consumption_type: "tool",
+  model: null,
+  gross_credit_micro: {
+    system: 0,
+    input: null,
+    result_footprint: null,
+    output: null,
+    reasoning: 0,
+    direct: 500_000,
+    total: 500_000,
+  },
+  tokens: {
+    system: 0,
+    input: null,
+    result_footprint: 15,
+    output: 5,
+    reasoning: 0,
+  },
+  tool: {
+    name: "search",
+    server_name: "server1",
+    parent_server_name: "",
+    action_id: "action1",
+    attributed_skill_ids: ["skill1"],
+  },
+  credit_micro: 500_000,
+  execution_time_ms: 250,
+};
+
+function mockDocs(docs: unknown[]) {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      hits: { hits: docs.map((doc) => ({ _source: doc, sort: [] })) },
+    }) as unknown as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+  );
+}
+
+function mockLabels(labels: Record<string, string>) {
+  vi.mocked(resolveDimensionLabels).mockImplementation(
+    async (_a, _d, keys) =>
+      new Map(
+        keys
+          .filter((key) => key in labels)
+          .map((key) => [key, { name: labels[key], pictureUrl: null }])
+      )
+  );
+}
+
+async function setupTest({
+  role = "admin",
+}: {
+  role?: MembershipRoleType;
+} = {}) {
+  return createPrivateApiMockRequest({ role });
+}
+
+function postExportRawRequest(wId: string, body: Record<string, unknown>) {
+  return honoApp.request(`/api/w/${wId}/analytics/consumption/export-raw`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/analytics/consumption/export-raw", () => {
+  it("returns every raw consumption line as a CSV in a zip attachment", async () => {
+    mockDocs([LLM_DOC, TOOL_DOC]);
+    mockLabels({
+      agent1: "@dust",
+      user1: "Alice",
+      group1: "Engineering",
+      "claude-sonnet-5": "Claude Sonnet 5",
+      server1: "Search Tool",
+      skill1: "Research",
+      api: "API",
+    });
+    const { workspace } = await setupTest({ role: "admin" });
+
+    const response = await postExportRawRequest(workspace.sId, {});
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("application/zip");
+    expect(response.headers.get("Content-Disposition")).toContain(
+      `filename="dust_consumption_lines_export_${workspace.sId}.zip"`
+    );
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const zip = new AdmZip(buffer);
+    expect(zip.getEntries().map((entry) => entry.entryName)).toEqual([
+      "lines.csv",
+    ]);
+
+    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8");
+    expect(csv).toContain(
+      "completedAt,conversationId,spaceId,agentMessageId,consumptionType,agentId,agentName"
+    );
+    // LLM row: resolved agent/user/group/model names, no tool columns.
+    expect(csv).toContain(
+      "2026-08-01T00:00:00.000Z,conv1,space1,msg1,llm,agent1,'@dust"
+    );
+    expect(csv).toContain("claude-sonnet-5,Claude Sonnet 5");
+    expect(csv).toContain("user1,Alice,group1,Engineering");
+    // Tool row: resolved tool/skill names, no model.
+    expect(csv).toContain(
+      "2026-08-01T00:00:00.000Z,conv1,space1,msg1,tool,agent1,'@dust"
+    );
+    expect(csv).toContain("search,server1,Search Tool");
+    expect(csv).toContain("skill1,Research");
+  });
+
+  it("is refused to non-managers", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await postExportRawRequest(workspace.sId, {});
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 400 for an invalid body", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await postExportRawRequest(workspace.sId, {
+      days: "not-a-number",
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 500 when the search fails", async () => {
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { workspace } = await setupTest();
+
+    const response = await postExportRawRequest(workspace.sId, {});
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: { type: "internal_server_error" },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
@@ -1,0 +1,59 @@
+import { fetchConsumptionLinesExportZip } from "@app/lib/api/analytics/consumption/export_lines";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  ConsumptionExportBodySchema,
+  toConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/schema";
+import logger from "@app/logger/logger";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+// Mounted at /api/w/:wId/analytics/consumption/export-raw.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsManager(),
+  validate("json", ConsumptionExportBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    const { filter, ...periodQuery } = ctx.req.valid("json");
+    const periodInput = toConsumptionPeriodInput(periodQuery);
+
+    const period = await resolveConsumptionPeriod(auth, periodInput);
+
+    const result = await fetchConsumptionLinesExportZip(auth, {
+      period,
+      filter,
+    });
+    if (result.isErr()) {
+      logger.error(
+        { workspaceId, err: result.error },
+        "[ConsumptionAnalytics] Failed to export raw consumption lines."
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to export consumption lines.",
+        },
+      });
+    }
+
+    // `Buffer` doesn't structurally match the `Uint8Array<ArrayBuffer>` that
+    // `ctx.body` expects, so return a raw `Response` instead.
+    return new Response(new Uint8Array(result.value), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="dust_consumption_lines_export_${workspaceId}.zip"`,
+      },
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/consumption/index.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/index.ts
@@ -1,4 +1,5 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import exportRawRoute from "./export-raw";
 import facets from "./facets";
 import overview from "./overview";
 import timeseries from "./timeseries";
@@ -12,6 +13,7 @@ import topUsers from "./top-users";
 
 const app = workspaceApp();
 
+app.route("/export-raw", exportRawRoute);
 app.route("/facets", facets);
 app.route("/overview", overview);
 app.route("/timeseries", timeseries);

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -123,39 +123,30 @@ export function AnalyticsConsumptionPage() {
                 />
               </SafeSuspense>
             </m.div>
-            <div className="flex flex-col gap-4">
-              <h3 className="text-base font-semibold text-foreground">
-                Attribution
-              </h3>
-              <ConsumptionAttributionTable
-                workspaceId={owner.sId}
-                period={period}
-                filter={scopeFilter}
-                onAddFilter={(selectedRow) => {
-                  setFilter((current) =>
-                    addUsageFilterFromAttributionRow(
-                      current,
-                      dimension,
-                      selectedRow
-                    )
-                  );
-                }}
-                dimension={dimension}
-                onDimensionChange={handleDimensionChange}
-                onViewAll={(nextDimension, selectedRow) => {
-                  setFilter((current) =>
-                    setUsageFilterFromAttributionRow(
-                      current,
-                      dimension,
-                      selectedRow
-                    )
-                  );
-                  handleDimensionChange(nextDimension);
-                }}
-              />
-            </div>
           </div>
         </LazyMotion>
+        <ConsumptionAttributionTable
+          workspaceId={owner.sId}
+          period={period}
+          filter={scopeFilter}
+          onAddFilter={(selectedRow) => {
+            setFilter((current) =>
+              addUsageFilterFromAttributionRow(current, dimension, selectedRow)
+            );
+          }}
+          dimension={dimension}
+          onDimensionChange={handleDimensionChange}
+          onViewAll={(nextDimension, selectedRow) => {
+            setFilter((current) =>
+              setUsageFilterFromAttributionRow(
+                current,
+                dimension,
+                selectedRow
+              )
+            );
+            handleDimensionChange(nextDimension);
+          }}
+        />
       </div>
     </Page.Vertical>
   );

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -138,11 +138,7 @@ export function AnalyticsConsumptionPage() {
           onDimensionChange={handleDimensionChange}
           onViewAll={(nextDimension, selectedRow) => {
             setFilter((current) =>
-              setUsageFilterFromAttributionRow(
-                current,
-                dimension,
-                selectedRow
-              )
+              setUsageFilterFromAttributionRow(current, dimension, selectedRow)
             );
             handleDimensionChange(nextDimension);
           }}

--- a/front/components/workspace/analytics/CsvDownloadButton.tsx
+++ b/front/components/workspace/analytics/CsvDownloadButton.tsx
@@ -4,19 +4,23 @@ interface CsvDownloadButtonProps {
   isDownloading: boolean;
   disabled: boolean;
   handleDownload: () => void;
+  label?: string;
 }
 
 export function CsvDownloadButton({
   isDownloading,
   disabled,
   handleDownload,
+  label,
 }: CsvDownloadButtonProps) {
   return (
     <Button
-      icon={Download01}
+      icon={label ? undefined : Download01}
+      iconRight={label ? Download01 : undefined}
+      label={label}
       variant="outline"
-      size="xs"
-      tooltip="Download CSV"
+      size={label ? "sm" : "xs"}
+      tooltip={label ? undefined : "Download CSV"}
       onClick={handleDownload}
       disabled={disabled}
       isLoading={isDownloading}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -1,5 +1,6 @@
 import { getModelLogoByModelId } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {
   AvatarNameCell,
   CostShareCell,
@@ -7,7 +8,11 @@ import {
 import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
@@ -466,76 +471,101 @@ export function ConsumptionAttributionTable({
       ? 0
       : transition.direction;
 
+  const exportBody: ConsumptionExportBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+  };
+
+  // Every raw consumption line with no aggregation, for users who want to
+  // build their own analysis on top of it.
+  const rawCsvDownload = useDownloadCsv({
+    url: `/api/w/${workspaceId}/analytics/consumption/export-raw`,
+    filename: `dust_consumption_lines_export_${workspaceId}.zip`,
+    body: exportBody,
+  });
+
   return (
-    <div className="rounded-lg border border-border bg-panel-background p-4">
-      <Tabs
-        value={dimension}
-        onValueChange={(value) => {
-          if (isConsumptionDimension(value)) {
-            setTransition({
-              target: value,
-              direction:
-                pendingPointerDimension.current === value
-                  ? getAttributionTransitionDirection(dimension, value)
-                  : 0,
-            });
-            pendingPointerDimension.current = null;
-            onDimensionChange(value);
-          }
-        }}
-      >
-        <TabsList border>
-          {CONSUMPTION_DIMENSIONS.map((tabDimension) => (
-            <TabsTrigger
-              key={tabDimension}
-              value={tabDimension}
-              label={CONSUMPTION_DIMENSION_CONFIG[tabDimension].label}
-              onPointerDown={() => {
-                pendingPointerDimension.current = tabDimension;
-              }}
-              onPointerCancel={() => {
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-4">
+        <h3 className="text-base font-semibold text-foreground">
+          Attribution
+        </h3>
+        <CsvDownloadButton {...rawCsvDownload} label="Download raw data" />
+      </div>
+      <div className="rounded-lg border border-border bg-panel-background p-4">
+        <div className="flex flex-col gap-3">
+          <Tabs
+            value={dimension}
+            onValueChange={(value) => {
+              if (isConsumptionDimension(value)) {
+                setTransition({
+                  target: value,
+                  direction:
+                    pendingPointerDimension.current === value
+                      ? getAttributionTransitionDirection(dimension, value)
+                      : 0,
+                });
                 pendingPointerDimension.current = null;
-              }}
-              onKeyDown={() => {
-                pendingPointerDimension.current = null;
-              }}
-            />
-          ))}
-        </TabsList>
-      </Tabs>
-      <SearchInput
-        name="consumption-attribution-search"
-        placeholder="Search…"
-        value={inputValue}
-        onChange={setValue}
-        className="mt-3 w-full"
-      />
-      <div className="relative overflow-hidden pt-3">
-        <AnimatePresence
-          initial={false}
-          mode="popLayout"
-          custom={effectiveTransitionDirection}
-        >
-          <m.div
-            key={dimension}
-            custom={effectiveTransitionDirection}
-            variants={ATTRIBUTION_BODY_VARIANTS}
-            initial="initial"
-            animate="animate"
-            exit="exit"
+                onDimensionChange(value);
+              }
+            }}
           >
-            {/* A dimension selects a different dataset, so its table state must not carry over. */}
-            <AttributionRows
-              workspaceId={workspaceId}
-              dimension={dimension}
-              period={period}
-              filter={filter}
-              onAddFilter={onAddFilter}
-              search={debouncedValue}
-              onViewAll={onViewAll}
-            />
-          </m.div>
-        </AnimatePresence>
+            <TabsList border>
+              {CONSUMPTION_DIMENSIONS.map((tabDimension) => (
+                <TabsTrigger
+                  key={tabDimension}
+                  value={tabDimension}
+                  label={CONSUMPTION_DIMENSION_CONFIG[tabDimension].label}
+                  onPointerDown={() => {
+                    pendingPointerDimension.current = tabDimension;
+                  }}
+                  onPointerCancel={() => {
+                    pendingPointerDimension.current = null;
+                  }}
+                  onKeyDown={() => {
+                    pendingPointerDimension.current = null;
+                  }}
+                />
+              ))}
+            </TabsList>
+          </Tabs>
+          <SearchInput
+            name="consumption-attribution-search"
+            placeholder="Search…"
+            value={inputValue}
+            onChange={setValue}
+            className="w-full"
+          />
+          <div className="relative overflow-hidden">
+            <AnimatePresence
+              initial={false}
+              mode="popLayout"
+              custom={effectiveTransitionDirection}
+            >
+              <m.div
+                key={dimension}
+                custom={effectiveTransitionDirection}
+                variants={ATTRIBUTION_BODY_VARIANTS}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+              >
+                {/* A dimension selects a different dataset, so its table state must not carry over. */}
+                <AttributionRows
+                  workspaceId={workspaceId}
+                  dimension={dimension}
+                  period={period}
+                  filter={filter}
+                  onAddFilter={onAddFilter}
+                  search={debouncedValue}
+                  onViewAll={onViewAll}
+                />
+              </m.div>
+            </AnimatePresence>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -489,9 +489,7 @@ export function ConsumptionAttributionTable({
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-4">
-        <h3 className="text-base font-semibold text-foreground">
-          Attribution
-        </h3>
+        <h3 className="text-base font-semibold text-foreground">Attribution</h3>
         <CsvDownloadButton {...rawCsvDownload} label="Download raw data" />
       </div>
       <div className="rounded-lg border border-border bg-panel-background p-4">

--- a/front/hooks/useDownloadCsv.ts
+++ b/front/hooks/useDownloadCsv.ts
@@ -5,19 +5,32 @@ interface UseDownloadCsvOptions {
   url: string;
   filename: string;
   disabled?: boolean;
+  // Some exports carry a filter too large to fit in a URL, so the request
+  // body must travel as JSON over POST instead of a GET query string.
+  body?: unknown;
 }
 
 export function useDownloadCsv({
   url,
   filename,
   disabled,
+  body,
 }: UseDownloadCsvOptions) {
   const [isDownloading, setIsDownloading] = useState(false);
 
   const handleDownload = useCallback(async () => {
     setIsDownloading(true);
     try {
-      const response = await clientFetch(url);
+      const response = await clientFetch(
+        url,
+        body === undefined
+          ? undefined
+          : {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify(body),
+            }
+      );
       if (!response.ok) {
         return;
       }
@@ -31,7 +44,7 @@ export function useDownloadCsv({
     } finally {
       setIsDownloading(false);
     }
-  }, [url, filename]);
+  }, [url, filename, body]);
 
   return {
     isDownloading,

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -34,6 +34,7 @@ async function fetchAllConsumptionDocuments(
             { consumption_key: "asc" },
           ],
           search_after: searchAfter,
+          source: { excludes: ["tokens"] },
         }
       );
 

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -2,7 +2,10 @@ import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/label
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
-import { roundToCents, rowsToCsv } from "@app/lib/api/analytics/csv_utils";
+import {
+  roundToTwoDecimals,
+  rowsToCsv,
+} from "@app/lib/api/analytics/csv_utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -15,48 +18,6 @@ import type { estypes } from "@elastic/elasticsearch";
 import AdmZip from "adm-zip";
 
 const EXPORT_PAGE_SIZE = 10_000;
-
-// One document per unit of billed credit consumption
-async function fetchAllConsumptionDocuments(
-  query: estypes.QueryDslQueryContainer
-): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
-  const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
-  let searchAfter: estypes.SortResults | undefined;
-
-  for (;;) {
-    const result =
-      await searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
-        query,
-        {
-          size: EXPORT_PAGE_SIZE,
-          sort: [
-            { completed_at: "asc" },
-            { agent_message_id: "asc" },
-            { consumption_key: "asc" },
-          ],
-          search_after: searchAfter,
-        }
-      );
-
-    if (result.isErr()) {
-      return result;
-    }
-
-    const { hits } = result.value.hits;
-    for (const hit of hits) {
-      if (hit._source) {
-        allDocs.push(hit._source);
-      }
-    }
-
-    if (hits.length < EXPORT_PAGE_SIZE) {
-      break;
-    }
-    searchAfter = hits[hits.length - 1].sort;
-  }
-
-  return new Ok(allDocs);
-}
 
 type ConsumptionLineExportRow = {
   completedAt: string;
@@ -145,6 +106,47 @@ const CONSUMPTION_LINE_EXPORT_HEADERS: (keyof ConsumptionLineExportRow)[] = [
   "stepIndex",
   "executionTimeMs",
 ];
+
+// One document per unit of billed credit consumption
+async function fetchAllConsumptionDocuments(
+  query: estypes.QueryDslQueryContainer
+): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
+  const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
+  let searchAfter: estypes.SortResults | undefined;
+  let hitCount: number;
+
+  do {
+    const result =
+      await searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
+        query,
+        {
+          size: EXPORT_PAGE_SIZE,
+          sort: [
+            { completed_at: "asc" },
+            { agent_message_id: "asc" },
+            { consumption_key: "asc" },
+          ],
+          search_after: searchAfter,
+        }
+      );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    const { hits } = result.value.hits;
+    for (const hit of hits) {
+      if (hit._source) {
+        allDocs.push(hit._source);
+      }
+    }
+
+    hitCount = hits.length;
+    searchAfter = hits[hits.length - 1]?.sort;
+  } while (hitCount === EXPORT_PAGE_SIZE);
+
+  return new Ok(allDocs);
+}
 
 async function buildConsumptionLineExportRows(
   auth: Authenticator,
@@ -237,14 +239,20 @@ async function buildConsumptionLineExportRows(
       attributedSkillNames: (tool?.attributed_skill_ids ?? [])
         .map((id) => skillLabels.get(id)?.name ?? id)
         .join("; "),
-      creditsSystem: roundToCents(microCreditsToCredits(gross.system ?? 0)),
-      creditsInput: roundToCents(microCreditsToCredits(gross.input ?? 0)),
-      creditsOutput: roundToCents(microCreditsToCredits(gross.output ?? 0)),
-      creditsReasoning: roundToCents(
+      creditsSystem: roundToTwoDecimals(
+        microCreditsToCredits(gross.system ?? 0)
+      ),
+      creditsInput: roundToTwoDecimals(microCreditsToCredits(gross.input ?? 0)),
+      creditsOutput: roundToTwoDecimals(
+        microCreditsToCredits(gross.output ?? 0)
+      ),
+      creditsReasoning: roundToTwoDecimals(
         microCreditsToCredits(gross.reasoning ?? 0)
       ),
-      creditsDirect: roundToCents(microCreditsToCredits(gross.direct ?? 0)),
-      totalCredits: roundToCents(microCreditsToCredits(doc.credit_micro)),
+      creditsDirect: roundToTwoDecimals(
+        microCreditsToCredits(gross.direct ?? 0)
+      ),
+      totalCredits: roundToTwoDecimals(microCreditsToCredits(doc.credit_micro)),
       usageType: doc.usage_type,
       status: doc.status,
       stepIndex: doc.step_index,

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -2,7 +2,6 @@ import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/label
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
-import { EXPORT_PAGE_SIZE } from "@app/lib/api/analytics/consumption/top";
 import { roundToCents, rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
@@ -14,6 +13,8 @@ import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { estypes } from "@elastic/elasticsearch";
 import AdmZip from "adm-zip";
+
+const EXPORT_PAGE_SIZE = 10_000;
 
 // One document per unit of billed credit consumption
 async function fetchAllConsumptionDocuments(
@@ -253,9 +254,7 @@ async function buildConsumptionLineExportRows(
   });
 }
 
-// Exports every raw consumption document over the period as a single CSV,
-// bundled as a zip archive — one row per LLM run-step or tool call, with no
-// aggregation, for users who want to build their own analysis on top of it.
+// Exports every raw consumption under zipped csv format
 export async function fetchConsumptionLinesExportZip(
   auth: Authenticator,
   {

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -89,11 +89,6 @@ type ConsumptionLineExportRow = {
   toolActionId: string;
   attributedSkillIds: string;
   attributedSkillNames: string;
-  tokensSystem: number;
-  tokensInput: number;
-  tokensOutput: number;
-  tokensReasoning: number;
-  tokensResultFootprint: number;
   creditsSystem: number;
   creditsInput: number;
   creditsOutput: number;
@@ -138,11 +133,6 @@ const CONSUMPTION_LINE_EXPORT_HEADERS: (keyof ConsumptionLineExportRow)[] = [
   "toolActionId",
   "attributedSkillIds",
   "attributedSkillNames",
-  "tokensSystem",
-  "tokensInput",
-  "tokensOutput",
-  "tokensReasoning",
-  "tokensResultFootprint",
   "creditsSystem",
   "creditsInput",
   "creditsOutput",
@@ -194,13 +184,6 @@ async function buildConsumptionLineExportRows(
   return docs.map((doc) => {
     const { agent, model, user, tool } = doc;
     // Older documents indexed before these buckets shipped don't carry them.
-    const tokens = doc.tokens ?? {
-      system: 0,
-      input: null,
-      result_footprint: null,
-      output: 0,
-      reasoning: 0,
-    };
     const gross = doc.gross_credit_micro ?? {
       system: 0,
       input: null,
@@ -253,11 +236,6 @@ async function buildConsumptionLineExportRows(
       attributedSkillNames: (tool?.attributed_skill_ids ?? [])
         .map((id) => skillLabels.get(id)?.name ?? id)
         .join("; "),
-      tokensSystem: tokens.system,
-      tokensInput: tokens.input ?? 0,
-      tokensOutput: tokens.output,
-      tokensReasoning: tokens.reasoning,
-      tokensResultFootprint: tokens.result_footprint ?? 0,
       creditsSystem: roundToCents(microCreditsToCredits(gross.system ?? 0)),
       creditsInput: roundToCents(microCreditsToCredits(gross.input ?? 0)),
       creditsOutput: roundToCents(microCreditsToCredits(gross.output ?? 0)),

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -35,7 +35,6 @@ async function fetchAllConsumptionDocuments(
             { consumption_key: "asc" },
           ],
           search_after: searchAfter,
-          source: { excludes: ["tokens"] },
         }
       );
 

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -1,0 +1,311 @@
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
+import { EXPORT_PAGE_SIZE } from "@app/lib/api/analytics/consumption/top";
+import { roundToCents, rowsToCsv } from "@app/lib/api/analytics/csv_utils";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
+import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/analytics";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { estypes } from "@elastic/elasticsearch";
+import AdmZip from "adm-zip";
+
+// One document per unit of billed credit consumption
+async function fetchAllConsumptionDocuments(
+  query: estypes.QueryDslQueryContainer
+): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
+  const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
+  let searchAfter: estypes.SortResults | undefined;
+
+  for (;;) {
+    const result =
+      await searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
+        query,
+        {
+          size: EXPORT_PAGE_SIZE,
+          sort: [
+            { completed_at: "asc" },
+            { agent_message_id: "asc" },
+            { consumption_key: "asc" },
+          ],
+          search_after: searchAfter,
+        }
+      );
+
+    if (result.isErr()) {
+      return result;
+    }
+
+    const { hits } = result.value.hits;
+    for (const hit of hits) {
+      if (hit._source) {
+        allDocs.push(hit._source);
+      }
+    }
+
+    if (hits.length < EXPORT_PAGE_SIZE) {
+      break;
+    }
+    searchAfter = hits[hits.length - 1].sort;
+  }
+
+  return new Ok(allDocs);
+}
+
+type ConsumptionLineExportRow = {
+  completedAt: string;
+  conversationId: string;
+  spaceId: string;
+  agentMessageId: string;
+  consumptionType: string;
+  agentId: string;
+  agentName: string;
+  agentVersion: string;
+  agentTagIds: string;
+  agentRootId: string;
+  agentParentId: string;
+  agentDepth: number;
+  modelProviderId: string;
+  modelId: string;
+  modelName: string;
+  modelReasoningEffort: string;
+  modelResolutionMethod: string;
+  userId: string;
+  userName: string;
+  userGroupIds: string;
+  userGroupNames: string;
+  triggerId: string;
+  contextOrigin: string;
+  apiKeyName: string;
+  toolName: string;
+  toolServerName: string;
+  toolDisplayName: string;
+  toolParentServerName: string;
+  toolActionId: string;
+  attributedSkillIds: string;
+  attributedSkillNames: string;
+  tokensSystem: number;
+  tokensInput: number;
+  tokensOutput: number;
+  tokensReasoning: number;
+  tokensResultFootprint: number;
+  creditsSystem: number;
+  creditsInput: number;
+  creditsOutput: number;
+  creditsReasoning: number;
+  creditsDirect: number;
+  totalCredits: number;
+  usageType: string;
+  status: string;
+  stepIndex: number;
+  executionTimeMs: number;
+};
+
+const CONSUMPTION_LINE_EXPORT_HEADERS: (keyof ConsumptionLineExportRow)[] = [
+  "completedAt",
+  "conversationId",
+  "spaceId",
+  "agentMessageId",
+  "consumptionType",
+  "agentId",
+  "agentName",
+  "agentVersion",
+  "agentTagIds",
+  "agentRootId",
+  "agentParentId",
+  "agentDepth",
+  "modelProviderId",
+  "modelId",
+  "modelName",
+  "modelReasoningEffort",
+  "modelResolutionMethod",
+  "userId",
+  "userName",
+  "userGroupIds",
+  "userGroupNames",
+  "triggerId",
+  "contextOrigin",
+  "apiKeyName",
+  "toolName",
+  "toolServerName",
+  "toolDisplayName",
+  "toolParentServerName",
+  "toolActionId",
+  "attributedSkillIds",
+  "attributedSkillNames",
+  "tokensSystem",
+  "tokensInput",
+  "tokensOutput",
+  "tokensReasoning",
+  "tokensResultFootprint",
+  "creditsSystem",
+  "creditsInput",
+  "creditsOutput",
+  "creditsReasoning",
+  "creditsDirect",
+  "totalCredits",
+  "usageType",
+  "status",
+  "stepIndex",
+  "executionTimeMs",
+];
+
+async function buildConsumptionLineExportRows(
+  auth: Authenticator,
+  docs: AgentMessageConsumptionAnalyticsData[]
+): Promise<ConsumptionLineExportRow[]> {
+  const [
+    agentLabels,
+    userLabels,
+    modelLabels,
+    toolLabels,
+    skillLabels,
+    groupLabels,
+    sourceLabels,
+  ] = await Promise.all([
+    resolveDimensionLabels(auth, "agent", [
+      ...new Set(docs.map((doc) => doc.agent.id)),
+    ]),
+    resolveDimensionLabels(auth, "user", [
+      ...new Set(removeNulls(docs.map((doc) => doc.user?.id))),
+    ]),
+    resolveDimensionLabels(auth, "model", [
+      ...new Set(removeNulls(docs.map((doc) => doc.model?.model_id))),
+    ]),
+    resolveDimensionLabels(auth, "tool", [
+      ...new Set(removeNulls(docs.map((doc) => doc.tool?.server_name))),
+    ]),
+    resolveDimensionLabels(auth, "skill", [
+      ...new Set(docs.flatMap((doc) => doc.tool?.attributed_skill_ids ?? [])),
+    ]),
+    resolveDimensionLabels(auth, "group", [
+      ...new Set(docs.flatMap((doc) => doc.user?.group_ids ?? [])),
+    ]),
+    resolveDimensionLabels(auth, "source", [
+      ...new Set(removeNulls(docs.map((doc) => doc.context_origin))),
+    ]),
+  ]);
+
+  return docs.map((doc) => {
+    const { agent, model, user, tool } = doc;
+    // Older documents indexed before these buckets shipped don't carry them.
+    const tokens = doc.tokens ?? {
+      system: 0,
+      input: null,
+      result_footprint: null,
+      output: 0,
+      reasoning: 0,
+    };
+    const gross = doc.gross_credit_micro ?? {
+      system: 0,
+      input: null,
+      result_footprint: null,
+      output: null,
+      reasoning: 0,
+      direct: 0,
+      total: 0,
+    };
+
+    return {
+      completedAt: doc.completed_at,
+      conversationId: doc.conversation_id,
+      spaceId: doc.space_id ?? "",
+      agentMessageId: doc.agent_message_id,
+      consumptionType: doc.consumption_type,
+      agentId: agent.id,
+      agentName: agentLabels.get(agent.id)?.name ?? agent.id,
+      agentVersion: agent.version ?? "",
+      agentTagIds: (agent.tag_ids ?? []).join("; "),
+      agentRootId: agent.root_id ?? "",
+      agentParentId: agent.direct_parent_id ?? "",
+      agentDepth: agent.depth ?? 0,
+      modelProviderId: model?.provider_id ?? "",
+      modelId: model?.model_id ?? "",
+      modelName: model
+        ? (modelLabels.get(model.model_id)?.name ?? model.model_id)
+        : "",
+      modelReasoningEffort: model?.reasoning_effort ?? "",
+      modelResolutionMethod: model?.resolution_method ?? "",
+      userId: user?.id ?? "",
+      userName: user ? (userLabels.get(user.id)?.name ?? user.id) : "",
+      userGroupIds: (user?.group_ids ?? []).join("; "),
+      userGroupNames: (user?.group_ids ?? [])
+        .map((id) => groupLabels.get(id)?.name ?? id)
+        .join("; "),
+      triggerId: doc.trigger_id ?? "",
+      contextOrigin: doc.context_origin
+        ? (sourceLabels.get(doc.context_origin)?.name ?? doc.context_origin)
+        : "",
+      apiKeyName: doc.api_key_name ?? "",
+      toolName: tool?.name ?? "",
+      toolServerName: tool?.server_name ?? "",
+      toolDisplayName: tool
+        ? (toolLabels.get(tool.server_name)?.name ?? tool.server_name)
+        : "",
+      toolParentServerName: tool?.parent_server_name ?? "",
+      toolActionId: tool?.action_id ?? "",
+      attributedSkillIds: (tool?.attributed_skill_ids ?? []).join("; "),
+      attributedSkillNames: (tool?.attributed_skill_ids ?? [])
+        .map((id) => skillLabels.get(id)?.name ?? id)
+        .join("; "),
+      tokensSystem: tokens.system,
+      tokensInput: tokens.input ?? 0,
+      tokensOutput: tokens.output,
+      tokensReasoning: tokens.reasoning,
+      tokensResultFootprint: tokens.result_footprint ?? 0,
+      creditsSystem: roundToCents(microCreditsToCredits(gross.system ?? 0)),
+      creditsInput: roundToCents(microCreditsToCredits(gross.input ?? 0)),
+      creditsOutput: roundToCents(microCreditsToCredits(gross.output ?? 0)),
+      creditsReasoning: roundToCents(
+        microCreditsToCredits(gross.reasoning ?? 0)
+      ),
+      creditsDirect: roundToCents(microCreditsToCredits(gross.direct ?? 0)),
+      totalCredits: roundToCents(microCreditsToCredits(doc.credit_micro)),
+      usageType: doc.usage_type,
+      status: doc.status,
+      stepIndex: doc.step_index,
+      executionTimeMs: doc.execution_time_ms ?? 0,
+    };
+  });
+}
+
+// Exports every raw consumption document over the period as a single CSV,
+// bundled as a zip archive — one row per LLM run-step or tool call, with no
+// aggregation, for users who want to build their own analysis on top of it.
+export async function fetchConsumptionLinesExportZip(
+  auth: Authenticator,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter?: ConsumptionScopeFilter;
+  }
+): Promise<Result<Buffer, ElasticsearchError>> {
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+    filter,
+  });
+
+  const docsResult = await fetchAllConsumptionDocuments(query);
+  if (docsResult.isErr()) {
+    return docsResult;
+  }
+
+  const rows = await buildConsumptionLineExportRows(auth, docsResult.value);
+
+  const zip = new AdmZip();
+  zip.addFile(
+    "lines.csv",
+    Buffer.from(rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows), "utf-8")
+  );
+
+  return new Ok(zip.toBuffer());
+}

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -47,6 +47,13 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
 
 export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;
 
+// The attribution table's CSV export: same period/filter as the `top-*`
+// endpoints, but always returns the breakdown for every dimension rather
+// than just whichever tab is currently toggled.
+export const ConsumptionExportBodySchema = ConsumptionBodySchema;
+
+export type ConsumptionExportBody = z.infer<typeof ConsumptionExportBodySchema>;
+
 export function toConsumptionPeriodInput({
   period,
   days,

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -48,8 +48,7 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
 export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;
 
 // The attribution table's CSV export: same period/filter as the `top-*`
-// endpoints, but always returns the breakdown for every dimension rather
-// than just whichever tab is currently toggled.
+// endpoints, but always returns the breakdown for every dimension.
 export const ConsumptionExportBodySchema = ConsumptionBodySchema;
 
 export type ConsumptionExportBody = z.infer<typeof ConsumptionExportBodySchema>;

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -34,9 +34,6 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
   source: "context_origin",
 };
 
-// Unit a ranking's count — and therefore its average — is denominated in.
-// "message" is the count of distinct messages, "invocation" is used for the
-// count of tool documents.
 export type ConsumptionTopUnit = "message" | "invocation";
 
 export const CONSUMPTION_DIMENSION_UNIT: Record<

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -34,6 +34,24 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
   source: "context_origin",
 };
 
+// Unit a ranking's count — and therefore its average — is denominated in.
+// "message" is the count of distinct messages, "invocation" is used for the
+// count of tool documents.
+export type ConsumptionTopUnit = "message" | "invocation";
+
+export const CONSUMPTION_DIMENSION_UNIT: Record<
+  ConsumptionScopeDimension,
+  ConsumptionTopUnit
+> = {
+  agent: "message",
+  user: "message",
+  group: "message",
+  model: "message",
+  tool: "invocation",
+  skill: "invocation",
+  source: "message",
+};
+
 export const CONSUMPTION_SCOPE_FILTER_KEYS = [
   "agents",
   "users",

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -2,11 +2,13 @@ import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/perio
 import type {
   ConsumptionScopeDimension,
   ConsumptionScopeFilter,
+  ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
   AGENT_MESSAGE_ID_FIELD,
   buildConsumptionScopeQuery,
   CONSUMPTION_DIMENSION_FIELDS,
+  CONSUMPTION_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
@@ -21,12 +23,7 @@ import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
 
-// Unit a ranking's count — and therefore its average — is denominated in.
-// "message" is the count of distinct messages,
-// "invocation" is used for the count of tool documents.
-type ConsumptionTopUnit = "message" | "invocation";
-
-export type ConsumptionTopGroup = {
+type ConsumptionTopGroup = {
   key: string;
   credits: number;
   // Distinct messages, or tool invocations, per the ranking's unit.
@@ -53,10 +50,23 @@ type GroupBucket = {
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
+function subAggs(unit: ConsumptionTopUnit) {
+  return {
+    [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+    ...(unit === "message"
+      ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
+      : {}),
+  };
+}
+
 type TopAggs = {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
   total_credit_micro?: estypes.AggregationsSumAggregate;
 };
+
+// Shared with the raw-lines export's own pagination in this module's sibling
+// file.
+export const EXPORT_PAGE_SIZE = 10_000;
 
 function countFromBucket(
   bucket: GroupBucket,
@@ -84,18 +94,17 @@ export async function fetchConsumptionTopGroups(
   auth: Authenticator,
   {
     dimension,
-    unit,
     period,
     limit,
     filter,
   }: {
     dimension: ConsumptionScopeDimension;
-    unit: ConsumptionTopUnit;
     period: ConsumptionPeriod;
     limit: number;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
+  const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
   const query = buildConsumptionScopeQuery({
     auth,
     startDate: period.startDate,
@@ -111,16 +120,7 @@ export async function fetchConsumptionTopGroups(
           size: limit,
           order: { [CREDIT_AGG]: "desc" },
         },
-        aggs: {
-          [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
-          ...(unit === "message"
-            ? {
-                [MESSAGES_AGG]: {
-                  cardinality: { field: AGENT_MESSAGE_ID_FIELD },
-                },
-              }
-            : {}),
-        },
+        aggs: subAggs(unit),
       },
       total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
     },

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -64,10 +64,6 @@ type TopAggs = {
   total_credit_micro?: estypes.AggregationsSumAggregate;
 };
 
-// Shared with the raw-lines export's own pagination in this module's sibling
-// file.
-export const EXPORT_PAGE_SIZE = 10_000;
-
 function countFromBucket(
   bucket: GroupBucket,
   unit: ConsumptionTopUnit

--- a/front/lib/api/analytics/consumption/top_agents.ts
+++ b/front/lib/api/analytics/consumption/top_agents.ts
@@ -51,7 +51,6 @@ export async function fetchConsumptionTopAgents(
 ): Promise<Result<ConsumptionTopAgents, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
     dimension: "agent",
-    unit: "message",
     period,
     limit,
     filter,

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -48,7 +48,6 @@ export async function fetchConsumptionTopGroups(
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroupBuckets(auth, {
     dimension: "group",
-    unit: "message",
     period,
     limit,
     filter,

--- a/front/lib/api/analytics/consumption/top_models.ts
+++ b/front/lib/api/analytics/consumption/top_models.ts
@@ -48,7 +48,6 @@ export async function fetchConsumptionTopModels(
 ): Promise<Result<ConsumptionTopModels, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
     dimension: "model",
-    unit: "message",
     period,
     limit,
     filter,

--- a/front/lib/api/analytics/consumption/top_skills.ts
+++ b/front/lib/api/analytics/consumption/top_skills.ts
@@ -56,7 +56,6 @@ export async function fetchConsumptionTopSkills(
 ): Promise<Result<ConsumptionTopSkills, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
     dimension: "skill",
-    unit: "invocation",
     period,
     limit,
     filter,

--- a/front/lib/api/analytics/consumption/top_sources.ts
+++ b/front/lib/api/analytics/consumption/top_sources.ts
@@ -49,7 +49,6 @@ export async function fetchConsumptionTopSources(
 ): Promise<Result<ConsumptionTopSources, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
     dimension: "source",
-    unit: "message",
     period,
     limit,
     filter,

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -53,7 +53,6 @@ export async function fetchConsumptionTopTools(
 ): Promise<Result<ConsumptionTopTools, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
     dimension: "tool",
-    unit: "invocation",
     period,
     limit,
     filter,

--- a/front/lib/api/analytics/consumption/top_users.ts
+++ b/front/lib/api/analytics/consumption/top_users.ts
@@ -52,7 +52,6 @@ export async function fetchConsumptionTopUsers(
 ): Promise<Result<ConsumptionTopUsers, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
     dimension: "user",
-    unit: "message",
     period,
     limit,
     filter,

--- a/front/lib/api/analytics/csv_utils.ts
+++ b/front/lib/api/analytics/csv_utils.ts
@@ -9,6 +9,13 @@ export function sanitizeCsvCell(value: string | number): string | number {
   return value;
 }
 
+// Credits are raw division results with long float tails which spreadsheet
+// apps render as text rather than a number. Round to a couple of decimals so
+// every numeric cell serializes as a plain, consistently-typed number.
+export function roundToCents(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
 // Serialize keyed rows to CSV with a header row, sanitizing every cell. Shared
 // serializer for all analytics CSV exports.
 export function rowsToCsv<

--- a/front/lib/api/analytics/csv_utils.ts
+++ b/front/lib/api/analytics/csv_utils.ts
@@ -9,10 +9,10 @@ export function sanitizeCsvCell(value: string | number): string | number {
   return value;
 }
 
-// Credits are raw division results with long float tails which spreadsheet
-// apps render as text rather than a number. Round to a couple of decimals so
-// every numeric cell serializes as a plain, consistently-typed number.
-export function roundToCents(value: number): number {
+// Raw division results carry long float tails which spreadsheet apps render
+// as text rather than a number. Round to two decimals so every numeric cell
+// serializes as a plain, consistently-typed number.
+export function roundToTwoDecimals(value: number): number {
   return Math.round(value * 100) / 100;
 }
 

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -272,6 +272,7 @@ export async function searchConsumptionAnalytics<
     from?: number;
     sort?: estypes.Sort;
     search_after?: estypes.SortResults;
+    source?: estypes.SearchSourceConfig;
   }
 ): Promise<
   Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
@@ -284,5 +285,6 @@ export async function searchConsumptionAnalytics<
     from: options?.from,
     sort: options?.sort,
     search_after: options?.search_after,
+    _source: options?.source,
   });
 }

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -272,7 +272,6 @@ export async function searchConsumptionAnalytics<
     from?: number;
     sort?: estypes.Sort;
     search_after?: estypes.SortResults;
-    source?: estypes.SearchSourceConfig;
   }
 ): Promise<
   Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
@@ -285,6 +284,8 @@ export async function searchConsumptionAnalytics<
     from: options?.from,
     sort: options?.sort,
     search_after: options?.search_after,
-    _source: options?.source,
+    // Never needed for aggregation-only queries (size: 0); excluded unconditionally
+    // to keep the raw-lines export from pulling the large tokens payload.
+    _source: { excludes: ["tokens"] },
   });
 }


### PR DESCRIPTION
## Description

Adds a **Download raw data** action to the consumption attribution table. The action uses the table's current period and scope filters and sends them to a new manager-only `POST /api/w/:wId/analytics/consumption/export-raw` endpoint.

**On the app:**
<img width="1137" height="548" alt="Capture d’écran 2026-08-13 à 12 38 39" src="https://github.com/user-attachments/assets/ddcc25a0-bc1d-40b8-a1c1-1b668c59a990" />

The endpoint paginates through all matching consumption documents with Elasticsearch `search_after`, resolves labels for agents, users, groups, models, tools, skills, and sources, and returns a ZIP attachment containing `lines.csv`. Each row represents a raw consumption line and includes attribution metadata, optional model/tool details, user and group information, status/timing fields, and a credit breakdown. Credit values are rounded before CSV serialization.

The change also extends the CSV download hook to support JSON POST bodies, extracts shared attribution-row conversion/types for the existing top-dimension table, and centralizes the message/invocation unit mapping used by the top aggregations. No data migration or feature flag is introduced.

## Tests

The PR adds route coverage for:

- Successful ZIP/CSV generation with resolved labels for LLM and tool rows.
- Rejection of non-manager requests with `403`.
- Invalid request bodies with `400`.
- Elasticsearch failures with `500`.

## Risk

The export is read-only, reuses the existing analytics period and scope filtering, and is restricted to managers. The main operational risk is resource usage for large workspaces: matching documents are accumulated in memory and then converted into a ZIP in a single request.

## Deploy Plan

- Deploy front