### PR TITLE
fix: show private agent owner in analytics

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -409,6 +409,7 @@ export async function getAgentConfiguration<V extends AgentFetchVariant>(
 
 type AgentLabel = {
   sId: string;
+  authorModelId: ModelId;
   name: string;
   pictureUrl: string | null;
   model: AgentModelConfigurationType;
@@ -431,6 +432,7 @@ export async function getAgentLabelsByIds(
   return agentModels.map((agent) => ({
     sId: agent.sId,
     name: agent.name,
+    authorModelId: agent.authorId,
     pictureUrl: agent.pictureUrl,
     model: getModelForAgentConfiguration(agent),
   }));

--- a/front/lib/api/assistant/observability/agent_labels.ts
+++ b/front/lib/api/assistant/observability/agent_labels.ts
@@ -4,6 +4,8 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import type { Authenticator } from "@app/lib/auth";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { removeNulls } from "@app/types/shared/utils/general";
 
 export type AnalyticsAgentLabel = {
   name: string;
@@ -14,6 +16,12 @@ export type AnalyticsAgentLabel = {
 };
 
 const PRIVATE_AGENT_DESCRIPTION = "Private agent: description unavailable";
+
+function privateAgentDescription(authorEmail: string | null | undefined) {
+  return authorEmail
+    ? `Private agent owned by ${authorEmail}`
+    : PRIVATE_AGENT_DESCRIPTION;
+}
 
 // Agent ids that no longer resolve to a configuration are absent from the
 // returned map; callers drop them instead of surfacing a placeholder row.
@@ -40,10 +48,29 @@ export async function resolveAnalyticsAgentLabels(
     fallbackLabels.map((label) => [label.sId, label])
   );
 
+  const authorModelIds = auth.isManager()
+    ? removeNulls([
+        ...agents
+          .filter((agent) => !agent.canRead)
+          .map((agent) => agent.versionAuthorId),
+        ...fallbackLabels.map((label) => label.authorModelId),
+      ])
+    : [];
+  const authors =
+    authorModelIds.length > 0
+      ? await UserResource.fetchByModelIds(authorModelIds)
+      : [];
+  const authorEmailByModelId = new Map(
+    authors.map((author) => [author.id, author.email])
+  );
+
   const labels = new Map<string, AnalyticsAgentLabel>();
   for (const agentId of agentIds) {
     const agent = agentsById.get(agentId);
     if (agent) {
+      const authorEmail = agent.versionAuthorId
+        ? authorEmailByModelId.get(agent.versionAuthorId)
+        : null;
       labels.set(agentId, {
         name: agent.name,
         pictureUrl: agent.pictureUrl,
@@ -51,7 +78,7 @@ export async function resolveAnalyticsAgentLabels(
         modelDisplayName: getAgentModelDisplayName(agent.model),
         description: agent.canRead
           ? agent.description
-          : PRIVATE_AGENT_DESCRIPTION,
+          : privateAgentDescription(authorEmail),
       });
       continue;
     }
@@ -63,7 +90,9 @@ export async function resolveAnalyticsAgentLabels(
         pictureUrl: fallback.pictureUrl,
         modelId: fallback.model.modelId,
         modelDisplayName: getAgentModelDisplayName(fallback.model),
-        description: PRIVATE_AGENT_DESCRIPTION,
+        description: privateAgentDescription(
+          authorEmailByModelId.get(fallback.authorModelId)
+        ),
       });
     }
   }


### PR DESCRIPTION
## Description

Every agent an analytics viewer can't read rendered as `Private agent: description unavailable`, so there was no way to tell who to go ask about one. Managers now see `Private agent owned by <email>`.

Two paths feed those rows: agents returned by `getAgentConfigurations` with `canRead: false`, and agents filtered out entirely by space permissions. Both resolve the author through one batched user query in `resolveAnalyticsAgentLabels`. Non-managers keep the placeholder, since `resolveAnalyticsAgentLabels` also runs on the conversation consumption path.

## Tests

`front-api` analytics consumption top tests pass. No new test: this is a description string on an existing path, and the fixtures don't set up private agents.

## Risk

Low. Read-only, one extra query when a manager's analytics range contains private agents. Revert to roll back.

## Deploy Plan

Deploy front.