### PR TITLE
feat(marketing): refresh homepage copy and section order

### DIFF
--- a/marketing/components/home/content/Product/HeroOfficeSection.tsx
+++ b/marketing/components/home/content/Product/HeroOfficeSection.tsx
@@ -11,9 +11,9 @@ import Link from "next/link";
 import { useEffect, useRef } from "react";
 
 const HEADLINE_LINE_1 = "Multiplayer AI for";
-const HEADLINE_LINE_2 = "human-agent collaboration.";
+const HEADLINE_LINE_2 = "human-agent collaboration";
 const LEAD_COPY =
-  "Dust is where people and agents collaborate as co-contributors, so that work doesn't just get done – it gets rewired.";
+  "Dust connects your company knowledge, tools, and teams so you can create, share, and run agents across real workflows. Use different models for different tasks, with people in control.";
 
 const OFFICE_FIRST_NAMES = [
   "Aisha",

--- a/marketing/components/home/content/Product/HomeAIOperatorsCTASection.tsx
+++ b/marketing/components/home/content/Product/HomeAIOperatorsCTASection.tsx
@@ -1,9 +1,7 @@
 // biome-ignore-all lint/plugin/noNextImports: Next.js-specific file
 import { HomeReveal } from "@marketing/components/home/content/Product/HomeReveal";
-import { useSignUpModal } from "@marketing/hooks/useSignUpModal";
 import { TRACKING_AREAS, withTracking } from "@marketing/lib/tracking";
 import { LegacyButton as Button } from "@dust-tt/sparkle";
-import Link from "next/link";
 
 type CTAStatAccent = "blue" | "golden" | "green";
 
@@ -38,8 +36,6 @@ const STAT_THEME: Record<CTAStatAccent, { number: string }> = {
 };
 
 export function HomeAIOperatorsCTASection() {
-  const { openSignUpModal } = useSignUpModal();
-
   return (
     <section className="relative w-full overflow-hidden bg-slate-950 py-32 text-white">
       <div
@@ -99,22 +95,11 @@ export function HomeAIOperatorsCTASection() {
           <Button
             variant="highlight"
             size="md"
-            label="Become an AI Operator"
-            className="active:scale-[0.97] transition-transform duration-100"
-            onClick={withTracking(
-              TRACKING_AREAS.HOME,
-              "ai_operator_become",
-              openSignUpModal
-            )}
-          />
-          <Link
+            label="We're hiring →"
             href="https://dust.tt/jobs"
-            className="group inline-flex items-center gap-2 font-mono text-sm uppercase tracking-[0.1em] text-white/80 transition-colors hover:text-white"
-          >
-            <span className="block h-px w-6 bg-white/40 transition-all duration-200 group-hover:w-10 group-hover:bg-white" />
-            We&apos;re hiring
-            <span aria-hidden="true">→</span>
-          </Link>
+            className="active:scale-[0.97] transition-transform duration-100"
+            onClick={withTracking(TRACKING_AREAS.HOME, "ai_operator_hiring")}
+          />
         </HomeReveal>
         <div className="mt-12 hidden w-full max-w-[760px] grid-cols-1 gap-8 sm:grid-cols-3 sm:gap-0 sm:divide-x sm:divide-white/10">
           {STATS.map((stat, index) => {

--- a/marketing/components/home/content/Product/HomeAgentsImproveSection.tsx
+++ b/marketing/components/home/content/Product/HomeAgentsImproveSection.tsx
@@ -30,17 +30,17 @@ interface FeatureCard {
 const CARDS: FeatureCard[] = [
   {
     number: "01",
-    title: "Knows your company",
+    title: "Agents with company context",
     subtitle:
-      "Connects to all your tools and data, your stack becomes the agent's memory.",
+      "Connect Dust to 70+ connectors, including Slack, Notion, Google Drive, GitHub, Salesforce, and Zendesk. Give agents the context they need to get work done.",
     accent: "text-blue-500",
     hoverVideoSrc: "/static/landing/home/features/knows-your-company.mp4",
   },
   {
     number: "02",
-    title: "Multiplayer AI",
+    title: "Multiplayer AI for cross-functional work",
     subtitle:
-      "Built for collaboration across departments, teams, and agents. Dust is a team sport.",
+      "Bring people and agents into the same workflow. Dust helps teams coordinate complex work across departments using shared context, reusable skills, connected tools, and human review.",
     accent: "text-rose-500",
     hoverVideoSrc: "/static/landing/home/features/team-sport.mp4",
   },
@@ -48,15 +48,15 @@ const CARDS: FeatureCard[] = [
     number: "03",
     title: "Model flexibility",
     subtitle:
-      "Switch seamlessly between frontier models from OpenAI, Anthropic, Google, and Mistral.",
+      "Build agents with 20+ frontier and open-source models from OpenAI, Anthropic, Google, Mistral, and more. Choose the model that fits each workflow.",
     accent: "text-golden-500",
     hoverVideoSrc: "/static/landing/home/features/best-model.mp4",
   },
   {
     number: "04",
-    title: "Productivity that compounds",
+    title: "AI-native governance",
     subtitle:
-      "Value grows with every teammate that joins. Skills, knowledge, and expertise flow.",
+      "Control how AI is used across your company. Set permissions for data, tools, systems, and agents, then use audit logs and analytics to monitor activity, adoption, usage, costs, and ROI.",
     accent: "text-green-700",
     hoverVideoSrc: "/static/landing/home/features/compounds.mp4",
   },
@@ -212,7 +212,7 @@ export function HomeAgentsImproveSection() {
           </HomeReveal>
           <HomeReveal delay={80}>
             <H2 className="max-w-[820px] text-balance text-center font-semibold leading-[1.08] tracking-[-0.03em] text-foreground text-center!">
-              Agents that get smarter the more you use them
+              One system for your company&apos;s AI work
             </H2>
           </HomeReveal>
           <HomeReveal delay={160}>
@@ -220,10 +220,10 @@ export function HomeAgentsImproveSection() {
               size="sm"
               className="max-w-[680px] text-center text-muted-foreground"
             >
-              Dust agents don&apos;t just search your data, they learn how you
-              work. Best practices consolidate into shared skills, improvements
-              spread automatically, and your fiftieth workflow is easier to
-              build than your fifth.
+              Dust brings your systems, models, and teams together so agents can
+              coordinate complex work across your company. Teams get the
+              flexibility to build and adapt agents, with the security and
+              control enterprise AI requires.
             </P>
           </HomeReveal>
         </div>

--- a/marketing/components/home/content/Product/HomeCoordinatedSection.tsx
+++ b/marketing/components/home/content/Product/HomeCoordinatedSection.tsx
@@ -10,13 +10,11 @@ export function HomeCoordinatedSection() {
       <div className="mx-auto flex w-full max-w-[1180px] flex-col items-center gap-12 px-6 lg:flex-row-reverse lg:items-center lg:gap-20">
         <div className="flex w-full flex-col gap-6 lg:w-1/2">
           <HomeReveal>
-            <HomeEyebrow label="Intelligent context layer" />
+            <HomeEyebrow label="See Dust in action" />
           </HomeReveal>
           <HomeReveal delay={80}>
             <H2 className="text-balance font-semibold leading-[1.08] tracking-[-0.03em] text-foreground">
-              Your company's knowledge,
-              <br />
-              deeply understood and actioned on
+              AI that uses your context to do real work
             </H2>
           </HomeReveal>
           <HomeReveal delay={160}>
@@ -24,9 +22,10 @@ export function HomeCoordinatedSection() {
               size="sm"
               className="max-w-[480px] leading-[1.6] text-muted-foreground"
             >
-              Any tool can pull from Slack or your CRM. Dust goes further – with
-              a semantic layer that synthesizes your company's knowledge so
-              agents don't just retrieve information – they understand it.
+              Most AI tools can retrieve a message from Slack or a record from
+              your CRM. Dust brings the relevant context together across Slack,
+              CRM, docs, and other company systems, so agents can answer with
+              the full picture and take action.
             </P>
           </HomeReveal>
         </div>

--- a/marketing/components/home/content/Product/HomeSecuritySection.tsx
+++ b/marketing/components/home/content/Product/HomeSecuritySection.tsx
@@ -54,42 +54,35 @@ interface ComplianceColumn {
 const COLUMNS: ComplianceColumn[] = [
   {
     code: "01",
-    title: "Security & compliance",
+    title: "Security and privacy",
     accent: "red",
     items: [
       "SOC 2 Type II certified",
-      "GDPR compliant, EU data residency",
-      "HIPAA-ready deployment",
-      "SSO (SAML, OIDC) + SCIM",
-      "Audit logs, 365-day retention",
-      "RBAC + dual-layer agent permissions",
-      "AES-256 at rest, TLS 1.3 in transit",
-      "Zero model training on your data",
+      "Data residency in the US or EU",
+      "Dedicated single-tenant deployment",
+      "Custom data retention policies",
     ],
   },
   {
     code: "02",
-    title: "Performance & scale",
+    title: "Governance and access",
     accent: "green",
     items: [
-      "99.9% uptime SLA",
-      "10,000+ users per workspace",
-      "Concurrent agent execution",
-      "Sub-2s response time (p95)",
+      "Single sign-on with your identity provider",
+      "Automated user provisioning and deprovisioning",
+      "Separate data and permissions by team",
+      "Audit logs and advanced security controls",
     ],
   },
   {
     code: "03",
-    title: "Integration architecture",
+    title: "Enterprise deployment",
     accent: "blue",
     items: [
-      "RESTful API for custom integrations",
-      "MCP for proprietary systems",
-      "Webhook support for event-driven workflows",
-      "OAuth2 for third-party permissions",
-      "Bi-directional sync, read + write",
-      "Incremental data refresh",
-      "100+ production connectors",
+      "Connect to your existing tools",
+      "Shared workspace credits and volume pricing",
+      "Dedicated customer success support",
+      "Priority support with an SLA",
     ],
   },
 ];
@@ -137,8 +130,6 @@ function PadlockIcon({ accent }: { accent: Accent }) {
   );
 }
 
-const TOTAL_CONTROLS = COLUMNS.reduce((sum, c) => sum + c.items.length, 0);
-
 export function HomeSecuritySection() {
   return (
     <section className="w-full bg-background py-14 lg:py-24">
@@ -149,8 +140,7 @@ export function HomeSecuritySection() {
           </HomeReveal>
           <HomeReveal delay={80}>
             <H2 className="max-w-[820px] text-balance font-semibold leading-[1.08] tracking-[-0.03em] text-foreground">
-              When AI has access to your company&apos;s knowledge, &ldquo;mostly
-              secure&rdquo; doesn&apos;t cut it.
+              Use AI on your terms, without giving up control of your data
             </H2>
           </HomeReveal>
           <HomeReveal delay={160}>
@@ -158,11 +148,11 @@ export function HomeSecuritySection() {
               size="sm"
               className="max-w-[820px] leading-[1.6] text-muted-foreground"
             >
-              Your operators build fast. Your data stays locked down.
               Dust&apos;s dual-layer permission model separates what agents can
-              access from who can use them, with SCIM-synced groups, admin-gated
-              overrides, and zero privilege escalation. Granular enough for your
-              CISO, invisible to everyone else.
+              access from who can use them. SCIM-synced groups, admin-gated
+              overrides, zero privilege escalation, and audit logs let teams
+              move quickly while keeping company data locked down. Granular
+              enough for your CISO, invisible to everyone else.
             </P>
           </HomeReveal>
         </div>
@@ -171,10 +161,7 @@ export function HomeSecuritySection() {
           {/* Caption strip — small, kept on-brand: foreground sans, mono only on the link */}
           <div className="flex flex-wrap items-baseline justify-between gap-3 px-1">
             <span className="text-sm text-muted-foreground">
-              Trust datasheet,{" "}
-              <span className="font-medium text-foreground">
-                {TOTAL_CONTROLS} controls live
-              </span>
+              Trust datasheet
             </span>
             <a
               href="https://dust.tt/security"

--- a/marketing/components/home/content/Product/HomeTeamSportSection.tsx
+++ b/marketing/components/home/content/Product/HomeTeamSportSection.tsx
@@ -15,12 +15,11 @@ export function HomeTeamSportSection() {
         <div className="flex flex-col items-stretch gap-12 lg:flex-row lg:items-center lg:gap-20">
           <div className="flex w-full flex-col gap-6 lg:w-1/2">
             <HomeReveal>
-              <HomeEyebrow label="Multiplayer collaboration surface" />
+              <HomeEyebrow label="Team collaboration" />
             </HomeReveal>
             <HomeReveal delay={80}>
               <H2 className="text-balance font-semibold leading-[1.08] tracking-[-0.03em] text-foreground">
-                A new kind of workspace where people and agents collaborate as
-                equal co-contributors
+                Work that moves between people and AI
               </H2>
             </HomeReveal>
             <HomeReveal delay={160}>
@@ -28,10 +27,11 @@ export function HomeTeamSportSection() {
                 size="sm"
                 className="max-w-[480px] leading-[1.6] text-muted-foreground"
               >
-                Most teams are stuck in single-player AI mode. Dust changes that
-                with a multiplayer AI workspace that gives teams and agents
-                shared access to the same knowledge, tools, conversations, and
-                notifications.
+                Dust gives people and agents shared access to company knowledge,
+                connected tools, conversations, and notifications. People guide
+                the work, while agents handle repeatable tasks across teams.
+                That is what we mean by multiplayer AI: shared work between
+                people, agents, and the systems they use.
               </P>
             </HomeReveal>
             <HomeReveal as="figure" delay={240} className="m-0 mt-4 w-full">

--- a/marketing/components/home/content/Product/HomeTrustedSection.tsx
+++ b/marketing/components/home/content/Product/HomeTrustedSection.tsx
@@ -217,7 +217,7 @@ export function HomeTrustedSection() {
       <div className="mx-auto flex w-full max-w-[1280px] flex-col items-center justify-center gap-12 text-center">
         <HomeReveal>
           <h2 className="m-0 text-balance px-6 text-center text-xl font-semibold tracking-[-0.02em] text-foreground md:text-2xl">
-            Trusted among AI Operators
+            Trusted by teams
             <br />
             at <span className="text-blue-500">3,000+</span> global
             organizations

--- a/marketing/components/home/content/Product/IntroSection.tsx
+++ b/marketing/components/home/content/Product/IntroSection.tsx
@@ -44,13 +44,13 @@ export function IntroSection({ news }: IntroSectionProps = {}) {
         <HeroOfficeSection />
         <div className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] flex w-screen flex-col">
           <HomeTrustedSection />
-          <HomeTeamSportSection />
-          <HomeQuotesSection quotes={QUOTES} />
           <HomeCoordinatedSection />
+          <HomeQuotesSection quotes={QUOTES} />
           <HomeAgentsImproveSection />
+          <HomeTeamSportSection />
+          <HomeSecuritySection />
           <HomeTeamUsageSection />
           <HomeNewsSection news={news} />
-          <HomeSecuritySection />
           <HomeAIOperatorsCTASection />
         </div>
       </div>

--- a/marketing/pages/home/index.tsx
+++ b/marketing/pages/home/index.tsx
@@ -33,7 +33,7 @@ export function Landing({ news }: HomeProps) {
     <>
       <PageMetadata
         title="Dust - Multiplayer AI for human-agent collaboration"
-        description="Dust is where people and agents collaborate as co-contributors, so that work doesn't just get done – it gets rewired."
+        description="Dust connects your company knowledge, tools, and teams so you can create, share, and run agents across real workflows. Use different models for different tasks, with people in control."
         pathname={router.asPath}
       />
       <IntroSection news={news} />


### PR DESCRIPTION
## Description
Updates copy and layout across the marketing homepage:
- Hero headline drops the trailing period; new subhead describes connecting company knowledge/tools/teams with model flexibility and human control. "Trusted among AI Operators" → "Trusted by teams".
- Reordered sections: Intelligent Context Layer (renamed eyebrow "See Dust in action") now follows the trust logos; Self-Improving AI now follows the Everett Berry quote; Enterprise-Ready now follows Multiplayer Collaboration Surface (renamed eyebrow "Team collaboration"); How Every Team Uses Dust now follows Enterprise-Ready, with In the Press staying between them.
- Rewrote headline/body copy and all four feature cards in the Self-Improving AI section.
- Rewrote headline/body copy in the Team Collaboration and See Dust in Action sections.
- Simplified Enterprise-Ready: new headline/body copy, removed the dynamic "N controls live" counter, renamed and trimmed each of the three columns to 4 focused bullets.
- Consolidated the "Become an AI Operator" button and separate "We're hiring" link into a single "We're hiring →" button linking to https://dust.tt/jobs.
- Updated the page's meta description to match the new hero copy.

## Tests
Manually verified in local dev (`npm run dev` in `marketing/`) after each change:
- Re-read the rendered page text/DOM to confirm every copy change and the new section order end-to-end.
- Confirmed Enterprise-ready bullets render on one line where intended.
- Confirmed the consolidated "We're hiring" CTA links to https://dust.tt/jobs and the old duplicate link/button is gone.
- Confirmed the updated `<meta name="description">` value via the page's document head.

No automated tests added — this is a copy/ordering change with no new logic, and existing component structure/props were left intact.

## Risk
Low. Changes are scoped to homepage copy, section order, and card content — no data-fetching, API, or business logic touched. One behavior change: the AI-operator CTA button now links out via `href` instead of opening the sign-up modal via `onClick`, so that button no longer opens the sign-up modal directly. Easily revertible by restoring the previous file contents.

## Deploy Plan
Standard deploy — no migrations, feature flags, or backend changes required. Recommend a quick visual pass on the preview/staging build to confirm section order and copy read well end-to-end before merging, then ship through the normal pipeline.