### PR TITLE
[front] fix: show lock avatars for private analytics agents

### DIFF
--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon.tsx
@@ -9,7 +9,7 @@ import type { UsageFilterOption } from "@app/components/workspace/analytics/usag
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import { getSkillIcon } from "@app/lib/skill";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import { Avatar, Icon } from "@dust-tt/sparkle";
+import { Avatar, Icon, Lock01, Tooltip } from "@dust-tt/sparkle";
 
 interface UsageFilterOptionIconProps {
   option: UsageFilterOption;
@@ -19,8 +19,30 @@ export function UsageFilterOptionIcon({ option }: UsageFilterOptionIconProps) {
   const { isDark } = useTheme();
 
   switch (option.kind) {
-    case "member":
     case "agent":
+      return option.scope === "hidden" ? (
+        <Tooltip
+          label="This agent is private"
+          tooltipTriggerAsChild
+          trigger={
+            <span className="flex shrink-0">
+              <Avatar
+                icon={Lock01}
+                iconColor="text-muted-foreground"
+                size="xxs"
+              />
+            </span>
+          }
+        />
+      ) : (
+        <Avatar
+          name={option.name}
+          visual={option.image ?? undefined}
+          size="xxs"
+          isRounded
+        />
+      );
+    case "member":
       return (
         <Avatar
           name={option.name}


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10036.

Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=12864-74697&m=dev).

Private agents in the analytics filter currently display their configured avatar, there's no way to tell them apart from published agents.

This replaces the avatar for `hidden` agents with a muted lock avatar and shows “This agent is private” on hover.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
