### PR TITLE
[front] enh: add pptx package validation to --compare and --validate

### DIFF
--- a/front/lib/api/sandbox/image/profile/soffice/ooxml.py
+++ b/front/lib/api/sandbox/image/profile/soffice/ooxml.py
@@ -36,7 +36,9 @@ def resolve_rel_target(rels_path: str, target: str) -> str:
     into an absolute path within the zip."""
     if target.startswith("/"):
         return target.lstrip("/")
-    base = rels_path.rsplit("/_rels/", 1)[0]
+    # The package's own `_rels/.rels` has no parent directory, so splitting on
+    # "/_rels/" would leave the rels path itself as the base.
+    base = rels_path.rsplit("/_rels/", 1)[0] if "/_rels/" in rels_path else ""
     parts = (base.split("/") if base else []) + target.split("/")
     resolved = []
     for p in parts:

--- a/front/lib/api/sandbox/image/profile/soffice/pptx_inspect.py
+++ b/front/lib/api/sandbox/image/profile/soffice/pptx_inspect.py
@@ -52,6 +52,7 @@ from pptx_typography import (
 from pptx_render_boxes import _annotate_boxes
 
 import pptx_grid
+import pptx_validate
 
 from pptx_audit import (
     BARE_MARGIN,
@@ -87,8 +88,8 @@ DEFAULT_MAX_SHAPES = 200
 
 USAGE = (
     "pptx_inspect <file> [--qa N | --slide N | --layouts | --text | --media | "
-    "--render] [--grid [--grid-cols N]] [--compare FILE] [--render-dir DIR] "
-    "[--max-shapes N] [--offset N]"
+    "--render | --validate] [--grid [--grid-cols N]] [--compare FILE] "
+    "[--render-dir DIR] [--max-shapes N] [--offset N]"
 )
 
 HELP_TEXT = (
@@ -97,6 +98,7 @@ HELP_TEXT = (
     "--slide N: shapes, box, ph, type, fit, [!] OVERSET/HIDDEN\n"
     "--layouts: placeholders + type; static = master text\n"
     "--compare F: vs template F, ends [QA: PASS/FAIL]\n"
+    "--validate: package integrity, does it open at all\n"
     "--grid: one image per grid; --grid-cols N: 2, max 4\n"
     "--text --media --render --render-dir --max-shapes --offset"
 )
@@ -1026,6 +1028,17 @@ def print_compare(file_path: str, source_path: str) -> str:
                 f"kept {kept}, dropped {dropped} exemplar shape(s)"
             )
 
+    # Package integrity, baselined against the template so its own faults are
+    # not reported as yours. Fidelity says nothing about whether the file opens.
+    invalid, inherited = pptx_validate.check_against(file_path, source_path)
+    if invalid or inherited:
+        lines.append("")
+        lines.append("Package:")
+        lines.extend(f"  [!] {problem}" for problem in invalid)
+        if inherited:
+            lines.append(f"  [i] {inherited} problem(s) already in the template")
+        blockers += len(invalid)
+
     lines.append("")
     if blockers:
         lines.append(
@@ -1541,6 +1554,7 @@ def main() -> int:
         default="/files/conversation",
     )
     parser.add_argument("--compare")
+    parser.add_argument("--validate", action="store_true")
     parser.add_argument("--max-shapes", type=int, default=DEFAULT_MAX_SHAPES)
     parser.add_argument("--offset", type=int, default=0)
     parser.add_argument("--help", "-h", action="store_true", dest="help_flag")
@@ -1580,7 +1594,9 @@ def main() -> int:
         f"{format_size(os.path.getsize(args.file))}]"
     )
 
-    if args.media:
+    if args.validate:
+        body = pptx_validate.report(args.file, args.compare)
+    elif args.media:
         body = print_media(args.file)
     elif args.compare is not None:
         body = print_compare(args.file, args.compare)

--- a/front/lib/api/sandbox/image/profile/soffice/pptx_validate.py
+++ b/front/lib/api/sandbox/image/profile/soffice/pptx_validate.py
@@ -1,0 +1,200 @@
+"""Package-integrity checks: will PowerPoint open this file at all?
+
+`--compare` measures design fidelity and says nothing about validity, so a deck
+PowerPoint refuses to open can pass QA clean. These are the OPC-level faults an
+edit script actually produces: a stranded part, a relationship pointing nowhere,
+an r:id with no relationship, a duplicate zip entry, a reused shape id.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from typing import Dict, List, Optional, Set, Tuple
+from xml.etree import ElementTree as ET
+
+import ooxml
+
+P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
+CT_NS = "http://schemas.openxmlformats.org/package/2006/content-types"
+R_ID_ATTRS = {
+    f"{{{ooxml.NS['r']}}}{name}"
+    for name in ("id", "embed", "link", "pict", "dm", "lo", "qs", "cs")
+}
+
+
+def _parse(zf: zipfile.ZipFile, path: str):
+    """Parse a part, returning None when it is missing or malformed."""
+    try:
+        return ET.fromstring(zf.read(path))
+    except (KeyError, ET.ParseError):
+        return None
+
+
+def _xml_parts(names: List[str]) -> List[str]:
+    return [n for n in names if n.endswith(".xml") or n.endswith(".rels")]
+
+
+def _duplicate_entries(zf: zipfile.ZipFile) -> List[str]:
+    seen: Set[str] = set()
+    dupes: Set[str] = set()
+    for info in zf.infolist():
+        if info.filename in seen:
+            dupes.add(info.filename)
+        seen.add(info.filename)
+    return sorted(dupes)
+
+
+def _content_type_gaps(zf: zipfile.ZipFile, names: List[str]) -> List[str]:
+    """Parts with no Default extension and no Override in [Content_Types].xml.
+    PowerPoint refuses a package whose parts are not typed."""
+    root = _parse(zf, "[Content_Types].xml")
+    if root is None:
+        return ["[Content_Types].xml is missing"]
+    defaults = {
+        (el.attrib.get("Extension") or "").lower()
+        for el in root.findall(f"{{{CT_NS}}}Default")
+    }
+    overrides = {
+        (el.attrib.get("PartName") or "").lstrip("/")
+        for el in root.findall(f"{{{CT_NS}}}Override")
+    }
+    gaps = []
+    for name in names:
+        if name.endswith("/") or name == "[Content_Types].xml":
+            continue
+        ext = name.rsplit(".", 1)[-1].lower() if "." in name else ""
+        if ext in defaults or name in overrides:
+            continue
+        gaps.append(f"no content type for {name}")
+    return gaps
+
+
+def _rel_problems(zf: zipfile.ZipFile, names: Set[str]) -> List[str]:
+    """Relationships whose internal target is not in the package, and r:id
+    references in a part with no matching relationship."""
+    problems: List[str] = []
+    for rels_path in [n for n in names if n.endswith(".rels")]:
+        root = _parse(zf, rels_path)
+        if root is None:
+            problems.append(f"{rels_path} is not readable")
+            continue
+        rels: Dict[str, str] = {}
+        for rel in root.findall("pr:Relationship", ooxml.NS):
+            rid = rel.attrib.get("Id", "")
+            rels[rid] = rel.attrib.get("Target", "")
+            if rel.attrib.get("TargetMode") == "External":
+                continue
+            target = ooxml.resolve_rel_target(rels_path, rel.attrib.get("Target", ""))
+            if target not in names:
+                problems.append(f"{rels_path}: {rid} points at missing {target}")
+
+        source = rels_path.replace("/_rels/", "/", 1)[: -len(".rels")]
+        if source.startswith("_rels/"):
+            source = source[len("_rels/"):]
+        if source not in names:
+            continue
+        root = _parse(zf, source)
+        if root is None:
+            continue  # malformed parts are already reported on their own
+        for el in root.iter():
+            for attr, value in el.attrib.items():
+                if attr in R_ID_ATTRS and value not in rels:
+                    problems.append(f"{source}: {value} has no relationship")
+    return problems
+
+
+def _slide_problems(zf: zipfile.ZipFile, names: Set[str]) -> List[str]:
+    """Slide parts missing from the slide order, and slide-order entries whose
+    relationship is gone. Both come from hand-editing sldIdLst."""
+    pres = _parse(zf, "ppt/presentation.xml")
+    if pres is None:
+        return ["ppt/presentation.xml is missing"]
+    rels = ooxml.parse_rels(zf, ooxml.rels_path_for("ppt/presentation.xml"))
+    listed: Set[str] = set()
+    problems: List[str] = []
+    for sld_id in pres.iter(f"{{{P_NS}}}sldId"):
+        rid = sld_id.attrib.get(ooxml.R_ID_ATTR, "")
+        target = rels.get(rid)
+        if target is None:
+            problems.append(f"slide order entry {rid} has no relationship")
+        else:
+            listed.add(target)
+    for name in sorted(names):
+        if name.startswith("ppt/slides/slide") and name.endswith(".xml"):
+            if name not in listed:
+                problems.append(f"{name} is in the package but not in the deck")
+    return problems
+
+
+def _duplicate_shape_ids(zf: zipfile.ZipFile, names: Set[str]) -> List[str]:
+    """Two shapes sharing a cNvPr id on one slide; PowerPoint repairs the file."""
+    problems: List[str] = []
+    for name in sorted(names):
+        if not (name.startswith("ppt/slides/slide") and name.endswith(".xml")):
+            continue
+        root = _parse(zf, name)
+        if root is None:
+            continue
+        seen: Set[str] = set()
+        for el in root.iter():
+            if not el.tag.endswith("}cNvPr"):
+                continue
+            shape_id = el.attrib.get("id", "")
+            if shape_id in seen:
+                problems.append(f"{name}: duplicate shape id {shape_id}")
+            seen.add(shape_id)
+    return problems
+
+
+def _malformed_parts(zf: zipfile.ZipFile, names: List[str]) -> List[str]:
+    problems = []
+    for name in _xml_parts(names):
+        try:
+            ET.fromstring(zf.read(name))
+        except (ET.ParseError, KeyError) as exc:
+            problems.append(f"{name} is not well-formed XML: {exc}")
+    return problems
+
+
+def check(path: str) -> List[str]:
+    """Every integrity problem found in the package, one per line."""
+    try:
+        zf = zipfile.ZipFile(path)
+    except (zipfile.BadZipFile, OSError) as exc:
+        return [f"not a readable .pptx package: {exc}"]
+    with zf:
+        names = zf.namelist()
+        name_set = set(names)
+        return (
+            [f"duplicate zip entry {n}" for n in _duplicate_entries(zf)]
+            + _malformed_parts(zf, names)
+            + _content_type_gaps(zf, names)
+            + _rel_problems(zf, name_set)
+            + _slide_problems(zf, name_set)
+            + _duplicate_shape_ids(zf, name_set)
+        )
+
+
+def check_against(path: str, original: Optional[str]) -> Tuple[List[str], int]:
+    """Problems in `path`, minus those the template already had.
+
+    Returns `(problems, inherited_count)`. A template can ship its own faults;
+    reporting them as yours buries the regression you actually caused.
+    """
+    problems = check(path)
+    if not original:
+        return problems, 0
+    inherited = set(check(original))
+    kept = [p for p in problems if p not in inherited]
+    return kept, len(problems) - len(kept)
+
+
+def report(path: str, original: Optional[str] = None) -> str:
+    problems, inherited = check_against(path, original)
+    lines = [f"[!] {p}" for p in problems]
+    if inherited:
+        lines.append(f"[i] {inherited} problem(s) inherited from the template")
+    lines.append(
+        "[VALID]" if not problems else f"[INVALID - {len(problems)} problem(s)]"
+    )
+    return "\n".join(lines)

