### PR TITLE
[Activation] Slack auto-responder skip thread replies option

### DIFF
--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -20,7 +20,10 @@ const PatchSlackChannelsLinkedWithAgentReqBodySchema = t.type({
   slack_channel_internal_ids: t.array(t.string),
   connector_id: t.string,
   auto_respond_without_mention: t.union([t.boolean, t.undefined]),
-  auto_respond_without_mention_skip_thread_replies: t.union([t.boolean, t.undefined]),
+  auto_respond_without_mention_skip_thread_replies: t.union([
+    t.boolean,
+    t.undefined,
+  ]),
 });
 
 type PatchSlackChannelsLinkedWithAgentReqBody = t.TypeOf<
@@ -59,7 +62,8 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     agent_configuration_id: agentConfigurationId,
     slack_channel_internal_ids: slackChannelInternalIds,
     auto_respond_without_mention: autoRespondWithoutMention,
-    auto_respond_without_mention_skip_thread_replies: autoRespondWithoutMentionSkipThreadReplies,
+    auto_respond_without_mention_skip_thread_replies:
+      autoRespondWithoutMentionSkipThreadReplies,
   } = bodyValidation.right;
 
   const slackChannelIds = slackChannelInternalIds.map((s) =>
@@ -113,7 +117,8 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
                 permission: "write",
                 private: !!remoteChannel.is_private,
                 autoRespondWithoutMention: autoRespondWithoutMention ?? false,
-                autoRespondWithoutMentionSkipThreadReplies: autoRespondWithoutMentionSkipThreadReplies ?? false,
+                autoRespondWithoutMentionSkipThreadReplies:
+                  autoRespondWithoutMentionSkipThreadReplies ?? false,
               },
               {
                 transaction: t,
@@ -144,7 +149,8 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
           {
             agentConfigurationId,
             autoRespondWithoutMention: autoRespondWithoutMention ?? false,
-            autoRespondWithoutMentionSkipThreadReplies: autoRespondWithoutMentionSkipThreadReplies ?? false,
+            autoRespondWithoutMentionSkipThreadReplies:
+              autoRespondWithoutMentionSkipThreadReplies ?? false,
           },
           { where: { connectorId, slackChannelId }, transaction: t }
         )
@@ -248,7 +254,8 @@ const _getSlackChannelsLinkedWithAgentHandler = async (
 
       agentConfigurationId: c.agentConfigurationId!,
       autoRespondWithoutMention: c.autoRespondWithoutMention,
-      autoRespondWithoutMentionSkipThreadReplies: c.autoRespondWithoutMentionSkipThreadReplies,
+      autoRespondWithoutMentionSkipThreadReplies:
+        c.autoRespondWithoutMentionSkipThreadReplies,
     })),
   });
 };

--- a/connectors/src/api/slack_channels_linked_with_agent.ts
+++ b/connectors/src/api/slack_channels_linked_with_agent.ts
@@ -20,6 +20,7 @@ const PatchSlackChannelsLinkedWithAgentReqBodySchema = t.type({
   slack_channel_internal_ids: t.array(t.string),
   connector_id: t.string,
   auto_respond_without_mention: t.union([t.boolean, t.undefined]),
+  auto_respond_without_mention_skip_thread_replies: t.union([t.boolean, t.undefined]),
 });
 
 type PatchSlackChannelsLinkedWithAgentReqBody = t.TypeOf<
@@ -58,6 +59,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
     agent_configuration_id: agentConfigurationId,
     slack_channel_internal_ids: slackChannelInternalIds,
     auto_respond_without_mention: autoRespondWithoutMention,
+    auto_respond_without_mention_skip_thread_replies: autoRespondWithoutMentionSkipThreadReplies,
   } = bodyValidation.right;
 
   const slackChannelIds = slackChannelInternalIds.map((s) =>
@@ -111,6 +113,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
                 permission: "write",
                 private: !!remoteChannel.is_private,
                 autoRespondWithoutMention: autoRespondWithoutMention ?? false,
+                autoRespondWithoutMentionSkipThreadReplies: autoRespondWithoutMentionSkipThreadReplies ?? false,
               },
               {
                 transaction: t,
@@ -141,6 +144,7 @@ const _patchSlackChannelsLinkedWithAgentHandler = async (
           {
             agentConfigurationId,
             autoRespondWithoutMention: autoRespondWithoutMention ?? false,
+            autoRespondWithoutMentionSkipThreadReplies: autoRespondWithoutMentionSkipThreadReplies ?? false,
           },
           { where: { connectorId, slackChannelId }, transaction: t }
         )
@@ -207,6 +211,7 @@ type GetSlackChannelsLinkedWithAgentResBody = WithConnectorsAPIErrorReponse<{
     slackChannelName: string;
     agentConfigurationId: string;
     autoRespondWithoutMention: boolean;
+    autoRespondWithoutMentionSkipThreadReplies: boolean;
   }[];
 }>;
 
@@ -243,6 +248,7 @@ const _getSlackChannelsLinkedWithAgentHandler = async (
 
       agentConfigurationId: c.agentConfigurationId!,
       autoRespondWithoutMention: c.autoRespondWithoutMention,
+      autoRespondWithoutMentionSkipThreadReplies: c.autoRespondWithoutMentionSkipThreadReplies,
     })),
   });
 };

--- a/connectors/src/api/webhooks/webhook_slack_bot.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot.ts
@@ -210,7 +210,10 @@ const _webhookSlackBotAPIHandler = async (
                   const isThreadReply =
                     !!event.thread_ts && event.thread_ts !== event.ts;
 
-                  if (isThreadReply && channel.autoRespondWithoutMentionSkipThreadReplies) {
+                  if (
+                    isThreadReply &&
+                    channel.autoRespondWithoutMentionSkipThreadReplies
+                  ) {
                     logger.info(
                       {
                         slackChannelId: event.channel,
@@ -227,7 +230,8 @@ const _webhookSlackBotAPIHandler = async (
                       agentConfigurationId: channel.agentConfigurationId,
                       autoRespondWithoutMention:
                         channel.autoRespondWithoutMention,
-                      autoRespondWithoutMentionSkipThreadReplies: channel.autoRespondWithoutMentionSkipThreadReplies,
+                      autoRespondWithoutMentionSkipThreadReplies:
+                        channel.autoRespondWithoutMentionSkipThreadReplies,
                     },
                     "Found enhanced default agent for channel - processing message"
                   );

--- a/connectors/src/api/webhooks/webhook_slack_bot.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot.ts
@@ -206,12 +206,28 @@ const _webhookSlackBotAPIHandler = async (
                   );
 
                 if (channel && channel.agentConfigurationId) {
+                  // A thread reply has thread_ts set to the parent message ts, which differs from its own ts.
+                  const isThreadReply =
+                    !!event.thread_ts && event.thread_ts !== event.ts;
+
+                  if (isThreadReply && channel.autoRespondWithoutMentionSkipThreadReplies) {
+                    logger.info(
+                      {
+                        slackChannelId: event.channel,
+                        agentConfigurationId: channel.agentConfigurationId,
+                      },
+                      "Skipping thread reply - channel configured for top-level posts only"
+                    );
+                    return res.status(200).send();
+                  }
+
                   logger.info(
                     {
                       slackChannelId: event.channel,
                       agentConfigurationId: channel.agentConfigurationId,
                       autoRespondWithoutMention:
                         channel.autoRespondWithoutMention,
+                      autoRespondWithoutMentionSkipThreadReplies: channel.autoRespondWithoutMentionSkipThreadReplies,
                     },
                     "Found enhanced default agent for channel - processing message"
                   );

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -20,6 +20,7 @@ const PatchLinkedSlackChannelsRequestBodySchema = z.object({
   slack_channel_internal_ids: z.array(z.string()),
   provider: z.enum(["slack", "slack_bot"]),
   auto_respond_without_mention: z.boolean().optional(),
+  auto_respond_without_mention_skip_thread_replies: z.boolean().optional(),
 });
 
 // Mounted at /api/w/:wId/assistant/agent_configurations/:aId/linked_slack_channels.
@@ -110,6 +111,7 @@ app.patch(
       agentConfigurationId: agentConfiguration.sId,
       slackChannelInternalIds: body.slack_channel_internal_ids,
       autoRespondWithoutMention: body.auto_respond_without_mention,
+      skipThreadReplies: body.auto_respond_without_mention_skip_thread_replies,
     });
 
     if (connectorsApiRes.isErr()) {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -111,7 +111,8 @@ app.patch(
       agentConfigurationId: agentConfiguration.sId,
       slackChannelInternalIds: body.slack_channel_internal_ids,
       autoRespondWithoutMention: body.auto_respond_without_mention,
-      skipThreadReplies: body.auto_respond_without_mention_skip_thread_replies,
+      autoRespondWithoutMentionSkipThreadReplies:
+        body.auto_respond_without_mention_skip_thread_replies,
     });
 
     if (connectorsApiRes.isErr()) {

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -294,7 +294,8 @@ function AgentBuilderForm({
         slackChannelId: channel.slackChannelId,
         slackChannelName: channel.slackChannelName,
         autoRespondWithoutMention: channel.autoRespondWithoutMention,
-        autoRespondWithoutMentionSkipThreadReplies: channel.autoRespondWithoutMentionSkipThreadReplies,
+        autoRespondWithoutMentionSkipThreadReplies:
+          channel.autoRespondWithoutMentionSkipThreadReplies,
       }));
   }, [agentConfiguration, slackChannelsLinkedWithAgent]);
 

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -294,6 +294,7 @@ function AgentBuilderForm({
         slackChannelId: channel.slackChannelId,
         slackChannelName: channel.slackChannelName,
         autoRespondWithoutMention: channel.autoRespondWithoutMention,
+        autoRespondWithoutMentionSkipThreadReplies: channel.autoRespondWithoutMentionSkipThreadReplies,
       }));
   }, [agentConfiguration, slackChannelsLinkedWithAgent]);
 

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -35,6 +35,7 @@ const agentSettingsSchema = z.object({
       slackChannelId: z.string(),
       slackChannelName: z.string(),
       autoRespondWithoutMention: z.boolean().optional(),
+      autoRespondWithoutMentionSkipThreadReplies: z.boolean().optional(),
     })
   ),
   tags: z.array(tagSchema),

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -8,6 +8,7 @@ import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
   Button,
