### PR TITLE
dry up tool/skill usage aggregations

### DIFF
--- a/front/lib/api/assistant/observability/nested_usage_metrics.ts
+++ b/front/lib/api/assistant/observability/nested_usage_metrics.ts
@@ -1,0 +1,211 @@
+import {
+  bucketsToArray,
+  formatDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+// Shared aggregation shapes for analytics stored as a nested field on the
+// per-message document (tools_used, skills_used, ...): a daily time series of
+// executions/unique users, optionally scoped to one value of the nested
+// field, and a terms breakdown of that field's distinct values.
+
+export type NestedUsagePoint = {
+  timestamp: number;
+  date: string;
+  uniqueUsers: number;
+  executionCount: number;
+};
+
+type DateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  nested: {
+    doc_count: number;
+    unique_users: {
+      doc_count: number;
+      cardinality: estypes.AggregationsCardinalityAggregate;
+    };
+  };
+};
+
+type UsageAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<DateBucket>;
+};
+
+type FilteredDateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  nested: {
+    filtered: {
+      doc_count: number;
+      unique_users: {
+        doc_count: number;
+        cardinality: estypes.AggregationsCardinalityAggregate;
+      };
+    };
+  };
+};
+
+type FilteredUsageAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<FilteredDateBucket>;
+};
+
+export async function fetchNestedUsageMetrics(
+  baseQuery: estypes.QueryDslQueryContainer,
+  {
+    nestedPath,
+    filterField,
+    filterValue,
+    timezone = "UTC",
+  }: {
+    nestedPath: string;
+    filterField: string;
+    filterValue: string | null;
+    timezone?: string;
+  }
+): Promise<Result<NestedUsagePoint[], Error>> {
+  const nestedAggs: Record<string, estypes.AggregationsAggregationContainer> =
+    filterValue
+      ? {
+          filtered: {
+            filter: { term: { [filterField]: filterValue } },
+            aggs: {
+              unique_users: {
+                reverse_nested: {},
+                aggs: { cardinality: { cardinality: { field: "user_id" } } },
+              },
+            },
+          },
+        }
+      : {
+          unique_users: {
+            reverse_nested: {},
+            aggs: { cardinality: { cardinality: { field: "user_id" } } },
+          },
+        };
+
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_date: {
+      date_histogram: {
+        field: "timestamp",
+        calendar_interval: "day",
+        time_zone: timezone,
+      },
+      aggs: {
+        nested: {
+          nested: { path: nestedPath },
+          aggs: nestedAggs,
+        },
+      },
+    },
+  };
+
+  if (filterValue) {
+    const result = await searchAnalytics<never, FilteredUsageAggs>(baseQuery, {
+      aggregations: aggs,
+      size: 0,
+    });
+
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    const dateBuckets = bucketsToArray<FilteredDateBucket>(
+      result.value.aggregations?.by_date?.buckets
+    );
+
+    return new Ok(
+      dateBuckets.map((bucket) => ({
+        timestamp: bucket.key,
+        date: formatDateFromMillis(bucket.key, timezone),
+        uniqueUsers:
+          bucket.nested?.filtered?.unique_users?.cardinality?.value ?? 0,
+        executionCount: bucket.nested?.filtered?.doc_count ?? 0,
+      }))
+    );
+  }
+
+  const result = await searchAnalytics<never, UsageAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const dateBuckets = bucketsToArray<DateBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  return new Ok(
+    dateBuckets.map((bucket) => ({
+      timestamp: bucket.key,
+      date: formatDateFromMillis(bucket.key, timezone),
+      uniqueUsers: bucket.nested?.unique_users?.cardinality?.value ?? 0,
+      executionCount: bucket.nested?.doc_count ?? 0,
+    }))
+  );
+}
+
+export type NestedTermBucket = {
+  key: string;
+  docCount: number;
+};
+
+type TermBucket = { key: string; doc_count: number };
+
+type TermListAggs = {
+  nested: {
+    by_term: estypes.AggregationsMultiBucketAggregateBase<TermBucket>;
+  };
+};
+
+export async function fetchNestedTermsBuckets(
+  baseQuery: estypes.QueryDslQueryContainer,
+  {
+    nestedPath,
+    field,
+    size = 100,
+  }: {
+    nestedPath: string;
+    field: string;
+    size?: number;
+  }
+): Promise<Result<NestedTermBucket[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    nested: {
+      nested: { path: nestedPath },
+      aggs: {
+        by_term: {
+          terms: { field, size, order: { _count: "desc" } },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, TermListAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const buckets = bucketsToArray<TermBucket>(
+    result.value.aggregations?.nested?.by_term?.buckets
+  );
+
+  return new Ok(
+    buckets.map((bucket) => ({
+      key: bucket.key,
+      docCount: bucket.doc_count,
+    }))
+  );
+}

--- a/front/lib/api/assistant/observability/skill_usage.ts
+++ b/front/lib/api/assistant/observability/skill_usage.ts
@@ -1,11 +1,14 @@
 import {
-  bucketsToArray,
-  formatDateFromMillis,
-  searchAnalytics,
-} from "@app/lib/api/elasticsearch";
+  fetchNestedTermsBuckets,
+  fetchNestedUsageMetrics,
+} from "@app/lib/api/assistant/observability/nested_usage_metrics";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
+
+const SKILLS_NESTED_PATH = "skills_used";
+const SKILLS_NAME_FIELD = "skills_used.skill_name";
+const SKILLS_ID_FIELD = "skills_used.skill_id";
 
 export type SkillUsagePoint = {
   timestamp: number;
@@ -28,200 +31,35 @@ export type GetWorkspaceSkillsResponse = {
   skills: AvailableSkill[];
 };
 
-type DateBucket = {
-  key: number;
-  key_as_string: string;
-  doc_count: number;
-  skills_nested: {
-    doc_count: number;
-    unique_users: {
-      doc_count: number;
-      cardinality: estypes.AggregationsCardinalityAggregate;
-    };
-  };
-};
-
-type SkillUsageAggs = {
-  by_date: estypes.AggregationsMultiBucketAggregateBase<DateBucket>;
-};
-
-type FilteredDateBucket = {
-  key: number;
-  key_as_string: string;
-  doc_count: number;
-  skills_nested: {
-    filtered: {
-      doc_count: number;
-      unique_users: {
-        doc_count: number;
-        cardinality: estypes.AggregationsCardinalityAggregate;
-      };
-    };
-  };
-};
-
-type FilteredSkillUsageAggs = {
-  by_date: estypes.AggregationsMultiBucketAggregateBase<FilteredDateBucket>;
-};
-
-type SkillBucket = {
-  key: string;
-  doc_count: number;
-};
-
-type SkillListAggs = {
-  skills_nested: {
-    by_skill: estypes.AggregationsMultiBucketAggregateBase<SkillBucket>;
-  };
-};
-
-type SkillIdListAggs = {
-  skills_nested: {
-    by_skill_id: estypes.AggregationsMultiBucketAggregateBase<SkillBucket>;
-  };
-};
-
-function bucketToPoint(bucket: DateBucket, timezone: string): SkillUsagePoint {
-  return {
-    timestamp: bucket.key,
-    date: formatDateFromMillis(bucket.key, timezone),
-    uniqueUsers: bucket.skills_nested?.unique_users?.cardinality?.value ?? 0,
-    executionCount: bucket.skills_nested?.doc_count ?? 0,
-  };
-}
-
-function filteredBucketToPoint(
-  bucket: FilteredDateBucket,
-  timezone: string
-): SkillUsagePoint {
-  return {
-    timestamp: bucket.key,
-    date: formatDateFromMillis(bucket.key, timezone),
-    uniqueUsers:
-      bucket.skills_nested?.filtered?.unique_users?.cardinality?.value ?? 0,
-    executionCount: bucket.skills_nested?.filtered?.doc_count ?? 0,
-  };
-}
-
 export async function fetchSkillUsageMetrics(
   baseQuery: estypes.QueryDslQueryContainer,
   skillName: string | null,
   timezone: string = "UTC"
 ): Promise<Result<SkillUsagePoint[], Error>> {
-  const nestedAggs: Record<string, estypes.AggregationsAggregationContainer> =
-    skillName
-      ? {
-          filtered: {
-            filter: { term: { "skills_used.skill_name": skillName } },
-            aggs: {
-              unique_users: {
-                reverse_nested: {},
-                aggs: {
-                  cardinality: {
-                    cardinality: { field: "user_id" },
-                  },
-                },
-              },
-            },
-          },
-        }
-      : {
-          unique_users: {
-            reverse_nested: {},
-            aggs: {
-              cardinality: {
-                cardinality: { field: "user_id" },
-              },
-            },
-          },
-        };
-
-  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-    by_date: {
-      date_histogram: {
-        field: "timestamp",
-        calendar_interval: "day",
-        time_zone: timezone,
-      },
-      aggs: {
-        skills_nested: {
-          nested: { path: "skills_used" },
-          aggs: nestedAggs,
-        },
-      },
-    },
-  };
-
-  if (skillName) {
-    const result = await searchAnalytics<never, FilteredSkillUsageAggs>(
-      baseQuery,
-      { aggregations: aggs, size: 0 }
-    );
-
-    if (result.isErr()) {
-      return new Err(new Error(result.error.message));
-    }
-
-    const dateBuckets = bucketsToArray<FilteredDateBucket>(
-      result.value.aggregations?.by_date?.buckets
-    );
-
-    return new Ok(
-      dateBuckets.map((bucket) => filteredBucketToPoint(bucket, timezone))
-    );
-  }
-
-  const result = await searchAnalytics<never, SkillUsageAggs>(baseQuery, {
-    aggregations: aggs,
-    size: 0,
+  return fetchNestedUsageMetrics(baseQuery, {
+    nestedPath: SKILLS_NESTED_PATH,
+    filterField: SKILLS_NAME_FIELD,
+    filterValue: skillName,
+    timezone,
   });
-
-  if (result.isErr()) {
-    return new Err(new Error(result.error.message));
-  }
-
-  const dateBuckets = bucketsToArray<DateBucket>(
-    result.value.aggregations?.by_date?.buckets
-  );
-
-  return new Ok(dateBuckets.map((bucket) => bucketToPoint(bucket, timezone)));
 }
 
 export async function fetchAvailableSkills(
   baseQuery: estypes.QueryDslQueryContainer
 ): Promise<Result<AvailableSkill[], Error>> {
-  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-    skills_nested: {
-      nested: { path: "skills_used" },
-      aggs: {
-        by_skill: {
-          terms: {
-            field: "skills_used.skill_name",
-            size: 100,
-            order: { _count: "desc" },
-          },
-        },
-      },
-    },
-  };
-
-  const result = await searchAnalytics<never, SkillListAggs>(baseQuery, {
-    aggregations: aggs,
-    size: 0,
+  const result = await fetchNestedTermsBuckets(baseQuery, {
+    nestedPath: SKILLS_NESTED_PATH,
+    field: SKILLS_NAME_FIELD,
   });
 
   if (result.isErr()) {
-    return new Err(new Error(result.error.message));
+    return result;
   }
 
-  const skillBuckets = bucketsToArray<SkillBucket>(
-    result.value.aggregations?.skills_nested?.by_skill?.buckets
-  );
-
   return new Ok(
-    skillBuckets.map((bucket) => ({
+    result.value.map((bucket) => ({
       skillName: bucket.key,
-      totalExecutions: bucket.doc_count,
+      totalExecutions: bucket.docCount,
     }))
   );
 }
@@ -229,38 +67,19 @@ export async function fetchAvailableSkills(
 export async function fetchAvailableSkillsBySkillId(
   baseQuery: estypes.QueryDslQueryContainer
 ): Promise<Result<AvailableSkillById[], Error>> {
-  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-    skills_nested: {
-      nested: { path: "skills_used" },
-      aggs: {
-        by_skill_id: {
-          terms: {
-            field: "skills_used.skill_id",
-            size: 100,
-            order: { _count: "desc" },
-          },
-        },
-      },
-    },
-  };
-
-  const result = await searchAnalytics<never, SkillIdListAggs>(baseQuery, {
-    aggregations: aggs,
-    size: 0,
+  const result = await fetchNestedTermsBuckets(baseQuery, {
+    nestedPath: SKILLS_NESTED_PATH,
+    field: SKILLS_ID_FIELD,
   });
 
   if (result.isErr()) {
-    return new Err(new Error(result.error.message));
+    return result;
   }
 
-  const skillBuckets = bucketsToArray<SkillBucket>(
-    result.value.aggregations?.skills_nested?.by_skill_id?.buckets
-  );
-
   return new Ok(
-    skillBuckets.map((bucket) => ({
+    result.value.map((bucket) => ({
       skillId: bucket.key,
-      totalExecutions: bucket.doc_count,
+      totalExecutions: bucket.docCount,
     }))
   );
 }
@@ -268,33 +87,15 @@ export async function fetchAvailableSkillsBySkillId(
 export async function fetchUsedSkills(
   baseQuery: estypes.QueryDslQueryContainer
 ): Promise<Result<string[], Error>> {
-  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-    skills_nested: {
-      nested: { path: "skills_used" },
-      aggs: {
-        by_skill_id: {
-          terms: {
-            field: "skills_used.skill_id",
-            size: 1000,
-            order: { _count: "desc" },
-          },
-        },
-      },
-    },
-  };
-
-  const result = await searchAnalytics<never, SkillIdListAggs>(baseQuery, {
-    aggregations: aggs,
-    size: 0,
+  const result = await fetchNestedTermsBuckets(baseQuery, {
+    nestedPath: SKILLS_NESTED_PATH,
+    field: SKILLS_ID_FIELD,
+    size: 1000,
   });
 
   if (result.isErr()) {
-    return new Err(new Error(result.error.message));
+    return result;
   }
 
-  const skillIdBuckets = bucketsToArray<SkillBucket>(
-    result.value.aggregations?.skills_nested?.by_skill_id?.buckets
-  );
-
-  return new Ok(skillIdBuckets.map((bucket) => bucket.key));
+  return new Ok(result.value.map((bucket) => bucket.key));
 }

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -1,14 +1,16 @@
 import {
-  bucketsToArray,
-  formatDateFromMillis,
-  searchAnalytics,
-} from "@app/lib/api/elasticsearch";
+  fetchNestedTermsBuckets,
+  fetchNestedUsageMetrics,
+} from "@app/lib/api/assistant/observability/nested_usage_metrics";
 import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { Result } from "@app/types/shared/result";
-import { Err, Ok } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
 import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 import type { estypes } from "@elastic/elasticsearch";
+
+const TOOLS_NESTED_PATH = "tools_used";
+const TOOLS_SERVER_NAME_FIELD = "tools_used.server_name";
 
 export type ToolUsagePoint = {
   timestamp: number;
@@ -31,199 +33,38 @@ export type GetWorkspaceToolUsageResponse = {
   points: ToolUsagePoint[];
 };
 
-type DateBucket = {
-  key: number;
-  key_as_string: string;
-  doc_count: number;
-  tools_nested: {
-    doc_count: number;
-    unique_users: {
-      doc_count: number;
-      cardinality: estypes.AggregationsCardinalityAggregate;
-    };
-  };
-};
-
-type ToolUsageAggs = {
-  by_date: estypes.AggregationsMultiBucketAggregateBase<DateBucket>;
-};
-
-type FilteredDateBucket = {
-  key: number;
-  key_as_string: string;
-  doc_count: number;
-  tools_nested: {
-    filtered: {
-      doc_count: number;
-      unique_users: {
-        doc_count: number;
-        cardinality: estypes.AggregationsCardinalityAggregate;
-      };
-    };
-  };
-};
-
-type FilteredToolUsageAggs = {
-  by_date: estypes.AggregationsMultiBucketAggregateBase<FilteredDateBucket>;
-};
-
-type ToolBucket = {
-  key: string;
-  doc_count: number;
-};
-
-type ToolListAggs = {
-  tools_nested: {
-    by_server: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>;
-  };
-};
-
-function bucketToPoint(bucket: DateBucket, timezone: string): ToolUsagePoint {
-  return {
-    timestamp: bucket.key,
-    date: formatDateFromMillis(bucket.key, timezone),
-    uniqueUsers: bucket.tools_nested?.unique_users?.cardinality?.value ?? 0,
-    executionCount: bucket.tools_nested?.doc_count ?? 0,
-  };
-}
-
-function filteredBucketToPoint(
-  bucket: FilteredDateBucket,
-  timezone: string
-): ToolUsagePoint {
-  return {
-    timestamp: bucket.key,
-    date: formatDateFromMillis(bucket.key, timezone),
-    uniqueUsers:
-      bucket.tools_nested?.filtered?.unique_users?.cardinality?.value ?? 0,
-    executionCount: bucket.tools_nested?.filtered?.doc_count ?? 0,
-  };
-}
-
 export async function fetchToolUsageMetrics(
   baseQuery: estypes.QueryDslQueryContainer,
   serverName: string | null,
   timezone: string = "UTC"
 ): Promise<Result<ToolUsagePoint[], Error>> {
-  // When serverName is provided, filter the nested tools_used aggregation
-  // When null, aggregate across all tools
-  const nestedAggs: Record<string, estypes.AggregationsAggregationContainer> =
-    serverName
-      ? {
-          filtered: {
-            filter: { term: { "tools_used.server_name": serverName } },
-            aggs: {
-              unique_users: {
-                reverse_nested: {},
-                aggs: {
-                  cardinality: {
-                    cardinality: { field: "user_id" },
-                  },
-                },
-              },
-            },
-          },
-        }
-      : {
-          unique_users: {
-            reverse_nested: {},
-            aggs: {
-              cardinality: {
-                cardinality: { field: "user_id" },
-              },
-            },
-          },
-        };
-
-  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-    by_date: {
-      date_histogram: {
-        field: "timestamp",
-        calendar_interval: "day",
-        time_zone: timezone,
-      },
-      aggs: {
-        tools_nested: {
-          nested: { path: "tools_used" },
-          aggs: nestedAggs,
-        },
-      },
-    },
-  };
-
-  if (serverName) {
-    const result = await searchAnalytics<never, FilteredToolUsageAggs>(
-      baseQuery,
-      { aggregations: aggs, size: 0 }
-    );
-
-    if (result.isErr()) {
-      return new Err(new Error(result.error.message));
-    }
-
-    const dateBuckets = bucketsToArray<FilteredDateBucket>(
-      result.value.aggregations?.by_date?.buckets
-    );
-
-    return new Ok(
-      dateBuckets.map((bucket) => filteredBucketToPoint(bucket, timezone))
-    );
-  }
-
-  const result = await searchAnalytics<never, ToolUsageAggs>(baseQuery, {
-    aggregations: aggs,
-    size: 0,
+  return fetchNestedUsageMetrics(baseQuery, {
+    nestedPath: TOOLS_NESTED_PATH,
+    filterField: TOOLS_SERVER_NAME_FIELD,
+    filterValue: serverName,
+    timezone,
   });
-
-  if (result.isErr()) {
-    return new Err(new Error(result.error.message));
-  }
-
-  const dateBuckets = bucketsToArray<DateBucket>(
-    result.value.aggregations?.by_date?.buckets
-  );
-
-  return new Ok(dateBuckets.map((bucket) => bucketToPoint(bucket, timezone)));
 }
 
 export async function fetchAvailableTools(
   baseQuery: estypes.QueryDslQueryContainer
 ): Promise<Result<AvailableTool[], Error>> {
-  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-    tools_nested: {
-      nested: { path: "tools_used" },
-      aggs: {
-        by_server: {
-          terms: {
-            field: "tools_used.server_name",
-            size: 100,
-            order: { _count: "desc" },
-          },
-        },
-      },
-    },
-  };
-
-  const result = await searchAnalytics<never, ToolListAggs>(baseQuery, {
-    aggregations: aggs,
-    size: 0,
+  const result = await fetchNestedTermsBuckets(baseQuery, {
+    nestedPath: TOOLS_NESTED_PATH,
+    field: TOOLS_SERVER_NAME_FIELD,
   });
 
   if (result.isErr()) {
-    return new Err(new Error(result.error.message));
+    return result;
   }
 
-  const toolBuckets = bucketsToArray<ToolBucket>(
-    result.value.aggregations?.tools_nested?.by_server?.buckets
+  return new Ok(
+    result.value.map((bucket) => ({
+      serverName: bucket.key,
+      displayName: bucket.key,
+      totalExecutions: bucket.docCount,
+    }))
   );
-
-  const tools: AvailableTool[] = toolBuckets.map((bucket) => ({
-    serverName: bucket.key,
-    displayName: bucket.key,
-    totalExecutions: bucket.doc_count,
-  }));
-
-  return new Ok(tools);
 }
 
 export async function resolveServerDisplayNames(


### PR DESCRIPTION
fetchToolUsageMetrics/fetchAvailableTools and fetchSkillUsageMetrics/
fetchAvailableSkills were near-identical aggregation code differing only by
field names; extracted into a shared nested_usage_metrics helper.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
