### PR TITLE
fix: update FeedbackSelector test after @ prefix removal

### DIFF
--- a/front/components/assistant/conversation/FeedbackSelector.test.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.test.tsx
@@ -63,7 +63,7 @@ describe("FeedbackSelector", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: "Provide feedback on @Helper" })
+      screen.getByRole("heading", { name: "Provide feedback on Helper" })
     ).toBeInTheDocument();
     expect(screen.getByText("Glad you liked it! Tell us more?")).toBeVisible();
 
@@ -135,7 +135,7 @@ describe("FeedbackSelector", () => {
       isConversationShared: false,
     });
     expect(
-      screen.queryByRole("heading", { name: "Provide feedback on @Helper" })
+      screen.queryByRole("heading", { name: "Provide feedback on Helper" })
     ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Description

#30444 removed the `@` prefix from the feedback dialog title but the test still asserted `Provide feedback on @Helper`, so it was failing. Updated both heading assertions.

## Tests

`npm run test -- components/assistant/conversation/FeedbackSelector.test.tsx`, 3/3 pass.

## Risk

None, test-only.

## Deploy Plan

Nothing special.