### PR TITLE
Optimize conversation message fetch payload

### DIFF
--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -57,6 +57,68 @@ type MessageTypeForView<V extends "light" | "full"> = V extends "light"
     ? MessageType
     : never;
 
+// Keep the hot conversation fetch from hydrating subtype columns that message rendering never
+// reads. In particular, agent and compaction runIds can grow over a message's lifetime.
+const USER_MESSAGE_RENDER_ATTRIBUTES: Array<keyof UserMessageModel> = [
+  "id",
+  "content",
+  "clientSideMCPServerIds",
+  "userContextUsername",
+  "userContextTimezone",
+  "userContextFullName",
+  "userContextEmail",
+  "userContextProfilePictureUrl",
+  "userContextOrigin",
+  "userContextLastTriggerRunAt",
+  "agenticMessageType",
+  "agenticOriginMessageId",
+  "requestedProviderId",
+  "requestedModelId",
+  "requestedReasoningEffort",
+  "userId",
+];
+
+const AGENT_MESSAGE_RENDER_ATTRIBUTES: Array<keyof AgentMessageModel> = [
+  "id",
+  "status",
+  "errorCode",
+  "errorMessage",
+  "errorMetadata",
+  "skipToolsValidation",
+  "agentConfigurationId",
+  "modelInteractionDurationMs",
+  "completedAt",
+  "prunedContext",
+  "costCredits",
+  "resolvedProviderId",
+  "resolvedModelId",
+  "resolvedReasoningEffort",
+  "modelResolutionMethod",
+];
+
+const CONTENT_FRAGMENT_RENDER_ATTRIBUTES: Array<keyof ContentFragmentModel> = [
+  "id",
+  "sId",
+  "title",
+  "contentType",
+  "sourceUrl",
+  "textBytes",
+  "userContextUsername",
+  "userContextFullName",
+  "userContextEmail",
+  "userContextProfilePictureUrl",
+  "fileId",
+  "nodeId",
+  "nodeDataSourceViewId",
+  "nodeType",
+  "version",
+  "expiredReason",
+];
+
+const COMPACTION_MESSAGE_RENDER_ATTRIBUTES: Array<
+  keyof CompactionMessageModel
+> = ["id", "sourceConversationId", "status", "content"];
+
 export const getConversation = async (
   auth: Authenticator,
   conversationId: string,
@@ -198,12 +260,14 @@ async function _getConversation<V extends "light" | "full">(
         {
           model: UserMessageModel,
           as: "userMessage",
+          attributes: USER_MESSAGE_RENDER_ATTRIBUTES,
           required: false,
           where: sideTableWhere,
         },
         {
           model: AgentMessageModel,
           as: "agentMessage",
+          attributes: AGENT_MESSAGE_RENDER_ATTRIBUTES,
           required: false,
           where: sideTableWhere,
         },
@@ -213,12 +277,14 @@ async function _getConversation<V extends "light" | "full">(
         {
           model: ContentFragmentModel,
           as: "contentFragment",
+          attributes: CONTENT_FRAGMENT_RENDER_ATTRIBUTES,
           required: false,
           where: sideTableWhere,
         },
         {
           model: CompactionMessageModel,
           as: "compactionMessage",
+          attributes: COMPACTION_MESSAGE_RENDER_ATTRIBUTES,
           required: false,
           where: sideTableWhere,
         },


### PR DESCRIPTION
## Description

Query Insights fingerprint `8238549108092761451` executed about 0.8k to 2.3k times per minute at 18 to 24 ms average latency, accounting for roughly 124 CPU-seconds per five minutes during the incident.

Tracing the full SQL showed that it comes from the non-paginated `getConversation` path, not `fetchAgentMessageConsumptionAnalyticsContext`. The query preserves the existing conversation-scoped indexed joins but currently selects every column from `user_messages`, `agent_messages`, `content_fragments`, and `compaction_messages`.

This change limits each joined subtype to the fields consumed by message rendering. It avoids transferring and hydrating unused timestamps, tenancy columns, metadata, and growing `runIds` arrays while preserving joins, ordering, and rendered conversation output.

## Tests

- `NODE_ENV=test npm test -- lib/api/assistant/conversation/fetch.test.ts` (5 tests)
- `NODE_ENV=test npm test -- lib/api/assistant/conversation.test.ts` (84 tests)
- `npm run tsgo -- --noEmit`
- `npx biome check --error-on-warnings front/lib/api/assistant/conversation/fetch.ts`

## Risk

Risk is limited to accidentally omitting a subtype field needed by rendering. The full conversation suite exercises user, agent, content-fragment, and compaction rendering and passes. The change is safe to roll back by reverting this commit, which restores the previous full-column projection without a schema or data migration.

## Deploy Plan

- [ ] Deploy through the standard front production rollout.
- [ ] After deployment, identify the replacement SQL fingerprint in GCP Query Insights. The fingerprint changes because the selected column list changes.
- [ ] Compare its CPU time, average latency, execution rate, and rows returned against fingerprint `8238549108092761451`.
- [ ] If conversation rendering errors increase or database performance regresses, revert the commit and redeploy.
