### PR TITLE
Add scheduled Temporal job to delete consumption exports after 15 days

### DIFF
--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -1,0 +1,225 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
+// This directive makes them available in the test environment.
+
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import {
+  ElasticsearchError,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import {
+  buildConsumptionExportGcsPrefix,
+  runConsumptionExportActivity,
+} from "@app/temporal/analytics_queue/activities/consumption_export";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import type {
+  AgentMessageConsumptionAnalyticsLlmData,
+  AgentMessageConsumptionAnalyticsToolData,
+} from "@app/types/assistant/analytics";
+import { Err, Ok } from "@app/types/shared/result";
+import AdmZip from "adm-zip";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, resolveDimensionLabels: vi.fn() };
+});
+
+const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
+  workspace_id: "w1",
+  agent: {
+    id: "agent1",
+    version: "1",
+    tag_ids: ["tag1"],
+    parent_ids: [],
+    direct_parent_id: null,
+    root_id: "agent1",
+    depth: 0,
+  },
+  agent_message_id: "msg1",
+  api_key_name: null,
+  attribution_version: 1,
+  completed_at: "2026-08-01T00:00:00.000Z",
+  consumption_key: "run-usage:1",
+  context_origin: "api",
+  conversation_id: "conv1",
+  credit_micro: 1_000_000,
+  execution_time_ms: null,
+  message_version: "1",
+  model: {
+    provider_id: "anthropic",
+    model_id: "claude-sonnet-5",
+    reasoning_effort: "medium",
+    resolution_method: "auto",
+  },
+  run_usage_id: "123",
+  space_id: "space1",
+  status: "succeeded",
+  step_index: 0,
+  trigger_id: null,
+  usage_type: "user",
+  user: { id: "user1", group_ids: ["group1"] },
+  consumption_type: "llm",
+  gross_credit_micro: {
+    system: 100_000,
+    input: 200_000,
+    result_footprint: null,
+    output: 300_000,
+    reasoning: 400_000,
+    direct: 0,
+    total: 1_000_000,
+  },
+  tokens: {
+    system: 10,
+    input: 20,
+    result_footprint: null,
+    output: 30,
+    reasoning: 40,
+  },
+  tool: null,
+};
+
+const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
+  ...LLM_DOC,
+  consumption_key: "action:1",
+  consumption_type: "tool",
+  model: null,
+  gross_credit_micro: {
+    system: 0,
+    input: null,
+    result_footprint: null,
+    output: null,
+    reasoning: 0,
+    direct: 500_000,
+    total: 500_000,
+  },
+  tokens: {
+    system: 0,
+    input: null,
+    result_footprint: 15,
+    output: 5,
+    reasoning: 0,
+  },
+  tool: {
+    name: "search",
+    server_name: "server1",
+    parent_server_name: "",
+    action_id: "action1",
+    attributed_skill_ids: ["skill1"],
+  },
+  credit_micro: 500_000,
+  execution_time_ms: 250,
+};
+
+function mockDocs(docs: unknown[]) {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      hits: { hits: docs.map((doc) => ({ _source: doc, sort: [] })) },
+    }) as unknown as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+  );
+}
+
+function mockLabels(labels: Record<string, string>) {
+  vi.mocked(resolveDimensionLabels).mockImplementation(
+    async (_a, _d, keys) =>
+      new Map(
+        keys
+          .filter((key) => key in labels)
+          .map((key) => [
+            key,
+            { name: labels[key], pictureUrl: null, description: null },
+          ])
+      )
+  );
+}
+
+async function setup() {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  return { authenticator, workspace };
+}
+
+describe("runConsumptionExportActivity", () => {
+  it("uploads the CSV export to GCS under the workspace prefix", async () => {
+    mockDocs([LLM_DOC, TOOL_DOC]);
+    mockLabels({
+      agent1: "@dust",
+      user1: "Alice",
+      group1: "Engineering",
+      "claude-sonnet-5": "Claude Sonnet 5",
+      server1: "Search Tool",
+      skill1: "Research",
+      api: "API",
+    });
+    const { authenticator, workspace } = await setup();
+
+    await runConsumptionExportActivity(authenticator.toJSON(), {
+      period: {
+        startDate: "2026-08-01T00:00:00.000Z",
+        endDate: "2026-08-02T00:00:00.000Z",
+      },
+      filter: {},
+    });
+
+    const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
+    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+      call.filePath.startsWith(prefix)
+    );
+    expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0].contentType).toBe("application/zip");
+
+    // Read back the exact buffer passed to `.save()` rather than round-tripping through the
+    // mock's in-memory object store, which stores content as a UTF-8 string and would corrupt
+    // this binary zip.
+    const content = saveCalls[0].content;
+    const zip = new AdmZip(
+      Buffer.isBuffer(content) ? content : Buffer.from(content)
+    );
+    expect(zip.getEntries().map((entry) => entry.entryName)).toEqual([
+      "lines.csv",
+    ]);
+
+    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8");
+    expect(csv).toContain(
+      "completedAt,conversationId,spaceId,agentMessageId,consumptionType,agentId,agentName"
+    );
+    expect(csv).toContain(
+      "2026-08-01T00:00:00.000Z,conv1,space1,msg1,llm,agent1,'@dust"
+    );
+    expect(csv).toContain("claude-sonnet-5,Claude Sonnet 5");
+    expect(csv).toContain("user1,Alice,group1,Engineering");
+    expect(csv).toContain(
+      "2026-08-01T00:00:00.000Z,conv1,space1,msg1,tool,agent1,'@dust"
+    );
+    expect(csv).toContain("search,server1,Search Tool");
+    expect(csv).toContain("skill1,Research");
+  });
+
+  it("throws and uploads nothing when the search fails", async () => {
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { authenticator, workspace } = await setup();
+
+    await expect(
+      runConsumptionExportActivity(authenticator.toJSON(), {
+        period: {
+          startDate: "2026-08-01T00:00:00.000Z",
+          endDate: "2026-08-02T00:00:00.000Z",
+        },
+        filter: {},
+      })
+    ).rejects.toThrow();
+
+    const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
+    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+      call.filePath.startsWith(prefix)
+    );
+    expect(saveCalls).toHaveLength(0);
+  });
+});

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -13,12 +13,20 @@ import {
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import type {
+  AgentMessageConsumptionAnalyticsData,
   AgentMessageConsumptionAnalyticsLlmData,
   AgentMessageConsumptionAnalyticsToolData,
 } from "@app/types/assistant/analytics";
 import { Err, Ok } from "@app/types/shared/result";
 import AdmZip from "adm-zip";
 import { describe, expect, it, vi } from "vitest";
+
+// Instantiation expression: pins the mock to the concrete TDocument the exporter
+// actually queries with, so mockResolvedValue can be given a fully-typed
+// SearchResponse below without an `as` cast.
+const mockedSearchConsumptionAnalytics = vi.mocked(
+  searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>
+);
 
 vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
   const mod = await orig();
@@ -115,11 +123,20 @@ const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
   execution_time_ms: 250,
 };
 
