### PR TITLE
[front] fix: resolve tool dimension labels in one query

### DIFF
--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -1,3 +1,4 @@
+import { getInternalMCPServerIconByName } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   resolveDimensionDisplayNames,
   resolveDimensionLabels,
@@ -5,7 +6,6 @@ import {
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -157,38 +157,27 @@ describe("resolveDimensionLabels", () => {
     });
   });
 
-  it("labels remote tools by server and view name", async () => {
+  it("labels internal tools by name and remote tools by id", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
     const server = await RemoteMCPServerFactory.create(workspace, {
       name: "Customer records",
     });
-    const view = await MCPServerViewResource.getMCPServerViewForSystemSpace(
-      authenticator,
-      server.sId
-    );
-    if (!view) {
-      throw new Error("Expected the remote server system view to exist.");
-    }
-    await view.updateNameAndDescription(
-      authenticator,
-      "customer_records_admin"
-    );
 
     const labels = await resolveDimensionLabels(authenticator, "tool", [
-      server.cachedName,
-      "customer_records_admin",
+      "image_generation",
+      server.sId,
     ]);
 
-    expect(labels.get(server.cachedName)).toEqual({
-      name: "Customer records",
+    expect(labels.get("image_generation")).toEqual({
+      name: "Create Images",
       pictureUrl: null,
       description: null,
-      icon: server.icon,
+      icon: getInternalMCPServerIconByName("image_generation"),
     });
-    expect(labels.get("customer_records_admin")).toEqual({
-      name: "Customer Records Admin",
+    expect(labels.get(server.sId)).toEqual({
+      name: "Customer records",
       pictureUrl: null,
       description: null,
       icon: server.icon,

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -5,9 +5,11 @@ import {
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
@@ -152,6 +154,51 @@ describe("resolveDimensionLabels", () => {
       name: "Engineering",
       pictureUrl: null,
       description: null,
+    });
+  });
+
+  it("labels remote tools by server id, server name, and view name", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Customer records",
+    });
+    const view = await MCPServerViewResource.getMCPServerViewForSystemSpace(
+      authenticator,
+      server.sId
+    );
+    if (!view) {
+      throw new Error("Expected the remote server system view to exist.");
+    }
+    await view.updateNameAndDescription(
+      authenticator,
+      "customer_records_admin"
+    );
+
+    const labels = await resolveDimensionLabels(authenticator, "tool", [
+      server.sId,
+      server.cachedName,
+      "customer_records_admin",
+    ]);
+
+    expect(labels.get(server.sId)).toEqual({
+      name: "Customer records",
+      pictureUrl: null,
+      description: null,
+      icon: server.icon,
+    });
+    expect(labels.get(server.cachedName)).toEqual({
+      name: "Customer records",
+      pictureUrl: null,
+      description: null,
+      icon: server.icon,
+    });
+    expect(labels.get("customer_records_admin")).toEqual({
+      name: "Customer Records Admin",
+      pictureUrl: null,
+      description: null,
+      icon: server.icon,
     });
   });
 });

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -157,7 +157,7 @@ describe("resolveDimensionLabels", () => {
     });
   });
 
-  it("labels remote tools by server id, server name, and view name", async () => {
+  it("labels remote tools by server and view name", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
@@ -177,17 +177,10 @@ describe("resolveDimensionLabels", () => {
     );
 
     const labels = await resolveDimensionLabels(authenticator, "tool", [
-      server.sId,
       server.cachedName,
       "customer_records_admin",
     ]);
 
-    expect(labels.get(server.sId)).toEqual({
-      name: "Customer records",
-      pictureUrl: null,
-      description: null,
-      icon: server.icon,
-    });
     expect(labels.get(server.cachedName)).toEqual({
       name: "Customer records",
       pictureUrl: null,

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -21,7 +21,7 @@ import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
  * - "user": user sIds
  * - "group": group sIds
  * - "model": raw model ids
- * - "tool": MCP server names
+ * - "tool": internal MCP server names or remote MCP server sIds
  * - "skill": skill sIds
  * - "source": origin slugs
  */
@@ -118,8 +118,10 @@ export async function resolveDimensionLabels(
       );
 
     case "tool": {
-      const metadata =
-        await MCPServerViewResource.resolveDisplayMetadataByNames(auth, keys);
+      const metadata = await MCPServerViewResource.resolveDisplayMetadata(
+        auth,
+        keys
+      );
       return new Map(
         keys.map((key) => {
           const tool = metadata.get(key);

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -118,11 +118,10 @@ export async function resolveDimensionLabels(
       );
 
     case "tool": {
-      const metadata =
-        await MCPServerViewResource.resolveDisplayMetadataByIdentifiers(
-          auth,
-          keys
-        );
+      const metadata = await MCPServerViewResource.resolveDisplayMetadataByIds(
+        auth,
+        keys
+      );
       return new Map(
         keys.map((key) => {
           const tool = metadata.get(key);

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -118,10 +118,8 @@ export async function resolveDimensionLabels(
       );
 
     case "tool": {
-      const metadata = await MCPServerViewResource.resolveDisplayMetadataByIds(
-        auth,
-        keys
-      );
+      const metadata =
+        await MCPServerViewResource.resolveDisplayMetadataByNames(auth, keys);
       return new Map(
         keys.map((key) => {
           const tool = metadata.get(key);

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -118,6 +118,7 @@ export async function resolveDimensionLabels(
       );
 
     case "tool": {
+      // Internal servers are keyed by name, while remote servers are keyed by sId.
       const metadata = await MCPServerViewResource.resolveDisplayMetadata(
         auth,
         keys

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -1,7 +1,3 @@
-import {
-  getInternalMCPServerIconByName,
-  isInternalMCPServerName,
-} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
 import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
 import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
@@ -10,7 +6,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
@@ -123,23 +118,21 @@ export async function resolveDimensionLabels(
       );
 
     case "tool": {
-      const [remoteMetadata, viewIcons] = await Promise.all([
-        RemoteMCPServerResource.resolveDisplayMetadataByIdentifiers(auth, keys),
-        MCPServerViewResource.resolveIconsByNames(auth, keys),
-      ]);
+      const metadata =
+        await MCPServerViewResource.resolveDisplayMetadataByIdentifiers(
+          auth,
+          keys
+        );
       return new Map(
         keys.map((key) => {
-          const remote = remoteMetadata.get(key);
-          const icon = isInternalMCPServerName(key)
-            ? getInternalMCPServerIconByName(key)
-            : (viewIcons.get(key) ?? remote?.icon ?? null);
+          const tool = metadata.get(key);
           return [
             key,
             {
-              name: remote?.name ?? asDisplayToolName(key),
+              name: tool?.name ?? asDisplayToolName(key),
               pictureUrl: null,
               description: null,
-              icon,
+              icon: tool?.icon ?? null,
             },
           ];
         })

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -21,7 +21,7 @@ import { Ok } from "@app/types/shared/result";
  */
 
 export type ConsumptionTopToolRow = {
-  // The MCP server name, which is also what the `tool` filter takes.
+  // The internal MCP server name or remote MCP server sId used by the `tool` filter.
   serverName: string;
   name: string;
   icon: string | null;

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -231,14 +231,17 @@ export async function resolveServerDisplayNames(
   serverNames: string[]
 ): Promise<Map<string, string>> {
   const unique = [...new Set(serverNames)];
-  const remoteNameMap = await RemoteMCPServerResource.resolveNamesBySIds(
+  const remoteServerMap = await RemoteMCPServerResource.fetchBySIdsAsMap(
     auth,
     unique
   );
 
   const displayMap = new Map<string, string>();
   for (const name of unique) {
-    displayMap.set(name, remoteNameMap.get(name) ?? asDisplayToolName(name));
+    displayMap.set(
+      name,
+      remoteServerMap.get(name)?.cachedName ?? asDisplayToolName(name)
+    );
   }
   return displayMap;
 }

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -231,9 +231,9 @@ export async function resolveServerDisplayNames(
   serverNames: string[]
 ): Promise<Map<string, string>> {
   const unique = [...new Set(serverNames)];
-  const remoteServerMap = await RemoteMCPServerResource.fetchBySIdsAsMap(
-    auth,
-    unique
+  const remoteServers = await RemoteMCPServerResource.fetchByIds(auth, unique);
+  const remoteServerMap = new Map(
+    remoteServers.map((server) => [server.sId, server])
   );
 
   const displayMap = new Map<string, string>();

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -729,9 +729,12 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       return metadata;
     }
 
-    const remoteServerMap = await RemoteMCPServerResource.fetchBySIdsAsMap(
+    const remoteServers = await RemoteMCPServerResource.fetchByIds(
       auth,
       remoteIds
+    );
+    const remoteServerMap = new Map(
+      remoteServers.map((server) => [server.sId, server])
     );
     for (const [id, server] of remoteServerMap) {
       metadata.set(id, {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -102,11 +102,6 @@ type MCPServerViewCreationResult = {
   affectedAgents?: AffectedAgent[];
 };
 
-type MCPServerDisplayMetadata = {
-  name: string;
-  icon: CustomResourceIconType | InternalAllowedIconType;
-};
-
 export type GetMCPServerViewsResponseBody = {
   success: boolean;
   serverViews: MCPServerViewType[];
@@ -710,12 +705,15 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
-  static async resolveDisplayMetadataByIds(
-    auth: Authenticator,
-    ids: string[]
-  ): Promise<Map<string, MCPServerDisplayMetadata>> {
+  static async resolveDisplayMetadataByIds(auth: Authenticator, ids: string[]) {
     const uniqueIds = [...new Set(ids)];
-    const metadata = new Map<string, MCPServerDisplayMetadata>();
+    const metadata = new Map<
+      string,
+      {
+        name: string;
+        icon: CustomResourceIconType | InternalAllowedIconType;
+      }
+    >();
 
     for (const id of uniqueIds) {
       if (isInternalMCPServerName(id)) {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -18,9 +18,11 @@ import {
   AVAILABLE_INTERNAL_MCP_SERVER_NAMES,
   getAvailabilityOfInternalMCPServerById,
   getAvailabilityOfInternalMCPServerByName,
+  getInternalMCPServerIconByName,
   getInternalMCPServerNameAndWorkspaceId,
   INTERNAL_MCP_SERVERS,
   isAutoInternalMCPServerName,
+  isInternalMCPServerName,
   isValidInternalMCPServerId,
   matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -38,6 +40,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
+import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
@@ -52,7 +55,11 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import {
+  getResourceIdFromSId,
+  isResourceSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
 import type {
   InferIncludeType,
   ResourceFindOptions,
@@ -69,6 +76,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
+import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
 import {
   formatUserFullName,
   isWorkspaceAnalyticsEnabled,
@@ -76,7 +84,7 @@ import {
 import assert from "assert";
 import uniq from "lodash/uniq";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
-import { Op } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 import { z } from "zod";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -92,6 +100,11 @@ type AffectedAgent = Pick<
 type MCPServerViewCreationResult = {
   view: MCPServerViewResource;
   affectedAgents?: AffectedAgent[];
+};
+
+type MCPServerDisplayMetadata = {
+  name: string;
+  icon: CustomResourceIconType | InternalAllowedIconType;
 };
 
 export type GetMCPServerViewsResponseBody = {
@@ -697,25 +710,99 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
-  static async resolveIconsByNames(
+  static async resolveDisplayMetadataByIdentifiers(
     auth: Authenticator,
-    names: string[]
-  ): Promise<Map<string, CustomResourceIconType | InternalAllowedIconType>> {
-    const uniqueNames = [...new Set(names)];
-    if (uniqueNames.length === 0) {
-      return new Map();
+    identifiers: string[]
+  ): Promise<Map<string, MCPServerDisplayMetadata>> {
+    const uniqueIdentifiers = [...new Set(identifiers)];
+    const metadata = new Map<string, MCPServerDisplayMetadata>();
+
+    for (const identifier of uniqueIdentifiers) {
+      if (isInternalMCPServerName(identifier)) {
+        metadata.set(identifier, {
+          name: asDisplayToolName(identifier),
+          icon: getInternalMCPServerIconByName(identifier),
+        });
+      }
     }
 
-    const views = await this.baseFetch(
-      auth,
-      { where: { name: { [Op.in]: uniqueNames } } },
-      { includeMetadata: false }
+    const remoteMCPServerModelIds = uniqueIdentifiers
+      .filter((identifier) => isResourceSId("remote_mcp_server", identifier))
+      .map((identifier) => getServerTypeAndIdFromSId(identifier).id);
+    const names = uniqueIdentifiers.filter(
+      (identifier) =>
+        !isInternalMCPServerName(identifier) &&
+        !isResourceSId("remote_mcp_server", identifier)
     );
-    return new Map(
-      views.flatMap((view) =>
-        view.name ? [[view.name, view.getServerDisplayMetadata().icon]] : []
-      )
-    );
+    if (remoteMCPServerModelIds.length === 0 && names.length === 0) {
+      return metadata;
+    }
+
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    // Keep this as one joined query: baseFetch would hydrate spaces and servers
+    // through additional queries that this display-only lookup does not need.
+    const views = await this.model.findAll({
+      attributes: ["name", "remoteMCPServerId"],
+      where: {
+        workspaceId: workspaceModelId,
+        serverType: "remote",
+        [Op.or]: [
+          ...(names.length > 0
+            ? [
+                { name: { [Op.in]: names } },
+                Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
+                  [Op.in]: names,
+                }),
+              ]
+            : []),
+          ...(remoteMCPServerModelIds.length > 0
+            ? [
+                {
+                  remoteMCPServerId: {
+                    [Op.in]: remoteMCPServerModelIds,
+                  },
+                },
+              ]
+            : []),
+        ],
+      },
+      include: [
+        {
+          model: RemoteMCPServerModel,
+          as: "remoteMCPServer",
+          attributes: ["id", "cachedName", "icon"],
+          required: true,
+          where: { workspaceId: workspaceModelId },
+        },
+      ],
+    });
+
+    const requestedIdentifiers = new Set(uniqueIdentifiers);
+    for (const view of views) {
+      const server = view.remoteMCPServer;
+      const serverId = remoteMCPServerNameToSId({
+        remoteMCPServerId: server.id,
+        workspaceId: workspaceModelId,
+      });
+      const serverMetadata = {
+        name: server.cachedName,
+        icon: server.icon,
+      };
+      if (view.name && requestedIdentifiers.has(view.name)) {
+        metadata.set(view.name, {
+          name: asDisplayToolName(view.name),
+          icon: server.icon,
+        });
+      }
+      if (requestedIdentifiers.has(server.cachedName)) {
+        metadata.set(server.cachedName, serverMetadata);
+      }
+      if (requestedIdentifiers.has(serverId)) {
+        metadata.set(serverId, serverMetadata);
+      }
+    }
+
+    return metadata;
   }
 
   static async listBySpaces(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -726,16 +726,14 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
     }
 
-    const remoteMCPServerModelIds = uniqueIds
-      .filter((id) => isResourceSId("remote_mcp_server", id))
-      .map((id) => getServerTypeAndIdFromSId(id).id);
-    const names = uniqueIds.filter(
-      (id) =>
-        !isInternalMCPServerName(id) && !isResourceSId("remote_mcp_server", id)
-    );
-    if (remoteMCPServerModelIds.length === 0 && names.length === 0) {
+    const remoteIds = uniqueIds.filter((id) => !isInternalMCPServerName(id));
+    if (remoteIds.length === 0) {
       return metadata;
     }
+
+    const remoteMCPServerModelIds = remoteIds
+      .filter((id) => isResourceSId("remote_mcp_server", id))
+      .map((id) => getServerTypeAndIdFromSId(id).id);
 
     const workspaceModelId = auth.getNonNullableWorkspace().id;
     // Keep this as one joined query: baseFetch would hydrate spaces and servers
@@ -746,14 +744,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         workspaceId: workspaceModelId,
         serverType: "remote",
         [Op.or]: [
-          ...(names.length > 0
-            ? [
-                { name: { [Op.in]: names } },
-                Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
-                  [Op.in]: names,
-                }),
-              ]
-            : []),
+          { name: { [Op.in]: remoteIds } },
+          Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
+            [Op.in]: remoteIds,
+          }),
           ...(remoteMCPServerModelIds.length > 0
             ? [
                 {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -55,11 +55,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
-import {
-  getResourceIdFromSId,
-  isResourceSId,
-  makeSId,
-} from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type {
   InferIncludeType,
   ResourceFindOptions,
@@ -705,8 +701,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
-  static async resolveDisplayMetadataByIds(auth: Authenticator, ids: string[]) {
-    const uniqueIds = [...new Set(ids)];
+  static async resolveDisplayMetadataByNames(
+    auth: Authenticator,
+    names: string[]
+  ) {
+    const uniqueNames = [...new Set(names)];
     const metadata = new Map<
       string,
       {
@@ -715,38 +714,19 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
     >();
 
-    for (const id of uniqueIds) {
-      if (isInternalMCPServerName(id)) {
-        metadata.set(id, {
-          name: asDisplayToolName(id),
-          icon: getInternalMCPServerIconByName(id),
+    for (const name of uniqueNames) {
+      if (isInternalMCPServerName(name)) {
+        metadata.set(name, {
+          name: asDisplayToolName(name),
+          icon: getInternalMCPServerIconByName(name),
         });
       }
     }
 
-    const remoteIds = uniqueIds.filter((id) => !isInternalMCPServerName(id));
-    if (remoteIds.length === 0) {
-      return metadata;
-    }
-
-    const remoteServers = await RemoteMCPServerResource.fetchByIds(
-      auth,
-      remoteIds
+    const remoteNames = uniqueNames.filter(
+      (name) => !isInternalMCPServerName(name)
     );
-    const remoteServerMap = new Map(
-      remoteServers.map((server) => [server.sId, server])
-    );
-    for (const [id, server] of remoteServerMap) {
-      metadata.set(id, {
-        name: server.cachedName,
-        icon: server.icon,
-      });
-    }
-
-    const names = remoteIds.filter(
-      (id) => !isResourceSId("remote_mcp_server", id)
-    );
-    if (names.length === 0) {
+    if (remoteNames.length === 0) {
       return metadata;
     }
 
@@ -757,9 +737,9 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         where: {
           serverType: "remote",
           [Op.or]: [
-            { name: { [Op.in]: names } },
+            { name: { [Op.in]: remoteNames } },
             Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
-              [Op.in]: names,
+              [Op.in]: remoteNames,
             }),
           ],
         },
@@ -776,20 +756,20 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       { includeMetadata: false }
     );
 
-    const requestedIds = new Set(uniqueIds);
+    const requestedNames = new Set(uniqueNames);
     for (const view of views) {
       const server = view.getRemoteMCPServerResource();
       const serverMetadata = {
         name: server.cachedName,
         icon: server.icon,
       };
-      if (view.name && requestedIds.has(view.name)) {
+      if (view.name && requestedNames.has(view.name)) {
         metadata.set(view.name, {
           name: asDisplayToolName(view.name),
           icon: server.icon,
         });
       }
-      if (requestedIds.has(server.cachedName)) {
+      if (requestedNames.has(server.cachedName)) {
         metadata.set(server.cachedName, serverMetadata);
       }
     }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -734,43 +734,43 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       .map((id) => getServerTypeAndIdFromSId(id).id);
 
     const workspaceModelId = auth.getNonNullableWorkspace().id;
-    // Keep this as one joined query: baseFetch would hydrate spaces and servers
-    // through additional queries that this display-only lookup does not need.
-    const views = await this.model.findAll({
-      attributes: ["name", "remoteMCPServerId"],
-      where: {
-        workspaceId: workspaceModelId,
-        serverType: "remote",
-        [Op.or]: [
-          { name: { [Op.in]: remoteIds } },
-          Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
-            [Op.in]: remoteIds,
-          }),
-          ...(remoteMCPServerModelIds.length > 0
-            ? [
-                {
-                  remoteMCPServerId: {
-                    [Op.in]: remoteMCPServerModelIds,
+    const views = await this.baseFetch(
+      auth,
+      {
+        where: {
+          serverType: "remote",
+          [Op.or]: [
+            { name: { [Op.in]: remoteIds } },
+            Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
+              [Op.in]: remoteIds,
+            }),
+            ...(remoteMCPServerModelIds.length > 0
+              ? [
+                  {
+                    remoteMCPServerId: {
+                      [Op.in]: remoteMCPServerModelIds,
+                    },
                   },
-                },
-              ]
-            : []),
+                ]
+              : []),
+          ],
+        },
+        includes: [
+          {
+            model: RemoteMCPServerModel,
+            as: "remoteMCPServer",
+            attributes: [],
+            required: true,
+            where: { workspaceId: workspaceModelId },
+          },
         ],
       },
-      include: [
-        {
-          model: RemoteMCPServerModel,
-          as: "remoteMCPServer",
-          attributes: ["id", "cachedName", "icon"],
-          required: true,
-          where: { workspaceId: workspaceModelId },
-        },
-      ],
-    });
+      { includeMetadata: false }
+    );
 
     const requestedIds = new Set(uniqueIds);
     for (const view of views) {
-      const server = view.remoteMCPServer;
+      const server = view.getRemoteMCPServerResource();
       const serverId = remoteMCPServerNameToSId({
         remoteMCPServerId: server.id,
         workspaceId: workspaceModelId,

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -40,7 +40,6 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
-import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
@@ -55,7 +54,11 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import {
+  getResourceIdFromSId,
+  isResourceSId,
+  makeSId,
+} from "@app/lib/resources/string_ids";
 import type {
   InferIncludeType,
   ResourceFindOptions,
@@ -80,7 +83,7 @@ import {
 import assert from "assert";
 import uniq from "lodash/uniq";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
-import { Op, Sequelize } from "sequelize";
+import { Op } from "sequelize";
 import { z } from "zod";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -701,11 +704,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
-  static async resolveDisplayMetadataByNames(
-    auth: Authenticator,
-    names: string[]
-  ) {
-    const uniqueNames = [...new Set(names)];
+  static async resolveDisplayMetadata(auth: Authenticator, keys: string[]) {
+    const uniqueKeys = [...new Set(keys)];
     const metadata = new Map<
       string,
       {
@@ -714,64 +714,31 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
     >();
 
-    for (const name of uniqueNames) {
-      if (isInternalMCPServerName(name)) {
-        metadata.set(name, {
-          name: asDisplayToolName(name),
-          icon: getInternalMCPServerIconByName(name),
+    for (const key of uniqueKeys) {
+      if (isInternalMCPServerName(key)) {
+        metadata.set(key, {
+          name: asDisplayToolName(key),
+          icon: getInternalMCPServerIconByName(key),
         });
       }
     }
 
-    const remoteNames = uniqueNames.filter(
-      (name) => !isInternalMCPServerName(name)
+    const remoteServerIds = uniqueKeys.filter((key) =>
+      isResourceSId("remote_mcp_server", key)
     );
-    if (remoteNames.length === 0) {
+    if (remoteServerIds.length === 0) {
       return metadata;
     }
 
-    const workspaceModelId = auth.getNonNullableWorkspace().id;
-    const views = await this.baseFetch(
+    const remoteServers = await RemoteMCPServerResource.fetchByIds(
       auth,
-      {
-        where: {
-          serverType: "remote",
-          [Op.or]: [
-            { name: { [Op.in]: remoteNames } },
-            Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
-              [Op.in]: remoteNames,
-            }),
-          ],
-        },
-        includes: [
-          {
-            model: RemoteMCPServerModel,
-            as: "remoteMCPServer",
-            attributes: [],
-            required: true,
-            where: { workspaceId: workspaceModelId },
-          },
-        ],
-      },
-      { includeMetadata: false }
+      remoteServerIds
     );
-
-    const requestedNames = new Set(uniqueNames);
-    for (const view of views) {
-      const server = view.getRemoteMCPServerResource();
-      const serverMetadata = {
+    for (const server of remoteServers) {
+      metadata.set(server.sId, {
         name: server.cachedName,
         icon: server.icon,
-      };
-      if (view.name && requestedNames.has(view.name)) {
-        metadata.set(view.name, {
-          name: asDisplayToolName(view.name),
-          icon: server.icon,
-        });
-      }
-      if (requestedNames.has(server.cachedName)) {
-        metadata.set(server.cachedName, serverMetadata);
-      }
+      });
     }
 
     return metadata;

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -710,29 +710,28 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
-  static async resolveDisplayMetadataByIdentifiers(
+  static async resolveDisplayMetadataByIds(
     auth: Authenticator,
-    identifiers: string[]
+    ids: string[]
   ): Promise<Map<string, MCPServerDisplayMetadata>> {
-    const uniqueIdentifiers = [...new Set(identifiers)];
+    const uniqueIds = [...new Set(ids)];
     const metadata = new Map<string, MCPServerDisplayMetadata>();
 
-    for (const identifier of uniqueIdentifiers) {
-      if (isInternalMCPServerName(identifier)) {
-        metadata.set(identifier, {
-          name: asDisplayToolName(identifier),
-          icon: getInternalMCPServerIconByName(identifier),
+    for (const id of uniqueIds) {
+      if (isInternalMCPServerName(id)) {
+        metadata.set(id, {
+          name: asDisplayToolName(id),
+          icon: getInternalMCPServerIconByName(id),
         });
       }
     }
 
-    const remoteMCPServerModelIds = uniqueIdentifiers
-      .filter((identifier) => isResourceSId("remote_mcp_server", identifier))
-      .map((identifier) => getServerTypeAndIdFromSId(identifier).id);
-    const names = uniqueIdentifiers.filter(
-      (identifier) =>
-        !isInternalMCPServerName(identifier) &&
-        !isResourceSId("remote_mcp_server", identifier)
+    const remoteMCPServerModelIds = uniqueIds
+      .filter((id) => isResourceSId("remote_mcp_server", id))
+      .map((id) => getServerTypeAndIdFromSId(id).id);
+    const names = uniqueIds.filter(
+      (id) =>
+        !isInternalMCPServerName(id) && !isResourceSId("remote_mcp_server", id)
     );
     if (remoteMCPServerModelIds.length === 0 && names.length === 0) {
       return metadata;
@@ -777,7 +776,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       ],
     });
 
-    const requestedIdentifiers = new Set(uniqueIdentifiers);
+    const requestedIds = new Set(uniqueIds);
     for (const view of views) {
       const server = view.remoteMCPServer;
       const serverId = remoteMCPServerNameToSId({
@@ -788,16 +787,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         name: server.cachedName,
         icon: server.icon,
       };
-      if (view.name && requestedIdentifiers.has(view.name)) {
+      if (view.name && requestedIds.has(view.name)) {
         metadata.set(view.name, {
           name: asDisplayToolName(view.name),
           icon: server.icon,
         });
       }
-      if (requestedIdentifiers.has(server.cachedName)) {
+      if (requestedIds.has(server.cachedName)) {
         metadata.set(server.cachedName, serverMetadata);
       }
-      if (requestedIdentifiers.has(serverId)) {
+      if (requestedIds.has(serverId)) {
         metadata.set(serverId, serverMetadata);
       }
     }

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -729,9 +729,23 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       return metadata;
     }
 
-    const remoteMCPServerModelIds = remoteIds
-      .filter((id) => isResourceSId("remote_mcp_server", id))
-      .map((id) => getServerTypeAndIdFromSId(id).id);
+    const remoteServerMap = await RemoteMCPServerResource.fetchBySIdsAsMap(
+      auth,
+      remoteIds
+    );
+    for (const [id, server] of remoteServerMap) {
+      metadata.set(id, {
+        name: server.cachedName,
+        icon: server.icon,
+      });
+    }
+
+    const names = remoteIds.filter(
+      (id) => !isResourceSId("remote_mcp_server", id)
+    );
+    if (names.length === 0) {
+      return metadata;
+    }
 
     const workspaceModelId = auth.getNonNullableWorkspace().id;
     const views = await this.baseFetch(
@@ -740,19 +754,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
         where: {
           serverType: "remote",
           [Op.or]: [
-            { name: { [Op.in]: remoteIds } },
+            { name: { [Op.in]: names } },
             Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
-              [Op.in]: remoteIds,
+              [Op.in]: names,
             }),
-            ...(remoteMCPServerModelIds.length > 0
-              ? [
-                  {
-                    remoteMCPServerId: {
-                      [Op.in]: remoteMCPServerModelIds,
-                    },
-                  },
-                ]
-              : []),
           ],
         },
         includes: [
@@ -771,10 +776,6 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     const requestedIds = new Set(uniqueIds);
     for (const view of views) {
       const server = view.getRemoteMCPServerResource();
-      const serverId = remoteMCPServerNameToSId({
-        remoteMCPServerId: server.id,
-        workspaceId: workspaceModelId,
-      });
       const serverMetadata = {
         name: server.cachedName,
         icon: server.icon,
@@ -787,9 +788,6 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
       if (requestedIds.has(server.cachedName)) {
         metadata.set(server.cachedName, serverMetadata);
-      }
-      if (requestedIds.has(serverId)) {
-        metadata.set(serverId, serverMetadata);
       }
     }
 

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -428,59 +428,6 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     return nameMap;
   }
 
-  static async resolveDisplayMetadataByIdentifiers(
-    auth: Authenticator,
-    identifiers: string[]
-  ): Promise<
-    Map<
-      string,
-      {
-        name: string;
-        icon: CustomResourceIconType | InternalAllowedIconType;
-      }
-    >
-  > {
-    const uniqueIdentifiers = [...new Set(identifiers)];
-    if (uniqueIdentifiers.length === 0) {
-      return new Map();
-    }
-
-    const remoteSIds = uniqueIdentifiers.filter((identifier) =>
-      isResourceSId("remote_mcp_server", identifier)
-    );
-    const names = uniqueIdentifiers.filter(
-      (identifier) => !isResourceSId("remote_mcp_server", identifier)
-    );
-    const modelIds = remoteSIds.map((sId) => getServerTypeAndIdFromSId(sId).id);
-    const servers = await this.baseFetch(auth, {
-      where: {
-        [Op.or]: [
-          ...(modelIds.length > 0 ? [{ id: { [Op.in]: modelIds } }] : []),
-          ...(names.length > 0 ? [{ cachedName: { [Op.in]: names } }] : []),
-        ],
-      },
-    });
-
-    const requestedIdentifiers = new Set(uniqueIdentifiers);
-    const metadata = new Map<
-      string,
-      {
-        name: string;
-        icon: CustomResourceIconType | InternalAllowedIconType;
-      }
-    >();
-    for (const server of servers) {
-      const value = { name: server.cachedName, icon: server.icon };
-      if (requestedIdentifiers.has(server.sId)) {
-        metadata.set(server.sId, value);
-      }
-      if (requestedIdentifiers.has(server.cachedName)) {
-        metadata.set(server.cachedName, value);
-      }
-    }
-    return metadata;
-  }
-
   static async listByWorkspace(
     auth: Authenticator,
     {

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -18,10 +18,7 @@ import { destroyMCPServerViewDependencies } from "@app/lib/resources/mcp_server_
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
-import {
-  getResourceIdFromSId,
-  isResourceSId,
-} from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { mcpToolsRequireConfiguration } from "@app/lib/utils/json_schemas";
 import logger from "@app/logger/logger";
@@ -402,20 +399,6 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       },
       transaction
     );
-  }
-
-  static async fetchBySIdsAsMap(
-    auth: Authenticator,
-    sIds: string[]
-  ): Promise<Map<string, RemoteMCPServerResource>> {
-    const remoteSIds = sIds.filter((sId) =>
-      isResourceSId("remote_mcp_server", sId)
-    );
-    if (remoteSIds.length === 0) {
-      return new Map();
-    }
-    const servers = await this.fetchByIds(auth, remoteSIds);
-    return new Map(servers.map((server) => [server.sId, server]));
   }
 
   static async listByWorkspace(

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -4,10 +4,7 @@ import type {
   InternalAllowedIconType,
 } from "@app/components/resources/resources_icons";
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
-import {
-  getServerTypeAndIdFromSId,
-  remoteMCPServerNameToSId,
-} from "@app/lib/actions/mcp_helper";
+import { remoteMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { MCPToolType, RemoteMCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { toGlobalResponse, untrustedFetch } from "@app/lib/egress/server";
@@ -407,25 +404,18 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     );
   }
 
-  static async resolveNamesBySIds(
+  static async fetchBySIdsAsMap(
     auth: Authenticator,
     sIds: string[]
-  ): Promise<Map<string, string>> {
+  ): Promise<Map<string, RemoteMCPServerResource>> {
     const remoteSIds = sIds.filter((sId) =>
       isResourceSId("remote_mcp_server", sId)
     );
     if (remoteSIds.length === 0) {
       return new Map();
     }
-    const modelIds = remoteSIds.map((sId) => getServerTypeAndIdFromSId(sId).id);
-    const servers = await this.fetchByModelIds(auth, modelIds);
-    const nameMap = new Map<string, string>();
-    for (const server of servers) {
-      if (server.cachedName) {
-        nameMap.set(server.sId, server.cachedName);
-      }
-    }
-    return nameMap;
+    const servers = await this.fetchByIds(auth, remoteSIds);
+    return new Map(servers.map((server) => [server.sId, server]));
   }
 
   static async listByWorkspace(

--- a/front/temporal/analytics_queue/activities/agent_analytics.ts
+++ b/front/temporal/analytics_queue/activities/agent_analytics.ts
@@ -452,9 +452,12 @@ async function collectToolUsageFromMessage(
       )
     ),
   ];
-  const remoteServerMap = await RemoteMCPServerResource.fetchBySIdsAsMap(
+  const remoteServers = await RemoteMCPServerResource.fetchByIds(
     auth,
     mcpServerIds
+  );
+  const remoteServerMap = new Map(
+    remoteServers.map((server) => [server.sId, server])
   );
 
   return billingLines.map(({ action, billedCredits }) => {

--- a/front/temporal/analytics_queue/activities/agent_analytics.ts
+++ b/front/temporal/analytics_queue/activities/agent_analytics.ts
@@ -452,7 +452,7 @@ async function collectToolUsageFromMessage(
       )
     ),
   ];
-  const remoteServerNameMap = await RemoteMCPServerResource.resolveNamesBySIds(
+  const remoteServerMap = await RemoteMCPServerResource.fetchBySIdsAsMap(
     auth,
     mcpServerIds
   );
@@ -462,7 +462,7 @@ async function collectToolUsageFromMessage(
     const { internalMCPServerName, mcpServerId } = actionResource.metadata;
     const serverName =
       internalMCPServerName ??
-      (mcpServerId && remoteServerNameMap.get(mcpServerId)) ??
+      (mcpServerId && remoteServerMap.get(mcpServerId)?.cachedName) ??
       mcpServerId ??
       "unknown";
 


### PR DESCRIPTION
## Description

We were making several database queries to load tool names and icons in consumption analytics (db hydration of the es results for the attribution table).

This PR replaces them with a single query on `MCPServerViewResource` (a few queries actually, but still better because we don't fetch twice on `remote_mcp_servers`). The output stays the same.

## Tests

- Added a test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
