### PR TITLE
[front] enh: show model and tool visuals in attribution rows

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -171,6 +171,7 @@ const TOP_TOOLS: GetConsumptionTopToolsResponse = {
     {
       serverName: "web_search_browse",
       name: "Web Search & Browse",
+      icon: "Globe01Icon",
       credits: 60,
       invocationCount: 12,
       avgCreditsPerInvocation: 5,

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -1,4 +1,9 @@
 import { getModelLogoByModelId } from "@app/components/providers/types";
+import {
+  getAvatarFromIcon,
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {
@@ -9,6 +14,7 @@ import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/constants";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
@@ -152,12 +158,14 @@ function buildColumns({
   isAvatarRounded,
   avgLabel,
   totalCredits,
+  isDark,
 }: {
   dimension: ConsumptionDimension;
   hasAvatar: boolean;
   isAvatarRounded: boolean;
   avgLabel: string;
   totalCredits: number;
+  isDark: boolean;
 }): ColumnDef<AttributionRowData>[] {
   return [
     {
@@ -167,18 +175,41 @@ function buildColumns({
       meta: { sizeRatio: 32, headerAlign: "left" },
       cell: (info) => {
         const row = info.row.original;
-        const { name, pictureUrl, description } = row;
-        const content = hasAvatar ? (
-          <div className="min-w-0">
-            <AvatarNameCell
-              name={name}
-              imageUrl={pictureUrl}
-              isRounded={isAvatarRounded}
-            />
-          </div>
-        ) : (
-          <span className="truncate text-sm">{name}</span>
-        );
+        const { name, pictureUrl, description, icon } = row;
+        const toolIcon =
+          icon &&
+          (isCustomResourceIconType(icon) || isInternalAllowedIcon(icon))
+            ? icon
+            : DEFAULT_MCP_SERVER_ICON;
+        const content =
+          dimension === "model" ? (
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="flex size-7 shrink-0 items-center justify-center">
+                <Icon
+                  visual={
+                    getModelLogoByModelId(row.id, isDark) ?? DustLogoSquare
+                  }
+                  size="sm"
+                />
+              </span>
+              <span className="truncate text-sm">{name}</span>
+            </div>
+          ) : dimension === "tool" ? (
+            <div className="flex min-w-0 items-center gap-2">
+              {getAvatarFromIcon(toolIcon, "xs")}
+              <span className="truncate text-sm">{name}</span>
+            </div>
+          ) : hasAvatar ? (
+            <div className="min-w-0">
+              <AvatarNameCell
+                name={name}
+                imageUrl={pictureUrl}
+                isRounded={isAvatarRounded}
+              />
+            </div>
+          ) : (
+            <span className="truncate text-sm">{name}</span>
+          );
 
         return (
           <DataTable.CellContent className="w-full justify-start text-left">
@@ -317,6 +348,7 @@ function AttributionRows({
   onViewAll,
 }: AttributionRowsProps) {
   const { hasAvatar, avgLabel } = CONSUMPTION_DIMENSION_CONFIG[dimension];
+  const { isDark } = useTheme();
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
   const shouldReduceMotion = useReducedMotion();
 
@@ -350,8 +382,9 @@ function AttributionRows({
         isAvatarRounded: dimension === "user",
         avgLabel,
         totalCredits,
+        isDark,
       }),
-    [hasAvatar, dimension, avgLabel, totalCredits]
+    [hasAvatar, dimension, avgLabel, totalCredits, isDark]
   );
 
   let contentKey = "content";

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -50,13 +50,13 @@ export const CONSUMPTION_DIMENSION_CONFIG: Record<
   model: {
     label: "Models",
     breakdownLabel: "model",
-    hasAvatar: false,
+    hasAvatar: true,
     avgLabel: MESSAGE_AVG_LABEL,
   },
   tool: {
     label: "Tools",
     breakdownLabel: "tool",
-    hasAvatar: false,
+    hasAvatar: true,
     avgLabel: INVOCATION_AVG_LABEL,
   },
   skill: {

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -109,7 +109,7 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
       name: row.name,
       pictureUrl: null,
       description: null,
-      icon: null,
+      icon: row.icon,
       modelId: null,
       modelDisplayName: null,
       credits: row.credits,

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -8,6 +8,7 @@ import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -135,6 +136,40 @@ describe("resolveDimensionLabels", () => {
       pictureUrl: null,
       description: "Researches a topic in depth",
       icon: skill.icon,
+    });
+  });
+
+  it("labels remote tools with their server icon", async () => {
+    const { authenticator } = await createResourceTest({ role: "manager" });
+    const workspace = authenticator.getNonNullableWorkspace();
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "CRM tools",
+      viewName: "Sales tools",
+    });
+
+    const labels = await resolveDimensionLabels(authenticator, "tool", [
+      "Sales tools",
+      "CRM tools",
+      server.sId,
+    ]);
+
+    expect(labels.get("Sales tools")).toEqual({
+      name: "Sales Tools",
+      pictureUrl: null,
+      description: null,
+      icon: server.icon,
+    });
+    expect(labels.get("CRM tools")).toEqual({
+      name: "CRM tools",
+      pictureUrl: null,
+      description: null,
+      icon: server.icon,
+    });
+    expect(labels.get(server.sId)).toEqual({
+      name: "CRM tools",
+      pictureUrl: null,
+      description: null,
+      icon: server.icon,
     });
   });
 

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -1,15 +1,21 @@
+import {
+  getInternalMCPServerIconByName,
+  isInternalMCPServerName,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
 import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
 import { getUserDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
-import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 
 /**
  * Resolve display names / labels (and pictureUrl where applicable)
@@ -34,7 +40,7 @@ export type DimensionLabel = {
   // Only agents have model metadata.
   modelId?: string;
   modelDisplayName?: string;
-  // Only skills have an icon.
+  // Only tools and skills have an icon.
   icon?: string | null;
 };
 
@@ -117,11 +123,26 @@ export async function resolveDimensionLabels(
       );
 
     case "tool": {
-      // The key is the MCP server name. Internal servers get their display name
-      // from the name itself; remote ones are keyed by sId and need a lookup.
-      const displayNames = await resolveServerDisplayNames(auth, keys);
-      return labelsFromNames(
-        new Map(keys.map((key) => [key, displayNames.get(key) || key]))
+      const [remoteMetadata, viewIcons] = await Promise.all([
+        RemoteMCPServerResource.resolveDisplayMetadataByIdentifiers(auth, keys),
+        MCPServerViewResource.resolveIconsByNames(auth, keys),
+      ]);
+      return new Map(
+        keys.map((key) => {
+          const remote = remoteMetadata.get(key);
+          const icon = isInternalMCPServerName(key)
+            ? getInternalMCPServerIconByName(key)
+            : (viewIcons.get(key) ?? remote?.icon ?? null);
+          return [
+            key,
+            {
+              name: remote?.name ?? asDisplayToolName(key),
+              pictureUrl: null,
+              description: null,
+              icon,
+            },
+          ];
+        })
       );
     }
 

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -156,7 +156,19 @@ describe("consumption top rankings", () => {
 
   it("counts tool invocations as documents, with no message sub-agg", async () => {
     const { auth } = await setup();
-    mockLabels({ web_search_browse: "Web Search & Browse" });
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(
+      new Map([
+        [
+          "web_search_browse",
+          {
+            name: "Web Search & Browse",
+            pictureUrl: null,
+            description: null,
+            icon: "Globe01Icon",
+          },
+        ],
+      ])
+    );
     mockAggs({
       buckets: [
         {
@@ -181,6 +193,7 @@ describe("consumption top rankings", () => {
       {
         serverName: "web_search_browse",
         name: "Web Search & Browse",
+        icon: "Globe01Icon",
         credits: 2,
         // 4 tool documents, one per call — not a message cardinality.
         invocationCount: 4,

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -25,6 +25,7 @@ export type ConsumptionTopToolRow = {
   // The MCP server name, which is also what the `tool` filter takes.
   serverName: string;
   name: string;
+  icon: string | null;
   credits: number;
   invocationCount: number;
   avgCreditsPerInvocation: number;
@@ -74,6 +75,7 @@ export async function fetchConsumptionTopTools(
     tools: groups.map((group) => ({
       serverName: group.key,
       name: labels.get(group.key)?.name ?? group.key,
+      icon: labels.get(group.key)?.icon ?? null,
       credits: group.credits,
       invocationCount: group.count,
       avgCreditsPerInvocation: avgCreditsPerUnit(group.credits, group.count),

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -697,6 +697,27 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
+  static async resolveIconsByNames(
+    auth: Authenticator,
+    names: string[]
+  ): Promise<Map<string, CustomResourceIconType | InternalAllowedIconType>> {
+    const uniqueNames = [...new Set(names)];
+    if (uniqueNames.length === 0) {
+      return new Map();
+    }
+
+    const views = await this.baseFetch(
+      auth,
+      { where: { name: { [Op.in]: uniqueNames } } },
+      { includeMetadata: false }
+    );
+    return new Map(
+      views.flatMap((view) =>
+        view.name ? [[view.name, view.getServerDisplayMetadata().icon]] : []
+      )
+    );
+  }
+
   static async listBySpaces(
     auth: Authenticator,
     spaces: SpaceResource[],

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -428,6 +428,59 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     return nameMap;
   }
 
+  static async resolveDisplayMetadataByIdentifiers(
+    auth: Authenticator,
+    identifiers: string[]
+  ): Promise<
+    Map<
+      string,
+      {
+        name: string;
+        icon: CustomResourceIconType | InternalAllowedIconType;
+      }
+    >
+  > {
+    const uniqueIdentifiers = [...new Set(identifiers)];
+    if (uniqueIdentifiers.length === 0) {
+      return new Map();
+    }
+
+    const remoteSIds = uniqueIdentifiers.filter((identifier) =>
+      isResourceSId("remote_mcp_server", identifier)
+    );
+    const names = uniqueIdentifiers.filter(
+      (identifier) => !isResourceSId("remote_mcp_server", identifier)
+    );
+    const modelIds = remoteSIds.map((sId) => getServerTypeAndIdFromSId(sId).id);
+    const servers = await this.baseFetch(auth, {
+      where: {
+        [Op.or]: [
+          ...(modelIds.length > 0 ? [{ id: { [Op.in]: modelIds } }] : []),
+          ...(names.length > 0 ? [{ cachedName: { [Op.in]: names } }] : []),
+        ],
+      },
+    });
+
+    const requestedIdentifiers = new Set(uniqueIdentifiers);
+    const metadata = new Map<
+      string,
+      {
+        name: string;
+        icon: CustomResourceIconType | InternalAllowedIconType;
+      }
+    >();
+    for (const server of servers) {
+      const value = { name: server.cachedName, icon: server.icon };
+      if (requestedIdentifiers.has(server.sId)) {
+        metadata.set(server.sId, value);
+      }
+      if (requestedIdentifiers.has(server.cachedName)) {
+        metadata.set(server.cachedName, value);
+      }
+    }
+    return metadata;
+  }
+
   static async listByWorkspace(
     auth: Authenticator,
     {

--- a/front/tests/utils/RemoteMCPServerFactory.ts
+++ b/front/tests/utils/RemoteMCPServerFactory.ts
@@ -16,6 +16,7 @@ export class RemoteMCPServerFactory {
       url?: string;
       description?: string;
       tools?: MCPToolType[];
+      viewName?: string;
     } = {}
   ) {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -40,6 +41,7 @@ export class RemoteMCPServerFactory {
       version: DEFAULT_MCP_ACTION_VERSION,
       authorization: null,
       oAuthUseCase: null,
+      viewName: options.viewName,
     });
   }
 }


### PR DESCRIPTION
## Description

Attribution table rows now show the same visual identity used elsewhere for models and tools. Models use the bare provider icon pattern from model pickers and filters, while tools use their MCP server avatar.

The top-tools response now resolves icons for internal servers, remote server names and IDs, and named server views using lookups bounded to the returned ranking keys. Unknown or deleted tools keep a default tool avatar.

## Tests

- Added coverage for remote tool icon resolution and updated top-tools response coverage.
- Covered by existing attribution table tests.

## Risk

- Low. Affects analytics attribution row rendering and adds icon metadata to the internal top-tools response.

## Deploy Plan

- Deploy front and front-api.