### PR TITLE
Analytics: give the @analyst agent to managers

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1197,7 +1197,7 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
     id: 1035,
     // Available to all workspaces unless the admin opts out, and hidden from the
     // builder tool-picker; the skill wires it by name. Data access is enforced
-    // per-tool via auth.isAdmin().
+    // per-tool via auth.isManager().
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isRestricted: ({ isWorkspaceAnalyticsEnabled }) =>

--- a/front/lib/actions/mcp_internal_actions/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.test.ts
@@ -1,7 +1,7 @@
 import { InMemoryWithAuthTransport } from "@app/lib/actions/mcp_internal_actions/in_memory_with_auth_transport";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
+import { workspaceManagerGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { ToolContext } from "@app/lib/actions/types";
 import { Authenticator } from "@app/lib/auth";
@@ -16,12 +16,12 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { describe, expect, it } from "vitest";
 
 // Two artificial tools to exercise the guard's behaviour through the real MCP
-// stack, decoupled from any feature tool: one wraps workspaceAdminGuard, the
+// stack, decoupled from any feature tool: one wraps workspaceManagerGuard, the
 // other (control) does not.
 const TEST_TOOLS_METADATA = [
   {
     name: "guarded_tool",
-    description: "Admin-guarded test tool.",
+    description: "Manager-guarded test tool.",
     schema: {},
     stake: "never_ask",
     displayLabels: { running: "Running", done: "Ran" },
@@ -41,7 +41,7 @@ const TEST_TOOLS_METADATA = [
 
 const handlers: ToolHandlers<typeof TEST_TOOLS_METADATA> = {
   guarded_tool: async (_params, { auth }) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -74,16 +74,19 @@ async function callTestTool(auth: Authenticator, toolName: string) {
       agentMessage: { sId: "message-id" },
     },
   } as unknown as ToolContext;
-  const server = new McpServer({ name: "admin_guard_test", version: "1.0.0" });
+  const server = new McpServer({
+    name: "manager_guard_test",
+    version: "1.0.0",
+  });
   for (const tool of TEST_TOOLS) {
     registerTool(auth, toolContext, server, tool, {
-      monitoringName: "admin_guard_test",
+      monitoringName: "manager_guard_test",
     });
   }
 
   const [clientTransport, serverTransport] =
     InMemoryWithAuthTransport.createLinkedPair();
-  const client = new Client({ name: "admin_guard_test", version: "1.0.0" });
+  const client = new Client({ name: "manager_guard_test", version: "1.0.0" });
   await server.connect(serverTransport);
   await client.connect(clientTransport);
 
@@ -92,9 +95,17 @@ async function callTestTool(auth: Authenticator, toolName: string) {
   return result;
 }
 
-describe("workspaceAdminGuard (via an in-memory MCP tool)", () => {
+describe("workspaceManagerGuard (via an in-memory MCP tool)", () => {
   it("lets an admin call a guarded tool", async () => {
     const auth = await authForRole("admin");
+    const result = await callTestTool(auth, "guarded_tool");
+
+    expect(result.isError).toBeFalsy();
+    expect(JSON.stringify(result.content)).toContain("guarded ok");
+  });
+
+  it("lets a manager call a guarded tool", async () => {
+    const auth = await authForRole("manager");
     const result = await callTestTool(auth, "guarded_tool");
 
     expect(result.isError).toBeFalsy();

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -25,14 +25,17 @@ export function makeInternalMCPServer(
   return new McpServer(serverInfo);
 }
 
-// Returns an MCPError when the caller is not a workspace admin, null otherwise.
-// For internal tools that expose workspace-wide data and must enforce admin
-// access independently of skill/agent/server visibility.
-export function workspaceAdminGuard(auth: Authenticator): MCPError | null {
-  if (!auth.isAdmin()) {
-    return new MCPError("This tool is restricted to workspace admins.", {
-      tracked: false,
-    });
+// Returns an MCPError when the caller is neither a workspace manager nor an
+// admin, null otherwise. For internal tools that expose workspace-wide data and
+// must enforce access independently of skill/agent/server visibility.
+export function workspaceManagerGuard(auth: Authenticator): MCPError | null {
+  if (!auth.isManager()) {
+    return new MCPError(
+      "This tool is restricted to workspace admins and managers.",
+      {
+        tracked: false,
+      }
+    );
   }
   return null;
 }

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -333,8 +333,8 @@ export const WORKSPACE_ANALYTICS_SERVER = {
     name: "workspace_analytics",
     version: "1.0.0",
     description:
-      "Answer workspace usage questions for admins (top agents, and more to " +
-      "come).",
+      "Answer workspace usage questions for admins and managers (top agents, " +
+      "and more to come).",
     icon: "ActionPieChartIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -35,7 +35,7 @@ describe("workspace_analytics tools", () => {
     "get_credit_usage",
     "get_credit_timeseries",
     "get_usage_timeseries",
-  ])("%s refuses non-admin callers", async (toolName) => {
+  ])("%s refuses callers below manager", async (toolName) => {
     const workspace = await WorkspaceFactory.basic();
     await GroupFactory.defaults(workspace);
     const user = await UserFactory.basic();
@@ -45,7 +45,7 @@ describe("workspace_analytics tools", () => {
       user.sId,
       workspace.sId
     );
-    expect(auth.isAdmin()).toBe(false);
+    expect(auth.isManager()).toBe(false);
 
     const tool = getToolByName(toolName);
     const result = await tool.handler({}, createTestExtra(auth));

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -4,7 +4,7 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { workspaceAdminGuard } from "@app/lib/actions/mcp_internal_actions/utils";
+import { workspaceManagerGuard } from "@app/lib/actions/mcp_internal_actions/utils";
 import { WORKSPACE_ANALYTICS_TOOLS_METADATA } from "@app/lib/api/actions/servers/workspace_analytics/metadata";
 import type { ResolvedTimeWindow } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
 import {
@@ -126,7 +126,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -195,7 +195,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -264,7 +264,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -333,7 +333,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -391,7 +391,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
   },
 
   get_agent_details: async ({ agentId }, { auth }) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -462,7 +462,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -529,7 +529,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -603,7 +603,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -673,7 +673,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -756,7 +756,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }
@@ -892,7 +892,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     },
     { auth }
   ) => {
-    const denied = workspaceAdminGuard(auth);
+    const denied = workspaceManagerGuard(auth);
     if (denied) {
       return new Err(denied);
     }

--- a/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
@@ -48,8 +48,18 @@ describe("analyst global agent visibility", () => {
     expect(agents[0].skills).toContain("frames");
   });
 
+  it("is available to managers by default", async () => {
+    const agents = await fetchAnalyst("manager");
+    expect(agents).toHaveLength(1);
+    expect(agents[0].sId).toBe(GLOBAL_AGENTS_SID.ANALYST);
+  });
+
   it("is hidden from admins when the workspace opts out", async () => {
     expect(await fetchAnalyst("admin", true)).toEqual([]);
+  });
+
+  it("is hidden from managers when the workspace opts out", async () => {
+    expect(await fetchAnalyst("manager", true)).toEqual([]);
   });
 
   it("is hidden from builders even by default", async () => {

--- a/front/lib/api/assistant/global_agents/configurations/analyst.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.ts
@@ -22,14 +22,14 @@ export function _getAnalystGlobalAgent({
   featureFlags: WhitelistableFeature[];
 }): AgentConfigurationType {
   const prompt = `<primary_goal>
-You are @analyst, an analytics assistant for workspace admins. You help admins understand how their Dust workspace is being used by answering questions with data retrieved through your tools.
+You are @analyst, an analytics assistant for workspace admins and managers. You help them understand how their Dust workspace is being used by answering questions with data retrieved through your tools.
 </primary_goal>
 
 <guidelines>
 1. Only report figures returned by your tools — never estimate or fabricate numbers.
 2. Use the workspace analytics tools to answer the question (e.g. which agents are used most). Present results as clear ranked lists or summaries.
 3. When a chart communicates the result better than text (trends over time, distributions, comparisons), use the Frames skill to render it. Default to a concise text answer for single figures.
-4. If a tool reports an authorization error, explain that workspace analytics is restricted to workspace admins.
+4. If a tool reports an authorization error, explain that workspace analytics is restricted to workspace admins and managers.
 5. Be concise and lead with the answer; add brief context only when it helps interpretation.
 </guidelines>`;
 

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.test.ts
@@ -17,7 +17,7 @@ async function authForRole(role: MembershipRoleType): Promise<Authenticator> {
 
 describe("canRoleSeeAudience", () => {
   it("makes 'everyone' visible to every role", async () => {
-    for (const role of ["admin", "builder", "user"] as const) {
+    for (const role of ["admin", "manager", "builder", "user"] as const) {
       const auth = await authForRole(role);
       expect(canRoleSeeAudience("everyone", auth)).toBe(true);
     }
@@ -25,9 +25,27 @@ describe("canRoleSeeAudience", () => {
 
   it("makes 'admins' visible to admins only", async () => {
     expect(canRoleSeeAudience("admins", await authForRole("admin"))).toBe(true);
+    expect(canRoleSeeAudience("admins", await authForRole("manager"))).toBe(
+      false
+    );
     expect(canRoleSeeAudience("admins", await authForRole("builder"))).toBe(
       false
     );
     expect(canRoleSeeAudience("admins", await authForRole("user"))).toBe(false);
+  });
+
+  it("makes 'managers' visible to managers and admins", async () => {
+    expect(canRoleSeeAudience("managers", await authForRole("admin"))).toBe(
+      true
+    );
+    expect(canRoleSeeAudience("managers", await authForRole("manager"))).toBe(
+      true
+    );
+    expect(canRoleSeeAudience("managers", await authForRole("builder"))).toBe(
+      false
+    );
+    expect(canRoleSeeAudience("managers", await authForRole("user"))).toBe(
+      false
+    );
   });
 });

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -33,7 +33,8 @@ import {
 } from "@app/types/assistant/models/openai";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-const GLOBAL_AGENT_AUDIENCES = ["everyone", "admins"] as const;
+// Audiences are role-hierarchical: `managers` means managers and admins.
+const GLOBAL_AGENT_AUDIENCES = ["everyone", "managers", "admins"] as const;
 type GlobalAgentAudience = (typeof GLOBAL_AGENT_AUDIENCES)[number];
 
 type AgentMetadata = {
@@ -51,6 +52,8 @@ export function canRoleSeeAudience(
   switch (audience) {
     case "everyone":
       return true;
+    case "managers":
+      return auth.isManager();
     case "admins":
       return auth.isAdmin();
     default:
@@ -813,10 +816,10 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         sId: GLOBAL_AGENTS_SID.ANALYST,
         name: "analyst",
         description:
-          "Admin-only agent that answers questions about how your workspace " +
-          "is being used.",
+          "Agent for admins and managers that answers questions about how " +
+          "your workspace is being used.",
         pictureUrl: DUST_AVATAR_URL,
-        audience: "admins",
+        audience: "managers",
       };
     default:
       assertNever(sId);

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -8,17 +8,18 @@ export const workspaceAnalyticsSkill = {
   name: "Workspace Analytics",
   userFacingDescription:
     "Analyze how your workspace is being used — for example, which agents " +
-    "are used most. Available to workspace admins only.",
+    "are used most. Available to workspace admins and managers only.",
   agentFacingDescription:
-    "Enable when a workspace admin asks about workspace usage analytics, " +
-    "such as which agents are used most. Restricted to admins.",
+    "Enable when a workspace admin or manager asks about workspace usage " +
+    "analytics, such as which agents are used most. Restricted to admins and " +
+    "managers.",
   instructions:
-    "You help workspace admins analyze how their Dust workspace is being " +
-    "used. Use the available workspace analytics tools to answer the admin's " +
+    "You help workspace admins and managers analyze how their Dust workspace " +
+    "is being used. Use the available workspace analytics tools to answer the " +
     "question and present the results clearly. Only report figures returned " +
     "by the tools — never fabricate numbers. If a tool reports an " +
     "authorization error, explain that workspace analytics is restricted to " +
-    "workspace admins.\n\n" +
+    "workspace admins and managers.\n\n" +
     "Choosing a tool:\n" +
     "- For trends over time — anything spanning multiple days or phrased as " +
     "'over time', 'per day', 'evolution', 'trend' — make a single timeseries " +
@@ -43,10 +44,10 @@ export const workspaceAnalyticsSkill = {
     "are approximate and point to the workspace Usage page for exact billed " +
     "amounts.",
   mcpServers: [{ name: "workspace_analytics" }],
-  version: 3,
+  version: 4,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
-    if (!auth.isAdmin()) {
+    if (!auth.isManager()) {
       return true;
     }
     return !isWorkspaceAnalyticsEnabled(auth.getNonNullableWorkspace());


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/9956

Manager should have access to the `@analyst` agent because they have access to analytics.
Nothing fancy in this PR, only a isAdmin check switch to isManager

## Tests

updated unit tests

## Risk

low

## Deploy Plan

deploy front
