### PR TITLE
[front] enh: add grid render, chop help text

### DIFF
--- a/front/lib/api/sandbox/image/profile/soffice/pptx_grid.py
+++ b/front/lib/api/sandbox/image/profile/soffice/pptx_grid.py
@@ -1,0 +1,80 @@
+"""Tile slide renders into one grid image."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+from pptx_render_boxes import _load_font
+
+# The long edge the reader's vision pipeline scales down to.
+GRID_MAX_PX = 1568
+GRID_PAD = 10
+DEFAULT_GRID_COLS = 2
+MAX_GRID_COLS = 4
+
+
+def grid_rows(cell_h: int, label_h: int) -> int:
+    """Rows that fit before the grid exceeds GRID_MAX_PX."""
+    return max(1, (GRID_MAX_PX - GRID_PAD) // (cell_h + label_h + GRID_PAD))
+
+
+def compose_grids(
+    cells: Sequence[Tuple[Path, str]],
+    out_dir: Path,
+    cols: int = DEFAULT_GRID_COLS,
+    name: str = "grid",
+) -> List[Tuple[Path, List[str]]]:
+    """Tile (path, label) cells into out_dir; returns (grid, its labels)."""
+    from PIL import Image, ImageDraw
+
+    cols = max(1, min(cols, MAX_GRID_COLS))
+    usable = [c for c in cells if c[0].exists()]
+    if not usable:
+        return []
+
+    with Image.open(usable[0][0]) as first:
+        aspect = first.height / first.width if first.width else 0.5625
+    cell_w = (GRID_MAX_PX - (cols + 1) * GRID_PAD) // cols
+    cell_h = int(cell_w * aspect)
+    label_h = max(18, cell_w // 26)
+    font = _load_font(max(13, int(label_h * 0.8)))
+    row_h = cell_h + label_h + GRID_PAD
+    per_image = cols * grid_rows(cell_h, label_h)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    grids: List[Tuple[Path, List[str]]] = []
+
+    for n, start in enumerate(range(0, len(usable), per_image), start=1):
+        chunk = usable[start : start + per_image]
+        chunk_rows = (len(chunk) + cols - 1) // cols
+        canvas = Image.new(
+            "RGB", (GRID_MAX_PX, chunk_rows * row_h + GRID_PAD), (24, 24, 24)
+        )
+        draw = ImageDraw.Draw(canvas)
+        for i, (path, label) in enumerate(chunk):
+            x = GRID_PAD + (i % cols) * (cell_w + GRID_PAD)
+            y = GRID_PAD + (i // cols) * row_h
+            draw.text((x, y), label, fill=(255, 214, 10), font=font)
+            try:
+                with Image.open(path) as img:
+                    thumb = img.convert("RGB")
+                    thumb.thumbnail((cell_w, cell_h), Image.Resampling.LANCZOS)
+                    canvas.paste(thumb, (x, y + label_h))
+            except (OSError, ValueError):
+                continue
+        dest = out_dir / f"{name}-{n:03d}.jpg"
+        canvas.save(dest, "JPEG", quality=85)
+        grids.append((dest, [label for _, label in chunk]))
+    return grids
+
+
+def grid_lines(
+    grids: List[Tuple[Path, Optional[str], List[int]]],
+) -> List[str]:
+    """One `grid N (slides ...): path` line per image."""
+    return [
+        f"  grid {n} (slides {','.join(str(s) for s in slide_nos)}): "
+        f"{scoped or f'{dest} (not on the conversation mount)'}"
+        for n, (dest, scoped, slide_nos) in enumerate(grids, start=1)
+    ]

--- a/front/lib/api/sandbox/image/profile/soffice/pptx_inspect.py
+++ b/front/lib/api/sandbox/image/profile/soffice/pptx_inspect.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import os
 import re
-import secrets
 import sys
 import zipfile
 from pathlib import Path
@@ -52,6 +51,8 @@ from pptx_typography import (
 
 from pptx_render_boxes import _annotate_boxes
 
+import pptx_grid
+
 from pptx_audit import (
     BARE_MARGIN,
     BARE_RATE,
@@ -85,73 +86,19 @@ DEFAULT_MAX_SHAPES = 200
 
 
 USAGE = (
-    "pptx_inspect <file> [--qa N[,N,...]] [--slide N[,N,...]] [--layouts] [--text] "
-    "[--media] [--render] [--render-dir DIR] [--compare FILE] "
+    "pptx_inspect <file> [--qa N | --slide N | --layouts | --text | --media | "
+    "--render] [--grid [--grid-cols N]] [--compare FILE] [--render-dir DIR] "
     "[--max-shapes N] [--offset N]"
 )
 
 HELP_TEXT = (
-    "pptx_inspect - Inspect .pptx deck structure\n"
-    "\n"
-    f"Usage: {USAGE}\n"
-    "\n"
-    "Arguments:\n"
-    "  file              Path to .pptx deck (required)\n"
-    "\n"
-    "Options:\n"
-    "  --qa N[,N,...]    QA gate - run after a round of edits. Takes one slide or a\n"
-    "                    pattern (e.g. 2,5,7-9); QA-ing several at once shares a\n"
-    "                    single render pass (the PDF is cached), so edit a batch of\n"
-    "                    slides then QA them together rather than one call each.\n"
-    "                    Prints each slide's #id-tagged text AND a boxed diagnostic\n"
-    "                    render (boxes labeled '#id', red wash where boxes overlap),\n"
-    "                    plus text checks read off the rendered PDF's word\n"
-    "                    positions: [!] (fix before delivery) for a confirmed\n"
-    "                    text-on-text overprint, [w] (review) when a box doesn't\n"
-    "                    contain its own text, and [i] (FYI) for softer advisories\n"
-    "                    - so tight-but-clear neighbours and box-only overlaps\n"
-    "                    don't false-alarm, and only [!] gates delivery.\n"
-    "                    The render is published to the conversation as a JPEG whose\n"
-    "                    path is printed per slide (a files__cat-readable image),\n"
-    "                    stamped with a READBACK CODE that appears only in the\n"
-    "                    pixels: open each render and quote its code to prove you\n"
-    "                    viewed it. The text checks are a structural pre-check, not\n"
-    "                    the visual pass - the readback is the gate.\n"
-    "  --slide N[,N,...] Show one or more slides' shapes (1-indexed; takes a\n"
-    "                    pattern like 2,5,7-9). Per shape: kind, position, size,\n"
-    "                    text, formatting, placeholder type, and a text-fit\n"
-    "                    estimate (holds~Nch@Spt / ~Nch/line@Spt), with a [!] TEXT\n"
-    "                    OVERSET flag when text won't fit and [!] HIDDEN when the\n"
-    "                    shape never renders. Inspect every slide you plan to edit\n"
-    "                    in one call rather than one call each.\n"
-    "  --layouts         List slide masters and their layouts with placeholder slots,\n"
-    "                    including each placeholder's resolved default typeface,\n"
-    "                    size, weight, color, and alignment (from layout / master /\n"
-    "                    theme inheritance). 'static' lines are master/layout text\n"
-    "                    shapes: they render on every inheriting slide and cannot be\n"
-    "                    edited slide-side.\n"
-    "  --text            Extract readable text per slide (preserves slide/shape boundaries).\n"
-    "  --media           List embedded media (images, audio, video) with file sizes.\n"
-    "  --render          Rasterize slide(s) to a plain JPEG (no overlay), published\n"
-    "                    to the conversation. Combine with --slide N[,N,...] to\n"
-    "                    render just those slides in one shared pass (the deck is\n"
-    "                    converted once, then cached); omit --slide for the whole\n"
-    "                    deck. For QA use --qa instead - it adds the boxes.\n"
-    "  --render-dir DIR  Base dir renders are published under, as\n"
-    "                    DIR/.pptx_render/<deck>/ (default: /files/conversation).\n"
-    "  --compare FILE    Compare <file> (your edited output) against FILE (the\n"
-    "                    source/template): slide count, embedded media, embedded\n"
-    "                    fonts, imagery/layout/density, and per-shape content-slot\n"
-    "                    fidelity (text written into the template's spacer\n"
-    "                    paragraphs). Ends with a [QA: PASS/FAIL] verdict.\n"
-    "  --max-shapes N    Maximum shapes to print in slide view (default 200).\n"
-    "  --offset N        Skip first N shapes in slide view (default 0).\n"
-    "\n"
-    "Output (slide view, one shape per line, paragraphs indented):\n"
-    "  <id>  <kind>  <left,top inWxinH>  [ph=<type>]  <summary>\n"
-    "    p[i]: <text>  [<font hints>]\n"
-    "Paragraphs are addressed by index p[i]; empty spacer paragraphs are shown\n"
-    "(trailing ones collapsed to a count); long text is ellipsized."
+    "pptx_inspect <file> [mode]; default overview. N = 5 | 2,5,8 | 2,5,7-9.\n"
+    "--qa N: post-edit gate, #id text + boxed render to open\n"
+    "--slide N: shapes, box, ph, type, fit, [!] OVERSET/HIDDEN\n"
+    "--layouts: placeholders + type; static = master text\n"
+    "--compare F: vs template F, ends [QA: PASS/FAIL]\n"
+    "--grid: one image per grid; --grid-cols N: 2, max 4\n"
+    "--text --media --render --render-dir --max-shapes --offset"
 )
 
 
@@ -849,7 +796,7 @@ def print_text(prs: PresentationType, slide_idx: Optional[int] = None) -> str:
     scope = (f"slide {slide_idx}" if slide_idx is not None
              else f"{len(prs.slides)} slides")
     head = f"[Text: {total_chars} chars | {scope} | each line is tagged with " \
-           "its shape #id - match against the --qa box labels for readback]"
+           "its shape #id - match against the --qa box labels]"
     if repeated:
         shown = ", ".join(
             f'"{ellipsize(t, 30)}" x{repeat_counts[t]}' for t in repeated[:6]
@@ -1323,15 +1270,10 @@ def _slide_findings_lines(
     return [f"[slide {idx}: no collisions in pre-check - open the render to QA]"]
 
 
-def _boxed_render(
-    file_path: str,
-    prs: PresentationType,
-    slide_idx: Optional[int],
-    render_dir: str = "/files/conversation",
-) -> str:
-    """Render slide(s) with the bounding-box overlay + pixel-metrics digest -
-    the diagnostic half of QA. Reached via --qa, not exposed on its own."""
-    total_slides = len(prs.slides)
+def _annotate_slide(
+    file_path: str, prs: PresentationType, slide_idx: int
+) -> Tuple[Path, List[str]]:
+    """Rasterize one slide with box overlay; returns image and digest."""
     out_dir, rendered = render.render_via_soffice(
         file_path,
         out_root=Path("/tmp/pptx_render"),
@@ -1342,34 +1284,32 @@ def _boxed_render(
     # word positions; reading them lets the collision check confirm overprints
     # against where glyphs actually landed rather than estimated box geometry.
     pdf_path = out_dir / f"{out_dir.name}.pdf"
-    digest: List[str] = []
-    annotated: List[Path] = []
-    for p in rendered:
-        m = re.search(r"-(\d+)\.", p.name)
-        idx = int(m.group(1)) if m else None
-        res = None
-        if idx is not None and 1 <= idx <= total_slides:
-            slide = prs.slides[idx - 1]
-            res = _annotate_boxes(
-                p, slide,
-                prs.slide_width or 0, prs.slide_height or 0,
-                effective_boxes=_text_extent_boxes(file_path, slide),
-                # A fresh per-render code, stamped into the pixels only: quoting
-                # it back is the proof the model actually opened the render.
-                readback_code=secrets.token_hex(2).upper(),
-            )
-        if res:
-            ap, findings = res
-            annotated.append(ap)
-            words = pdf_text.page_word_boxes(pdf_path, idx)
-            digest.extend(
-                _slide_findings_lines(prs.slides[idx - 1], idx, findings, words)
-            )
-        else:
-            annotated.append(p)
+    slide = prs.slides[slide_idx - 1]
+    raw = rendered[0]
+    res = _annotate_boxes(
+        raw, slide,
+        prs.slide_width or 0, prs.slide_height or 0,
+        effective_boxes=_text_extent_boxes(file_path, slide),
+    )
+    if not res:
+        return raw, []
+    annotated, findings = res
+    words = pdf_text.page_word_boxes(pdf_path, slide_idx)
+    return annotated, _slide_findings_lines(slide, slide_idx, findings, words)
+
+
+def _boxed_render(
+    file_path: str,
+    prs: PresentationType,
+    slide_idx: int,
+    render_dir: str = "/files/conversation",
+) -> str:
+    """Render one slide with the bounding-box overlay + pixel-metrics digest -
+    the diagnostic half of QA. Reached via --qa, not exposed on its own."""
+    annotated, digest = _annotate_slide(file_path, prs, slide_idx)
     basename = os.path.splitext(os.path.basename(file_path))[0]
     published = render_publish.publish_renders(
-        basename, annotated, render_dir, _VIEW_SUBDIR
+        basename, [annotated], render_dir, _VIEW_SUBDIR
     )
     plural = "" if len(published) == 1 else "s"
     lines = [f"[Rendered {len(published)} slide{plural}, bbox overlay:]"]
@@ -1378,12 +1318,12 @@ def _boxed_render(
     viewable = [scoped for _, scoped in published if scoped]
     if len(viewable) < len(published):
         # A render that is not on the conversation mount cannot be opened with
-        # files__cat, so the visual readback - the actual QA gate - is impossible.
+        # files__cat, so the visual check - the actual QA gate - is impossible.
         # Say so as a blocker instead of letting the pre-checks below read as a
         # pass.
         lines.append(
             "[!] some renders are NOT viewable (not on the conversation mount): "
-            "the visual readback cannot be performed, so QA is INCOMPLETE for "
+            "the visual check cannot be performed, so QA is INCOMPLETE for "
             "those slides. Run against a deck under /files/conversation."
         )
 
@@ -1399,13 +1339,36 @@ def _boxed_render(
         lines.extend(digest)
 
     if viewable:
-        lines.append(
-            "[Readback (required): open each render above with files__cat and "
-            "quote the READBACK CODE stamped across its top. The code is only in "
-            "the image - a slide whose code you cannot quote has not been read "
-            "back, and is not done.]"
-        )
+        lines.append("[Open each render above with files__cat: the gate is visual.]")
     return "\n".join(lines)
+
+
+def _publish_grids(
+    file_path: str,
+    cells: List[Tuple[Path, str]],
+    slide_nos: List[int],
+    render_dir: str,
+    grid_cols: int,
+) -> List[Tuple[Path, Optional[str], List[int]]]:
+    """Publish the grids; returns (path, scoped path, slides) each."""
+    basename = os.path.splitext(os.path.basename(file_path))[0]
+    # Drop missing renders here, not in the composer, so slide numbers stay aligned.
+    present = [(c, n) for c, n in zip(cells, slide_nos) if c[0].exists()]
+    grids = pptx_grid.compose_grids(
+        [c for c, _ in present],
+        Path("/tmp/pptx_render") / basename / "grids",
+        grid_cols,
+    )
+    published = render_publish.publish_renders(
+        basename, [path for path, _ in grids], render_dir, _VIEW_SUBDIR
+    )
+    grouped: List[Tuple[Path, Optional[str], List[int]]] = []
+    consumed = 0
+    for (dest, scoped), (_, labels) in zip(published, grids):
+        held = [n for _, n in present[consumed : consumed + len(labels)]]
+        grouped.append((dest, scoped, held))
+        consumed += len(labels)
+    return grouped
 
 
 def print_render(
@@ -1413,6 +1376,7 @@ def print_render(
     prs: PresentationType,
     slide_nos: Optional[List[int]],
     render_dir: str = "/files/conversation",
+    grid_cols: Optional[int] = None,
 ) -> str:
     """Plain rasterized slide(s) - no overlay - for a quick visual look. Pass a
     list of 1-based slide numbers (from a --slide N[,N,...] pattern) to rasterize
