### PR TITLE
Avoid large system key permission queries

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -957,6 +957,11 @@ export class Authenticator {
       ? allGroups.map((g) => g.id)
       : [];
     const keyGroupModelIds = allGroups.map((g) => g.id);
+    // Unscoped system keys represent nearly every group in their workspace. Resolve their grants
+    // from the workspace grant set so large workspaces do not send thousands of group ids to
+    // Postgres on every request. Explicitly scoped system keys keep the group-id query.
+    const scanWorkspacePermissions =
+      key.isSystem && requestedGroupIds === undefined;
 
     let permissions: GroupPermissions;
     let keyPermissions: GroupPermissions;
@@ -966,6 +971,7 @@ export class Authenticator {
       permissions = await this.resolvePermissions({
         workspace,
         groupModelIds: workspaceGroupModelIds,
+        scanWorkspacePermissions,
       });
       keyPermissions = permissions;
     } else {
@@ -973,10 +979,12 @@ export class Authenticator {
         this.resolvePermissions({
           workspace,
           groupModelIds: workspaceGroupModelIds,
+          scanWorkspacePermissions,
         }),
         this.resolvePermissions({
           workspace: keyWorkspace,
           groupModelIds: keyGroupModelIds,
+          scanWorkspacePermissions,
         }),
       ]);
     }
@@ -1281,18 +1289,25 @@ export class Authenticator {
   static async resolvePermissions({
     workspace,
     groupModelIds,
+    scanWorkspacePermissions = false,
   }: {
     workspace?: WorkspaceResource | null;
     groupModelIds: ModelId[];
+    scanWorkspacePermissions?: boolean;
   }): Promise<GroupPermissions> {
     if (!workspace) {
       return GroupPermissions.empty();
     }
 
-    const grants = await GroupPermissionResource.listForGroups(
-      renderLightWorkspaceType({ workspace }),
-      { groupModelIds }
-    );
+    const lightWorkspace = renderLightWorkspaceType({ workspace });
+    const grants = scanWorkspacePermissions
+      ? await GroupPermissionResource.listForGroupsFromWorkspaceScan(
+          lightWorkspace,
+          groupModelIds
+        )
+      : await GroupPermissionResource.listForGroups(lightWorkspace, {
+          groupModelIds,
+        });
 
     return GroupPermissions.fromGrants(grants);
   }

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -2,11 +2,12 @@ import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { emptyWorkspacePermissions } from "@app/types/group_permissions";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const CAPABILITY = { grantType: "create", resourceType: "agent" } as const;
 const RESOURCE_TYPE = "agent";
@@ -221,5 +222,94 @@ describe("Authenticator.fromJSON", () => {
     expect(await restored.hasWorkspacePermission("publish", "agent")).toBe(
       true
     );
+  });
+});
+
+describe("Authenticator.fromKey permission resolution", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses a workspace grant scan for unscoped system keys", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const { systemGroup } = await GroupFactory.defaults(workspace);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const includedGroup = await GroupFactory.regularManual(
+      workspace,
+      "included"
+    );
+    const excludedGroup = await GroupResource.makeNew({
+      name: "excluded",
+      kind: "agent_editors",
+      workspaceId: workspace.id,
+    });
+    await GroupPermissionResource.grant(adminAuth, {
+      group: includedGroup,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: 42,
+    });
+    await GroupPermissionResource.grant(adminAuth, {
+      group: excludedGroup,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: 42,
+    });
+
+    const workspaceScanSpy = vi.spyOn(
+      GroupPermissionResource,
+      "listForGroupsFromWorkspaceScan"
+    );
+    const key = await KeyFactory.system(systemGroup);
+    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
+
+    expect(workspaceScanSpy).toHaveBeenCalledTimes(1);
+    expect(
+      workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
+    ).toEqual([includedGroup.id]);
+  });
+
+  it("keeps explicitly scoped system keys on the group-id lookup", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const { systemGroup } = await GroupFactory.defaults(workspace);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const includedGroup = await GroupFactory.regularManual(
+      workspace,
+      "included"
+    );
+    const excludedGroup = await GroupFactory.regularManual(
+      workspace,
+      "excluded"
+    );
+    await GroupPermissionResource.grant(adminAuth, {
+      group: includedGroup,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: 42,
+    });
+    await GroupPermissionResource.grant(adminAuth, {
+      group: excludedGroup,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: 42,
+    });
+
+    const workspaceScanSpy = vi.spyOn(
+      GroupPermissionResource,
+      "listForGroupsFromWorkspaceScan"
+    );
+    const key = await KeyFactory.system(systemGroup);
+    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId, [
+      includedGroup.sId,
+    ]);
+
+    expect(workspaceScanSpy).not.toHaveBeenCalled();
+    expect(
+      workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
+    ).toEqual([includedGroup.id]);
   });
 });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -419,6 +419,29 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     return rows.map((row) => new this(GroupPermissionModel, row.get()));
   }
 
+  // System keys can represent nearly every group in a workspace. Expanding those group ids into
+  // an IN clause on every authenticated request is much more expensive than reading the usually
+  // small workspace grant set through its workspace-leading index and filtering it in memory.
+  // Keep the exact caller group semantics by intersecting with the ids already resolved for the
+  // Authenticator.
+  static async listForGroupsFromWorkspaceScan(
+    workspace: LightWorkspaceType,
+    groupModelIds: ModelId[]
+  ): Promise<GroupPermissionResource[]> {
+    if (groupModelIds.length === 0) {
+      return [];
+    }
+
+    const groupModelIdSet = new Set(groupModelIds);
+    const rows = await GroupPermissionModel.findAll({
+      where: { workspaceId: workspace.id },
+    });
+
+    return rows
+      .filter((row) => groupModelIdSet.has(row.groupId))
+      .map((row) => new this(GroupPermissionModel, row.get()));
+  }
+
   // Deletion-integrity hook: drop every grant (across all groups) targeting one resource. There is
   // no FK on the resource side, so callers invoke this when a resource is deleted. Guards against
   // wiping the type-wide wildcard rows.


### PR DESCRIPTION
## Description

Unscoped system keys currently expand every workspace group into the `group_permissions` query. One production workspace sends 8,181 group IDs on every connector request even though it has 182 permission rows.

Read the workspace grant set through the existing `workspaceId` index, then intersect it with the system key's resolved group IDs in memory. Explicitly scoped system keys and regular keys keep the existing group-ID query.

## Tests

Added database-backed coverage for unscoped system keys and explicitly scoped system keys.

## Risk

Low. The returned permission set is unchanged. Unscoped system keys trade a large SQL `IN` clause for a workspace grant scan, so workspaces with unusually large grant tables may return more rows before filtering.

## Deploy Plan

Standard deploy. Monitor US front DB CPU and the `group_permissions` Query Insights family after rollout.