### PR TITLE
Admin governance: fix the skill migration script 2

### DIFF
--- a/front/migrations/20260812_backfill_skill_group_permissions.ts
+++ b/front/migrations/20260812_backfill_skill_group_permissions.ts
@@ -19,7 +19,12 @@ async function backfillWorkspaceSkillGroupPermissions(
   logger: Logger,
   workspace: LightWorkspaceType
 ): Promise<void> {
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  // All groups: `listByWorkspace` filters on read access to the spaces a skill references, and
+  // restricted spaces grant read through group membership only. The default single-group auth
+  // silently skips those skills.
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+    dangerouslyRequestAllGroups: true,
+  });
 
   // Every status: archived and suggested skills keep their editor group, so their grants must be
   // written too (an archived skill can be restored). `onlyCustom` skips the code-defined


### PR DESCRIPTION
## Description

without the flag we missed some skills which have not been migrated correctly :( 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

merge
rerun the script 

Run this query to check:
```
 SELECT s."workspaceId",
         s.id            AS skill_model_id,
         s.status,
         s."createdAt",
         gs."groupId"    AS editor_group_model_id
  FROM skill_configurations s
  JOIN group_skills gs
       ON gs."skillConfigurationId" = s.id
      AND gs."workspaceId"          = s."workspaceId"
  LEFT JOIN group_permissions gp
       ON gp."workspaceId"  = s."workspaceId"
      AND gp."resourceType" = 'skill'
      AND gp."resourceId"   = s.id
      AND gp."groupId"      = gs."groupId"
      AND gp."grantType"    = 'editor'
  WHERE gp.id IS NULL
  ORDER BY s."workspaceId", s."createdAt" DESC;
```