### PR TITLE
Use domMax for consumption layout animation

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -13,7 +13,7 @@ import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_perio
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { BarChart01, cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
-import { domAnimation, LazyMotion, m, useReducedMotion } from "framer-motion";
+import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
 
 import { useMemo, useState } from "react";
 
@@ -89,7 +89,7 @@ export function AnalyticsConsumptionPage() {
           period={period}
           filter={scopeFilter}
         />
-        <LazyMotion features={domAnimation}>
+        <LazyMotion features={domMax}>
           <div className="flex flex-col gap-4">
             <div className="flex flex-col">
               <div className="flex items-center justify-between">


### PR DESCRIPTION
## Description

Follow up form https://github.com/dust-tt/dust/pull/30425#discussion_r3767221386.

This PR switches the consumption analytics `LazyMotion` provider from `domAnimation` to `domMax` so its layout animation feature is loaded. This makes the existing layout prop animate correctly.