### PR TITLE
Adding pagination to usage consumption attribution table

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -11,11 +11,17 @@ import {
   DataTable,
   Icon,
   LoadingBlock,
+  Pagination,
 } from "@dust-tt/sparkle";
-import type { ColumnDef } from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  PaginationState,
+  Updater,
+} from "@tanstack/react-table";
 import {
   flexRender,
   getCoreRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
@@ -107,6 +113,8 @@ interface ConsumptionAttributionRowsTableProps {
     dimension: ConsumptionDimension,
     selectedRow: ConsumptionTopRow
   ) => void;
+  pagination: PaginationState;
+  setPagination: (pagination: PaginationState) => void;
   isLoading?: boolean;
   hasAvatar?: boolean;
   isAvatarRounded?: boolean;
@@ -120,6 +128,8 @@ export function ConsumptionAttributionRowsTable({
   period,
   filter,
   onViewAll,
+  pagination,
+  setPagination,
   isLoading = false,
   hasAvatar = false,
   isAvatarRounded = false,
@@ -129,124 +139,143 @@ export function ConsumptionAttributionRowsTable({
     columns,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: (updater: Updater<PaginationState>) => {
+      const newValue =
+        typeof updater === "function" ? updater(pagination) : updater;
+      setPagination(newValue);
+    },
+    state: {
+      pagination,
+    },
   });
 
   return (
-    <DataTable.Root className="min-w-150">
-      <DataTable.Header>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <DataTable.Row key={headerGroup.id} widthClassName="w-full">
-            {headerGroup.headers.map((header) => (
-              <DataTable.Head
-                column={header.column}
-                key={header.id}
-                onClick={
-                  header.column.getCanSort()
-                    ? header.column.getToggleSortingHandler()
-                    : undefined
-                }
-                className={cn(header.column.getCanSort() && "cursor-pointer")}
-              >
-                <div
-                  className={cn(
-                    "flex items-center space-x-1 whitespace-nowrap",
-                    header.column.columnDef.meta?.headerAlign === "right" &&
-                      "justify-end"
-                  )}
+    <div className="flex flex-col gap-2">
+      <DataTable.Root className="min-w-150">
+        <DataTable.Header>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <DataTable.Row key={headerGroup.id} widthClassName="w-full">
+              {headerGroup.headers.map((header) => (
+                <DataTable.Head
+                  column={header.column}
+                  key={header.id}
+                  onClick={
+                    header.column.getCanSort()
+                      ? header.column.getToggleSortingHandler()
+                      : undefined
+                  }
+                  className={cn(header.column.getCanSort() && "cursor-pointer")}
                 >
-                  {flexRender(
-                    header.column.columnDef.header,
-                    header.getContext()
-                  )}
-                  {header.column.getCanSort() && (
-                    <Icon
-                      visual={
-                        header.column.getIsSorted() === "asc"
-                          ? ArrowUp
-                          : header.column.getIsSorted() === "desc"
-                            ? ArrowDown
-                            : ChevronSelectorVertical
-                      }
-                      size="xs"
-                      className="ml-1"
-                    />
-                  )}
-                </div>
-              </DataTable.Head>
-            ))}
-          </DataTable.Row>
-        ))}
-      </DataTable.Header>
-      <DataTable.Body>
-        {isLoading
-          ? Array.from(
-              { length: ATTRIBUTION_SKELETON_ROW_COUNT },
-              (_, rowIndex) => (
-                <DataTable.Row
-                  key={rowIndex}
-                  widthClassName="w-full"
-                  aria-hidden="true"
-                >
-                  {table.getAllLeafColumns().map((column) => (
-                    <DataTable.Cell column={column} key={column.id}>
-                      <AttributionSkeletonCell
-                        columnId={column.id}
-                        rowIndex={rowIndex}
-                        hasAvatar={hasAvatar}
-                        isAvatarRounded={isAvatarRounded}
-                      />
-                    </DataTable.Cell>
-                  ))}
-                </DataTable.Row>
-              )
-            )
-          : table.getRowModel().rows.map((row) => (
-              <Fragment key={row.id}>
-                <DataTable.Row
-                  widthClassName="w-full"
-                  onClick={row.original.onClick}
-                  rowData={row.original}
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <DataTable.Cell column={cell.column} key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext()
-                      )}
-                    </DataTable.Cell>
-                  ))}
-                </DataTable.Row>
-                <tr>
-                  <td
-                    className="max-w-0"
-                    colSpan={row.getVisibleCells().length}
+                  <div
+                    className={cn(
+                      "flex items-center space-x-1 whitespace-nowrap",
+                      header.column.columnDef.meta?.headerAlign === "right" &&
+                        "justify-end"
+                    )}
                   >
-                    <Collapsible open={row.original.isExpanded}>
-                      <CollapsibleContent
-                        animated={false}
-                        className={cn(
-                          "transition-none ease-enter motion-reduce:animate-none",
-                          "data-[state=open]:animate-in data-[state=open]:fade-in-0",
-                          "data-[state=open]:slide-in-from-top-1 data-[state=open]:duration-enter",
-                          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
-                          "data-[state=closed]:slide-out-to-top-1 data-[state=closed]:duration-exit"
-                        )}
-                      >
-                        <ConsumptionAttributionBreakdown
-                          workspaceId={workspaceId}
-                          selectedDimension={dimension}
-                          selectedRow={row.original}
-                          period={period}
-                          filter={filter}
-                          onViewAll={onViewAll}
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext()
+                    )}
+                    {header.column.getCanSort() && (
+                      <Icon
+                        visual={
+                          header.column.getIsSorted() === "asc"
+                            ? ArrowUp
+                            : header.column.getIsSorted() === "desc"
+                              ? ArrowDown
+                              : ChevronSelectorVertical
+                        }
+                        size="xs"
+                        className="ml-1"
+                      />
+                    )}
+                  </div>
+                </DataTable.Head>
+              ))}
+            </DataTable.Row>
+          ))}
+        </DataTable.Header>
+        <DataTable.Body>
+          {isLoading
+            ? Array.from(
+                { length: ATTRIBUTION_SKELETON_ROW_COUNT },
+                (_, rowIndex) => (
+                  <DataTable.Row
+                    key={rowIndex}
+                    widthClassName="w-full"
+                    aria-hidden="true"
+                  >
+                    {table.getAllLeafColumns().map((column) => (
+                      <DataTable.Cell column={column} key={column.id}>
+                        <AttributionSkeletonCell
+                          columnId={column.id}
+                          rowIndex={rowIndex}
+                          hasAvatar={hasAvatar}
+                          isAvatarRounded={isAvatarRounded}
                         />
-                      </CollapsibleContent>
-                    </Collapsible>
-                  </td>
-                </tr>
-              </Fragment>
-            ))}
-      </DataTable.Body>
-    </DataTable.Root>
+                      </DataTable.Cell>
+                    ))}
+                  </DataTable.Row>
+                )
+              )
+            : table.getRowModel().rows.map((row) => (
+                <Fragment key={row.id}>
+                  <DataTable.Row
+                    widthClassName="w-full"
+                    onClick={row.original.onClick}
+                    rowData={row.original}
+                  >
+                    {row.getVisibleCells().map((cell) => (
+                      <DataTable.Cell column={cell.column} key={cell.id}>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </DataTable.Cell>
+                    ))}
+                  </DataTable.Row>
+                  <tr>
+                    <td
+                      className="max-w-0"
+                      colSpan={row.getVisibleCells().length}
+                    >
+                      <Collapsible open={row.original.isExpanded}>
+                        <CollapsibleContent
+                          animated={false}
+                          className={cn(
+                            "transition-none ease-enter motion-reduce:animate-none",
+                            "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+                            "data-[state=open]:slide-in-from-top-1 data-[state=open]:duration-enter",
+                            "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+                            "data-[state=closed]:slide-out-to-top-1 data-[state=closed]:duration-exit"
+                          )}
+                        >
+                          <ConsumptionAttributionBreakdown
+                            workspaceId={workspaceId}
+                            selectedDimension={dimension}
+                            selectedRow={row.original}
+                            period={period}
+                            filter={filter}
+                            onViewAll={onViewAll}
+                          />
+                        </CollapsibleContent>
+                      </Collapsible>
+                    </td>
+                  </tr>
+                </Fragment>
+              ))}
+        </DataTable.Body>
+      </DataTable.Root>
+      {!isLoading && (
+        <Pagination
+          size="xs"
+          pagination={pagination}
+          setPagination={setPagination}
+          rowCount={table.getRowCount()}
+        />
+      )}
+    </div>
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -271,11 +271,6 @@ function AttributionRows({
       : allRows;
   }, [allRows, search]);
 
