### PR TITLE
Fix enabled skill tool footprint attribution

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -65,6 +65,7 @@ import {
   makeToolInterruptionError,
   shouldRetryToolInterruption,
 } from "@app/lib/actions/tool_interruptions";
+import { applyToolSourceLoadingPolicy } from "@app/lib/actions/tool_loading";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type {
   AgentLoopListToolsContext,
@@ -1291,8 +1292,7 @@ export async function tryListMCPTools(
         }
 
         processedTools.push({
-          ...toolConfig,
-          ...(isFromSkillServer ? { eager: undefined } : {}),
+          ...applyToolSourceLoadingPolicy(toolConfig, { isFromSkillServer }),
           originalName: toolConfig.name,
           mcpServerName: action.name,
           name: toolName,

--- a/front/lib/actions/tool_loading.test.ts
+++ b/front/lib/actions/tool_loading.test.ts
@@ -1,0 +1,21 @@
+import { applyToolSourceLoadingPolicy } from "@app/lib/actions/tool_loading";
+import { describe, expect, it } from "vitest";
+
+describe("applyToolSourceLoadingPolicy", () => {
+  it("clears eager metadata for a dynamically enabled skill tool", () => {
+    expect(
+      applyToolSourceLoadingPolicy(
+        { name: "skill_tool", eager: true },
+        { isFromSkillServer: true }
+      )
+    ).toEqual({ name: "skill_tool", eager: undefined });
+  });
+
+  it("preserves eager metadata for tools from other sources", () => {
+    const tool = { name: "configured_tool", eager: true };
+
+    expect(
+      applyToolSourceLoadingPolicy(tool, { isFromSkillServer: false })
+    ).toBe(tool);
+  });
+});

--- a/front/lib/actions/tool_loading.ts
+++ b/front/lib/actions/tool_loading.ts
@@ -1,0 +1,12 @@
+/**
+ * Applies the agent-loop loading policy attached to a tool's source.
+ *
+ * Tools introduced only through a dynamically enabled skill must remain discoverable through
+ * provider-side tool search even when their server metadata marks them eager.
+ */
+export function applyToolSourceLoadingPolicy<T extends { eager?: boolean }>(
+  tool: T,
+  { isFromSkillServer }: { isFromSkillServer: boolean }
+): T {
+  return isFromSkillServer ? { ...tool, eager: undefined } : tool;
+}

--- a/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
@@ -15,8 +15,10 @@ import assert from "assert";
 // requests. Version 4 keeps sandbox-child actions as direct-charge-only rows because their calls
 // and results reach the outer model through their parent Computer action. Version 5 removes the
 // context-window safety padding from tool footprints and uses o200k for GPT-5 provider accounting.
+// Version 6 excludes enabled-skill tool definitions when provider-side tool search keeps those
+// non-eager tools deferred, while continuing to attribute the enabled skill's instructions.
 // Each version remains a separate, self-consistent set of rows.
-export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 5;
+export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 6;
 
 export type RunUsageForAttribution = Pick<
   RunUsageType,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint.ts
@@ -1,10 +1,12 @@
 import { MAX_TOOL_DESCRIPTION_LENGTH } from "@app/lib/actions/mcp";
 import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { applyToolSourceLoadingPolicy } from "@app/lib/actions/tool_loading";
 import { tryGetPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { getEnableSkillIdFromOutputBlock } from "@app/lib/api/actions/servers/skill_management/rendering";
 import { renderEnabledSkillUserMessageFromInstructions } from "@app/lib/api/assistant/skills_rendering";
 import type { Authenticator } from "@app/lib/auth";
+import { isToolDeferred } from "@app/lib/model_constructors/types/tool_search";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -58,28 +60,41 @@ function enabledSkillToolDefinitions(
       }
 
       const inputSchema = tool.inputSchema ?? EMPTY_INPUT_SCHEMA;
-      definitions.push({
-        name: prefixedName.value,
-        description: tool.description.slice(0, MAX_TOOL_DESCRIPTION_LENGTH),
-        inputSchema:
-          configuration.view.internalMCPServerId === null
-            ? inputSchema
-            : hideInternalConfiguration(inputSchema),
-      });
+      definitions.push(
+        applyToolSourceLoadingPolicy(
+          {
+            name: prefixedName.value,
+            description: tool.description.slice(0, MAX_TOOL_DESCRIPTION_LENGTH),
+            inputSchema:
+              configuration.view.internalMCPServerId === null
+                ? inputSchema
+                : hideInternalConfiguration(inputSchema),
+            eager: tool.eager,
+          },
+          // Best-effort attribution treats definitions attached to the enabled skill as
+          // skill-originated; unlike the live loop, it does not reconstruct cross-source deduping.
+          { isFromSkillServer: true }
+        )
+      );
     }
   }
 
   return definitions.sort((left, right) => left.name.localeCompare(right.name));
 }
 
-function enabledSkillInputText(skill: SkillResource): string {
+function enabledSkillInputText(
+  skill: SkillResource,
+  { toolSearchEnabled }: { toolSearchEnabled: boolean }
+): string {
   const instructionsMessage = renderEnabledSkillUserMessageFromInstructions({
     skill,
   });
   const instructionsText = instructionsMessage.content.flatMap((content) =>
     content.type === "text" ? [content.text] : []
   );
-  const toolDefinitions = enabledSkillToolDefinitions(skill);
+  const toolDefinitions = enabledSkillToolDefinitions(skill).filter(
+    (tool) => !isToolDeferred(tool, toolSearchEnabled)
+  );
 
   return [
     ...instructionsText,
@@ -99,12 +114,13 @@ function enabledSkillInputText(skill: SkillResource): string {
 
 /**
  * Resolves the additional model input caused by successful enable-skill actions. A normal action
- * has no entry. An enable-skill action contributes the instructions rendered as a user message and
- * the definitions of the tools exposed by the skill.
+ * has no entry. An enable-skill action contributes the instructions rendered as a user message and,
+ * when the provider loads them eagerly, the definitions of the tools exposed by the skill.
  */
 export async function getEnabledSkillInputTextByActionId(
   auth: Authenticator,
-  actions: AgentMCPActionWithOutputType[]
+  actions: AgentMCPActionWithOutputType[],
+  { toolSearchEnabled }: { toolSearchEnabled: boolean }
 ): Promise<ReadonlyMap<string, string>> {
   const enabledSkillIdsByAction = actions.map((action) => ({
     action,
@@ -119,7 +135,10 @@ export async function getEnabledSkillInputTextByActionId(
 
   const skills = await SkillResource.fetchByIds(auth, skillIds);
   const inputTextBySkillId = new Map(
-    skills.map((skill) => [skill.sId, enabledSkillInputText(skill)])
+    skills.map((skill) => [
+      skill.sId,
+      enabledSkillInputText(skill, { toolSearchEnabled }),
+    ])
   );
 
   return new Map(

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -17,6 +17,10 @@ import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RunFactory } from "@app/tests/utils/RunFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { MISTRAL_SMALL_MODEL_CONFIG } from "@app/types/assistant/models/mistral";
+import { GPT_5_4_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import type { ModelIdType } from "@app/types/assistant/models/types";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -40,9 +44,11 @@ const TOKENS_PER_FOOTPRINT = 2;
 async function setupSettledMessageWithUsage({
   runCount = 1,
   restrictedConversation = false,
+  modelId,
 }: {
   runCount?: number;
   restrictedConversation?: boolean;
+  modelId?: ModelIdType;
 } = {}) {
   const { authenticator, globalSpace, user, workspace } =
     await createResourceTest({ role: "admin" });
@@ -72,6 +78,7 @@ async function setupSettledMessageWithUsage({
       inputTokens: INPUT_TOKENS_COUNT,
       outputTokens: OUTPUT_TOKENS_COUNT,
       reasoningTokens: REASONING_TOKENS_COUNT,
+      modelId,
     });
     runs.push(run);
   }
@@ -538,7 +545,23 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     );
   });
 
-  it("attributes enabled skill instructions and tool definitions to the tool input", async () => {
+  it.each([
+    {
+      caseName: "omits deferred tool definitions for Anthropic tool search",
+      modelId: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
+      includesToolDefinitions: false,
+    },
+    {
+      caseName: "omits deferred tool definitions for OpenAI tool search",
+      modelId: GPT_5_4_MODEL_CONFIG.modelId,
+      includesToolDefinitions: false,
+    },
+    {
+      caseName: "includes tool definitions when tool search is disabled",
+      modelId: MISTRAL_SMALL_MODEL_CONFIG.modelId,
+      includesToolDefinitions: true,
+    },
+  ])("$caseName", async ({ modelId, includesToolDefinitions }) => {
     const {
       auth,
       globalSpace,
@@ -548,7 +571,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
       conversationId,
       agentMessageId,
       agentMessageModelId,
-    } = await setupSettledMessageWithUsage();
+    } = await setupSettledMessageWithUsage({ modelId });
 
     const internalServer = await InternalMCPServerInMemoryResource.makeNew(
       auth,
@@ -597,9 +620,12 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
     expect(inputTexts[0]).toContain(
       "<dust_system>\n<Measured Skill>\nFollow the enabled skill instructions."
     );
-    expect(inputTexts[0]).toContain(
-      '"name":"common_utilities__set_conversation_title"'
-    );
+    const toolDefinition = '"name":"common_utilities__set_conversation_title"';
+    if (includesToolDefinitions) {
+      expect(inputTexts[0]).toContain(toolDefinition);
+    } else {
+      expect(inputTexts[0]).not.toContain(toolDefinition);
+    }
 
     const items =
       await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.test.ts
@@ -1,3 +1,4 @@
+import { getEnabledSkillInputTextByActionId } from "@app/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint";
 import type { ToolCallFootprintInput } from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
 import {
   measureToolCallFootprints,
@@ -7,6 +8,7 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
 import {
   GPT_4_1_MODEL_CONFIG,
   GPT_5_6_SOL_MODEL_ID,
@@ -18,6 +20,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@app/lib/api/provider_credentials", () => ({
   getLlmCredentials: vi.fn(),
 }));
+
+vi.mock(
+  "@app/lib/api/assistant/agent_message_consumption_attribution/enabled_skill_footprint",
+  () => ({
+    getEnabledSkillInputTextByActionId: vi.fn(async () => new Map()),
+  })
+);
 
 vi.mock("@app/lib/tokenization", () => ({
   tokenCountForTexts: vi.fn(),
@@ -151,6 +160,32 @@ describe("measureToolCallFootprints", () => {
     // Count is the character length of each text, keeping the assertions readable.
     vi.mocked(tokenCountForTexts).mockImplementation(
       async (texts) => new Ok(texts.map((text) => text.length))
+    );
+  });
+
+  it("omits deferred enabled-skill definitions for an Anthropic tool-search model", async () => {
+    await measureToolCallFootprints(auth, {
+      modelId: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG.modelId,
+      toolCalls: [footprintInput(makeAction())],
+    });
+
+    expect(getEnabledSkillInputTextByActionId).toHaveBeenCalledWith(
+      auth,
+      expect.any(Array),
+      { toolSearchEnabled: true }
+    );
+  });
+
+  it("includes enabled-skill definitions when tool search is disabled", async () => {
+    await measureToolCallFootprints(auth, {
+      modelId: GPT_4_1_MODEL_CONFIG.modelId,
+      toolCalls: [footprintInput(makeAction())],
+    });
+
+    expect(getEnabledSkillInputTextByActionId).toHaveBeenCalledWith(
+      auth,
+      expect.any(Array),
+      { toolSearchEnabled: false }
     );
   });
 

--- a/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/tool_footprint.ts
@@ -3,6 +3,7 @@ import { renderToolResultForModelAsText } from "@app/lib/api/assistant/conversat
 import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
+import { isToolSearchEnabledForModel } from "@app/lib/model_constructors/types/tool_search";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import {
@@ -119,7 +120,10 @@ export async function measureToolCallFootprints(
   const enabledSkillInputTextByActionId =
     await getEnabledSkillInputTextByActionId(
       auth,
-      toolCalls.map(({ action }) => action)
+      toolCalls.map(({ action }) => action),
+      {
+        toolSearchEnabled: isToolSearchEnabledForModel(model),
+      }
     );
 
   // Tokenize the calls and inputs as two homogeneous lists so each count maps back to its call by

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/input/utils.ts
@@ -40,6 +40,7 @@ import type {
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
 import { ANTHROPIC_LAB } from "@app/lib/model_constructors/types/labs";
+import { isToolDeferred } from "@app/lib/model_constructors/types/tool_search";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -421,7 +422,7 @@ export function toolSpecToAnthropicAITool(
     // Defer non-eager tools behind tool search when it is enabled. Eager tools
     // (and every tool when tool search is off) stay in the cached prefix. Only
     // set when true so non-deferred tools serialize identically (stable bytes).
-    ...(toolSearchEnabled && !tool.eager ? { defer_loading: true } : {}),
+    ...(isToolDeferred(tool, toolSearchEnabled) ? { defer_loading: true } : {}),
   };
 }
 

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -20,6 +20,7 @@ import type {
   CacheOption,
   SystemTextMessage,
 } from "@app/lib/model_constructors/types/input/messages";
+import { isToolDeferred } from "@app/lib/model_constructors/types/tool_search";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   FunctionTool,
@@ -317,7 +318,7 @@ export function toFunctionTool(
     // the core provider, which sends `strict: false` for function tools.
     strict: false,
     parameters: { type: "object", ...tool.inputSchema },
-    ...(toolSearchEnabled && !tool.eager ? { defer_loading: true } : {}),
+    ...(isToolDeferred(tool, toolSearchEnabled) ? { defer_loading: true } : {}),
   };
 }
 

--- a/front/lib/model_constructors/types/tool_search.ts
+++ b/front/lib/model_constructors/types/tool_search.ts
@@ -1,3 +1,9 @@
+import {
+  ANTHROPIC_PROVIDER_ID,
+  OPENAI_PROVIDER_ID,
+} from "@app/types/assistant/models/providers";
+import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+
 // Shared guidance for providers that can defer tool definitions behind a
 // server-side search tool.
 export const TOOL_SEARCH_INSTRUCTION =
@@ -7,3 +13,22 @@ export const TOOL_SEARCH_INSTRUCTION =
   "action your visible tools cannot take, search for a tool before making " +
   "something up, answering from stale memory, or telling the user it is not " +
   "possible.";
+
+/** Whether this model actually uses the provider-side deferred-tool path. */
+export function isToolSearchEnabledForModel(
+  model: ModelConfigurationType
+): boolean {
+  return (
+    (model.providerId === ANTHROPIC_PROVIDER_ID ||
+      model.providerId === OPENAI_PROVIDER_ID) &&
+    model.supportsToolSearch === true
+  );
+}
+
+/** The single deferral rule shared by provider serialization and token attribution. */
+export function isToolDeferred(
+  tool: { eager?: boolean },
+  toolSearchEnabled: boolean
+): boolean {
+  return toolSearchEnabled && tool.eager !== true;
+}

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -65,6 +65,10 @@ import {
   parseAnthropicToolSearchBlock,
   TOOL_SEARCH_SERVER_TOOL_NAMES,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough";
+import {
+  isToolDeferred,
+  isToolSearchEnabledForModel,
+} from "@app/lib/model_constructors/types/tool_search";
 import { getModelTierAccessErrorForAgentConfiguration } from "@app/lib/model_tiers/access";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -98,11 +102,7 @@ import type {
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { isTextContent } from "@app/types/assistant/generation";
-import {
-  ANTHROPIC_PROVIDER_ID,
-  isByokProviderId,
-  OPENAI_PROVIDER_ID,
-} from "@app/types/assistant/models/providers";
+import { isByokProviderId } from "@app/types/assistant/models/providers";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -143,7 +143,9 @@ export function buildToolDefinitionsForTokenCount(
   toolSearchEnabled: boolean
 ): string {
   const specsInContext = toolSearchEnabled
-    ? specifications.filter((s) => s.eager)
+    ? specifications.filter(
+        (specification) => !isToolDeferred(specification, toolSearchEnabled)
+      )
     : specifications;
   return JSON.stringify([
     ...(toolSearchEnabled ? [TOOL_SEARCH_TOOL] : []),
@@ -656,10 +658,7 @@ export async function runModel(
 
   // Specs carry the intrinsic `eager` property only. Whether a non-eager tool is
   // deferred behind tool search is a provider-specific policy applied downstream.
-  const toolSearchEnabled =
-    (modelConfig.providerId === ANTHROPIC_PROVIDER_ID ||
-      modelConfig.providerId === OPENAI_PROVIDER_ID) &&
-    !!modelConfig.supportsToolSearch;
+  const toolSearchEnabled = isToolSearchEnabledForModel(modelConfig);
   const baseSpecifications: AgentActionSpecification[] =
     buildBaseSpecifications(availableActions, agentConfiguration);
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Carrying on the journey to reconcile credits billed with tool attribution.

This PR focuses around skill tool attribution estimation that wrongly assumed that all tools would be exposed to the model directly on the subsequent calls. Since we introduced `tool_search` this is not conditioned by provider. This PR aims at aligning this. I've bumped the attribution schema so I can restart all stuck workflows.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
