### PR TITLE
Retry interruptible sandbox child tools

### DIFF
--- a/front/temporal/agent_loop/activities/finalize_sandbox_child_tool.test.ts
+++ b/front/temporal/agent_loop/activities/finalize_sandbox_child_tool.test.ts
@@ -1,0 +1,75 @@
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { finalizeErroredSandboxChildToolActivity } from "@app/temporal/agent_loop/activities/finalize_sandbox_child_tool";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/actions/types", () => ({
+  isSandboxChildActionInfo: vi.fn(),
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  Authenticator: {
+    fromJsonWithRefrehedGroups: vi.fn(),
+  },
+}));
+
+vi.mock("@app/lib/resources/agent_mcp_action_resource", () => ({
+  AgentMCPActionResource: {
+    fetchByModelIdWithAuth: vi.fn(),
+  },
+}));
+
+const authType: AuthenticatorType = {
+  authMethod: "internal",
+  groupIds: [],
+  isByok: false,
+  role: "admin",
+  subscriptionId: null,
+  userId: null,
+  workspaceId: "w123",
+};
+
+describe("finalizeErroredSandboxChildToolActivity", () => {
+  const auth = { workspaceId: "w123" };
+  const updateStatusFromExpected = vi.fn();
+  const action = {
+    stepContext: {
+      sandboxChildActionInfo: { parentActionId: "parent" },
+    },
+    updateStatusFromExpected,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(Authenticator.fromJsonWithRefrehedGroups).mockResolvedValue(
+      auth as never
+    );
+    vi.mocked(AgentMCPActionResource.fetchByModelIdWithAuth).mockResolvedValue(
+      action as never
+    );
+    vi.mocked(isSandboxChildActionInfo).mockReturnValue(true);
+  });
+
+  it("moves only a running sandbox child action to errored", async () => {
+    await finalizeErroredSandboxChildToolActivity(authType, {
+      actionModelId: 123,
+    });
+
+    expect(updateStatusFromExpected).toHaveBeenCalledWith(auth, {
+      expectedStatus: "running",
+      status: "errored",
+    });
+  });
+
+  it("ignores an action that is not a sandbox child", async () => {
+    vi.mocked(isSandboxChildActionInfo).mockReturnValue(false);
+
+    await finalizeErroredSandboxChildToolActivity(authType, {
+      actionModelId: 123,
+    });
+
+    expect(updateStatusFromExpected).not.toHaveBeenCalled();
+  });
+});

--- a/front/temporal/agent_loop/activities/finalize_sandbox_child_tool.ts
+++ b/front/temporal/agent_loop/activities/finalize_sandbox_child_tool.ts
@@ -1,0 +1,28 @@
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type { ModelId } from "@app/types/shared/model_id";
+
+export async function finalizeErroredSandboxChildToolActivity(
+  authType: AuthenticatorType,
+  { actionModelId }: { actionModelId: ModelId }
+): Promise<void> {
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  const action = await AgentMCPActionResource.fetchByModelIdWithAuth(
+    auth,
+    actionModelId
+  );
+
+  if (
+    !action ||
+    !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+  ) {
+    return;
+  }
+
+  await action.updateStatusFromExpected(auth, {
+    expectedStatus: "running",
+    status: "errored",
+  });
+}

