### PR TITLE
Replace synchronous raw consumption export with a background-job panel

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -49,6 +49,13 @@ function postExportRawRequest(wId: string, body: Record<string, unknown>) {
   });
 }
 
+function getDownloadRequest(wId: string, name: string) {
+  return honoApp.request(
+    `/api/w/${wId}/analytics/consumption/export-raw/${name}/download`,
+    { redirect: "manual" }
+  );
+}
+
 describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
   it("returns an empty list and not-generating when nothing exists", async () => {
     fileStorageMock.setFilesByPrefix(() => []);
@@ -60,7 +67,7 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
     expect(await response.json()).toEqual({ exports: [], isGenerating: false });
   });
 
-  it("lists past exports for the workspace, newest first, with a download url", async () => {
+  it("lists past exports for the workspace, newest first", async () => {
     const { workspace } = await setupTest();
     const prefix = `consumption_exports/w/${workspace.sId}/`;
     fileStorageMock.setFilesByPrefix((requestedPrefix) => {
@@ -95,13 +102,11 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
         name: "2000.zip",
         createdAt: "2026-08-02T00:00:00.000Z",
         sizeBytes: 200,
-        downloadUrl: "https://signed-url.test",
       },
       {
         name: "1000.zip",
         createdAt: "2026-08-01T00:00:00.000Z",
         sizeBytes: 100,
-        downloadUrl: "https://signed-url.test",
       },
     ]);
   });
@@ -115,6 +120,36 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ exports: [], isGenerating: true });
+  });
+});
+
+describe("GET /api/w/:wId/analytics/consumption/export-raw/:name/download", () => {
+  it("redirects to a freshly signed download url", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await getDownloadRequest(workspace.sId, "2000.zip");
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("https://signed-url.test");
+  });
+
+  it("rejects a file name that escapes the workspace's export prefix", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await getDownloadRequest(
+      workspace.sId,
+      "..%2f..%2fother-workspace%2f2000.zip"
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("is refused to non-managers", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await getDownloadRequest(workspace.sId, "2000.zip");
+
+    expect(response.status).toBe(403);
   });
 });
 

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -1,139 +1,33 @@
-// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
-// This directive makes them available in the test environment.
-
-import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
-import {
-  ElasticsearchError,
-  searchConsumptionAnalytics,
-} from "@app/lib/api/elasticsearch";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import type {
-  AgentMessageConsumptionAnalyticsLlmData,
-  AgentMessageConsumptionAnalyticsToolData,
-} from "@app/types/assistant/analytics";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import type { MembershipRoleType } from "@app/types/memberships";
-import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
-import AdmZip from "adm-zip";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
-  const mod = await orig();
-  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+const { describeWorkflowMock, startWorkflowMock } = vi.hoisted(() => ({
+  describeWorkflowMock: vi.fn().mockResolvedValue({
+    status: { name: "COMPLETED" },
+  }),
+  startWorkflowMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@app/lib/temporal", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/temporal")>();
+  return {
+    ...actual,
+    getTemporalClientForFrontNamespace: vi.fn().mockResolvedValue({
+      workflow: {
+        start: startWorkflowMock,
+        getHandle: vi.fn().mockReturnValue({ describe: describeWorkflowMock }),
+      },
+    }),
+  };
 });
-vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
-  const mod = await orig();
-  return { ...mod, resolveDimensionLabels: vi.fn() };
+
+beforeEach(() => {
+  describeWorkflowMock.mockResolvedValue({ status: { name: "COMPLETED" } });
+  startWorkflowMock.mockResolvedValue(undefined);
 });
