### PR TITLE
Add the Dust filesystem data model

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -90,6 +90,9 @@ import { CreditUsageConfigurationModel } from "@app/lib/resources/storage/models
 import { CreditModel } from "@app/lib/resources/storage/models/credits";
 import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
 import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { FileSystemBlobCleanupModel } from "@app/lib/resources/storage/models/file_system_blob_cleanup";
+import { FileSystemMutationModel } from "@app/lib/resources/storage/models/file_system_mutation";
+import { FileSystemNodeModel } from "@app/lib/resources/storage/models/file_system_node";
 import {
   AuthorizedFileAccessModel,
   ExternalViewerSessionModel,
@@ -180,6 +183,9 @@ export function loadAllModels() {
     CloneModel,
     KeyModel,
     FileModel,
+    FileSystemNodeModel,
+    FileSystemMutationModel,
+    FileSystemBlobCleanupModel,
     SandboxFunctionModel,
     SandboxFunctionInvocationModel,
     ShareableFileModel,

--- a/front/lib/resources/storage/models/file_system_blob_cleanup.ts
+++ b/front/lib/resources/storage/models/file_system_blob_cleanup.ts
@@ -1,0 +1,54 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional } from "sequelize";
+
+/** A blob that can be deleted after every signed read URL has expired. */
+export class FileSystemBlobCleanupModel extends WorkspaceAwareModel<FileSystemBlobCleanupModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare nodeId: number;
+  declare blobId: string;
+  declare notBefore: Date;
+  declare attempts: number;
+  declare lastError: string | null;
+}
+
+FileSystemBlobCleanupModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    nodeId: { type: DataTypes.BIGINT, allowNull: false },
+    blobId: { type: DataTypes.STRING, allowNull: false },
+    notBefore: { type: DataTypes.DATE, allowNull: false },
+    attempts: { type: DataTypes.INTEGER, allowNull: false, defaultValue: 0 },
+    lastError: { type: DANGEROUSLY_UNBOUNDED_TEXT, allowNull: true },
+  },
+  {
+    modelName: "file_system_blob_cleanup",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "file_system_blob_cleanups_blob_idx",
+        unique: true,
+        fields: ["workspaceId", "nodeId", "blobId"],
+      },
+      {
+        name: "file_system_blob_cleanups_pending_idx",
+        fields: ["notBefore"],
+      },
+    ],
+  }
+);

--- a/front/lib/resources/storage/models/file_system_mutation.ts
+++ b/front/lib/resources/storage/models/file_system_mutation.ts
@@ -1,0 +1,52 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional } from "sequelize";
+
+export type FileSystemMutationKind = "create" | "remove" | "rename";
+
+/** A completed namespace change, kept briefly so HTTP retries are safe. */
+export class FileSystemMutationModel extends WorkspaceAwareModel<FileSystemMutationModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare completedAt: Date;
+
+  declare requestId: string;
+  declare kind: FileSystemMutationKind;
+  declare response: unknown;
+}
+
+FileSystemMutationModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    completedAt: { type: DataTypes.DATE, allowNull: false },
+    requestId: { type: DataTypes.STRING, allowNull: false },
+    kind: { type: DataTypes.STRING, allowNull: false },
+    response: { type: DataTypes.JSONB, allowNull: false },
+  },
+  {
+    modelName: "file_system_mutation",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "file_system_mutations_request_idx",
+        unique: true,
+        fields: ["workspaceId", "requestId"],
+      },
+      {
+        name: "file_system_mutations_completed_idx",
+        fields: ["workspaceId", "completedAt"],
+      },
+    ],
+  }
+);

