### PR TITLE
Add Temporal job to generate raw consumption exports and store them in GCS

### DIFF
--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -325,6 +325,7 @@ describe("fetchConsumptionFacets", () => {
     expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(8);
   });
 
+
   it("returns the Elasticsearch failure before resolving historical labels", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
     const error = new ElasticsearchError("query_error", "query failed");

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -325,7 +325,6 @@ describe("fetchConsumptionFacets", () => {
     expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(8);
   });
 
-
   it("returns the Elasticsearch failure before resolving historical labels", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
     const error = new ElasticsearchError("query_error", "query failed");

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -1,0 +1,225 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
+// This directive makes them available in the test environment.
+
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import {
+  ElasticsearchError,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import {
+  buildConsumptionExportGcsPrefix,
+  runConsumptionExportActivity,
+} from "@app/temporal/analytics_queue/activities/consumption_export";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import type {
+  AgentMessageConsumptionAnalyticsLlmData,
+  AgentMessageConsumptionAnalyticsToolData,
+} from "@app/types/assistant/analytics";
+import { Err, Ok } from "@app/types/shared/result";
+import AdmZip from "adm-zip";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, resolveDimensionLabels: vi.fn() };
+});
+
+const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
+  workspace_id: "w1",
+  agent: {
+    id: "agent1",
+    version: "1",
+    tag_ids: ["tag1"],
+    parent_ids: [],
+    direct_parent_id: null,
+    root_id: "agent1",
+    depth: 0,
+  },
+  agent_message_id: "msg1",
+  api_key_name: null,
+  attribution_version: 1,
+  completed_at: "2026-08-01T00:00:00.000Z",
+  consumption_key: "run-usage:1",
+  context_origin: "api",
+  conversation_id: "conv1",
+  credit_micro: 1_000_000,
+  execution_time_ms: null,
+  message_version: "1",
+  model: {
+    provider_id: "anthropic",
+    model_id: "claude-sonnet-5",
+    reasoning_effort: "medium",
+    resolution_method: "auto",
+  },
+  run_usage_id: "123",
+  space_id: "space1",
+  status: "succeeded",
+  step_index: 0,
+  trigger_id: null,
+  usage_type: "user",
+  user: { id: "user1", group_ids: ["group1"] },
+  consumption_type: "llm",
+  gross_credit_micro: {
+    system: 100_000,
+    input: 200_000,
+    result_footprint: null,
+    output: 300_000,
+    reasoning: 400_000,
+    direct: 0,
+    total: 1_000_000,
+  },
+  tokens: {
+    system: 10,
+    input: 20,
+    result_footprint: null,
+    output: 30,
+    reasoning: 40,
+  },
+  tool: null,
+};
+
+const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
+  ...LLM_DOC,
+  consumption_key: "action:1",
+  consumption_type: "tool",
+  model: null,
+  gross_credit_micro: {
+    system: 0,
+    input: null,
+    result_footprint: null,
+    output: null,
+    reasoning: 0,
+    direct: 500_000,
+    total: 500_000,
+  },
+  tokens: {
+    system: 0,
+    input: null,
+    result_footprint: 15,
+    output: 5,
+    reasoning: 0,
+  },
+  tool: {
+    name: "search",
+    server_name: "server1",
+    parent_server_name: "",
+    action_id: "action1",
+    attributed_skill_ids: ["skill1"],
+  },
+  credit_micro: 500_000,
+  execution_time_ms: 250,
+};
+
+function mockDocs(docs: unknown[]) {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      hits: { hits: docs.map((doc) => ({ _source: doc, sort: [] })) },
+    }) as unknown as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+  );
+}
+
+function mockLabels(labels: Record<string, string>) {
+  vi.mocked(resolveDimensionLabels).mockImplementation(
+    async (_a, _d, keys) =>
+      new Map(
+        keys
+          .filter((key) => key in labels)
+          .map((key) => [
+            key,
+            { name: labels[key], pictureUrl: null, description: null },
+          ])
+      )
+  );
+}
+
+async function setup() {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  return { authenticator, workspace };
+}
+
+describe("runConsumptionExportActivity", () => {
+  it("uploads the CSV export to GCS under the workspace prefix", async () => {
+    mockDocs([LLM_DOC, TOOL_DOC]);
+    mockLabels({
+      agent1: "@dust",
+      user1: "Alice",
+      group1: "Engineering",
+      "claude-sonnet-5": "Claude Sonnet 5",
+      server1: "Search Tool",
+      skill1: "Research",
+      api: "API",
+    });
+    const { authenticator, workspace } = await setup();
+
+    await runConsumptionExportActivity(authenticator.toJSON(), {
+      period: {
+        startDate: "2026-08-01T00:00:00.000Z",
+        endDate: "2026-08-02T00:00:00.000Z",
+      },
+      filter: {},
+    });
+
+    const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
+    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+      call.filePath.startsWith(prefix)
+    );
+    expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0].contentType).toBe("application/zip");
+
+    // Read back the exact buffer passed to `.save()` rather than round-tripping through the
+    // mock's in-memory object store, which stores content as a UTF-8 string and would corrupt
+    // this binary zip.
+    const content = saveCalls[0].content;
+    const zip = new AdmZip(
+      Buffer.isBuffer(content) ? content : Buffer.from(content)
+    );
+    expect(zip.getEntries().map((entry) => entry.entryName)).toEqual([
+      "lines.csv",
+    ]);
+
+    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8");
+    expect(csv).toContain(
+      "completedAt,conversationId,spaceId,agentMessageId,consumptionType,agentId,agentName"
+    );
+    expect(csv).toContain(
+      "2026-08-01T00:00:00.000Z,conv1,space1,msg1,llm,agent1,'@dust"
+    );
+    expect(csv).toContain("claude-sonnet-5,Claude Sonnet 5");
+    expect(csv).toContain("user1,Alice,group1,Engineering");
+    expect(csv).toContain(
+      "2026-08-01T00:00:00.000Z,conv1,space1,msg1,tool,agent1,'@dust"
+    );
+    expect(csv).toContain("search,server1,Search Tool");
+    expect(csv).toContain("skill1,Research");
+  });
+
+  it("throws and uploads nothing when the search fails", async () => {
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { authenticator, workspace } = await setup();
+
+    await expect(
+      runConsumptionExportActivity(authenticator.toJSON(), {
+        period: {
+          startDate: "2026-08-01T00:00:00.000Z",
+          endDate: "2026-08-02T00:00:00.000Z",
+        },
+        filter: {},
+      })
+    ).rejects.toThrow();
+
+    const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
+    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+      call.filePath.startsWith(prefix)
+    );
+    expect(saveCalls).toHaveLength(0);
+  });
+});

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -13,12 +13,20 @@ import {
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import type {
+  AgentMessageConsumptionAnalyticsData,
   AgentMessageConsumptionAnalyticsLlmData,
   AgentMessageConsumptionAnalyticsToolData,
 } from "@app/types/assistant/analytics";
 import { Err, Ok } from "@app/types/shared/result";
 import AdmZip from "adm-zip";
 import { describe, expect, it, vi } from "vitest";
+
+// Instantiation expression: pins the mock to the concrete TDocument the exporter
+// actually queries with, so mockResolvedValue can be given a fully-typed
+// SearchResponse below without an `as` cast.
+const mockedSearchConsumptionAnalytics = vi.mocked(
+  searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>
+);
 
 vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
   const mod = await orig();
@@ -115,11 +123,20 @@ const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
   execution_time_ms: 250,
 };
 
-function mockDocs(docs: unknown[]) {
-  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+function mockDocs(docs: AgentMessageConsumptionAnalyticsData[]) {
+  mockedSearchConsumptionAnalytics.mockResolvedValue(
     new Ok({
-      hits: { hits: docs.map((doc) => ({ _source: doc, sort: [] })) },
-    }) as unknown as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+      took: 0,
+      timed_out: false,
+      _shards: { failed: 0, successful: 1, total: 1 },
+      hits: {
+        hits: docs.map((doc) => ({
+          _index: "consumption_analytics",
+          _source: doc,
+          sort: [],
+        })),
+      },
+    })
   );
 }
 
@@ -164,6 +181,7 @@ describe("runConsumptionExportActivity", () => {
         endDate: "2026-08-02T00:00:00.000Z",
       },
       filter: {},
+      exportId: "consumption-export-test-run",
     });
 
     const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
@@ -171,6 +189,9 @@ describe("runConsumptionExportActivity", () => {
       call.filePath.startsWith(prefix)
     );
     expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0].filePath).toBe(
+      `${prefix}consumption-export-test-run.zip`
+    );
     expect(saveCalls[0].contentType).toBe("application/zip");
 
     // Read back the exact buffer passed to `.save()` rather than round-tripping through the
@@ -201,7 +222,7 @@ describe("runConsumptionExportActivity", () => {
   });
 
   it("throws and uploads nothing when the search fails", async () => {
-    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    mockedSearchConsumptionAnalytics.mockResolvedValue(
       new Err(new ElasticsearchError("query_error", "boom"))
     );
     const { authenticator, workspace } = await setup();
@@ -213,6 +234,7 @@ describe("runConsumptionExportActivity", () => {
           endDate: "2026-08-02T00:00:00.000Z",
         },
         filter: {},
+        exportId: "consumption-export-test-run",
       })
     ).rejects.toThrow();
 

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -54,6 +54,7 @@ const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
   completed_at: "2026-08-01T00:00:00.000Z",
   consumption_key: "run-usage:1",
   context_origin: "api",
