### PR TITLE
[Activation] Simplify work-area statuses to suggested/dismissed

### DIFF
--- a/front-api/routes/w/[wId]/activation-work-areas/index.ts
+++ b/front-api/routes/w/[wId]/activation-work-areas/index.ts
@@ -14,11 +14,11 @@ import { z } from "zod";
 
 const ListWorkAreasQuerySchema = z.object({
   podId: z.string().optional(),
-  status: z.enum(["candidate", "confirmed", "dismissed"]).optional(),
+  status: z.enum(["suggested", "dismissed"]).optional(),
 });
 
 const UpdateWorkAreaBodySchema = z.object({
-  status: z.enum(["candidate", "confirmed", "dismissed"]).optional(),
+  status: z.enum(["suggested", "dismissed"]).optional(),
   title: z.string().max(255).optional(),
   description: z.string().max(512).optional(),
 });

--- a/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
+++ b/front/components/pages/workspace/GetStartedPage/WorkAreaSection.tsx
@@ -13,16 +13,24 @@ import type { UserType, WorkspaceType } from "@app/types/user";
 import { Button, Chip, Spinner, Tooltip } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
 
-export const WORK_AREA_ACTIONS = [
+const WORK_AREA_ACTIONS = [
   {
     label: "Scan my sources",
     message:
-      "Before generating a recommendation, re-evaluate my work by scanning my connected sources and personal usage. Allow me to confirm the work areas.",
+      "This conversation is to update my work areas, then generate a new idea.\n\n" +
+      "1. Re-evaluate my work by scanning my connected sources and personal usage.\n" +
+      "2. Present the updated work areas and let me correct them if they're off.\n" +
+      "3. Once the work areas are settled, continue the regular flow: set a session goal from the updated work areas and generate a new recommendation (create_recommendation) so it appears on my Get Started page.\n\n" +
+      "Do not generate a recommendation until the work areas are settled.",
   },
   {
     label: "Ask me questions",
     message:
-      "Before generating a recommendation, learn more about my work by asking me questions, interview style. Allow me to confirm the work areas.",
+      "This conversation is to update my work areas, then generate a new idea.\n\n" +
+      "1. Learn more about my work by asking me questions, interview style. Do this before generating a recommendation.\n" +
+      "2. Update my work areas based on what I tell you, and let me correct them if they're off.\n" +
+      "3. Once the work areas are settled, continue the regular flow: set a session goal from the updated work areas and generate a new recommendation (create_recommendation) so it appears on my Get Started page.\n\n" +
+      "Do not generate a recommendation until the work areas are settled.",
   },
 ] as const;
 
@@ -69,14 +77,13 @@ export function WorkAreaSection({
     workspaceId: owner.sId,
   });
 
-  const confirmed = workAreas.filter((r) => r.status === "confirmed");
-  const candidates = workAreas.filter((r) => r.status === "candidate");
-  const hasContent = confirmed.length > 0 || candidates.length > 0;
+  const visibleWorkAreas = workAreas.filter((r) => r.status !== "dismissed");
+  const hasContent = visibleWorkAreas.length > 0;
 
-  const handleUpdate = useCallback(
-    async (sId: string, status: "confirmed" | "dismissed") => {
+  const handleDismiss = useCallback(
+    async (sId: string) => {
       setUpdatingId(sId);
-      await updateWorkArea(sId, { status });
+      await updateWorkArea(sId, { status: "dismissed" });
       void mutateWorkAreas();
       setUpdatingId(null);
     },
@@ -124,7 +131,7 @@ export function WorkAreaSection({
         Your work
       </h2>
       <p className="mt-1 text-sm leading-5 tracking-tight text-muted-foreground">
-        What Dust thinks you're responsible for.
+        What you care about at work. Ideas below are based on this.
       </p>
 
       <div className="mt-6 border-t border-border">
@@ -132,82 +139,64 @@ export function WorkAreaSection({
           <div className="flex items-center justify-center py-10">
             <Spinner size="md" />
           </div>
-        ) : !hasContent ? (
+        ) : (
           <div className="py-4">
-            {runningConversation ? (
+            {runningConversation && !hasContent && (
               <ActivationRunningBanner
                 owner={owner}
                 runningConversation={runningConversation}
                 message="An agent is actively learning about your work."
               />
+            )}
+            {hasContent ? (
+              <div className="flex flex-wrap gap-2">
+                {visibleWorkAreas.map((workArea) => (
+                  <WorkAreaChip
+                    key={workArea.sId}
+                    workArea={workArea}
+                    isUpdating={updatingId === workArea.sId}
+                    onDismiss={() => void handleDismiss(workArea.sId)}
+                  />
+                ))}
+              </div>
             ) : (
-              <>
+              !runningConversation && (
                 <p className="text-sm leading-5 tracking-tight text-muted-foreground">
-                  No work areas yet. Help Dust learn what you own so it can
-                  suggest relevant ideas.
+                  We don't know what you care about yet.
                 </p>
-                <div className="mt-4 flex flex-wrap gap-2">
-                  {WORK_AREA_ACTIONS.map((action) => (
-                    <Button
-                      key={action.label}
-                      variant="outline"
-                      size="sm"
-                      isRounded
-                      label={action.label}
-                      disabled={isCreating}
-                      onClick={() => void startConversation(action.message)}
-                    />
-                  ))}
-                </div>
-              </>
+              )
             )}
+            <p className="mt-4 text-sm leading-5 tracking-tight text-muted-foreground">
+              Select an option below to give us feedback. We'll update this and
+              suggest a new idea.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              {WORK_AREA_ACTIONS.map((action) => (
+                <Button
+                  key={action.label}
+                  variant="outline"
+                  size="sm"
+                  isRounded
+                  label={action.label}
+                  disabled={isCreating}
+                  onClick={() => void startConversation(action.message)}
+                />
+              ))}
+            </div>
           </div>
-        ) : (
-          <>
-            {confirmed.length > 0 && (
-              <div className="flex flex-wrap gap-2 py-4">
-                {confirmed.map((r) => (
-                  <ConfirmedWorkAreaChip
-                    key={r.sId}
-                    workArea={r}
-                    isUpdating={updatingId === r.sId}
-                    onDismiss={() => void handleUpdate(r.sId, "dismissed")}
-                  />
-                ))}
-              </div>
-            )}
-
-            {candidates.length > 0 && (
-              <div className="divide-y divide-border border-t border-border">
-                {candidates.map((r) => (
-                  <CandidateWorkAreaRow
-                    key={r.sId}
-                    workArea={r}
-                    isUpdating={updatingId === r.sId}
-                    onConfirm={() => void handleUpdate(r.sId, "confirmed")}
-                    onDismiss={() => void handleUpdate(r.sId, "dismissed")}
-                  />
-                ))}
-              </div>
-            )}
-          </>
         )}
       </div>
     </div>
   );
 }
 
-interface ConfirmedWorkAreaChipProps {
+interface WorkAreaChipProps {
   workArea: ActivationWorkAreaForUserType;
   isUpdating: boolean;
   onDismiss: () => void;
 }
 
-function ConfirmedWorkAreaChip({
-  workArea,
-  isUpdating,
-  onDismiss,
-}: ConfirmedWorkAreaChipProps) {
+function WorkAreaChip({ workArea, isUpdating, onDismiss }: WorkAreaChipProps) {
   return (
     <Tooltip
       label={workArea.description}
@@ -221,49 +210,5 @@ function ConfirmedWorkAreaChip({
         />
       }
     />
-  );
-}
-
-interface CandidateWorkAreaRowProps {
-  workArea: ActivationWorkAreaForUserType;
-  isUpdating: boolean;
-  onConfirm: () => void;
-  onDismiss: () => void;
-}
-
-function CandidateWorkAreaRow({
-  workArea,
-  isUpdating,
-  onConfirm,
-  onDismiss,
-}: CandidateWorkAreaRowProps) {
-  return (
-    <div className="py-4">
-      <h3 className="text-base font-semibold leading-6 tracking-tight text-foreground">
-        {workArea.title}
-      </h3>
-      <p className="mt-1 text-sm leading-5 tracking-tight text-muted-foreground">
-        {workArea.description}
-      </p>
-      <div className="mt-4 flex items-center gap-2">
-        <Button
-          variant="highlight"
-          size="sm"
-          isRounded
-          label="Confirm"
-          disabled={isUpdating}
-          onClick={onConfirm}
-        />
-        <Button
-          variant="outline"
-          size="sm"
-          isRounded
-          label="Not Relevant"
-          disabled={isUpdating}
-          onClick={onDismiss}
-        />
-        {isUpdating && <Spinner size="xs" />}
-      </div>
-    </div>
   );
 }

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -4,10 +4,7 @@ import { JustAskComposer } from "@app/components/pages/workspace/GetStartedPage/
 import { PreviouslyDoneRow } from "@app/components/pages/workspace/GetStartedPage/PreviouslyDoneRow";
 import { RecentConversations } from "@app/components/pages/workspace/GetStartedPage/RecentConversations";
 import { RecommendationItem } from "@app/components/pages/workspace/GetStartedPage/RecommendationItem";
-import {
-  WORK_AREA_ACTIONS,
-  WorkAreaSection,
-} from "@app/components/pages/workspace/GetStartedPage/WorkAreaSection";
+import { WorkAreaSection } from "@app/components/pages/workspace/GetStartedPage/WorkAreaSection";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { usePodConversations } from "@app/hooks/conversations";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
@@ -30,16 +27,19 @@ import { useCallback, useEffect, useState } from "react";
 
 const QUICK_PROMPTS = [
   {
-    label: "Scan my connected sources to understand my work.",
-    message: WORK_AREA_ACTIONS[0].message,
+    label: "What skills and agents are my coworkers using?",
+    message:
+      "What skills and agents are my coworkers using? Show me what's catching on in this workspace and whether any of it would help my work.",
   },
   {
-    label: "Ask me questions to learn how I work.",
-    message: WORK_AREA_ACTIONS[1].message,
+    label: "What's coming up that I should prep for?",
+    message:
+      "Look at my calendar and recent work. What's coming up that I should prep for, and how can Dust help?",
   },
   {
-    label: "How does my learning space work?",
-    message: "How does my learning space work?",
+    label: "How are people in my role using Dust?",
+    message:
+      "How are people in the same role as me using Dust? Show me the skills and agents they actually use, and which of those would help my work.",
   },
 ];
 
@@ -242,7 +242,7 @@ export function GetStartedPage() {
                         />
                       ) : (
                         <>
-                          <p className="text-sm text-muted-foreground">
+                          <p className="text-sm leading-5 tracking-tight text-muted-foreground">
                             No new ideas yet. Let Dust suggest things to try.
                           </p>
                           <div className="mt-4">

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -294,10 +294,10 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         ]);
       }
 
-      const lines = rows.map(
-        (r, i) =>
-          `${i + 1}. [${r.status}] ${r.sId} — "${r.title}": ${r.description}`
-      );
+      const lines = rows.map((r, i) => {
+        const workArea = r.toJSON();
+        return `${i + 1}. [${workArea.status}] ${workArea.sId} — "${workArea.title}": ${workArea.description}`;
+      });
 
       return new Ok([
         {
@@ -338,7 +338,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       );
 
       const lines = created.map(
-        (r) => `${r.sId} — "${r.title}" (status: candidate)`
+        (r) => `${r.sId} — "${r.title}" (status: suggested)`
       );
 
       return new Ok([

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -190,7 +190,7 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
           "The current Pod ID from the activation context. Always pass it to scope results to this Pod."
         ),
       status: z
-        .enum(["candidate", "confirmed", "dismissed"])
+        .enum(["suggested", "dismissed"])
         .optional()
         .describe("Only return work areas with this status. Omit for all."),
     },
@@ -206,7 +206,7 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
     name: "create_work_areas",
     description:
       "Create one or more work areas for the current Activation Pod. Each is created " +
-      "with status 'candidate'. Returns the created work areas with their ids.",
+      "with status 'suggested'. Returns the created work areas with their ids.",
     schema: {
       workAreas: z
         .array(
@@ -241,9 +241,11 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
     schema: {
       workAreaId: z.string().describe("The id of the work area to update."),
       status: z
-        .enum(["confirmed", "dismissed"])
+        .enum(["dismissed", "suggested"])
         .optional()
-        .describe("New status for the work area."),
+        .describe(
+          "New status for the work area. `dismissed` hides it. `suggested` marks it live. Omit to leave status unchanged."
+        ),
       title: z.string().max(255).optional().describe("New title."),
       description: z.string().max(512).optional().describe("New description."),
     },

--- a/front/lib/api/activation/work_areas.ts
+++ b/front/lib/api/activation/work_areas.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
+import type { PublicActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -11,7 +11,7 @@ export interface ActivationWorkAreaForUserType {
   sId: string;
   title: string;
   description: string;
-  status: ActivationWorkAreaStatus;
+  status: PublicActivationWorkAreaStatus;
   createdAt: number;
 }
 
@@ -29,7 +29,7 @@ export async function listActivationWorkAreasForUser(
     status,
     podId,
   }: {
-    status?: ActivationWorkAreaStatus;
+    status?: PublicActivationWorkAreaStatus;
     podId?: string;
   } = {}
 ): Promise<ActivationWorkAreaForUserType[]> {
@@ -64,7 +64,7 @@ export async function updateActivationWorkAreaForUser(
     description,
   }: {
     workAreaId: string;
-    status?: ActivationWorkAreaStatus;
+    status?: PublicActivationWorkAreaStatus;
     title?: string;
     description?: string;
   }

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -44,12 +44,8 @@ async function setupSettledMessageWithUsage({
   runCount?: number;
   restrictedConversation?: boolean;
 } = {}) {
-  const {
-    authenticator,
-    globalSpace,
-    user,
-    workspace,
-  } = await createResourceTest({ role: "admin" });
+  const { authenticator, globalSpace, user, workspace } =
+    await createResourceTest({ role: "admin" });
 
   let auth = authenticator;
   const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
@@ -175,12 +171,8 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
   });
 
   it("writes attribution for a project conversation hidden from the workflow auth", async () => {
-    const {
-      workspace,
-      conversationId,
-      agentMessageId,
-      agentMessageModelId,
-    } = await setupSettledMessageWithUsage({ restrictedConversation: true });
+    const { workspace, conversationId, agentMessageId, agentMessageModelId } =
+      await setupSettledMessageWithUsage({ restrictedConversation: true });
     const workflowAuth = await Authenticator.internalBuilderForWorkspace(
       workspace.sId
     );

--- a/front/lib/models/activation/activation_work_area.ts
+++ b/front/lib/models/activation/activation_work_area.ts
@@ -3,7 +3,6 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
 export const ACTIVATION_WORK_AREA_STATUSES = [
@@ -18,34 +17,6 @@ export type ActivationWorkAreaStatus =
   (typeof ACTIVATION_WORK_AREA_STATUSES)[number];
 
 export type PublicActivationWorkAreaStatus = "suggested" | "dismissed";
-
-export function publicActivationWorkAreaStatus(
-  status: ActivationWorkAreaStatus
-): PublicActivationWorkAreaStatus {
-  switch (status) {
-    case "dismissed":
-      return "dismissed";
-    case "suggested":
-    case "candidate":
-    case "confirmed":
-      return "suggested";
-    default:
-      assertNever(status);
-  }
-}
-
-export function matchingActivationWorkAreaStatuses(
-  status: PublicActivationWorkAreaStatus
-): ActivationWorkAreaStatus[] {
-  switch (status) {
-    case "dismissed":
-      return ["dismissed"];
-    case "suggested":
-      return ["suggested", "candidate", "confirmed"];
-    default:
-      assertNever(status);
-  }
-}
 
 export class ActivationWorkAreaModel extends WorkspaceAwareModel<ActivationWorkAreaModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/activation/activation_work_area.ts
+++ b/front/lib/models/activation/activation_work_area.ts
@@ -5,7 +5,33 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
-export type ActivationWorkAreaStatus = "candidate" | "confirmed" | "dismissed";
+export const ACTIVATION_WORK_AREA_STATUSES = [
+  "suggested",
+  "dismissed",
+  // Legacy values still present on existing rows. Treat as `suggested`.
+  "candidate",
+  "confirmed",
+] as const;
+
+export type ActivationWorkAreaStatus =
+  (typeof ACTIVATION_WORK_AREA_STATUSES)[number];
+
+export type PublicActivationWorkAreaStatus = "suggested" | "dismissed";
+
+export function publicActivationWorkAreaStatus(
+  status: ActivationWorkAreaStatus
+): PublicActivationWorkAreaStatus {
+  return status === "dismissed" ? "dismissed" : "suggested";
+}
+
+export function matchingActivationWorkAreaStatuses(
+  status: PublicActivationWorkAreaStatus
+): ActivationWorkAreaStatus[] {
+  if (status === "dismissed") {
+    return ["dismissed"];
+  }
+  return ["suggested", "candidate", "confirmed"];
+}
 
 export class ActivationWorkAreaModel extends WorkspaceAwareModel<ActivationWorkAreaModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/activation/activation_work_area.ts
+++ b/front/lib/models/activation/activation_work_area.ts
@@ -3,6 +3,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { CreationOptional, ForeignKey } from "sequelize";
 
 export const ACTIVATION_WORK_AREA_STATUSES = [
@@ -21,16 +22,29 @@ export type PublicActivationWorkAreaStatus = "suggested" | "dismissed";
 export function publicActivationWorkAreaStatus(
   status: ActivationWorkAreaStatus
 ): PublicActivationWorkAreaStatus {
-  return status === "dismissed" ? "dismissed" : "suggested";
+  switch (status) {
+    case "dismissed":
+      return "dismissed";
+    case "suggested":
+    case "candidate":
+    case "confirmed":
+      return "suggested";
+    default:
+      assertNever(status);
+  }
 }
 
 export function matchingActivationWorkAreaStatuses(
   status: PublicActivationWorkAreaStatus
 ): ActivationWorkAreaStatus[] {
-  if (status === "dismissed") {
-    return ["dismissed"];
+  switch (status) {
+    case "dismissed":
+      return ["dismissed"];
+    case "suggested":
+      return ["suggested", "candidate", "confirmed"];
+    default:
+      assertNever(status);
   }
-  return ["suggested", "candidate", "confirmed"];
 }
 
 export class ActivationWorkAreaModel extends WorkspaceAwareModel<ActivationWorkAreaModel> {

--- a/front/lib/resources/activation_work_area_resource.ts
+++ b/front/lib/resources/activation_work_area_resource.ts
@@ -3,11 +3,7 @@ import type {
   ActivationWorkAreaStatus,
   PublicActivationWorkAreaStatus,
 } from "@app/lib/models/activation/activation_work_area";
-import {
-  ActivationWorkAreaModel,
-  matchingActivationWorkAreaStatuses,
-  publicActivationWorkAreaStatus,
-} from "@app/lib/models/activation/activation_work_area";
+import { ActivationWorkAreaModel } from "@app/lib/models/activation/activation_work_area";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -16,6 +12,7 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   Attributes,
   CreationAttributes,
@@ -24,6 +21,38 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
+
+// Maps a stored status (which may hold legacy values) to the public status
+// exposed to callers. Legacy `candidate`/`confirmed` rows read as `suggested`.
+function publicActivationWorkAreaStatus(
+  status: ActivationWorkAreaStatus
+): PublicActivationWorkAreaStatus {
+  switch (status) {
+    case "dismissed":
+      return "dismissed";
+    case "suggested":
+    case "candidate":
+    case "confirmed":
+      return "suggested";
+    default:
+      assertNever(status);
+  }
+}
+
+// Expands a public status into the set of stored values that match it, so
+// filtering by `suggested` also returns legacy `candidate`/`confirmed` rows.
+function matchingActivationWorkAreaStatuses(
+  status: PublicActivationWorkAreaStatus
+): ActivationWorkAreaStatus[] {
+  switch (status) {
+    case "dismissed":
+      return ["dismissed"];
+    case "suggested":
+      return ["suggested", "candidate", "confirmed"];
+    default:
+      assertNever(status);
+  }
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ActivationWorkAreaResource

--- a/front/lib/resources/activation_work_area_resource.ts
+++ b/front/lib/resources/activation_work_area_resource.ts
@@ -1,6 +1,13 @@
 import type { Authenticator } from "@app/lib/auth";
-import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
-import { ActivationWorkAreaModel } from "@app/lib/models/activation/activation_work_area";
+import type {
+  ActivationWorkAreaStatus,
+  PublicActivationWorkAreaStatus,
+} from "@app/lib/models/activation/activation_work_area";
+import {
+  ActivationWorkAreaModel,
+  matchingActivationWorkAreaStatuses,
+  publicActivationWorkAreaStatus,
+} from "@app/lib/models/activation/activation_work_area";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
@@ -16,6 +23,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
+import { Op } from "sequelize";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ActivationWorkAreaResource
@@ -63,7 +71,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
     const row = await this.model.create({
       workspaceId: workspace.id,
       userId: user.id,
-      status: "candidate",
+      status: "suggested",
       title: blob.title,
       description: blob.description,
       podId: blob.podId ?? null,
@@ -101,7 +109,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       status,
       activationPodModelId,
     }: {
-      status?: ActivationWorkAreaStatus;
+      status?: PublicActivationWorkAreaStatus;
       activationPodModelId?: ModelId;
     }
   ): Promise<ActivationWorkAreaResource[]> {
@@ -113,7 +121,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
     };
 
     if (status !== undefined) {
-      where.status = status;
+      where.status = { [Op.in]: matchingActivationWorkAreaStatuses(status) };
     }
     if (activationPodModelId !== undefined) {
       where.podId = activationPodModelId;
@@ -195,7 +203,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       sId: this.sId,
       title: this.title,
       description: this.description,
-      status: this.status,
+      status: publicActivationWorkAreaStatus(this.status),
       createdAt: this.createdAt.getTime(),
     };
   }

--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -152,8 +152,9 @@ Run this at the beginning of EVERY conversation, after maintaining the Recommend
 - When the nudge context provides Work Areas, use them as the initial map and persist them with \`create_work_areas\` when they do
   not yet exist for this Pod. Do not replace them unless later evidence or user feedback clearly corrects them.
 - Call \`create_work_areas\` for genuinely new or materially changed areas. Preserve existing areas that still fit the evidence.
-- Treat existing and newly created Work Areas as the current working map. Do not ask the user to confirm it before making the first
-  recommendation. Update an area only when later user feedback clearly confirms or rejects it.
+- Treat existing and newly created Work Areas as the current working map. Do not ask the user to approve them before making the first
+  recommendation. Dismiss an area with \`update_work_area\` when later user feedback clearly rejects it; update title or description
+  when they correct it.
 - Record the Work Areas considered and the selected Work Area in \`session_plan.md\` once that file is created.
 
 # Step 2 — Set the Session Goal

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -5,7 +5,7 @@ import type {
 } from "@app/lib/api/activation/recommendations";
 import type { GetActivationWorkAreasResponseBody } from "@app/lib/api/activation/work_areas";
 import { clientFetch } from "@app/lib/egress/client";
-import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
+import type { PublicActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -134,7 +134,7 @@ export function useActivationWorkAreas({
 }: {
   workspaceId: string;
   podId?: string;
-  status?: ActivationWorkAreaStatus;
+  status?: PublicActivationWorkAreaStatus;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -177,7 +177,7 @@ export function useUpdateActivationWorkArea({
     async (
       workAreaId: string,
       body: {
-        status?: "confirmed" | "dismissed";
+        status?: PublicActivationWorkAreaStatus;
         title?: string;
         description?: string;
       }


### PR DESCRIPTION
## Summary

Collapses the activation work-area lifecycle from `candidate` / `confirmed` / `dismissed` down to a public `suggested` / `dismissed` model. Maintaining backwards compatibility for now as I am unsure if we will end up using the statuses.
- Minor clean up on work areas UX to simplify the view

## Risk

Low

## Testing

<img width="727" height="761" alt="Screenshot 2026-08-12 at 11 10 02 PM" src="https://github.com/user-attachments/assets/92a70cfb-7d8c-4844-a3d9-ebf0d003ac91" />


## Deploy

1. Deploy front
