### PR TITLE
[front] enh: add API keys to attribution breakdowns

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.test.tsx
@@ -1,0 +1,59 @@
+import { ConsumptionAttributionBreakdown } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown";
+import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseConsumptionTop } = vi.hoisted(() => ({
+  mockUseConsumptionTop: vi.fn(),
+}));
+
+vi.mock("@app/hooks/useConsumptionTop", () => ({
+  useConsumptionTop: mockUseConsumptionTop,
+}));
+
+const period = { kind: "days", days: 30 } as const;
+
+const selectedRow: ConsumptionTopRow = {
+  id: "agent-1",
+  name: "Research agent",
+  pictureUrl: null,
+  description: null,
+  icon: null,
+  modelId: null,
+  modelDisplayName: null,
+  credits: 100,
+  avgCredits: 10,
+};
+
+describe("ConsumptionAttributionBreakdown", () => {
+  it("includes API keys in the cross-attribution breakdown", () => {
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [],
+      totalCredits: 0,
+      isTopLoading: false,
+      isTopError: undefined,
+    });
+
+    render(
+      <ConsumptionAttributionBreakdown
+        workspaceId="workspace-id"
+        selectedDimension="agent"
+        selectedRow={selectedRow}
+        period={period}
+        filter={{ tools: ["existing-tool"] }}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("heading", { name: "By API key" })).toBeVisible();
+    expect(mockUseConsumptionTop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dimension: "api_key",
+        filter: {
+          agents: [selectedRow.id],
+          tools: ["existing-tool"],
+        },
+      })
+    );
+  });
+});

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -10,13 +10,14 @@ import { CONSUMPTION_DIMENSION_CONFIG } from "./consumptionDimensions";
 
 const BREAKDOWN_LIMIT = 3;
 
-const BREAKDOWN_DIMENSIONS = ["model", "tool", "user"] as const;
+const BREAKDOWN_DIMENSIONS = ["model", "tool", "user", "api_key"] as const;
 type BreakdownDimension = (typeof BREAKDOWN_DIMENSIONS)[number];
 
 const BREAKDOWN_LABELS: Record<BreakdownDimension, string> = {
   model: "By model",
   tool: "By tools",
   user: "By users",
+  api_key: "By API key",
 };
 
 function BreakdownColumnSkeleton() {
@@ -154,7 +155,7 @@ export function ConsumptionAttributionBreakdown({
     <div
       className={cn(
         "grid gap-20",
-        visibleDimensions.length === 2 ? "grid-cols-2" : "grid-cols-3",
+        visibleDimensions.length === 3 ? "grid-cols-3" : "grid-cols-2",
         "border-b border-separator px-2 pb-6 pt-4"
       )}
     >


### PR DESCRIPTION
## Description

Expanded consumption attribution rows should show which API keys contributed to the selected entity.

This follow-up to #30538 adds API keys as a fourth cross-attribution dimension. Breakdowns with four cards use a balanced two-column layout, while selections that leave three cards keep the existing three-column layout.

## Tests

- Added coverage for API-key cross-attribution and selected-row filter scoping.

## Risk

- Low, limited to expanded consumption attribution rows.

## Deploy Plan

- Deploy front.
