### PR TITLE
Free usage: increase sidekick messages to 200 for enterprise + 

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -49,6 +49,7 @@ import {
   makeProgrammaticUsageRateLimitKeyForWorkspace,
   makeSidekickMessageRateLimitKeyForWorkspaceActor,
   SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY,
+  SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY_ENTERPRISE,
   SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY_WINDOW_SECONDS,
 } from "@app/lib/api/assistant/rate_limits";
 import {
@@ -103,6 +104,7 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { notifyNewProjectConversation } from "@app/lib/notifications/triggers/project-new-conversation";
 import { triggerConversationUnreadNotifications } from "@app/lib/notifications/workflows/conversation-unread";
+import { isEnterpriseOrDust } from "@app/lib/plans/plan_codes";
 import { computeEffectiveMessageLimit } from "@app/lib/plans/usage/limits";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
@@ -2465,12 +2467,15 @@ export async function checkMessagesLimit(
       });
     }
 
+    const sidekickDailyLimit = isEnterpriseOrDust(auth.plan())
+      ? SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY_ENTERPRISE
+      : SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY;
     const remaining = await rateLimiter({
       key: makeSidekickMessageRateLimitKeyForWorkspaceActor(
         auth.getNonNullableWorkspace(),
         getMessageRateLimitActor(auth)
       ),
-      maxPerTimeframe: SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY,
+      maxPerTimeframe: sidekickDailyLimit,
       timeframeSeconds:
         SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY_WINDOW_SECONDS,
       logger,
@@ -2480,8 +2485,7 @@ export async function checkMessagesLimit(
         status_code: 429,
         api_error: {
           type: "rate_limit_error",
-          message:
-            "You have reached the sidekick usage limit. Please try again later.",
+          message: `You have reached the sidekick usage limit (${sidekickDailyLimit} messages per 24h). Please try again later.`,
         },
       });
     }

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -21,8 +21,10 @@ export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR_WINDOW_SECONDS = 60 * 60;
 
 // Sidekick messages are free (unbilled) usage, so they bypass the credit/plan
 // caps. Cap them per actor to bound how much free usage a single user can
-// generate through the builder assistant.
+// generate through the builder assistant. Enterprise (and Dust internal)
+// accounts get a higher allowance.
 export const SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY = 100;
+export const SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY_ENTERPRISE = 200;
 export const SIDEKICK_MESSAGE_RATE_LIMIT_PER_ACTOR_PER_DAY_WINDOW_SECONDS =
   24 * 60 * 60;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -796,7 +796,7 @@ export async function runModel(
     await publishAgentError({
       code: "free_usage_limit_reached",
       message:
-        "The daily free-usage limit has been reached. Please try again later.",
+        "You have reached the free usage credits cap for this 24h period. Please try again later.",
       metadata: null,
     });
     return null;


### PR DESCRIPTION


## Description

 - increase sidekick messages to 200 for enterprise users
 - improve error messages to make them easier to understand

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