-
-const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
-  workspace_id: "w1",
-  agent: {
-    id: "agent1",
-    version: "1",
-    tag_ids: ["tag1"],
-    parent_ids: [],
-    direct_parent_id: null,
-    root_id: "agent1",
-    depth: 0,
-  },
-  agent_message_id: "msg1",
-  api_key_name: null,
-  attribution_version: 1,
-  completed_at: "2026-08-01T00:00:00.000Z",
-  consumption_key: "run-usage:1",
-  context_origin: "api",
-  normalized_origin: "api",
-  conversation_id: "conv1",
-  credit_micro: 1_000_000,
-  execution_time_ms: null,
-  message_version: "1",
-  model: {
-    provider_id: "anthropic",
-    model_id: "claude-sonnet-5",
-    reasoning_effort: "medium",
-    resolution_method: "auto",
-  },
-  run_usage_id: "123",
-  space_id: "space1",
-  status: "succeeded",
-  step_index: 0,
-  trigger_id: null,
-  usage_type: "user",
-  user: { id: "user1", group_ids: ["group1"] },
-  consumption_type: "llm",
-  gross_credit_micro: {
-    system: 100_000,
-    input: 200_000,
-    result_footprint: null,
-    output: 300_000,
-    reasoning: 400_000,
-    direct: 0,
-    total: 1_000_000,
-  },
-  tokens: {
-    system: 10,
-    input: 20,
-    result_footprint: null,
-    output: 30,
-    reasoning: 40,
-  },
-  tool: null,
-};
-
-const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
-  ...LLM_DOC,
-  consumption_key: "action:1",
-  consumption_type: "tool",
-  model: null,
-  gross_credit_micro: {
-    system: 0,
-    input: null,
-    result_footprint: null,
-    output: null,
-    reasoning: 0,
-    direct: 500_000,
-    total: 500_000,
-  },
-  tokens: {
-    system: 0,
-    input: null,
-    result_footprint: 15,
-    output: 5,
-    reasoning: 0,
-  },
-  tool: {
-    name: "search",
-    server_name: "server1",
-    parent_server_name: "",
-    action_id: "action1",
-    attributed_skill_ids: ["skill1"],
-  },
-  credit_micro: 500_000,
-  execution_time_ms: 250,
-};
-
-function mockDocs(docs: unknown[]) {
-  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
-    new Ok({
-      hits: { hits: docs.map((doc) => ({ _source: doc, sort: [] })) },
-    }) as unknown as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
-  );
-}
-
-function mockLabels(labels: Record<string, string>) {
-  vi.mocked(resolveDimensionLabels).mockImplementation(
-    async (_a, _d, keys) =>
-      new Map(
-        keys
-          .filter((key) => key in labels)
-          .map((key) => [
-            key,
-            { name: labels[key], pictureUrl: null, description: null },
-          ])
-      )
-  );
-}
 
 async function setupTest({
   role = "admin",
@@ -141,6 +35,10 @@ async function setupTest({
   role?: MembershipRoleType;
 } = {}) {
   return createPrivateApiMockRequest({ role });
+}
+
+function getExportRawRequest(wId: string) {
+  return honoApp.request(`/api/w/${wId}/analytics/consumption/export-raw`);
 }
 
 function postExportRawRequest(wId: string, body: Record<string, unknown>) {
@@ -151,50 +49,84 @@ function postExportRawRequest(wId: string, body: Record<string, unknown>) {
   });
 }
 
-describe("POST /api/w/:wId/analytics/consumption/export-raw", () => {
-  it("returns every raw consumption line as a CSV in a zip attachment", async () => {
-    mockDocs([LLM_DOC, TOOL_DOC]);
-    mockLabels({
-      agent1: "@dust",
-      user1: "Alice",
-      group1: "Engineering",
-      "claude-sonnet-5": "Claude Sonnet 5",
-      server1: "Search Tool",
-      skill1: "Research",
-      api: "API",
+describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
+  it("returns an empty list and not-generating when nothing exists", async () => {
+    fileStorageMock.setFilesByPrefix(() => []);
+    const { workspace } = await setupTest();
+
+    const response = await getExportRawRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ exports: [], isGenerating: false });
+  });
+
+  it("lists past exports for the workspace, newest first, with a download url", async () => {
+    const { workspace } = await setupTest();
+    const prefix = `consumption_exports/w/${workspace.sId}/`;
+    fileStorageMock.setFilesByPrefix((requestedPrefix) => {
+      if (requestedPrefix !== prefix) {
+        return null;
+      }
+      return [
+        {
+          name: `${prefix}1000.zip`,
+          metadata: {
+            timeCreated: "2026-08-01T00:00:00.000Z",
+            size: "100",
+          },
+        },
+        {
+          name: `${prefix}2000.zip`,
+          metadata: {
+            timeCreated: "2026-08-02T00:00:00.000Z",
+            size: "200",
+          },
+        },
+      ];
     });
+
+    const response = await getExportRawRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.isGenerating).toBe(false);
+    expect(body.exports).toEqual([
+      {
+        name: "2000.zip",
+        createdAt: "2026-08-02T00:00:00.000Z",
+        sizeBytes: 200,
+        downloadUrl: "https://signed-url.test",
+      },
+      {
+        name: "1000.zip",
+        createdAt: "2026-08-01T00:00:00.000Z",
+        sizeBytes: 100,
+        downloadUrl: "https://signed-url.test",
+      },
+    ]);
+  });
+
+  it("reports isGenerating when the workspace's export workflow is running", async () => {
+    describeWorkflowMock.mockResolvedValue({ status: { name: "RUNNING" } });
+    fileStorageMock.setFilesByPrefix(() => []);
+    const { workspace } = await setupTest();
+
+    const response = await getExportRawRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ exports: [], isGenerating: true });
+  });
+});
+
+describe("POST /api/w/:wId/analytics/consumption/export-raw", () => {
+  it("starts the export workflow and returns immediately", async () => {
     const { workspace } = await setupTest({ role: "admin" });
 
     const response = await postExportRawRequest(workspace.sId, {});
 
-    expect(response.status).toBe(200);
-    expect(response.headers.get("Content-Type")).toContain("application/zip");
-    expect(response.headers.get("Content-Disposition")).toContain(
-      `filename="dust_consumption_lines_export_${workspace.sId}.zip"`
-    );
-
-    const buffer = Buffer.from(await response.arrayBuffer());
-    const zip = new AdmZip(buffer);
-    expect(zip.getEntries().map((entry) => entry.entryName)).toEqual([
-      "lines.csv",
-    ]);
-
-    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8");
-    expect(csv).toContain(
-      "completedAt,conversationId,spaceId,agentMessageId,consumptionType,agentId,agentName"
-    );
-    // LLM row: resolved agent/user/group/model names, no tool columns.
-    expect(csv).toContain(
-      "2026-08-01T00:00:00.000Z,conv1,space1,msg1,llm,agent1,'@dust"
-    );
-    expect(csv).toContain("claude-sonnet-5,Claude Sonnet 5");
-    expect(csv).toContain("user1,Alice,group1,Engineering");
-    // Tool row: resolved tool/skill names, no model.
-    expect(csv).toContain(
-      "2026-08-01T00:00:00.000Z,conv1,space1,msg1,tool,agent1,'@dust"
-    );
-    expect(csv).toContain("search,server1,Search Tool");
-    expect(csv).toContain("skill1,Research");
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({ isGenerating: true });
+    expect(startWorkflowMock).toHaveBeenCalledTimes(1);
   });
 
   it("is refused to non-managers", async () => {
@@ -203,6 +135,7 @@ describe("POST /api/w/:wId/analytics/consumption/export-raw", () => {
     const response = await postExportRawRequest(workspace.sId, {});
 
     expect(response.status).toBe(403);
+    expect(startWorkflowMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 for an invalid body", async () => {
@@ -213,19 +146,5 @@ describe("POST /api/w/:wId/analytics/consumption/export-raw", () => {
     });
 
     expect(response.status).toBe(400);
-  });
-
-  it("returns 500 when the search fails", async () => {
-    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
-      new Err(new ElasticsearchError("query_error", "boom"))
-    );
-    const { workspace } = await setupTest();
-
-    const response = await postExportRawRequest(workspace.sId, {});
-
-    expect(response.status).toBe(500);
-    expect(await response.json()).toMatchObject({
-      error: { type: "internal_server_error" },
-    });
   });
 });

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -147,4 +147,15 @@ describe("POST /api/w/:wId/analytics/consumption/export-raw", () => {
 
     expect(response.status).toBe(400);
   });
+
+  it("returns a 5xx and does not report isGenerating when the workflow fails to launch", async () => {
+    startWorkflowMock.mockRejectedValue(new Error("temporal unavailable"));
+    const { workspace } = await setupTest({ role: "admin" });
+
+    const response = await postExportRawRequest(workspace.sId, {});
+
+    expect(response.status).toBeGreaterThanOrEqual(500);
+    const body = await response.json();
+    expect(body).not.toEqual({ isGenerating: true });
+  });
 });

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -4,12 +4,24 @@ import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { describeWorkflowMock, startWorkflowMock } = vi.hoisted(() => ({
-  describeWorkflowMock: vi.fn().mockResolvedValue({
-    status: { name: "COMPLETED" },
-  }),
-  startWorkflowMock: vi.fn().mockResolvedValue(undefined),
-}));
+const { describeWorkflowMock, startWorkflowMock, listWorkflowMock } =
+  vi.hoisted(() => ({
+    describeWorkflowMock: vi.fn().mockResolvedValue({
+      status: { name: "COMPLETED" },
+    }),
+    startWorkflowMock: vi.fn().mockResolvedValue(undefined),
+    listWorkflowMock: vi.fn(),
+  }));
+
+function asyncIterableOf<T>(items: T[]) {
+  return {
+    [Symbol.asyncIterator]: async function* () {
+      for (const item of items) {
+        yield item;
+      }
+    },
+  };
+}
 
 vi.mock("@app/lib/temporal", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@app/lib/temporal")>();
@@ -19,6 +31,7 @@ vi.mock("@app/lib/temporal", async (importOriginal) => {
       workflow: {
         start: startWorkflowMock,
         getHandle: vi.fn().mockReturnValue({ describe: describeWorkflowMock }),
+        list: listWorkflowMock,
       },
     }),
   };
