### PR TITLE
[analytics] skip composite pagination for bounded dimensions

### DIFF
--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -164,6 +164,15 @@ export async function fetchConsumptionTopGroups(
   });
 }
 
+// Dimensions whose distinct values are bounded well under a single composite
+// page (the models, tools and origins a workspace can use), so a single
+// terms request beats paginating through the composite cursor.
+const BOUNDED_DIMENSIONS: ReadonlySet<ConsumptionScopeDimension> = new Set([
+  "model",
+  "tool",
+  "source",
+]);
+
 /**
  * Every key of `dimension` by gross credits over the period, with no cap
  */
@@ -181,6 +190,16 @@ export async function fetchConsumptionAllGroups(
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
+  if (BOUNDED_DIMENSIONS.has(dimension)) {
+    return fetchConsumptionTopGroups(auth, {
+      dimension,
+      unit,
+      period,
+      limit: EXPORT_PAGE_SIZE,
+      filter,
+    });
+  }
+
   const query = buildConsumptionScopeQuery({
     auth,
     startDate: period.startDate,


### PR DESCRIPTION
model, tool and source have a distinct-value count bounded well under a
single composite page, so paginating through the composite cursor for them
is pure overhead. Route them through fetchConsumptionTopGroups (a single
terms request) instead, capped at EXPORT_PAGE_SIZE.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
