### PR TITLE
Notify the requesting user when their consumption export finishes

### DIFF
--- a/front-api/routes/novu/index.ts
+++ b/front-api/routes/novu/index.ts
@@ -2,6 +2,7 @@ import { activationNewConversationWorkflow } from "@app/lib/notifications/workfl
 import { agentMessageFeedbackWorkflow } from "@app/lib/notifications/workflows/agent-message-feedback";
 import { agentSuggestionsReadyWorkflow } from "@app/lib/notifications/workflows/agent-suggestions-ready";
 import { balanceThresholdReachedWorkflow } from "@app/lib/notifications/workflows/balance-threshold-reached";
+import { consumptionExportReadyWorkflow } from "@app/lib/notifications/workflows/consumption-export-ready";
 import { conversationUnreadWorkflow } from "@app/lib/notifications/workflows/conversation-unread";
 import { manualActionRequiredWorkflow } from "@app/lib/notifications/workflows/manual-action-required";
 import { podAddedAsMemberWorkflow } from "@app/lib/notifications/workflows/pod-added-as-member";
@@ -76,6 +77,7 @@ const options: ServeHandlerOptions = {
     upgradeRequestCreatedWorkflow,
     seatAutoUpgradedWorkflow,
     manualActionRequiredWorkflow,
+    consumptionExportReadyWorkflow,
   ],
 };
 