@@ -27,6 +40,9 @@ vi.mock("@app/lib/temporal", async (importOriginal) => {
 beforeEach(() => {
   describeWorkflowMock.mockResolvedValue({ status: { name: "COMPLETED" } });
   startWorkflowMock.mockResolvedValue(undefined);
+  listWorkflowMock.mockReturnValue(asyncIterableOf([]));
+  // No cached export by default, so POST tests exercise the actual workflow start.
+  fileStorageMock.setFileExists(() => false);
 });
 
 async function setupTest({
@@ -69,7 +85,7 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
 
   it("lists past exports for the workspace, newest first", async () => {
     const { workspace } = await setupTest();
-    const prefix = `consumption_exports/w/${workspace.sId}/`;
+    const prefix = `w/${workspace.sId}/consumption_exports/`;
     fileStorageMock.setFilesByPrefix((requestedPrefix) => {
       if (requestedPrefix !== prefix) {
         return null;
@@ -112,7 +128,7 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
   });
 
   it("reports isGenerating when the workspace's export workflow is running", async () => {
-    describeWorkflowMock.mockResolvedValue({ status: { name: "RUNNING" } });
+    listWorkflowMock.mockReturnValue(asyncIterableOf([{}]));
     fileStorageMock.setFilesByPrefix(() => []);
     const { workspace } = await setupTest();
 

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
@@ -10,6 +10,7 @@ import {
 } from "@app/lib/api/analytics/consumption/schema";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
 // Mounted at /api/w/:wId/analytics/consumption/export-raw.
@@ -39,7 +40,17 @@ app.post(
 
     const period = await resolveConsumptionPeriod(auth, periodInput);
 
-    await startConsumptionExport(auth, { period, filter });
+    const result = await startConsumptionExport(auth, { period, filter });
+
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: `Failed to start consumption export: ${result.error.message}`,
+        },
+      });
+    }
 
     return ctx.json({ isGenerating: true }, 202);
   }

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
@@ -1,17 +1,31 @@
-import { fetchConsumptionLinesExportZip } from "@app/lib/api/analytics/consumption/export_lines";
+import {
+  isConsumptionExportGenerating,
+  listConsumptionExports,
+  startConsumptionExport,
+} from "@app/lib/api/analytics/consumption/export_jobs";
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
   ConsumptionExportBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
-import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
-import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
 // Mounted at /api/w/:wId/analytics/consumption/export-raw.
 const app = workspaceApp();
+
+/** @ignoreswagger */
+app.get("/", ensureIsManager(), async (ctx) => {
+  const auth = ctx.get("auth");
+
+  const [exports, isGenerating] = await Promise.all([
+    listConsumptionExports(auth),
+    isConsumptionExportGenerating(auth),
+  ]);
+
+  return ctx.json({ exports, isGenerating });
+});
 
 /** @ignoreswagger */
 app.post(
@@ -20,39 +34,14 @@ app.post(
   validate("json", ConsumptionExportBodySchema),
   async (ctx) => {
     const auth = ctx.get("auth");
-    const workspaceId = auth.getNonNullableWorkspace().sId;
     const { filter, ...periodQuery } = ctx.req.valid("json");
     const periodInput = toConsumptionPeriodInput(periodQuery);
 
     const period = await resolveConsumptionPeriod(auth, periodInput);
 
-    const result = await fetchConsumptionLinesExportZip(auth, {
-      period,
-      filter,
-    });
-    if (result.isErr()) {
-      logger.error(
-        { workspaceId, err: result.error },
-        "[ConsumptionAnalytics] Failed to export raw consumption lines."
-      );
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Failed to export consumption lines.",
-        },
-      });
-    }
+    await startConsumptionExport(auth, { period, filter });
 
-    // `Buffer` doesn't structurally match the `Uint8Array<ArrayBuffer>` that
-    // `ctx.body` expects, so return a raw `Response` instead.
-    return new Response(new Uint8Array(result.value), {
-      status: 200,
-      headers: {
-        "Content-Type": "application/zip",
-        "Content-Disposition": `attachment; filename="dust_consumption_lines_export_${workspaceId}.zip"`,
-      },
-    });
+    return ctx.json({ isGenerating: true }, 202);
   }
 );
 

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
@@ -1,4 +1,5 @@
 import {
+  getConsumptionExportDownloadUrl,
   isConsumptionExportGenerating,
   listConsumptionExports,
   startConsumptionExport,
@@ -12,9 +13,14 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
 
 // Mounted at /api/w/:wId/analytics/consumption/export-raw.
 const app = workspaceApp();
+
+const DownloadParamsSchema = z.object({
+  name: z.string(),
+});
 
 /** @ignoreswagger */
 app.get("/", ensureIsManager(), async (ctx) => {
@@ -53,6 +59,30 @@ app.post(
     }
 
     return ctx.json({ isGenerating: true }, 202);
+  }
+);
+
+/** @ignoreswagger */
+app.get(
+  "/:name/download",
+  ensureIsManager(),
+  validate("param", DownloadParamsSchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { name } = ctx.req.valid("param");
+
+    const result = await getConsumptionExportDownloadUrl(auth, name);
+    if (result.isErr()) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "file_not_found",
+          message: "Export not found.",
+        },
+      });
+    }
+
+    return ctx.redirect(result.value);
   }
 );
 

--- a/front/components/poke/pages/FramePage.tsx
+++ b/front/components/poke/pages/FramePage.tsx
@@ -1,6 +1,7 @@
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
+import { formatFileSize } from "@app/lib/utils";
 import { usePokePageMetadata } from "@app/poke/swr/currentPage";
 import { usePokeFileDetails } from "@app/poke/swr/frame_details";
 import { dateToHumanReadable } from "@app/types/shared/utils/date_utils";
@@ -62,16 +63,6 @@ export function FramePage() {
       </div>
     );
   }
