### PR TITLE
fix: manage agents page should display full agent name

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -181,7 +181,7 @@ const getTableColumns = ({
         </DataTable.CellContent>
       ),
       meta: {
-        className: "w-32 @lg:w-full",
+        className: "w-48 @lg:w-full",
       },
     },
     {
@@ -235,7 +235,7 @@ const getTableColumns = ({
         </DataTable.CellContent>
       ),
       meta: {
-        className: "hidden @sm:w-32 @sm:table-cell",
+        className: "hidden @lg:w-32 @lg:table-cell",
       },
     },
     {
@@ -267,7 +267,7 @@ const getTableColumns = ({
         );
       },
       meta: {
-        className: "hidden @sm:w-24 @sm:table-cell",
+        className: "hidden @lg:w-24 @lg:table-cell",
       },
     },
     {
@@ -301,7 +301,7 @@ const getTableColumns = ({
       ),
       isFilterable: true,
       meta: {
-        className: "w-24 xl:w-40",
+        className: "hidden @lg:table-cell @lg:w-24 @xl:w-40",
         tooltip: "Tags",
       },
     },
@@ -351,7 +351,7 @@ const getTableColumns = ({
         }
       },
       meta: {
-        className: "hidden @sm:w-20 @sm:table-cell",
+        className: "hidden @lg:w-20 @lg:table-cell",
         tooltip: "Active users in the last 30 days",
       },
     },
@@ -396,7 +396,7 @@ const getTableColumns = ({
         );
       },
       meta: {
-        className: "w-14",
+        className: "hidden @md:table-cell @md:w-14",
       },
     },
   ];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

In small screens, agent names were cropped in the Manage agents view. To make room for them, we make some other columns hidden in smaller screens.
Also, minimal width of agent column is now 48.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

By hand, we now render the full name of the agents as per the screenshot below.

<img width="1380" height="1506" alt="Capture d’écran 2026-08-12 à 18 32 13" src="https://github.com/user-attachments/assets/25fb246b-a2db-4371-bf54-270b58de2d0d" />

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front