--- a/front/temporal/agent_loop/client.ts
+++ b/front/temporal/agent_loop/client.ts
@@ -1,3 +1,4 @@
+import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
@@ -271,7 +272,17 @@ export async function launchSandboxChildToolWorkflow(
 
   try {
     await client.workflow.start(runSandboxChildToolWorkflow, {
-      args: [{ authType, agentLoopArgs, actionModelId: action.id, step }],
+      args: [
+        {
+          authType,
+          agentLoopArgs,
+          actionModelId: action.id,
+          retryPolicy: getRetryPolicyFromToolConfiguration(
+            action.toolConfiguration
+          ),
+          step,
+        },
+      ],
       taskQueue: await getTaskQueueForRun(auth, {
         userMessageOrigin: agentLoopArgs.userMessageOrigin,
         conversationId: agentLoopArgs.conversationId,

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -21,6 +21,7 @@ import {
   finalizeInterruptedAgentLoopActivity,
   finalizeSuccessfulAgentLoopActivity,
 } from "@app/temporal/agent_loop/activities/finalize";
+import { finalizeErroredSandboxChildToolActivity } from "@app/temporal/agent_loop/activities/finalize_sandbox_child_tool";
 import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
@@ -110,6 +111,7 @@ async function runAgentLoopWorkerForQueue({
       finalizeCancelledAgentLoopActivity,
       finalizeInterruptedAgentLoopActivity,
       finalizeErroredAgentLoopActivity,
+      finalizeErroredSandboxChildToolActivity,
       checkCreditsActivity,
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,

--- a/front/temporal/agent_loop/workflows.test.ts
+++ b/front/temporal/agent_loop/workflows.test.ts
@@ -5,11 +5,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   patched,
+  finalizeErroredSandboxChildToolActivity,
   runToolActivity,
   runRetryableToolActivity,
   publishDeferredEventsActivity,
 } = vi.hoisted(() => ({
   patched: vi.fn(),
+  finalizeErroredSandboxChildToolActivity: vi.fn(),
   runToolActivity: vi.fn(),
   runRetryableToolActivity: vi.fn(),
   publishDeferredEventsActivity: vi.fn(),
@@ -22,7 +24,11 @@ vi.mock("@temporalio/workflow", () => {
     ActivityCancellationType: {
       WAIT_CANCELLATION_COMPLETED: "WAIT_CANCELLATION_COMPLETED",
     },
-    CancellationScope: class {},
+    CancellationScope: class {
+      static nonCancellable<T>(fn: () => Promise<T>) {
+        return fn();
+      }
+    },
     defineSignal: (name: string) => name,
     patched,
     proxyActivities: (options: {
@@ -36,6 +42,7 @@ vi.mock("@temporalio/workflow", () => {
       finalizeCancelledAgentLoopActivity: unusedActivity,
       finalizeCreditStoppedAgentLoopActivity: unusedActivity,
       finalizeErroredAgentLoopActivity: unusedActivity,
+      finalizeErroredSandboxChildToolActivity,
       finalizeGracefullyStoppedAgentLoopActivity: unusedActivity,
       finalizeInterruptedAgentLoopActivity: unusedActivity,
       finalizeSuccessfulAgentLoopActivity: unusedActivity,
@@ -89,6 +96,7 @@ describe("runSandboxChildToolWorkflow", () => {
     patched.mockReturnValue(true);
     runToolActivity.mockResolvedValue({ deferredEvents: [] });
     runRetryableToolActivity.mockResolvedValue({ deferredEvents: [] });
+    finalizeErroredSandboxChildToolActivity.mockResolvedValue(undefined);
   });
 
   it.each([
@@ -135,9 +143,37 @@ describe("runSandboxChildToolWorkflow", () => {
     expect(runRetryableToolActivity).not.toHaveBeenCalled();
   });
 
-  it("propagates terminal activity failures", async () => {
+  it.each([
+    "no_retry",
+    "retry_on_interrupt",
+  ] as const)("finalizes and propagates terminal activity failures for %s", async (retryPolicy) => {
     const error = new Error("activity attempts exhausted");
-    runRetryableToolActivity.mockRejectedValue(error);
+    const runActivity =
+      retryPolicy === "retry_on_interrupt"
+        ? runRetryableToolActivity
+        : runToolActivity;
+    runActivity.mockRejectedValue(error);
+
+    await expect(
+      runSandboxChildToolWorkflow({
+        actionModelId: 123,
+        agentLoopArgs,
+        authType,
+        retryPolicy,
+        step: 1,
+      })
+    ).rejects.toBe(error);
+
+    expect(finalizeErroredSandboxChildToolActivity).toHaveBeenCalledWith(
+      authType,
+      { actionModelId: 123 }
+    );
+  });
+
+  it("does not change failure bookkeeping when replaying without the patch marker", async () => {
+    const error = new Error("activity failed");
+    patched.mockReturnValue(false);
+    runToolActivity.mockRejectedValue(error);
 
     await expect(
       runSandboxChildToolWorkflow({
@@ -148,5 +184,7 @@ describe("runSandboxChildToolWorkflow", () => {
         step: 1,
       })
     ).rejects.toBe(error);
+
+    expect(finalizeErroredSandboxChildToolActivity).not.toHaveBeenCalled();
   });
 });

--- a/front/temporal/agent_loop/workflows.test.ts
+++ b/front/temporal/agent_loop/workflows.test.ts
@@ -99,20 +99,31 @@ describe("runSandboxChildToolWorkflow", () => {
     finalizeErroredSandboxChildToolActivity.mockResolvedValue(undefined);
   });
 
-  it.each([
-    undefined,
-    "no_retry",
-  ] as const)("uses the single-attempt activity for retry policy %s", async (retryPolicy) => {
+  it("defaults missing legacy input to no_retry without recording a patch marker", async () => {
     await runSandboxChildToolWorkflow({
       actionModelId: 123,
       agentLoopArgs,
       authType,
-      retryPolicy,
       step: 1,
     });
 
     expect(runToolActivity).toHaveBeenCalledOnce();
     expect(runRetryableToolActivity).not.toHaveBeenCalled();
+    expect(patched).not.toHaveBeenCalled();
+  });
+
+  it("uses the single-attempt activity for no_retry", async () => {
+    await runSandboxChildToolWorkflow({
+      actionModelId: 123,
+      agentLoopArgs,
+      authType,
+      retryPolicy: "no_retry",
+      step: 1,
+    });
+
+    expect(runToolActivity).toHaveBeenCalledOnce();
+    expect(runRetryableToolActivity).not.toHaveBeenCalled();
+    expect(patched).toHaveBeenCalledWith("sandbox-child-tool-retry-policy");
   });
 
   it("uses the retryable activity only for retry_on_interrupt", async () => {

--- a/front/temporal/agent_loop/workflows.test.ts
+++ b/front/temporal/agent_loop/workflows.test.ts
@@ -1,0 +1,152 @@
+import type { AuthenticatorType } from "@app/lib/auth";
+import { runSandboxChildToolWorkflow } from "@app/temporal/agent_loop/workflows";
+import type { AgentLoopArgsWithTiming } from "@app/types/assistant/agent_run";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  patched,
+  runToolActivity,
+  runRetryableToolActivity,
+  publishDeferredEventsActivity,
+} = vi.hoisted(() => ({
+  patched: vi.fn(),
+  runToolActivity: vi.fn(),
+  runRetryableToolActivity: vi.fn(),
+  publishDeferredEventsActivity: vi.fn(),
+}));
+
+vi.mock("@temporalio/workflow", () => {
+  const unusedActivity = vi.fn();
+
+  return {
+    ActivityCancellationType: {
+      WAIT_CANCELLATION_COMPLETED: "WAIT_CANCELLATION_COMPLETED",
+    },
+    CancellationScope: class {},
+    defineSignal: (name: string) => name,
+    patched,
+    proxyActivities: (options: {
+      cancellationType?: unknown;
+      retry?: { maximumAttempts?: number };
+    }) => ({
+      checkCreditsActivity: unusedActivity,
+      compactionActivity: unusedActivity,
+      compactionCleanupActivity: unusedActivity,
+      ensureConversationTitleActivity: unusedActivity,
+      finalizeCancelledAgentLoopActivity: unusedActivity,
+      finalizeCreditStoppedAgentLoopActivity: unusedActivity,
+      finalizeErroredAgentLoopActivity: unusedActivity,
+      finalizeGracefullyStoppedAgentLoopActivity: unusedActivity,
+      finalizeInterruptedAgentLoopActivity: unusedActivity,
+      finalizeSuccessfulAgentLoopActivity: unusedActivity,
+      publishDeferredEventsActivity,
+      runModelAndCreateActionsActivity: unusedActivity,
+      runToolActivity:
+        options.cancellationType === undefined &&
+        options.retry?.maximumAttempts === 1
+          ? runToolActivity
+          : runRetryableToolActivity,
+    }),
+    proxySinks: () => ({
+      metrics: {
+        logAgentLoopDuration: vi.fn(),
+        logAgentLoopError: vi.fn(),
+        logPhaseCompletion: vi.fn(),
+        logPhaseStart: vi.fn(),
+        logStepCompletion: vi.fn(),
+      },
+    }),
+    setHandler: vi.fn(),
+    startChild: vi.fn(),
+    workflowInfo: vi.fn(),
+  };
+});
+
+const authType: AuthenticatorType = {
+  authMethod: "internal",
+  groupIds: [],
+  isByok: false,
+  role: "admin",
+  subscriptionId: null,
+  userId: null,
+  workspaceId: "w123",
+};
+
+const agentLoopArgs: AgentLoopArgsWithTiming = {
+  agentMessageId: "am123",
+  agentMessageVersion: 0,
+  conversationId: "c123",
+  conversationTitle: null,
+  initialStartTime: 0,
+  userMessageId: "um123",
+  userMessageOrigin: "web",
+  userMessageVersion: 0,
+};
+
+describe("runSandboxChildToolWorkflow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    patched.mockReturnValue(true);
+    runToolActivity.mockResolvedValue({ deferredEvents: [] });
+    runRetryableToolActivity.mockResolvedValue({ deferredEvents: [] });
+  });
+
+  it.each([
+    undefined,
+    "no_retry",
+  ] as const)("uses the single-attempt activity for retry policy %s", async (retryPolicy) => {
+    await runSandboxChildToolWorkflow({
+      actionModelId: 123,
+      agentLoopArgs,
+      authType,
+      retryPolicy,
+      step: 1,
+    });
+
+    expect(runToolActivity).toHaveBeenCalledOnce();
+    expect(runRetryableToolActivity).not.toHaveBeenCalled();
+  });
+
+  it("uses the retryable activity only for retry_on_interrupt", async () => {
+    await runSandboxChildToolWorkflow({
+      actionModelId: 123,
+      agentLoopArgs,
+      authType,
+      retryPolicy: "retry_on_interrupt",
+      step: 1,
+    });
+
+    expect(runRetryableToolActivity).toHaveBeenCalledOnce();
+    expect(runToolActivity).not.toHaveBeenCalled();
+  });
+
+  it("keeps the single-attempt activity when replaying without the patch marker", async () => {
+    patched.mockReturnValue(false);
+
+    await runSandboxChildToolWorkflow({
+      actionModelId: 123,
+      agentLoopArgs,
+      authType,
+      retryPolicy: "retry_on_interrupt",
+      step: 1,
+    });
+
+    expect(runToolActivity).toHaveBeenCalledOnce();
+    expect(runRetryableToolActivity).not.toHaveBeenCalled();
+  });
+
+  it("propagates terminal activity failures", async () => {
+    const error = new Error("activity attempts exhausted");
+    runRetryableToolActivity.mockRejectedValue(error);
+
+    await expect(
+      runSandboxChildToolWorkflow({
+        actionModelId: 123,
+        agentLoopArgs,
+        authType,
+        retryPolicy: "retry_on_interrupt",
+        step: 1,
+      })
+    ).rejects.toBe(error);
+  });
+});

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -578,7 +578,7 @@ export async function runSandboxChildToolWorkflow({
   authType,
   agentLoopArgs,
   actionModelId,
-  retryPolicy = "no_retry",
+  retryPolicy,
   step,
 }: {
   authType: AuthenticatorType;
@@ -594,9 +594,11 @@ export async function runSandboxChildToolWorkflow({
     runAgentArgs: agentLoopArgs,
     step,
   };
-  const useRetryPolicy = patched("sandbox-child-tool-retry-policy");
+  const effectiveRetryPolicy = retryPolicy ?? "no_retry";
+  const useRetryPolicy =
+    retryPolicy !== undefined && patched("sandbox-child-tool-retry-policy");
   let shouldRetryOnInterrupt: boolean;
-  switch (retryPolicy) {
+  switch (effectiveRetryPolicy) {
     case "retry_on_interrupt":
       shouldRetryOnInterrupt = useRetryPolicy;
       break;
@@ -604,7 +606,7 @@ export async function runSandboxChildToolWorkflow({
       shouldRetryOnInterrupt = false;
       break;
     default:
-      assertNever(retryPolicy);
+      assertNever(effectiveRetryPolicy);
   }
   let toolResult: ToolExecutionResult;
   try {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -594,34 +594,29 @@ export async function runSandboxChildToolWorkflow({
     runAgentArgs: agentLoopArgs,
     step,
   };
-  const effectiveRetryPolicy = retryPolicy ?? "no_retry";
-  const useRetryPolicy =
-    retryPolicy !== undefined && patched("sandbox-child-tool-retry-policy");
-  let shouldRetryOnInterrupt: boolean;
-  switch (effectiveRetryPolicy) {
-    case "retry_on_interrupt":
-      shouldRetryOnInterrupt = useRetryPolicy;
-      break;
-    case "no_retry":
-      shouldRetryOnInterrupt = false;
-      break;
-    default:
-      assertNever(effectiveRetryPolicy);
-  }
   let toolResult: ToolExecutionResult;
-  try {
-    toolResult = shouldRetryOnInterrupt
-      ? await runRetryableToolActivity(authType, activityArgs)
-      : await runToolActivity(authType, activityArgs);
-  } catch (error) {
-    if (useRetryPolicy) {
+  if (retryPolicy !== undefined && patched("sandbox-child-tool-retry-policy")) {
+    try {
+      switch (retryPolicy) {
+        case "retry_on_interrupt":
+          toolResult = await runRetryableToolActivity(authType, activityArgs);
+          break;
+        case "no_retry":
+          toolResult = await runToolActivity(authType, activityArgs);
+          break;
+        default:
+          assertNever(retryPolicy);
+      }
+    } catch (error) {
       await CancellationScope.nonCancellable(() =>
         finalizeErroredSandboxChildToolActivity(authType, {
           actionModelId,
         })
       );
+      throw error;
     }
-    throw error;
+  } else {
+    toolResult = await runToolActivity(authType, activityArgs);
   }
 
   const { deferredEvents } = toolResult;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -3,6 +3,7 @@ import {
   RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
   RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } from "@app/lib/actions/constants";
+import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as compactionActivities from "@app/temporal/agent_loop/activities/compaction";
 import type * as creditCheckActivities from "@app/temporal/agent_loop/activities/credit_check";
@@ -569,18 +570,28 @@ export async function runSandboxChildToolWorkflow({
   authType,
   agentLoopArgs,
   actionModelId,
+  retryPolicy = "no_retry",
   step,
 }: {
   authType: AuthenticatorType;
   agentLoopArgs: AgentLoopArgsWithTiming;
   actionModelId: number;
+  // Optional so workflows started before this argument was added replay with the previous
+  // single-attempt behavior.
+  retryPolicy?: MCPToolRetryPolicyType;
   step: number;
 }) {
-  const { deferredEvents } = await runToolActivity(authType, {
+  const activityArgs = {
     actionId: actionModelId,
     runAgentArgs: agentLoopArgs,
     step,
-  });
+  };
+  const shouldRetryOnInterrupt =
+    retryPolicy === "retry_on_interrupt" &&
+    patched("sandbox-child-tool-retry-policy");
+  const { deferredEvents } = shouldRetryOnInterrupt
+    ? await runRetryableToolActivity(authType, activityArgs)
+    : await runToolActivity(authType, activityArgs);
 
   if (deferredEvents.length > 0) {
     await publishDeferredEventsActivity(deferredEvents);

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -37,6 +37,7 @@ import type {
 } from "@app/types/assistant/agent_run";
 import type { CompactionSourceConversation } from "@app/types/assistant/compaction";
 import type { SupportedModel } from "@app/types/assistant/models/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/common";
 import type {
   ChildWorkflowHandle,
@@ -586,9 +587,17 @@ export async function runSandboxChildToolWorkflow({
     runAgentArgs: agentLoopArgs,
     step,
   };
-  const shouldRetryOnInterrupt =
-    retryPolicy === "retry_on_interrupt" &&
-    patched("sandbox-child-tool-retry-policy");
+  let shouldRetryOnInterrupt: boolean;
+  switch (retryPolicy) {
+    case "retry_on_interrupt":
+      shouldRetryOnInterrupt = patched("sandbox-child-tool-retry-policy");
+      break;
+    case "no_retry":
+      shouldRetryOnInterrupt = false;
+      break;
+    default:
+      assertNever(retryPolicy);
+  }
   const { deferredEvents } = shouldRetryOnInterrupt
     ? await runRetryableToolActivity(authType, activityArgs)
     : await runToolActivity(authType, activityArgs);

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -9,6 +9,7 @@ import type * as compactionActivities from "@app/temporal/agent_loop/activities/
 import type * as creditCheckActivities from "@app/temporal/agent_loop/activities/credit_check";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
+import type * as finalizeSandboxChildToolActivities from "@app/temporal/agent_loop/activities/finalize_sandbox_child_tool";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
@@ -170,6 +171,12 @@ const {
   finalizeInterruptedAgentLoopActivity,
   finalizeErroredAgentLoopActivity,
 } = proxyActivities<typeof finalizeActivities>({
+  startToCloseTimeout: "1 minute",
+});
+
+const { finalizeErroredSandboxChildToolActivity } = proxyActivities<
+  typeof finalizeSandboxChildToolActivities
+>({
   startToCloseTimeout: "1 minute",
 });
 
@@ -587,10 +594,11 @@ export async function runSandboxChildToolWorkflow({
     runAgentArgs: agentLoopArgs,
     step,
   };
+  const useRetryPolicy = patched("sandbox-child-tool-retry-policy");
   let shouldRetryOnInterrupt: boolean;
   switch (retryPolicy) {
     case "retry_on_interrupt":
-      shouldRetryOnInterrupt = patched("sandbox-child-tool-retry-policy");
+      shouldRetryOnInterrupt = useRetryPolicy;
       break;
     case "no_retry":
       shouldRetryOnInterrupt = false;
@@ -598,9 +606,23 @@ export async function runSandboxChildToolWorkflow({
     default:
       assertNever(retryPolicy);
   }
-  const { deferredEvents } = shouldRetryOnInterrupt
-    ? await runRetryableToolActivity(authType, activityArgs)
-    : await runToolActivity(authType, activityArgs);
+  let toolResult: ToolExecutionResult;
+  try {
+    toolResult = shouldRetryOnInterrupt
+      ? await runRetryableToolActivity(authType, activityArgs)
+      : await runToolActivity(authType, activityArgs);
+  } catch (error) {
+    if (useRetryPolicy) {
+      await CancellationScope.nonCancellable(() =>
+        finalizeErroredSandboxChildToolActivity(authType, {
+          actionModelId,
+        })
+      );
+    }
+    throw error;
+  }
+
+  const { deferredEvents } = toolResult;
 
   if (deferredEvents.length > 0) {
     await publishDeferredEventsActivity(deferredEvents);


### PR DESCRIPTION
## Description

Sandbox child workflows always used the single-attempt tool activity, even when the stored tool policy was `retry_on_interrupt`. This caused 14 child workflow failures in 24 hours and left 13 actions stuck in `running`.

Pass the stored retry policy into the child workflow. Missing policies default to `no_retry` without recording a patch marker, which preserves old histories and lets a launcher-first rollback stop new marked workflows. Only `retry_on_interrupt` tools use the existing retryable activity proxy.

On terminal activity failure, a dedicated finalizer atomically moves only sandbox child actions still in `running` to `errored` before the workflow rethrows the original failure.

## Tests

Added focused workflow tests for both policies, missing legacy input without a patch marker, mixed-version replay, and terminal activity failures. Added activity tests for the sandbox-child guard and compare-and-set status transition. Ran these tests and the existing tool-interruption policy tests locally.

Full local typecheck was blocked by stale linked Notion and Novu dependencies in the fresh Hive environment. CI runs with a clean dependency install.

## Risk

Retrying may repeat side effects only for tools already explicitly configured as `retry_on_interrupt`, matching the main agent-loop dispatch. `no_retry` tools remain single-attempt. Failure finalization cannot overwrite actions that already reached a terminal or blocked status.

A forward rolling deploy is replay-safe because the patch marker preserves histories first executed by an older worker. A full rollback to pre-change workers is not safe while marked child workflows remain open: stop creating new marked workflows, keep patch-aware workers running until those executions close, then finish the worker rollback.

## Deploy Plan

Standard forward rolling deploy. Monitor sandbox child workflow failures and actions remaining in `running` after closed workflows. If rollback is needed, revert the launcher first so new workflows omit the policy and remain unmarked, drain marked child workflows on patch-aware workers, then revert the workers.