### PR TITLE
Wait for all tool activities before finalizing cancelled agent runs

### DIFF
--- a/front/temporal/agent_loop/lib/wait_for_all_promises.test.ts
+++ b/front/temporal/agent_loop/lib/wait_for_all_promises.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { waitForAllPromises } from "./wait_for_all_promises";
+
+describe("waitForAllPromises", () => {
+  it("preserves result order after every promise succeeds", async () => {
+    await expect(
+      waitForAllPromises([Promise.resolve("first"), Promise.resolve("second")])
+    ).resolves.toEqual(["first", "second"]);
+  });
+
+  it("waits for the remaining promises before reporting a rejection", async () => {
+    const activityFailure = new Error("activity cancelled");
+    let resolveRemainingActivity: (() => void) | undefined;
+    const remainingActivity = new Promise<void>((resolve) => {
+      resolveRemainingActivity = resolve;
+    });
+
+    const result = waitForAllPromises([
+      Promise.reject(activityFailure),
+      remainingActivity,
+    ]);
+    let rejectionReported = false;
+    void result.catch(() => {
+      rejectionReported = true;
+    });
+
+    await Promise.resolve();
+    expect(rejectionReported).toBe(false);
+
+    resolveRemainingActivity?.();
+    await expect(result).rejects.toBe(activityFailure);
+  });
+});

--- a/front/temporal/agent_loop/lib/wait_for_all_promises.ts
+++ b/front/temporal/agent_loop/lib/wait_for_all_promises.ts
@@ -1,0 +1,26 @@
+/**
+ * Wait for every promise to settle, then preserve Promise.all's success and failure contract.
+ * This prevents one cancelled activity from letting a workflow finalize while sibling activities
+ * are still completing.
+ */
+export async function waitForAllPromises<T>(
+  promises: readonly Promise<T>[]
+): Promise<T[]> {
+  const results = await Promise.allSettled(promises);
+  const values: T[] = [];
+  let firstRejection: PromiseRejectedResult | undefined;
+
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      values.push(result.value);
+    } else if (!firstRejection) {
+      firstRejection = result;
+    }
+  }
+
+  if (firstRejection) {
+    throw firstRejection.reason;
+  }
+
+  return values;
+}

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -16,6 +16,8 @@ import {
   RUN_MODEL_MAX_RETRIES,
   TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
 } from "@app/temporal/agent_loop/config";
+import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
+import { waitForAllPromises } from "@app/temporal/agent_loop/lib/wait_for_all_promises";
 import {
   isRunModelLLMUnresponsiveError,
   isTerminalRunModelTimeout,
@@ -40,7 +42,9 @@ import type {
   WorkflowInterceptorsFactory,
 } from "@temporalio/workflow";
 import {
+  ActivityCancellationType,
   CancellationScope,
+  patched,
   proxyActivities,
   proxySinks,
   setHandler,
@@ -95,6 +99,26 @@ const { runToolActivity: runRetryableToolActivity } = proxyActivities<
     maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
   },
 });
+
+const { runToolActivity: runToolActivityWithExplicitCancellation } =
+  proxyActivities<typeof runToolActivities>({
+    startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
+    heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
+    cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+    retry: {
+      maximumAttempts: 1,
+    },
+  });
+
+const { runToolActivity: runRetryableToolActivityWithExplicitCancellation } =
+  proxyActivities<typeof runToolActivities>({
+    startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
+    heartbeatTimeout: TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
+    cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+    retry: {
+      maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
+    },
+  });
 
 const { publishDeferredEventsActivity } = proxyActivities<
   typeof publishDeferredEventsActivities
@@ -478,23 +502,43 @@ async function executeStepIteration({
   }
 
   // Execute tools and collect any deferred events.
-  const toolResults = await Promise.all(
-    actionBlobs.map(({ actionId, retryPolicy }) =>
+  let toolResults: ToolExecutionResult[];
+  if (patched("wait-for-all-tool-activities-before-finalization")) {
+    const toolActivityPromises = actionBlobs.map(({ actionId, retryPolicy }) =>
       retryPolicy === "no_retry"
-        ? runToolActivity(authType, {
+        ? runToolActivityWithExplicitCancellation(authType, {
             actionId,
             runAgentArgs: agentLoopArgs,
             step: currentStep,
             runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
           })
-        : runRetryableToolActivity(authType, {
+        : runRetryableToolActivityWithExplicitCancellation(authType, {
             actionId,
             runAgentArgs: agentLoopArgs,
             step: currentStep,
             runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
           })
-    )
-  );
+    );
+    toolResults = await waitForAllPromises(toolActivityPromises);
+  } else {
+    toolResults = await Promise.all(
+      actionBlobs.map(({ actionId, retryPolicy }) =>
+        retryPolicy === "no_retry"
+          ? runToolActivity(authType, {
+              actionId,
+              runAgentArgs: agentLoopArgs,
+              step: currentStep,
+              runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
+            })
+          : runRetryableToolActivity(authType, {
+              actionId,
+              runAgentArgs: agentLoopArgs,
+              step: currentStep,
+              runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
+            })
+      )
+    );
+  }
 
   // Collect all deferred events from tool executions.
   const allDeferredEvents = toolResults.flatMap(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In our journey to ensure analytics data always sums up to billed credits, we found cancelled agent messages being finalized and billed while tool activities were still running. Those tools could later succeed and add direct credits that were absent from the message’s bill. Attribution would then find more non-input credits than total billed credits, leaving no valid input-credit remainder and failing as incomplete.

There were two cancellation issues behind this:
1. Although Temporal’s TypeScript documentation describes waiting for activity cancellation as the default, the SDK version we use leaves the cancellation mode unset. At the protocol level, the default value is `TRY_CANCEL`. When the agent workflow was cancelled, Temporal therefore released the activity promises immediately while the underlying tools continued running.
2. Even with the correct cancellation mode, the tools were grouped using fail-fast promise aggregation. If one tool acknowledged cancellation before its siblings, the aggregate rejected immediately and allowed message finalization to begin while the remaining tools were still settling.

This change explicitly configures tool activities with `WAIT_CANCELLATION_COMPLETED`, ensuring each activity promise remains pending until the tool has completed, failed, or acknowledged cancellation. It also waits for every tool activity to settle before propagating a failure, ensuring billing and attribution only start once the complete set of tool outcomes is known.

The behavior is protected by a Temporal patch. Existing workflow histories replay the original path, while new histories use the corrected cancellation and aggregation behavior. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
