### PR TITLE
[front] fix: Harden sandbox deployment process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,12 +67,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  ensure-sandbox-images:
+  verify-sandbox-images:
     if: inputs.component == 'front' || inputs.component == 'front-edge'
     permissions:
       contents: read
-      id-token: write
-    uses: ./.github/workflows/sandbox-img-registry.yml
+    uses: ./.github/workflows/sandbox-img-verify.yml
     secrets: inherit
 
   check-branch:
@@ -150,7 +149,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    needs: [prepare, notify-start, create-matrix]
+    needs: [prepare, notify-start, create-matrix, verify-sandbox-images]
+    if: ${{ !failure() && !cancelled() && (needs.verify-sandbox-images.result == 'success' || needs.verify-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -226,9 +226,9 @@ jobs:
         build,
         deploy-app,
         deploy-poke,
-        ensure-sandbox-images,
+        verify-sandbox-images,
       ]
-    if: ${{ !failure() && !cancelled() && (needs.ensure-sandbox-images.result == 'success' || needs.ensure-sandbox-images.result == 'skipped') }}
+    if: ${{ !failure() && !cancelled() && (needs.verify-sandbox-images.result == 'success' || needs.verify-sandbox-images.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/sandbox-img-registry.yml
+++ b/.github/workflows/sandbox-img-registry.yml
@@ -1,11 +1,6 @@
 name: Sandbox Image Registry
 
 on:
-  workflow_call:
-    outputs:
-      images-built:
-        description: "Number of images built"
-        value: ${{ jobs.summary.outputs.built-count }}
   workflow_dispatch:
     inputs:
       rebuild:
@@ -19,7 +14,17 @@ permissions:
   id-token: write
 
 jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if the run is from main branch
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: |
+          echo "Error: sandbox images can only be built from the main branch"
+          exit 1
+
   check-and-build:
+    needs: [ check-branch ]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -142,8 +147,6 @@ jobs:
     needs: [ check-and-build ]
     if: always() && needs['check-and-build'].result == 'success'
     runs-on: ubuntu-latest
-    outputs:
-      built-count: ${{ steps.count.outputs.built }}
     steps:
       - name: Download check results (eu)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -171,11 +174,6 @@ jobs:
             echo "missing-summary=$SUMMARY"
             echo "planned-builds=$COUNT"
           } >> "$GITHUB_OUTPUT"
-          if [ "$HAS" == "true" ]; then
-            echo "built=$COUNT" >> "$GITHUB_OUTPUT"
-          else
-            echo "built=0" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Summary
         run: |

--- a/.github/workflows/sandbox-img-verify.yml
+++ b/.github/workflows/sandbox-img-verify.yml
@@ -1,0 +1,42 @@
+name: Sandbox Image Verify
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        region: [ eu, us ]
+    steps:
+      - name: Configure E2B for ${{ matrix.region }}
+        run: |
+          if [ "${{ matrix.region }}" = "eu" ]; then
+            echo "E2B_API_KEY=${{ secrets.E2B_API_KEY }}" >> "$GITHUB_ENV"
+            echo "E2B_DOMAIN=e2b-juliett.dev" >> "$GITHUB_ENV"
+          else
+            echo "E2B_API_KEY=${{ secrets.E2B_US_API_KEY }}" >> "$GITHUB_ENV"
+            echo "E2B_DOMAIN=e2b.dev" >> "$GITHUB_ENV"
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
+        with:
+          build-sdks: "true"
+
+      - name: Verify sandbox templates
+        working-directory: front
+        run: |
+          if ! npx tsx scripts/sandbox_image_verify.ts; then
+            echo "::error::Sandbox template verification failed (${{ matrix.region }}). Build the missing templates from main with the Sandbox Image Registry workflow before deploying."
+            exit 1
+          fi

--- a/front/lib/api/sandbox/providers/e2b_template.test.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.test.ts
@@ -5,7 +5,13 @@ import type { TemplateBuilder } from "e2b";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import type { DockerRegistryFactory } from "./e2b_template";
-import { buildSandboxImage } from "./e2b_template";
+import {
+  buildSandboxImage,
+  deleteE2BTemplate,
+  deleteUnbuiltE2BTemplate,
+  findE2BTemplate,
+  listE2BTemplates,
+} from "./e2b_template";
 
 function createTestImage(): SandboxImage {
   return SandboxImage.fromDocker("test-image:v1")
@@ -67,12 +73,23 @@ function createMockDockerRegistryFactory(): DockerRegistryFactory {
 const mockDockerRegistryFactory = vi.fn(createMockDockerRegistryFactory());
 
 const mockBuild = vi.fn();
+const mockApiGet = vi.fn();
+const mockApiDelete = vi.fn();
 
 vi.mock("e2b", () => ({
   Template: Object.assign(() => mockE2BTemplateFactory, {
     build: (...args: unknown[]) => mockBuild(...args),
   }),
   defaultBuildLogger: vi.fn(() => vi.fn()),
+  ConnectionConfig: class {
+    constructor(readonly opts: unknown) {}
+  },
+  ApiClient: class {
+    api = {
+      GET: (...args: unknown[]) => mockApiGet(...args),
+      DELETE: (...args: unknown[]) => mockApiDelete(...args),
+    };
+  },
 }));
 
 describe("formatSandboxImageId()", () => {
@@ -99,6 +116,197 @@ describe("formatSandboxImageId()", () => {
   test("handles alphanumeric and hyphens without modification", () => {
     const id: SandboxImageId = { imageName: "dust-base", tag: "edge" };
     expect(formatSandboxImageId(id)).toBe("dust-base_edge");
+  });
+});
+
+describe("listE2BTemplates()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("reports a template whose build never completed as having no envd version", async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: [
+        {
+          templateID: "tmpl-built",
+          aliases: ["dust-base_v0-1-1"],
+          envdVersion: "0.2.4",
+        },
+        {
+          templateID: "tmpl-failed",
+          aliases: ["dust-base_v0-1-2"],
+          envdVersion: "",
+        },
+      ],
+    });
+
+    const result = await listE2BTemplates();
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual([
+        {
+          templateId: "tmpl-built",
+          aliases: ["dust-base_v0-1-1"],
+          envdVersion: "0.2.4",
+        },
+        {
+          templateId: "tmpl-failed",
+          aliases: ["dust-base_v0-1-2"],
+          envdVersion: null,
+        },
+      ]);
+    }
+  });
+
+  test("returns Err when the E2B API errors", async () => {
+    mockApiGet.mockResolvedValueOnce({ error: { message: "unauthorized" } });
+
+    const result = await listE2BTemplates();
+
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("findE2BTemplate()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("matches the template carrying the image alias", async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: [
+        { templateID: "tmpl-other", aliases: ["other_v1"], envdVersion: "1.0" },
+        {
+          templateID: "tmpl-wanted",
+          aliases: ["dust-base_v0-1-1"],
+          envdVersion: "1.0",
+        },
+      ],
+    });
+
+    const result = await findE2BTemplate({
+      imageName: "dust-base",
+      tag: "v0.1.1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value?.templateId).toBe("tmpl-wanted");
+    }
+  });
+
+  test("returns null when no template carries the alias", async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: [
+        { templateID: "tmpl-other", aliases: ["other_v1"], envdVersion: "1.0" },
+      ],
+    });
+
+    const result = await findE2BTemplate({
+      imageName: "dust-base",
+      tag: "v0.1.1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBeNull();
+    }
+  });
+});
+
+describe("deleteE2BTemplate()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("deletes by template id", async () => {
+    mockApiDelete.mockResolvedValueOnce({ data: undefined });
+
+    const result = await deleteE2BTemplate("tmpl-failed");
+
+    expect(result.isOk()).toBe(true);
+    expect(mockApiDelete).toHaveBeenCalledWith("/templates/{templateID}", {
+      params: { path: { templateID: "tmpl-failed" } },
+    });
+  });
+
+  test("returns Err when the E2B API errors", async () => {
+    mockApiDelete.mockResolvedValueOnce({ error: { message: "not found" } });
+
+    const result = await deleteE2BTemplate("tmpl-failed");
+
+    expect(result.isErr()).toBe(true);
+  });
+});
+
+describe("deleteUnbuiltE2BTemplate()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("deletes a template whose build never completed", async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: [
+        {
+          templateID: "tmpl-failed",
+          aliases: ["dust-base_v0-1-1"],
+          envdVersion: "",
+        },
+      ],
+    });
+    mockApiDelete.mockResolvedValueOnce({ data: undefined });
+
+    const result = await deleteUnbuiltE2BTemplate({
+      imageName: "dust-base",
+      tag: "v0.1.1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(true);
+    }
+    expect(mockApiDelete).toHaveBeenCalledWith("/templates/{templateID}", {
+      params: { path: { templateID: "tmpl-failed" } },
+    });
+  });
+
+  test("leaves a bootable template in place", async () => {
+    mockApiGet.mockResolvedValueOnce({
+      data: [
+        {
+          templateID: "tmpl-built",
+          aliases: ["dust-base_v0-1-1"],
+          envdVersion: "0.2.4",
+        },
+      ],
+    });
+
+    const result = await deleteUnbuiltE2BTemplate({
+      imageName: "dust-base",
+      tag: "v0.1.1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(false);
+    }
+    expect(mockApiDelete).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when no template carries the alias", async () => {
+    mockApiGet.mockResolvedValueOnce({ data: [] });
+
+    const result = await deleteUnbuiltE2BTemplate({
+      imageName: "dust-base",
+      tag: "v0.1.1",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toBe(false);
+    }
+    expect(mockApiDelete).not.toHaveBeenCalled();
   });
 });
 

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -187,24 +187,30 @@ class E2BTemplateBuilder {
   }
 }
 
