### PR TITLE
Optimize latest agent configuration lookup

### DIFF
--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -4,6 +4,7 @@ import {
   createAgentConfiguration,
   createPendingAgentConfiguration,
   getAgentConfiguration,
+  getAgentConfigurations,
   restoreAgentConfiguration,
   updateAgentConfigurationsScope,
 } from "@app/lib/api/assistant/configuration/agent";
@@ -31,6 +32,48 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WakeUpFactory } from "@app/tests/utils/WakeUpFactory";
 import { Err, Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
+
+describe("getAgentConfigurations", () => {
+  it("returns only the latest version of each requested agent", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const firstAgent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const secondAgent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Second agent" }
+    );
+
+    await AgentConfigurationFactory.updateTestAgent(
+      authenticator,
+      firstAgent.sId
+    );
+    const latestFirstAgent = await AgentConfigurationFactory.updateTestAgent(
+      authenticator,
+      firstAgent.sId
+    );
+    const latestSecondAgent = await AgentConfigurationFactory.updateTestAgent(
+      authenticator,
+      secondAgent.sId,
+      { name: "Second agent" }
+    );
+
+    const agents = await getAgentConfigurations(authenticator, {
+      agentIds: [
+        firstAgent.sId,
+        secondAgent.sId,
+        firstAgent.sId,
+        generateRandomModelSId(),
+      ],
+      variant: "light",
+      dangerouslySkipPermissionFiltering: true,
+    });
+
+    expect(agents.map(({ sId, version }) => ({ sId, version }))).toEqual([
+      { sId: latestFirstAgent.sId, version: latestFirstAgent.version },
+      { sId: latestSecondAgent.sId, version: latestSecondAgent.version },
+    ]);
+  });
+});
 
 describe("createAgentConfiguration with pending agent", () => {
   it("converts pending agent to active when agentConfigurationId points to a pending agent", async () => {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -253,27 +253,33 @@ async function fetchLatestWorkspaceAgentModels(
   if (workspaceAgentIds.length === 0) {
     return [];
   }
-  // Use window function for optimal performance - single query, single pass
+
+  // Agent sIds are globally unique (every agent starts at version 0, and
+  // (sId, version) is unique). Resolve the latest model id through that index
+  // first, then enforce workspace isolation while loading the model row. This
+  // avoids sorting every historical version of heavily edited agents.
   const query = `
-    SELECT *
+    SELECT agent_configuration.*
     FROM (
-      SELECT *,
-              ROW_NUMBER() OVER (
-                PARTITION BY "sId"
-                ORDER BY version DESC
-              ) as rn
+      SELECT DISTINCT unnest($agentIds::text[]) AS "sId"
+    ) requested_agent
+    JOIN LATERAL (
+      SELECT id
       FROM agent_configurations
-      WHERE "workspaceId" = :workspaceId
-        AND "sId" IN (:agentIds)
-    ) ranked_agents
-    WHERE rn = 1
-    ORDER BY version DESC
+      WHERE "sId" = requested_agent."sId"
+      ORDER BY version DESC
+      LIMIT 1
+    ) latest_agent ON true
+    JOIN agent_configurations AS agent_configuration
+      ON agent_configuration.id = latest_agent.id
+      AND agent_configuration."workspaceId" = $workspaceId
+    ORDER BY agent_configuration.version DESC
   `;
 
   return (
     (await AgentConfigurationModel.sequelize?.query(query, {
       type: QueryTypes.SELECT,
-      replacements: {
+      bind: {
         workspaceId: auth.getNonNullableWorkspace().id,
         agentIds: workspaceAgentIds,
       },


### PR DESCRIPTION
## Description

Replace the window query used by `getAgentConfigurations` with one backward index probe per requested agent ID, followed by a workspace-scoped row load. The existing `(sId, version)` index serves the lookup, so no migration is needed.

In US Query Insights this fingerprint was running about 1.3k to 3.3k times per minute and consuming about 119 CPU-seconds per 5 minutes. On the production read replica, an agent with 2,355 versions made the old query sort all versions and spill 2.8 MiB to temp storage. The new shape returned the same row in 0.145 ms, versus 129 ms cold and 4 to 14 ms warm for the prior shapes.

## Tests

Added a regression test covering multiple versions, duplicate IDs, and a missing ID. The full configuration test file passes with 31 tests. Verified both query shapes with `EXPLAIN (ANALYZE, BUFFERS)` on the US production read replica.

## Risk

Low. The lookup relies on the existing globally unique agent ID invariant, then applies the workspace predicate when loading the selected model row. Rollback is a code revert with no schema or data change.

## Deploy Plan

Standard deploy. After rollout, verify Query Insights hash `1679070933274962595` drops in CPU time and latency without agent lookup errors. Revert if lookup errors increase.