### PR TITLE
Add partial index for generated file lookups

### DIFF
--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -9,6 +9,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import {
   DANGEROUSLY_UNBOUNDED_TEXT,
   DataTypes,
+  Op,
 } from "@app/lib/resources/storage/data_types";
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -437,6 +438,12 @@ AgentMCPActionOutputItemModel.init(
         fields: ["workspaceId", "agentMCPActionId", "contentGcsPath"],
         concurrently: true,
         name: "agent_mcp_action_output_items_ws_action_gcs_path",
+      },
+      {
+        fields: ["workspaceId", "agentMCPActionId", "fileId", "id"],
+        where: { fileId: { [Op.ne]: null } },
+        concurrently: true,
+        name: "agent_mcp_action_output_items_ws_action_file_id",
       },
     ],
   }

--- a/front/migrations/pre-deploy/20260813145341_add_generated_files_lookup_index.sql
+++ b/front/migrations/pre-deploy/20260813145341_add_generated_files_lookup_index.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_mcp_action_output_items_ws_action_file_id ON public.agent_mcp_action_output_items USING btree ("workspaceId", "agentMCPActionId", "fileId", id) WHERE ("fileId" IS NOT NULL);


### PR DESCRIPTION
## Description

Add a concurrent partial covering index for generated-file lookups on `agent_mcp_action_output_items`.

The current plan intersects the workspace/action/content path index with the global non-null `fileId` index. During the US front DB incident, one captured execution scanned 8,763,744 index entries and 68,085 shared buffers to return no rows.

Query Insights recorded 167 executions of this query family between 14:00 and 14:35 CEST. They consumed about 1,894 seconds of execution time, or 5.1% of the database total in that interval. This is a meaningful contributor, but not the sole cause of the CPU saturation.

## Tests

- Generated the pre-deploy migration with the repository migration generator.
- Applied the migration in an isolated Dust Hive database.
- Confirmed `npm run migration:check` reports no pending migrations.
- Confirmed `EXPLAIN` selects an index-only scan for the generated-file lookup.
- Ran Biome on the changed model.
- Ran `npm run tsgo --workspace front -- --noEmit`.

## Risk

The index is partial and is built concurrently, so it does not block writes. The build will still consume database CPU and I/O. Apply it once the current front DB CPU alert is stable, and monitor CPU plus migration duration while it builds.

If the index causes unexpected overhead, remove it in a follow-up concurrent drop and remove it from the model.

## Deploy Plan

1. Wait for the US front DB CPU alert to recover or reach a stable operating level.
2. Apply the pre-deploy migration and monitor front DB CPU and migration completion.
3. Verify the generated-file query no longer intersects with the global `fileId` index in Query Insights.
4. Proceed with the normal application deploy. There is no application behavior change.
