### PR TITLE
[front] fix: show skeleton during pagination in attribution table

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -107,6 +107,7 @@ interface ConsumptionAttributionRowsTableProps {
   ) => void;
   expandedRowId: string | null;
   isLoading?: boolean;
+  skeletonRowCount?: number;
   hasAvatar?: boolean;
   isAvatarRounded?: boolean;
 }
@@ -121,6 +122,7 @@ export function ConsumptionAttributionRowsTable({
   onViewAll,
   expandedRowId,
   isLoading = false,
+  skeletonRowCount = ATTRIBUTION_SKELETON_ROW_COUNT,
   hasAvatar = false,
   isAvatarRounded = false,
 }: ConsumptionAttributionRowsTableProps) {
@@ -179,27 +181,24 @@ export function ConsumptionAttributionRowsTable({
       </DataTable.Header>
       <DataTable.Body>
         {isLoading
-          ? Array.from(
-              { length: ATTRIBUTION_SKELETON_ROW_COUNT },
-              (_, rowIndex) => (
-                <DataTable.Row
-                  key={rowIndex}
-                  widthClassName="w-full"
-                  aria-hidden="true"
-                >
-                  {table.getAllLeafColumns().map((column) => (
-                    <DataTable.Cell column={column} key={column.id}>
-                      <AttributionSkeletonCell
-                        columnId={column.id}
-                        rowIndex={rowIndex}
-                        hasAvatar={hasAvatar}
-                        isAvatarRounded={isAvatarRounded}
-                      />
-                    </DataTable.Cell>
-                  ))}
-                </DataTable.Row>
-              )
-            )
+          ? Array.from({ length: skeletonRowCount }, (_, rowIndex) => (
+              <DataTable.Row
+                key={rowIndex}
+                widthClassName="w-full"
+                aria-hidden="true"
+              >
+                {table.getAllLeafColumns().map((column) => (
+                  <DataTable.Cell column={column} key={column.id}>
+                    <AttributionSkeletonCell
+                      columnId={column.id}
+                      rowIndex={rowIndex}
+                      hasAvatar={hasAvatar}
+                      isAvatarRounded={isAvatarRounded}
+                    />
+                  </DataTable.Cell>
+                ))}
+              </DataTable.Row>
+            ))
           : table.getRowModel().rows.map((row) => (
               <Fragment key={row.id}>
                 <DataTable.Row

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -96,6 +96,74 @@ describe("ConsumptionAttributionTable", () => {
     });
   });
 
+  it("shows a destination-sized skeleton while changing pages", async () => {
+    const rows = Array.from({ length: 30 }, (_, index) => ({
+      id: `agent-${index + 1}`,
+      name: `Agent ${index + 1}`,
+      pictureUrl: null,
+      description: null,
+      icon: null,
+      modelId: null,
+      modelDisplayName: null,
+      credits: 100 - index,
+      avgCredits: 10,
+    }));
+    let secondPageLoaded = false;
+    mockUseConsumptionTop.mockImplementation(
+      ({ limit, offset }: { limit: number; offset: number }) => ({
+        rows:
+          offset === 0 || secondPageLoaded
+            ? rows.slice(offset, offset + limit)
+            : rows.slice(0, limit),
+        totalCredits: 2_565,
+        totalCount: rows.length,
+        hasMore: offset + limit < rows.length,
+        isTopLoading: offset > 0 && !secondPageLoaded,
+        isTopError: undefined,
+        isTopValidating: offset > 0 && !secondPageLoaded,
+      })
+    );
+
+    const { container, rerender } = render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    const loadingContent =
+      container.querySelector<HTMLElement>('[aria-busy="true"]');
+    if (!loadingContent) {
+      throw new Error("Expected paginated attribution rows to be loading");
+    }
+    expect(
+      loadingContent.querySelectorAll('tbody tr[aria-hidden="true"]')
+    ).toHaveLength(5);
+    expect(
+      within(loadingContent).getByRole("button", { name: "2" })
+    ).toBeInTheDocument();
+
+    secondPageLoaded = true;
+    rerender(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    expect(await screen.findByText("Agent 30")).toBeInTheDocument();
+  });
+
   it("sends the search to the backend", async () => {
     mockUseConsumptionTop.mockReturnValue({
       rows: [],

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -432,6 +432,24 @@ function AttributionRows({
     [rows, onAddFilter]
   );
   const isLoading = isTopLoading;
+  const skeletonRowCount =
+    cappedRowCount > 0
+      ? Math.min(
+          pagination.pageSize,
+          cappedRowCount - pagination.pageIndex * pagination.pageSize
+        )
+      : undefined;
+  const paginationControls = cappedRowCount > pagination.pageSize && (
+    <div className="mt-2 p-1">
+      <Pagination
+        size="xs"
+        showDetails={false}
+        pagination={pagination}
+        setPagination={setPagination}
+        rowCount={cappedRowCount}
+      />
+    </div>
+  );
 
   let contentKey = "content";
   let content: ReactNode;
@@ -439,19 +457,25 @@ function AttributionRows({
   if (isLoading) {
     contentKey = "loading";
     content = (
-      <ConsumptionAttributionRowsTable
-        data={data}
-        columns={columns}
-        workspaceId={workspaceId}
-        dimension={dimension}
-        period={period}
-        filter={filter}
-        onViewAll={onViewAll}
-        expandedRowId={expandedRowId}
-        isLoading
-        hasAvatar={hasAvatar}
-        isAvatarRounded={dimension === "user"}
-      />
+      <div>
+        <div className="overflow-x-auto">
+          <ConsumptionAttributionRowsTable
+            data={data}
+            columns={columns}
+            workspaceId={workspaceId}
+            dimension={dimension}
+            period={period}
+            filter={filter}
+            onViewAll={onViewAll}
+            expandedRowId={expandedRowId}
+            isLoading
+            skeletonRowCount={skeletonRowCount}
+            hasAvatar={hasAvatar}
+            isAvatarRounded={dimension === "user"}
+          />
+        </div>
+        {paginationControls}
+      </div>
     );
   } else if (isTopError) {
     content = (
@@ -482,17 +506,7 @@ function AttributionRows({
             />
           </div>
         )}
-        {cappedRowCount > pagination.pageSize && (
-          <div className="mt-2 p-1">
-            <Pagination
-              size="xs"
-              showDetails={false}
-              pagination={pagination}
-              setPagination={setPagination}
-              rowCount={cappedRowCount}
-            />
-          </div>
-        )}
+        {paginationControls}
       </div>
     );
   }

--- a/front/hooks/useConsumptionQuery.ts
+++ b/front/hooks/useConsumptionQuery.ts
@@ -106,7 +106,7 @@ export function useConsumptionQuery<TBody extends object, TResponse>({
     };
   }, []);
 
-  const { data, error, isValidating } = useSWRWithDefaults(
+  const { data, error, isLoading, isValidating } = useSWRWithDefaults(
     cacheKey,
     fetchData,
     {
@@ -118,5 +118,10 @@ export function useConsumptionQuery<TBody extends object, TResponse>({
     }
   );
 
-  return { data, error, isValidating: isValidating || isDebouncing };
+  return {
+    data,
+    error,
+    isLoading: !disabled && (isLoading || isDebouncing),
+    isValidating: isValidating || isDebouncing,
+  };
 }

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -176,7 +176,7 @@ export function useConsumptionTop({
     search: search?.trim(),
   };
 
-  const { data, error, isValidating } = useConsumptionQuery<
+  const { data, error, isLoading, isValidating } = useConsumptionQuery<
     ConsumptionTopBody,
     ConsumptionTopResponse
   >({ url, body, disabled });
@@ -193,7 +193,7 @@ export function useConsumptionTop({
     totalCredits: data?.totalCredits ?? 0,
     totalCount: data?.totalCount ?? 0,
     hasMore: data?.hasMore ?? false,
-    isTopLoading: !error && !data && !disabled,
+    isTopLoading: !error && isLoading,
     isTopError: error,
     isTopValidating: isValidating,
   };


### PR DESCRIPTION
## Description

In the new analytics we have a table for the attribution.
Changing pages on this table currently leaves cached rows visible while the next page loads, which makes pagination feel unresponsive.

This PR displays a skeleton during the page change. Also updates the skeleton to use the destination page row count so that full and partial pages reserve exactly the final table height.

## Tests

- Added a test (could be overkill).

## Risk

- Low.

## Deploy Plan

- Deploy front.