--- a/front/lib/resources/storage/models/file_system_node.ts
+++ b/front/lib/resources/storage/models/file_system_node.ts
@@ -1,0 +1,83 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey } from "sequelize";
+
+export type FileSystemNodeKind = "directory" | "file";
+export type FileSystemRootKind = "conversation" | "pod";
+
+/** One stable inode in Dust's PostgreSQL-owned file tree. */
+export class FileSystemNodeModel extends WorkspaceAwareModel<FileSystemNodeModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare parentId: ForeignKey<FileSystemNodeModel["id"]> | null;
+  declare rootKind: FileSystemRootKind;
+  declare rootId: string;
+  declare name: string;
+  declare kind: FileSystemNodeKind;
+  declare mode: number;
+  declare size: number;
+  declare contentType: string | null;
+  declare blobId: string | null;
+  declare contentRevision: number;
+}
+
+FileSystemNodeModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    parentId: { type: DataTypes.BIGINT, allowNull: true },
+    rootKind: { type: DataTypes.STRING, allowNull: false },
+    rootId: { type: DataTypes.STRING, allowNull: false },
+    name: { type: DataTypes.STRING, allowNull: false },
+    kind: { type: DataTypes.STRING, allowNull: false },
+    mode: { type: DataTypes.INTEGER, allowNull: false },
+    size: { type: DataTypes.BIGINT, allowNull: false, defaultValue: 0 },
+    contentType: { type: DataTypes.STRING, allowNull: true },
+    blobId: { type: DataTypes.STRING, allowNull: true },
+    contentRevision: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0,
+    },
+  },
+  {
+    modelName: "file_system_node",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        name: "file_system_nodes_parent_name_idx",
+        unique: true,
+        fields: ["workspaceId", "parentId", "name"],
+        where: { parentId: { [Op.ne]: null } },
+      },
+      {
+        name: "file_system_nodes_root_idx",
+        unique: true,
+        fields: ["workspaceId", "rootKind", "rootId"],
+        where: { parentId: { [Op.is]: null } },
+      },
+      { name: "file_system_nodes_parent_id_idx", fields: ["parentId"] },
+      {
+        name: "file_system_nodes_workspace_id_idx",
+        fields: ["workspaceId", "id"],
+      },
+    ],
+  }
+);
+
+FileSystemNodeModel.belongsTo(FileSystemNodeModel, {
+  as: "parent",
+  foreignKey: { name: "parentId", allowNull: true },
+  onDelete: "CASCADE",
+});

--- a/front/migrations/pre-deploy/20260812102242_create_file_system_nodes.sql
+++ b/front/migrations/pre-deploy/20260812102242_create_file_system_nodes.sql
@@ -1,0 +1,23 @@
+CREATE TABLE "file_system_nodes" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "parentId" BIGINT REFERENCES "file_system_nodes" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+  "rootKind" VARCHAR(255) NOT NULL,
+  "rootId" VARCHAR(255) NOT NULL,
+  "name" VARCHAR(255) NOT NULL,
+  "kind" VARCHAR(255) NOT NULL,
+  "mode" INTEGER NOT NULL,
+  "size" BIGINT NOT NULL DEFAULT 0,
+  "contentType" VARCHAR(255),
+  "blobId" VARCHAR(255),
+  "contentRevision" INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE UNIQUE INDEX "file_system_nodes_parent_name_idx" ON "file_system_nodes"
+  ("workspaceId", "parentId", "name") WHERE "parentId" IS NOT NULL;
+CREATE UNIQUE INDEX "file_system_nodes_root_idx" ON "file_system_nodes"
+  ("workspaceId", "rootKind", "rootId") WHERE "parentId" IS NULL;
+CREATE INDEX "file_system_nodes_parent_id_idx" ON "file_system_nodes" ("parentId");
+CREATE INDEX "file_system_nodes_workspace_id_idx" ON "file_system_nodes" ("workspaceId", "id");

--- a/front/migrations/pre-deploy/20260812144057_add_file_system_mutation_journal.sql
+++ b/front/migrations/pre-deploy/20260812144057_add_file_system_mutation_journal.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "file_system_mutations" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "completedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "requestId" VARCHAR(255) NOT NULL,
+  "kind" VARCHAR(255) NOT NULL,
+  "response" JSONB NOT NULL
+);
+
+CREATE UNIQUE INDEX "file_system_mutations_request_idx" ON "file_system_mutations"
+  ("workspaceId", "requestId");
+CREATE INDEX "file_system_mutations_completed_idx" ON "file_system_mutations"
+  ("workspaceId", "completedAt");

--- a/front/migrations/pre-deploy/20260812161724_add_file_system_blob_cleanup_queue.sql
+++ b/front/migrations/pre-deploy/20260812161724_add_file_system_blob_cleanup_queue.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "file_system_blob_cleanups" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "nodeId" BIGINT NOT NULL,
+  "blobId" VARCHAR(255) NOT NULL,
+  "notBefore" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "attempts" INTEGER NOT NULL DEFAULT 0,
+  "lastError" TEXT
+);
+
+CREATE UNIQUE INDEX "file_system_blob_cleanups_blob_idx" ON "file_system_blob_cleanups"
+  ("workspaceId", "nodeId", "blobId");
+CREATE INDEX "file_system_blob_cleanups_pending_idx" ON "file_system_blob_cleanups"
+  ("notBefore");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds the database foundation for Dust’s file system:
- `FileSystemNode`: one row per file or folder. It keeps a stable identity while the item is renamed or moved, and points to its current content in GCS.
- `FileSystemMutation`: a short-lived receipt for create, move, rename, and delete operations. It makes retries safe by preventing the same operation from running twice.
- `FileSystemBlobCleanup`: a retryable queue for deleting old GCS content once it is no longer referenced.

The full approach and rationale are covered in the design [document](https://app.notion.com/p/dust-tt/Design-Doc-Robust-Dust-File-System-3bb28599d94180ca8bfddcbd2ab7b2c3).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Apply pre-deploy migrations
- [ ] Deploy front
