### PR TITLE
[Activation] Remove isCompactUIView column & model

### DIFF
--- a/front/lib/models/activation/activation_pod.ts
+++ b/front/lib/models/activation/activation_pod.ts
@@ -15,8 +15,6 @@ export class ActivationPodModel extends WorkspaceAwareModel<ActivationPodModel> 
   declare spaceId: ForeignKey<SpaceModel["id"]>;
   // The user for whom we created the activation pod.
   declare userId: ForeignKey<UserModel["id"]>;
-  // Whether the Pod uses the compact UI variant.
-  declare isCompactUIView: CreationOptional<boolean>;
 }
 
 ActivationPodModel.init(
@@ -30,11 +28,6 @@ ActivationPodModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    isCompactUIView: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
     },
   },
   {

--- a/front/migrations/post-deploy/20260813105754_drop_compact_ui_view_from_activation_pods.sql
+++ b/front/migrations/post-deploy/20260813105754_drop_compact_ui_view_from_activation_pods.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - DELETES_DATA: Deletes all values in the column
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" DROP COLUMN "isCompactUIView";


### PR DESCRIPTION
## Description

Remove the obsolete `isCompactUIView` field from `activation-pods` now that compact UI is derived client-side from the conversation's `uiView` rather than persisted on the Activation Pod record.

- Remove the `isCompactUIView` attribute from `ActivationPodModel`.
- Add a post-deploy migration to drop the `isCompactUIView` column from `public.activation_pods`.
- No backfill is required because the column is no longer read or written by the application.

## Tests

## Risk

Low application risk because the column is no longer used by the compact UI flow.

## Deploy Plan
Follow post-deploy migration steps.
