### PR TITLE
feat(sandbox): remove legacy egress policy scrubbing and the workspace-layout dual-write

### DIFF
--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -39,7 +39,6 @@ vi.mock("@app/lib/file_storage", () => ({
 
 import {
   addOwnerPolicyDomain,
-  deleteLegacySandboxPolicy,
   deleteOwnerPolicy,
   deleteWorkspacePolicy,
   parseExactEgressDomain,
@@ -361,16 +360,6 @@ describe("owner egress policy storage", () => {
         expect.anything()
       );
     });
-  });
-
-  it("deletes legacy per-provider policy files without invalidation", async () => {
-    const result = await deleteLegacySandboxPolicy("provider-id");
-
-    expect(result).toEqual(new Ok(undefined));
-    expect(mockDelete).toHaveBeenCalledWith("sandboxes/provider-id.json", {
-      ignoreNotFound: true,
-    });
-    expect(mockMintEgressInvalidationJwt).not.toHaveBeenCalled();
   });
 
   it("parses exact domains and rejects malformed entries", () => {

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -52,7 +52,6 @@ const mockAuth = {
 } as unknown as Authenticator;
 
 const WORKSPACE_PATH = "w/workspace-sid/sandbox-egress-policy.json";
-const LEGACY_WORKSPACE_PATH = "workspaces/workspace-sid.json";
 const OWNER_PATH = "w/workspace-sid/sandboxes/owner-sid.json";
 
 const NOT_FOUND = { code: 404 };
@@ -100,33 +99,7 @@ describe("workspace egress policy storage", () => {
     expect(mockFetchFileContent).toHaveBeenCalledWith(WORKSPACE_PATH);
   });
 
-  it("falls back to the legacy path when the new object is absent", async () => {
-    setGcsObjects({
-      [LEGACY_WORKSPACE_PATH]: { allowedDomains: ["legacy.example.com"] },
-    });
-
-    const result = await readWorkspacePolicy(mockAuth);
-
-    expect(result).toEqual(new Ok({ allowedDomains: ["legacy.example.com"] }));
-    expect(mockFetchFileContent).toHaveBeenCalledWith(WORKSPACE_PATH);
-    expect(mockFetchFileContent).toHaveBeenCalledWith(LEGACY_WORKSPACE_PATH);
-  });
-
-  it("prefers the new layout over the legacy path when both exist", async () => {
-    setGcsObjects({
-      [WORKSPACE_PATH]: { allowedDomains: ["new.example.com"] },
-      [LEGACY_WORKSPACE_PATH]: { allowedDomains: ["legacy.example.com"] },
-    });
-
-    const result = await readWorkspacePolicy(mockAuth);
-
-    expect(result).toEqual(new Ok({ allowedDomains: ["new.example.com"] }));
-    expect(mockFetchFileContent).not.toHaveBeenCalledWith(
-      LEGACY_WORKSPACE_PATH
-    );
-  });
-
-  it("returns an empty policy when neither layout has a file", async () => {
+  it("returns an empty policy when no file exists", async () => {
     setGcsObjects({});
 
     const result = await readWorkspacePolicy(mockAuth);
@@ -134,7 +107,7 @@ describe("workspace egress policy storage", () => {
     expect(result).toEqual(new Ok({ allowedDomains: [] }));
   });
 
-  it("writes normalized policy files to both layouts", async () => {
+  it("writes the normalized policy file", async () => {
     const result = await writeWorkspacePolicy(mockAuth, {
       policy: {
         allowedDomains: ["API.GitHub.COM", "*.GitHub.COM"],
@@ -146,36 +119,14 @@ describe("workspace egress policy storage", () => {
         allowedDomains: ["api.github.com", "*.github.com"],
       })
     );
-    const content = JSON.stringify({
-      allowedDomains: ["api.github.com", "*.github.com"],
-    });
+    expect(mockUploadRawContentToBucket).toHaveBeenCalledTimes(1);
     expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
-      content,
+      content: JSON.stringify({
+        allowedDomains: ["api.github.com", "*.github.com"],
+      }),
       contentType: "application/json",
       filePath: WORKSPACE_PATH,
     });
-    // Dual-write to the legacy path for front rollback safety.
-    expect(mockUploadRawContentToBucket).toHaveBeenCalledWith({
-      content,
-      contentType: "application/json",
-      filePath: LEGACY_WORKSPACE_PATH,
-    });
-  });
-
-  it("succeeds when only the legacy dual-write fails", async () => {
-    mockUploadRawContentToBucket.mockImplementation(
-      async ({ filePath }: { filePath: string }) => {
-        if (filePath === LEGACY_WORKSPACE_PATH) {
-          throw new Error("legacy write failed");
-        }
-      }
-    );
-
-    const result = await writeWorkspacePolicy(mockAuth, {
-      policy: { allowedDomains: ["api.github.com"] },
-    });
-
-    expect(result).toEqual(new Ok({ allowedDomains: ["api.github.com"] }));
   });
 
   it("does not write invalid domain entries", async () => {
@@ -189,14 +140,12 @@ describe("workspace egress policy storage", () => {
     expect(mockUploadRawContentToBucket).not.toHaveBeenCalled();
   });
 
-  it("deletes both layouts and ignores missing objects", async () => {
+  it("deletes the policy file and ignores missing objects", async () => {
     const result = await deleteWorkspacePolicy(mockAuth);
 
     expect(result).toEqual(new Ok(undefined));
+    expect(mockDelete).toHaveBeenCalledTimes(1);
     expect(mockDelete).toHaveBeenCalledWith(WORKSPACE_PATH, {
-      ignoreNotFound: true,
-    });
-    expect(mockDelete).toHaveBeenCalledWith(LEGACY_WORKSPACE_PATH, {
       ignoreNotFound: true,
     });
   });

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -32,13 +32,6 @@ function getWorkspacePolicyPath(auth: Authenticator): string {
   return `w/${auth.getNonNullableWorkspace().sId}/sandbox-egress-policy.json`;
 }
 
-// TODO(2026-08-15 EGRESS_RELAYOUT): drop the legacy path (reads fall back to
-// it, writes dual-write it for front rollback safety) once the backfill has
-// run and legacy objects are deleted.
-function getLegacyWorkspacePolicyPath(auth: Authenticator): string {
-  return `workspaces/${auth.getNonNullableWorkspace().sId}.json`;
-}
-
 function getOwnerPolicyPath(auth: Authenticator, ownerId: string): string {
   return `w/${auth.getNonNullableWorkspace().sId}/sandboxes/${ownerId}.json`;
 }
@@ -77,16 +70,8 @@ export async function readWorkspacePolicy(
   if (current.isErr()) {
     return current;
   }
-  if (current.value !== null) {
-    return new Ok(current.value);
-  }
 
-  const legacy = await fetchPolicyAtPath(getLegacyWorkspacePolicyPath(auth));
-  if (legacy.isErr()) {
-    return legacy;
-  }
-
-  return new Ok(legacy.value ?? EMPTY_EGRESS_POLICY);
+  return new Ok(current.value ?? EMPTY_EGRESS_POLICY);
 }
 
 export async function writeWorkspacePolicy(
@@ -109,25 +94,6 @@ export async function writeWorkspacePolicy(
     return new Err(normalizeError(error));
   }
 
-  // Dual-write the legacy path so a front rollback keeps seeing (and safely
-  // editing) the same policy. Best-effort: the new path is canonical and the
-  // proxy prefers it.
-  try {
-    await getPolicyBucket().uploadRawContentToBucket({
-      content: JSON.stringify(normalizedPolicy.value),
-      contentType: "application/json",
-      filePath: getLegacyWorkspacePolicyPath(auth),
-    });
-  } catch (error) {
-    logger.warn(
-      {
-        error: normalizeError(error),
-        workspaceId: auth.getNonNullableWorkspace().sId,
-      },
-      "Failed to dual-write legacy workspace egress policy path"
-    );
-  }
-
   await invalidateWorkspacePolicyCache(auth);
 
   return new Ok(normalizedPolicy.value);
@@ -137,13 +103,6 @@ export async function deleteWorkspacePolicy(
   auth: Authenticator
 ): Promise<Result<void, Error>> {
   try {
-    // Legacy first: if the new-path delete succeeded but the legacy delete
-    // failed, reads would fall back to the still-present legacy file and the
-    // "deleted" policy would resurrect. Deleting legacy first leaves the
-    // (canonical) new path authoritative in every partial-failure state.
-    await getPolicyBucket().delete(getLegacyWorkspacePolicyPath(auth), {
-      ignoreNotFound: true,
-    });
     await getPolicyBucket().delete(getWorkspacePolicyPath(auth), {
       ignoreNotFound: true,
     });

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -273,26 +273,6 @@ export async function addOwnerPolicyDomain(
   }
 }
 
-// Deletes the legacy per-providerId policy file written before the
-// owner-keyed layout. Still called on sandbox destroy so pre-migration files
-// get cleaned up as their sandboxes die. No proxy cache invalidation: the
-// sandbox (and its token) is gone, so the cached entry just ages out with
-// the TTL.
-// TODO(2026-08-15 EGRESS_RELAYOUT): remove with the legacy layout.
-export async function deleteLegacySandboxPolicy(
-  sandboxProviderId: string
-): Promise<Result<void, Error>> {
-  try {
-    await getPolicyBucket().delete(`sandboxes/${sandboxProviderId}.json`, {
-      ignoreNotFound: true,
-    });
-
-    return new Ok(undefined);
-  } catch (error) {
-    return new Err(normalizeError(error));
-  }
-}
-
 // Owner files outlive individual sandboxes by design; they are deleted when
 // their owner is (conversation destruction, pod space deletion), not when a
 // sandbox is destroyed.

--- a/front/lib/resources/sandbox_resource.test.ts
+++ b/front/lib/resources/sandbox_resource.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockDeleteLegacySandboxPolicy,
   mockDistribution,
   mockExecuteWithLock,
   mockGetSandboxImage,
@@ -12,7 +11,6 @@ const {
   mockProviderWake,
   mockRevokeAllExecTokensForSandbox,
 } = vi.hoisted(() => ({
-  mockDeleteLegacySandboxPolicy: vi.fn(),
   mockDistribution: vi.fn(),
   mockExecuteWithLock: vi.fn(),
   mockGetSandboxImage: vi.fn(),
@@ -37,10 +35,6 @@ vi.mock("@app/lib/api/sandbox", () => ({
 
 vi.mock("@app/lib/api/sandbox/access_tokens", () => ({
   revokeAllExecTokensForSandbox: mockRevokeAllExecTokensForSandbox,
-}));
-
-vi.mock("@app/lib/api/sandbox/egress_policy", () => ({
-  deleteLegacySandboxPolicy: mockDeleteLegacySandboxPolicy,
 }));
 
 vi.mock("@app/lib/api/sandbox/image", () => ({
@@ -86,7 +80,6 @@ describe("SandboxResource.updateStatus", () => {
       destroy: mockProviderDestroy,
     });
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
-    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
     const testSetup = await createResourceTest({ role: "admin" });
@@ -188,7 +181,6 @@ describe("ConversationSandboxAdapter.withScopeTransition", () => {
       destroy: mockProviderDestroy,
     });
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
-    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
 
     const testSetup = await createResourceTest({ role: "admin" });
     authenticator = testSetup.authenticator;
@@ -380,7 +372,6 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping", () =>
       destroy: mockProviderDestroy,
     });
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
-    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
     const testSetup = await createResourceTest({ role: "admin" });
@@ -421,9 +412,6 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfSleeping", () =>
     expect(mockProviderDestroy).toHaveBeenCalledWith(sandbox.providerId, {
       workspaceId: authenticator.getNonNullableWorkspace().sId,
     });
-    expect(mockDeleteLegacySandboxPolicy).toHaveBeenCalledWith(
-      sandbox.providerId
-    );
 
     const reloaded = await ConversationSandboxAdapter.fetchSandbox(
       authenticator,
@@ -507,7 +495,6 @@ describe("ConversationSandboxAdapter.dangerouslyDestroySandboxIfKillRequested", 
       destroy: mockProviderDestroy,
     });
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
-    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
     const testSetup = await createResourceTest({ role: "admin" });
@@ -624,7 +611,6 @@ describe("SandboxResource.dangerouslyDestroyIfKillRequested pre-destroy flush", 
     );
     mockGetSandboxProvider.mockReturnValue({ destroy: mockProviderDestroy });
     mockProviderDestroy.mockResolvedValue(new Ok(undefined));
-    mockDeleteLegacySandboxPolicy.mockResolvedValue(new Ok(undefined));
     mockRevokeAllExecTokensForSandbox.mockResolvedValue(undefined);
 
     const testSetup = await createResourceTest({ role: "admin" });

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -436,7 +436,7 @@ export class SandboxResource extends BaseResource<SandboxModel> {
   //
   // The sandbox row and its owner association are preserved (recreation
   // updates the row in place), as are the owner's egress policy file and GCS
-  // files; only the provider runtime and provider-specific legacy state go.
+  // files; only the provider runtime goes.
   //
   // /!\ Both callbacks run while the lifecycle lock is held: they must not
   // call back into any lifecycle operation on the same owner, and `commit`

--- a/front/lib/resources/sandbox_resource.ts
+++ b/front/lib/resources/sandbox_resource.ts
@@ -1,6 +1,5 @@
 import { getSandboxProvider } from "@app/lib/api/sandbox";
 import { revokeAllExecTokensForSandbox } from "@app/lib/api/sandbox/access_tokens";
-import { deleteLegacySandboxPolicy } from "@app/lib/api/sandbox/egress_policy";
 import { SandboxNotRunningError } from "@app/lib/api/sandbox/errors";
 import { getSandboxImage } from "@app/lib/api/sandbox/image";
 import {
@@ -156,25 +155,6 @@ export interface SandboxResource extends ReadonlyAttributesType<SandboxModel> {}
 export class SandboxResource extends BaseResource<SandboxModel> {
   static model: ModelStaticWorkspaceAware<SandboxModel> = SandboxModel;
 
-  // Owner policy files (w/{wId}/sandboxes/{ownerId}.json) intentionally
-  // survive sandbox destruction; only the legacy per-providerId file is
-  // scrubbed here. Owner files are deleted with their owner (conversation
-  // destruction, pod space deletion).
-  private static deleteEgressPolicyAfterDestroy(
-    sandbox: SandboxResource
-  ): void {
-    void deleteLegacySandboxPolicy(sandbox.providerId).catch((err) =>
-      logger.warn(
-        {
-          err,
-          sandboxId: sandbox.sId,
-          sandboxProviderId: sandbox.providerId,
-        },
-        "Failed to delete sandbox egress policy"
-      )
-    );
-  }
-
   // No-op when there is no check or the sandbox is not running — a sleeping
   // or pending_approval sandbox already passed the check when it paused.
   private static async runPreSleepCheck(
@@ -192,7 +172,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
     opts: { recordLifecycle: boolean }
   ): Promise<void> {
     await sandbox.updateStatus("deleted");
-    SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
     if (opts.recordLifecycle) {
       recordLifecycleOperation("destroy");
     }
@@ -501,7 +480,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
                 )
               );
             }
-            SandboxResource.deleteEgressPolicyAfterDestroy(existing);
             recordLifecycleOperation("destroy");
           }
 
@@ -543,8 +521,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
             { sandbox: sandbox.toLogJSON(), error: result.error.message },
             "Failed to destroy sandbox at provider — proceeding with DB cleanup."
           );
-        } else {
-          SandboxResource.deleteEgressPolicyAfterDestroy(sandbox);
         }
       }
 
@@ -843,8 +819,6 @@ export class SandboxResource extends BaseResource<SandboxModel> {
               "Failed to destroy kill-requested sandbox at provider — proceeding with recreation."
             );
           }
-        } else {
-          SandboxResource.deleteEgressPolicyAfterDestroy(existing);
         }
         effectiveStatus = "deleted";
       }


### PR DESCRIPTION
## Description

Front companion to the egress-proxy legacy-layer removal (`30464`): the per-providerId policy files (`sandboxes/{providerId}.json`) are dead — nothing writes them and the proxy no longer reads them — so the destroy-path cleanup goes: `deleteLegacySandboxPolicy` and its call sites in the kill-requested branch, `deleteByOwner`, and the scope-transition destroy, plus the test plumbing that mocked it.

**Second commit — the legacy workspace layout compatibility plumbing** also goes: reads no longer fall back to `workspaces/{wId}.json`, writes no longer dual-write it, deletes no longer scrub it first. This formally closes the front rollback window past the relayout — a rolled-back front would read and write only the legacy path, which nothing maintains anymore.

Merge order relative to `30464` does not matter. Leftover objects are handled by the tidy-up in `30464`'s deploy plan.

> [!NOTE]
> Gate satisfied: the `30468` backfill dry run (2026-08-12) verified **zero uncopied legacy objects in both regions** — the backfill was unnecessary (dual-write covered everything over time) and its PR is closed.

## Risk

None — deletion of dead cleanup code. Safe to rollback.

## Deploy Plan

- [x] Verified zero legacy-only workspace objects in both regions (dry run, 2026-08-12)
- [ ] Deploy front (no ordering constraints relative to `30464`)

## Tests

Affected suites green (sandbox resource 48, egress policy 15); the legacy-path read/write/delete tests are removed with the plumbing they pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
