### PR TITLE
Instrument Google Drive content processing phases

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file/content_memory_telemetry.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/content_memory_telemetry.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { runWithGoogleDriveContentMemoryTelemetry } from "./content_memory_telemetry";
+import {
+  getGoogleDrivePayloadSizeBytes,
+  runWithGoogleDriveContentMemoryTelemetry,
+  runWithGoogleDriveContentPhaseMemoryTelemetry,
+} from "./content_memory_telemetry";
 
 const { statsDClient } = vi.hoisted(() => ({
   statsDClient: {
@@ -125,5 +129,78 @@ describe("runWithGoogleDriveContentMemoryTelemetry", () => {
       800,
       ["mime_type:application/pdf", "file_size_known:true", "outcome:success"]
     );
+  });
+});
+
+describe("runWithGoogleDriveContentPhaseMemoryTelemetry", () => {
+  it("records actual payload bytes and memory for a processing phase", async () => {
+    const memoryAtStart = {
+      rss: 1_000,
+      heapTotal: 500,
+      heapUsed: 300,
+      external: 200,
+      arrayBuffers: 100,
+    };
+    const memoryAtEnd = {
+      rss: 1_800,
+      heapTotal: 700,
+      heapUsed: 600,
+      external: 900,
+      arrayBuffers: 800,
+    };
+    vi.spyOn(process, "memoryUsage")
+      .mockReturnValueOnce(memoryAtStart)
+      .mockReturnValueOnce(memoryAtEnd);
+
+    const result = await runWithGoogleDriveContentPhaseMemoryTelemetry({
+      task: async () => new TextEncoder().encode("payload"),
+      getPayloadSizeBytes: (payload) => getGoogleDrivePayloadSizeBytes(payload),
+      logger,
+      mimeType: "application/vnd.google-apps.document",
+      phase: "download_export",
+    });
+
+    expect(result.byteLength).toBe(7);
+    const tags = [
+      "phase:download_export",
+      "mime_type:application/vnd.google-apps.document",
+      "payload_size_known:true",
+      "outcome:success",
+    ];
+    expect(statsDClient.distribution).toHaveBeenCalledWith(
+      "google_drive.content_processing.phase.payload_size_bytes",
+      7,
+      tags
+    );
+    expect(statsDClient.distribution).toHaveBeenCalledWith(
+      "google_drive.content_processing.phase.memory.rss.peak_growth_bytes",
+      800,
+      tags
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mimeType: "application/vnd.google-apps.document",
+        phase: "download_export",
+        payloadSizeBytes: 7,
+        outcome: "success",
+        memoryAtStart,
+        peakMemory: memoryAtEnd,
+        memoryAtEnd,
+      }),
+      "Google Drive content phase memory telemetry"
+    );
+  });
+});
+
+describe("getGoogleDrivePayloadSizeBytes", () => {
+  it("measures binary and UTF-8 payloads", () => {
+    expect(getGoogleDrivePayloadSizeBytes(new ArrayBuffer(42))).toBe(42);
+    expect(getGoogleDrivePayloadSizeBytes("hé")).toBe(3);
+    expect(getGoogleDrivePayloadSizeBytes(123)).toBe(3);
+  });
+
+  it("returns null when the response representation is unknown", () => {
+    expect(getGoogleDrivePayloadSizeBytes(null)).toBeNull();
+    expect(getGoogleDrivePayloadSizeBytes({ payload: "unknown" })).toBeNull();
   });
 });

