### PR TITLE
[front] enh: add API keys to consumption attribution

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -9,6 +9,7 @@ import {
   within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 const { mockUseConsumptionTop } = vi.hoisted(() => ({
@@ -45,6 +46,28 @@ vi.mock(
 );
 
 const period = { kind: "days", days: 30 } as const;
+
+function ControlledAttributionTable({
+  onDimensionChange,
+}: {
+  onDimensionChange: (dimension: ConsumptionDimension) => void;
+}) {
+  const [dimension, setDimension] = useState<ConsumptionDimension>("source");
+
+  return (
+    <ConsumptionAttributionTable
+      workspaceId="workspace-id"
+      period={period}
+      dimension={dimension}
+      onDimensionChange={(nextDimension) => {
+        onDimensionChange(nextDimension);
+        setDimension(nextDimension);
+      }}
+      onAddFilter={vi.fn()}
+      onViewAll={vi.fn()}
+    />
+  );
+}
 
 describe("ConsumptionAttributionTable", () => {
   it("caps the available pages and fetches the selected fixed-size page", async () => {
@@ -195,6 +218,54 @@ describe("ConsumptionAttributionTable", () => {
         expect.objectContaining({ search: "Agent 080", offset: 0, limit: 25 })
       );
     });
+  });
+
+  it("selects the API key dimension with a pointer", () => {
+    const onDimensionChange = vi.fn();
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [],
+      totalCredits: 0,
+      isTopLoading: false,
+      isTopError: undefined,
+    });
+
+    render(
+      <ControlledAttributionTable onDimensionChange={onDimensionChange} />
+    );
+
+    const apiKeysTab = screen.getByRole("tab", { name: "API keys" });
+    fireEvent.pointerDown(apiKeysTab);
+    fireEvent.mouseDown(apiKeysTab, { button: 0, ctrlKey: false });
+
+    expect(onDimensionChange).toHaveBeenCalledWith("api_key");
+    expect(apiKeysTab).toHaveAttribute("aria-selected", "true");
+    expect(mockUseConsumptionTop).toHaveBeenLastCalledWith(
+      expect.objectContaining({ dimension: "api_key" })
+    );
+  });
+
+  it("selects the API key dimension with the keyboard", () => {
+    const onDimensionChange = vi.fn();
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [],
+      totalCredits: 0,
+      isTopLoading: false,
+      isTopError: undefined,
+    });
+
+    render(
+      <ControlledAttributionTable onDimensionChange={onDimensionChange} />
+    );
+
+    const apiKeysTab = screen.getByRole("tab", { name: "API keys" });
+    fireEvent.focus(apiKeysTab);
+    fireEvent.keyDown(apiKeysTab, { key: "Enter" });
+
+    expect(onDimensionChange).toHaveBeenCalledWith("api_key");
+    expect(apiKeysTab).toHaveAttribute("aria-selected", "true");
+    expect(mockUseConsumptionTop).toHaveBeenLastCalledWith(
+      expect.objectContaining({ dimension: "api_key" })
+    );
   });
 
   it("resets expanded rows when switching dimensions", async () => {

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
@@ -1,10 +1,29 @@
-import { consumptionDimensionFromQueryParam } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import {
+  CONSUMPTION_DIMENSION_CONFIG,
+  CONSUMPTION_DIMENSIONS,
+  consumptionDimensionFromQueryParam,
+} from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { describe, expect, it } from "vitest";
 
 describe("consumption dimension URL state", () => {
   it("reads valid dimensions and falls back to agents", () => {
     expect(consumptionDimensionFromQueryParam("user")).toBe("user");
+    expect(consumptionDimensionFromQueryParam("api_key")).toBe("api_key");
     expect(consumptionDimensionFromQueryParam("invalid")).toBe("agent");
     expect(consumptionDimensionFromQueryParam(undefined)).toBe("agent");
+  });
+
+  it("registers the API key attribution tab", () => {
+    expect(CONSUMPTION_DIMENSIONS).toEqual([
+      "agent",
+      "user",
+      "group",
+      "model",
+      "tool",
+      "skill",
+      "source",
+      "api_key",
+    ]);
+    expect(CONSUMPTION_DIMENSION_CONFIG.api_key.label).toBe("API keys");
   });
 });

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -13,6 +13,7 @@ export const CONSUMPTION_DIMENSIONS: ConsumptionDimension[] = [
   "tool",
   "skill",
   "source",
+  "api_key",
 ];
 
 interface ConsumptionDimensionConfig {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/10059

This PR adds api keys as an attribution dimension.

The existing charts and table flows can rank usage by key and preserve the selection in the URL.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
