### PR TITLE
Add For You email opt-out and click tracking

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -1,6 +1,7 @@
 import { UsageUpgradeButton } from "@app/components/credits/UsageUpgradeButton";
 import { MarkdownEditor } from "@app/components/editor/MarkdownEditor";
 import {
+  ForYouNotificationPreferences,
   NotificationPreferences,
   useNotificationPreferencesForm,
 } from "@app/components/me/NotificationPreferences";
@@ -750,12 +751,22 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
                 <NotificationPreferences
                   control={notif.control}
                   displaySlackOption={notif.displaySlackOption}
-                  displayForYouOption={displayForYouOption}
                   workflowEnabled={notif.workflowEnabled}
                 />
               )}
             </div>
           )}
+          {showNotificationPreferences &&
+            displayForYouOption &&
+            notif.status !== "error" && (
+              <div className="flex flex-col gap-4">
+                <Page.SectionHeader
+                  title="For you"
+                  description="Recommendation emails from your learning space"
+                />
+                <ForYouNotificationPreferences control={notif.control} />
+              </div>
+            )}
         </>
       )}
     </SectionContent>

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -22,6 +22,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
 import { useAppRouter } from "@app/lib/platform";
+import { useActivationPod } from "@app/lib/swr/activation";
 import {
   useMyTopConversations,
   useMyUsage,
@@ -669,14 +670,22 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const showNotificationPreferences = Boolean(user?.subscriberHash);
+  const { activationPodId, isActivationPodLoading } = useActivationPod({
+    workspaceId: owner.sId,
+    disabled: !showNotificationPreferences,
+  });
+  const displayForYouOption = activationPodId !== null;
   const notif = useNotificationPreferencesForm({
     owner,
     disabled: !showNotificationPreferences,
+    displayForYouOption,
   });
 
   const isDirty = sound.isDirty || notif.isDirty;
   const isLoading =
-    sound.isLoading || (showNotificationPreferences && notif.isLoading);
+    sound.isLoading ||
+    (showNotificationPreferences &&
+      (notif.isLoading || isActivationPodLoading));
 
   const handleSave = async () => {
     setIsSubmitting(true);
@@ -741,6 +750,7 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
                 <NotificationPreferences
                   control={notif.control}
                   displaySlackOption={notif.displaySlackOption}
+                  displayForYouOption={displayForYouOption}
                   workflowEnabled={notif.workflowEnabled}
                 />
               )}

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -61,7 +61,7 @@ const NotificationPreferencesFormSchema = z.object({
   inApp: z.boolean(),
   slack: z.boolean(),
   email: z.boolean(),
-  allowForYouNotifications: z.boolean(),
+  forYou: z.boolean(),
 });
 
 type NotificationPreferencesFormValues = z.infer<
@@ -116,7 +116,7 @@ export function useNotificationPreferencesForm({
       inApp: false,
       slack: false,
       email: false,
-      allowForYouNotifications: true,
+      forYou: true,
     },
   });
 
@@ -136,9 +136,7 @@ export function useNotificationPreferencesForm({
       inApp: Boolean(conversationPreferences.channels.in_app),
       slack: Boolean(conversationPreferences.channels.chat),
       email: Boolean(conversationPreferences.channels.email),
-      allowForYouNotifications: isForYouNotificationsEnabled(
-        forYouMetadata?.value
-      ),
+      forYou: isForYouNotificationsEnabled(forYouMetadata?.value),
     });
   }, [
     conversationPreferences,
@@ -177,10 +175,10 @@ export function useNotificationPreferencesForm({
           });
           await mutateNotifyCondition();
         }
