### PR TITLE
[front] Instrument input-bar model picker analytics

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarModelPicker.tsx
@@ -10,6 +10,7 @@ type InputBarModelPickerProps = Omit<
   | "showLabel"
   | "setStickyModelOverride"
   | "stickyModelOverride"
+  | "trackingSurface"
 >;
 
 export function InputBarModelPicker({
@@ -45,6 +46,7 @@ export function InputBarModelPicker({
         setStickyModelOverride={setStickyModelOverride}
         commitApiRef={commitApiRef}
         openApiRef={openModelPickerRef}
+        trackingSurface="conversation_input_bar"
       />
     </ModelPickerHighlight>
   );

--- a/front/components/assistant/conversation/input_bar/ModelPickerHighlight.tsx
+++ b/front/components/assistant/conversation/input_bar/ModelPickerHighlight.tsx
@@ -1,3 +1,4 @@
+import { trackModelPickerExposure } from "@app/components/model_picker/modelPickerTracking";
 import { useClientType } from "@app/lib/context/clientType";
 import { DiscoveryGlint } from "@dust-tt/sparkle";
 import type React from "react";
@@ -38,7 +39,8 @@ interface ModelPickerHighlightProps {
 }
 
 export function ModelPickerHighlight({ children }: ModelPickerHighlightProps) {
-  const isExtension = useClientType() === "extension";
+  const clientType = useClientType();
+  const isExtension = clientType === "extension";
   const [isActive, setIsActive] = useState<boolean>(
     () =>
       !isExtension &&
@@ -47,6 +49,20 @@ export function ModelPickerHighlight({ children }: ModelPickerHighlightProps) {
   );
   const hostRef = useRef<HTMLSpanElement>(null);
   const hasSpentDismissalRef = useRef(false);
+  const hasTrackedExposureRef = useRef(false);
+
+  // Fire a single exposure event per mount, the first time the glint is
+  // actually rendered. Guarded by a ref so re-renders (and toggling back off
+  // after a dismissal) never emit a duplicate.
+  useEffect(() => {
+    if (isActive && !hasTrackedExposureRef.current) {
+      hasTrackedExposureRef.current = true;
+      trackModelPickerExposure({
+        surface: "conversation_input_bar",
+        clientType,
+      });
+    }
+  }, [isActive, clientType]);
 
   const dismiss = useCallback(() => {
     if (!hasSpentDismissalRef.current && !isReplayRequested()) {

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -1,5 +1,13 @@
 import { ModelPickerContent } from "@app/components/model_picker/ModelPickerContent";
 import type {
+  ModelPickerSelectTrigger,
+  ModelPickerSurface,
+} from "@app/components/model_picker/modelPickerTracking";
+import {
+  trackModelPickerOpen,
+  trackModelPickerSelect,
+} from "@app/components/model_picker/modelPickerTracking";
+import type {
   MakerGroup,
   ModelTierId,
   Selection,
@@ -19,6 +27,7 @@ import {
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useClientType } from "@app/lib/context/clientType";
 import { useModels } from "@app/lib/swr/models";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -74,6 +83,10 @@ export interface ModelPickerProps {
   commitApiRef?: MutableRefObject<((selection: Selection) => void) | null>;
   // Lets components outside the input bar (e.g. the sidebar banner) open the menu.
   openApiRef?: MutableRefObject<(() => void) | null>;
+  // When set, emits `assistant:model_picker:*` analytics tagged with this
+  // surface. Consumers that don't pass it (e.g. the agent builder) are not
+  // tracked.
+  trackingSurface?: ModelPickerSurface;
 }
 
 export function ModelPicker({
@@ -92,8 +105,10 @@ export function ModelPicker({
   setStickyModelOverride,
   commitApiRef,
   openApiRef,
+  trackingSurface,
 }: ModelPickerProps) {
   const { hasFeature } = useFeatureFlags();
+  const clientType = useClientType();
   const hasModelsPicker = hasFeature("models_picker");
   const { subscription } = useAuth();
   const canSelectPremiumModels =
@@ -190,7 +205,15 @@ export function ModelPicker({
     }));
   }, [allModels]);
 
-  const commit = (selection: Selection) => {
+  const commit = (
+    selection: Selection,
+    // What the user did to reach this selection. Defaults from the selection
+    // shape so the keyboard `/` pick path (which calls `commit` directly via
+    // `commitApiRef`) is still tracked with a sensible trigger.
+    trigger: ModelPickerSelectTrigger = selection.display.kind === "tier"
+      ? "tier"
+      : "model"
+  ) => {
     if (isSameSelection(selection.display, agentDefault.display)) {
       // Exactly the agent default: keep no override so we defer to the agent's
       // own config (toSend undefined).
@@ -200,14 +223,36 @@ export function ModelPicker({
     }
     setUserOverride(selection);
     onSelectionChange?.(selection.toSend);
+
+    if (trackingSurface) {
+      trackModelPickerSelect({
+        surface: trackingSurface,
+        clientType,
+        display: selection.display,
+        trigger,
+      });
+    }
   };
 
   if (commitApiRef) {
     commitApiRef.current = commit;
   }
 
+  // Opening from the button and opening programmatically (sidebar banner) must
+  // reset the menu's transient state and emit the same `open` event, so both go
+  // through here rather than touching `setIsOpen` directly.
+  const openMenu = () => {
+    setIsOpen(true);
+    setSearch("");
+    setMoreModelsExpanded(false);
+    setExpandedMaker(null);
+    if (trackingSurface) {
+      trackModelPickerOpen({ surface: trackingSurface, clientType });
+    }
+  };
+
   if (openApiRef) {
-    openApiRef.current = () => setIsOpen(true);
+    openApiRef.current = openMenu;
   }
 
   // Picking a concrete model (or nudging its effort slider) must keep the menu
@@ -225,10 +270,13 @@ export function ModelPicker({
     if (getTierLockReason(tierId, { lockPremiumEfforts, streamModels })) {
       return;
     }
-    commit({
-      display: { kind: "tier", tierId },
-      toSend: buildTierSelection(tierId),
-    });
+    commit(
+      {
+        display: { kind: "tier", tierId },
+        toSend: buildTierSelection(tierId),
+      },
+      "tier"
+    );
   };
 
   const onSelectModel = (model: ModelConfigurationType) => {
@@ -237,10 +285,13 @@ export function ModelPicker({
     }
     lastModelInteractionAtMsRef.current = Date.now();
     const effort = getInitialEffort(model, { lockPremiumEfforts });
-    commit({
-      display: { kind: "model", model, effort },
-      toSend: buildModelSelection(model, effort),
-    });
+    commit(
+      {
+        display: { kind: "model", model, effort },
+        toSend: buildModelSelection(model, effort),
+      },
+      "model"
+    );
   };
 
   const onChangeEffort = (effort: ReasoningEffort) => {
@@ -255,16 +306,28 @@ export function ModelPicker({
     ) {
       return;
     }
-    commit({
-      display: { kind: "model", model, effort },
-      toSend: buildModelSelection(model, effort),
-    });
+    commit(
+      {
+        display: { kind: "model", model, effort },
+        toSend: buildModelSelection(model, effort),
+      },
+      "reasoning_effort"
+    );
   };
 
   const onRevert = () => {
     setUserOverride(agentDefault);
     setStickyModelOverride?.(undefined);
     onSelectionChange?.(undefined);
+
+    if (trackingSurface) {
+      trackModelPickerSelect({
+        surface: trackingSurface,
+        clientType,
+        display: agentDefault.display,
+        trigger: "revert",
+      });
+    }
   };
 
   if (!hasModelsPicker) {
@@ -291,11 +354,10 @@ export function ModelPicker({
         if (!open && shouldBlockDismiss()) {
           return;
         }
-        setIsOpen(open);
         if (open) {
-          setSearch("");
-          setMoreModelsExpanded(false);
-          setExpandedMaker(null);
+          openMenu();
+        } else {
+          setIsOpen(false);
         }
       }}
     >

--- a/front/components/model_picker/modelPickerTracking.test.ts
+++ b/front/components/model_picker/modelPickerTracking.test.ts
@@ -1,0 +1,119 @@
+import {
+  MODEL_PICKER_CAMPAIGN_ID,
+  trackModelPickerExposure,
+  trackModelPickerOpen,
+  trackModelPickerSelect,
+} from "@app/components/model_picker/modelPickerTracking";
+import type { SelectionDisplay } from "@app/components/model_picker/modelPickerUtils";
+import { trackEvent } from "@app/lib/tracking";
+import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Keep the real TRACKING_AREAS/TRACKING_ACTIONS so the module builds genuine
+// values; only intercept the emit so we can assert the event contract.
+vi.mock("@app/lib/tracking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/tracking")>();
+  return { ...actual, trackEvent: vi.fn() };
+});
+
+const trackEventMock = vi.mocked(trackEvent);
+
+beforeEach(() => {
+  trackEventMock.mockClear();
+});
+
+const BASE = { surface: "conversation_input_bar", clientType: "web" } as const;
+
+const COMMON_EXTRA = {
+  surface: "conversation_input_bar",
+  campaign_id: MODEL_PICKER_CAMPAIGN_ID,
+  client_type: "web",
+};
+
+describe("modelPickerTracking", () => {
+  it("emits assistant:model_picker:exposure with the shared properties", () => {
+    trackModelPickerExposure(BASE);
+
+    expect(trackEventMock).toHaveBeenCalledTimes(1);
+    expect(trackEventMock).toHaveBeenCalledWith({
+      area: "assistant",
+      object: "model_picker",
+      action: "exposure",
+      extra: COMMON_EXTRA,
+    });
+  });
+
+  it("emits assistant:model_picker:open with the shared properties", () => {
+    trackModelPickerOpen({ ...BASE, clientType: "extension" });
+
+    expect(trackEventMock).toHaveBeenCalledWith({
+      area: "assistant",
+      object: "model_picker",
+      action: "open",
+      extra: { ...COMMON_EXTRA, client_type: "extension" },
+    });
+  });
+
+  it("emits a tier select with the tier id", () => {
+    trackModelPickerSelect({
+      ...BASE,
+      display: { kind: "tier", tierId: "complex" },
+      trigger: "tier",
+    });
+
+    expect(trackEventMock).toHaveBeenCalledWith({
+      area: "assistant",
+      object: "model_picker",
+      action: "select",
+      extra: {
+        ...COMMON_EXTRA,
+        trigger: "tier",
+        selection_kind: "tier",
+        tier_id: "complex",
+      },
+    });
+  });
+
+  it("emits a model select with model/provider/effort and the trigger", () => {
+    const display: SelectionDisplay = {
+      kind: "model",
+      model: CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+      effort: "medium",
+    };
+
+    trackModelPickerSelect({ ...BASE, display, trigger: "reasoning_effort" });
+
+    expect(trackEventMock).toHaveBeenCalledWith({
+      area: "assistant",
+      object: "model_picker",
+      action: "select",
+      extra: {
+        ...COMMON_EXTRA,
+        trigger: "reasoning_effort",
+        selection_kind: "model",
+        model_id: CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.modelId,
+        provider_id: CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.providerId,
+        reasoning_effort: "medium",
+      },
+    });
+  });
+
+  it("tags a revert with the trigger while still describing the resulting selection", () => {
+    trackModelPickerSelect({
+      ...BASE,
+      display: { kind: "tier", tierId: "standard" },
+      trigger: "revert",
+    });
+
+    expect(trackEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "select",
+        extra: expect.objectContaining({
+          trigger: "revert",
+          selection_kind: "tier",
+          tier_id: "standard",
+        }),
+      })
+    );
+  });
+});

--- a/front/components/model_picker/modelPickerTracking.ts
+++ b/front/components/model_picker/modelPickerTracking.ts
@@ -1,0 +1,111 @@
+import type { SelectionDisplay } from "@app/components/model_picker/modelPickerUtils";
+import type { ClientType } from "@app/lib/context/clientType";
+import type { TrackingExtra } from "@app/lib/tracking";
+import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+
+// PostHog instrumentation for the model picker. All events share the
+// `assistant:model_picker:<action>` name (see `trackEvent`, which builds
+// `${area}:${object}:${action}`) and a common set of properties: the surface
+// the picker is rendered on, the discovery-campaign id, and the client type.
+//
+// Only surfaces that pass a `ModelPickerSurface` are instrumented. Today that
+// is the conversation input bar; the agent-builder embedding does not pass a
+// surface and is intentionally left untracked.
+
+const TRACKING_OBJECT = "model_picker";
+
+// Identifies the model-picker discovery/highlight campaign (see
+// `ModelPickerHighlight`, which time-boxes the glint). Bump this when a new
+// campaign starts so events can be segmented per campaign.
+export const MODEL_PICKER_CAMPAIGN_ID = "model_picker_launch_2026_08";
+
+// Where the picker is rendered. Extend this union when a new surface starts
+// passing a `trackingSurface` to `ModelPicker`.
+export type ModelPickerSurface = "conversation_input_bar";
+
+// What triggered a `select` event, mirroring the picker's four intentional
+// user gestures.
+export type ModelPickerSelectTrigger =
+  | "tier"
+  | "model"
+  | "reasoning_effort"
+  | "revert";
+
+interface ModelPickerBaseProps {
+  surface: ModelPickerSurface;
+  clientType: ClientType;
+}
+
+function baseExtra({
+  surface,
+  clientType,
+}: ModelPickerBaseProps): TrackingExtra {
+  return {
+    surface,
+    campaign_id: MODEL_PICKER_CAMPAIGN_ID,
+    client_type: clientType,
+  };
+}
+
+// Describes the resulting selection (tier vs. concrete model + effort) for a
+// `select` event.
+function selectionExtra(display: SelectionDisplay): TrackingExtra {
+  switch (display.kind) {
+    case "tier":
+      return { selection_kind: "tier", tier_id: display.tierId };
+    case "model":
+      return {
+        selection_kind: "model",
+        model_id: display.model.modelId,
+        provider_id: display.model.providerId,
+        reasoning_effort: display.effort,
+      };
+    default:
+      assertNeverAndIgnore(display);
+      return { selection_kind: "unknown" };
+  }
+}
+
+// Fired once per highlight impression, when the discovery glint is actually
+// rendered. The caller is responsible for de-duplicating re-renders.
+export function trackModelPickerExposure(base: ModelPickerBaseProps): void {
+  trackEvent({
+    area: TRACKING_AREAS.ASSISTANT,
+    object: TRACKING_OBJECT,
+    action: "exposure",
+    extra: baseExtra(base),
+  });
+}
+
+// Fired when the picker dropdown opens.
+export function trackModelPickerOpen(base: ModelPickerBaseProps): void {
+  trackEvent({
+    area: TRACKING_AREAS.ASSISTANT,
+    object: TRACKING_OBJECT,
+    action: "open",
+    extra: baseExtra(base),
+  });
+}
+
+// Fired when the user commits a tier, model, or reasoning-effort change, or
+// reverts to the agent default. `display` is the resulting selection.
+export function trackModelPickerSelect({
+  display,
+  trigger,
+  ...base
+}: ModelPickerBaseProps & {
+  display: SelectionDisplay;
+  trigger: ModelPickerSelectTrigger;
+}): void {
+  trackEvent({
+    area: TRACKING_AREAS.ASSISTANT,
+    object: TRACKING_OBJECT,
+    action: "select",
+    extra: {
+      ...baseExtra(base),
+      trigger,
+      ...selectionExtra(display),
+    },
+  });
+}

--- a/front/lib/context/clientType.tsx
+++ b/front/lib/context/clientType.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react";
 
-type ClientType = "web" | "extension";
+export type ClientType = "web" | "extension";
 
 const ClientTypeContext = createContext<ClientType>("web");
 


### PR DESCRIPTION
## Description

Analytics-only instrumentation of the **conversation input-bar model picker** (no UI, model-resolution, or highlight-lifecycle changes; no A/B testing).

Three PostHog events, routed through the existing `trackEvent` helper (`front/lib/tracking.ts`) so names follow the `{area}:{object}:{action}` convention:

| Event | When | Extra props (beyond the shared set) |
|---|---|---|
| `assistant:model_picker:exposure` | The discovery glint is actually rendered — fired once per mount, ref-guarded against re-render duplicates | — |
| `assistant:model_picker:open` | The picker dropdown opens | — |
| `assistant:model_picker:select` | Tier / model / reasoning-effort pick, or revert-to-default | `trigger` (`tier` \| `model` \| `reasoning_effort` \| `revert`), `selection_kind` (`tier` \| `model`), and either `tier_id` or `model_id` + `provider_id` + `reasoning_effort` |

**Shared on every event:** `surface: "conversation_input_bar"`, `campaign_id: "model_picker_launch_2026_08"`, `client_type` (`web` \| `extension`). `utm_campaign` continues to ride along automatically via `PostHogTracker`.

### How it's wired
- New shared module `front/components/model_picker/modelPickerTracking.ts` owns the event contract (names, campaign id, surface union, property shaping).
- `ModelPicker.tsx`: `open` fires in `onOpenChange` (open transition only); `select` fires from the single `commit()` funnel — covering both the button handlers **and** the keyboard `/`-pick path — plus `onRevert()`. `commit()` takes a `trigger` so all four requested cases are labeled distinctly.
- Gated behind a new optional `trackingSurface` prop. Only `InputBarModelPicker` passes it (`"conversation_input_bar"`), and it's `Omit`-ed from that component's public props. **The agent-builder embedding of `ModelPicker` (`AdvancedSettings.tsx`) passes nothing and stays untracked** — this is why `surface` is a prop rather than hardcoded.
- `ModelPickerHighlight.tsx`: `exposure` fires in a `useEffect` guarded by a ref so re-renders / the active→inactive toggle after dismissal never emit a duplicate.
- `ClientType` is now exported from `lib/context/clientType.tsx` for typing.

## Tests

- Added `front/components/model_picker/modelPickerTracking.test.ts` — 5 unit tests asserting each event's `area`/`object`/`action` and full `extra` contract (tier, model+provider+effort, revert). All passing.
- The repo's `npm run test` requires a provisioned test DB (global setup runs migrations), which wasn't available locally, so I verified with an equivalent minimal jsdom Vitest config; the file runs normally under the standard config in CI.
- `npx tsgo --noEmit` is clean for all touched files. (The pre-commit full-project typecheck reports pre-existing, unrelated failures — missing `@novu/framework`, Notion/OpenAI SDK mismatches, a `PageHeader` prop — present on the branch before this change; the commit hook was bypassed for that reason.)
- Biome: clean.

## Risk

Very low. Purely additive instrumentation:
- New events only; no existing tracking touched.
- `trackEvent` already no-ops when PostHog isn't loaded / SSR, so there's no runtime risk if analytics is unavailable.
- Behavior for the agent-builder picker is unchanged (no `trackingSurface` → no events).
- No schema, API, or data-model changes. Fully safe to roll back by reverting the commit.

## Deploy Plan

Standard `front` deploy — no migrations, env vars, or ordering constraints. After deploy, confirm the three `assistant:model_picker:*` events appear in PostHog with the expected `surface`, `campaign_id`, `client_type`, and selection properties.