### PR TITLE
[Activation] Add usefulness on activation recommendations

### DIFF
--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -17,6 +17,17 @@ export type ActivationRecommendationStatus =
   | "executed"
   | "dismissed";
 
+// Post-execution answer from Step 7. Independent of `status`.
+// "feedback" is the Provide Feedback option — not a usefulness rating.
+export const ACTIVATION_RECOMMENDATION_USEFULNESS = [
+  "useful",
+  "not_useful",
+  "feedback",
+] as const;
+
+export type ActivationRecommendationUsefulness =
+  (typeof ACTIVATION_RECOMMENDATION_USEFULNESS)[number];
+
 export class ActivationRecommendationModel extends WorkspaceAwareModel<ActivationRecommendationModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
@@ -32,8 +43,8 @@ export class ActivationRecommendationModel extends WorkspaceAwareModel<Activatio
   declare ctaLabel: string | null;
   declare sourceIcon: string | null;
   declare sourceLabel: string | null;
-  // Set after the user answers Useful / Not Useful on an executed recommendation.
-  declare isUseful: boolean | null;
+  // Set after the user answers Useful / Not Useful / Provide Feedback.
+  declare usefulness: ActivationRecommendationUsefulness | null;
 
   // The conversation in which the recommendation was (originally) made
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
@@ -96,8 +107,8 @@ ActivationRecommendationModel.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
-    isUseful: {
-      type: DataTypes.BOOLEAN,
+    usefulness: {
+      type: DataTypes.STRING,
       allowNull: true,
     },
     conversationId: {

--- a/front/lib/models/activation/activation_recommendation.ts
+++ b/front/lib/models/activation/activation_recommendation.ts
@@ -32,6 +32,8 @@ export class ActivationRecommendationModel extends WorkspaceAwareModel<Activatio
   declare ctaLabel: string | null;
   declare sourceIcon: string | null;
   declare sourceLabel: string | null;
+  // Set after the user answers Useful / Not Useful on an executed recommendation.
+  declare isUseful: boolean | null;
 
   // The conversation in which the recommendation was (originally) made
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
@@ -92,6 +94,10 @@ ActivationRecommendationModel.init(
     },
     sourceLabel: {
       type: DataTypes.STRING,
+      allowNull: true,
+    },
+    isUseful: {
+      type: DataTypes.BOOLEAN,
       allowNull: true,
     },
     conversationId: {

--- a/front/migrations/pre-deploy/20260813103545_add_is_useful_to_activation_recommendations.sql
+++ b/front/migrations/pre-deploy/20260813103545_add_is_useful_to_activation_recommendations.sql
@@ -1,0 +1,8 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+
+ALTER TABLE "public"."activation_recommendations"
+  ADD COLUMN IF NOT EXISTS "isUseful" boolean;

--- a/front/migrations/pre-deploy/20260813103545_add_usefulness_to_activation_recommendations.sql
+++ b/front/migrations/pre-deploy/20260813103545_add_usefulness_to_activation_recommendations.sql
@@ -5,4 +5,4 @@ SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;
 
 ALTER TABLE "public"."activation_recommendations"
-  ADD COLUMN IF NOT EXISTS "isUseful" boolean;
+  ADD COLUMN IF NOT EXISTS "usefulness" character varying(255);


### PR DESCRIPTION
## Summary
- Add a nullable `usefulness` column on `activation_recommendations`: `'useful' | 'not_useful' | 'feedback'`.
- Maps to the post-execution Step 7 choices (Useful / Not Useful / Provide Feedback). `null` means unanswered; `feedback` is the third option, not a free-text field.
- Pre-deploy migration only (`ADD COLUMN IF NOT EXISTS`). No backfill.

Wiring to persist the rating is intentionally not in this PR so the schema can land first.

## Test plan
- [ ] Confirm the pre-deploy migration applies cleanly (`npm run migration:apply:pre-deploy` in `front`)
- [ ] Confirm existing recommendation create/list/update paths still work with `usefulness` left null