### PR TITLE
feat(front): open consumption analytics to managers

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -252,10 +252,10 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     );
   });
 
-  it("narrows the analytics view to non-private agents below the admin role", async () => {
+  it("narrows the analytics view to non-private agents below the manager role", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "GET",
-      role: "manager",
+      role: "user",
     });
     const { agentOwner } = await setupAgentOwner(workspace, "user");
     await setupTestAgents(workspace, agentOwner);

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -354,7 +354,7 @@ export const subNavigationAdmin = ({
               icon: BarChart01,
               href: `/w/${owner.sId}/analytics/consumption`,
               current: isCurrent("analytics_consumption"),
-              disabled: !hasAdminRole,
+              disabled: !hasManagerRole,
             },
           ]
         : []),

--- a/front/lib/api/analytics/consumption/facet_catalog.test.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.test.ts
@@ -50,7 +50,10 @@ describe("listConsumptionFacetCatalog", () => {
     );
   });
 
-  it("lists private agents of other users for admins", async () => {
+  it.each([
+    "admin",
+    "manager",
+  ] as const)("lists private agents of other users for %ss", async (role) => {
     const { workspace, authenticator: editorAuth } = await createResourceTest({
       role: "user",
     });
@@ -58,21 +61,21 @@ describe("listConsumptionFacetCatalog", () => {
       name: "Secret agent",
       scope: "hidden",
     });
-    const adminUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
-    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      adminUser.sId,
+    const reportingUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, reportingUser, { role });
+    const reportingAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      reportingUser.sId,
       workspace.sId
     );
 
-    const catalog = await listConsumptionFacetCatalog(adminAuth);
+    const catalog = await listConsumptionFacetCatalog(reportingAuth);
 
     expect(catalog.agent).toContainEqual(
       expect.objectContaining({ value: agent.sId, label: "Secret agent" })
     );
   });
 