-interface E2BTemplateInfo {
+export interface E2BTemplateInfo {
   templateId: string;
   aliases: readonly string[];
+  // Null until a build completes: E2B registers the template (and its alias) as
+  // soon as a build starts, and only attaches an envd version once one of them
+  // succeeds. A template without it can never be started.
+  envdVersion: string | null;
+}
+
+function createE2BApiClient(apiKey?: string): ApiClient {
+  const e2bConfig = config.getE2BSandboxConfig();
+  const connectionConfig = new ConnectionConfig({
+    apiKey: apiKey ?? e2bConfig.apiKey,
+    ...(e2bConfig.domain ? { domain: e2bConfig.domain } : {}),
+  });
+
+  return new ApiClient(connectionConfig, { requireApiKey: true });
 }
 
 export async function listE2BTemplates(
   apiKey?: string
 ): Promise<Result<E2BTemplateInfo[], Error>> {
-  const e2bConfig = config.getE2BSandboxConfig();
-  const key = apiKey ?? e2bConfig.apiKey;
-  const domain = e2bConfig.domain;
-
   try {
-    const connectionConfig = new ConnectionConfig({
-      apiKey: key,
-      ...(domain ? { domain } : {}),
-    });
-    const client = new ApiClient(connectionConfig, { requireApiKey: true });
+    const client = createE2BApiClient(apiKey);
 
     const response = await client.api.GET("/templates");
 
@@ -217,6 +223,7 @@ export async function listE2BTemplates(
       templates.map((t) => ({
         templateId: t.templateID,
         aliases: t.aliases ?? [],
+        envdVersion: t.envdVersion || null,
       }))
     );
   } catch (err) {
@@ -225,21 +232,85 @@ export async function listE2BTemplates(
   }
 }
 
-export async function templateExists(
+export async function findE2BTemplate(
   imageId: SandboxImageId,
   apiKey?: string
-): Promise<Result<boolean, Error>> {
+): Promise<Result<E2BTemplateInfo | null, Error>> {
   const templatesResult = await listE2BTemplates(apiKey);
   if (templatesResult.isErr()) {
     return templatesResult;
   }
 
   const expectedAlias = formatSandboxImageId(imageId);
-  const exists = templatesResult.value.some((template) =>
-    template.aliases.includes(expectedAlias)
+  const template = templatesResult.value.find((t) =>
+    t.aliases.includes(expectedAlias)
   );
 
-  return new Ok(exists);
+  return new Ok(template ?? null);
+}
+
+export async function templateExists(
+  imageId: SandboxImageId,
+  apiKey?: string
+): Promise<Result<boolean, Error>> {
+  const templateResult = await findE2BTemplate(imageId, apiKey);
+  if (templateResult.isErr()) {
+    return templateResult;
+  }
+
+  return new Ok(templateResult.value !== null);
+}
+
+// Reciprocal of a failed build: E2B registers the template and its alias the
+// moment a build starts, so a failure leaves an alias that
+// `sandbox_image_check.ts` reads as "already built". A template carrying an
+// envd version completed a build and may be serving sandboxes, so it is never
+// touched here.
+export async function deleteUnbuiltE2BTemplate(
+  imageId: SandboxImageId,
+  apiKey?: string
+): Promise<Result<boolean, Error>> {
+  const templateResult = await findE2BTemplate(imageId, apiKey);
+  if (templateResult.isErr()) {
+    return templateResult;
+  }
+
+  const template = templateResult.value;
+  if (!template || template.envdVersion) {
+    return new Ok(false);
+  }
+
+  const deleteResult = await deleteE2BTemplate(template.templateId, apiKey);
+  if (deleteResult.isErr()) {
+    return deleteResult;
+  }
+
+  return new Ok(true);
+}
+
+export async function deleteE2BTemplate(
+  templateId: string,
+  apiKey?: string
+): Promise<Result<void, Error>> {
+  try {
+    const client = createE2BApiClient(apiKey);
+
+    const response = await client.api.DELETE("/templates/{templateID}", {
+      params: { path: { templateID: templateId } },
+    });
+
+    if (response.error) {
+      throw new Error(`E2B API error: ${JSON.stringify(response.error)}`);
+    }
+
+    return new Ok(undefined);
+  } catch (err) {
+    logger.error(
+      { err: normalizeError(err), templateId },
+      "Failed to delete E2B template"
+    );
+    return new Err(normalizeError(err));
+  }
 }
 
 export async function buildSandboxImage(

--- a/front/lib/api/sandbox/providers/e2b_template.ts
+++ b/front/lib/api/sandbox/providers/e2b_template.ts
@@ -190,9 +190,10 @@ class E2BTemplateBuilder {
 export interface E2BTemplateInfo {
   templateId: string;
   aliases: readonly string[];
-  // Null until a build completes: E2B registers the template (and its alias) as
-  // soon as a build starts, and only attaches an envd version once one of them
-  // succeeds. A template without it can never be started.
+  // Null until a build completes. E2B registers the template and its alias when
+  // a build starts and only attaches an envd version once one finishes, so an
+  // alias carrying no envd version is the symptom of a half-baked build: it
+  // answers an existence check, but no sandbox can boot from it.
   envdVersion: string | null;
 }
 

--- a/front/scripts/sandbox_image_build.ts
+++ b/front/scripts/sandbox_image_build.ts
@@ -8,6 +8,7 @@ import {
 import {
   buildSandboxImage,
   createGCPRegistryFactory,
+  deleteUnbuiltE2BTemplate,
   templateExists,
 } from "@app/lib/api/sandbox/providers/e2b_template";
 import logger from "@app/logger/logger";
@@ -186,6 +187,18 @@ async function buildImage(args: BuildArgs): Promise<void> {
   });
 
   if (result.isErr()) {
+    const cleanupResult = await deleteUnbuiltE2BTemplate(imageId);
+    if (cleanupResult.isErr()) {
+      logger.error(
+        { err: cleanupResult.error, imageId: formatSandboxImageId(imageId) },
+        "Failed to delete the template left behind by the failed build"
+      );
+    } else if (cleanupResult.value) {
+      logger.info(
+        { imageId: formatSandboxImageId(imageId) },
+        "Deleted the template left behind by the failed build"
+      );
+    }
     process.exit(1);
   }
 

--- a/front/scripts/sandbox_image_verify.ts
+++ b/front/scripts/sandbox_image_verify.ts
@@ -1,0 +1,70 @@
+import type { SandboxImageId } from "@app/lib/api/sandbox/image";
+import {
+  formatSandboxImageId,
+  getRegisteredImages,
+} from "@app/lib/api/sandbox/image";
+import { listE2BTemplates } from "@app/lib/api/sandbox/providers/e2b_template";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// Deploy gate: every image this revision of the code would start must already
+// resolve to a template E2B can boot. A template whose build never completed
+// still answers the "does the alias exist" check `sandbox_image_check.ts` runs,
+// so the envd version is what separates "built" from "registered".
+async function verifySandboxImages(): Promise<void> {
+  const requiredIds = getRegisteredImages()
+    .map((image) => image.imageId)
+    .filter((id): id is SandboxImageId => id !== undefined)
+    .map(formatSandboxImageId);
+
+  const templatesResult = await listE2BTemplates();
+  if (templatesResult.isErr()) {
+    logger.error(
+      { err: templatesResult.error },
+      "Failed to list E2B templates"
+    );
+    process.exit(1);
+  }
+
+  const envdVersionByAlias = new Map<string, string | null>();
+  for (const template of templatesResult.value) {
+    for (const alias of template.aliases) {
+      envdVersionByAlias.set(alias, template.envdVersion);
+    }
+  }
+
+  const missing: string[] = [];
+  const unbuilt: string[] = [];
+  for (const id of requiredIds) {
+    const envdVersion = envdVersionByAlias.get(id);
+    if (envdVersion === undefined) {
+      missing.push(id);
+    } else if (!envdVersion) {
+      unbuilt.push(id);
+    }
+  }
+
+  if (missing.length > 0 || unbuilt.length > 0) {
+    logger.error(
+      { missing, unbuilt, required: requiredIds },
+      "Sandbox templates required by this revision are not deployable. Run " +
+        "the Sandbox Image Registry workflow on main and retry."
+    );
+    process.exit(1);
+  }
+
+  logger.info(
+    { required: requiredIds },
+    "All required sandbox templates are built"
+  );
+}
+
+verifySandboxImages()
+  .then(() => process.exit(0))
+  .catch((err: unknown) => {
+    logger.error(
+      { err: normalizeError(err) },
+      "Sandbox image verification failed"
+    );
+    process.exit(1);
+  });

--- a/front/scripts/sandbox_image_verify.ts
+++ b/front/scripts/sandbox_image_verify.ts
@@ -8,9 +8,7 @@ import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 // Deploy gate: every image this revision of the code would start must already
-// resolve to a template E2B can boot. A template whose build never completed
-// still answers the "does the alias exist" check `sandbox_image_check.ts` runs,
-// so the envd version is what separates "built" from "registered".
+// resolve to a template E2B can boot.
 async function verifySandboxImages(): Promise<void> {
   const requiredIds = getRegisteredImages()
     .map((image) => image.imageId)
@@ -33,6 +31,9 @@ async function verifySandboxImages(): Promise<void> {
     }
   }
 
+  // No alias at all means nothing ever tried to build the image; an alias with
+  // no envd version is the symptom of a half-baked build, which the alias
+  // existence check in `sandbox_image_check.ts` reads as already built.
   const missing: string[] = [];
   const unbuilt: string[] = [];
   for (const id of requiredIds) {


### PR DESCRIPTION
## Description

- Removed front auto build of sbx images, it was brittle (incident-prone) and not the current recommend way ([runbook](https://app.notion.com/p/dust-tt/Runbook-deploying-a-new-sandbox-image-3b828599d941808e8ac5c0d8afb26063?source=copy_link))
- Instead, add a new check step on front that fails if the registered tag in the code does not match with a template in our e2b clusters.
- Add a cleanup step in build sandbox to delete the template if the build failed to avoid false skips

## Tests

N/A

## Risk

Low

## Deploy Plan

Merge