### PR TITLE
chore: add Elias to authors

### DIFF
--- a/.authors
+++ b/.authors
@@ -54,3 +54,4 @@ sfriquet: sylvain@dust.tt
 A-Marc: marc@dust.tt
 avervaet: arthur.vervaet@dust.tt
 achilleburah: achille.burah@dust.tt
+Elias-Nef: elias@dust.tt


### PR DESCRIPTION
## Description

Add Elias Nefzi's GitHub handle to the repository authors file:

`Elias-Nef: elias@dust.tt`

## Tests

Ran `git diff --check` locally. No automated tests were needed for this metadata-only change.

## Risk

Low risk. This only updates the authors mapping and is straightforward to roll back.

## Deploy Plan

No deployment steps required.