--- a/front/lib/api/sandbox/image/profile/soffice/tests/test_validate.py
+++ b/front/lib/api/sandbox/image/profile/soffice/tests/test_validate.py
@@ -1,0 +1,155 @@
+"""Tier-2 tests for pptx_validate: each check fires on a deck broken the way an
+edit script breaks it, and a clean deck stays clean. Run directly
+(`python test_validate.py`) or under pytest.
+
+Lives in soffice/tests/, a subdir getLocalDirContent skips: it copies only the
+regular files directly in soffice/ (never recursing), so tests never ship in the image. It adds soffice/ to sys.path to import the module.
+"""
+import shutil
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pptx import Presentation  # noqa: E402
+
+import pptx_validate as V  # noqa: E402
+
+
+def _deck(path: Path, slides: int = 3) -> None:
+    prs = Presentation()
+    for _ in range(slides):
+        prs.slides.add_slide(prs.slide_layouts[6])
+    prs.save(path)
+
+
+def _rewrite(src: Path, dest: Path, mutate) -> None:
+    """Copy the package, letting `mutate(name, data)` drop or edit each part."""
+    with zipfile.ZipFile(src) as zin, zipfile.ZipFile(
+        dest, "w", zipfile.ZIP_DEFLATED
+    ) as zout:
+        for info in zin.infolist():
+            out = mutate(info.filename, zin.read(info.filename))
+            if out is not None:
+                zout.writestr(info, out)
+
+
+def test_clean_deck_is_valid():
+    with tempfile.TemporaryDirectory() as d:
+        deck = Path(d) / "deck.pptx"
+        _deck(deck)
+        assert V.check(str(deck)) == []
+        assert "[VALID]" in V.report(str(deck))
+
+
+def test_orphan_slide_part_is_reported():
+    with tempfile.TemporaryDirectory() as d:
+        deck, broken = Path(d) / "deck.pptx", Path(d) / "broken.pptx"
+        _deck(deck)
+        # Drop slide 2 from the slide order only, the way a hand-edited
+        # sldIdLst does: the part stays behind as an orphan.
+        def mutate(name, data):
+            if name != "ppt/presentation.xml":
+                return data
+            xml = data.decode()
+            start = xml.index("<p:sldId ")
+            end = xml.index("/>", start) + 2
+            return (xml[:start] + xml[end:]).encode()
+
+        _rewrite(deck, broken, mutate)
+        problems = V.check(str(broken))
+        assert any("not in the deck" in p for p in problems), problems
+        assert "[INVALID" in V.report(str(broken))
+
+
+def test_missing_relationship_target_is_reported():
+    with tempfile.TemporaryDirectory() as d:
+        deck, broken = Path(d) / "deck.pptx", Path(d) / "broken.pptx"
+        _deck(deck)
+        _rewrite(
+            deck, broken,
+            lambda name, data: None if name == "ppt/slides/slide2.xml" else data,
+        )
+        assert any("points at missing" in p for p in V.check(str(broken)))
+
+
+def test_dangling_rid_in_a_part_is_reported():
+    with tempfile.TemporaryDirectory() as d:
+        deck, broken = Path(d) / "deck.pptx", Path(d) / "broken.pptx"
+        _deck(deck)
+
+        def mutate(name, data):
+            if name != "ppt/_rels/presentation.xml.rels":
+                return data
+            xml = data.decode()
+            start = xml.index("<Relationship ")
+            end = xml.index("/>", start) + 2
+            return (xml[:start] + xml[end:]).encode()
+
+        _rewrite(deck, broken, mutate)
+        assert any("has no relationship" in p for p in V.check(str(broken)))
+
+
+def test_malformed_part_is_reported():
+    with tempfile.TemporaryDirectory() as d:
+        deck, broken = Path(d) / "deck.pptx", Path(d) / "broken.pptx"
+        _deck(deck)
+        _rewrite(
+            deck, broken,
+            lambda name, data: b"<p:sld><unclosed>"
+            if name == "ppt/slides/slide1.xml" else data,
+        )
+        assert any("not well-formed" in p for p in V.check(str(broken)))
+
+
+def test_duplicate_shape_id_is_reported():
+    with tempfile.TemporaryDirectory() as d:
+        deck = Path(d) / "deck.pptx"
+        _deck(deck, slides=1)
+        prs = Presentation(deck)
+        slide = prs.slides[0]
+        from pptx.util import Inches
+        a = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(2), Inches(1))
+        b = slide.shapes.add_textbox(Inches(1), Inches(3), Inches(2), Inches(1))
+        for el in b._element.iter():
+            if el.tag.endswith("}cNvPr"):
+                el.set("id", a._element.find(
+                    ".//{http://schemas.openxmlformats.org/presentationml/"
+                    "2006/main}cNvPr").get("id"))
+                break
+        prs.save(deck)
+        assert any("duplicate shape id" in p for p in V.check(str(deck)))
+
+
+def test_template_problems_are_not_reported_as_yours():
+    with tempfile.TemporaryDirectory() as d:
+        template, out = Path(d) / "t.pptx", Path(d) / "out.pptx"
+        _deck(template)
+        broken = Path(d) / "broken.pptx"
+        _rewrite(
+            template, broken,
+            lambda name, data: b"<p:sld><unclosed>"
+            if name == "ppt/slides/slide1.xml" else data,
+        )
+        shutil.copyfile(broken, out)
+        problems, inherited = V.check_against(str(out), str(broken))
+        assert problems == []
+        assert inherited > 0
+
+
+def test_unreadable_file_is_reported():
+    with tempfile.TemporaryDirectory() as d:
+        junk = Path(d) / "junk.pptx"
+        junk.write_bytes(b"not a zip")
+        assert V.check(str(junk)) == ["not a readable .pptx package: File is not a zip file"]
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items())
+             if k.startswith("test_") and callable(v)]
+    for fn in tests:
+        fn()
+        print(f"ok   {fn.__name__}")
+    print(f"\n{len(tests)} validate tests passed")

