### PR TITLE
[analytics] only compute the export total on the first composite page

### DIFF
--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -193,6 +193,11 @@ export async function fetchConsumptionAllGroups(
   let afterKey: estypes.AggregationsCompositeAggregateKey | undefined;
 
   for (;;) {
+    // The overall total does not depend on the composite cursor, so it is
+    // only requested on the first page — repeating a full-dataset sum on
+    // every subsequent page would be pure waste.
+    const isFirstPage = afterKey === undefined;
+
     const result = await searchConsumptionAnalytics<never, CompositeTopAggs>(
       query,
       {
@@ -211,7 +216,13 @@ export async function fetchConsumptionAllGroups(
             },
             aggs: subAggs(unit),
           },
-          total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+          ...(isFirstPage
+            ? {
+                total_credit_micro: {
+                  sum: { field: CREDIT_MICRO_FIELD },
+                },
+              }
+            : {}),
         },
         size: 0,
       }
@@ -233,10 +244,10 @@ export async function fetchConsumptionAllGroups(
         })
       )
     );
-    // The overall total does not depend on the composite cursor, but the
-    // aggregation is cheap to repeat and this keeps every page self-contained.
-    totalCreditsMicro =
-      result.value.aggregations?.total_credit_micro?.value ?? totalCreditsMicro;
+    if (isFirstPage) {
+      totalCreditsMicro =
+        result.value.aggregations?.total_credit_micro?.value ?? 0;
+    }
 
     if (!page?.after_key || pageBuckets.length < EXPORT_PAGE_SIZE) {
       break;


### PR DESCRIPTION
total_credit_micro doesn't depend on the composite cursor, but it was being
recomputed (a full-dataset sum) on every single page. Request it only on the
first page and reuse the value for the rest of the pagination.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