+  CheckBoxWithTextAndDescription,
   Checkbox,
   ContentMessage,
   Icon,
@@ -49,7 +50,7 @@ type SheetAction =
   | { type: "sync"; channels: SlackChannel[] }
   | { type: "set_channels"; channels: SlackChannel[] }
   | { type: "toggle_auto_respond" }
-  | { type: "toggle_skip_thread_replies" };
+  | { type: "set_skip_thread_replies"; value: boolean };
 
 function sheetReducer(state: SheetState, action: SheetAction): SheetState {
   switch (action.type) {
@@ -72,10 +73,10 @@ function sheetReducer(state: SheetState, action: SheetAction): SheetState {
         skipThreadRepliesEnabled: next ? state.skipThreadRepliesEnabled : false,
       };
     }
-    case "toggle_skip_thread_replies":
+    case "set_skip_thread_replies":
       return {
         ...state,
-        skipThreadRepliesEnabled: !state.skipThreadRepliesEnabled,
+        skipThreadRepliesEnabled: action.value,
       };
     default:
       return assertNever(action);
@@ -404,25 +405,18 @@ export function SlackSettingsSheet({
                   onClick={() => dispatch({ type: "toggle_auto_respond" })}
                 />
               </div>
-              {autoRespondWithoutMentionEnabled && (
-                <div className="flex items-center justify-between gap-4">
-                  <div className="flex min-w-0 flex-1 flex-col gap-1">
-                    <span className="text-sm font-medium text-foreground">
-                      Top-level posts only
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      Only respond to new channel messages, not replies within
-                      threads
-                    </span>
-                  </div>
-                  <SliderToggle
-                    selected={skipThreadRepliesEnabled}
-                    onClick={() =>
-                      dispatch({ type: "toggle_skip_thread_replies" })
-                    }
-                  />
-                </div>
-              )}
+              <CheckBoxWithTextAndDescription
+                text="Top-level posts only"
+                description="Only respond to new channel messages, not replies within threads"
+                checked={skipThreadRepliesEnabled}
+                disabled={!autoRespondWithoutMentionEnabled}
+                onCheckedChange={(checked) =>
+                  dispatch({
+                    type: "set_skip_thread_replies",
+                    value: checked === true,
+                  })
+                }
+              />
             </div>
           )}
         </SheetFooter>

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -1,13 +1,7 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { useSendNotification } from "@app/hooks/useNotification";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { useSlackUserPrivateChannels } from "@app/lib/swr/assistants";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
-import {
-  useCreatePersonalConnection,
-  useMCPServer,
-} from "@app/lib/swr/mcp_servers";
 import type { DataSourceType } from "@app/types/data_source";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
@@ -17,7 +11,6 @@ import {
   ContentMessage,
   Icon,
   LinkExternal01,
-  Lock01,
   SearchInput,
   Sheet,
   SheetContainer,
@@ -43,7 +36,6 @@ type SlackChannel = {
   sourceUrl?: string | null;
   autoRespondWithoutMention?: boolean;
   autoRespondWithoutMentionSkipThreadReplies?: boolean;
-  isPrivate?: boolean;
 };
 
 interface SlackChannelsListProps {
@@ -62,10 +54,6 @@ function SlackChannelsList({
   slackDataSource,
 }: SlackChannelsListProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [isConnectingPersonalSlack, setIsConnectingPersonalSlack] =
-    useState(false);
-  const sendNotification = useSendNotification();
-  const { createPersonalConnection } = useCreatePersonalConnection(owner);
 
   const { resources, isResourcesLoading, isResourcesError } =
     useConnectorPermissions({
@@ -77,24 +65,7 @@ function SlackChannelsList({
       viewType: "all",
     });
 
-  const {
-    status: privateChannelsStatus,
-    privateChannels,
-    mcpServerId,
-    isPrivateChannelsLoading,
-    mutatePrivateChannels,
-  } = useSlackUserPrivateChannels({
-    workspaceId: owner.sId,
-    disabled,
-  });
-
-  const { server: slackMcpServer } = useMCPServer({
-    owner,
-    serverId: mcpServerId ?? "",
-    disabled: !mcpServerId || privateChannelsStatus !== "not_connected",
-  });
-
-  const publicChannels = useMemo(() => {
+  const filteredChannels = useMemo(() => {
     if (!resources) {
       return [];
     }
@@ -109,41 +80,15 @@ function SlackChannelsList({
         ),
         slackChannelName: resource.title,
         sourceUrl: resource.sourceUrl,
-        isPrivate: false as const,
-      }));
-  }, [resources]);
-
-  const mergedChannels = useMemo(() => {
-    const byId = new Map<string, SlackChannel>();
-
-    for (const channel of publicChannels) {
-      byId.set(channel.slackChannelId, channel);
-    }
-
-    for (const channel of privateChannels) {
-      // Prefer the private-channel entry so admins see the lock affordance.
-      byId.set(channel.slackChannelId, {
-        slackChannelId: channel.slackChannelId,
-        slackChannelName: channel.slackChannelName,
-        sourceUrl: channel.sourceUrl,
-        isPrivate: true,
-      });
-    }
-
-    return Array.from(byId.values()).sort((a, b) =>
-      a.slackChannelName.localeCompare(b.slackChannelName)
-    );
-  }, [publicChannels, privateChannels]);
-
-  const filteredChannels = useMemo(() => {
-    if (searchQuery.trim() === "") {
-      return mergedChannels;
-    }
-    const query = searchQuery.toLowerCase();
-    return mergedChannels.filter((channel) =>
-      channel.slackChannelName.toLowerCase().includes(query)
-    );
-  }, [mergedChannels, searchQuery]);
+      }))
+      .filter(
+        (channel) =>
+          searchQuery.trim() === "" ||
+          channel.slackChannelName
+            .toLowerCase()
+            .includes(searchQuery.toLowerCase())
+      );
+  }, [resources, searchQuery]);
 
   const handleChannelToggle = useCallback(
     (channel: SlackChannel, isChecked?: boolean) => {
@@ -157,7 +102,6 @@ function SlackChannelsList({
           slackChannelId: channel.slackChannelId,
           slackChannelName: channel.slackChannelName,
           sourceUrl: channel.sourceUrl,
-          isPrivate: channel.isPrivate,
         };
         onSelectionChange([...existingSelection, channelForSelection]);
       } else {
@@ -179,55 +123,6 @@ function SlackChannelsList({
     [existingSelection]
   );
 
-  const handleConnectPersonalSlack = useCallback(async () => {
-    if (!mcpServerId || !slackMcpServer?.authorization) {
-      sendNotification({
-        type: "error",
-        title: "Slack Tools unavailable",
-        description:
-          "Activate Slack Tools in your workspace and try again, or ask an admin.",
-      });
-      return;
-    }
-
-    setIsConnectingPersonalSlack(true);
-    try {
-      const result = await createPersonalConnection({
-        mcpServerId,
-        mcpServerDisplayName: "Slack",
-        authorization: slackMcpServer.authorization,
-        provider: "slack_tools",
-        useCase: "personal_actions",
-      });
-
-      if (!result.success) {
-        sendNotification({
-          type: "error",
-          title: "Failed to connect Slack",
-          description:
-            result.error ?? "Could not connect your Slack account. Try again.",
-        });
-        return;
-      }
-
-      await mutatePrivateChannels();
-      sendNotification({
-        type: "success",
-        title: "Slack connected",
-        description:
-          "Private channels you belong to can now appear in this list.",
-      });
-    } finally {
-      setIsConnectingPersonalSlack(false);
-    }
-  }, [
-    createPersonalConnection,
-    mcpServerId,
-    mutatePrivateChannels,
-    sendNotification,
-    slackMcpServer?.authorization,
-  ]);
-
   if (isResourcesError) {
     return (
       <div className="text-sm text-warning">
@@ -236,65 +131,8 @@ function SlackChannelsList({
     );
   }
 
-  const isLoading = isResourcesLoading || isPrivateChannelsLoading;
-
   return (
     <div className="space-y-4">
-      {privateChannelsStatus === "not_connected" && (
-        <ContentMessage
-          size="md"
-          variant="info"
-          title="Show private channels"
-          icon={Lock01}
-        >
-          <div className="flex flex-col gap-3">
-            <p>
-              Connect your personal Slack account to list private channels you
-              are a member of (and where the Dust app is present). This stays
-              scoped to you — other admins will not see your private channels.
-            </p>
-            <div>
-              <Button
-                label={
-                  isConnectingPersonalSlack
-                    ? "Connecting..."
-                    : "Connect Slack account"
-                }
-                variant="outline"
-                size="sm"
-                icon={SlackLogo}
-                disabled={isConnectingPersonalSlack || !mcpServerId}
-                onClick={() => {
-                  void handleConnectPersonalSlack();
-                }}
-              />
-            </div>
-          </div>
-        </ContentMessage>
-      )}
-
-      {privateChannelsStatus === "tool_unavailable" && (
-        <ContentMessage
-          size="md"
-          variant="warning"
-          title="Private channels unavailable"
-          icon={InformationCircleIcon}
-        >
-          <p>
-            Activate the Slack Tools integration in your workspace to list
-            private channels you belong to.
-          </p>
-        </ContentMessage>
-      )}
-
-      {privateChannelsStatus === "ok" && privateChannels.length > 0 && (
-        <div className="text-xs text-muted-foreground">
-          Including {privateChannels.length} private channel
-          {privateChannels.length === 1 ? "" : "s"} from your Slack account.
-          Dust must still be added to a private channel to reply there.
-        </div>
-      )}
-
       <SearchInput
         name="slack-channel-search"
         placeholder="Search channels..."
@@ -302,7 +140,7 @@ function SlackChannelsList({
         onChange={setSearchQuery}
       />
 
-      {isLoading ? (
+      {isResourcesLoading ? (
         <div className="flex justify-center py-8">
           <Spinner size="sm" />
         </div>
@@ -332,13 +170,6 @@ function SlackChannelsList({
                   <span className="text-sm font-medium text-primary-900">
                     {channel.slackChannelName}
                   </span>
-                  {channel.isPrivate && (
-                    <Icon
-                      visual={Lock01}
-                      size="xs"
-                      className="text-muted-foreground"
-                    />
-                  )}
                 </div>
                 {channel.sourceUrl && (
                   <div className="opacity-0 transition-opacity group-hover:opacity-100">

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -373,7 +373,7 @@ export function SlackSettingsSheet({
         >
           {hasFeature("slack_enhanced_default_agent") && isAdmin(owner) && (
             <div className="flex flex-col gap-3 border-t p-4">
-              <div className="flex items-start justify-between gap-4">
+              <div className="flex items-center justify-between gap-4">
                 <div className="flex min-w-0 flex-1 flex-col gap-1">
                   <span className="text-sm font-medium text-foreground">
                     Respond to all messages in channel
@@ -383,40 +383,39 @@ export function SlackSettingsSheet({
                     channels (not just @mentions)
                   </span>
                 </div>
-                <div className="flex-shrink-0">
-                  <SliderToggle
-                    selected={autoRespondWithoutMentionEnabled}
-                    onClick={() => {
-                      const next = !autoRespondWithoutMentionEnabled;
-                      setAutoRespondWithoutMentionEnabled(next);
-                      if (!next) {
-                        setSkipThreadRepliesEnabled(false);
-                      }
-                    }}
-                  />
-                </div>
+                <SliderToggle
+                  selected={autoRespondWithoutMentionEnabled}
+                  onClick={() => {
+                    const next = !autoRespondWithoutMentionEnabled;
+                    setAutoRespondWithoutMentionEnabled(next);
+                    if (!next) {
+                      setSkipThreadRepliesEnabled(false);
+                    }
+                  }}
+                />
               </div>
-              {autoRespondWithoutMentionEnabled && (
-                <div className="ml-4 flex items-start justify-between gap-4 border-l pl-4">
-                  <div className="flex min-w-0 flex-1 flex-col gap-1">
-                    <span className="text-sm font-medium text-foreground">
-                      Top-level posts only
-                    </span>
-                    <span className="text-xs text-muted-foreground">
-                      Only respond to new channel messages, not to replies
-                      within threads
-                    </span>
-                  </div>
-                  <div className="flex-shrink-0">
-                    <SliderToggle
-                      selected={autoRespondWithoutMentionSkipThreadRepliesEnabled}
-                      onClick={() =>
-                        setSkipThreadRepliesEnabled(!autoRespondWithoutMentionSkipThreadRepliesEnabled)
-                      }
-                    />
-                  </div>
+              <div
+                className={`flex items-center justify-between gap-4 pl-4 ${!autoRespondWithoutMentionEnabled ? "cursor-not-allowed opacity-50" : ""}`}
+              >
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <span className="text-sm font-medium text-foreground">
+                    Top-level posts only
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Only respond to new channel messages, not replies within
+                    threads
+                  </span>
                 </div>
-              )}
+                <SliderToggle
+                  selected={autoRespondWithoutMentionSkipThreadRepliesEnabled}
+                  disabled={!autoRespondWithoutMentionEnabled}
+                  onClick={() =>
+                    setSkipThreadRepliesEnabled(
+                      !autoRespondWithoutMentionSkipThreadRepliesEnabled
+                    )
+                  }
+                />
+              </div>
             </div>
           )}
         </SheetFooter>

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -1,7 +1,13 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useSlackUserPrivateChannels } from "@app/lib/swr/assistants";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
+import {
+  useCreatePersonalConnection,
+  useMCPServer,
+} from "@app/lib/swr/mcp_servers";
 import type { DataSourceType } from "@app/types/data_source";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
@@ -11,6 +17,7 @@ import {
   ContentMessage,
   Icon,
   LinkExternal01,
+  Lock01,
   SearchInput,
   Sheet,
   SheetContainer,
@@ -36,6 +43,7 @@ type SlackChannel = {
   sourceUrl?: string | null;
   autoRespondWithoutMention?: boolean;
   autoRespondWithoutMentionSkipThreadReplies?: boolean;
+  isPrivate?: boolean;
 };
 
 interface SlackChannelsListProps {
@@ -54,6 +62,10 @@ function SlackChannelsList({
   slackDataSource,
 }: SlackChannelsListProps) {
   const [searchQuery, setSearchQuery] = useState("");
+  const [isConnectingPersonalSlack, setIsConnectingPersonalSlack] =
+    useState(false);
+  const sendNotification = useSendNotification();
+  const { createPersonalConnection } = useCreatePersonalConnection(owner);
 
   const { resources, isResourcesLoading, isResourcesError } =
     useConnectorPermissions({
@@ -65,7 +77,24 @@ function SlackChannelsList({
       viewType: "all",
     });
 
-  const filteredChannels = useMemo(() => {
+  const {
+    status: privateChannelsStatus,
+    privateChannels,
+    mcpServerId,
+    isPrivateChannelsLoading,
+    mutatePrivateChannels,
+  } = useSlackUserPrivateChannels({
+    workspaceId: owner.sId,
+    disabled,
+  });
+
+  const { server: slackMcpServer } = useMCPServer({
+    owner,
+    serverId: mcpServerId ?? "",
+    disabled: !mcpServerId || privateChannelsStatus !== "not_connected",
+  });
+
+  const publicChannels = useMemo(() => {
     if (!resources) {
       return [];
     }
@@ -80,15 +109,41 @@ function SlackChannelsList({
         ),
         slackChannelName: resource.title,
         sourceUrl: resource.sourceUrl,
-      }))
-      .filter(
-        (channel) =>
-          searchQuery.trim() === "" ||
-          channel.slackChannelName
-            .toLowerCase()
-            .includes(searchQuery.toLowerCase())
-      );
-  }, [resources, searchQuery]);
+        isPrivate: false as const,
+      }));
+  }, [resources]);
+
+  const mergedChannels = useMemo(() => {
+    const byId = new Map<string, SlackChannel>();
+
+    for (const channel of publicChannels) {
+      byId.set(channel.slackChannelId, channel);
+    }
+
+    for (const channel of privateChannels) {
+      // Prefer the private-channel entry so admins see the lock affordance.
+      byId.set(channel.slackChannelId, {
+        slackChannelId: channel.slackChannelId,
+        slackChannelName: channel.slackChannelName,
+        sourceUrl: channel.sourceUrl,
+        isPrivate: true,
+      });
+    }
+
+    return Array.from(byId.values()).sort((a, b) =>
+      a.slackChannelName.localeCompare(b.slackChannelName)
+    );
+  }, [publicChannels, privateChannels]);
+
+  const filteredChannels = useMemo(() => {
+    if (searchQuery.trim() === "") {
+      return mergedChannels;
+    }
+    const query = searchQuery.toLowerCase();
+    return mergedChannels.filter((channel) =>
+      channel.slackChannelName.toLowerCase().includes(query)
+    );
+  }, [mergedChannels, searchQuery]);
 
   const handleChannelToggle = useCallback(
     (channel: SlackChannel, isChecked?: boolean) => {
@@ -102,6 +157,7 @@ function SlackChannelsList({
           slackChannelId: channel.slackChannelId,
           slackChannelName: channel.slackChannelName,
           sourceUrl: channel.sourceUrl,
+          isPrivate: channel.isPrivate,
         };
         onSelectionChange([...existingSelection, channelForSelection]);
       } else {
@@ -123,6 +179,55 @@ function SlackChannelsList({
     [existingSelection]
   );
 
+  const handleConnectPersonalSlack = useCallback(async () => {
+    if (!mcpServerId || !slackMcpServer?.authorization) {
+      sendNotification({
+        type: "error",
+        title: "Slack Tools unavailable",
+        description:
+          "Activate Slack Tools in your workspace and try again, or ask an admin.",
+      });
+      return;
+    }
+
+    setIsConnectingPersonalSlack(true);
+    try {
+      const result = await createPersonalConnection({
+        mcpServerId,
+        mcpServerDisplayName: "Slack",
+        authorization: slackMcpServer.authorization,
+        provider: "slack_tools",
+        useCase: "personal_actions",
+      });
+
+      if (!result.success) {
+        sendNotification({
+          type: "error",
+          title: "Failed to connect Slack",
+          description:
+            result.error ?? "Could not connect your Slack account. Try again.",
+        });
+        return;
+      }
+
+      await mutatePrivateChannels();
+      sendNotification({
+        type: "success",
+        title: "Slack connected",
+        description:
+          "Private channels you belong to can now appear in this list.",
+      });
+    } finally {
+      setIsConnectingPersonalSlack(false);
+    }
+  }, [
+    createPersonalConnection,
+    mcpServerId,
+    mutatePrivateChannels,
+    sendNotification,
+    slackMcpServer?.authorization,
+  ]);
+
   if (isResourcesError) {
     return (
       <div className="text-sm text-warning">
@@ -131,8 +236,65 @@ function SlackChannelsList({
     );
   }
 
+  const isLoading = isResourcesLoading || isPrivateChannelsLoading;
+
   return (
     <div className="space-y-4">
+      {privateChannelsStatus === "not_connected" && (
+        <ContentMessage
+          size="md"
+          variant="info"
+          title="Show private channels"
+          icon={Lock01}
+        >
+          <div className="flex flex-col gap-3">
+            <p>
+              Connect your personal Slack account to list private channels you
+              are a member of (and where the Dust app is present). This stays
+              scoped to you — other admins will not see your private channels.
+            </p>
+            <div>
+              <Button
+                label={
+                  isConnectingPersonalSlack
+                    ? "Connecting..."
+                    : "Connect Slack account"
+                }
+                variant="outline"
+                size="sm"
+                icon={SlackLogo}
+                disabled={isConnectingPersonalSlack || !mcpServerId}
+                onClick={() => {
+                  void handleConnectPersonalSlack();
+                }}
+              />
+            </div>
+          </div>
+        </ContentMessage>
+      )}
+
+      {privateChannelsStatus === "tool_unavailable" && (
+        <ContentMessage
+          size="md"
+          variant="warning"
+          title="Private channels unavailable"
+          icon={InformationCircleIcon}
+        >
+          <p>
+            Activate the Slack Tools integration in your workspace to list
+            private channels you belong to.
+          </p>
+        </ContentMessage>
+      )}
+
+      {privateChannelsStatus === "ok" && privateChannels.length > 0 && (
+        <div className="text-xs text-muted-foreground">
+          Including {privateChannels.length} private channel
+          {privateChannels.length === 1 ? "" : "s"} from your Slack account.
+          Dust must still be added to a private channel to reply there.
+        </div>
+      )}
+
       <SearchInput
         name="slack-channel-search"
         placeholder="Search channels..."
@@ -140,7 +302,7 @@ function SlackChannelsList({
         onChange={setSearchQuery}
       />
 
-      {isResourcesLoading ? (
+      {isLoading ? (
         <div className="flex justify-center py-8">
           <Spinner size="sm" />
         </div>
@@ -170,6 +332,13 @@ function SlackChannelsList({
                   <span className="text-sm font-medium text-primary-900">
                     {channel.slackChannelName}
                   </span>
+                  {channel.isPrivate && (
+                    <Icon
+                      visual={Lock01}
+                      size="xs"
+                      className="text-muted-foreground"
+                    />
+                  )}
                 </div>
                 {channel.sourceUrl && (
                   <div className="opacity-0 transition-opacity group-hover:opacity-100">
@@ -213,20 +382,24 @@ export function SlackSettingsSheet({
 
   const stateFromChannels = useCallback(
     (channels: typeof slackChannels) => {
-      const ch = channels || [];
+      const ch = channels ?? [];
       return {
         localSlackChannels: [...ch],
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        autoRespondWithoutMentionEnabled: ch[0]?.autoRespondWithoutMention || false,
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        skipThreadRepliesEnabled: ch[0]?.autoRespondWithoutMentionSkipThreadReplies || false,
+        autoRespondWithoutMentionEnabled:
+          ch[0]?.autoRespondWithoutMention ?? false,
+        skipThreadRepliesEnabled:
+          ch[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false,
       };
     },
     []
   );
 
   const [
-    { localSlackChannels, autoRespondWithoutMentionEnabled, skipThreadRepliesEnabled },
+    {
+      localSlackChannels,
+      autoRespondWithoutMentionEnabled,
+      skipThreadRepliesEnabled,
+    },
     setLocalState,
   ] = useState(() => stateFromChannels(slackChannels));
 
@@ -248,9 +421,8 @@ export function SlackSettingsSheet({
     const channelsWithSettings = localSlackChannels.map((channel) => ({
       ...channel,
       autoRespondWithoutMention: autoRespondWithoutMentionEnabled,
-      autoRespondWithoutMentionSkipThreadReplies: autoRespondWithoutMentionEnabled
-        ? skipThreadRepliesEnabled
-        : false,
+      autoRespondWithoutMentionSkipThreadReplies:
+        autoRespondWithoutMentionEnabled ? skipThreadRepliesEnabled : false,
     }));
     onChange(channelsWithSettings);
     onOpenChange();
@@ -263,7 +435,7 @@ export function SlackSettingsSheet({
 
   const hasUnsavedChanges = useMemo(() => {
     const currentChannelIds = new Set(
-      (slackChannels || []).map((c) => c.slackChannelId)
+      (slackChannels ?? []).map((c) => c.slackChannelId)
     );
     const localChannelIds = new Set(
       localSlackChannels.map((c) => c.slackChannelId)
@@ -277,10 +449,11 @@ export function SlackSettingsSheet({
       (id) => !localChannelIds.has(id as string)
     );
 
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const savedAutoRespond = (slackChannels || [])[0]?.autoRespondWithoutMention || false;
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const savedSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
+    const savedAutoRespond =
+      (slackChannels ?? [])[0]?.autoRespondWithoutMention ?? false;
+    const savedSkipThreadReplies =
+      (slackChannels ?? [])[0]?.autoRespondWithoutMentionSkipThreadReplies ??
+      false;
 
     return (
       channelSelectionChanged ||
@@ -371,10 +544,12 @@ export function SlackSettingsSheet({
                   onClick={() =>
                     setLocalState((prev) => ({
                       ...prev,
-                      autoRespondWithoutMentionEnabled: !prev.autoRespondWithoutMentionEnabled,
-                      skipThreadRepliesEnabled: prev.autoRespondWithoutMentionEnabled
-                        ? false
-                        : prev.skipThreadRepliesEnabled,
+                      autoRespondWithoutMentionEnabled:
+                        !prev.autoRespondWithoutMentionEnabled,
+                      skipThreadRepliesEnabled:
+                        prev.autoRespondWithoutMentionEnabled
+                          ? false
+                          : prev.skipThreadRepliesEnabled,
                     }))
                   }
                 />
@@ -395,7 +570,8 @@ export function SlackSettingsSheet({
                     onClick={() =>
                       setLocalState((prev) => ({
                         ...prev,
-                        skipThreadRepliesEnabled: !prev.skipThreadRepliesEnabled,
+                        skipThreadRepliesEnabled:
+                          !prev.skipThreadRepliesEnabled,
                       }))
                     }
                   />

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -26,7 +26,7 @@ import {
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useReducer } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { useController } from "react-hook-form";
 
 const SLACK_CHANNEL_INTERNAL_ID_PREFIX = "slack-channel-";

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -35,6 +35,7 @@ type SlackChannel = {
   slackChannelName: string;
   sourceUrl?: string | null;
   autoRespondWithoutMention?: boolean;
+  autoRespondWithoutMentionSkipThreadReplies?: boolean;
 };
 
 interface SlackChannelsListProps {
@@ -210,6 +211,8 @@ export function SlackSettingsSheet({
     autoRespondWithoutMentionEnabled,
     setAutoRespondWithoutMentionEnabled,
   ] = useState(false);
+  const [autoRespondWithoutMentionSkipThreadRepliesEnabled, setSkipThreadRepliesEnabled] =
+    useState(false);
 
   const {
     field: { onChange, value: slackChannels },
@@ -223,6 +226,9 @@ export function SlackSettingsSheet({
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (slackChannels || [])[0]?.autoRespondWithoutMention || false;
     setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const currentSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
+    setSkipThreadRepliesEnabled(currentSkipThreadReplies);
   }, [slackChannels]);
 
   useEffect(() => {
@@ -232,6 +238,9 @@ export function SlackSettingsSheet({
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         (slackChannels || [])[0]?.autoRespondWithoutMention || false;
       setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      const currentSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
+      setSkipThreadRepliesEnabled(currentSkipThreadReplies);
     }
   }, [isOpen, slackChannels]);
 
@@ -240,13 +249,14 @@ export function SlackSettingsSheet({
   };
 
   const onSave = () => {
-    const channelsWithAutoRespondWithoutMention = localSlackChannels.map(
-      (channel) => ({
-        ...channel,
-        autoRespondWithoutMention: autoRespondWithoutMentionEnabled,
-      })
-    );
-    onChange(channelsWithAutoRespondWithoutMention);
+    const channelsWithSettings = localSlackChannels.map((channel) => ({
+      ...channel,
+      autoRespondWithoutMention: autoRespondWithoutMentionEnabled,
+      autoRespondWithoutMentionSkipThreadReplies: autoRespondWithoutMentionEnabled
+        ? autoRespondWithoutMentionSkipThreadRepliesEnabled
+        : false,
+    }));
+    onChange(channelsWithSettings);
     onOpenChange();
   };
 
@@ -256,6 +266,9 @@ export function SlackSettingsSheet({
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       (slackChannels || [])[0]?.autoRespondWithoutMention || false;
     setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const currentSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
+    setSkipThreadRepliesEnabled(currentSkipThreadReplies);
     onOpenChange();
   };
 
@@ -281,8 +294,22 @@ export function SlackSettingsSheet({
     const autoRespondWithoutMentionChanged =
       autoRespondWithoutMentionEnabled !== currentAutoRespondWithoutMention;
 
-    return channelSelectionChanged || autoRespondWithoutMentionChanged;
-  }, [slackChannels, localSlackChannels, autoRespondWithoutMentionEnabled]);
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const currentSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
+    const autoRespondWithoutMentionSkipThreadRepliesChanged =
+      autoRespondWithoutMentionSkipThreadRepliesEnabled !== currentSkipThreadReplies;
+
+    return (
+      channelSelectionChanged ||
+      autoRespondWithoutMentionChanged ||
+      autoRespondWithoutMentionSkipThreadRepliesChanged
+    );
+  }, [
+    slackChannels,
+    localSlackChannels,
+    autoRespondWithoutMentionEnabled,
+    autoRespondWithoutMentionSkipThreadRepliesEnabled,
+  ]);
 
   return (
     <Sheet open={isOpen} onOpenChange={handleClose}>
@@ -345,28 +372,51 @@ export function SlackSettingsSheet({
           }}
         >
           {hasFeature("slack_enhanced_default_agent") && isAdmin(owner) && (
-            <div className="flex flex-col border-t p-4">
+            <div className="flex flex-col gap-3 border-t p-4">
               <div className="flex items-start justify-between gap-4">
                 <div className="flex min-w-0 flex-1 flex-col gap-1">
                   <span className="text-sm font-medium text-foreground">
                     Respond to all messages in channel
                   </span>
                   <span className="text-xs text-muted-foreground">
-                    Agent will automatically respond to all messages and thread
-                    replies in selected channels (not just @mentions)
+                    Agent will automatically respond to messages in selected
+                    channels (not just @mentions)
                   </span>
                 </div>
                 <div className="flex-shrink-0">
                   <SliderToggle
                     selected={autoRespondWithoutMentionEnabled}
-                    onClick={() =>
-                      setAutoRespondWithoutMentionEnabled(
-                        !autoRespondWithoutMentionEnabled
-                      )
-                    }
+                    onClick={() => {
+                      const next = !autoRespondWithoutMentionEnabled;
+                      setAutoRespondWithoutMentionEnabled(next);
+                      if (!next) {
+                        setSkipThreadRepliesEnabled(false);
+                      }
+                    }}
                   />
                 </div>
               </div>
+              {autoRespondWithoutMentionEnabled && (
+                <div className="ml-4 flex items-start justify-between gap-4 border-l pl-4">
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <span className="text-sm font-medium text-foreground">
+                      Top-level posts only
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      Only respond to new channel messages, not to replies
+                      within threads
+                    </span>
+                  </div>
+                  <div className="flex-shrink-0">
+                    <SliderToggle
+                      selected={autoRespondWithoutMentionSkipThreadRepliesEnabled}
+                      onClick={() =>
+                        setSkipThreadRepliesEnabled(!autoRespondWithoutMentionSkipThreadRepliesEnabled)
+                      }
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </SheetFooter>

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -24,8 +24,9 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type React from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer } from "react";
 import { useController } from "react-hook-form";
 
 const SLACK_CHANNEL_INTERNAL_ID_PREFIX = "slack-channel-";
@@ -38,6 +39,48 @@ type SlackChannel = {
   autoRespondWithoutMentionSkipThreadReplies?: boolean;
 };
 
+type SheetState = {
+  localSlackChannels: SlackChannel[];
+  autoRespondWithoutMentionEnabled: boolean;
+  skipThreadRepliesEnabled: boolean;
+};
+
+type SheetAction =
+  | { type: "sync"; channels: SlackChannel[] }
+  | { type: "set_channels"; channels: SlackChannel[] }
+  | { type: "toggle_auto_respond" }
+  | { type: "toggle_skip_thread_replies" };
+
+function sheetReducer(state: SheetState, action: SheetAction): SheetState {
+  switch (action.type) {
+    case "sync":
+      return {
+        localSlackChannels: [...action.channels],
+        autoRespondWithoutMentionEnabled:
+          action.channels[0]?.autoRespondWithoutMention ?? false,
+        skipThreadRepliesEnabled:
+          action.channels[0]?.autoRespondWithoutMentionSkipThreadReplies ??
+          false,
+      };
+    case "set_channels":
+      return { ...state, localSlackChannels: action.channels };
+    case "toggle_auto_respond": {
+      const next = !state.autoRespondWithoutMentionEnabled;
+      return {
+        ...state,
+        autoRespondWithoutMentionEnabled: next,
+        skipThreadRepliesEnabled: next ? state.skipThreadRepliesEnabled : false,
+      };
+    }
+    case "toggle_skip_thread_replies":
+      return {
+        ...state,
+        skipThreadRepliesEnabled: !state.skipThreadRepliesEnabled,
+      };
+    default:
+      return assertNever(action);
+  }
+}
 
 interface SlackChannelsListProps {
   disabled?: boolean;
@@ -212,27 +255,23 @@ export function SlackSettingsSheet({
     name: "agentSettings.slackChannels",
   });
 
-  const [localSlackChannels, setLocalSlackChannels] = useState<SlackChannel[]>(
-    slackChannels ?? []
-  );
-  const [autoRespondWithoutMentionEnabled, setAutoRespondWithoutMentionEnabled] =
-    useState(slackChannels?.[0]?.autoRespondWithoutMention ?? false);
-  const [skipThreadRepliesEnabled, setSkipThreadRepliesEnabled] = useState(
-    slackChannels?.[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false
-  );
+  const [
+    { localSlackChannels, autoRespondWithoutMentionEnabled, skipThreadRepliesEnabled },
+    dispatch,
+  ] = useReducer(sheetReducer, slackChannels ?? [], (channels) => ({
+    localSlackChannels: [...channels],
+    autoRespondWithoutMentionEnabled:
+      channels[0]?.autoRespondWithoutMention ?? false,
+    skipThreadRepliesEnabled:
+      channels[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false,
+  }));
 
   useEffect(() => {
-    setLocalSlackChannels([...(slackChannels ?? [])]);
-    setAutoRespondWithoutMentionEnabled(
-      slackChannels?.[0]?.autoRespondWithoutMention ?? false
-    );
-    setSkipThreadRepliesEnabled(
-      slackChannels?.[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false
-    );
+    dispatch({ type: "sync", channels: slackChannels ?? [] });
   }, [slackChannels]);
 
   const handleSelectionChange = (channels: SlackChannel[]) => {
-    setLocalSlackChannels(channels);
+    dispatch({ type: "set_channels", channels });
   };
 
   const onSave = () => {
@@ -247,13 +286,7 @@ export function SlackSettingsSheet({
   };
 
   const handleClose = () => {
-    setLocalSlackChannels([...(slackChannels ?? [])]);
-    setAutoRespondWithoutMentionEnabled(
-      slackChannels?.[0]?.autoRespondWithoutMention ?? false
-    );
-    setSkipThreadRepliesEnabled(
-      slackChannels?.[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false
-    );
+    dispatch({ type: "sync", channels: slackChannels ?? [] });
     onOpenChange();
   };
 
@@ -364,13 +397,7 @@ export function SlackSettingsSheet({
                 </div>
                 <SliderToggle
                   selected={autoRespondWithoutMentionEnabled}
-                  onClick={() => {
-                    const next = !autoRespondWithoutMentionEnabled;
-                    setAutoRespondWithoutMentionEnabled(next);
-                    if (!next) {
-                      setSkipThreadRepliesEnabled(false);
-                    }
-                  }}
+                  onClick={() => dispatch({ type: "toggle_auto_respond" })}
                 />
               </div>
               {autoRespondWithoutMentionEnabled && (
@@ -387,7 +414,7 @@ export function SlackSettingsSheet({
                   <SliderToggle
                     selected={skipThreadRepliesEnabled}
                     onClick={() =>
-                      setSkipThreadRepliesEnabled(!skipThreadRepliesEnabled)
+                      dispatch({ type: "toggle_skip_thread_replies" })
                     }
                   />
                 </div>

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -8,7 +8,6 @@ import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
   Button,
-  CheckBoxWithTextAndDescription,
   Checkbox,
   ContentMessage,
   Icon,
@@ -405,18 +404,31 @@ export function SlackSettingsSheet({
                   onClick={() => dispatch({ type: "toggle_auto_respond" })}
                 />
               </div>
-              <CheckBoxWithTextAndDescription
-                text="Top-level posts only"
-                description="Only respond to new channel messages, not replies within threads"
-                checked={skipThreadRepliesEnabled}
-                disabled={!autoRespondWithoutMentionEnabled}
-                onCheckedChange={(checked) =>
-                  dispatch({
-                    type: "set_skip_thread_replies",
-                    value: checked === true,
-                  })
-                }
-              />
+              <div className="flex items-center justify-between gap-4">
+                <div
+                  className={`flex min-w-0 flex-1 flex-col gap-1 ${
+                    autoRespondWithoutMentionEnabled ? "" : "opacity-50"
+                  }`}
+                >
+                  <span className="text-sm text-foreground">
+                    Top-level posts only
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Only respond to new channel messages, not replies within
+                    threads
+                  </span>
+                </div>
+                <Checkbox
+                  checked={skipThreadRepliesEnabled}
+                  disabled={!autoRespondWithoutMentionEnabled}
+                  onCheckedChange={(checked) =>
+                    dispatch({
+                      type: "set_skip_thread_replies",
+                      value: checked === true,
+                    })
+                  }
+                />
+              </div>
             </div>
           )}
         </SheetFooter>

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -38,6 +38,22 @@ type SlackChannel = {
   autoRespondWithoutMentionSkipThreadReplies?: boolean;
 };
 
+type LocalState = {
+  localSlackChannels: SlackChannel[];
+  autoRespondWithoutMentionEnabled: boolean;
+  skipThreadRepliesEnabled: boolean;
+};
+
+function stateFromChannels(channels: SlackChannel[] | undefined): LocalState {
+  const ch = channels ?? [];
+  return {
+    localSlackChannels: [...ch],
+    autoRespondWithoutMentionEnabled: ch[0]?.autoRespondWithoutMention ?? false,
+    skipThreadRepliesEnabled:
+      ch[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false,
+  };
+}
+
 interface SlackChannelsListProps {
   disabled?: boolean;
   existingSelection: SlackChannel[];
@@ -211,20 +227,6 @@ export function SlackSettingsSheet({
     name: "agentSettings.slackChannels",
   });
 
-  const stateFromChannels = useCallback(
-    (channels: typeof slackChannels) => {
-      const ch = channels ?? [];
-      return {
-        localSlackChannels: [...ch],
-        autoRespondWithoutMentionEnabled:
-          ch[0]?.autoRespondWithoutMention ?? false,
-        skipThreadRepliesEnabled:
-          ch[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false,
-      };
-    },
-    []
-  );
-
   const [
     {
       localSlackChannels,
@@ -232,17 +234,17 @@ export function SlackSettingsSheet({
       skipThreadRepliesEnabled,
     },
     setLocalState,
-  ] = useState(() => stateFromChannels(slackChannels));
+  ] = useState<LocalState>(() => stateFromChannels(slackChannels));
 
   useEffect(() => {
     setLocalState(stateFromChannels(slackChannels));
-  }, [slackChannels, stateFromChannels]);
+  }, [slackChannels]);
 
   useEffect(() => {
     if (isOpen) {
       setLocalState(stateFromChannels(slackChannels));
     }
-  }, [isOpen, slackChannels, stateFromChannels]);
+  }, [isOpen, slackChannels]);
 
   const handleSelectionChange = (channels: SlackChannel[]) => {
     setLocalState((prev) => ({ ...prev, localSlackChannels: channels }));

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -3,6 +3,7 @@ import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBu
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import type { DataSourceType } from "@app/types/data_source";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
@@ -24,7 +25,6 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { InformationCircleIcon } from "@heroicons/react/20/solid";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { useController } from "react-hook-form";
@@ -256,7 +256,11 @@ export function SlackSettingsSheet({
   });
 
   const [
-    { localSlackChannels, autoRespondWithoutMentionEnabled, skipThreadRepliesEnabled },
+    {
+      localSlackChannels,
+      autoRespondWithoutMentionEnabled,
+      skipThreadRepliesEnabled,
+    },
     dispatch,
   ] = useReducer(sheetReducer, slackChannels ?? [], (channels) => ({
     localSlackChannels: [...channels],

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -204,15 +204,6 @@ export function SlackSettingsSheet({
 }: SlackSettingsSheetProps) {
   const { owner } = useAgentBuilderContext();
   const { hasFeature } = useFeatureFlags();
-  const [localSlackChannels, setLocalSlackChannels] = useState<SlackChannel[]>(
-    []
-  );
-  const [
-    autoRespondWithoutMentionEnabled,
-    setAutoRespondWithoutMentionEnabled,
-  ] = useState(false);
-  const [autoRespondWithoutMentionSkipThreadRepliesEnabled, setSkipThreadRepliesEnabled] =
-    useState(false);
 
   const {
     field: { onChange, value: slackChannels },
@@ -220,32 +211,37 @@ export function SlackSettingsSheet({
     name: "agentSettings.slackChannels",
   });
 
+  const stateFromChannels = useCallback(
+    (channels: typeof slackChannels) => {
+      const ch = channels || [];
+      return {
+        localSlackChannels: [...ch],
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        autoRespondWithoutMentionEnabled: ch[0]?.autoRespondWithoutMention || false,
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+        skipThreadRepliesEnabled: ch[0]?.autoRespondWithoutMentionSkipThreadReplies || false,
+      };
+    },
+    []
+  );
+
+  const [
+    { localSlackChannels, autoRespondWithoutMentionEnabled, skipThreadRepliesEnabled },
+    setLocalState,
+  ] = useState(() => stateFromChannels(slackChannels));
+
   useEffect(() => {
-    setLocalSlackChannels([...(slackChannels || [])]);
-    const currentAutoRespondWithoutMention =
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      (slackChannels || [])[0]?.autoRespondWithoutMention || false;
-    setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const currentSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
-    setSkipThreadRepliesEnabled(currentSkipThreadReplies);
-  }, [slackChannels]);
+    setLocalState(stateFromChannels(slackChannels));
+  }, [slackChannels, stateFromChannels]);
 
   useEffect(() => {
     if (isOpen) {
-      setLocalSlackChannels([...(slackChannels || [])]);
-      const currentAutoRespondWithoutMention =
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        (slackChannels || [])[0]?.autoRespondWithoutMention || false;
-      setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      const currentSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
-      setSkipThreadRepliesEnabled(currentSkipThreadReplies);
+      setLocalState(stateFromChannels(slackChannels));
     }
-  }, [isOpen, slackChannels]);
+  }, [isOpen, slackChannels, stateFromChannels]);
 
   const handleSelectionChange = (channels: SlackChannel[]) => {
-    setLocalSlackChannels(channels);
+    setLocalState((prev) => ({ ...prev, localSlackChannels: channels }));
   };
 
   const onSave = () => {
@@ -253,7 +249,7 @@ export function SlackSettingsSheet({
       ...channel,
       autoRespondWithoutMention: autoRespondWithoutMentionEnabled,
       autoRespondWithoutMentionSkipThreadReplies: autoRespondWithoutMentionEnabled
-        ? autoRespondWithoutMentionSkipThreadRepliesEnabled
+        ? skipThreadRepliesEnabled
         : false,
     }));
     onChange(channelsWithSettings);
@@ -261,14 +257,7 @@ export function SlackSettingsSheet({
   };
 
   const handleClose = () => {
-    setLocalSlackChannels([...(slackChannels || [])]);
-    const currentAutoRespondWithoutMention =
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      (slackChannels || [])[0]?.autoRespondWithoutMention || false;
-    setAutoRespondWithoutMentionEnabled(currentAutoRespondWithoutMention);
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const currentSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
-    setSkipThreadRepliesEnabled(currentSkipThreadReplies);
+    setLocalState(stateFromChannels(slackChannels));
     onOpenChange();
   };
 
@@ -288,27 +277,21 @@ export function SlackSettingsSheet({
       (id) => !localChannelIds.has(id as string)
     );
 
-    const currentAutoRespondWithoutMention =
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      (slackChannels || [])[0]?.autoRespondWithoutMention || false;
-    const autoRespondWithoutMentionChanged =
-      autoRespondWithoutMentionEnabled !== currentAutoRespondWithoutMention;
-
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    const currentSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
-    const autoRespondWithoutMentionSkipThreadRepliesChanged =
-      autoRespondWithoutMentionSkipThreadRepliesEnabled !== currentSkipThreadReplies;
+    const savedAutoRespond = (slackChannels || [])[0]?.autoRespondWithoutMention || false;
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const savedSkipThreadReplies = (slackChannels || [])[0]?.autoRespondWithoutMentionSkipThreadReplies || false;
 
     return (
       channelSelectionChanged ||
-      autoRespondWithoutMentionChanged ||
-      autoRespondWithoutMentionSkipThreadRepliesChanged
+      autoRespondWithoutMentionEnabled !== savedAutoRespond ||
+      skipThreadRepliesEnabled !== savedSkipThreadReplies
     );
   }, [
     slackChannels,
     localSlackChannels,
     autoRespondWithoutMentionEnabled,
-    autoRespondWithoutMentionSkipThreadRepliesEnabled,
+    skipThreadRepliesEnabled,
   ]);
 
   return (
@@ -385,13 +368,15 @@ export function SlackSettingsSheet({
                 </div>
                 <SliderToggle
                   selected={autoRespondWithoutMentionEnabled}
-                  onClick={() => {
-                    const next = !autoRespondWithoutMentionEnabled;
-                    setAutoRespondWithoutMentionEnabled(next);
-                    if (!next) {
-                      setSkipThreadRepliesEnabled(false);
-                    }
-                  }}
+                  onClick={() =>
+                    setLocalState((prev) => ({
+                      ...prev,
+                      autoRespondWithoutMentionEnabled: !prev.autoRespondWithoutMentionEnabled,
+                      skipThreadRepliesEnabled: prev.autoRespondWithoutMentionEnabled
+                        ? false
+                        : prev.skipThreadRepliesEnabled,
+                    }))
+                  }
                 />
               </div>
               {autoRespondWithoutMentionEnabled && (
@@ -406,11 +391,12 @@ export function SlackSettingsSheet({
                     </span>
                   </div>
                   <SliderToggle
-                    selected={autoRespondWithoutMentionSkipThreadRepliesEnabled}
+                    selected={skipThreadRepliesEnabled}
                     onClick={() =>
-                      setSkipThreadRepliesEnabled(
-                        !autoRespondWithoutMentionSkipThreadRepliesEnabled
-                      )
+                      setLocalState((prev) => ({
+                        ...prev,
+                        skipThreadRepliesEnabled: !prev.skipThreadRepliesEnabled,
+                      }))
                     }
                   />
                 </div>

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -38,21 +38,6 @@ type SlackChannel = {
   autoRespondWithoutMentionSkipThreadReplies?: boolean;
 };
 
-type LocalState = {
-  localSlackChannels: SlackChannel[];
-  autoRespondWithoutMentionEnabled: boolean;
-  skipThreadRepliesEnabled: boolean;
-};
-
-function stateFromChannels(channels: SlackChannel[] | undefined): LocalState {
-  const ch = channels ?? [];
-  return {
-    localSlackChannels: [...ch],
-    autoRespondWithoutMentionEnabled: ch[0]?.autoRespondWithoutMention ?? false,
-    skipThreadRepliesEnabled:
-      ch[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false,
-  };
-}
 
 interface SlackChannelsListProps {
   disabled?: boolean;
@@ -227,27 +212,27 @@ export function SlackSettingsSheet({
     name: "agentSettings.slackChannels",
   });
 
-  const [
-    {
-      localSlackChannels,
-      autoRespondWithoutMentionEnabled,
-      skipThreadRepliesEnabled,
-    },
-    setLocalState,
-  ] = useState<LocalState>(() => stateFromChannels(slackChannels));
+  const [localSlackChannels, setLocalSlackChannels] = useState<SlackChannel[]>(
+    slackChannels ?? []
+  );
+  const [autoRespondWithoutMentionEnabled, setAutoRespondWithoutMentionEnabled] =
+    useState(slackChannels?.[0]?.autoRespondWithoutMention ?? false);
+  const [skipThreadRepliesEnabled, setSkipThreadRepliesEnabled] = useState(
+    slackChannels?.[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false
+  );
 
   useEffect(() => {
-    setLocalState(stateFromChannels(slackChannels));
+    setLocalSlackChannels([...(slackChannels ?? [])]);
+    setAutoRespondWithoutMentionEnabled(
+      slackChannels?.[0]?.autoRespondWithoutMention ?? false
+    );
+    setSkipThreadRepliesEnabled(
+      slackChannels?.[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false
+    );
   }, [slackChannels]);
 
-  useEffect(() => {
-    if (isOpen) {
-      setLocalState(stateFromChannels(slackChannels));
-    }
-  }, [isOpen, slackChannels]);
-
   const handleSelectionChange = (channels: SlackChannel[]) => {
-    setLocalState((prev) => ({ ...prev, localSlackChannels: channels }));
+    setLocalSlackChannels(channels);
   };
 
   const onSave = () => {
@@ -262,7 +247,13 @@ export function SlackSettingsSheet({
   };
 
   const handleClose = () => {
-    setLocalState(stateFromChannels(slackChannels));
+    setLocalSlackChannels([...(slackChannels ?? [])]);
+    setAutoRespondWithoutMentionEnabled(
+      slackChannels?.[0]?.autoRespondWithoutMention ?? false
+    );
+    setSkipThreadRepliesEnabled(
+      slackChannels?.[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false
+    );
     onOpenChange();
   };
 
@@ -283,10 +274,9 @@ export function SlackSettingsSheet({
     );
 
     const savedAutoRespond =
-      (slackChannels ?? [])[0]?.autoRespondWithoutMention ?? false;
+      slackChannels?.[0]?.autoRespondWithoutMention ?? false;
     const savedSkipThreadReplies =
-      (slackChannels ?? [])[0]?.autoRespondWithoutMentionSkipThreadReplies ??
-      false;
+      slackChannels?.[0]?.autoRespondWithoutMentionSkipThreadReplies ?? false;
 
     return (
       channelSelectionChanged ||
@@ -374,17 +364,13 @@ export function SlackSettingsSheet({
                 </div>
                 <SliderToggle
                   selected={autoRespondWithoutMentionEnabled}
-                  onClick={() =>
-                    setLocalState((prev) => ({
-                      ...prev,
-                      autoRespondWithoutMentionEnabled:
-                        !prev.autoRespondWithoutMentionEnabled,
-                      skipThreadRepliesEnabled:
-                        prev.autoRespondWithoutMentionEnabled
-                          ? false
-                          : prev.skipThreadRepliesEnabled,
-                    }))
-                  }
+                  onClick={() => {
+                    const next = !autoRespondWithoutMentionEnabled;
+                    setAutoRespondWithoutMentionEnabled(next);
+                    if (!next) {
+                      setSkipThreadRepliesEnabled(false);
+                    }
+                  }}
                 />
               </div>
               {autoRespondWithoutMentionEnabled && (
@@ -401,11 +387,7 @@ export function SlackSettingsSheet({
                   <SliderToggle
                     selected={skipThreadRepliesEnabled}
                     onClick={() =>
-                      setLocalState((prev) => ({
-                        ...prev,
-                        skipThreadRepliesEnabled:
-                          !prev.skipThreadRepliesEnabled,
-                      }))
+                      setSkipThreadRepliesEnabled(!skipThreadRepliesEnabled)
                     }
                   />
                 </div>

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -394,28 +394,27 @@ export function SlackSettingsSheet({
                   }}
                 />
               </div>
-              <div
-                className={`flex items-center justify-between gap-4 pl-4 ${!autoRespondWithoutMentionEnabled ? "cursor-not-allowed opacity-50" : ""}`}
-              >
-                <div className="flex min-w-0 flex-1 flex-col gap-1">
-                  <span className="text-sm font-medium text-foreground">
-                    Top-level posts only
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    Only respond to new channel messages, not replies within
-                    threads
-                  </span>
+              {autoRespondWithoutMentionEnabled && (
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex min-w-0 flex-1 flex-col gap-1">
+                    <span className="text-sm font-medium text-foreground">
+                      Top-level posts only
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      Only respond to new channel messages, not replies within
+                      threads
+                    </span>
+                  </div>
+                  <SliderToggle
+                    selected={autoRespondWithoutMentionSkipThreadRepliesEnabled}
+                    onClick={() =>
+                      setSkipThreadRepliesEnabled(
+                        !autoRespondWithoutMentionSkipThreadRepliesEnabled
+                      )
+                    }
+                  />
                 </div>
-                <SliderToggle
-                  selected={autoRespondWithoutMentionSkipThreadRepliesEnabled}
-                  disabled={!autoRespondWithoutMentionEnabled}
-                  onClick={() =>
-                    setSkipThreadRepliesEnabled(
-                      !autoRespondWithoutMentionSkipThreadRepliesEnabled
-                    )
-                  }
-                />
-              </div>
+              )}
             </div>
           )}
         </SheetFooter>

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -575,12 +575,15 @@ export async function submitAgentBuilderForm({
         slackChannels.length > 0
           ? slackChannels[0].autoRespondWithoutMention
           : false;
+      const autoRespondWithoutMentionSkipThreadReplies =
+        slackChannels.length > 0 ? slackChannels[0].autoRespondWithoutMentionSkipThreadReplies : false;
       const slackRequestBody = JSON.stringify({
         provider: slackProvider,
         slack_channel_internal_ids: slackChannels.map(
           ({ slackChannelId }) => slackChannelId
         ),
         auto_respond_without_mention: autoRespondWithoutMention,
+        auto_respond_without_mention_skip_thread_replies: autoRespondWithoutMentionSkipThreadReplies,
       });
       const slackLinkRes = await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/linked_slack_channels`,

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -576,14 +576,17 @@ export async function submitAgentBuilderForm({
           ? slackChannels[0].autoRespondWithoutMention
           : false;
       const autoRespondWithoutMentionSkipThreadReplies =
-        slackChannels.length > 0 ? slackChannels[0].autoRespondWithoutMentionSkipThreadReplies : false;
+        slackChannels.length > 0
+          ? slackChannels[0].autoRespondWithoutMentionSkipThreadReplies
+          : false;
       const slackRequestBody = JSON.stringify({
         provider: slackProvider,
         slack_channel_internal_ids: slackChannels.map(
           ({ slackChannelId }) => slackChannelId
         ),
         auto_respond_without_mention: autoRespondWithoutMention,
-        auto_respond_without_mention_skip_thread_replies: autoRespondWithoutMentionSkipThreadReplies,
+        auto_respond_without_mention_skip_thread_replies:
+          autoRespondWithoutMentionSkipThreadReplies,
       });
       const slackLinkRes = await clientFetch(
         `/api/w/${owner.sId}/assistant/agent_configurations/${agentConfiguration.sId}/linked_slack_channels`,

--- a/front/types/api/assistant/builder/slack/channels_linked_with_agent.ts
+++ b/front/types/api/assistant/builder/slack/channels_linked_with_agent.ts
@@ -7,6 +7,7 @@ export type GetSlackChannelsLinkedWithAgentResponseBody = {
     slackChannelName: string;
     agentConfigurationId: string;
     autoRespondWithoutMention: boolean;
+    autoRespondWithoutMentionSkipThreadReplies: boolean;
   }[];
   slackDataSource?: DataSourceType;
 };

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -501,11 +501,13 @@ export class ConnectorsAPI {
     slackChannelInternalIds,
     agentConfigurationId,
     autoRespondWithoutMention,
+    autoRespondWithoutMentionSkipThreadReplies,
   }: {
     connectorId: string;
     slackChannelInternalIds: string[];
     agentConfigurationId: string;
     autoRespondWithoutMention?: boolean;
+    autoRespondWithoutMentionSkipThreadReplies?: boolean;
   }): Promise<ConnectorsAPIResponse<{ success: true }>> {
     const res = await this._fetchWithError(
       `${this._url}/slack/channels/linked_with_agent`,
@@ -517,6 +519,7 @@ export class ConnectorsAPI {
           agent_configuration_id: agentConfigurationId,
           slack_channel_internal_ids: slackChannelInternalIds,
           auto_respond_without_mention: autoRespondWithoutMention,
+          auto_respond_without_mention_skip_thread_replies: autoRespondWithoutMentionSkipThreadReplies,
         }),
       }
     );
@@ -535,6 +538,7 @@ export class ConnectorsAPI {
         slackChannelName: string;
         agentConfigurationId: string;
         autoRespondWithoutMention: boolean;
+        autoRespondWithoutMentionSkipThreadReplies: boolean;
       }[];
     }>
   > {

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -519,7 +519,8 @@ export class ConnectorsAPI {
           agent_configuration_id: agentConfigurationId,
           slack_channel_internal_ids: slackChannelInternalIds,
           auto_respond_without_mention: autoRespondWithoutMention,
-          auto_respond_without_mention_skip_thread_replies: autoRespondWithoutMentionSkipThreadReplies,
+          auto_respond_without_mention_skip_thread_replies:
+            autoRespondWithoutMentionSkipThreadReplies,
         }),
       }
     );


### PR DESCRIPTION
## Summary

- Adds a \"Top-level posts only\" sub-toggle to the Slack auto-responder settings. When enabled alongside \"Respond to all messages\", the bot will skip thread replies and only respond to new top-level channel posts.


## Testing
<img width="345" height="967" alt="Screenshot 2026-08-12 at 4 06 45 PM" src="https://github.com/user-attachments/assets/b26942ed-553d-4970-a3c5-d612c64a91d0" />


## Risk

Low

## Deploy Plan

1. Deploy connector
2. Deploy front