### PR TITLE
[front] feat: add search on attribution table

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
@@ -23,7 +23,8 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopAgentsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -34,6 +35,7 @@ app.post(
       period,
       limit,
       offset,
+      search,
       filter,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
@@ -23,7 +23,8 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopGroupsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -34,6 +35,7 @@ app.post(
       period,
       limit,
       offset,
+      search,
       filter,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
@@ -23,7 +23,8 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopModelsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -34,6 +35,7 @@ app.post(
       period,
       limit,
       offset,
+      search,
       filter,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
@@ -23,7 +23,8 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSkillsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -34,6 +35,7 @@ app.post(
       period,
       limit,
       offset,
+      search,
       filter,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
@@ -23,7 +23,8 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSourcesResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -34,6 +35,7 @@ app.post(
       period,
       limit,
       offset,
+      search,
       filter,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
@@ -23,7 +23,8 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopToolsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -34,6 +35,7 @@ app.post(
       period,
       limit,
       offset,
+      search,
       filter,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
@@ -23,7 +23,8 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopUsersResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -34,6 +35,7 @@ app.post(
       period,
       limit,
       offset,
+      search,
       filter,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -380,20 +380,6 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
     });
   });
 
-  it("returns 400 when the ranked page extends beyond the bucket cap", async () => {
-    const { workspace } = await setupTest();
-
-    const response = await postRankingRequest(workspace.sId, "top-agents", {
-      limit: 5,
-      offset: 996,
-    });
-
-    expect(response.status).toBe(400);
-    expect(await response.json()).toMatchObject({
-      error: { type: "invalid_request_error" },
-    });
-  });
-
   it("returns 500 when the search fails", async () => {
     vi.mocked(fetchConsumptionTopTools).mockResolvedValue(
       new Err(new ElasticsearchError("query_error", "boom"))

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -333,7 +333,7 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
 
     const response = await postRankingRequest(workspace.sId, "top-agents", {
       limit: 5,
-      offset: 25,
+      offset: 995,
       period: "days",
       days: 7,
       search: "  Agent 080  ",
@@ -345,7 +345,7 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
       expect.anything(),
       expect.objectContaining({
         limit: 5,
-        offset: 25,
+        offset: 995,
         search: "Agent 080",
         filter: { sources: ["slack"] },
       })
@@ -372,6 +372,20 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
 
     const response = await postRankingRequest(workspace.sId, "top-agents", {
       limit: 1000,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+  });
+
+  it("returns 400 when the ranked page extends beyond the bucket cap", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await postRankingRequest(workspace.sId, "top-agents", {
+      limit: 5,
+      offset: 996,
     });
 
     expect(response.status).toBe(400);

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -314,6 +314,7 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
       limit: 10,
       offset: 0,
       period: { startDate: expect.any(String), endDate: expect.any(String) },
+      search: undefined,
       filter: undefined,
     });
   });
@@ -326,7 +327,7 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
     expect(response.status).toBe(403);
   });
 
-  it("forwards the page, the period and the filter", async () => {
+  it("forwards the page, the period, the search and the filter", async () => {
     vi.mocked(fetchConsumptionTopAgents).mockResolvedValue(new Ok(TOP_AGENTS));
     const { workspace } = await setupTest();
 
@@ -335,6 +336,7 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
       offset: 25,
       period: "days",
       days: 7,
+      search: "  Agent 080  ",
       filter: { sources: ["slack"] },
     });
 
@@ -344,6 +346,7 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
       expect.objectContaining({
         limit: 5,
         offset: 25,
+        search: "Agent 080",
         filter: { sources: ["slack"] },
       })
     );

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -92,6 +92,59 @@ describe("ConsumptionAttributionTable", () => {
     });
   });
 
+  it("sends the search to the backend and renders a match beyond page one", async () => {
+    const firstPageRow = {
+      id: "agent-1",
+      name: "Agent 1",
+      pictureUrl: null,
+      description: null,
+      icon: null,
+      modelId: null,
+      modelDisplayName: null,
+      credits: 100,
+      avgCredits: 10,
+    };
+    const searchedRow = {
+      ...firstPageRow,
+      id: "agent-80",
+      name: "Pagination Agent 080",
+      credits: 1,
+    };
+    mockUseConsumptionTop.mockImplementation(
+      ({ search }: { search: string }) => ({
+        rows: search === "Agent 080" ? [searchedRow] : [firstPageRow],
+        totalCredits: 100,
+        totalCount: search === "Agent 080" ? 1 : 80,
+        hasMore: search !== "Agent 080",
+        isTopLoading: false,
+        isTopError: undefined,
+        isTopValidating: false,
+      })
+    );
+
+    render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search…"), {
+      target: { value: "Agent 080" },
+    });
+
+    await waitFor(() => {
+      expect(mockUseConsumptionTop).toHaveBeenCalledWith(
+        expect.objectContaining({ search: "Agent 080", offset: 0, limit: 25 })
+      );
+      expect(screen.getByText("Pagination Agent 080")).toBeInTheDocument();
+    });
+  });
+
   it("resets expanded rows when switching dimensions", () => {
     mockUseConsumptionTop.mockImplementation(
       ({ dimension }: { dimension: ConsumptionDimension }) => ({

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -95,35 +95,16 @@ describe("ConsumptionAttributionTable", () => {
     });
   });
 
-  it("sends the search to the backend and renders a match beyond page one", async () => {
-    const firstPageRow = {
-      id: "agent-1",
-      name: "Agent 1",
-      pictureUrl: null,
-      description: null,
-      icon: null,
-      modelId: null,
-      modelDisplayName: null,
-      credits: 100,
-      avgCredits: 10,
-    };
-    const searchedRow = {
-      ...firstPageRow,
-      id: "agent-80",
-      name: "Pagination Agent 080",
-      credits: 1,
-    };
-    mockUseConsumptionTop.mockImplementation(
-      ({ search }: { search: string }) => ({
-        rows: search === "Agent 080" ? [searchedRow] : [firstPageRow],
-        totalCredits: 100,
-        totalCount: search === "Agent 080" ? 1 : 80,
-        hasMore: search !== "Agent 080",
-        isTopLoading: false,
-        isTopError: undefined,
-        isTopValidating: false,
-      })
-    );
+  it("sends the search to the backend", async () => {
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [],
+      totalCredits: 0,
+      totalCount: 0,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    });
 
     render(
       <ConsumptionAttributionTable
@@ -144,7 +125,6 @@ describe("ConsumptionAttributionTable", () => {
       expect(mockUseConsumptionTop).toHaveBeenCalledWith(
         expect.objectContaining({ search: "Agent 080", offset: 0, limit: 25 })
       );
-      expect(screen.getByText("Pagination Agent 080")).toBeInTheDocument();
     });
   });
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -46,8 +46,8 @@ vi.mock(
 const period = { kind: "days", days: 30 } as const;
 
 describe("ConsumptionAttributionTable", () => {
-  it("shows every page upfront and fetches the selected fixed-size page", async () => {
-    const rows = Array.from({ length: 80 }, (_, index) => ({
+  it("caps the available pages and fetches the selected fixed-size page", async () => {
+    const rows = Array.from({ length: 1_025 }, (_, index) => ({
       id: `agent-${index + 1}`,
       name: `Agent ${index + 1}`,
       pictureUrl: null,
@@ -81,14 +81,17 @@ describe("ConsumptionAttributionTable", () => {
       expect.objectContaining({ limit: 25, offset: 0 })
     );
 
-    expect(screen.getByRole("button", { name: "4" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "4" }));
+    expect(screen.getByRole("button", { name: "40" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "41" })
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "40" }));
 
     await waitFor(() => {
       expect(mockUseConsumptionTop).toHaveBeenCalledWith(
-        expect.objectContaining({ limit: 25, offset: 75 })
+        expect.objectContaining({ limit: 25, offset: 975 })
       );
-      expect(screen.getByText("Agent 80")).toBeInTheDocument();
+      expect(screen.getByText("Agent 1000")).toBeInTheDocument();
     });
   });
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -18,7 +18,10 @@ import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/constants";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
-import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/api/analytics/consumption/schema";
+import {
+  DEFAULT_CONSUMPTION_PERIOD_DAYS,
+  MAX_CONSUMPTION_TOP_BUCKETS,
+} from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
@@ -483,7 +486,7 @@ function AttributionRows({
               showDetails={false}
               pagination={pagination}
               setPagination={setPagination}
-              rowCount={totalCount}
+              rowCount={Math.min(totalCount, MAX_CONSUMPTION_TOP_BUCKETS)}
             />
           </div>
         )}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -18,10 +18,7 @@ import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/constants";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
-import {
-  DEFAULT_CONSUMPTION_PERIOD_DAYS,
-  MAX_CONSUMPTION_TOP_BUCKETS,
-} from "@app/lib/api/analytics/consumption/schema";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
@@ -372,7 +369,7 @@ function AttributionRows({
   const shouldReduceMotion = useReducedMotion();
 
   const {
-    rows: allRows,
+    rows,
     totalCredits,
     totalCount,
     isTopLoading,
@@ -387,8 +384,6 @@ function AttributionRows({
     search,
     filter,
   });
-
-  const rows = allRows;
 
   const selectedIdSet = useMemo(
     () => new Set(filter?.[CONSUMPTION_DIMENSION_FILTER_KEYS[dimension]] ?? []),
@@ -486,7 +481,7 @@ function AttributionRows({
               showDetails={false}
               pagination={pagination}
               setPagination={setPagination}
-              rowCount={Math.min(totalCount, MAX_CONSUMPTION_TOP_BUCKETS)}
+              rowCount={totalCount}
             />
           </div>
         )}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -381,16 +381,11 @@ function AttributionRows({
     period,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
+    search,
     filter,
   });
 
-  // Client-side filter over the loaded ranking returned by the endpoint.
-  const rows = useMemo(() => {
-    const needle = search.trim().toLowerCase();
-    return needle
-      ? allRows.filter((row) => row.name.toLowerCase().includes(needle))
-      : allRows;
-  }, [allRows, search]);
+  const rows = allRows;
 
   const selectedIdSet = useMemo(
     () => new Set(filter?.[CONSUMPTION_DIMENSION_FILTER_KEYS[dimension]] ?? []),

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -152,6 +152,7 @@ export function useConsumptionTop({
   period,
   limit,
   offset = 0,
+  search,
   filter,
   disabled,
 }: {
@@ -160,6 +161,7 @@ export function useConsumptionTop({
   period: ConsumptionPeriodSelection;
   limit: number;
   offset?: number;
+  search?: string;
   filter?: ConsumptionScopeFilter;
   disabled?: boolean;
 }) {
@@ -171,6 +173,7 @@ export function useConsumptionTop({
     filter: normalizedConsumptionFilter(filter),
     limit,
     offset,
+    search: search?.trim() || undefined,
   };
 
   const { data, error, isValidating } = useConsumptionQuery<

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -173,7 +173,7 @@ export function useConsumptionTop({
     filter: normalizedConsumptionFilter(filter),
     limit,
     offset,
-    search: search?.trim() || undefined,
+    search: search?.trim(),
   };
 
   const { data, error, isValidating } = useConsumptionQuery<

--- a/front/lib/api/analytics/consumption/facet_catalog.test.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.test.ts
@@ -1,4 +1,7 @@
-import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
+import {
+  listConsumptionFacetCatalog,
+  listConsumptionFacetCatalogDimension,
+} from "@app/lib/api/analytics/consumption/facet_catalog";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -15,9 +18,12 @@ describe("listConsumptionFacetCatalog", () => {
       role: "manager",
     });
 
-    const catalog = await listConsumptionFacetCatalog(authenticator);
+    const users = await listConsumptionFacetCatalogDimension(
+      authenticator,
+      "user"
+    );
 
-    expect(catalog.user).toContainEqual({
+    expect(users).toContainEqual({
       value: user.sId,
       label: user.fullName(),
       pictureUrl: user.imageUrl,

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -47,8 +47,14 @@ type ConsumptionFacetCatalogSource =
 
 function traceFacetCatalogLoad<T>(
   source: ConsumptionFacetCatalogSource,
+  dimension: ConsumptionScopeDimension,
+  requestedDimension: ConsumptionScopeDimension | null,
   fn: () => Promise<T[]>
 ): Promise<T[]> {
+  if (requestedDimension !== null && requestedDimension !== dimension) {
+    return Promise.resolve([]);
+  }
+
   return tracer.trace(
     "analytics.consumption.facets.catalog.load",
     { resource: source },
@@ -97,43 +103,69 @@ function toolFacetCatalogEntries(
 
 /** Lists current workspace entities that can be selected as consumption filters. */
 async function listConsumptionFacetCatalogWithoutTracing(
-  auth: Authenticator
+  auth: Authenticator,
+  requestedDimension: ConsumptionScopeDimension | null = null
 ): Promise<ConsumptionFacetCatalog> {
   // TODO(2026-08-11 OBSERVABILITY): This eagerly loads several complete
   // workspace catalogs and is known to perform poorly on large workspaces.
   // Move most facet metadata into Elasticsearch so this endpoint can query ES
   // instead of loading several unbounded database-backed catalogs.
-  const members = await traceFacetCatalogLoad("members", async () => {
-    const result = await getMembers(auth, { activeOnly: true });
-    return result.members;
-  });
-  const groups = await traceFacetCatalogLoad("groups", () =>
-    GroupResource.listAllWorkspaceGroups(auth, {
-      groupKinds: [...MANAGEABLE_GROUP_KINDS],
-    })
+  const members = await traceFacetCatalogLoad(
+    "members",
+    "user",
+    requestedDimension,
+    async () => {
+      const result = await getMembers(auth, { activeOnly: true });
+      return result.members;
+    }
   );
-  const agents = await traceFacetCatalogLoad("agents", () =>
-    getAgentConfigurationsForView({
-      auth,
-      agentsGetView: "analytics",
-      variant: "extra_light",
-      omitInstructions: true,
-    })
+  const groups = await traceFacetCatalogLoad(
+    "groups",
+    "group",
+    requestedDimension,
+    () =>
+      GroupResource.listAllWorkspaceGroups(auth, {
+        groupKinds: [...MANAGEABLE_GROUP_KINDS],
+      })
   );
-  const models = await traceFacetCatalogLoad("models", async () => {
-    const result = await getModelsForAuth(auth);
-    return result.models;
-  });
-  const mcpServers = await traceFacetCatalogLoad("mcp_servers", () =>
-    listMCPServersWithViews(auth)
+  const agents = await traceFacetCatalogLoad(
+    "agents",
+    "agent",
+    requestedDimension,
+    () =>
+      getAgentConfigurationsForView({
+        auth,
+        agentsGetView: "analytics",
+        variant: "extra_light",
+        omitInstructions: true,
+      })
   );
-  const skills = await traceFacetCatalogLoad("skills", () =>
-    SkillResource.listByWorkspace(auth, {
-      status: "active",
-      withInstructions: false,
-      withTools: false,
-      withFileAttachments: false,
-    })
+  const models = await traceFacetCatalogLoad(
+    "models",
+    "model",
+    requestedDimension,
+    async () => {
+      const result = await getModelsForAuth(auth);
+      return result.models;
+    }
+  );
+  const mcpServers = await traceFacetCatalogLoad(
+    "mcp_servers",
+    "tool",
+    requestedDimension,
+    () => listMCPServersWithViews(auth)
+  );
+  const skills = await traceFacetCatalogLoad(
+    "skills",
+    "skill",
+    requestedDimension,
+    () =>
+      SkillResource.listByWorkspace(auth, {
+        status: "active",
+        withInstructions: false,
+        withTools: false,
+        withFileAttachments: false,
+      })
   );
 
   return {
@@ -179,6 +211,17 @@ async function listConsumptionFacetCatalogWithoutTracing(
       pictureUrl: null,
     })),
   };
+}
+
+export async function listConsumptionFacetCatalogDimension(
+  auth: Authenticator,
+  dimension: ConsumptionScopeDimension
+): Promise<ConsumptionFacetCatalogEntry[]> {
+  const catalog = await listConsumptionFacetCatalogWithoutTracing(
+    auth,
+    dimension
+  );
+  return catalog[dimension];
 }
 
 export async function listConsumptionFacetCatalog(

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -21,7 +21,6 @@ import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type ConsumptionFacetCatalogEntry = {
   value: string;
@@ -96,136 +95,6 @@ function toolFacetCatalogEntries(
   return [...new Map(entries.map((entry) => [entry.value, entry])).values()];
 }
 
-async function listMemberFacetCatalog(
-  auth: Authenticator
-): Promise<ConsumptionFacetCatalogEntry[]> {
-  const members = await traceFacetCatalogLoad("members", async () => {
-    const result = await getMembers(auth, { activeOnly: true });
-    return result.members;
-  });
-  return members.map((member) => ({
-    value: member.sId,
-    label: member.fullName,
-    pictureUrl: member.image,
-  }));
-}
-
-async function listGroupFacetCatalog(
-  auth: Authenticator
-): Promise<ConsumptionFacetCatalogEntry[]> {
-  const groups = await traceFacetCatalogLoad("groups", () =>
-    GroupResource.listAllWorkspaceGroups(auth, {
-      groupKinds: [...MANAGEABLE_GROUP_KINDS],
-    })
-  );
-  return groups.map((group) => ({
-    value: group.sId,
-    label: group.name,
-    pictureUrl: null,
-  }));
-}
-
-async function listAgentFacetCatalog(
-  auth: Authenticator
-): Promise<ConsumptionFacetCatalogEntry[]> {
-  const agents = await traceFacetCatalogLoad("agents", () =>
-    getAgentConfigurationsForView({
-      auth,
-      agentsGetView: "analytics",
-      variant: "extra_light",
-      omitInstructions: true,
-    })
-  );
-  return agents.map((agent) => ({
-    value: agent.sId,
-    label: agent.name,
-    pictureUrl: agent.pictureUrl,
-    scope: agent.scope,
-  }));
-}
-
-async function listModelFacetCatalog(
-  auth: Authenticator
-): Promise<ConsumptionFacetCatalogEntry[]> {
-  const models = await traceFacetCatalogLoad("models", async () => {
-    const result = await getModelsForAuth(auth);
-    return result.models;
-  });
-  return models
-    .filter((model) => !isModelStreamId(model.modelId))
-    .map((model) => ({
-      value: model.modelId,
-      label: model.displayName,
-      pictureUrl: null,
-      maker: getModelMaker(model),
-      tier:
-        ModelsTierResource.getTierForModel(
-          model.modelId,
-          model.defaultReasoningEffort
-        ) ?? undefined,
-    }));
-}
-
-async function listToolFacetCatalog(
-  auth: Authenticator
-): Promise<ConsumptionFacetCatalogEntry[]> {
-  const mcpServers = await traceFacetCatalogLoad("mcp_servers", () =>
-    listMCPServersWithViews(auth)
-  );
-  return toolFacetCatalogEntries(mcpServers);
-}
-
-async function listSkillFacetCatalog(
-  auth: Authenticator
-): Promise<ConsumptionFacetCatalogEntry[]> {
-  const skills = await traceFacetCatalogLoad("skills", () =>
-    SkillResource.listByWorkspace(auth, {
-      status: "active",
-      withInstructions: false,
-      withTools: false,
-      withFileAttachments: false,
-    })
-  );
-  return skills.map((skill) => ({
-    value: skill.sId,
-    label: skill.name,
-    pictureUrl: null,
-    icon: skill.icon,
-  }));
-}
-
-function listSourceFacetCatalog(): ConsumptionFacetCatalogEntry[] {
-  return Object.entries(SOURCE_ORIGIN_LABELS).map(([value, label]) => ({
-    value,
-    label,
-    pictureUrl: null,
-  }));
-}
-
-export async function listConsumptionFacetCatalogDimension(
-  auth: Authenticator,
-  dimension: ConsumptionScopeDimension
-): Promise<ConsumptionFacetCatalogEntry[]> {
-  switch (dimension) {
-    case "agent":
-      return listAgentFacetCatalog(auth);
-    case "user":
-      return listMemberFacetCatalog(auth);
-    case "group":
-      return listGroupFacetCatalog(auth);
-    case "model":
-      return listModelFacetCatalog(auth);
-    case "tool":
-      return listToolFacetCatalog(auth);
-    case "skill":
-      return listSkillFacetCatalog(auth);
-    case "source":
-      return listSourceFacetCatalog();
-    default:
-      return assertNever(dimension);
-  }
-}
-
 /** Lists current workspace entities that can be selected as consumption filters. */
 async function listConsumptionFacetCatalogWithoutTracing(
   auth: Authenticator
@@ -234,21 +103,81 @@ async function listConsumptionFacetCatalogWithoutTracing(
   // workspace catalogs and is known to perform poorly on large workspaces.
   // Move most facet metadata into Elasticsearch so this endpoint can query ES
   // instead of loading several unbounded database-backed catalogs.
-  const members = await listMemberFacetCatalog(auth);
-  const groups = await listGroupFacetCatalog(auth);
-  const agents = await listAgentFacetCatalog(auth);
-  const models = await listModelFacetCatalog(auth);
-  const tools = await listToolFacetCatalog(auth);
-  const skills = await listSkillFacetCatalog(auth);
+  const members = await traceFacetCatalogLoad("members", async () => {
+    const result = await getMembers(auth, { activeOnly: true });
+    return result.members;
+  });
+  const groups = await traceFacetCatalogLoad("groups", () =>
+    GroupResource.listAllWorkspaceGroups(auth, {
+      groupKinds: [...MANAGEABLE_GROUP_KINDS],
+    })
+  );
+  const agents = await traceFacetCatalogLoad("agents", () =>
+    getAgentConfigurationsForView({
+      auth,
+      agentsGetView: "analytics",
+      variant: "extra_light",
+      omitInstructions: true,
+    })
+  );
+  const models = await traceFacetCatalogLoad("models", async () => {
+    const result = await getModelsForAuth(auth);
+    return result.models;
+  });
+  const mcpServers = await traceFacetCatalogLoad("mcp_servers", () =>
+    listMCPServersWithViews(auth)
+  );
+  const skills = await traceFacetCatalogLoad("skills", () =>
+    SkillResource.listByWorkspace(auth, {
+      status: "active",
+      withInstructions: false,
+      withTools: false,
+      withFileAttachments: false,
+    })
+  );
 
   return {
-    agent: agents,
-    user: members,
-    group: groups,
-    model: models,
-    tool: tools,
-    skill: skills,
-    source: listSourceFacetCatalog(),
+    agent: agents.map((agent) => ({
+      value: agent.sId,
+      label: agent.name,
+      pictureUrl: agent.pictureUrl,
+      scope: agent.scope,
+    })),
+    user: members.map((member) => ({
+      value: member.sId,
+      label: member.fullName,
+      pictureUrl: member.image,
+    })),
+    group: groups.map((group) => ({
+      value: group.sId,
+      label: group.name,
+      pictureUrl: null,
+    })),
+    model: models
+      .filter((model) => !isModelStreamId(model.modelId))
+      .map((model) => ({
+        value: model.modelId,
+        label: model.displayName,
+        pictureUrl: null,
+        maker: getModelMaker(model),
+        tier:
+          ModelsTierResource.getTierForModel(
+            model.modelId,
+            model.defaultReasoningEffort
+          ) ?? undefined,
+      })),
+    tool: toolFacetCatalogEntries(mcpServers),
+    skill: skills.map((skill) => ({
+      value: skill.sId,
+      label: skill.name,
+      pictureUrl: null,
+      icon: skill.icon,
+    })),
+    source: Object.entries(SOURCE_ORIGIN_LABELS).map(([value, label]) => ({
+      value,
+      label,
+      pictureUrl: null,
+    })),
   };
 }
 

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -21,6 +21,7 @@ import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type ConsumptionFacetCatalogEntry = {
   value: string;
@@ -95,23 +96,38 @@ function toolFacetCatalogEntries(
   return [...new Map(entries.map((entry) => [entry.value, entry])).values()];
 }
 
-/** Lists current workspace entities that can be selected as consumption filters. */
-async function listConsumptionFacetCatalogWithoutTracing(
+async function listMemberFacetCatalog(
   auth: Authenticator
-): Promise<ConsumptionFacetCatalog> {
-  // TODO(2026-08-11 OBSERVABILITY): This eagerly loads several complete
-  // workspace catalogs and is known to perform poorly on large workspaces.
-  // Move most facet metadata into Elasticsearch so this endpoint can query ES
-  // instead of loading several unbounded database-backed catalogs.
+): Promise<ConsumptionFacetCatalogEntry[]> {
   const members = await traceFacetCatalogLoad("members", async () => {
     const result = await getMembers(auth, { activeOnly: true });
     return result.members;
   });
+  return members.map((member) => ({
+    value: member.sId,
+    label: member.fullName,
+    pictureUrl: member.image,
+  }));
+}
+
+async function listGroupFacetCatalog(
+  auth: Authenticator
+): Promise<ConsumptionFacetCatalogEntry[]> {
   const groups = await traceFacetCatalogLoad("groups", () =>
     GroupResource.listAllWorkspaceGroups(auth, {
       groupKinds: [...MANAGEABLE_GROUP_KINDS],
     })
   );
+  return groups.map((group) => ({
+    value: group.sId,
+    label: group.name,
+    pictureUrl: null,
+  }));
+}
+
+async function listAgentFacetCatalog(
+  auth: Authenticator
+): Promise<ConsumptionFacetCatalogEntry[]> {
   const agents = await traceFacetCatalogLoad("agents", () =>
     getAgentConfigurationsForView({
       auth,
@@ -120,13 +136,48 @@ async function listConsumptionFacetCatalogWithoutTracing(
       omitInstructions: true,
     })
   );
+  return agents.map((agent) => ({
+    value: agent.sId,
+    label: agent.name,
+    pictureUrl: agent.pictureUrl,
+    scope: agent.scope,
+  }));
+}
+
+async function listModelFacetCatalog(
+  auth: Authenticator
+): Promise<ConsumptionFacetCatalogEntry[]> {
   const models = await traceFacetCatalogLoad("models", async () => {
     const result = await getModelsForAuth(auth);
     return result.models;
   });
+  return models
+    .filter((model) => !isModelStreamId(model.modelId))
+    .map((model) => ({
+      value: model.modelId,
+      label: model.displayName,
+      pictureUrl: null,
+      maker: getModelMaker(model),
+      tier:
+        ModelsTierResource.getTierForModel(
+          model.modelId,
+          model.defaultReasoningEffort
+        ) ?? undefined,
+    }));
+}
+
+async function listToolFacetCatalog(
+  auth: Authenticator
+): Promise<ConsumptionFacetCatalogEntry[]> {
   const mcpServers = await traceFacetCatalogLoad("mcp_servers", () =>
     listMCPServersWithViews(auth)
   );
+  return toolFacetCatalogEntries(mcpServers);
+}
+
+async function listSkillFacetCatalog(
+  auth: Authenticator
+): Promise<ConsumptionFacetCatalogEntry[]> {
   const skills = await traceFacetCatalogLoad("skills", () =>
     SkillResource.listByWorkspace(auth, {
       status: "active",
@@ -135,49 +186,69 @@ async function listConsumptionFacetCatalogWithoutTracing(
       withFileAttachments: false,
     })
   );
+  return skills.map((skill) => ({
+    value: skill.sId,
+    label: skill.name,
+    pictureUrl: null,
+    icon: skill.icon,
+  }));
+}
+
+function listSourceFacetCatalog(): ConsumptionFacetCatalogEntry[] {
+  return Object.entries(SOURCE_ORIGIN_LABELS).map(([value, label]) => ({
+    value,
+    label,
+    pictureUrl: null,
+  }));
+}
+
+export async function listConsumptionFacetCatalogDimension(
+  auth: Authenticator,
+  dimension: ConsumptionScopeDimension
+): Promise<ConsumptionFacetCatalogEntry[]> {
+  switch (dimension) {
+    case "agent":
+      return listAgentFacetCatalog(auth);
+    case "user":
+      return listMemberFacetCatalog(auth);
+    case "group":
+      return listGroupFacetCatalog(auth);
+    case "model":
+      return listModelFacetCatalog(auth);
+    case "tool":
+      return listToolFacetCatalog(auth);
+    case "skill":
+      return listSkillFacetCatalog(auth);
+    case "source":
+      return listSourceFacetCatalog();
+    default:
+      return assertNever(dimension);
+  }
+}
+
+/** Lists current workspace entities that can be selected as consumption filters. */
+async function listConsumptionFacetCatalogWithoutTracing(
+  auth: Authenticator
+): Promise<ConsumptionFacetCatalog> {
+  // TODO(2026-08-11 OBSERVABILITY): This eagerly loads several complete
+  // workspace catalogs and is known to perform poorly on large workspaces.
+  // Move most facet metadata into Elasticsearch so this endpoint can query ES
+  // instead of loading several unbounded database-backed catalogs.
+  const members = await listMemberFacetCatalog(auth);
+  const groups = await listGroupFacetCatalog(auth);
+  const agents = await listAgentFacetCatalog(auth);
+  const models = await listModelFacetCatalog(auth);
+  const tools = await listToolFacetCatalog(auth);
+  const skills = await listSkillFacetCatalog(auth);
 
   return {
-    agent: agents.map((agent) => ({
-      value: agent.sId,
-      label: agent.name,
-      pictureUrl: agent.pictureUrl,
-      scope: agent.scope,
-    })),
-    user: members.map((member) => ({
-      value: member.sId,
-      label: member.fullName,
-      pictureUrl: member.image,
-    })),
-    group: groups.map((group) => ({
-      value: group.sId,
-      label: group.name,
-      pictureUrl: null,
-    })),
-    model: models
-      .filter((model) => !isModelStreamId(model.modelId))
-      .map((model) => ({
-        value: model.modelId,
-        label: model.displayName,
-        pictureUrl: null,
-        maker: getModelMaker(model),
-        tier:
-          ModelsTierResource.getTierForModel(
-            model.modelId,
-            model.defaultReasoningEffort
-          ) ?? undefined,
-      })),
-    tool: toolFacetCatalogEntries(mcpServers),
-    skill: skills.map((skill) => ({
-      value: skill.sId,
-      label: skill.name,
-      pictureUrl: null,
-      icon: skill.icon,
-    })),
-    source: Object.entries(SOURCE_ORIGIN_LABELS).map(([value, label]) => ({
-      value,
-      label,
-      pictureUrl: null,
-    })),
+    agent: agents,
+    user: members,
+    group: groups,
+    model: models,
+    tool: tools,
+    skill: skills,
+    source: listSourceFacetCatalog(),
   };
 }
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -46,6 +46,7 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .default(DEFAULT_CONSUMPTION_TOP_LIMIT)
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().optional().default(0),
+  search: z.string().trim().max(200).optional(),
 });
 
 export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -46,7 +46,7 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .default(DEFAULT_CONSUMPTION_TOP_LIMIT)
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().default(0),
-  search: z.string().trim().max(200).optional(),
+  search: z.string().trim().optional(),
 });
 
 export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -45,7 +45,7 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .optional()
     .default(DEFAULT_CONSUMPTION_TOP_LIMIT)
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
-  offset: z.number().int().nonnegative().optional().default(0),
+  offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().max(200).optional(),
 });
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -7,7 +7,6 @@ import { z } from "zod";
 export const DEFAULT_CONSUMPTION_PERIOD_DAYS = 30;
 
 export const DEFAULT_CONSUMPTION_TOP_LIMIT = 10;
-export const MAX_CONSUMPTION_TOP_BUCKETS = 1_000;
 
 const ConsumptionFilterSchema = z.record(
   z.enum(CONSUMPTION_SCOPE_FILTER_KEYS),

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -48,13 +48,7 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().max(200).optional(),
-}).refine(
-  ({ limit, offset }) => offset + limit <= MAX_CONSUMPTION_TOP_BUCKETS,
-  {
-    message: `A ranked page cannot extend beyond ${MAX_CONSUMPTION_TOP_BUCKETS} items.`,
-    path: ["offset"],
-  }
-);
+});
 
 export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 export const DEFAULT_CONSUMPTION_PERIOD_DAYS = 30;
 
 export const DEFAULT_CONSUMPTION_TOP_LIMIT = 10;
+export const MAX_CONSUMPTION_TOP_BUCKETS = 1_000;
 
 const ConsumptionFilterSchema = z.record(
   z.enum(CONSUMPTION_SCOPE_FILTER_KEYS),
@@ -47,7 +48,13 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().max(200).optional(),
-});
+}).refine(
+  ({ limit, offset }) => offset + limit <= MAX_CONSUMPTION_TOP_BUCKETS,
+  {
+    message: `A ranked page cannot extend beyond ${MAX_CONSUMPTION_TOP_BUCKETS} items.`,
+    path: ["offset"],
+  }
+);
 
 export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;
 

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,4 +1,4 @@
-import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
+import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
@@ -23,7 +23,7 @@ vi.mock(
   import("@app/lib/api/analytics/consumption/facet_catalog"),
   async (orig) => {
     const mod = await orig();
-    return { ...mod, listConsumptionFacetCatalogDimension: vi.fn() };
+    return { ...mod, listConsumptionFacetCatalog: vi.fn() };
   }
 );
 
@@ -92,7 +92,7 @@ function lastSearchCall() {
 describe("consumption top rankings", () => {
   afterEach(() => {
     vi.mocked(searchConsumptionAnalytics).mockReset();
-    vi.mocked(listConsumptionFacetCatalogDimension).mockReset();
+    vi.mocked(listConsumptionFacetCatalog).mockReset();
     vi.mocked(resolveDimensionLabels).mockReset();
   });
 
@@ -177,7 +177,6 @@ describe("consumption top rankings", () => {
       precision_threshold: 40_000,
     });
     expect(options?.aggregations?.ranking).toBeUndefined();
-    expect(listConsumptionFacetCatalogDimension).not.toHaveBeenCalled();
   });
 
   it("returns one ranked page with the total number of groups", async () => {
@@ -234,63 +233,22 @@ describe("consumption top rankings", () => {
     });
   });
 
-  it("searches the complete dimension catalog before ranking a page", async () => {
+  it.each([
+    ["AGENT 080", { terms: { "agent.id": ["agent80"] } }],
+    ["missing", { match_none: {} }],
+  ])("filters the ranking for search %s", async (search, expectedFilter) => {
     const { auth } = await setup();
-    vi.mocked(listConsumptionFacetCatalogDimension).mockResolvedValue([
-      { value: "agent1", label: "Agent 1", pictureUrl: null },
-      { value: "agent80", label: "Pagination Agent 080", pictureUrl: null },
-    ]);
-    mockLabels({ agent80: "Pagination Agent 080" });
-    mockAggs({
-      buckets: [
-        {
-          key: "agent80",
-          doc_count: 1,
-          credit_micro: { value: 1_000_000 },
-          messages: { value: 1 },
-        },
+    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
+      agent: [
+        { value: "agent80", label: "Pagination Agent 080", pictureUrl: null },
       ],
-      totalCount: 1,
-      totalMicro: 10_000_000,
-      filtered: true,
+      user: [],
+      group: [],
+      model: [],
+      tool: [],
+      skill: [],
+      source: [],
     });
-
-    const result = await fetchConsumptionTopAgents(auth, {
-      period: PERIOD,
-      limit: 25,
-      search: "  AGENT 080  ",
-    });
-
-    expect(result.isOk()).toBe(true);
-    if (!result.isOk()) {
-      return;
-    }
-    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
-      "agent80",
-    ]);
-    expect(result.value.totalCount).toBe(1);
-    // Searching only narrows the ranking. Cost share still uses all scoped
-    // consumption, so the period total remains unchanged.
-    expect(result.value.totalCredits).toBe(10);
-    expect(listConsumptionFacetCatalogDimension).toHaveBeenCalledWith(
-      auth,
-      "agent"
-    );
-
-    const [query, options] = lastSearchCall();
-    expect(query.bool?.filter).not.toContainEqual({
-      terms: { "agent.id": ["agent80"] },
-    });
-    expect(options?.aggregations?.ranking?.filter).toEqual({
-      terms: { "agent.id": ["agent80"] },
-    });
-  });
-
-  it("returns no ranked rows when no catalog entry matches the search", async () => {
-    const { auth } = await setup();
-    vi.mocked(listConsumptionFacetCatalogDimension).mockResolvedValue([
-      { value: "agent1", label: "Agent 1", pictureUrl: null },
-    ]);
     mockLabels({});
     mockAggs({
       buckets: [],
@@ -302,18 +260,18 @@ describe("consumption top rankings", () => {
     const result = await fetchConsumptionTopAgents(auth, {
       period: PERIOD,
       limit: 25,
-      search: "missing",
+      search,
     });
 
     expect(result.isOk()).toBe(true);
     if (!result.isOk()) {
       return;
     }
-    expect(result.value.agents).toEqual([]);
-    expect(result.value.totalCount).toBe(0);
-    expect(lastSearchCall()[1]?.aggregations?.ranking?.filter).toEqual({
-      match_none: {},
-    });
+    expect(result.value.totalCredits).toBe(10);
+    expect(listConsumptionFacetCatalog).toHaveBeenCalledWith(auth);
+    expect(lastSearchCall()[1]?.aggregations?.ranking?.filter).toEqual(
+      expectedFilter
+    );
   });
 
   it("counts tool invocations as documents, with no message sub-agg", async () => {

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -274,6 +274,49 @@ describe("consumption top rankings", () => {
     );
   });
 
+  it("splits broad searches into bounded terms clauses", async () => {
+    const { auth } = await setup();
+    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
+      agent: Array.from({ length: 65_537 }, (_, index) => ({
+        value: `agent${index}`,
+        label: "Agent",
+        pictureUrl: null,
+      })),
+      user: [],
+      group: [],
+      model: [],
+      tool: [],
+      skill: [],
+      source: [],
+    });
+    mockLabels({});
+    mockAggs({
+      buckets: [],
+      totalCount: 0,
+      totalMicro: 0,
+      filtered: true,
+    });
+
+    await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 25,
+      search: "agent",
+    });
+
+    const searchFilter = lastSearchCall()[1]?.aggregations?.ranking?.filter;
+    expect(searchFilter?.bool?.minimum_should_match).toBe(1);
+
+    const termsClauses = searchFilter?.bool?.should;
+    expect(Array.isArray(termsClauses)).toBe(true);
+    if (!Array.isArray(termsClauses)) {
+      return;
+    }
+
+    expect(termsClauses).toHaveLength(2);
+    expect(termsClauses[0]?.terms?.["agent.id"]).toHaveLength(65_536);
+    expect(termsClauses[1]?.terms?.["agent.id"]).toHaveLength(1);
+  });
+
   it("counts tool invocations as documents, with no message sub-agg", async () => {
     const { auth } = await setup();
     vi.mocked(resolveDimensionLabels).mockResolvedValue(

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,4 +1,4 @@
-import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
+import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
@@ -23,7 +23,7 @@ vi.mock(
   import("@app/lib/api/analytics/consumption/facet_catalog"),
   async (orig) => {
     const mod = await orig();
-    return { ...mod, listConsumptionFacetCatalog: vi.fn() };
+    return { ...mod, listConsumptionFacetCatalogDimension: vi.fn() };
   }
 );
 
@@ -92,7 +92,7 @@ function lastSearchCall() {
 describe("consumption top rankings", () => {
   afterEach(() => {
     vi.mocked(searchConsumptionAnalytics).mockReset();
-    vi.mocked(listConsumptionFacetCatalog).mockReset();
+    vi.mocked(listConsumptionFacetCatalogDimension).mockReset();
     vi.mocked(resolveDimensionLabels).mockReset();
   });
 
@@ -238,17 +238,9 @@ describe("consumption top rankings", () => {
     ["missing", { match_none: {} }],
   ])("filters the ranking for search %s", async (search, expectedFilter) => {
     const { auth } = await setup();
-    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
-      agent: [
-        { value: "agent80", label: "Pagination Agent 080", pictureUrl: null },
-      ],
-      user: [],
-      group: [],
-      model: [],
-      tool: [],
-      skill: [],
-      source: [],
-    });
+    vi.mocked(listConsumptionFacetCatalogDimension).mockResolvedValue([
+      { value: "agent80", label: "Pagination Agent 080", pictureUrl: null },
+    ]);
     mockLabels({});
     mockAggs({
       buckets: [],
@@ -268,7 +260,10 @@ describe("consumption top rankings", () => {
       return;
     }
     expect(result.value.totalCredits).toBe(10);
-    expect(listConsumptionFacetCatalog).toHaveBeenCalledWith(auth);
+    expect(listConsumptionFacetCatalogDimension).toHaveBeenCalledWith(
+      auth,
+      "agent"
+    );
     expect(lastSearchCall()[1]?.aggregations?.ranking?.filter).toEqual(
       expectedFilter
     );
@@ -276,19 +271,13 @@ describe("consumption top rankings", () => {
 
   it("splits broad searches into bounded terms clauses", async () => {
     const { auth } = await setup();
-    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
-      agent: Array.from({ length: 65_537 }, (_, index) => ({
+    vi.mocked(listConsumptionFacetCatalogDimension).mockResolvedValue(
+      Array.from({ length: 65_537 }, (_, index) => ({
         value: `agent${index}`,
         label: "Agent",
         pictureUrl: null,
-      })),
-      user: [],
-      group: [],
-      model: [],
-      tool: [],
-      skill: [],
-      source: [],
-    });
+      }))
+    );
     mockLabels({});
     mockAggs({
       buckets: [],

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,3 +1,4 @@
+import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
@@ -17,6 +18,14 @@ vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
   const mod = await orig();
   return { ...mod, searchConsumptionAnalytics: vi.fn() };
 });
+
+vi.mock(
+  import("@app/lib/api/analytics/consumption/facet_catalog"),
+  async (orig) => {
+    const mod = await orig();
+    return { ...mod, listConsumptionFacetCatalogDimension: vi.fn() };
+  }
+);
 
 vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
   const mod = await orig();
@@ -38,15 +47,20 @@ function mockAggs({
   buckets,
   totalCount = buckets.length,
   totalMicro,
+  filtered = false,
 }: {
   buckets: unknown[];
   totalCount?: number;
   totalMicro: number;
+  filtered?: boolean;
 }) {
+  const ranking = {
+    by_group: { buckets },
+    total_count: { value: totalCount },
+  };
   vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
     esResponse({
-      by_group: { buckets },
-      total_count: { value: totalCount },
+      ...(filtered ? { ranking } : ranking),
       total_credit_micro: { value: totalMicro },
     })
   );
@@ -78,6 +92,7 @@ function lastSearchCall() {
 describe("consumption top rankings", () => {
   afterEach(() => {
     vi.mocked(searchConsumptionAnalytics).mockReset();
+    vi.mocked(listConsumptionFacetCatalogDimension).mockReset();
     vi.mocked(resolveDimensionLabels).mockReset();
   });
 
@@ -161,6 +176,8 @@ describe("consumption top rankings", () => {
       field: "agent.id",
       precision_threshold: 40_000,
     });
+    expect(options?.aggregations?.ranking).toBeUndefined();
+    expect(listConsumptionFacetCatalogDimension).not.toHaveBeenCalled();
   });
 
   it("returns one ranked page with the total number of groups", async () => {
@@ -214,6 +231,88 @@ describe("consumption top rankings", () => {
     expect(result.value.totalCount).toBe(4);
     expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
       size: 3,
+    });
+  });
+
+  it("searches the complete dimension catalog before ranking a page", async () => {
+    const { auth } = await setup();
+    vi.mocked(listConsumptionFacetCatalogDimension).mockResolvedValue([
+      { value: "agent1", label: "Agent 1", pictureUrl: null },
+      { value: "agent80", label: "Pagination Agent 080", pictureUrl: null },
+    ]);
+    mockLabels({ agent80: "Pagination Agent 080" });
+    mockAggs({
+      buckets: [
+        {
+          key: "agent80",
+          doc_count: 1,
+          credit_micro: { value: 1_000_000 },
+          messages: { value: 1 },
+        },
+      ],
+      totalCount: 1,
+      totalMicro: 10_000_000,
+      filtered: true,
+    });
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 25,
+      search: "  AGENT 080  ",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
+      "agent80",
+    ]);
+    expect(result.value.totalCount).toBe(1);
+    // Searching only narrows the ranking. Cost share still uses all scoped
+    // consumption, so the period total remains unchanged.
+    expect(result.value.totalCredits).toBe(10);
+    expect(listConsumptionFacetCatalogDimension).toHaveBeenCalledWith(
+      auth,
+      "agent"
+    );
+
+    const [query, options] = lastSearchCall();
+    expect(query.bool?.filter).not.toContainEqual({
+      terms: { "agent.id": ["agent80"] },
+    });
+    expect(options?.aggregations?.ranking?.filter).toEqual({
+      terms: { "agent.id": ["agent80"] },
+    });
+  });
+
+  it("returns no ranked rows when no catalog entry matches the search", async () => {
+    const { auth } = await setup();
+    vi.mocked(listConsumptionFacetCatalogDimension).mockResolvedValue([
+      { value: "agent1", label: "Agent 1", pictureUrl: null },
+    ]);
+    mockLabels({});
+    mockAggs({
+      buckets: [],
+      totalCount: 0,
+      totalMicro: 10_000_000,
+      filtered: true,
+    });
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 25,
+      search: "missing",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.agents).toEqual([]);
+    expect(result.value.totalCount).toBe(0);
+    expect(lastSearchCall()[1]?.aggregations?.ranking?.filter).toEqual({
+      match_none: {},
     });
   });
 

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -24,6 +24,7 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
+import chunk from "lodash/chunk";
 
 type ConsumptionTopGroup = {
   key: string;
@@ -49,6 +50,8 @@ const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
 const TOTAL_COUNT_AGG = "total_count";
 const CARDINALITY_PRECISION_THRESHOLD = 40_000;
+const MAX_ES_QUERY_CLAUSES = 1_024;
+const MAX_ES_TERMS_QUERY_VALUES = 65_536;
 
 type GroupBucket = {
   key: string;
@@ -94,6 +97,39 @@ function countFromBucket(
   }
 }
 
+function buildConsumptionTopSearchTermsQuery(
+  dimensionField: string,
+  matchingValues: string[]
+): estypes.QueryDslQueryContainer {
+  const termsClauses = chunk(matchingValues, MAX_ES_TERMS_QUERY_VALUES).map(
+    (values) => ({ terms: { [dimensionField]: values } })
+  );
+  const [firstClause, ...remainingClauses] = termsClauses;
+
+  if (!firstClause) {
+    return { match_none: {} };
+  }
+
+  if (remainingClauses.length === 0) {
+    return firstClause;
+  }
+
+  // Count the bool query itself and each terms clause, as search_store.rs does.
+  const clauseCount = termsClauses.length + 1;
+  if (clauseCount > MAX_ES_QUERY_CLAUSES) {
+    throw new Error(
+      `Consumption ranking search requires ${clauseCount} Elasticsearch clauses, the max is ${MAX_ES_QUERY_CLAUSES}.`
+    );
+  }
+
+  return {
+    bool: {
+      should: [firstClause, ...remainingClauses],
+      minimum_should_match: 1,
+    },
+  };
+}
+
 async function resolveConsumptionTopSearchFilter(
   auth: Authenticator,
   {
@@ -111,13 +147,10 @@ async function resolveConsumptionTopSearchFilter(
     .filter((entry) => entry.label.toLowerCase().includes(normalizedSearch))
     .map((entry) => entry.value);
 
-  if (matchingValues.length === 0) {
-    return { match_none: {} };
-  }
-
-  return {
-    terms: { [CONSUMPTION_DIMENSION_FIELDS[dimension]]: matchingValues },
-  };
+  return buildConsumptionTopSearchTermsQuery(
+    CONSUMPTION_DIMENSION_FIELDS[dimension],
+    matchingValues
+  );
 }
 
 function buildConsumptionTopAggregations({

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -126,12 +126,11 @@ export async function fetchConsumptionTopGroups(
       .filter((entry) => entry.label.toLowerCase().includes(normalizedSearch))
       .map((entry) => entry.value);
   }
-  const rankingFilter: estypes.QueryDslQueryContainer | null =
-    matchingValues
-      ? matchingValues.length > 0
-        ? { terms: { [dimensionField]: matchingValues } }
-        : { match_none: {} }
-      : null;
+  const rankingFilter: estypes.QueryDslQueryContainer | null = matchingValues
+    ? matchingValues.length > 0
+      ? { terms: { [dimensionField]: matchingValues } }
+      : { match_none: {} }
+    : null;
   const query = buildConsumptionScopeQuery({
     auth,
     startDate: period.startDate,

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -119,6 +119,7 @@ export async function fetchConsumptionTopGroups(
   const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
   const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
   const normalizedSearch = search?.trim().toLowerCase();
+
   let matchingValues: string[] | undefined;
   if (normalizedSearch) {
     const catalog = await listConsumptionFacetCatalog(auth);
@@ -126,17 +127,20 @@ export async function fetchConsumptionTopGroups(
       .filter((entry) => entry.label.toLowerCase().includes(normalizedSearch))
       .map((entry) => entry.value);
   }
+
   const rankingFilter: estypes.QueryDslQueryContainer | null = matchingValues
     ? matchingValues.length > 0
       ? { terms: { [dimensionField]: matchingValues } }
       : { match_none: {} }
     : null;
+
   const query = buildConsumptionScopeQuery({
     auth,
     startDate: period.startDate,
     endDate: period.endDate,
     filter,
   });
+
   const requestedBucketCount = offset + limit;
   const rankingAggregations = {
     by_group: {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -1,4 +1,4 @@
-import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
+import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
@@ -146,8 +146,10 @@ async function resolveConsumptionTopSearchFilter(
     return null;
   }
 
-  const catalog = await listConsumptionFacetCatalog(auth);
-  const matchingValues = catalog[dimension]
+  // TODO(2026-08-14 aubin): Store searchable dimension names in consumption
+  // analytics documents so Elasticsearch can perform this search directly.
+  const catalog = await listConsumptionFacetCatalogDimension(auth, dimension);
+  const matchingValues = catalog
     .filter((entry) => entry.label.toLowerCase().includes(normalizedSearch))
     .map((entry) => entry.value);
 

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -1,3 +1,4 @@
+import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
@@ -65,9 +66,13 @@ function subAggs(unit: ConsumptionTopUnit) {
   };
 }
 
-type TopAggs = {
+type RankingAggs = {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
   [TOTAL_COUNT_AGG]?: estypes.AggregationsCardinalityAggregate;
+};
+
+type TopAggs = RankingAggs & {
+  ranking?: estypes.AggregationsSingleBucketAggregateBase & RankingAggs;
   total_credit_micro?: estypes.AggregationsSumAggregate;
 };
 
@@ -100,16 +105,33 @@ export async function fetchConsumptionTopGroups(
     period,
     limit,
     offset = 0,
+    search,
     filter,
   }: {
     dimension: ConsumptionScopeDimension;
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
+    search?: string;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
   const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
+  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
+  const normalizedSearch = search?.trim().toLowerCase();
+  let matchingValues: string[] | undefined;
+  if (normalizedSearch) {
+    const catalog = await listConsumptionFacetCatalog(auth);
+    matchingValues = catalog[dimension]
+      .filter((entry) => entry.label.toLowerCase().includes(normalizedSearch))
+      .map((entry) => entry.value);
+  }
+  const rankingFilter: estypes.QueryDslQueryContainer | null =
+    matchingValues
+      ? matchingValues.length > 0
+        ? { terms: { [dimensionField]: matchingValues } }
+        : { match_none: {} }
+      : null;
   const query = buildConsumptionScopeQuery({
     auth,
     startDate: period.startDate,
@@ -117,24 +139,28 @@ export async function fetchConsumptionTopGroups(
     filter,
   });
   const requestedBucketCount = offset + limit;
-  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
+  const rankingAggregations = {
+    by_group: {
+      terms: {
+        field: dimensionField,
+        size: requestedBucketCount,
+        order: { [CREDIT_AGG]: "desc" },
+      },
+      aggs: subAggs(unit),
+    },
+    [TOTAL_COUNT_AGG]: {
+      cardinality: {
+        field: dimensionField,
+        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+      },
+    },
+  } satisfies Record<string, estypes.AggregationsAggregationContainer>;
 
   const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
     aggregations: {
-      by_group: {
-        terms: {
-          field: dimensionField,
-          size: requestedBucketCount,
-          order: { [CREDIT_AGG]: "desc" },
-        },
-        aggs: subAggs(unit),
-      },
-      [TOTAL_COUNT_AGG]: {
-        cardinality: {
-          field: dimensionField,
-          precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
-        },
-      },
+      ...(rankingFilter
+        ? { ranking: { filter: rankingFilter, aggs: rankingAggregations } }
+        : rankingAggregations),
       total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
     },
     size: 0,
@@ -144,16 +170,17 @@ export async function fetchConsumptionTopGroups(
     return result;
   }
 
+  const ranking = rankingFilter
+    ? result.value.aggregations?.ranking
+    : result.value.aggregations;
   const rankedGroups = bucketsToArray<GroupBucket>(
-    result.value.aggregations?.by_group?.buckets
+    ranking?.by_group?.buckets
   ).map((bucket) => ({
     key: String(bucket.key),
     credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
     count: countFromBucket(bucket, unit),
   }));
-  const totalCount = Math.round(
-    result.value.aggregations?.[TOTAL_COUNT_AGG]?.value ?? 0
-  );
+  const totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
 
   return new Ok({
     groups: rankedGroups.slice(offset, offset + limit),

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -96,8 +96,10 @@ function countFromBucket(
 
 async function resolveConsumptionTopSearchFilter(
   auth: Authenticator,
-  dimension: ConsumptionScopeDimension,
-  search?: string
+  {
+    dimension,
+    search,
+  }: { dimension: ConsumptionScopeDimension; search?: string }
 ): Promise<estypes.QueryDslQueryContainer | null> {
   const normalizedSearch = search?.trim().toLowerCase();
   if (!normalizedSearch) {
@@ -119,18 +121,19 @@ async function resolveConsumptionTopSearchFilter(
 }
 
 function buildConsumptionTopAggregations({
-  dimensionField,
-  unit,
+  dimension,
   limit,
   offset,
   searchFilter,
 }: {
-  dimensionField: string;
-  unit: ConsumptionTopUnit;
+  dimension: ConsumptionScopeDimension;
   limit: number;
   offset: number;
   searchFilter: estypes.QueryDslQueryContainer | null;
 }): Record<string, estypes.AggregationsAggregationContainer> {
+  const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
+  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
+
   // TODO(2026-08-14 aubin): Add pagination beyond the maximum bucket count.
   const requestedBucketCount = offset + limit;
   const rankingAggregations = {
@@ -187,13 +190,10 @@ export async function fetchConsumptionTopGroups(
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
-  const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
-  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
-  const searchFilter = await resolveConsumptionTopSearchFilter(
-    auth,
+  const searchFilter = await resolveConsumptionTopSearchFilter(auth, {
     dimension,
-    search
-  );
+    search,
+  });
 
   const query = buildConsumptionScopeQuery({
     auth,
@@ -201,9 +201,9 @@ export async function fetchConsumptionTopGroups(
     endDate: period.endDate,
     filter,
   });
+
   const aggregations = buildConsumptionTopAggregations({
-    dimensionField,
-    unit,
+    dimension,
     limit,
     offset,
     searchFilter,
@@ -226,7 +226,7 @@ export async function fetchConsumptionTopGroups(
   ).map((bucket) => ({
     key: String(bucket.key),
     credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-    count: countFromBucket(bucket, unit),
+    count: countFromBucket(bucket, CONSUMPTION_DIMENSION_UNIT[dimension]),
   }));
   const totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
 

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -113,8 +113,9 @@ async function resolveConsumptionTopSearchFilter(
     return { match_none: {} };
   }
 
-  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
-  return { terms: { [dimensionField]: matchingValues } };
+  return {
+    terms: { [CONSUMPTION_DIMENSION_FIELDS[dimension]]: matchingValues },
+  };
 }
 
 function buildConsumptionTopAggregations({

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -142,6 +142,7 @@ export async function fetchConsumptionTopGroups(
     filter,
   });
 
+  // TODO(2026-08-14 aubin): Add pagination beyond the maximum bucket count.
   const requestedBucketCount = offset + limit;
   const rankingAggregations = {
     by_group: {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -128,11 +128,12 @@ export async function fetchConsumptionTopGroups(
       .map((entry) => entry.value);
   }
 
-  const rankingFilter: estypes.QueryDslQueryContainer | null = matchingValues
-    ? matchingValues.length > 0
-      ? { terms: { [dimensionField]: matchingValues } }
-      : { match_none: {} }
-    : null;
+  let searchFilter: estypes.QueryDslQueryContainer | null = null;
+  if (matchingValues?.length) {
+    searchFilter = { terms: { [dimensionField]: matchingValues } };
+  } else if (matchingValues) {
+    searchFilter = { match_none: {} };
+  }
 
   const query = buildConsumptionScopeQuery({
     auth,
@@ -159,13 +160,21 @@ export async function fetchConsumptionTopGroups(
     },
   } satisfies Record<string, estypes.AggregationsAggregationContainer>;
 
+  const rankingRootAggregations = searchFilter
+    ? {
+        ranking: {
+          filter: searchFilter,
+          aggs: rankingAggregations,
+        },
+      }
+    : rankingAggregations;
+  const aggregations = {
+    ...rankingRootAggregations,
+    total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+  };
+
   const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
-    aggregations: {
-      ...(rankingFilter
-        ? { ranking: { filter: rankingFilter, aggs: rankingAggregations } }
-        : rankingAggregations),
-      total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
-    },
+    aggregations,
     size: 0,
   });
 
@@ -173,7 +182,7 @@ export async function fetchConsumptionTopGroups(
     return result;
   }
 
-  const ranking = rankingFilter
+  const ranking = searchFilter
     ? result.value.aggregations?.ranking
     : result.value.aggregations;
   const rankedGroups = bucketsToArray<GroupBucket>(

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -94,54 +94,42 @@ function countFromBucket(
   }
 }
 
-/**
- * Top `limit` keys of `dimension` by gross credits over the period, with the
- * count each one's average is denominated in.
- */
-export async function fetchConsumptionTopGroups(
+async function resolveConsumptionTopSearchFilter(
   auth: Authenticator,
-  {
-    dimension,
-    period,
-    limit,
-    offset = 0,
-    search,
-    filter,
-  }: {
-    dimension: ConsumptionScopeDimension;
-    period: ConsumptionPeriod;
-    limit: number;
-    offset?: number;
-    search?: string;
-    filter?: ConsumptionScopeFilter;
-  }
-): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
-  const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
-  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
+  dimension: ConsumptionScopeDimension,
+  search?: string
+): Promise<estypes.QueryDslQueryContainer | null> {
   const normalizedSearch = search?.trim().toLowerCase();
-
-  let matchingValues: string[] | undefined;
-  if (normalizedSearch) {
-    const catalog = await listConsumptionFacetCatalog(auth);
-    matchingValues = catalog[dimension]
-      .filter((entry) => entry.label.toLowerCase().includes(normalizedSearch))
-      .map((entry) => entry.value);
+  if (!normalizedSearch) {
+    return null;
   }
 
-  let searchFilter: estypes.QueryDslQueryContainer | null = null;
-  if (matchingValues?.length) {
-    searchFilter = { terms: { [dimensionField]: matchingValues } };
-  } else if (matchingValues) {
-    searchFilter = { match_none: {} };
+  const catalog = await listConsumptionFacetCatalog(auth);
+  const matchingValues = catalog[dimension]
+    .filter((entry) => entry.label.toLowerCase().includes(normalizedSearch))
+    .map((entry) => entry.value);
+
+  if (matchingValues.length === 0) {
+    return { match_none: {} };
   }
 
-  const query = buildConsumptionScopeQuery({
-    auth,
-    startDate: period.startDate,
-    endDate: period.endDate,
-    filter,
-  });
+  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
+  return { terms: { [dimensionField]: matchingValues } };
+}
 
+function buildConsumptionTopAggregations({
+  dimensionField,
+  unit,
+  limit,
+  offset,
+  searchFilter,
+}: {
+  dimensionField: string;
+  unit: ConsumptionTopUnit;
+  limit: number;
+  offset: number;
+  searchFilter: estypes.QueryDslQueryContainer | null;
+}): Record<string, estypes.AggregationsAggregationContainer> {
   // TODO(2026-08-14 aubin): Add pagination beyond the maximum bucket count.
   const requestedBucketCount = offset + limit;
   const rankingAggregations = {
@@ -169,10 +157,56 @@ export async function fetchConsumptionTopGroups(
         },
       }
     : rankingAggregations;
-  const aggregations = {
+
+  return {
     ...rankingRootAggregations,
     total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
   };
+}
+
+/**
+ * Top `limit` keys of `dimension` by gross credits over the period, with the
+ * count each one's average is denominated in.
+ */
+export async function fetchConsumptionTopGroups(
+  auth: Authenticator,
+  {
+    dimension,
+    period,
+    limit,
+    offset = 0,
+    search,
+    filter,
+  }: {
+    dimension: ConsumptionScopeDimension;
+    period: ConsumptionPeriod;
+    limit: number;
+    offset?: number;
+    search?: string;
+    filter?: ConsumptionScopeFilter;
+  }
+): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
+  const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
+  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
+  const searchFilter = await resolveConsumptionTopSearchFilter(
+    auth,
+    dimension,
+    search
+  );
+
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+    filter,
+  });
+  const aggregations = buildConsumptionTopAggregations({
+    dimensionField,
+    unit,
+    limit,
+    offset,
+    searchFilter,
+  });
 
   const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
     aggregations,

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -136,7 +136,10 @@ async function resolveConsumptionTopSearchFilter(
   {
     dimension,
     search,
-  }: { dimension: ConsumptionScopeDimension; search?: string }
+  }: {
+    dimension: ConsumptionScopeDimension;
+    search?: string;
+  }
 ): Promise<estypes.QueryDslQueryContainer | null> {
   const normalizedSearch = search?.trim().toLowerCase();
   if (!normalizedSearch) {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -118,7 +118,8 @@ function buildConsumptionTopSearchTermsQuery(
   const clauseCount = termsClauses.length + 1;
   if (clauseCount > MAX_ES_QUERY_CLAUSES) {
     throw new Error(
-      `Consumption ranking search requires ${clauseCount} Elasticsearch clauses, the max is ${MAX_ES_QUERY_CLAUSES}.`
+      `Consumption ranking search requires ${clauseCount} Elasticsearch clauses, ` +
+        `the max is ${MAX_ES_QUERY_CLAUSES}.`
     );
   }
 

--- a/front/lib/api/analytics/consumption/top_agents.ts
+++ b/front/lib/api/analytics/consumption/top_agents.ts
@@ -44,11 +44,13 @@ export async function fetchConsumptionTopAgents(
     period,
     limit,
     offset = 0,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
+    search?: string;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopAgents, ElasticsearchError>> {
@@ -57,6 +59,7 @@ export async function fetchConsumptionTopAgents(
     period,
     limit,
     offset,
+    search,
     filter,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -41,11 +41,13 @@ export async function fetchConsumptionTopGroups(
     period,
     limit,
     offset = 0,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
+    search?: string;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
@@ -54,6 +56,7 @@ export async function fetchConsumptionTopGroups(
     period,
     limit,
     offset,
+    search,
     filter,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_models.ts
+++ b/front/lib/api/analytics/consumption/top_models.ts
@@ -41,11 +41,13 @@ export async function fetchConsumptionTopModels(
     period,
     limit,
     offset = 0,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
+    search?: string;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopModels, ElasticsearchError>> {
@@ -54,6 +56,7 @@ export async function fetchConsumptionTopModels(
     period,
     limit,
     offset,
+    search,
     filter,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_skills.ts
+++ b/front/lib/api/analytics/consumption/top_skills.ts
@@ -49,11 +49,13 @@ export async function fetchConsumptionTopSkills(
     period,
     limit,
     offset = 0,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
+    search?: string;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopSkills, ElasticsearchError>> {
@@ -62,6 +64,7 @@ export async function fetchConsumptionTopSkills(
     period,
     limit,
     offset,
+    search,
     filter,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_sources.ts
+++ b/front/lib/api/analytics/consumption/top_sources.ts
@@ -42,11 +42,13 @@ export async function fetchConsumptionTopSources(
     period,
     limit,
     offset = 0,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
+    search?: string;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopSources, ElasticsearchError>> {
@@ -55,6 +57,7 @@ export async function fetchConsumptionTopSources(
     period,
     limit,
     offset,
+    search,
     filter,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -47,11 +47,13 @@ export async function fetchConsumptionTopTools(
     period,
     limit,
     offset = 0,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
+    search?: string;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopTools, ElasticsearchError>> {
@@ -60,6 +62,7 @@ export async function fetchConsumptionTopTools(
     period,
     limit,
     offset,
+    search,
     filter,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_users.ts
+++ b/front/lib/api/analytics/consumption/top_users.ts
@@ -45,11 +45,13 @@ export async function fetchConsumptionTopUsers(
     period,
     limit,
     offset = 0,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
+    search?: string;
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionTopUsers, ElasticsearchError>> {
@@ -58,6 +60,7 @@ export async function fetchConsumptionTopUsers(
     period,
     limit,
     offset,
+    search,
     filter,
   });
   if (result.isErr()) {


### PR DESCRIPTION
## Description

In the new analytics page, we currently have a client-side search.
https://github.com/dust-tt/dust/pull/30487 added pagination, keeping the client-side search for now (so only affects the first page, wasn't an issue before because we showed only the first page).

This PR adds a search handled by the backend.
It's a very crude version, we can't actually search within labels (agent/skill/tool/user names) so will be quite slow for the dimensions that are slow to load. The goal here is really to reach a functional version first, then see exactly where to put our efforts in.

## Tests

- Added tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
