### PR TITLE
[front] fix: exclude expired pending invitations from plan seat count

### DIFF
--- a/front-api/routes/w/[wId]/invitations/index.test.ts
+++ b/front-api/routes/w/[wId]/invitations/index.test.ts
@@ -2,6 +2,8 @@ import { Authenticator } from "@app/lib/auth";
 import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipInvitationFactory } from "@app/tests/utils/MembershipInvitationFactory";
+import { PlanFactory } from "@app/tests/utils/PlanFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import sgMail from "@sendgrid/mail";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -261,5 +263,64 @@ describe("POST /api/w/:wId/invitations", () => {
       await MembershipInvitationResource.getPendingInvitations(adminAuth);
     expect(invitations).toHaveLength(0);
     expect(sgSendMock).not.toHaveBeenCalled();
+  });
+
+  it("does not count an expired pending invitation against the plan seat limit", async () => {
+    // 1 seat for the admin created below + 1 seat that the expired invitation
+    // must free up for the new invite to succeed.
+    const plan = await PlanFactory.enterprise("ENT_INVITE_SEAT_EXPIRED_TEST", {
+      maxUsersInWorkspace: 2,
+    });
+    const planWorkspace = await WorkspaceFactory.fromPlan(plan);
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+      workspace: planWorkspace,
+    });
+
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+    await MembershipInvitationFactory.create(workspace, {
+      inviteEmail: "expired@example.com",
+      status: "pending",
+      createdAt: eightDaysAgo,
+    });
+
+    const response = await honoApp.request(invitationsUrl(workspace.sId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([{ email: "new-user@example.com", role: "user" }]),
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.every((r: { success: boolean }) => r.success)).toBe(true);
+  });
+
+  it("still counts a fresh pending invitation against the plan seat limit", async () => {
+    // Same 2-seat setup as above: 1 for the admin, 1 already held by the
+    // fresh (non-expired) pending invitation, leaving none for a new invite.
+    const plan = await PlanFactory.enterprise("ENT_INVITE_SEAT_FRESH_TEST", {
+      maxUsersInWorkspace: 2,
+    });
+    const planWorkspace = await WorkspaceFactory.fromPlan(plan);
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+      workspace: planWorkspace,
+    });
+
+    await MembershipInvitationFactory.create(workspace, {
+      inviteEmail: "fresh@example.com",
+      status: "pending",
+    });
+
+    const response = await honoApp.request(invitationsUrl(workspace.sId), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([{ email: "new-user@example.com", role: "user" }]),
+    });
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("plan_limit_error");
   });
 });

--- a/front/lib/resources/membership_invitation_resource.ts
+++ b/front/lib/resources/membership_invitation_resource.ts
@@ -310,10 +310,22 @@ export class MembershipInvitationResource extends BaseResource<MembershipInvitat
     workspace: LightWorkspaceType;
     transaction?: Transaction;
   }): Promise<number> {
+    // Only count invitations whose 7-day acceptance token has not expired yet, mirroring
+    // isExpired(): not expired if max(reminderSentAt, createdAt) is still within the window.
+    const notExpiredSinceMs = new Date(
+      Date.now() - INVITATION_EXPIRATION_TIME_MS
+    );
     return this.model.count({
       where: {
         workspaceId: workspace.id,
         status: "pending",
+        [Op.or]: [
+          { reminderSentAt: { [Op.gte]: notExpiredSinceMs } },
+          {
+            reminderSentAt: { [Op.eq]: null },
+            createdAt: { [Op.gte]: notExpiredSinceMs },
+          },
+        ],
       },
       transaction,
     });


### PR DESCRIPTION
## Description

Each Dust plan (Free Pilot, Enterprise Pilot 100, etc.) enforces a `maxUsers` seat limit, computed as `active members + pending invitations`. 
That pending-invitation count included invitations whose 7-day acceptance link had already expired but were never explicitly revoked, so stale invitations kept occupying a seat indefinitely, blocking admins from sending new invites and blocking new users from auto-joining via verified domain on signup, even though the seat was never actually usable.

This PR excludes expired pending invitations from that count (`MembershipInvitationResource.getPendingInvitationsCountForWorkspace`), using the same expiration rule already used elsewhere in the codebase (`isExpired()`, and the admin invitations list which already hides expired invites by default). 
Both places that enforce `maxUsers` (`handleMembershipInvitations` (new invites) and `evaluateWorkspaceSeatAvailability` (signup auto-join)) call this same function, so fixing it here fixes both paths. No DB migration is needed: expiration is derived (`max(reminderSentAt, createdAt) + 7 days`), never stored.

## Tests

Added two functional tests in `front-api/routes/w/[wId]/invitations/index.test.ts`:
- an expired pending invitation no longer blocks a new invite once the plan would otherwise be full
- a fresh (non-expired) pending invitation still correctly blocks it (regression guard against over-relaxing the check)

Ran and confirmed no regressions in the related suites:
- `routes/w/[wId]/invitations/index.test.ts` — 12/12 passing
- `routes/w/[wId]/invitations/[iId]/index.test.ts` — 8/8 passing
- `lib/api/plan_limit_overrides.test.ts` (front) — 8/8 passing
- `npx tsgo --noEmit` — clean

## Risk

Low. This only relaxes an over-counting bug.
Billing (Metronome) is unaffected, since seat billing already only counts active members, never pending invitations. 
The only externally visible change: workspaces with old, un-actionable pending invitations will immediately regain the seats those invitations were wrongly holding.
Trivially revertible (single function, no schema/data change) if unexpected behavior surfaces.

## Deploy Plan

Standard deploy, no special steps. No migration, no feature flag, no ordering constraints.
The new counting logic takes effect as soon as the deploy lands.
