### PR TITLE
[front] enh: show agent/skill descriptions on hover in attribution table

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -97,6 +97,7 @@ const TOP_AGENTS: GetConsumptionTopAgentsResponse = {
       agentId: "agent1",
       name: "@dust",
       pictureUrl: null,
+      description: "Answers questions about Dust",
       credits: 2230,
       messageCount: 10,
       avgCreditsPerMessage: 223,
@@ -182,6 +183,7 @@ const TOP_SKILLS: GetConsumptionTopSkillsResponse = {
     {
       skillId: "skl_1",
       name: "Research",
+      description: "Researches a topic in depth",
       credits: 40,
       invocationCount: 8,
       avgCreditsPerInvocation: 5,

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -21,6 +21,7 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import type { Transition, Variants } from "framer-motion";
@@ -102,17 +103,27 @@ function buildColumns({
       header: "Name",
       meta: { sizeRatio: 32, headerAlign: "left" },
       cell: (info) => {
-        const { name, pictureUrl } = info.row.original;
+        const { name, pictureUrl, description } = info.row.original;
+        const content = hasAvatar ? (
+          <AvatarNameCell
+            name={name}
+            imageUrl={pictureUrl}
+            isRounded={isAvatarRounded}
+          />
+        ) : (
+          <span className="truncate text-sm">{name}</span>
+        );
+
         return (
           <DataTable.CellContent className="w-full justify-start text-left">
-            {hasAvatar ? (
-              <AvatarNameCell
-                name={name}
-                imageUrl={pictureUrl}
-                isRounded={isAvatarRounded}
+            {description ? (
+              <Tooltip
+                label={description}
+                tooltipTriggerAsChild
+                trigger={content}
               />
             ) : (
-              <span className="truncate text-sm">{name}</span>
+              content
             )}
           </DataTable.CellContent>
         );

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -105,11 +105,13 @@ function buildColumns({
       cell: (info) => {
         const { name, pictureUrl, description } = info.row.original;
         const content = hasAvatar ? (
-          <AvatarNameCell
-            name={name}
-            imageUrl={pictureUrl}
-            isRounded={isAvatarRounded}
-          />
+          <div className="min-w-0">
+            <AvatarNameCell
+              name={name}
+              imageUrl={pictureUrl}
+              isRounded={isAvatarRounded}
+            />
+          </div>
         ) : (
           <span className="truncate text-sm">{name}</span>
         );

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -30,6 +30,7 @@ export type ConsumptionTopRow = {
   id: string;
   name: string;
   pictureUrl: string | null;
+  description: string | null;
   credits: number;
   avgCredits: number;
 };
@@ -52,6 +53,7 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       id: row.agentId,
       name: row.name,
       pictureUrl: row.pictureUrl,
+      description: row.description,
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
     }));
@@ -61,6 +63,7 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       id: row.userId,
       name: row.name,
       pictureUrl: row.pictureUrl,
+      description: null,
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
     }));
@@ -70,6 +73,7 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       id: row.groupId,
       name: row.name,
       pictureUrl: null,
+      description: null,
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
     }));
@@ -79,6 +83,7 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       id: row.modelId,
       name: row.name,
       pictureUrl: null,
+      description: null,
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
     }));
@@ -88,6 +93,7 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       id: row.serverName,
       name: row.name,
       pictureUrl: null,
+      description: null,
       credits: row.credits,
       avgCredits: row.avgCreditsPerInvocation,
     }));
@@ -97,6 +103,7 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       id: row.skillId,
       name: row.name,
       pictureUrl: null,
+      description: row.description,
       credits: row.credits,
       avgCredits: row.avgCreditsPerInvocation,
     }));
@@ -106,6 +113,7 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       id: row.source,
       name: row.name,
       pictureUrl: null,
