### PR TITLE
[front] enh: show skill avatars in attribution rows (new analytics)

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -162,18 +162,25 @@ function buildColumns({
       meta: { sizeRatio: 32, headerAlign: "left" },
       cell: (info) => {
         const row = info.row.original;
-        const { name, pictureUrl, description } = row;
-        const content = hasAvatar ? (
-          <div className="min-w-0">
-            <AvatarNameCell
-              name={name}
-              imageUrl={pictureUrl}
-              isRounded={isAvatarRounded}
-            />
-          </div>
-        ) : (
-          <span className="truncate text-sm">{name}</span>
-        );
+        const { name, pictureUrl, description, icon } = row;
+        const SkillAvatar = getSkillAvatarIcon(icon);
+        const content =
+          dimension === "skill" ? (
+            <div className="flex min-w-0 items-center gap-2">
+              <SkillAvatar name={name} size="xs" />
+              <span className="truncate text-sm">{name}</span>
+            </div>
+          ) : hasAvatar ? (
+            <div className="min-w-0">
+              <AvatarNameCell
+                name={name}
+                imageUrl={pictureUrl}
+                isRounded={isAvatarRounded}
+              />
+            </div>
+          ) : (
+            <span className="truncate text-sm">{name}</span>
+          );
 
         return (
           <DataTable.CellContent className="w-full justify-start text-left">

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -62,7 +62,7 @@ export const CONSUMPTION_DIMENSION_CONFIG: Record<
   skill: {
     label: "Skills",
     breakdownLabel: "skill",
-    hasAvatar: false,
+    hasAvatar: true,
     avgLabel: INVOCATION_AVG_LABEL,
   },
   source: {


### PR DESCRIPTION
## Description

Skill rows in the attribution table of the new analytics currently show only the skill name.
This PR adds the skill avatar alongside the name, similarly to agents.

The loading skeleton was also updated to reserve space for the avatar.

<img width="1040" height="998" alt="image" src="https://github.com/user-attachments/assets/b52a700a-3ee8-4966-8d1f-42fd246541bf" />

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
