### PR TITLE
Speed up Dust Hive environment creation

### DIFF
--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -9,16 +9,12 @@
 // NOTE: cargo target is symlinked to share Rust compilation cache.
 
 import { mkdirSync, readdirSync, readlinkSync, symlinkSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { cp, mkdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 
 import { ALL_BINARIES, buildBinaries } from "./cache";
 import { directoryExists } from "./fs";
 import { logger } from "./logger";
-
-// User config directories to copy from main repo to worktree
-// These are personal/local files that aren't tracked in git
-const USER_CONFIG_DIRS = [".claude"];
 
 // Configuration for how to install each dependency type
 export interface DependencyConfig {
@@ -130,6 +126,22 @@ async function findAgentsFiles(srcDir: string): Promise<string[]> {
     .filter((line) => line.length > 0);
 }
 
+export async function copyClaudeConfig(srcDir: string, destDir: string): Promise<void> {
+  const srcPath = join(srcDir, ".claude");
+  if (!(await directoryExists(srcPath))) {
+    return;
+  }
+
+  const destPath = join(destDir, ".claude");
+  const worktreesPath = join(srcPath, "worktrees");
+  await mkdir(destPath, { recursive: true });
+  await cp(srcPath, destPath, {
+    recursive: true,
+    force: true,
+    filter: (source) => source !== worktreesPath,
+  });
+}
+
 // Copy user config files (AGENTS.local.md, AGENTS.override.md files, .claude/) from main repo to worktree
 async function copyUserConfigFiles(srcDir: string, destDir: string): Promise<void> {
   // Find and copy all AGENTS.local.md and AGENTS.override.md files, preserving directory structure
@@ -142,19 +154,8 @@ async function copyUserConfigFiles(srcDir: string, destDir: string): Promise<voi
     logger.success(`Copied ${relativePath}`);
   }
 
-  // Copy directories recursively, merging with existing content
-  // Note: We use "cp -r srcPath/. destPath/" to copy CONTENTS rather than the directory itself.
-  // This is critical when destPath already exists (e.g., when git creates .claude/ with tracked skills).
-  // Without the "/." pattern, cp -r creates a nested srcPath inside destPath.
-  for (const dir of USER_CONFIG_DIRS) {
-    const srcPath = `${srcDir}/${dir}`;
-    const destPath = `${destDir}/${dir}`;
-    if (await directoryExists(srcPath)) {
-      await mkdir(destPath, { recursive: true });
-      await Bun.spawn(["cp", "-r", `${srcPath}/.`, destPath]).exited;
-      logger.success(`Copied ${dir}/`);
-    }
-  }
+  await copyClaudeConfig(srcDir, destDir);
+  logger.success("Copied .claude/");
 }
 
 // Run npm install in a directory

--- a/x/henry/dust-hive/tests/lib/setup.test.ts
+++ b/x/henry/dust-hive/tests/lib/setup.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { copyClaudeConfig } from "../../src/lib/setup";
+
+let tmpDir: string;
+let srcDir: string;
+let destDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "dust-hive-setup-test-"));
+  srcDir = join(tmpDir, "source");
+  destDir = join(tmpDir, "destination");
+  await mkdir(join(srcDir, ".claude", "skills", "local-skill"), { recursive: true });
+  await mkdir(join(srcDir, ".claude", "worktrees", "nested-worktree"), { recursive: true });
+  await mkdir(join(destDir, ".claude", "skills", "tracked-skill"), { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("copyClaudeConfig", () => {
+  it("merges local config without copying worktrees", async () => {
+    await writeFile(join(srcDir, ".claude", "settings.local.json"), "{}");
+    await writeFile(join(srcDir, ".claude", "skills", "local-skill", "SKILL.md"), "local");
+    await writeFile(
+      join(srcDir, ".claude", "worktrees", "nested-worktree", "large-file"),
+      "unwanted"
+    );
+    await writeFile(join(destDir, ".claude", "skills", "tracked-skill", "SKILL.md"), "tracked");
+
+    await copyClaudeConfig(srcDir, destDir);
+
+    expect(await Bun.file(join(destDir, ".claude", "settings.local.json")).text()).toBe("{}");
+    expect(
+      await Bun.file(join(destDir, ".claude", "skills", "local-skill", "SKILL.md")).text()
+    ).toBe("local");
+    expect(
+      await Bun.file(join(destDir, ".claude", "skills", "tracked-skill", "SKILL.md")).text()
+    ).toBe("tracked");
+    expect(await Bun.file(join(destDir, ".claude", "worktrees")).exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Skip nested local worktree caches when copying developer configuration into a new Dust Hive environment. These caches can contain full repository checkouts and package trees, making cold creation take several minutes.

## Tests

Added regression coverage for config merging and cache exclusion. Timed cold creation at 326.53s before and 9.88s after.

## Risk

Low. The change is limited to local Dust Hive setup, and regular settings and skills are still copied.

## Deploy Plan

Standard deploy.