### PR TITLE
Private Slack channel selection for default agents

### DIFF
--- a/front-api/routes/w/[wId]/assistant/builder/slack/index.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/slack/index.ts
@@ -1,10 +1,12 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
 import channelsLinkedWithAgent from "./channels_linked_with_agent";
+import userPrivateChannels from "./user_private_channels";
 
 // Mounted under /api/w/:wId/assistant/builder/slack.
 const app = workspaceApp();
 
 app.route("/channels_linked_with_agent", channelsLinkedWithAgent);
+app.route("/user_private_channels", userPrivateChannels);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/builder/slack/user_private_channels.test.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/slack/user_private_channels.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the external boundaries (Slack Web API + OAuth token service). Keep the
+// rest of each module intact so unrelated exports (e.g. SLACK_API_PAGE_SIZE)
+// still resolve.
+vi.mock(
+  "@app/lib/api/actions/servers/slack/helpers",
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import("@app/lib/api/actions/servers/slack/helpers")
+    >()),
+    getSlackClient: vi.fn(),
+  })
+);
+
+vi.mock("@app/lib/api/oauth_access_token", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/oauth_access_token")>()),
+  getOAuthConnectionAccessToken: vi.fn(),
+}));
+
+import { getSlackClient } from "@app/lib/api/actions/servers/slack/helpers";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import { Err, Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+
+const URL_PATH = "assistant/builder/slack/user_private_channels";
+
+function get(workspace: { sId: string }) {
+  return honoApp.request(`/api/w/${workspace.sId}/${URL_PATH}`);
+}
+
+// Marks Slack Tools as activated in the workspace by making the internal MCP
+// server listing include a "slack" server.
+function enableSlackTools() {
+  vi.spyOn(
+    InternalMCPServerInMemoryResource,
+    "listByWorkspace"
+  ).mockResolvedValue([
+    { toJSON: () => ({ name: "slack" }) },
+  ] as unknown as Awaited<
+    ReturnType<typeof InternalMCPServerInMemoryResource.listByWorkspace>
+  >);
+}
+
+// Makes the current user look connected to personal Slack Tools.
+function mockPersonalConnection(connectionId: string) {
+  vi.spyOn(
+    MCPServerConnectionResource,
+    "findByInternalServerName"
+  ).mockResolvedValue({
+    connectionId,
+  } as unknown as MCPServerConnectionResource);
+}
+
+// Returns an OAuth access-token result carrying the given token + team id.
+function oauthResult(accessToken: string, teamId: string | null) {
+  return new Ok({
+    access_token: accessToken,
+    access_token_expiry: null,
+    connection: {
+      metadata: teamId ? { team_id: teamId } : {},
+    },
+  }) as unknown as Awaited<ReturnType<typeof getOAuthConnectionAccessToken>>;
+}
+
+// Builds a fake Slack client whose users.conversations returns `channels`.
+function slackClientReturning(channels: { id: string; name: string }[]) {
+  return {
+    users: {
+      conversations: vi.fn().mockResolvedValue({
+        ok: true,
+        channels,
+        response_metadata: { next_cursor: undefined },
+      }),
+    },
+  } as unknown as Awaited<ReturnType<typeof getSlackClient>>;
+}
+
+describe("GET /api/w/:wId/assistant/builder/slack/user_private_channels", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(403);
+    expect((await response.json()).error.type).toBe("workspace_auth_error");
+  });
+
+  it("returns tool_unavailable when Slack Tools is not activated", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // No Slack internal MCP server in the workspace.
+    vi.spyOn(
+      InternalMCPServerInMemoryResource,
+      "listByWorkspace"
+    ).mockResolvedValue([]);
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "tool_unavailable",
+      channels: [],
+    });
+  });
+
+  it("returns not_connected when the admin has no personal Slack connection", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    enableSlackTools();
+    // No personal connection registered for this user.
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "not_connected",
+      channels: [],
+    });
+  });
+
+  it("returns the intersection of the admin's and the bot's private channels", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    enableSlackTools();
+    mockPersonalConnection("personal-conn");
+
+    // The bot is present on the workspace via a Slack data source; the bot
+    // connector resolves to its own OAuth connection.
+    vi.spyOn(DataSourceResource, "listByConnectorProvider").mockImplementation(
+      ((_auth: unknown, provider: string) =>
+        Promise.resolve(
+          provider === "slack" ? [{ connectorId: "conn-slack" }] : []
+        )) as unknown as typeof DataSourceResource.listByConnectorProvider
+    );
+
+    vi.spyOn(ConnectorsAPI.prototype, "getConnector").mockResolvedValue(
+      new Ok({ connectionId: "bot-conn" }) as unknown as Awaited<
+        ReturnType<ConnectorsAPI["getConnector"]>
+      >
+    );
+
+    // Personal token → the admin's channels; bot token → the bot's channels.
+    vi.mocked(getOAuthConnectionAccessToken).mockImplementation(
+      async ({ connectionId }) =>
+        connectionId === "personal-conn"
+          ? oauthResult("user-token", "T123")
+          : oauthResult("bot-token", null)
+    );
+
+    vi.mocked(getSlackClient).mockImplementation(async (accessToken) =>
+      accessToken === "user-token"
+        ? slackClientReturning([
+            { id: "C1", name: "alpha" },
+            { id: "C2", name: "beta" },
+            { id: "C3", name: "gamma" },
+          ])
+        : slackClientReturning([
+            { id: "C2", name: "beta" },
+            { id: "C3", name: "gamma" },
+            { id: "C4", name: "delta" },
+          ])
+    );
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+    // Only channels the admin and the bot both belong to, sorted by name.
+    expect(body.channels).toEqual([
+      {
+        slackChannelId: "C2",
+        slackChannelName: "#beta",
+        sourceUrl: "https://app.slack.com/client/T123/C2",
+      },
+      {
+        slackChannelId: "C3",
+        slackChannelName: "#gamma",
+        sourceUrl: "https://app.slack.com/client/T123/C3",
+      },
+    ]);
+  });
+
+  it("returns 500 when the personal Slack token cannot be fetched", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    enableSlackTools();
+    mockPersonalConnection("personal-conn");
+
+    vi.mocked(getOAuthConnectionAccessToken).mockResolvedValue(
+      new Err({
+        code: "connection_not_found",
+        message: "token exchange failed",
+      }) as unknown as Awaited<ReturnType<typeof getOAuthConnectionAccessToken>>
+    );
+
+    const response = await get(workspace);
+
+    expect(response.status).toBe(500);
+    expect((await response.json()).error.type).toBe("internal_server_error");
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/builder/slack/user_private_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/slack/user_private_channels.ts
@@ -1,0 +1,34 @@
+import { listUserPrivateSlackChannels } from "@app/lib/api/assistant/builder/slack/user_private_channels";
+import type { GetSlackUserPrivateChannelsResponseBody } from "@app/types/api/assistant/builder/slack/user_private_channels";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get(
+  "/",
+  ensureIsAdmin(),
+  async (
+    ctx
+  ): HandlerResult<GetSlackUserPrivateChannelsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const result = await listUserPrivateSlackChannels(auth);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/builder/slack/user_private_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/builder/slack/user_private_channels.ts
@@ -11,9 +11,7 @@ const app = workspaceApp();
 app.get(
   "/",
   ensureIsAdmin(),
-  async (
-    ctx
-  ): HandlerResult<GetSlackUserPrivateChannelsResponseBody> => {
+  async (ctx): HandlerResult<GetSlackUserPrivateChannelsResponseBody> => {
     const auth = ctx.get("auth");
 
     const result = await listUserPrivateSlackChannels(auth);

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -1,6 +1,7 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useSlackUserPrivateChannels } from "@app/lib/swr/assistants";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import type { DataSourceType } from "@app/types/data_source";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -12,6 +13,7 @@ import {
   ContentMessage,
   Icon,
   LinkExternal01,
+  Lock01,
   SearchInput,
   Sheet,
   SheetContainer,
@@ -37,6 +39,7 @@ type SlackChannel = {
   sourceUrl?: string | null;
   autoRespondWithoutMention?: boolean;
   autoRespondWithoutMentionSkipThreadReplies?: boolean;
+  isPrivate?: boolean;
 };
 
 type SheetState = {
@@ -109,7 +112,13 @@ function SlackChannelsList({
       viewType: "all",
     });
 
-  const filteredChannels = useMemo(() => {
+  const { privateChannels, isPrivateChannelsLoading } =
+    useSlackUserPrivateChannels({
+      workspaceId: owner.sId,
+      disabled,
+    });
+
+  const publicChannels = useMemo(() => {
     if (!resources) {
       return [];
     }
@@ -124,15 +133,41 @@ function SlackChannelsList({
         ),
         slackChannelName: resource.title,
         sourceUrl: resource.sourceUrl,
-      }))
-      .filter(
-        (channel) =>
-          searchQuery.trim() === "" ||
-          channel.slackChannelName
-            .toLowerCase()
-            .includes(searchQuery.toLowerCase())
-      );
-  }, [resources, searchQuery]);
+        isPrivate: false as const,
+      }));
+  }, [resources]);
+
+  const mergedChannels = useMemo(() => {
+    const byId = new Map<string, SlackChannel>();
+
+    for (const channel of publicChannels) {
+      byId.set(channel.slackChannelId, channel);
+    }
+
+    for (const channel of privateChannels) {
+      // Prefer the private-channel entry so admins see the lock affordance.
+      byId.set(channel.slackChannelId, {
+        slackChannelId: channel.slackChannelId,
+        slackChannelName: channel.slackChannelName,
+        sourceUrl: channel.sourceUrl,
+        isPrivate: true,
+      });
+    }
+
+    return Array.from(byId.values()).sort((a, b) =>
+      a.slackChannelName.localeCompare(b.slackChannelName)
+    );
+  }, [publicChannels, privateChannels]);
+
+  const filteredChannels = useMemo(() => {
+    if (searchQuery.trim() === "") {
+      return mergedChannels;
+    }
+    const query = searchQuery.toLowerCase();
+    return mergedChannels.filter((channel) =>
+      channel.slackChannelName.toLowerCase().includes(query)
+    );
+  }, [mergedChannels, searchQuery]);
 
   const handleChannelToggle = useCallback(
     (channel: SlackChannel, isChecked?: boolean) => {
@@ -146,6 +181,7 @@ function SlackChannelsList({
           slackChannelId: channel.slackChannelId,
           slackChannelName: channel.slackChannelName,
           sourceUrl: channel.sourceUrl,
+          isPrivate: channel.isPrivate,
         };
         onSelectionChange([...existingSelection, channelForSelection]);
       } else {
@@ -175,6 +211,8 @@ function SlackChannelsList({
     );
   }
 
+  const isLoading = isResourcesLoading || isPrivateChannelsLoading;
+
   return (
     <div className="space-y-4">
       <SearchInput
@@ -184,7 +222,7 @@ function SlackChannelsList({
         onChange={setSearchQuery}
       />
 
-      {isResourcesLoading ? (
+      {isLoading ? (
         <div className="flex justify-center py-8">
           <Spinner size="sm" />
         </div>
@@ -214,6 +252,13 @@ function SlackChannelsList({
                   <span className="text-sm font-medium text-primary-900">
                     {channel.slackChannelName}
                   </span>
+                  {channel.isPrivate && (
+                    <Icon
+                      visual={Lock01}
+                      size="xs"
+                      className="text-muted-foreground"
+                    />
+                  )}
                 </div>
                 {channel.sourceUrl && (
                   <div className="opacity-0 transition-opacity group-hover:opacity-100">

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -392,8 +392,9 @@ export function SlackSettingsSheet({
               Set this agent as the default agent on one or several of your
               Slack channels. It will answer by default when the{" "}
               <span className="font-bold">@Dust</span> Slack bot is mentioned in
-              these channels. To see private channels, activate the Slack tool
-              and connect your personal Slack account.
+              these channels. Private channels you belong to appear here after
+              you add the Slack tool, connect your personal Slack account, and
+              invite <span className="font-bold">@Dust</span> to the channel.
             </div>
             {!isAdmin(owner) && (
               <ContentMessage

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -392,7 +392,8 @@ export function SlackSettingsSheet({
               Set this agent as the default agent on one or several of your
               Slack channels. It will answer by default when the{" "}
               <span className="font-bold">@Dust</span> Slack bot is mentioned in
-              these channels.
+              these channels. To see private channels, activate the Slack tool
+              and connect your personal Slack account.
             </div>
             {!isAdmin(owner) && (
               <ContentMessage

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -325,7 +325,6 @@ describe("fetchConsumptionFacets", () => {
     expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(8);
   });
 
-
   it("returns the Elasticsearch failure before resolving historical labels", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
     const error = new ElasticsearchError("query_error", "query failed");

--- a/front/lib/api/assistant/builder/slack/user_private_channels.ts
+++ b/front/lib/api/assistant/builder/slack/user_private_channels.ts
@@ -17,6 +17,7 @@ import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { isString } from "@app/types/shared/utils/general";
 
 async function isSlackToolsAvailable(auth: Authenticator): Promise<boolean> {
   const servers = await InternalMCPServerInMemoryResource.listByWorkspace(auth);
@@ -184,10 +185,9 @@ export async function listUserPrivateSlackChannels(
     );
   }
 
-  const teamId =
-    typeof tokenRes.value.connection.metadata.team_id === "string"
-      ? tokenRes.value.connection.metadata.team_id
-      : null;
+  const teamId = isString(tokenRes.value.connection.metadata.team_id)
+    ? tokenRes.value.connection.metadata.team_id
+    : null;
 
   const [userChannelsRes, botChannelIdsRes] = await Promise.all([
     listPrivateChannelsWithToken(tokenRes.value.access_token, teamId),

--- a/front/lib/api/assistant/builder/slack/user_private_channels.ts
+++ b/front/lib/api/assistant/builder/slack/user_private_channels.ts
@@ -1,0 +1,213 @@
+import {
+  getSlackClient,
+  SLACK_API_PAGE_SIZE,
+} from "@app/lib/api/actions/servers/slack/helpers";
+import config from "@app/lib/api/config";
+import { getOAuthConnectionAccessToken } from "@app/lib/api/oauth_access_token";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
+import type {
+  GetSlackUserPrivateChannelsResponseBody,
+  SlackUserPrivateChannel,
+} from "@app/types/api/assistant/builder/slack/user_private_channels";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+async function isSlackToolsAvailable(auth: Authenticator): Promise<boolean> {
+  const servers = await InternalMCPServerInMemoryResource.listByWorkspace(auth);
+  return servers.some((server) => server.toJSON().name === "slack");
+}
+
+async function listPrivateChannelsWithToken(
+  accessToken: string,
+  teamId: string | null
+): Promise<Result<SlackUserPrivateChannel[], Error>> {
+  try {
+    const slackClient = await getSlackClient(accessToken);
+    const channels: SlackUserPrivateChannel[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const response = await slackClient.users.conversations({
+        cursor,
+        limit: SLACK_API_PAGE_SIZE,
+        exclude_archived: true,
+        types: "private_channel",
+      });
+
+      if (!response.ok) {
+        return new Err(
+          new Error(
+            `Failed to list private Slack channels: ${response.error ?? "unknown"}`
+          )
+        );
+      }
+
+      for (const channel of response.channels ?? []) {
+        if (!channel.id || !channel.name) {
+          continue;
+        }
+        channels.push({
+          slackChannelId: channel.id,
+          slackChannelName: `#${channel.name}`,
+          sourceUrl: teamId
+            ? `https://app.slack.com/client/${teamId}/${channel.id}`
+            : null,
+        });
+      }
+
+      cursor = response.response_metadata?.next_cursor || undefined;
+    } while (cursor);
+
+    return new Ok(channels);
+  } catch (error) {
+    return new Err(normalizeError(error));
+  }
+}
+
+async function listPrivateChannelIdsWithToken(
+  accessToken: string
+): Promise<Result<Set<string>, Error>> {
+  const channelsRes = await listPrivateChannelsWithToken(accessToken, null);
+  if (channelsRes.isErr()) {
+    return channelsRes;
+  }
+  return new Ok(
+    new Set(channelsRes.value.map((channel) => channel.slackChannelId))
+  );
+}
+
+// Resolves the workspace Slack / Slack Bot connector and returns the set of
+// private channel IDs the Dust bot has joined. Used to keep private-channel
+// picker parity with public channels (write permission = bot is present).
+async function listDustBotPrivateChannelIds(
+  auth: Authenticator
+): Promise<Result<Set<string>, Error>> {
+  const [[dataSourceSlack], [dataSourceSlackBot]] = await Promise.all([
+    DataSourceResource.listByConnectorProvider(auth, "slack"),
+    DataSourceResource.listByConnectorProvider(auth, "slack_bot"),
+  ]);
+
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  let isSlackBotEnabled = false;
+  if (dataSourceSlackBot?.connectorId) {
+    const configRes = await connectorsAPI.getConnectorConfig(
+      dataSourceSlackBot.connectorId,
+      "botEnabled"
+    );
+    if (configRes.isOk()) {
+      isSlackBotEnabled = configRes.value.configValue === "true";
+    }
+  }
+
+  const dataSource = isSlackBotEnabled ? dataSourceSlackBot : dataSourceSlack;
+  if (!dataSource?.connectorId) {
+    return new Ok(new Set());
+  }
+
+  const connRes = await connectorsAPI.getConnector(dataSource.connectorId);
+  if (connRes.isErr() || !connRes.value.connectionId) {
+    return new Err(
+      new Error(
+        `Failed to get Slack connector: ${
+          connRes.isErr() ? connRes.error.message : "missing connectionId"
+        }`
+      )
+    );
+  }
+
+  const tokenRes = await getOAuthConnectionAccessToken({
+    config: config.getOAuthAPIConfig(),
+    logger,
+    connectionId: connRes.value.connectionId,
+  });
+  if (tokenRes.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to get Slack bot access token: ${tokenRes.error.message}`
+      )
+    );
+  }
+
+  return listPrivateChannelIdsWithToken(tokenRes.value.access_token);
+}
+
+/**
+ * Lists private Slack channels the current user is a member of *and* where the
+ * Dust bot is present. User membership is discovered via the personal Slack
+ * Tools OAuth token (ToS-safe; scoped to the requesting admin). Dust presence
+ * is the intersection with the bot's joined private channels — matching the
+ * public-channel picker, which only surfaces channels the bot can write to.
+ */
+export async function listUserPrivateSlackChannels(
+  auth: Authenticator
+): Promise<Result<GetSlackUserPrivateChannelsResponseBody, Error>> {
+  if (!(await isSlackToolsAvailable(auth))) {
+    return new Ok({
+      status: "tool_unavailable",
+      channels: [],
+    });
+  }
+
+  const personalConnection =
+    await MCPServerConnectionResource.findByInternalServerName(auth, {
+      serverName: "slack",
+      connectionType: "personal",
+    });
+
+  if (!personalConnection?.connectionId) {
+    return new Ok({
+      status: "not_connected",
+      channels: [],
+    });
+  }
+
+  const tokenRes = await getOAuthConnectionAccessToken({
+    config: config.getOAuthAPIConfig(),
+    logger,
+    connectionId: personalConnection.connectionId,
+  });
+
+  if (tokenRes.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to get Slack personal access token: ${tokenRes.error.message}`
+      )
+    );
+  }
+
+  const teamId =
+    typeof tokenRes.value.connection.metadata.team_id === "string"
+      ? tokenRes.value.connection.metadata.team_id
+      : null;
+
+  const [userChannelsRes, botChannelIdsRes] = await Promise.all([
+    listPrivateChannelsWithToken(tokenRes.value.access_token, teamId),
+    listDustBotPrivateChannelIds(auth),
+  ]);
+
+  if (userChannelsRes.isErr()) {
+    return userChannelsRes;
+  }
+  if (botChannelIdsRes.isErr()) {
+    return botChannelIdsRes;
+  }
+
+  const channels = userChannelsRes.value
+    .filter((channel) => botChannelIdsRes.value.has(channel.slackChannelId))
+    .sort((a, b) => a.slackChannelName.localeCompare(b.slackChannelName));
+
+  return new Ok({
+    status: "ok",
+    channels,
+  });
+}

--- a/front/lib/api/assistant/builder/slack/user_private_channels.ts
+++ b/front/lib/api/assistant/builder/slack/user_private_channels.ts
@@ -83,8 +83,7 @@ async function listPrivateChannelIdsWithToken(
 }
 
 // Resolves the workspace Slack / Slack Bot connector and returns the set of
-// private channel IDs the Dust bot has joined. Used to keep private-channel
-// picker parity with public channels (write permission = bot is present).
+// private channel IDs the Dust bot has joined.
 async function listDustBotPrivateChannelIds(
   auth: Authenticator
 ): Promise<Result<Set<string>, Error>> {

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -37,6 +37,7 @@ import {
 import { BROWSER_TIMEZONE } from "@app/lib/swr/workspaces";
 import type { GetAgentUsageResponseBody } from "@app/types/api/assistant/agent_usage";
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/types/api/assistant/builder/slack/channels_linked_with_agent";
+import type { GetSlackUserPrivateChannelsResponseBody } from "@app/types/api/assistant/builder/slack/user_private_channels";
 import type { GetAgentConfigurationsResponseBody } from "@app/types/api/assistant/configuration";
 import { BatchUpdateAgentModelResponseBodySchema } from "@app/types/api/assistant/configuration";
 import type { GetSimilarAgentsResponseBody } from "@app/types/api/assistant/configuration/existing_agent_checker";
@@ -550,6 +551,34 @@ export function useSlackChannelsLinkedWithAgent({
     isSlackChannelsLoading: !error && !data,
     isSlackChannelsError: error,
     mutateSlackChannels: mutate,
+  };
+}
+
+export function useSlackUserPrivateChannels({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const userPrivateChannelsFetcher: Fetcher<GetSlackUserPrivateChannelsResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/assistant/builder/slack/user_private_channels`,
+    userPrivateChannelsFetcher,
+    {
+      disabled: !!disabled,
+    }
+  );
+
+  return {
+    status: data?.status ?? null,
+    privateChannels: data?.channels ?? emptyArray(),
+    isPrivateChannelsLoading: !disabled && !error && !data,
+    isPrivateChannelsError: error,
+    mutatePrivateChannels: mutate,
   };
 }
 

--- a/front/types/api/assistant/builder/slack/user_private_channels.ts
+++ b/front/types/api/assistant/builder/slack/user_private_channels.ts
@@ -1,0 +1,15 @@
+export type SlackUserPrivateChannel = {
+  slackChannelId: string;
+  slackChannelName: string;
+  sourceUrl: string | null;
+};
+
+export type GetSlackUserPrivateChannelsResponseBody = {
+  /**
+   * - `ok`: personal Slack Tools connection found; private channels listed.
+   * - `not_connected`: user has not connected personal Slack Tools yet.
+   * - `tool_unavailable`: Slack Tools is not activated in this workspace.
+   */
+  status: "ok" | "not_connected" | "tool_unavailable";
+  channels: SlackUserPrivateChannel[];
+};


### PR DESCRIPTION
## Summary

Lets admins surface **private** Slack channels they belong to in the default-agent channel picker. The admin connects their personal Slack account; private-channel listing is scoped per-user (other admins don't see each other's private channels). Dust must still be present in a private channel to reply there. We cannot do this via non-user credential mechanisms today because Slack ToS says we can't present a private channel of admin A to admin B.

## Testing

<img width="338" height="958" alt="Screenshot 2026-08-12 at 5 49 36 PM" src="https://github.com/user-attachments/assets/565f6a81-d91d-4cb2-97dc-97c302b2737a" />

## Risk

Low-ish. Impact is scoped to just Slack panel, but we do introduce a new API that uses personal credentials for Slack

## Deploy
1. Depoy front