### PR TITLE
fix: analytics cost share bar color fix

### DIFF
--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -37,15 +37,14 @@ interface CostShareBarProps {
 
 export function CostShareBar({ percentage, className }: CostShareBarProps) {
   return (
-    <progress
-      aria-hidden="true"
-      className={cn(
-        "block h-1.5 overflow-hidden rounded-full bg-muted accent-primary",
-        className
-      )}
-      max={100}
-      value={percentage}
-    />
+    <div
+      className={cn("h-1.5 overflow-hidden rounded-full bg-muted", className)}
+    >
+      <div
+        className="h-full rounded-full bg-primary"
+        style={{ width: `${percentage}%` }}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

#30412 refactored the progress bar to re-use it but moved the nested `<div>`s elements to a `<progress>` HTML element. Tailwind can't really natively style progress bars and seems to need to use pseudo elements for each browers to properly be styled.

This moves back to the previous method, nested-divs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94
180e09250ff256d6ac46e) -->

By hand, rendered the UI and fix works

<img width="1380" height="1506" alt="Capture d’écran 2026-08-13 à 10 18 20" src="https://github.com/user-attachments/assets/ab4418b4-34b4-41a4-9cc0-d9717478801a" />

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy spa