### PR TITLE
[front] fix: Surface the real reason a webhook trigger was blocked

### DIFF
--- a/front/components/agent_builder/triggers/RecentWebhookRequests.tsx
+++ b/front/components/agent_builder/triggers/RecentWebhookRequests.tsx
@@ -94,25 +94,32 @@ function RecentWebhookRequestsContent({
     );
   }
 
-  const wasRateLimited = webhookRequests.some(
-    (request) => request.status === "rate_limited"
+  const lastBlocked = webhookRequests.find(
+    (request) =>
+      request.status === "rate_limited" ||
+      request.status === "credits_exhausted"
   );
 
   return (
     <div className="space-y-2">
-      {wasRateLimited && (
+      {lastBlocked && (
         <div className="text-sm text-muted-foreground">
           <p>
-            Some requests were rate limited.
-            <br />
-            Contact{" "}
-            <LinkWrapper
-              href="mailto:support@dust.tt?subject=Increase%20Webhook%20Trigger%20Rate%20Limit"
-              className="underline"
-            >
-              support@dust.tt
-            </LinkWrapper>{" "}
-            to increase the rate limit for this trigger.
+            {lastBlocked.errorMessage ??
+              "Some requests were not processed for this trigger."}
+            {lastBlocked.status === "rate_limited" && (
+              <>
+                <br />
+                Contact{" "}
+                <LinkWrapper
+                  href="mailto:support@dust.tt?subject=Increase%20Webhook%20Trigger%20Rate%20Limit"
+                  className="underline"
+                >
+                  support@dust.tt
+                </LinkWrapper>{" "}
+                to increase the rate limit for this trigger.
+              </>
+            )}
           </p>
         </div>
       )}
@@ -131,7 +138,12 @@ function RecentWebhookRequestsContent({
                 </div>
               </CollapsibleTrigger>
               <CollapsibleContent>
-                {request.payload ? (
+                {request.errorMessage && (
+                  <p className="pb-2 text-sm text-muted-foreground">
+                    {request.errorMessage}
+                  </p>
+                )}
+                {request.payload && (
                   <div className="rounded">
                     <pre className="max-h-64 overflow-auto text-xs">
                       <Markdown
@@ -140,7 +152,8 @@ function RecentWebhookRequestsContent({
                       />
                     </pre>
                   </div>
-                ) : (
+                )}
+                {!request.payload && !request.errorMessage && (
                   <p className="text-sm text-muted-foreground">
                     No payload available.
                   </p>

--- a/front/components/agent_builder/triggers/WebhookRequestStatusBadge.tsx
+++ b/front/components/agent_builder/triggers/WebhookRequestStatusBadge.tsx
@@ -29,9 +29,13 @@ export function WebhookRequestStatusBadge({
       label: "Rate Limited",
       variant: "warning",
     },
+    credits_exhausted: {
+      label: "Out Of Credits",
+      variant: "warning",
+    },
   };
 
-  const config = statusConfig[status];
+  const config = statusConfig[status] ?? { label: status, variant: "info" };
 
   return (
     <Chip

--- a/front/components/poke/triggers/ExecutionStats.tsx
+++ b/front/components/poke/triggers/ExecutionStats.tsx
@@ -40,7 +40,12 @@ export function ExecutionStats({ owner, triggerId }: ExecutionStatsProps) {
 
   const maxDailyCount = Math.max(
     ...data.dailyVolume.map(
-      (d) => d.succeeded + d.failed + d.notMatched + d.rateLimited
+      (d) =>
+        d.succeeded +
+        d.failed +
+        d.notMatched +
+        d.rateLimited +
+        d.creditsExhausted
     ),
     1
   );
@@ -84,11 +89,19 @@ export function ExecutionStats({ owner, triggerId }: ExecutionStatsProps) {
               <div className="h-2.5 w-2.5 rounded-sm bg-yellow-400" />
               <span>Not matched</span>
             </div>
+            <div className="flex items-center gap-1">
+              <div className="h-2.5 w-2.5 rounded-sm bg-red-400" />
+              <span>Out of credits</span>
+            </div>
           </div>
           <div className="flex flex-col gap-1">
             {data.dailyVolume.map((day) => {
               const total =
-                day.succeeded + day.failed + day.notMatched + day.rateLimited;
+                day.succeeded +
+                day.failed +
+                day.notMatched +
+                day.rateLimited +
+                day.creditsExhausted;
               const barWidth = (total / maxDailyCount) * 100;
 
               return (
@@ -141,6 +154,20 @@ export function ExecutionStats({ owner, triggerId }: ExecutionStatsProps) {
                               className="h-full bg-yellow-400"
                               style={{
                                 width: `${(day.notMatched / total) * 100}%`,
+                              }}
+                            />
+                          }
+                        />
+                      )}
+                      {day.creditsExhausted > 0 && (
+                        <Tooltip
+                          tooltipTriggerAsChild
+                          label={`Out of credits: ${day.creditsExhausted}`}
+                          trigger={
+                            <div
+                              className="h-full bg-red-400"
+                              style={{
+                                width: `${(day.creditsExhausted / total) * 100}%`,
                               }}
                             />
                           }

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -31,6 +31,7 @@ const STATUS_FILTER_LABELS: Record<WebhookRequestTriggerStatus, string> = {
   workflow_start_failed: "Failed",
   not_matched: "Not Matched",
   rate_limited: "Rate Limited",
+  credits_exhausted: "Out Of Credits",
 };
 
 export function PokeRecentWebhookRequests({
@@ -107,8 +108,10 @@ function PokeRecentWebhookRequestsContent({
     );
   }
 
-  const wasRateLimited = webhookRequests.some(
-    (request) => request.status === "rate_limited"
+  const lastBlocked = webhookRequests.find(
+    (request) =>
+      request.status === "rate_limited" ||
+      request.status === "credits_exhausted"
   );
 
   return (
@@ -146,9 +149,10 @@ function PokeRecentWebhookRequestsContent({
         </p>
       ) : (
         <>
-          {wasRateLimited && !statusFilter && (
+          {lastBlocked && !statusFilter && (
             <div className="text-sm text-muted-foreground">
-              Some requests were rate limited.
+              {lastBlocked.errorMessage ??
+                `Some requests were blocked (${STATUS_FILTER_LABELS[lastBlocked.status]}).`}
             </div>
           )}
           <div className="flex flex-col px-4">
@@ -166,7 +170,12 @@ function PokeRecentWebhookRequestsContent({
                     </div>
                   </CollapsibleTrigger>
                   <CollapsibleContent>
-                    {request.payload ? (
+                    {request.errorMessage && (
+                      <p className="pb-2 text-sm text-muted-foreground">
+                        {request.errorMessage}
+                      </p>
+                    )}
+                    {request.payload && (
                       <div className="rounded">
                         <pre className="max-h-64 overflow-auto text-xs">
                           <Markdown
@@ -175,7 +184,8 @@ function PokeRecentWebhookRequestsContent({
                           />
                         </pre>
                       </div>
-                    ) : (
+                    )}
+                    {!request.payload && !request.errorMessage && (
                       <p className="text-sm text-muted-foreground">
                         No payload available.
                       </p>

--- a/front/lib/api/poke/triggers.ts
+++ b/front/lib/api/poke/triggers.ts
@@ -17,6 +17,7 @@ export type PokeGetTriggerExecutionStats = {
     failed: number;
     notMatched: number;
     rateLimited: number;
+    creditsExhausted: number;
   }>;
 };
 

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -15,6 +15,7 @@ import type {
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type {
   Attributes,
   CreationAttributes,
@@ -359,6 +360,7 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
       failed: number;
       notMatched: number;
       rateLimited: number;
+      creditsExhausted: number;
     }>;
   }> {
     const workspace = auth.getNonNullableWorkspace();
@@ -408,6 +410,7 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
         failed: number;
         notMatched: number;
         rateLimited: number;
+        creditsExhausted: number;
       }
     >();
     for (const row of dailyRows) {
@@ -421,6 +424,7 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
           failed: 0,
           notMatched: 0,
           rateLimited: 0,
+          creditsExhausted: 0,
         });
       }
       const entry = dailyMap.get(date)!;
@@ -437,6 +441,11 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
         case "rate_limited":
           entry.rateLimited += count;
           break;
+        case "credits_exhausted":
+          entry.creditsExhausted += count;
+          break;
+        default:
+          assertNeverAndIgnore(status);
       }
     }
 

--- a/front/lib/triggers/webhook.test.ts
+++ b/front/lib/triggers/webhook.test.ts
@@ -1,0 +1,166 @@
+import { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
+import type { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
+import {
+  fetchRecentWebhookRequestTriggersWithPayload,
+  processWebhookRequest,
+} from "@app/lib/triggers/webhook";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockIsApiBlocked, mockCheckWebhookRequestForRateLimit } = vi.hoisted(
+  () => ({
+    mockIsApiBlocked: vi.fn(),
+    mockCheckWebhookRequestForRateLimit: vi.fn(),
+  })
+);
+
+vi.mock("@app/lib/metronome/user_block", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/metronome/user_block")>()),
+  isApiBlocked: mockIsApiBlocked,
+}));
+
+vi.mock("@app/lib/triggers/rate_limits", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/triggers/rate_limits")>()),
+  checkWebhookRequestForRateLimit: mockCheckWebhookRequestForRateLimit,
+}));
+
+vi.mock("@app/lib/temporal", () => ({
+  heartbeat: vi.fn().mockResolvedValue(undefined),
+  getTemporalClientForAgentNamespace: vi.fn().mockResolvedValue({
+    schedule: {
+      getHandle: vi.fn().mockReturnValue({
+        update: vi.fn(),
+        delete: vi.fn(),
+      }),
+    },
+    workflow: {
+      start: vi.fn().mockResolvedValue(undefined),
+    },
+  }),
+  getTemporalClientForFrontNamespace: vi.fn().mockResolvedValue({
+    workflow: {
+      start: vi.fn().mockResolvedValue(undefined),
+    },
+  }),
+}));
+
+describe("processWebhookRequest", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let webhookSource: WebhookSourceResource;
+  let trigger: TriggerResource;
+
+  beforeEach(async () => {
+    mockIsApiBlocked.mockResolvedValue(false);
+    mockCheckWebhookRequestForRateLimit.mockResolvedValue({
+      rateLimited: false,
+    });
+
+    workspace = await WorkspaceFactory.creditPriced();
+    const editorUser = await UserFactory.basic();
+    const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+    await MembershipFactory.associate(workspace, editorUser, { role: "admin" });
+
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceResource.makeDefaultsForWorkspace(internalAdminAuth, {
+      globalGroup,
+      systemGroup,
+    });
+
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      editorUser.sId,
+      workspace.sId
+    );
+
+    const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Webhook Agent",
+    });
+    const globalSpace =
+      await SpaceResource.fetchWorkspaceGlobalSpace(internalAdminAuth);
+    const webhookSourceView = await new WebhookSourceViewFactory(
+      workspace
+    ).create(globalSpace);
+    webhookSource = webhookSourceView.webhookSource;
+
+    trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      name: "Webhook Trigger",
+      status: "enabled",
+      webhookSourceViewId: webhookSourceView.id,
+      configuration: { includePayload: false },
+    });
+  });
+
+  async function postWebhookRequest() {
+    const webhookRequest = await WebhookRequestResource.makeNew({
+      workspaceId: workspace.id,
+      webhookSourceId: webhookSource.id,
+      status: "received",
+    });
+
+    const body = { event: "something.happened" };
+
+    return processWebhookRequest(auth, {
+      webhookSource,
+      webhookRequest,
+      headers: {},
+      body,
+      rawBody: JSON.stringify(body),
+    });
+  }
+
+  async function fetchTriggerRequests() {
+    return fetchRecentWebhookRequestTriggersWithPayload(auth, {
+      trigger: trigger.toJSON(),
+    });
+  }
+
+  it("marks the request as credits_exhausted when the credit pool is depleted", async () => {
+    mockIsApiBlocked.mockResolvedValue(true);
+
+    const result = await postWebhookRequest();
+    expect(result.isOk()).toBe(true);
+
+    const requests = await fetchTriggerRequests();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].status).toBe("credits_exhausted");
+    expect(requests[0].errorMessage).toContain("run out of credits");
+  });
+
+  it("marks the request as rate_limited when the workspace fair-use limit is reached", async () => {
+    mockCheckWebhookRequestForRateLimit.mockResolvedValue({
+      rateLimited: true,
+      message: "Webhook triggers rate limit exceeded.",
+    });
+
+    const result = await postWebhookRequest();
+    expect(result.isOk()).toBe(true);
+
+    const requests = await fetchTriggerRequests();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].status).toBe("rate_limited");
+    expect(requests[0].errorMessage).toContain("rate limit exceeded");
+  });
+
+  it("starts the trigger workflow when nothing blocks the request", async () => {
+    const result = await postWebhookRequest();
+    expect(result.isOk()).toBe(true);
+
+    const requests = await fetchTriggerRequests();
+    expect(requests).toHaveLength(1);
+    expect(requests[0].status).toBe("workflow_start_succeeded");
+    expect(requests[0].errorMessage).toBeNull();
+  });
+});

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -45,6 +45,7 @@ export interface GetWebhookRequestsResponseBody {
     id: number;
     timestamp: number;
     status: WebhookRequestTriggerStatus;
+    errorMessage: string | null;
     payload?: {
       headers?: Record<string, string | string[]>;
       body?: unknown;
@@ -258,6 +259,18 @@ async function validateEventSubscription({
   return new Ok({ skipReason: null, receivedEventValue });
 }
 
+type WorkspaceBlock = {
+  status: Extract<
+    WebhookRequestTriggerStatus,
+    "rate_limited" | "credits_exhausted"
+  >;
+  message: string;
+};
+
+type WorkspaceBlockCheckResult =
+  | { blocked: false; block?: undefined }
+  | { blocked: true; block: WorkspaceBlock };
+
 async function checkWorkspaceRateLimit({
   auth,
   trigger,
@@ -270,8 +283,8 @@ async function checkWorkspaceRateLimit({
   workspaceId: string;
   webhookRequestId: number;
   provider: WebhookProvider | null;
-}): Promise<RateLimitCheckResult> {
-  let errorMessage: string | null = null;
+}): Promise<WorkspaceBlockCheckResult> {
+  let block: WorkspaceBlock | null = null;
 
   const plan = auth.subscription()?.plan;
   const owner = auth.getNonNullableWorkspace();
@@ -281,20 +294,26 @@ async function checkWorkspaceRateLimit({
   // spinning up the trigger workflow only to fail in `checkMessagesLimit`.
   if (plan && isCreditPricedPlan(plan)) {
     if (owner.metronomeCustomerId && (await isApiBlocked(owner.sId))) {
-      errorMessage =
-        "Your workspace has run out of credits. Please purchase more credits to continue.";
+      block = {
+        status: "credits_exhausted",
+        message:
+          "Your workspace has run out of credits. Please purchase more credits to continue.",
+      };
     }
 
     // Programmatic monthly cap gate: if the programmatic cap is reached, reject
     // early for programmatic triggers.
     if (
-      !errorMessage &&
+      !block &&
       owner.metronomeCustomerId &&
       trigger.executionMode === "programmatic" &&
       (await isProgrammaticApiBlocked(owner.sId))
     ) {
-      errorMessage =
-        "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.";
+      block = {
+        status: "credits_exhausted",
+        message:
+          "Your workspace has reached its programmatic monthly spending cap. An admin can raise the cap in the workspace's usage settings.",
+      };
     }
   }
 
@@ -303,12 +322,12 @@ async function checkWorkspaceRateLimit({
    * - for fair use execution mode, check global rate limits
    * - for programmatic usage mode, check public API limits
    */
-  if (!errorMessage) {
+  if (!block) {
     if (!trigger.executionMode || trigger.executionMode === "fair_use") {
       const { rateLimited, message } =
         await checkWebhookRequestForRateLimit(auth);
       if (rateLimited) {
-        errorMessage = message;
+        block = { status: "rate_limited", message };
       }
     } else {
       // Programmatic execution mode: legacy programmatic-credit gate applies
@@ -317,16 +336,20 @@ async function checkWorkspaceRateLimit({
       if (!plan || !isCreditPricedPlan(plan)) {
         const limitsResult = await checkProgrammaticUsageLimits(auth);
         if (limitsResult.isErr()) {
-          errorMessage = limitsResult.error.message;
+          block = {
+            status: "rate_limited",
+            message: limitsResult.error.message,
+          };
         }
       }
     }
   }
 
-  if (errorMessage !== null) {
+  if (block !== null) {
     getStatsDClient().increment("webhook_workspace_rate_limit.hit.count", 1, [
       `provider:${provider}`,
       `workspace_id:${workspaceId}`,
+      `block_status:${block.status}`,
     ]);
     logger.error(
       {
@@ -334,13 +357,14 @@ async function checkWorkspaceRateLimit({
         webhookRequestId,
         triggerId: trigger.sId,
         provider,
+        blockStatus: block.status,
       },
-      errorMessage
+      block.message
     );
-    return { rateLimited: true, message: errorMessage };
+    return { blocked: true, block };
   }
 
-  return { rateLimited: false };
+  return { blocked: false };
 }
 
 async function checkTriggerRateLimit({
@@ -478,21 +502,22 @@ async function filterTriggers(
     }
 
     // Check 3: Workspace-level rate limit.
-    const workspaceRateLimitResult = await checkWorkspaceRateLimit({
+    const workspaceBlockResult = await checkWorkspaceRateLimit({
       auth,
       trigger,
       workspaceId,
       webhookRequestId: webhookRequest.id,
       provider,
     });
-    if (workspaceRateLimitResult.rateLimited) {
+    if (workspaceBlockResult.blocked) {
+      const { status, message } = workspaceBlockResult.block;
       await webhookRequest.markRelatedTrigger({
         trigger,
-        status: "rate_limited",
-        errorMessage: workspaceRateLimitResult.message,
+        status,
+        errorMessage: message,
       });
       // If it's a workspace-level rate limit, return an error immediately.
-      return new Err(new Error(workspaceRateLimitResult.message));
+      return new Err(new Error(message));
     }
 
     // Check 4: Trigger-specific rate limit.
@@ -785,6 +810,7 @@ export async function fetchRecentWebhookRequestTriggersWithPayload(
     id: number;
     timestamp: number;
     status: WebhookRequestTriggerStatus;
+    errorMessage: string | null;
     payload?: {
       headers?: Record<string, string | string[]>;
       body?: unknown;
@@ -846,6 +872,7 @@ export async function fetchRecentWebhookRequestTriggersWithPayload(
         id: wrt.webhookRequest.id,
         timestamp: wrt.webhookRequest.createdAt.getTime(),
         status: wrt.status,
+        errorMessage: wrt.errorMessage,
         payload,
       };
     })

--- a/front/types/api/poke/triggers.ts
+++ b/front/types/api/poke/triggers.ts
@@ -5,6 +5,7 @@ export interface PokeGetWebhookRequestsResponseBody {
     id: number;
     timestamp: number;
     status: WebhookRequestTriggerStatus;
+    errorMessage: string | null;
     payload?: {
       headers?: Record<string, string | string[]>;
       body?: unknown;

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -85,6 +85,7 @@ export const WEBHOOK_REQUEST_TRIGGER_STATUSES = [
   "workflow_start_failed",
   "not_matched",
   "rate_limited",
+  "credits_exhausted",
 ] as const;
 
 export type WebhookRequestTriggerStatus =


### PR DESCRIPTION
## Description

Bubble up trigger errors caused by running out of credit to users.
This is done by introducing a new failure mode for triggers "credits_exhausted" to WebhookRequestTriggerStatus.
I won't backfill, this is not backward compatible, but at least users will get clearer errors in the future.

## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy front