### PR TITLE
feat(egress-proxy): remove the legacy per-sandbox and workspace-layout policy reads

### DIFF
--- a/egress-proxy/src/connection.rs
+++ b/egress-proxy/src/connection.rs
@@ -215,7 +215,6 @@ async fn handle_connection_inner(
                 token.w_id.as_deref(),
                 token.owner_id.as_deref(),
                 token.pod_id.as_deref(),
-                sb_id,
                 &request.domain,
             )
             .await

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -68,30 +68,17 @@ impl GcsPolicyProvider {
         self.cache.invalidate(cache_key).await;
     }
 
-    // Workspace policy lives at `w/{wId}/sandbox-egress-policy.json`. During the layout
-    // migration we fall back to the legacy `workspaces/{wId}.json` path when
-    // the new object is absent (not on errors: those stay fail-closed).
-    // TODO(2026-08-15 EGRESS_RELAYOUT): drop the legacy fallback once the
-    // backfill has run and legacy objects are deleted.
+    // Workspace policy lives at `w/{wId}/sandbox-egress-policy.json`. The
+    // "w2:" cache key is load-bearing: invalidation tokens minted by older
+    // front builds evict exactly this key.
     pub async fn get_workspace_policy(&self, w_id: &str) -> Result<Option<Policy>> {
-        let current = self
-            .get_policy(
-                &format!("w2:{w_id}"),
-                &format!("w/{w_id}/sandbox-egress-policy.json"),
-            )
-            .await?;
-
-        if current.is_some() {
-            return Ok(current);
-        }
-
-        self.get_policy(&format!("w:{w_id}"), &format!("workspaces/{w_id}.json"))
-            .await
+        self.get_policy(
+            &format!("w2:{w_id}"),
+            &format!("w/{w_id}/sandbox-egress-policy.json"),
+        )
+        .await
     }
 
-    // Legacy per-sandbox policy, keyed by the ephemeral provider id. Still
-    // read (unioned with the owner policy) so in-flight approvals from before
-    // the layout migration keep working until those sandboxes age out.
     // Owner policy: the stable per-owner allowlist at
     // `w/{wId}/sandboxes/{ownerId}.json`, where ownerId is a conversation sId
     // (conversation sandboxes) or a space sId (pod sandboxes). Survives

--- a/egress-proxy/src/gcs.rs
+++ b/egress-proxy/src/gcs.rs
@@ -92,13 +92,6 @@ impl GcsPolicyProvider {
     // Legacy per-sandbox policy, keyed by the ephemeral provider id. Still
     // read (unioned with the owner policy) so in-flight approvals from before
     // the layout migration keep working until those sandboxes age out.
-    // TODO(2026-08-15 EGRESS_RELAYOUT): drop once pre-migration sandboxes are
-    // gone.
-    pub async fn get_sandbox_policy(&self, sb_id: &str) -> Result<Option<Policy>> {
-        self.get_policy(&format!("s:{sb_id}"), &format!("sandboxes/{sb_id}.json"))
-            .await
-    }
-
     // Owner policy: the stable per-owner allowlist at
     // `w/{wId}/sandboxes/{ownerId}.json`, where ownerId is a conversation sId
     // (conversation sandboxes) or a space sId (pod sandboxes). Survives
@@ -111,16 +104,15 @@ impl GcsPolicyProvider {
         .await
     }
 
-    // A domain is allowed if ANY of the workspace, owner, pod, or legacy
-    // sandbox policies allows it. `pod_id` is the inherited pod layer for
-    // conversation sandboxes running inside a pod — same file scheme as
-    // owner policies. Every lookup fails closed: a GCS error never grants.
+    // A domain is allowed if ANY of the workspace, owner, or pod policies
+    // allows it. `pod_id` is the inherited pod layer for conversation
+    // sandboxes running inside a pod — same file scheme as owner policies.
+    // Every lookup fails closed: a GCS error never grants.
     pub async fn evaluate(
         &self,
         w_id: Option<&str>,
         owner_id: Option<&str>,
         pod_id: Option<&str>,
-        sb_id: &str,
         domain: &str,
     ) -> bool {
         let workspace_allows = match w_id {
@@ -139,8 +131,7 @@ impl GcsPolicyProvider {
             return true;
         }
 
-        // The owner path needs both ids; tokens minted before the layout
-        // migration carry no ownerId and skip straight to the legacy file.
+        // The owner path needs both ids.
         let owner_allows = match (w_id, owner_id) {
             (Some(w_id), Some(owner_id)) => match self.get_owner_policy(w_id, owner_id).await {
                 Ok(Some(policy)) => policy.allows(domain),
@@ -169,18 +160,7 @@ impl GcsPolicyProvider {
             _ => false,
         };
 
-        if pod_allows {
-            return true;
-        }
-
-        match self.get_sandbox_policy(sb_id).await {
-            Ok(Some(policy)) => policy.allows(domain),
-            Ok(None) => false,
-            Err(error) => {
-                warn!(error = %error, sb_id, "sandbox policy lookup failed");
-                false
-            }
-        }
+        pod_allows
     }
 
     async fn get_policy(&self, cache_key: &str, object_name: &str) -> Result<Option<Policy>> {

--- a/egress-proxy/src/health.rs
+++ b/egress-proxy/src/health.rs
@@ -78,16 +78,16 @@ async fn invalidate_policy(
     }
 
     // Derive the cache keys from claims:
-    // - wId alone evicts the workspace policy (both layouts during the
-    //   migration window);
-    // - wId + ownerId evicts the owner policy (the cache key needs both);
-    // - sbId alone evicts the legacy per-sandbox policy.
+    // - wId alone evicts the workspace policy;
+    // - wId + ownerId evicts the owner policy (the cache key needs both).
+    // sbId-only tokens are still accepted — older front builds mint them —
+    // and evict "s:" keys nothing writes, so they no-op.
     let cache_keys = match (
         validated.w_id.as_deref(),
         validated.owner_id.as_deref(),
         validated.sb_id.as_deref(),
     ) {
-        (Some(w_id), None, None) => vec![format!("w2:{w_id}"), format!("w:{w_id}")],
+        (Some(w_id), None, None) => vec![format!("w2:{w_id}")],
         (Some(w_id), Some(owner_id), None) => vec![format!("o:{w_id}:{owner_id}")],
         (None, None, Some(sb_id)) => vec![format!("s:{sb_id}")],
         _ => {

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -61,7 +61,6 @@ enum MockGcsResponse {
 #[derive(Default)]
 struct MockPolicies {
     workspace: Option<MockGcsResponse>,
-    workspace_new: Option<MockGcsResponse>,
     owner: Option<MockGcsResponse>,
     // The pod's policy file — same `w/{wId}/sandboxes/{id}.json` scheme as
     // owner files, keyed by the pod space sId.
@@ -194,7 +193,6 @@ async fn workspace_policy_allows_domain() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["localhost"])),
-            workspace_new: None,
             owner: None,
             pod: None,
         },
@@ -221,67 +219,6 @@ async fn workspace_policy_allows_domain() -> Result<()> {
 
     drop(stream);
     wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
-    Ok(())
-}
-
-#[tokio::test]
-async fn workspace_policy_new_layout_allows_domain() -> Result<()> {
-    let (upstream_port, mut upstream_handles) =
-        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
-    let proxy = start_proxy_with_mock_gcs(
-        MockPolicies {
-            workspace: None,
-            workspace_new: Some(policy_response(&["localhost"])),
-            owner: None,
-            pod: None,
-        },
-        None,
-        true,
-        "test",
-    )
-    .await?;
-    let token = make_token(SECRET, 60);
-    let mut stream = connect_forwarder(&proxy).await?;
-
-    stream
-        .write_all(&build_frame(&token, "localhost", upstream_port)?)
-        .await?;
-
-    let mut response = [0; 1];
-    stream.read_exact(&mut response).await?;
-    assert_eq!(response[0], ALLOW_RESPONSE);
-
-    stream.write_all(b"ping").await?;
-    let mut echoed = [0; 4];
-    stream.read_exact(&mut echoed).await?;
-    assert_eq!(&echoed, b"ping");
-
-    drop(stream);
-    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
-    Ok(())
-}
-
-#[tokio::test]
-async fn workspace_policy_new_layout_preferred_over_legacy() -> Result<()> {
-    // When the new-layout file exists, the legacy file is NOT consulted:
-    // fallback happens only when the new object is absent.
-    let proxy = start_proxy_with_mock_gcs(
-        MockPolicies {
-            workspace: Some(policy_response(&["localhost"])),
-            workspace_new: Some(policy_response(&["other.example.com"])),
-            owner: None,
-            pod: None,
-        },
-        None,
-        false,
-        "production",
-    )
-    .await?;
-    let token = make_token(SECRET, 60);
-
-    let response = send_handshake(&proxy, &token, "localhost", 254).await?;
-
-    assert_eq!(response, Some(DENY_RESPONSE));
     Ok(())
 }
 
@@ -292,7 +229,6 @@ async fn owner_policy_allows_domain() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: Some(policy_response(&["localhost"])),
             pod: None,
         },
@@ -331,7 +267,6 @@ async fn owner_policy_ignored_without_owner_id_claim() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: Some(policy_response(&["localhost"])),
             pod: None,
         },
@@ -358,7 +293,6 @@ async fn pod_policy_allows_conversation_inside_pod() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: None,
             pod: Some(policy_response(&["localhost"])),
         },
@@ -397,7 +331,6 @@ async fn pod_policy_ignored_without_pod_id_claim() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: None,
             pod: Some(policy_response(&["localhost"])),
         },
@@ -424,7 +357,6 @@ async fn pod_id_without_owner_id_is_rejected() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: None,
             pod: Some(policy_response(&["localhost"])),
         },
@@ -450,7 +382,6 @@ async fn pod_function_allowed_through_pod_file_as_owner() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: None,
             pod: Some(policy_response(&["localhost"])),
         },
@@ -477,7 +408,6 @@ async fn conversation_policy_does_not_apply_to_pod_function() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: Some(policy_response(&["localhost"])),
             pod: None,
         },
@@ -499,7 +429,6 @@ async fn denied_when_no_policy_allows_with_owner_id() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["a.example.com"])),
-            workspace_new: Some(policy_response(&["b.example.com"])),
             owner: Some(policy_response(&["c.example.com"])),
             pod: None,
         },
@@ -523,7 +452,6 @@ async fn owner_gcs_failure_denies_connection() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
             pod: None,
         },
@@ -541,10 +469,10 @@ async fn owner_gcs_failure_denies_connection() -> Result<()> {
 }
 
 #[tokio::test]
-async fn legacy_token_without_workspace_id_is_denied() -> Result<()> {
-    // The legacy per-sandbox policy layer is gone: a pre-relayout token
-    // carrying only sbId can no longer be allowed by anything, even when a
-    // workspace policy would allow the domain.
+async fn token_without_workspace_id_is_denied() -> Result<()> {
+    // Every policy layer requires the wId claim: a token carrying only sbId
+    // can never be allowed by anything, even when a workspace policy would
+    // allow the domain.
     let proxy = start_proxy_with_workspace_policy(&["localhost"], true, "test").await?;
     let token = make_token_with_claims(
         SECRET,
@@ -571,7 +499,6 @@ async fn denied_when_workspace_policy_does_not_allow_domain() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["other.example.com"])),
-            workspace_new: None,
             owner: None,
             pod: None,
         },
@@ -1027,7 +954,6 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: Some(policy_response(&["localhost"])),
-            workspace_new: None,
             owner: None,
             pod: None,
         },
@@ -1131,7 +1057,6 @@ async fn invalidate_policy_evicts_cached_owner_entry() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
             owner: Some(policy_response(&["localhost"])),
             pod: None,
         },
@@ -1181,8 +1106,7 @@ async fn invalidate_policy_workspace_evicts_both_layouts() -> Result<()> {
         start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
-            workspace: None,
-            workspace_new: Some(policy_response(&["localhost"])),
+            workspace: Some(policy_response(&["localhost"])),
             owner: None,
             pod: None,
         },