+  normalized_origin: "api",
   conversation_id: "conv1",
   credit_micro: 1_000_000,
   execution_time_ms: null,

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -35,24 +35,18 @@ function canonicalizeConsumptionScopeFilter(
 }
 
 // Hashed (rather than kept as plain text) because a filter selecting many agents/users/tools
-// can get long, and this value is used as a GCS object name. `salt`, when passed, forces a
-// unique key regardless of period/filter — used for open-ended periods (e.g. "this cycle")
-// whose data keeps changing while the period itself stays the same, so every trigger must
-// produce its own export rather than reusing a previous, now-stale one.
+// can get long, and this value is used as a GCS object name.
 export function buildConsumptionExportCacheKey({
   period,
   filter,
-  salt,
 }: {
   period: ConsumptionPeriod;
   filter: ConsumptionScopeFilter;
-  salt?: string;
 }): string {
   const payload = JSON.stringify({
     startDate: period.startDate,
     endDate: period.endDate,
     filter: canonicalizeConsumptionScopeFilter(filter),
-    salt: salt ?? null,
   });
   return createHash("sha256").update(payload).digest("hex");
 }

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -30,7 +30,7 @@ function canonicalizeConsumptionScopeFilter(
       const [, values] = entry;
       return values !== undefined && values.length > 0;
     })
-    .map(([key, values]) => [key, [...values].sort()] as const)
+    .map(([key, values]) => [key, [...values].sort()])
     .sort(([a], [b]) => a.localeCompare(b));
 }
 

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -1,0 +1,52 @@
+import { fetchConsumptionLinesExportZip } from "@app/lib/api/analytics/consumption/export_lines";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import logger from "@app/logger/logger";
+
+// Files are namespaced by workspace under a single top-level prefix so the cleanup job can
+// scan every workspace's exports in one bucket listing.
+export function buildConsumptionExportGcsPrefix(workspaceSId: string): string {
+  return `consumption_exports/w/${workspaceSId}/`;
+}
+
+function buildConsumptionExportGcsPath(
+  workspaceSId: string,
+  timestamp: number
+): string {
+  return `${buildConsumptionExportGcsPrefix(workspaceSId)}${timestamp}.zip`;
+}
+
+export async function runConsumptionExportActivity(
+  authType: AuthenticatorType,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter: ConsumptionScopeFilter;
+  }
+): Promise<void> {
+  const auth = await Authenticator.fromJSON(authType);
+  const workspaceSId = auth.getNonNullableWorkspace().sId;
+
+  const result = await fetchConsumptionLinesExportZip(auth, { period, filter });
+  if (result.isErr()) {
+    logger.error(
+      { workspaceId: workspaceSId, err: result.error },
+      "[ConsumptionExport] Failed to build consumption lines export."
+    );
+    throw result.error;
+  }
+
+  // Generated inside the activity (not the workflow, which must stay deterministic). Safe as
+  // a plain timestamp because the deterministic per-workspace workflow ID guarantees at most
+  // one export activity runs per workspace at a time.
+  const gcsPath = buildConsumptionExportGcsPath(workspaceSId, Date.now());
+
+  await getPrivateUploadBucket()
+    .file(gcsPath)
+    .save(result.value, { contentType: "application/zip", resumable: false });
+}

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -10,14 +10,12 @@ import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
 import { createHash } from "crypto";
 
-// Files live under the workspace's own prefix (matching the `w/{wId}/...` layout used elsewhere
-// in this bucket) so relocation and scrubbing can operate on the workspace prefix directly.
 export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
   return `w/${workspaceId}/consumption_exports/`;
 }
 
-// exportId is a content hash (see buildConsumptionExportCacheKey) identifying the export's
-// GCS object, so a retry within the same triggered export (same args, same hash) overwrites
+// exportId is a content hash identifying the export's GCS object, so a retry within the same
+// triggered export (same args, same hash) overwrites
 // the same object instead of leaving an orphaned duplicate zip, and — for closed periods —
 // a later request for the same period/filter reuses it instead of recrunching.
 export function buildConsumptionExportGcsPath(

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -1,10 +1,14 @@
 import { fetchConsumptionLinesExportZip } from "@app/lib/api/analytics/consumption/export_lines";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionScopeFilterKey,
+} from "@app/lib/api/analytics/consumption/scope";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
+import { createHash } from "crypto";
 
 // Files live under the workspace's own prefix (matching the `w/{wId}/...` layout used elsewhere
 // in this bucket) so relocation and scrubbing can operate on the workspace prefix directly.
@@ -12,15 +16,51 @@ export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
   return `w/${workspaceId}/consumption_exports/`;
 }
 
-// exportId is the workflow run ID (stable across activity retries within a
-// run, unlike a timestamp computed here, but unique per triggered export), so
-// a retry after a lost completion ack overwrites the same object instead of
-// leaving an orphaned duplicate zip.
-function buildConsumptionExportGcsPath(
+// exportId is a content hash (see buildConsumptionExportCacheKey) identifying the export's
+// GCS object, so a retry within the same triggered export (same args, same hash) overwrites
+// the same object instead of leaving an orphaned duplicate zip, and — for closed periods —
+// a later request for the same period/filter reuses it instead of recrunching.
+export function buildConsumptionExportGcsPath(
   workspaceId: string,
   exportId: string
 ): string {
   return `${buildConsumptionExportGcsPrefix(workspaceId)}${exportId}.zip`;
+}
+
+// Sorted independently of request key/array order so equivalent filters hash identically.
+function canonicalizeConsumptionScopeFilter(
+  filter: ConsumptionScopeFilter
+): ReadonlyArray<readonly [ConsumptionScopeFilterKey, string[]]> {
+  return Object.entries(filter)
+    .filter((entry): entry is [ConsumptionScopeFilterKey, string[]] => {
+      const [, values] = entry;
+      return values !== undefined && values.length > 0;
+    })
+    .map(([key, values]) => [key, [...values].sort()] as const)
+    .sort(([a], [b]) => a.localeCompare(b));
+}
+
+// Hashed (rather than kept as plain text) because a filter selecting many agents/users/tools
+// can get long, and this value is used as a GCS object name. `salt`, when passed, forces a
+// unique key regardless of period/filter — used for open-ended periods (e.g. "this cycle")
+// whose data keeps changing while the period itself stays the same, so every trigger must
+// produce its own export rather than reusing a previous, now-stale one.
+export function buildConsumptionExportCacheKey({
+  period,
+  filter,
+  salt,
+}: {
+  period: ConsumptionPeriod;
+  filter: ConsumptionScopeFilter;
+  salt?: string;
+}): string {
+  const payload = JSON.stringify({
+    startDate: period.startDate,
+    endDate: period.endDate,
+    filter: canonicalizeConsumptionScopeFilter(filter),
+    salt: salt ?? null,
+  });
+  return createHash("sha256").update(payload).digest("hex");
 }
 
 export async function runConsumptionExportActivity(

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -6,10 +6,10 @@ import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
 
-// Files are namespaced by workspace under a single top-level prefix so the cleanup job can
-// scan every workspace's exports in one bucket listing.
+// Files live under the workspace's own prefix (matching the `w/{wId}/...` layout used elsewhere
+// in this bucket) so relocation and scrubbing can operate on the workspace prefix directly.
 export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
-  return `consumption_exports/w/${workspaceId}/`;
+  return `w/${workspaceId}/consumption_exports/`;
 }
 
 // exportId is the workflow run ID (stable across activity retries within a

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -8,15 +8,18 @@ import logger from "@app/logger/logger";
 
 // Files are namespaced by workspace under a single top-level prefix so the cleanup job can
 // scan every workspace's exports in one bucket listing.
-export function buildConsumptionExportGcsPrefix(workspaceSId: string): string {
-  return `consumption_exports/w/${workspaceSId}/`;
+export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
+  return `consumption_exports/w/${workspaceId}/`;
 }
 
+// exportId is the workflow ID (stable across activity retries, unlike a
+// timestamp computed here), so a retry after a lost completion ack overwrites
+// the same object instead of leaving an orphaned duplicate zip.
 function buildConsumptionExportGcsPath(
-  workspaceSId: string,
-  timestamp: number
+  workspaceId: string,
+  exportId: string
 ): string {
-  return `${buildConsumptionExportGcsPrefix(workspaceSId)}${timestamp}.zip`;
+  return `${buildConsumptionExportGcsPrefix(workspaceId)}${exportId}.zip`;
 }
 
 export async function runConsumptionExportActivity(
@@ -24,24 +27,26 @@ export async function runConsumptionExportActivity(
   {
     period,
     filter,
+    exportId,
   }: {
     period: ConsumptionPeriod;
     filter: ConsumptionScopeFilter;
+    exportId: string;
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJSON(authType);
-  const workspaceSId = auth.getNonNullableWorkspace().sId;
+  const workspaceId = auth.getNonNullableWorkspace().sId;
 
   const result = await fetchConsumptionLinesExportZip(auth, { period, filter });
   if (result.isErr()) {
     logger.error(
-      { workspaceId: workspaceSId, err: result.error },
+      { workspaceId, err: result.error },
       "[ConsumptionExport] Failed to build consumption lines export."
     );
     throw result.error;
   }
 
-  const gcsPath = buildConsumptionExportGcsPath(workspaceSId, Date.now());
+  const gcsPath = buildConsumptionExportGcsPath(workspaceId, exportId);
 
   await getPrivateUploadBucket()
     .file(gcsPath)

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -14,10 +14,6 @@ export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
   return `w/${workspaceId}/consumption_exports/`;
 }
 
-// exportId is a content hash identifying the export's GCS object, so a retry within the same
-// triggered export (same args, same hash) overwrites
-// the same object instead of leaving an orphaned duplicate zip, and — for closed periods —
-// a later request for the same period/filter reuses it instead of recrunching.
 export function buildConsumptionExportGcsPath(
   workspaceId: string,
   exportId: string

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -41,9 +41,6 @@ export async function runConsumptionExportActivity(
     throw result.error;
   }
 
-  // Generated inside the activity (not the workflow, which must stay deterministic). Safe as
-  // a plain timestamp because the deterministic per-workspace workflow ID guarantees at most
-  // one export activity runs per workspace at a time.
   const gcsPath = buildConsumptionExportGcsPath(workspaceSId, Date.now());
 
   await getPrivateUploadBucket()

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -30,7 +30,10 @@ function canonicalizeConsumptionScopeFilter(
       const [, values] = entry;
       return values !== undefined && values.length > 0;
     })
-    .map(([key, values]) => [key, [...values].sort()] as const)
+    .map(([key, values]): readonly [ConsumptionScopeFilterKey, string[]] => [
+      key,
+      [...values].sort(),
+    ])
     .sort(([a], [b]) => a.localeCompare(b));
 }
 

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -30,7 +30,7 @@ function canonicalizeConsumptionScopeFilter(
       const [, values] = entry;
       return values !== undefined && values.length > 0;
     })
-    .map(([key, values]) => [key, [...values].sort()])
+    .map(([key, values]) => [key, [...values].sort()] as const)
     .sort(([a], [b]) => a.localeCompare(b));
 }
 

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -12,9 +12,10 @@ export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
   return `consumption_exports/w/${workspaceId}/`;
 }
 
