### PR TITLE
fix(agents): revert agents wrongly swept to Auto by the Sonnet 4.6 migration

### DIFF
--- a/front/migrations/20260813_revert_sonnet46_to_auto_migration.test.ts
+++ b/front/migrations/20260813_revert_sonnet46_to_auto_migration.test.ts
@@ -1,0 +1,521 @@
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import baseLogger from "@app/logger/logger";
+import type { AgentModelVersion } from "@app/migrations/20260813_revert_sonnet46_to_auto_migration";
+import {
+  planAutoRevert,
+  revertSonnet46AutoSwitch,
+} from "@app/migrations/20260813_revert_sonnet46_to_auto_migration";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { AgentStatus } from "@app/types/assistant/agent";
+import {
+  CLAUDE_4_SONNET_20250514_MODEL_ID,
+  CLAUDE_OPUS_4_7_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import {
+  GPT_5_5_MODEL_ID,
+  GPT_5_6_LUNA_MODEL_ID,
+} from "@app/types/assistant/models/openai";
+import type {
+  ModelIdType,
+  ModelProviderIdType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
+import type { LightWorkspaceType } from "@app/types/user";
+import { describe, expect, it } from "vitest";
+
+// The 20260810 migration ran at 2026-08-10T16:39:26.539Z; its window closes two hours later.
+const BEFORE_WINDOW = new Date("2026-08-10T18:39:00.000Z");
+const AFTER_WINDOW = new Date("2026-08-10T18:40:00.000Z");
+const JAN = new Date("2026-01-10T00:00:00.000Z");
+const FEB = new Date("2026-02-10T00:00:00.000Z");
+const MAR = new Date("2026-03-10T00:00:00.000Z");
+const MAY = new Date("2026-05-10T00:00:00.000Z");
+const JUN = new Date("2026-06-10T00:00:00.000Z");
+const RESAVED_AT = new Date("2026-08-12T00:00:00.000Z");
+
+const logger = baseLogger.child({}, { level: "silent" });
+
+interface SeededVersion {
+  version: number;
+  modelId: ModelIdType;
+  reasoningEffort: ReasoningEffort | null;
+  createdAt: Date;
+  updatedAt?: Date;
+  status?: AgentStatus;
+}
+
+function makeVersion({
+  version,
+  modelId,
+  reasoningEffort = null,
+  createdAt,
+}: {
+  version: number;
+  modelId: ModelIdType;
+  reasoningEffort?: ReasoningEffort | null;
+  createdAt: Date;
+}): AgentModelVersion {
+  return { version, modelId, reasoningEffort, createdAt };
+}
+
+// The migration wrote `auto` at `none` reasoning.
+function autoVersion(version: number, createdAt: Date): AgentModelVersion {
+  return makeVersion({
+    version,
+    modelId: AUTO_MODEL_ID,
+    reasoningEffort: "none",
+    createdAt,
+  });
+}
+
+function sonnet46Medium(version: number, createdAt: Date): AgentModelVersion {
+  return makeVersion({
+    version,
+    modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+    reasoningEffort: "medium",
+    createdAt,
+  });
+}
+
+describe("planAutoRevert", () => {
+  it("reverts an agent whose earlier version was on a legacy model", () => {
+    const plan = planAutoRevert([
+      makeVersion({
+        version: 0,
+        modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+        reasoningEffort: "medium",
+        createdAt: JAN,
+      }),
+      autoVersion(1, MAY),
+    ]);
+
+    expect(plan.shouldRevert).toBe(true);
+    if (!plan.shouldRevert) {
+      return;
+    }
+    expect(plan.autoVersions.map((v) => v.version)).toEqual([1]);
+    expect(plan.deliberateVersion.version).toBe(0);
+    expect(plan.switchedVersion.version).toBe(1);
+  });
+
+  it("keeps an agent that was genuinely on Sonnet 4.6 medium", () => {
+    const plan = planAutoRevert([
+      sonnet46Medium(0, JUN),
+      autoVersion(1, BEFORE_WINDOW),
+    ]);
+
+    expect(plan.shouldRevert).toBe(false);
+  });
+
+  it("does not revert an agent with no earlier version to compare against", () => {
+    const plan = planAutoRevert([autoVersion(0, JUN)]);
+
+    expect(plan.shouldRevert).toBe(false);
+  });
+
+  it("finds the deliberate model more than one version below the switch", () => {
+    const plan = planAutoRevert([
+      makeVersion({
+        version: 0,
+        modelId: GPT_5_5_MODEL_ID,
+        reasoningEffort: "medium",
+        createdAt: FEB,
+      }),
+      sonnet46Medium(1, MAR),
+      autoVersion(2, MAY),
+    ]);
+
+    expect(plan.shouldRevert).toBe(true);
+    if (!plan.shouldRevert) {
+      return;
+    }
+    expect(plan.autoVersions.map((v) => v.version)).toEqual([2]);
+    expect(plan.deliberateVersion.version).toBe(0);
+  });
+
+  it("reverts the versions that inherited Auto when the agent was re-saved", () => {
+    const plan = planAutoRevert([
+      makeVersion({
+        version: 0,
+        modelId: CLAUDE_OPUS_4_7_MODEL_ID,
+        reasoningEffort: "high",
+        createdAt: JAN,
+      }),
+      autoVersion(1, MAY),
+      autoVersion(2, RESAVED_AT),
+      autoVersion(3, RESAVED_AT),
+    ]);
+
+    expect(plan.shouldRevert).toBe(true);
+    if (!plan.shouldRevert) {
+      return;
+    }
+    expect(plan.autoVersions.map((v) => v.version)).toEqual([1, 2, 3]);
+  });
+
+  it("stops the run at a version that is not on Auto", () => {
+    const plan = planAutoRevert([
+      makeVersion({
+        version: 0,
+        modelId: GPT_5_5_MODEL_ID,
+        reasoningEffort: "medium",
+        createdAt: FEB,
+      }),
+      autoVersion(1, MAY),
+      makeVersion({
+        version: 2,
+        modelId: GPT_5_6_LUNA_MODEL_ID,
+        reasoningEffort: "high",
+        createdAt: RESAVED_AT,
+      }),
+      autoVersion(3, RESAVED_AT),
+    ]);
+
+    expect(plan.shouldRevert).toBe(true);
+    if (!plan.shouldRevert) {
+      return;
+    }
+    expect(plan.autoVersions.map((v) => v.version)).toEqual([1]);
+  });
+
+  it("ignores a switch to Auto made after the migration window", () => {
+    const plan = planAutoRevert([
+      makeVersion({
+        version: 0,
+        modelId: GPT_5_5_MODEL_ID,
+        reasoningEffort: "medium",
+        createdAt: FEB,
+      }),
+      autoVersion(1, AFTER_WINDOW),
+    ]);
+
+    expect(plan.shouldRevert).toBe(false);
+  });
+
+  it("treats Sonnet 4.6 at another reasoning effort as a deliberate model", () => {
+    const plan = planAutoRevert([
+      makeVersion({
+        version: 0,
+        modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+        reasoningEffort: "high",
+        createdAt: JUN,
+      }),
+      autoVersion(1, BEFORE_WINDOW),
+    ]);
+
+    expect(plan.shouldRevert).toBe(true);
+  });
+
+  it("keeps an agent that never went through Auto", () => {
+    const plan = planAutoRevert([
+      makeVersion({
+        version: 0,
+        modelId: GPT_5_5_MODEL_ID,
+        reasoningEffort: "medium",
+        createdAt: FEB,
+      }),
+    ]);
+
+    expect(plan.shouldRevert).toBe(false);
+  });
+
+  it("accepts a version created on the last millisecond of the window", () => {
+    const earlier = makeVersion({
+      version: 0,
+      modelId: GPT_5_5_MODEL_ID,
+      reasoningEffort: "medium",
+      createdAt: FEB,
+    });
+
+    expect(
+      planAutoRevert([
+        earlier,
+        autoVersion(1, new Date("2026-08-10T18:39:26.539Z")),
+      ]).shouldRevert
+    ).toBe(true);
+    expect(
+      planAutoRevert([
+        earlier,
+        autoVersion(1, new Date("2026-08-10T18:39:26.540Z")),
+      ]).shouldRevert
+    ).toBe(false);
+  });
+});
+
+async function seedAgent({
+  workspace,
+  authorId,
+  name,
+  versions,
+}: {
+  workspace: LightWorkspaceType;
+  authorId: number;
+  name: string;
+  versions: SeededVersion[];
+}): Promise<string> {
+  const agentId = generateRandomModelSId("agent");
+
+  for (const version of versions) {
+    const providerId: ModelProviderIdType =
+      version.modelId === AUTO_MODEL_ID ? "auto" : "anthropic";
+
+    const row = await AgentConfigurationModel.create({
+      sId: agentId,
+      version: version.version,
+      status: version.status ?? "archived",
+      scope: "visible",
+      name,
+      description: "Test agent",
+      instructions: "Test instructions",
+      instructionsHtml: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      providerId,
+      modelId: version.modelId,
+      temperature: 0.7,
+      reasoningEffort: version.reasoningEffort,
+      maxStepsPerRun: 8,
+      reinforcement: "auto",
+      requestedSpaceIds: [],
+      workspaceId: workspace.id,
+      authorId,
+    });
+
+    // Sequelize stamps its own timestamps on create, so force them afterwards: `createdAt` is what
+    // the migration reads, and `updatedAt` needs to be wrong on purpose to prove it is not used.
+    await AgentConfigurationModel.update(
+      {
+        createdAt: version.createdAt,
+        updatedAt: version.updatedAt ?? version.createdAt,
+      },
+      {
+        where: { id: row.id, workspaceId: workspace.id },
+        silent: true,
+      }
+    );
+  }
+
+  return agentId;
+}
+
+async function readVersions(
+  workspace: LightWorkspaceType,
+  agentId: string
+): Promise<Array<{ modelId: string; reasoningEffort: string | null }>> {
+  const versions = await AgentConfigurationModel.findAll({
+    where: { workspaceId: workspace.id, sId: agentId },
+    order: [["version", "ASC"]],
+  });
+
+  return versions.map((version) => ({
+    modelId: version.modelId,
+    reasoningEffort: version.reasoningEffort,
+  }));
+}
+
+const SONNET_46_MEDIUM = {
+  modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+  reasoningEffort: "medium",
+};
+const AUTO_NONE = { modelId: AUTO_MODEL_ID, reasoningEffort: "none" };
+
+describe("revertSonnet46AutoSwitch", () => {
+  it("reverts the swept agents and leaves the others alone", async () => {
+    const { workspace, user } = await createResourceTest({ role: "admin" });
+
+    // Flipped in place from a legacy model that the 20260518 migration had moved to Sonnet 4.6.
+    const legacyAgentId = await seedAgent({
+      workspace,
+      authorId: user.id,
+      name: "Legacy model agent",
+      versions: [
+        {
+          version: 0,
+          modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+          reasoningEffort: "medium",
+          createdAt: JAN,
+        },
+        {
+          version: 1,
+          modelId: AUTO_MODEL_ID,
+          reasoningEffort: "none",
+          createdAt: MAY,
+          status: "active",
+        },
+      ],
+    });
+
+    // Genuinely on Sonnet 4.6 medium before the sweep: stays on Auto.
+    const genuineAgentId = await seedAgent({
+      workspace,
+      authorId: user.id,
+      name: "Genuine sonnet agent",
+      versions: [
+        {
+          version: 0,
+          modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+          reasoningEffort: "medium",
+          createdAt: JUN,
+        },
+        {
+          version: 1,
+          modelId: AUTO_MODEL_ID,
+          reasoningEffort: "none",
+          createdAt: BEFORE_WINDOW,
+          status: "active",
+        },
+      ],
+    });
+
+    // Re-saved after the sweep: archiving rewrote `updatedAt` on every row, and the new versions
+    // inherited Auto.
+    const resavedAgentId = await seedAgent({
+      workspace,
+      authorId: user.id,
+      name: "Re-saved agent",
+      versions: [
+        {
+          version: 0,
+          modelId: CLAUDE_OPUS_4_7_MODEL_ID,
+          reasoningEffort: "high",
+          createdAt: JAN,
+          updatedAt: RESAVED_AT,
+        },
+        {
+          version: 1,
+          modelId: AUTO_MODEL_ID,
+          reasoningEffort: "none",
+          createdAt: MAY,
+          updatedAt: RESAVED_AT,
+        },
+        {
+          version: 2,
+          modelId: AUTO_MODEL_ID,
+          reasoningEffort: "none",
+          createdAt: RESAVED_AT,
+        },
+        {
+          version: 3,
+          modelId: AUTO_MODEL_ID,
+          reasoningEffort: "none",
+          createdAt: RESAVED_AT,
+          status: "active",
+        },
+      ],
+    });
+
+    // Auto picked again after the sweep, on top of a non-Auto version.
+    const repickedAgentId = await seedAgent({
+      workspace,
+      authorId: user.id,
+      name: "Re-picked auto agent",
+      versions: [
+        {
+          version: 0,
+          modelId: GPT_5_5_MODEL_ID,
+          reasoningEffort: "medium",
+          createdAt: FEB,
+        },
+        {
+          version: 1,
+          modelId: AUTO_MODEL_ID,
+          reasoningEffort: "none",
+          createdAt: MAY,
+        },
+        {
+          version: 2,
+          modelId: GPT_5_6_LUNA_MODEL_ID,
+          reasoningEffort: "high",
+          createdAt: RESAVED_AT,
+        },
+        {
+          version: 3,
+          modelId: AUTO_MODEL_ID,
+          reasoningEffort: "none",
+          createdAt: RESAVED_AT,
+          status: "active",
+        },
+      ],
+    });
+
+    // Never swept: the builder moved to Auto after the window closed.
+    const lateAgentId = await seedAgent({
+      workspace,
+      authorId: user.id,
+      name: "Late auto agent",
+      versions: [
+        {
+          version: 0,
+          modelId: GPT_5_5_MODEL_ID,
+          reasoningEffort: "medium",
+          createdAt: FEB,
+        },
+        {
+          version: 1,
+          modelId: AUTO_MODEL_ID,
+          reasoningEffort: "none",
+          createdAt: AFTER_WINDOW,
+          status: "active",
+        },
+      ],
+    });
+
+    const dryRun = await revertSonnet46AutoSwitch({ execute: false, logger });
+
+    expect(dryRun.revertedAgentIds).toEqual(
+      expect.arrayContaining([legacyAgentId, resavedAgentId, repickedAgentId])
+    );
+    expect(dryRun.revertedAgentIds).not.toContain(genuineAgentId);
+    expect(dryRun.revertedAgentIds).not.toContain(lateAgentId);
+    expect(await readVersions(workspace, legacyAgentId)).toEqual([
+      {
+        modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      AUTO_NONE,
+    ]);
+
+    await revertSonnet46AutoSwitch({ execute: true, logger });
+
+    expect(await readVersions(workspace, legacyAgentId)).toEqual([
+      {
+        modelId: CLAUDE_4_SONNET_20250514_MODEL_ID,
+        reasoningEffort: "medium",
+      },
+      SONNET_46_MEDIUM,
+    ]);
+
+    expect(await readVersions(workspace, genuineAgentId)).toEqual([
+      SONNET_46_MEDIUM,
+      AUTO_NONE,
+    ]);
+
+    expect(await readVersions(workspace, resavedAgentId)).toEqual([
+      { modelId: CLAUDE_OPUS_4_7_MODEL_ID, reasoningEffort: "high" },
+      SONNET_46_MEDIUM,
+      SONNET_46_MEDIUM,
+      SONNET_46_MEDIUM,
+    ]);
+
+    expect(await readVersions(workspace, repickedAgentId)).toEqual([
+      { modelId: GPT_5_5_MODEL_ID, reasoningEffort: "medium" },
+      SONNET_46_MEDIUM,
+      { modelId: GPT_5_6_LUNA_MODEL_ID, reasoningEffort: "high" },
+      AUTO_NONE,
+    ]);
+
+    expect(await readVersions(workspace, lateAgentId)).toEqual([
+      { modelId: GPT_5_5_MODEL_ID, reasoningEffort: "medium" },
+      AUTO_NONE,
+    ]);
+
+    // Rerunning is a no-op for the agents that were reverted.
+    const rerun = await revertSonnet46AutoSwitch({ execute: true, logger });
+
+    expect(rerun.revertedAgentIds).not.toContain(legacyAgentId);
+    expect(rerun.revertedAgentIds).not.toContain(resavedAgentId);
+    expect(rerun.revertedAgentIds).not.toContain(repickedAgentId);
+  });
+});

--- a/front/migrations/20260813_revert_sonnet46_to_auto_migration.ts
+++ b/front/migrations/20260813_revert_sonnet46_to_auto_migration.ts
@@ -12,8 +12,7 @@ import { Op } from "sequelize";
 
 // `20260810_migrate_sonnet46_medium_to_auto.ts` moved every active agent on Claude Sonnet 4.6 with
 // medium reasoning to the Auto meta-model. It swept in agents that had only landed on Sonnet 4.6
-// medium because an earlier in-place migration put them there (e.g.
-// `20260518_migrate_legacy_anthropic_models.ts`), burying a model the builder had actually picked.
+// after another model change,  burying a model the builder had actually picked.
 //
 // Nothing was on Auto before that migration ran, so any version showing Auto and created by the end
 // of the migration window is one it flipped in place. From there we walk the agent's whole history:

--- a/front/migrations/20260813_revert_sonnet46_to_auto_migration.ts
+++ b/front/migrations/20260813_revert_sonnet46_to_auto_migration.ts
@@ -1,0 +1,249 @@
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import {
+  CLAUDE_SONNET_4_6_MODEL_ID,
+  CLAUDE_4_5_SONNET_20250929_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import { chunk, uniq } from "lodash";
+import { Op } from "sequelize";
+
+// `20260810_migrate_sonnet46_medium_to_auto.ts` moved every active agent on Claude Sonnet 4.6 with
+// medium reasoning to the Auto meta-model. It swept in agents that had only landed on Sonnet 4.6
+// medium because an earlier in-place migration put them there (e.g.
+// `20260518_migrate_legacy_anthropic_models.ts`), burying a model the builder had actually picked.
+//
+// Nothing was on Auto before that migration ran, so any version showing Auto and created by the end
+// of the migration window is one it flipped in place. From there we walk the agent's whole history:
+// if any earlier version shows a model other than Sonnet 4.6 medium, the agent had a deliberate
+// model choice and goes back to Sonnet 4.6. An agent that has only ever been on Sonnet 4.6 medium
+// stays on Auto.
+const MIGRATION_WINDOW_MS = 2 * 60 * 60 * 1000;
+const MIGRATED_AT = new Date(1786379966539);
+const MIGRATION_WINDOW_END = new Date(
+  MIGRATED_AT.getTime() + MIGRATION_WINDOW_MS
+);
+
+const REVERT_TO = {
+  providerId: "anthropic",
+  modelId: CLAUDE_SONNET_4_6_MODEL_ID,
+  reasoningEffort: "medium",
+} as const;
+
+const FETCH_CHUNK_SIZE = 500;
+
+const AgentConfigurationModelWithBypass: ModelStaticWorkspaceAware<AgentConfigurationModel> =
+  AgentConfigurationModel;
+
+export type AgentModelVersion = Pick<
+  AgentConfigurationModel,
+  "createdAt" | "modelId" | "reasoningEffort" | "version"
+>;
+
+export type AutoRevertPlan<T extends AgentModelVersion> =
+  | { shouldRevert: false }
+  | {
+      shouldRevert: true;
+      switchedVersion: T;
+      deliberateVersion: T;
+      autoVersions: T[];
+    };
+
+function isAuto(version: AgentModelVersion): boolean {
+  return version.modelId === AUTO_MODEL_ID;
+}
+
+function isSonnet46or45Medium(version: AgentModelVersion): boolean {
+  return (
+    (version.modelId === CLAUDE_SONNET_4_6_MODEL_ID ||
+      version.modelId === CLAUDE_4_5_SONNET_20250929_MODEL_ID) &&
+    version.reasoningEffort === "medium"
+  );
+}
+
+/**
+ * Decides what to roll back for a single agent, given its full version history in ascending
+ * version order.
+ */
+export function planAutoRevert<T extends AgentModelVersion>(
+  versions: T[]
+): AutoRevertPlan<T> {
+  // The version the migration flipped: the first one on Auto, gated at the end of the window so
+  // that a builder switching to Auto later on is left alone.
+  const switchIndex = versions.findIndex(
+    (version) => isAuto(version) && version.createdAt <= MIGRATION_WINDOW_END
+  );
+  if (switchIndex < 0) {
+    return { shouldRevert: false };
+  }
+
+  // Only ever Sonnet 4.6 or 4.5 medium before the switch (or no earlier version at all): nothing was
+  // buried, the agent stays on Auto.
+  const deliberateVersion = versions
+    .slice(0, switchIndex)
+    .find((version) => !isSonnet46or45Medium(version));
+  if (!deliberateVersion) {
+    return { shouldRevert: false };
+  }
+
+  // Roll back the unbroken run of Auto versions starting at the switch: versions saved after the
+  // migration inherited Auto from it. A version that is not on Auto ends the run — an Auto version
+  // above it is a fresh, deliberate choice.
+  const autoVersions: T[] = [];
+  for (const version of versions.slice(switchIndex)) {
+    if (!isAuto(version)) {
+      break;
+    }
+    autoVersions.push(version);
+  }
+
+  return {
+    shouldRevert: true,
+    switchedVersion: versions[switchIndex],
+    deliberateVersion,
+    autoVersions,
+  };
+}
+
+export async function revertSonnet46AutoSwitch({
+  execute,
+  logger,
+}: {
+  execute: boolean;
+  logger: Logger;
+}): Promise<{
+  revertedAgentIds: string[];
+  revertedVersionCount: number;
+  keptOnAutoCount: number;
+}> {
+  const switchedVersions = await AgentConfigurationModelWithBypass.findAll({
+    attributes: ["sId"],
+    where: {
+      modelId: AUTO_MODEL_ID,
+      createdAt: { [Op.lte]: MIGRATION_WINDOW_END },
+    },
+    // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+    // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+    dangerouslyBypassWorkspaceIsolationSecurity: true,
+  });
+
+  const switchedAgentIds = uniq(switchedVersions.map((agent) => agent.sId));
+
+  logger.info(
+    {
+      count: switchedAgentIds.length,
+      windowEnd: MIGRATION_WINDOW_END.toISOString(),
+    },
+    `Found ${switchedAgentIds.length} agents switched to ${AUTO_MODEL_ID} by the end of the migration window.`
+  );
+
+  if (switchedAgentIds.length === 0) {
+    return {
+      revertedAgentIds: [],
+      revertedVersionCount: 0,
+      keptOnAutoCount: 0,
+    };
+  }
+
+  // Full version history of each agent, ascending. `sId` + `version` is unique, so no workspace
+  // scoping is needed to reconstruct a history.
+  const versionsByAgentId = new Map<string, AgentConfigurationModel[]>();
+
+  for (const agentIds of chunk(switchedAgentIds, FETCH_CHUNK_SIZE)) {
+    const versions = await AgentConfigurationModelWithBypass.findAll({
+      attributes: [
+        "id",
+        "sId",
+        "version",
+        "status",
+        "createdAt",
+        "providerId",
+        "modelId",
+        "reasoningEffort",
+        "workspaceId",
+      ],
+      where: { sId: { [Op.in]: agentIds } },
+      order: [["version", "ASC"]],
+      // WORKSPACE_ISOLATION_BYPASS: Migration runs across all workspaces.
+      // biome-ignore lint/plugin/noUnverifiedWorkspaceBypass: WORKSPACE_ISOLATION_BYPASS verified
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+
+    for (const version of versions) {
+      const history = versionsByAgentId.get(version.sId);
+      if (history) {
+        history.push(version);
+      } else {
+        versionsByAgentId.set(version.sId, [version]);
+      }
+    }
+  }
+
+  const toRevert: AgentConfigurationModel[] = [];
+  const revertedAgentIds: string[] = [];
+  let keptOnAutoCount = 0;
+
+  for (const [agentId, versions] of versionsByAgentId) {
+    const plan = planAutoRevert(versions);
+
+    if (!plan.shouldRevert) {
+      keptOnAutoCount++;
+      continue;
+    }
+
+    const { switchedVersion, deliberateVersion, autoVersions } = plan;
+
+    logger.info(
+      {
+        sId: agentId,
+        workspaceId: switchedVersion.workspaceId,
+        switchedAtVersion: switchedVersion.version,
+        revertedVersions: autoVersions.map((version) => version.version),
+        deliberateVersion: deliberateVersion.version,
+        deliberateModelId: deliberateVersion.modelId,
+        deliberateReasoningEffort: deliberateVersion.reasoningEffort,
+      },
+      `Reverting ${autoVersions.length} ${AUTO_MODEL_ID} version(s) of agent ${agentId} to ${REVERT_TO.modelId}: version ${deliberateVersion.version} was on ${deliberateVersion.modelId}.`
+    );
+
+    toRevert.push(...autoVersions);
+    revertedAgentIds.push(agentId);
+  }
+
+  logger.info(
+    {
+      agentCount: revertedAgentIds.length,
+      versionCount: toRevert.length,
+      keptOnAutoCount,
+    },
+    `Reverting ${toRevert.length} agent version(s) to ${REVERT_TO.modelId} (${REVERT_TO.reasoningEffort} reasoning), keeping ${keptOnAutoCount} agents on ${AUTO_MODEL_ID}.`
+  );
+
+  if (execute) {
+    for (const version of toRevert) {
+      await version.update(REVERT_TO);
+    }
+
+    logger.info("Migration complete.");
+  }
+
+  return {
+    revertedAgentIds,
+    revertedVersionCount: toRevert.length,
+    keptOnAutoCount,
+  };
+}
+
+function runScript(): void {
+  makeScript({}, async ({ execute }, logger) => {
+    await revertSonnet46AutoSwitch({ execute, logger });
+  });
+}
+
+if (
+  process.argv[1]?.endsWith("20260813_revert_sonnet46_to_auto_migration.ts")
+) {
+  runScript();
+}


### PR DESCRIPTION
## Description

`20260810_migrate_sonnet46_medium_to_auto.ts` moved every active agent on Claude Sonnet 4.6 with
medium reasoning to the Auto meta-model. That sweep also caught agents that had only landed on
Sonnet 4.6 medium after another model change so it buried a model the builder had actually
picked.

This migration rolls those agents back to Sonnet 4.6 medium. Nothing was on Auto before the sweep,
so any version on Auto created by the end of the migration window is one the sweep flipped in
place. From there it walks the agent's full version history:

- if any version below the switch is on something other than Sonnet 4.6 / 4.5 medium, the agent had
  a deliberate model choice and goes back to Sonnet 4.6 medium;
- an agent that has only ever been on Sonnet 4.6 / 4.5 medium keeps Auto;
- a switch to Auto made after the window closed is a builder's own choice and is left alone.

It reverts the unbroken run of Auto versions starting at the switch, so versions saved after the
migration (which inherited Auto from it) are fixed too. A non-Auto version ends the run — an Auto
version above it is a fresh, deliberate pick.

Supersedes the approach in #30458.

## Tests

`front/migrations/20260813_revert_sonnet46_to_auto_migration.test.ts` covers the decision function
over every history shape (legacy model below the switch, genuine Sonnet 4.6 medium, re-saved
agents, Auto re-picked after the sweep, late switch, window boundary to the millisecond), plus an
end-to-end run against the database asserting the dry run mutates nothing, the execute run rewrites
only the intended versions, and a rerun is a no-op.

Run a dry run before executing:
`npx tsx front/migrations/20260813_revert_sonnet46_to_auto_migration.ts` and check the logged agent
and version counts.

## Risk

The migration rewrites the model on existing agent configuration versions, including archived ones.
The window gate and the "only ever Sonnet 4.6 medium" check keep it off agents that chose Auto
themselves, and rerunning is a no-op, but a bad match is not automatically reversible — review the
dry-run output before executing.

## Deploy Plan

Run the script manually after deploy, dry run first, then with `--execute`.
