### PR TITLE
[front] fix: remove @ prefixes from agent names

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -392,7 +392,7 @@ function MCPRunAgentActionDetailsDisplay({
                 <>
                   <div className="flex items-center justify-between py-2">
                     <span className="font-medium text-foreground">
-                      @{childAgent.name}'s Answer
+                      {childAgent.name}'s Answer
                     </span>
                     {conversationUrl && (
                       <Button

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -214,7 +214,7 @@ export function FeedbackSelector({
       >
         <DialogContent size="lg">
           <DialogHeader>
-            <DialogTitle>Provide feedback on @{agentName}</DialogTitle>
+            <DialogTitle>Provide feedback on {agentName}</DialogTitle>
           </DialogHeader>
 
           <DialogContainer className="py-3">

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -123,7 +123,7 @@ export function MentionValidationRequired({
     case "pending_project_membership":
       description = isAgentMessageWithStreaming(message) ? (
         <>
-          <span className="font-semibold">@{message.configuration.name}</span>{" "}
+          <span className="font-semibold">{message.configuration.name}</span>{" "}
           mentioned <span className="font-semibold">{mention.label}</span>. Do
           you want to add them to this Pod?
         </>
@@ -134,7 +134,7 @@ export function MentionValidationRequired({
     case "pending_conversation_access":
       description = isAgentMessageWithStreaming(message) ? (
         <>
-          <span className="font-semibold">@{message.configuration.name}</span>{" "}
+          <span className="font-semibold">{message.configuration.name}</span>{" "}
           mentioned <span className="font-semibold">{mention.label}</span>. Do
           you want to invite them? They'll see the full history and be able to
           reply.

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -171,7 +171,7 @@ const getTableColumns = ({
             </div>
             <div className="flex min-w-0 grow flex-col">
               <div className="heading-sm overflow-hidden truncate text-foreground">
-                {`@${info.getValue()}`}
+                {info.getValue()}
               </div>
               <div className="overflow-hidden truncate text-sm text-muted-foreground">
                 {info.row.original.description}

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -179,7 +179,7 @@ export function CommandPaletteSearchPhase({
               >
                 <Avatar visual={agent.pictureUrl} size="xs" />
                 <div className="flex min-w-0 items-center gap-1.5">
-                  <span className="shrink-0 font-medium">@{agent.name}</span>
+                  <span className="shrink-0 font-medium">{agent.name}</span>
                   <span className="shrink-0 text-muted-foreground">-</span>
                   <span className="min-w-0 truncate text-muted-foreground">
                     {agent.description}

--- a/front/components/labs/transcripts/ProcessingConfiguration.tsx
+++ b/front/components/labs/transcripts/ProcessingConfiguration.tsx
@@ -108,7 +108,7 @@ export function ProcessingConfiguration({
             {assistantSelected && (
               <div className="mt-2">
                 <Page.P>
-                  <strong>@{assistantSelected.name}</strong>
+                  <strong>{assistantSelected.name}</strong>
                 </Page.P>
               </div>
             )}

--- a/front/components/poke/assistants/AgentOverviewTable.tsx
+++ b/front/components/poke/assistants/AgentOverviewTable.tsx
@@ -35,10 +35,10 @@ export function AgentOverviewTable({
 
   return (
     <>
-      <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
+      <div className="border-material-200 flex grow flex-col rounded-lg border p-4">
         <div className="flex items-center justify-between gap-3">
-          <h2 className="text-md flex-grow pb-4 font-bold">
-            @{agentConfiguration.name}
+          <h2 className="text-md grow pb-4 font-bold">
+            {agentConfiguration.name}
           </h2>
         </div>
         {restrictedSpaces.length > 0 && (

--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -134,7 +134,7 @@ export function AssistantDetailsPage() {
               owner={owner}
               spacesById={spacesById}
             />
-            <div className="flex flex-grow flex-col">
+            <div className="flex grow flex-col">
               <PluginList
                 pluginResourceTarget={{
                   resourceId: agentConfigurations[0].sId,
@@ -176,7 +176,7 @@ export function AssistantDetailsPage() {
                 return (
                   <ContextItem
                     key={a.version}
-                    title={`@${a.name} (${a.sId}) v${a.version}`}
+                    title={`${a.name} (${a.sId}) v${a.version}`}
                     visual={<></>}
                   >
                     <ContextItem.Description>

--- a/front/components/poke/pages/AssistantInstructionsPage.tsx
+++ b/front/components/poke/pages/AssistantInstructionsPage.tsx
@@ -101,7 +101,7 @@ export function AssistantInstructionsPage() {
 
   return (
     <div>
-      <h3 className="mb-4 text-xl font-bold">Instructions for @{agentName}</h3>
+      <h3 className="mb-4 text-xl font-bold">Instructions for {agentName}</h3>
       <div className="overflow-auto rounded-xl border border-border p-2">
         <EditorContent editor={editor} className="leading-7" />
       </div>

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -98,7 +98,7 @@ function ConsumptionSummary({
         />
         <SummaryCard
           label="Top agent"
-          value={topAgent ? `@${topAgent.name}` : "—"}
+          value={topAgent?.name ?? "—"}
           hint={
             topAgent && totalCredits > 0
               ? `${Math.round((topAgent.credits / totalCredits) * 100)}% of total spend`


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10038

Agent names in Manage Agents and consumption analytics (+ a few other misc locations like the feedback form) were still shown with a decorative @ prefix.
This PR removes it.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
