### PR TITLE
Admin governance: dual write + migration for skills

### DIFF
--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -1,5 +1,6 @@
 import {
   assertValidGrant,
+  grantTypesForVerb,
   ROLE_REGISTRY,
 } from "@app/lib/resources/group_permission_registry";
 import {
@@ -199,6 +200,13 @@ describe("ROLE_REGISTRY invariants", () => {
     for (const verb of GRANT_VERBS) {
       expect(reachable.has(verb)).toBe(true);
     }
+  });
+
+  it("lets the skill editor role administrate its skill", () => {
+    // A skill's editor group is also its administrator (archive / restore / manage editors, all
+    // gated by SkillResource.canAdministrate), so `editor` must confer `admin` at instance level —
+    // otherwise editors lose those actions once group_permissions becomes the read source.
+    expect(grantTypesForVerb("skill", "admin", "instance")).toContain("editor");
   });
 
   it("keeps every type-level role a singleton whose name is its verb", () => {

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -37,11 +37,11 @@ import assert from "assert";
  * grant applies to the whole type (or all types) and is only ever a type-level (`-1`) grant.
  */
 
-type ConcreteGrantType = Exclude<GrantType, "*">;
+export type ConcreteGrantType = Exclude<GrantType, "*">;
 
 // A grant applies either to a specific resource instance (resourceId > 0) or to the whole type
 // (resourceId = -1). A role declares the levels at which it can be granted.
-type GrantLevel = "instance" | "type";
+export type GrantLevel = "instance" | "type";
 
 interface RoleDefinition {
   verbs: GrantVerb[];
@@ -63,7 +63,7 @@ export const ROLE_REGISTRY: Record<
     publish: { verbs: ["publish"], levels: ["type"] },
   },
   skill: {
-    editor: { verbs: ["read", "write"], levels: ["instance"] },
+    editor: { verbs: ["read", "write", "admin"], levels: ["instance"] },
     create: { verbs: ["create"], levels: ["type"] },
     publish: { verbs: ["publish"], levels: ["type"] },
     make_discoverable: { verbs: ["make_discoverable"], levels: ["type"] },
@@ -152,7 +152,7 @@ export function grantTypesForVerb(
 
 // Verbs a grant type confers at `level`; empty when the role is not valid at that level, or the
 // resource type is unknown (e.g. a stale grant row for a removed type).
-function verbsForGrantAtLevel(
+export function verbsForGrantAtLevel(
   grantType: ConcreteGrantType,
   resourceType: ConcreteResourceType,
   level: GrantLevel

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -8,6 +8,7 @@ import {
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { SkillUserFavoriteModel } from "@app/lib/models/skill/skill_user_favorite";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
@@ -29,6 +30,8 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { ModelId } from "@app/types/shared/model_id";
+import assert from "assert";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("SkillResource", () => {
@@ -61,6 +64,64 @@ describe("SkillResource", () => {
 
       expect(skill.canWrite(auth)).toBe(true);
       expect(skill.canAdministrate(auth)).toBe(true);
+    });
+  });
+
+  describe("group_permissions dual-write", () => {
+    // The grants held on a skill by its editor group, straight from the table.
+    async function fetchSkillGrants(
+      editorGroupModelId: ModelId,
+      skillModelId: ModelId
+    ) {
+      return GroupPermissionResource.listForGroups(
+        testContext.authenticator.getNonNullableWorkspace(),
+        {
+          groupModelIds: [editorGroupModelId],
+          resourceType: "skill",
+          resourceId: skillModelId,
+        }
+      );
+    }
+
+    it("writes an editor grant for the editor group when a skill is created", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With Grants",
+      });
+      const editorGroupId = skill.editorGroup?.id;
+      assert(editorGroupId, "skill should have an editor group");
+
+      const grants = await fetchSkillGrants(editorGroupId, skill.id);
+
+      expect(grants).toHaveLength(1);
+      expect(grants[0].grantType).toBe("editor");
+      expect(grants[0].resourceId).toBe(skill.id);
+    });
+
+    it("clears the grants when the skill is deleted", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill To Delete With Grants",
+      });
+      const editorGroupId = skill.editorGroup?.id;
+      assert(editorGroupId, "skill should have an editor group");
+      expect(await fetchSkillGrants(editorGroupId, skill.id)).toHaveLength(1);
+
+      const result = await skill.delete(testContext.authenticator);
+      expect(result.isOk()).toBe(true);
+
+      expect(await fetchSkillGrants(editorGroupId, skill.id)).toHaveLength(0);
+    });
+
+    it("is idempotent: reconciling twice leaves a single grant", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill Reconciled Twice",
+      });
+      const editorGroupId = skill.editorGroup?.id;
+      assert(editorGroupId, "skill should have an editor group");
+
+      await skill.reconcileGroupPermissions(testContext.authenticator);
+      await skill.reconcileGroupPermissions(testContext.authenticator);
+
+      expect(await fetchSkillGrants(editorGroupId, skill.id)).toHaveLength(1);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -87,10 +87,10 @@ describe("SkillResource", () => {
       const skill = await SkillFactory.create(testContext.authenticator, {
         name: "Skill With Grants",
       });
-      const editorGroupId = skill.editorGroup?.id;
-      assert(editorGroupId, "skill should have an editor group");
+      const editorGroupModelId = skill.editorGroup?.id;
+      assert(editorGroupModelId, "skill should have an editor group");
 
-      const grants = await fetchSkillGrants(editorGroupId, skill.id);
+      const grants = await fetchSkillGrants(editorGroupModelId, skill.id);
 
       expect(grants).toHaveLength(1);
       expect(grants[0].grantType).toBe("editor");
@@ -101,27 +101,33 @@ describe("SkillResource", () => {
       const skill = await SkillFactory.create(testContext.authenticator, {
         name: "Skill To Delete With Grants",
       });
-      const editorGroupId = skill.editorGroup?.id;
-      assert(editorGroupId, "skill should have an editor group");
-      expect(await fetchSkillGrants(editorGroupId, skill.id)).toHaveLength(1);
+      const editorGroupModelId = skill.editorGroup?.id;
+      assert(editorGroupModelId, "skill should have an editor group");
+      expect(await fetchSkillGrants(editorGroupModelId, skill.id)).toHaveLength(
+        1
+      );
 
       const result = await skill.delete(testContext.authenticator);
       expect(result.isOk()).toBe(true);
 
-      expect(await fetchSkillGrants(editorGroupId, skill.id)).toHaveLength(0);
+      expect(await fetchSkillGrants(editorGroupModelId, skill.id)).toHaveLength(
+        0
+      );
     });
 
     it("is idempotent: reconciling twice leaves a single grant", async () => {
       const skill = await SkillFactory.create(testContext.authenticator, {
         name: "Skill Reconciled Twice",
       });
-      const editorGroupId = skill.editorGroup?.id;
-      assert(editorGroupId, "skill should have an editor group");
+      const editorGroupModelId = skill.editorGroup?.id;
+      assert(editorGroupModelId, "skill should have an editor group");
 
       await skill.reconcileGroupPermissions(testContext.authenticator);
       await skill.reconcileGroupPermissions(testContext.authenticator);
 
-      expect(await fetchSkillGrants(editorGroupId, skill.id)).toHaveLength(1);
+      expect(await fetchSkillGrants(editorGroupModelId, skill.id)).toHaveLength(
+        1
+      );
     });
   });
 
@@ -1691,10 +1697,10 @@ describe("SkillResource", () => {
       });
       expect(groupSkillBefore).not.toBeNull();
 
-      const editorGroupId = groupSkillBefore!.groupId;
+      const editorGroupModelId = groupSkillBefore!.groupId;
       const [editorGroupBefore] = await GroupResource.fetchByModelIds(
         testContext.authenticator,
-        [editorGroupId]
+        [editorGroupModelId]
       );
       expect(editorGroupBefore).not.toBeNull();
       expect(editorGroupBefore!.kind).toBe("skill_editors");
@@ -1722,7 +1728,7 @@ describe("SkillResource", () => {
       // Verify the editor group is deleted.
       const editorGroupsAfter = await GroupResource.fetchByModelIds(
         testContext.authenticator,
-        [editorGroupId]
+        [editorGroupModelId]
       );
       expect(editorGroupsAfter).toHaveLength(0);
     });
@@ -2344,15 +2350,15 @@ describe("SkillResource", () => {
       const groupSkills = await GroupSkillModel.findAll({
         where: { workspaceId: testContext.workspace.id },
       });
-      const editorGroupIds = groupSkills.map((gs) => gs.groupId);
-      expect(editorGroupIds.length).toBeGreaterThanOrEqual(2);
+      const editorGroupModelIds = groupSkills.map((gs) => gs.groupId);
+      expect(editorGroupModelIds.length).toBeGreaterThanOrEqual(2);
 
       // Verify editor groups exist.
       const editorGroupsBefore = await GroupResource.fetchByModelIds(
         testContext.authenticator,
-        editorGroupIds
+        editorGroupModelIds
       );
-      expect(editorGroupsBefore.length).toBe(editorGroupIds.length);
+      expect(editorGroupsBefore.length).toBe(editorGroupModelIds.length);
       expect(editorGroupsBefore.every((g) => g.kind === "skill_editors")).toBe(
         true
       );
@@ -2381,7 +2387,7 @@ describe("SkillResource", () => {
       // Verify editor groups are deleted.
       const editorGroupsAfter = await GroupResource.fetchByModelIds(
         testContext.authenticator,
-        editorGroupIds
+        editorGroupModelIds
       );
       expect(editorGroupsAfter).toHaveLength(0);
     });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -33,6 +33,8 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { verbsForGrantAtLevel } from "@app/lib/resources/group_permission_registry";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -91,6 +93,7 @@ import type {
 import { isDefaultFromAvailability } from "@app/types/assistant/skill_configuration";
 import type { AgentsUsageType } from "@app/types/data_source";
 import { SKILL_GROUP_PREFIX } from "@app/types/groups";
+import type { GroupGrant } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -251,6 +254,10 @@ export interface SkillResource
  * @see GlobalSkillsRegistry for global skill definitions
  * @see SystemSkillsRegistry for always-enabled system skill definitions
  */
+
+// The role a skill's editor group holds on the skill. Its verbs live in ROLE_REGISTRY.skill.
+const SKILL_EDITOR_GRANT_TYPE = "editor" as const;
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static model: ModelStatic<SkillConfigurationModel> = SkillConfigurationModel;
@@ -509,6 +516,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       await skillResource.normalizeSkillReferenceTags(auth, { transaction });
       await skillResource.syncSkillReferences(auth, { transaction });
+
+      // Mirror the editor-group association into group_permissions, in the same transaction as the
+      // association itself.
+      await skillResource.writeGroupPermissions(auth, { transaction });
 
       return skillResource;
     });
@@ -2123,6 +2134,74 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this.editorGroup.canAdministrate(auth);
   }
 
+  // The group grants a skill confers, derived from its `group_skills` association: the editor
+  // group holds the `editor` role. The verbs come from the registry rather than being restated
+  // here, so this cannot drift from `ROLE_REGISTRY.skill.editor`.
+  private skillGroupGrants(): GroupGrant[] {
+    if (!this.editorGroup) {
+      return [];
+    }
+
+    return [
+      {
+        id: this.editorGroup.id,
+        permissions: verbsForGrantAtLevel(
+          SKILL_EDITOR_GRANT_TYPE,
+          "skill",
+          "instance"
+        ),
+      },
+    ];
+  }
+
+  // Writes this skill's `group_permissions` rows directly from its `group_skills` association
+  // (see `skillGroupGrants`). The skill mutation paths call this to keep the table in sync as it
+  // becomes the source of truth. Idempotent — it clears the skill's instance grants then
+  // re-inserts the desired set, so it is safe to re-run.
+  async writeGroupPermissions(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    // Clear this skill's instance grants, then re-insert the desired set. `resourceId` is the
+    // skill id (> 0), so the type-wide governance rows (-1) are never touched.
+    await GroupPermissionResource.deleteAllForResource(auth, {
+      resourceType: "skill",
+      resourceId: this.id,
+      transaction,
+    });
+
+    const desiredGrants = this.skillGroupGrants();
+    if (desiredGrants.length === 0) {
+      return;
+    }
+
+    const groups = await GroupResource.fetchByModelIds(
+      auth,
+      desiredGrants.map((grant) => grant.id),
+      { transaction }
+    );
+
+    await GroupPermissionResource.grantMany(auth, {
+      grants: groups.map((group) => ({
+        group,
+        grantType: SKILL_EDITOR_GRANT_TYPE,
+        resourceType: "skill" as const,
+        resourceId: this.id,
+      })),
+      transaction,
+    });
+  }
+
+  // Backfill entry: (re-)derive this skill's `group_permissions` from its `group_skills`
+  // association. Delegates to `writeGroupPermissions` — the same logic the mutation paths use — so
+  // the one-off backfill and the ongoing writes can never disagree. Idempotent; safe to re-run.
+  async reconcileGroupPermissions(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    return this.writeGroupPermissions(auth, { transaction });
+  }
+
   private async listActiveAgents(
     auth: Authenticator
   ): Promise<AgentConfigurationModel[]> {
@@ -3673,6 +3752,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
         await GroupSkillModel.destroy({
           where: whereWorkspaceIdAndSkillId,
+          transaction,
+        });
+
+        // Drop the skill's instance grants before the editor group goes away: group_permissions
+        // rows are keyed by both, and this also covers grants held by any other group.
+        await GroupPermissionResource.deleteAllForResource(auth, {
+          resourceType: "skill",
+          resourceId: this.id,
           transaction,
         });
 

--- a/front/migrations/20260812_backfill_skill_group_permissions.ts
+++ b/front/migrations/20260812_backfill_skill_group_permissions.ts
@@ -1,0 +1,102 @@
+import { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { SKILL_STATUSES } from "@app/types/assistant/skill_configuration";
+import type { LightWorkspaceType } from "@app/types/user";
+
+// Backfill: (re-)derive every skill's group_permissions from its group_skills association. The
+// write goes through SkillResource.reconcileGroupPermissions, which delegates to the same
+// writeGroupPermissions the skill mutation paths use, so the backfill and the ongoing writes can
+// never disagree. Idempotent (clears + re-inserts), so it is safe to re-run if grants get corrupted.
+async function backfillWorkspaceSkillGroupPermissions(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // Every status: archived and suggested skills keep their editor group, so their grants must be
+  // written too (an archived skill can be restored).
+  const skills = await SkillResource.listByWorkspace(auth, {
+    status: [...SKILL_STATUSES],
+    withInstructions: false,
+    withTools: false,
+    withFileAttachments: false,
+  });
+
+  await concurrentExecutor(
+    skills,
+    async (skill) => {
+      const editorGroupId = skill.editorGroup?.id ?? null;
+
+      if (!execute) {
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            skillId: skill.sId,
+            skillStatus: skill.status,
+            editorGroupId,
+          },
+          "Dry-run: would reconcile skill group permissions"
+        );
+        return;
+      }
+
+      // One transaction per skill so a skill is never left without its grants mid-reconcile.
+      await frontSequelize.transaction(async (transaction) => {
+        await skill.reconcileGroupPermissions(auth, { transaction });
+      });
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          skillId: skill.sId,
+          skillStatus: skill.status,
+          editorGroupId,
+        },
+        "Reconciled skill group permissions"
+      );
+    },
+    { concurrency: 4 }
+  );
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting skill group_permissions backfill");
+
+    if (wId) {
+      const ws = await WorkspaceResource.fetchById(wId);
+      if (!ws) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      await backfillWorkspaceSkillGroupPermissions(
+        execute,
+        logger,
+        renderLightWorkspaceType({ workspace: ws })
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await backfillWorkspaceSkillGroupPermissions(
+            execute,
+            logger,
+            workspace
+          );
+        },
+        { concurrency: 4 }
+      );
+    }
+
+    logger.info("Skill group_permissions backfill completed");
+  }
+);


### PR DESCRIPTION
## Description

First part of https://github.com/dust-tt/tasks/issues/9472

Implement dual write of permissions for skills.
We actually just need to add the "editor" permission to the editor group upon creation and remove it on skill deletion.

Also include the migration to run post deploy 

## Tests

added unit test

## Risk

low: Can be reverted if needed, permissions are still stored and checked as before

## Deploy Plan

merge
deploy front
run post deploy migration 
```
npx tsx front/migrations/20260812_backfill_skill_group_permissions.ts --execute
```
