### PR TITLE
[analytics] share label resolution + average computation across consumption rankings

### DIFF
--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -1,3 +1,4 @@
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeDimension,
@@ -169,4 +170,44 @@ export async function fetchConsumptionTopGroups(
 // non-finite average.
 export function avgCreditsPerUnit(credits: number, count: number): number {
   return count > 0 ? credits / count : 0;
+}
+
+export type ResolvedConsumptionGroup = {
+  key: string;
+  name: string;
+  pictureUrl: string | null;
+  description: string | null;
+  // Only agents have model metadata.
+  modelId?: string;
+  modelDisplayName?: string;
+  // Only skills have an icon.
+  icon?: string | null;
+  credits: number;
+  count: number;
+  avgCredits: number;
+};
+
+export async function resolveConsumptionGroupLabels(
+  auth: Authenticator,
+  dimension: ConsumptionScopeDimension,
+  groups: ConsumptionTopGroup[]
+): Promise<ResolvedConsumptionGroup[]> {
+  const labels = await resolveDimensionLabels(
+    auth,
+    dimension,
+    groups.map((group) => group.key)
+  );
+
+  return groups.map((group) => ({
+    key: group.key,
+    name: labels.get(group.key)?.name ?? group.key,
+    pictureUrl: labels.get(group.key)?.pictureUrl ?? null,
+    description: labels.get(group.key)?.description ?? null,
+    modelId: labels.get(group.key)?.modelId,
+    modelDisplayName: labels.get(group.key)?.modelDisplayName,
+    icon: labels.get(group.key)?.icon,
+    credits: group.credits,
+    count: group.count,
+    avgCredits: avgCreditsPerUnit(group.credits, group.count),
+  }));
 }

--- a/front/lib/api/analytics/consumption/top_agents.ts
+++ b/front/lib/api/analytics/consumption/top_agents.ts
@@ -1,9 +1,8 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -65,27 +64,23 @@ export async function fetchConsumptionTopAgents(
   }
   const { groups, hasMore, totalCount, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "agent",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "agent", groups);
 
   return new Ok({
     period,
     totalCredits,
     hasMore,
     totalCount,
-    agents: groups.map((group) => ({
-      agentId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      pictureUrl: labels.get(group.key)?.pictureUrl ?? null,
-      description: labels.get(group.key)?.description ?? null,
-      modelId: labels.get(group.key)?.modelId ?? null,
-      modelDisplayName: labels.get(group.key)?.modelDisplayName ?? null,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    agents: rows.map((row) => ({
+      agentId: row.key,
+      name: row.name,
+      pictureUrl: row.pictureUrl,
+      description: row.description,
+      modelId: row.modelId ?? null,
+      modelDisplayName: row.modelDisplayName ?? null,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -1,9 +1,8 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups as fetchConsumptionTopGroupBuckets,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -62,23 +61,19 @@ export async function fetchConsumptionTopGroups(
   }
   const { groups, hasMore, totalCount, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "group",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "group", groups);
 
   return new Ok({
     period,
     totalCredits,
     hasMore,
     totalCount,
-    groups: groups.map((group) => ({
-      groupId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    groups: rows.map((row) => ({
+      groupId: row.key,
+      name: row.name,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_models.ts
+++ b/front/lib/api/analytics/consumption/top_models.ts
@@ -1,9 +1,8 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -62,23 +61,19 @@ export async function fetchConsumptionTopModels(
   }
   const { groups, hasMore, totalCount, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "model",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "model", groups);
 
   return new Ok({
     period,
     totalCredits,
     hasMore,
     totalCount,
-    models: groups.map((group) => ({
-      modelId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    models: rows.map((row) => ({
+      modelId: row.key,
+      name: row.name,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_skills.ts
+++ b/front/lib/api/analytics/consumption/top_skills.ts
@@ -1,9 +1,8 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -70,25 +69,21 @@ export async function fetchConsumptionTopSkills(
   }
   const { groups, hasMore, totalCount, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "skill",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "skill", groups);
 
   return new Ok({
     period,
     totalCredits,
     hasMore,
     totalCount,
-    skills: groups.map((group) => ({
-      skillId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      description: labels.get(group.key)?.description ?? null,
-      icon: labels.get(group.key)?.icon ?? null,
-      credits: group.credits,
-      invocationCount: group.count,
-      avgCreditsPerInvocation: avgCreditsPerUnit(group.credits, group.count),
+    skills: rows.map((row) => ({
+      skillId: row.key,
+      name: row.name,
+      description: row.description,
+      icon: row.icon ?? null,
+      credits: row.credits,
+      invocationCount: row.count,
+      avgCreditsPerInvocation: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_sources.ts
+++ b/front/lib/api/analytics/consumption/top_sources.ts
@@ -1,9 +1,8 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -63,23 +62,19 @@ export async function fetchConsumptionTopSources(
   }
   const { groups, hasMore, totalCount, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "source",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "source", groups);
 
   return new Ok({
     period,
     totalCredits,
     hasMore,
     totalCount,
-    sources: groups.map((group) => ({
-      source: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    sources: rows.map((row) => ({
+      source: row.key,
+      name: row.name,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -1,9 +1,8 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -68,24 +67,20 @@ export async function fetchConsumptionTopTools(
   }
   const { groups, hasMore, totalCount, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "tool",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "tool", groups);
 
   return new Ok({
     period,
     totalCredits,
     hasMore,
     totalCount,
-    tools: groups.map((group) => ({
-      serverName: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      icon: labels.get(group.key)?.icon ?? null,
-      credits: group.credits,
-      invocationCount: group.count,
-      avgCreditsPerInvocation: avgCreditsPerUnit(group.credits, group.count),
+    tools: rows.map((row) => ({
+      serverName: row.key,
+      name: row.name,
+      icon: row.icon ?? null,
+      credits: row.credits,
+      invocationCount: row.count,
+      avgCreditsPerInvocation: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_users.ts
+++ b/front/lib/api/analytics/consumption/top_users.ts
@@ -1,9 +1,8 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -66,24 +65,20 @@ export async function fetchConsumptionTopUsers(
   }
   const { groups, hasMore, totalCount, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "user",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "user", groups);
 
   return new Ok({
     period,
     totalCredits,
     hasMore,
     totalCount,
-    users: groups.map((group) => ({
-      userId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      pictureUrl: labels.get(group.key)?.pictureUrl ?? null,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    users: rows.map((row) => ({
+      userId: row.key,
+      name: row.name,
+      pictureUrl: row.pictureUrl,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }


### PR DESCRIPTION
## Description

Centralizes label resolution and average-credit computation for all consumption ranking endpoints in a shared `resolveConsumptionGroupLabels` helper. The helper resolves labels for the requested dimension, preserves the raw group key as a fallback name, and computes the average with the existing zero-count guard.

The agents, groups, models, skills, sources, tools, and users endpoints now consume the shared resolved rows while continuing to expose their existing endpoint-specific response fields and null handling. This removes duplicated mapping logic without changing the ranking data source or the public response shape.

## Tests

Localy tested

## Risk

The change affects the response-mapping layer of all seven consumption ranking endpoints. The main risk is a regression in label metadata mapping or endpoint-specific field conversion. The shared helper retains the existing fallback behavior and average calculation, while each endpoint continues to map to its existing response shape. No database or data migration is introduced, and the change is straightforward to roll back.

## Deploy Plan
- Deploy front