### PR TITLE
Make generated files index migration retryable

### DIFF
--- a/front/migrations/pre-deploy/20260813145341_add_generated_files_lookup_index.sql
+++ b/front/migrations/pre-deploy/20260813145341_add_generated_files_lookup_index.sql
@@ -2,6 +2,7 @@
 Statement 0
   - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
 */
-SET SESSION statement_timeout = 1200000;
+SET SESSION statement_timeout = 3600000;
 SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY IF EXISTS agent_mcp_action_output_items_ws_action_file_id;
 CREATE INDEX CONCURRENTLY agent_mcp_action_output_items_ws_action_file_id ON public.agent_mcp_action_output_items USING btree ("workspaceId", "agentMCPActionId", "fileId", id) WHERE ("fileId" IS NOT NULL);


### PR DESCRIPTION
## Description

The first production attempt to build `agent_mcp_action_output_items_ws_action_file_id` timed out after 20 minutes in US, leaving an invalid index stub. The fail-fast rollout stopped before EU, and the migration remains pending in both ledgers.

Drop any same-named index concurrently before rebuilding and raise this migration's statement timeout to 60 minutes. This lets the same checked-in migration recover the US stub and follow the clean path in EU.

## Tests

Applied the migration twice against an isolated PostgreSQL database: once with no existing index and once with the same-named valid index. Both completed, and the final index reported `indisvalid=true` and `indisready=true`.

## Risk

The concurrent drop and build do not block writes, but the rebuild can consume database CPU and I/O for up to 60 minutes. The migration is still pending in both production ledgers. US currently has only an invalid stub and EU has no index.

Before application, rollback is a code revert. After application, removal requires a forward concurrent index drop.

## Deploy Plan

1. Merge this PR.
2. Confirm front DB CPU has sufficient headroom.
3. Run `./scripts/run-migrations.sh pre-deploy front`; it applies US first and stops before EU on failure.
4. Confirm migration status is clean in both regions and the index is valid.
5. Verify the generated-file lookup uses the new index in Query Insights.