### PR TITLE
Fix analytics consumption rows disappearing

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -1,5 +1,6 @@
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import {
   fireEvent,
   render,
@@ -92,7 +93,7 @@ describe("ConsumptionAttributionTable", () => {
     });
   });
 
-  it("resets expanded rows when switching dimensions", () => {
+  it("resets expanded rows when switching dimensions", async () => {
     mockUseConsumptionTop.mockImplementation(
       ({ dimension }: { dimension: ConsumptionDimension }) => ({
         rows: [
@@ -155,7 +156,115 @@ describe("ConsumptionAttributionTable", () => {
         name: "Expand breakdown for Large model",
       })
     ).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByText("Attribution breakdown")).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("Attribution breakdown")
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps rows visible while refreshing cached data", () => {
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [
+        {
+          id: "agent-id",
+          name: "Cached agent",
+          pictureUrl: null,
+          description: null,
+          icon: null,
+          modelId: null,
+          modelDisplayName: null,
+          credits: 100,
+          avgCredits: 10,
+        },
+      ],
+      totalCredits: 100,
+      totalCount: 1,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: true,
+    });
+
+    render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Cached agent")).toBeInTheDocument();
+  });
+
+  it("reveals rows that arrive after the initial loading state", async () => {
+    const emptyRows: ConsumptionTopRow[] = [];
+    let result = {
+      rows: emptyRows,
+      totalCredits: 0,
+      totalCount: 0,
+      hasMore: false,
+      isTopLoading: true,
+      isTopError: undefined,
+      isTopValidating: true,
+    };
+    mockUseConsumptionTop.mockImplementation(() => result);
+
+    const { rerender } = render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    result = {
+      rows: [
+        {
+          id: "fresh-agent-id",
+          name: "Fresh agent",
+          pictureUrl: null,
+          description: null,
+          icon: null,
+          modelId: null,
+          modelDisplayName: null,
+          credits: 100,
+          avgCredits: 10,
+        },
+      ],
+      totalCredits: 100,
+      totalCount: 1,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    };
+    rerender(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    const row = await screen.findByText("Fresh agent");
+    await waitFor(() => {
+      let animatedAncestor: HTMLElement | null = row;
+      while (animatedAncestor && !animatedAncestor.style.opacity) {
+        animatedAncestor = animatedAncestor.parentElement;
+      }
+
+      expect(animatedAncestor).toHaveStyle({ opacity: "1" });
+    });
   });
 
   it("renders the skill identity and description without a model", () => {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -43,7 +43,13 @@ import {
 } from "@dust-tt/sparkle";
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import type { Transition, Variants } from "framer-motion";
-import { AnimatePresence, m, useReducedMotion } from "framer-motion";
+import {
+  AnimatePresence,
+  domMax,
+  LazyMotion,
+  m,
+  useReducedMotion,
+} from "framer-motion";
 import type { ReactNode } from "react";
 import { useMemo, useRef, useState } from "react";
 import type { AttributionRowData } from "./ConsumptionAttributionRowsTable";
@@ -430,7 +436,7 @@ function AttributionRows({
       })),
     [rows, onAddFilter]
   );
-  const isLoading = isTopLoading || isTopValidating;
+  const isLoading = isTopLoading;
 
   let contentKey = "content";
   let content: ReactNode;
@@ -507,7 +513,7 @@ function AttributionRows({
           duration: shouldReduceMotion ? 0 : 0.1,
           ease: MOTION_EASINGS.enter,
         }}
-        aria-busy={isLoading}
+        aria-busy={isLoading || isTopValidating}
       >
         {content}
       </m.div>
@@ -617,38 +623,40 @@ export function ConsumptionAttributionTable({
             onChange={setValue}
             className="w-full"
           />
-          <div className="relative overflow-hidden">
-            <AnimatePresence
-              initial={false}
-              mode="popLayout"
-              custom={effectiveTransitionDirection}
-            >
-              <m.div
-                key={dimension}
+          <LazyMotion features={domMax}>
+            <div className="relative overflow-hidden">
+              <AnimatePresence
+                initial={false}
+                mode="popLayout"
                 custom={effectiveTransitionDirection}
-                variants={ATTRIBUTION_BODY_VARIANTS}
-                initial="initial"
-                animate="animate"
-                exit="exit"
               >
-                {/* Reset table state whenever its dataset or local search changes. */}
-                <AttributionRows
-                  key={JSON.stringify({
-                    period,
-                    filter,
-                    search: debouncedValue,
-                  })}
-                  workspaceId={workspaceId}
-                  dimension={dimension}
-                  period={period}
-                  filter={filter}
-                  onAddFilter={onAddFilter}
-                  search={debouncedValue}
-                  onViewAll={onViewAll}
-                />
-              </m.div>
-            </AnimatePresence>
-          </div>
+                <m.div
+                  key={dimension}
+                  custom={effectiveTransitionDirection}
+                  variants={ATTRIBUTION_BODY_VARIANTS}
+                  initial="initial"
+                  animate="animate"
+                  exit="exit"
+                >
+                  {/* Reset table state whenever its dataset or local search changes. */}
+                  <AttributionRows
+                    key={JSON.stringify({
+                      period,
+                      filter,
+                      search: debouncedValue,
+                    })}
+                    workspaceId={workspaceId}
+                    dimension={dimension}
+                    period={period}
+                    filter={filter}
+                    onAddFilter={onAddFilter}
+                    search={debouncedValue}
+                    onViewAll={onViewAll}
+                  />
+                </m.div>
+              </AnimatePresence>
+            </div>
+          </LazyMotion>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The attribution table has two separate issues that looked very similar:

1. Rows disappeared during background refreshes
The table treated every refresh as a first load. Even though the existing rows were still available, it replaced them with loading placeholders/skeleton until the refresh completed.

2. Newly loaded tabs stayed invisible
A layout change moved the table outside the animation setup it relied on. Rows loaded after opening an uncached tab
started hidden but never completed their fade-in. Returning to the tab worked because cached rows skipped that
animation.

## Fix

- Keep existing rows visible during background refreshes.
- Give the table its own animation setup so asynchronously loaded rows always become visible.
- Add regression tests for cached refreshes and first-time tab loads.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
