### PR TITLE
[front] fix: restart litestream when a Pod app's databases are deleted

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
@@ -22,6 +22,16 @@ vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
 
 const EMPTY_SCHEMA = { type: "object", properties: {} } as const;
 
+/** Records every root command front runs on the sandbox (the litestream restart), answering ok. */
+function mockSandboxExecRoot(sandbox: SandboxResource): string[] {
+  const commands: string[] = [];
+  vi.spyOn(sandbox, "execRoot").mockImplementation(async (_auth, command) => {
+    commands.push(command.command);
+    return new Ok({ exitCode: 0, stdout: "", stderr: "" });
+  });
+  return commands;
+}
+
 /** Records every command front runs on the sandbox, answering db execs with an ok envelope. */
 function mockSandboxExec(sandbox: SandboxResource): string[] {
   const commands: string[] = [];
@@ -50,8 +60,9 @@ async function setupPod() {
   vi.mocked(ensurePodSandboxReady).mockResolvedValue(
     new Ok({ sandbox, freshlyCreated: false })
   );
+  const rootCommands = mockSandboxExecRoot(sandbox);
 
-  return { workspace, user, auth, pod, sandbox };
+  return { workspace, user, auth, pod, sandbox, rootCommands };
 }
 
 function gcsObject(
@@ -151,7 +162,7 @@ describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix", () => {
     );
   });
 