-  it("hides private agents of other users below the admin role", async () => {
+  it("hides private agents of other users below the manager role", async () => {
     const { workspace, authenticator: editorAuth } = await createResourceTest({
       role: "user",
     });
@@ -80,16 +83,16 @@ describe("listConsumptionFacetCatalog", () => {
       name: "Secret agent",
       scope: "hidden",
     });
-    const managerUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, managerUser, {
-      role: "manager",
+    const memberUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, memberUser, {
+      role: "user",
     });
-    const managerAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      managerUser.sId,
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      memberUser.sId,
       workspace.sId
     );
 
-    const catalog = await listConsumptionFacetCatalog(managerAuth);
+    const catalog = await listConsumptionFacetCatalog(memberAuth);
 
     expect(catalog.agent).not.toContainEqual(
       expect.objectContaining({ value: agent.sId })

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -65,10 +65,14 @@ describe("resolveDimensionDisplayNames", () => {
     const skills = await resolveDimensionDisplayNames(auth, "skill", [
       "deleted_skill",
     ]);
+    const agents = await resolveDimensionDisplayNames(auth, "agent", [
+      "deleted_agent",
+    ]);
 
     expect(names.get("deleted_model")).toBe("deleted_model");
     expect(origins.get("deleted_origin")).toBe("deleted_origin");
     expect(skills.get("deleted_skill")).toBe("deleted_skill");
+    expect(agents.get("deleted_agent")).toBe("deleted_agent");
   });
 
   it("returns nothing for an empty breakdown", async () => {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.ts
@@ -157,24 +157,30 @@ export async function getConversationConsumption(
   const agents: ConversationConsumptionAgentDetails[] = [
     ...detailsByAgentId.entries(),
   ]
-    .map(([agentId, entries]) => {
+    .flatMap(([agentId, entries]) => {
+      const label = agentLabels.get(agentId);
+      if (!label) {
+        return [];
+      }
+
       const aggregate = aggregateMessageDetails(
         entries.map(({ details }) => details)
       );
-      const label = agentLabels.get(agentId);
 
-      return {
-        agentId,
-        name: label?.name ?? "Unknown agent",
-        pictureUrl: label?.pictureUrl ?? null,
-        billedCredits: entries.reduce(
-          (total, { message }) => total + (message.billedCredits ?? 0),
-          0
-        ),
-        agentWorkCredits: aggregate.agentWorkCredits,
-        tools: aggregate.tools,
-        models: aggregate.models,
-      };
+      return [
+        {
+          agentId,
+          name: label.name,
+          pictureUrl: label.pictureUrl,
+          billedCredits: entries.reduce(
+            (total, { message }) => total + (message.billedCredits ?? 0),
+            0
+          ),
+          agentWorkCredits: aggregate.agentWorkCredits,
+          tools: aggregate.tools,
+          models: aggregate.models,
+        },
+      ];
     })
     .sort((left, right) => right.billedCredits - left.billedCredits);
 

--- a/front/lib/api/assistant/configuration/views.test.ts
+++ b/front/lib/api/assistant/configuration/views.test.ts
@@ -27,8 +27,12 @@ async function listAgentIdsForAnalytics(auth: Authenticator) {
   return agents.map((agent) => agent.sId);
 }
 
+const REPORTING_ROLES = ["admin", "manager"] as const;
+
 describe("getAgentConfigurationsForView, 'analytics' view", () => {
-  it("lists private agents of other users for admins", async () => {
+  it.each(
+    REPORTING_ROLES
+  )("lists private agents of other users for %ss", async (role) => {
     const { workspace, authenticator: editorAuth } = await createResourceTest({
       role: "user",
     });
@@ -36,14 +40,12 @@ describe("getAgentConfigurationsForView, 'analytics' view", () => {
       editorAuth,
       { name: "Secret agent", scope: "hidden" }
     );
-    const adminAuth = await authenticatorForNewMember(workspace, "admin");
+    const auth = await authenticatorForNewMember(workspace, role);
 
-    expect(await listAgentIdsForAnalytics(adminAuth)).toContain(
-      privateAgent.sId
-    );
+    expect(await listAgentIdsForAnalytics(auth)).toContain(privateAgent.sId);
   });
 
-  it("hides private agents of other users below the admin role", async () => {
+  it("hides private agents of other users below the manager role", async () => {
     const { workspace, authenticator: editorAuth } = await createResourceTest({
       role: "user",
     });
@@ -55,14 +57,16 @@ describe("getAgentConfigurationsForView, 'analytics' view", () => {
       editorAuth,
       { name: "Shared agent", scope: "visible" }
     );
-    const managerAuth = await authenticatorForNewMember(workspace, "manager");
+    const memberAuth = await authenticatorForNewMember(workspace, "user");
 
-    const agentIds = await listAgentIdsForAnalytics(managerAuth);
+    const agentIds = await listAgentIdsForAnalytics(memberAuth);
     expect(agentIds).toContain(sharedAgent.sId);
     expect(agentIds).not.toContain(privateAgent.sId);
   });
 
-  it("lists agents built on spaces the admin is not a member of", async () => {
+  it.each(
+    REPORTING_ROLES
+  )("lists agents built on spaces the %s is not a member of", async (role) => {
     const { workspace, authenticator: editorAuth } = await createResourceTest({
       role: "user",
     });
@@ -74,20 +78,20 @@ describe("getAgentConfigurationsForView, 'analytics' view", () => {
       scope: "visible",
       requestedSpaceIds: [space.id],
     });
-    const adminAuth = await authenticatorForNewMember(workspace, "admin");
+    const auth = await authenticatorForNewMember(workspace, role);
 
-    expect(await listAgentIdsForAnalytics(adminAuth)).toContain(agent.sId);
-    // The admin is not a member of the space, so every other view still hides
-    // the agent: only the analytics view opens it up.
-    const listedForAdmin = await getAgentConfigurationsForView({
-      auth: adminAuth,
+    expect(await listAgentIdsForAnalytics(auth)).toContain(agent.sId);
+    // The caller is not a member of the space, so every other view still
+    // hides the agent: only the analytics view opens it up.
+    const listedForAll = await getAgentConfigurationsForView({
+      auth,
       agentsGetView: "all",
       variant: "light",
     });
-    expect(listedForAdmin.map((a) => a.sId)).not.toContain(agent.sId);
+    expect(listedForAll.map((a) => a.sId)).not.toContain(agent.sId);
   });
 
-  it("hides agents built on unreadable spaces below the admin role", async () => {
+  it("hides agents built on unreadable spaces below the manager role", async () => {
     const { workspace, authenticator: editorAuth } = await createResourceTest({
       role: "user",
     });
@@ -99,11 +103,9 @@ describe("getAgentConfigurationsForView, 'analytics' view", () => {
       scope: "visible",
       requestedSpaceIds: [space.id],
     });
-    const managerAuth = await authenticatorForNewMember(workspace, "manager");
+    const memberAuth = await authenticatorForNewMember(workspace, "user");
 
-    expect(await listAgentIdsForAnalytics(managerAuth)).not.toContain(
-      agent.sId
-    );
+    expect(await listAgentIdsForAnalytics(memberAuth)).not.toContain(agent.sId);
   });
 
   it("returns the 'all' set to a plain member instead of throwing", async () => {

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -171,12 +171,12 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         where: baseWhereConditions,
       });
 
-    // Analytics reports on every agent, so admins get the private ones too.
-    // Everyone else sees what `all` returns.
+    // Analytics reports on every agent, so managers and admins get the private
+    // ones too. Everyone else sees what `all` returns.
     case "analytics":
       return AgentConfigurationModel.findAll({
         ...baseAgentsSequelizeQuery,
-        where: auth.isAdmin()
+        where: auth.isManager()
           ? baseWhereConditions
           : baseConditionsAndScopesIn(["workspace", "published", "visible"]),
       });
@@ -333,11 +333,11 @@ async function fetchWorkspaceAgentConfigurationsForView(
     }
   );
 
-  // Analytics counts credits for agents built on spaces an admin cannot read,
-  // so the admin analytics view has to list them as well.
+  // Analytics counts credits for agents built on spaces a manager cannot read,
+  // so the manager analytics view has to list them as well.
   const skipPermissionFiltering =
     dangerouslySkipPermissionFiltering ||
-    (agentsGetView === "analytics" && auth.isAdmin());
+    (agentsGetView === "analytics" && auth.isManager());
 
   const allowedAgentModels = skipPermissionFiltering
     ? agentModels

--- a/front/lib/api/assistant/observability/agent_credits.ts
+++ b/front/lib/api/assistant/observability/agent_credits.ts
@@ -1,9 +1,6 @@
 import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration/agent";
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
-import {
-  resolveAnalyticsAgentLabels,
-  UNKNOWN_AGENT_LABEL,
-} from "@app/lib/api/assistant/observability/agent_labels";
+import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import { getUserDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import {
   buildCreditsScopeQuery,
@@ -184,9 +181,12 @@ export async function fetchAgentCreditBreakdown(
   // fetchByIds only returns skills the admin can read; others get no description.
   const skillsById = new Map(skills.map((skill) => [skill.sId, skill]));
 
-  const rows: AgentCreditRow[] = buckets.map((bucket) => {
+  const rows: AgentCreditRow[] = buckets.flatMap((bucket) => {
     const agentId = String(bucket.key);
-    const label = agentLabels.get(agentId) ?? UNKNOWN_AGENT_LABEL;
+    const label = agentLabels.get(agentId);
+    if (!label) {
+      return [];
+    }
 
     const topUsers: AgentCreditUser[] = bucketsToArray<SubBucket>(
       bucket.top_users?.buckets
@@ -214,17 +214,19 @@ export async function fetchAgentCreditBreakdown(
       };
     });
 
-    return {
-      agentId,
-      name: label.name,
-      pictureUrl: label.pictureUrl,
-      modelDisplayName: label.modelDisplayName,
-      description: label.description,
-      messageCount: bucket.doc_count,
-      credits: Math.round(bucket.credits?.value ?? 0),
-      topUsers,
-      topSkills,
-    };
+    return [
+      {
+        agentId,
+        name: label.name,
+        pictureUrl: label.pictureUrl,
+        modelDisplayName: label.modelDisplayName,
+        description: label.description,
+        messageCount: bucket.doc_count,
+        credits: Math.round(bucket.credits?.value ?? 0),
+        topUsers,
+        topSkills,
+      },
+    ];
   });
 
   return new Ok(rows);

--- a/front/lib/api/assistant/observability/agent_labels.ts
+++ b/front/lib/api/assistant/observability/agent_labels.ts
@@ -5,7 +5,7 @@ import {
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import type { Authenticator } from "@app/lib/auth";
 
-type AnalyticsAgentLabel = {
+export type AnalyticsAgentLabel = {
   name: string;
   pictureUrl: string | null;
   modelDisplayName: string;
@@ -14,13 +14,8 @@ type AnalyticsAgentLabel = {
 
 const PRIVATE_AGENT_DESCRIPTION = "Private agent: description unavailable";
 
-export const UNKNOWN_AGENT_LABEL: AnalyticsAgentLabel = {
-  name: "Unknown agent",
-  pictureUrl: null,
-  modelDisplayName: getAgentModelDisplayName(undefined),
-  description: "",
-};
-
+// Agent ids that no longer resolve to a configuration are absent from the
+// returned map; callers drop them instead of surfacing a placeholder row.
 export async function resolveAnalyticsAgentLabels(
   auth: Authenticator,
   agentIds: string[]
@@ -44,37 +39,31 @@ export async function resolveAnalyticsAgentLabels(
     fallbackLabels.map((label) => [label.sId, label])
   );
 
-  return new Map(
-    agentIds.map((agentId) => {
-      const agent = agentsById.get(agentId);
-      if (agent) {
-        return [
-          agentId,
-          {
-            name: agent.name,
-            pictureUrl: agent.pictureUrl,
-            modelDisplayName: getAgentModelDisplayName(agent.model),
-            description: agent.canRead
-              ? agent.description
-              : PRIVATE_AGENT_DESCRIPTION,
-          },
-        ];
-      }
+  const labels = new Map<string, AnalyticsAgentLabel>();
+  for (const agentId of agentIds) {
+    const agent = agentsById.get(agentId);
+    if (agent) {
+      labels.set(agentId, {
+        name: agent.name,
+        pictureUrl: agent.pictureUrl,
+        modelDisplayName: getAgentModelDisplayName(agent.model),
+        description: agent.canRead
+          ? agent.description
+          : PRIVATE_AGENT_DESCRIPTION,
+      });
+      continue;
+    }
 
-      const fallback = fallbackById.get(agentId);
-      if (fallback) {
-        return [
-          agentId,
-          {
-            name: fallback.name,
-            pictureUrl: fallback.pictureUrl,
-            modelDisplayName: getAgentModelDisplayName(fallback.model),
-            description: PRIVATE_AGENT_DESCRIPTION,
-          },
-        ];
-      }
+    const fallback = fallbackById.get(agentId);
+    if (fallback) {
+      labels.set(agentId, {
+        name: fallback.name,
+        pictureUrl: fallback.pictureUrl,
+        modelDisplayName: getAgentModelDisplayName(fallback.model),
+        description: PRIVATE_AGENT_DESCRIPTION,
+      });
+    }
+  }
 
-      return [agentId, UNKNOWN_AGENT_LABEL];
-    })
-  );
+  return labels;
 }

--- a/front/lib/api/assistant/observability/credit_usage.ts
+++ b/front/lib/api/assistant/observability/credit_usage.ts
@@ -155,10 +155,10 @@ function groupTermsAggFor(
   return terms;
 }
 
-function fallbackGroupName(groupBy: CreditBreakdownBy): string {
+function fallbackGroupName(
+  groupBy: Exclude<CreditBreakdownBy, "agent">
+): string {
   switch (groupBy) {
-    case "agent":
-      return "Unknown agent";
     case "user":
       return "Programmatic usage";
     case "origin":
@@ -345,10 +345,13 @@ export async function fetchCreditUsage(
     ranked.map((row) => row.groupKey)
   );
 
-  const rows: CreditUsageRow[] = ranked.map((row) => ({
-    ...row,
-    name: namesById.get(row.groupKey) ?? fallbackGroupName(groupBy),
-  }));
+  const rows: CreditUsageRow[] = ranked.flatMap((row) => {
+    const name = namesById.get(row.groupKey);
+    if (groupBy === "agent") {
+      return name ? [{ ...row, name }] : [];
+    }
+    return [{ ...row, name: name ?? fallbackGroupName(groupBy) }];
+  });
 
   return new Ok({ totalCredits, rows });
 }

--- a/front/lib/api/assistant/observability/top_agents.ts
+++ b/front/lib/api/assistant/observability/top_agents.ts
@@ -1,7 +1,4 @@
-import {
-  resolveAnalyticsAgentLabels,
-  UNKNOWN_AGENT_LABEL,
-} from "@app/lib/api/assistant/observability/agent_labels";
+import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import {
   fetchAgentCostStats,
   getAgentCostStats,
@@ -114,18 +111,23 @@ export async function fetchTopAgents(
   }
   const costStatsMap = costStatsResult.value;
 
-  const rows = buckets.map((bucket) => {
+  const rows = buckets.flatMap((bucket) => {
     const agentId = String(bucket.key);
-    const label = agents.get(agentId) ?? UNKNOWN_AGENT_LABEL;
-    return {
-      agentId,
-      name: label.name,
-      pictureUrl: label.pictureUrl,
-      messageCount: bucket.doc_count ?? 0,
-      userCount: Math.round(bucket.unique_users?.value ?? 0),
-      totalCostCredits: getAgentCostStats(costStatsMap, agentId)
-        .totalCostCredits,
-    };
+    const label = agents.get(agentId);
+    if (!label) {
+      return [];
+    }
+    return [
+      {
+        agentId,
+        name: label.name,
+        pictureUrl: label.pictureUrl,
+        messageCount: bucket.doc_count ?? 0,
+        userCount: Math.round(bucket.unique_users?.value ?? 0),
+        totalCostCredits: getAgentCostStats(costStatsMap, agentId)
+          .totalCostCredits,
+      },
+    ];
   });
 
   return new Ok(rows);

--- a/front/lib/api/assistant/observability/user_credits.ts
+++ b/front/lib/api/assistant/observability/user_credits.ts
@@ -1,7 +1,4 @@
-import {
-  resolveAnalyticsAgentLabels,
-  UNKNOWN_AGENT_LABEL,
-} from "@app/lib/api/assistant/observability/agent_labels";
+import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import { getUserDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import {
   buildCreditsScopeQuery,
@@ -138,18 +135,25 @@ export async function fetchUserCreditBreakdown(
     const userId = String(bucket.key);
     const user = usersById.get(userId);
 
+    // Agents that no longer resolve to a configuration are dropped: they cannot
+    // be named or linked to.
     const topAgents: UserCreditAgent[] = bucketsToArray<AgentBucket>(
       bucket.top_agents?.buckets
-    ).map((agentBucket) => {
+    ).flatMap((agentBucket) => {
       const agentId = String(agentBucket.key);
-      const label = agentLabels.get(agentId) ?? UNKNOWN_AGENT_LABEL;
-      return {
-        agentId,
-        name: label.name,
-        pictureUrl: label.pictureUrl,
-        modelDisplayName: label.modelDisplayName,
-        description: label.description,
-      };
+      const label = agentLabels.get(agentId);
+      if (!label) {
+        return [];
+      }
+      return [
+        {
+          agentId,
+          name: label.name,
+          pictureUrl: label.pictureUrl,
+          modelDisplayName: label.modelDisplayName,
+          description: label.description,
+        },
+      ];
     });
 
     return {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -88,11 +88,11 @@ export type AgentConfigurationScope =
  * - 'published': Retrieves all published agents.
  * - 'global': Retrieves all agents exclusively with a 'global' scope.
  * - 'analytics': Agents the caller may report on, for the workspace analytics
- *   surfaces. Admins get every active agent in the workspace — whatever its
- *   scope, whoever edits it, and whether or not they can read the spaces it is
- *   built on — since analytics reports on all of them. Everyone else gets the
- *   same set as 'all'. Never fails on permissions: the scope opens up with the
- *   caller's role.
+ *   surfaces. Managers and admins get every active agent in the workspace —
+ *   whatever its scope, whoever edits it, and whether or not they can read the
+ *   spaces it is built on — since analytics reports on all of them. Everyone
+ *   else gets the same set as 'all'. Never fails on permissions: the scope
+ *   opens up with the caller's role.
  * - 'admin_internal': Grants access to all agents, including private ones.
  * - 'manage': Retrieves all agents for the manage agents view (same as list, but including disabled agents).
  * - 'archived': Retrieves all agents that are archived. Only available to super


### PR DESCRIPTION
## Description

Widening `/analytics/consumption` to managers, the nav entry and every endpoint behind it were already manager-gated, only the page itself and the `analytics` agents view were admin-only.

Small cleanup that falls out of it: dropped the "Unknown agent" placeholder. Archived and retired agents still resolve fine.

## Tests

Updated tests files. Tested locally with a manager role account.

## Risk

Low. Managers see private agent names and descriptions in the analytics tables now, which is the point of the change but worth calling out. Everything below the manager role is unchanged. Straight rollback.

## Deploy Plan

Deploy `front`.