@@ -1295,8 +1219,7 @@ async fn start_proxy_with_workspace_policy(
 ) -> Result<ProxyProcess> {
     start_proxy_with_mock_gcs(
         MockPolicies {
-            workspace: None,
-            workspace_new: Some(policy_response(allowed_domains)),
+            workspace: Some(policy_response(allowed_domains)),
             owner: None,
             pod: None,
         },
@@ -1361,12 +1284,9 @@ async fn start_proxy_with_mock_gcs(
 async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> {
     let mut objects = HashMap::new();
     if let Some(workspace) = policies.workspace {
-        objects.insert(format!("workspaces/{TEST_WORKSPACE_ID}.json"), workspace);
-    }
-    if let Some(workspace_new) = policies.workspace_new {
         objects.insert(
             format!("w/{TEST_WORKSPACE_ID}/sandbox-egress-policy.json"),
-            workspace_new,
+            workspace,
         );
     }
     if let Some(owner) = policies.owner {
@@ -1597,9 +1517,8 @@ fn build_oversized_domain_frame(token: &str) -> Vec<u8> {
     frame
 }
 
-// The baseline token: front has always minted the wId claim since the
-// owner-keyed layout, and with the legacy per-sandbox layer gone a token
-// without it can never be allowed by any policy.
+// The baseline token: front always mints the wId claim, and every policy
+// layer requires it — a token without it can never be allowed.
 fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
     make_token_with_claims(
         secret,

--- a/egress-proxy/tests/integration.rs
+++ b/egress-proxy/tests/integration.rs
@@ -66,7 +66,6 @@ struct MockPolicies {
     // The pod's policy file — same `w/{wId}/sandboxes/{id}.json` scheme as
     // owner files, keyed by the pod space sId.
     pod: Option<MockGcsResponse>,
-    sandbox: Option<MockGcsResponse>,
 }
 
 const TEST_WORKSPACE_ID: &str = "workspace-456";
@@ -166,7 +165,7 @@ async fn missing_policy_bucket_fails_startup() -> Result<()> {
 async fn allowed_domain_forwards_bytes() -> Result<()> {
     let (upstream_port, mut upstream_handles) =
         start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
-    let proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
+    let proxy = start_proxy_with_workspace_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
@@ -198,52 +197,13 @@ async fn workspace_policy_allows_domain() -> Result<()> {
             workspace_new: None,
             owner: None,
             pod: None,
-            sandbox: None,
         },
         None,
         true,
         "test",
     )
     .await?;
-    let token = make_token_with_workspace(SECRET, 60);
-    let mut stream = connect_forwarder(&proxy).await?;
-
-    stream
-        .write_all(&build_frame(&token, "localhost", upstream_port)?)
-        .await?;
-
-    let mut response = [0; 1];
-    stream.read_exact(&mut response).await?;
-    assert_eq!(response[0], ALLOW_RESPONSE);
-
-    stream.write_all(b"ping").await?;
-    let mut echoed = [0; 4];
-    stream.read_exact(&mut echoed).await?;
-    assert_eq!(&echoed, b"ping");
-
-    drop(stream);
-    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
-    Ok(())
-}
-
-#[tokio::test]
-async fn sandbox_policy_allows_when_workspace_has_no_policy() -> Result<()> {
-    let (upstream_port, mut upstream_handles) =
-        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
-    let proxy = start_proxy_with_mock_gcs(
-        MockPolicies {
-            workspace: None,
-            workspace_new: None,
-            owner: None,
-            pod: None,
-            sandbox: Some(policy_response(&["localhost"])),
-        },
-        None,
-        true,
-        "test",
-    )
-    .await?;
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
     stream
@@ -274,14 +234,13 @@ async fn workspace_policy_new_layout_allows_domain() -> Result<()> {
             workspace_new: Some(policy_response(&["localhost"])),
             owner: None,
             pod: None,
-            sandbox: None,
         },
         None,
         true,
         "test",
     )
     .await?;
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
     stream
@@ -312,14 +271,13 @@ async fn workspace_policy_new_layout_preferred_over_legacy() -> Result<()> {
             workspace_new: Some(policy_response(&["other.example.com"])),
             owner: None,
             pod: None,
-            sandbox: None,
         },
         None,
         false,
         "production",
     )
     .await?;
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "localhost", 254).await?;
 
@@ -337,7 +295,6 @@ async fn owner_policy_allows_domain() -> Result<()> {
             workspace_new: None,
             owner: Some(policy_response(&["localhost"])),
             pod: None,
-            sandbox: None,
         },
         None,
         true,
@@ -377,14 +334,13 @@ async fn owner_policy_ignored_without_owner_id_claim() -> Result<()> {
             workspace_new: None,
             owner: Some(policy_response(&["localhost"])),
             pod: None,
-            sandbox: None,
         },
         None,
         true,
         "test",
     )
     .await?;
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
 
@@ -405,7 +361,6 @@ async fn pod_policy_allows_conversation_inside_pod() -> Result<()> {
             workspace_new: None,
             owner: None,
             pod: Some(policy_response(&["localhost"])),
-            sandbox: None,
         },
         None,
         true,
@@ -445,7 +400,6 @@ async fn pod_policy_ignored_without_pod_id_claim() -> Result<()> {
             workspace_new: None,
             owner: None,
             pod: Some(policy_response(&["localhost"])),
-            sandbox: None,
         },
         None,
         true,
@@ -473,7 +427,6 @@ async fn pod_id_without_owner_id_is_rejected() -> Result<()> {
             workspace_new: None,
             owner: None,
             pod: Some(policy_response(&["localhost"])),
-            sandbox: None,
         },
         None,
         true,
@@ -500,7 +453,6 @@ async fn pod_function_allowed_through_pod_file_as_owner() -> Result<()> {
             workspace_new: None,
             owner: None,
             pod: Some(policy_response(&["localhost"])),
-            sandbox: None,
         },
         None,
         true,
@@ -528,7 +480,6 @@ async fn conversation_policy_does_not_apply_to_pod_function() -> Result<()> {
             workspace_new: None,
             owner: Some(policy_response(&["localhost"])),
             pod: None,
-            sandbox: None,
         },
         None,
         true,
@@ -544,87 +495,6 @@ async fn conversation_policy_does_not_apply_to_pod_function() -> Result<()> {
 }
 
 #[tokio::test]
-async fn legacy_sandbox_policy_unioned_with_owner_policy() -> Result<()> {
-    // In-flight approvals from before the layout migration live in the legacy
-    // per-sandbox file; tokens that already carry ownerId must still honor
-    // them until those sandboxes age out.
-    let (upstream_port, mut upstream_handles) =
-        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
-    let proxy = start_proxy_with_mock_gcs(
-        MockPolicies {
-            workspace: None,
-            workspace_new: None,
-            owner: Some(policy_response(&["other.example.com"])),
-            pod: None,
-            sandbox: Some(policy_response(&["localhost"])),
-        },
-        None,
-        true,
-        "test",
-    )
-    .await?;
-    let token = make_token_with_owner(SECRET, 60);
-    let mut stream = connect_forwarder(&proxy).await?;
-
-    stream
-        .write_all(&build_frame(&token, "localhost", upstream_port)?)
-        .await?;
-
-    let mut response = [0; 1];
-    stream.read_exact(&mut response).await?;
-    assert_eq!(response[0], ALLOW_RESPONSE);
-
-    stream.write_all(b"ping").await?;
-    let mut echoed = [0; 4];
-    stream.read_exact(&mut echoed).await?;
-    assert_eq!(&echoed, b"ping");
-
-    drop(stream);
-    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
-    Ok(())
-}
-
-#[tokio::test]
-async fn owner_gcs_failure_falls_back_to_legacy_sandbox() -> Result<()> {
-    // An owner policy lookup error fails closed for the owner policy but the
-    // union still consults the legacy sandbox policy.
-    let (upstream_port, mut upstream_handles) =
-        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
-    let proxy = start_proxy_with_mock_gcs(
-        MockPolicies {
-            workspace: None,
-            workspace_new: None,
-            owner: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
-            pod: None,
-            sandbox: Some(policy_response(&["localhost"])),
-        },
-        None,
-        true,
-        "test",
-    )
-    .await?;
-    let token = make_token_with_owner(SECRET, 60);
-    let mut stream = connect_forwarder(&proxy).await?;
-
-    stream
-        .write_all(&build_frame(&token, "localhost", upstream_port)?)
-        .await?;
-
-    let mut response = [0; 1];
-    stream.read_exact(&mut response).await?;
-    assert_eq!(response[0], ALLOW_RESPONSE);
-
-    stream.write_all(b"ping").await?;
-    let mut echoed = [0; 4];
-    stream.read_exact(&mut echoed).await?;
-    assert_eq!(&echoed, b"ping");
-
-    drop(stream);
-    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
-    Ok(())
-}
-
-#[tokio::test]
 async fn denied_when_no_policy_allows_with_owner_id() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
@@ -632,7 +502,6 @@ async fn denied_when_no_policy_allows_with_owner_id() -> Result<()> {
             workspace_new: Some(policy_response(&["b.example.com"])),
             owner: Some(policy_response(&["c.example.com"])),
             pod: None,
-            sandbox: Some(policy_response(&["d.example.com"])),
         },
         None,
         false,
@@ -648,75 +517,63 @@ async fn denied_when_no_policy_allows_with_owner_id() -> Result<()> {
 }
 
 #[tokio::test]
-async fn denied_when_neither_workspace_nor_sandbox_allows_domain() -> Result<()> {
+async fn owner_gcs_failure_denies_connection() -> Result<()> {
+    // Every policy lookup fails closed: a GCS error on the only layer that
+    // could allow never grants.
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
-            workspace: Some(policy_response(&["other.example.com"])),
+            workspace: None,
             workspace_new: None,
-            owner: None,
+            owner: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
             pod: None,
-            sandbox: Some(policy_response(&["another.example.com"])),
         },
         None,
         false,
         "production",
     )
     .await?;
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token_with_owner(SECRET, 60);
 
-    let response = send_handshake(&proxy, &token, "denied.example.com", 443).await?;
+    let response = send_handshake(&proxy, &token, "example.com", 443).await?;
 
     assert_eq!(response, Some(DENY_RESPONSE));
     Ok(())
 }
 
 #[tokio::test]
-async fn workspace_gcs_failure_falls_back_to_sandbox() -> Result<()> {
-    let (upstream_port, mut upstream_handles) =
-        start_localhost_servers(UpstreamBehavior::EchoFixed { read_len: 4 }).await?;
-    let proxy = start_proxy_with_mock_gcs(
-        MockPolicies {
-            workspace: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
-            workspace_new: None,
-            owner: None,
-            pod: None,
-            sandbox: Some(policy_response(&["localhost"])),
+async fn legacy_token_without_workspace_id_is_denied() -> Result<()> {
+    // The legacy per-sandbox policy layer is gone: a pre-relayout token
+    // carrying only sbId can no longer be allowed by anything, even when a
+    // workspace policy would allow the domain.
+    let proxy = start_proxy_with_workspace_policy(&["localhost"], true, "test").await?;
+    let token = make_token_with_claims(
+        SECRET,
+        FullClaims {
+            sb_id: Some(TEST_SANDBOX_ID),
+            w_id: None,
+            owner_id: None,
+            pod_id: None,
+            action: None,
+            iss: "dust-front",
+            aud: "dust-egress-proxy",
+            exp_offset_seconds: 60,
         },
-        None,
-        true,
-        "test",
-    )
-    .await?;
-    let token = make_token_with_workspace(SECRET, 60);
-    let mut stream = connect_forwarder(&proxy).await?;
+    );
 
-    stream
-        .write_all(&build_frame(&token, "localhost", upstream_port)?)
-        .await?;
+    let response = send_handshake(&proxy, &token, "localhost", 254).await?;
 
-    let mut response = [0; 1];
-    stream.read_exact(&mut response).await?;
-    assert_eq!(response[0], ALLOW_RESPONSE);
-
-    stream.write_all(b"ping").await?;
-    let mut echoed = [0; 4];
-    stream.read_exact(&mut echoed).await?;
-    assert_eq!(&echoed, b"ping");
-
-    drop(stream);
-    wait_for_upstream_completion(&mut upstream_handles, Duration::from_secs(2)).await?;
+    assert_eq!(response, Some(DENY_RESPONSE));
     Ok(())
 }
 
 #[tokio::test]
-async fn sandbox_gcs_failure_denies_connection() -> Result<()> {
+async fn denied_when_workspace_policy_does_not_allow_domain() -> Result<()> {
     let proxy = start_proxy_with_mock_gcs(
         MockPolicies {
-            workspace: None,
+            workspace: Some(policy_response(&["other.example.com"])),
             workspace_new: None,
             owner: None,
             pod: None,
-            sandbox: Some(MockGcsResponse::Status(StatusCode::INTERNAL_SERVER_ERROR)),
         },
         None,
         false,
@@ -725,7 +582,7 @@ async fn sandbox_gcs_failure_denies_connection() -> Result<()> {
     .await?;
     let token = make_token(SECRET, 60);
 
-    let response = send_handshake(&proxy, &token, "example.com", 443).await?;
+    let response = send_handshake(&proxy, &token, "denied.example.com", 443).await?;
 
     assert_eq!(response, Some(DENY_RESPONSE));
     Ok(())
@@ -862,7 +719,7 @@ async fn empty_sandbox_id_claim_returns_deny() -> Result<()> {
 
 #[tokio::test]
 async fn allowed_loopback_without_ssrf_bypass_returns_deny() -> Result<()> {
-    let proxy = start_proxy_with_sandbox_policy(&["localhost"], false, "production").await?;
+    let proxy = start_proxy_with_workspace_policy(&["localhost"], false, "production").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "localhost", 443).await?;
@@ -915,7 +772,8 @@ async fn globally_blocklisted_domain_returns_deny() -> Result<()> {
 #[tokio::test]
 async fn dns_resolution_failure_returns_deny() -> Result<()> {
     let unresolved_domain = "sandbox-egress-contract-test.invalid";
-    let proxy = start_proxy_with_sandbox_policy(&[unresolved_domain], false, "production").await?;
+    let proxy =
+        start_proxy_with_workspace_policy(&[unresolved_domain], false, "production").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, unresolved_domain, 443).await?;
@@ -938,7 +796,7 @@ async fn empty_domain_returns_deny() -> Result<()> {
 #[tokio::test]
 async fn upstream_connect_failure_returns_deny() -> Result<()> {
     let upstream_addr = free_addr()?;
-    let proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
+    let proxy = start_proxy_with_workspace_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
 
     let response = send_handshake(&proxy, &token, "localhost", upstream_addr.port()).await?;
@@ -1061,7 +919,7 @@ async fn relay_supports_upstream_banner_and_large_response() -> Result<()> {
             response: response.clone(),
         })
         .await?;
-    let proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
+    let proxy = start_proxy_with_workspace_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
@@ -1095,7 +953,7 @@ async fn sigterm_keeps_active_tunnel_alive_until_client_closes() -> Result<()> {
             chunks: vec![b"pingpong".to_vec(), b"pingpong".to_vec()],
         })
         .await?;
-    let mut proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
+    let mut proxy = start_proxy_with_workspace_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
@@ -1129,7 +987,7 @@ async fn sigterm_keeps_active_tunnel_alive_until_client_closes() -> Result<()> {
 async fn sigterm_aborts_stuck_tunnel_after_drain_timeout() -> Result<()> {
     let (upstream_port, mut upstream_handles) =
         start_localhost_servers(UpstreamBehavior::HoldUntilPeerCloses).await?;
-    let mut proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
+    let mut proxy = start_proxy_with_workspace_policy(&["localhost"], true, "test").await?;
     let token = make_token(SECRET, 60);
     let mut stream = connect_forwarder(&proxy).await?;
 
@@ -1172,7 +1030,6 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
             workspace_new: None,
             owner: None,
             pod: None,
-            sandbox: None,
         },
         None,
         true,
@@ -1181,7 +1038,7 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
     .await?;
 
     // First request populates the cache with a policy allowing "localhost".
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token(SECRET, 60);
     let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
     assert_eq!(response, Some(ALLOW_RESPONSE));
 
@@ -1208,7 +1065,7 @@ async fn invalidate_policy_evicts_cached_workspace_entry() -> Result<()> {
 
     // After invalidation, the proxy re-fetches from GCS and gets the new policy
     // which no longer allows "localhost" — connection should be denied.
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token(SECRET, 60);
     let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
     assert_eq!(response, Some(DENY_RESPONSE));
 
@@ -1277,7 +1134,6 @@ async fn invalidate_policy_evicts_cached_owner_entry() -> Result<()> {
             workspace_new: None,
             owner: Some(policy_response(&["localhost"])),
             pod: None,
-            sandbox: None,
         },
         None,
         true,
@@ -1329,7 +1185,6 @@ async fn invalidate_policy_workspace_evicts_both_layouts() -> Result<()> {
             workspace_new: Some(policy_response(&["localhost"])),
             owner: None,
             pod: None,
-            sandbox: None,
         },
         None,
         true,
@@ -1338,7 +1193,7 @@ async fn invalidate_policy_workspace_evicts_both_layouts() -> Result<()> {
     .await?;
 
     // Populate the new-layout workspace cache entry.
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token(SECRET, 60);
     let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
     assert_eq!(response, Some(ALLOW_RESPONSE));
 
@@ -1362,7 +1217,7 @@ async fn invalidate_policy_workspace_evicts_both_layouts() -> Result<()> {
     .await?;
     assert_eq!(status, 200);
 
-    let token = make_token_with_workspace(SECRET, 60);
+    let token = make_token(SECRET, 60);
     let response = send_handshake(&proxy, &token, "localhost", upstream_port).await?;
     assert_eq!(response, Some(DENY_RESPONSE));
 
@@ -1397,7 +1252,7 @@ async fn invalidate_policy_rejects_owner_without_wid() -> Result<()> {
 #[tokio::test]
 async fn invalidate_policy_rejects_sandbox_token_without_action() -> Result<()> {
     let proxy = start_proxy(false, "production").await?;
-    let sandbox_token = make_token_with_workspace(SECRET, 60);
+    let sandbox_token = make_token(SECRET, 60);
 
     let status = http_post_status(
         proxy.health_addr,
@@ -1413,7 +1268,7 @@ async fn invalidate_policy_rejects_sandbox_token_without_action() -> Result<()> 
 
 #[tokio::test]
 async fn forwarder_rejects_token_with_action_claim() -> Result<()> {
-    let proxy = start_proxy_with_sandbox_policy(&["localhost"], true, "test").await?;
+    let proxy = start_proxy_with_workspace_policy(&["localhost"], true, "test").await?;
     // An invalidation token (has action claim) should be rejected by the forwarder.
     let token = make_invalidation_token(SECRET, 60);
 
@@ -1433,7 +1288,7 @@ async fn start_proxy(unsafe_skip_ssrf_check: bool, environment: &str) -> Result<
     .await
 }
 
-async fn start_proxy_with_sandbox_policy(
+async fn start_proxy_with_workspace_policy(
     allowed_domains: &[&str],
     unsafe_skip_ssrf_check: bool,
     environment: &str,
@@ -1441,10 +1296,9 @@ async fn start_proxy_with_sandbox_policy(
     start_proxy_with_mock_gcs(
         MockPolicies {
             workspace: None,
-            workspace_new: None,
+            workspace_new: Some(policy_response(allowed_domains)),
             owner: None,
             pod: None,
-            sandbox: Some(policy_response(allowed_domains)),
         },
         None,
         unsafe_skip_ssrf_check,
@@ -1526,9 +1380,6 @@ async fn start_mock_gcs_server(policies: MockPolicies) -> Result<MockGcsServer> 
             format!("w/{TEST_WORKSPACE_ID}/sandboxes/{TEST_POD_ID}.json"),
             pod,
         );
-    }
-    if let Some(sandbox) = policies.sandbox {
-        objects.insert(format!("sandboxes/{TEST_SANDBOX_ID}.json"), sandbox);
     }
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -1746,23 +1597,10 @@ fn build_oversized_domain_frame(token: &str) -> Vec<u8> {
     frame
 }
 
+// The baseline token: front has always minted the wId claim since the
+// owner-keyed layout, and with the legacy per-sandbox layer gone a token
+// without it can never be allowed by any policy.
 fn make_token(secret: &str, exp_offset_seconds: i64) -> String {
-    make_token_with_claims(
-        secret,
-        FullClaims {
-            sb_id: Some(TEST_SANDBOX_ID),
-            w_id: None,
-            owner_id: None,
-            pod_id: None,
-            action: None,
-            iss: "dust-front",
-            aud: "dust-egress-proxy",
-            exp_offset_seconds,
-        },
-    )
-}
-
-fn make_token_with_workspace(secret: &str, exp_offset_seconds: i64) -> String {
     make_token_with_claims(
         secret,
         FullClaims {


### PR DESCRIPTION
## Description

Removes the legacy per-sandbox egress policy layer from the proxy — the `sandboxes/{providerId}.json` lookups keyed by ephemeral provider sandbox id, superseded by the owner-keyed layout (`w/{wId}/sandboxes/{ownerId}.json`) in the relayout campaign. A domain is now allowed by the workspace, owner, or pod policy only — each still fail-closed.

**Why it is safe now:** the layer existed for pre-relayout sandboxes whose in-flight approvals lived only in the legacy file. All pre-relayout sandboxes have been manually destroyed in both regions, and the 24h egress JWT TTL retired `ownerId`-less tokens within a day of the relayout deploy — nothing writes these files and no live token resolves through them.

**Worst case for a straggler** (a pre-relayout sandbox that somehow survived the kills): its old approvals get denied and the user re-approves — the grant lands in its owner file. Fail closed; never an over-grant.

**Second commit — the legacy workspace layout dual-read** (`workspaces/{wId}.json`) also goes: the workspace policy is read from `w/{wId}/sandbox-egress-policy.json` only. The cache key stays `w2:` and the invalidation route still accepts (and no-ops) `sbId`-only eviction tokens, so invalidations minted by older front builds keep working through the deploy transition.

The front half (destroy-path scrub + dual-write removal) is the companion PR `30469`; merge order between the two does not matter.

> [!NOTE]
> Gate satisfied: the `30468` backfill dry run (2026-08-12) verified **zero uncopied legacy objects in both regions** (US 67/67, EU 66/66 already covered by the dual-write) — the backfill itself was unnecessary and its PR is closed. Legacy-only files cannot reappear: the legacy path's only writer also writes the new path.

## Risk

None expected: the layer is unreachable by any live token. Worst case is the straggler scenario above — fail closed, self-serviced by a re-approval. Safe to rollback.

## Deploy Plan

- [x] Verified zero legacy-only workspace objects in both regions (dry run, 2026-08-12)
- [ ] Deploy egress-proxy (both regions)
- [ ] Delete legacy `workspaces/*.json` objects (nothing reads them once this deploys)
- [ ] Optional tidy-up: remove leftover `sandboxes/*.json` objects from the policy buckets — the bucket in each region's `EGRESS_PROXY_POLICY_BUCKET` (nothing reads them anymore): `gsutil -m rm "gs://<bucket>/sandboxes/*.json"`

## Tests

81 green — the legacy-compat cases are deleted with the layer, the baseline test token now carries `wId` (matching every token front has minted since the relayout), a regression test pins `sbId`-only tokens denied even with a permissive workspace policy, and GCS-error fail-closed coverage moved to the owner layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
