### PR TITLE
feat(analytics): cumulative consumption view

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
@@ -29,7 +29,7 @@ const OVERVIEW: GetConsumptionOverviewResponse = {
     status: {
       usedPercentage: 36,
       resetAt: "2026-08-01T00:00:00.000Z",
-      pace: "on_pace",
+      target: "on_target",
     },
   },
 };

--- a/front/components/app/CreditUsage.test.tsx
+++ b/front/components/app/CreditUsage.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { CreditUsageState } from "./CreditUsage";
 import { CreditUsage } from "./CreditUsage";
 
-const ON_PACE_STATE = {
+const ON_TARGET_STATE = {
   usedPercentage: 80,
   resetInDays: 5,
   target: "on_target",
@@ -11,7 +11,7 @@ const ON_PACE_STATE = {
 
 describe("CreditUsage", () => {
   it("renders the compact profile menu presentation", () => {
-    render(<CreditUsage state={ON_PACE_STATE} variant="profile_menu" />);
+    render(<CreditUsage state={ON_TARGET_STATE} variant="profile_menu" />);
 
     expect(screen.getByText("Credits")).toBeInTheDocument();
     expect(screen.getByText("80%")).toBeInTheDocument();
@@ -26,7 +26,7 @@ describe("CreditUsage", () => {
     const rendered = render(
       <CreditUsage
         state={{
-          ...ON_PACE_STATE,
+          ...ON_TARGET_STATE,
           usedPercentage: 120,
           resetInDays: 1,
           target: "critical",
@@ -49,7 +49,7 @@ describe("CreditUsage", () => {
   it("uses the warning treatment for elevated usage", () => {
     render(
       <CreditUsage
-        state={{ ...ON_PACE_STATE, target: "elevated" }}
+        state={{ ...ON_TARGET_STATE, target: "elevated" }}
         variant="companion"
       />
     );

--- a/front/components/app/CreditUsage.test.tsx
+++ b/front/components/app/CreditUsage.test.tsx
@@ -6,7 +6,7 @@ import { CreditUsage } from "./CreditUsage";
 const ON_PACE_STATE = {
   usedPercentage: 80,
   resetInDays: 5,
-  pace: "on_pace",
+  target: "on_target",
 } satisfies CreditUsageState;
 
 describe("CreditUsage", () => {
@@ -29,7 +29,7 @@ describe("CreditUsage", () => {
           ...ON_PACE_STATE,
           usedPercentage: 120,
           resetInDays: 1,
-          pace: "critical",
+          target: "critical",
         }}
         variant="companion"
       />
@@ -37,7 +37,7 @@ describe("CreditUsage", () => {
 
     expect(screen.getByText("100%")).toBeInTheDocument();
     expect(
-      screen.getByText("Usage is well above pace · Credit reset in 1 day")
+      screen.getByText("Usage is well above target · Credit reset in 1 day")
     ).toBeInTheDocument();
     const progressbar = rendered.getByRole("progressbar", {
       name: "Credits used",
@@ -49,7 +49,7 @@ describe("CreditUsage", () => {
   it("uses the warning treatment for elevated usage", () => {
     render(
       <CreditUsage
-        state={{ ...ON_PACE_STATE, pace: "elevated" }}
+        state={{ ...ON_PACE_STATE, target: "elevated" }}
         variant="companion"
       />
     );

--- a/front/components/app/CreditUsage.tsx
+++ b/front/components/app/CreditUsage.tsx
@@ -1,11 +1,11 @@
 import type { CreditUsageCardVariant } from "@app/components/app/CreditUsageCard";
 import { CreditUsageCard } from "@app/components/app/CreditUsageCard";
-import type { CreditUsagePace } from "@app/types/api/credits/usage_status";
+import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
 
 export interface CreditUsageState {
   usedPercentage: number;
   resetInDays: number;
-  pace: CreditUsagePace;
+  target: CreditUsageTarget;
 }
 
 const RESET_LABEL_PREFIX: Record<CreditUsageCardVariant, string> = {
@@ -14,11 +14,11 @@ const RESET_LABEL_PREFIX: Record<CreditUsageCardVariant, string> = {
 };
 
 const COMPANION_STATUS_LABELS: Record<
-  Exclude<CreditUsagePace, "on_pace">,
+  Exclude<CreditUsageTarget, "on_target">,
   string
 > = {
-  elevated: "Usage is above pace",
-  critical: "Usage is well above pace",
+  elevated: "Usage is above target",
+  critical: "Usage is well above target",
 };
 
 interface CreditUsageProps {
@@ -29,15 +29,15 @@ interface CreditUsageProps {
 export function CreditUsage({ state, variant }: CreditUsageProps) {
   const resetUnit = state.resetInDays === 1 ? "day" : "days";
   const companionStatusLabel =
-    variant === "companion" && state.pace !== "on_pace"
-      ? COMPANION_STATUS_LABELS[state.pace]
+    variant === "companion" && state.target !== "on_target"
+      ? COMPANION_STATUS_LABELS[state.target]
       : null;
 
   return (
     <CreditUsageCard
       label="Credits"
       usedPercentage={state.usedPercentage}
-      tone={state.pace}
+      tone={state.target}
       variant={variant}
     >
       {companionStatusLabel ? `${companionStatusLabel} · ` : null}

--- a/front/components/app/CreditUsageCard.tsx
+++ b/front/components/app/CreditUsageCard.tsx
@@ -1,7 +1,7 @@
 import { CoinsStacked01, cn } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
-export type CreditUsageTone = "on_pace" | "elevated" | "critical";
+export type CreditUsageTone = "on_target" | "elevated" | "critical";
 export type CreditUsageCardVariant = "profile_menu" | "companion";
 
 const CONTAINER_CLASSES: Record<CreditUsageCardVariant, string> = {
@@ -11,13 +11,13 @@ const CONTAINER_CLASSES: Record<CreditUsageCardVariant, string> = {
 };
 
 const TONE_BAR_CLASSES: Record<CreditUsageTone, string> = {
-  on_pace: "bg-highlight-500",
+  on_target: "bg-highlight-500",
   elevated: "bg-warning-500",
   critical: "bg-red-500",
 };
 
 const TONE_TEXT_CLASSES: Record<CreditUsageTone, string> = {
-  on_pace: "text-highlight-500",
+  on_target: "text-highlight-500",
   elevated: "text-warning-500",
   critical: "text-red-500",
 };

--- a/front/components/navigation/SidebarUserMenu.tsx
+++ b/front/components/navigation/SidebarUserMenu.tsx
@@ -35,10 +35,10 @@ export function SidebarUserMenu({
               DAY_DURATION_MS
           )
         ),
-        pace: creditUsageStatus.pace,
+        target: creditUsageStatus.target,
       }
     : null;
-  const showCreditUsageInProfileMenu = creditUsageState?.pace === "on_pace";
+  const showCreditUsageInProfileMenu = creditUsageState?.target === "on_target";
 
   return (
     <>

--- a/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
@@ -1,0 +1,234 @@
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import type { LegendItem } from "@app/components/charts/ChartLegend";
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
+import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
+import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import {
+  findPartialTimestamp,
+  formatConsumptionDate,
+} from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+const ACTUAL_COLOR = "text-blue-500";
+const TARGET_COLOR = "text-stone-300";
+
+const BURNUP_ACTUAL_KEY = "actual";
+const BURNUP_TARGET_KEY = "target";
+
+// What the workspace has actually spent so far against what an evenly spread cap
+// allows by then. `actual` stops at the bucket in progress, `target` runs to the
+// end of the cycle, and the gap between the two is the headroom (or the
+// overshoot).
+type BurnUpPoint = {
+  timestamp: number;
+  [BURNUP_ACTUAL_KEY]: number | null;
+  [BURNUP_TARGET_KEY]: number | null;
+};
+
+// Recharts hands the tooltip its datum as `unknown`; the points go into the
+// chart unchanged, so this narrows back to what was built below.
+function isBurnUpPoint(data: unknown): data is BurnUpPoint {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "timestamp" in data &&
+    BURNUP_ACTUAL_KEY in data &&
+    BURNUP_TARGET_KEY in data
+  );
+}
+
+function ConsumptionBurnUpTooltip({
+  active,
+  payload,
+}: TooltipContentProps<number, string>) {
+  const datum = payload?.[0]?.payload;
+  if (!active || !isBurnUpPoint(datum) || datum.actual === null) {
+    return null;
+  }
+
+  const rows = [
+    {
+      key: BURNUP_ACTUAL_KEY,
+      label: "Actual consumption",
+      value: formatCredits(datum.actual),
+      colorClassName: ACTUAL_COLOR,
+    },
+    ...(datum.target !== null
+      ? [
+          {
+            key: BURNUP_TARGET_KEY,
+            label: "Target consumption",
+            value: formatCredits(datum.target),
+            colorClassName: TARGET_COLOR,
+          },
+        ]
+      : []),
+  ];
+
+  const delta = datum.target !== null ? datum.actual - datum.target : null;
+
+  return (
+    <ChartTooltipCard
+      title={formatConsumptionDate(datum.timestamp)}
+      rows={rows}
+      footer={
+        delta !== null
+          ? `${formatCredits(Math.abs(delta))} ${delta > 0 ? "ahead of" : "behind"} target`
+          : undefined
+      }
+    />
+  );
+}
+
+interface ConsumptionBurnUpChartProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+}
+
+export function ConsumptionBurnUpChart({
+  workspaceId,
+  period,
+  filter,
+}: ConsumptionBurnUpChartProps) {
+  const { overview } = useConsumptionOverview({ workspaceId, period, filter });
+  // A cap only exists on a billing cycle. Gating on the selection rather than on
+  // the response alone keeps a previous cycle's cap — kept around by
+  // `keepPreviousData` while the new request lands — from drawing a target over
+  // a period that has none.
+  const capCredits =
+    period.kind === "cycle"
+      ? (overview?.creditUsage?.capCredits ?? null)
+      : null;
+
+  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
+    useConsumptionTimeseries({
+      workspaceId,
+      period,
+      mode: "cumulative",
+      filter,
+    });
+
+  const chartData = useMemo<BurnUpPoint[]>(() => {
+    const points = timeseries?.points ?? [];
+    const partialTimestamp = findPartialTimestamp(points);
+    const bucketTarget =
+      capCredits === null ? null : capCredits / points.length;
+
+    return points.map((point, index) => ({
+      timestamp: point.timestamp,
+      // Buckets that have not started yet come back zeroed, which would drag the
+      // actual line back down to the axis instead of ending it at today.
+      [BURNUP_ACTUAL_KEY]:
+        partialTimestamp !== undefined && point.timestamp > partialTimestamp
+          ? null
+          : Object.values(point.values).reduce(
+              (sum, credits) => sum + credits,
+              0
+            ),
+      [BURNUP_TARGET_KEY]:
+        bucketTarget === null ? null : bucketTarget * (index + 1),
+    }));
+  }, [timeseries, capCredits]);
+
+  const legendItems: LegendItem[] = [
+    {
+      key: BURNUP_ACTUAL_KEY,
+      label: "Actual consumption",
+      colorClassName: ACTUAL_COLOR,
+    },
+    ...(capCredits !== null
+      ? [
+          {
+            key: BURNUP_TARGET_KEY,
+            label: "Target consumption",
+            colorClassName: TARGET_COLOR,
+          },
+        ]
+      : []),
+  ];
+
+  const hasConsumption = chartData.some(
+    (point) => point.actual !== null && point.actual > 0
+  );
+
+  return (
+    <ChartContainer
+      title="Cumulative credits"
+      isLoading={isTimeseriesLoading}
+      errorMessage={
+        isTimeseriesError ? "Failed to load consumption." : undefined
+      }
+      emptyMessage={
+        !isTimeseriesLoading && !hasConsumption
+          ? "No consumption over this period."
+          : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+    >
+      <LineChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
+        <CartesianGrid vertical={false} className="stroke-border" />
+        <XAxis
+          dataKey="timestamp"
+          className="text-xs text-muted-foreground"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={24}
+          tickFormatter={(timestamp: number) =>
+            formatConsumptionDate(timestamp)
+          }
+        />
+        <YAxis
+          className="text-xs text-muted-foreground"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={formatCreditsCompact}
+        />
+        <Tooltip
+          content={ConsumptionBurnUpTooltip}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+        />
+        {capCredits !== null && (
+          <Line
+            dataKey={BURNUP_TARGET_KEY}
+            name="Target consumption"
+            className={TARGET_COLOR}
+            stroke="currentColor"
+            strokeWidth={1}
+            strokeDasharray="2 4"
+            strokeLinecap="round"
+            dot={false}
+            activeDot={false}
+            isAnimationActive={false}
+          />
+        )}
+        <Line
+          dataKey={BURNUP_ACTUAL_KEY}
+          name="Actual consumption"
+          className={ACTUAL_COLOR}
+          stroke="currentColor"
+          strokeWidth={2}
+          dot={false}
+          connectNulls={false}
+          isAnimationActive={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -2,10 +2,12 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
-import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
+import {
+  findPartialTimestamp,
+  formatConsumptionDate,
+} from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type {
   ConsumptionTimeseriesGroup,
@@ -20,21 +22,17 @@ import {
   BarChart,
   CartesianGrid,
   Cell,
-  Line,
-  LineChart,
   ReferenceLine,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+import { ConsumptionBurnUpChart } from "./ConsumptionBurnUpChart";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 
 // The bucket in progress (if mapped to today) is drawn faded across every series.
 const PARTIAL_BAR_OPACITY = "opacity-40";
-
-const ACTUAL_COLOR = "text-blue-500";
-const TARGET_COLOR = "text-stone-300";
 
 const CONSUMPTION_CHART_COLORS = [
   "text-blue-900",
@@ -69,16 +67,6 @@ function isConsumptionTimeseriesPoint(
     "timestamp" in data &&
     "values" in data
   );
-}
-
-// The endpoint buckets the whole period, so the tail of the series is the part
-// of the cycle still to come. The bucket holding the present is the last one
-// that has started, which is all it takes to tell the two apart.
-function findPartialTimestamp(
-  points: { timestamp: number }[]
-): number | undefined {
-  const nowMs = Date.now();
-  return points.findLast((point) => point.timestamp <= nowMs)?.timestamp;
 }
 
 interface ConsumptionDailyTooltipProps
@@ -277,205 +265,6 @@ function ConsumptionDailyChart({
           </Bar>
         ))}
       </BarChart>
-    </ChartContainer>
-  );
-}
-
-const BURNUP_ACTUAL_KEY = "actual";
-const BURNUP_TARGET_KEY = "target";
-
-// What the workspace has actually spent so far against what an evenly spread cap
-// allows by then. `actual` stops at the bucket in progress, `target` runs to the
-// end of the cycle, and the gap between the two is the headroom (or the
-// overshoot).
-type BurnUpPoint = {
-  timestamp: number;
-  [BURNUP_ACTUAL_KEY]: number | null;
-  [BURNUP_TARGET_KEY]: number | null;
-};
-
-function isBurnUpPoint(data: unknown): data is BurnUpPoint {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "timestamp" in data &&
-    BURNUP_ACTUAL_KEY in data
-  );
-}
-
-function ConsumptionBurnUpTooltip({
-  active,
-  payload,
-}: TooltipContentProps<number, string>) {
-  const datum = payload?.[0]?.payload;
-  if (!active || !isBurnUpPoint(datum) || datum.actual === null) {
-    return null;
-  }
-
-  const rows = [
-    {
-      key: BURNUP_ACTUAL_KEY,
-      label: "Actual consumption",
-      value: formatCredits(datum.actual),
-      colorClassName: ACTUAL_COLOR,
-    },
-    ...(datum.target !== null
-      ? [
-          {
-            key: BURNUP_TARGET_KEY,
-            label: "Target consumption",
-            value: formatCredits(datum.target),
-            colorClassName: TARGET_COLOR,
-          },
-        ]
-      : []),
-  ];
-
-  const delta = datum.target !== null ? datum.actual - datum.target : null;
-
-  return (
-    <ChartTooltipCard
-      title={formatConsumptionDate(datum.timestamp)}
-      rows={rows}
-      footer={
-        delta !== null
-          ? `${formatCredits(Math.abs(delta))} ${delta > 0 ? "ahead of" : "behind"} target`
-          : undefined
-      }
-    />
-  );
-}
-
-interface ConsumptionBurnUpChartProps {
-  workspaceId: string;
-  period: ConsumptionPeriodSelection;
-  filter?: ConsumptionScopeFilter;
-}
-
-function ConsumptionBurnUpChart({
-  workspaceId,
-  period,
-  filter,
-}: ConsumptionBurnUpChartProps) {
-  const { overview } = useConsumptionOverview({ workspaceId, period, filter });
-  const capCredits =
-    period.kind === "cycle"
-      ? (overview?.creditUsage?.capCredits ?? null)
-      : null;
-
-  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
-    useConsumptionTimeseries({
-      workspaceId,
-      period,
-      mode: "cumulative",
-      filter,
-    });
-
-  const chartData = useMemo<BurnUpPoint[]>(() => {
-    const points = timeseries?.points ?? [];
-    const partialTimestamp = findPartialTimestamp(points);
-    const bucketTarget =
-      capCredits === null ? null : capCredits / points.length;
-
-    return points.map((point, index) => ({
-      timestamp: point.timestamp,
-      [BURNUP_ACTUAL_KEY]:
-        partialTimestamp !== undefined && point.timestamp > partialTimestamp
-          ? null
-          : Object.values(point.values).reduce(
-              (sum, credits) => sum + credits,
-              0
-            ),
-      [BURNUP_TARGET_KEY]:
-        bucketTarget === null ? null : bucketTarget * (index + 1),
-    }));
-  }, [timeseries, capCredits]);
-
-  const legendItems: LegendItem[] = [
-    {
-      key: BURNUP_ACTUAL_KEY,
-      label: "Actual consumption",
-      colorClassName: ACTUAL_COLOR,
-    },
-    ...(capCredits !== null
-      ? [
-          {
-            key: BURNUP_TARGET_KEY,
-            label: `Target consumption`,
-            colorClassName: TARGET_COLOR,
-          },
-        ]
-      : []),
-  ];
-
-  const hasConsumption = chartData.some(
-    (point) => point.actual !== null && point.actual > 0
-  );
-
-  return (
-    <ChartContainer
-      title="Cumulative credits"
-      isLoading={isTimeseriesLoading}
-      errorMessage={
-        isTimeseriesError ? "Failed to load consumption." : undefined
-      }
-      emptyMessage={
-        !isTimeseriesLoading && !hasConsumption
-          ? "No consumption over this period."
-          : undefined
-      }
-      height={CHART_HEIGHT}
-      legendItems={legendItems}
-    >
-      <LineChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
-        <CartesianGrid vertical={false} className="stroke-border" />
-        <XAxis
-          dataKey="timestamp"
-          className="text-xs text-muted-foreground"
-          tickLine={false}
-          axisLine={false}
-          tickMargin={8}
-          minTickGap={24}
-          tickFormatter={(timestamp: number) =>
-            formatConsumptionDate(timestamp)
-          }
-        />
-        <YAxis
-          className="text-xs text-muted-foreground"
-          tickLine={false}
-          axisLine={false}
-          tickMargin={8}
-          tickFormatter={formatCreditsCompact}
-        />
-        <Tooltip
-          content={ConsumptionBurnUpTooltip}
-          wrapperStyle={{ outline: "none", zIndex: 50 }}
-        />
-        {capCredits !== null && (
-          <Line
-            dataKey={BURNUP_TARGET_KEY}
-            name="Target consumption"
-            className={TARGET_COLOR}
-            stroke="currentColor"
-            strokeWidth={1}
-            strokeDasharray="2 4"
-            strokeLinecap="round"
-            dot={false}
-            activeDot={false}
-            isAnimationActive={false}
-          />
-        )}
-        <Line
-          dataKey={BURNUP_ACTUAL_KEY}
-          name="Actual consumption"
-          className={ACTUAL_COLOR}
-          stroke="currentColor"
-          strokeWidth={2}
-          dot={false}
-          connectNulls={false}
-          isAnimationActive={false}
-        />
-      </LineChart>
     </ChartContainer>
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -2,22 +2,26 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
+import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type {
   ConsumptionTimeseriesGroup,
+  ConsumptionTimeseriesMode,
   ConsumptionTimeseriesPoint,
 } from "@app/lib/api/analytics/consumption/timeseries";
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
-import { cn } from "@dust-tt/sparkle";
-import { useCallback, useMemo } from "react";
+import { ButtonsSwitch, ButtonsSwitchList, cn } from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
 import {
   Bar,
   BarChart,
   CartesianGrid,
   Cell,
+  Line,
+  LineChart,
   ReferenceLine,
   Tooltip,
   XAxis,
@@ -25,10 +29,12 @@ import {
 } from "recharts";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 import type { ConsumptionDimension } from "./consumptionDimensions";
-import { CONSUMPTION_DIMENSION_CONFIG } from "./consumptionDimensions";
 
 // The bucket in progress (if mapped to today) is drawn faded across every series.
 const PARTIAL_BAR_OPACITY = "opacity-40";
+
+const ACTUAL_COLOR = "text-blue-500";
+const TARGET_COLOR = "text-stone-300";
 
 const CONSUMPTION_CHART_COLORS = [
   "text-blue-900",
@@ -69,26 +75,26 @@ function isConsumptionTimeseriesPoint(
 // of the cycle still to come. The bucket holding the present is the last one
 // that has started, which is all it takes to tell the two apart.
 function findPartialTimestamp(
-  points: ConsumptionTimeseriesPoint[]
+  points: { timestamp: number }[]
 ): number | undefined {
   const nowMs = Date.now();
   return points.findLast((point) => point.timestamp <= nowMs)?.timestamp;
 }
 
-interface ConsumptionChartTooltipProps
+interface ConsumptionDailyTooltipProps
   extends TooltipContentProps<number, string> {
   groups: ConsumptionTimeseriesGroup[];
   colorByGroupKey: Map<string, string>;
   partialTimestamp: number | undefined;
 }
 
-function ConsumptionChartTooltip({
+function ConsumptionDailyTooltip({
   active,
   payload,
   groups,
   colorByGroupKey,
   partialTimestamp,
-}: ConsumptionChartTooltipProps) {
+}: ConsumptionDailyTooltipProps) {
   const datum = payload?.[0]?.payload;
   if (!active || !isConsumptionTimeseriesPoint(datum)) {
     return null;
@@ -134,19 +140,19 @@ function ConsumptionChartTooltip({
   );
 }
 
-interface ConsumptionChartProps {
+interface ConsumptionDailyChartProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   dimension: ConsumptionDimension;
   filter?: ConsumptionScopeFilter;
 }
 
-export function ConsumptionChart({
+function ConsumptionDailyChart({
   workspaceId,
   period,
   dimension,
   filter,
-}: ConsumptionChartProps) {
+}: ConsumptionDailyChartProps) {
   const { timeseries, isTimeseriesLoading, isTimeseriesError } =
     useConsumptionTimeseries({
       workspaceId,
@@ -179,7 +185,7 @@ export function ConsumptionChart({
 
   const renderTooltip = useCallback(
     (props: TooltipContentProps<number, string>) => (
-      <ConsumptionChartTooltip
+      <ConsumptionDailyTooltip
         {...props}
         groups={groups}
         colorByGroupKey={colorByGroupKey}
@@ -201,7 +207,7 @@ export function ConsumptionChart({
 
   return (
     <ChartContainer
-      title={`Daily credits by ${CONSUMPTION_DIMENSION_CONFIG[dimension].breakdownLabel}`}
+      title="Daily credits"
       isLoading={isTimeseriesLoading}
       errorMessage={
         isTimeseriesError ? "Failed to load consumption." : undefined
@@ -272,5 +278,254 @@ export function ConsumptionChart({
         ))}
       </BarChart>
     </ChartContainer>
+  );
+}
+
+const BURNUP_ACTUAL_KEY = "actual";
+const BURNUP_TARGET_KEY = "target";
+
+// What the workspace has actually spent so far against what an evenly spread cap
+// allows by then. `actual` stops at the bucket in progress, `target` runs to the
+// end of the cycle, and the gap between the two is the headroom (or the
+// overshoot).
+type BurnUpPoint = {
+  timestamp: number;
+  [BURNUP_ACTUAL_KEY]: number | null;
+  [BURNUP_TARGET_KEY]: number | null;
+};
+
+function isBurnUpPoint(data: unknown): data is BurnUpPoint {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "timestamp" in data &&
+    BURNUP_ACTUAL_KEY in data
+  );
+}
+
+function ConsumptionBurnUpTooltip({
+  active,
+  payload,
+}: TooltipContentProps<number, string>) {
+  const datum = payload?.[0]?.payload;
+  if (!active || !isBurnUpPoint(datum) || datum.actual === null) {
+    return null;
+  }
+
+  const rows = [
+    {
+      key: BURNUP_ACTUAL_KEY,
+      label: "Actual consumption",
+      value: formatCredits(datum.actual),
+      colorClassName: ACTUAL_COLOR,
+    },
+    ...(datum.target !== null
+      ? [
+          {
+            key: BURNUP_TARGET_KEY,
+            label: "Target consumption",
+            value: formatCredits(datum.target),
+            colorClassName: TARGET_COLOR,
+          },
+        ]
+      : []),
+  ];
+
+  const delta = datum.target !== null ? datum.actual - datum.target : null;
+
+  return (
+    <ChartTooltipCard
+      title={formatConsumptionDate(datum.timestamp)}
+      rows={rows}
+      footer={
+        delta !== null
+          ? `${formatCredits(Math.abs(delta))} ${delta > 0 ? "ahead of" : "behind"} target`
+          : undefined
+      }
+    />
+  );
+}
+
+interface ConsumptionBurnUpChartProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+}
+
+function ConsumptionBurnUpChart({
+  workspaceId,
+  period,
+  filter,
+}: ConsumptionBurnUpChartProps) {
+  const { overview } = useConsumptionOverview({ workspaceId, period, filter });
+  const capCredits =
+    period.kind === "cycle"
+      ? (overview?.creditUsage?.capCredits ?? null)
+      : null;
+
+  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
+    useConsumptionTimeseries({
+      workspaceId,
+      period,
+      mode: "cumulative",
+      filter,
+    });
+
+  const chartData = useMemo<BurnUpPoint[]>(() => {
+    const points = timeseries?.points ?? [];
+    const partialTimestamp = findPartialTimestamp(points);
+    const bucketTarget =
+      capCredits === null ? null : capCredits / points.length;
+
+    return points.map((point, index) => ({
+      timestamp: point.timestamp,
+      [BURNUP_ACTUAL_KEY]:
+        partialTimestamp !== undefined && point.timestamp > partialTimestamp
+          ? null
+          : Object.values(point.values).reduce(
+              (sum, credits) => sum + credits,
+              0
+            ),
+      [BURNUP_TARGET_KEY]:
+        bucketTarget === null ? null : bucketTarget * (index + 1),
+    }));
+  }, [timeseries, capCredits]);
+
+  const legendItems: LegendItem[] = [
+    {
+      key: BURNUP_ACTUAL_KEY,
+      label: "Actual consumption",
+      colorClassName: ACTUAL_COLOR,
+    },
+    ...(capCredits !== null
+      ? [
+          {
+            key: BURNUP_TARGET_KEY,
+            label: `Target consumption`,
+            colorClassName: TARGET_COLOR,
+          },
+        ]
+      : []),
+  ];
+
+  const hasConsumption = chartData.some(
+    (point) => point.actual !== null && point.actual > 0
+  );
+
+  return (
+    <ChartContainer
+      title="Cumulative credits"
+      isLoading={isTimeseriesLoading}
+      errorMessage={
+        isTimeseriesError ? "Failed to load consumption." : undefined
+      }
+      emptyMessage={
+        !isTimeseriesLoading && !hasConsumption
+          ? "No consumption over this period."
+          : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+    >
+      <LineChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
+        <CartesianGrid vertical={false} className="stroke-border" />
+        <XAxis
+          dataKey="timestamp"
+          className="text-xs text-muted-foreground"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={24}
+          tickFormatter={(timestamp: number) =>
+            formatConsumptionDate(timestamp)
+          }
+        />
+        <YAxis
+          className="text-xs text-muted-foreground"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={formatCreditsCompact}
+        />
+        <Tooltip
+          content={ConsumptionBurnUpTooltip}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+        />
+        {capCredits !== null && (
+          <Line
+            dataKey={BURNUP_TARGET_KEY}
+            name="Target consumption"
+            className={TARGET_COLOR}
+            stroke="currentColor"
+            strokeWidth={1}
+            strokeDasharray="2 4"
+            strokeLinecap="round"
+            dot={false}
+            activeDot={false}
+            isAnimationActive={false}
+          />
+        )}
+        <Line
+          dataKey={BURNUP_ACTUAL_KEY}
+          name="Actual consumption"
+          className={ACTUAL_COLOR}
+          stroke="currentColor"
+          strokeWidth={2}
+          dot={false}
+          connectNulls={false}
+          isAnimationActive={false}
+        />
+      </LineChart>
+    </ChartContainer>
+  );
+}
+
+interface ConsumptionChartProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  dimension: ConsumptionDimension;
+  filter?: ConsumptionScopeFilter;
+}
+
+export function ConsumptionChart({
+  workspaceId,
+  period,
+  dimension,
+  filter,
+}: ConsumptionChartProps) {
+  const [mode, setMode] = useState<ConsumptionTimeseriesMode>("daily");
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <h2 className="text-base font-semibold text-foreground">Consumption</h2>
+        <ButtonsSwitchList value={mode} size="sm">
+          <ButtonsSwitch
+            value="daily"
+            label="Daily"
+            onClick={() => setMode("daily")}
+          />
+          <ButtonsSwitch
+            value="cumulative"
+            label="Cumulative"
+            onClick={() => setMode("cumulative")}
+          />
+        </ButtonsSwitchList>
+      </div>
+      {mode === "cumulative" ? (
+        <ConsumptionBurnUpChart
+          workspaceId={workspaceId}
+          period={period}
+          filter={filter}
+        />
+      ) : (
+        <ConsumptionDailyChart
+          workspaceId={workspaceId}
+          period={period}
+          dimension={dimension}
+          filter={filter}
+        />
+      )}
+    </div>
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -6,15 +6,15 @@ import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/perio
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import { timeAgoFrom } from "@app/lib/utils";
-import type { CreditUsagePace } from "@app/types/api/credits/usage_status";
+import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
 import { ArrowUpRight, Button, Chip } from "@dust-tt/sparkle";
 
-const PACE_CHIP: Record<
-  CreditUsagePace,
+const TARGET_CHIP: Record<
+  CreditUsageTarget,
   { label: string; color: "highlight" | "info" | "warning" }
 > = {
-  on_pace: { label: "On pace", color: "highlight" },
-  elevated: { label: "Off pace", color: "info" },
+  on_target: { label: "On target", color: "highlight" },
+  elevated: { label: "Off target", color: "info" },
   critical: { label: "Critical", color: "warning" },
 };
 
@@ -69,8 +69,8 @@ function ConsumptionSummary({
           <div className="flex items-center gap-2">
             <Chip
               size="mini"
-              color={PACE_CHIP[creditUsage.status.pace].color}
-              label={PACE_CHIP[creditUsage.status.pace].label}
+              color={TARGET_CHIP[creditUsage.status.target].color}
+              label={TARGET_CHIP[creditUsage.status.target].label}
             />
             <span className="text-sm text-muted-foreground">
               {creditUsage.status.usedPercentage}% of the cap used,{" "}

--- a/front/lib/analytics/consumption_period.ts
+++ b/front/lib/analytics/consumption_period.ts
@@ -30,6 +30,16 @@ export function formatConsumptionDate(date: string | number): string {
   });
 }
 
+// The endpoints bucket the whole period, so the tail of a series is the part of
+// the cycle still to come. The bucket holding the present is the last one that
+// has started, which is all it takes to tell the two apart.
+export function findPartialTimestamp(
+  points: { timestamp: number }[]
+): number | undefined {
+  const nowMs = Date.now();
+  return points.findLast((point) => point.timestamp <= nowMs)?.timestamp;
+}
+
 export function consumptionPeriodLabel(
   selection: ConsumptionPeriodSelection
 ): string {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1064,7 +1064,7 @@ export async function resyncSpendLimitCountersFromEsUsage(
 
 export type GetMemberUsageResponseBody = {
   member: MemberUsageType | null;
-  // Optional for backward compatibility with clients deployed before pace
+  // Optional for backward compatibility with clients deployed before target
   // information was added to this endpoint.
   creditUsageStatus?: CreditUsageStatus | null;
 };

--- a/front/lib/api/credits/usage_status.test.ts
+++ b/front/lib/api/credits/usage_status.test.ts
@@ -8,7 +8,7 @@ const billingCycle = {
 };
 
 describe("computeCreditUsageStatus", () => {
-  it("marks usage with enough remaining-cycle coverage as on pace", () => {
+  it("marks usage with enough remaining-cycle coverage as on target", () => {
     expect(
       computeCreditUsageStatus({
         consumedAwuCredits: 80,
@@ -19,7 +19,7 @@ describe("computeCreditUsageStatus", () => {
     ).toEqual({
       usedPercentage: 80,
       resetAt: "2026-09-01T00:00:00.000Z",
-      pace: "on_pace",
+      target: "on_target",
     });
   });
 
@@ -33,7 +33,7 @@ describe("computeCreditUsageStatus", () => {
       })
     ).toMatchObject({
       usedPercentage: 65,
-      pace: "elevated",
+      target: "elevated",
     });
   });
 
@@ -47,7 +47,7 @@ describe("computeCreditUsageStatus", () => {
       })
     ).toMatchObject({
       usedPercentage: 80,
-      pace: "critical",
+      target: "critical",
     });
   });
 
@@ -61,7 +61,7 @@ describe("computeCreditUsageStatus", () => {
       })
     ).toMatchObject({
       usedPercentage: 100,
-      pace: "critical",
+      target: "critical",
     });
   });
 

--- a/front/lib/api/credits/usage_status.ts
+++ b/front/lib/api/credits/usage_status.ts
@@ -1,10 +1,10 @@
 import type { BillingCycle } from "@app/lib/client/subscription";
 import type {
-  CreditUsagePace,
   CreditUsageStatus,
+  CreditUsageTarget,
 } from "@app/types/api/credits/usage_status";
 
-const ON_PACE_REMAINING_COVERAGE = 0.85;
+const ON_TARGET_REMAINING_COVERAGE = 0.85;
 const ELEVATED_REMAINING_COVERAGE = 0.5;
 
 /**
@@ -13,35 +13,35 @@ const ELEVATED_REMAINING_COVERAGE = 0.5;
  *
  *   remaining coverage = remaining credit ratio / remaining cycle ratio
  *
- * - on_pace (blue): coverage >= 0.85. The 15% relative tolerance absorbs
+ * - on_target (blue): coverage >= 0.85. The 15% relative tolerance absorbs
  *   normal usage variation and avoids noisy warnings near the boundary. For
  *   example, with 80% of the cycle left, 68% of credits remaining is blue.
  * - elevated (orange): 0.5 <= coverage < 0.85. Usage is meaningfully ahead of
- *   pace and deserves attention.
+ *   target and deserves attention.
  * - critical (red): coverage < 0.5. The remaining credits cover less than half
  *   of the remaining cycle, so the user is likely to run out well before reset.
  *
  * Exhausted credits are always critical. Once the cycle has ended, any
- * positive remaining balance is on pace.
+ * positive remaining balance is on target.
  */
-function classifyCreditUsagePace({
+function classifyCreditUsageTarget({
   remainingCreditRatio,
   remainingCycleRatio,
 }: {
   remainingCreditRatio: number;
   remainingCycleRatio: number;
-}): CreditUsagePace {
+}): CreditUsageTarget {
   if (remainingCreditRatio <= 0) {
     return "critical";
   }
 
   if (remainingCycleRatio <= 0) {
-    return "on_pace";
+    return "on_target";
   }
 
   const remainingCoverage = remainingCreditRatio / remainingCycleRatio;
-  if (remainingCoverage >= ON_PACE_REMAINING_COVERAGE) {
-    return "on_pace";
+  if (remainingCoverage >= ON_TARGET_REMAINING_COVERAGE) {
+    return "on_target";
   }
   if (remainingCoverage >= ELEVATED_REMAINING_COVERAGE) {
     return "elevated";
@@ -82,7 +82,7 @@ export function computeCreditUsageStatus({
   return {
     usedPercentage: Math.round(usedRatio * 100),
     resetAt: billingCycle.cycleEnd.toISOString(),
-    pace: classifyCreditUsagePace({
+    target: classifyCreditUsageTarget({
       remainingCreditRatio,
       remainingCycleRatio,
     }),

--- a/front/types/api/credits/usage_status.ts
+++ b/front/types/api/credits/usage_status.ts
@@ -1,7 +1,7 @@
-export type CreditUsagePace = "on_pace" | "elevated" | "critical";
+export type CreditUsageTarget = "on_target" | "elevated" | "critical";
 
 export interface CreditUsageStatus {
   usedPercentage: number;
   resetAt: string;
-  pace: CreditUsagePace;
+  target: CreditUsageTarget;
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds a new cumulative consumption view to the new Analytics page. Cumulative view is a burn up chart composed of two lines : 
- Actual consumption : Current consumption cumulated by day
- Target consumption : Linear estimate of the ideal consumption of the workspace (# credits / # days in the current period) 

Renamed all "pace" to "target" over the codebase.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand on a credit based workspace. UI below : 

<img width="1262" height="795" alt="Capture d’écran 2026-08-12 à 17 08 40" src="https://github.com/user-attachments/assets/d89c48db-f247-4e36-a439-3d5abe78bd13" />

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, only add a new front-end to the 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.