--- a/front/lib/notifications/workflows/consumption-export-ready.test.ts
+++ b/front/lib/notifications/workflows/consumption-export-ready.test.ts
@@ -1,0 +1,101 @@
+import * as novuClientModule from "@app/lib/notifications/novu-client";
+import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/consumption-export-ready";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { CONSUMPTION_EXPORT_READY_TRIGGER_ID } from "@app/types/notification_preferences";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockTriggerBulk = vi.fn();
+
+vi.mock(import("@app/lib/notifications/novu-client"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, getNovuClient: vi.fn() };
+});
+
+beforeEach(() => {
+  mockTriggerBulk.mockReset();
+  vi.mocked(novuClientModule.getNovuClient).mockResolvedValue({
+    triggerBulk: mockTriggerBulk,
+  } as unknown as Awaited<ReturnType<typeof novuClientModule.getNovuClient>>);
+});
+
+async function setup() {
+  const { authenticator, workspace, user } = await createResourceTest({
+    role: "admin",
+  });
+  return { authenticator, workspace, user };
+}
+
+// Flushes the fire-and-forget promise chain started by notifyConsumptionExportReady.
+async function flush() {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe("notifyConsumptionExportReady", () => {
+  it("triggers the workflow for the requesting user with a stable, deduplicating transactionId", async () => {
+    mockTriggerBulk.mockResolvedValue({ result: [{}] });
+    const { authenticator, workspace, user } = await setup();
+
+    notifyConsumptionExportReady(authenticator, "export-run-1");
+    await flush();
+
+    expect(mockTriggerBulk).toHaveBeenCalledTimes(1);
+    const call = mockTriggerBulk.mock.calls[0][0];
+    expect(call.events).toHaveLength(1);
+    const [event] = call.events;
+
+    expect(event.workflowId).toBe(CONSUMPTION_EXPORT_READY_TRIGGER_ID);
+    expect(event.to).toEqual({
+      subscriberId: user.sId,
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName ?? undefined,
+    });
+    expect(event.payload).toEqual({ workspaceId: workspace.sId });
+
+    const firstTransactionId = event.transactionId;
+    expect(firstTransactionId).toContain(workspace.sId);
+    expect(firstTransactionId).toContain(user.sId);
+    expect(firstTransactionId).toContain("export-run-1");
+
+    // A retry of the same export must reuse the exact same transactionId so Novu
+    // deduplicates instead of sending a second in-app notification.
+    notifyConsumptionExportReady(authenticator, "export-run-1");
+    await flush();
+
+    expect(mockTriggerBulk.mock.calls[1][0].events[0].transactionId).toBe(
+      firstTransactionId
+    );
+
+    // A different export must get a different transactionId.
+    notifyConsumptionExportReady(authenticator, "export-run-2");
+    await flush();
+
+    expect(mockTriggerBulk.mock.calls[2][0].events[0].transactionId).not.toBe(
+      firstTransactionId
+    );
+  });
+
+  it("logs an error without throwing when Novu reports a per-event error", async () => {
+    mockTriggerBulk.mockResolvedValue({ result: [{ error: ["boom"] }] });
+    const { authenticator } = await setup();
+
+    expect(() =>
+      notifyConsumptionExportReady(authenticator, "export-run-1")
+    ).not.toThrow();
+    await flush();
+
+    expect(mockTriggerBulk).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs an error without throwing when the Novu call rejects", async () => {
+    mockTriggerBulk.mockRejectedValue(new Error("network error"));
+    const { authenticator } = await setup();
+
+    expect(() =>
+      notifyConsumptionExportReady(authenticator, "export-run-1")
+    ).not.toThrow();
+    await flush();
+
+    expect(mockTriggerBulk).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front/lib/notifications/workflows/consumption-export-ready.ts
+++ b/front/lib/notifications/workflows/consumption-export-ready.ts
@@ -43,7 +43,10 @@ export const consumptionExportReadyWorkflow = workflow(
  * Fire-and-forget helper to notify the requesting user that their consumption export is
  * ready to download. Errors are logged but don't block the caller.
  */
-export function notifyConsumptionExportReady(auth: Authenticator): void {
+export function notifyConsumptionExportReady(
+  auth: Authenticator,
+  exportId: string
+): void {
   const user = auth.user();
   if (!user) {
     return;
@@ -53,12 +56,17 @@ export function notifyConsumptionExportReady(auth: Authenticator): void {
 
   const payload: ConsumptionExportReadyPayloadType = { workspaceId };
 
+  // Ties the Novu transaction to the stable exportId so a Temporal retry after the
+  // completion ack is lost re-sends the same transaction instead of a duplicate notification.
+  const transactionId = `consumption-export-ready-${workspaceId}-${userSId}-${exportId}`;
+
   void getNovuClient()
     .then((novuClient) =>
       novuClient.triggerBulk({
         events: [
           {
             workflowId: CONSUMPTION_EXPORT_READY_TRIGGER_ID,
+            transactionId,
             to: {
               subscriberId: userSId,
               email: user.email,
@@ -73,14 +81,14 @@ export function notifyConsumptionExportReady(auth: Authenticator): void {
     .then((r) => {
       if (r.result.some((res) => !!res.error?.length)) {
         logger.error(
-          { workspaceId, userSId },
+          { workspaceId, userSId, transactionId },
           "Failed to trigger consumption export ready notification"
         );
       }
     })
     .catch((err) => {
       logger.error(
-        { err, workspaceId, userSId },
+        { err, workspaceId, userSId, transactionId },
         "Failed to trigger consumption export ready notification"
       );
     });

--- a/front/lib/notifications/workflows/consumption-export-ready.ts
+++ b/front/lib/notifications/workflows/consumption-export-ready.ts
@@ -52,13 +52,13 @@ export function notifyConsumptionExportReady(
     return;
   }
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const userSId = user.sId;
+  const userId = user.sId;
 
   const payload: ConsumptionExportReadyPayloadType = { workspaceId };
 
   // Ties the Novu transaction to the stable exportId so a Temporal retry after the
   // completion ack is lost re-sends the same transaction instead of a duplicate notification.
-  const transactionId = `consumption-export-ready-${workspaceId}-${userSId}-${exportId}`;
+  const transactionId = `consumption-export-ready-${workspaceId}-${userId}-${exportId}`;
 
   void getNovuClient()
     .then((novuClient) =>
@@ -68,7 +68,7 @@ export function notifyConsumptionExportReady(
             workflowId: CONSUMPTION_EXPORT_READY_TRIGGER_ID,
             transactionId,
             to: {
-              subscriberId: userSId,
+              subscriberId: userId,
               email: user.email,
               firstName: user.firstName,
               lastName: user.lastName ?? undefined,
@@ -81,14 +81,14 @@ export function notifyConsumptionExportReady(
     .then((r) => {
       if (r.result.some((res) => !!res.error?.length)) {
         logger.error(
-          { workspaceId, userSId, transactionId },
+          { workspaceId, userId, transactionId },
           "Failed to trigger consumption export ready notification"
         );
       }
     })
     .catch((err) => {
       logger.error(
-        { err, workspaceId, userSId, transactionId },
+        { err, workspaceId, userId, transactionId },
         "Failed to trigger consumption export ready notification"
       );
     });

--- a/front/lib/notifications/workflows/consumption-export-ready.ts
+++ b/front/lib/notifications/workflows/consumption-export-ready.ts
@@ -1,0 +1,87 @@
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { getNovuClient } from "@app/lib/notifications";
+import logger from "@app/logger/logger";
+import { CONSUMPTION_EXPORT_READY_TRIGGER_ID } from "@app/types/notification_preferences";
+import { workflow } from "@novu/framework";
+import z from "zod";
+
+const ConsumptionExportReadyPayloadSchema = z.object({
+  workspaceId: z.string(),
+});
+
+type ConsumptionExportReadyPayloadType = z.infer<
+  typeof ConsumptionExportReadyPayloadSchema
+>;
+
+export const consumptionExportReadyWorkflow = workflow(
+  CONSUMPTION_EXPORT_READY_TRIGGER_ID,
+  async ({ step, payload }) => {
+    await step.inApp("send-in-app", async () => {
+      return {
+        subject: "Your consumption export is ready",
+        body: "The raw consumption data you requested has finished generating and is ready to download.",
+        primaryAction: {
+          label: "Download",
+          redirect: {
+            url: `${config.getAppUrl()}/w/${payload.workspaceId}/analytics/consumption`,
+          },
+        },
+        data: {
+          workspaceId: payload.workspaceId,
+        },
+      };
+    });
+  },
+  {
+    payloadSchema: ConsumptionExportReadyPayloadSchema,
+    tags: ["admin"],
+  }
+);
+
+/**
+ * Fire-and-forget helper to notify the requesting user that their consumption export is
+ * ready to download. Errors are logged but don't block the caller.
+ */
+export function notifyConsumptionExportReady(auth: Authenticator): void {
+  const user = auth.user();
+  if (!user) {
+    return;
+  }
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const userSId = user.sId;
+
+  const payload: ConsumptionExportReadyPayloadType = { workspaceId };
+
+  void getNovuClient()
+    .then((novuClient) =>
+      novuClient.triggerBulk({
+        events: [
+          {
+            workflowId: CONSUMPTION_EXPORT_READY_TRIGGER_ID,
+            to: {
+              subscriberId: userSId,
+              email: user.email,
+              firstName: user.firstName,
+              lastName: user.lastName ?? undefined,
+            },
+            payload,
+          },
+        ],
+      })
+    )
+    .then((r) => {
+      if (r.result.some((res) => !!res.error?.length)) {
+        logger.error(
+          { workspaceId, userSId },
+          "Failed to trigger consumption export ready notification"
+        );
+      }
+    })
+    .catch((err) => {
+      logger.error(
+        { err, workspaceId, userSId },
+        "Failed to trigger consumption export ready notification"
+      );
+    });
+}

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -6,6 +6,7 @@ import {
   ElasticsearchError,
   searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
+import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/consumption-export-ready";
 import {
   buildConsumptionExportGcsPrefix,
   runConsumptionExportActivity,
@@ -19,7 +20,7 @@ import type {
 } from "@app/types/assistant/analytics";
 import { Err, Ok } from "@app/types/shared/result";
 import AdmZip from "adm-zip";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Instantiation expression: pins the mock to the concrete TDocument the exporter
 // actually queries with, so mockResolvedValue can be given a fully-typed
@@ -35,6 +36,17 @@ vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
 vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
   const mod = await orig();
   return { ...mod, resolveDimensionLabels: vi.fn() };
+});
+vi.mock(
+  import("@app/lib/notifications/workflows/consumption-export-ready"),
+  async (orig) => {
+    const mod = await orig();
+    return { ...mod, notifyConsumptionExportReady: vi.fn() };
+  }
+);
+
+beforeEach(() => {
+  vi.mocked(notifyConsumptionExportReady).mockClear();
 });
 
 const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
@@ -220,6 +232,8 @@ describe("runConsumptionExportActivity", () => {
     );
     expect(csv).toContain("search,server1,Search Tool");
     expect(csv).toContain("skill1,Research");
+
+    expect(notifyConsumptionExportReady).toHaveBeenCalledTimes(1);
   });
 
   it("throws and uploads nothing when the search fails", async () => {
@@ -244,5 +258,6 @@ describe("runConsumptionExportActivity", () => {
       call.filePath.startsWith(prefix)
     );
     expect(saveCalls).toHaveLength(0);
+    expect(notifyConsumptionExportReady).not.toHaveBeenCalled();
   });
 });

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -7,6 +7,7 @@ import type {
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/consumption-export-ready";
 import logger from "@app/logger/logger";
 import { createHash } from "crypto";
 
@@ -101,4 +102,6 @@ export async function runConsumptionExportActivity(
   await getPrivateUploadBucket()
     .file(gcsPath)
     .save(result.value, { contentType: "application/zip", resumable: false });
+
+  notifyConsumptionExportReady(auth);
 }

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -103,5 +103,5 @@ export async function runConsumptionExportActivity(
     .file(gcsPath)
     .save(result.value, { contentType: "application/zip", resumable: false });
 
-  notifyConsumptionExportReady(auth);
+  notifyConsumptionExportReady(auth, exportId);
 }

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -109,6 +109,9 @@ export const PROVIDER_CREDENTIALS_HEALTH_UPDATED_TAG =
 export const USER_AWU_CAP_REACHED_TRIGGER_ID = "user-awu-cap-reached" as const;
 export const USER_AWU_CAP_REACHED_TAG = "user-awu-cap-reached" as const;
 
+export const CONSUMPTION_EXPORT_READY_TRIGGER_ID =
+  "consumption-export-ready" as const;
+
 export const BALANCE_THRESHOLD_REACHED_TRIGGER_ID =
   "balance-threshold-reached" as const;
 export const BALANCE_THRESHOLD_REACHED_TAG =


### PR DESCRIPTION
## Description

Adds an in-app Novu notification for consumption export completion. The new `consumption-export-ready` workflow is registered with the Novu route and presents a “Download” action linking back to the workspace’s consumption analytics page.

The export activity triggers the notification only after the ZIP has been uploaded successfully, targeting the requesting user. The transaction ID includes the workspace, user, and export ID, so retries of the same export reuse the same Novu transaction and can be deduplicated. Notification delivery is fire-and-forget: Novu errors are logged without blocking or failing an otherwise successful export.

The change also adds coverage for the notification payload, transaction ID stability, Novu error handling, and the activity’s success/failure notification behavior.

## Tests

Vitest coverage was added/updated for the new workflow helper and the consumption export activity. N

## Risk

Low - The behavioral scope is limited to notifying users after a consumption export has been successfully uploaded. If Novu is unavailable or reports an error, the export itself still completes and the error is logged. Failed exports do not trigger a completion notification. Stable transaction IDs reduce the risk of duplicate in-app notifications when the export activity is retried.

## Deploy Plan

- Deploy front
