### PR TITLE
feat(analytics): personal consumption view for non-managers

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6140,7 +6140,7 @@
     "/api/w/{wId}/analytics/consumption/facets": {
       "post": {
         "summary": "List consumption analytics facets",
-        "description": "Lists current workspace entities and historical indexed values present in the selected period for each consumption dimension. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.",
+        "description": "Lists current workspace entities and historical indexed values present in the selected period for each consumption dimension. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension. Callers below the manager role only see facets of their own consumption, and get no member or group facets.",
         "tags": [
           "Private Analytics"
         ],
@@ -6325,9 +6325,6 @@
           },
           "400": {
             "description": "Invalid request body"
-          },
-          "403": {
-            "description": "Manager role required"
           },
           "500": {
             "description": "Failed to retrieve consumption facets"

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
@@ -65,18 +65,23 @@ describe("POST /api/w/:wId/analytics/consumption/facets", () => {
     );
   });
 
-  it("requires a manager and reports Elasticsearch failures", async () => {
-    const memberRequest = await createPrivateApiMockRequest({ role: "user" });
-    const forbiddenResponse = await honoApp.request(
-      `/api/w/${memberRequest.workspace.sId}/analytics/consumption/facets`,
+  it("serves members, whose facets cover their own consumption", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+    vi.mocked(fetchConsumptionFacets).mockResolvedValue(new Ok(RESPONSE));
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/analytics/consumption/facets`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       }
     );
-    expect(forbiddenResponse.status).toBe(403);
 
+    expect(response.status).toBe(200);
+  });
+
+  it("reports Elasticsearch failures", async () => {
     const managerRequest = await createPrivateApiMockRequest({
       role: "manager",
     });

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.ts
@@ -6,7 +6,6 @@ import {
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -18,7 +17,7 @@ const app = workspaceApp();
  * /api/w/{wId}/analytics/consumption/facets:
  *   post:
  *     summary: List consumption analytics facets
- *     description: Lists current workspace entities and historical indexed values present in the selected period for each consumption dimension. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.
+ *     description: Lists current workspace entities and historical indexed values present in the selected period for each consumption dimension. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension. Callers below the manager role only see facets of their own consumption, and get no member or group facets.
  *     tags:
  *       - Private Analytics
  *     parameters:
@@ -128,8 +127,6 @@ const app = workspaceApp();
  *                       type: array
  *                       items:
  *                         $ref: '#/components/schemas/PrivateConsumptionFacet'
- *       403:
- *         description: Manager role required
  *       400:
  *         description: Invalid request body
  *       500:
@@ -137,7 +134,6 @@ const app = workspaceApp();
  */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionBodySchema),
   async (ctx): HandlerResult<GetConsumptionFacetsResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
@@ -51,13 +51,15 @@ function postOverviewRequest(wId: string, body: Record<string, unknown> = {}) {
 }
 
 describe("POST /api/w/:wId/analytics/consumption/overview", () => {
-  it("returns 403 for non-manager users", async () => {
+  // The scope is enforced in the query builder, not by a guard on the route.
+  it("serves members, who read their own consumption", async () => {
+    vi.mocked(fetchConsumptionOverview).mockResolvedValue(new Ok(OVERVIEW));
     const { workspace } = await setupTest({ role: "user" });
 
     const response = await postOverviewRequest(workspace.sId);
 
-    expect(response.status).toBe(403);
-    expect(vi.mocked(fetchConsumptionOverview)).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchConsumptionOverview)).toHaveBeenCalled();
   });
 
   it("returns the overview for managers, defaulting to the current cycle", async () => {

--- a/front-api/routes/w/[wId]/analytics/consumption/overview.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.ts
@@ -6,7 +6,6 @@ import {
 } from "@app/lib/api/analytics/consumption/schema";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -16,7 +15,6 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionBodySchema),
   async (ctx): HandlerResult<GetConsumptionOverviewResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/consumption/timeseries.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/timeseries.ts
@@ -15,7 +15,6 @@ import {
 } from "@app/lib/api/analytics/consumption/timeseries";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { z } from "zod";
@@ -47,7 +46,6 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", BodySchema),
   async (ctx): HandlerResult<GetConsumptionTimeseriesResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
@@ -7,7 +7,6 @@ import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/con
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -19,7 +18,6 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopAgentsResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
@@ -7,7 +7,6 @@ import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/con
 import { fetchConsumptionTopModels } from "@app/lib/api/analytics/consumption/top_models";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -19,7 +18,6 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopModelsResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
@@ -7,7 +7,6 @@ import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/con
 import { fetchConsumptionTopSkills } from "@app/lib/api/analytics/consumption/top_skills";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -19,7 +18,6 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSkillsResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
@@ -7,7 +7,6 @@ import type { GetConsumptionTopSourcesResponse } from "@app/lib/api/analytics/co
 import { fetchConsumptionTopSources } from "@app/lib/api/analytics/consumption/top_sources";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -19,7 +18,6 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSourcesResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
@@ -7,7 +7,6 @@ import type { GetConsumptionTopToolsResponse } from "@app/lib/api/analytics/cons
 import { fetchConsumptionTopTools } from "@app/lib/api/analytics/consumption/top_tools";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -19,7 +18,6 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopToolsResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -273,6 +273,9 @@ const RANKINGS = [
   },
 ];
 
+// The rankings that rank people could only ever describe the member themselves.
+const MANAGER_ONLY_PATHS = ["top-users", "top-groups"];
+
 async function setupTest({
   role = "admin",
 }: {
@@ -319,12 +322,25 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
     });
   });
 
-  it.each(RANKINGS)("$path is refused to non-managers", async ({ path }) => {
+  it.each(
+    RANKINGS.filter((r) => MANAGER_ONLY_PATHS.includes(r.path))
+  )("$path is refused to members", async ({ path }) => {
     const { workspace } = await setupTest({ role: "user" });
 
     const response = await postRankingRequest(workspace.sId, path);
 
     expect(response.status).toBe(403);
+  });
+
+  it.each(
+    RANKINGS.filter((r) => !MANAGER_ONLY_PATHS.includes(r.path))
+  )("$path is served to members", async ({ path, arrangeOk }) => {
+    arrangeOk();
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await postRankingRequest(workspace.sId, path);
+
+    expect(response.status).toBe(200);
   });
 
   it("forwards the page, the period, the search and the filter", async () => {

--- a/front-spa/src/app/layouts/RequireRoleLayout.tsx
+++ b/front-spa/src/app/layouts/RequireRoleLayout.tsx
@@ -1,20 +1,31 @@
 import { AdminLayout } from "@dust-tt/front/components/layouts/AdminLayout";
 import Custom404 from "@dust-tt/front/components/pages/Custom404";
 import { useAuth } from "@dust-tt/front/lib/auth/AuthContext";
-import { isAdmin, isManager, type RoleType } from "@dust-tt/front/types/user";
+import {
+  isAdmin,
+  isManager,
+  isUser,
+  type RoleType,
+  type WorkspaceType,
+} from "@dust-tt/front/types/user";
 import { Outlet } from "react-router-dom";
 
+const ROLE_PREDICATES = {
+  admin: isAdmin,
+  manager: isManager,
+  user: isUser,
+} as const satisfies Partial<
+  Record<RoleType, (workspace: WorkspaceType | null) => boolean>
+>;
+
 interface RequireRoleProps {
-  requiredRole: Extract<RoleType, "admin" | "manager">;
+  requiredRole: keyof typeof ROLE_PREDICATES;
 }
 
 export function RequireRoleLayout({ requiredRole }: RequireRoleProps) {
   const { workspace } = useAuth();
 
-  const hasRequiredRole =
-    requiredRole === "admin" ? isAdmin(workspace) : isManager(workspace);
-
-  if (!hasRequiredRole) {
+  if (!ROLE_PREDICATES[requiredRole](workspace)) {
     return <Custom404 />;
   }
 

--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -106,15 +106,21 @@ const GovernancePage = withSuspense(
 
 export const adminRoutes: RouteObject[] = [
   {
+    // Managers report on the workspace, everyone else on their own consumption.
+    element: <RequireRoleLayout requiredRole="user" />,
+    children: [
+      {
+        path: "analytics/consumption",
+        element: <AnalyticsConsumptionPage />,
+      },
+    ],
+  },
+  {
     // Accessible to admins and managers.
     element: <RequireRoleLayout requiredRole="manager" />,
     children: [
       { path: "members", element: <MembersPage /> },
       { path: "analytics", element: <AnalyticsPage /> },
-      {
-        path: "analytics/consumption",
-        element: <AnalyticsConsumptionPage />,
-      },
       { path: "usage", element: <UsagePage /> },
       { path: "governance", element: <GovernancePage /> },
       // Legacy Workspace Settings page, merged into Settings & Governance.

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -36,7 +36,8 @@ function getAdminSectionHref(
   hasPermission: (
     verb: GrantVerb,
     resourceType: ConcreteResourceType
-  ) => boolean
+  ) => boolean,
+  hasConsumptionAnalytics: boolean
 ): string | null {
   if (isManager(owner)) {
     return `/w/${owner.sId}/members`;
@@ -46,6 +47,9 @@ function getAdminSectionHref(
   }
   if (hasPermission("admin", "security")) {
     return `/w/${owner.sId}/identity-and-provisioning`;
+  }
+  if (hasConsumptionAnalytics) {
+    return `/w/${owner.sId}/analytics/consumption`;
   }
   return null;
 }
@@ -85,7 +89,11 @@ export const NavigationSidebar = React.forwardRef<
   const { hasFeature } = useFeatureFlags();
   const { hasPermission } = useWorkspacePermissions();
 
-  const adminSectionHref = getAdminSectionHref(owner, hasPermission);
+  const adminSectionHref = getAdminSectionHref(
+    owner,
+    hasPermission,
+    hasFeature("enable_analytics_consumption")
+  );
 
   const showAdminSection = adminSectionHref !== null;
 

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -265,9 +265,18 @@ export const subNavigationAdmin = ({
   const canAdminBilling = hasPermission("admin", "billing");
   const canAdminSecurity = hasPermission("admin", "security");
 
+  const hasConsumptionAnalytics = featureFlags.includes(
+    "enable_analytics_consumption"
+  );
+
   // Admins and managers see the admin sidebar; builders and members do
   // not. Each item is then individually enabled/disabled based on permission.
-  if (!isManager(owner) && !canAdminBilling && !canAdminSecurity) {
+  if (
+    !isManager(owner) &&
+    !canAdminBilling &&
+    !canAdminSecurity &&
+    !hasConsumptionAnalytics
+  ) {
     return nav;
   }
 
@@ -346,7 +355,7 @@ export const subNavigationAdmin = ({
         current: isCurrent("analytics"),
         disabled: !hasManagerRole,
       },
-      ...(featureFlags.includes("enable_analytics_consumption")
+      ...(hasConsumptionAnalytics
         ? [
             {
               id: "analytics_consumption" as const,
@@ -354,7 +363,6 @@ export const subNavigationAdmin = ({
               icon: BarChart01,
               href: `/w/${owner.sId}/analytics/consumption`,
               current: isCurrent("analytics_consumption"),
-              disabled: !hasManagerRole,
             },
           ]
         : []),

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -2,19 +2,29 @@ import { ConsumptionAttributionTable } from "@app/components/workspace/analytics
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
-import { consumptionDimensionFromQueryParam } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import {
+  CONSUMPTION_DIMENSIONS,
+  consumptionDimensionFromQueryParam,
+} from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
 import { UsageFilterSummary } from "@app/components/workspace/analytics/UsageFilterSummary";
 import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
 import {
   addUsageFilterFromAttributionRow,
+  PERSONAL_USAGE_FILTER_CATEGORIES,
   setUsageFilterFromAttributionRow,
   toConsumptionScopeFilter,
+  USAGE_FILTER_CATEGORIES,
 } from "@app/components/workspace/analytics/usageFilter";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
-import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
+import { PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
 import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
@@ -37,13 +47,27 @@ function ChartFallback() {
 
 export function AnalyticsConsumptionPage() {
   const owner = useWorkspace();
+  const { isManager } = useAuth();
   const { hasFeature } = useFeatureFlags();
   const isEnabled = hasFeature("enable_analytics_consumption");
+
+  const isPersonalScope = !isManager;
+
+  const dimensions = isPersonalScope
+    ? PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS
+    : CONSUMPTION_DIMENSIONS;
+  const filterCategories = isPersonalScope
+    ? PERSONAL_USAGE_FILTER_CATEGORIES
+    : USAGE_FILTER_CATEGORIES;
+
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
   );
   const { dimension: dimensionParam } = useQueryParams(["dimension"]);
-  const dimension = consumptionDimensionFromQueryParam(dimensionParam.value);
+  const dimension = consumptionDimensionFromQueryParam(
+    dimensionParam.value,
+    dimensions
+  );
   const [filter, setFilter] = useState<UsageFilter>({});
   const scopeFilter = useMemo(() => toConsumptionScopeFilter(filter), [filter]);
   const shouldReduceMotion = useReducedMotion();
@@ -88,6 +112,7 @@ export function AnalyticsConsumptionPage() {
           workspaceId={owner.sId}
           period={period}
           filter={scopeFilter}
+          isPersonalScope={isPersonalScope}
         />
         <LazyMotion features={domMax}>
           <div className="flex flex-col gap-4">
@@ -101,6 +126,7 @@ export function AnalyticsConsumptionPage() {
                   period={period}
                   filter={filter}
                   onFilterChange={setFilter}
+                  categories={filterCategories}
                 />
               </div>
               <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
@@ -131,6 +157,7 @@ export function AnalyticsConsumptionPage() {
             );
           }}
           dimension={dimension}
+          dimensions={dimensions}
           onDimensionChange={handleDimensionChange}
           onViewAll={(nextDimension, selectedRow) => {
             setFilter((current) =>

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -8,7 +8,6 @@ import type {
 import {
   toConsumptionScopeFilter,
   USAGE_FILTER_AGENT_SCOPES,
-  USAGE_FILTER_CATEGORIES,
   USAGE_FILTER_CATEGORY_LABEL,
   usageFilterSelectionCount,
 } from "@app/components/workspace/analytics/usageFilter";
@@ -44,6 +43,7 @@ interface UsageFilterPanelProps {
   period: ConsumptionPeriodSelection;
   filter: UsageFilter;
   onFilterChange: (next: UsageFilter) => void;
+  categories: readonly UsageFilterCategory[];
 }
 
 export function UsageFilterPanel({
@@ -51,6 +51,7 @@ export function UsageFilterPanel({
   period,
   filter,
   onFilterChange,
+  categories,
 }: UsageFilterPanelProps) {
   const [isOpen, setIsOpen] = useState(false);
   // Selections are staged while the panel is open and only propagated when
@@ -155,10 +156,8 @@ export function UsageFilterPanel({
   const appliedSelectionCount = usageFilterSelectionCount(filter);
   const categoriesWithSelection = useMemo(
     () =>
-      USAGE_FILTER_CATEGORIES.filter(
-        (category) => (draftFilter[category]?.length ?? 0) > 0
-      ),
-    [draftFilter]
+      categories.filter((category) => (draftFilter[category]?.length ?? 0) > 0),
+    [categories, draftFilter]
   );
 
   const handleOpenChange = (open: boolean) => {
@@ -192,7 +191,7 @@ export function UsageFilterPanel({
       <PopoverContent fullWidth align="end" className="w-auto rounded-2xl p-0">
         <div className="flex h-96 flex-row divide-x divide-border">
           <UsageFilterCategoryNav
-            categories={USAGE_FILTER_CATEGORIES}
+            categories={categories}
             draftFilter={draftFilter}
             activeCategory={activeCategory}
             onCategoryChange={handleCategoryChange}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -125,6 +125,7 @@ function BreakdownColumn({
 interface ConsumptionAttributionBreakdownProps {
   workspaceId: string;
   selectedDimension: ConsumptionDimension;
+  dimensions: ConsumptionDimension[];
   selectedRow: ConsumptionTopRow;
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
@@ -137,6 +138,7 @@ interface ConsumptionAttributionBreakdownProps {
 export function ConsumptionAttributionBreakdown({
   workspaceId,
   selectedDimension,
+  dimensions,
   selectedRow,
   period,
   filter,
@@ -147,14 +149,14 @@ export function ConsumptionAttributionBreakdown({
     [CONSUMPTION_DIMENSION_FILTER_KEYS[selectedDimension]]: [selectedRow.id],
   };
   const visibleDimensions = BREAKDOWN_DIMENSIONS.filter(
-    (dimension) => dimension !== selectedDimension
+    (dimension) =>
+      dimension !== selectedDimension && dimensions.includes(dimension)
   );
 
   return (
     <div
       className={cn(
-        "grid gap-20",
-        visibleDimensions.length === 2 ? "grid-cols-2" : "grid-cols-3",
+        "grid grid-flow-col auto-cols-fr gap-20",
         "border-b border-separator px-2 pb-6 pt-4"
       )}
     >

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -99,6 +99,7 @@ interface ConsumptionAttributionRowsTableProps {
   columns: ColumnDef<AttributionRowData>[];
   workspaceId: string;
   dimension: ConsumptionDimension;
+  dimensions: ConsumptionDimension[];
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
   onViewAll: (
@@ -117,6 +118,7 @@ export function ConsumptionAttributionRowsTable({
   columns,
   workspaceId,
   dimension,
+  dimensions,
   period,
   filter,
   onViewAll,
@@ -234,6 +236,7 @@ export function ConsumptionAttributionRowsTable({
                         <ConsumptionAttributionBreakdown
                           workspaceId={workspaceId}
                           selectedDimension={dimension}
+                          dimensions={dimensions}
                           selectedRow={row.original}
                           period={period}
                           filter={filter}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -1,5 +1,6 @@
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import { CONSUMPTION_DIMENSIONS } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import {
   fireEvent,
@@ -71,6 +72,7 @@ describe("ConsumptionAttributionTable", () => {
       <ConsumptionAttributionTable
         workspaceId="workspace-id"
         period={period}
+        dimensions={CONSUMPTION_DIMENSIONS}
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
@@ -179,6 +181,7 @@ describe("ConsumptionAttributionTable", () => {
       <ConsumptionAttributionTable
         workspaceId="workspace-id"
         period={period}
+        dimensions={CONSUMPTION_DIMENSIONS}
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
@@ -226,6 +229,7 @@ describe("ConsumptionAttributionTable", () => {
       <ConsumptionAttributionTable
         workspaceId="workspace-id"
         period={period}
+        dimensions={CONSUMPTION_DIMENSIONS}
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
@@ -248,6 +252,7 @@ describe("ConsumptionAttributionTable", () => {
       <ConsumptionAttributionTable
         workspaceId="workspace-id"
         period={period}
+        dimensions={CONSUMPTION_DIMENSIONS}
         dimension="model"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
@@ -294,6 +299,7 @@ describe("ConsumptionAttributionTable", () => {
       <ConsumptionAttributionTable
         workspaceId="workspace-id"
         period={period}
+        dimensions={CONSUMPTION_DIMENSIONS}
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
@@ -321,6 +327,7 @@ describe("ConsumptionAttributionTable", () => {
       <ConsumptionAttributionTable
         workspaceId="workspace-id"
         period={period}
+        dimensions={CONSUMPTION_DIMENSIONS}
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
@@ -353,6 +360,7 @@ describe("ConsumptionAttributionTable", () => {
       <ConsumptionAttributionTable
         workspaceId="workspace-id"
         period={period}
+        dimensions={CONSUMPTION_DIMENSIONS}
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
@@ -395,6 +403,7 @@ describe("ConsumptionAttributionTable", () => {
       <ConsumptionAttributionTable
         workspaceId="workspace-id"
         period={period}
+        dimensions={CONSUMPTION_DIMENSIONS}
         dimension="skill"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -347,6 +347,7 @@ function buildColumns({
 interface AttributionRowsProps {
   workspaceId: string;
   dimension: ConsumptionDimension;
+  dimensions: ConsumptionDimension[];
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
   onAddFilter: (row: ConsumptionTopRow) => void;
@@ -360,6 +361,7 @@ interface AttributionRowsProps {
 function AttributionRows({
   workspaceId,
   dimension,
+  dimensions,
   period,
   filter,
   onAddFilter,
@@ -464,6 +466,7 @@ function AttributionRows({
             columns={columns}
             workspaceId={workspaceId}
             dimension={dimension}
+            dimensions={dimensions}
             period={period}
             filter={filter}
             onViewAll={onViewAll}
@@ -499,6 +502,7 @@ function AttributionRows({
               columns={columns}
               workspaceId={workspaceId}
               dimension={dimension}
+              dimensions={dimensions}
               period={period}
               filter={filter}
               onViewAll={onViewAll}
@@ -537,6 +541,7 @@ interface ConsumptionAttributionTableProps {
   onAddFilter: (row: ConsumptionTopRow) => void;
   // Owned by the page: the selected tab also drives the chart's breakdown.
   dimension: ConsumptionDimension;
+  dimensions: ConsumptionDimension[];
   onDimensionChange: (dimension: ConsumptionDimension) => void;
   onViewAll: (
     dimension: ConsumptionDimension,
@@ -550,6 +555,7 @@ export function ConsumptionAttributionTable({
   filter,
   onAddFilter,
   dimension,
+  dimensions,
   onDimensionChange,
   onViewAll,
 }: ConsumptionAttributionTableProps) {
@@ -607,7 +613,7 @@ export function ConsumptionAttributionTable({
             }}
           >
             <TabsList border>
-              {CONSUMPTION_DIMENSIONS.map((tabDimension) => (
+              {dimensions.map((tabDimension) => (
                 <TabsTrigger
                   key={tabDimension}
                   value={tabDimension}
@@ -656,6 +662,7 @@ export function ConsumptionAttributionTable({
                     })}
                     workspaceId={workspaceId}
                     dimension={dimension}
+                    dimensions={dimensions}
                     period={period}
                     filter={filter}
                     onAddFilter={onAddFilter}

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -54,17 +54,19 @@ function SummaryCard({ label, value, hint }: SummaryCardProps) {
 interface ConsumptionSummaryProps {
   workspaceId: string;
   overview: ConsumptionOverviewType;
+  isPersonalScope: boolean;
 }
 
 function ConsumptionSummary({
   workspaceId,
   overview,
+  isPersonalScope,
 }: ConsumptionSummaryProps) {
   const { topAgent, totalCredits, creditUsage } = overview;
 
   return (
     <div className="flex flex-col gap-4">
-      {creditUsage && (
+      {!isPersonalScope && creditUsage && (
         <div className="flex items-center justify-between gap-4 rounded-xl border border-border bg-panel-background p-2">
           <div className="flex items-center gap-2">
             <Chip
@@ -114,12 +116,14 @@ interface ConsumptionOverviewProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
+  isPersonalScope: boolean;
 }
 
 export function ConsumptionOverview({
   workspaceId,
   period: periodSelection,
   filter,
+  isPersonalScope,
 }: ConsumptionOverviewProps) {
   const { overview, isOverviewLoading, isOverviewError } =
     useConsumptionOverview({ workspaceId, period: periodSelection, filter });
@@ -141,7 +145,11 @@ export function ConsumptionOverview({
 
   const header = [
     `${formatConsumptionDate(period.startDate)} to ${formatConsumptionDate(period.endDate)}`,
-    `${members.active.toLocaleString()} of ${members.total.toLocaleString()} members active`,
+    ...(isPersonalScope
+      ? []
+      : [
+          `${members.active.toLocaleString()} of ${members.total.toLocaleString()} members active`,
+        ]),
     ...(lastRecordAt
       ? [`Updated ${timeAgoFrom(new Date(lastRecordAt).getTime())} ago`]
       : []),
@@ -161,7 +169,11 @@ export function ConsumptionOverview({
           </span>
         ))}
       </p>
-      <ConsumptionSummary workspaceId={workspaceId} overview={overview} />
+      <ConsumptionSummary
+        workspaceId={workspaceId}
+        overview={overview}
+        isPersonalScope={isPersonalScope}
+      />
     </div>
   );
 }

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
@@ -1,10 +1,41 @@
-import { consumptionDimensionFromQueryParam } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import {
+  CONSUMPTION_DIMENSIONS,
+  consumptionDimensionFromQueryParam,
+} from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import { PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
 import { describe, expect, it } from "vitest";
 
 describe("consumption dimension URL state", () => {
   it("reads valid dimensions and falls back to agents", () => {
-    expect(consumptionDimensionFromQueryParam("user")).toBe("user");
-    expect(consumptionDimensionFromQueryParam("invalid")).toBe("agent");
-    expect(consumptionDimensionFromQueryParam(undefined)).toBe("agent");
+    expect(
+      consumptionDimensionFromQueryParam("user", CONSUMPTION_DIMENSIONS)
+    ).toBe("user");
+    expect(
+      consumptionDimensionFromQueryParam("invalid", CONSUMPTION_DIMENSIONS)
+    ).toBe("agent");
+    expect(
+      consumptionDimensionFromQueryParam(undefined, CONSUMPTION_DIMENSIONS)
+    ).toBe("agent");
+  });
+
+  it("falls back to agents for a dimension the scope does not offer", () => {
+    expect(
+      consumptionDimensionFromQueryParam(
+        "user",
+        PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS
+      )
+    ).toBe("agent");
+    expect(
+      consumptionDimensionFromQueryParam(
+        "group",
+        PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS
+      )
+    ).toBe("agent");
+    expect(
+      consumptionDimensionFromQueryParam(
+        "model",
+        PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS
+      )
+    ).toBe("model");
   });
 });

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -80,9 +80,11 @@ export function isConsumptionDimension(
 }
 
 export function consumptionDimensionFromQueryParam(
-  value: string | undefined
+  value: string | undefined,
+  dimensions: ConsumptionDimension[]
 ): ConsumptionDimension {
-  return value !== undefined && isConsumptionDimension(value)
-    ? value
-    : DEFAULT_CONSUMPTION_DIMENSION;
+  return (
+    dimensions.find((dimension) => dimension === value) ??
+    DEFAULT_CONSUMPTION_DIMENSION
+  );
 }

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -26,6 +26,10 @@ export const USAGE_FILTER_CATEGORIES = [
 
 export type UsageFilterCategory = (typeof USAGE_FILTER_CATEGORIES)[number];
 
+export const PERSONAL_USAGE_FILTER_CATEGORIES = USAGE_FILTER_CATEGORIES.filter(
+  (category) => category !== "member" && category !== "group"
+);
+
 export const USAGE_FILTER_CATEGORY_LABEL: Record<UsageFilterCategory, string> =
   {
     agent: "Agents",

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -4,6 +4,7 @@ import {
   isRemoteMCPServerType,
 } from "@app/lib/actions/mcp_helper";
 import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
+import { isPersonalConsumptionScope } from "@app/lib/api/analytics/consumption/scope";
 import { SOURCE_ORIGIN_LABELS } from "@app/lib/api/analytics/source_labels";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
@@ -110,24 +111,27 @@ async function listConsumptionFacetCatalogWithoutTracing(
   // workspace catalogs and is known to perform poorly on large workspaces.
   // Move most facet metadata into Elasticsearch so this endpoint can query ES
   // instead of loading several unbounded database-backed catalogs.
-  const members = await traceFacetCatalogLoad(
-    "members",
-    "user",
-    requestedDimension,
-    async () => {
-      const result = await getMembers(auth, { activeOnly: true });
-      return result.members;
-    }
-  );
-  const groups = await traceFacetCatalogLoad(
-    "groups",
-    "group",
-    requestedDimension,
-    () =>
-      GroupResource.listAllWorkspaceGroups(auth, {
-        groupKinds: [...MANAGEABLE_GROUP_KINDS],
-      })
-  );
+  // A personal scope has no member or group filter, so their catalogs are never
+  // read.
+  const isPersonalScope = isPersonalConsumptionScope(auth);
+  const members = isPersonalScope
+    ? []
+    : await traceFacetCatalogLoad(
+        "members",
+        "user",
+        requestedDimension,
+        async () => {
+          const result = await getMembers(auth, { activeOnly: true });
+          return result.members;
+        }
+      );
+  const groups = isPersonalScope
+    ? []
+    : await traceFacetCatalogLoad("groups", "group", requestedDimension, () =>
+        GroupResource.listAllWorkspaceGroups(auth, {
+          groupKinds: [...MANAGEABLE_GROUP_KINDS],
+        })
+      );
   const agents = await traceFacetCatalogLoad(
     "agents",
     "agent",

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -11,6 +11,8 @@ import {
   CONSUMPTION_DIMENSION_FIELDS,
   CONSUMPTION_DIMENSION_FILTER_KEYS,
   CONSUMPTION_SCOPE_DIMENSIONS,
+  isPersonalConsumptionScope,
+  PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
@@ -233,11 +235,13 @@ async function resolveFacets(
   );
   const entries = [
     ...catalogEntries,
-    ...missingCatalogValues.map((value) => ({
-      value,
-      label: historicalLabels.get(value)?.name ?? value,
-      pictureUrl: historicalLabels.get(value)?.pictureUrl ?? null,
-    })),
+    ...missingCatalogValues.flatMap((value) => {
+      const label = historicalLabels.get(value);
+      if (!label) {
+        return [];
+      }
+      return [{ value, label: label.name, pictureUrl: label.pictureUrl }];
+    }),
   ];
 
   return entries
@@ -270,8 +274,13 @@ async function fetchConsumptionFacetsWithoutTracing(
     filter?: ConsumptionScopeFilter;
   }
 ): Promise<Result<ConsumptionFacets, ElasticsearchError>> {
+  const isPersonalScope = isPersonalConsumptionScope(auth);
+  const dimensions = isPersonalScope
+    ? PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS
+    : CONSUMPTION_SCOPE_DIMENSIONS;
+
   const bucketResults = await concurrentExecutor(
-    CONSUMPTION_SCOPE_DIMENSIONS,
+    dimensions,
     async (dimension) => ({
       dimension,
       result: await fetchDimensionFacetBuckets({
@@ -302,18 +311,22 @@ async function fetchConsumptionFacetsWithoutTracing(
     getFacetBuckets(bucketsByDimension, "agent"),
     catalog.agent
   );
-  const userFacets = await resolveFacets(
-    auth,
-    "user",
-    getFacetBuckets(bucketsByDimension, "user"),
-    catalog.user
-  );
-  const groupFacets = await resolveFacets(
-    auth,
-    "group",
-    getFacetBuckets(bucketsByDimension, "group"),
-    catalog.group
-  );
+  const userFacets = isPersonalScope
+    ? []
+    : await resolveFacets(
+        auth,
+        "user",
+        getFacetBuckets(bucketsByDimension, "user"),
+        catalog.user
+      );
+  const groupFacets = isPersonalScope
+    ? []
+    : await resolveFacets(
+        auth,
+        "group",
+        getFacetBuckets(bucketsByDimension, "group"),
+        catalog.group
+      );
   const modelFacets = await resolveFacets(
     auth,
     "model",

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -67,14 +67,20 @@ describe("resolveDimensionDisplayNames", () => {
     const skills = await resolveDimensionDisplayNames(auth, "skill", [
       "deleted_skill",
     ]);
-    const agents = await resolveDimensionDisplayNames(auth, "agent", [
-      "deleted_agent",
-    ]);
 
     expect(names.get("deleted_model")).toBe("deleted_model");
     expect(origins.get("deleted_origin")).toBe("deleted_origin");
     expect(skills.get("deleted_skill")).toBe("deleted_skill");
-    expect(agents.get("deleted_agent")).toBe("deleted_agent");
+  });
+
+  // Callers drop the row instead, so an unreadable agent never surfaces as a
+  // bare sId.
+  it("omits an agent it cannot resolve", async () => {
+    const agents = await resolveDimensionDisplayNames(auth, "agent", [
+      "deleted_agent",
+    ]);
+
+    expect(agents.has("deleted_agent")).toBe(false);
   });
 
   it("returns nothing for an empty breakdown", async () => {

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -65,22 +65,21 @@ export async function resolveDimensionLabels(
   }
 
   switch (dimension) {
+    // An agent the caller cannot read has no entry: `resolveAnalyticsAgentLabels`
+    // omits it, and callers drop the row rather than show a bare sId.
     case "agent": {
       const labels = await resolveAnalyticsAgentLabels(auth, keys);
       return new Map(
-        keys.map((key) => {
-          const label = labels.get(key);
-          return [
-            key,
-            {
-              name: label?.name ?? key,
-              pictureUrl: label?.pictureUrl ?? null,
-              description: label?.description || null,
-              modelId: label?.modelId,
-              modelDisplayName: label?.modelDisplayName,
-            },
-          ];
-        })
+        [...labels].map(([key, label]) => [
+          key,
+          {
+            name: label.name,
+            pictureUrl: label.pictureUrl,
+            description: label.description || null,
+            modelId: label.modelId,
+            modelDisplayName: label.modelDisplayName,
+          },
+        ])
       );
     }
 

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -10,8 +10,10 @@ import {
   COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
   CREDIT_MICRO_FIELD,
+  isPersonalConsumptionScope,
 } from "@app/lib/api/analytics/consumption/scope";
 import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import { getEffectiveSpendCapAwuCreditsForUser } from "@app/lib/api/credits/members_usage";
 import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
@@ -74,12 +76,18 @@ function lastRecordAtFromAgg(
   return agg.value_as_string ?? new Date(agg.value).toISOString();
 }
 
-async function fetchPoolCapCredits(
+async function fetchCapCredits(
   auth: Authenticator,
   periodInput: ConsumptionPeriodInput
 ): Promise<number | null> {
   if (periodInput.kind !== "cycle") {
     return null;
+  }
+
+  if (isPersonalConsumptionScope(auth)) {
+    return getEffectiveSpendCapAwuCreditsForUser(auth, {
+      user: auth.getNonNullableUser(),
+    });
   }
 
   const poolResult = await getAwuPoolSummary(auth);
@@ -129,10 +137,11 @@ async function topAgentFromAgg(
 
   const agentId = String(bucket.key);
   const labels = await resolveDimensionLabels(auth, "agent", [agentId]);
+  const label = labels.get(agentId);
 
   return {
     agentId,
-    name: labels.get(agentId)?.name ?? agentId,
+    name: label ? label.name : "Unknown Agent",
     credits: microCreditsToCredits(bucket[AGENT_CREDIT_AGG]?.value ?? 0),
   };
 }
@@ -174,7 +183,7 @@ export async function fetchConsumptionOverview(
       size: 0,
     }),
     MembershipResource.countActiveMembersForWorkspace({ workspace }),
-    fetchPoolCapCredits(auth, periodInput),
+    fetchCapCredits(auth, periodInput),
   ]);
 
   if (searchResult.isErr()) {

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -61,6 +61,38 @@ describe("buildConsumptionScopeQuery", () => {
     ]);
   });
 
+  it("confines a non-manager to their own user, dropping the group filter", async () => {
+    const { authenticator } = await createResourceTest({ role: "user" });
+    const query = buildConsumptionScopeQuery({
+      auth: authenticator,
+      ...WINDOW,
+      filter: {
+        agents: ["a1"],
+        users: ["someone-else", "another-member"],
+        groups: ["group1"],
+      },
+    });
+
+    expect(query.bool?.filter).toEqual([
+      { term: { workspace_id: authenticator.getNonNullableWorkspace().sId } },
+      expect.objectContaining({ range: expect.anything() }),
+      { term: { "agent.id": "a1" } },
+      { term: { "user.id": authenticator.getNonNullableUser().sId } },
+    ]);
+  });
+
+  it("confines a non-manager even when no filter is sent", async () => {
+    const { authenticator } = await createResourceTest({ role: "user" });
+    const query = buildConsumptionScopeQuery({
+      auth: authenticator,
+      ...WINDOW,
+    });
+
+    expect(query.bool?.filter).toContainEqual({
+      term: { "user.id": authenticator.getNonNullableUser().sId },
+    });
+  });
+
   it("ignores empty selections", async () => {
     const { authenticator } = await createResourceTest({
       role: "admin",

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -139,6 +139,30 @@ function termFilter(
   ];
 }
 
+export function isPersonalConsumptionScope(auth: Authenticator): boolean {
+  return !auth.isManager();
+}
+
+export const PERSONAL_CONSUMPTION_SCOPE_DIMENSIONS: ConsumptionScopeDimension[] =
+  CONSUMPTION_SCOPE_DIMENSIONS.filter(
+    (dimension) => dimension !== "user" && dimension !== "group"
+  );
+
+function scopedFilterForAuth(
+  auth: Authenticator,
+  filter: ConsumptionScopeFilter
+): ConsumptionScopeFilter {
+  if (!isPersonalConsumptionScope(auth)) {
+    return filter;
+  }
+
+  return {
+    ...filter,
+    users: [auth.getNonNullableUser().sId],
+    groups: undefined,
+  };
+}
+
 /**
  * Workspace-scoped query over a half-open [startDate, endDate) window.
  */
@@ -156,6 +180,7 @@ export function buildConsumptionScopeQuery({
   extraFilters?: estypes.QueryDslQueryContainer[];
 }): estypes.QueryDslQueryContainer {
   const workspaceId = auth.getNonNullableWorkspace().sId;
+  const scopedFilter = scopedFilterForAuth(auth, filter);
   const filters: estypes.QueryDslQueryContainer[] = [
     { term: { workspace_id: workspaceId } },
     { range: { [COMPLETED_AT_FIELD]: { gte: startDate, lt: endDate } } },
@@ -165,7 +190,7 @@ export function buildConsumptionScopeQuery({
     filters.push(
       ...termFilter(
         CONSUMPTION_DIMENSION_FIELDS[dimension],
-        filter[CONSUMPTION_DIMENSION_FILTER_KEYS[dimension]]
+        scopedFilter[CONSUMPTION_DIMENSION_FILTER_KEYS[dimension]]
       )
     );
   }

--- a/front/lib/api/analytics/consumption/timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/timeseries.test.ts
@@ -439,5 +439,42 @@ describe("fetchConsumptionTimeseries", () => {
         { agent1: 0, agent2: 0 },
       ]);
     });
+
+    it("folds an unlabelled group into others instead of charting its sId", async () => {
+      const { auth, period } = await setup();
+      // "unreadable" ranks but resolves to no name.
+      mockGroupNames({ agent1: "@dust" });
+      mockBreakdown({
+        rankedKeys: ["agent1", "unreadable"],
+        buckets: [groupDayBucket(0, 3_000_000, { agent1: 2_000_000 })],
+      });
+
+      const result = await fetchConsumptionTimeseries(auth, {
+        period,
+        granularity: "day",
+        mode: "daily",
+        breakdownBy: "agent",
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (!result.isOk()) {
+        return;
+      }
+      expect(result.value.groups).toEqual([
+        { groupKey: "agent1", name: "@dust" },
+        { groupKey: OTHERS_GROUP_KEY, name: "Others" },
+      ]);
+      // The histogram only ever asked for the readable key.
+      const [, histogramOptions] = vi.mocked(searchConsumptionAnalytics).mock
+        .calls[1];
+      expect(
+        histogramOptions?.aggregations?.by_date?.aggs?.by_group?.terms
+      ).toMatchObject({ include: ["agent1"] });
+      // The dropped group's credits survive as "others", so the total holds.
+      expect(result.value.points[0]?.values).toEqual({
+        agent1: 2,
+        [OTHERS_GROUP_KEY]: 1,
+      });
+    });
   });
 });

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -179,7 +179,20 @@ async function fetchTimeseriesBreakdown(
   if (rankingResult.isErr()) {
     return rankingResult;
   }
-  const topDimensionKeys = rankingResult.value;
+  const rankedKeys = rankingResult.value;
+
+  if (rankedKeys.length === 0) {
+    return fetchTimeseries(query, scope);
+  }
+
+  // We resolve names before the histogram so a key not readable by the caller is dropped
+  // from the breakdown.
+  const names = await resolveDimensionDisplayNames(
+    auth,
+    breakdownBy,
+    rankedKeys
+  );
+  const topDimensionKeys = rankedKeys.filter((groupKey) => names.has(groupKey));
 
   if (topDimensionKeys.length === 0) {
     return fetchTimeseries(query, scope);
@@ -200,11 +213,6 @@ async function fetchTimeseriesBreakdown(
     topDimensionKeys
   );
 
-  const names = await resolveDimensionDisplayNames(
-    auth,
-    breakdownBy,
-    topDimensionKeys
-  );
   const rankedGroups = topDimensionKeys.map((groupKey) => ({
     groupKey,
     name: names.get(groupKey) ?? groupKey,

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -362,6 +362,42 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
+  it("drops an agent it cannot label, keeping its credits in the total", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "@dust" });
+    mockAggs({
+      buckets: [
+        {
+          key: "agent1",
+          doc_count: 4,
+          credit_micro: { value: 3_000_000 },
+          messages: { value: 2 },
+        },
+        {
+          key: "unreadable",
+          doc_count: 2,
+          credit_micro: { value: 1_000_000 },
+          messages: { value: 1 },
+        },
+      ],
+      totalMicro: 5_000_000,
+    });
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
+      "agent1",
+    ]);
+    expect(result.value.totalCredits).toBe(5);
+  });
+
   it("credits a skill with the invocations attributed to it", async () => {
     const { auth } = await setup();
     vi.mocked(resolveDimensionLabels).mockResolvedValue(
@@ -544,22 +580,18 @@ describe("consumption top rankings", () => {
     });
   });
 
+  // Agents are the exception — they get dropped instead, see above.
   it("falls back to the raw key when a group has no label left", async () => {
     const { auth } = await setup();
     mockLabels({});
     mockAggs({
       buckets: [
-        {
-          key: "agent_gone",
-          doc_count: 1,
-          credit_micro: { value: 1_000_000 },
-          messages: { value: 1 },
-        },
+        { key: "skl_gone", doc_count: 1, credit_micro: { value: 1_000_000 } },
       ],
       totalMicro: 1_000_000,
     });
 
-    const result = await fetchConsumptionTopAgents(auth, {
+    const result = await fetchConsumptionTopSkills(auth, {
       period: PERIOD,
       limit: 10,
     });
@@ -568,10 +600,9 @@ describe("consumption top rankings", () => {
     if (!result.isOk()) {
       return;
     }
-    expect(result.value.agents[0]).toMatchObject({
-      agentId: "agent_gone",
-      name: "agent_gone",
-      pictureUrl: null,
+    expect(result.value.skills[0]).toMatchObject({
+      skillId: "skl_gone",
+      name: "skl_gone",
       description: null,
     });
   });

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -312,16 +312,27 @@ export async function resolveConsumptionGroupLabels(
     groups.map((group) => group.key)
   );
 
-  return groups.map((group) => ({
-    key: group.key,
-    name: labels.get(group.key)?.name ?? group.key,
-    pictureUrl: labels.get(group.key)?.pictureUrl ?? null,
-    description: labels.get(group.key)?.description ?? null,
-    modelId: labels.get(group.key)?.modelId,
-    modelDisplayName: labels.get(group.key)?.modelDisplayName,
-    icon: labels.get(group.key)?.icon,
-    credits: group.credits,
-    count: group.count,
-    avgCredits: avgCreditsPerUnit(group.credits, group.count),
-  }));
+  return groups.flatMap((group) => {
+    const label = labels.get(group.key);
+    // Agent labels are permission-gated: `resolveDimensionLabels` omits an agent
+    // the caller cannot read, and it gets no row rather than a bare sId. Its
+    // credits stay in `totalCredits`. Every other dimension falls back to the key.
+    if (!label && dimension === "agent") {
+      return [];
+    }
+    return [
+      {
+        key: group.key,
+        name: label?.name ?? group.key,
+        pictureUrl: label?.pictureUrl ?? null,
+        description: label?.description ?? null,
+        modelId: label?.modelId,
+        modelDisplayName: label?.modelDisplayName,
+        icon: label?.icon,
+        credits: group.credits,
+        count: group.count,
+        avgCredits: avgCreditsPerUnit(group.credits, group.count),
+      },
+    ];
+  });
 }


### PR DESCRIPTION
## Description

Consumption analytics was manager-only. Members and builders now get the same page, scoped to their own consumption:

- The user filter is forced to the caller inside `buildConsumptionScopeQuery`, so no endpoint can opt out (the facets composite agg in particular passes no filter).
- Cap credits come from the caller's own seat instead of the workspace pool.
- Member/group filters and attribution dimensions are dropped, along with the "n of m members active" line and the cap-status header row.
- The Admin tab shows up for members when `enable_analytics_consumption` is on, with only that page unlocked.
- `top-users` and `top-groups` keep `ensureIsManager`.

Also: an agent the caller can't read is now dropped from rankings/facets rather than rendered as a bare sId. In the chart its credits fold into "Others" so totals still match.

## Tests

Unit tests updated/added across `front` (scope, labels, top, timeseries, dimensions) and `front-api` (overview, facets, top).

## Risk

Widens read access on 8 consumption endpoints. Behind `enable_analytics_consumption`; rollback is a revert.

## Deploy Plan

Deploy front