### PR TITLE
[front] fix: keep pptx slide deletes from stranding parts, surface hidden and inherited shapes

### DIFF
--- a/front/lib/api/sandbox/image/profile/soffice/pptx_inspect.py
+++ b/front/lib/api/sandbox/image/profile/soffice/pptx_inspect.py
@@ -121,12 +121,15 @@ HELP_TEXT = (
     "                    pattern like 2,5,7-9). Per shape: kind, position, size,\n"
     "                    text, formatting, placeholder type, and a text-fit\n"
     "                    estimate (holds~Nch@Spt / ~Nch/line@Spt), with a [!] TEXT\n"
-    "                    OVERSET flag when text won't fit. Inspect every slide you\n"
-    "                    plan to edit in one call rather than one call each.\n"
+    "                    OVERSET flag when text won't fit and [!] HIDDEN when the\n"
+    "                    shape never renders. Inspect every slide you plan to edit\n"
+    "                    in one call rather than one call each.\n"
     "  --layouts         List slide masters and their layouts with placeholder slots,\n"
     "                    including each placeholder's resolved default typeface,\n"
     "                    size, weight, color, and alignment (from layout / master /\n"
-    "                    theme inheritance).\n"
+    "                    theme inheritance). 'static' lines are master/layout text\n"
+    "                    shapes: they render on every inheriting slide and cannot be\n"
+    "                    edited slide-side.\n"
     "  --text            Extract readable text per slide (preserves slide/shape boundaries).\n"
     "  --media           List embedded media (images, audio, video) with file sizes.\n"
     "  --render          Rasterize slide(s) to a plain JPEG (no overlay), published\n"
@@ -261,6 +264,14 @@ def count_shapes_by_kind(shapes: Iterable[BaseShape]) -> dict:
     return counts
 
 
+def shape_is_hidden(shape: BaseShape) -> bool:
+    """True when PowerPoint hides the shape from every render."""
+    for el in shape._element.iter():
+        if el.tag.endswith("}cNvPr"):
+            return el.get("hidden") in ("1", "true")
+    return False
+
+
 def describe_shape(
     shape: BaseShape,
     *,
@@ -325,6 +336,8 @@ def describe_shape(
                 parts.append(f"vanchor={va_name.lower()}")
             elif not ph:
                 parts.append("vanchor=top")
+    if shape_is_hidden(shape):
+        parts.append("[!] HIDDEN (never renders; clear hidden=\"1\" to use it)")
     for marker in _shape_warning_markers(
         shape, ph, ctx, cover_candidates, all_boxes
     ):
@@ -698,6 +711,22 @@ def _text_extent_boxes(file_path: str, slide: Slide) -> Dict[int, Tuple[int, int
     return out
 
 
+def _static_text_lines(shapes: Iterable[BaseShape], indent: str) -> List[str]:
+    """Master/layout text shapes every inheriting slide renders."""
+    lines: List[str] = []
+    for shape in shapes:
+        if shape.is_placeholder or not shape.has_text_frame:
+            continue
+        text = flatten_text(shape.text_frame.text).strip()
+        if not text:
+            continue
+        lines.append(
+            f"{indent}static  #{shape.shape_id}  {pad(format_box(shape), 24)}"
+            f'  "{ellipsize(text, 60)}"'
+        )
+    return lines
+
+
 def print_layouts(prs: PresentationType, file_path: str) -> str:
     lines = [f"[Masters: {len(prs.slide_masters)}]"]
     try:
@@ -712,12 +741,20 @@ def print_layouts(prs: PresentationType, file_path: str) -> str:
                 f"# Master {mi}: {master_name}  layouts: {
                     len(master.slide_layouts)}"
             )
+            master_static = _static_text_lines(master.shapes, "  ")
+            if master_static:
+                lines.append(
+                    "  [inherited text - renders on every slide using this "
+                    "master, editable only on the master itself:]"
+                )
+                lines.extend(master_static)
             for layout in master.slide_layouts:
                 placeholders = list(layout.placeholders)
                 lines.append(
                     f"- {pad(layout.name or '?', 28)
                          } placeholders: {len(placeholders)}"
                 )
+                lines.extend(_static_text_lines(layout.shapes, "    "))
 
                 layout_path = _layout_part_path(layout)
                 layout_xml = master_xml = theme_xml = None
@@ -739,6 +776,8 @@ def print_layouts(prs: PresentationType, file_path: str) -> str:
                     idx_str = str(idx) if idx is not None else "?"
                     box = format_box(ph)
                     head = f"    [{idx_str}] {pad(ph_name, 14)} {pad(box, 24)}"
+                    if shape_is_hidden(ph):
+                        head = f'{head}  [!] HIDDEN (never renders; clear hidden="1" to use it)'
                     if layout_xml is not None:
                         defaults = resolve_placeholder_defaults(
                             layout_xml,

--- a/front/lib/api/sandbox/image/profile/soffice/pptx_slides.py
+++ b/front/lib/api/sandbox/image/profile/soffice/pptx_slides.py
@@ -214,6 +214,22 @@ def op_move(prs, slide_no: int, to: int) -> str:
     return f"Moved slide {slide_no} to position {to}"
 
 
+def _purge_slide_refs(pres_el: etree._Element, rId: str) -> None:
+    """Drop presentation.xml elements still pointing at `rId`.
+
+    A custom show reuses the slide's rId, and drop_rel keeps any rel still
+    referenced - so the slide leaves the order but its part stays as an orphan.
+    """
+    for el in list(pres_el.iter()):
+        if any(
+            name.startswith("{" + R_NS + "}") and value == rId
+            for name, value in el.attrib.items()
+        ):
+            parent = el.getparent()
+            if parent is not None:
+                parent.remove(el)
+
+
 def op_delete(prs, slide_nos: List[int]) -> str:
     n = len(prs.slides)
     for s in slide_nos:
@@ -225,8 +241,15 @@ def op_delete(prs, slide_nos: List[int]) -> str:
     for s in sorted(set(slide_nos), reverse=True):
         sld_id = sld_ids[s - 1]
         rId = sld_id.get(qn("r:id"))
-        prs.part.drop_rel(rId)  # drop only this slide's rel; shared media stays
         sld_id_lst.remove(sld_id)
+        _purge_slide_refs(prs.part._element, rId)
+        prs.part.drop_rel(rId)  # drop only this slide's rel; shared media stays
+        if rId in prs.part.rels:
+            raise ValueError(
+                f"slide {s} is still referenced from presentation.xml after "
+                f"its slide order entry was removed ({rId}); deleting it would "
+                "strand its part in the package"
+            )
     return f"Deleted slide(s) {','.join(map(str, sorted(set(slide_nos))))}"
 
 

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_slides.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_slides.py
@@ -1,0 +1,107 @@
+"""Tier-2 tests for pptx_slides.op_delete: a deleted slide leaves no part
+behind, custom shows included. Builds decks with python-pptx, no soffice. Run
+directly (`python test_slides.py`) or under pytest.
+
+Lives in soffice/tests/, a subdir getLocalDirContent skips: it copies only the
+regular files directly in soffice/ (never recursing), so tests never ship in the image. It adds soffice/ to sys.path to import the module.
+"""
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from lxml import etree  # noqa: E402
+from pptx import Presentation  # noqa: E402
+from pptx.oxml.ns import qn  # noqa: E402
+
+import pptx_slides as S  # noqa: E402
+
+P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+
+
+def _deck(path: Path, slides: int = 3, custom_show_on: int = 0) -> None:
+    """A deck; custom_show_on=N adds a custom show referencing slide N."""
+    prs = Presentation()
+    for _ in range(slides):
+        prs.slides.add_slide(prs.slide_layouts[6])
+    if custom_show_on:
+        rid = list(prs.slides._sldIdLst)[custom_show_on - 1].get(qn("r:id"))
+        cust = etree.SubElement(prs.part._element, f"{{{P_NS}}}custShowLst")
+        show = etree.SubElement(cust, f"{{{P_NS}}}custShow")
+        show.set("name", "Short version")
+        show.set("id", "0")
+        ref = etree.SubElement(
+            etree.SubElement(show, f"{{{P_NS}}}sldLst"), f"{{{P_NS}}}sld"
+        )
+        ref.set(f"{{{R_NS}}}id", rid)
+    prs.save(path)
+
+
+def _slide_parts(path: Path) -> int:
+    with zipfile.ZipFile(path) as zf:
+        return len(
+            [n for n in zf.namelist() if n.startswith("ppt/slides/slide")
+             and n.endswith(".xml")]
+        )
+
+
+def _delete(path: Path, slide_nos):
+    prs = Presentation(path)
+    msg = S.op_delete(prs, slide_nos)
+    prs.save(path)
+    return msg
+
+
+def test_delete_drops_the_slide_part():
+    with tempfile.TemporaryDirectory() as d:
+        deck = Path(d) / "deck.pptx"
+        _deck(deck)
+        _delete(deck, [2])
+        assert len(Presentation(deck).slides) == 2
+        assert _slide_parts(deck) == 2
+
+
+def test_delete_drops_the_part_when_a_custom_show_also_references_it():
+    with tempfile.TemporaryDirectory() as d:
+        deck = Path(d) / "deck.pptx"
+        _deck(deck, custom_show_on=2)
+        _delete(deck, [2])
+        assert len(Presentation(deck).slides) == 2
+        # Without the purge, drop_rel no-ops and slide2.xml survives.
+        assert _slide_parts(deck) == 2
+
+
+def test_delete_leaves_the_custom_shows_other_slides_alone():
+    with tempfile.TemporaryDirectory() as d:
+        deck = Path(d) / "deck.pptx"
+        _deck(deck, custom_show_on=2)
+        _delete(deck, [3])
+        assert len(Presentation(deck).slides) == 2
+        assert _slide_parts(deck) == 2
+        with zipfile.ZipFile(deck) as zf:
+            pres = zf.read("ppt/presentation.xml").decode("utf-8")
+        assert "custShow" in pres
+
+
+def test_delete_out_of_range_raises():
+    with tempfile.TemporaryDirectory() as d:
+        deck = Path(d) / "deck.pptx"
+        _deck(deck)
+        for bad in ([0], [4], [1, 9]):
+            try:
+                _delete(deck, bad)
+            except ValueError:
+                continue
+            raise AssertionError(f"expected ValueError for {bad!r}")
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    for fn in tests:
+        fn()
+        print(f"ok   {fn.__name__}")
+    print(f"\n{len(tests)} slides tests passed")


### PR DESCRIPTION
## Description

Deleting a slide could leave its part behind in the package. drop_rel keeps any rel that is still
referenced, and a custom show references the slide by the same rId, so the slide left the order
while its part stayed as an orphan and PowerPoint complains about the file. It now strips every
presentation.xml element pointing at that rId before dropping the rel, and raise if the rel
survives rather than write a deck I know is broken.

Two blind spots in inspection while I was in there: a shape with hidden="1" never renders, and
master/layout text renders on every inheriting slide but cannot be touched slide-side. Neither
showed up in --slide or --layouts, so the model kept writing into shapes nobody sees and kept
trying to fix text it does not own.

## Tests

Added tests in test_slides.py, and tested locally on real decks.

## Risk

Low. Blast radius: pptx_slides --delete and the pptx_inspect --slide / --layouts output

## Deploy Plan

Merge
Will build sandbox img when merging the last PR