### PR TITLE
[front] enh: polish the Pod app tile

### DIFF
--- a/front/components/pod/apps/PodAppTile.tsx
+++ b/front/components/pod/apps/PodAppTile.tsx
@@ -1,12 +1,14 @@
 import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
-import { getIcon } from "@app/components/resources/resources_icons";
+import {
+  getIcon,
+  ResourceAvatar,
+} from "@app/components/resources/resources_icons";
 import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
 import {
   Card,
   CardActionButton,
   Chip,
   GitBranch01,
-  Icon,
   Trash01,
 } from "@dust-tt/sparkle";
 
@@ -81,23 +83,18 @@ export function PodAppTile({
         )
       }
     >
-      <div className="flex min-w-0 grow flex-col gap-2">
-        <div className="flex items-center gap-2">
-          <Icon
-            visual={getIcon(appIcon(app, iconByFramePath, defaultIcon))}
-            size="sm"
-          />
-          <span className="truncate copy-sm font-semibold">{app.name}</span>
-        </div>
-        <span className="truncate font-mono copy-xs text-muted-foreground dark:text-muted-foreground-night">
-          {frame ? frame.fileName : "No Frame in this app"}
+      <div className="flex min-w-0 grow items-center gap-3">
+        <ResourceAvatar
+          icon={getIcon(appIcon(app, iconByFramePath, defaultIcon))}
+          size="md"
+          backgroundColor="bg-background dark:bg-background-night"
+        />
+        <span className="truncate heading-base text-foreground dark:text-foreground-night">
+          {app.name}
         </span>
-        <div className="flex flex-wrap gap-1">
-          {isDraft && <Chip size="xs" color="primary" label="Draft" />}
-          {frame?.isPinnedAsTab && (
-            <Chip size="xs" color="info" label="Pinned as tab" />
-          )}
-        </div>
+        {isDraft && (
+          <Chip size="xs" color="primary" label="Draft" className="shrink-0" />
+        )}
       </div>
     </Card>
   );

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -5,7 +5,6 @@ import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
 import { usePodApps } from "@app/lib/swr/pods";
 import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
-import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import type { PodType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -20,6 +19,10 @@ interface PodAppsTabProps {
   owner: WorkspaceType;
   pod: PodType;
 }
+
+// Not DEFAULT_POD_FRAME_TAB_ICON (a gauge that reads as a clock at tile size): an app is a Frame,
+// so the fallback is the Frame glyph.
+const DEFAULT_POD_APP_ICON = "ActionFrameIcon" satisfies CustomResourceIconType;
 
 // NavTabPillContent is a bare Radix Tabs.Content with no forceMount, so this only mounts while the
 // Apps tab is active — hence no `disabled` flag on the hook below.
@@ -103,7 +106,7 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
                 key={app.prefix}
                 app={app}
                 iconByFramePath={iconByFramePath}
-                defaultIcon={DEFAULT_POD_FRAME_TAB_ICON}
+                defaultIcon={DEFAULT_POD_APP_ICON}
                 onOpenFrame={setFramePreview}
                 onClone={canEdit ? () => setAppPendingClone(app) : undefined}
                 onDelete={


### PR DESCRIPTION
## Description

Visual pass on the Pod Apps tab tiles, following up on #30430:

- Drop the "Pinned as tab" chip — not needed on the tile.
- Drop the Frame filename line — the app name is enough.
- New default icon: the previous fallback (`ActionDashboardIcon`, shared with frame tabs) is a gauge that reads as a clock at tile size. Apps now fall back to the Frame glyph (`ActionFrameIcon`), which matches what an app is. Apps whose Frame is pinned as a tab keep showing their tab's icon.
- Nicer tile now that it shows so little: the icon gets a `ResourceAvatar` treatment on a contrasting background, and the title steps up from `copy-sm` to `heading-base`, vertically centered. The Draft chip stays for apps with no functions and no databases.

## Risk

Low — presentation-only change to the Apps tab tiles.

## Deploy Plan

Deploy front.