-
-  const formatFileSize = (bytes: number) => {
-    if (bytes < 1024) {
-      return `${bytes} B`;
-    }
-    if (bytes < 1024 * 1024) {
-      return `${(bytes / 1024).toFixed(1)} KB`;
-    }
-    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-  };
 
   return (
     <div className="mx-auto max-w-6xl">

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -10,14 +10,25 @@ import {
 } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseConsumptionTop } = vi.hoisted(() => ({
+const {
+  mockUseConsumptionTop,
+  mockUseConsumptionExports,
+  mockUseStartConsumptionExport,
+} = vi.hoisted(() => ({
   mockUseConsumptionTop: vi.fn(),
+  mockUseConsumptionExports: vi.fn(),
+  mockUseStartConsumptionExport: vi.fn(),
 }));
 
 vi.mock("@app/hooks/useConsumptionTop", () => ({
   useConsumptionTop: mockUseConsumptionTop,
+}));
+
+vi.mock("@app/hooks/useConsumptionExports", () => ({
+  useConsumptionExports: mockUseConsumptionExports,
+  useStartConsumptionExport: mockUseStartConsumptionExport,
 }));
 
 vi.mock("@app/components/sparkle/ThemeContext", () => ({
@@ -71,6 +82,19 @@ function ControlledAttributionTable({
 }
 
 describe("ConsumptionAttributionTable", () => {
+  beforeEach(() => {
+    mockUseConsumptionExports.mockReturnValue({
+      exports: [],
+      isGenerating: false,
+      isConsumptionExportsLoading: false,
+      isConsumptionExportsError: undefined,
+    });
+    mockUseStartConsumptionExport.mockReturnValue({
+      isStarting: false,
+      startConsumptionExport: vi.fn().mockResolvedValue(undefined),
+    });
+  });
+
   it("caps the available pages and fetches the selected fixed-size page", async () => {
     const rows = Array.from({ length: 1_025 }, (_, index) => ({
       id: `agent-${index + 1}`,

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -5,7 +5,7 @@ import {
   isInternalAllowedIcon,
 } from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
+import { ConsumptionExportPanel } from "@app/components/workspace/analytics/consumption/ConsumptionExportPanel";
 import {
   AvatarNameCell,
   CostShareCell,
@@ -13,7 +13,6 @@ import {
 import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useDebounce } from "@app/hooks/useDebounce";
-import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/constants";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
@@ -645,19 +644,14 @@ export function ConsumptionAttributionTable({
     filter: normalizedConsumptionFilter(filter),
   };
 
-  // Every raw consumption line with no aggregation, for users who want to
-  // build their own analysis on top of it.
-  const rawCsvDownload = useDownloadCsv({
-    url: `/api/w/${workspaceId}/analytics/consumption/export-raw`,
-    filename: `dust_consumption_lines_export_${workspaceId}.zip`,
-    body: exportBody,
-  });
-
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-4">
         <h3 className="text-base font-semibold text-foreground">Attribution</h3>
-        <CsvDownloadButton {...rawCsvDownload} label="Download raw data" />
+        <ConsumptionExportPanel
+          workspaceId={workspaceId}
+          exportBody={exportBody}
+        />
       </div>
       <div className="rounded-lg border border-border bg-panel-background p-4">
         <div className="flex flex-col gap-3">

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.test.tsx
@@ -1,4 +1,5 @@
 import { ConsumptionExportPanel } from "@app/components/workspace/analytics/consumption/ConsumptionExportPanel";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -49,7 +50,7 @@ describe("ConsumptionExportPanel", () => {
 
     // Even though the export never appears (a failed/timed-out workflow also leaves
     // exports empty with isGenerating false), the effect must not fire again.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setTimeoutAsync(0);
     expect(startConsumptionExport).toHaveBeenCalledTimes(1);
     expect(
       screen.getByText("The export failed to generate.")
@@ -78,7 +79,7 @@ describe("ConsumptionExportPanel", () => {
 
     openPanel();
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setTimeoutAsync(0);
 
     expect(startConsumptionExport).not.toHaveBeenCalled();
     expect(screen.getByText("Could not load exports.")).toBeInTheDocument();

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.test.tsx
@@ -1,0 +1,89 @@
+import { ConsumptionExportPanel } from "@app/components/workspace/analytics/consumption/ConsumptionExportPanel";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { mockUseConsumptionExports, mockUseStartConsumptionExport } = vi.hoisted(
+  () => ({
+    mockUseConsumptionExports: vi.fn(),
+    mockUseStartConsumptionExport: vi.fn(),
+  })
+);
+
+vi.mock("@app/hooks/useConsumptionExports", () => ({
+  useConsumptionExports: mockUseConsumptionExports,
+  useStartConsumptionExport: mockUseStartConsumptionExport,
+}));
+
+const exportBody = { period: "days", days: 30 } as const;
+
+function openPanel() {
+  fireEvent.click(screen.getByRole("button", { name: "Download raw data" }));
+}
+
+describe("ConsumptionExportPanel", () => {
+  it("automatically starts an export exactly once when opened with nothing generated", async () => {
+    const startConsumptionExport = vi.fn().mockResolvedValue(undefined);
+    mockUseConsumptionExports.mockReturnValue({
+      exports: [],
+      isGenerating: false,
+      isConsumptionExportsLoading: false,
+      isConsumptionExportsError: undefined,
+    });
+    mockUseStartConsumptionExport.mockReturnValue({
+      isStarting: false,
+      startConsumptionExport,
+    });
+
+    render(
+      <ConsumptionExportPanel
+        workspaceId="workspace-id"
+        exportBody={exportBody}
+      />
+    );
+
+    openPanel();
+
+    await waitFor(() => {
+      expect(startConsumptionExport).toHaveBeenCalledTimes(1);
+    });
+
+    // Even though the export never appears (a failed/timed-out workflow also leaves
+    // exports empty with isGenerating false), the effect must not fire again.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(startConsumptionExport).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByText("The export failed to generate.")
+    ).toBeInTheDocument();
+  });
+
+  it("does not auto-start or show a stale generating spinner when the export list fails to load", async () => {
+    const startConsumptionExport = vi.fn().mockResolvedValue(undefined);
+    mockUseConsumptionExports.mockReturnValue({
+      exports: [],
+      isGenerating: false,
+      isConsumptionExportsLoading: false,
+      isConsumptionExportsError: new Error("boom"),
+    });
+    mockUseStartConsumptionExport.mockReturnValue({
+      isStarting: false,
+      startConsumptionExport,
+    });
+
+    render(
+      <ConsumptionExportPanel
+        workspaceId="workspace-id"
+        exportBody={exportBody}
+      />
+    );
+
+    openPanel();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(startConsumptionExport).not.toHaveBeenCalled();
+    expect(screen.getByText("Could not load exports.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Generating your export…")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
@@ -7,6 +7,7 @@ import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/s
 import {
   Button,
   Download01,
+  Plus,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -38,8 +39,9 @@ function ConsumptionExportRow({ item }: { item: ConsumptionExportListItem }) {
       <span className="text-sm text-foreground">
         {new Date(item.createdAt).toLocaleString()}
       </span>
-      <span className="text-xs text-muted-foreground">
+      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
         {formatFileSize(item.sizeBytes)}
+        <Download01 className="h-3.5 w-3.5" />
       </span>
     </a>
   );
@@ -90,6 +92,14 @@ export function ConsumptionExportPanel({
       </PopoverTrigger>
       <PopoverContent align="end" className="w-80 p-3">
         <div className="flex flex-col gap-2">
+          <Button
+            icon={Plus}
+            label="New export"
+            variant="outline"
+            size="xs"
+            disabled={isGenerating || isStarting}
+            onClick={() => void startConsumptionExport(exportBody)}
+          />
           <span className="text-sm font-medium text-foreground">
             Raw data exports
           </span>
@@ -111,6 +121,17 @@ export function ConsumptionExportPanel({
               </span>
             </div>
           )}
+          {isGenerating && exports.length > 0 && (
+            <div className="flex items-center gap-2">
+              <Spinner size="xs" />
+              <span className="text-xs text-muted-foreground">
+                Generating a new export…
+              </span>
+            </div>
+          )}
+          <span className="text-xs text-muted-foreground">
+            Exports are kept for a maximum of 15 days.
+          </span>
         </div>
       </PopoverContent>
     </PopoverRoot>

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
@@ -63,13 +63,13 @@ export function ConsumptionExportPanel({
     workspaceId,
   });
 
-  // Reset the auto-start guard each time the panel closes, so reopening it gives the
-  // automatic flow one fresh attempt.
-  useEffect(() => {
-    if (!isOpen) {
+  // Give the automatic flow one fresh attempt each time the panel is reopened.
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (!open) {
       setHasAttemptedAutoStart(false);
     }
-  }, [isOpen]);
+  };
 
   // Opening the panel with no past export and nothing already generating starts one
   // automatically, so the user doesn't have to find a separate "generate" action. This
@@ -108,7 +108,7 @@ export function ConsumptionExportPanel({
     exports.length === 0;
 
   return (
-    <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
+    <PopoverRoot open={isOpen} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           icon={Download01}
@@ -121,6 +121,9 @@ export function ConsumptionExportPanel({
         <div className="flex flex-col gap-2">
           <span className="text-sm font-medium text-foreground">
             Raw data exports
+          </span>
+          <span className="text-xs text-muted-foreground">
+            Exports are kept for a maximum of 15 days.
           </span>
           {isConsumptionExportsLoading ? (
             <div className="flex justify-center py-4">
@@ -164,13 +167,10 @@ export function ConsumptionExportPanel({
             icon={Plus}
             label="New export"
             variant="outline"
-            size="xs"
+            size="sm"
             disabled={isGenerating || isStarting}
             onClick={() => void startConsumptionExport(exportBody)}
           />
-          <span className="text-xs text-muted-foreground">
-            Exports are kept for a maximum of 15 days.
-          </span>
         </div>
       </PopoverContent>
     </PopoverRoot>

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
@@ -52,33 +52,60 @@ export function ConsumptionExportPanel({
   exportBody,
 }: ConsumptionExportPanelProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const { exports, isGenerating, isConsumptionExportsLoading } =
-    useConsumptionExports({ workspaceId, disabled: !isOpen });
+  const [hasAttemptedAutoStart, setHasAttemptedAutoStart] = useState(false);
+  const {
+    exports,
+    isGenerating,
+    isConsumptionExportsLoading,
+    isConsumptionExportsError,
+  } = useConsumptionExports({ workspaceId, disabled: !isOpen });
   const { isStarting, startConsumptionExport } = useStartConsumptionExport({
     workspaceId,
   });
 
+  // Reset the auto-start guard each time the panel closes, so reopening it gives the
+  // automatic flow one fresh attempt.
+  useEffect(() => {
+    if (!isOpen) {
+      setHasAttemptedAutoStart(false);
+    }
+  }, [isOpen]);
+
   // Opening the panel with no past export and nothing already generating starts one
-  // automatically, so the user doesn't have to find a separate "generate" action.
+  // automatically, so the user doesn't have to find a separate "generate" action. This
+  // only fires once per time the panel is opened: a workflow that failed or timed out
+  // also leaves exports empty with isGenerating false, so without this guard the effect
+  // would relaunch an expensive export indefinitely instead of surfacing the failure.
   useEffect(() => {
     if (
       isOpen &&
       !isConsumptionExportsLoading &&
+      !isConsumptionExportsError &&
       !isGenerating &&
       !isStarting &&
+      !hasAttemptedAutoStart &&
       exports.length === 0
     ) {
+      setHasAttemptedAutoStart(true);
       void startConsumptionExport(exportBody);
     }
   }, [
     isOpen,
     isConsumptionExportsLoading,
+    isConsumptionExportsError,
     isGenerating,
     isStarting,
+    hasAttemptedAutoStart,
     exports.length,
     exportBody,
     startConsumptionExport,
   ]);
+
+  const hasAutoStartFailed =
+    hasAttemptedAutoStart &&
+    !isGenerating &&
+    !isStarting &&
+    exports.length === 0;
 
   return (
     <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
@@ -99,11 +126,23 @@ export function ConsumptionExportPanel({
             <div className="flex justify-center py-4">
               <Spinner size="sm" />
             </div>
+          ) : isConsumptionExportsError ? (
+            <div className="flex items-center justify-center py-4">
+              <span className="text-sm text-muted-foreground">
+                Could not load exports.
+              </span>
+            </div>
           ) : exports.length > 0 ? (
             <div className="flex max-h-40 flex-col overflow-y-auto">
               {exports.map((item) => (
                 <ConsumptionExportRow key={item.name} item={item} />
               ))}
+            </div>
+          ) : hasAutoStartFailed ? (
+            <div className="flex items-center justify-center py-4">
+              <span className="text-sm text-muted-foreground">
+                The export failed to generate.
+              </span>
             </div>
           ) : (
             <div className="flex items-center gap-2 py-4">

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
@@ -92,14 +92,6 @@ export function ConsumptionExportPanel({
       </PopoverTrigger>
       <PopoverContent align="end" className="w-80 p-3">
         <div className="flex flex-col gap-2">
-          <Button
-            icon={Plus}
-            label="New export"
-            variant="outline"
-            size="xs"
-            disabled={isGenerating || isStarting}
-            onClick={() => void startConsumptionExport(exportBody)}
-          />
           <span className="text-sm font-medium text-foreground">
             Raw data exports
           </span>
@@ -108,7 +100,7 @@ export function ConsumptionExportPanel({
               <Spinner size="sm" />
             </div>
           ) : exports.length > 0 ? (
-            <div className="flex flex-col">
+            <div className="flex max-h-40 flex-col overflow-y-auto">
               {exports.map((item) => (
                 <ConsumptionExportRow key={item.name} item={item} />
               ))}
@@ -129,6 +121,14 @@ export function ConsumptionExportPanel({
               </span>
             </div>
           )}
+          <Button
+            icon={Plus}
+            label="New export"
+            variant="outline"
+            size="xs"
+            disabled={isGenerating || isStarting}
+            onClick={() => void startConsumptionExport(exportBody)}
+          />
           <span className="text-xs text-muted-foreground">
             Exports are kept for a maximum of 15 days.
           </span>

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
@@ -4,6 +4,7 @@ import {
 } from "@app/hooks/useConsumptionExports";
 import type { ConsumptionExportListItem } from "@app/lib/api/analytics/consumption/export_jobs";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
+import { formatFileSize } from "@app/lib/utils";
 import {
   Button,
   Download01,
@@ -20,20 +21,16 @@ interface ConsumptionExportPanelProps {
   exportBody: ConsumptionExportBody;
 }
 
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) {
-    return `${bytes} B`;
-  }
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
-}
-
-function ConsumptionExportRow({ item }: { item: ConsumptionExportListItem }) {
+function ConsumptionExportRow({
+  workspaceId,
+  item,
+}: {
+  workspaceId: string;
+  item: ConsumptionExportListItem;
+}) {
   return (
     <a
-      href={item.downloadUrl}
+      href={`/api/w/${workspaceId}/analytics/consumption/export-raw/${item.name}/download`}
       className="flex items-center justify-between gap-4 rounded-md px-2 py-1.5 hover:bg-muted-background"
     >
       <span className="text-sm text-foreground">
@@ -138,7 +135,11 @@ export function ConsumptionExportPanel({
           ) : exports.length > 0 ? (
             <div className="flex max-h-40 flex-col overflow-y-auto">
               {exports.map((item) => (
-                <ConsumptionExportRow key={item.name} item={item} />
+                <ConsumptionExportRow
+                  key={item.name}
+                  workspaceId={workspaceId}
+                  item={item}
+                />
               ))}
             </div>
           ) : hasAutoStartFailed ? (

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
@@ -1,0 +1,118 @@
+import {
+  useConsumptionExports,
+  useStartConsumptionExport,
+} from "@app/hooks/useConsumptionExports";
+import type { ConsumptionExportListItem } from "@app/lib/api/analytics/consumption/export_jobs";
+import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
+import {
+  Button,
+  Download01,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+
+interface ConsumptionExportPanelProps {
+  workspaceId: string;
+  exportBody: ConsumptionExportBody;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function ConsumptionExportRow({ item }: { item: ConsumptionExportListItem }) {
+  return (
+    <a
+      href={item.downloadUrl}
+      className="flex items-center justify-between gap-4 rounded-md px-2 py-1.5 hover:bg-muted-background"
+    >
+      <span className="text-sm text-foreground">
+        {new Date(item.createdAt).toLocaleString()}
+      </span>
+      <span className="text-xs text-muted-foreground">
+        {formatFileSize(item.sizeBytes)}
+      </span>
+    </a>
+  );
+}
+
+export function ConsumptionExportPanel({
+  workspaceId,
+  exportBody,
+}: ConsumptionExportPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { exports, isGenerating, isConsumptionExportsLoading } =
+    useConsumptionExports({ workspaceId, disabled: !isOpen });
+  const { isStarting, startConsumptionExport } = useStartConsumptionExport({
+    workspaceId,
+  });
+
+  // Opening the panel with no past export and nothing already generating starts one
+  // automatically, so the user doesn't have to find a separate "generate" action.
+  useEffect(() => {
+    if (
+      isOpen &&
+      !isConsumptionExportsLoading &&
+      !isGenerating &&
+      !isStarting &&
+      exports.length === 0
+    ) {
+      void startConsumptionExport(exportBody);
+    }
+  }, [
+    isOpen,
+    isConsumptionExportsLoading,
+    isGenerating,
+    isStarting,
+    exports.length,
+    exportBody,
+    startConsumptionExport,
+  ]);
+
+  return (
+    <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          icon={Download01}
+          label="Download raw data"
+          variant="outline"
+          size="sm"
+        />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-80 p-3">
+        <div className="flex flex-col gap-2">
+          <span className="text-sm font-medium text-foreground">
+            Raw data exports
+          </span>
+          {isConsumptionExportsLoading ? (
+            <div className="flex justify-center py-4">
+              <Spinner size="sm" />
+            </div>
+          ) : exports.length > 0 ? (
+            <div className="flex flex-col">
+              {exports.map((item) => (
+                <ConsumptionExportRow key={item.name} item={item} />
+              ))}
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 py-4">
+              <Spinner size="sm" />
+              <span className="text-sm text-muted-foreground">
+                Generating your export…
+              </span>
+            </div>
+          )}
+        </div>
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}

--- a/front/hooks/useConsumptionExports.ts
+++ b/front/hooks/useConsumptionExports.ts
@@ -1,0 +1,79 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import type { ConsumptionExportListItem } from "@app/lib/api/analytics/consumption/export_jobs";
+import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
+import { clientFetch } from "@app/lib/egress/client";
+import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { useCallback, useState } from "react";
+import type { Fetcher } from "swr";
+import { useSWRConfig } from "swr";
+
+const GENERATING_POLL_INTERVAL_MS = 3_000;
+
+type GetConsumptionExportsResponse = {
+  exports: ConsumptionExportListItem[];
+  isGenerating: boolean;
+};
+
+export function useConsumptionExports({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const url = `/api/w/${workspaceId}/analytics/consumption/export-raw`;
+  const exportsFetcher: Fetcher<GetConsumptionExportsResponse> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(url, exportsFetcher, {
+    disabled,
+    refreshInterval: (latest) =>
+      latest?.isGenerating ? GENERATING_POLL_INTERVAL_MS : 0,
+  });
+
+  return {
+    exports: data?.exports ?? [],
+    isGenerating: data?.isGenerating ?? false,
+    mutateConsumptionExports: mutate,
+    isConsumptionExportsLoading: !error && !data && !disabled,
+    isConsumptionExportsError: error,
+  };
+}
+
+export function useStartConsumptionExport({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const [isStarting, setIsStarting] = useState(false);
+  const sendNotification = useSendNotification();
+  const { mutate } = useSWRConfig();
+  const url = `/api/w/${workspaceId}/analytics/consumption/export-raw`;
+
+  const startConsumptionExport = useCallback(
+    async (body: ConsumptionExportBody) => {
+      setIsStarting(true);
+      try {
+        const response = await clientFetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        if (!response.ok) {
+          sendNotification({
+            type: "error",
+            title: "Failed to start export",
+            description: "Could not start generating the export.",
+          });
+          return;
+        }
+        await mutate(url);
+      } finally {
+        setIsStarting(false);
+      }
+    },
+    [url, sendNotification, mutate]
+  );
+
+  return { isStarting, startConsumptionExport };
+}

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -2,14 +2,11 @@ import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/perio
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import {
-  describeTemporalWorkflow,
-  getTemporalClientForFrontNamespace,
-} from "@app/lib/temporal";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import { buildConsumptionExportGcsPrefix } from "@app/temporal/analytics_queue/activities/consumption_export";
 import type { LaunchConsumptionExportOutcome } from "@app/temporal/analytics_queue/client";
 import { launchConsumptionExportWorkflow } from "@app/temporal/analytics_queue/client";
-import { makeConsumptionExportWorkflowId } from "@app/temporal/analytics_queue/helpers";
+import { makeConsumptionExportWorkflowIdPrefix } from "@app/temporal/analytics_queue/helpers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -72,11 +69,14 @@ export async function isConsumptionExportGenerating(
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const client = await getTemporalClientForFrontNamespace();
 
-  const description = await describeTemporalWorkflow(client, {
-    workflowId: makeConsumptionExportWorkflowId({ workspaceId }),
-  });
+  // Workflow IDs are keyed by period+filter (see makeConsumptionExportWorkflowId), so a running
+  // export for this workspace is matched by prefix rather than by a single fixed workflow ID.
+  const query = `WorkflowId STARTS_WITH "${makeConsumptionExportWorkflowIdPrefix({ workspaceId })}" AND ExecutionStatus="Running"`;
+  for await (const _workflow of client.workflow.list({ query })) {
+    return true;
+  }
 
-  return description?.status.name === "RUNNING";
+  return false;
 }
 
 export async function startConsumptionExport(

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -23,7 +23,7 @@ export type ConsumptionExportListItem = {
 export async function listConsumptionExports(
   auth: Authenticator
 ): Promise<ConsumptionExportListItem[]> {
-  const workspaceSId = auth.getNonNullableWorkspace().sId;
+  const workspaceId = auth.getNonNullableWorkspace().sId;
   const bucket = getPrivateUploadBucket();
 
   const { files } = await bucket.getAllFilesByPrefix({

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -6,7 +6,9 @@ import {
   describeTemporalWorkflow,
   getTemporalClientForFrontNamespace,
 } from "@app/lib/temporal";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { buildConsumptionExportGcsPrefix } from "@app/temporal/analytics_queue/activities/consumption_export";
+import type { LaunchConsumptionExportOutcome } from "@app/temporal/analytics_queue/client";
 import { launchConsumptionExportWorkflow } from "@app/temporal/analytics_queue/client";
 import { makeConsumptionExportWorkflowId } from "@app/temporal/analytics_queue/helpers";
 import type { Result } from "@app/types/shared/result";
@@ -27,14 +29,15 @@ export async function listConsumptionExports(
   const bucket = getPrivateUploadBucket();
 
   const { files } = await bucket.getAllFilesByPrefix({
-    prefix: buildConsumptionExportGcsPrefix(workspaceSId),
+    prefix: buildConsumptionExportGcsPrefix(workspaceId),
   });
 
-  const items = await Promise.all(
-    files.map(async (file) => {
+  const items = await concurrentExecutor(
+    files,
+    async (file) => {
       const downloadUrl = await bucket.getSignedUrl(file.name, {
         expirationDelayMs: DOWNLOAD_URL_EXPIRATION_DELAY_MS,
-        promptSaveAs: `dust_consumption_lines_export_${workspaceSId}.zip`,
+        promptSaveAs: `dust_consumption_lines_export_${workspaceId}.zip`,
       });
 
       return {
@@ -43,7 +46,8 @@ export async function listConsumptionExports(
         sizeBytes: Number(file.metadata.size ?? 0),
         downloadUrl,
       };
-    })
+    },
+    { concurrency: 8 }
   );
 
   return items.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
@@ -71,7 +75,7 @@ export async function startConsumptionExport(
     period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
   }
-): Promise<Result<undefined, Error>> {
+): Promise<Result<LaunchConsumptionExportOutcome, Error>> {
   return launchConsumptionExportWorkflow(auth, {
     period,
     filter: filter ?? {},

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -6,20 +6,22 @@ import {
   describeTemporalWorkflow,
   getTemporalClientForFrontNamespace,
 } from "@app/lib/temporal";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { buildConsumptionExportGcsPrefix } from "@app/temporal/analytics_queue/activities/consumption_export";
 import type { LaunchConsumptionExportOutcome } from "@app/temporal/analytics_queue/client";
 import { launchConsumptionExportWorkflow } from "@app/temporal/analytics_queue/client";
 import { makeConsumptionExportWorkflowId } from "@app/temporal/analytics_queue/helpers";
 import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 const DOWNLOAD_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000;
+
+// exportId.zip, matching the naming built by `buildConsumptionExportGcsPath`.
+const EXPORT_FILE_NAME_REGEX = /^[A-Za-z0-9_-]+\.zip$/;
 
 export type ConsumptionExportListItem = {
   name: string;
   createdAt: string;
   sizeBytes: number;
-  downloadUrl: string;
 };
 
 export async function listConsumptionExports(
@@ -32,25 +34,36 @@ export async function listConsumptionExports(
     prefix: buildConsumptionExportGcsPrefix(workspaceId),
   });
 
-  const items = await concurrentExecutor(
-    files,
-    async (file) => {
-      const downloadUrl = await bucket.getSignedUrl(file.name, {
-        expirationDelayMs: DOWNLOAD_URL_EXPIRATION_DELAY_MS,
-        promptSaveAs: `dust_consumption_lines_export_${workspaceId}.zip`,
-      });
-
-      return {
-        name: file.name.split("/").pop() ?? file.name,
-        createdAt: file.metadata.timeCreated ?? new Date(0).toISOString(),
-        sizeBytes: Number(file.metadata.size ?? 0),
-        downloadUrl,
-      };
-    },
-    { concurrency: 8 }
-  );
+  const items = files.map((file) => ({
+    name: file.name.split("/").pop() ?? file.name,
+    createdAt: file.metadata.timeCreated ?? new Date(0).toISOString(),
+    sizeBytes: Number(file.metadata.size ?? 0),
+  }));
 
   return items.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+// The download link embedded in the export list would otherwise go stale after
+// DOWNLOAD_URL_EXPIRATION_DELAY_MS if the panel is left open: generate it fresh on each
+// download request instead, scoped to this workspace's own export files.
+export async function getConsumptionExportDownloadUrl(
+  auth: Authenticator,
+  fileName: string
+): Promise<Result<string, Error>> {
+  if (!EXPORT_FILE_NAME_REGEX.test(fileName)) {
+    return new Err(new Error("Invalid export file name."));
+  }
+
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const bucket = getPrivateUploadBucket();
+  const path = `${buildConsumptionExportGcsPrefix(workspaceId)}${fileName}`;
+
+  const downloadUrl = await bucket.getSignedUrl(path, {
+    expirationDelayMs: DOWNLOAD_URL_EXPIRATION_DELAY_MS,
+    promptSaveAs: `dust_consumption_lines_export_${workspaceId}.zip`,
+  });
+
+  return new Ok(downloadUrl);
 }
 
 export async function isConsumptionExportGenerating(

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -3,10 +3,12 @@ import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
-import { buildConsumptionExportGcsPrefix } from "@app/temporal/analytics_queue/activities/consumption_export";
+import {
+  buildConsumptionExportGcsPrefix,
+  makeConsumptionExportWorkflowIdPrefix,
+} from "@app/temporal/analytics_queue/activities/consumption_export";
 import type { LaunchConsumptionExportOutcome } from "@app/temporal/analytics_queue/client";
 import { launchConsumptionExportWorkflow } from "@app/temporal/analytics_queue/client";
-import { makeConsumptionExportWorkflowIdPrefix } from "@app/temporal/analytics_queue/helpers";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -69,8 +69,7 @@ export async function isConsumptionExportGenerating(
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const client = await getTemporalClientForFrontNamespace();
 
-  // Workflow IDs are keyed by period+filter (see makeConsumptionExportWorkflowId), so a running
-  // export for this workspace is matched by prefix rather than by a single fixed workflow ID.
+  // Export for this workspace is matched by prefix.
   const query = `WorkflowId STARTS_WITH "${makeConsumptionExportWorkflowIdPrefix({ workspaceId })}" AND ExecutionStatus="Running"`;
   for await (const _workflow of client.workflow.list({ query })) {
     return true;

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -1,0 +1,79 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import {
+  describeTemporalWorkflow,
+  getTemporalClientForFrontNamespace,
+} from "@app/lib/temporal";
+import { buildConsumptionExportGcsPrefix } from "@app/temporal/analytics_queue/activities/consumption_export";
+import { launchConsumptionExportWorkflow } from "@app/temporal/analytics_queue/client";
+import { makeConsumptionExportWorkflowId } from "@app/temporal/analytics_queue/helpers";
+import type { Result } from "@app/types/shared/result";
+
+const DOWNLOAD_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000;
+
+export type ConsumptionExportListItem = {
+  name: string;
+  createdAt: string;
+  sizeBytes: number;
+  downloadUrl: string;
+};
+
+export async function listConsumptionExports(
+  auth: Authenticator
+): Promise<ConsumptionExportListItem[]> {
+  const workspaceSId = auth.getNonNullableWorkspace().sId;
+  const bucket = getPrivateUploadBucket();
+
+  const { files } = await bucket.getAllFilesByPrefix({
+    prefix: buildConsumptionExportGcsPrefix(workspaceSId),
+  });
+
+  const items = await Promise.all(
+    files.map(async (file) => {
+      const downloadUrl = await bucket.getSignedUrl(file.name, {
+        expirationDelayMs: DOWNLOAD_URL_EXPIRATION_DELAY_MS,
+        promptSaveAs: `dust_consumption_lines_export_${workspaceSId}.zip`,
+      });
+
+      return {
+        name: file.name.split("/").pop() ?? file.name,
+        createdAt: file.metadata.timeCreated ?? new Date(0).toISOString(),
+        sizeBytes: Number(file.metadata.size ?? 0),
+        downloadUrl,
+      };
+    })
+  );
+
+  return items.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export async function isConsumptionExportGenerating(
+  auth: Authenticator
+): Promise<boolean> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const client = await getTemporalClientForFrontNamespace();
+
+  const description = await describeTemporalWorkflow(client, {
+    workflowId: makeConsumptionExportWorkflowId({ workspaceId }),
+  });
+
+  return description?.status.name === "RUNNING";
+}
+
+export async function startConsumptionExport(
+  auth: Authenticator,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter?: ConsumptionScopeFilter;
+  }
+): Promise<Result<undefined, Error>> {
+  return launchConsumptionExportWorkflow(auth, {
+    period,
+    filter: filter ?? {},
+  });
+}

--- a/front/lib/utils.ts
+++ b/front/lib/utils.ts
@@ -71,6 +71,16 @@ export const timeAgoFrom = (
  * compact: Sep, 2025
  *
  */
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
 export function formatTimestampToFriendlyDate(
   timestamp: number,
   version: "long" | "short" | "compact" | "compactWithDay" = "long"

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -21,6 +21,24 @@ export function buildConsumptionExportGcsPath(
   return `${buildConsumptionExportGcsPrefix(workspaceId)}${exportId}.zip`;
 }
 
+export function makeConsumptionExportWorkflowIdPrefix({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): string {
+  return `consumption-export-${workspaceId}-`;
+}
+
+export function makeConsumptionExportWorkflowId({
+  workspaceId,
+  exportId,
+}: {
+  workspaceId: string;
+  exportId: string;
+}): string {
+  return `${makeConsumptionExportWorkflowIdPrefix({ workspaceId })}${exportId}`;
+}
+
 // Sorted independently of request key/array order so equivalent filters hash identically.
 function canonicalizeConsumptionScopeFilter(
   filter: ConsumptionScopeFilter

--- a/front/temporal/analytics_queue/client.test.ts
+++ b/front/temporal/analytics_queue/client.test.ts
@@ -3,16 +3,14 @@ import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/
 import {
   buildConsumptionExportCacheKey,
   buildConsumptionExportGcsPath,
+  makeConsumptionExportWorkflowId,
 } from "@app/temporal/analytics_queue/activities/consumption_export";
 import {
   launchConsumptionExportWorkflow,
   launchStoreAgentMessageConsumptionAttributionWorkflow,
 } from "@app/temporal/analytics_queue/client";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
-import {
-  makeAgentMessageAnalyticsWorkflowId,
-  makeConsumptionExportWorkflowId,
-} from "@app/temporal/analytics_queue/helpers";
+import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import { storeAgentMessageConsumptionAttributionV3Workflow } from "@app/temporal/analytics_queue/workflows";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -11,12 +11,10 @@ import logger from "@app/logger/logger";
 import {
   buildConsumptionExportCacheKey,
   buildConsumptionExportGcsPath,
+  makeConsumptionExportWorkflowId,
 } from "@app/temporal/analytics_queue/activities/consumption_export";
 import { QUEUE_NAME } from "@app/temporal/analytics_queue/config";
-import {
-  makeAgentMessageAnalyticsWorkflowId,
-  makeConsumptionExportWorkflowId,
-} from "@app/temporal/analytics_queue/helpers";
+import { makeAgentMessageAnalyticsWorkflowId } from "@app/temporal/analytics_queue/helpers";
 import { storeAgentMessageConsumptionAttributionV3Signal } from "@app/temporal/analytics_queue/signals";
 import {
   runConsumptionExportWorkflow,

--- a/front/temporal/analytics_queue/helpers.ts
+++ b/front/temporal/analytics_queue/helpers.ts
@@ -9,26 +9,3 @@ export function makeAgentMessageAnalyticsWorkflowId({
 }): string {
   return `agent-message-analytics-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
-
-// Shared by makeConsumptionExportWorkflowId and by callers that need to match any export
-// workflow for a workspace regardless of its cache key (e.g. a WorkflowId STARTS_WITH query).
-export function makeConsumptionExportWorkflowIdPrefix({
-  workspaceId,
-}: {
-  workspaceId: string;
-}): string {
-  return `consumption-export-${workspaceId}-`;
-}
-
-// Deterministic, one per workspace and export cache key (see buildConsumptionExportCacheKey):
-// requests for the same period+filter dedupe onto the same workflow, while requests for a
-// different period+filter get their own workflow and can run concurrently.
-export function makeConsumptionExportWorkflowId({
-  workspaceId,
-  exportId,
-}: {
-  workspaceId: string;
-  exportId: string;
-}): string {
-  return `${makeConsumptionExportWorkflowIdPrefix({ workspaceId })}${exportId}`;
-}

--- a/front/temporal/analytics_queue/helpers.ts
+++ b/front/temporal/analytics_queue/helpers.ts
@@ -10,6 +10,16 @@ export function makeAgentMessageAnalyticsWorkflowId({
   return `agent-message-analytics-${workspaceId}-${conversationId}-${agentMessageId}`;
 }
 
+// Shared by makeConsumptionExportWorkflowId and by callers that need to match any export
+// workflow for a workspace regardless of its cache key (e.g. a WorkflowId STARTS_WITH query).
+export function makeConsumptionExportWorkflowIdPrefix({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): string {
+  return `consumption-export-${workspaceId}-`;
+}
+
 // Deterministic, one per workspace and export cache key (see buildConsumptionExportCacheKey):
 // requests for the same period+filter dedupe onto the same workflow, while requests for a
 // different period+filter get their own workflow and can run concurrently.
@@ -20,5 +30,5 @@ export function makeConsumptionExportWorkflowId({
   workspaceId: string;
   exportId: string;
 }): string {
-  return `consumption-export-${workspaceId}-${exportId}`;
+  return `${makeConsumptionExportWorkflowIdPrefix({ workspaceId })}${exportId}`;
 }


### PR DESCRIPTION
## Description

Replace the synchronous raw consumption export with an asynchronous export panel backed by the Temporal workflow introduced in https://github.com/dust-tt/dust/pull/30551.  The `Download raw data` action now opens a popover that lists workspace exports from the private upload bucket, sorted newest first, with five-minute signed download URLs. 

**Visuals:**
<img width="1148" height="477" alt="Capture d’écran 2026-08-14 à 16 06 40" src="https://github.com/user-attachments/assets/223cb464-3e22-4d06-98d2-ebe1d9800f5b" />

<img width="629" height="389" alt="Capture d’écran 2026-08-14 à 16 07 49" src="https://github.com/user-attachments/assets/f4a8fee0-3028-4208-8040-5dc421c30c10" />

The API now provides a manager-only `GET` endpoint returning available exports and whether the workspace export workflow is running. The manager-only `POST` endpoint resolves the requested period and filter, starts the workflow, and immediately returns `202 { isGenerating: true }` instead of generating and returning the ZIP in the request. 

The frontend polls while a job is running and shows generation state in the panel. 

## Tests

Automated route coverage was updated for empty export lists, export listing and ordering, signed download URLs, running workflow state, successful asynchronous job creation, authorization, and invalid request bodies

## Risk

Low. The main compatibility change is the `POST` response: it no longer returns a ZIP attachment synchronously and instead starts a background job, so direct API consumers that depend on the old response contract would need updating. Export generation and downloads now depend on the Temporal workflow, private bucket listing, and signed URL generation; failures in those services can affect export availability. 

## Deploy Plan

-Deploy front 