-        if (displayForYouOption && dirtyFields.allowForYouNotifications) {
+        if (displayForYouOption && dirtyFields.forYou) {
           await setUserMetadataFromClient({
             key: FOR_YOU_NOTIFICATION_METADATA_KEY,
-            value: String(data.allowForYouNotifications),
+            value: String(data.forYou),
           });
           await mutateForYou();
         }
@@ -214,14 +212,12 @@ export function useNotificationPreferencesForm({
 interface NotificationPreferencesProps {
   control: Control<NotificationPreferencesFormValues>;
   displaySlackOption: boolean;
-  displayForYouOption: boolean;
   workflowEnabled: boolean;
 }
 
 export function NotificationPreferences({
   control,
   displaySlackOption,
-  displayForYouOption,
   workflowEnabled,
 }: NotificationPreferencesProps) {
   const { field: notifyConditionField } = useController({
@@ -235,10 +231,6 @@ export function NotificationPreferences({
   const { field: inAppField } = useController({ name: "inApp", control });
   const { field: slackField } = useController({ name: "slack", control });
   const { field: emailField } = useController({ name: "email", control });
-  const { field: allowForYouField } = useController({
-    name: "allowForYouNotifications",
-    control,
-  });
 
   const [portalContainer] = useState<HTMLElement | undefined>(() =>
     typeof document !== "undefined" ? document.body : undefined
@@ -346,19 +338,32 @@ export function NotificationPreferences({
           </DropdownMenu>
         }
       />
+    </SettingsList>
+  );
+}
 
-      {displayForYouOption && (
-        <SettingsList.Row
-          title="Allow For You Notifications"
-          description="Receive email notifications when Dust has a new recommendation for you"
-          action={
-            <SliderToggle
-              selected={allowForYouField.value}
-              onClick={() => allowForYouField.onChange(!allowForYouField.value)}
-            />
-          }
-        />
-      )}
+export function ForYouNotificationPreferences({
+  control,
+}: {
+  control: Control<NotificationPreferencesFormValues>;
+}) {
+  const { field: forYouField } = useController({
+    name: "forYou",
+    control,
+  });
+
+  return (
+    <SettingsList>
+      <SettingsList.Row
+        title="For you"
+        description="Email when Dust has a new recommendation for you"
+        action={
+          <SliderToggle
+            selected={forYouField.value}
+            onClick={() => forYouField.onChange(!forYouField.value)}
+          />
+        }
+      />
     </SettingsList>
   );
 }

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -350,7 +350,7 @@ export function NotificationPreferences({
       {displayForYouOption && (
         <SettingsList.Row
           title="Allow For You Notifications"
-          description="Email when Dust has a new recommendation for you"
+          description="Receive email notifications when Dust has a new recommendation for you"
           action={
             <SliderToggle
               selected={allowForYouField.value}

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -11,6 +11,8 @@ import {
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
   DEFAULT_NOTIFICATION_CONDITION,
   DEFAULT_NOTIFICATION_DELAY,
+  FOR_YOU_NOTIFICATION_METADATA_KEY,
+  isForYouNotificationsEnabled,
   isNotificationCondition,
   isNotificationPreferencesDelay,
   makeNotificationPreferencesUserMetadata,
@@ -59,6 +61,7 @@ const NotificationPreferencesFormSchema = z.object({
   inApp: z.boolean(),
   slack: z.boolean(),
   email: z.boolean(),
+  allowForYouNotifications: z.boolean(),
 });
 
 type NotificationPreferencesFormValues = z.infer<
@@ -68,9 +71,11 @@ type NotificationPreferencesFormValues = z.infer<
 export function useNotificationPreferencesForm({
   owner,
   disabled,
+  displayForYouOption,
 }: {
   owner: LightWorkspaceType;
   disabled: boolean;
+  displayForYouOption: boolean;
 }) {
   const sendNotification = useSendNotification();
   const { hasFeature } = useFeatureFlags();
@@ -95,6 +100,13 @@ export function useNotificationPreferencesForm({
     metadata: notifyConditionMetadata,
     mutateMetadata: mutateNotifyCondition,
   } = useUserMetadata(CONVERSATION_NOTIFICATION_METADATA_KEYS.notifyCondition);
+  const {
+    metadata: forYouMetadata,
+    mutateMetadata: mutateForYou,
+    isMetadataLoading: isForYouLoading,
+  } = useUserMetadata(FOR_YOU_NOTIFICATION_METADATA_KEY, {
+    disabled: disabled || !displayForYouOption,
+  });
 
   const form = useForm<NotificationPreferencesFormValues>({
     resolver: zodResolver(NotificationPreferencesFormSchema),
@@ -104,6 +116,7 @@ export function useNotificationPreferencesForm({
       inApp: false,
       slack: false,
       email: false,
+      allowForYouNotifications: true,
     },
   });
 
@@ -123,11 +136,15 @@ export function useNotificationPreferencesForm({
       inApp: Boolean(conversationPreferences.channels.in_app),
       slack: Boolean(conversationPreferences.channels.chat),
       email: Boolean(conversationPreferences.channels.email),
+      allowForYouNotifications: isForYouNotificationsEnabled(
+        forYouMetadata?.value
+      ),
     });
   }, [
     conversationPreferences,
     conversationEmailMetadata,
     notifyConditionMetadata,
+    forYouMetadata,
     form,
   ]);
 
@@ -160,6 +177,13 @@ export function useNotificationPreferencesForm({
           });
           await mutateNotifyCondition();
         }
+        if (displayForYouOption && dirtyFields.allowForYouNotifications) {
+          await setUserMetadataFromClient({
+            key: FOR_YOU_NOTIFICATION_METADATA_KEY,
+            value: String(data.allowForYouNotifications),
+          });
+          await mutateForYou();
+        }
         form.reset(data);
         succeeded = true;
       } catch (error) {
@@ -177,7 +201,10 @@ export function useNotificationPreferencesForm({
     control: form.control,
     displaySlackOption,
     isDirty: form.formState.isDirty,
-    isLoading: status === "loading" || isSlackSetupLoading,
+    isLoading:
+      status === "loading" ||
+      isSlackSetupLoading ||
+      (displayForYouOption && isForYouLoading),
     save,
     status,
     workflowEnabled: Boolean(conversationPreferences?.enabled),
@@ -187,12 +214,14 @@ export function useNotificationPreferencesForm({
 interface NotificationPreferencesProps {
   control: Control<NotificationPreferencesFormValues>;
   displaySlackOption: boolean;
+  displayForYouOption: boolean;
   workflowEnabled: boolean;
 }
 
 export function NotificationPreferences({
   control,
   displaySlackOption,
+  displayForYouOption,
   workflowEnabled,
 }: NotificationPreferencesProps) {
   const { field: notifyConditionField } = useController({
@@ -206,6 +235,10 @@ export function NotificationPreferences({
   const { field: inAppField } = useController({ name: "inApp", control });
   const { field: slackField } = useController({ name: "slack", control });
   const { field: emailField } = useController({ name: "email", control });
+  const { field: allowForYouField } = useController({
+    name: "allowForYouNotifications",
+    control,
+  });
 
   const [portalContainer] = useState<HTMLElement | undefined>(() =>
     typeof document !== "undefined" ? document.body : undefined
@@ -287,7 +320,7 @@ export function NotificationPreferences({
 
       <SettingsList.Row
         title="Email frequency"
-        description="We'll never email you more often than this"
+        description="How often to send email notification summaries"
         action={
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -313,6 +346,19 @@ export function NotificationPreferences({
           </DropdownMenu>
         }
       />
+
+      {displayForYouOption && (
+        <SettingsList.Row
+          title="Allow For You Notifications"
+          description="Email when Dust has a new recommendation for you"
+          action={
+            <SliderToggle
+              selected={allowForYouField.value}
+              onClick={() => allowForYouField.onChange(!allowForYouField.value)}
+            />
+          }
+        />
+      )}
     </SettingsList>
   );
 }

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -142,6 +142,8 @@ export function GetStartedPage() {
 
   const firstName = user?.firstName ?? user?.fullName?.split(" ")[0] ?? "there";
 
+  // useLayoutEffect runs before paint; RootLayout only strips UTMs in a
+  // useEffect (after paint), so the campaign params are still on the URL here.
   useLayoutEffect(() => {
     const params = new URLSearchParams(window.location.search);
     if (params.get("utm_campaign") !== FOR_YOU_EMAIL_UTM.utm_campaign) {

--- a/front/components/pages/workspace/GetStartedPage/index.tsx
+++ b/front/components/pages/workspace/GetStartedPage/index.tsx
@@ -20,10 +20,16 @@ import {
   useActivationRecommendations,
 } from "@app/lib/swr/activation";
 import { usePodMetadata } from "@app/lib/swr/pods";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
+import { FOR_YOU_EMAIL_UTM } from "@app/lib/tracking/campaigns";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { resolveDefaultAgentId } from "@app/types/user";
 import { Button, Spinner } from "@dust-tt/sparkle";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
 
 const QUICK_PROMPTS = [
   {
@@ -135,6 +141,20 @@ export function GetStartedPage() {
   }, [startConversation]);
 
   const firstName = user?.firstName ?? user?.fullName?.split(" ")[0] ?? "there";
+
+  useLayoutEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("utm_campaign") !== FOR_YOU_EMAIL_UTM.utm_campaign) {
+      return;
+    }
+    const conversationId = params.get("utm_content");
+    trackEvent({
+      area: TRACKING_AREAS.WORKSPACE,
+      object: "for_you_email",
+      action: TRACKING_ACTIONS.CLICK,
+      extra: conversationId ? { conversation_id: conversationId } : undefined,
+    });
+  }, []);
 
   // The whole surface is scoped to the user's activation Pod, so without one
   // there is nothing to show. Redirect to the workspace home once the Pod

--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -1,6 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { getNovuClient } from "@app/lib/notifications";
 import {
+  areForYouNotificationsEnabled,
   filterMembersByNotifyCondition,
   notifyActivationConversationAgentReplied,
 } from "@app/lib/notifications/triggers/project-new-conversation";
@@ -19,6 +20,7 @@ import type { NotificationCondition } from "@app/types/notification_preferences"
 import {
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
   DEFAULT_NOTIFICATION_CONDITION,
+  FOR_YOU_NOTIFICATION_METADATA_KEY,
 } from "@app/types/notification_preferences";
 import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -351,5 +353,49 @@ describe("notifyActivationConversationAgentReplied", () => {
     });
 
     expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
+  });
+
+  test("triggers the activation email when For You notifications are explicitly enabled", async () => {
+    await user.setMetadata(FOR_YOU_NOTIFICATION_METADATA_KEY, "true");
+    const conversation = await createNudgeConversation();
+
+    await notifyActivationConversationAgentReplied(auth, {
+      conversationId: conversation.sId,
+    });
+
+    expect(vi.mocked(getNovuClient)).toHaveBeenCalled();
+  });
+
+  test("does not trigger the activation email when For You notifications are disabled", async () => {
+    await user.setMetadata(FOR_YOU_NOTIFICATION_METADATA_KEY, "false");
+    const conversation = await createNudgeConversation();
+
+    await notifyActivationConversationAgentReplied(auth, {
+      conversationId: conversation.sId,
+    });
+
+    expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
+  });
+});
+
+describe("areForYouNotificationsEnabled", () => {
+  test("allows sending when metadata is missing", async () => {
+    const { user } = await createResourceTest({ role: "user" });
+
+    expect(await areForYouNotificationsEnabled(user)).toBe(true);
+  });
+
+  test("allows sending when metadata is true", async () => {
+    const { user } = await createResourceTest({ role: "user" });
+    await user.setMetadata(FOR_YOU_NOTIFICATION_METADATA_KEY, "true");
+
+    expect(await areForYouNotificationsEnabled(user)).toBe(true);
+  });
+
+  test("skips sending when metadata is false", async () => {
+    const { user } = await createResourceTest({ role: "user" });
+    await user.setMetadata(FOR_YOU_NOTIFICATION_METADATA_KEY, "false");
+
+    expect(await areForYouNotificationsEnabled(user)).toBe(false);
   });
 });

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -20,6 +20,8 @@ import {
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
   CONVERSATION_UNREAD_TRIGGER_ID,
   DEFAULT_NOTIFICATION_CONDITION,
+  FOR_YOU_NOTIFICATION_METADATA_KEY,
+  isForYouNotificationsEnabled,
   isNotificationCondition,
 } from "@app/types/notification_preferences";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -237,14 +239,21 @@ export function notifyNewProjectConversation(
   });
 }
 
+export async function areForYouNotificationsEnabled(
+  user: UserResource
+): Promise<boolean> {
+  const metadata = await user.getMetadata(FOR_YOU_NOTIFICATION_METADATA_KEY);
+  return isForYouNotificationsEnabled(metadata?.value);
+}
+
 /**
  * Send the dedicated activation email once the agent has replied in an
  * activation-pod conversation. Called from the agent-loop completion path so
- * the notification (and its per-user delay) starts only after the reply exists.
+ * the notification starts only after the reply exists.
  *
  * Runs only if the conversation belongs to an activation pod and was started
- * by the activation nudge workflow. Respects the target user's notification
- * settings.
+ * by the activation nudge workflow. Respects the target user's For You toggle
+ * and "Notify me about" condition; Email frequency does not apply.
  */
 export async function notifyActivationConversationAgentReplied(
   auth: Authenticator,
@@ -293,6 +302,10 @@ export async function notifyActivationConversationAgentReplied(
     space.id
   );
   if (!allowedUser) {
+    return;
+  }
+
+  if (!(await areForYouNotificationsEnabled(allowedUser))) {
     return;
   }
 

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -2,10 +2,7 @@ import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
-import {
-  getNovuClient,
-  getUserNotificationDelay,
-} from "@app/lib/notifications";
+import { getNovuClient } from "@app/lib/notifications";
 import { hasUnreadSucceededAgentReply } from "@app/lib/notifications/conversation_fetch";
 import { renderEmail } from "@app/lib/notifications/email-templates/activation-new-conversation";
 import {
@@ -13,13 +10,10 @@ import {
   getConversationDetails,
 } from "@app/lib/notifications/helpers";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { FOR_YOU_EMAIL_UTM } from "@app/lib/tracking/campaigns";
 import { getGetStartedRoute } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
-import {
-  ACTIVATION_NEW_CONVERSATION_TRIGGER_ID,
-  NOTIFICATION_DELAY_OPTIONS,
-  NOTIFICATION_PREFERENCES_DELAYS,
-} from "@app/types/notification_preferences";
+import { ACTIVATION_NEW_CONVERSATION_TRIGGER_ID } from "@app/types/notification_preferences";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -49,10 +43,6 @@ const activationNewConversationDetailsSchema = z.object({
 type activationNewConversationDetailsType = z.infer<
   typeof activationNewConversationDetailsSchema
 >;
-
-const userNotificationDelaySchema = z.object({
-  delay: z.enum(NOTIFICATION_DELAY_OPTIONS),
-});
 
 export const shouldSkipActivationNewConversation = async ({
   subscriberId,
@@ -131,29 +121,16 @@ export const activationNewConversationWorkflow = workflow(
       }
     );
 
-    // Respect all the user's email notification preferences.
-    const { delay } = await step.custom(
-      "get-user-notification-delay",
-      async () => {
-        const userNotificationDelay = await getUserNotificationDelay({
-          subscriberId: subscriber.subscriberId,
-          workspaceId: payload.workspaceId,
-          channel: "email",
-        });
-        return { delay: userNotificationDelay };
-      },
-      {
-        outputSchema: userNotificationDelaySchema,
-      }
-    );
-
-    await step.delay("apply-user-delay", async () => {
-      return { type: "regular", ...NOTIFICATION_PREFERENCES_DELAYS[delay] };
-    });
-
     await step.email(
       "send-email",
       async () => {
+        const forYouUrl = `${config.getAppUrl()}${getGetStartedRoute(payload.workspaceId)}?${new URLSearchParams(
+          {
+            ...FOR_YOU_EMAIL_UTM,
+            utm_content: payload.conversationId,
+          }
+        ).toString()}`;
+
         const body = await renderEmail({
           name: subscriber.firstName ?? "You",
           workspace: {
@@ -164,7 +141,7 @@ export const activationNewConversationWorkflow = workflow(
           goal: details.goal,
           action: {
             label: details.subject,
-            url: config.getAppUrl() + getGetStartedRoute(payload.workspaceId),
+            url: forYouUrl,
           },
         });
 

--- a/front/lib/tracking/campaigns.ts
+++ b/front/lib/tracking/campaigns.ts
@@ -1,0 +1,5 @@
+export const FOR_YOU_EMAIL_UTM = {
+  utm_source: "notification",
+  utm_medium: "email",
+  utm_campaign: "for_you",
+} as const;

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -132,6 +132,19 @@ export const MANUAL_ACTION_REQUIRED_TAG = "manual-action-required" as const;
 export const ACTIVATION_NEW_CONVERSATION_TRIGGER_ID =
   "activation-new-conversation" as const;
 
+/**
+ * User metadata key for the dedicated For You (activation) email opt-out.
+ * Missing key means enabled.
+ */
+export const FOR_YOU_NOTIFICATION_METADATA_KEY =
+  "allow_for_you_notifications" as const;
+
+export function isForYouNotificationsEnabled(
+  value: string | null | undefined
+): boolean {
+  return value !== "false";
+}
+
 export const SOUND_NOTIFICATION_OPTIONS = [
   "Pluck",
   "Wood",


### PR DESCRIPTION
## Summary
- Currently, activation nudge emails abide by the same frequency as all emails (the default is at maximum you can receive one email a week across the system)
- This is creating the biggest bottleneck in the funnel. Instead, we are not abiding by the email frequency and surfacing a new toggle to be able to turn off the for you notifications independently. 

## Testing
<img width="796" height="606" alt="Screenshot 2026-08-13 at 3 59 01 PM" src="https://github.com/user-attachments/assets/28881645-e75c-4d47-bff7-5cae2a837f39" />

## Risk
Low

## Deploy
1. Front