+      description: null,
       credits: row.credits,
       avgCredits: row.avgCreditsPerMessage,
     }));

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -64,6 +64,7 @@ describe("fetchConsumptionFacets", () => {
             {
               name: value === "agent_disabled" ? "Alpha" : "Zulu",
               pictureUrl: null,
+              description: null,
             },
           ])
         )

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -7,6 +7,7 @@ import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -93,14 +94,15 @@ describe("resolveDimensionLabels", () => {
     expect(labels.get(user.sId)).toEqual({
       name: user.fullName(),
       pictureUrl: user.imageUrl ?? null,
+      description: null,
     });
   });
 
-  it("labels agents with their name and picture", async () => {
+  it("labels agents with their name, picture and description", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const agent = await AgentConfigurationFactory.createTestAgent(
       authenticator,
-      { name: "Analytics agent" }
+      { name: "Analytics agent", description: "Answers analytics questions" }
     );
 
     const labels = await resolveDimensionLabels(authenticator, "agent", [
@@ -110,6 +112,25 @@ describe("resolveDimensionLabels", () => {
     expect(labels.get(agent.sId)).toEqual({
       name: "Analytics agent",
       pictureUrl: agent.pictureUrl,
+      description: "Answers analytics questions",
+    });
+  });
+
+  it("labels skills with their name and user-facing description", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const skill = await SkillFactory.create(authenticator, {
+      name: "Research",
+      userFacingDescription: "Researches a topic in depth",
+    });
+
+    const labels = await resolveDimensionLabels(authenticator, "skill", [
+      skill.sId,
+    ]);
+
+    expect(labels.get(skill.sId)).toEqual({
+      name: "Research",
+      pictureUrl: null,
+      description: "Researches a topic in depth",
     });
   });
 
@@ -126,6 +147,7 @@ describe("resolveDimensionLabels", () => {
     expect(labels.get(group.sId)).toEqual({
       name: "Engineering",
       pictureUrl: null,
+      description: null,
     });
   });
 });

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -29,13 +29,18 @@ export type DimensionLabel = {
   name: string;
   // Only agents and users have one; null for every other dimension.
   pictureUrl: string | null;
+  // Only agents and skills have one; null for every other dimension.
+  description: string | null;
 };
 
 function labelsFromNames(
   names: Map<string, string>
 ): Map<string, DimensionLabel> {
   return new Map(
-    [...names].map(([key, name]) => [key, { name, pictureUrl: null }])
+    [...names].map(([key, name]) => [
+      key,
+      { name, pictureUrl: null, description: null },
+    ])
   );
 }
 
@@ -53,8 +58,19 @@ export async function resolveDimensionLabels(
       const labels = await resolveAnalyticsAgentLabels(auth, keys);
       return new Map(
         keys.map((key) => {
-          const label = labels.get(key) ?? { name: key, pictureUrl: null };
-          return [key, { name: label.name, pictureUrl: label.pictureUrl }];
+          const label = labels.get(key) ?? {
+            name: key,
+            pictureUrl: null,
+            description: null,
+          };
+          return [
+            key,
+            {
+              name: label.name,
+              pictureUrl: label.pictureUrl,
+              description: label.description || null,
+            },
+          ];
         })
       );
     }
@@ -70,6 +86,7 @@ export async function resolveDimensionLabels(
             {
               name: getUserDisplayName(user),
               pictureUrl: user?.imageUrl ?? null,
+              description: null,
             },
           ];
         })
