### PR TITLE
[Activation] Batch evaluation when a workspace exceeds the ES user cap

### DIFF
--- a/front/lib/api/activation/queries/user_day_cells.test.ts
+++ b/front/lib/api/activation/queries/user_day_cells.test.ts
@@ -1,0 +1,140 @@
+import { fetchUserDayCells } from "@app/lib/api/activation/queries/user_day_cells";
+import {
+  ElasticsearchError,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/elasticsearch")>();
+  return { ...actual, searchAnalytics: vi.fn() };
+});
+
+function emptyEsResponse() {
+  const response: estypes.SearchResponse<never> = {
+    took: 1,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, failed: 0, skipped: 0 },
+    hits: { hits: [] },
+    aggregations: {
+      by_user_day: { buckets: [] },
+    },
+  };
+  return new Ok(response);
+}
+
+function esResponseWithBucket({
+  userId,
+  dayMs,
+}: {
+  userId: string;
+  dayMs: number;
+}) {
+  const response: estypes.SearchResponse<never> = {
+    took: 1,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, failed: 0, skipped: 0 },
+    hits: { hits: [] },
+    aggregations: {
+      by_user_day: {
+        buckets: [
+          {
+            key: { user_id: userId, day: dayMs },
+            doc_count: 1,
+            dau: { doc_count: 1 },
+            hvuc_signal: { doc_count: 1 },
+          },
+        ],
+      },
+    },
+  };
+  return new Ok(response);
+}
+
+describe("fetchUserDayCells", () => {
+  const windowStart = new Date("2026-07-01T00:00:00.000Z");
+  const windowEnd = new Date("2026-07-29T00:00:00.000Z");
+
+  beforeEach(() => {
+    vi.mocked(searchAnalytics).mockReset();
+  });
+
+  it("returns an empty map without querying Elasticsearch", async () => {
+    const result = await fetchUserDayCells({
+      workspaceId: "ws",
+      userIds: [],
+      windowStart,
+      windowEnd,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.size).toBe(0);
+    }
+    expect(searchAnalytics).not.toHaveBeenCalled();
+  });
+
+  it("splits users above the ES cap into multiple calls and merges facts", async () => {
+    // The poke cohort path previously failed with
+    // "activation evaluation supports at most 100 users per call, got 239".
+    const userIds = Array.from({ length: 239 }, (_, i) => `user-${i}`);
+    const dayMs = Date.UTC(2026, 6, 15);
+
+    vi.mocked(searchAnalytics)
+      .mockResolvedValueOnce(esResponseWithBucket({ userId: "user-0", dayMs }))
+      .mockResolvedValueOnce(
+        esResponseWithBucket({ userId: "user-100", dayMs })
+      )
+      .mockResolvedValueOnce(
+        esResponseWithBucket({ userId: "user-200", dayMs })
+      );
+
+    const result = await fetchUserDayCells({
+      workspaceId: "ws",
+      userIds,
+      windowStart,
+      windowEnd,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(searchAnalytics).toHaveBeenCalledTimes(3);
+    if (result.isOk()) {
+      expect(result.value.size).toBe(239);
+      expect(result.value.get("user-0")).toEqual([
+        { userId: "user-0", dayMs, isDau: true, isHvuc: true },
+      ]);
+      expect(result.value.get("user-100")).toEqual([
+        { userId: "user-100", dayMs, isDau: true, isHvuc: true },
+      ]);
+      expect(result.value.get("user-200")).toEqual([
+        { userId: "user-200", dayMs, isDau: true, isHvuc: true },
+      ]);
+      expect(result.value.get("user-1")).toEqual([]);
+    }
+  });
+
+  it("fails the whole call when a later batch errors", async () => {
+    const userIds = Array.from({ length: 101 }, (_, i) => `user-${i}`);
+
+    vi.mocked(searchAnalytics)
+      .mockResolvedValueOnce(emptyEsResponse())
+      .mockResolvedValueOnce(
+        new Err(new ElasticsearchError("query_error", "es unavailable"))
+      );
+
+    const result = await fetchUserDayCells({
+      workspaceId: "ws",
+      userIds,
+      windowStart,
+      windowEnd,
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("es unavailable");
+    }
+  });
+});

--- a/front/lib/api/activation/queries/user_day_cells.ts
+++ b/front/lib/api/activation/queries/user_day_cells.ts
@@ -8,6 +8,7 @@ import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversati
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
+import chunk from "lodash/chunk";
 
 // ---------------------------------------------------------------------------
 // Elasticsearch query: per-(user, day) activity facts.
@@ -24,9 +25,10 @@ const DAILY_ACTIVE_USER_ORIGINS = USER_USAGE_ORIGINS.filter(
   (origin) => origin !== "triggered"
 );
 
-// Hard cap on users per call. The composite page size is sized so that the
-// entire (user × day) grid fits in a single page for a capped user set, making
-// the pagination loop complete by construction (see below).
+// Hard cap on users per Elasticsearch call. Larger sets are fetched in
+// sequential batches. The composite page size is sized so that the entire
+// (user × day) grid fits in a single page for a capped user set, making the
+// pagination loop complete by construction (see below).
 const ELASTICSEARCH_MAX_USERS_PER_CALL = 100;
 // Upper bound on distinct day-buckets a single user can produce over any
 // trailing window of up to ~one month.
@@ -79,12 +81,10 @@ function bucketToFact(bucket: CompositeDayBucket): UserDayFact {
 
 /**
  * Fetches per-(user, day) activity facts for the given users over
- * [windowStart, windowEnd), keyed by user sId. One composite Elasticsearch
- * aggregation per call (not per user).
- *
- * Fails (rather than returning partial data) if the user set exceeds the cap or
- * if pagination does not exhaust — a partial result would silently under-count
- * activity and cause false "not activated" verdicts.
+ * [windowStart, windowEnd), keyed by user sId. Elasticsearch composite
+ * aggregations are capped at ELASTICSEARCH_MAX_USERS_PER_CALL so the
+ * (user × day) grid fits in a single page; larger sets are fetched in
+ * batches and merged.
  */
 export async function fetchUserDayCells({
   workspaceId,
@@ -103,15 +103,39 @@ export async function fetchUserDayCells({
   if (uniqueUserIds.length === 0) {
     return new Ok(factsByUser);
   }
-  if (uniqueUserIds.length > ELASTICSEARCH_MAX_USERS_PER_CALL) {
-    return new Err(
-      new Error(
-        `activation evaluation supports at most ${ELASTICSEARCH_MAX_USERS_PER_CALL} ` +
-          `users per call, got ${uniqueUserIds.length}`
-      )
-    );
+
+  const batches = chunk(uniqueUserIds, ELASTICSEARCH_MAX_USERS_PER_CALL);
+  for (const batch of batches) {
+    const batchResult = await fetchUserDayCellsBatch({
+      workspaceId,
+      userIds: batch,
+      windowStart,
+      windowEnd,
+    });
+    if (batchResult.isErr()) {
+      return batchResult;
+    }
+    for (const [userId, facts] of batchResult.value) {
+      factsByUser.set(userId, facts);
+    }
   }
-  for (const userId of uniqueUserIds) {
+
+  return new Ok(factsByUser);
+}
+
+async function fetchUserDayCellsBatch({
+  workspaceId,
+  userIds,
+  windowStart,
+  windowEnd,
+}: {
+  workspaceId: string;
+  userIds: string[];
+  windowStart: Date;
+  windowEnd: Date;
+}): Promise<Result<Map<string, UserDayFact[]>, Error>> {
+  const factsByUser = new Map<string, UserDayFact[]>();
+  for (const userId of userIds) {
     factsByUser.set(userId, []);
   }
 
@@ -122,7 +146,7 @@ export async function fetchUserDayCells({
         // never search documents from another workspace.
         buildAgentAnalyticsBaseQuery({
           workspaceId,
-          userIds: uniqueUserIds,
+          userIds,
           // Include only known human/user origins rather than excluding
           // programmatic ones with a costly must_not clause.
           contextOrigin: USER_USAGE_ORIGINS,


### PR DESCRIPTION
## Summary
- We had a hard limit of one ES call where it was not paginated. This caused a hard limit of ~100 users in a workspace at each time. We want to paginate ES calls to avoid this limit safely.

## Testing
* Ran Temporal workflow normally
* new unit test

## Risk
Low - Should be following best practices to mitigate ES load

## Deploy
1. Deploy front