### PR TITLE
Fix EU hosted model billing uplift

### DIFF
--- a/front/lib/api/assistant/token_pricing/eu.ts
+++ b/front/lib/api/assistant/token_pricing/eu.ts
@@ -1,58 +1,98 @@
 import type { PricingEntry } from "@app/lib/api/assistant/token_pricing/global";
+import { MODEL_PRICING } from "@app/lib/api/assistant/token_pricing/global";
+import {
+  CLAUDE_4_5_HAIKU_20251001_MODEL_ID,
+  CLAUDE_4_5_OPUS_20251101_MODEL_ID,
+  CLAUDE_4_5_SONNET_20250929_MODEL_ID,
+  CLAUDE_OPUS_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_7_MODEL_ID,
+  CLAUDE_OPUS_4_8_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+  CLAUDE_SONNET_5_MODEL_ID,
+} from "@app/types/assistant/models/anthropic";
+import type { StaticModelIdType } from "@app/types/assistant/models/models";
+import {
+  GPT_5_4_MINI_MODEL_ID,
+  GPT_5_4_MODEL_ID,
+  GPT_5_4_NANO_MODEL_ID,
+  GPT_5_5_MODEL_ID,
+  GPT_5_6_LUNA_MODEL_ID,
+  GPT_5_6_SOL_MODEL_ID,
+  GPT_5_6_TERRA_MODEL_ID,
+} from "@app/types/assistant/models/openai";
 
-// EU-hosted pricing overrides for Anthropic models served via Google Vertex AI in EU.
-// Anthropic charges a 10% surcharge on Vertex AI EU inference.
-// Only models currently routable via Vertex in EU are listed here.
-// https://www.anthropic.com/pricing
+// Regional and multi-region endpoints charge a 10% premium over global endpoints.
+// Anthropic: Claude 4.5 and later models served through Vertex AI in EU.
+// OpenAI: models whose pricing pages specify the data-residency uplift.
+// Verified 2026-08-13:
+// https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai
+// https://openai.com/api/pricing/
+const EU_PRICING_MULTIPLIER = 1.1;
 