-function mockDocs(docs: unknown[]) {
-  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+function mockDocs(docs: AgentMessageConsumptionAnalyticsData[]) {
+  mockedSearchConsumptionAnalytics.mockResolvedValue(
     new Ok({
-      hits: { hits: docs.map((doc) => ({ _source: doc, sort: [] })) },
-    }) as unknown as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+      took: 0,
+      timed_out: false,
+      _shards: { failed: 0, successful: 1, total: 1 },
+      hits: {
+        hits: docs.map((doc) => ({
+          _index: "consumption_analytics",
+          _source: doc,
+          sort: [],
+        })),
+      },
+    })
   );
 }
 
@@ -164,6 +181,7 @@ describe("runConsumptionExportActivity", () => {
         endDate: "2026-08-02T00:00:00.000Z",
       },
       filter: {},
+      exportId: "consumption-export-test-run",
     });
 
     const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
@@ -171,6 +189,9 @@ describe("runConsumptionExportActivity", () => {
       call.filePath.startsWith(prefix)
     );
     expect(saveCalls).toHaveLength(1);
+    expect(saveCalls[0].filePath).toBe(
+      `${prefix}consumption-export-test-run.zip`
+    );
     expect(saveCalls[0].contentType).toBe("application/zip");
 
     // Read back the exact buffer passed to `.save()` rather than round-tripping through the
@@ -201,7 +222,7 @@ describe("runConsumptionExportActivity", () => {
   });
 
   it("throws and uploads nothing when the search fails", async () => {
-    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    mockedSearchConsumptionAnalytics.mockResolvedValue(
       new Err(new ElasticsearchError("query_error", "boom"))
     );
     const { authenticator, workspace } = await setup();
@@ -213,6 +234,7 @@ describe("runConsumptionExportActivity", () => {
           endDate: "2026-08-02T00:00:00.000Z",
         },
         filter: {},
+        exportId: "consumption-export-test-run",
       })
     ).rejects.toThrow();
 

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -1,0 +1,52 @@
+import { fetchConsumptionLinesExportZip } from "@app/lib/api/analytics/consumption/export_lines";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import logger from "@app/logger/logger";
+
+// Files are namespaced by workspace under a single top-level prefix so the cleanup job can
+// scan every workspace's exports in one bucket listing.
+export function buildConsumptionExportGcsPrefix(workspaceSId: string): string {
+  return `consumption_exports/w/${workspaceSId}/`;
+}
+
+function buildConsumptionExportGcsPath(
+  workspaceSId: string,
+  timestamp: number
+): string {
+  return `${buildConsumptionExportGcsPrefix(workspaceSId)}${timestamp}.zip`;
+}
+
+export async function runConsumptionExportActivity(
+  authType: AuthenticatorType,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter: ConsumptionScopeFilter;
+  }
+): Promise<void> {
+  const auth = await Authenticator.fromJSON(authType);
+  const workspaceSId = auth.getNonNullableWorkspace().sId;
+
+  const result = await fetchConsumptionLinesExportZip(auth, { period, filter });
+  if (result.isErr()) {
+    logger.error(
+      { workspaceId: workspaceSId, err: result.error },
+      "[ConsumptionExport] Failed to build consumption lines export."
+    );
+    throw result.error;
+  }
+
+  // Generated inside the activity (not the workflow, which must stay deterministic). Safe as
+  // a plain timestamp because the deterministic per-workspace workflow ID guarantees at most
+  // one export activity runs per workspace at a time.
+  const gcsPath = buildConsumptionExportGcsPath(workspaceSId, Date.now());
+
+  await getPrivateUploadBucket()
+    .file(gcsPath)
+    .save(result.value, { contentType: "application/zip", resumable: false });
+}

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -8,15 +8,18 @@ import logger from "@app/logger/logger";
 
 // Files are namespaced by workspace under a single top-level prefix so the cleanup job can
 // scan every workspace's exports in one bucket listing.
