### PR TITLE
Admin governance: shadow compare skill permissions

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -71,6 +71,7 @@ import {
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, removeNulls } from "@app/types/shared/utils/general";
 import { decodeUtf8HeaderValue } from "@app/types/shared/utils/http_headers";
 import type {
@@ -1476,6 +1477,65 @@ export class Authenticator {
     resourceId: number
   ): GroupGrant[] {
     return this._permissions.forResource(resourceType, resourceId);
+  }
+
+  /**
+   * Shadow-compare (#9479) for the group_permissions rollout: while the `group_permissions_shadow`
+   * flag is on for the workspace, compare two composed decisions for the same check — the served
+   * `legacyAcls` and the `candidateAcls` (the same roles routed through the group_permissions
+   * table) — and log mismatches so a Datadog monitor can confirm parity before the flip (#9480).
+   * The caller builds both shapes. Fire-and-forget: never changes the served result and swallows its
+   * own failures. (Inlined rather than reusing `lib/api/permissions/shadow` to avoid an auth <->
+   * shadow import cycle.)
+   */
+  shadowComparePermission(
+    verb: GrantVerb,
+    legacyAcls: AccessControlList[],
+    candidateAcls: AccessControlList[],
+    context: Record<string, string | number | boolean | null>
+  ): void {
+    void this.runShadowComparePermission(
+      verb,
+      legacyAcls,
+      candidateAcls,
+      context
+    );
+  }
+
+  private async runShadowComparePermission(
+    verb: GrantVerb,
+    legacyAcls: AccessControlList[],
+    candidateAcls: AccessControlList[],
+    context: Record<string, string | number | boolean | null>
+  ): Promise<void> {
+    try {
+      const flags = await getFeatureFlags(this);
+      if (!flags.includes("group_permissions_shadow")) {
+        return;
+      }
+
+      const legacyResult = this.hasPermissionForAcls(verb, legacyAcls);
+      const candidateResult = this.hasPermissionForAcls(verb, candidateAcls);
+
+      // The literal message is the Datadog monitor key — keep it stable.
+      if (legacyResult !== candidateResult) {
+        logger.warn(
+          {
+            ...context,
+            legacyResult,
+            candidateResult,
+            legacyAcls,
+            candidateAcls,
+          },
+          "group_permissions_shadow_mismatch"
+        );
+      }
+    } catch (err) {
+      logger.error(
+        { ...context, err: normalizeError(err) },
+        "group_permissions_shadow_error"
+      );
+    }
   }
 
   /**

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -17,9 +17,11 @@ import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_reso
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { serializeSkillTag } from "@app/lib/skills/format";
+import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
@@ -2756,6 +2758,113 @@ describe("SkillResource", () => {
         []
       );
       expect(editedByMap.size).toBe(0);
+    });
+  });
+
+  describe("group_permissions shadow-compare", () => {
+    // A skill's editor group grants [read, write, admin]; a "user" role grants only read, so write
+    // and admin flow purely through the group — isolating the group-vs-table check.
+    //
+    // Returns a `buildEditorAuth` thunk rather than a ready authenticator: an Authenticator
+    // snapshots its grants at construction, so callers must build it AFTER any grant mutation.
+    async function setupSkillWithEditor(name: string): Promise<{
+      skill: SkillResource;
+      buildEditorAuth: () => Promise<Authenticator>;
+    }> {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name,
+      });
+
+      const editor = await UserFactory.basic();
+      await MembershipFactory.associate(testContext.workspace, editor, {
+        role: "user",
+      });
+      const upsert = await skill.upsertEditors(testContext.authenticator, [
+        editor,
+      ]);
+      expect(upsert.isOk()).toBe(true);
+
+      return {
+        skill,
+        buildEditorAuth: () =>
+          Authenticator.fromUserIdAndWorkspaceId(
+            editor.sId,
+            testContext.workspace.sId
+          ),
+      };
+    }
+
+    // Simulates a skill created before the dual-write shipped: the association exists but the
+    // table holds no grant for it.
+    async function clearSkillGrants(skill: SkillResource): Promise<void> {
+      await GroupPermissionResource.deleteAllForResource(
+        testContext.authenticator,
+        { resourceType: "skill", resourceId: skill.id }
+      );
+    }
+
+    it("logs a mismatch when the table diverges from the editor-group rules", async () => {
+      const { skill, buildEditorAuth } = await setupSkillWithEditor(
+        "Shadow Mismatch Skill"
+      );
+      await clearSkillGrants(skill);
+      await FeatureFlagFactory.basic(
+        testContext.authenticator,
+        "group_permissions_shadow"
+      );
+
+      const editorAuth = await buildEditorAuth();
+      const warn = vi.spyOn(logger, "warn");
+
+      // Served result is unchanged: the editor group still grants write via code.
+      expect(skill.canWrite(editorAuth)).toBe(true);
+
+      await vi.waitFor(() =>
+        expect(warn).toHaveBeenCalledWith(
+          expect.objectContaining({
+            resource: "skill",
+            skillId: skill.sId,
+            permission: "write",
+          }),
+          "group_permissions_shadow_mismatch"
+        )
+      );
+    });
+
+    it("keeps the governance role rules in sync with the editor-group ACL", async () => {
+      // `governanceAcls` restates the role rules so it can stand alone at the flip; they must stay
+      // identical to what the skill_editors group declares while both paths coexist.
+      const { skill, buildEditorAuth } = await setupSkillWithEditor(
+        "Shadow Role Rules Skill"
+      );
+      const editorAuth = await buildEditorAuth();
+
+      const byRole = (grants: { role: string }[]) =>
+        [...grants].sort((a, b) => a.role.localeCompare(b.role));
+
+      expect(byRole(skill.governanceAcls(editorAuth)[0].roles)).toEqual(
+        byRole(skill.editorGroup!.getAccessControlLists(editorAuth)[0].roles)
+      );
+    });
+
+    it("never logs a mismatch while the flag is off", async () => {
+      const { skill, buildEditorAuth } = await setupSkillWithEditor(
+        "Shadow Flag Off Skill"
+      );
+      await clearSkillGrants(skill);
+
+      const editorAuth = await buildEditorAuth();
+      const warn = vi.spyOn(logger, "warn");
+
+      expect(skill.canWrite(editorAuth)).toBe(true);
+
+      // Flush the fire-and-forget; with the flag off it short-circuits before comparing.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        "group_permissions_shadow_mismatch"
+      );
     });
   });
 });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -92,8 +92,13 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import { isDefaultFromAvailability } from "@app/types/assistant/skill_configuration";
 import type { AgentsUsageType } from "@app/types/data_source";
+import type { GrantVerb } from "@app/types/group_permissions";
 import { SKILL_GROUP_PREFIX } from "@app/types/groups";
-import type { GroupGrant } from "@app/types/resource_permissions";
+import type {
+  AccessControlList,
+  GroupGrant,
+  RoleGrant,
+} from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -257,6 +262,13 @@ export interface SkillResource
 
 // The role a skill's editor group holds on the skill. Its verbs live in ROLE_REGISTRY.skill.
 const SKILL_EDITOR_GRANT_TYPE = "editor" as const;
+
+const SKILL_ROLE_GRANTS: RoleGrant[] = [
+  { role: "admin", permissions: ["read", "admin"] },
+  { role: "manager", permissions: ["read"] },
+  { role: "user", permissions: ["read"] },
+  { role: "builder", permissions: ["read"] },
+];
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SkillResource extends BaseResource<SkillConfigurationModel> {
@@ -2117,7 +2129,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return false;
     }
 
-    return this.editorGroup.canWrite(auth);
+    const legacyAcls = this.editorGroup.getAccessControlLists(auth);
+    this.shadowCompareSkillPermission(auth, legacyAcls, "write");
+
+    return auth.hasPermissionForAcls("write", legacyAcls);
   }
 
   canAdministrate(auth: Authenticator): boolean {
@@ -2131,7 +2146,55 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return false;
     }
 
-    return this.editorGroup.canAdministrate(auth);
+    const legacyAcls = this.editorGroup.getAccessControlLists(auth);
+    this.shadowCompareSkillPermission(auth, legacyAcls, "admin");
+
+    return auth.hasPermissionForAcls("admin", legacyAcls);
+  }
+
+  /**
+   * The skill's access-control list built from governance data: the code role rules plus the
+   * groups held in `group_permissions`. Stands on its own — it reads nothing from the editor-group
+   * association — so at the flip (#9480) this becomes the served `getAccessControlLists(auth)` and
+   * the legacy path is deleted without touching it.
+   *
+   * Until then it is the shadow-compare candidate.
+   */
+  governanceAcls(auth: Authenticator): AccessControlList[] {
+    return [
+      {
+        roles: SKILL_ROLE_GRANTS,
+        groups: auth.getGroupPermissions("skill", this.id),
+        workspaceId: this.workspaceId,
+      },
+    ];
+  }
+
+  // Shadow-compare (#9479): while the `group_permissions_shadow` flag is on for the workspace, check
+  // whether the governance ACL yields the same decision as the legacy editor-group ACL. Legacy is
+  // the editor group's own `getAccessControlLists(auth)` (the group listed inline); the candidate is
+  // `governanceAcls`, built independently from the table. Delegates the flag lookup + compare + log
+  // to the Authenticator as fire-and-forget — never changes the served result.
+  //
+  // Callers skip this for API keys (code-ruled: any key may write any skill, which the table has no
+  // way to express) and for skills without an editor group (global/system skills, not part of the
+  // migration).
+  private shadowCompareSkillPermission(
+    auth: Authenticator,
+    legacyAcls: AccessControlList[],
+    permission: GrantVerb
+  ): void {
+    auth.shadowComparePermission(
+      permission,
+      legacyAcls,
+      this.governanceAcls(auth),
+      {
+        resource: "skill",
+        skillId: this.sId,
+        permission,
+        workspaceId: this.workspaceId,
+      }
+    );
   }
 
   // The group grants a skill confers, derived from its `group_skills` association: the editor


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/9472

Shadow compare permissions from group and from permissions table for skills.
Only when feature flag is activated
Warn on difference

## Tests

added unit test

## Risk

low, just a warning + feature flag

## Deploy Plan

wait for migration to be run
deploy front
deploy sse