-export const EU_MODEL_PRICING: Partial<Record<string, PricingEntry>> = {
-  "claude-sonnet-4-5-20250929": {
-    input: 3.3,
-    output: 16.5,
-    cache_creation_input_tokens: 4.125,
-    long_cache_creation_input_tokens: 6.6,
-    cache_read_input_tokens: 0.33,
-  },
-  "claude-sonnet-4-6": {
-    input: 3.3,
-    output: 16.5,
-    cache_creation_input_tokens: 4.125,
-    long_cache_creation_input_tokens: 6.6,
-    cache_read_input_tokens: 0.33,
-  },
-  "claude-opus-4-5-20251101": {
-    input: 5.5,
-    output: 27.5,
-    cache_creation_input_tokens: 6.875,
-    long_cache_creation_input_tokens: 11.0,
-    cache_read_input_tokens: 0.55,
-  },
-  "claude-opus-4-6": {
-    input: 5.5,
-    output: 27.5,
-    cache_creation_input_tokens: 6.875,
-    long_cache_creation_input_tokens: 11.0,
-    cache_read_input_tokens: 0.55,
-  },
-  "claude-opus-4-7": {
-    input: 5.5,
-    output: 27.5,
-    cache_creation_input_tokens: 6.875,
-    long_cache_creation_input_tokens: 11.0,
-    cache_read_input_tokens: 0.55,
-  },
-  "claude-opus-4-8": {
-    input: 5.5,
-    output: 27.5,
-    cache_creation_input_tokens: 6.875,
-    long_cache_creation_input_tokens: 11.0,
-    cache_read_input_tokens: 0.55,
-  },
-  "claude-haiku-4-5-20251001": {
-    input: 1.1,
-    output: 5.5,
-    cache_creation_input_tokens: 1.375,
-    long_cache_creation_input_tokens: 2.2,
-    cache_read_input_tokens: 0.11,
-  },
-};
+export const EU_UPLIFT_MODEL_IDS = [
+  CLAUDE_4_5_SONNET_20250929_MODEL_ID,
+  CLAUDE_SONNET_4_6_MODEL_ID,
+  CLAUDE_SONNET_5_MODEL_ID,
+  CLAUDE_4_5_OPUS_20251101_MODEL_ID,
+  CLAUDE_OPUS_4_6_MODEL_ID,
+  CLAUDE_OPUS_4_7_MODEL_ID,
+  CLAUDE_OPUS_4_8_MODEL_ID,
+  CLAUDE_4_5_HAIKU_20251001_MODEL_ID,
+  GPT_5_4_MODEL_ID,
+  GPT_5_4_MINI_MODEL_ID,
+  GPT_5_4_NANO_MODEL_ID,
+  GPT_5_5_MODEL_ID,
+  GPT_5_6_SOL_MODEL_ID,
+  GPT_5_6_TERRA_MODEL_ID,
+  GPT_5_6_LUNA_MODEL_ID,
+] as const satisfies readonly StaticModelIdType[];
+
+function applyRegionalUplift(pricing: PricingEntry): PricingEntry {
+  return {
+    input: pricing.input * EU_PRICING_MULTIPLIER,
+    output: pricing.output * EU_PRICING_MULTIPLIER,
+    ...(pricing.cache_creation_input_tokens !== undefined && {
+      cache_creation_input_tokens:
+        pricing.cache_creation_input_tokens * EU_PRICING_MULTIPLIER,
+    }),
+    ...(pricing.long_cache_creation_input_tokens !== undefined && {
+      long_cache_creation_input_tokens:
+        pricing.long_cache_creation_input_tokens * EU_PRICING_MULTIPLIER,
+    }),
+    ...(pricing.cache_read_input_tokens !== undefined && {
+      cache_read_input_tokens:
+        pricing.cache_read_input_tokens * EU_PRICING_MULTIPLIER,
+    }),
+    ...(pricing.long_context && {
+      long_context: {
+        prompt_token_threshold: pricing.long_context.prompt_token_threshold,
+        input: pricing.long_context.input * EU_PRICING_MULTIPLIER,
+        output: pricing.long_context.output * EU_PRICING_MULTIPLIER,
+        ...(pricing.long_context.cache_creation_input_tokens !== undefined && {
+          cache_creation_input_tokens:
+            pricing.long_context.cache_creation_input_tokens *
+            EU_PRICING_MULTIPLIER,
+        }),
+        ...(pricing.long_context.long_cache_creation_input_tokens !==
+          undefined && {
+          long_cache_creation_input_tokens:
+            pricing.long_context.long_cache_creation_input_tokens *
+            EU_PRICING_MULTIPLIER,
+        }),
+        ...(pricing.long_context.cache_read_input_tokens !== undefined && {
+          cache_read_input_tokens:
+            pricing.long_context.cache_read_input_tokens *
+            EU_PRICING_MULTIPLIER,
+        }),
+      },
+    }),
+  };
+}
+
+export const EU_MODEL_PRICING: Partial<Record<string, PricingEntry>> =
+  Object.fromEntries(
+    EU_UPLIFT_MODEL_IDS.map((modelId) => [
+      modelId,
+      applyRegionalUplift(MODEL_PRICING[modelId]),
+    ])
+  );

