### PR TITLE
perf(front): lighten MCP server list payload and drop a redundant fetch

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -17,7 +17,10 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
-import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
+import type {
+  MCPServerType,
+  MCPServerViewInServerListType,
+} from "@app/lib/api/mcp";
 import { filterMCPServer } from "@app/lib/mcp";
 import {
   useCreateInternalMCPServer,
@@ -26,18 +29,25 @@ import {
   useMCPServersUsage,
 } from "@app/lib/swr/mcp_servers";
 import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
+import { emptyArray } from "@app/lib/swr/swr";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { SkillUsageType } from "@app/types/assistant/skill_configuration";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
-import { Chip, cn, DataTable, EmptyCTA, Spinner } from "@dust-tt/sparkle";
+import {
+  Chip,
+  cn,
+  DataTable,
+  DataTableLoadingSkeleton,
+  EmptyCTA,
+} from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
 type RowData = {
   mcpServer: MCPServerType;
-  mcpServerView?: MCPServerViewType;
+  mcpServerView?: MCPServerViewInServerListType;
   usage: SkillUsageType | null;
   isConnected: boolean;
   account: string;
@@ -412,15 +422,16 @@ export const AdminActionsList = ({
         createRemoteMCPServer={onCreateRemoteMCPServer}
         createInternalMCPServer={onCreateInternalMCPServer}
       />
-      {rows.length > 0 &&
+      {(showLoader || rows.length > 0) &&
         portalToHeader(
           <AddToolsButton onClick={() => setIsAddToolsOpen(true)} />
         )}
 
       {showLoader && (
-        <div className="mt-16 flex justify-center">
-          <Spinner />
-        </div>
+        <>
+          <DataTable data={emptyArray<RowData>()} columns={columns} />
+          <DataTableLoadingSkeleton rows={5} showSelectionColumn={false} />
+        </>
       )}
 
       {!showLoader &&

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
@@ -15,7 +15,7 @@ import {
   isServerSideMCPServerConfigurationWithName,
 } from "@app/lib/actions/types/guards";
 import type {
-  MCPServerTypeWithViews,
+  MCPServerTypeWithLightViews,
   MCPServerViewType,
 } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
@@ -263,7 +263,7 @@ function useAvailableToolsets({
 
 function renderOtherAction(
   action: MCPServerConfigurationType,
-  mcpServers: MCPServerTypeWithViews[]
+  mcpServers: MCPServerTypeWithLightViews[]
 ): ActionData | null {
   if (isServerSideMCPServerConfiguration(action)) {
     const mcpServer = mcpServers.find((s) =>

--- a/front/components/spaces/SystemSpaceActionsList.tsx
+++ b/front/components/spaces/SystemSpaceActionsList.tsx
@@ -3,7 +3,7 @@ import { MCPServerDetails } from "@app/components/actions/mcp/MCPServerDetails";
 import { SpaceSearchContext } from "@app/components/spaces/search/SpaceSearchContext";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { MCPServerType } from "@app/lib/api/mcp";
-import { useMCPServerViews } from "@app/lib/swr/mcp_servers";
+import { useMCPServers } from "@app/lib/swr/mcp_servers";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
@@ -28,17 +28,18 @@ export const SystemSpaceActionsList = ({
   const [selectedMcpServer, setSelectedMcpServer] =
     useState<MCPServerType | null>(null);
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
-  const { serverViews } = useMCPServerViews({
-    owner,
-    space,
-  });
 
-  const mcpServerView = useMemo(
-    () =>
-      serverViews.find((view) => view.server.sId === selectedMcpServer?.sId) ??
-      null,
-    [serverViews, selectedMcpServer?.sId]
-  );
+  const { mcpServers } = useMCPServers({ owner });
+
+  const mcpServerView = useMemo(() => {
+    const server = mcpServers.find((s) => s.sId === selectedMcpServer?.sId);
+    const view = server?.views.find((v) => v.spaceId === space.sId);
+    if (!server || !view) {
+      return null;
+    }
+
+    return { ...view, server: { ...view.server, tools: server.tools } };
+  }, [mcpServers, selectedMcpServer?.sId, space.sId]);
 
   const { frontendListFilterQuery } = useContext(SpaceSearchContext);
   const { q: searchParam } = useQueryParams(["q"]);

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -12,7 +12,6 @@ import {
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type {
   MCPServerType,
-  MCPServerTypeWithViews,
   MCPServerViewType,
   RemoteMCPServerType,
 } from "@app/lib/api/mcp";
@@ -150,14 +149,19 @@ export const mcpServerViewSortingFn = (
   return mcpServersSortingFn({ mcpServer: a.server }, { mcpServer: b.server });
 };
 
+type MCPServerViewForDisplay = {
+  name: string | null;
+  server: Pick<MCPServerType, "sId" | "name">;
+};
+
 export const mcpServersSortingFn = (
   a: {
-    mcpServer: MCPServerType | MCPServerTypeWithViews;
-    mcpServerView?: MCPServerViewType;
+    mcpServer: MCPServerType;
+    mcpServerView?: MCPServerViewForDisplay;
   },
   b: {
-    mcpServer: MCPServerType | MCPServerTypeWithViews;
-    mcpServerView?: MCPServerViewType;
+    mcpServer: MCPServerType;
+    mcpServerView?: MCPServerViewForDisplay;
   }
 ) => {
   const aDisplayName = a.mcpServerView

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -7,7 +7,7 @@ import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumpti
 import { SOURCE_ORIGIN_LABELS } from "@app/lib/api/analytics/source_labels";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
-import type { MCPServerTypeWithViews } from "@app/lib/api/mcp";
+import type { MCPServerTypeWithLightViews } from "@app/lib/api/mcp";
 import { listMCPServersWithViews } from "@app/lib/api/mcp/servers";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
@@ -62,7 +62,7 @@ function traceFacetCatalogLoad<T>(
 }
 
 function toolFacetCatalogEntries(
-  mcpServers: MCPServerTypeWithViews[]
+  mcpServers: MCPServerTypeWithLightViews[]
 ): ConsumptionFacetCatalogEntry[] {
   const entries = mcpServers.flatMap<ConsumptionFacetCatalogEntry>((server) => {
     if (!isRemoteMCPServerType(server)) {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -200,6 +200,17 @@ export type MCPServerTypeWithViews = MCPServerType & {
   views: MCPServerViewType[];
 };
 
+export type MCPServerViewInServerListType = Omit<
+  MCPServerViewType,
+  "server"
+> & {
+  server: Omit<MCPServerType, "tools">;
+};
+
+export type MCPServerTypeWithLightViews = MCPServerType & {
+  views: MCPServerViewInServerListType[];
+};
+
 export type DeveloperSecretSelectionType = "required" | "optional";
 
 export type GetMCPServerViewsNotActivatedResponseBody = {
@@ -209,7 +220,7 @@ export type GetMCPServerViewsNotActivatedResponseBody = {
 
 export type GetMCPServersResponseBody = {
   success: true;
-  servers: MCPServerTypeWithViews[];
+  servers: MCPServerTypeWithLightViews[];
 };
 
 export type CreateMCPServerResponseBody = {

--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -14,9 +14,9 @@ import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction
 import { getMCPConnectionAccessToken } from "@app/lib/actions/mcp_oauth_access_token";
 import type {
   MCPServerType,
-  MCPServerTypeWithViews,
+  MCPServerTypeWithLightViews,
+  MCPServerViewInServerListType,
   MCPServerViewNameConflict,
-  MCPServerViewType,
   MCPToolType,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
@@ -40,7 +40,7 @@ type CustomHeader = { key: string; value: string };
 
 export async function listMCPServersWithViews(
   auth: Authenticator
-): Promise<MCPServerTypeWithViews[]> {
+): Promise<MCPServerTypeWithLightViews[]> {
   const [remoteMCPs, internalMCPs] = await Promise.all([
     RemoteMCPServerResource.listByWorkspace(auth, {
       includeHeavyAttributes: [
@@ -73,10 +73,10 @@ export async function listMCPServersWithViews(
     }
   );
 
-  const viewsByServerId = new Map<string, MCPServerViewType[]>();
+  const viewsByServerId = new Map<string, MCPServerViewInServerListType[]>();
   for (const view of allViews) {
     const existing = viewsByServerId.get(view.mcpServerId) ?? [];
-    existing.push(view.toJSON());
+    existing.push(view.toJSONForServerList());
     viewsByServerId.set(view.mcpServerId, existing);
   }
 

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -29,6 +29,7 @@ import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/
 import type {
   MCPServerLightType,
   MCPServerType,
+  MCPServerViewInServerListType,
   MCPServerViewLightType,
   MCPServerViewType,
   MCPToolType,
@@ -1866,6 +1867,14 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         enabled: t.enabled,
       })),
     };
+  }
+
+  toJSONForServerList(): MCPServerViewInServerListType {
+    const { server, ...rest } = this.toJSON();
+    const { tools, ...serverWithoutTools } = server;
+    void tools;
+
+    return { ...rest, server: serverWithoutTools };
   }
 
   /**


### PR DESCRIPTION
## Description

`GET /api/w/:wId/mcp` embedded a full copy of each server, tools included, in every one of its
views. Auto internal servers have two views, so each tool schema shipped three times: 2.17MB ->
0.80MB with all internal servers installed. Nested views now omit `tools` via
`toJSONForServerList()`; they keep their own `authorization` override. `/mcp/:serverId` still
returns full views, which is what `CapabilityDetailsSheets` resolves on open.

The system space Tools page also fetched `/spaces/:spaceId/mcp_views` (3.15s p50) only to resolve
the detail sheet's view — a subset of the `/mcp` response it already loads. It now derives that
from `useMCPServers` under the same SWR key. Loading state is a skeleton so the header, Add Tools
button and column headers render before `/mcp` lands.

## Tests

Typecheck clean on `front` and `front-api`. Not run: `front-api/routes/w/[wId]/mcp/*` tests, no
local redis. Needs a manual pass on the system space Tools page — list, detail sheet tools tab,
add/remove from space.

## Risk

Private-API field removal (`views[].server.tools` on the list endpoint). Checked every reader;
none consumed it, but a stale browser tab would read `undefined` there. Rollback is a revert.

## Deploy Plan

Standard. No migration.