-export function buildConsumptionExportGcsPrefix(workspaceSId: string): string {
-  return `consumption_exports/w/${workspaceSId}/`;
+export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
+  return `consumption_exports/w/${workspaceId}/`;
 }
 
+// exportId is the workflow ID (stable across activity retries, unlike a
+// timestamp computed here), so a retry after a lost completion ack overwrites
+// the same object instead of leaving an orphaned duplicate zip.
 function buildConsumptionExportGcsPath(
-  workspaceSId: string,
-  timestamp: number
+  workspaceId: string,
+  exportId: string
 ): string {
-  return `${buildConsumptionExportGcsPrefix(workspaceSId)}${timestamp}.zip`;
+  return `${buildConsumptionExportGcsPrefix(workspaceId)}${exportId}.zip`;
 }
 
 export async function runConsumptionExportActivity(
@@ -24,24 +27,26 @@ export async function runConsumptionExportActivity(
   {
     period,
     filter,
+    exportId,
   }: {
     period: ConsumptionPeriod;
     filter: ConsumptionScopeFilter;
+    exportId: string;
   }
 ): Promise<void> {
   const auth = await Authenticator.fromJSON(authType);
-  const workspaceSId = auth.getNonNullableWorkspace().sId;
+  const workspaceId = auth.getNonNullableWorkspace().sId;
 
   const result = await fetchConsumptionLinesExportZip(auth, { period, filter });
   if (result.isErr()) {
     logger.error(
-      { workspaceId: workspaceSId, err: result.error },
+      { workspaceId, err: result.error },
       "[ConsumptionExport] Failed to build consumption lines export."
     );
     throw result.error;
   }
 
-  const gcsPath = buildConsumptionExportGcsPath(workspaceSId, Date.now());
+  const gcsPath = buildConsumptionExportGcsPath(workspaceId, exportId);
 
   await getPrivateUploadBucket()
     .file(gcsPath)

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -41,9 +41,6 @@ export async function runConsumptionExportActivity(
     throw result.error;
   }
 
-  // Generated inside the activity (not the workflow, which must stay deterministic). Safe as
-  // a plain timestamp because the deterministic per-workspace workflow ID guarantees at most
-  // one export activity runs per workspace at a time.
   const gcsPath = buildConsumptionExportGcsPath(workspaceSId, Date.now());
 
   await getPrivateUploadBucket()

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -12,9 +12,10 @@ export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
   return `consumption_exports/w/${workspaceId}/`;
 }
 
-// exportId is the workflow ID (stable across activity retries, unlike a
-// timestamp computed here), so a retry after a lost completion ack overwrites
-// the same object instead of leaving an orphaned duplicate zip.
+// exportId is the workflow run ID (stable across activity retries within a
+// run, unlike a timestamp computed here, but unique per triggered export), so
+// a retry after a lost completion ack overwrites the same object instead of
+// leaving an orphaned duplicate zip.
 function buildConsumptionExportGcsPath(
   workspaceId: string,
   exportId: string

--- a/front/temporal/analytics_queue/activities/consumption_export_cleanup.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export_cleanup.test.ts
@@ -1,0 +1,58 @@
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { cleanupConsumptionExportsActivity } from "@app/temporal/analytics_queue/activities/consumption_export_cleanup";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { describe, expect, it } from "vitest";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const FRESH_PATH = "consumption_exports/w/w1/fresh.zip";
+const STALE_PATH = "consumption_exports/w/w2/stale.zip";
+const NO_TIMESTAMP_PATH = "consumption_exports/w/w3/no-timestamp.zip";
+
+describe("cleanupConsumptionExportsActivity", () => {
+  it("deletes only files older than the retention window", async () => {
+    const bucket = getPrivateUploadBucket();
+    await bucket
+      .file(FRESH_PATH)
+      .save(Buffer.from("fresh"), { contentType: "application/zip" });
+    await bucket
+      .file(STALE_PATH)
+      .save(Buffer.from("stale"), { contentType: "application/zip" });
+    await bucket
+      .file(NO_TIMESTAMP_PATH)
+      .save(Buffer.from("unknown-age"), { contentType: "application/zip" });
+
+    const now = Date.now();
+    fileStorageMock.setFilesByPrefix((prefix) => {
+      if (prefix !== "consumption_exports/") {
+        return null;
+      }
+      return [
+        {
+          name: FRESH_PATH,
+          metadata: { timeCreated: new Date(now - 1 * DAY_MS).toISOString() },
+        },
+        {
+          name: STALE_PATH,
+          metadata: { timeCreated: new Date(now - 16 * DAY_MS).toISOString() },
+        },
+        {
+          name: NO_TIMESTAMP_PATH,
+          metadata: {},
+        },
+      ];
+    });
+
+    await cleanupConsumptionExportsActivity();
+
+    expect(fileStorageMock.getObject(FRESH_PATH)).toBeDefined();
+    expect(fileStorageMock.getObject(NO_TIMESTAMP_PATH)).toBeDefined();
+    expect(fileStorageMock.getObject(STALE_PATH)).toBeUndefined();
+  });
+
+  it("does nothing when there are no exports", async () => {
+    fileStorageMock.setFilesByPrefix(() => []);
+
+    await expect(cleanupConsumptionExportsActivity()).resolves.toBeUndefined();
+  });
+});

--- a/front/temporal/analytics_queue/activities/consumption_export_cleanup.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export_cleanup.ts
@@ -17,7 +17,9 @@ export async function cleanupConsumptionExportsActivity(): Promise<void> {
 
   const staleFiles = files.filter((file) => {
     const timeCreated = file.metadata.timeCreated;
-    return typeof timeCreated === "string" && Date.parse(timeCreated) < cutoffMs;
+    return (
+      typeof timeCreated === "string" && Date.parse(timeCreated) < cutoffMs
+    );
   });
 
   for (const file of staleFiles) {

--- a/front/temporal/analytics_queue/activities/consumption_export_cleanup.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export_cleanup.ts
@@ -17,7 +17,7 @@ export async function cleanupConsumptionExportsActivity(): Promise<void> {
 
   const staleFiles = files.filter((file) => {
     const timeCreated = file.metadata.timeCreated;
-    return typeof timeCreated === "string" && Date.parse(timeCreated) < cutoff;
+    return typeof timeCreated === "string" && Date.parse(timeCreated) < cutoffMs;
   });
 
   for (const file of staleFiles) {

--- a/front/temporal/analytics_queue/activities/consumption_export_cleanup.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export_cleanup.ts
@@ -1,0 +1,31 @@
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import logger from "@app/logger/logger";
+
+// Top-level prefix shared by every workspace's exports (see consumption_export.ts), scanned
+// in one bucket listing rather than iterating per workspace.
+const CONSUMPTION_EXPORTS_PREFIX = "consumption_exports/";
+
+const RETENTION_DAYS = 15;
+
+export async function cleanupConsumptionExportsActivity(): Promise<void> {
+  const cutoff = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const bucket = getPrivateUploadBucket();
+
+  const { files } = await bucket.getAllFilesByPrefix({
+    prefix: CONSUMPTION_EXPORTS_PREFIX,
+  });
+
+  const staleFiles = files.filter((file) => {
+    const timeCreated = file.metadata.timeCreated;
+    return typeof timeCreated === "string" && Date.parse(timeCreated) < cutoff;
+  });
+
+  for (const file of staleFiles) {
+    await bucket.delete(file.name, { ignoreNotFound: true });
+  }
+
+  logger.info(
+    { deletedCount: staleFiles.length, scannedCount: files.length },
+    "[ConsumptionExport] Cleaned up stale consumption exports."
+  );
+}

--- a/front/temporal/analytics_queue/activities/consumption_export_cleanup.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export_cleanup.ts
@@ -8,7 +8,7 @@ const CONSUMPTION_EXPORTS_PREFIX = "consumption_exports/";
 const RETENTION_DAYS = 15;
 
 export async function cleanupConsumptionExportsActivity(): Promise<void> {
-  const cutoff = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+  const cutoffMs = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
   const bucket = getPrivateUploadBucket();
 
   const { files } = await bucket.getAllFilesByPrefix({

--- a/front/temporal/analytics_queue/activities/index.ts
+++ b/front/temporal/analytics_queue/activities/index.ts
@@ -1,2 +1,3 @@
 export * from "@app/temporal/analytics_queue/activities/agent_analytics";
 export * from "@app/temporal/analytics_queue/activities/consumption_attribution";
+export * from "@app/temporal/analytics_queue/activities/consumption_export";

--- a/front/temporal/analytics_queue/activities/index.ts
+++ b/front/temporal/analytics_queue/activities/index.ts
@@ -1,3 +1,4 @@
 export * from "@app/temporal/analytics_queue/activities/agent_analytics";
 export * from "@app/temporal/analytics_queue/activities/consumption_attribution";
 export * from "@app/temporal/analytics_queue/activities/consumption_export";
+export * from "@app/temporal/analytics_queue/activities/consumption_export_cleanup";

--- a/front/temporal/analytics_queue/admin/cli.sh
+++ b/front/temporal/analytics_queue/admin/cli.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx temporal/analytics_queue/admin/cli.ts "$@"

--- a/front/temporal/analytics_queue/admin/cli.ts
+++ b/front/temporal/analytics_queue/admin/cli.ts
@@ -6,7 +6,7 @@ const main = async () => {
 
   const [command] = argv._;
 
-  console.log(`Running command: ${command}`);
+  logger.info({ command }, "Running command");
 
   switch (command) {
     case "start-consumption-export-cleanup":

--- a/front/temporal/analytics_queue/admin/cli.ts
+++ b/front/temporal/analytics_queue/admin/cli.ts
@@ -1,5 +1,7 @@
+import logger from "@app/logger/logger";
 import { createOrUpdateConsumptionExportCleanupSchedule } from "@app/temporal/analytics_queue/client";
 import parseArgs from "minimist";
+
 
 const main = async () => {
   const argv = parseArgs(process.argv.slice(2));

--- a/front/temporal/analytics_queue/admin/cli.ts
+++ b/front/temporal/analytics_queue/admin/cli.ts
@@ -2,7 +2,6 @@ import logger from "@app/logger/logger";
 import { createOrUpdateConsumptionExportCleanupSchedule } from "@app/temporal/analytics_queue/client";
 import parseArgs from "minimist";
 
-
 const main = async () => {
   const argv = parseArgs(process.argv.slice(2));
 
@@ -15,7 +14,7 @@ const main = async () => {
       await createOrUpdateConsumptionExportCleanupSchedule();
       return;
     default:
-      console.log(
+      logger.warn(
         "Unknown command, possible values: `start-consumption-export-cleanup`"
       );
       return;
@@ -24,11 +23,10 @@ const main = async () => {
 
 main()
   .then(() => {
-    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    logger.info("Done");
     process.exit(0);
   })
   .catch((err) => {
-    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
-    console.log(err);
+    logger.error({ err }, "Error details");
     process.exit(1);
   });

--- a/front/temporal/analytics_queue/admin/cli.ts
+++ b/front/temporal/analytics_queue/admin/cli.ts
@@ -1,0 +1,32 @@
+import { createOrUpdateConsumptionExportCleanupSchedule } from "@app/temporal/analytics_queue/client";
+import parseArgs from "minimist";
+
+const main = async () => {
+  const argv = parseArgs(process.argv.slice(2));
+
+  const [command] = argv._;
+
+  console.log(`Running command: ${command}`);
+
+  switch (command) {
+    case "start-consumption-export-cleanup":
+      await createOrUpdateConsumptionExportCleanupSchedule();
+      return;
+    default:
+      console.log(
+        "Unknown command, possible values: `start-consumption-export-cleanup`"
+      );
+      return;
+  }
+};
+
+main()
+  .then(() => {
+    console.error("\x1b[32m%s\x1b[0m", `Done`);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\x1b[31m%s\x1b[0m", `Error: ${err.message}`);
+    console.log(err);
+    process.exit(1);
+  });

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -1,20 +1,36 @@
-import { launchStoreAgentMessageConsumptionAttributionWorkflow } from "@app/temporal/analytics_queue/client";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import {
+  launchConsumptionExportWorkflow,
+  launchStoreAgentMessageConsumptionAttributionWorkflow,
+} from "@app/temporal/analytics_queue/client";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
-import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
+import {
+  makeAgentMessageAnalyticsWorkflowId,
+  makeConsumptionExportWorkflowId,
+} from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import { storeAgentMessageConsumptionAttributionV3Workflow } from "@app/temporal/analytics_queue/workflows";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+import { WorkflowNotFoundError } from "@temporalio/common";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockSignalWithStart } = vi.hoisted(() => ({
-  mockSignalWithStart: vi.fn(),
-}));
+const { mockSignalWithStart, mockStart, mockDescribe, mockGetHandle } =
+  vi.hoisted(() => ({
+    mockSignalWithStart: vi.fn(),
+    mockStart: vi.fn(),
+    mockDescribe: vi.fn(),
+    mockGetHandle: vi.fn(),
+  }));
 
 vi.mock("@app/lib/temporal", () => ({
   getTemporalClientForFrontNamespace: vi.fn(async () => ({
     workflow: {
       signalWithStart: mockSignalWithStart,
+      start: mockStart,
+      getHandle: mockGetHandle,
     },
   })),
 }));
@@ -72,5 +88,112 @@ describe("launchStoreAgentMessageConsumptionAttributionWorkflow", () => {
         signalArgs: undefined,
       })
     );
+  });
+});
+
+describe("launchConsumptionExportWorkflow", () => {
+  const periodA: ConsumptionPeriod = {
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+  };
+  const filterA: ConsumptionScopeFilter = { agents: ["agent_a"] };
+
+  const periodB: ConsumptionPeriod = {
+    startDate: "2026-06-01T00:00:00.000Z",
+    endDate: "2026-07-01T00:00:00.000Z",
+  };
+  const filterB: ConsumptionScopeFilter = { agents: ["agent_b"] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetHandle.mockReturnValue({ describe: mockDescribe });
+  });
+
+  it("starts the workflow when none is running for the workspace", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workflowId = makeConsumptionExportWorkflowId({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+
+    mockDescribe.mockRejectedValue(
+      new WorkflowNotFoundError("not found", workflowId, undefined)
+    );
+    mockStart.mockResolvedValue(undefined);
+
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: periodA,
+      filter: filterA,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "started",
+      workflowId,
+    });
+    expect(mockStart).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports already_running with the running export's own parameters when a second, differently-scoped export is requested concurrently", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workflowId = makeConsumptionExportWorkflowId({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+
+    // Export A is already in flight for this workspace.
+    mockDescribe.mockResolvedValue({
+      status: { name: "RUNNING" },
+      memo: { period: periodA, filter: filterA },
+    });
+
+    // Export B, with a different period/filter, is requested while A runs.
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: periodB,
+      filter: filterB,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "already_running",
+      workflowId,
+      running: { period: periodA, filter: filterA },
+    });
+    // B's parameters must never be silently dropped by starting nothing and
+    // reporting success as if B had been queued.
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("reports already_running when the start call itself loses the race to a concurrent launch", async () => {
+    const { authenticator } = await createResourceTest({});
+    const workflowId = makeConsumptionExportWorkflowId({
+      workspaceId: authenticator.getNonNullableWorkspace().sId,
+    });
+
+    // No export running yet at describe() time...
+    mockDescribe
+      .mockRejectedValueOnce(
+        new WorkflowNotFoundError("not found", workflowId, undefined)
+      )
+      // ...but by the time we look it up again after losing the start race,
+      // export A (started by a concurrent request) is running.
+      .mockResolvedValueOnce({
+        status: { name: "RUNNING" },
+        memo: { period: periodA, filter: filterA },
+      });
+    mockStart.mockRejectedValue(
+      new WorkflowExecutionAlreadyStartedError(
+        "already started",
+        workflowId,
+        "runConsumptionExportWorkflow"
+      )
+    );
+
+    const result = await launchConsumptionExportWorkflow(authenticator, {
+      period: periodB,
+      filter: filterB,
+    });
+
+    expect(result.isOk() && result.value).toEqual({
+      status: "already_running",
+      workflowId,
+      running: { period: periodA, filter: filterA },
+    });
   });
 });

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -164,9 +164,8 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
   }
 }
 
-// Deterministic workflow ID (one per workspace) means a duplicate call while a previous
-// export is still running fails with `WorkflowExecutionAlreadyStartedError`, which is treated
-// as success here: it just means an export is already being generated.
+// Workflow ID is unique per worksapce meaning a duplicate call while a previous
+// export is still running fails
 export async function launchConsumptionExportWorkflow(
   auth: Authenticator,
   {

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -1,3 +1,5 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -6,9 +8,13 @@ import {
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
-import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
+import {
+  makeAgentMessageAnalyticsWorkflowId,
+  makeConsumptionExportWorkflowId,
+} from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import {
+  runConsumptionExportWorkflow,
   storeAgentAnalyticsWorkflow,
   storeAgentMessageConsumptionAttributionV3Workflow,
   storeAgentMessageFeedbackWorkflow,
@@ -152,6 +158,54 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
         error: e,
       },
       "Failed starting agent message consumption attribution workflow"
+    );
+
+    return new Err(normalizeError(e));
+  }
+}
+
+// Deterministic workflow ID (one per workspace) means a duplicate call while a previous
+// export is still running fails with `WorkflowExecutionAlreadyStartedError`, which is treated
+// as success here: it just means an export is already being generated.
+export async function launchConsumptionExportWorkflow(
+  auth: Authenticator,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter: ConsumptionScopeFilter;
+  }
+): Promise<Result<undefined, Error>> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const authType = auth.toJSON();
+
+  const client = await getTemporalClientForFrontNamespace();
+
+  const workflowId = makeConsumptionExportWorkflowId({ workspaceId });
+
+  try {
+    await client.workflow.start(runConsumptionExportWorkflow, {
+      args: [authType, { period, filter }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: {
+        workspaceId,
+      },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    if (e instanceof WorkflowExecutionAlreadyStartedError) {
+      return new Ok(undefined);
+    }
+
+    logger.error(
+      {
+        workflowId,
+        workspaceId,
+        error: e,
+      },
+      "Failed starting consumption export workflow"
     );
 
     return new Err(normalizeError(e));

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -1,5 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { CONSUMPTION_SCOPE_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import {
   AgentMessageModel,
@@ -27,7 +28,12 @@ import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+import type { WorkflowHandle } from "@temporalio/client";
+import {
+  WorkflowExecutionAlreadyStartedError,
+  WorkflowNotFoundError,
+} from "@temporalio/client";
+import { z } from "zod";
 
 // Resolves the agent configuration id backing an agent message (referenced by its
 // message sId). Used to decide whether the feedback workflow needs to wait for
@@ -164,8 +170,48 @@ export async function launchStoreAgentMessageConsumptionAttributionWorkflow({
   }
 }
 
-// Workflow ID is unique per worksapce meaning a duplicate call while a previous
-// export is still running fails
+const ConsumptionExportMemoSchema = z.object({
+  period: z.object({ startDate: z.string(), endDate: z.string() }),
+  filter: z.record(z.enum(CONSUMPTION_SCOPE_FILTER_KEYS), z.string().array()),
+});
+
+// A running export's parameters, read back from its memo. `null` means an export
+// is (or, in the AlreadyStarted race below, was) running but its parameters could
+// not be recovered.
+export type RunningConsumptionExport = {
+  period: ConsumptionPeriod;
+  filter: ConsumptionScopeFilter;
+} | null;
+
+export type LaunchConsumptionExportOutcome =
+  | { status: "started"; workflowId: string }
+  | {
+      status: "already_running";
+      workflowId: string;
+      running: RunningConsumptionExport;
+    };
+
+async function describeRunningConsumptionExport(
+  handle: WorkflowHandle
+): Promise<RunningConsumptionExport | undefined> {
+  try {
+    const execution = await handle.describe();
+    if (execution.status.name !== "RUNNING") {
+      return undefined;
+    }
+
+    const memo = ConsumptionExportMemoSchema.safeParse(execution.memo);
+    return memo.success ? memo.data : null;
+  } catch (e) {
+    if (e instanceof WorkflowNotFoundError) {
+      return undefined;
+    }
+    throw e;
+  }
+}
+
+// Only one export runs per workspace at a time
+// A concurrent request while one is in flight is surfaced as "already_running"
 export async function launchConsumptionExportWorkflow(
   auth: Authenticator,
   {
@@ -175,7 +221,7 @@ export async function launchConsumptionExportWorkflow(
     period: ConsumptionPeriod;
     filter: ConsumptionScopeFilter;
   }
-): Promise<Result<undefined, Error>> {
+): Promise<Result<LaunchConsumptionExportOutcome, Error>> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const authType = auth.toJSON();
 
@@ -184,18 +230,37 @@ export async function launchConsumptionExportWorkflow(
   const workflowId = makeConsumptionExportWorkflowId({ workspaceId });
 
   try {
+    const running = await describeRunningConsumptionExport(
+      client.workflow.getHandle(workflowId)
+    );
+    if (running !== undefined) {
+      return new Ok({ status: "already_running", workflowId, running });
+    }
+
     await client.workflow.start(runConsumptionExportWorkflow, {
       args: [authType, { period, filter }],
       taskQueue: QUEUE_NAME,
       workflowId,
       memo: {
         workspaceId,
+        period,
+        filter,
       },
     });
-    return new Ok(undefined);
+    return new Ok({ status: "started", workflowId });
   } catch (e) {
     if (e instanceof WorkflowExecutionAlreadyStartedError) {
-      return new Ok(undefined);
+      // Lost the race to start: another request started an export between our
+      // describe() check and start() above. Look up what it's running so the
+      // caller can still report accurate parameters instead of a bare success.
+      const running = await describeRunningConsumptionExport(
+        client.workflow.getHandle(workflowId)
+      );
+      return new Ok({
+        status: "already_running",
+        workflowId,
+        running: running ?? null,
+      });
     }
 
     logger.error(

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -15,6 +15,7 @@ import {
 } from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import {
+  cleanupConsumptionExportsWorkflow,
   runConsumptionExportWorkflow,
   storeAgentAnalyticsWorkflow,
   storeAgentMessageConsumptionAttributionV3Workflow,
@@ -30,6 +31,8 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WorkflowHandle } from "@temporalio/client";
 import {
+  ScheduleNotFoundError,
+  ScheduleOverlapPolicy,
   WorkflowExecutionAlreadyStartedError,
   WorkflowNotFoundError,
 } from "@temporalio/client";
@@ -336,5 +339,66 @@ export async function launchAgentMessageFeedbackWorkflow(
     }
 
     return new Err(normalizeError(e));
+  }
+}
+
+const CONSUMPTION_EXPORT_CLEANUP_SCHEDULE_ID =
+  "consumption-export-cleanup-schedule";
+
+// Get-or-create, matching the idiom in `triggers_garbage_collect/client.ts`: update the
+// schedule if it already exists, create it otherwise. Run once per environment (see
+// `front/lib/triggers/admin/cli.ts` for the equivalent bootstrap entry point).
+export async function createOrUpdateConsumptionExportCleanupSchedule(): Promise<
+  Result<void, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+  const scheduleId = CONSUMPTION_EXPORT_CLEANUP_SCHEDULE_ID;
+  const scheduleOptions = {
+    action: {
+      type: "startWorkflow" as const,
+      workflowType: cleanupConsumptionExportsWorkflow,
+      args: [],
+      taskQueue: QUEUE_NAME,
+    },
+    scheduleId,
+    policies: {
+      overlap: ScheduleOverlapPolicy.SKIP,
+    },
+    spec: {
+      // Once a day at 03:00 UTC.
+      cronExpressions: ["0 3 * * *"] as string[],
+      timezone: "UTC",
+    },
+  } as const;
+
+  const existingSchedule = client.schedule.getHandle(scheduleId);
+  try {
+    await existingSchedule.update((previous) => ({
+      ...scheduleOptions,
+      state: previous.state,
+    }));
+
+    logger.info("Updated existing consumption export cleanup schedule.");
+    return new Ok(undefined);
+  } catch (err) {
+    if (!(err instanceof ScheduleNotFoundError)) {
+      logger.error(
+        { err },
+        "Failed to update existing consumption export cleanup schedule."
+      );
+      return new Err(normalizeError(err));
+    }
+  }
+
+  try {
+    await client.schedule.create(scheduleOptions);
+    logger.info("Created new consumption export cleanup schedule.");
+    return new Ok(undefined);
+  } catch (error) {
+    logger.error(
+      { error },
+      "Failed to create new consumption export cleanup schedule."
+    );
+    return new Err(normalizeError(error));
   }
 }

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -345,9 +345,7 @@ export async function launchAgentMessageFeedbackWorkflow(
 const CONSUMPTION_EXPORT_CLEANUP_SCHEDULE_ID =
   "consumption-export-cleanup-schedule";
 
-// Get-or-create, matching the idiom in `triggers_garbage_collect/client.ts`: update the
-// schedule if it already exists, create it otherwise. Run once per environment (see
-// `front/lib/triggers/admin/cli.ts` for the equivalent bootstrap entry point).
+// Get-or-create
 export async function createOrUpdateConsumptionExportCleanupSchedule(): Promise<
   Result<void, Error>
 > {

--- a/front/temporal/analytics_queue/helpers.ts
+++ b/front/temporal/analytics_queue/helpers.ts
@@ -9,3 +9,14 @@ export function makeAgentMessageAnalyticsWorkflowId({
 }): string {
   return `agent-message-analytics-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
+
+// Deterministic, one per workspace: this is what keeps at most one consumption export
+// running per workspace at a time (a duplicate `start()` call fails with
+// `WorkflowExecutionAlreadyStartedError` instead of launching a second run).
+export function makeConsumptionExportWorkflowId({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): string {
+  return `consumption-export-${workspaceId}`;
+}

--- a/front/temporal/analytics_queue/helpers.ts
+++ b/front/temporal/analytics_queue/helpers.ts
@@ -10,9 +10,7 @@ export function makeAgentMessageAnalyticsWorkflowId({
   return `agent-message-analytics-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
 
-// Deterministic, one per workspace: this is what keeps at most one consumption export
-// running per workspace at a time (a duplicate `start()` call fails with
-// `WorkflowExecutionAlreadyStartedError` instead of launching a second run).
+// Deterministic, one per workspace
 export function makeConsumptionExportWorkflowId({
   workspaceId,
 }: {

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -47,6 +47,12 @@ const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
   },
 });
 
+const { cleanupConsumptionExportsActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "10 minutes",
+});
+
 export async function storeAgentAnalyticsWorkflow(
   authType: AuthenticatorType,
   {
@@ -120,4 +126,8 @@ export async function runConsumptionExportWorkflow(
     filter,
     exportId: runId,
   });
+}
+
+export async function cleanupConsumptionExportsWorkflow(): Promise<void> {
+  await cleanupConsumptionExportsActivity();
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -1,3 +1,5 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as activities from "@app/temporal/analytics_queue/activities";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
@@ -24,6 +26,12 @@ const {
   storeAgentMessageConsumptionAttributionForMessageActivity,
 } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
+});
+
+// A raw consumption export can page through a large number of Elasticsearch documents, so it
+// gets a much longer ceiling than the other analytics activities on this queue.
+const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "30 minutes",
 });
 
 export async function storeAgentAnalyticsWorkflow(
@@ -74,4 +82,17 @@ export async function storeAgentMessageConsumptionAttributionV3Workflow(
       message,
     });
   }
+}
+
+export async function runConsumptionExportWorkflow(
+  authType: AuthenticatorType,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter: ConsumptionScopeFilter;
+  }
+): Promise<void> {
+  await runConsumptionExportActivity(authType, { period, filter });
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -107,14 +107,17 @@ export async function runConsumptionExportWorkflow(
     filter: ConsumptionScopeFilter;
   }
 ): Promise<void> {
-  // Stable across activity retries (unlike Date.now() computed inside the
+  // runId (not workflowId) so each trigger produces its own GCS object: the
+  // workflow ID is stable per workspace to enforce a single in-flight export,
+  // but runId is unique per execution while still stable across activity
+  // retries within that execution (unlike Date.now() computed inside the
   // activity), so a retry after a lost completion ack re-uploads to the same
   // GCS path instead of leaving an orphaned duplicate zip.
-  const { workflowId } = workflowInfo();
+  const { runId } = workflowInfo();
 
   await runConsumptionExportActivity(authType, {
     period,
     filter,
-    exportId: workflowId,
+    exportId: runId,
   });
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -7,7 +7,11 @@ import type {
   AgentLoopArgs,
   AgentMessageRef,
 } from "@app/types/assistant/agent_run";
-import { proxyActivities, setHandler } from "@temporalio/workflow";
+import {
+  proxyActivities,
+  setHandler,
+  workflowInfo,
+} from "@temporalio/workflow";
 
 const { storeAgentAnalyticsActivity, storeAgentMessageFeedbackActivity } =
   proxyActivities<typeof activities>({
@@ -28,8 +32,19 @@ const {
   startToCloseTimeout: "5 minutes",
 });
 
+// scheduleToCloseTimeout bounds the total time across all retries: a persistent
+// Elasticsearch/GCS failure must eventually fail the workflow rather than retry
+// forever, since the workflow ID is stable per workspace and blocks subsequent
+// export requests while running. 3 attempts at up to 30 minutes each, plus
+// backoff, comfortably fits inside the 3-hour ceiling.
 const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
+  scheduleToCloseTimeout: "3 hours",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "2 minutes",
+    backoffCoefficient: 2,
+  },
 });
 
 export async function storeAgentAnalyticsWorkflow(
@@ -92,5 +107,14 @@ export async function runConsumptionExportWorkflow(
     filter: ConsumptionScopeFilter;
   }
 ): Promise<void> {
-  await runConsumptionExportActivity(authType, { period, filter });
+  // Stable across activity retries (unlike Date.now() computed inside the
+  // activity), so a retry after a lost completion ack re-uploads to the same
+  // GCS path instead of leaving an orphaned duplicate zip.
+  const { workflowId } = workflowInfo();
+
+  await runConsumptionExportActivity(authType, {
+    period,
+    filter,
+    exportId: workflowId,
+  });
 }

--- a/front/temporal/analytics_queue/workflows.ts
+++ b/front/temporal/analytics_queue/workflows.ts
@@ -28,8 +28,6 @@ const {
   startToCloseTimeout: "5 minutes",
 });
 
-// A raw consumption export can page through a large number of Elasticsearch documents, so it
-// gets a much longer ceiling than the other analytics activities on this queue.
 const { runConsumptionExportActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "30 minutes",
 });


### PR DESCRIPTION
## Description

Adds a daily Temporal schedule on the `analytics_queue` task queue to clean up 15 days or older consumption export archives from the shared `consumption_exports/` GCS prefix.

The schedule runs daily at 03:00 UTC.

## Tests

Added unit coverage for deleting only stale exports, retaining fresh and timestamp-less exports, and handling an empty export prefix.

## Risk

Low as GCS export are introduced by this stack of PR. Thus, this introduces an automated, irreversible deletion path for objects older than the 15-day retention window. T

The schedule is provisioned out of band through the admin CLI, so an already-created Temporal schedule may need to be disabled or removed separately if the code is rolled back.

## Deploy Plan

From `front/`, run the schedule bootstrap once per environment:

````sh
temporal/analytics_queue/admin/cli.sh start-consumption-export-cleanup