### PR TITLE
Remove icon from Page.Header, align consumers with Figma design

### DIFF
--- a/front/components/data_source/CreateConnectionOAuthModal.tsx
+++ b/front/components/data_source/CreateConnectionOAuthModal.tsx
@@ -1,4 +1,3 @@
-import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { ConnectorProviderConfiguration } from "@app/lib/connector_providers";
 import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
 import {
@@ -28,7 +27,6 @@ export function CreateConnectionOAuthModal({
   onClose,
   onConfirm,
 }: CreateConnectionOAuthModalProps) {
-  const { isDark } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const [extraConfig, setExtraConfig] = useState<Record<string, string>>({});
   const [isExtraConfigValid, setIsExtraConfigValid] = useState(true);
@@ -65,7 +63,6 @@ export function CreateConnectionOAuthModal({
             <Page.Vertical gap="lg" align="stretch">
               <Page.Header
                 title={`Connecting ${connectorProviderConfiguration.name}`}
-                icon={connectorUIConfiguration.getLogoComponent(isDark)}
               />
               <Button
                 label="Read our guide"

--- a/front/components/layouts/AdminLayout.tsx
+++ b/front/components/layouts/AdminLayout.tsx
@@ -42,7 +42,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
     <div
       className={cn("flex h-full w-full flex-col items-center pt-4 sm:pt-8")}
     >
-      <div className="flex w-full max-w-6xl grow flex-col px-4 sm:px-8 pb-4 sm:pb-8">
+      <div className="flex w-full max-w-6xl grow flex-col px-4 sm:px-10 pb-4 sm:pb-8">
         {children}
       </div>
     </div>

--- a/front/components/onboarding/ProfileOnboardingSteps.tsx
+++ b/front/components/onboarding/ProfileOnboardingSteps.tsx
@@ -96,10 +96,8 @@ export function UserProfileStep({
 }: UserProfileStepProps) {
   return (
     <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
-      <Page.Header
-        title={`Hello ${formData.firstName || "there"}!`}
-        icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
-      />
+      <DustLogoSquare className="-ml-11 h-10 w-32" />
+      <Page.Header title={`Hello ${formData.firstName || "there"}!`} />
       <p className="text-muted-foreground">Let's check a few things.</p>
       {!isAdmin && (
         <p className="text-muted-foreground">

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -31,7 +31,6 @@ import { isAdmin } from "@app/types/user";
 import {
   Button,
   Chip,
-  ContactsRobot,
   EmptyCTA,
   ListSelect,
   Page,
@@ -284,7 +283,7 @@ export function ManageAgentsPage() {
         onClose={() => setDetailedAgentId(null)}
       />
       <div className="flex w-full flex-col gap-8 pb-4">
-        <Page.Header title="Manage Agents" icon={ContactsRobot} />
+        <Page.Header title="Manage Agents" />
         <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">
             <SearchInput

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -283,7 +283,7 @@ export function ManageAgentsPage() {
         onClose={() => setDetailedAgentId(null)}
       />
       <div className="flex w-full flex-col gap-8 pb-4">
-        <Page.Header title="Manage Agents" />
+        <Page.Header title="Manage Agents" noTopPadding />
         <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">
             <SearchInput

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -435,6 +435,7 @@ export function ManageSkillsPage() {
         <Page.Header
           title="Manage Skills"
           description="Reusable packages of instructions and tools that agents can share."
+          noTopPadding
         />
         <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -434,7 +434,6 @@ export function ManageSkillsPage() {
       <div className="flex w-full flex-col gap-8 pb-4">
         <Page.Header
           title="Manage Skills"
-          icon={SKILL_ICON}
           description="Reusable packages of instructions and tools that agents can share."
         />
         <Page.Vertical gap="md" align="stretch">

--- a/front/components/pages/onboarding/JoinPage.tsx
+++ b/front/components/pages/onboarding/JoinPage.tsx
@@ -94,10 +94,8 @@ export function JoinPage() {
   return (
     <OnboardingLayout owner={workspace}>
       <div className="flex h-full flex-col gap-8 pt-4 md:justify-center md:pt-0">
-        <Page.Header
-          title={`Hello there!`}
-          icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
-        />
+        <DustLogoSquare className="-ml-11 h-10 w-32" />
+        <Page.Header title={`Hello there!`} />
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
             <p>Welcome aboard!</p>

--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -22,7 +22,7 @@ import {
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { BillingPeriod } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
-import { BarHeader, Button, Lock01, Page, Spinner } from "@dust-tt/sparkle";
+import { BarHeader, Button, Page, Spinner } from "@dust-tt/sparkle";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
 import React, { useEffect } from "react";
 
@@ -85,7 +85,7 @@ function CPSubscribePage() {
           <div className="flex h-full flex-col justify-center">
             <Page.Horizontal>
               <Page.Vertical sizing="grow" gap="lg">
-                <Page.Header icon={Lock01} title="Workspace locked" />
+                <Page.Header title="Workspace locked" />
                 <Page.P>
                   <span className="font-bold">
                     The subscription for this workspace is not active.
@@ -233,7 +233,6 @@ function LegacySubscribePage() {
             <Page.Horizontal>
               <Page.Vertical sizing="grow" gap="lg">
                 <Page.Header
-                  icon={CreditCardIcon}
                   title={
                     isInFreePhoneTrial
                       ? "Subscribe to a paid plan"
@@ -346,7 +345,7 @@ function LegacySubscribePage() {
           ) : (
             <Page.Horizontal>
               <Page.Vertical sizing="grow" gap="lg">
-                <Page.Header icon={Lock01} title="Workspace locked" />
+                <Page.Header title="Workspace locked" />
                 <Page.P>
                   <span className="font-bold">
                     The subscription for this workspace is not active.

--- a/front/components/pages/onboarding/TrialPage.tsx
+++ b/front/components/pages/onboarding/TrialPage.tsx
@@ -44,10 +44,8 @@ export function TrialPage() {
         <div className="flex h-full flex-col justify-center">
           <Page.Horizontal>
             <Page.Vertical sizing="grow" gap="lg">
-              <Page.Header
-                title="Get started for free"
-                icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
-              />
+              <DustLogoSquare className="-ml-11 h-10 w-32" />
+              <Page.Header title="Get started for free" />
               <p className="-mt-4 text-muted-foreground">
                 No credit card required · No time limit
               </p>
@@ -89,10 +87,8 @@ export function TrialPage() {
       <div className="flex h-full flex-col justify-center">
         <Page.Horizontal>
           <Page.Vertical sizing="grow" gap="lg">
-            <Page.Header
-              title="Start your free trial"
-              icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
-            />
+            <DustLogoSquare className="-ml-11 h-10 w-32" />
+            <Page.Header title="Start your free trial" />
             <p className="-mt-4 text-muted-foreground">
               No credit card required
             </p>

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -479,10 +479,8 @@ function PhoneInputStep({
               </div>
             ) : (
               <>
-                <Page.Header
-                  title="Phone number"
-                  icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
-                />
+                <DustLogoSquare className="-ml-11 h-10 w-32" />
+                <Page.Header title="Phone number" />
                 <p className="-mt-4 text-muted-foreground">
                   To start your free trial, we need to verify your account with
                   an SMS code. <br />
@@ -635,10 +633,8 @@ function CaptchaStep({
       <div className="flex h-full flex-col justify-center">
         <Page.Horizontal>
           <Page.Vertical sizing="grow" gap="lg">
-            <Page.Header
-              title="Verify you're human"
-              icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
-            />
+            <DustLogoSquare className="-ml-11 h-10 w-32" />
+            <Page.Header title="Verify you're human" />
             <p className="-mt-4 text-muted-foreground">
               A quick check before we send your verification code.
             </p>

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -9,7 +9,7 @@ import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/a
 import { WorkspaceUserCreditsTable } from "@app/components/workspace/analytics/WorkspaceUserCreditsTable";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
-import { BarChart01, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
+import { Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 // Dynamic imports for chart components to exclude recharts from server bundle.
@@ -89,7 +89,6 @@ export function AnalyticsPage() {
             </div>
           </div>
         }
-        icon={BarChart01}
         description="Track how your team uses Dust"
       />
       <WorkspaceAnalyticsOverviewCards

--- a/front/components/pages/workspace/MembersPage.tsx
+++ b/front/components/pages/workspace/MembersPage.tsx
@@ -19,7 +19,6 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
-  Users01,
 } from "@dust-tt/sparkle";
 
 export function MembersPage() {
@@ -76,7 +75,6 @@ export function MembersPage() {
       <div className="flex flex-col gap-6">
         <Page.Header
           title="People"
-          icon={Users01}
           description="Manage team members and their roles."
         />
         <Tabs value={activeTab} onValueChange={(value) => tab.setParam(value)}>

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -109,7 +109,6 @@ import {
   DropdownMenuTrigger,
   Icon,
   Page,
-  PieChart01,
   SearchInput,
   Spinner,
   Tabs,
@@ -986,7 +985,7 @@ export function UsagePage() {
 
       <div className="flex flex-col items-stretch gap-10 pb-20">
         <div className="flex items-center justify-between">
-          <Page.Header title="Usage" icon={PieChart01} />
+          <Page.Header title="Usage" />
           {!isReadOnly && usageSettings.topUpEnabled && isWorkspaceAdmin && (
             <Button
               label="Top up"

--- a/front/components/pages/workspace/WorkspaceBrandingPage.tsx
+++ b/front/components/pages/workspace/WorkspaceBrandingPage.tsx
@@ -1,6 +1,6 @@
 import { BrandingSection } from "@app/components/workspace/settings/BrandingSection";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
-import { cn, Page, Palette } from "@dust-tt/sparkle";
+import { cn, Page } from "@dust-tt/sparkle";
 
 export function WorkspaceBrandingPage() {
   const owner = useWorkspace();
@@ -9,7 +9,7 @@ export function WorkspaceBrandingPage() {
 
   return (
     <Page.Vertical align="stretch" gap="xl">
-      <Page.Header title="Branding" icon={Palette} />
+      <Page.Header title="Branding" />
       {isWhitelabelFramesAllowed ? (
         <BrandingSection owner={owner} />
       ) : (

--- a/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.tsx
+++ b/front/components/pages/workspace/WorkspaceIdentityProvisioningPage.tsx
@@ -1,7 +1,7 @@
 import WorkspaceAccessPanel from "@app/components/workspace/WorkspaceAccessPanel";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useWorkspaceVerifiedDomains } from "@app/lib/swr/workspaces";
-import { Fingerprint04, Page, Spinner } from "@dust-tt/sparkle";
+import { Page, Spinner } from "@dust-tt/sparkle";
 
 export function WorkspaceIdentityProvisioningPage() {
   const owner = useWorkspace();
@@ -24,7 +24,6 @@ export function WorkspaceIdentityProvisioningPage() {
       <Page.Vertical gap="lg" align="stretch">
         <Page.Header
           title="IT & Security"
-          icon={Fingerprint04}
           description="Verify your domain, manage team members and their permissions."
         />
         <WorkspaceAccessPanel

--- a/front/components/pages/workspace/billing/BillingPage.tsx
+++ b/front/components/pages/workspace/billing/BillingPage.tsx
@@ -14,7 +14,6 @@ import { useAppRouter } from "@app/lib/platform";
 import { useWorkspaceCoupons } from "@app/lib/swr/workspaces";
 import { isCreditPricedPlan } from "@app/types/plan";
 import {
-  CreditCard01,
   Page,
   Tabs,
   TabsContent,
@@ -51,7 +50,6 @@ export function BillingPage() {
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
         title="Billing"
-        icon={CreditCard01}
         description="Change your subscription and edit your billing information."
       />
       <SubscriptionProvider owner={owner} subscription={subscription}>

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -15,7 +15,7 @@ import type { KeyType } from "@app/types/key";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
-import { BookOpen01, Button, Lock01, Page, Spinner } from "@dust-tt/sparkle";
+import { BookOpen01, Button, Page, Spinner } from "@dust-tt/sparkle";
 import get from "lodash/get";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -246,7 +246,6 @@ export function APIKeysPage() {
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
           title="API Keys"
-          icon={Lock01}
           description="API Keys allow you to securely connect to Dust from other applications and work with your data programmatically."
         />
         <Page.Vertical align="stretch" gap="md">

--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -20,7 +20,6 @@ import {
   ContentMessage,
   Hoverable,
   Page,
-  Zap,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
@@ -328,7 +327,6 @@ export function CreditsUsagePage() {
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
           title={"Programmatic Usage"}
-          icon={Zap}
           description={
             <div>
               <p>

--- a/front/components/pages/workspace/developers/ProvidersPage.tsx
+++ b/front/components/pages/workspace/developers/ProvidersPage.tsx
@@ -12,7 +12,7 @@ import {
 import { useProviders } from "@app/lib/swr/apps";
 import { redactString } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
-import { Button, Chip, Container, cn, Page, Shapes } from "@dust-tt/sparkle";
+import { Button, Chip, Container, cn, Page } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 interface ProvidersProps {
@@ -197,7 +197,6 @@ export function ProvidersPage() {
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
         title="App Credentials"
-        icon={Shapes}
         description="Configure model and service providers to enable advanced capabilities in your Apps. Note: These providers are not used by Dust agents at all, but are required for running your own custom Dust Apps."
       />
       <Page.Vertical align="stretch" gap="md">

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -2,7 +2,7 @@ import { EnvironmentSection } from "@app/components/pages/workspace/developers/s
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
-import { ContentMessage, Globe01, InfoCircle, Page } from "@dust-tt/sparkle";
+import { ContentMessage, InfoCircle, Page } from "@dust-tt/sparkle";
 
 export function SandboxPage() {
   const { isAdmin } = useAuth();
@@ -38,7 +38,6 @@ export function SandboxPage() {
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
         title="Computer"
-        icon={Globe01}
         description="Configure workspace-level network access and environment variables for the Computer."
       />
       {renderBody()}

--- a/front/components/pages/workspace/developers/SecretsPage.tsx
+++ b/front/components/pages/workspace/developers/SecretsPage.tsx
@@ -6,7 +6,6 @@ import { useDustAppSecrets } from "@app/lib/swr/apps";
 import type { DustAppSecretType } from "@app/types/dust_app_secret";
 import {
   BookOpen01,
-  Brackets,
   Button,
   Clipboard,
   Dialog,
@@ -195,7 +194,6 @@ export function SecretsPage() {
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
           title="Developer Secrets"
-          icon={Brackets}
           description="Secrets usable in Dust apps or MCP servers to safely store sensitive data."
         />{" "}
         <Page.Vertical align="stretch" gap="md">

--- a/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
+++ b/front/components/pages/workspace/developers/SelfImprovingSkillsPage.tsx
@@ -10,7 +10,7 @@ import {
   getWorkspaceDefaultSelfImprovementCapPerSkillMicroUsd,
 } from "@app/lib/reinforcement/consumption";
 import { useReinforcementBillingUnit } from "@app/lib/swr/useSelfImprovingSkillsSettings";
-import { ContentMessage, InfoCircle, Page, Stars02 } from "@dust-tt/sparkle";
+import { ContentMessage, InfoCircle, Page } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 export function SelfImprovingSkillsPage() {
@@ -70,7 +70,6 @@ export function SelfImprovingSkillsPage() {
       <Page.Vertical gap="xl" align="stretch">
         <Page.Header
           title="Self-Improving Skills"
-          icon={Stars02}
           description={
             <span>
               Configure self-improving skills settings for this workspace.{" "}

--- a/front/components/pages/workspace/governance/GovernancePageLayout.tsx
+++ b/front/components/pages/workspace/governance/GovernancePageLayout.tsx
@@ -1,4 +1,4 @@
-import { Page, Toggle01Left } from "@dust-tt/sparkle";
+import { Page } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
 interface GovernancePageLayoutProps {
@@ -11,7 +11,6 @@ export function GovernancePageLayout({ children }: GovernancePageLayoutProps) {
       <Page.Header
         title="Settings & Governance"
         description="Manage what members can do in your workspace"
-        icon={Toggle01Left}
       />
       {children}
     </div>

--- a/front/components/pages/workspace/labs/LabsPage.tsx
+++ b/front/components/pages/workspace/labs/LabsPage.tsx
@@ -12,7 +12,7 @@ import {
 } from "@app/lib/auth/AuthContext";
 import type { LabsFeatureItemType } from "@app/types/labs";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import { Beaker02, ContextItem, Eye, Icon, Page } from "@dust-tt/sparkle";
+import { ContextItem, Eye, Icon, Page } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 const LABS_FEATURES: LabsFeatureItemType[] = [
@@ -54,7 +54,6 @@ export function LabsPage() {
     <>
       <Page.Header
         title="Exploratory features"
-        icon={Beaker02}
         description="Expect some bumps and changes. Feedback welcome, tell us what you think!"
       />
       <Page.Layout direction="vertical">

--- a/front/components/pages/workspace/labs/TranscriptsPage.tsx
+++ b/front/components/pages/workspace/labs/TranscriptsPage.tsx
@@ -17,7 +17,7 @@ import { useDataSourceViews } from "@app/lib/swr/data_source_views";
 import { useLabsTranscriptsConfiguration } from "@app/lib/swr/labs";
 import { useSpaces } from "@app/lib/swr/spaces";
 import { isProviderWithDefaultWorkspaceConfiguration } from "@app/types/oauth/lib";
-import { BookOpen01, Breadcrumbs, Page, Spinner } from "@dust-tt/sparkle";
+import { Breadcrumbs, Page, Spinner } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useState } from "react";
 
 export function TranscriptsPage() {
@@ -136,7 +136,6 @@ export function TranscriptsPage() {
           <Page>
             <Page.Header
               title="Meeting transcripts processing"
-              icon={BookOpen01}
               description="Receive meeting minutes processed by email automatically and store them in a Dust Folder."
             />
             <Page.Layout direction="vertical">

--- a/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
+++ b/front/components/pages/workspace/model_providers/ModelProvidersPage.tsx
@@ -2,7 +2,7 @@ import { ModelProvidersPageContent } from "@app/components/pages/workspace/model
 import { useProvidersSelection } from "@app/hooks/useProvidersSelection";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useWorkspace as useWorkspaceDetails } from "@app/lib/swr/workspaces";
-import { Brain, Page, Spinner } from "@dust-tt/sparkle";
+import { Page, Spinner } from "@dust-tt/sparkle";
 
 export function ModelProvidersPage() {
   const owner = useWorkspace();
@@ -23,7 +23,6 @@ export function ModelProvidersPage() {
     <Page.Vertical align="stretch" gap="xl">
       <Page.Header
         title="Model Providers"
-        icon={Brain}
         description="Choose which AI providers and models are available to your workspace."
       />
       <Page.Vertical align="stretch" gap="md">

--- a/front/components/pages/workspace/subscription/SubscriptionPage.tsx
+++ b/front/components/pages/workspace/subscription/SubscriptionPage.tsx
@@ -657,11 +657,7 @@ export function SubscriptionPage() {
       )}
 
       <Page.Vertical gap="xl" align="stretch">
-        <Page.Header
-          title="Subscription"
-          icon={CreditCard01}
-          description="Manage your plan."
-        />
+        <Page.Header title="Subscription" description="Manage your plan." />
         <Page.Vertical align="stretch" gap="md">
           <Page.H variant="h5">Your plan </Page.H>
 

--- a/sparkle/src/components/Page.tsx
+++ b/sparkle/src/components/Page.tsx
@@ -1,9 +1,8 @@
 import { Separator } from "@sparkle/components/Separator";
 import { cn } from "@sparkle/lib/utils";
-import React, { type ComponentType } from "react";
+import React from "react";
 
 import { Button, type ButtonProps } from "./Button";
-import { Icon } from "./Icon";
 
 interface PageProps {
   children: React.ReactNode;
@@ -33,13 +32,11 @@ export function Page({ children, variant = "normal" }: PageProps) {
 interface PageHeaderProps {
   title: React.ReactNode;
   description?: React.ReactNode;
-  icon?: ComponentType<{ className?: string }>;
 }
 
-Page.Header = function ({ title, description, icon }: PageHeaderProps) {
+Page.Header = function ({ title, description }: PageHeaderProps) {
   return (
-    <Page.Vertical gap="xs">
-      <Icon visual={icon} className="text-primary-400" size="lg" />
+    <Page.Vertical gap="xs" className="pt-4 sm:pt-6 md:pt-8">
       {typeof title === "string" ? (
         <Page.H variant="h3">{title}</Page.H>
       ) : (
@@ -192,6 +189,7 @@ interface PageDivProps {
   sizing?: "shrink" | "grow";
   align?: "stretch" | "left" | "center" | "right";
   gap?: "xs" | "sm" | "md" | "lg" | "xl" | "none";
+  className?: string;
 }
 Page.Horizontal = function ({
   children,
@@ -222,6 +220,7 @@ Page.Vertical = function ({
   sizing,
   align = "left",
   gap = "md",
+  className,
 }: PageDivProps) {
   return (
     <div
@@ -232,7 +231,8 @@ Page.Vertical = function ({
         gapSizes[gap],
         align === "left" ? "items-start" : "",
         align === "center" ? "items-center" : "",
-        align === "right" ? "items-end" : ""
+        align === "right" ? "items-end" : "",
+        className
       )}
     >
       {children}

--- a/sparkle/src/components/Page.tsx
+++ b/sparkle/src/components/Page.tsx
@@ -32,11 +32,15 @@ export function Page({ children, variant = "normal" }: PageProps) {
 interface PageHeaderProps {
   title: React.ReactNode;
   description?: React.ReactNode;
+  noTopPadding?: boolean;
 }
 
-Page.Header = function ({ title, description }: PageHeaderProps) {
+Page.Header = function ({ title, description, noTopPadding }: PageHeaderProps) {
   return (
-    <Page.Vertical gap="xs" className="pt-4 sm:pt-6 md:pt-8">
+    <Page.Vertical
+      gap="xs"
+      className={noTopPadding ? undefined : "pt-4 sm:pt-6 md:pt-8"}
+    >
       {typeof title === "string" ? (
         <Page.H variant="h3">{title}</Page.H>
       ) : (

--- a/sparkle/src/stories/Bar.stories.tsx
+++ b/sparkle/src/stories/Bar.stories.tsx
@@ -12,7 +12,6 @@ import {
   ResizablePanelGroup,
 } from "../index_with_tw_base";
 import { Robot } from "@sparkle/icons/v2-stroke";
-import { MessageCircle01 } from "@sparkle/icons/v2-stroke";
 
 const meta = {
   title: "Navigation/Bar",
@@ -96,7 +95,7 @@ export const BasicBarHeaderValidate = () => {
         }
       />
       <div className="mt-16 h-full w-full overflow-y-auto">
-        <Page.Header title="Page Title" icon={MessageCircle01} />
+        <Page.Header title="Page Title" />
         <div className="flex flex-col gap-y-96">
           <img
             src="/static/landing/mainVisual/MainVisual1.png"
@@ -124,7 +123,7 @@ export const BasicBarFooterValidate = () => {
   return (
     <div className="flex h-full w-full flex-col">
       <div className="flex-1 overflow-y-auto p-4">
-        <Page.Header title="Page Title" icon={MessageCircle01} />
+        <Page.Header title="Page Title" />
         <div className="flex flex-col gap-y-96">
           <img
             src="/static/landing/mainVisual/MainVisual1.png"
@@ -183,7 +182,7 @@ export const HeaderAndFooterCombined = () => {
         }
       />
       <div className="flex-1 overflow-y-auto p-4">
-        <Page.Header title="Page Content" icon={MessageCircle01} />
+        <Page.Header title="Page Content" />
         <div className="flex flex-col gap-y-96">
           <img
             src="/static/landing/mainVisual/MainVisual1.png"
@@ -254,7 +253,7 @@ export const DefaultVariantInPanel = () => {
               }
             />
             <div className="flex-1 overflow-y-auto p-4">
-              <Page.Header title="Left Panel Content" icon={MessageCircle01} />
+              <Page.Header title="Left Panel Content" />
               <p className="text-sm text-gray-600">
                 This demonstrates the "default" variant of Bar that is contained
                 within its parent container, perfect for panels and sidebars.
@@ -308,7 +307,7 @@ export const DefaultVariantInPanel = () => {
               }
             />
             <div className="flex-1 overflow-y-auto p-4">
-              <Page.Header title="Right Panel Content" icon={MessageCircle01} />
+              <Page.Header title="Right Panel Content" />
               <p className="text-sm text-gray-600">
                 Notice how each Bar is scoped to its own panel width, unlike the
                 "full" variant which would span the entire viewport width. You

--- a/sparkle/src/stories/Page.stories.tsx
+++ b/sparkle/src/stories/Page.stories.tsx
@@ -4,14 +4,12 @@ import React from "react";
 import {
   Avatar,
   Button,
-  MessageCircle01,
   CloudArrowLeftRight,
   ContextItem,
   Folder,
   Globe01,
   Icon,
   Page,
-  Rocket02,
 } from "../index_with_tw_base";
 import { MessageChatSquare } from "@sparkle/icons/v2-stroke";
 
@@ -39,11 +37,7 @@ export default meta;
 export const PageSimpleExample = () => {
   return (
     <Page>
-      <Page.Header
-        title="Title"
-        description="Description"
-        icon={MessageCircle01}
-      />
+      <Page.Header title="Title" description="Description" />
       <Page.P>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod
         a massa quis lacinia. Donec euismod nisl eget nunc Lorem ipsum dolor sit
@@ -66,7 +60,6 @@ export const QIGExample = () => {
   return (
     <Page>
       <Page.Header
-        icon={Rocket02}
         title={
           <>
             Get Started: <br />
@@ -210,11 +203,7 @@ export const QIGExample = () => {
 export const PageExample = () => {
   return (
     <Page>
-      <Page.Header
-        title="Title"
-        description="Description"
-        icon={MessageCircle01}
-      />
+      <Page.Header title="Title" description="Description" />
       <Page.P>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam euismod
         a massa quis lacinia. Donec euismod nisl eget nunc Lorem ipsum dolor sit
@@ -343,7 +332,7 @@ export const AssistantBuilder = () => {
 export const HelpExample = () => {
   return (
     <Page>
-      <Page.Header title="Welcome to Agent" icon={MessageCircle01} />
+      <Page.Header title="Welcome to Agent" />
       <Page.Layout direction="vertical" gap="xs" align="left">
         <Page.SectionHeader title="Getting started?" />
         <Page.P variant="secondary">

--- a/sparkle/src/stories/Sheet.stories.tsx
+++ b/sparkle/src/stories/Sheet.stories.tsx
@@ -111,10 +111,7 @@ export function ContentDemo() {
         </SheetTrigger>
         <SheetContent size="xl">
           <SheetHeader>
-            <Page.Header
-              icon={Rocket02}
-              title={<>Quick Guide for new members</>}
-            />
+            <Page.Header title={<>Quick Guide for new members</>} />
           </SheetHeader>
           <SheetContainer>
             <QIG />


### PR DESCRIPTION
## Description

This PR is stacked on #30523 and completes the related Figma-driven page-header cleanup. It removes the `icon` prop from Sparkle's `Page.Header` component and updates the affected in-repo consumers. 

Onboarding pages now render the Dust logo separately from the text header, while regular page headers render only their title and optional description. 

The shared header also receives responsive top padding.

## Tests

Local tested

## Risk

Low functional risk: the changes are limited to shared page-header rendering, spacing, imports, and Storybook examples. The main risk is visual regression.

## Deploy Plan

- Deploy front.