@@ -107,9 +124,19 @@ export async function resolveDimensionLabels(
 
     case "skill": {
       const skills = await SkillResource.fetchByIds(auth, keys);
-      const namesById = new Map(skills.map((skill) => [skill.sId, skill.name]));
-      return labelsFromNames(
-        new Map(keys.map((key) => [key, namesById.get(key) ?? key]))
+      const skillsById = new Map(skills.map((skill) => [skill.sId, skill]));
+      return new Map(
+        keys.map((key) => {
+          const skill = skillsById.get(key);
+          return [
+            key,
+            {
+              name: skill?.name ?? key,
+              pictureUrl: null,
+              description: skill?.userFacingDescription ?? null,
+            },
+          ];
+        })
       );
     }
 

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -54,7 +54,7 @@ function mockLabels(labels: Record<string, string>) {
     new Map(
       Object.entries(labels).map(([key, name]) => [
         key,
-        { name, pictureUrl: null },
+        { name, pictureUrl: null, description: null },
       ])
     )
   );
@@ -81,7 +81,16 @@ describe("consumption top rankings", () => {
   it("ranks agents on gross credits and averages over distinct messages", async () => {
     const { auth } = await setup();
     vi.mocked(resolveDimensionLabels).mockResolvedValue(
-      new Map([["agent1", { name: "@dust", pictureUrl: "http://pic/dust" }]])
+      new Map([
+        [
+          "agent1",
+          {
+            name: "@dust",
+            pictureUrl: "http://pic/dust",
+            description: "Answers questions about Dust",
+          },
+        ],
+      ])
     );
     mockAggs({
       buckets: [
@@ -111,6 +120,7 @@ describe("consumption top rankings", () => {
         agentId: "agent1",
         name: "@dust",
         pictureUrl: "http://pic/dust",
+        description: "Answers questions about Dust",
         credits: 3,
         // The 7 documents of the bucket belong to 2 messages.
         messageCount: 2,
@@ -185,7 +195,18 @@ describe("consumption top rankings", () => {
 
   it("credits a skill with the invocations attributed to it", async () => {
     const { auth } = await setup();
-    mockLabels({ skl_1: "Research" });
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(
+      new Map([
+        [
+          "skl_1",
+          {
+            name: "Research",
+            pictureUrl: null,
+            description: "Researches a topic in depth",
+          },
+        ],
+      ])
+    );
     mockAggs({
       buckets: [
         { key: "skl_1", doc_count: 5, credit_micro: { value: 2_500_000 } },
@@ -206,6 +227,7 @@ describe("consumption top rankings", () => {
       {
         skillId: "skl_1",
         name: "Research",
+        description: "Researches a topic in depth",
         credits: 2.5,
         invocationCount: 5,
         avgCreditsPerInvocation: 0.5,
@@ -379,6 +401,7 @@ describe("consumption top rankings", () => {
       agentId: "agent_gone",
       name: "agent_gone",
       pictureUrl: null,
+      description: null,
     });
   });
 

--- a/front/lib/api/analytics/consumption/top_agents.ts
+++ b/front/lib/api/analytics/consumption/top_agents.ts
@@ -20,6 +20,7 @@ export type ConsumptionTopAgentRow = {
   agentId: string;
   name: string;
   pictureUrl: string | null;
+  description: string | null;
   credits: number;
   messageCount: number;
   avgCreditsPerMessage: number;
@@ -71,6 +72,7 @@ export async function fetchConsumptionTopAgents(
       agentId: group.key,
       name: labels.get(group.key)?.name ?? group.key,
       pictureUrl: labels.get(group.key)?.pictureUrl ?? null,
+      description: labels.get(group.key)?.description ?? null,
       credits: group.credits,
       messageCount: group.count,
       avgCreditsPerMessage: avgCreditsPerUnit(group.credits, group.count),

--- a/front/lib/api/analytics/consumption/top_skills.ts
+++ b/front/lib/api/analytics/consumption/top_skills.ts
@@ -26,6 +26,7 @@ import { Ok } from "@app/types/shared/result";
 export type ConsumptionTopSkillRow = {
   skillId: string;
   name: string;
+  description: string | null;
   credits: number;
   invocationCount: number;
   avgCreditsPerInvocation: number;
@@ -76,6 +77,7 @@ export async function fetchConsumptionTopSkills(
     skills: groups.map((group) => ({
       skillId: group.key,
       name: labels.get(group.key)?.name ?? group.key,
+      description: labels.get(group.key)?.description ?? null,
       credits: group.credits,
       invocationCount: group.count,
       avgCreditsPerInvocation: avgCreditsPerUnit(group.credits, group.count),


### PR DESCRIPTION
## Description

This PR adds tooltips that show agents or skill's descriptions in the rows of the attribution table.
The field was not surfaced in the API, this PR adds the relevant plumbing.

<img width="1037" height="322" alt="image" src="https://github.com/user-attachments/assets/dfce2272-f0b5-401a-9c08-21db6b74e607" />

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