--- a/connectors/src/connectors/google_drive/temporal/file/content_memory_telemetry.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/content_memory_telemetry.ts
@@ -11,6 +11,11 @@ type ContentLogger = {
 
 type MemorySnapshot = ReturnType<typeof process.memoryUsage>;
 
+export type GoogleDriveContentPhase =
+  | "download_export"
+  | "extraction"
+  | "dust_upsert";
+
 function maxMemorySnapshot(
   currentPeak: MemorySnapshot,
   sample: MemorySnapshot
@@ -22,6 +27,65 @@ function maxMemorySnapshot(
     external: Math.max(currentPeak.external, sample.external),
     arrayBuffers: Math.max(currentPeak.arrayBuffers, sample.arrayBuffers),
   };
+}
+
+function emitMemoryDistributions({
+  metricPrefix,
+  tags,
+  memoryAtStart,
+  peakMemory,
+  memoryAtEnd,
+}: {
+  metricPrefix: string;
+  tags: string[];
+  memoryAtStart: MemorySnapshot;
+  peakMemory: MemorySnapshot;
+  memoryAtEnd: MemorySnapshot;
+}) {
+  const statsDClient = getStatsDClient();
+
+  for (const [memoryType, startBytes, peakBytes, endBytes] of [
+    ["rss", memoryAtStart.rss, peakMemory.rss, memoryAtEnd.rss],
+    [
+      "heap_used",
+      memoryAtStart.heapUsed,
+      peakMemory.heapUsed,
+      memoryAtEnd.heapUsed,
+    ],
+    [
+      "external",
+      memoryAtStart.external,
+      peakMemory.external,
+      memoryAtEnd.external,
+    ],
+    [
+      "array_buffers",
+      memoryAtStart.arrayBuffers,
+      peakMemory.arrayBuffers,
+      memoryAtEnd.arrayBuffers,
+    ],
+  ] as const) {
+    statsDClient.distribution(
+      `${metricPrefix}.memory.${memoryType}.start_bytes`,
+      startBytes,
+      tags
+    );
+    statsDClient.distribution(
+      `${metricPrefix}.memory.${memoryType}.peak_bytes`,
+      peakBytes,
+      tags
+    );
+    statsDClient.distribution(
+      `${metricPrefix}.memory.${memoryType}.end_bytes`,
+      endBytes,
+      tags
+    );
+    statsDClient.distribution(
+      `${metricPrefix}.memory.${memoryType}.peak_growth_bytes`,
+      peakBytes - startBytes,
+      tags
+    );
+  }
 }
 
 function emitContentMemoryTelemetry({
@@ -66,48 +130,13 @@ function emitContentMemoryTelemetry({
       tags
     );
   }
-  for (const [memoryType, startBytes, peakBytes, endBytes] of [
-    ["rss", memoryAtStart.rss, peakMemory.rss, memoryAtEnd.rss],
-    [
-      "heap_used",
-      memoryAtStart.heapUsed,
-      peakMemory.heapUsed,
-      memoryAtEnd.heapUsed,
-    ],
-    [
-      "external",
-      memoryAtStart.external,
-      peakMemory.external,
-      memoryAtEnd.external,
-    ],
-    [
-      "array_buffers",
-      memoryAtStart.arrayBuffers,
-      peakMemory.arrayBuffers,
-      memoryAtEnd.arrayBuffers,
-    ],
-  ] as const) {
-    statsDClient.distribution(
-      `${CONTENT_METRIC_PREFIX}.memory.${memoryType}.start_bytes`,
-      startBytes,
-      tags
-    );
-    statsDClient.distribution(
-      `${CONTENT_METRIC_PREFIX}.memory.${memoryType}.peak_bytes`,
-      peakBytes,
-      tags
-    );
-    statsDClient.distribution(
-      `${CONTENT_METRIC_PREFIX}.memory.${memoryType}.end_bytes`,
-      endBytes,
-      tags
-    );
-    statsDClient.distribution(
-      `${CONTENT_METRIC_PREFIX}.memory.${memoryType}.peak_growth_bytes`,
-      peakBytes - startBytes,
-      tags
-    );
-  }
+  emitMemoryDistributions({
+    metricPrefix: CONTENT_METRIC_PREFIX,
+    tags,
+    memoryAtStart,
+    peakMemory,
+    memoryAtEnd,
+  });
 
   logger.info(
     {
@@ -123,6 +152,135 @@ function emitContentMemoryTelemetry({
     },
     "Google Drive content memory telemetry"
   );
+}
+
+function emitContentPhaseMemoryTelemetry({
+  logger,
+  mimeType,
+  phase,
+  payloadSizeBytes,
+  processingDurationMs,
+  outcome,
+  memoryAtStart,
+  peakMemory,
+  memoryAtEnd,
+}: {
+  logger: ContentLogger;
+  mimeType: string;
+  phase: GoogleDriveContentPhase;
+  payloadSizeBytes: number | null;
+  processingDurationMs: number;
+  outcome: "success" | "error";
+  memoryAtStart: MemorySnapshot;
+  peakMemory: MemorySnapshot;
+  memoryAtEnd: MemorySnapshot;
+}) {
+  const metricPrefix = `${CONTENT_METRIC_PREFIX}.phase`;
+  const tags = [
+    `phase:${phase}`,
+    `mime_type:${mimeType}`,
+    `payload_size_known:${payloadSizeBytes !== null}`,
+    `outcome:${outcome}`,
+  ];
+  const statsDClient = getStatsDClient();
+
+  statsDClient.distribution(
+    `${metricPrefix}.duration_ms`,
+    processingDurationMs,
+    tags
+  );
+  if (payloadSizeBytes !== null) {
+    statsDClient.distribution(
+      `${metricPrefix}.payload_size_bytes`,
+      payloadSizeBytes,
+      tags
+    );
+  }
+  emitMemoryDistributions({
+    metricPrefix,
+    tags,
+    memoryAtStart,
+    peakMemory,
+    memoryAtEnd,
+  });
+
+  logger.info(
+    {
+      mimeType,
+      phase,
+      payloadSizeBytes,
+      processingDurationMs,
+      outcome,
+      memoryAtStart,
+      peakMemory,
+      memoryAtEnd,
+    },
+    "Google Drive content phase memory telemetry"
+  );
+}
+
+export function getGoogleDrivePayloadSizeBytes(data: unknown): number | null {
+  if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+    return data.byteLength;
+  }
+
+  switch (typeof data) {
+    case "string":
+      return Buffer.byteLength(data, "utf8");
+    case "number":
+    case "boolean":
+    case "bigint":
+      return Buffer.byteLength(data.toString(), "utf8");
+    default:
+      return null;
+  }
+}
+
+export async function runWithGoogleDriveContentPhaseMemoryTelemetry<T>({
+  task,
+  getPayloadSizeBytes,
+  logger,
+  mimeType,
+  phase,
+}: {
+  task: () => Promise<T>;
+  getPayloadSizeBytes: (result: T) => number | null;
+  logger: ContentLogger;
+  mimeType: string;
+  phase: GoogleDriveContentPhase;
+}): Promise<T> {
+  const startedAtMs = Date.now();
+  const memoryAtStart = process.memoryUsage();
+  let peakMemory = memoryAtStart;
+  let outcome: "success" | "error" = "success";
+  let payloadSizeBytes: number | null = null;
+  const memorySampleInterval = setInterval(() => {
+    peakMemory = maxMemorySnapshot(peakMemory, process.memoryUsage());
+  }, CONTENT_MEMORY_SAMPLE_INTERVAL_MS);
+
+  try {
+    const result = await task();
+    payloadSizeBytes = getPayloadSizeBytes(result);
+    return result;
+  } catch (error) {
+    outcome = "error";
+    throw error;
+  } finally {
+    clearInterval(memorySampleInterval);
+    const memoryAtEnd = process.memoryUsage();
+    peakMemory = maxMemorySnapshot(peakMemory, memoryAtEnd);
+    emitContentPhaseMemoryTelemetry({
+      logger,
+      mimeType,
+      phase,
+      payloadSizeBytes,
+      processingDurationMs: Date.now() - startedAtMs,
+      outcome,
+      memoryAtStart,
+      peakMemory,
+      memoryAtEnd,
+    });
+  }
 }
 
 export async function runWithGoogleDriveContentMemoryTelemetry<T>({

--- a/connectors/src/connectors/google_drive/temporal/file/handle_file_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_file_export.ts
@@ -1,5 +1,9 @@
 import { getFileParentsMemoized } from "@connectors/connectors/google_drive/lib/hierarchy";
 import {
+  getGoogleDrivePayloadSizeBytes,
+  runWithGoogleDriveContentPhaseMemoryTelemetry,
+} from "@connectors/connectors/google_drive/temporal/file/content_memory_telemetry";
+import {
   getDriveClient,
   getInternalId,
   isFileTooLargeToDownloadError,
@@ -34,23 +38,34 @@ export async function handleFileExport(
   dataSourceConfig: DataSourceConfig,
   connectorId: ModelId,
   startSyncTs: number
-): Promise<CoreAPIDataSourceDocumentSection | null> {
+): Promise<{
+  content: CoreAPIDataSourceDocumentSection | null;
+  payloadSizeBytes: number | null;
+}> {
   const drive = await getDriveClient(oauth2client);
   let res;
   try {
-    res = await drive.files.get(
-      {
-        fileId: file.id,
-        alt: "media",
-      },
-      {
-        responseType: "arraybuffer",
-        // Google-native files report no size in their metadata, so the pre-download guard cannot
-        // catch them. Cap the download itself so a huge file is aborted mid-stream instead of being
-        // fully buffered in memory (a source of OOMs).
-        maxContentLength: MAX_FILE_SIZE_TO_DOWNLOAD,
-      }
-    );
+    res = await runWithGoogleDriveContentPhaseMemoryTelemetry({
+      logger: localLogger,
+      mimeType: file.mimeType,
+      phase: "download_export",
+      getPayloadSizeBytes: (response) =>
+        getGoogleDrivePayloadSizeBytes(response.data),
+      task: () =>
+        drive.files.get(
+          {
+            fileId: file.id,
+            alt: "media",
+          },
+          {
+            responseType: "arraybuffer",
+            // Google-native files report no size in their metadata, so the pre-download guard cannot
+            // catch them. Cap the download itself so a huge file is aborted mid-stream instead of being
+            // fully buffered in memory (a source of OOMs).
+            maxContentLength: MAX_FILE_SIZE_TO_DOWNLOAD,
+          }
+        ),
+    });
   } catch (e) {
     if (e instanceof GaxiosError) {
       if (e.response?.status === 404) {
@@ -60,7 +75,7 @@ export async function handleFileExport(
           },
           "Can't export Gdrive file. 404 error returned. Skipping."
         );
-        return null;
+        return { content: null, payloadSizeBytes: null };
       }
       if (e.response?.status === 403) {
         const skippableReasons = ["cannotDownloadAbusiveFile"];
@@ -79,7 +94,7 @@ export async function handleFileExport(
               { error: parsedBody.error },
               `Can't export Gdrive file. Skippable reason: ${firstSkippableReason} Skipping.`
             );
-            return null;
+            return { content: null, payloadSizeBytes: null };
           }
         } catch (e) {
           localLogger.error({ error: e }, "Error while parsing error response");
@@ -89,7 +104,7 @@ export async function handleFileExport(
 
     if (isFileTooLargeToDownloadError(e)) {
       localLogger.info({}, "File too big to be downloaded. Skipping");
-      return null;
+      return { content: null, payloadSizeBytes: null };
     }
     throw e;
   }
@@ -102,60 +117,69 @@ export async function handleFileExport(
 
   if (!(res.data instanceof ArrayBuffer)) {
     localLogger.error({}, "res.data is not an ArrayBuffer");
-    return null;
+    return { content: null, payloadSizeBytes: null };
   }
-  let result;
-  if (file.mimeType === "text/plain") {
-    result = handleTextFile(res.data, maxDocumentLen);
-  } else if (file.mimeType === "text/csv") {
-    const parentGoogleIds = await getFileParentsMemoized(
-      connectorId,
-      oauth2client,
-      file,
-      startSyncTs
-    );
+  const payload = res.data;
+  const payloadSizeBytes = payload.byteLength;
+  const result = await runWithGoogleDriveContentPhaseMemoryTelemetry({
+    logger: localLogger,
+    mimeType: file.mimeType,
+    phase: "extraction",
+    getPayloadSizeBytes: () => payloadSizeBytes,
+    task: async () => {
+      if (file.mimeType === "text/plain") {
+        return handleTextFile(payload, maxDocumentLen);
+      } else if (file.mimeType === "text/csv") {
+        const parentGoogleIds = await getFileParentsMemoized(
+          connectorId,
+          oauth2client,
+          file,
+          startSyncTs
+        );
 
-    const parents = parentGoogleIds.map((parent) => getInternalId(parent));
+        const parents = parentGoogleIds.map((parent) => getInternalId(parent));
 
-    result = await handleCsvFile({
-      data: res.data,
-      tableId: documentId,
-      fileName: file.name || "",
-      maxDocumentLen,
-      localLogger,
-      dataSourceConfig,
-      provider: "google_drive",
-      connectorId,
-      parents,
-      tags: file.labels,
-    });
-  } else if (file.mimeType === "text/markdown") {
-    const textContent = handleTextFile(res.data, maxDocumentLen);
-    if (textContent.isErr()) {
-      result = textContent;
-    } else {
-      result = new Ok(
-        await renderDocumentTitleAndContent({
+        return handleCsvFile({
+          data: payload,
+          tableId: documentId,
+          fileName: file.name || "",
+          maxDocumentLen,
+          localLogger,
           dataSourceConfig,
-          title: file.name || "",
-          createdAt: new Date(file.createdAtMs),
-          content: await renderMarkdownSection(
+          provider: "google_drive",
+          connectorId,
+          parents,
+          tags: file.labels,
+        });
+      } else if (file.mimeType === "text/markdown") {
+        const textContent = handleTextFile(payload, maxDocumentLen);
+        if (textContent.isErr()) {
+          return textContent;
+        }
+
+        return new Ok(
+          await renderDocumentTitleAndContent({
             dataSourceConfig,
-            textContent.value.content || ""
-          ),
-          ...(file.updatedAtMs
-            ? { updatedAt: new Date(file.updatedAtMs) }
-            : {}),
-        })
-      );
-    }
-  } else {
-    result = await handleTextExtraction(res.data, localLogger, file.mimeType);
-  }
+            title: file.name || "",
+            createdAt: new Date(file.createdAtMs),
+            content: await renderMarkdownSection(
+              dataSourceConfig,
+              textContent.value.content || ""
+            ),
+            ...(file.updatedAtMs
+              ? { updatedAt: new Date(file.updatedAtMs) }
+              : {}),
+          })
+        );
+      } else {
+        return handleTextExtraction(payload, localLogger, file.mimeType);
+      }
+    },
+  });
   if (result.isErr()) {
     localLogger.error({ error: result.error }, "Could not handle file.");
-    return null;
+    return { content: null, payloadSizeBytes };
   }
 
-  return result.value;
+  return { content: result.value, payloadSizeBytes };
 }

--- a/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
@@ -1,3 +1,7 @@
+import {
+  getGoogleDrivePayloadSizeBytes,
+  runWithGoogleDriveContentPhaseMemoryTelemetry,
+} from "@connectors/connectors/google_drive/temporal/file/content_memory_telemetry";
 import { MIME_TYPES_TO_EXPORT } from "@connectors/connectors/google_drive/temporal/mime_types";
 import {
   getDriveClient,
@@ -13,6 +17,7 @@ import { GaxiosError } from "googleapis-common";
 
 export type GoogleDriveExportResult = {
   content: CoreAPIDataSourceDocumentSection | null;
+  payloadSizeBytes: number | null;
   skipReason?: string;
 };
 
@@ -31,18 +36,26 @@ export async function handleGoogleDriveExport(
 
   for (;;) {
     try {
-      const res = await drive.files.export(
-        {
-          fileId: file.id,
-          mimeType: MIME_TYPES_TO_EXPORT[file.mimeType],
-        },
-        {
-          // Google-native docs report no size in their metadata, so the pre-download guard cannot
-          // catch them. Cap the export so a huge document is aborted mid-stream instead of being
-          // fully buffered in memory (a source of OOMs).
-          maxContentLength: MAX_FILE_SIZE_TO_DOWNLOAD,
-        }
-      );
+      const res = await runWithGoogleDriveContentPhaseMemoryTelemetry({
+        logger: localLogger,
+        mimeType: file.mimeType,
+        phase: "download_export",
+        getPayloadSizeBytes: (response) =>
+          getGoogleDrivePayloadSizeBytes(response.data),
+        task: () =>
+          drive.files.export(
+            {
+              fileId: file.id,
+              mimeType: MIME_TYPES_TO_EXPORT[file.mimeType],
+            },
+            {
+              // Google-native docs report no size in their metadata, so the pre-download guard cannot
+              // catch them. Cap the export so a huge document is aborted mid-stream instead of being
+              // fully buffered in memory (a source of OOMs).
+              maxContentLength: MAX_FILE_SIZE_TO_DOWNLOAD,
+            }
+          ),
+      });
       if (res.status !== 200) {
         localLogger.error({}, "Error exporting Google document");
         throw new Error(
@@ -50,44 +63,55 @@ export async function handleGoogleDriveExport(
         );
       }
 
-      if (typeof res.data === "string") {
-        return {
-          content:
-            res.data.trim().length > 0
-              ? {
-                  prefix: null,
-                  content: res.data.trim(),
-                  sections: [],
-                }
-              : null,
-        };
-      } else if (
-        ["object", "number", "boolean", "bigint"].includes(typeof res.data)
-      ) {
-        // In case the contents returned by the file export matches a JS type,
-        // we need to convert it
-        // Example: a Google presentation with just the number
-        // 1 in it, the export will return the number 1 instead of a string
-        return {
-          content:
-            res.data && res.data.toString().trim().length > 0
-              ? {
-                  prefix: null,
-                  content: res.data.toString().trim(),
-                  sections: [],
-                }
-              : null,
-        };
-      } else {
-        localLogger.error(
-          {
-            resDataTypeOf: typeof res.data,
-            type: "export",
-          },
-          "Unexpected GDrive export response type"
-        );
-        return { content: null };
-      }
+      const payloadSizeBytes = getGoogleDrivePayloadSizeBytes(res.data);
+      return await runWithGoogleDriveContentPhaseMemoryTelemetry({
+        logger: localLogger,
+        mimeType: file.mimeType,
+        phase: "extraction",
+        getPayloadSizeBytes: () => payloadSizeBytes,
+        task: async () => {
+          if (typeof res.data === "string") {
+            return {
+              content:
+                res.data.trim().length > 0
+                  ? {
+                      prefix: null,
+                      content: res.data.trim(),
+                      sections: [],
+                    }
+                  : null,
+              payloadSizeBytes,
+            };
+          } else if (
+            ["object", "number", "boolean", "bigint"].includes(typeof res.data)
+          ) {
+            // In case the contents returned by the file export matches a JS type,
+            // we need to convert it
+            // Example: a Google presentation with just the number
+            // 1 in it, the export will return the number 1 instead of a string
+            return {
+              content:
+                res.data && res.data.toString().trim().length > 0
+                  ? {
+                      prefix: null,
+                      content: res.data.toString().trim(),
+                      sections: [],
+                    }
+                  : null,
+              payloadSizeBytes,
+            };
+          } else {
+            localLogger.error(
+              {
+                resDataTypeOf: typeof res.data,
+                type: "export",
+              },
+              "Unexpected GDrive export response type"
+            );
+            return { content: null, payloadSizeBytes };
+          }
+        },
+      });
     } catch (e) {
       if (e instanceof GaxiosError) {
         if (e.response?.status === 404) {
@@ -97,7 +121,7 @@ export async function handleGoogleDriveExport(
             },
             "Can't export Gdrive document. 404 error returned, even though we know the file exists. Skipping."
           );
-          return { content: null };
+          return { content: null, payloadSizeBytes: null };
         }
 
         if (e.response?.status === 403) {
@@ -118,7 +142,7 @@ export async function handleGoogleDriveExport(
               { error: parsedBody.error },
               `Can't export Gdrive document. Skippable reason: ${firstSkippableReason}. Skipping.`
             );
-            return { content: null };
+            return { content: null, payloadSizeBytes: null };
           }
         }
 
@@ -131,7 +155,7 @@ export async function handleGoogleDriveExport(
             { error: e.message },
             "File is too large to be exported. Skipping."
           );
-          return { content: null };
+          return { content: null, payloadSizeBytes: null };
         }
 
         // If Google consistently returns 500 Internal Server Error after many
@@ -149,6 +173,7 @@ export async function handleGoogleDriveExport(
               );
               return {
                 content: null,
+                payloadSizeBytes: null,
                 skipReason: "google_internal_server_error",
               };
             }
@@ -161,7 +186,7 @@ export async function handleGoogleDriveExport(
 
       if (isFileTooLargeToDownloadError(e)) {
         localLogger.info("Google document too large to be exported, skipping.");
-        return { content: null };
+        return { content: null, payloadSizeBytes: null };
       }
 
       localLogger.error({ error: e }, "Error exporting Google document");

--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
@@ -1,3 +1,4 @@
+import { runWithGoogleDriveContentPhaseMemoryTelemetry } from "@connectors/connectors/google_drive/temporal/file/content_memory_telemetry";
 import { handleFileExport } from "@connectors/connectors/google_drive/temporal/file/handle_file_export";
 import { handleGoogleDriveExport } from "@connectors/connectors/google_drive/temporal/file/handle_google_drive_export";
 import { updateGoogleDriveFiles } from "@connectors/connectors/google_drive/temporal/file/update_google_drive_files";
@@ -31,6 +32,7 @@ export async function syncOneFileTextDocument(
   maxDocumentLen: number
 ) {
   let documentContent: CoreAPIDataSourceDocumentSection | null = null;
+  let payloadSizeBytes: number | null = null;
   let skipReason: string | undefined;
 
   const mimeTypesToDownload = getMimeTypesToDownload({
@@ -43,6 +45,7 @@ export async function syncOneFileTextDocument(
   if (MIME_TYPES_TO_EXPORT[file.mimeType]) {
     const res = await handleGoogleDriveExport(oauth2client, file, localLogger);
     documentContent = res.content;
+    payloadSizeBytes = res.payloadSizeBytes;
     if (res.skipReason) {
       localLogger.info(
         {},
@@ -52,7 +55,7 @@ export async function syncOneFileTextDocument(
     }
   } else if (mimeTypesToDownload.includes(file.mimeType)) {
     try {
-      documentContent = await handleFileExport(
+      const res = await handleFileExport(
         oauth2client,
         documentId,
         file,
@@ -62,6 +65,8 @@ export async function syncOneFileTextDocument(
         connectorId,
         startSyncTs
       );
+      documentContent = res.content;
+      payloadSizeBytes = res.payloadSizeBytes;
     } catch (e) {
       if (e instanceof WithRetriesError) {
         localLogger.warn(
@@ -76,18 +81,25 @@ export async function syncOneFileTextDocument(
   if (documentContent) {
     let upsertTimestampMs: number | undefined;
     try {
-      upsertTimestampMs = await upsertGdriveDocument(
-        dataSourceConfig,
-        file,
-        documentContent,
-        documentId,
-        maxDocumentLen,
-        localLogger,
-        oauth2client,
-        connectorId,
-        startSyncTs,
-        isBatchSync
-      );
+      upsertTimestampMs = await runWithGoogleDriveContentPhaseMemoryTelemetry({
+        logger: localLogger,
+        mimeType: file.mimeType,
+        phase: "dust_upsert",
+        getPayloadSizeBytes: () => payloadSizeBytes,
+        task: () =>
+          upsertGdriveDocument(
+            dataSourceConfig,
+            file,
+            documentContent,
+            documentId,
+            maxDocumentLen,
+            localLogger,
+            oauth2client,
+            connectorId,
+            startSyncTs,
+            isBatchSync
+          ),
+      });
     } catch (error) {
       if (error instanceof DataSourceQuotaExceededError) {
         localLogger.warn(


### PR DESCRIPTION
## Description

Measure the actual Google Drive response payload size and process memory during download/export, extraction, and Dust document upsert. The existing 256 MiB transport cap remains unchanged, with no concurrency limit added.

## Tests

Added focused coverage for binary and UTF-8 payload sizing and phase memory telemetry.

## Risk

Low. This only adds logs and StatsD distributions around existing operations. Roll back the PR if log or metric volume is higher than expected.

## Deploy Plan

Standard deploy. Verify phase logs and metrics arrive in both regions, then collect 24 to 48 hours of telemetry before choosing a guardrail.