-  it("deletes the live database before wiping its replica", async () => {
+  it("deletes the live database, restarts litestream, then wipes the replica", async () => {
     const { workspace, pod, sandbox } = await setupPod();
 
     const order: string[] = [];
@@ -164,6 +175,12 @@ describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix", () => {
         stdout: `${JSON.stringify({ ok: true })}\n`,
         stderr: "",
       });
+    });
+    vi.spyOn(sandbox, "execRoot").mockImplementation(async (_auth, command) => {
+      if (command.command.includes("systemctl restart litestream")) {
+        order.push("restart");
+      }
+      return new Ok({ exitCode: 0, stdout: "", stderr: "" });
     });
 
     fileStorageMock.setFilesByPrefix(() => [
@@ -183,8 +200,40 @@ describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix", () => {
     );
 
     expect(res.status).toBe(200);
-    // A live litestream re-replicates a database it can still see, so this order is load-bearing.
-    expect(order).toEqual(["live", "replica"]);
+    // A live litestream re-replicates a database it can still see, and removing the files does not
+    // make it let go — only the restart does. This whole order is load-bearing.
+    expect(order).toEqual(["live", "restart", "replica"]);
+  });
+
+  it("does not wipe the replica when the litestream restart fails", async () => {
+    const { workspace, pod, sandbox } = await setupPod();
+    mockSandboxExec(sandbox);
+
+    vi.spyOn(sandbox, "execRoot").mockResolvedValue(
+      new Ok({ exitCode: 1, stdout: "", stderr: "Job for litestream failed." })
+    );
+
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "TaskList/"),
+      gcsObject(workspace.sId, pod.sId, "TaskList/databases/tasks.db.ts"),
+    ]);
+    fileStorageMock.setSubdirectoryNames(() => ["tasklist__tasks.db"]);
+    const wipedPrefixes: string[] = [];
+    fileStorageMock.setOnDeleteByPrefix((prefix) => {
+      wipedPrefixes.push(prefix);
+    });
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/tasklist`,
+      { method: "DELETE" }
+    );
+
+    // A daemon still holding the deleted database would recreate the prefix right after the wipe,
+    // and the pod's next cold start would restore the database from it. Better to fail and be retried.
+    expect(res.status).toBe(500);
+    expect(
+      wipedPrefixes.filter((prefix) => prefix.includes("tasklist__tasks.db/"))
+    ).toEqual([]);
   });
 
   it("fails when the replica survives, rather than reporting a delete that would come back", async () => {

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -4,7 +4,10 @@ import { getPodStateBasePath } from "@app/lib/api/files/mount_path";
 import { getFileContent } from "@app/lib/api/files/utils";
 import { deleteProjectFile } from "@app/lib/api/projects/context";
 import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
-import { deletePodDatabaseReplica } from "@app/lib/api/sandbox/db";
+import {
+  deletePodDatabaseReplica,
+  restartLitestreamDaemon,
+} from "@app/lib/api/sandbox/db";
 import {
   appPrefixFromPodDatabaseName,
   podDatabaseNameWithoutAppPrefix,
@@ -21,6 +24,7 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type {
   FileSystemEntry,
@@ -454,7 +458,9 @@ export type DeletePodAppResult = PodAppDeleteSummary;
  *
  *  - Functions go first, so no invocation can arrive while the data underneath it is being removed.
  *  - A database's live files must go before its replica, because a running litestream keeps
- *    replicating a database it can still see (the same hazard the pod-scrub path notes).
+ *    replicating a database it can still see (the same hazard the pod-scrub path notes). Removing the
+ *    files does not make the daemon let go of them — its directory watcher only enumerates at start —
+ *    so the daemon is restarted in between, once every live file is gone.
  *
  * And the source folder goes LAST on purpose. Every step is idempotent, and the folder is what makes
  * the app appear in the Apps tab, so a failure part-way through leaves the app still listed and
@@ -500,7 +506,8 @@ export async function deletePodApp(
     }
   }
 
-  // 2. Live database files, then 3. their replicas. Wakes the pod if it is asleep.
+  // 2. Live database files. Wakes the pod if it is asleep.
+  let sandbox: SandboxResource | null = null;
   for (const database of app.databases) {
     const deleteLiveResult = await deleteDatabaseOnSandbox(auth, {
       space: pod,
@@ -516,7 +523,23 @@ export async function deletePodApp(
         )
       );
     }
+    sandbox = deleteLiveResult.value.sandbox;
+  }
 
+  // 3. Make the daemon let go of the files it just lost, so that step 4 wipes replicas nothing is
+  // writing to. A daemon that kept a deleted database open would recreate its prefix right after,
+  // and the pod's next cold start would restore the database from it.
+  if (sandbox) {
+    const restartResult = await restartLitestreamDaemon(auth, sandbox);
+    if (restartResult.isErr()) {
+      return new Err(
+        new PodAppDeleteError("internal", restartResult.error.message)
+      );
+    }
+  }
+
+  // 4. Replicas: the durable copy, and so the step that makes a database deletion stick.
+  for (const database of app.databases) {
     const deleteReplicaResult = await deletePodDatabaseReplica(auth, pod, {
       database: database.onDiskName,
     });
@@ -527,7 +550,7 @@ export async function deletePodApp(
     }
   }
 
-  // 4. Drop the Frames' pinned tabs before their files go, mirroring the delete_frame poke plugin.
+  // 5. Drop the Frames' pinned tabs before their files go, mirroring the delete_frame poke plugin.
   const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
   if (metadata) {
     for (const frame of app.frames) {
@@ -537,7 +560,7 @@ export async function deletePodApp(
     }
   }
 
-  // 5. Source folder last. `deleteProjectFile` recurses and deletes each FileResource underneath,
+  // 6. Source folder last. `deleteProjectFile` recurses and deletes each FileResource underneath,
   // which is what revokes the Frames' share tokens along with them. Colliding folders all normalize
   // onto this one prefix, so every one of them belongs to the app being deleted.
   const folderNames =

--- a/front/lib/api/sandbox/db.ts
+++ b/front/lib/api/sandbox/db.ts
@@ -90,6 +90,10 @@ const SYNC_WAIT_TIMEOUT_SECONDS = 10;
 const SYNC_EXEC_TIMEOUT_MS = 15_000;
 // Cheap probes and file operations stay tightly bounded.
 const PROBE_EXEC_TIMEOUT_MS = 10_000;
+// A restart waits out the stop half, and litestream's graceful shutdown syncs
+// every managed database before exiting: seconds normally, up to the unit's
+// 90s TimeoutStopSec when one of them cannot reach its replica.
+const DAEMON_RESTART_EXEC_TIMEOUT_MS = 120_000;
 // Cold-start restore may pull a large snapshot + LTX chain through gcsfuse.
 const RESTORE_EXEC_TIMEOUT_MS = 120_000;
 
@@ -409,6 +413,36 @@ async function startLitestreamDaemon(
 }
 
 /**
+ * Restart the litestream daemon: re-derive the managed set from what is live on disk right now.
+ *
+ * The directory watcher only enumerates /pod-state/databases at start, so a database whose live
+ * files were just deleted stays open in the running daemon — free to keep writing to, and so
+ * recreate, the replica prefix a delete is about to wipe. A restart is what makes the daemon let go
+ * of it, and the static config (baked at image build) brings back every database that IS still live.
+ *
+ * The default budget covers a full graceful shutdown; callers on a tight path (the pre-sleep check
+ * runs inside the reaper's per-batch budget) pass their own and accept a timeout instead.
+ */
+export async function restartLitestreamDaemon(
+  auth: Authenticator,
+  sandbox: SandboxResource,
+  { timeoutMs = DAEMON_RESTART_EXEC_TIMEOUT_MS }: { timeoutMs?: number } = {}
+): Promise<Result<void, Error>> {
+  const result = await sandbox.execRoot(
+    auth,
+    rootCommand.exec(SYSTEMCTL_BIN, ["restart", LITESTREAM_UNIT_NAME]),
+    { timeoutMs }
+  );
+  if (result.isErr()) {
+    return result;
+  }
+  if (result.value.exitCode !== 0) {
+    return new Err(execFailure("litestream daemon restart", result.value));
+  }
+  return new Ok(undefined);
+}
+
+/**
  * Pre-sleep health check (reaper sleep, pauseForApproval, and best-effort
  * before kill-requested destroys): make sure every committed transaction
  * reached the GCS replica before the VM is allowed to pause (and later be
@@ -549,14 +583,11 @@ export async function ensurePodStateHealthOnSleep(
         "Pod state pre-sleep: litestream sync failed — restarting daemon, not pausing"
       );
       // Best-effort recovery; the reaper retries the whole check on its next
-      // cycle (status stays `running`). The config is static (baked at image
-      // build) and the directory watcher re-discovers every live database on
-      // start, so a plain restart recovers the full managed set.
-      await sandbox.execRoot(
-        auth,
-        rootCommand.exec(SYSTEMCTL_BIN, ["restart", LITESTREAM_UNIT_NAME]),
-        { timeoutMs: PROBE_EXEC_TIMEOUT_MS }
-      );
+      // cycle (status stays `running`), so this keeps the probe budget rather
+      // than waiting out a full graceful shutdown here.
+      await restartLitestreamDaemon(auth, sandbox, {
+        timeoutMs: PROBE_EXEC_TIMEOUT_MS,
+      });
       return new Err(failure);
     }
   }
@@ -731,8 +762,10 @@ export async function deletePodStatePrefix(
  * replica it finds. So a replica that survives resurrects a database whose live files were deleted —
  * which makes this the step that actually makes a database deletion stick.
  *
- * Call it AFTER the live files are gone: a running litestream keeps replicating a database it can
- * still see, so wiping the prefix first just gets it recreated. The delete is verified by re-listing,
+ * Call it AFTER the live files are gone AND the daemon has been restarted (`restartLitestreamDaemon`):
+ * a running litestream keeps replicating a database it can still see, and removing the files does not
+ * make it let go — the directory watcher only enumerates at start, so until the restart the daemon
+ * still holds the database and recreates the prefix this wipes. The delete is verified by re-listing,
  * because a silently-surviving replica is indistinguishable from success until the pod next boots.
  */
 export async function deletePodDatabaseReplica(

--- a/front/lib/api/sandbox_functions/dsbx_db.ts
+++ b/front/lib/api/sandbox_functions/dsbx_db.ts
@@ -361,13 +361,14 @@ const deleteEnvelopeSchema = z.union([
  * listing never has to check what is live first.
  *
  * Only the LIVE files go. The litestream replica is the durable copy, so a caller deleting a database
- * for good must also wipe its replica prefix (`deletePodDatabaseReplica`), or the next cold-start
- * restore brings the database back.
+ * for good must also restart the daemon (`restartLitestreamDaemon`, which is what makes it let go of
+ * the removed files) and wipe the replica prefix (`deletePodDatabaseReplica`), or the next cold-start
+ * restore brings the database back. Returns the sandbox so that restart needs no second lookup.
  */
 export async function deleteDatabaseOnSandbox(
   auth: Authenticator,
   { space, database }: { space: SpaceResource; database: string }
-): Promise<Result<void, SandboxFunctionError>> {
+): Promise<Result<{ sandbox: SandboxResource }, SandboxFunctionError>> {
   // The name contract (`^[a-z][a-z0-9_]{0,63}$`) admits no separator or dot, so a validated name
   // cannot escape the databases directory. The same guard runs on the replica path.
   if (!isValidPodDatabaseName(database)) {
@@ -400,7 +401,7 @@ export async function deleteDatabaseOnSandbox(
   if (result.isErr()) {
     return result;
   }
-  const { envelope } = result.value;
+  const { envelope, sandbox } = result.value;
 
   if ("ok" in envelope && envelope.ok) {
     logger.info(
@@ -411,7 +412,7 @@ export async function deleteDatabaseOnSandbox(
       },
       "Pod database deleted: removed live files"
     );
-    return new Ok(undefined);
+    return new Ok({ sandbox });
   }
 
   return new Err(dbErrorToSandboxFunctionError(database, envelope, "internal"));


### PR DESCRIPTION
## Description

Deleting a Pod app removes each database's live files and then wipes its replica prefix, on the assumption that a litestream which can no longer see the files stops replicating them. It does not. The directory watcher only enumerates `/pod-state/databases` at daemon start, so until a restart the daemon still holds the deleted database open and is free to recreate the prefix the wipe just removed.

So the delete now restarts the daemon between the two steps: remove every live file, restart, then wipe every replica.

## Risk

Low. One extra root command on a path that already wakes the pod and can take as long as a cold start. The delete gets slower by one daemon restart, and a restart that fails now fails the delete instead of silently leaving a resurrectable replica.

## Deploy Plan

Front
