### PR TITLE
Avervaet/page analytics consumption aligning visual with figma

### DIFF
--- a/front/components/charts/ChartContainer.tsx
+++ b/front/components/charts/ChartContainer.tsx
@@ -3,6 +3,7 @@ import { ChartLegend } from "@app/components/charts/ChartLegend";
 import { CHART_HEIGHT } from "@app/components/charts/constants";
 import {
   Button,
+  cn,
   Maximize01,
   Sheet,
   SheetContainer,
@@ -28,6 +29,7 @@ interface ChartContainerProps {
   description?: string;
   legendItems?: LegendItem[];
   isAllowFullScreen?: boolean;
+  showHeaderDivider?: boolean;
 }
 
 export function ChartContainer({
@@ -43,13 +45,19 @@ export function ChartContainer({
   description,
   legendItems,
   isAllowFullScreen,
+  showHeaderDivider,
 }: ChartContainerProps) {
   const message = isLoading ? null : (errorMessage ?? emptyMessage);
   const [isFullscreen, setIsFullscreen] = useState(false);
   return (
     <>
       <div className="observability-chart-container rounded-lg border border-border bg-background p-4">
-        <div className="flex items-center justify-between">
+        <div
+          className={cn(
+            "flex items-center justify-between",
+            showHeaderDivider && "border-b border-border pb-3"
+          )}
+        >
           <div className="flex shrink-0 items-center justify-between gap-2">
             <h3 className="text-base font-medium text-foreground">{title}</h3>
             {statusChip}
@@ -74,7 +82,10 @@ export function ChartContainer({
         )}
         {isLoading || message ? (
           <div
-            className="flex items-center justify-center"
+            className={cn(
+              "flex items-center justify-center",
+              showHeaderDivider && "mt-3"
+            )}
             style={{ height: height ?? CHART_HEIGHT }}
           >
             {isLoading ? (
@@ -85,7 +96,11 @@ export function ChartContainer({
           </div>
         ) : (
           <>
-            <ResponsiveContainer width="100%" height={height}>
+            <ResponsiveContainer
+              className={cn(showHeaderDivider && "mt-3")}
+              width="100%"
+              height={height}
+            >
               {children}
             </ResponsiveContainer>
             {bottomControls}

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -16,7 +16,7 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
-import { BarChart01, cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
+import { cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
 import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
 
 import { useMemo, useState } from "react";
@@ -55,10 +55,7 @@ export function AnalyticsConsumptionPage() {
   if (!isEnabled) {
     return (
       <Page.Vertical align="stretch" gap="xl">
-        <Page.Header
-          title={<Page.H variant="h3">Analytics</Page.H>}
-          icon={BarChart01}
-        />
+        <Page.Header title={<Page.H variant="h3">Analytics</Page.H>} />
         <div
           className={cn(
             "flex flex-col gap-2 rounded-xl border p-6",
@@ -85,7 +82,6 @@ export function AnalyticsConsumptionPage() {
             />
           </div>
         }
-        icon={BarChart01}
       />
       <div className="flex flex-col gap-8 pb-8">
         <ConsumptionOverview

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -71,7 +71,7 @@ export function AnalyticsConsumptionPage() {
   }
 
   return (
-    <Page.Vertical align="stretch" gap="xl">
+    <Page.Vertical align="stretch" gap="none">
       <Page.Header
         title={
           <div className="flex w-full flex-row justify-between">
@@ -83,7 +83,7 @@ export function AnalyticsConsumptionPage() {
           </div>
         }
       />
-      <div className="flex flex-col gap-8 pb-8">
+      <div className="flex flex-col gap-8 pb-8 pt-4">
         <ConsumptionOverview
           workspaceId={owner.sId}
           period={period}

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -27,8 +27,8 @@ import { useGroups } from "@app/lib/swr/groups";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
-  BarChart05,
   Button,
+  FilterFunnel01,
   NavigationListLabel,
   PopoverContent,
   PopoverRoot,
@@ -181,7 +181,7 @@ export function UsageFilterPanel({
     <PopoverRoot open={isOpen} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
-          icon={BarChart05}
+          icon={FilterFunnel01}
           label="Filters"
           size="sm"
           variant="outline"

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -25,12 +25,12 @@ import { formatCredits } from "@app/lib/client/credits";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
   Avatar,
-  BarChart01,
   Button,
   ChevronDown,
   ChevronUp,
   DataTable,
   DustLogoSquare,
+  FilterFunnel01,
   Icon,
   MOTION_DURATIONS,
   MOTION_EASINGS,
@@ -319,7 +319,7 @@ function buildColumns({
         return (
           <DataTable.CellContent className="w-full justify-end">
             <Button
-              icon={BarChart01}
+              icon={FilterFunnel01}
               variant="ghost-secondary"
               size="xs"
               disabled={isFilterSelected}

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -56,7 +56,7 @@ function TodayPartialLabel({ viewBox }: RechartsLabelProps) {
   const fontSize = 11;
   const rectWidth = textWidth + paddingX * 2;
   const rectHeight = fontSize + paddingY * 2;
-  const rectY = y - rectHeight - 4;
+  const rectY = y - rectHeight + 16;
 
   return (
     <g>
@@ -289,7 +289,7 @@ function ConsumptionDailyChart({
         {partialTimestamp !== undefined && (
           <ReferenceLine
             x={partialTimestamp}
-            className="stroke-muted-foreground"
+            stroke="var(--color-primary)"
             strokeDasharray="5 5"
             label={{ position: "top", content: TodayPartialLabel }}
             ifOverflow="extendDomain"

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -256,6 +256,7 @@ function ConsumptionDailyChart({
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
+      showHeaderDivider
     >
       <BarChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
         <CartesianGrid

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -16,7 +16,7 @@ import type {
 } from "@app/lib/api/analytics/consumption/timeseries";
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { ButtonsSwitch, ButtonsSwitchList, cn } from "@dust-tt/sparkle";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Bar,
   BarChart,
@@ -27,9 +27,62 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import type { Props as RechartsLabelProps } from "recharts/types/component/Label";
 import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 import { ConsumptionBurnUpChart } from "./ConsumptionBurnUpChart";
 import type { ConsumptionDimension } from "./consumptionDimensions";
+
+const TODAY_PARTIAL_LABEL = "Today (partial)";
+
+// Renders the reference line's label as a pill with the same fill as the
+// line itself, since the default text-only label has no background.
+function TodayPartialLabel({ viewBox }: RechartsLabelProps) {
+  const textRef = useRef<SVGTextElement>(null);
+  const [textWidth, setTextWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    if (textRef.current) {
+      setTextWidth(textRef.current.getComputedTextLength());
+    }
+  }, []);
+
+  if (!viewBox || !("x" in viewBox)) {
+    return null;
+  }
+
+  const { x = 0, y = 0 } = viewBox;
+  const paddingX = 6;
+  const paddingY = 6;
+  const fontSize = 11;
+  const rectWidth = textWidth + paddingX * 2;
+  const rectHeight = fontSize + paddingY * 2;
+  const rectY = y - rectHeight - 4;
+
+  return (
+    <g>
+      {textWidth > 0 && (
+        <rect
+          x={x - rectWidth / 2}
+          y={rectY}
+          width={rectWidth}
+          height={rectHeight}
+          rx={4}
+          className="fill-gray-700"
+        />
+      )}
+      <text
+        ref={textRef}
+        x={x}
+        y={rectY + rectHeight / 2}
+        textAnchor="middle"
+        dominantBaseline="central"
+        className="fill-background text-xs"
+      >
+        {TODAY_PARTIAL_LABEL}
+      </text>
+    </g>
+  );
+}
 
 // The bucket in progress (if mapped to today) is drawn faded across every series.
 const PARTIAL_BAR_OPACITY = "opacity-40";
@@ -238,7 +291,7 @@ function ConsumptionDailyChart({
             x={partialTimestamp}
             className="stroke-muted-foreground"
             strokeDasharray="5 5"
-            label={{ value: "Today (partial)", position: "top", fontSize: 11 }}
+            label={{ position: "top", content: TodayPartialLabel }}
             ifOverflow="extendDomain"
           />
         )}

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -36,7 +36,11 @@ const TODAY_PARTIAL_LABEL = "Today (partial)";
 
 // Renders the reference line's label as a pill with the same fill as the
 // line itself, since the default text-only label has no background.
-function TodayPartialLabel({ viewBox }: RechartsLabelProps) {
+interface TodayPartialLabelProps {
+  viewBox?: RechartsLabelProps["viewBox"];
+}
+
+function TodayPartialLabel({ viewBox }: TodayPartialLabelProps) {
   const textRef = useRef<SVGTextElement>(null);
   const [textWidth, setTextWidth] = useState(0);
 

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -205,10 +205,14 @@ function ConsumptionDailyChart({
       legendItems={legendItems}
     >
       <BarChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
-        <CartesianGrid vertical={false} className="stroke-border" />
+        <CartesianGrid
+          vertical={false}
+          strokeDasharray="4 4"
+          className="stroke-border"
+        />
         <XAxis
           dataKey="timestamp"
-          className="text-xs text-muted-foreground"
+          className="text-xs text-faint"
           tickLine={false}
           axisLine={false}
           tickMargin={8}
@@ -218,7 +222,7 @@ function ConsumptionDailyChart({
           }
         />
         <YAxis
-          className="text-xs text-muted-foreground"
+          className="text-xs text-faint"
           tickLine={false}
           axisLine={false}
           tickMargin={8}
@@ -232,7 +236,7 @@ function ConsumptionDailyChart({
         {partialTimestamp !== undefined && (
           <ReferenceLine
             x={partialTimestamp}
-            stroke="hsl(var(--primary))"
+            className="stroke-muted-foreground"
             strokeDasharray="5 5"
             label={{ value: "Today (partial)", position: "top", fontSize: 11 }}
             ifOverflow="extendDomain"


### PR DESCRIPTION
## Description

Aligns the workspace Analytics consumption page with the Figma visual design. This is a UI-only change: it removes the page/header analytics icons, adjusts page spacing, adds optional header-divider support to `ChartContainer`, and replaces chart-style icons with filter icons for filter actions. The daily consumption chart now uses dashed grid lines, lighter axis labels, and a custom pill-style “Today (partial)” reference-line label. No API, data, or analytics behavior changes are included.

## Tests
**Before:**
<img width="1163" height="784" alt="Capture d’écran 2026-08-13 à 18 30 31" src="https://github.com/user-attachments/assets/20905dbe-0ace-4a8b-9bb2-a23f38f26da6" />

**After:**
<img width="984" height="724" alt="Capture d’écran 2026-08-13 à 18 48 14" src="https://github.com/user-attachments/assets/51ca2401-bfaf-4f8e-840a-fa2be7591320" />

## Risk

Low functional risk because the changes are limited to presentation and shared chart-container layout.

## Deploy Plan
- Deploy front
