### PR TITLE
[analytics] parallelize per-dimension label resolution in CSV export

### DIFF
--- a/front/lib/api/analytics/consumption/export.ts
+++ b/front/lib/api/analytics/consumption/export.ts
@@ -1,4 +1,3 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeDimension,
@@ -9,8 +8,8 @@ import {
   CONSUMPTION_SCOPE_DIMENSIONS,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionAllGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
@@ -71,22 +70,22 @@ export async function fetchConsumptionTopExportCsv(
 
     const dimension = CONSUMPTION_SCOPE_DIMENSIONS[index];
     const { groups, totalCredits } = result.value;
-    const labels = await resolveDimensionLabels(
+    const resolvedRows = await resolveConsumptionGroupLabels(
       auth,
       dimension,
-      groups.map((group) => group.key)
+      groups
     );
 
     rows.push(
-      ...groups.map((group) => ({
+      ...resolvedRows.map((row) => ({
         dimension,
-        name: labels.get(group.key)?.name ?? group.key,
+        name: row.name,
         costSharePercent:
           totalCredits > 0
-            ? roundToCents((group.credits / totalCredits) * 100)
+            ? roundToCents((row.credits / totalCredits) * 100)
             : 0,
-        credits: roundToCents(group.credits),
-        avgCredits: roundToCents(avgCreditsPerUnit(group.credits, group.count)),
+        credits: roundToCents(row.credits),
+        avgCredits: roundToCents(row.avgCredits),
       }))
     );
   }

--- a/front/lib/api/analytics/consumption/export.ts
+++ b/front/lib/api/analytics/consumption/export.ts
@@ -62,32 +62,43 @@ export async function fetchConsumptionTopExportCsv(
     )
   );
 
+  // Label resolution hits the database (users, groups, skills, ...); run it
+  // for every dimension concurrently rather than awaiting one at a time.
+  const dimensionRows = await Promise.all(
+    results.map(async (result, index) => {
+      if (result.isErr()) {
+        return result;
+      }
+
+      const dimension = CONSUMPTION_SCOPE_DIMENSIONS[index];
+      const { groups, totalCredits } = result.value;
+      const resolvedRows = await resolveConsumptionGroupLabels(
+        auth,
+        dimension,
+        groups
+      );
+
+      return new Ok(
+        resolvedRows.map((row) => ({
+          dimension,
+          name: row.name,
+          costSharePercent:
+            totalCredits > 0
+              ? roundToCents((row.credits / totalCredits) * 100)
+              : 0,
+          credits: roundToCents(row.credits),
+          avgCredits: roundToCents(row.avgCredits),
+        }))
+      );
+    })
+  );
+
   const rows: ConsumptionExportCsvRow[] = [];
-  for (const [index, result] of results.entries()) {
+  for (const result of dimensionRows) {
     if (result.isErr()) {
       return result;
     }
-
-    const dimension = CONSUMPTION_SCOPE_DIMENSIONS[index];
-    const { groups, totalCredits } = result.value;
-    const resolvedRows = await resolveConsumptionGroupLabels(
-      auth,
-      dimension,
-      groups
-    );
-
-    rows.push(
-      ...resolvedRows.map((row) => ({
-        dimension,
-        name: row.name,
-        costSharePercent:
-          totalCredits > 0
-            ? roundToCents((row.credits / totalCredits) * 100)
-            : 0,
-        credits: roundToCents(row.credits),
-        avgCredits: roundToCents(row.avgCredits),
-      }))
-    );
+    rows.push(...result.value);
   }
 
   return new Ok(rowsToCsv(CONSUMPTION_EXPORT_HEADERS, rows));

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -274,9 +274,6 @@ export type ResolvedConsumptionGroup = {
   avgCredits: number;
 };
 
-// Shared by every per-dimension `top_<dimension>.ts` ranking and the CSV
-// export: both need the same key -> display label lookup and average
-// computation over a dimension's groups, only the final field names differ.
 export async function resolveConsumptionGroupLabels(
   auth: Authenticator,
   dimension: ConsumptionScopeDimension,

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -1,3 +1,4 @@
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeDimension,
@@ -262,4 +263,37 @@ export async function fetchConsumptionAllGroups(
 // non-finite average.
 export function avgCreditsPerUnit(credits: number, count: number): number {
   return count > 0 ? credits / count : 0;
+}
+
+export type ResolvedConsumptionGroup = {
+  key: string;
+  name: string;
+  pictureUrl: string | null;
+  credits: number;
+  count: number;
+  avgCredits: number;
+};
+
+// Shared by every per-dimension `top_<dimension>.ts` ranking and the CSV
+// export: both need the same key -> display label lookup and average
+// computation over a dimension's groups, only the final field names differ.
+export async function resolveConsumptionGroupLabels(
+  auth: Authenticator,
+  dimension: ConsumptionScopeDimension,
+  groups: ConsumptionTopGroup[]
+): Promise<ResolvedConsumptionGroup[]> {
+  const labels = await resolveDimensionLabels(
+    auth,
+    dimension,
+    groups.map((group) => group.key)
+  );
+
+  return groups.map((group) => ({
+    key: group.key,
+    name: labels.get(group.key)?.name ?? group.key,
+    pictureUrl: labels.get(group.key)?.pictureUrl ?? null,
+    credits: group.credits,
+    count: group.count,
+    avgCredits: avgCreditsPerUnit(group.credits, group.count),
+  }));
 }

--- a/front/lib/api/analytics/consumption/top_agents.ts
+++ b/front/lib/api/analytics/consumption/top_agents.ts
@@ -1,10 +1,9 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -59,22 +58,18 @@ export async function fetchConsumptionTopAgents(
   }
   const { groups, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "agent",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "agent", groups);
 
   return new Ok({
     period,
     totalCredits,
-    agents: groups.map((group) => ({
-      agentId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      pictureUrl: labels.get(group.key)?.pictureUrl ?? null,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    agents: rows.map((row) => ({
+      agentId: row.key,
+      name: row.name,
+      pictureUrl: row.pictureUrl,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -1,10 +1,9 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups as fetchConsumptionTopGroupBuckets,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -59,21 +58,17 @@ export async function fetchConsumptionTopGroups(
   }
   const { groups, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "group",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "group", groups);
 
   return new Ok({
     period,
     totalCredits,
-    groups: groups.map((group) => ({
-      groupId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    groups: rows.map((row) => ({
+      groupId: row.key,
+      name: row.name,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_models.ts
+++ b/front/lib/api/analytics/consumption/top_models.ts
@@ -1,10 +1,9 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -59,21 +58,17 @@ export async function fetchConsumptionTopModels(
   }
   const { groups, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "model",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "model", groups);
 
   return new Ok({
     period,
     totalCredits,
-    models: groups.map((group) => ({
-      modelId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    models: rows.map((row) => ({
+      modelId: row.key,
+      name: row.name,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_skills.ts
+++ b/front/lib/api/analytics/consumption/top_skills.ts
@@ -1,10 +1,9 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -65,21 +64,17 @@ export async function fetchConsumptionTopSkills(
   }
   const { groups, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "skill",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "skill", groups);
 
   return new Ok({
     period,
     totalCredits,
-    skills: groups.map((group) => ({
-      skillId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      credits: group.credits,
-      invocationCount: group.count,
-      avgCreditsPerInvocation: avgCreditsPerUnit(group.credits, group.count),
+    skills: rows.map((row) => ({
+      skillId: row.key,
+      name: row.name,
+      credits: row.credits,
+      invocationCount: row.count,
+      avgCreditsPerInvocation: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_sources.ts
+++ b/front/lib/api/analytics/consumption/top_sources.ts
@@ -1,10 +1,9 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -60,21 +59,17 @@ export async function fetchConsumptionTopSources(
   }
   const { groups, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "source",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "source", groups);
 
   return new Ok({
     period,
     totalCredits,
-    sources: groups.map((group) => ({
-      source: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    sources: rows.map((row) => ({
+      source: row.key,
+      name: row.name,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -1,10 +1,9 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -64,21 +63,17 @@ export async function fetchConsumptionTopTools(
   }
   const { groups, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "tool",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "tool", groups);
 
   return new Ok({
     period,
     totalCredits,
-    tools: groups.map((group) => ({
-      serverName: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      credits: group.credits,
-      invocationCount: group.count,
-      avgCreditsPerInvocation: avgCreditsPerUnit(group.credits, group.count),
+    tools: rows.map((row) => ({
+      serverName: row.key,
+      name: row.name,
+      credits: row.credits,
+      invocationCount: row.count,
+      avgCreditsPerInvocation: row.avgCredits,
     })),
   });
 }

--- a/front/lib/api/analytics/consumption/top_users.ts
+++ b/front/lib/api/analytics/consumption/top_users.ts
@@ -1,10 +1,9 @@
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_UNIT } from "@app/lib/api/analytics/consumption/scope";
 import {
-  avgCreditsPerUnit,
   fetchConsumptionTopGroups,
+  resolveConsumptionGroupLabels,
 } from "@app/lib/api/analytics/consumption/top";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -63,22 +62,18 @@ export async function fetchConsumptionTopUsers(
   }
   const { groups, totalCredits } = result.value;
 
-  const labels = await resolveDimensionLabels(
-    auth,
-    "user",
-    groups.map((group) => group.key)
-  );
+  const rows = await resolveConsumptionGroupLabels(auth, "user", groups);
 
   return new Ok({
     period,
     totalCredits,
-    users: groups.map((group) => ({
-      userId: group.key,
-      name: labels.get(group.key)?.name ?? group.key,
-      pictureUrl: labels.get(group.key)?.pictureUrl ?? null,
-      credits: group.credits,
-      messageCount: group.count,
-      avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),
+    users: rows.map((row) => ({
+      userId: row.key,
+      name: row.name,
+      pictureUrl: row.pictureUrl,
+      credits: row.credits,
+      messageCount: row.count,
+      avgCreditsPerMessage: row.avgCredits,
     })),
   });
 }


### PR DESCRIPTION
Label resolution does real DB lookups per dimension (users, groups, skills,
tools, agents). The ES fetch across dimensions already runs concurrently via
Promise.all, but label resolution was awaited one dimension at a time
afterwards. Run it concurrently too.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