-// exportId is the workflow ID (stable across activity retries, unlike a
-// timestamp computed here), so a retry after a lost completion ack overwrites
-// the same object instead of leaving an orphaned duplicate zip.
+// exportId is the workflow run ID (stable across activity retries within a
+// run, unlike a timestamp computed here, but unique per triggered export), so
+// a retry after a lost completion ack overwrites the same object instead of
+// leaving an orphaned duplicate zip.
 function buildConsumptionExportGcsPath(
   workspaceId: string,
   exportId: string

--- a/front/temporal/analytics_queue/activities/index.ts
+++ b/front/temporal/analytics_queue/activities/index.ts
@@ -1,2 +1,3 @@
 export * from "@app/temporal/analytics_queue/activities/agent_analytics";
 export * from "@app/temporal/analytics_queue/activities/consumption_attribution";
+export * from "@app/temporal/analytics_queue/activities/consumption_export";

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -1,6 +1,10 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
+  buildConsumptionExportCacheKey,
+  buildConsumptionExportGcsPath,
+} from "@app/temporal/analytics_queue/activities/consumption_export";
+import {
   launchConsumptionExportWorkflow,
   launchStoreAgentMessageConsumptionAttributionWorkflow,
 } from "@app/temporal/analytics_queue/client";
@@ -12,18 +16,25 @@ import {
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import { storeAgentMessageConsumptionAttributionV3Workflow } from "@app/temporal/analytics_queue/workflows";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 import { WorkflowNotFoundError } from "@temporalio/common";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockSignalWithStart, mockStart, mockDescribe, mockGetHandle } =
-  vi.hoisted(() => ({
-    mockSignalWithStart: vi.fn(),
-    mockStart: vi.fn(),
-    mockDescribe: vi.fn(),
-    mockGetHandle: vi.fn(),
-  }));
+const {
+  mockSignalWithStart,
+  mockStart,
+  mockDescribe,
+  mockQuery,
+  mockGetHandle,
+} = vi.hoisted(() => ({
+  mockSignalWithStart: vi.fn(),
+  mockStart: vi.fn(),
+  mockDescribe: vi.fn(),
+  mockQuery: vi.fn(),
+  mockGetHandle: vi.fn(),
+}));
 
 vi.mock("@app/lib/temporal", () => ({
   getTemporalClientForFrontNamespace: vi.fn(async () => ({
@@ -106,7 +117,9 @@ describe("launchConsumptionExportWorkflow", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetHandle.mockReturnValue({ describe: mockDescribe });
+    mockGetHandle.mockReturnValue({ describe: mockDescribe, query: mockQuery });
+    // No cached export exists unless a test says otherwise.
+    fileStorageMock.setFileExists(() => false);
   });
 
   it("starts the workflow when none is running for the workspace", async () => {
@@ -132,6 +145,59 @@ describe("launchConsumptionExportWorkflow", () => {
     expect(mockStart).toHaveBeenCalledTimes(1);
   });
 
+  it("reuses a previously completed export for the same closed period and filter instead of recomputing it", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workspaceId = authenticator.getNonNullableWorkspace().sId;
+    const gcsPath = buildConsumptionExportGcsPath(
+      workspaceId,
+      buildConsumptionExportCacheKey({ period: periodA, filter: filterA })
+    );
+    fileStorageMock.setFileExists((filePath) => filePath === gcsPath);
+
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: periodA,
+      filter: filterA,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "cached",
+      gcsPath,
+    });
+    // No need to even check for a running workflow: the cache hit is enough.
+    expect(mockDescribe).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("never reuses a previous export for an open-ended period, even if one exists in GCS", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workflowId = makeConsumptionExportWorkflowId({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+    const openEndedPeriod: ConsumptionPeriod = {
+      startDate: "2026-08-01T00:00:00.000Z",
+      // In the future relative to the current test-suite date: this cycle's data keeps
+      // accruing, so a same-looking export from earlier today must not be served back.
+      endDate: "2027-01-01T00:00:00.000Z",
+    };
+    // Would be a cache hit if this were treated as a closed period.
+    fileStorageMock.setFileExists(() => true);
+    mockDescribe.mockRejectedValue(
+      new WorkflowNotFoundError("not found", workflowId, undefined)
+    );
+    mockStart.mockResolvedValue(undefined);
+
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: openEndedPeriod,
+      filter: filterA,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "started",
+      workflowId,
+    });
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
   it("reports already_running with the running export's own parameters when a second, differently-scoped export is requested concurrently", async () => {
     const { authenticator } = await createResourceTest({});
     const workflowId = makeConsumptionExportWorkflowId({
@@ -139,10 +205,8 @@ describe("launchConsumptionExportWorkflow", () => {
     });
 
     // Export A is already in flight for this workspace.
-    mockDescribe.mockResolvedValue({
-      status: { name: "RUNNING" },
-      memo: { period: periodA, filter: filterA },
-    });
+    mockDescribe.mockResolvedValue({ status: { name: "RUNNING" } });
+    mockQuery.mockResolvedValue({ period: periodA, filter: filterA });
 
     // Export B, with a different period/filter, is requested while A runs.
     const result = await launchConsumptionExportWorkflow(authenticator, {
@@ -173,10 +237,8 @@ describe("launchConsumptionExportWorkflow", () => {
       )
       // ...but by the time we look it up again after losing the start race,
       // export A (started by a concurrent request) is running.
-      .mockResolvedValueOnce({
-        status: { name: "RUNNING" },
-        memo: { period: periodA, filter: filterA },
-      });
+      .mockResolvedValueOnce({ status: { name: "RUNNING" } });
+    mockQuery.mockResolvedValue({ period: periodA, filter: filterA });
     mockStart.mockRejectedValue(
       new WorkflowExecutionAlreadyStartedError(
         "already started",

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -1,20 +1,36 @@
-import { launchStoreAgentMessageConsumptionAttributionWorkflow } from "@app/temporal/analytics_queue/client";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import {
+  launchConsumptionExportWorkflow,
+  launchStoreAgentMessageConsumptionAttributionWorkflow,
+} from "@app/temporal/analytics_queue/client";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
-import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
+import {
+  makeAgentMessageAnalyticsWorkflowId,
+  makeConsumptionExportWorkflowId,
+} from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import { storeAgentMessageConsumptionAttributionV3Workflow } from "@app/temporal/analytics_queue/workflows";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/common";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockSignalWithStart } = vi.hoisted(() => ({
-  mockSignalWithStart: vi.fn(),
-}));
+const { mockSignalWithStart, mockStart, mockDescribe, mockGetHandle } =
+  vi.hoisted(() => ({
+    mockSignalWithStart: vi.fn(),
+    mockStart: vi.fn(),
+    mockDescribe: vi.fn(),
+    mockGetHandle: vi.fn(),
+  }));
 
 vi.mock("@app/lib/temporal", () => ({
   getTemporalClientForFrontNamespace: vi.fn(async () => ({
     workflow: {
       signalWithStart: mockSignalWithStart,
+      start: mockStart,
+      getHandle: mockGetHandle,
     },
   })),
 }));
@@ -72,5 +88,112 @@ describe("launchStoreAgentMessageConsumptionAttributionWorkflow", () => {
         signalArgs: undefined,
       })
     );
+  });
+});
+
+describe("launchConsumptionExportWorkflow", () => {
+  const periodA: ConsumptionPeriod = {
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+  };
+  const filterA: ConsumptionScopeFilter = { agents: ["agent_a"] };
+
+  const periodB: ConsumptionPeriod = {
+    startDate: "2026-06-01T00:00:00.000Z",
+    endDate: "2026-07-01T00:00:00.000Z",
+  };
+  const filterB: ConsumptionScopeFilter = { agents: ["agent_b"] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHandle.mockReturnValue({ describe: mockDescribe });
+  });
+
+  it("starts the workflow when none is running for the workspace", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workflowId = makeConsumptionExportWorkflowId({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+
+    mockDescribe.mockRejectedValue(
+      new WorkflowNotFoundError("not found", workflowId, undefined)
+    );
+    mockStart.mockResolvedValue(undefined);
+
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: periodA,
+      filter: filterA,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "started",
+      workflowId,
+    });
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports already_running with the running export's own parameters when a second, differently-scoped export is requested concurrently", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workflowId = makeConsumptionExportWorkflowId({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+
+    // Export A is already in flight for this workspace.
+    mockDescribe.mockResolvedValue({
+      status: { name: "RUNNING" },
+      memo: { period: periodA, filter: filterA },
+    });
+
+    // Export B, with a different period/filter, is requested while A runs.
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: periodB,
+      filter: filterB,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "already_running",
+      workflowId,
+      running: { period: periodA, filter: filterA },
+    });
+    // B's parameters must never be silently dropped by starting nothing and
+    // reporting success as if B had been queued.
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("reports already_running when the start call itself loses the race to a concurrent launch", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workflowId = makeConsumptionExportWorkflowId({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+
+    // No export running yet at describe() time...
+    mockDescribe
+      .mockRejectedValueOnce(
+        new WorkflowNotFoundError("not found", workflowId, undefined)
+      )
+      // ...but by the time we look it up again after losing the start race,
+      // export A (started by a concurrent request) is running.
+      .mockResolvedValueOnce({
+        status: { name: "RUNNING" },
+        memo: { period: periodA, filter: filterA },
+      });
+    mockStart.mockRejectedValue(
+      new WorkflowExecutionAlreadyStartedError(
+        "already started",
+        workflowId,
+        "runConsumptionExportWorkflow"
+      )
+    );
+
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: periodB,
+      filter: filterB,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "already_running",
+      workflowId,
+      running: { period: periodA, filter: filterA },
+    });
   });
 });

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -122,10 +122,14 @@ describe("launchConsumptionExportWorkflow", () => {
     fileStorageMock.setFileExists(() => false);
   });
 
-  it("starts the workflow when none is running for the workspace", async () => {
+  it("starts the workflow when none is running for this export", async () => {
     const { authenticator } = await createResourceTest({});
     const workflowId = makeConsumptionExportWorkflowId({
       workspaceId: authenticator.getNonNullableWorkspace().sId,
+      exportId: buildConsumptionExportCacheKey({
+        period: periodA,
+        filter: filterA,
+      }),
     });
 
     mockDescribe.mockRejectedValue(
@@ -213,7 +217,14 @@ describe("launchConsumptionExportWorkflow", () => {
     it("does not reuse a previous day's export, so freshly accrued data is captured", async () => {
       const { authenticator } = await createResourceTest({});
       const workspaceId = authenticator.getNonNullableWorkspace().sId;
-      const workflowId = makeConsumptionExportWorkflowId({ workspaceId });
+      const workflowId = makeConsumptionExportWorkflowId({
+        workspaceId,
+        exportId: buildConsumptionExportCacheKey({
+          period: openEndedPeriod,
+          filter: filterA,
+          salt: "2026-08-14",
+        }),
+      });
 
       // Yesterday's export exists in GCS...
       const yesterdaysGcsPath = buildConsumptionExportGcsPath(
@@ -248,47 +259,78 @@ describe("launchConsumptionExportWorkflow", () => {
     });
   });
 
-  it("reports already_running with the running export's own parameters when a second, differently-scoped export is requested concurrently", async () => {
+  it("starts its own workflow when a differently-scoped export is requested while another is running", async () => {
     const { authenticator } = await createResourceTest({});
-    const workflowId = makeConsumptionExportWorkflowId({
-      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    const workspaceId = authenticator.getNonNullableWorkspace().sId;
+    const workflowIdB = makeConsumptionExportWorkflowId({
+      workspaceId,
+      exportId: buildConsumptionExportCacheKey({
+        period: periodB,
+        filter: filterB,
+      }),
     });
 
-    // Export A is already in flight for this workspace.
-    mockDescribe.mockResolvedValue({ status: { name: "RUNNING" } });
-    mockQuery.mockResolvedValue({ period: periodA, filter: filterA });
+    // Export A is already in flight for this workspace, under its own workflow ID.
+    mockDescribe.mockRejectedValue(
+      new WorkflowNotFoundError("not found", workflowIdB, undefined)
+    );
+    mockStart.mockResolvedValue(undefined);
 
-    // Export B, with a different period/filter, is requested while A runs.
+    // Export B, with a different period/filter, gets its own workflow instead of
+    // being blocked by A.
     const result = await launchConsumptionExportWorkflow(authenticator, {
       period: periodB,
       filter: filterB,
     });
 
     expect(result.isOk() && result.value).toEqual({
-      status: "already_running",
-      workflowId,
-      running: { period: periodA, filter: filterA },
+      status: "started",
+      workflowId: workflowIdB,
     });
-    // B's parameters must never be silently dropped by starting nothing and
-    // reporting success as if B had been queued.
-    expect(mockStart).not.toHaveBeenCalled();
+    expect(mockStart).toHaveBeenCalledTimes(1);
   });
 
-  it("reports already_running when the start call itself loses the race to a concurrent launch", async () => {
+  it("reports already_running with the request's own parameters when the exact same export is already in flight", async () => {
     const { authenticator } = await createResourceTest({});
     const workflowId = makeConsumptionExportWorkflowId({
       workspaceId: authenticator.getNonNullableWorkspace().sId,
+      exportId: buildConsumptionExportCacheKey({
+        period: periodA,
+        filter: filterA,
+      }),
     });
 
-    // No export running yet at describe() time...
-    mockDescribe
-      .mockRejectedValueOnce(
-        new WorkflowNotFoundError("not found", workflowId, undefined)
-      )
-      // ...but by the time we look it up again after losing the start race,
-      // export A (started by a concurrent request) is running.
-      .mockResolvedValueOnce({ status: { name: "RUNNING" } });
-    mockQuery.mockResolvedValue({ period: periodA, filter: filterA });
+    mockDescribe.mockResolvedValue({ status: { name: "RUNNING" } });
+
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: periodA,
+      filter: filterA,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "already_running",
+      workflowId,
+      period: periodA,
+      filter: filterA,
+    });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("reports already_running when the start call itself loses the race to a concurrent identical launch", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workflowId = makeConsumptionExportWorkflowId({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+      exportId: buildConsumptionExportCacheKey({
+        period: periodA,
+        filter: filterA,
+      }),
+    });
+
+    // No export running yet at describe() time, but by the time start() is
+    // called, a concurrent identical request has already won the race.
+    mockDescribe.mockRejectedValue(
+      new WorkflowNotFoundError("not found", workflowId, undefined)
+    );
     mockStart.mockRejectedValue(
       new WorkflowExecutionAlreadyStartedError(
         "already started",
@@ -298,14 +340,15 @@ describe("launchConsumptionExportWorkflow", () => {
     );
 
     const result = await launchConsumptionExportWorkflow(authenticator, {
-      period: periodB,
-      filter: filterB,
+      period: periodA,
+      filter: filterA,
     });
 
     expect(result.isOk() && result.value).toEqual({
       status: "already_running",
       workflowId,
-      running: { period: periodA, filter: filterA },
+      period: periodA,
+      filter: filterA,
     });
   });
 });

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -20,7 +20,7 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
 import { WorkflowNotFoundError } from "@temporalio/common";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockSignalWithStart,
@@ -168,34 +168,84 @@ describe("launchConsumptionExportWorkflow", () => {
     expect(mockStart).not.toHaveBeenCalled();
   });
 
-  it("never reuses a previous export for an open-ended period, even if one exists in GCS", async () => {
-    const { authenticator } = await createResourceTest({});
-    const workflowId = makeConsumptionExportWorkflowId({
-      workspaceId: authenticator.getNonNullableWorkspace().sId,
-    });
+  describe("open-ended period (e.g. 'this cycle')", () => {
+    // In the future relative to the mocked "now" below: this cycle's data keeps accruing
+    // while the period value itself stays the same for its whole duration.
     const openEndedPeriod: ConsumptionPeriod = {
       startDate: "2026-08-01T00:00:00.000Z",
-      // In the future relative to the current test-suite date: this cycle's data keeps
-      // accruing, so a same-looking export from earlier today must not be served back.
       endDate: "2027-01-01T00:00:00.000Z",
     };
-    // Would be a cache hit if this were treated as a closed period.
-    fileStorageMock.setFileExists(() => true);
-    mockDescribe.mockRejectedValue(
-      new WorkflowNotFoundError("not found", workflowId, undefined)
-    );
-    mockStart.mockResolvedValue(undefined);
 
-    const result = await launchConsumptionExportWorkflow(authenticator, {
-      period: openEndedPeriod,
-      filter: filterA,
+    afterEach(() => {
+      vi.useRealTimers();
     });
 
-    expect(result.isOk() && result.value).toEqual({
-      status: "started",
-      workflowId,
+    it("reuses the same day's export instead of recrunching on a same-day retrigger", async () => {
+      const { authenticator } = await createResourceTest({});
+      const workspaceId = authenticator.getNonNullableWorkspace().sId;
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-14T09:00:00.000Z"));
+      const gcsPath = buildConsumptionExportGcsPath(
+        workspaceId,
+        buildConsumptionExportCacheKey({
+          period: openEndedPeriod,
+          filter: filterA,
+          salt: "2026-08-14",
+        })
+      );
+      fileStorageMock.setFileExists((filePath) => filePath === gcsPath);
+
+      // A user retriggers "this cycle" again later the same day.
+      vi.setSystemTime(new Date("2026-08-14T18:00:00.000Z"));
+      const result = await launchConsumptionExportWorkflow(authenticator, {
+        period: openEndedPeriod,
+        filter: filterA,
+      });
+
+      expect(result.isOk() && result.value).toEqual({
+        status: "cached",
+        gcsPath,
+      });
+      expect(mockStart).not.toHaveBeenCalled();
     });
-    expect(mockStart).toHaveBeenCalledTimes(1);
+
+    it("does not reuse a previous day's export, so freshly accrued data is captured", async () => {
+      const { authenticator } = await createResourceTest({});
+      const workspaceId = authenticator.getNonNullableWorkspace().sId;
+      const workflowId = makeConsumptionExportWorkflowId({ workspaceId });
+
+      // Yesterday's export exists in GCS...
+      const yesterdaysGcsPath = buildConsumptionExportGcsPath(
+        workspaceId,
+        buildConsumptionExportCacheKey({
+          period: openEndedPeriod,
+          filter: filterA,
+          salt: "2026-08-13",
+        })
+      );
+      fileStorageMock.setFileExists(
+        (filePath) => filePath === yesterdaysGcsPath
+      );
+      mockDescribe.mockRejectedValue(
+        new WorkflowNotFoundError("not found", workflowId, undefined)
+      );
+      mockStart.mockResolvedValue(undefined);
+
+      // ...but the request comes in today, so it must not be served back.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-08-14T09:00:00.000Z"));
+      const result = await launchConsumptionExportWorkflow(authenticator, {
+        period: openEndedPeriod,
+        filter: filterA,
+      });
+
+      expect(result.isOk() && result.value).toEqual({
+        status: "started",
+        workflowId,
+      });
+      expect(mockStart).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("reports already_running with the running export's own parameters when a second, differently-scoped export is requested concurrently", async () => {

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -193,9 +193,11 @@ describe("launchConsumptionExportWorkflow", () => {
       const gcsPath = buildConsumptionExportGcsPath(
         workspaceId,
         buildConsumptionExportCacheKey({
-          period: openEndedPeriod,
+          period: {
+            startDate: openEndedPeriod.startDate,
+            endDate: "2026-08-14T23:59:59.999Z",
+          },
           filter: filterA,
-          salt: "2026-08-14",
         })
       );
       fileStorageMock.setFileExists((filePath) => filePath === gcsPath);
@@ -220,9 +222,11 @@ describe("launchConsumptionExportWorkflow", () => {
       const workflowId = makeConsumptionExportWorkflowId({
         workspaceId,
         exportId: buildConsumptionExportCacheKey({
-          period: openEndedPeriod,
+          period: {
+            startDate: openEndedPeriod.startDate,
+            endDate: "2026-08-14T23:59:59.999Z",
+          },
           filter: filterA,
-          salt: "2026-08-14",
         }),
       });
 
@@ -230,9 +234,11 @@ describe("launchConsumptionExportWorkflow", () => {
       const yesterdaysGcsPath = buildConsumptionExportGcsPath(
         workspaceId,
         buildConsumptionExportCacheKey({
-          period: openEndedPeriod,
+          period: {
+            startDate: openEndedPeriod.startDate,
+            endDate: "2026-08-13T23:59:59.999Z",
+          },
           filter: filterA,
-          salt: "2026-08-13",
         })
       );
       fileStorageMock.setFileExists(

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -164,9 +164,8 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
   }
 }
 
-// Deterministic workflow ID (one per workspace) means a duplicate call while a previous
-// export is still running fails with `WorkflowExecutionAlreadyStartedError`, which is treated
-// as success here: it just means an export is already being generated.
+// Workflow ID is unique per worksapce meaning a duplicate call while a previous
+// export is still running fails
 export async function launchConsumptionExportWorkflow(
   auth: Authenticator,
   {

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -1,3 +1,5 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -6,9 +8,13 @@ import {
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
-import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
+import {
+  makeAgentMessageAnalyticsWorkflowId,
+  makeConsumptionExportWorkflowId,
+} from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import {
+  runConsumptionExportWorkflow,
   storeAgentAnalyticsWorkflow,
   storeAgentMessageConsumptionAttributionV3Workflow,
   storeAgentMessageFeedbackWorkflow,
@@ -152,6 +158,54 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
         error: e,
       },
       "Failed starting agent message consumption attribution workflow"
+    );
+
+    return new Err(normalizeError(e));
+  }
+}
+
+// Deterministic workflow ID (one per workspace) means a duplicate call while a previous
+// export is still running fails with `WorkflowExecutionAlreadyStartedError`, which is treated
+// as success here: it just means an export is already being generated.
+export async function launchConsumptionExportWorkflow(
+  auth: Authenticator,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter: ConsumptionScopeFilter;
+  }
+): Promise<Result<undefined, Error>> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const authType = auth.toJSON();
+
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workflowId = makeConsumptionExportWorkflowId({ workspaceId });
+
+  try {
+    await client.workflow.start(runConsumptionExportWorkflow, {
+      args: [authType, { period, filter }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: {
+        workspaceId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      return new Ok(undefined);
+    }
+
+    logger.error(
+      {
+        workflowId,
+        workspaceId,
+        error: e,
+      },
+      "Failed starting consumption export workflow"
     );
 
     return new Err(normalizeError(e));

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -1,6 +1,5 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
-import { CONSUMPTION_SCOPE_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -15,6 +14,7 @@ import {
 } from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import {
+  getConsumptionExportParamsQuery,
   runConsumptionExportWorkflow,
   storeAgentAnalyticsWorkflow,
   storeAgentMessageConsumptionAttributionV3Workflow,
@@ -33,7 +33,6 @@ import {
   WorkflowExecutionAlreadyStartedError,
   WorkflowNotFoundError,
 } from "@temporalio/client";
-import { z } from "zod";
 
 // Resolves the agent configuration id backing an agent message (referenced by its
 // message sId). Used to decide whether the feedback workflow needs to wait for
@@ -170,14 +169,9 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
   }
 }
 
-const ConsumptionExportMemoSchema = z.object({
-  period: z.object({ startDate: z.string(), endDate: z.string() }),
-  filter: z.record(z.enum(CONSUMPTION_SCOPE_FILTER_KEYS), z.string().array()),
-});
-
-// A running export's parameters, read back from its memo. `null` means an export
-// is (or, in the AlreadyStarted race below, was) running but its parameters could
-// not be recovered.
+// A running export's parameters, read back via a workflow query. `null` means an export
+// is (or, in the AlreadyStarted race below, was) running but its parameters could not be
+// recovered (e.g. the workflow hadn't installed its query handler yet).
 export type RunningConsumptionExport = {
   period: ConsumptionPeriod;
   filter: ConsumptionScopeFilter;
@@ -200,8 +194,11 @@ async function describeRunningConsumptionExport(
       return undefined;
     }
 
-    const memo = ConsumptionExportMemoSchema.safeParse(execution.memo);
-    return memo.success ? memo.data : null;
+    try {
+      return await handle.query(getConsumptionExportParamsQuery);
+    } catch {
+      return null;
+    }
   } catch (e) {
     if (e instanceof WorkflowNotFoundError) {
       return undefined;
@@ -243,8 +240,6 @@ export async function launchConsumptionExportWorkflow(
       workflowId,
       memo: {
         workspaceId,
-        period,
-        filter,
       },
     });
     return new Ok({ status: "started", workflowId });

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -1,5 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { CONSUMPTION_SCOPE_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -27,7 +28,12 @@ import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+import type { WorkflowHandle } from "@temporalio/client";
+import {
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowNotFoundError,
+} from "@temporalio/client";
+import { z } from "zod";
 
 // Resolves the agent configuration id backing an agent message (referenced by its
 // message sId). Used to decide whether the feedback workflow needs to wait for
@@ -164,8 +170,48 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
   }
 }
 
-// Workflow ID is unique per worksapce meaning a duplicate call while a previous
-// export is still running fails
+const ConsumptionExportMemoSchema = z.object({
+  period: z.object({ startDate: z.string(), endDate: z.string() }),
+  filter: z.record(z.enum(CONSUMPTION_SCOPE_FILTER_KEYS), z.string().array()),
+});
+
+// A running export's parameters, read back from its memo. `null` means an export
+// is (or, in the AlreadyStarted race below, was) running but its parameters could
+// not be recovered.
+export type RunningConsumptionExport = {
+  period: ConsumptionPeriod;
+  filter: ConsumptionScopeFilter;
+} | null;
+
+export type LaunchConsumptionExportOutcome =
+  | { status: "started"; workflowId: string }
+  | {
+      status: "already_running";
+      workflowId: string;
+      running: RunningConsumptionExport;
+    };
+
+async function describeRunningConsumptionExport(
+  handle: WorkflowHandle
+): Promise<RunningConsumptionExport | undefined> {
+  try {
+    const execution = await handle.describe();
+    if (execution.status.name !== "RUNNING") {
+      return undefined;
+    }
+
+    const memo = ConsumptionExportMemoSchema.safeParse(execution.memo);
+    return memo.success ? memo.data : null;
+  } catch (e) {
+    if (e instanceof WorkflowNotFoundError) {
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+// Only one export runs per workspace at a time
+// A concurrent request while one is in flight is surfaced as "already_running"
 export async function launchConsumptionExportWorkflow(
   auth: Authenticator,
   {
@@ -175,7 +221,7 @@ export async function launchConsumptionExportWorkflow(
     period: ConsumptionPeriod;
     filter: ConsumptionScopeFilter;
   }
-): Promise<Result<undefined, Error>> {
+): Promise<Result<LaunchConsumptionExportOutcome, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const authType = auth.toJSON();
 
@@ -184,18 +230,37 @@ export async function launchConsumptionExportWorkflow(
   const workflowId = makeConsumptionExportWorkflowId({ workspaceId });
 
   try {
+    const running = await describeRunningConsumptionExport(
+      client.workflow.getHandle(workflowId)
+    );
+    if (running !== undefined) {
+      return new Ok({ status: "already_running", workflowId, running });
+    }
+
     await client.workflow.start(runConsumptionExportWorkflow, {
       args: [authType, { period, filter }],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {
         workspaceId,
+        period,
+        filter,
       },
     });
-    return new Ok(undefined);
+    return new Ok({ status: "started", workflowId });
   } catch (e) {
     if (e instanceof WorkflowExecutionAlreadyStartedError) {
-      return new Ok(undefined);
+      // Lost the race to start: another request started an export between our
+      // describe() check and start() above. Look up what it's running so the
+      // caller can still report accurate parameters instead of a bare success.
+      const running = await describeRunningConsumptionExport(
+        client.workflow.getHandle(workflowId)
+      );
+      return new Ok({
+        status: "already_running",
+        workflowId,
+        running: running ?? null,
+      });
     }
 
     logger.error(

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -207,13 +207,6 @@ async function isConsumptionExportRunning(
   }
 }
 
-// The workflow ID is derived from (workspace, period, filter, salt) (see
-// makeConsumptionExportWorkflowId), so a running export at that ID always matches the
-// period/filter of the incoming request: concurrent requests with different period/filter get
-// their own workflow, and a concurrent request for the exact same one is surfaced as
-// "already_running" instead of starting a duplicate.
-// A previously computed export for the exact same period+filter (and, for an open-ended
-// period, the same calendar day) is surfaced as "cached" instead of recomputing it
 export async function launchConsumptionExportWorkflow(
   auth: Authenticator,
   {
@@ -264,7 +257,7 @@ export async function launchConsumptionExportWorkflow(
     if (e instanceof WorkflowExecutionAlreadyStartedError) {
       // Lost the race to start: another request started this exact export (same
       // workflow ID, since it's derived from period+filter) between our describe()
-      // check and start() above.
+      // check and start().
       return new Ok({ status: "already_running", workflowId, period, filter });
     }
 

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -1,12 +1,17 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import {
   AgentMessageModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
+import {
+  buildConsumptionExportCacheKey,
+  buildConsumptionExportGcsPath,
+} from "@app/temporal/analytics_queue/activities/consumption_export";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
 import {
   makeAgentMessageAnalyticsWorkflowId,
@@ -179,11 +184,22 @@ export type RunningConsumptionExport = {
 
 export type LaunchConsumptionExportOutcome =
   | { status: "started"; workflowId: string }
+  | { status: "cached"; gcsPath: string }
   | {
       status: "already_running";
       workflowId: string;
       running: RunningConsumptionExport;
     };
+
+// A period is "open-ended" while its end is still in the future relative to now (e.g. "this
+// cycle", whose endDate is the cycle's future close date) or was only just resolved to now
+// (e.g. "last N days"): its underlying data keeps changing even though the period value
+// itself doesn't, so every trigger must produce its own export instead of reusing a
+// previous, now-stale one. A period whose end has already passed is "closed": its data is
+// settled, so requests for the same period+filter can safely reuse a prior export.
+function isOpenEndedPeriod(period: ConsumptionPeriod): boolean {
+  return new Date(period.endDate).getTime() > Date.now();
+}
 
 async function describeRunningConsumptionExport(
   handle: WorkflowHandle
@@ -209,6 +225,8 @@ async function describeRunningConsumptionExport(
 
 // Only one export runs per workspace at a time
 // A concurrent request while one is in flight is surfaced as "already_running"
+// A closed period (see isOpenEndedPeriod) whose export already exists in GCS for the
+// exact same period+filter is surfaced as "cached" instead of recomputing it
 export async function launchConsumptionExportWorkflow(
   auth: Authenticator,
   {
@@ -221,6 +239,21 @@ export async function launchConsumptionExportWorkflow(
 ): Promise<Result<LaunchConsumptionExportOutcome, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const authType = auth.toJSON();
+
+  const openEnded = isOpenEndedPeriod(period);
+  const exportId = buildConsumptionExportCacheKey({
+    period,
+    filter,
+    salt: openEnded ? new Date().toISOString() : undefined,
+  });
+  const gcsPath = buildConsumptionExportGcsPath(workspaceId, exportId);
+
+  if (!openEnded) {
+    const [cached] = await getPrivateUploadBucket().file(gcsPath).exists();
+    if (cached) {
+      return new Ok({ status: "cached", gcsPath });
+    }
+  }
 
   const client = await getTemporalClientForFrontNamespace();
 
@@ -235,7 +268,7 @@ export async function launchConsumptionExportWorkflow(
     }
 
     await client.workflow.start(runConsumptionExportWorkflow, {
-      args: [authType, { period, filter }],
+      args: [authType, { period, filter, exportId }],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -194,11 +194,18 @@ export type LaunchConsumptionExportOutcome =
 // A period is "open-ended" while its end is still in the future relative to now (e.g. "this
 // cycle", whose endDate is the cycle's future close date) or was only just resolved to now
 // (e.g. "last N days"): its underlying data keeps changing even though the period value
-// itself doesn't, so every trigger must produce its own export instead of reusing a
-// previous, now-stale one. A period whose end has already passed is "closed": its data is
-// settled, so requests for the same period+filter can safely reuse a prior export.
+// itself doesn't. A period whose end has already passed is "closed": its data is settled, so
+// requests for the same period+filter can be reused indefinitely.
 function isOpenEndedPeriod(period: ConsumptionPeriod): boolean {
   return new Date(period.endDate).getTime() > Date.now();
+}
+
+// Open-ended periods are salted by calendar day (UTC), not by exact trigger moment: a user
+// retriggering "this cycle" several times the same day reuses that day's export instead of
+// recrunching Elasticsearch every time (a cheap abuse/DDoS vector otherwise), while the next
+// day still gets a fresh one to pick up newly accrued data.
+function currentUtcDayBucket(): string {
+  return new Date().toISOString().slice(0, 10);
 }
 
 async function describeRunningConsumptionExport(
@@ -225,8 +232,8 @@ async function describeRunningConsumptionExport(
 
 // Only one export runs per workspace at a time
 // A concurrent request while one is in flight is surfaced as "already_running"
-// A closed period (see isOpenEndedPeriod) whose export already exists in GCS for the
-// exact same period+filter is surfaced as "cached" instead of recomputing it
+// A previously computed export for the exact same period+filter (and, for an open-ended
+// period, the same calendar day) is surfaced as "cached" instead of recomputing it
 export async function launchConsumptionExportWorkflow(
   auth: Authenticator,
   {
@@ -240,19 +247,16 @@ export async function launchConsumptionExportWorkflow(
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const authType = auth.toJSON();
 
-  const openEnded = isOpenEndedPeriod(period);
   const exportId = buildConsumptionExportCacheKey({
     period,
     filter,
-    salt: openEnded ? new Date().toISOString() : undefined,
+    salt: isOpenEndedPeriod(period) ? currentUtcDayBucket() : undefined,
   });
   const gcsPath = buildConsumptionExportGcsPath(workspaceId, exportId);
 
-  if (!openEnded) {
-    const [cached] = await getPrivateUploadBucket().file(gcsPath).exists();
-    if (cached) {
-      return new Ok({ status: "cached", gcsPath });
-    }
+  const [cached] = await getPrivateUploadBucket().file(gcsPath).exists();
+  if (cached) {
+    return new Ok({ status: "cached", gcsPath });
   }
 
   const client = await getTemporalClientForFrontNamespace();

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -19,7 +19,6 @@ import {
 } from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import {
-  getConsumptionExportParamsQuery,
   runConsumptionExportWorkflow,
   storeAgentAnalyticsWorkflow,
   storeAgentMessageConsumptionAttributionV3Workflow,
@@ -174,64 +173,45 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
   }
 }
 
-// A running export's parameters, read back via a workflow query. `null` means an export
-// is (or, in the AlreadyStarted race below, was) running but its parameters could not be
-// recovered (e.g. the workflow hadn't installed its query handler yet).
-export type RunningConsumptionExport = {
-  period: ConsumptionPeriod;
-  filter: ConsumptionScopeFilter;
-} | null;
-
 export type LaunchConsumptionExportOutcome =
   | { status: "started"; workflowId: string }
   | { status: "cached"; gcsPath: string }
   | {
       status: "already_running";
       workflowId: string;
-      running: RunningConsumptionExport;
+      period: ConsumptionPeriod;
+      filter: ConsumptionScopeFilter;
     };
 
-// A period is "open-ended" while its end is still in the future relative to now (e.g. "this
-// cycle", whose endDate is the cycle's future close date) or was only just resolved to now
-// (e.g. "last N days"): its underlying data keeps changing even though the period value
-// itself doesn't. A period whose end has already passed is "closed": its data is settled, so
-// requests for the same period+filter can be reused indefinitely.
+// A period is "open-ended" while its end is still in the future relative to now
 function isOpenEndedPeriod(period: ConsumptionPeriod): boolean {
   return new Date(period.endDate).getTime() > Date.now();
 }
 
-// Open-ended periods are salted by calendar day (UTC), not by exact trigger moment: a user
-// retriggering "this cycle" several times the same day reuses that day's export instead of
-// recrunching Elasticsearch every time (a cheap abuse/DDoS vector otherwise), while the next
-// day still gets a fresh one to pick up newly accrued data.
+// Open-ended periods are salted by calendar day (UTC)
 function currentUtcDayBucket(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
-async function describeRunningConsumptionExport(
+async function isConsumptionExportRunning(
   handle: WorkflowHandle
-): Promise<RunningConsumptionExport | undefined> {
+): Promise<boolean> {
   try {
     const execution = await handle.describe();
-    if (execution.status.name !== "RUNNING") {
-      return undefined;
-    }
-
-    try {
-      return await handle.query(getConsumptionExportParamsQuery);
-    } catch {
-      return null;
-    }
+    return execution.status.name === "RUNNING";
   } catch (e) {
     if (e instanceof WorkflowNotFoundError) {
-      return undefined;
+      return false;
     }
     throw e;
   }
 }
 
-// Only one export runs per workspace at a time
-// A concurrent request while one is in flight is surfaced as "already_running"
+// The workflow ID is derived from (workspace, period, filter, salt) (see
+// makeConsumptionExportWorkflowId), so a running export at that ID always matches the
+// period/filter of the incoming request: concurrent requests with different period/filter get
+// their own workflow, and a concurrent request for the exact same one is surfaced as
+// "already_running" instead of starting a duplicate.
 // A previously computed export for the exact same period+filter (and, for an open-ended
 // period, the same calendar day) is surfaced as "cached" instead of recomputing it
 export async function launchConsumptionExportWorkflow(
@@ -261,14 +241,14 @@ export async function launchConsumptionExportWorkflow(
 
   const client = await getTemporalClientForFrontNamespace();
 
-  const workflowId = makeConsumptionExportWorkflowId({ workspaceId });
+  const workflowId = makeConsumptionExportWorkflowId({ workspaceId, exportId });
 
   try {
-    const running = await describeRunningConsumptionExport(
+    const running = await isConsumptionExportRunning(
       client.workflow.getHandle(workflowId)
     );
-    if (running !== undefined) {
-      return new Ok({ status: "already_running", workflowId, running });
+    if (running) {
+      return new Ok({ status: "already_running", workflowId, period, filter });
     }
 
     await client.workflow.start(runConsumptionExportWorkflow, {
@@ -282,17 +262,10 @@ export async function launchConsumptionExportWorkflow(
     return new Ok({ status: "started", workflowId });
   } catch (e) {
     if (e instanceof WorkflowExecutionAlreadyStartedError) {
-      // Lost the race to start: another request started an export between our
-      // describe() check and start() above. Look up what it's running so the
-      // caller can still report accurate parameters instead of a bare success.
-      const running = await describeRunningConsumptionExport(
-        client.workflow.getHandle(workflowId)
-      );
-      return new Ok({
-        status: "already_running",
-        workflowId,
-        running: running ?? null,
-      });
+      // Lost the race to start: another request started this exact export (same
+      // workflow ID, since it's derived from period+filter) between our describe()
+      // check and start() above.
+      return new Ok({ status: "already_running", workflowId, period, filter });
     }
 
     logger.error(

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -183,14 +183,22 @@ export type LaunchConsumptionExportOutcome =
       filter: ConsumptionScopeFilter;
     };
 
-// A period is "open-ended" while its end is still in the future relative to now
-function isOpenEndedPeriod(period: ConsumptionPeriod): boolean {
-  return new Date(period.endDate).getTime() > Date.now();
+function endOfUtcToday(): Date {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1) - 1
+  );
 }
 
-// Open-ended periods are salted by calendar day (UTC)
-function currentUtcDayBucket(): string {
-  return new Date().toISOString().slice(0, 10);
+// Caps an open-ended period (e.g. "this cycle") to today, so exports stay
+// cacheable within a day but refresh once new data can have accrued.
+function resolveExportPeriod(period: ConsumptionPeriod): ConsumptionPeriod {
+  const endOfTodayMs = endOfUtcToday().getTime();
+  const endMs = Math.min(new Date(period.endDate).getTime(), endOfTodayMs);
+  return {
+    startDate: period.startDate,
+    endDate: new Date(endMs).toISOString(),
+  };
 }
 
 async function isConsumptionExportRunning(
@@ -220,13 +228,15 @@ export async function launchConsumptionExportWorkflow(
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const authType = auth.toJSON();
 
+  const exportPeriod = resolveExportPeriod(period);
   const exportId = buildConsumptionExportCacheKey({
-    period,
+    period: exportPeriod,
     filter,
-    salt: isOpenEndedPeriod(period) ? currentUtcDayBucket() : undefined,
   });
   const gcsPath = buildConsumptionExportGcsPath(workspaceId, exportId);
 
+  // Checked here rather than inside the workflow so a cache hit returns immediately,
+  // without paying for a Temporal round-trip.
   const [cached] = await getPrivateUploadBucket().file(gcsPath).exists();
   if (cached) {
     return new Ok({ status: "cached", gcsPath });
@@ -237,6 +247,9 @@ export async function launchConsumptionExportWorkflow(
   const workflowId = makeConsumptionExportWorkflowId({ workspaceId, exportId });
 
   try {
+    // Distinct from the WorkflowExecutionAlreadyStartedError caught below: this catches
+    // an in-flight export before start() is even attempted, so callers get an
+    // "already_running" outcome instead of paying for and then discarding a start call.
     const running = await isConsumptionExportRunning(
       client.workflow.getHandle(workflowId)
     );
@@ -245,7 +258,7 @@ export async function launchConsumptionExportWorkflow(
     }
 
     await client.workflow.start(runConsumptionExportWorkflow, {
-      args: [authType, { period, filter, exportId }],
+      args: [authType, { period: exportPeriod, filter, exportId }],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {

--- a/front/temporal/analytics_queue/helpers.ts
+++ b/front/temporal/analytics_queue/helpers.ts
@@ -9,3 +9,14 @@ export function makeAgentMessageAnalyticsWorkflowId({
 }): string {
   return `agent-message-analytics-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
+
+// Deterministic, one per workspace: this is what keeps at most one consumption export
+// running per workspace at a time (a duplicate `start()` call fails with
+// `WorkflowExecutionAlreadyStartedError` instead of launching a second run).
+export function makeConsumptionExportWorkflowId({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): string {
+  return `consumption-export-${workspaceId}`;
+}

--- a/front/temporal/analytics_queue/helpers.ts
+++ b/front/temporal/analytics_queue/helpers.ts
@@ -10,9 +10,7 @@ export function makeAgentMessageAnalyticsWorkflowId({
   return `agent-message-analytics-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
 
-// Deterministic, one per workspace: this is what keeps at most one consumption export
-// running per workspace at a time (a duplicate `start()` call fails with
-// `WorkflowExecutionAlreadyStartedError` instead of launching a second run).
+// Deterministic, one per workspace
 export function makeConsumptionExportWorkflowId({
   workspaceId,
 }: {

--- a/front/temporal/analytics_queue/helpers.ts
+++ b/front/temporal/analytics_queue/helpers.ts
@@ -10,11 +10,15 @@ export function makeAgentMessageAnalyticsWorkflowId({
   return `agent-message-analytics-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
 
-// Deterministic, one per workspace
+// Deterministic, one per workspace and export cache key (see buildConsumptionExportCacheKey):
+// requests for the same period+filter dedupe onto the same workflow, while requests for a
+// different period+filter get their own workflow and can run concurrently.
 export function makeConsumptionExportWorkflowId({
   workspaceId,
+  exportId,
 }: {
   workspaceId: string;
+  exportId: string;
 }): string {
-  return `consumption-export-${workspaceId}`;
+  return `consumption-export-${workspaceId}-${exportId}`;
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -7,15 +7,7 @@ import type {
   AgentLoopArgs,
   AgentMessageRef,
 } from "@app/types/assistant/agent_run";
-import { defineQuery, proxyActivities, setHandler } from "@temporalio/workflow";
-
-// Queried by the launcher to recover a running export's parameters instead of relying on the
-// workflow memo, which is persisted to the visibility store and size-limited: a filter can carry
-// arbitrarily many scope ids (agents, users, tools, ...) and would risk exceeding that limit.
-export const getConsumptionExportParamsQuery = defineQuery<{
-  period: ConsumptionPeriod;
-  filter: ConsumptionScopeFilter;
-}>("get_consumption_export_params");
+import { proxyActivities, setHandler } from "@temporalio/workflow";
 
 const { storeAgentAnalyticsActivity, storeAgentMessageFeedbackActivity } =
   proxyActivities<typeof activities>({
@@ -38,9 +30,9 @@ const {
 
 // scheduleToCloseTimeout bounds the total time across all retries: a persistent
 // Elasticsearch/GCS failure must eventually fail the workflow rather than retry
-// forever, since the workflow ID is stable per workspace and blocks subsequent
-// export requests while running. 3 attempts at up to 30 minutes each, plus
-// backoff, comfortably fits inside the 3-hour ceiling.
+// forever, since the workflow ID is stable per (workspace, period, filter) and
+// blocks subsequent identical export requests while running. 3 attempts at up
+// to 30 minutes each, plus backoff, comfortably fits inside the 3-hour ceiling.
 const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });
@@ -107,11 +99,6 @@ export async function runConsumptionExportWorkflow(
     exportId: string;
   }
 ): Promise<void> {
-  setHandler(getConsumptionExportParamsQuery, () => ({ period, filter }));
-
-  // exportId is computed by the launcher (see buildConsumptionExportCacheKey) rather than
-  // here, so it stays fixed across activity retries within this run just like the old
-  // runId-based scheme, but can also be reused across separate runs for closed periods.
   await runConsumptionExportActivity(authType, {
     period,
     filter,

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -7,12 +7,7 @@ import type {
   AgentLoopArgs,
   AgentMessageRef,
 } from "@app/types/assistant/agent_run";
-import {
-  defineQuery,
-  proxyActivities,
-  setHandler,
-  workflowInfo,
-} from "@temporalio/workflow";
+import { defineQuery, proxyActivities, setHandler } from "@temporalio/workflow";
 
 // Queried by the launcher to recover a running export's parameters instead of relying on the
 // workflow memo, which is persisted to the visibility store and size-limited: a filter can carry
@@ -105,24 +100,21 @@ export async function runConsumptionExportWorkflow(
   {
     period,
     filter,
+    exportId,
   }: {
     period: ConsumptionPeriod;
     filter: ConsumptionScopeFilter;
+    exportId: string;
   }
 ): Promise<void> {
   setHandler(getConsumptionExportParamsQuery, () => ({ period, filter }));
 
-  // runId (not workflowId) so each trigger produces its own GCS object: the
-  // workflow ID is stable per workspace to enforce a single in-flight export,
-  // but runId is unique per execution while still stable across activity
-  // retries within that execution (unlike Date.now() computed inside the
-  // activity), so a retry after a lost completion ack re-uploads to the same
-  // GCS path instead of leaving an orphaned duplicate zip.
-  const { runId } = workflowInfo();
-
+  // exportId is computed by the launcher (see buildConsumptionExportCacheKey) rather than
+  // here, so it stays fixed across activity retries within this run just like the old
+  // runId-based scheme, but can also be reused across separate runs for closed periods.
   await runConsumptionExportActivity(authType, {
     period,
     filter,
-    exportId: runId,
+    exportId,
   });
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -1,3 +1,5 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/analytics_queue/activities";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
@@ -24,6 +26,12 @@ const {
   storeAgentMessageConsumptionAttributionForMessageActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
+});
+
+// A raw consumption export can page through a large number of Elasticsearch documents, so it
+// gets a much longer ceiling than the other analytics activities on this queue.
+const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "30 minutes",
 });
 
 export async function storeAgentAnalyticsWorkflow(
@@ -74,4 +82,17 @@ export async function storeAgentMessageConsumptionAttributionV3Workflow(
       message,
     });
   }
+}
+
+export async function runConsumptionExportWorkflow(
+  authType: AuthenticatorType,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter: ConsumptionScopeFilter;
+  }
+): Promise<void> {
+  await runConsumptionExportActivity(authType, { period, filter });
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -107,14 +107,17 @@ export async function runConsumptionExportWorkflow(
     filter: ConsumptionScopeFilter;
   }
 ): Promise<void> {
-  // Stable across activity retries (unlike Date.now() computed inside the
+  // runId (not workflowId) so each trigger produces its own GCS object: the
+  // workflow ID is stable per workspace to enforce a single in-flight export,
+  // but runId is unique per execution while still stable across activity
+  // retries within that execution (unlike Date.now() computed inside the
   // activity), so a retry after a lost completion ack re-uploads to the same
   // GCS path instead of leaving an orphaned duplicate zip.
-  const { workflowId } = workflowInfo();
+  const { runId } = workflowInfo();
 
   await runConsumptionExportActivity(authType, {
     period,
     filter,
-    exportId: workflowId,
+    exportId: runId,
   });
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -28,11 +28,6 @@ const {
   startToCloseTimeout: "5 minutes",
 });
 
-// scheduleToCloseTimeout bounds the total time across all retries: a persistent
-// Elasticsearch/GCS failure must eventually fail the workflow rather than retry
-// forever, since the workflow ID is stable per (workspace, period, filter) and
-// blocks subsequent identical export requests while running. 3 attempts at up
-// to 30 minutes each, plus backoff, comfortably fits inside the 3-hour ceiling.
 const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
 });

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -7,7 +7,11 @@ import type {
   AgentLoopArgs,
   AgentMessageRef,
 } from "@app/types/assistant/agent_run";
-import { proxyActivities, setHandler } from "@temporalio/workflow";
+import {
+  proxyActivities,
+  setHandler,
+  workflowInfo,
+} from "@temporalio/workflow";
 
 const { storeAgentAnalyticsActivity, storeAgentMessageFeedbackActivity } =
   proxyActivities<typeof activities>({
@@ -28,8 +32,19 @@ const {
   startToCloseTimeout: "5 minutes",
 });
 
+// scheduleToCloseTimeout bounds the total time across all retries: a persistent
+// Elasticsearch/GCS failure must eventually fail the workflow rather than retry
+// forever, since the workflow ID is stable per workspace and blocks subsequent
+// export requests while running. 3 attempts at up to 30 minutes each, plus
+// backoff, comfortably fits inside the 3-hour ceiling.
 const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
+  scheduleToCloseTimeout: "3 hours",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "2 minutes",
+    backoffCoefficient: 2,
+  },
 });
 
 export async function storeAgentAnalyticsWorkflow(
@@ -92,5 +107,14 @@ export async function runConsumptionExportWorkflow(
     filter: ConsumptionScopeFilter;
   }
 ): Promise<void> {
-  await runConsumptionExportActivity(authType, { period, filter });
+  // Stable across activity retries (unlike Date.now() computed inside the
+  // activity), so a retry after a lost completion ack re-uploads to the same
+  // GCS path instead of leaving an orphaned duplicate zip.
+  const { workflowId } = workflowInfo();
+
+  await runConsumptionExportActivity(authType, {
+    period,
+    filter,
+    exportId: workflowId,
+  });
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -28,8 +28,6 @@ const {
   startToCloseTimeout: "5 minutes",
 });
 
-// A raw consumption export can page through a large number of Elasticsearch documents, so it
-// gets a much longer ceiling than the other analytics activities on this queue.
 const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
 });

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -8,10 +8,19 @@ import type {
   AgentMessageRef,
 } from "@app/types/assistant/agent_run";
 import {
+  defineQuery,
   proxyActivities,
   setHandler,
   workflowInfo,
 } from "@temporalio/workflow";
+
+// Queried by the launcher to recover a running export's parameters instead of relying on the
+// workflow memo, which is persisted to the visibility store and size-limited: a filter can carry
+// arbitrarily many scope ids (agents, users, tools, ...) and would risk exceeding that limit.
+export const getConsumptionExportParamsQuery = defineQuery<{
+  period: ConsumptionPeriod;
+  filter: ConsumptionScopeFilter;
+}>("get_consumption_export_params");
 
 const { storeAgentAnalyticsActivity, storeAgentMessageFeedbackActivity } =
   proxyActivities<typeof activities>({
@@ -38,13 +47,7 @@ const {
 // export requests while running. 3 attempts at up to 30 minutes each, plus
 // backoff, comfortably fits inside the 3-hour ceiling.
 const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
-  startToCloseTimeout: "30 minutes",
-  scheduleToCloseTimeout: "3 hours",
-  retry: {
-    maximumAttempts: 3,
-    initialInterval: "2 minutes",
-    backoffCoefficient: 2,
-  },
+  startToCloseTimeout: "5 minutes",
 });
 
 export async function storeAgentAnalyticsWorkflow(
@@ -107,6 +110,8 @@ export async function runConsumptionExportWorkflow(
     filter: ConsumptionScopeFilter;
   }
 ): Promise<void> {
+  setHandler(getConsumptionExportParamsQuery, () => ({ period, filter }));
+
   // runId (not workflowId) so each trigger produces its own GCS object: the
   // workflow ID is stable per workspace to enforce a single in-flight export,
   // but runId is unique per execution while still stable across activity


### PR DESCRIPTION
## Description

This is the base PR for the consumption-export stack:

- [[#30557](https://github.com/dust-tt/dust/pull/30557)](https://github.com/dust-tt/dust/pull/30557): replaces the synchronous raw-data download with a background-job panel that lists GCS exports and starts the Temporal job.
- [[#30558](https://github.com/dust-tt/dust/pull/30558)](https://github.com/dust-tt/dust/pull/30558): notifies the requesting user when an export is ready.

This PR moves raw consumption-lines CSV/ZIP generation out of the inline API request and into the a Temporal workflow on the `analytics_queue`. The activity reuses the existing Elasticsearch-backed export builder and uploads the resulting ZIP to the private GCS bucket at `w/{workspaceId}/consumption_exports/{exportId}.zip`.

The launcher derives `exportId` from a canonicalized SHA-256 hash of the requested period and scope filter. It first serves an existing GCS object when available, otherwise starts a workflow with a deterministic ID for that workspace/export combination. Requests for the same export are deduplicated, including the race between the running-workflow check and `start`; differently scoped exports receive separate workflow IDs. Open-ended periods are capped at the end of the current UTC day so they can be reused within the day and refreshed as new data accrues on subsequent days.

The launcher and workflow are wired in this PR, while the production caller is introduced by [[#30557](https://github.com/dust-tt/dust/pull/30557)](https://github.com/dust-tt/dust/pull/30557). Existing synchronous export behavior remains unchanged in this base PR.

## Tests

Added Vitest coverage for the export activity's success and failure paths. The success case verifies that a ZIP containing `lines.csv` is uploaded with expected LLM and tool rows, resolved labels, and workspace prefix; the failure case verifies that Elasticsearch errors are propagated and no file is uploaded.

Added launcher coverage for starting new exports, reusing completed GCS exports, refreshing open-ended periods across UTC days, allowing differently scoped exports to run independently, and deduplicating both already-running workflows and concurrent start races. Manual testing was also performed.

## Risk

Low for this PR in isolation. The new workflow and storage path do not change existing callers, and the dependent UI and notification behavior is implemented in later stack PRs. Once invoked, export failures are propagated before upload, cache keys are scoped to the period and filter, and deterministic workflow IDs prevent duplicate work for the same export while allowing different exports to run independently. 

## Deploy Plan

- Deploy front