--- a/front/lib/resources/skill/code_defined/global/pptx.ts
+++ b/front/lib/resources/skill/code_defined/global/pptx.ts
@@ -111,7 +111,7 @@ The renderer only has metric-compatible stand-ins for Calibri, Cambria, Arial, T
 
 \`pptx_inspect out.pptx --compare /files/conversation/template.pptx\`
 
-Clear every \`[!]\`: orphans (redo the deletes with \`pptx_slides\`), fonts dropped or imagery stripped (you rebuilt instead of editing: start again from the copy), layout collapse, density. Deliver on \`[QA: PASS]\`, every slide read back clean.
+Design fidelity + package integrity in one pass. Clear every \`[!]\`: fonts dropped or imagery stripped (you rebuilt instead of editing: start again from the copy), layout collapse, density, and under \`Package:\` anything that stops PowerPoint opening the file (stranded part, relationship pointing nowhere, duplicate shape id). Package faults mean you edited the zip by hand: redo those edits through \`pptx_slides\` and python-pptx. No template: \`--validate\` runs the package half alone. Deliver on \`[QA: PASS]\`, every slide read back clean.
 
 ## Defaults
 


### PR DESCRIPTION
## Description

--compare measures design fidelity and says nothing about whether the file opens, so a deck
PowerPoint refuses to open can pass QA clean. --validate walks the package for the faults an edit
script actually produces: a stranded part, a relationship pointing nowhere, an r:id with no
relationship, a duplicate zip entry, a reused shape id, an untyped part, malformed XML.

We were generating pptx that could not be opened according to some customer reports


## Tests

Added test_validate.py. Tested locally against decks I broke on purpose.

## Risk

Low. 
Blast radius: --compare grows a Package section and can now FAIL a deck that used to pass,
which is the point.

## Deploy Plan

Merge
