### PR TITLE
Clarify Google Drive phase telemetry

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/file/content_memory_telemetry.test.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/content_memory_telemetry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  getGoogleDriveDocumentContentSizeBytes,
   getGoogleDrivePayloadSizeBytes,
   runWithGoogleDriveContentMemoryTelemetry,
   runWithGoogleDriveContentPhaseMemoryTelemetry,
@@ -158,11 +159,13 @@ describe("runWithGoogleDriveContentPhaseMemoryTelemetry", () => {
       logger,
       mimeType: "application/vnd.google-apps.document",
       phase: "download_export",
+      payloadKind: "google_response",
     });
 
     expect(result.byteLength).toBe(7);
     const tags = [
       "phase:download_export",
+      "payload_kind:google_response",
       "mime_type:application/vnd.google-apps.document",
       "payload_size_known:true",
       "outcome:success",
@@ -181,8 +184,11 @@ describe("runWithGoogleDriveContentPhaseMemoryTelemetry", () => {
       expect.objectContaining({
         mimeType: "application/vnd.google-apps.document",
         phase: "download_export",
+        payloadKind: "google_response",
         payloadSizeBytes: 7,
         outcome: "success",
+        activeOperationsAtStart: 0,
+        peakActiveOperations: 0,
         memoryAtStart,
         peakMemory: memoryAtEnd,
         memoryAtEnd,
@@ -197,6 +203,21 @@ describe("getGoogleDrivePayloadSizeBytes", () => {
     expect(getGoogleDrivePayloadSizeBytes(new ArrayBuffer(42))).toBe(42);
     expect(getGoogleDrivePayloadSizeBytes("hé")).toBe(3);
     expect(getGoogleDrivePayloadSizeBytes(123)).toBe(3);
+  });
+
+  it("measures extracted document content separately from source bytes", () => {
+    const documentContent = {
+      prefix: null,
+      content: "hé",
+      sections: [],
+    };
+
+    expect(getGoogleDriveDocumentContentSizeBytes(documentContent)).toBe(
+      Buffer.byteLength(JSON.stringify(documentContent), "utf8")
+    );
+    expect(getGoogleDriveDocumentContentSizeBytes(documentContent)).not.toBe(
+      getGoogleDrivePayloadSizeBytes(documentContent.content)
+    );
   });
 
   it("returns null when the response representation is unknown", () => {

--- a/connectors/src/connectors/google_drive/temporal/file/content_memory_telemetry.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/content_memory_telemetry.ts
@@ -1,3 +1,4 @@
+import type { CoreAPIDataSourceDocumentSection } from "@connectors/lib/data_sources";
 import { getStatsDClient } from "@connectors/types/shared/statsd";
 
 const CONTENT_MEMORY_SAMPLE_INTERVAL_MS = 1_000;
@@ -15,6 +16,10 @@ export type GoogleDriveContentPhase =
   | "download_export"
   | "extraction"
   | "dust_upsert";
+
+export type GoogleDriveContentPayloadKind =
+  | "google_response"
+  | "extracted_document";
 
 function maxMemorySnapshot(
   currentPeak: MemorySnapshot,
@@ -158,9 +163,12 @@ function emitContentPhaseMemoryTelemetry({
   logger,
   mimeType,
   phase,
+  payloadKind,
   payloadSizeBytes,
   processingDurationMs,
   outcome,
+  activeOperationsAtStart,
+  peakActiveOperations,
   memoryAtStart,
   peakMemory,
   memoryAtEnd,
@@ -168,9 +176,12 @@ function emitContentPhaseMemoryTelemetry({
   logger: ContentLogger;
   mimeType: string;
   phase: GoogleDriveContentPhase;
+  payloadKind: GoogleDriveContentPayloadKind;
   payloadSizeBytes: number | null;
   processingDurationMs: number;
   outcome: "success" | "error";
+  activeOperationsAtStart: number;
+  peakActiveOperations: number;
   memoryAtStart: MemorySnapshot;
   peakMemory: MemorySnapshot;
   memoryAtEnd: MemorySnapshot;
@@ -178,6 +189,7 @@ function emitContentPhaseMemoryTelemetry({
   const metricPrefix = `${CONTENT_METRIC_PREFIX}.phase`;
   const tags = [
     `phase:${phase}`,
+    `payload_kind:${payloadKind}`,
     `mime_type:${mimeType}`,
     `payload_size_known:${payloadSizeBytes !== null}`,
     `outcome:${outcome}`,
@@ -208,9 +220,12 @@ function emitContentPhaseMemoryTelemetry({
     {
       mimeType,
       phase,
+      payloadKind,
       payloadSizeBytes,
       processingDurationMs,
       outcome,
+      activeOperationsAtStart,
+      peakActiveOperations,
       memoryAtStart,
       peakMemory,
       memoryAtEnd,
@@ -236,25 +251,39 @@ export function getGoogleDrivePayloadSizeBytes(data: unknown): number | null {
   }
 }
 
+export function getGoogleDriveDocumentContentSizeBytes(
+  documentContent: CoreAPIDataSourceDocumentSection
+): number {
+  return Buffer.byteLength(JSON.stringify(documentContent), "utf8");
+}
+
 export async function runWithGoogleDriveContentPhaseMemoryTelemetry<T>({
   task,
   getPayloadSizeBytes,
   logger,
   mimeType,
   phase,
+  payloadKind,
 }: {
   task: () => Promise<T>;
   getPayloadSizeBytes: (result: T) => number | null;
   logger: ContentLogger;
   mimeType: string;
   phase: GoogleDriveContentPhase;
+  payloadKind: GoogleDriveContentPayloadKind;
 }): Promise<T> {
   const startedAtMs = Date.now();
+  const activeOperationsAtStart = activeContentOperations;
+  let peakActiveOperations = activeContentOperations;
   const memoryAtStart = process.memoryUsage();
   let peakMemory = memoryAtStart;
   let outcome: "success" | "error" = "success";
   let payloadSizeBytes: number | null = null;
   const memorySampleInterval = setInterval(() => {
+    peakActiveOperations = Math.max(
+      peakActiveOperations,
+      activeContentOperations
+    );
     peakMemory = maxMemorySnapshot(peakMemory, process.memoryUsage());
   }, CONTENT_MEMORY_SAMPLE_INTERVAL_MS);
 
@@ -267,15 +296,22 @@ export async function runWithGoogleDriveContentPhaseMemoryTelemetry<T>({
     throw error;
   } finally {
     clearInterval(memorySampleInterval);
+    peakActiveOperations = Math.max(
+      peakActiveOperations,
+      activeContentOperations
+    );
     const memoryAtEnd = process.memoryUsage();
     peakMemory = maxMemorySnapshot(peakMemory, memoryAtEnd);
     emitContentPhaseMemoryTelemetry({
       logger,
       mimeType,
       phase,
+      payloadKind,
       payloadSizeBytes,
       processingDurationMs: Date.now() - startedAtMs,
       outcome,
+      activeOperationsAtStart,
+      peakActiveOperations,
       memoryAtStart,
       peakMemory,
       memoryAtEnd,

--- a/connectors/src/connectors/google_drive/temporal/file/handle_file_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_file_export.ts
@@ -38,10 +38,7 @@ export async function handleFileExport(
   dataSourceConfig: DataSourceConfig,
   connectorId: ModelId,
   startSyncTs: number
-): Promise<{
-  content: CoreAPIDataSourceDocumentSection | null;
-  payloadSizeBytes: number | null;
-}> {
+): Promise<CoreAPIDataSourceDocumentSection | null> {
   const drive = await getDriveClient(oauth2client);
   let res;
   try {
@@ -49,6 +46,7 @@ export async function handleFileExport(
       logger: localLogger,
       mimeType: file.mimeType,
       phase: "download_export",
+      payloadKind: "google_response",
       getPayloadSizeBytes: (response) =>
         getGoogleDrivePayloadSizeBytes(response.data),
       task: () =>
@@ -75,7 +73,7 @@ export async function handleFileExport(
           },
           "Can't export Gdrive file. 404 error returned. Skipping."
         );
-        return { content: null, payloadSizeBytes: null };
+        return null;
       }
       if (e.response?.status === 403) {
         const skippableReasons = ["cannotDownloadAbusiveFile"];
@@ -94,7 +92,7 @@ export async function handleFileExport(
               { error: parsedBody.error },
               `Can't export Gdrive file. Skippable reason: ${firstSkippableReason} Skipping.`
             );
-            return { content: null, payloadSizeBytes: null };
+            return null;
           }
         } catch (e) {
           localLogger.error({ error: e }, "Error while parsing error response");
@@ -104,7 +102,7 @@ export async function handleFileExport(
 
     if (isFileTooLargeToDownloadError(e)) {
       localLogger.info({}, "File too big to be downloaded. Skipping");
-      return { content: null, payloadSizeBytes: null };
+      return null;
     }
     throw e;
   }
@@ -117,7 +115,7 @@ export async function handleFileExport(
 
   if (!(res.data instanceof ArrayBuffer)) {
     localLogger.error({}, "res.data is not an ArrayBuffer");
-    return { content: null, payloadSizeBytes: null };
+    return null;
   }
   const payload = res.data;
   const payloadSizeBytes = payload.byteLength;
@@ -125,6 +123,7 @@ export async function handleFileExport(
     logger: localLogger,
     mimeType: file.mimeType,
     phase: "extraction",
+    payloadKind: "google_response",
     getPayloadSizeBytes: () => payloadSizeBytes,
     task: async () => {
       if (file.mimeType === "text/plain") {
@@ -178,8 +177,8 @@ export async function handleFileExport(
   });
   if (result.isErr()) {
     localLogger.error({ error: result.error }, "Could not handle file.");
-    return { content: null, payloadSizeBytes };
+    return null;
   }
 
-  return { content: result.value, payloadSizeBytes };
+  return result.value;
 }

--- a/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/handle_google_drive_export.ts
@@ -17,7 +17,6 @@ import { GaxiosError } from "googleapis-common";
 
 export type GoogleDriveExportResult = {
   content: CoreAPIDataSourceDocumentSection | null;
-  payloadSizeBytes: number | null;
   skipReason?: string;
 };
 
@@ -40,6 +39,7 @@ export async function handleGoogleDriveExport(
         logger: localLogger,
         mimeType: file.mimeType,
         phase: "download_export",
+        payloadKind: "google_response",
         getPayloadSizeBytes: (response) =>
           getGoogleDrivePayloadSizeBytes(response.data),
         task: () =>
@@ -68,6 +68,7 @@ export async function handleGoogleDriveExport(
         logger: localLogger,
         mimeType: file.mimeType,
         phase: "extraction",
+        payloadKind: "google_response",
         getPayloadSizeBytes: () => payloadSizeBytes,
         task: async () => {
           if (typeof res.data === "string") {
@@ -80,7 +81,6 @@ export async function handleGoogleDriveExport(
                       sections: [],
                     }
                   : null,
-              payloadSizeBytes,
             };
           } else if (
             ["object", "number", "boolean", "bigint"].includes(typeof res.data)
@@ -98,7 +98,6 @@ export async function handleGoogleDriveExport(
                       sections: [],
                     }
                   : null,
-              payloadSizeBytes,
             };
           } else {
             localLogger.error(
@@ -108,7 +107,7 @@ export async function handleGoogleDriveExport(
               },
               "Unexpected GDrive export response type"
             );
-            return { content: null, payloadSizeBytes };
+            return { content: null };
           }
         },
       });
@@ -121,7 +120,7 @@ export async function handleGoogleDriveExport(
             },
             "Can't export Gdrive document. 404 error returned, even though we know the file exists. Skipping."
           );
-          return { content: null, payloadSizeBytes: null };
+          return { content: null };
         }
 
         if (e.response?.status === 403) {
@@ -142,7 +141,7 @@ export async function handleGoogleDriveExport(
               { error: parsedBody.error },
               `Can't export Gdrive document. Skippable reason: ${firstSkippableReason}. Skipping.`
             );
-            return { content: null, payloadSizeBytes: null };
+            return { content: null };
           }
         }
 
@@ -155,7 +154,7 @@ export async function handleGoogleDriveExport(
             { error: e.message },
             "File is too large to be exported. Skipping."
           );
-          return { content: null, payloadSizeBytes: null };
+          return { content: null };
         }
 
         // If Google consistently returns 500 Internal Server Error after many
@@ -173,7 +172,6 @@ export async function handleGoogleDriveExport(
               );
               return {
                 content: null,
-                payloadSizeBytes: null,
                 skipReason: "google_internal_server_error",
               };
             }
@@ -186,7 +184,7 @@ export async function handleGoogleDriveExport(
 
       if (isFileTooLargeToDownloadError(e)) {
         localLogger.info("Google document too large to be exported, skipping.");
-        return { content: null, payloadSizeBytes: null };
+        return { content: null };
       }
 
       localLogger.error({ error: e }, "Error exporting Google document");

--- a/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
+++ b/connectors/src/connectors/google_drive/temporal/file/sync_one_file_text_document.ts
@@ -1,4 +1,7 @@
-import { runWithGoogleDriveContentPhaseMemoryTelemetry } from "@connectors/connectors/google_drive/temporal/file/content_memory_telemetry";
+import {
+  getGoogleDriveDocumentContentSizeBytes,
+  runWithGoogleDriveContentPhaseMemoryTelemetry,
+} from "@connectors/connectors/google_drive/temporal/file/content_memory_telemetry";
 import { handleFileExport } from "@connectors/connectors/google_drive/temporal/file/handle_file_export";
 import { handleGoogleDriveExport } from "@connectors/connectors/google_drive/temporal/file/handle_google_drive_export";
 import { updateGoogleDriveFiles } from "@connectors/connectors/google_drive/temporal/file/update_google_drive_files";
@@ -32,7 +35,6 @@ export async function syncOneFileTextDocument(
   maxDocumentLen: number
 ) {
   let documentContent: CoreAPIDataSourceDocumentSection | null = null;
-  let payloadSizeBytes: number | null = null;
   let skipReason: string | undefined;
 
   const mimeTypesToDownload = getMimeTypesToDownload({
@@ -45,7 +47,6 @@ export async function syncOneFileTextDocument(
   if (MIME_TYPES_TO_EXPORT[file.mimeType]) {
     const res = await handleGoogleDriveExport(oauth2client, file, localLogger);
     documentContent = res.content;
-    payloadSizeBytes = res.payloadSizeBytes;
     if (res.skipReason) {
       localLogger.info(
         {},
@@ -55,7 +56,7 @@ export async function syncOneFileTextDocument(
     }
   } else if (mimeTypesToDownload.includes(file.mimeType)) {
     try {
-      const res = await handleFileExport(
+      documentContent = await handleFileExport(
         oauth2client,
         documentId,
         file,
@@ -65,8 +66,6 @@ export async function syncOneFileTextDocument(
         connectorId,
         startSyncTs
       );
-      documentContent = res.content;
-      payloadSizeBytes = res.payloadSizeBytes;
     } catch (e) {
       if (e instanceof WithRetriesError) {
         localLogger.warn(
@@ -79,13 +78,16 @@ export async function syncOneFileTextDocument(
   }
 
   if (documentContent) {
+    const upsertPayloadSizeBytes =
+      getGoogleDriveDocumentContentSizeBytes(documentContent);
     let upsertTimestampMs: number | undefined;
     try {
       upsertTimestampMs = await runWithGoogleDriveContentPhaseMemoryTelemetry({
         logger: localLogger,
         mimeType: file.mimeType,
         phase: "dust_upsert",
-        getPayloadSizeBytes: () => payloadSizeBytes,
+        payloadKind: "extracted_document",
+        getPayloadSizeBytes: () => upsertPayloadSizeBytes,
         task: () =>
           upsertGdriveDocument(
             dataSourceConfig,


### PR DESCRIPTION
## Description

Follow-up to #30536. Add phase-level active-operation counts so process memory samples can be interpreted under concurrent file processing. Download/export and extraction report Google response bytes; Dust upsert reports the UTF-8 serialized size of the extracted document it receives.

## Tests

Added focused coverage for phase overlap fields and the distinction between Google response bytes and extracted document bytes.

## Risk

Low. This only clarifies telemetry. The instrumentation can add up to 3 info logs and 54 StatsD distributions per successfully upserted text document. The collection window is limited to 24 to 48 hours, and the guardrail follow-up should remove or narrow it. Roll back this PR and #30536 if volume is higher than expected.

## Deploy Plan

Standard deploy. Verify payload kinds, overlap counts, logs, and metrics in both regions during the 24 to 48 hour collection window.