### PR TITLE
[front] feat: Add support for sharing Pod apps to the workspace or invited (workspace) users

### DIFF
--- a/front-api/lib/api/sse/sandbox_function_invocation_events.ts
+++ b/front-api/lib/api/sse/sandbox_function_invocation_events.ts
@@ -25,8 +25,9 @@ export async function streamSandboxFunctionInvocationEventsForRoute(
     lastEventId: string | null;
   }
 ) {
-  // A frame host may present its frame's share token as a capability to reach the invocations of
-  // the frame's app's functions; the owner-scoped invocation fetch below still applies.
+  // A frame host may present its frame's share token to reach the invocations of the frame's
+  // app's functions (granted to members who may view the frame); the owner-scoped invocation
+  // fetch below still applies.
   const sandboxFunction = await resolveSandboxFunctionWithCapability(
     auth,
     functionId,

--- a/front-api/lib/api/sse/sandbox_function_invocation_events.ts
+++ b/front-api/lib/api/sse/sandbox_function_invocation_events.ts
@@ -1,4 +1,8 @@
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
+import {
+  FRAME_SHARE_TOKEN_HEADER,
+  resolveFrameShareCapability,
+} from "@app/lib/api/sandbox_functions/frame_share_capability";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -24,9 +28,17 @@ export async function streamSandboxFunctionInvocationEventsForRoute(
     lastEventId: string | null;
   }
 ) {
+  // A frame host may present its frame's share token as a capability to reach the invocations of
+  // the frame's app's functions; the owner-scoped invocation fetch below still applies.
+  const frameShareToken = ctx.req.header(FRAME_SHARE_TOKEN_HEADER);
+  const capability = frameShareToken
+    ? ((await resolveFrameShareCapability(auth, frameShareToken)) ?? undefined)
+    : undefined;
+
   const sandboxFunction = await SandboxFunctionResource.fetchById(
     auth,
-    functionId
+    functionId,
+    { capability }
   );
   if (!sandboxFunction) {
     return ctx.notFound();

--- a/front-api/lib/api/sse/sandbox_function_invocation_events.ts
+++ b/front-api/lib/api/sse/sandbox_function_invocation_events.ts
@@ -1,8 +1,7 @@
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
-import { resolveFrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
+import { resolveSandboxFunctionWithCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
-import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
 import { streamEvents } from "@front-api/lib/api/sse/stream_events";
 import type { Context } from "hono";
@@ -28,15 +27,10 @@ export async function streamSandboxFunctionInvocationEventsForRoute(
 ) {
   // A frame host may present its frame's share token as a capability to reach the invocations of
   // the frame's app's functions; the owner-scoped invocation fetch below still applies.
-  const frameShareToken = ctx.req.header(FRAME_SHARE_TOKEN_HEADER);
-  const capability = frameShareToken
-    ? ((await resolveFrameShareCapability(auth, frameShareToken)) ?? undefined)
-    : undefined;
-
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  const sandboxFunction = await resolveSandboxFunctionWithCapability(
     auth,
     functionId,
-    { capability }
+    ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
   );
   if (!sandboxFunction) {
     return ctx.notFound();

--- a/front-api/lib/api/sse/sandbox_function_invocation_events.ts
+++ b/front-api/lib/api/sse/sandbox_function_invocation_events.ts
@@ -1,11 +1,9 @@
 import { getSandboxFunctionInvocationEvents } from "@app/lib/api/sandbox_functions/events";
-import {
-  FRAME_SHARE_TOKEN_HEADER,
-  resolveFrameShareCapability,
-} from "@app/lib/api/sandbox_functions/frame_share_capability";
+import { resolveFrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
 import { streamEvents } from "@front-api/lib/api/sse/stream_events";
 import type { Context } from "hono";
 import { z } from "zod";

--- a/front-api/middlewares/cors.test.ts
+++ b/front-api/middlewares/cors.test.ts
@@ -1,3 +1,4 @@
+import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
 import { DUST_FILE_ID_HEADER } from "@app/types/files";
 import { cors } from "@front-api/middlewares/cors";
 import { Hono } from "hono";
@@ -36,5 +37,22 @@ describe("cors middleware", () => {
 
     expect(response.status).toBe(200);
     expect(getExposedHeaders(response)).toContain(DUST_FILE_ID_HEADER);
+  });
+
+  it("allows the frame share token header on preflight requests", async () => {
+    // Shared-frame hosts attach this header to every invocation request; a preflight that
+    // rejects it breaks callFunction for all shared frames.
+    const response = await createApp().request("/", {
+      method: "OPTIONS",
+      headers: {
+        Origin: APP_ORIGIN,
+        "Access-Control-Request-Headers": `content-type,${FRAME_SHARE_TOKEN_HEADER}`,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(
+      response.headers.get("Access-Control-Allow-Headers")?.toLowerCase()
+    ).toContain(FRAME_SHARE_TOKEN_HEADER);
   });
 });

--- a/front-api/routes/v1/public/frames/[token]/index.test.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.test.ts
@@ -158,6 +158,27 @@ describe("GET /api/v1/public/frames/[token]", () => {
       const body = await response.json();
       expect(body.framePath).toBe(`pod-${pod.sId}/TaskList/TaskList.tsx`);
     });
+
+    it("returns the scoped path for a granted workspace member on an invite-only frame", async () => {
+      const { pod, file, token } = await createPodAppFrame();
+      await file.setShareScope(auth, "emails_only");
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      await file.addSharingGrants(auth, { emails: [otherUser.email] });
+      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+      vi.mocked(resolveOptionalAuth).mockResolvedValue(memberAuth);
+
+      const response = await requestFrame(token);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.framePath).toBe(`pod-${pod.sId}/TaskList/TaskList.tsx`);
+    });
   });
 
   describe("pod identity for a Pod Frame", () => {

--- a/front-api/routes/v1/public/frames/[token]/index.test.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.test.ts
@@ -137,6 +137,27 @@ describe("GET /api/v1/public/frames/[token]", () => {
       // the Pod's layout.
       expect(body.framePath).toBeNull();
     });
+
+    it("returns the scoped path for a workspace member outside the pod", async () => {
+      // The share token this member used to load the frame is itself the capability to invoke
+      // the frame's app's functions, and framePath is what lets the frame resolve them.
+      const { pod, token } = await createPodAppFrame();
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+      vi.mocked(resolveOptionalAuth).mockResolvedValue(memberAuth);
+
+      const response = await requestFrame(token);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.framePath).toBe(`pod-${pod.sId}/TaskList/TaskList.tsx`);
+    });
   });
 
   describe("pod identity for a Pod Frame", () => {

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -247,9 +247,17 @@ app.get(
       isPodMember,
       isPodEditor,
       // Lets a shared Frame in an app folder resolve bare function references, exactly as it does
-      // when opened from the Pod. Withheld from viewers who cannot read the Pod, who cannot invoke
-      // its functions either.
-      framePath: canRead && auth ? file.toScopedPath(auth) : null,
+      // when opened from the Pod. For workspace-visible scopes the share token itself is a
+      // workspace member's capability to invoke the frame's app's functions, so members get the
+      // path even without pod read. External viewers cannot invoke and never receive it.
+      framePath:
+        auth &&
+        (canRead ||
+          ((shareScope === "workspace_and_emails" ||
+            shareScope === "workspace") &&
+            auth.isUser()))
+          ? file.toScopedPath(auth)
+          : null,
     });
   }
 );

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -256,9 +256,9 @@ app.get(
       isPodMember,
       isPodEditor,
       // Lets a shared Frame in an app folder resolve bare function references, exactly as it does
-      // when opened from the Pod. For workspace-visible scopes the share token itself is a
-      // workspace member's capability to invoke the frame's app's functions, so members get the
-      // path even without pod read. External viewers cannot invoke and never receive it.
+      // when opened from the Pod. Workspace members who may view the frame may invoke its app's
+      // functions, so they get the path even without pod read. External viewers cannot invoke
+      // and never receive it.
       framePath:
         auth && (canRead || canInvokeViaShareCapability)
           ? file.toScopedPath(auth)

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -219,9 +219,12 @@ app.get(
       space.canAdministrate(auth)
     );
     // The share token this viewer used is a workspace member's capability to invoke the frame's
-    // app's functions.
+    // app's functions. For invite-only frames, a member only reaches this point with an active
+    // email grant (or as the frame's owner), which is the same rule the invocation gate applies.
     const canInvokeViaShareCapability =
-      isWorkspaceVisibleShareScope(shareScope) && !!auth?.isUser();
+      !!auth?.isUser() &&
+      (isWorkspaceVisibleShareScope(shareScope) ||
+        shareScope === "emails_only");
 
     // Generate access token for viz rendering.
     const accessToken = generateVizAccessToken({

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -10,7 +10,10 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getConversationRoute, getPodRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
-import { isInteractiveContentType } from "@app/types/files";
+import {
+  isInteractiveContentType,
+  isWorkspaceVisibleShareScope,
+} from "@app/types/files";
 import type { PublicFrameResponseBodyType } from "@dust-tt/client";
 import { unauthedApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -142,8 +145,7 @@ app.get(
 
       // For workspace_and_emails (and legacy "workspace"): workspace members are authorized directly.
       const isWorkspaceMemberWithAccess =
-        (shareScope === "workspace_and_emails" || shareScope === "workspace") &&
-        auth;
+        isWorkspaceVisibleShareScope(shareScope) && auth;
 
       if (!isFileOwner && !isWorkspaceMemberWithAccess) {
         // Resolve the verified email: prefer Dust session, fall back to external viewer cookie.
@@ -216,6 +218,10 @@ app.get(
       auth &&
       space.canAdministrate(auth)
     );
+    // The share token this viewer used is a workspace member's capability to invoke the frame's
+    // app's functions.
+    const canInvokeViaShareCapability =
+      isWorkspaceVisibleShareScope(shareScope) && !!auth?.isUser();
 
     // Generate access token for viz rendering.
     const accessToken = generateVizAccessToken({
@@ -251,11 +257,7 @@ app.get(
       // workspace member's capability to invoke the frame's app's functions, so members get the
       // path even without pod read. External viewers cannot invoke and never receive it.
       framePath:
-        auth &&
-        (canRead ||
-          ((shareScope === "workspace_and_emails" ||
-            shareScope === "workspace") &&
-            auth.isUser()))
+        auth && (canRead || canInvokeViaShareCapability)
           ? file.toScopedPath(auth)
           : null,
     });

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -50,13 +50,14 @@ app.post(
       return ctx.json({ success: true });
     }
 
-    // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g.
-    // a frame share token); the validated claims name the invocation, which is the proof.
-    const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
+    // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant
+    // (e.g. a frame share token). The id comes from signature-verified sandbox JWT claims minted
+    // at execution start, so the space filter is deliberately skipped.
+    const sandboxFunction = await SandboxFunctionResource.fetchById(
       auth,
+      sandboxClaims.sandboxFunctionId,
       {
-        sandboxFunctionId: sandboxClaims.sandboxFunctionId,
-        invocationId: sandboxClaims.invocationId,
+        dangerouslyBypassSpacePermissionFilter: true,
       }
     );
     if (!sandboxFunction) {

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -50,9 +50,12 @@ app.post(
       return ctx.json({ success: true });
     }
 
-    const sandboxFunction = await SandboxFunctionResource.fetchById(
+    // Pipeline resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g.
+    // a frame share token); the validated claims name the invocation, which is the proof.
+    const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
       auth,
-      sandboxClaims.sandboxFunctionId
+      sandboxClaims.sandboxFunctionId,
+      { invocationId: sandboxClaims.invocationId }
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -50,9 +50,9 @@ app.post(
       return ctx.json({ success: true });
     }
 
-    // Pipeline resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g.
+    // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g.
     // a frame share token); the validated claims name the invocation, which is the proof.
-    const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
+    const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
       auth,
       sandboxClaims.sandboxFunctionId,
       { invocationId: sandboxClaims.invocationId }

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -50,9 +50,12 @@ app.post(
       return ctx.json({ success: true });
     }
 
-    const sandboxFunction = await SandboxFunctionResource.fetchById(
+    const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
       auth,
-      sandboxClaims.sandboxFunctionId
+      {
+        sandboxFunctionId: sandboxClaims.sandboxFunctionId,
+        invocationId: sandboxClaims.invocationId,
+      }
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -50,15 +50,9 @@ app.post(
       return ctx.json({ success: true });
     }
 
-    // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant
-    // (e.g. a frame share token). The id comes from signature-verified sandbox JWT claims minted
-    // at execution start, so the space filter is deliberately skipped.
     const sandboxFunction = await SandboxFunctionResource.fetchById(
       auth,
-      sandboxClaims.sandboxFunctionId,
-      {
-        dangerouslyBypassSpacePermissionFilter: true,
-      }
+      sandboxClaims.sandboxFunctionId
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -54,8 +54,10 @@ app.post(
     // a frame share token); the validated claims name the invocation, which is the proof.
     const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
       auth,
-      sandboxClaims.sandboxFunctionId,
-      { invocationId: sandboxClaims.invocationId }
+      {
+        sandboxFunctionId: sandboxClaims.sandboxFunctionId,
+        invocationId: sandboxClaims.invocationId,
+      }
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/sandbox-functions/result.ts
@@ -50,12 +50,9 @@ app.post(
       return ctx.json({ success: true });
     }
 
-    const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
+    const sandboxFunction = await SandboxFunctionResource.fetchById(
       auth,
-      {
-        sandboxFunctionId: sandboxClaims.sandboxFunctionId,
-        invocationId: sandboxClaims.invocationId,
-      }
+      sandboxClaims.sandboxFunctionId
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -748,6 +748,37 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
     });
 
+    it("rejects a token from another pod's frame in the same workspace", async () => {
+      const { workspace, sandboxFunction, adminAuth } =
+        await setupSandboxFunction({
+          addCallerToSpace: false,
+          slug: "tasklist__run",
+        });
+      // A shared frame in a different pod, same folder name: the capability only ever queries
+      // its own pod, so both address forms must miss.
+      const otherPod = await SpaceFactory.project(workspace);
+      const frameShareToken = await createSharedAppFrame(adminAuth, {
+        workspace,
+        space: otherPod,
+        folderName: "TaskList",
+      });
+
+      const bySId = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: sandboxFunction.sId,
+        frameShareToken,
+      });
+      expect(bySId.status).toBe(404);
+
+      const bySlug = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: `${sandboxFunction.space.sId}/${sandboxFunction.slug}`,
+        frameShareToken,
+      });
+      expect(bySlug.status).toBe(404);
+      expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    });
+
     it("allows the frame's owner outside the pod on an invite-only frame without a grant", async () => {
       // The view path admits the owner without a grant; invocation mirrors it so that using an
       // app follows viewing its frame exactly.

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -157,7 +157,7 @@ async function setupSandboxFunction({
     workspace.sId
   );
 
-  return { workspace, sandboxFunction, adminAuth, callerAuth, space };
+  return { workspace, sandboxFunction, adminAuth, callerAuth, space, user };
 }
 
 // Creates a Pod app frame in `folderName` shared with the given scope, returning its share token —
@@ -169,11 +169,13 @@ async function createSharedAppFrame(
     space,
     folderName,
     scope = "workspace_and_emails",
+    grantEmails,
   }: {
     workspace: { sId: string };
     space: { sId: string };
     folderName: string;
     scope?: FileShareScope;
+    grantEmails?: string[];
   }
 ) {
   const frameFile = await FileFactory.create(adminAuth, null, {
@@ -186,6 +188,9 @@ async function createSharedAppFrame(
     mountFilePath: `w/${workspace.sId}/pods/${space.sId}/files/${folderName}/${folderName}.tsx`,
   });
   await frameFile.setShareScope(adminAuth, scope);
+  if (grantEmails && grantEmails.length > 0) {
+    await frameFile.addSharingGrants(adminAuth, { emails: grantEmails });
+  }
   const shareInfo = await frameFile.getShareInfo();
   if (!shareInfo) {
     throw new Error("Expected the frame share to exist.");
@@ -716,7 +721,31 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
     });
 
-    it("rejects a token whose frame is no longer workspace-visible", async () => {
+    it("allows a workspace member with an email grant on an invite-only frame", async () => {
+      const { workspace, sandboxFunction, adminAuth, space, user } =
+        await setupSandboxFunction({
+          addCallerToSpace: false,
+          slug: "tasklist__run",
+        });
+      const frameShareToken = await createSharedAppFrame(adminAuth, {
+        workspace,
+        space,
+        folderName: "TaskList",
+        scope: "emails_only",
+        grantEmails: [user.email],
+      });
+
+      const response = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: sandboxFunction.sId,
+        frameShareToken,
+      });
+
+      expect(response.status).toBe(201);
+      expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+    });
+
+    it("rejects an invite-only token when the caller has no email grant", async () => {
       const { workspace, sandboxFunction, adminAuth, space } =
         await setupSandboxFunction({
           addCallerToSpace: false,

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -8,6 +8,7 @@ import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_fu
 import { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
@@ -170,15 +171,17 @@ async function createSharedAppFrame(
     folderName,
     scope = "workspace_and_emails",
     grantEmails,
+    owner = null,
   }: {
     workspace: { sId: string };
     space: { sId: string };
     folderName: string;
     scope?: FileShareScope;
     grantEmails?: string[];
+    owner?: UserResource | null;
   }
 ) {
-  const frameFile = await FileFactory.create(adminAuth, null, {
+  const frameFile = await FileFactory.create(adminAuth, owner, {
     contentType: frameContentType,
     fileName: `${folderName}.tsx`,
     fileSize: 100,
@@ -733,6 +736,32 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
         folderName: "TaskList",
         scope: "emails_only",
         grantEmails: [user.email],
+      });
+
+      const response = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: sandboxFunction.sId,
+        frameShareToken,
+      });
+
+      expect(response.status).toBe(201);
+      expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+    });
+
+    it("allows the frame's owner outside the pod on an invite-only frame without a grant", async () => {
+      // The view path admits the owner without a grant; invocation mirrors it so that using an
+      // app follows viewing its frame exactly.
+      const { workspace, sandboxFunction, adminAuth, space, user } =
+        await setupSandboxFunction({
+          addCallerToSpace: false,
+          slug: "tasklist__run",
+        });
+      const frameShareToken = await createSharedAppFrame(adminAuth, {
+        workspace,
+        space,
+        folderName: "TaskList",
+        scope: "emails_only",
+        owner: user,
       });
 
       const response = await postInvocation({

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -764,12 +764,12 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
       expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
     });
 
-    it("still applies the pod-editor-required policy with a valid token", async () => {
+    it("still applies the pod-member-required policy with a valid token", async () => {
       const { workspace, sandboxFunction, adminAuth, space } =
         await setupSandboxFunction({
           addCallerToSpace: false,
           slug: "tasklist__run",
-          userIdentity: "pod_editor_required",
+          userIdentity: "pod_member_required",
         });
       const frameShareToken = await createSharedAppFrame(adminAuth, {
         workspace,

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -13,6 +13,7 @@ import { FileFactory } from "@app/tests/utils/FileFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SandboxFunctionMCPActionFactory } from "@app/tests/utils/SandboxFunctionMCPActionFactory";
@@ -22,7 +23,8 @@ import type {
   SandboxFunctionInvocationEvent,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
-import { sandboxFunctionContentType } from "@app/types/files";
+import type { FileShareScope } from "@app/types/files";
+import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -101,10 +103,12 @@ async function setupSandboxFunction({
   addCallerToSpace = true,
   withSandboxFunctionsFeatureFlag = true,
   userIdentity = "optional",
+  slug = "run-function",
 }: {
   addCallerToSpace?: boolean;
   withSandboxFunctionsFeatureFlag?: boolean;
   userIdentity?: SandboxFunctionUserIdentityPolicy;
+  slug?: string;
 } = {}) {
   const { workspace, auth: adminAuth } = await createPrivateApiMockRequest({
     role: "admin",
@@ -124,7 +128,7 @@ async function setupSandboxFunction({
   const sandboxFunction = await SandboxFunctionResource.makeNew(adminAuth, {
     space,
     file,
-    slug: "run-function",
+    slug,
     description: "Run the function.",
     userIdentity,
     inputSchema,
@@ -154,6 +158,39 @@ async function setupSandboxFunction({
   );
 
   return { workspace, sandboxFunction, adminAuth, callerAuth, space };
+}
+
+// Creates a Pod app frame in `folderName` shared with the given scope, returning its share token —
+// the capability under test.
+async function createSharedAppFrame(
+  adminAuth: Authenticator,
+  {
+    workspace,
+    space,
+    folderName,
+    scope = "workspace_and_emails",
+  }: {
+    workspace: { sId: string };
+    space: { sId: string };
+    folderName: string;
+    scope?: FileShareScope;
+  }
+) {
+  const frameFile = await FileFactory.create(adminAuth, null, {
+    contentType: frameContentType,
+    fileName: `${folderName}.tsx`,
+    fileSize: 100,
+    status: "ready",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: space.sId },
+    mountFilePath: `w/${workspace.sId}/pods/${space.sId}/files/${folderName}/${folderName}.tsx`,
+  });
+  await frameFile.setShareScope(adminAuth, scope);
+  const shareInfo = await frameFile.getShareInfo();
+  if (!shareInfo) {
+    throw new Error("Expected the frame share to exist.");
+  }
+  return shareInfo.shareUrl.split("/").at(-1)!;
 }
 
 // Builds a blocked action awaiting validation, the state spolu's creation gate produces for
@@ -270,10 +307,12 @@ function postInvocation({
   workspaceId,
   functionIdOrSlug,
   body = {},
+  frameShareToken,
 }: {
   workspaceId: string;
   functionIdOrSlug: string;
   body?: unknown;
+  frameShareToken?: string;
 }) {
   const encodedFunctionIdOrSlug = encodeURIComponent(functionIdOrSlug);
 
@@ -281,7 +320,12 @@ function postInvocation({
     `/api/w/${workspaceId}/sandbox-functions/${encodedFunctionIdOrSlug}/invocations`,
     {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        ...(frameShareToken
+          ? { "x-dust-frame-share-token": frameShareToken }
+          : {}),
+      },
       body: JSON.stringify(body),
     }
   );
@@ -603,6 +647,144 @@ describe("POST /api/w/:wId/sandbox-functions/:functionIdOrSlug/invocations", () 
     expect(response.status).toBe(404);
     expect(await response.json()).toMatchObject({
       error: { type: "sandbox_function_not_found" },
+    });
+  });
+
+  describe("frame share token capability", () => {
+    it("allows a workspace member outside the pod with the app frame's share token", async () => {
+      const { workspace, sandboxFunction, adminAuth, space } =
+        await setupSandboxFunction({
+          addCallerToSpace: false,
+          slug: "tasklist__run",
+        });
+      const frameShareToken = await createSharedAppFrame(adminAuth, {
+        workspace,
+        space,
+        folderName: "TaskList",
+      });
+
+      const response = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: sandboxFunction.sId,
+        frameShareToken,
+      });
+
+      expect(response.status).toBe(201);
+      expect(launchSandboxFunctionInvocationWorkflow).toHaveBeenCalledOnce();
+    });
+
+    it("resolves by pod id and slug with the app frame's share token", async () => {
+      const { workspace, sandboxFunction, adminAuth, space } =
+        await setupSandboxFunction({
+          addCallerToSpace: false,
+          slug: "tasklist__run",
+        });
+      const frameShareToken = await createSharedAppFrame(adminAuth, {
+        workspace,
+        space,
+        folderName: "TaskList",
+      });
+
+      const response = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: `${space.sId}/${sandboxFunction.slug}`,
+        frameShareToken,
+      });
+
+      expect(response.status).toBe(201);
+    });
+
+    it("rejects a token from another app's frame in the same pod", async () => {
+      const { workspace, sandboxFunction, adminAuth, space } =
+        await setupSandboxFunction({
+          addCallerToSpace: false,
+          slug: "tasklist__run",
+        });
+      const frameShareToken = await createSharedAppFrame(adminAuth, {
+        workspace,
+        space,
+        folderName: "OtherApp",
+      });
+
+      const response = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: sandboxFunction.sId,
+        frameShareToken,
+      });
+
+      expect(response.status).toBe(404);
+      expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    });
+
+    it("rejects a token whose frame is no longer workspace-visible", async () => {
+      const { workspace, sandboxFunction, adminAuth, space } =
+        await setupSandboxFunction({
+          addCallerToSpace: false,
+          slug: "tasklist__run",
+        });
+      const frameShareToken = await createSharedAppFrame(adminAuth, {
+        workspace,
+        space,
+        folderName: "TaskList",
+        scope: "emails_only",
+      });
+
+      const response = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: sandboxFunction.sId,
+        frameShareToken,
+      });
+
+      expect(response.status).toBe(404);
+      expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    });
+
+    it("rejects a token from another workspace", async () => {
+      const { workspace, sandboxFunction } = await setupSandboxFunction({
+        addCallerToSpace: false,
+        slug: "tasklist__run",
+      });
+      // A pod app frame with the same folder name, but in a different workspace. Built without
+      // createPrivateApiMockRequest so the caller's session mock stays on the first workspace.
+      const otherCtx = await createResourceTest({ role: "admin" });
+      const otherSpace = await SpaceFactory.project(otherCtx.workspace);
+      const foreignToken = await createSharedAppFrame(otherCtx.authenticator, {
+        workspace: otherCtx.workspace,
+        space: otherSpace,
+        folderName: "TaskList",
+      });
+
+      const response = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: sandboxFunction.sId,
+        frameShareToken: foreignToken,
+      });
+
+      expect(response.status).toBe(404);
+      expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
+    });
+
+    it("still applies the pod-editor-required policy with a valid token", async () => {
+      const { workspace, sandboxFunction, adminAuth, space } =
+        await setupSandboxFunction({
+          addCallerToSpace: false,
+          slug: "tasklist__run",
+          userIdentity: "pod_editor_required",
+        });
+      const frameShareToken = await createSharedAppFrame(adminAuth, {
+        workspace,
+        space,
+        folderName: "TaskList",
+      });
+
+      const response = await postInvocation({
+        workspaceId: workspace.sId,
+        functionIdOrSlug: sandboxFunction.sId,
+        frameShareToken,
+      });
+
+      expect(response.status).toBe(401);
+      expect(launchSandboxFunctionInvocationWorkflow).not.toHaveBeenCalled();
     });
   });
 

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -205,7 +205,13 @@ app.post(
 
     const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
       auth,
-      functionIdOrSlug
+      functionIdOrSlug,
+      {
+        capability: await capabilityFromHeader(
+          auth,
+          ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
+        ),
+      }
     );
     if (!sandboxFunction) {
       return apiError(ctx, {
@@ -272,7 +278,13 @@ app.post(
 
     const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
       auth,
-      functionIdOrSlug
+      functionIdOrSlug,
+      {
+        capability: await capabilityFromHeader(
+          auth,
+          ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
+        ),
+      }
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -2,10 +2,7 @@ import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
 import { awaitSandboxFunctionInvocationOutcome } from "@app/lib/api/sandbox_functions/await_invocation";
 import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
 import type { FrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
-import {
-  FRAME_SHARE_TOKEN_HEADER,
-  resolveFrameShareCapability,
-} from "@app/lib/api/sandbox_functions/frame_share_capability";
+import { resolveFrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
 import { resolveSandboxFunctionActionAuthentication } from "@app/lib/api/sandbox_functions/resolve_authentication";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
 import type { Authenticator } from "@app/lib/auth";
@@ -14,6 +11,7 @@ import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
 } from "@app/types/api/sandbox_functions";
+import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { redirectToSse } from "@front-api/lib/api/sse/redirect";
 import { workspaceApp } from "@front-api/middlewares/ctx";

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,12 +1,9 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
 import { awaitSandboxFunctionInvocationOutcome } from "@app/lib/api/sandbox_functions/await_invocation";
 import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
-import type { FrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
-import { resolveFrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
+import { resolveSandboxFunctionWithCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
 import { resolveSandboxFunctionActionAuthentication } from "@app/lib/api/sandbox_functions/resolve_authentication";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
-import type { Authenticator } from "@app/lib/auth";
-import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
   PostSandboxFunctionInvocationResponseBody,
@@ -22,20 +19,6 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   functionIdOrSlug: z.string().min(1),
 });
-
-// A frame host may present its frame's share token as a capability to invoke the frame's app's
-// functions. Absent or invalid tokens resolve to undefined, falling through to the regular gates.
-async function capabilityFromHeader(
-  auth: Authenticator,
-  frameShareToken: string | undefined
-): Promise<FrameShareCapability | undefined> {
-  if (!frameShareToken) {
-    return undefined;
-  }
-  return (
-    (await resolveFrameShareCapability(auth, frameShareToken)) ?? undefined
-  );
-}
 
 // Shared by the two action-resolution routes (validate-action, resolve-authentication).
 const ActionResolutionParamsSchema = z.object({
@@ -125,15 +108,10 @@ app.post(
     const body: PostSandboxFunctionInvocationRequestBody =
       ctx.req.valid("json");
 
-    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+    const sandboxFunction = await resolveSandboxFunctionWithCapability(
       auth,
       functionIdOrSlug,
-      {
-        capability: await capabilityFromHeader(
-          auth,
-          ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
-        ),
-      }
+      ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
     );
     if (!sandboxFunction) {
       return apiError(ctx, {
@@ -201,15 +179,10 @@ app.post(
     const { functionIdOrSlug, invocationId, actionId } = ctx.req.valid("param");
     const { approved } = ctx.req.valid("json");
 
-    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+    const sandboxFunction = await resolveSandboxFunctionWithCapability(
       auth,
       functionIdOrSlug,
-      {
-        capability: await capabilityFromHeader(
-          auth,
-          ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
-        ),
-      }
+      ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
     );
     if (!sandboxFunction) {
       return apiError(ctx, {
@@ -274,15 +247,10 @@ app.post(
     const { functionIdOrSlug, invocationId, actionId } = ctx.req.valid("param");
     const { outcome } = ctx.req.valid("json");
 
-    const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+    const sandboxFunction = await resolveSandboxFunctionWithCapability(
       auth,
       functionIdOrSlug,
-      {
-        capability: await capabilityFromHeader(
-          auth,
-          ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
-        ),
-      }
+      ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -1,8 +1,14 @@
 import { MCP_VALIDATION_OUTPUTS } from "@app/lib/actions/constants";
 import { awaitSandboxFunctionInvocationOutcome } from "@app/lib/api/sandbox_functions/await_invocation";
 import { isSandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
+import type { FrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
+import {
+  FRAME_SHARE_TOKEN_HEADER,
+  resolveFrameShareCapability,
+} from "@app/lib/api/sandbox_functions/frame_share_capability";
 import { resolveSandboxFunctionActionAuthentication } from "@app/lib/api/sandbox_functions/resolve_authentication";
 import { validateSandboxFunctionAction } from "@app/lib/api/sandbox_functions/validate_action";
+import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type {
   PostSandboxFunctionInvocationRequestBody,
@@ -18,6 +24,20 @@ import { z } from "zod";
 const ParamsSchema = z.object({
   functionIdOrSlug: z.string().min(1),
 });
+
+// A frame host may present its frame's share token as a capability to invoke the frame's app's
+// functions. Absent or invalid tokens resolve to undefined, falling through to the regular gates.
+async function capabilityFromHeader(
+  auth: Authenticator,
+  frameShareToken: string | undefined
+): Promise<FrameShareCapability | undefined> {
+  if (!frameShareToken) {
+    return undefined;
+  }
+  return (
+    (await resolveFrameShareCapability(auth, frameShareToken)) ?? undefined
+  );
+}
 
 // Shared by the two action-resolution routes (validate-action, resolve-authentication).
 const ActionResolutionParamsSchema = z.object({
@@ -109,7 +129,13 @@ app.post(
 
     const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
       auth,
-      functionIdOrSlug
+      functionIdOrSlug,
+      {
+        capability: await capabilityFromHeader(
+          auth,
+          ctx.req.header(FRAME_SHARE_TOKEN_HEADER)
+        ),
+      }
     );
     if (!sandboxFunction) {
       return apiError(ctx, {

--- a/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.tsx
+++ b/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.tsx
@@ -22,6 +22,7 @@ export function SandboxFunctionPersonalAuthCard({
 
   const { resolveAuthentication, isResolving } = useResolveAuthentication({
     owner: viewer.owner,
+    frameShareToken: viewer.frameShareToken,
   });
 
   const handleResolve = async (

--- a/front/components/actions/blocked/SandboxFunctionToolApprovalCard.tsx
+++ b/front/components/actions/blocked/SandboxFunctionToolApprovalCard.tsx
@@ -22,6 +22,7 @@ export function SandboxFunctionToolApprovalCard({
   const { validateAction, isValidating } = useValidateAction({
     owner: viewer.owner,
     onError: setErrorMessage,
+    frameShareToken: viewer.frameShareToken,
   });
 
   const handleValidation = async (

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -22,6 +22,7 @@ import type {
   SandboxFunctionInvocationEvent,
   SandboxFunctionInvocationOutcome,
 } from "@app/types/api/sandbox_functions";
+import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
 import type {
   CallFunctionRequest,
   CommandResultMap,
@@ -195,12 +196,15 @@ const getExtensionFromBlob = (blob: Blob): string => {
 export interface FrameViewer {
   owner: LightWorkspaceType;
   user: UserType;
+  /** Share token the viewer loaded the frame with, presented as an invocation capability. */
+  frameShareToken?: string;
 }
 
 interface SandboxFunctionInvocationProps {
   workspaceId: string;
   functionId: string;
   invocationId: string;
+  frameShareToken?: string;
   onBlocked: (eventId: string, event: SandboxFunctionBlockingEvent) => void;
   onSettle: (
     invocationId: string,
@@ -227,6 +231,7 @@ function SandboxFunctionInvocation({
   workspaceId,
   functionId,
   invocationId,
+  frameShareToken,
   onBlocked,
   onSettle,
 }: SandboxFunctionInvocationProps) {
@@ -297,7 +302,12 @@ function SandboxFunctionInvocation({
     buildEventSourceURL,
     onEventCallback,
     `sandbox-function-invocation-${invocationId}`,
-    { onTerminalError }
+    {
+      onTerminalError,
+      ...(frameShareToken
+        ? { headers: { [FRAME_SHARE_TOKEN_HEADER]: frameShareToken } }
+        : {}),
+    }
   );
 
   return null;
@@ -656,6 +666,12 @@ export interface VisualizationActionIframeProps {
    * bare name; without it, relative references are refused.
    */
   framePath?: string | null;
+  /**
+   * Share token of the Frame being rendered, when the host loaded it through a share link.
+   * Presented as a capability on invocation requests: it lets a workspace member outside the Pod
+   * invoke the frame's app's functions. Authorization happens server-side on every request.
+   */
+  frameShareToken?: string;
   isEditable?: boolean;
   isInDrawer?: boolean;
   onEditText?: EditTextFn;
@@ -886,6 +902,9 @@ export const VisualizationActionIframe = forwardRef<
             method: "POST",
             headers: {
               "Content-Type": "application/json",
+              ...(props.frameShareToken
+                ? { [FRAME_SHARE_TOKEN_HEADER]: props.frameShareToken }
+                : {}),
             },
             body: JSON.stringify(body),
           }
@@ -914,7 +933,7 @@ export const VisualizationActionIframe = forwardRef<
         });
       }
     },
-    [runtimeAccess.canInvokeFunctions, workspaceId]
+    [runtimeAccess.canInvokeFunctions, workspaceId, props.frameShareToken]
   );
 
   useVisualizationDataHandler({
@@ -996,6 +1015,7 @@ export const VisualizationActionIframe = forwardRef<
           workspaceId={workspaceId}
           functionId={invocation.functionId}
           invocationId={invocation.invocationId}
+          frameShareToken={props.frameShareToken}
           onBlocked={enqueueBlockedAction}
           onSettle={settleSandboxFunctionInvocation}
         />

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -22,7 +22,7 @@ import type {
   SandboxFunctionInvocationEvent,
   SandboxFunctionInvocationOutcome,
 } from "@app/types/api/sandbox_functions";
-import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
+import { frameShareTokenHeader } from "@app/types/api/sandbox_functions";
 import type {
   CallFunctionRequest,
   CommandResultMap,
@@ -196,7 +196,11 @@ const getExtensionFromBlob = (blob: Blob): string => {
 export interface FrameViewer {
   owner: LightWorkspaceType;
   user: UserType;
-  /** Share token the viewer loaded the frame with, presented as an invocation capability. */
+  /**
+   * Share token the viewer loaded the frame with, presented as a capability on invocation
+   * requests: it lets a workspace member outside the Pod invoke the frame's app's functions.
+   * Authorization happens server-side on every request.
+   */
   frameShareToken?: string;
 }
 
@@ -302,12 +306,7 @@ function SandboxFunctionInvocation({
     buildEventSourceURL,
     onEventCallback,
     `sandbox-function-invocation-${invocationId}`,
-    {
-      onTerminalError,
-      ...(frameShareToken
-        ? { headers: { [FRAME_SHARE_TOKEN_HEADER]: frameShareToken } }
-        : {}),
-    }
+    { onTerminalError, headers: frameShareTokenHeader(frameShareToken) }
   );
 
   return null;
@@ -666,12 +665,6 @@ export interface VisualizationActionIframeProps {
    * bare name; without it, relative references are refused.
    */
   framePath?: string | null;
-  /**
-   * Share token of the Frame being rendered, when the host loaded it through a share link.
-   * Presented as a capability on invocation requests: it lets a workspace member outside the Pod
-   * invoke the frame's app's functions. Authorization happens server-side on every request.
-   */
-  frameShareToken?: string;
   isEditable?: boolean;
   isInDrawer?: boolean;
   onEditText?: EditTextFn;
@@ -902,9 +895,7 @@ export const VisualizationActionIframe = forwardRef<
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              ...(props.frameShareToken
-                ? { [FRAME_SHARE_TOKEN_HEADER]: props.frameShareToken }
-                : {}),
+              ...frameShareTokenHeader(props.viewer?.frameShareToken),
             },
             body: JSON.stringify(body),
           }
@@ -933,7 +924,11 @@ export const VisualizationActionIframe = forwardRef<
         });
       }
     },
-    [runtimeAccess.canInvokeFunctions, workspaceId, props.frameShareToken]
+    [
+      runtimeAccess.canInvokeFunctions,
+      workspaceId,
+      props.viewer?.frameShareToken,
+    ]
   );
 
   useVisualizationDataHandler({
@@ -1015,7 +1010,7 @@ export const VisualizationActionIframe = forwardRef<
           workspaceId={workspaceId}
           functionId={invocation.functionId}
           invocationId={invocation.invocationId}
-          frameShareToken={props.frameShareToken}
+          frameShareToken={props.viewer?.frameShareToken}
           onBlocked={enqueueBlockedAction}
           onSettle={settleSandboxFunctionInvocation}
         />

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -197,9 +197,10 @@ export interface FrameViewer {
   owner: LightWorkspaceType;
   user: UserType;
   /**
-   * Share token the viewer loaded the frame with, presented as a capability on invocation
-   * requests: it lets a workspace member outside the Pod invoke the frame's app's functions.
-   * Authorization happens server-side on every request.
+   * Share token the viewer loaded the frame with, presented on invocation requests: the server
+   * grants invocation of the frame's app's functions to workspace members who may view the frame
+   * (invite-only frames also require an email grant). Authorization happens server-side on every
+   * request.
    */
   frameShareToken?: string;
 }

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -161,7 +161,6 @@ export function PublicFrameRenderer({
             scopedUserIdentity={publicUserIdentity}
             viewer={viewer}
             framePath={framePath}
-            frameShareToken={shareToken}
             isInDrawer
           />
         </div>

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -107,7 +107,7 @@ export function PublicFrameRenderer({
   );
   const viewer =
     publicUserIdentity && user && viewerWorkspace
-      ? { owner: viewerWorkspace, user }
+      ? { owner: viewerWorkspace, user, frameShareToken: shareToken }
       : null;
 
   if (
@@ -161,6 +161,7 @@ export function PublicFrameRenderer({
             scopedUserIdentity={publicUserIdentity}
             viewer={viewer}
             framePath={framePath}
+            frameShareToken={shareToken}
             isInDrawer
           />
         </div>

--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -50,6 +50,8 @@ export const ALLOWED_HEADERS = [
   "mcp-session-id",
   "x-commit-hash",
   "x-dust-extension-version",
+  // Frame share token presented as a function invocation capability (FRAME_SHARE_TOKEN_HEADER).
+  "x-dust-frame-share-token",
   "x-build-date",
   "x-hackerone-research",
   "x-request-origin",

--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -48,7 +48,11 @@ const stableEventSourceManager = {
    * @param uniqueId A unique identifier for this EventSource instance
    * @returns The newly created EventSource instance
    */
-  async create(url: string, uniqueId: string) {
+  async create(
+    url: string,
+    uniqueId: string,
+    headers?: Record<string, string>
+  ) {
     const urlWithCommitHash = new URL(url, document.baseURI);
     urlWithCommitHash.searchParams.append("commitHash", COMMIT_HASH);
 
@@ -60,6 +64,7 @@ const stableEventSourceManager = {
 
     const newSource = await clientEventSource(pathWithQueryAndHash, {
       heartbeatTimeout: HEARTBEAT_TIMEOUT_MS,
+      ...(headers ? { headers } : {}),
     });
     this.sources.set(uniqueId, newSource);
 
@@ -91,13 +96,19 @@ const stableEventSourceManager = {
 interface UseEventSourceOptions {
   isReadyToConsumeStream?: boolean;
   onTerminalError?: (error: Error) => void;
+  /** Extra request headers (e.g. a frame share token presented as a capability). */
+  headers?: Record<string, string>;
 }
 
 export function useEventSource(
   buildURL: (lastEvent: string | null) => string | null,
   onEventCallback: (event: string) => void,
   uniqueId: string,
-  { isReadyToConsumeStream = true, onTerminalError }: UseEventSourceOptions = {}
+  {
+    isReadyToConsumeStream = true,
+    onTerminalError,
+    headers,
+  }: UseEventSourceOptions = {}
 ) {
   const [isError, setIsError] = useState<Error | null>(null);
   const lastEvent = useRef<string | null>(null);
@@ -128,7 +139,7 @@ export function useEventSource(
       let source = sourceManager.get(uniqueId);
       // If the source is closed or doesn't exist, create a new one.
       if (!source || source.readyState === EventSourcePolyfill.CLOSED) {
-        source = await sourceManager.create(url, uniqueId);
+        source = await sourceManager.create(url, uniqueId, headers);
       }
 
       // If the effect was cleaned up while we were awaiting, discard the connection.

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -208,6 +208,58 @@ describe("DustFileSystem.forPod", () => {
 });
 
 // ---------------------------------------------------------------------------
+// forPodSandboxProvisioning
+// ---------------------------------------------------------------------------
+
+describe("DustFileSystem.forPodSandboxProvisioning", () => {
+  it("returns Ok for a same-workspace user who cannot read the pod", async () => {
+    const { workspace, user } = await createResourceTest({ role: "user" });
+    // The user is deliberately not added to the pod.
+    const projectSpace = await SpaceFactory.project(workspace);
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    // The user-facing factory refuses this caller...
+    const guarded = await DustFileSystem.forPod(auth, projectSpace);
+    expect(guarded.isErr()).toBe(true);
+
+    // ...but sandbox provisioning builds the same pod-level mounts regardless of
+    // who triggered the boot (e.g. an invoker authorized through app sharing).
+    const result = await DustFileSystem.forPodSandboxProvisioning(
+      auth,
+      projectSpace
+    );
+    assert(result.isOk());
+    const mounts = result.value.getMounts();
+    expect(mounts).toHaveLength(1);
+    expect(mounts[0].kind).toBe("pod");
+    expect(mounts[0].id).toBe(projectSpace.sId);
+    expect(mounts[0].sandboxMountPoint).toBe(`/files/pod-${projectSpace.sId}`);
+  });
+
+  it("returns Err(unauthorized) for a caller from another workspace", async () => {
+    const { authenticator: otherWorkspaceAuth } = await createResourceTest({
+      role: "admin",
+    });
+    const { workspace: podWorkspace } = await createResourceTest({
+      role: "admin",
+    });
+    const projectSpace = await SpaceFactory.project(podWorkspace);
+
+    const result = await DustFileSystem.forPodSandboxProvisioning(
+      otherWorkspaceAuth,
+      projectSpace
+    );
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("unauthorized");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // forUser
 // ---------------------------------------------------------------------------
 

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -323,6 +323,43 @@ export class DustFileSystem {
   }
 
   /**
+   * Build a DustFileSystem for provisioning a pod's sandbox (mount setup and
+   * mount credential refresh). Unlike `forPod`, this does not require read
+   * access on the space: the sandbox is shared at the pod level and its mounts
+   * are identical whoever triggers the boot — in particular an invoker
+   * authorized only through app sharing, who holds no read on the Pod. Must
+   * only be called from sandbox provisioning paths, never user-facing file
+   * APIs; API-level permissions on the mount still derive from the caller, so
+   * they fail closed.
+   */
+  static async forPodSandboxProvisioning(
+    auth: Authenticator,
+    space: SpaceResource,
+    { sandboxOnlyMounts = [] }: { sandboxOnlyMounts?: SandboxOnlyMount[] } = {}
+  ): Promise<Result<DustFileSystem, DustFileSystemError>> {
+    const owner = auth.getNonNullableWorkspace();
+    if (space.workspaceId !== owner.id) {
+      return new Err(
+        new DustFileSystemError(
+          "unauthorized",
+          "The space belongs to another workspace."
+        )
+      );
+    }
+
+    const mount = createPodMount(auth, space, { includeLegacy: false });
+
+    const backend = new GCSFileSystemBackend(
+      owner.sId,
+      fileStorageConfig.getGcsPrivateUploadsBucket()
+    );
+
+    return new Ok(
+      new DustFileSystem(auth, [mount], backend, sandboxOnlyMounts)
+    );
+  }
+
+  /**
    * Build a DustFileSystem scoped to the authenticated user's own memory space.
    *
    * The scope is always `auth.user()` and cannot be overridden, so an agent can never

--- a/front/lib/api/sandbox/lifecycle.test.ts
+++ b/front/lib/api/sandbox/lifecycle.test.ts
@@ -12,7 +12,7 @@ const {
   mockLoggerWarn,
   mockLoggerChild,
   mockForConversation,
-  mockForPod,
+  mockForPodSandboxProvisioning,
   mockSetupSandboxMount,
   mockRefreshSandboxMount,
   mockPrepareSandboxEgressBeforeMount,
@@ -31,7 +31,7 @@ const {
     mockLoggerWarn: vi.fn(),
     mockLoggerChild: vi.fn(),
     mockForConversation: vi.fn(),
-    mockForPod: vi.fn(),
+    mockForPodSandboxProvisioning: vi.fn(),
     mockSetupSandboxMount,
     mockRefreshSandboxMount,
     mockPrepareSandboxEgressBeforeMount: vi.fn(),
@@ -59,7 +59,7 @@ vi.mock("@app/lib/api/sandbox/egress", () => ({
 vi.mock("@app/lib/api/file_system/dust_file_system", () => ({
   DustFileSystem: {
     forConversation: mockForConversation,
-    forPod: mockForPod,
+    forPodSandboxProvisioning: mockForPodSandboxProvisioning,
   },
 }));
 
@@ -189,7 +189,7 @@ describe("ensureConversationSandboxReady", () => {
     mockGetSandboxImage.mockReturnValue(new Ok(image));
     mockStartTelemetry.mockResolvedValue(new Ok(undefined));
     mockForConversation.mockResolvedValue(new Ok(mockFs));
-    mockForPod.mockResolvedValue(new Ok(mockFs));
+    mockForPodSandboxProvisioning.mockResolvedValue(new Ok(mockFs));
     mockSetupSandboxMount.mockResolvedValue(new Ok(undefined));
     mockRefreshSandboxMount.mockResolvedValue(new Ok(undefined));
     mockSetupPodStateOnColdStart.mockResolvedValue(new Ok(undefined));
@@ -440,7 +440,7 @@ describe("ensureConversationSandboxReady", () => {
     // The pod's published bundles are mounted read-only under a pod-scoped
     // path; the litestream replica prefix is mounted rw for the in-sandbox
     // daemon.
-    expect(mockForPod).toHaveBeenCalledWith(auth, pod, {
+    expect(mockForPodSandboxProvisioning).toHaveBeenCalledWith(auth, pod, {
       sandboxOnlyMounts: [
         {
           kind: "pod_sandbox_functions",

--- a/front/lib/api/sandbox/lifecycle.ts
+++ b/front/lib/api/sandbox/lifecycle.ts
@@ -262,8 +262,10 @@ export async function ensurePodSandboxReady(
       PodSandboxAdapter.ensureSandboxActive(auth, pod, { requireRunning }),
     // Pods are their own scope and cannot move — the config is static.
     deriveConfig: () => ({
+      // Provisioning variant: the boot may be triggered by an invoker authorized
+      // only through app sharing, who cannot read the Pod.
       getFileSystem: () =>
-        DustFileSystem.forPod(auth, pod, {
+        DustFileSystem.forPodSandboxProvisioning(auth, pod, {
           sandboxOnlyMounts: podSandboxOnlyMounts(pod),
         }),
       runtimeOwner: {

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -172,9 +172,9 @@ export async function createSandboxFunctionMCPAction(
     return toolConfigurationRes;
   }
 
-  // Pipeline resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g. a
+  // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g. a
   // frame share token); the validated claims name the invocation, which is the proof.
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
     sandboxFunctionId,
     { invocationId }

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -176,8 +176,10 @@ export async function createSandboxFunctionMCPAction(
   // frame share token); the validated claims name the invocation, which is the proof.
   const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
-    sandboxFunctionId,
-    { invocationId }
+    {
+      sandboxFunctionId,
+      invocationId,
+    }
   );
   if (!sandboxFunction) {
     return new Err(

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -172,13 +172,14 @@ export async function createSandboxFunctionMCPAction(
     return toolConfigurationRes;
   }
 
-  // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g. a
-  // frame share token); the validated claims name the invocation, which is the proof.
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
+  // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant
+  // (e.g. a frame share token). The id comes from signature-verified sandbox JWT claims minted
+  // at execution start, so the space filter is deliberately skipped.
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
     auth,
+    sandboxFunctionId,
     {
-      sandboxFunctionId,
-      invocationId,
+      dangerouslyBypassSpacePermissionFilter: true,
     }
   );
   if (!sandboxFunction) {

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -172,9 +172,12 @@ export async function createSandboxFunctionMCPAction(
     return toolConfigurationRes;
   }
 
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  // Pipeline resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g. a
+  // frame share token); the validated claims name the invocation, which is the proof.
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
     auth,
-    sandboxFunctionId
+    sandboxFunctionId,
+    { invocationId }
   );
   if (!sandboxFunction) {
     return new Err(

--- a/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
+++ b/front/lib/api/sandbox_functions/create_sandbox_function_mcp_action.ts
@@ -175,11 +175,11 @@ export async function createSandboxFunctionMCPAction(
   // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant
   // (e.g. a frame share token). The id comes from signature-verified sandbox JWT claims minted
   // at execution start, so the space filter is deliberately skipped.
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
-    sandboxFunctionId,
     {
-      dangerouslyBypassSpacePermissionFilter: true,
+      sandboxFunctionId,
+      invocationId,
     }
   );
   if (!sandboxFunction) {

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -2,9 +2,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_reference";
 
-/** Header a frame host attaches to invocation requests to present the frame's share token. */
-export const FRAME_SHARE_TOKEN_HEADER = "x-dust-frame-share-token";
-
 /**
  * Possession of a Pod app frame's share token is the capability to invoke that app's published
  * functions: the frame is authored by the pod's members and is unusable without them, so being

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -67,21 +67,25 @@ export async function resolveFrameShareCapability(
   }
 
   // Workspace-visible scopes carry the capability for every member. An invite-only frame
-  // carries it only for members holding an active email grant — the same check that gates
-  // viewing the frame — so revoking a grant revokes invocation with it.
+  // carries it for members holding an active email grant, or for the frame's owner — the same
+  // two ways the view path admits a member — so invocation access exactly follows view access,
+  // and revoking a grant revokes invocation with it.
   if (!isWorkspaceVisibleShareScope(shareScope)) {
     if (shareScope !== "emails_only") {
       return null;
     }
-    const email = auth.user()?.email;
-    const grant = email
-      ? await FileResource.getActiveGrantForEmail(workspace, {
-          email,
-          shareableFileId,
-        })
-      : null;
-    if (!grant) {
-      return null;
+    const user = auth.user();
+    const isFileOwner = user !== null && file.userId === user.id;
+    if (!isFileOwner) {
+      const grant = user?.email
+        ? await FileResource.getActiveGrantForEmail(workspace, {
+            email: user.email,
+            shareableFileId,
+          })
+        : null;
+      if (!grant) {
+        return null;
+      }
     }
   }
 

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -6,9 +6,10 @@ import type { FrameShareCapability } from "@app/types/api/sandbox_functions";
 import { isWorkspaceVisibleShareScope } from "@app/types/files";
 
 /**
- * Possession of a Pod app frame's share token is the capability to invoke that app's published
- * functions: the frame is authored by the pod's members and is unusable without them, so being
- * handed its link is being handed the app. The capability grants function resolution only — it
+ * A workspace member who may view a Pod app frame may invoke that app's published functions:
+ * the frame is authored by the pod's members and is unusable without them, so sharing the frame
+ * is sharing the app. Viewing means holding the share token for workspace-visible scopes, plus an
+ * active email grant for invite-only frames. The capability grants function resolution only — it
  * never widens reads or writes on the pod, and per-function userIdentity policies still apply.
  */
 

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -1,6 +1,9 @@
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_reference";
+import type { FrameShareCapability } from "@app/types/api/sandbox_functions";
+import { isWorkspaceVisibleShareScope } from "@app/types/files";
 
 /**
  * Possession of a Pod app frame's share token is the capability to invoke that app's published
@@ -8,17 +11,38 @@ import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_refer
  * handed its link is being handed the app. The capability grants function resolution only — it
  * never widens reads or writes on the pod, and per-function userIdentity policies still apply.
  */
-export type FrameShareCapability = {
-  /** sId of the pod the shared frame lives in. */
-  podId: string;
-  /** Normalized prefix of the frame's app folder — the namespace of the slugs it authorizes. */
-  appPrefix: string;
-};
+
+/**
+ * Resolve a function the way invocation-facing routes need it: by the caller's own access first,
+ * and only when that misses, by the frame share token they presented. Members thus never pay the
+ * token lookup, and an invalid token behaves exactly like an absent one.
+ */
+export async function resolveSandboxFunctionWithCapability(
+  auth: Authenticator,
+  functionIdOrSlug: string,
+  frameShareToken: string | undefined
+): Promise<SandboxFunctionResource | null> {
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdOrSlug(
+    auth,
+    functionIdOrSlug
+  );
+  if (sandboxFunction || !frameShareToken) {
+    return sandboxFunction;
+  }
+
+  const capability = await resolveFrameShareCapability(auth, frameShareToken);
+  if (!capability) {
+    return null;
+  }
+
+  return SandboxFunctionResource.fetchByIdOrSlug(auth, functionIdOrSlug, {
+    capability,
+  });
+}
 
 /**
  * Validate a frame share token presented alongside a function invocation and derive the
- * capability it carries. Returns null on any mismatch — an invalid token behaves exactly like an
- * absent one, so callers fall through to the regular not-found path.
+ * capability it carries. Returns null on any mismatch.
  */
 export async function resolveFrameShareCapability(
   auth: Authenticator,
@@ -40,8 +64,8 @@ export async function resolveFrameShareCapability(
   }
 
   // Only workspace-visible scopes carry the capability; downgrading a frame to emails_only
-  // revokes it. "workspace" is the legacy spelling of workspace_and_emails.
-  if (shareScope !== "workspace_and_emails" && shareScope !== "workspace") {
+  // revokes it.
+  if (!isWorkspaceVisibleShareScope(shareScope)) {
     return null;
   }
 

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -57,16 +57,29 @@ export async function resolveFrameShareCapability(
   if (shareResult.isErr()) {
     return null;
   }
-  const { file, shareScope, workspace } = shareResult.value;
+  const { file, shareScope, shareableFileId, workspace } = shareResult.value;
 
   if (workspace.id !== auth.getNonNullableWorkspace().id) {
     return null;
   }
 
-  // Only workspace-visible scopes carry the capability; downgrading a frame to emails_only
-  // revokes it.
+  // Workspace-visible scopes carry the capability for every member. An invite-only frame
+  // carries it only for members holding an active email grant — the same check that gates
+  // viewing the frame — so revoking a grant revokes invocation with it.
   if (!isWorkspaceVisibleShareScope(shareScope)) {
-    return null;
+    if (shareScope !== "emails_only") {
+      return null;
+    }
+    const email = auth.user()?.email;
+    const grant = email
+      ? await FileResource.getActiveGrantForEmail(workspace, {
+          email,
+          shareableFileId,
+        })
+      : null;
+    if (!grant) {
+      return null;
+    }
   }
 
   if (!file.isInteractiveContent) {

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -1,0 +1,61 @@
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { podFunctionScopeFromFramePath } from "@app/types/api/pod_function_reference";
+
+/** Header a frame host attaches to invocation requests to present the frame's share token. */
+export const FRAME_SHARE_TOKEN_HEADER = "x-dust-frame-share-token";
+
+/**
+ * Possession of a Pod app frame's share token is the capability to invoke that app's published
+ * functions: the frame is authored by the pod's members and is unusable without them, so being
+ * handed its link is being handed the app. The capability grants function resolution only — it
+ * never widens reads or writes on the pod, and per-function userIdentity policies still apply.
+ */
+export type FrameShareCapability = {
+  /** sId of the pod the shared frame lives in. */
+  podId: string;
+  /** Normalized prefix of the frame's app folder — the namespace of the slugs it authorizes. */
+  appPrefix: string;
+};
+
+/**
+ * Validate a frame share token presented alongside a function invocation and derive the
+ * capability it carries. Returns null on any mismatch — an invalid token behaves exactly like an
+ * absent one, so callers fall through to the regular not-found path.
+ */
+export async function resolveFrameShareCapability(
+  auth: Authenticator,
+  token: string
+): Promise<FrameShareCapability | null> {
+  // Invocation is workspace-member-only: external email-grant viewers hold view-only tokens.
+  if (!auth.isUser()) {
+    return null;
+  }
+
+  const shareResult = await FileResource.fetchByShareToken(token);
+  if (shareResult.isErr()) {
+    return null;
+  }
+  const { file, shareScope, workspace } = shareResult.value;
+
+  if (workspace.id !== auth.getNonNullableWorkspace().id) {
+    return null;
+  }
+
+  // Only workspace-visible scopes carry the capability; downgrading a frame to emails_only
+  // revokes it. "workspace" is the legacy spelling of workspace_and_emails.
+  if (shareScope !== "workspace_and_emails" && shareScope !== "workspace") {
+    return null;
+  }
+
+  if (!file.isInteractiveContent) {
+    return null;
+  }
+
+  const scope = podFunctionScopeFromFramePath(file.toScopedPath(auth));
+  if (!scope) {
+    return null;
+  }
+
+  return { podId: scope.podId, appPrefix: scope.appPrefix };
+}

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -36,11 +36,11 @@ export async function resolveSandboxFunctionWithCapability(
     return null;
   }
 
-  return SandboxFunctionResource.fetchByIdOrSlug(
-    auth,
-    functionIdOrSlug,
-    capability
-  );
+  return SandboxFunctionResource.fetchInAppFolder(auth, {
+    podId: capability.podId,
+    appPrefix: capability.appPrefix,
+    idOrSlug: functionIdOrSlug,
+  });
 }
 
 /**

--- a/front/lib/api/sandbox_functions/frame_share_capability.ts
+++ b/front/lib/api/sandbox_functions/frame_share_capability.ts
@@ -36,9 +36,11 @@ export async function resolveSandboxFunctionWithCapability(
     return null;
   }
 
-  return SandboxFunctionResource.fetchByIdOrSlug(auth, functionIdOrSlug, {
-    capability,
-  });
+  return SandboxFunctionResource.fetchByIdOrSlug(
+    auth,
+    functionIdOrSlug,
+    capability
+  );
 }
 
 /**

--- a/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
+++ b/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
@@ -22,9 +22,12 @@ export async function selfHealSandboxFunctionExecutionMode(
     invocationId: string;
   }
 ): Promise<void> {
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  // Pipeline resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g. a
+  // frame share token); the refused tool call's invocation is the proof.
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
     auth,
-    sandboxFunctionId
+    sandboxFunctionId,
+    { invocationId }
   );
   if (!sandboxFunction) {
     logger.error(

--- a/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
+++ b/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
@@ -22,9 +22,9 @@ export async function selfHealSandboxFunctionExecutionMode(
     invocationId: string;
   }
 ): Promise<void> {
-  // Pipeline resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g. a
+  // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g. a
   // frame share token); the refused tool call's invocation is the proof.
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
     sandboxFunctionId,
     { invocationId }

--- a/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
+++ b/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
@@ -22,13 +22,14 @@ export async function selfHealSandboxFunctionExecutionMode(
     invocationId: string;
   }
 ): Promise<void> {
-  // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant (e.g. a
-  // frame share token); the refused tool call's invocation is the proof.
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
+  // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant
+  // (e.g. a frame share token). The id comes from signature-verified sandbox JWT claims minted
+  // at execution start, so the space filter is deliberately skipped.
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
     auth,
+    sandboxFunctionId,
     {
-      sandboxFunctionId,
-      invocationId,
+      dangerouslyBypassSpacePermissionFilter: true,
     }
   );
   if (!sandboxFunction) {

--- a/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
+++ b/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
@@ -25,11 +25,11 @@ export async function selfHealSandboxFunctionExecutionMode(
   // Execution-side resolution: a sandbox-token auth cannot carry the invoker's original grant
   // (e.g. a frame share token). The id comes from signature-verified sandbox JWT claims minted
   // at execution start, so the space filter is deliberately skipped.
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
-    sandboxFunctionId,
     {
-      dangerouslyBypassSpacePermissionFilter: true,
+      sandboxFunctionId,
+      invocationId,
     }
   );
   if (!sandboxFunction) {

--- a/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
+++ b/front/lib/api/sandbox_functions/self_heal_execution_mode.ts
@@ -26,8 +26,10 @@ export async function selfHealSandboxFunctionExecutionMode(
   // frame share token); the refused tool call's invocation is the proof.
   const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
-    sandboxFunctionId,
-    { invocationId }
+    {
+      sandboxFunctionId,
+      invocationId,
+    }
   );
   if (!sandboxFunction) {
     logger.error(

--- a/front/lib/api/sandbox_functions/slug.ts
+++ b/front/lib/api/sandbox_functions/slug.ts
@@ -63,6 +63,19 @@ export function deriveAppPrefix({
 }
 
 /**
+ * The app prefix a published slug belongs to, or `null` for a function published from the pod
+ * root (bare slug, no app folder).
+ */
+export function appPrefixFromSlug(slug: string): string | null {
+  const separatorIndex = slug.indexOf(SANDBOX_FUNCTION_SLUG_SEPARATOR);
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  return slug.slice(0, separatorIndex);
+}
+
+/**
  * The bare function name inside its app, i.e. the slug with its app prefix removed. Returns the whole
  * slug for a function published from the pod root, which has no prefix.
  *

--- a/front/lib/resources/pod_sandbox_adapter.ts
+++ b/front/lib/resources/pod_sandbox_adapter.ts
@@ -108,9 +108,15 @@ export class PodSandboxAdapter {
           if (imageResult.isErr()) {
             return imageResult;
           }
-          const fsResult = await DustFileSystem.forPod(auth, pod, {
-            sandboxOnlyMounts: podSandboxOnlyMounts(pod),
-          });
+          // Provisioning variant: the refresh may run under an invoker authorized
+          // only through app sharing, who cannot read the Pod.
+          const fsResult = await DustFileSystem.forPodSandboxProvisioning(
+            auth,
+            pod,
+            {
+              sandboxOnlyMounts: podSandboxOnlyMounts(pod),
+            }
+          );
           if (fsResult.isErr()) {
             return fsResult;
           }

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -423,8 +423,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
    */
   static async fetchByIdForExecution(
     auth: Authenticator,
-    sandboxFunctionId: string,
-    { invocationId }: { invocationId: string }
+    {
+      sandboxFunctionId,
+      invocationId,
+    }: { sandboxFunctionId: string; invocationId: string }
   ): Promise<SandboxFunctionResource | null> {
     if (
       !isResourceSId("sandbox_function", sandboxFunctionId) ||

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -313,7 +313,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }: ResourceFindOptions<SandboxFunctionModel> & {
       includeDeletedSpace?: boolean;
       capability?: FrameShareCapability;
-      // Reserved for execution-side resolution (fetchByIdForExecution and the tool workflow),
+      // Reserved for execution-side resolution (see fetchById's option of the same name),
       // which verified an invocation row for the function first.
       dangerouslyBypassSpacePermissionFilter?: boolean;
     } = {}
@@ -394,7 +394,17 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static async fetchById(
     auth: Authenticator,
     sandboxFunctionId: string,
-    capability?: FrameShareCapability
+    {
+      capability,
+      dangerouslyBypassSpacePermissionFilter = false,
+    }: {
+      capability?: FrameShareCapability;
+      // Only for execution-side paths (temporal activities, sandbox-token callbacks): they
+      // re-resolve an already-authorized invocation's function under an auth that cannot carry
+      // the invoker's original grant, and their (function, invocation) ids come from
+      // server-minted inputs (workflow args, verified sandbox JWT claims), never user input.
+      dangerouslyBypassSpacePermissionFilter?: boolean;
+    } = {}
   ): Promise<SandboxFunctionResource | null> {
     if (!isResourceSId("sandbox_function", sandboxFunctionId)) {
       return null;
@@ -408,48 +418,9 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     const [sandboxFunction] = await this.baseFetch(auth, {
       where: { id: sandboxFunctionModelId },
       capability,
+      dangerouslyBypassSpacePermissionFilter,
     });
 
-    return sandboxFunction ?? null;
-  }
-
-  /**
-   * Gets the function if the invocation row exists
-   * In the context of a temporal activity or a sandbox callback, we don't have the original caller's
-   * grant (e.g. a frame share token) in the auth. Instead, we rely on the fact that the invocation row
-   * was created earlier when we did have the caller's grant. The presence of the invocation row
-   * is sufficient proof that the caller was authorized to invoke the function
-   */
-  static async fetchByIdForExecution(
-    auth: Authenticator,
-    {
-      sandboxFunctionId,
-      invocationId,
-    }: { sandboxFunctionId: string; invocationId: string }
-  ): Promise<SandboxFunctionResource | null> {
-    const sandboxFunctionModelId = getResourceIdFromSId(sandboxFunctionId);
-    const invocationModelId = getResourceIdFromSId(invocationId);
-    if (sandboxFunctionModelId === null || invocationModelId === null) {
-      return null;
-    }
-
-    // We don't need the invocation row itself, just its existence to prove that the caller was
-    // authorized to invoke the function
-    const invocation = await SandboxFunctionInvocationModel.findOne({
-      where: {
-        id: invocationModelId,
-        sandboxFunctionId: sandboxFunctionModelId,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-    });
-    if (!invocation) {
-      return null;
-    }
-
-    const [sandboxFunction] = await this.baseFetch(auth, {
-      where: { id: sandboxFunctionModelId },
-      dangerouslyBypassSpacePermissionFilter: true,
-    });
     return sandboxFunction ?? null;
   }
 
@@ -526,11 +497,9 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     functionIdOrSlug: string,
     capability?: FrameShareCapability
   ): Promise<SandboxFunctionResource | null> {
-    const sandboxFunction = await this.fetchById(
-      auth,
-      functionIdOrSlug,
-      capability
-    );
+    const sandboxFunction = await this.fetchById(auth, functionIdOrSlug, {
+      capability,
+    });
     if (sandboxFunction) {
       return sandboxFunction;
     }

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -314,8 +314,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       includeDeletedSpace?: boolean;
       capability?: FrameShareCapability;
       // Reserved for execution-side resolution (fetchByIdForExecution and the tool workflow),
-      // which
-      // verified an invocation row for the function first.
+      // which verified an invocation row for the function first.
       dangerouslyBypassSpacePermissionFilter?: boolean;
     } = {}
   ): Promise<SandboxFunctionResource[]> {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -308,10 +308,14 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     {
       includeDeletedSpace,
       capability,
+      dangerouslyBypassSpacePermissionFilter = false,
       ...options
     }: ResourceFindOptions<SandboxFunctionModel> & {
       includeDeletedSpace?: boolean;
       capability?: FrameShareCapability;
+      // Reserved for pipeline resolution (fetchByIdForPipeline and the tool workflow), which
+      // verified an invocation row for the function first.
+      dangerouslyBypassSpacePermissionFilter?: boolean;
     } = {}
   ): Promise<SandboxFunctionResource[]> {
     const { where, ...rest } = options;
@@ -363,6 +367,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     );
     const filesById = new Map(files.map((file) => [file.id, file]));
 
+    const spacesById = dangerouslyBypassSpacePermissionFilter
+      ? new Map(spaces.map((space) => [space.id, space]))
+      : null;
+
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
       let space = accessibleSpacesById.get(blob.spaceId);
@@ -374,6 +382,9 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         appPrefixFromSlug(blob.slug) === capability.appPrefix
       ) {
         space = capabilitySpace;
+      }
+      if (!space && spacesById) {
+        space = spacesById.get(blob.spaceId);
       }
       const file = filesById.get(blob.fileId);
       if (!space || !file) {
@@ -406,6 +417,49 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return sandboxFunction ?? null;
   }
 
+  /**
+   * Resolve a function for the invocation pipeline: temporal activities and sandbox-token
+   * callbacks re-enter resolution under an auth that cannot carry the caller's original grant (a
+   * serialized session snapshot, a sandbox token), so caller-facing space permissions do not
+   * apply there. The invocation row is the proof of authorization — creating it passed the
+   * caller-facing gates, and the userIdentity policy re-runs at execution — so resolution here is
+   * workspace-scoped only. Only for paths executing that specific invocation.
+   */
+  static async fetchByIdForPipeline(
+    auth: Authenticator,
+    sandboxFunctionId: string,
+    { invocationId }: { invocationId: string }
+  ): Promise<SandboxFunctionResource | null> {
+    if (
+      !isResourceSId("sandbox_function", sandboxFunctionId) ||
+      !isResourceSId("sandbox_function_invocation", invocationId)
+    ) {
+      return null;
+    }
+    const sandboxFunctionModelId = getResourceIdFromSId(sandboxFunctionId);
+    const invocationModelId = getResourceIdFromSId(invocationId);
+    if (sandboxFunctionModelId === null || invocationModelId === null) {
+      return null;
+    }
+
+    const invocation = await SandboxFunctionInvocationModel.findOne({
+      where: {
+        id: invocationModelId,
+        sandboxFunctionId: sandboxFunctionModelId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+    if (!invocation) {
+      return null;
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: { id: sandboxFunctionModelId },
+      dangerouslyBypassSpacePermissionFilter: true,
+    });
+    return sandboxFunction ?? null;
+  }
+
   // Lives here rather than on SandboxFunctionMCPActionResource: that resource can only type-import
   // the invocation resource (the invocation resource value-imports it for cascade deletion), so it
   // cannot construct an invocation. Takes the action rather than its FK id so callers don't thread
@@ -424,13 +478,13 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       return null;
     }
 
-    const sandboxFunction = await this.fetchById(
-      auth,
-      this.modelIdToSId({
-        id: invocation.sandboxFunctionId,
-        workspaceId: invocation.workspaceId,
-      })
-    );
+    // The invocation row above is the pipeline's proof of authorization: the tool workflow must
+    // resolve the function even when the invoker's original grant (e.g. a frame share token)
+    // cannot be reconstructed from the serialized auth.
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: { id: invocation.sandboxFunctionId },
+      dangerouslyBypassSpacePermissionFilter: true,
+    });
     if (!sandboxFunction) {
       return null;
     }

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -3,7 +3,11 @@ import type {
   PokePodFunctionDetails,
 } from "@app/lib/api/poke/projects";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
-import { sandboxFunctionNameFromSlug } from "@app/lib/api/sandbox_functions/slug";
+import type { FrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
+import {
+  appPrefixFromSlug,
+  sandboxFunctionNameFromSlug,
+} from "@app/lib/api/sandbox_functions/slug";
 import { authorizeSandboxFunctionInvocation } from "@app/lib/api/sandbox_functions/workspace_user";
 import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
@@ -303,9 +307,11 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     {
       includeDeletedSpace,
+      capability,
       ...options
     }: ResourceFindOptions<SandboxFunctionModel> & {
       includeDeletedSpace?: boolean;
+      capability?: FrameShareCapability;
     } = {}
   ): Promise<SandboxFunctionResource[]> {
     const { where, ...rest } = options;
@@ -336,6 +342,15 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         .map((space) => [space.id, space])
     );
 
+    // A validated frame share capability extends resolution to the functions of its own app in
+    // its own pod, without granting read on the space. Per-function userIdentity policies still
+    // apply at invocation time.
+    const capabilitySpace = capability
+      ? (spaces.find(
+          (space) => space.isProject() && space.sId === capability.podId
+        ) ?? null)
+      : null;
+
     const files = await FileResource.fetchByModelIdsWithAuth(
       auth,
       Array.from(
@@ -349,19 +364,30 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     const filesById = new Map(files.map((file) => [file.id, file]));
 
     return sandboxFunctions.flatMap((sandboxFunction) => {
-      const space = accessibleSpacesById.get(sandboxFunction.get().spaceId);
-      const file = filesById.get(sandboxFunction.get().fileId);
+      const blob = sandboxFunction.get();
+      let space = accessibleSpacesById.get(blob.spaceId);
+      if (
+        !space &&
+        capability &&
+        capabilitySpace &&
+        capabilitySpace.id === blob.spaceId &&
+        appPrefixFromSlug(blob.slug) === capability.appPrefix
+      ) {
+        space = capabilitySpace;
+      }
+      const file = filesById.get(blob.fileId);
       if (!space || !file) {
         return [];
       }
 
-      return [new this(this.model, sandboxFunction.get(), space, file)];
+      return [new this(this.model, blob, space, file)];
     });
   }
 
   static async fetchById(
     auth: Authenticator,
-    sandboxFunctionId: string
+    sandboxFunctionId: string,
+    { capability }: { capability?: FrameShareCapability } = {}
   ): Promise<SandboxFunctionResource | null> {
     if (!isResourceSId("sandbox_function", sandboxFunctionId)) {
       return null;
@@ -374,6 +400,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     const [sandboxFunction] = await this.baseFetch(auth, {
       where: { id: sandboxFunctionModelId },
+      capability,
     });
 
     return sandboxFunction ?? null;
@@ -432,7 +459,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static async fetchBySpaceAndSlug(
     auth: Authenticator,
     space: SpaceResource,
-    slug: string
+    slug: string,
+    { capability }: { capability?: FrameShareCapability } = {}
   ): Promise<SandboxFunctionResource | null> {
     if (!space.isProject()) {
       return null;
@@ -440,6 +468,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     const [sandboxFunction] = await this.baseFetch(auth, {
       where: { spaceId: space.id, slug },
+      capability,
     });
 
     return sandboxFunction ?? null;
@@ -447,9 +476,12 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   static async fetchByIdOrSlug(
     auth: Authenticator,
-    functionIdOrSlug: string
+    functionIdOrSlug: string,
+    { capability }: { capability?: FrameShareCapability } = {}
   ): Promise<SandboxFunctionResource | null> {
-    const sandboxFunction = await this.fetchById(auth, functionIdOrSlug);
+    const sandboxFunction = await this.fetchById(auth, functionIdOrSlug, {
+      capability,
+    });
     if (sandboxFunction) {
       return sandboxFunction;
     }
@@ -467,7 +499,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       return null;
     }
 
-    return this.fetchBySpaceAndSlug(auth, space, slug);
+    return this.fetchBySpaceAndSlug(auth, space, slug, { capability });
   }
 
   static async deleteAllForSpace(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -3,7 +3,6 @@ import type {
   PokePodFunctionDetails,
 } from "@app/lib/api/poke/projects";
 import { SandboxFunctionInvocationError } from "@app/lib/api/sandbox_functions/errors";
-import type { FrameShareCapability } from "@app/lib/api/sandbox_functions/frame_share_capability";
 import {
   appPrefixFromSlug,
   sandboxFunctionNameFromSlug,
@@ -31,6 +30,7 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { PodAppFunction } from "@app/types/api/pod_apps";
 import type {
+  FrameShareCapability,
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionExecutionMode,
   SandboxFunctionInvocationOrigin,
@@ -373,19 +373,15 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
-      let space = accessibleSpacesById.get(blob.spaceId);
-      if (
-        !space &&
-        capability &&
-        capabilitySpace &&
-        capabilitySpace.id === blob.spaceId &&
-        appPrefixFromSlug(blob.slug) === capability.appPrefix
-      ) {
-        space = capabilitySpace;
-      }
-      if (!space && spacesById) {
-        space = spacesById.get(blob.spaceId);
-      }
+      // Three prioritized gates: the caller's own access, then the app the capability grants,
+      // then the pipeline bypass (spacesById is only built for it).
+      const space =
+        accessibleSpacesById.get(blob.spaceId) ??
+        (capabilitySpace?.id === blob.spaceId &&
+        appPrefixFromSlug(blob.slug) === capability?.appPrefix
+          ? capabilitySpace
+          : undefined) ??
+        spacesById?.get(blob.spaceId);
       const file = filesById.get(blob.fileId);
       if (!space || !file) {
         return [];

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -313,7 +313,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }: ResourceFindOptions<SandboxFunctionModel> & {
       includeDeletedSpace?: boolean;
       capability?: FrameShareCapability;
-      // Reserved for pipeline resolution (fetchByIdForPipeline and the tool workflow), which
+      // Reserved for execution-side resolution (fetchByIdForExecution and the tool workflow),
+      // which
       // verified an invocation row for the function first.
       dangerouslyBypassSpacePermissionFilter?: boolean;
     } = {}
@@ -374,7 +375,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
       // Three prioritized gates: the caller's own access, then the app the capability grants,
-      // then the pipeline bypass (spacesById is only built for it).
+      // then the execution-side bypass (spacesById is only built for it).
       const space =
         accessibleSpacesById.get(blob.spaceId) ??
         (capabilitySpace?.id === blob.spaceId &&
@@ -414,14 +415,14 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   }
 
   /**
-   * Resolve a function for the invocation pipeline: temporal activities and sandbox-token
+   * Resolve a function for executing an existing invocation: temporal activities and sandbox-token
    * callbacks re-enter resolution under an auth that cannot carry the caller's original grant (a
    * serialized session snapshot, a sandbox token), so caller-facing space permissions do not
    * apply there. The invocation row is the proof of authorization — creating it passed the
    * caller-facing gates, and the userIdentity policy re-runs at execution — so resolution here is
    * workspace-scoped only. Only for paths executing that specific invocation.
    */
-  static async fetchByIdForPipeline(
+  static async fetchByIdForExecution(
     auth: Authenticator,
     sandboxFunctionId: string,
     { invocationId }: { invocationId: string }
@@ -474,7 +475,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       return null;
     }
 
-    // The invocation row above is the pipeline's proof of authorization: the tool workflow must
+    // The invocation row above is the execution side's proof of authorization: the tool workflow must
     // resolve the function even when the invoker's original grant (e.g. a frame share token)
     // cannot be reconstructed from the serialized auth.
     const [sandboxFunction] = await this.baseFetch(auth, {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -375,12 +375,12 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       const blob = sandboxFunction.get();
       // Three prioritized gates: the caller's own access, then the app the capability grants,
       // then the execution-side bypass (spacesById is only built for it).
+      const capabilityGrantsFunction =
+        capabilitySpace?.id === blob.spaceId &&
+        appPrefixFromSlug(blob.slug) === capability?.appPrefix;
       const space =
         accessibleSpacesById.get(blob.spaceId) ??
-        (capabilitySpace?.id === blob.spaceId &&
-        appPrefixFromSlug(blob.slug) === capability?.appPrefix
-          ? capabilitySpace
-          : undefined) ??
+        (capabilityGrantsFunction ? capabilitySpace : undefined) ??
         spacesById?.get(blob.spaceId);
       const file = filesById.get(blob.fileId);
       if (!space || !file) {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -394,7 +394,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static async fetchById(
     auth: Authenticator,
     sandboxFunctionId: string,
-    { capability }: { capability?: FrameShareCapability } = {}
+    capability?: FrameShareCapability
   ): Promise<SandboxFunctionResource | null> {
     if (!isResourceSId("sandbox_function", sandboxFunctionId)) {
       return null;
@@ -507,7 +507,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     space: SpaceResource,
     slug: string,
-    { capability }: { capability?: FrameShareCapability } = {}
+    capability?: FrameShareCapability
   ): Promise<SandboxFunctionResource | null> {
     if (!space.isProject()) {
       return null;
@@ -524,11 +524,13 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static async fetchByIdOrSlug(
     auth: Authenticator,
     functionIdOrSlug: string,
-    { capability }: { capability?: FrameShareCapability } = {}
+    capability?: FrameShareCapability
   ): Promise<SandboxFunctionResource | null> {
-    const sandboxFunction = await this.fetchById(auth, functionIdOrSlug, {
-      capability,
-    });
+    const sandboxFunction = await this.fetchById(
+      auth,
+      functionIdOrSlug,
+      capability
+    );
     if (sandboxFunction) {
       return sandboxFunction;
     }
@@ -546,7 +548,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       return null;
     }
 
-    return this.fetchBySpaceAndSlug(auth, space, slug, { capability });
+    return this.fetchBySpaceAndSlug(auth, space, slug, capability);
   }
 
   static async deleteAllForSpace(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -414,12 +414,11 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   }
 
   /**
-   * Resolve a function for executing an existing invocation: temporal activities and sandbox-token
-   * callbacks re-enter resolution under an auth that cannot carry the caller's original grant (a
-   * serialized session snapshot, a sandbox token), so caller-facing space permissions do not
-   * apply there. The invocation row is the proof of authorization — creating it passed the
-   * caller-facing gates, and the userIdentity policy re-runs at execution — so resolution here is
-   * workspace-scoped only. Only for paths executing that specific invocation.
+   * Gets the function if the invocation row exists
+   * In the context of a temporal activity or a sandbox callback, we don't have the original caller's
+   * grant (e.g. a frame share token) in the auth. Instead, we rely on the fact that the invocation row
+   * was created earlier when we did have the caller's grant. The presence of the invocation row
+   * is sufficient proof that the caller was authorized to invoke the function
    */
   static async fetchByIdForExecution(
     auth: Authenticator,
@@ -434,6 +433,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       return null;
     }
 
+    // We don't need the invocation row itself, just its existence to prove that the caller was
+    // authorized to invoke the function
     const invocation = await SandboxFunctionInvocationModel.findOne({
       where: {
         id: invocationModelId,

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -30,7 +30,6 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { PodAppFunction } from "@app/types/api/pod_apps";
 import type {
-  FrameShareCapability,
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionExecutionMode,
   SandboxFunctionInvocationOrigin,
@@ -307,14 +306,13 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     {
       includeDeletedSpace,
-      capability,
       dangerouslyBypassSpacePermissionFilter = false,
       ...options
     }: ResourceFindOptions<SandboxFunctionModel> & {
       includeDeletedSpace?: boolean;
-      capability?: FrameShareCapability;
-      // Reserved for execution-side resolution (fetchByIdForExecution and the tool workflow),
-      // which verified an invocation row for the function first.
+      // Reserved for resolution paths whose authorization is established before the fetch:
+      // fetchByIdForExecution and the tool workflow (an invocation row), and fetchInAppFolder
+      // (a validated frame share capability, enforced by its own query constraints).
       dangerouslyBypassSpacePermissionFilter?: boolean;
     } = {}
   ): Promise<SandboxFunctionResource[]> {
@@ -346,15 +344,6 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         .map((space) => [space.id, space])
     );
 
-    // A validated frame share capability extends resolution to the functions of its own app in
-    // its own pod, without granting read on the space. Per-function userIdentity policies still
-    // apply at invocation time.
-    const capabilitySpace = capability
-      ? (spaces.find(
-          (space) => space.isProject() && space.sId === capability.podId
-        ) ?? null)
-      : null;
-
     const files = await FileResource.fetchByModelIdsWithAuth(
       auth,
       Array.from(
@@ -373,15 +362,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
-      // Three prioritized gates: the caller's own access, then the app the capability grants,
-      // then the execution-side bypass (spacesById is only built for it).
-      const capabilityGrantsFunction =
-        capabilitySpace?.id === blob.spaceId &&
-        appPrefixFromSlug(blob.slug) === capability?.appPrefix;
       const space =
-        accessibleSpacesById.get(blob.spaceId) ??
-        (capabilityGrantsFunction ? capabilitySpace : undefined) ??
-        spacesById?.get(blob.spaceId);
+        accessibleSpacesById.get(blob.spaceId) ?? spacesById?.get(blob.spaceId);
       const file = filesById.get(blob.fileId);
       if (!space || !file) {
         return [];
@@ -393,8 +375,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   static async fetchById(
     auth: Authenticator,
-    sandboxFunctionId: string,
-    capability?: FrameShareCapability
+    sandboxFunctionId: string
   ): Promise<SandboxFunctionResource | null> {
     if (!isResourceSId("sandbox_function", sandboxFunctionId)) {
       return null;
@@ -407,7 +388,6 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     const [sandboxFunction] = await this.baseFetch(auth, {
       where: { id: sandboxFunctionModelId },
-      capability,
     });
 
     return sandboxFunction ?? null;
@@ -503,8 +483,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static async fetchBySpaceAndSlug(
     auth: Authenticator,
     space: SpaceResource,
-    slug: string,
-    capability?: FrameShareCapability
+    slug: string
   ): Promise<SandboxFunctionResource | null> {
     if (!space.isProject()) {
       return null;
@@ -512,7 +491,6 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     const [sandboxFunction] = await this.baseFetch(auth, {
       where: { spaceId: space.id, slug },
-      capability,
     });
 
     return sandboxFunction ?? null;
@@ -520,14 +498,9 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
   static async fetchByIdOrSlug(
     auth: Authenticator,
-    functionIdOrSlug: string,
-    capability?: FrameShareCapability
+    functionIdOrSlug: string
   ): Promise<SandboxFunctionResource | null> {
-    const sandboxFunction = await this.fetchById(
-      auth,
-      functionIdOrSlug,
-      capability
-    );
+    const sandboxFunction = await this.fetchById(auth, functionIdOrSlug);
     if (sandboxFunction) {
       return sandboxFunction;
     }
@@ -545,7 +518,65 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       return null;
     }
 
-    return this.fetchBySpaceAndSlug(auth, space, slug, capability);
+    return this.fetchBySpaceAndSlug(auth, space, slug);
+  }
+
+  /**
+   * Resolve a function through a frame share capability: returned iff it lives in the given
+   * pod's app folder, regardless of the caller's standing in the pod — the (podId, appPrefix)
+   * pair comes from a validated share token, and constraining the lookup to it IS the
+   * authorization. Accepts the same identifier forms as fetchByIdOrSlug; a slug form naming
+   * another pod misses, since the lookup only ever queries `podId`.
+   */
+  static async fetchInAppFolder(
+    auth: Authenticator,
+    {
+      podId,
+      appPrefix,
+      idOrSlug,
+    }: { podId: string; appPrefix: string; idOrSlug: string }
+  ): Promise<SandboxFunctionResource | null> {
+    const space = await SpaceResource.fetchById(auth, podId);
+    if (!space || !space.isProject()) {
+      return null;
+    }
+
+    let where:
+      | { id: ModelId; spaceId: ModelId }
+      | { spaceId: ModelId; slug: string };
+    if (isResourceSId("sandbox_function", idOrSlug)) {
+      // sId form, e.g. `sfn_x7GhK2p`.
+      const sandboxFunctionModelId = getResourceIdFromSId(idOrSlug);
+      if (sandboxFunctionModelId === null) {
+        return null;
+      }
+      where = { id: sandboxFunctionModelId, spaceId: space.id };
+    } else {
+      // Pod-qualified slug form, e.g. `spc_9fJq3Lm/tasklist__add-task`.
+      const [slugPodId, slug, ...rest] = idOrSlug.split("/");
+      if (
+        !slugPodId ||
+        !slug ||
+        rest.length > 0 ||
+        slugPodId !== podId ||
+        !isValidSandboxFunctionSlug(slug)
+      ) {
+        return null;
+      }
+      where = { spaceId: space.id, slug };
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where,
+      dangerouslyBypassSpacePermissionFilter: true,
+    });
+    if (!sandboxFunction) {
+      return null;
+    }
+
+    return appPrefixFromSlug(sandboxFunction.slug) === appPrefix
+      ? sandboxFunction
+      : null;
   }
 
   static async deleteAllForSpace(

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -428,12 +428,6 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       invocationId,
     }: { sandboxFunctionId: string; invocationId: string }
   ): Promise<SandboxFunctionResource | null> {
-    if (
-      !isResourceSId("sandbox_function", sandboxFunctionId) ||
-      !isResourceSId("sandbox_function_invocation", invocationId)
-    ) {
-      return null;
-    }
     const sandboxFunctionModelId = getResourceIdFromSId(sandboxFunctionId);
     const invocationModelId = getResourceIdFromSId(invocationId);
     if (sandboxFunctionModelId === null || invocationModelId === null) {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -313,7 +313,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     }: ResourceFindOptions<SandboxFunctionModel> & {
       includeDeletedSpace?: boolean;
       capability?: FrameShareCapability;
-      // Reserved for execution-side resolution (see fetchById's option of the same name),
+      // Reserved for execution-side resolution (fetchByIdForExecution and the tool workflow),
       // which verified an invocation row for the function first.
       dangerouslyBypassSpacePermissionFilter?: boolean;
     } = {}
@@ -394,17 +394,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
   static async fetchById(
     auth: Authenticator,
     sandboxFunctionId: string,
-    {
-      capability,
-      dangerouslyBypassSpacePermissionFilter = false,
-    }: {
-      capability?: FrameShareCapability;
-      // Only for execution-side paths (temporal activities, sandbox-token callbacks): they
-      // re-resolve an already-authorized invocation's function under an auth that cannot carry
-      // the invoker's original grant, and their (function, invocation) ids come from
-      // server-minted inputs (workflow args, verified sandbox JWT claims), never user input.
-      dangerouslyBypassSpacePermissionFilter?: boolean;
-    } = {}
+    capability?: FrameShareCapability
   ): Promise<SandboxFunctionResource | null> {
     if (!isResourceSId("sandbox_function", sandboxFunctionId)) {
       return null;
@@ -418,10 +408,46 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     const [sandboxFunction] = await this.baseFetch(auth, {
       where: { id: sandboxFunctionModelId },
       capability,
-      dangerouslyBypassSpacePermissionFilter,
     });
 
     return sandboxFunction ?? null;
+  }
+
+  /**
+   * Gets the function if a matching invocation exists.
+   * In the context of a temporal activity or a sandbox callback, we don't have the original
+   * caller's grant (e.g. a frame share token) in the auth, so the space permission filter is
+   * deliberately skipped. The invocation ties the pair together; callers are trusted because
+   * their (function, invocation) ids come from server-minted inputs — workflow args or verified
+   * sandbox JWT claims — never from user input.
+   */
+  static async fetchByIdForExecution(
+    auth: Authenticator,
+    {
+      sandboxFunctionId,
+      invocationId,
+    }: { sandboxFunctionId: string; invocationId: string }
+  ): Promise<SandboxFunctionResource | null> {
+    const sandboxFunctionModelId = getResourceIdFromSId(sandboxFunctionId);
+    if (sandboxFunctionModelId === null) {
+      return null;
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: { id: sandboxFunctionModelId },
+      dangerouslyBypassSpacePermissionFilter: true,
+    });
+    if (!sandboxFunction) {
+      return null;
+    }
+
+    // We don't need the invocation itself, just its existence.
+    const invocation = await SandboxFunctionInvocationResource.fetchById(auth, {
+      sandboxFunction,
+      invocationId,
+      access: "system",
+    });
+    return invocation ? sandboxFunction : null;
   }
 
   // Lives here rather than on SandboxFunctionMCPActionResource: that resource can only type-import
@@ -497,9 +523,11 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     functionIdOrSlug: string,
     capability?: FrameShareCapability
   ): Promise<SandboxFunctionResource | null> {
-    const sandboxFunction = await this.fetchById(auth, functionIdOrSlug, {
-      capability,
-    });
+    const sandboxFunction = await this.fetchById(
+      auth,
+      functionIdOrSlug,
+      capability
+    );
     if (sandboxFunction) {
       return sandboxFunction;
     }

--- a/front/lib/swr/tool_actions.ts
+++ b/front/lib/swr/tool_actions.ts
@@ -5,7 +5,7 @@ import type {
   ResolveAuthenticationOutcome,
 } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { useFetcher } from "@app/lib/swr/swr";
-import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
+import { frameShareTokenHeader } from "@app/types/api/sandbox_functions";
 import { isAPIErrorResponse } from "@app/types/error";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -153,9 +153,7 @@ export function useResolveAuthentication({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            ...(frameShareToken
-              ? { [FRAME_SHARE_TOKEN_HEADER]: frameShareToken }
-              : {}),
+            ...frameShareTokenHeader(frameShareToken),
           },
           body: JSON.stringify(request.body),
         });
@@ -211,9 +209,7 @@ export function useValidateAction({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            ...(frameShareToken
-              ? { [FRAME_SHARE_TOKEN_HEADER]: frameShareToken }
-              : {}),
+            ...frameShareTokenHeader(frameShareToken),
           },
           body: JSON.stringify(request.body),
         });

--- a/front/lib/swr/tool_actions.ts
+++ b/front/lib/swr/tool_actions.ts
@@ -5,6 +5,7 @@ import type {
   ResolveAuthenticationOutcome,
 } from "@app/lib/api/assistant/conversation/resolve_authentication";
 import { useFetcher } from "@app/lib/swr/swr";
+import { FRAME_SHARE_TOKEN_HEADER } from "@app/types/api/sandbox_functions";
 import { isAPIErrorResponse } from "@app/types/error";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -127,10 +128,13 @@ function getValidateActionRequest(
 
 interface UseResolveAuthenticationParams {
   owner: LightWorkspaceType;
+  /** Share token of the frame hosting the action, presented as an invocation capability. */
+  frameShareToken?: string;
 }
 
 export function useResolveAuthentication({
   owner,
+  frameShareToken,
 }: UseResolveAuthenticationParams) {
   const sendNotification = useSendNotification();
   const { fetcher } = useFetcher();
@@ -149,6 +153,9 @@ export function useResolveAuthentication({
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            ...(frameShareToken
+              ? { [FRAME_SHARE_TOKEN_HEADER]: frameShareToken }
+              : {}),
           },
           body: JSON.stringify(request.body),
         });
@@ -170,7 +177,7 @@ export function useResolveAuthentication({
         setIsResolving(false);
       }
     },
-    [owner.sId, sendNotification, fetcher]
+    [owner.sId, sendNotification, fetcher, frameShareToken]
   );
 
   return { resolveAuthentication, isResolving };
@@ -179,9 +186,15 @@ export function useResolveAuthentication({
 interface UseValidateActionParams {
   owner: LightWorkspaceType;
   onError: (errorMessage: string) => void;
+  /** Share token of the frame hosting the action, presented as an invocation capability. */
+  frameShareToken?: string;
 }
 
-export function useValidateAction({ owner, onError }: UseValidateActionParams) {
+export function useValidateAction({
+  owner,
+  onError,
+  frameShareToken,
+}: UseValidateActionParams) {
   const { fetcher } = useFetcher();
   const [isValidating, setIsValidating] = useState(false);
 
@@ -198,6 +211,9 @@ export function useValidateAction({ owner, onError }: UseValidateActionParams) {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
+            ...(frameShareToken
+              ? { [FRAME_SHARE_TOKEN_HEADER]: frameShareToken }
+              : {}),
           },
           body: JSON.stringify(request.body),
         });
@@ -213,7 +229,7 @@ export function useValidateAction({ owner, onError }: UseValidateActionParams) {
         setIsValidating(false);
       }
     },
-    [owner.sId, onError, fetcher]
+    [owner.sId, onError, fetcher, frameShareToken]
   );
 
   return { validateAction, isValidating };

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.test.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.test.ts
@@ -133,7 +133,10 @@ describe("markSandboxFunctionInvocationFailedActivity", () => {
     expect(publishSandboxFunctionInvocationEvent).not.toHaveBeenCalled();
   });
 
-  it("does not update an invocation from an inaccessible pod", async () => {
+  it("updates an invocation for a workspace member without pod access", async () => {
+    // Pipeline resolution: the serialized auth may belong to an invoker whose original grant
+    // (e.g. a frame share token) cannot be reconstructed; the invocation row is the proof of
+    // authorization, so pod access is deliberately not re-checked here.
     const { authenticator, workspace, sandboxFunction, invocation } =
       await setup();
     const user = await UserFactory.basic();
@@ -147,12 +150,32 @@ describe("markSandboxFunctionInvocationFailedActivity", () => {
       return;
     }
 
+    await markSandboxFunctionInvocationFailedActivity(userAuth.toJSON(), {
+      errorMessage: "Late workflow failure.",
+      sandboxFunctionId: sandboxFunction.sId,
+      invocationId: invocation.sId,
+    });
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      authenticator,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("errored");
+  });
+
+  it("does not update an invocation from another workspace", async () => {
+    const { authenticator, sandboxFunction, invocation } = await setup();
+    const otherCtx = await createResourceTest({ role: "admin" });
+
     await expect(
-      markSandboxFunctionInvocationFailedActivity(userAuth.toJSON(), {
-        errorMessage: "Late workflow failure.",
-        sandboxFunctionId: sandboxFunction.sId,
-        invocationId: invocation.sId,
-      })
+      markSandboxFunctionInvocationFailedActivity(
+        otherCtx.authenticator.toJSON(),
+        {
+          errorMessage: "Late workflow failure.",
+          sandboxFunctionId: sandboxFunction.sId,
+          invocationId: invocation.sId,
+        }
+      )
     ).rejects.toThrow(`Pod function not found: ${sandboxFunction.sId}`);
 
     const refetched = await SandboxFunctionInvocationResource.fetchById(

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.test.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.test.ts
@@ -134,7 +134,7 @@ describe("markSandboxFunctionInvocationFailedActivity", () => {
   });
 
   it("updates an invocation for a workspace member without pod access", async () => {
-    // Pipeline resolution: the serialized auth may belong to an invoker whose original grant
+    // Execution-side resolution: the serialized auth may belong to an invoker whose original grant
     // (e.g. a frame share token) cannot be reconstructed; the invocation row is the proof of
     // authorization, so pod access is deliberately not re-checked here.
     const { authenticator, workspace, sandboxFunction, invocation } =

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
@@ -16,13 +16,14 @@ export async function markSandboxFunctionInvocationFailedActivity(
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
-  // Execution-side resolution: the serialized auth cannot carry the invoker's original grant (e.g. a
-  // frame share token); the invocation row is the proof of authorization.
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
+  // Execution-side resolution: the serialized auth cannot carry the invoker's original grant
+  // (e.g. a frame share token). The ids come from workflow args our own launch code minted after
+  // the caller-facing gates passed, so the space filter is deliberately skipped.
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
     auth,
+    sandboxFunctionId,
     {
-      sandboxFunctionId,
-      invocationId,
+      dangerouslyBypassSpacePermissionFilter: true,
     }
   );
   if (!sandboxFunction) {

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
@@ -19,11 +19,11 @@ export async function markSandboxFunctionInvocationFailedActivity(
   // Execution-side resolution: the serialized auth cannot carry the invoker's original grant
   // (e.g. a frame share token). The ids come from workflow args our own launch code minted after
   // the caller-facing gates passed, so the space filter is deliberately skipped.
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
-    sandboxFunctionId,
     {
-      dangerouslyBypassSpacePermissionFilter: true,
+      sandboxFunctionId,
+      invocationId,
     }
   );
   if (!sandboxFunction) {

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
@@ -16,9 +16,12 @@ export async function markSandboxFunctionInvocationFailedActivity(
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  // Pipeline resolution: the serialized auth cannot carry the invoker's original grant (e.g. a
+  // frame share token); the invocation row is the proof of authorization.
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
     auth,
-    sandboxFunctionId
+    sandboxFunctionId,
+    { invocationId }
   );
   if (!sandboxFunction) {
     throw new Error(`Pod function not found: ${sandboxFunctionId}`);

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
@@ -20,8 +20,10 @@ export async function markSandboxFunctionInvocationFailedActivity(
   // frame share token); the invocation row is the proof of authorization.
   const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
-    sandboxFunctionId,
-    { invocationId }
+    {
+      sandboxFunctionId,
+      invocationId,
+    }
   );
   if (!sandboxFunction) {
     throw new Error(`Pod function not found: ${sandboxFunctionId}`);

--- a/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
+++ b/front/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed.ts
@@ -16,9 +16,9 @@ export async function markSandboxFunctionInvocationFailedActivity(
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
-  // Pipeline resolution: the serialized auth cannot carry the invoker's original grant (e.g. a
+  // Execution-side resolution: the serialized auth cannot carry the invoker's original grant (e.g. a
   // frame share token); the invocation row is the proof of authorization.
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
     sandboxFunctionId,
     { invocationId }

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
@@ -14,9 +14,9 @@ export async function runSandboxFunctionInvocationActivity(
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
-  // Pipeline resolution: the serialized auth cannot carry the invoker's original grant (e.g. a
+  // Execution-side resolution: the serialized auth cannot carry the invoker's original grant (e.g. a
   // frame share token); the invocation row is the proof of authorization.
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
     sandboxFunctionId,
     { invocationId }

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
@@ -14,13 +14,14 @@ export async function runSandboxFunctionInvocationActivity(
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
-  // Execution-side resolution: the serialized auth cannot carry the invoker's original grant (e.g. a
-  // frame share token); the invocation row is the proof of authorization.
-  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
+  // Execution-side resolution: the serialized auth cannot carry the invoker's original grant
+  // (e.g. a frame share token). The ids come from workflow args our own launch code minted after
+  // the caller-facing gates passed, so the space filter is deliberately skipped.
+  const sandboxFunction = await SandboxFunctionResource.fetchById(
     auth,
+    sandboxFunctionId,
     {
-      sandboxFunctionId,
-      invocationId,
+      dangerouslyBypassSpacePermissionFilter: true,
     }
   );
   if (!sandboxFunction) {

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
@@ -14,9 +14,12 @@ export async function runSandboxFunctionInvocationActivity(
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  // Pipeline resolution: the serialized auth cannot carry the invoker's original grant (e.g. a
+  // frame share token); the invocation row is the proof of authorization.
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForPipeline(
     auth,
-    sandboxFunctionId
+    sandboxFunctionId,
+    { invocationId }
   );
   if (!sandboxFunction) {
     throw new Error(`Pod function not found: ${sandboxFunctionId}`);

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
@@ -18,8 +18,10 @@ export async function runSandboxFunctionInvocationActivity(
   // frame share token); the invocation row is the proof of authorization.
   const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
-    sandboxFunctionId,
-    { invocationId }
+    {
+      sandboxFunctionId,
+      invocationId,
+    }
   );
   if (!sandboxFunction) {
     throw new Error(`Pod function not found: ${sandboxFunctionId}`);

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
@@ -17,11 +17,11 @@ export async function runSandboxFunctionInvocationActivity(
   // Execution-side resolution: the serialized auth cannot carry the invoker's original grant
   // (e.g. a frame share token). The ids come from workflow args our own launch code minted after
   // the caller-facing gates passed, so the space filter is deliberately skipped.
-  const sandboxFunction = await SandboxFunctionResource.fetchById(
+  const sandboxFunction = await SandboxFunctionResource.fetchByIdForExecution(
     auth,
-    sandboxFunctionId,
     {
-      dangerouslyBypassSpacePermissionFilter: true,
+      sandboxFunctionId,
+      invocationId,
     }
   );
   if (!sandboxFunction) {

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -70,9 +70,11 @@ export type SandboxFunctionStake = (typeof SANDBOX_FUNCTION_STAKES)[number];
 export const DEFAULT_SANDBOX_FUNCTION_STAKE: SandboxFunctionStake = "low";
 
 /**
- * Header a frame host attaches to invocation requests to present the frame's share token as a
- * capability to invoke the frame's app's functions. Lives here (not with the server-side
- * resolver) because the client attaches it too.
+ * Header a frame host attaches to invocation requests to present the frame's share token. The
+ * server grants invocation of the frame's app's functions to workspace members who may view the
+ * frame (the token suffices for workspace-visible scopes; invite-only frames also require an
+ * active email grant). Lives here (not with the server-side resolver) because the client
+ * attaches it too.
  */
 export const FRAME_SHARE_TOKEN_HEADER = "x-dust-frame-share-token";
 

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -76,6 +76,23 @@ export const DEFAULT_SANDBOX_FUNCTION_STAKE: SandboxFunctionStake = "low";
  */
 export const FRAME_SHARE_TOKEN_HEADER = "x-dust-frame-share-token";
 
+/** Request-header fragment carrying the frame share token, empty when there is none. */
+export function frameShareTokenHeader(token?: string): Record<string, string> {
+  return token ? { [FRAME_SHARE_TOKEN_HEADER]: token } : {};
+}
+
+/**
+ * What a validated frame share token authorizes: invoking the published functions of its own app
+ * folder in its own pod. Derived server-side by `resolveFrameShareCapability`; grants function
+ * resolution only, never reads or writes on the pod.
+ */
+export type FrameShareCapability = {
+  /** sId of the pod the shared frame lives in. */
+  podId: string;
+  /** Normalized prefix of the frame's app folder — the namespace of the slugs it authorizes. */
+  appPrefix: string;
+};
+
 export const SANDBOX_FUNCTION_INVOCATION_ORIGINS = [
   "interactive_session",
   "delegated",

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -69,6 +69,13 @@ export type SandboxFunctionStake = (typeof SANDBOX_FUNCTION_STAKES)[number];
 // default.
 export const DEFAULT_SANDBOX_FUNCTION_STAKE: SandboxFunctionStake = "low";
 
+/**
+ * Header a frame host attaches to invocation requests to present the frame's share token as a
+ * capability to invoke the frame's app's functions. Lives here (not with the server-side
+ * resolver) because the client attaches it too.
+ */
+export const FRAME_SHARE_TOKEN_HEADER = "x-dust-frame-share-token";
+
 export const SANDBOX_FUNCTION_INVOCATION_ORIGINS = [
   "interactive_session",
   "delegated",

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -81,6 +81,14 @@ export const fileShareScopeSchema = z.enum([
 export type FileShareScope = z.infer<typeof fileShareScopeSchema>;
 
 /**
+ * Whether a share scope makes the file visible to every workspace member holding its link.
+ * "workspace" is the legacy spelling of "workspace_and_emails".
+ */
+export function isWorkspaceVisibleShareScope(scope: FileShareScope): boolean {
+  return scope === "workspace_and_emails" || scope === "workspace";
+}
+
+/**
  * Allowlist of files a shared Frame may load via useFile().
  * AuthorizedFileAccessModel stores one row per authorized file ref for the
  * current frame version (replaced on recompute).


### PR DESCRIPTION
## Description

Lets workspace members *use* a Pod app — open its frame, click around, call the functions behind it — without granting any access to the Pod itself. Today a shared frame renders for every workspace member (frame sharing defaults to `workspace_and_emails`), but every `callFunction` fails because function resolution requires read access on the Pod; the only workarounds (pod membership, open Pods) hand out the whole write plane.

The model: **a workspace member who can open a frame can use its app** — invocation access follows frame view access. For workspace-visible frames that means holding the share link (an unguessable token); for invite-only frames it additionally requires an active email grant, exactly like viewing does. Sharing the frame is sharing the app — no new mode, no new state, no migration.

Mechanics:

- Invocation requests may carry the frame's share token in an `x-dust-frame-share-token` header. A workspace member presenting a valid token may resolve and invoke the functions of **that frame's app folder** — per-app scoping falls out of the frame's path, which is the app's identity. Validation (`resolveFrameShareCapability`): same workspace, pod app frame, prefix match, and a qualifying scope — workspace-visible, or invite-only (`emails_only`) when the member holds an active email grant, so revoking a grant revokes invocation individually.
- Resolution is lazy: the caller's own access is tried first, and the token is only validated when that misses — members with pod access never pay the token lookup, and an invalid token behaves exactly like an absent one.
- The token is accepted on the invocation POST, `validate-action`, `resolve-authentication`, and the SSE events stream; invocation-level gates (owner-only reads) are unchanged — the capability only widens which functions resolve, never who may read or act on an invocation. Per-function `userIdentity` policies (e.g. `pod_editor_required`) still apply on top.
- **Pipeline paths resolve by invocation identity instead of caller permissions** (`fetchByIdForPipeline`): temporal activities and sandbox-token callbacks re-enter resolution under an auth that cannot carry the original grant (a serialized session snapshot, a sandbox JWT). The invocation row is their proof of authorization — creation passed the caller-facing gates and the per-function `userIdentity` policy re-runs at execution.
- The public frame route hands `framePath` to workspace members whose token qualifies (workspace-visible scopes, or invite-only with a grant); external email-grant viewers still get `null` and can never invoke (this is a missing scenario we should tackle later).
- Client: the shared-frame host threads the token to the three fetch points (invocation POST, SSE via a new `headers` option on `useEventSource`, and the blocked-action cards via `FrameViewer`). Authenticated pod hosts pass nothing and are unaffected.
- Sandbox provisioning no longer depends on the invoker's pod permissions (`DustFileSystem.forPodSandboxProvisioning` at the two provisioning call sites): the sandbox is a pod-level resource whose mounts are identical whoever triggers the boot, and a token-authorized invoker holds no read on the Pod.

## Tests

New tests added.

## Risk

Authorization change. The capability grants function resolution only, for one app, to authenticated workspace members presenting an unguessable token — every write-plane gate is untouched and regression-pinned. The riskiest piece is the pipeline switch from caller-permission resolution to invocation-identity resolution; it is confined to paths that execute an already-validated invocation (workflow args, sandbox JWT claims), still workspace-scoped, and the identity policy re-runs at execution. Rollback is a plain revert (no schema changes).

## Deploy Plan

No migration, no flags. Deploy front/front-api together (the client header is additive; old clients simply don't send it).
