### PR TITLE
[front] feat: add nullable metadata column to skills

### DIFF
--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -11,6 +11,7 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   SkillAvailability,
+  SkillMetadata,
   SkillReinforcementMode,
   SkillSourceMetadata,
   SkillSourceType,
@@ -71,6 +72,10 @@ const SKILL_MODEL_ATTRIBUTES = {
     type: DataTypes.JSONB,
     allowNull: true,
   },
+  metadata: {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  },
   availability: {
     type: DataTypes.STRING,
     allowNull: false,
@@ -113,6 +118,7 @@ export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurat
 
   declare source: SkillSourceType | null;
   declare sourceMetadata: SkillSourceMetadata | null;
+  declare metadata: SkillMetadata | null;
   declare availability: CreationOptional<SkillAvailability>;
   declare favoriteCount: CreationOptional<number>;
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2071,6 +2071,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         icon: def.icon,
         source: null,
         sourceMetadata: null,
+        metadata: null,
         availability: SystemSkillsRegistry.isSystemSkill(def.sId)
           ? "workspace_users"
           : "users_and_agents",
@@ -2373,6 +2374,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           requestedSpaceIds: versionModel.requestedSpaceIds,
           source: versionModel.source,
           sourceMetadata: versionModel.sourceMetadata,
+          metadata: versionModel.metadata,
           availability: versionModel.availability,
           favoriteCount: this.favoriteCount,
           reinforcement: "auto",

--- a/front/migrations/pre-deploy/20260812120000_add_metadata_to_skills.sql
+++ b/front/migrations/pre-deploy/20260812120000_add_metadata_to_skills.sql
@@ -1,0 +1,16 @@
+/*
+Add a nullable, client-owned `metadata` JSONB label map to skills and their versions.
+Nullable with no default, so no backfill is required.
+
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_configurations" ADD COLUMN "metadata" jsonb;
+
+/*
+Statement 1
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."skill_versions" ADD COLUMN "metadata" jsonb;

--- a/front/types/assistant/skill_configuration.ts
+++ b/front/types/assistant/skill_configuration.ts
@@ -58,6 +58,13 @@ export const SkillSourceMetadataSchema = z.object({
 
 export type SkillSourceMetadata = z.infer<typeof SkillSourceMetadataSchema>;
 
+// Client-owned key/value labels attached to a skill (akin to Kubernetes labels
+// or cloud-resource tags). Dust does not prescribe the keys; external systems
+// use them to tag skills they manage and reconcile them without storing sIds.
+export const SkillMetadataSchema = z.record(z.string(), z.string());
+
+export type SkillMetadata = z.infer<typeof SkillMetadataSchema>;
+
 export const SkillWithoutInstructionsAndToolsSchema = z.object({
   id: z.number(),
   sId: z.string(),


### PR DESCRIPTION
Adds a client-owned metadata JSONB column (label map) to skill_configurations and
skill_versions, the SkillMetadata type, and the two forced attribute defaults on the
global-skill and restore-from-version builders. Nullable, no default, no backfill.
Schema-only migrate PR; the API read/write code ships in a follow-up.

## Description

Closes https://github.com/dust-tt/tasks/issues/10025

Adds a first-class, client-owned metadata field (a Record<string, string> label map, like Kubernetes labels / cloud-resource tags) to skills. It's settable at import via the public API and returned on GET.

Dust doesn't prescribe the keys, callers pick their own (e.g. { "managedBy": "acme-ci" }).

Semantics: sending metadata on re-import overwrites it; omitting it preserves the existing value (matches updateSkill's ...(x ? { x } : {}) guards).

## Tests
locally

## Risk
no breaking change: additive only

## Deploy Plan
front/migrations/pre-deploy/20260812120000_add_metadata_to_skills.sql
then deploy front

(adds a nullable JSONB metadata column to skill_configurations and skill_versions. Nullable, no default, no backfill.)