### PR TITLE
[danger] chore: trigger `documentation-ack` danger on api/v1 only

### DIFF
--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -170,7 +170,7 @@ function checkDocumentationLabel() {
 
 function failDocumentationAck() {
   fail(
-    "Files in `front-api/routes/` have been modified. " +
+    "Files in `front-api/routes/v1/` have been modified. " +
       `Please add the \`${documentationAckLabel}\` label to acknowledge that if anything changes
       in a documented endpoint, you need to edit the JSDoc comment
       above the handler definition and/or the swagger_schemas.ts file and regenerate the documentation using \`npm -w front-api run docs\``
@@ -179,7 +179,7 @@ function failDocumentationAck() {
 
 function warnDocumentationAck(documentationAckLabel: string) {
   warn(
-    "Files in `front-api/routes/` have been modified and the PR has the `" +
+    "Files in `front-api/routes/v1/` have been modified and the PR has the `" +
       documentationAckLabel +
       "` label. \n" +
       "Don't forget to run `npm -w front-api run docs` and use the `Deploy OpenAPI Docs` Github action to update https://docs.dust.tt/reference."

--- a/front/dangerfile.ts
+++ b/front/dangerfile.ts
@@ -506,7 +506,7 @@ async function checkDiffFiles() {
 
   // Documented API files (front-api owns OpenAPI generation).
   const modifiedDocumentedApiFiles = diffFiles.filter((path) => {
-    return path.startsWith("front-api/routes/");
+    return path.startsWith("front-api/routes/v1/");
   });
 
   if (modifiedDocumentedApiFiles.length > 0) {


### PR DESCRIPTION
## Description

The `documentation-ack` dangerjs triggers on all changes to any route.
This PR changes it to only trigger on `api/v1` routes, the message seems to only hint at changes on documented endpoints.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- No deploy.
