### PR TITLE
Reuse MCP actions during consumption indexing

### DIFF
--- a/front/lib/analytics/agent_message_consumption/index.ts
+++ b/front/lib/analytics/agent_message_consumption/index.ts
@@ -3,6 +3,7 @@ import { loadAgentMessageConsumptionAnalyticsInput } from "@app/lib/analytics/ag
 import { upsertAgentMessageConsumptionAnalyticsDocuments } from "@app/lib/analytics/agent_message_consumption/store";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import assert from "assert";
@@ -14,10 +15,17 @@ import assert from "assert";
  */
 export async function indexAgentMessageConsumptionAnalytics(
   auth: Authenticator,
-  { agentMessageId }: { agentMessageId: string }
+  {
+    agentMessageId,
+    preloadedActions,
+  }: {
+    agentMessageId: string;
+    preloadedActions?: AgentMCPActionResource[];
+  }
 ): Promise<Result<void, ElasticsearchError>> {
   const input = await loadAgentMessageConsumptionAnalyticsInput(auth, {
     agentMessageId,
+    preloadedActions,
   });
   if (!input) {
     return new Ok(undefined);

--- a/front/lib/analytics/agent_message_consumption/index.ts
+++ b/front/lib/analytics/agent_message_consumption/index.ts
@@ -10,8 +10,8 @@ import assert from "assert";
 
 /**
  * Loads, projects, and indexes the complete consumption analytics snapshot for one agent message.
- * Callers only identify the message. This module owns the ordering and completeness requirements
- * of the indexed snapshot.
+ * The attribution activity may reuse its already-loaded action snapshot; this module still owns
+ * the ordering, projection, and completeness requirements of the indexed snapshot.
  */
 export async function indexAgentMessageConsumptionAnalytics(
   auth: Authenticator,

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -165,7 +165,13 @@ async function loadAnalyticsUser({
 
 export async function loadAgentMessageConsumptionAnalyticsInput(
   auth: Authenticator,
-  { agentMessageId }: { agentMessageId: string }
+  {
+    agentMessageId,
+    preloadedActions,
+  }: {
+    agentMessageId: string;
+    preloadedActions?: AgentMCPActionResource[];
+  }
 ): Promise<AgentMessageConsumptionAnalyticsInput | null> {
   const workspace = auth.getNonNullableWorkspace();
   const context =
@@ -224,9 +230,11 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
       agentMessageModelIds: [agentMessage.agentMessageModelId],
       maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
     });
-  const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
-    agentMessage.agentMessageModelId,
-  ]);
+  const actions =
+    preloadedActions ??
+    (await AgentMCPActionResource.listByAgentMessageIds(auth, [
+      agentMessage.agentMessageModelId,
+    ]));
   const actionsWithOutputs =
     await AgentMCPActionResource.enrichActionsWithOutputItems(auth, {
       actions,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -452,13 +452,18 @@ async function persistMessageConsumptionAttribution(
  * becomes terminal without another reported model run, that footprint is removed in place: the
  * result was produced, but never consumed.
  */
-export async function computeAndStoreAgentMessageConsumptionAttribution(
+export interface AgentMessageConsumptionAttributionComputation {
+  actions?: AgentMCPActionResource[];
+  consumptionUpdate?: { costCredits: number | null };
+}
+
+async function computeAndStoreAgentMessageConsumptionAttributionComputation(
   auth: Authenticator,
   {
     agentMessageId,
     conversationId,
   }: { agentMessageId: string; conversationId: string }
-): Promise<{ costCredits: number | null } | undefined> {
+): Promise<AgentMessageConsumptionAttributionComputation> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
 
   const creditContext =
@@ -470,7 +475,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
       { workspaceId, agentMessageId },
       "[ConsumptionAttribution] Agent message not found."
     );
-    return;
+    return {};
   }
 
   const {
@@ -484,12 +489,12 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
   // Attribution only explains what was billed, so it mirrors the billing status gate: an untracked
   // status has no charge to compose.
   if (!AGENT_MESSAGE_STATUSES_TO_TRACK.includes(status)) {
-    return;
+    return {};
   }
 
   const dustRunIds = [...new Set(runIds ?? [])];
   if (dustRunIds.length === 0) {
-    return;
+    return {};
   }
 
   const conversation = await ConversationResource.fetchById(
@@ -505,7 +510,7 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
       { workspaceId, agentMessageId, conversationId },
       "[ConsumptionAttribution] Conversation not found."
     );
-    return;
+    return {};
   }
 
   // Every usage is reached through this message's own runIds, so each one belongs to this message.
@@ -612,5 +617,37 @@ export async function computeAndStoreAgentMessageConsumptionAttribution(
     }
   );
 
-  return hasCompleteAllocation ? { costCredits: billedCredits } : undefined;
+  return {
+    actions,
+    consumptionUpdate: hasCompleteAllocation
+      ? { costCredits: billedCredits }
+      : undefined,
+  };
+}
+
+export async function computeAndStoreAgentMessageConsumptionAttribution(
+  auth: Authenticator,
+  message: { agentMessageId: string; conversationId: string }
+): Promise<{ costCredits: number | null } | undefined> {
+  const { consumptionUpdate } =
+    await computeAndStoreAgentMessageConsumptionAttributionComputation(
+      auth,
+      message
+    );
+
+  return consumptionUpdate;
+}
+
+/**
+ * Returns the action snapshot loaded for attribution so the immediately following analytics index
+ * can reuse it instead of querying the same rows again.
+ */
+export async function computeAndStoreAgentMessageConsumptionAttributionForAnalytics(
+  auth: Authenticator,
+  message: { agentMessageId: string; conversationId: string }
+): Promise<AgentMessageConsumptionAttributionComputation> {
+  return computeAndStoreAgentMessageConsumptionAttributionComputation(
+    auth,
+    message
+  );
 }

--- a/front/temporal/analytics_queue/activities/consumption_attribution.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_attribution.test.ts
@@ -1,9 +1,13 @@
 import { indexAgentMessageConsumptionAnalytics } from "@app/lib/analytics/agent_message_consumption";
-import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
+import {
+  computeAndStoreAgentMessageConsumptionAttribution,
+  computeAndStoreAgentMessageConsumptionAttributionForAnalytics,
+} from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import {
   storeAgentMessageConsumptionAnalyticsActivity,
   storeAgentMessageConsumptionAttributionForMessageActivity,
@@ -25,7 +29,10 @@ vi.mock(
 
 vi.mock(
   "@app/lib/api/assistant/agent_message_consumption_attribution/store",
-  () => ({ computeAndStoreAgentMessageConsumptionAttribution: vi.fn() })
+  () => ({
+    computeAndStoreAgentMessageConsumptionAttribution: vi.fn(),
+    computeAndStoreAgentMessageConsumptionAttributionForAnalytics: vi.fn(),
+  })
 );
 
 vi.mock("@app/lib/api/assistant/streaming/events", () => ({
@@ -87,9 +94,10 @@ describe("storeAgentMessageConsumptionAnalyticsActivity", () => {
   });
 
   it("completes when indexing succeeds", async () => {
+    const actions: AgentMCPActionResource[] = [];
     vi.mocked(
-      computeAndStoreAgentMessageConsumptionAttribution
-    ).mockResolvedValue(undefined);
+      computeAndStoreAgentMessageConsumptionAttributionForAnalytics
+    ).mockResolvedValue({ actions });
     vi.mocked(indexAgentMessageConsumptionAnalytics).mockResolvedValue(
       new Ok(undefined)
     );
@@ -101,11 +109,18 @@ describe("storeAgentMessageConsumptionAnalyticsActivity", () => {
     ).resolves.toBeUndefined();
 
     expect(
-      computeAndStoreAgentMessageConsumptionAttribution
+      computeAndStoreAgentMessageConsumptionAttributionForAnalytics
     ).toHaveBeenCalledWith(expect.anything(), message);
+    expect(indexAgentMessageConsumptionAnalytics).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        agentMessageId: message.agentMessageId,
+        preloadedActions: actions,
+      }
+    );
     expect(
-      vi.mocked(computeAndStoreAgentMessageConsumptionAttribution).mock
-        .invocationCallOrder[0]
+      vi.mocked(computeAndStoreAgentMessageConsumptionAttributionForAnalytics)
+        .mock.invocationCallOrder[0]
     ).toBeLessThan(
       vi.mocked(indexAgentMessageConsumptionAnalytics).mock
         .invocationCallOrder[0]
@@ -114,6 +129,9 @@ describe("storeAgentMessageConsumptionAnalyticsActivity", () => {
 
   it("throws the Elasticsearch error so Temporal retries the activity", async () => {
     const error = new ElasticsearchError("query_error", "invalid mapping", 400);
+    vi.mocked(
+      computeAndStoreAgentMessageConsumptionAttributionForAnalytics
+    ).mockResolvedValue({});
     vi.mocked(indexAgentMessageConsumptionAnalytics).mockResolvedValue(
       new Err(error)
     );

--- a/front/temporal/analytics_queue/activities/consumption_attribution.ts
+++ b/front/temporal/analytics_queue/activities/consumption_attribution.ts
@@ -1,5 +1,8 @@
 import { indexAgentMessageConsumptionAnalytics } from "@app/lib/analytics/agent_message_consumption";
-import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
+import {
+  computeAndStoreAgentMessageConsumptionAttribution,
+  computeAndStoreAgentMessageConsumptionAttributionForAnalytics,
+} from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
@@ -45,10 +48,15 @@ export async function storeAgentMessageConsumptionAnalyticsActivity(
 
   // TEMPORARY: activity 2 retries independently, so workflows already stuck here will not rerun
   // their completed attribution activity. Recompute until that retry backlog has drained.
-  await computeAndStoreAgentMessageConsumptionAttribution(auth, message);
+  const { actions } =
+    await computeAndStoreAgentMessageConsumptionAttributionForAnalytics(
+      auth,
+      message
+    );
 
   const result = await indexAgentMessageConsumptionAnalytics(auth, {
     agentMessageId: message.agentMessageId,
+    preloadedActions: actions,
   });
 
   if (result.isErr()) {


### PR DESCRIPTION
## Description

Query Insights fingerprint `16697422976372582740` is running about 1.6k to 3.2k times per minute at 15 to 20 ms average latency, accounting for roughly 266 CPU-seconds per five minutes.

The retry-safe consumption analytics activity recomputes attribution, then indexing immediately reloads the same full `agent_mcp_actions` rows. Return the action snapshot from attribution and pass it into indexing instead. This removes one full-row query per normal v3 pass and one per indexing retry. The v3 path goes from three executions to two on a normal pass, and from two to one on an indexing retry.

## Tests

Updated the activity test to verify that indexing receives the exact action snapshot loaded during attribution. Ran the focused test locally, 4 tests passed.

## Risk

Low. Reuse is limited to two consecutive operations in the same activity. No Temporal workflow or activity name, signature, queue, or retry policy changes. Callers without a preloaded snapshot keep the existing fetch behavior. Rollback restores the redundant read.

## Deploy Plan

Standard deploy. Watch Query Insights fingerprint `16697422976372582740`, analytics activity failures, and the consumption attribution backlog after rollout.