### PR TITLE
feat(sandbox): request_egress_domain tool and publish-time domain requests

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2066,6 +2066,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "request_egress_domain": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
   },
   "sandbox_functions": {
     "call": {
@@ -3283,6 +3287,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "add_egress_domain": "high",
     "bash": "never_ask",
     "describe_toolset": "never_ask",
+    "request_egress_domain": "low",
   },
   "sandbox_functions": {
     "call": "low",

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -102,9 +102,7 @@ export const SANDBOX_TOOLS_METADATA = [
       "allowlist surface as denied entries in `<network_proxy_logs>` in " +
       "the bash tool output. Allowlist entries added through this tool " +
       "persist for the lifetime of the conversation (across sandbox " +
-      "restarts) and are scoped to this conversation only — including " +
-      "inside a Pod, where Pod-wide domains are managed by admins in the " +
-      "Pod's network settings.",
+      "restarts) and are scoped to this conversation only.",
     schema: {
       domain: z
         .string()
@@ -125,6 +123,38 @@ export const SANDBOX_TOOLS_METADATA = [
     displayLabels: {
       running: "Requesting Computer network access",
       done: "Allow domain in the Computer",
+      icon: "ActionGlobeAltIcon",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+  {
+    name: "request_egress_domain",
+    description:
+      "Request a domain be permanently added to a shared network allowlist, " +
+      "for a workspace admin to approve. `pod` scope covers all sandboxes " +
+      "in the current Pod (only call it inside a Pod); `workspace` scope " +
+      "covers all sandboxes in the workspace. One domain per call; wildcards " +
+      "allowed.",
+    schema: {
+      domain: z
+        .string()
+        .min(1)
+        .describe(
+          'Domain to request, e.g. "api.stripe.com" or "*.stripe.com".'
+        ),
+      scope: z
+        .enum(["pod", "workspace"])
+        .describe(
+          "`pod` adds it to this Pod's allowlist (for the Pod's functions); " +
+            "`workspace` adds it for every sandbox in the workspace. Prefer " +
+            "`pod` unless all sandboxes genuinely need the domain."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Requesting network access",
+      done: "Requested a domain",
       icon: "ActionGlobeAltIcon",
     },
     toolCostCategory: "basic",

--- a/front/lib/api/actions/servers/sandbox/tools/index.test.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.test.ts
@@ -1,3 +1,4 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -9,6 +10,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockAddOwnerPolicyDomain,
+  mockRequestOwnerPolicyDomain,
+  mockRequestWorkspacePolicyDomain,
   mockReadNewDenyLogEntries,
   mockEmitAuditLogEvent,
   mockGenerateExecId,
@@ -24,6 +27,8 @@ const {
   mockFetchActionById,
 } = vi.hoisted(() => ({
   mockAddOwnerPolicyDomain: vi.fn(),
+  mockRequestOwnerPolicyDomain: vi.fn(),
+  mockRequestWorkspacePolicyDomain: vi.fn(),
   mockReadNewDenyLogEntries: vi.fn(),
   mockEmitAuditLogEvent: vi.fn(),
   mockGenerateExecId: vi.fn(),
@@ -57,6 +62,8 @@ vi.mock("@app/lib/api/sandbox/egress_policy", async (importOriginal) => {
   return {
     ...actual,
     addOwnerPolicyDomain: mockAddOwnerPolicyDomain,
+    requestOwnerPolicyDomain: mockRequestOwnerPolicyDomain,
+    requestWorkspacePolicyDomain: mockRequestWorkspacePolicyDomain,
   };
 });
 
@@ -124,16 +131,20 @@ import {
   addEgressDomainTool,
   buildDescribeToolsetOutput,
   createSandboxTools,
+  requestEgressDomainTool,
   runSandboxBashTool,
 } from "./index";
 
 describe("createSandboxTools", () => {
-  it("omits add_egress_domain by default", async () => {
+  it("keeps request_egress_domain but omits self-serve add_egress_domain by default", async () => {
     const { authenticator: auth } = await createResourceTest({});
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
 
     const tools = await createSandboxTools(auth);
+    const names = tools.map((tool) => tool.name);
 
-    expect(tools.map((tool) => tool.name)).not.toContain("add_egress_domain");
+    expect(names).not.toContain("add_egress_domain");
+    expect(names).toContain("request_egress_domain");
   });
 
   it("includes add_egress_domain when Computer and metadata are enabled", async () => {
@@ -145,13 +156,16 @@ describe("createSandboxTools", () => {
       user.sId,
       workspace.sId
     );
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
 
     const tools = await createSandboxTools(auth);
+    const names = tools.map((tool) => tool.name);
 
-    expect(tools.map((tool) => tool.name)).toContain("add_egress_domain");
+    expect(names).toContain("add_egress_domain");
+    expect(names).toContain("request_egress_domain");
   });
 
-  it("omits add_egress_domain when Computer is disabled", async () => {
+  it("omits both egress tools when Computer is disabled", async () => {
     const { workspace, user } = await createResourceTest({});
     await WorkspaceResource.updateMetadata(workspace.id, {
       sandboxAllowAgentEgressRequests: true,
@@ -160,23 +174,46 @@ describe("createSandboxTools", () => {
       user.sId,
       workspace.sId
     );
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
     await FeatureFlagFactory.basic(auth, "disable_computer_feature");
 
     const tools = await createSandboxTools(auth);
+    const names = tools.map((tool) => tool.name);
 
-    expect(tools.map((tool) => tool.name)).not.toContain("add_egress_domain");
+    expect(names).not.toContain("add_egress_domain");
+    expect(names).not.toContain("request_egress_domain");
   });
 
-  it("omits add_egress_domain when metadata is off", async () => {
+  it("omits request_egress_domain when sandbox_functions is off", async () => {
     const { workspace, user } = await createResourceTest({});
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      sandboxAllowAgentEgressRequests: true,
+    });
     const auth = await Authenticator.fromUserIdAndWorkspaceId(
       user.sId,
       workspace.sId
     );
 
     const tools = await createSandboxTools(auth);
+    const names = tools.map((tool) => tool.name);
 
-    expect(tools.map((tool) => tool.name)).not.toContain("add_egress_domain");
+    expect(names).toContain("add_egress_domain");
+    expect(names).not.toContain("request_egress_domain");
+  });
+
+  it("keeps request_egress_domain when the on-the-fly toggle is off", async () => {
+    const { workspace, user } = await createResourceTest({});
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+
+    const tools = await createSandboxTools(auth);
+    const names = tools.map((tool) => tool.name);
+
+    expect(names).not.toContain("add_egress_domain");
+    expect(names).toContain("request_egress_domain");
   });
 });
 
@@ -230,7 +267,7 @@ describe("runSandboxBashTool", () => {
 
   function makeExtra(
     overrides: {
-      // The fixture is an untyped fake (the runContext is cast as never), so
+      // The fixture is an untyped fake (cast to ToolHandlerExtra via unknown), so
       // this Picks only the fields the tools read — typed against the real
       // conversation shape so renames surface at compile time.
       conversation?: Pick<ConversationWithoutContentType, "sId"> &
@@ -265,7 +302,7 @@ describe("runSandboxBashTool", () => {
         },
       },
       signal: new AbortController().signal,
-    } as never;
+    } as unknown as ToolHandlerExtra;
   }
 
   it("executes as agent-proxied when the forwarder is healthy", async () => {
@@ -765,7 +802,7 @@ describe("runSandboxBashTool", () => {
           }),
         },
         signal: new AbortController().signal,
-      } as never;
+      } as unknown as ToolHandlerExtra;
     }
 
     it("runs wait-and-collect when resumeState carries a valid execId", async () => {
@@ -861,7 +898,7 @@ describe("addEgressDomainTool", () => {
         },
       },
       signal: new AbortController().signal,
-    } as never;
+    } as unknown as ToolHandlerExtra;
   }
 
   it("refuses to run when agent egress requests are disabled", async () => {
@@ -1067,5 +1104,169 @@ describe("addEgressDomainTool", () => {
 
     expect(result.isErr()).toBe(true);
     expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe("requestEgressDomainTool", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequestOwnerPolicyDomain.mockResolvedValue(
+      new Ok({
+        outcome: "requested",
+        policy: {
+          allowedDomains: [],
+          requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+        },
+      })
+    );
+    mockRequestWorkspacePolicyDomain.mockResolvedValue(
+      new Ok({
+        outcome: "requested",
+        policy: {
+          allowedDomains: [],
+          requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+        },
+      })
+    );
+  });
+
+  function makeExtra({
+    conversationSpaceId = "pod-space-id",
+    allowAgentEgressRequests = true,
+  }: {
+    conversationSpaceId?: string | null;
+    allowAgentEgressRequests?: boolean;
+  } = {}) {
+    return {
+      auth: {
+        getNonNullableWorkspace: () => ({
+          name: "Workspace",
+          sId: "workspace-id",
+          metadata: {
+            sandboxAllowAgentEgressRequests: allowAgentEgressRequests,
+          },
+        }),
+      },
+      runContext: {
+        contextType: "agent_loop",
+        conversation: {
+          sId: "conversation-id",
+          spaceId: conversationSpaceId,
+        },
+      },
+      signal: new AbortController().signal,
+    } as unknown as ToolHandlerExtra;
+  }
+
+  it("errors on pod scope outside a Pod", async () => {
+    const result = await requestEgressDomainTool(
+      { domain: "api.stripe.com", scope: "pod" },
+      makeExtra({ conversationSpaceId: null })
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("not in a Pod");
+    }
+    expect(mockRequestOwnerPolicyDomain).not.toHaveBeenCalled();
+  });
+
+  it("records a pod request against the Pod's own policy file", async () => {
+    const result = await requestEgressDomainTool(
+      { domain: "api.stripe.com", scope: "pod" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value[0].text).toContain("Requested for the Pod");
+    }
+    expect(mockRequestOwnerPolicyDomain).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        ownerId: "pod-space-id",
+        domain: "api.stripe.com",
+      }
+    );
+  });
+
+  it("records a workspace request against the workspace policy file", async () => {
+    const result = await requestEgressDomainTool(
+      { domain: "api.stripe.com", scope: "workspace" },
+      // Workspace scope needs no Pod.
+      makeExtra({ conversationSpaceId: null })
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value[0].text).toContain("Requested for the workspace");
+    }
+    expect(mockRequestWorkspacePolicyDomain).toHaveBeenCalledWith(
+      expect.anything(),
+      { domain: "api.stripe.com" }
+    );
+    expect(mockRequestOwnerPolicyDomain).not.toHaveBeenCalled();
+  });
+
+  it("accepts a wildcard domain", async () => {
+    const result = await requestEgressDomainTool(
+      { domain: "*.Stripe.COM", scope: "pod" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockRequestOwnerPolicyDomain).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        ownerId: "pod-space-id",
+        domain: "*.stripe.com",
+      }
+    );
+  });
+
+  it("reports when the domain is already allowed", async () => {
+    mockRequestOwnerPolicyDomain.mockResolvedValue(
+      new Ok({ outcome: "already_allowed", policy: { allowedDomains: [] } })
+    );
+
+    const result = await requestEgressDomainTool(
+      { domain: "api.stripe.com", scope: "pod" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value[0].text).toContain("Already allowed for the Pod");
+    }
+  });
+
+  it("surfaces an already-pending request to the caller", async () => {
+    mockRequestOwnerPolicyDomain.mockResolvedValue(
+      new Ok({ outcome: "already_requested", policy: { allowedDomains: [] } })
+    );
+
+    const result = await requestEgressDomainTool(
+      { domain: "api.stripe.com", scope: "pod" },
+      makeExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value[0].text).toContain("Already requested for the Pod");
+    }
+  });
+
+  it("still records a request when the on-the-fly egress toggle is off", async () => {
+    const result = await requestEgressDomainTool(
+      { domain: "api.stripe.com", scope: "pod" },
+      makeExtra({ allowAgentEgressRequests: false })
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(mockRequestOwnerPolicyDomain).toHaveBeenCalled();
   });
 });

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -28,9 +28,12 @@ import {
   revokeExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
 import { readNewDenyLogEntries } from "@app/lib/api/sandbox/egress";
+import type { RequestOwnerPolicyDomainOutcome } from "@app/lib/api/sandbox/egress_policy";
 import {
   addOwnerPolicyDomain,
   parseExactEgressDomain,
+  requestOwnerPolicyDomain,
+  requestWorkspacePolicyDomain,
 } from "@app/lib/api/sandbox/egress_policy";
 import {
   createToolManifest,
@@ -52,11 +55,15 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { SandboxEnvVarResource } from "@app/lib/resources/sandbox_env_var_resource";
 import logger from "@app/logger/logger";
 import type { ConversationType } from "@app/types/assistant/conversation";
+import { isPodConversation } from "@app/types/assistant/conversation";
 import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
 import { isDevelopment } from "@app/types/shared/env";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import assert from "assert";
 import { z } from "zod";
@@ -64,6 +71,7 @@ import { z } from "zod";
 const DEFAULT_WORKING_DIRECTORY = "/home/agent";
 const DEFAULT_EXEC_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24h
 const ADD_EGRESS_DOMAIN_TOOL_NAME = "add_egress_domain" as const;
+const REQUEST_EGRESS_DOMAIN_TOOL_NAME = "request_egress_domain" as const;
 const REDACTION_MARKER_PREFIX = "«redacted:";
 const REDACTION_MARKER_SUFFIX = "»";
 const REDACTION_MIN_LENGTH = 16;
@@ -290,21 +298,27 @@ export async function createSandboxTools(
       return buildDescribeToolsetOutput(auth, providerId, format ?? "yaml");
     },
     [ADD_EGRESS_DOMAIN_TOOL_NAME]: addEgressDomainTool,
+    [REQUEST_EGRESS_DOMAIN_TOOL_NAME]: requestEgressDomainTool,
   };
 
   const tools = buildTools(SANDBOX_TOOLS_METADATA, handlers);
 
-  // The add_egress_domain tool requires Computer access and the
-  // per-workspace setting that admins toggle on top of it.
+  // Both require Computer. add_egress_domain is also gated on the self-serve
+  // toggle; request_egress_domain on sandbox_functions instead — so it only
+  // appears where its Pod/workspace review settings exist, never the toggle.
   const flags = await getFeatureFlags(auth);
-  if (
-    isComputerFeatureEnabled(flags) &&
-    isSandboxAgentEgressRequestsAllowed(auth)
-  ) {
-    return tools;
+  const computerEnabled = isComputerFeatureEnabled(flags);
+  const excluded = new Set<string>();
+  if (!computerEnabled || !isSandboxAgentEgressRequestsAllowed(auth)) {
+    excluded.add(ADD_EGRESS_DOMAIN_TOOL_NAME);
+  }
+  if (!computerEnabled || !flags.includes("sandbox_functions")) {
+    excluded.add(REQUEST_EGRESS_DOMAIN_TOOL_NAME);
   }
 
-  return tools.filter((tool) => tool.name !== ADD_EGRESS_DOMAIN_TOOL_NAME);
+  return excluded.size === 0
+    ? tools
+    : tools.filter((tool) => !excluded.has(tool.name));
 }
 
 export async function buildDescribeToolsetOutput(
@@ -619,4 +633,95 @@ export async function addEgressDomainTool(
         `No change made; this domain is already allowed for this conversation.`;
 
   return new Ok([{ type: "text" as const, text }]);
+}
+
+export async function requestEgressDomainTool(
+  { domain, scope }: { domain: string; scope: "pod" | "workspace" },
+  { auth, runContext }: ToolHandlerExtra
+): Promise<Result<Array<{ type: "text"; text: string }>, MCPError>> {
+  assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
+
+  const parsed = normalizeEgressPolicyDomain(domain);
+  if (parsed.isErr()) {
+    return new Err(new MCPError(parsed.error.message));
+  }
+
+  const requestResult = await fileEgressDomainRequest(
+    auth,
+    runContext.conversation,
+    {
+      scope,
+      domain: parsed.value,
+    }
+  );
+  if (requestResult.isErr()) {
+    return new Err(new MCPError(requestResult.error.message));
+  }
+
+  const target = scope === "workspace" ? "workspace" : "Pod";
+  return new Ok([
+    {
+      type: "text" as const,
+      text: requestOutcomeText(
+        requestResult.value.outcome,
+        target,
+        parsed.value
+      ),
+    },
+  ]);
+}
+
+// Pod scope keys the Pod's policy file by the conversation's spaceId.
+function fileEgressDomainRequest(
+  auth: Authenticator,
+  conversation: ConversationType,
+  { scope, domain }: { scope: "pod" | "workspace"; domain: string }
+): Promise<
+  Result<
+    { policy: EgressPolicy; outcome: RequestOwnerPolicyDomainOutcome },
+    Error
+  >
+> {
+  if (scope === "workspace") {
+    return requestWorkspacePolicyDomain(auth, { domain });
+  }
+  if (!isPodConversation(conversation)) {
+    return Promise.resolve(
+      new Err(
+        new Error(
+          "This conversation is not in a Pod. Request `workspace` scope, or " +
+            "use add_egress_domain to allow a domain for this conversation."
+        )
+      )
+    );
+  }
+  return requestOwnerPolicyDomain(auth, {
+    ownerId: conversation.spaceId,
+    domain,
+  });
+}
+
+function requestOutcomeText(
+  outcome: RequestOwnerPolicyDomainOutcome,
+  target: string,
+  domain: string
+): string {
+  switch (outcome) {
+    case "requested":
+      return (
+        `Requested for the ${target}: ${domain}\n` +
+        `A workspace admin will review this before sandboxes can reach it.`
+      );
+    case "already_allowed":
+      return (
+        `Already allowed for the ${target}: ${domain}\n` + `No request needed.`
+      );
+    case "already_requested":
+      return (
+        `Already requested for the ${target}: ${domain}\n` +
+        `It is waiting for a workspace admin to review.`
+      );
+    default:
+      return assertNever(outcome);
+  }
 }

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -89,6 +89,16 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
             "interaction or on a poll `fast`, and isolate `dsbx tools` calls in their own " +
             "`durable` functions."
         ),
+      domains: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Exact domains or wildcards (e.g. `api.stripe.com`, `*.stripe.com`) the function " +
+            "makes outbound HTTPS requests to at runtime. Declare every domain the function " +
+            "needs — each becomes a request a workspace admin reviews before the Pod can reach " +
+            "it; it never grants access on its own. A domain the Pod (or workspace) already " +
+            "allows is skipped."
+        ),
     },
     stake: "low",
     displayLabels: {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -48,6 +48,7 @@ const outputSchema: JSONSchema = {
 beforeEach(() => {
   vi.clearAllMocks();
   fileStorageMock.reset();
+  fileStorageMock.setFetchFileContentNotFound(() => true);
   vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
     new Ok({
       bundleCode: "export default {};",
@@ -57,6 +58,11 @@ beforeEach(() => {
     })
   );
 });
+
+function firstText(content: Array<{ type: string; text?: string }>): string {
+  const first = content[0];
+  return first.type === "text" ? (first.text ?? "") : "";
+}
 
 describe("publishHandler", () => {
   it("reports the app-prefixed slug and the reference a Frame needs", async () => {
@@ -81,6 +87,55 @@ describe("publishHandler", () => {
         text: `Published pod function "tasklist__add-task". Frames call it by reference "${projectId}/tasklist__add-task".`,
       },
     ]);
+  });
+
+  it("records declared domains as Pod requests, even for an admin publisher", async () => {
+    const { auth, conversation, projectId } =
+      await setupProjectConversation("admin");
+
+    const result = await publishHandler(
+      {
+        slug: "charge",
+        description: "Charge a card.",
+        path: `pod-${projectId}/Billing/functions/charge.ts`,
+        executionMode: "fast",
+        domains: ["API.Stripe.COM", "*.stripe.com"],
+      },
+      makeExtra(auth, conversation)
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(firstText(result.value)).toContain("Requested for the Pod");
+
+    const policyPath = `w/${auth.getNonNullableWorkspace().sId}/sandboxes/${projectId}.json`;
+    const policy = JSON.parse(fileStorageMock.getObject(policyPath) ?? "{}");
+    expect(policy.allowedDomains).toEqual([]);
+    expect(
+      policy.requestedDomains.map((r: { domain: string }) => r.domain)
+    ).toEqual(["api.stripe.com", "*.stripe.com"]);
+  });
+
+  it("publishes with no domain note when no domains are declared", async () => {
+    const { auth, conversation, projectId } =
+      await setupProjectConversation("admin");
+
+    const result = await publishHandler(
+      {
+        slug: "greet",
+        description: "Greet.",
+        path: `pod-${projectId}/App/functions/greet.ts`,
+        executionMode: "fast",
+      },
+      makeExtra(auth, conversation)
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(firstText(result.value)).not.toContain("Pod allowlist");
+    expect(firstText(result.value)).not.toContain("Requested");
   });
 
   it("accepts a bare function name but not one that already carries a prefix", () => {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -4,8 +4,11 @@ import type {
   ToolHandlerResult,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getWritablePodContext } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import { requestOwnerPolicyDomain } from "@app/lib/api/sandbox/egress_policy";
 import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -13,11 +16,13 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 export async function publishHandler(
   {
     description,
+    domains,
     executionMode,
     path,
     slug,
   }: {
     description: string;
+    domains?: string[];
     executionMode: SandboxFunctionExecutionMode;
     path: string;
     slug: string;
@@ -47,12 +52,68 @@ export async function publishHandler(
   // the slug alone; only a Frame needs the qualified reference, so name that consumer.
   const { slug: publishedSlug } = result.value;
 
+  // Failures become a note, not a publish failure — the function is already
+  // published and its domains can be retried.
+  const domainNote = await routePublishedFunctionDomains(auth, {
+    pod: podResult.value.pod,
+    domains: domains ?? [],
+  });
+
   return new Ok([
     {
       type: "text",
-      text: `Published pod function "${publishedSlug}". Frames call it by reference "${podResult.value.pod.sId}/${publishedSlug}".`,
+      text:
+        `Published pod function "${publishedSlug}". Frames call it by reference ` +
+        `"${podResult.value.pod.sId}/${publishedSlug}".` +
+        (domainNote ? `\n${domainNote}` : ""),
     },
   ]);
+}
+
+// Files each declared domain as a Pod request. Bounded to one function's
+// domains, so the sequential per-domain writes are fine.
+async function routePublishedFunctionDomains(
+  auth: Authenticator,
+  { pod, domains }: { pod: SpaceResource; domains: string[] }
+): Promise<string | null> {
+  if (domains.length === 0) {
+    return null;
+  }
+
+  const requested: string[] = [];
+  const alreadyAllowed: string[] = [];
+  const failed: string[] = [];
+
+  for (const domain of domains) {
+    const result = await requestOwnerPolicyDomain(auth, {
+      ownerId: pod.sId,
+      domain,
+    });
+    if (result.isErr()) {
+      failed.push(domain);
+    } else if (result.value.outcome === "already_allowed") {
+      alreadyAllowed.push(domain);
+    } else {
+      // "requested" or "already_requested": pending an admin's review.
+      requested.push(domain);
+    }
+  }
+
+  const parts: string[] = [];
+  if (requested.length > 0) {
+    parts.push(
+      `Requested for the Pod (pending admin approval): ${requested.join(", ")}.`
+    );
+  }
+  if (alreadyAllowed.length > 0) {
+    parts.push(`Already allowed: ${alreadyAllowed.join(", ")}.`);
+  }
+  if (failed.length > 0) {
+    parts.push(
+      `Could not process (retry with request_egress_domain): ${failed.join(", ")}.`
+    );
+  }
+  return parts.join(" ");
 }
 
 function toMCPError(error: SandboxFunctionError): MCPError {


### PR DESCRIPTION
## Description

Follow up of `30474` (stacked on it). Adds the two **request producers** for the sandbox egress allowlist — an agent tool and a publish side-effect. Both only ever file a domain as a request a workspace admin reviews; neither grants access.

- **`request_egress_domain`** — the tool an agent calls for a domain a sandbox will need. One arg beyond the domain: **scope**.
  - `pod` (default) — for a Pod's published functions; recorded on the Pod's allowlist. Only usable inside a Pod.
  - `workspace` — for every sandbox in the workspace.
  - Distinct from `add_egress_domain` (unchanged), which grants there-and-then for the current conversation.
- **`publish`** — declaring a function's runtime `domains` files each as a `pod` request through the same helper.

Response copy reflects the outcome (`Requested` / `Already allowed` / `Already requested`).

**Stakes:** `request_egress_domain` is **low** (it only queues a request); `add_egress_domain` stays **high** (grants in-conversation, needs user approval).

**Gating:** both require Computer. `add_egress_domain` is additionally gated on the on-the-fly self-serve toggle; `request_egress_domain` on **`sandbox_functions`**, which pairs it with the Pod/workspace network settings that review its requests (Pod settings are `sandbox_functions`-only, Computer is on by default).

Stacked: the admin surface that reviews these requests (pod + workspace) is `29347`.

## Risk

Low. Both producers are request-only — they never write `allowedDomains`. Worst case a lost read-merge-write race drops a queued request; re-creatable, never touches the allowlist. Safe to rollback.

## Tests

`request_egress_domain` handler: pod request on the Pod's file; workspace request on the workspace file; errors on `pod` scope outside a Pod; wildcard accepted; already-allowed / already-requested surfaced. Tool gating across Computer / `sandbox_functions` / the self-serve toggle. Publish: declared domains recorded as Pod requests; no note when none declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
