### PR TITLE
[front] fix: Guard tool display label lookup against unknown internal MCP server names

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1590,7 +1590,11 @@ export function resolveInternalMCPServerToolStakeLevel(
 export function getInternalMCPServerToolDisplayLabels(
   name: InternalMCPServerNameType
 ): Record<string, ToolDisplayLabels> | null {
-  const server = INTERNAL_MCP_SERVERS[name];
+  const server: InternalMCPServerEntry | undefined = INTERNAL_MCP_SERVERS[name];
+  if (!server) {
+    return null;
+  }
+
   const displayLabelsByTool: Record<string, ToolDisplayLabels> = {};
   let hasDisplayLabels = false;
 


### PR DESCRIPTION


## Description

When we release new mcp servers and don't release the extension, current code deployed tries to dereference action's mcp tool from a map that does not contain it (yet), which makes the whole conversation render crash.

This patch makes it fail without crashing, not amazing but at least limits the blast radius, the real fix is simply to release the extension more often.


## Tests

Not tested

## Risk

Low

## Deploy Plan

Merge
Release the extension