### PR TITLE
[front] enh: ui polish on filter usage panel of new analytics

### DIFF
--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -10,7 +10,6 @@ import {
   USAGE_FILTER_AGENT_SCOPES,
   USAGE_FILTER_CATEGORIES,
   USAGE_FILTER_CATEGORY_LABEL,
-  USAGE_MODEL_TIERS,
   usageFilterSelectionCount,
 } from "@app/components/workspace/analytics/usageFilter";
 import { UsageFilterAgentScopeControls } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls";
@@ -37,6 +36,8 @@ import {
   SearchInput,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
+
+const DEFAULT_MODEL_TIER: UsageModelTier = "standard";
 
 interface UsageFilterPanelProps {
   owner: LightWorkspaceType;
@@ -66,9 +67,8 @@ export function UsageFilterPanel({
   const [activeCategory, setActiveCategory] =
     useState<UsageFilterCategory>("agent");
   const [activeScope, setActiveScope] = useState<UsageFilterAgentScope>("all");
-  const [activeTier, setActiveTier] = useState<UsageModelTier>(
-    USAGE_MODEL_TIERS[0]
-  );
+  const [activeTier, setActiveTier] =
+    useState<UsageModelTier>(DEFAULT_MODEL_TIER);
   const [searchText, setSearchText] = useState("");
   const selectedGroups = useToggleSelectionList<UsageFilterGroup>();
 

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
@@ -17,7 +17,7 @@ export function UsageFilterAgentScopeControls({
     <>
       <NavigationListLabel
         label="Scopes"
-        className="bg-transparent font-medium"
+        className="bg-transparent font-medium pt-2 pb-0"
       />
       <div className="flex items-center gap-1">
         {scopes.map((scope) => (

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterMemberGroupsControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterMemberGroupsControls.tsx
@@ -37,7 +37,7 @@ export function UsageFilterMemberGroupsControls({
     <>
       <NavigationListLabel
         label="Groups"
-        className="bg-transparent font-medium"
+        className="bg-transparent font-medium pt-2 pb-0"
         action={
           <Button
             label="Add group"

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -113,7 +113,7 @@ export function UsageFilterModelComplexityControls({
     <>
       <NavigationListLabel
         label="Complexity"
-        className="bg-transparent font-medium"
+        className="bg-transparent font-medium pt-2 pb-0"
         action={
           <DropdownMenu
             open={isMoreModelsOpen}

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterSelectionSummary.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterSelectionSummary.tsx
@@ -61,7 +61,7 @@ export function UsageFilterSelectionSummary({
         label={`${selectionCount} filter${pluralize(selectionCount)} selected`}
       />
       <NavigationList className="min-h-0 flex-1">
-        {categoriesWithSelection.length > 0 ? (
+        {categoriesWithSelection.length > 0 &&
           categoriesWithSelection.map((category) => {
             const isCategoryOpen = !collapsedCategories.has(category);
             return (
@@ -114,12 +114,7 @@ export function UsageFilterSelectionSummary({
                 </Collapsible>
               </div>
             );
-          })
-        ) : (
-          <div className="flex items-center p-2 text-sm text-muted-foreground">
-            No filters selected
-          </div>
-        )}
+          })}
       </NavigationList>
     </div>
   );


### PR DESCRIPTION
## Description

This PR tweaks a few UI details on the new analytics page, specifically in the filter usage panel:
- Less padding around additional controls for models/agents/members
- Selects Standard as the default model tier
- Removes the redundant `No filters selected` on the right, the first line already says `0 filters selected`

<img width="673" height="436" alt="image" src="https://github.com/user-attachments/assets/b14fe8e7-ee8e-4810-80b6-9ca50642d51f" />

<img width="680" height="441" alt="image" src="https://github.com/user-attachments/assets/79b6b042-b230-461f-82a0-e3d2ca726756" />


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
