### PR TITLE
Fix GPT-5 tool footprint attribution

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
@@ -13,9 +13,10 @@ import assert from "assert";
 // tool-call emission out of the assistant output bucket. Version 3 expands an enabled skill's tool
 // input footprint with the instructions and tool definitions that the action adds to later model
 // requests. Version 4 keeps sandbox-child actions as direct-charge-only rows because their calls
-// and results reach the outer model through their parent Computer action. Each version remains a
-// separate, self-consistent set of rows.
-export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 4;
+// and results reach the outer model through their parent Computer action. Version 5 removes the
+// context-window safety padding from tool footprints and uses o200k for GPT-5 provider accounting.
+// Each version remains a separate, self-consistent set of rows.
+export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 5;
 
 export type RunUsageForAttribution = Pick<
   RunUsageType,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -9,6 +9,7 @@ import { tokenCountForTexts } from "@app/lib/tokenization";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import {
   GPT_4_1_MODEL_CONFIG,
+  GPT_5_6_SOL_MODEL_ID,
   GPT_5_MODEL_ID,
 } from "@app/types/assistant/models/openai";
 import { Err, Ok } from "@app/types/shared/result";
@@ -183,7 +184,28 @@ describe("measureToolCallFootprints", () => {
     expect(res.isOk()).toBe(true);
     expect(tokenCountForTexts).toHaveBeenCalledWith(
       expect.any(Array),
-      GPT_4_1_MODEL_CONFIG,
+      {
+        ...GPT_4_1_MODEL_CONFIG,
+        tokenCountAdjustment: 1,
+      },
+      expect.anything()
+    );
+  });
+
+  it("tokenizes GPT-5 footprints without safety padding using o200k", async () => {
+    const res = await measureToolCallFootprints(auth, {
+      modelId: GPT_5_6_SOL_MODEL_ID,
+      toolCalls: [footprintInput(makeAction())],
+    });
+
+    expect(res.isOk()).toBe(true);
+    expect(tokenCountForTexts).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({
+        modelId: GPT_5_6_SOL_MODEL_ID,
+        tokenCountAdjustment: 1,
+        tokenizer: { type: "tiktoken", base: "o200k_base" },
+      }),
       expect.anything()
     );
   });

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -9,6 +9,7 @@ import {
   GPT_4_1_MINI_MODEL_CONFIG,
   GPT_4_1_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -18,6 +19,17 @@ const HISTORICAL_TOKENIZATION_MODEL_CONFIGS = [
   GPT_4_1_MODEL_CONFIG,
   GPT_4_1_MINI_MODEL_CONFIG,
 ];
+
+function modelForToolFootprintAttribution(
+  model: ModelConfigurationType
+): ModelConfigurationType {
+  return {
+    ...model,
+    // The shared default is a context-window safety margin. Attribution needs the raw estimate.
+    // Preserve only explicit adjustments that compensate for a model-specific tokenizer mismatch.
+    tokenCountAdjustment: model.tokenCountAdjustment ?? 1,
+  };
+}
 
 /**
  * The two texts an MCP action contributes to the model's token budget: the tool call the model
@@ -71,8 +83,8 @@ export function toolCallFootprintTexts(
  * Measures, for each action, how many tokens the model spent emitting the tool call and how many
  * input tokens the execution contributes. Results stay aligned with `toolCalls`.
  *
- * Uses the exact tokenizer of the run's model through core, the same path conversation rendering
- * uses to size messages, so the counts closely match provider tokenization rather than a heuristic.
+ * Uses the run model's tokenizer through core, without conversation rendering's context-window
+ * safety padding.
  */
 export async function measureToolCallFootprints(
   auth: Authenticator,
@@ -98,6 +110,7 @@ export async function measureToolCallFootprints(
       new Error(`Cannot tokenize tool footprints: unknown model ${modelId}.`)
     );
   }
+  const attributionModel = modelForToolFootprintAttribution(model);
 
   const credentials = await getLlmCredentials(auth, {
     skipEmbeddingApiKeyRequirement: true,
@@ -120,12 +133,12 @@ export async function measureToolCallFootprints(
   const [callCountsRes, inputCountsRes] = await Promise.all([
     tokenCountForTexts(
       footprints.map((footprint) => footprint.callText),
-      model,
+      attributionModel,
       credentials
     ),
     tokenCountForTexts(
       footprints.map((footprint) => footprint.inputText),
-      model,
+      attributionModel,
       credentials
     ),
   ]);

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -265,6 +265,9 @@ INCORRECT examples (what you must NEVER do):
 - Never: {"query": "caf\\u00e9 fran\\u00e7ais"}
 - Never: {"query": "na\\u00efvet\\u00e9"}
 The tools expect properly formed JSON with actual UTF-8 characters, not escape sequences.`;
+// Validated against OpenAI's input-token count API on 2026-08-13: for the incident payload,
+// GPT-5.6 Sol reported 20,473 input tokens while o200k_base counted 20,467 content tokens.
+// https://developers.openai.com/api/docs/guides/token-counting
 export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "openai",
   modelId: GPT_5_MODEL_ID,
@@ -293,7 +296,7 @@ export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -325,7 +328,7 @@ export const GPT_5_1_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -358,7 +361,7 @@ export const GPT_5_2_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -392,7 +395,7 @@ export const GPT_5_4_MODEL_CONFIG: ModelConfigurationType = {
   supportsToolSearch: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -426,7 +429,7 @@ export const GPT_5_5_MODEL_CONFIG: ModelConfigurationType = {
   supportsToolSearch: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -468,7 +471,7 @@ export const GPT_5_6_SOL_MODEL_CONFIG: ModelConfigurationType = {
   },
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -505,7 +508,7 @@ export const GPT_5_6_TERRA_MODEL_CONFIG: ModelConfigurationType = {
   supportsToolSearch: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -542,7 +545,7 @@ export const GPT_5_6_LUNA_MODEL_CONFIG: ModelConfigurationType = {
   supportsToolSearch: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -577,7 +580,7 @@ export const GPT_5_4_MINI_MODEL_CONFIG: ModelConfigurationType = {
   supportsToolSearch: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -611,7 +614,7 @@ export const GPT_5_4_NANO_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -644,7 +647,7 @@ export const GPT_5_MINI_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,
@@ -676,7 +679,7 @@ export const GPT_5_NANO_MODEL_CONFIG: ModelConfigurationType = {
   supportsBatchProcessing: true,
   formattingMetaPrompt: OPENAI_FORMATTING_META_PROMPT,
   toolUseMetaPrompt: OPENAI_TOOL_USE_META_PROMPT,
-  tokenizer: { type: "tiktoken", base: "r50k_base" },
+  tokenizer: { type: "tiktoken", base: "o200k_base" },
   regionalAvailability: {
     "us-central1": true,
     "europe-west1": true,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Tool result footprints were overestimated because GPT-5 models used `r50k_base` with a 15% safety margin. This could
make the attributed tool footprint larger than the provider’s billed input and leave consumption attribution incomplete, causing analytics indexing to retry indefinitely.

This changes the shared GPT-5 model configurations to `o200k_base` and removes context-window safety padding when
computing attribution footprints. Attribution now uses a multiplier of 1.

For the production failure investigated, OpenAI reported 20,473 input tokens while `o200k_base` counted 20,467 content
tokens. The previous calculation stored `29,991` tokens.

The attribution version is bumped so retried workflows recompute existing records. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
