### PR TITLE
[front] fix: keep analytics agent avatars square, not rounded

### DIFF
--- a/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceAgentCreditsTable.tsx
@@ -38,6 +38,7 @@ function TopUsersCell({ users }: { users: AgentCreditUser[] }) {
           key={user.userId}
           name={user.name}
           imageUrl={user.imageUrl}
+          isRounded
         />
       )}
     />

--- a/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceUserCreditsTable.tsx
@@ -45,7 +45,6 @@ function TopAgentsCell({ agents, onAgentClick }: TopAgentsCellProps) {
               name={agent.name}
               visual={agent.pictureUrl ?? undefined}
               size="xs"
-              isRounded
             />
             <span className="flex min-w-0 items-baseline gap-1.5">
               <span className="truncate text-sm">{agent.name}</span>
@@ -95,6 +94,7 @@ const columns: ColumnDef<UserCreditRowData>[] = [
         <AvatarNameCell
           name={info.row.original.name}
           imageUrl={info.row.original.imageUrl}
+          isRounded
         />
       </DataTable.CellContent>
     ),

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -50,10 +50,12 @@ function CostShareCell({ share }: { share: number }) {
 
 function buildColumns({
   hasAvatar,
+  isAvatarRounded,
   avgLabel,
   totalCredits,
 }: {
   hasAvatar: boolean;
+  isAvatarRounded: boolean;
   avgLabel: string;
   totalCredits: number;
 }): ColumnDef<AttributionRowData>[] {
@@ -68,7 +70,11 @@ function buildColumns({
         return (
           <DataTable.CellContent className="w-full justify-start text-left">
             {hasAvatar ? (
-              <AvatarNameCell name={name} imageUrl={pictureUrl} />
+              <AvatarNameCell
+                name={name}
+                imageUrl={pictureUrl}
+                isRounded={isAvatarRounded}
+              />
             ) : (
               <span className="truncate text-sm">{name}</span>
             )}
@@ -157,8 +163,14 @@ function AttributionRows({
   }, [allRows, search]);
 
   const columns = useMemo(
-    () => buildColumns({ hasAvatar, avgLabel, totalCredits }),
-    [hasAvatar, avgLabel, totalCredits]
+    () =>
+      buildColumns({
+        hasAvatar,
+        isAvatarRounded: dimension === "user",
+        avgLabel,
+        totalCredits,
+      }),
+    [hasAvatar, dimension, avgLabel, totalCredits]
   );
 
   if (isTopLoading) {

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -6,16 +6,25 @@ function EmptyCell() {
   return <span className="text-xs text-muted-foreground">—</span>;
 }
 
+interface AvatarNameCellProps {
+  name: string;
+  imageUrl: string | null;
+  isRounded?: boolean;
+}
+
 export function AvatarNameCell({
   name,
   imageUrl,
-}: {
-  name: string;
-  imageUrl: string | null;
-}) {
+  isRounded,
+}: AvatarNameCellProps) {
   return (
     <div className="flex items-center gap-2">
-      <Avatar name={name} visual={imageUrl ?? undefined} size="xs" isRounded />
+      <Avatar
+        name={name}
+        visual={imageUrl ?? undefined}
+        size="xs"
+        isRounded={isRounded}
+      />
       <span className="truncate text-sm">{name}</span>
     </div>
   );

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon.tsx
@@ -26,7 +26,7 @@ export function UsageFilterOptionIcon({ option }: UsageFilterOptionIconProps) {
           name={option.name}
           visual={option.image ?? undefined}
           size="xxs"
-          isRounded
+          isRounded={option.kind === "member"}
         />
       );
     case "source": {


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10035

Agents should have a square avatar, rounded avatars are for human users.
This PR fixes this for the new analytics page.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
