### PR TITLE
[front] fix: limit consumption chart legend to top five items

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -40,10 +40,6 @@ const CONSUMPTION_CHART_COLORS = [
   "text-blue-700",
   "text-blue-600",
   "text-blue-500",
-  "text-blue-400",
-  "text-blue-300",
-  "text-blue-200",
-  "text-blue-100",
   "text-blue-50",
 ] as const;
 


### PR DESCRIPTION
## Description

The daily consumption chart can show up to 10 items (including the Others).
This can be a lot, sometimes causing the content to not fit in one line (which causes a shift and layout, ideally the only thing that takes a variable height is the attribution table), and the goal here is really to display the top items to give an overview of the consumption.

This PR limits it to 5 items (excluding Others, hence the 4 deletions in the diff).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
