### PR TITLE
Fix merged consumption layout regressions

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -89,28 +89,27 @@ export function AnalyticsConsumptionPage() {
           period={period}
           filter={scopeFilter}
         />
-        <div className="flex flex-col gap-4">
-          <div className="sticky top-0 z-30 flex flex-col bg-background pb-4 pt-4">
-            <div className="flex items-center justify-between gap-4">
-              <h2 className="text-lg font-semibold text-foreground">Explore</h2>
-              <UsageFilterPanel
-                owner={owner}
-                period={period}
-                filter={filter}
-                onFilterChange={setFilter}
-              />
+        <LazyMotion features={domMax}>
+          <div className="flex flex-col gap-4">
+            <div className="sticky top-0 z-30 -mb-4 flex flex-col bg-background pb-4 pt-4">
+              <div className="flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold text-foreground">
+                  Explore
+                </h2>
+                <UsageFilterPanel
+                  owner={owner}
+                  period={period}
+                  filter={filter}
+                  onFilterChange={setFilter}
+                />
+              </div>
+              <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
             </div>
-            <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
-          </div>
-          <LazyMotion features={domMax}>
             <m.div
               layout={!shouldReduceMotion}
               transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
-              className="flex flex-col gap-4"
+              className="flex flex-col"
             >
-              <h3 className="text-base font-semibold text-foreground">
-                Consumption
-              </h3>
               <SafeSuspense fallback={<ChartFallback />}>
                 <ConsumptionChart
                   workspaceId={owner.sId}
@@ -120,20 +119,20 @@ export function AnalyticsConsumptionPage() {
                 />
               </SafeSuspense>
             </m.div>
-          </LazyMotion>
-          <div className="flex flex-col gap-4">
-            <h3 className="text-base font-semibold text-foreground">
-              Attribution
-            </h3>
-            <ConsumptionAttributionTable
-              workspaceId={owner.sId}
-              period={period}
-              filter={scopeFilter}
-              dimension={dimension}
-              onDimensionChange={handleDimensionChange}
-            />
+            <div className="flex flex-col gap-4">
+              <h3 className="text-base font-semibold text-foreground">
+                Attribution
+              </h3>
+              <ConsumptionAttributionTable
+                workspaceId={owner.sId}
+                period={period}
+                filter={scopeFilter}
+                dimension={dimension}
+                onDimensionChange={handleDimensionChange}
+              />
+            </div>
           </div>
-        </div>
+        </LazyMotion>
       </div>
     </Page.Vertical>
   );

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -285,7 +285,7 @@ export function ConsumptionChart({
   const [mode, setMode] = useState<ConsumptionTimeseriesMode>("daily");
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <h2 className="text-base font-semibold text-foreground">Consumption</h2>
         <ButtonsSwitchList value={mode} size="sm">


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the few glitches caused by all our successive merges:
- duplicated `consumption` header
- heavy padding bottom on "explore"
- invisible filter chips

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