-  // Derived, not stored: a narrower search (or a ranking that shrank) can
-  // leave `pagination.pageIndex` past the last page. Clamping here — instead
-  // of writing the correction back with a render-phase setState — keeps the
-  // effective page always valid without any risk of a setState-during-render
-  // loop if `rows` ever fails to stay referentially stable across renders.
   const clampedPagination: PaginationState = useMemo(() => {
     const pageCount = Math.max(1, Math.ceil(rows.length / pagination.pageSize));
     return {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -22,7 +22,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
-import type { ColumnDef } from "@tanstack/react-table";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import type { Transition, Variants } from "framer-motion";
 import { AnimatePresence, m, useReducedMotion } from "framer-motion";
 import type { ReactNode } from "react";
@@ -36,7 +36,12 @@ import {
   isConsumptionDimension,
 } from "./consumptionDimensions";
 
-const TOP_LIMIT = 25;
+// The consumption endpoints rank via an Elasticsearch terms aggregation
+// (no offset/cursor support), so we fetch the maximum allowed batch once and
+// paginate over it client-side.
+const TOP_FETCH_LIMIT = 100;
+
+const ATTRIBUTION_PAGE_SIZE = 25;
 
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
 
@@ -238,6 +243,10 @@ function AttributionRows({
 }: AttributionRowsProps) {
   const { hasAvatar, avgLabel } = CONSUMPTION_DIMENSION_CONFIG[dimension];
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: ATTRIBUTION_PAGE_SIZE,
+  });
   const shouldReduceMotion = useReducedMotion();
 
   const {
@@ -249,18 +258,31 @@ function AttributionRows({
     workspaceId,
     dimension,
     period,
-    limit: TOP_LIMIT,
+    limit: TOP_FETCH_LIMIT,
     filter,
   });
 
   // Client-side filter over the loaded ranking. A row outside the top
-  // TOP_LIMIT will not appear — the endpoint has no server-side search yet.
+  // TOP_FETCH_LIMIT will not appear — the endpoint has no server-side search yet.
   const rows = useMemo(() => {
     const needle = search.trim().toLowerCase();
     return needle
       ? allRows.filter((row) => row.name.toLowerCase().includes(needle))
       : allRows;
   }, [allRows, search]);
+
+  // Derived, not stored: a narrower search (or a ranking that shrank) can
+  // leave `pagination.pageIndex` past the last page. Clamping here — instead
+  // of writing the correction back with a render-phase setState — keeps the
+  // effective page always valid without any risk of a setState-during-render
+  // loop if `rows` ever fails to stay referentially stable across renders.
+  const clampedPagination: PaginationState = useMemo(() => {
+    const pageCount = Math.max(1, Math.ceil(rows.length / pagination.pageSize));
+    return {
+      pageSize: pagination.pageSize,
+      pageIndex: Math.min(pagination.pageIndex, pageCount - 1),
+    };
+  }, [rows.length, pagination.pageSize, pagination.pageIndex]);
 
   const columns = useMemo(
     () =>
@@ -272,6 +294,20 @@ function AttributionRows({
       }),
     [hasAvatar, dimension, avgLabel, totalCredits]
   );
+
+  const attributionData: AttributionRowData[] = useMemo(() => {
+    const selectedIdSet = new Set(
+      filter?.[CONSUMPTION_DIMENSION_FILTER_KEYS[dimension]] ?? []
+    );
+    return rows.map((row) => ({
+      ...row,
+      isExpanded: expandedRowId === row.id,
+      isFilterSelected: selectedIdSet.has(row.id),
+      onClick: () =>
+        setExpandedRowId((current) => (current === row.id ? null : row.id)),
+      onAddFilter: () => onAddFilter(row),
+    }));
+  }, [rows, expandedRowId, filter, dimension, onAddFilter]);
 
   let contentKey = "content";
   let content: ReactNode;
@@ -287,6 +323,8 @@ function AttributionRows({
         period={period}
         filter={filter}
         onViewAll={onViewAll}
+        pagination={pagination}
+        setPagination={setPagination}
         isLoading
         hasAvatar={hasAvatar}
         isAvatarRounded={dimension === "user"}
@@ -307,28 +345,18 @@ function AttributionRows({
       </div>
     );
   } else {
-    const selectedIdSet = new Set(
-      filter?.[CONSUMPTION_DIMENSION_FILTER_KEYS[dimension]] ?? []
-    );
-    const data: AttributionRowData[] = rows.map((row) => ({
-      ...row,
-      isExpanded: expandedRowId === row.id,
-      isFilterSelected: selectedIdSet.has(row.id),
-      onClick: () =>
-        setExpandedRowId((current) => (current === row.id ? null : row.id)),
-      onAddFilter: () => onAddFilter(row),
-    }));
-
     content = (
       <div className="overflow-x-auto">
         <ConsumptionAttributionRowsTable
-          data={data}
+          data={attributionData}
           columns={columns}
           workspaceId={workspaceId}
           dimension={dimension}
           period={period}
           filter={filter}
           onViewAll={onViewAll}
+          pagination={clampedPagination}
+          setPagination={setPagination}
         />
       </div>
     );


### PR DESCRIPTION
## Description

Adds client-side pagination to the usage consumption attribution table. Previously, the table fetched and rendered the top 25 ranked rows; it now fetches up to 100 rows from the consumption endpoint and displays them in 25-row pages using TanStack Table pagination and Sparkle's `Pagination` component.

Existing client-side search, row expansion, and filter actions are preserved. Search remains limited to the fetched top 100 rows because the consumption endpoint ranks via an Elasticsearch terms aggregation without offset/cursor support. The 100-row fetch limit is intentional: returning more results would require the fetcher to request increasingly larger batches, since pagination is not performed inside Elasticsearch for this aggregation. 

## Tests

Local testing

## Risk

Low. The change is limited to the consumption attribution UI and does not alter persisted data or API contracts. Reverting the change is straightforward if needed.

## Deploy Plan
- Deploy front