--- a/front/lib/api/assistant/token_pricing/index.test.ts
+++ b/front/lib/api/assistant/token_pricing/index.test.ts
@@ -1,4 +1,9 @@
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
+import { EU_UPLIFT_MODEL_IDS } from "@app/lib/api/assistant/token_pricing/eu";
+import {
+  GPT_5_5_MODEL_ID,
+  GPT_5_MODEL_ID,
+} from "@app/types/assistant/models/openai";
 import {
   GROK_4_5_MODEL_ID,
   GROK_4_6_MODEL_ID,
@@ -6,6 +11,74 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("computeTokensCostForUsageInMicroUsd", () => {
+  it.each(
+    EU_UPLIFT_MODEL_IDS
+  )("applies the EU uplift to every token rate for %s", (modelId) => {
+    const usage = {
+      modelId,
+      promptTokens: 4_000_000,
+      completionTokens: 1_000_000,
+      cachedTokens: 1_000_000,
+      cacheCreationTokens: 2_000_000,
+      longCacheCreationTokens: 1_000_000,
+    };
+
+    const globalCostMicroUsd = computeTokensCostForUsageInMicroUsd({
+      ...usage,
+      inferenceRegion: "global",
+    });
+    const euCostMicroUsd = computeTokensCostForUsageInMicroUsd({
+      ...usage,
+      inferenceRegion: "eu",
+    });
+
+    expect(euCostMicroUsd).toBeCloseTo(globalCostMicroUsd * 1.1, 6);
+  });
+
+  it("combines the OpenAI EU uplift with the batch discount", () => {
+    const usage = {
+      modelId: GPT_5_5_MODEL_ID,
+      promptTokens: 1_000_000,
+      completionTokens: 1_000_000,
+      cachedTokens: null,
+      isBatch: true,
+    };
+
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        ...usage,
+        inferenceRegion: "global",
+      })
+    ).toBe(17_500_000);
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        ...usage,
+        inferenceRegion: "eu",
+      })
+    ).toBe(19_250_000);
+  });
+
+  it("does not uplift OpenAI models without regional premium pricing", () => {
+    const usage = {
+      modelId: GPT_5_MODEL_ID,
+      promptTokens: 1_000_000,
+      completionTokens: 1_000_000,
+      cachedTokens: null,
+    };
+
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        ...usage,
+        inferenceRegion: "eu",
+      })
+    ).toBe(
+      computeTokensCostForUsageInMicroUsd({
+        ...usage,
+        inferenceRegion: "global",
+      })
+    );
+  });
+
   it("uses long-context Grok 4.5 pricing at 200k prompt tokens", () => {
     expect(
       computeTokensCostForUsageInMicroUsd({

--- a/front/lib/api/llm/run_lifecycle.test.ts
+++ b/front/lib/api/llm/run_lifecycle.test.ts
@@ -1,8 +1,11 @@
-import { getStreamLLM } from "@app/lib/api/llm";
+import { getBatchLLM, getStreamLLM } from "@app/lib/api/llm";
 import { LLMRunLifecycle } from "@app/lib/api/llm/run_lifecycle";
 import { createLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { LLMStreamParameters } from "@app/lib/api/llm/types/options";
+import { DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch } from "@app/lib/llms/batch/endpoints/openai_gpt_five_dot_five_eu_openai_responses";
 import { DustNoopNoopGlobalNoopStream } from "@app/lib/llms/stream/endpoints/noop_noop_global_noop";
+import { DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_five_eu_openai_responses";
+import { DustOpenAIGptFiveDotFiveGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_five_global_openai_responses";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -167,6 +170,65 @@ describe("LLMRunLifecycle", () => {
     expect(await run?.listRunUsages(auth)).toMatchObject([
       { costMicroUsd: 310 },
     ]);
+  });
+});
+
+describe("endpoint billing metadata", () => {
+  it("uses EU pricing for EU stream and batch endpoints", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const credentials = { OPENAI_API_KEY: "test" };
+
+    const streamLlm = getStreamLLM(auth, {
+      credentials,
+      modelInfo: {
+        endpoint: DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesStream,
+        temperature: 0,
+      },
+    });
+    if (!streamLlm) {
+      throw new Error("Expected the EU stream LLM to be available");
+    }
+
+    const batchLlm = await getBatchLLM(auth, {
+      credentials,
+      modelInfo: {
+        endpoint: DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch,
+        temperature: 0,
+      },
+    });
+    if (!batchLlm) {
+      throw new Error("Expected the EU batch LLM to be available");
+    }
+
+    expect(streamLlm.getMetadata()).toMatchObject({
+      inferenceProvider: "openai-responses",
+      inferenceRegion: "eu",
+      region: "eu",
+    });
+    expect(batchLlm.getMetadata()).toMatchObject({
+      inferenceProvider: "openai-responses",
+      inferenceRegion: "eu",
+      region: "eu",
+    });
+  });
+
+  it("keeps global endpoints on global pricing", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const llm = getStreamLLM(auth, {
+      credentials: { OPENAI_API_KEY: "test" },
+      modelInfo: {
+        endpoint: DustOpenAIGptFiveDotFiveGlobalOpenAIResponsesStream,
+        temperature: 0,
+      },
+    });
+    if (!llm) {
+      throw new Error("Expected the global stream LLM to be available");
+    }
+
+    expect(llm.getMetadata()).toMatchObject({
+      inferenceRegion: "global",
+      region: "global",
+    });
   });
 });
 

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -1,6 +1,7 @@
 import {
   convertToOldEvent,
   getPromptCacheKeyForHost,
+  inferenceRegionForEndpointRegion,
   reasoningContentToLegacyMetadata,
   toBaseMessages,
   withMessageCacheBreakpoints,
@@ -39,6 +40,24 @@ const serverToolUseBlock = {
   name: "tool_search_tool_bm25",
   input: { query: "x" },
 };
+
+describe("inferenceRegionForEndpointRegion", () => {
+  it.each([
+    { endpointRegion: "eu" as const, expectedInferenceRegion: "eu" },
+    {
+      endpointRegion: "global" as const,
+      expectedInferenceRegion: "global",
+    },
+    { endpointRegion: "us" as const, expectedInferenceRegion: "global" },
+  ])("maps $endpointRegion endpoints to $expectedInferenceRegion pricing", ({
+    endpointRegion,
+    expectedInferenceRegion,
+  }) => {
+    expect(inferenceRegionForEndpointRegion(endpointRegion)).toBe(
+      expectedInferenceRegion
+    );
+  });
+});
 
 describe("getPromptCacheKeyForHost", () => {
   const metadata = {

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -1,3 +1,4 @@
+import type { InferenceRegionType } from "@app/lib/api/assistant/token_pricing";
 import { LLM } from "@app/lib/api/llm/llm";
 import type {
   BatchDeletionOutcome,
@@ -68,6 +69,8 @@ import type {
   NonDeltaResponseEvent,
   PassthroughLab,
 } from "@app/lib/model_constructors/types/output/events";
+import type { Region } from "@app/lib/model_constructors/types/regions";
+import { EUROPE, GLOBAL, US } from "@app/lib/model_constructors/types/regions";
 import { isCacheMissReason } from "@app/lib/model_constructors/utils/cache_miss_reason";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type {
@@ -88,6 +91,20 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString } from "@app/types/shared/utils/general";
+
+export function inferenceRegionForEndpointRegion(
+  region: Region
+): InferenceRegionType {
+  switch (region) {
+    case EUROPE:
+      return "eu";
+    case GLOBAL:
+    case US:
+      return "global";
+    default:
+      return assertNever(region);
+  }
+}
 
 /**
  * Maps a reasoning effort to the model constructor's effort values.
@@ -819,6 +836,7 @@ export class StreamEndpointTransition extends BaseTransition {
     this.metadata = {
       ...this.metadata,
       inferenceProvider: api,
+      inferenceRegion: inferenceRegionForEndpointRegion(region),
       region,
     };
   }
@@ -969,6 +987,14 @@ export class BatchEndpointTransition extends BaseTransition {
       llmParameters
     );
     this.model = new modelConstructor(llmParameters.credentials);
+
+    const { host: api, region } = this.model.metadata();
+    this.metadata = {
+      ...this.metadata,
+      inferenceProvider: api,
+      inferenceRegion: inferenceRegionForEndpointRegion(region),
+      region,
+    };
   }
 
   // Builds the per-request payload for tracing (the base class captures batch


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
### Chapter 3 in our journey to reconcile costs

EU-hosted Anthropic and OpenAI models carry a 10% pricing uplift.

Our legacy Anthropic integration explicitly marked European requests with `inferenceRegion: "eu"`. That signal disappeared
when the legacy clients were removed in https://github.com/dust-tt/dust/commit/10d5e4d967270865bde00a4fb6afda3614b664a8. The new endpoint layer still knew its region, but that information was not reaching billing, which (very) quietly fell back to global pricing.

The regional pricing table had also fallen behind. It only covered a hardcoded subset of Anthropic models and none of the eligible OpenAI models, meaning that knowing a request was European was not always enough to price it correctly.

This PR reconnects the selected endpoint region to billing for both streaming and batch inference. When a request is served
from Europe and its model is eligible for the provider uplift, we now apply the 1.1× tariff. The EU rates are derived directly from global prices, including cache and long-context pricing, so they remain aligned as base prices evolve. Models without an EU-specific uplift continue to use global pricing.

### Pricing references

- [Anthropic Vertex AI pricing](https://platform.claude.com/docs/en/build-with-claude/claude-on-vertex-ai)
- [OpenAI API pricing](https://openai.com/api/pricing/)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
