### PR TITLE
[front] fix: align tool output rendering in consumption items with `renderConversationForModel`

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -158,12 +158,14 @@ function runUsageModelIdsWithUnconsumedToolResults({
 async function buildRunUsageConsumptionEvidence(
   auth: Authenticator,
   {
+    conversationId,
     enrichedActionByModelId,
     includeToolResultFootprints,
     runActions,
     triggeringUserMessageOrigin,
     usage,
   }: {
+    conversationId: string;
     enrichedActionByModelId: ReadonlyMap<ModelId, AgentMCPActionWithOutputType>;
     includeToolResultFootprints: boolean;
     runActions: AgentMCPActionResource[];
@@ -200,6 +202,7 @@ async function buildRunUsageConsumptionEvidence(
   // Selected usages need both sides of every model-visible tool call so their shared provider
   // output budget is partitioned consistently with the immutable evidence already stored.
   const footprintsRes = await measureToolCallFootprints(auth, {
+    conversationId,
     modelId: usage.modelId,
     // TODO(2026-07-31 FLAV) Refactor `enrichActionsWithOutputItems` so it still returns the
     // resource.
@@ -585,6 +588,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
     const usageEvidence = await buildRunUsageConsumptionEvidence(auth, {
+      conversationId: conversation.sId,
       enrichedActionByModelId,
       includeToolResultFootprints: !unconsumedToolResultRunUsageModelIds.has(
         usage.runUsageModelId

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -58,10 +58,22 @@ function footprintInput(
 
 // The auth is only forwarded to getLlmCredentials, which is mocked, so a bare stub is enough.
 const auth = {} as Authenticator;
+const conversationId = "conversation_1";
+
+function renderFootprintTexts(
+  toolCall: ToolCallFootprintInput,
+  additionalInputText?: string
+) {
+  return toolCallFootprintTexts(auth, toolCall, {
+    additionalInputText,
+    conversationId,
+    model: GPT_4_1_MODEL_CONFIG,
+  });
+}
 
 describe("toolCallFootprintTexts", () => {
-  it("serializes a call from the emitted arguments, not the augmented params", () => {
-    const { callText } = toolCallFootprintTexts(
+  it("serializes a call from the emitted arguments, not the augmented params", async () => {
+    const { callText } = await renderFootprintTexts(
       footprintInput(
         makeAction({
           functionCallName: "search",
@@ -75,8 +87,8 @@ describe("toolCallFootprintTexts", () => {
     expect(callText).toBe('search\n{"query":"hello"}');
   });
 
-  it("renders a denied action as the rejection notice, ignoring any output", () => {
-    const { inputText } = toolCallFootprintTexts(
+  it("renders a denied action as the rejection notice, ignoring any output", async () => {
+    const { inputText } = await renderFootprintTexts(
       footprintInput(
         makeAction({
           status: "denied",
@@ -90,8 +102,8 @@ describe("toolCallFootprintTexts", () => {
     );
   });
 
-  it("renders an action awaiting validation as the validation notice", () => {
-    const { inputText } = toolCallFootprintTexts(
+  it("renders an action awaiting validation as the validation notice", async () => {
+    const { inputText } = await renderFootprintTexts(
       footprintInput(makeAction({ status: "blocked_validation_required" }))
     );
 
@@ -100,16 +112,16 @@ describe("toolCallFootprintTexts", () => {
     );
   });
 
-  it("renders an empty output as the no-output notice", () => {
-    const { inputText } = toolCallFootprintTexts(
+  it("renders an empty output as the no-output notice", async () => {
+    const { inputText } = await renderFootprintTexts(
       footprintInput(makeAction({ status: "succeeded", output: [] }))
     );
 
     expect(inputText).toBe("Successfully executed action, no output.");
   });
 
-  it("joins text output items with newlines", () => {
-    const { inputText } = toolCallFootprintTexts(
+  it("joins text output items with newlines", async () => {
+    const { inputText } = await renderFootprintTexts(
       footprintInput(
         makeAction({
           status: "succeeded",
@@ -124,8 +136,8 @@ describe("toolCallFootprintTexts", () => {
     expect(inputText).toBe("first\nsecond");
   });
 
-  it("serializes non-text output as JSON with the mime type stripped", () => {
-    const { inputText } = toolCallFootprintTexts(
+  it("serializes non-text output as JSON with the mime type stripped", async () => {
+    const { inputText } = await renderFootprintTexts(
       footprintInput(
         makeAction({
           status: "succeeded",
@@ -141,6 +153,23 @@ describe("toolCallFootprintTexts", () => {
 
     expect(inputText).toBe(JSON.stringify([{ uri: "u", text: "body" }]));
   });
+
+  it("includes the user-edited inputs rendered in the model result", async () => {
+    const { inputText } = await renderFootprintTexts(
+      footprintInput(
+        makeAction({
+          output: [{ type: "text", text: "Email sent." }],
+          userEditedInputs: {
+            subject: "New subject",
+          },
+        })
+      )
+    );
+
+    expect(inputText).toBe(
+      `The tool was executed with these user-edited input values:\n- subject: "New subject".\nEmail sent.`
+    );
+  });
 });
 
 describe("measureToolCallFootprints", () => {
@@ -155,6 +184,7 @@ describe("measureToolCallFootprints", () => {
 
   it("returns an empty result without tokenizing when there are no actions", async () => {
     const res = await measureToolCallFootprints(auth, {
+      conversationId,
       modelId: GPT_5_MODEL_ID,
       toolCalls: [],
     });
@@ -166,6 +196,7 @@ describe("measureToolCallFootprints", () => {
 
   it("fails when the run's model is not a known configuration", async () => {
     const res = await measureToolCallFootprints(auth, {
+      conversationId,
       modelId: "not-a-real-model",
       toolCalls: [footprintInput(makeAction())],
     });
@@ -176,6 +207,7 @@ describe("measureToolCallFootprints", () => {
 
   it("tokenizes historical runs whose model is no longer served", async () => {
     const res = await measureToolCallFootprints(auth, {
+      conversationId,
       modelId: GPT_4_1_MODEL_CONFIG.modelId,
       toolCalls: [footprintInput(makeAction())],
     });
@@ -201,6 +233,7 @@ describe("measureToolCallFootprints", () => {
     ];
 
     const res = await measureToolCallFootprints(auth, {
+      conversationId,
       modelId: GPT_5_MODEL_ID,
       toolCalls,
     });
@@ -232,6 +265,7 @@ describe("measureToolCallFootprints", () => {
     );
 
     const res = await measureToolCallFootprints(auth, {
+      conversationId,
       modelId: GPT_5_MODEL_ID,
       toolCalls: [footprintInput(makeAction())],
     });

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -3,6 +3,8 @@ import {
   measureToolCallFootprints,
   toolCallFootprintTexts,
 } from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
+import { renderActionForMultiActionsModel } from "@app/lib/api/assistant/conversation_rendering/helpers";
+import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { tokenCountForTexts } from "@app/lib/tokenization";
@@ -257,6 +259,34 @@ describe("measureToolCallFootprints", () => {
         inputTokensCount: "result-of-b".length,
       },
     ]);
+  });
+
+  it("tokenizes the same result content as conversation rendering", async () => {
+    const action = makeAction({
+      output: [{ type: "text", text: "Email sent." }],
+      userEditedInputs: {
+        subject: "New subject",
+      },
+    });
+    const renderedResult = await renderActionForMultiActionsModel(
+      auth,
+      action,
+      GPT_4_1_MODEL_CONFIG,
+      { conversationId }
+    );
+    const renderedResultText = getTextContentFromMessage(renderedResult);
+
+    const res = await measureToolCallFootprints(auth, {
+      conversationId,
+      modelId: GPT_4_1_MODEL_CONFIG.modelId,
+      toolCalls: [footprintInput(action)],
+    });
+
+    const [inputTexts] = vi.mocked(tokenCountForTexts).mock.calls[1];
+    expect(inputTexts).toEqual([renderedResultText]);
+    expect(res.isOk() && res.value[0].inputTokensCount).toBe(
+      renderedResultText.length
+    );
   });
 
   it("propagates a tokenizer failure", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -1,5 +1,6 @@
 import { getEnabledSkillInputTextByActionId } from "@app/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint";
-import { renderToolResultForModelAsText } from "@app/lib/api/assistant/conversation_rendering/helpers";
+import { renderActionForMultiActionsModel } from "@app/lib/api/assistant/conversation_rendering/helpers";
+import { getTextContentFromMessage } from "@app/lib/api/assistant/utils";
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
@@ -9,6 +10,7 @@ import {
   GPT_4_1_MINI_MODEL_CONFIG,
   GPT_4_1_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -51,17 +53,33 @@ export interface ToolCallFootprintInput {
   functionCallArguments: string;
 }
 
-export function toolCallFootprintTexts(
+export async function toolCallFootprintTexts(
+  auth: Authenticator,
   { action, functionCallArguments }: ToolCallFootprintInput,
-  additionalInputText?: string
-): ToolFootprintTexts {
+  {
+    additionalInputText,
+    conversationId,
+    model,
+  }: {
+    additionalInputText?: string;
+    conversationId: string;
+    model: ModelConfigurationType;
+  }
+): Promise<ToolFootprintTexts> {
+  const renderedResult = await renderActionForMultiActionsModel(
+    auth,
+    action,
+    model,
+    { conversationId }
+  );
+
   return {
     // The tool call as the model emitted it: its name plus the arguments it generated.
     callText: `${action.functionCallName}\n${functionCallArguments}`,
     // Tool input means the model input created by this execution. Most tools contribute only their
     // rendered result. Enabling a skill also adds its instructions and tool definitions to later
     // requests, so those consequences belong to the same tool row.
-    inputText: [renderToolResultForModelAsText(action), additionalInputText]
+    inputText: [getTextContentFromMessage(renderedResult), additionalInputText]
       .filter((text): text is string => text !== undefined)
       .join("\n"),
   };
@@ -77,9 +95,11 @@ export function toolCallFootprintTexts(
 export async function measureToolCallFootprints(
   auth: Authenticator,
   {
+    conversationId,
     modelId,
     toolCalls,
   }: {
+    conversationId: string;
     modelId: string;
     toolCalls: ToolCallFootprintInput[];
   }
@@ -111,10 +131,15 @@ export async function measureToolCallFootprints(
 
   // Tokenize the calls and inputs as two homogeneous lists so each count maps back to its call by
   // plain index, with no call-vs-input position juggling.
-  const footprints = toolCalls.map((toolCall) =>
-    toolCallFootprintTexts(
-      toolCall,
-      enabledSkillInputTextByActionId.get(toolCall.action.sId)
+  const footprints = await Promise.all(
+    toolCalls.map((toolCall) =>
+      toolCallFootprintTexts(auth, toolCall, {
+        additionalInputText: enabledSkillInputTextByActionId.get(
+          toolCall.action.sId
+        ),
+        conversationId,
+        model,
+      })
     )
   );
   const [callCountsRes, inputCountsRes] = await Promise.all([

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -67,6 +67,7 @@ export async function toolCallFootprintTexts(
     model: ModelConfigurationType;
   }
 ): Promise<ToolFootprintTexts> {
+  // This applies model-facing output rewrites, such as semantic search rendering.
   const renderedResult = await renderActionForMultiActionsModel(
     auth,
     action,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -5,6 +5,7 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { tokenCountForTexts } from "@app/lib/tokenization";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import {
   GPT_4_1_MINI_MODEL_CONFIG,
@@ -129,19 +130,21 @@ export async function measureToolCallFootprints(
       toolCalls.map(({ action }) => action)
     );
 
-  // Tokenize the calls and inputs as two homogeneous lists so each count maps back to its call by
-  // plain index, with no call-vs-input position juggling.
-  const footprints = await Promise.all(
-    toolCalls.map((toolCall) =>
+  // Rendering can sign model-facing file URLs, so keep it bounded while preserving input order.
+  const footprints = await concurrentExecutor(
+    toolCalls,
+    (toolCall) =>
       toolCallFootprintTexts(auth, toolCall, {
         additionalInputText: enabledSkillInputTextByActionId.get(
           toolCall.action.sId
         ),
         conversationId,
         model,
-      })
-    )
+      }),
+    { concurrency: 5 }
   );
+  // Tokenize the calls and inputs as two homogeneous lists so each count maps back to its call by
+  // plain index, with no call-vs-input position juggling.
   const [callCountsRes, inputCountsRes] = await Promise.all([
     tokenCountForTexts(
       footprints.map((footprint) => footprint.callText),

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -197,7 +197,7 @@ function renderEnabledSkillMessagesForAction(
 /**
  * Renders an action result for multi-actions model
  */
-async function renderActionForMultiActionsModel(
+export async function renderActionForMultiActionsModel(
   auth: Authenticator,
   action: AgentMCPActionWithOutputType,
   model: ModelConfigurationType,


### PR DESCRIPTION
## Description

When counting the tokens of the output of a tool for recording as consumption items, we sometimes undercount them compared to what we actually show the model, notably when we rewrite the content for the model (which we do for the semantic search for instance).

We can't change what we store in the output items, as these serve both the UI and the model. What we do in this PR is that we make sure that we follow the same code path for rendering the tool outputs as text.

## Tests

- Added tests that check that we count tokens the same way.

## Risk

- Low.

## Deploy Plan

- Deploy front.
