### PR TITLE
[analytics] trim ES response payload for the composite export pages

### DIFF
--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -244,6 +244,9 @@ export async function fetchConsumptionAllGroups(
             : {}),
         },
         size: 0,
+        // filter_path applies to error responses too — keep "error" so a
+        // failed request still carries a diagnosable reason.
+        filterPath: ["aggregations", "error"],
       }
     );
 

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -272,6 +272,9 @@ export async function searchConsumptionAnalytics<
     from?: number;
     sort?: estypes.Sort;
     search_after?: estypes.SortResults;
+    // Restricts the response to these top-level paths, so ES skips
+    // serializing fields the caller has no use for (shard stats, hits, ...).
+    filterPath?: string | string[];
   }
 ): Promise<
   Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
@@ -284,5 +287,6 @@ export async function searchConsumptionAnalytics<
     from: options?.from,
     sort: options?.sort,
     search_after: options?.search_after,
+    filter_path: options?.filterPath,
   });
 }


### PR DESCRIPTION
The composite pagination loop already returns size:0, but the response
still carries shard stats and other fields the caller never reads. Add a
filterPath passthrough on searchConsumptionAnalytics and scope the
composite-page request to aggregations (plus error, so a failed request
still carries a diagnosable reason).

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