@@ -1442,6 +1406,23 @@ def print_render(
                 item_idx=idx,
             )
             rendered.extend(one)
+
+    rendered_nos = slide_nos or list(range(1, len(rendered) + 1))
+    if grid_cols:
+        grids = _publish_grids(
+            file_path,
+            [(p, f"slide {n}") for p, n in zip(rendered, rendered_nos)],
+            rendered_nos,
+            render_dir,
+            grid_cols,
+        )
+        lines = [
+            f"[Rendered {len(rendered)} slides into {len(grids)} grid(s), "
+            f"{grid_cols}/row @ 100 dpi:]"
+        ]
+        lines.extend(pptx_grid.grid_lines(grids))
+        return "\n".join(lines)
+
     basename = os.path.splitext(os.path.basename(file_path))[0]
     published = render_publish.publish_renders(
         basename, rendered, render_dir, _VIEW_SUBDIR
@@ -1452,11 +1433,56 @@ def print_render(
     return "\n".join(lines)
 
 
+def _print_qa_grids(
+    file_path: str,
+    prs: PresentationType,
+    slide_nos: List[int],
+    render_dir: str,
+    grid_cols: int,
+) -> str:
+    """QA a batch with the renders tiled into grids."""
+    cells: List[Tuple[Path, str]] = []
+    blocks: List[str] = []
+    for slide_idx in slide_nos:
+        annotated, digest = _annotate_slide(file_path, prs, slide_idx)
+        cells.append((annotated, f"slide {slide_idx}"))
+        block = f"[QA slide {slide_idx} - #id text:]\n\n" + print_text(
+            prs, slide_idx
+        )
+        if digest:
+            block += (
+                "\n\n[Structural pre-checks - NOT a visual pass; open the grid "
+                "to QA. [!] fix before delivery · [w] review · [i] FYI:]\n"
+                + "\n".join(digest)
+            )
+        blocks.append(block)
+
+    grids = _publish_grids(file_path, cells, slide_nos, render_dir, grid_cols)
+    lines = [
+        f"[{len(cells)} slides in {len(grids)} grid(s), {grid_cols}/row, "
+        "bbox overlay:]"
+    ]
+    lines.extend(pptx_grid.grid_lines(grids))
+    if any(scoped is None for _, scoped, _ in grids):
+        lines.append(
+            "[!] grids NOT viewable (not on the conversation mount): QA is "
+            "INCOMPLETE. Run against a deck under /files/conversation."
+        )
+    else:
+        lines.append(
+            "[Open each grid with files__cat: the gate is visual. Cells are "
+            f"1/{grid_cols} width - re-run --qa N on any you cannot read.]"
+        )
+    blocks.append("\n".join(lines))
+    return "\n\n".join(blocks)
+
+
 def print_qa(
     file_path: str,
     prs: PresentationType,
     slide_nos: List[int],
     render_dir: str = "/files/conversation",
+    grid_cols: Optional[int] = None,
 ) -> str:
     """QA gate - run after a round of edits. Accepts one slide or several (a
     pattern like `2,5,7-9`); for each, bundles the slide's authoritative text
@@ -1464,7 +1490,8 @@ def print_qa(
     checked together. QA-ing several slides at once shares a single soffice
     conversion (the PDF is cached after the first render), so batching the
     changed slides is much faster than one call per slide. Each slide's render is
-    published to the conversation (its scoped path is printed below the text)."""
+    published to the conversation (its scoped path is printed below the text);
+    with `grid_cols` the renders are tiled into grids instead."""
     total_slides = len(prs.slides)
     for slide_idx in slide_nos:
         if slide_idx < 1 or slide_idx > total_slides:
@@ -1472,6 +1499,10 @@ def print_qa(
                 f"slide index out of range: {slide_idx} "
                 f"(deck has {total_slides} slides)"
             )
+    if grid_cols:
+        return _print_qa_grids(
+            file_path, prs, slide_nos, render_dir, grid_cols
+        )
     blocks = [
         f"[QA slide {slide_idx} - #id text + render path:]\n\n"
         + print_text(prs, slide_idx)
@@ -1495,6 +1526,14 @@ def main() -> int:
     parser.add_argument("--media", action="store_true")
     parser.add_argument("--render", action="store_true")
     parser.add_argument("--qa", metavar="N[,N,...]")
+    parser.add_argument("--grid", action="store_true")
+    parser.add_argument(
+        "--grid-cols",
+        dest="grid_cols",
+        type=int,
+        default=pptx_grid.DEFAULT_GRID_COLS,
+        metavar="N",
+    )
     parser.add_argument(
         "--render-dir",
         dest="render_dir",
@@ -1526,6 +1565,12 @@ def main() -> int:
     if args.offset < 0:
         sys.stderr.write("Error: --offset must be >= 0\n")
         return 1
+    if not 1 <= args.grid_cols <= pptx_grid.MAX_GRID_COLS:
+        sys.stderr.write(
+            f"Error: --grid-cols must be 1..{pptx_grid.MAX_GRID_COLS}\n"
+        )
+        return 1
+    grid_cols = args.grid_cols if args.grid else None
     if args.compare is not None and not os.path.isfile(args.compare):
         sys.stderr.write(f"Error: --compare file not found: {args.compare}\n")
         return 1
@@ -1543,11 +1588,17 @@ def main() -> int:
         prs = Presentation(args.file)
         if args.qa is not None:
             body = print_qa(
-                args.file, prs, parse_slide_patterns(args.qa), args.render_dir
+                args.file,
+                prs,
+                parse_slide_patterns(args.qa),
+                args.render_dir,
+                grid_cols,
             )
         elif args.render:
             slide_nos = parse_slide_patterns(args.slide) if args.slide else None
-            body = print_render(args.file, prs, slide_nos, args.render_dir)
+            body = print_render(
+                args.file, prs, slide_nos, args.render_dir, grid_cols
+            )
         elif args.layouts:
             body = print_layouts(prs, args.file)
         elif args.text:

--- a/front/lib/api/sandbox/image/profile/soffice/pptx_render_boxes.py
+++ b/front/lib/api/sandbox/image/profile/soffice/pptx_render_boxes.py
@@ -240,34 +240,12 @@ def _load_font(size: int):
     return None
 
 
-def _add_readback_band(img, code: str):
-    """Stamp a proof-of-readback band across the top of the diagnostic render.
-
-    The code lives ONLY in the pixels (it is never printed in the tool's text
-    output), so quoting it back is the one thing that proves the render was
-    actually opened with files__cat. The band is added ABOVE the slide rather
-    than drawn over it, so the stamp never hides content QA has to judge."""
-    from PIL import Image, ImageDraw
-
-    w, h = img.size
-    band = max(40, h // 18)
-    out = Image.new("RGB", (w, h + band), (17, 17, 17))
-    out.paste(img, (0, band))
-    draw = ImageDraw.Draw(out)
-    fsize = max(18, int(band * 0.55))
-    font = _load_font(fsize)
-    text = f"READBACK CODE: {code}   (quote this to prove you opened this render)"
-    draw.text((12, max(0, (band - fsize) // 2)), text, fill=(255, 214, 10), font=font)
-    return out
-
-
 def _annotate_boxes(
     image_path: Path,
     slide: Slide,
     slide_w_emu: int,
     slide_h_emu: int,
     effective_boxes: Optional[Dict[int, BoxEmu]] = None,
-    readback_code: Optional[str] = None,
 ):
     """Overlay each top-level shape's bounding box on the slide image and
     compute pixel metrics. Box positions are read from the file (exact even
@@ -281,10 +259,6 @@ def _annotate_boxes(
     box, so an overflowing text box visibly wraps its text and a spill onto a
     neighbour is caught (a containment that appears only after a box grows is
     spillover, not a designed fg/bg overlay, so it is surfaced not suppressed).
-
-    `readback_code`, when given, is stamped into a band above the slide (only in
-    the pixels, never in the tool's text) so quoting it proves the render was
-    opened - the proof-of-readback for the QA gate.
 
     Returns (out_path, findings) where findings has keys: "overlaps" (a list of
     _overlap_finding dicts - which shape spilled onto which, the kind, axis,
@@ -431,10 +405,7 @@ def _annotate_boxes(
 
     out_path = image_path.with_name(image_path.stem + "-boxes.png")
     try:
-        flat = Image.alpha_composite(base, overlay).convert("RGB")
-        if readback_code:
-            flat = _add_readback_band(flat, readback_code)
-        flat.save(out_path)
+        Image.alpha_composite(base, overlay).convert("RGB").save(out_path)
     except (OSError, ValueError):
         return None
     return out_path, findings

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_grid.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_grid.py
@@ -1,0 +1,107 @@
+"""Tier-1 tests for pptx_grid.compose_grids, the tiler behind `pptx_inspect
+--qa/--render --grid`. Synthetic PIL images, no soffice. Run directly
+(`python test_grid.py`) or under pytest.
+
+Lives in soffice/tests/, a subdir getLocalDirContent skips: it copies only the
+regular files directly in soffice/ (never recursing), so tests never ship in the image. It adds soffice/ to sys.path to import the module.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from PIL import Image  # noqa: E402
+
+import pptx_grid as S  # noqa: E402
+
+
+def _slides(d: Path, n: int, size=(1333, 750)):
+    cells = []
+    for i in range(1, n + 1):
+        p = d / f"slide-{i:03d}.jpg"
+        Image.new("RGB", size, (255, 255, 255)).save(p, "JPEG")
+        cells.append((p, f"slide {i}"))
+    return cells
+
+
+def test_sixteen_by_nine_fits_six_per_two_column_grid():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        grids = S.compose_grids(_slides(d, 6), d / "out", cols=2)
+        assert len(grids) == 1
+        assert len(grids[0][1]) == 6
+
+
+def test_overflow_spills_into_a_second_grid():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        grids = S.compose_grids(_slides(d, 7), d / "out", cols=2)
+        assert len(grids) == 2
+        assert [len(labels) for _, labels in grids] == [6, 1]
+        assert grids[1][1] == ["slide 7"]
+
+
+def test_grid_never_exceeds_the_vision_ceiling_on_its_long_edge():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        for cols in (1, 2, 3, 4):
+            grids = S.compose_grids(_slides(d, 8), d / f"out{cols}", cols=cols)
+            for path, _ in grids:
+                with Image.open(path) as img:
+                    assert max(img.size) <= S.GRID_MAX_PX, (cols, img.size)
+
+
+def test_more_columns_means_smaller_cells():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        widths = []
+        for cols in (1, 2, 4):
+            cell_w = (S.GRID_MAX_PX - (cols + 1) * S.GRID_PAD) // cols
+            widths.append(cell_w)
+        assert widths == sorted(widths, reverse=True)
+
+
+def test_cols_are_clamped_to_the_supported_range():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        cells = _slides(d, 4)
+        assert len(S.compose_grids(cells, d / "hi", cols=99)[0][1]) == len(
+            S.compose_grids(cells, d / "max", cols=S.MAX_GRID_COLS)[0][1]
+        )
+        assert S.compose_grids(cells, d / "lo", cols=0)
+
+
+def test_missing_render_is_skipped_not_fatal():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        cells = _slides(d, 3) + [(d / "gone.jpg", "slide 4")]
+        grids = S.compose_grids(cells, d / "out", cols=2)
+        assert len(grids) == 1
+        assert len(grids[0][1]) == 3
+
+
+def test_no_usable_render_returns_nothing():
+    with tempfile.TemporaryDirectory() as d:
+        d = Path(d)
+        assert S.compose_grids([(d / "gone.jpg", "slide 1")], d / "out") == []
+
+
+def test_grid_lines_report_the_slides_each_grid_holds():
+    lines = S.grid_lines(
+        [
+            (Path("/tmp/grid-001.jpg"), "conversation-x/grid-001.jpg", [1, 2]),
+            (Path("/tmp/grid-002.jpg"), None, [3]),
+        ]
+    )
+    assert lines[0] == "  grid 1 (slides 1,2): conversation-x/grid-001.jpg"
+    assert "not on the conversation mount" in lines[1]
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    for fn in tests:
+        fn()
+        print(f"ok   {fn.__name__}")
+    print(f"\n{len(tests)} grid tests passed")

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_render_boxes.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_render_boxes.py
@@ -126,17 +126,6 @@ def test_contrast_text_picks_legible_color():
     assert R._contrast_text((150, 210, 0)) == (0, 0, 0, 255)  # light -> black
 
 
-def test_readback_band_adds_header_without_covering_slide():
-    # The proof-of-readback stamp lives in a band ABOVE the slide, never over it:
-    # width is unchanged, height grows by the band, and the slide pixels survive
-    # shifted down. (The code text itself is only in the band, i.e. the pixels.)
-    slide = Image.new("RGB", (1000, 562), (200, 200, 200))
-    out = R._add_readback_band(slide, "7F3A")
-    band = max(40, 562 // 18)
-    assert out.mode == "RGB"
-    assert out.size == (1000, 562 + band)  # header added, width untouched
-    assert out.getpixel((0, 0)) != (200, 200, 200)  # dark band sits on top
-    assert out.getpixel((500, band + 5)) == (200, 200, 200)  # slide preserved below
 
 
 def test_load_font_returns_a_font():

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -833,22 +833,9 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
   .registerTool({
     name: "pptx_inspect",
     description:
-      "Inspect and QA .pptx structure (slides, layouts, shapes, text, charts, tables, embedded media) throughout the edit loop. Overview by default, plus modes --slide, --layouts, --text, --media, --render, --qa (post-edit boxed-render + text-readback visual gate) and --compare FILE (template-fidelity [QA: PASS/FAIL] gate). Run with --help for the full per-mode flag reference; the pptx skill covers when and how to use each.",
-    usage:
-      "pptx_inspect <file> [--qa N[,N,...]] [--slide N[,N,...]] [--layouts] [--text] [--media] [--render] [--render-dir DIR] [--compare FILE] [--max-shapes N] [--offset N] (see --help)",
-    returns:
-      "A per-mode text report: deck overview, or per-slide shapes with [!] blockers / [i] advisories, or layouts / text / media listings. --qa and --render publish JPEGs and print their files__cat scoped paths; --compare ends in a [QA: PASS/FAIL] verdict. See --help for field-level detail.",
-    runtime: "system",
-    isDustTool: true,
-  })
-  // --- pptx_slides: safe slide-level structural edits ---
-  .registerTool({
-    name: "pptx_slides",
-    description:
-      "Duplicate, move, or delete .pptx slides without corrupting the package - shares image parts, deep-clones charts, rewrites relationship ids. --duplicate and --delete take a slide pattern (a single slide, a comma list, or ranges, e.g. 2,5,7-9), so do every duplicate or delete in one call rather than one slide at a time. Edit copies afterward with python-pptx",
-    usage:
-      "pptx_slides <file> (--duplicate N[,N,...] [--count K] [--after M] | --move N --to M | --delete N[,N,...])",
-    returns: "A one-line summary of the change and the deck's new slide count",
+      "Inspect and QA .pptx decks: slides, layouts, shapes, text, media",
+    usage: "pptx_inspect <file> [mode]; see --help",
+    returns: "Text report; --qa/--render publish JPEGs and print paths",
     runtime: "system",
     isDustTool: true,
   })

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -4,10 +4,10 @@ import {
   grantTypesForVerb,
   ROLE_REGISTRY,
 } from "@app/lib/resources/group_permission_registry";
+import type { GrantVerb } from "@app/types/group_permissions";
 import {
   GRANT_TYPES,
   GRANT_VERBS,
-  type GrantVerb,
   WHOLE_TYPE_RESOURCE_ID,
 } from "@app/types/group_permissions";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION


## Description

Add grid render, allowing models to render everything in one go.
Also cut down the help text

## Tests

Tested locally (top of the stack)

## Risk

Low

## Deploy Plan

Merge