### PR TITLE
fix: biome formatting in consumption attribution store test

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -44,12 +44,8 @@ async function setupSettledMessageWithUsage({
   runCount?: number;
   restrictedConversation?: boolean;
 } = {}) {
-  const {
-    authenticator,
-    globalSpace,
-    user,
-    workspace,
-  } = await createResourceTest({ role: "admin" });
+  const { authenticator, globalSpace, user, workspace } =
+    await createResourceTest({ role: "admin" });
 
   let auth = authenticator;
   const agentConfiguration = await AgentConfigurationFactory.createTestAgent(
@@ -175,12 +171,8 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
   });
 
   it("writes attribution for a project conversation hidden from the workflow auth", async () => {
-    const {
-      workspace,
-      conversationId,
-      agentMessageId,
-      agentMessageModelId,
-    } = await setupSettledMessageWithUsage({ restrictedConversation: true });
+    const { workspace, conversationId, agentMessageId, agentMessageModelId } =
+      await setupSettledMessageWithUsage({ restrictedConversation: true });
     const workflowAuth = await Authenticator.internalBuilderForWorkspace(
       workspace.sId
     );


### PR DESCRIPTION
## Summary
- `store.test.ts` was merged unformatted in #30473, breaking the format-check CI job on main and on any branch rebased on top of it.
- Applies `biome check --write` to bring the file back in line with formatting rules.

## Test plan
- [x] `npx biome check front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts` passes