### PR TITLE
[front] Pod app portability: export/import apps as zip archives

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
+// This directive makes them available in the test environment.
+
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { PodAppManifest } from "@app/types/api/pod_app_archive";
+import { PodAppManifestSchema } from "@app/types/api/pod_app_archive";
+import { sandboxFunctionContentType } from "@app/types/files";
+import { honoApp } from "@front-api/app";
+import AdmZip from "adm-zip";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const EMPTY_SCHEMA = { type: "object", properties: {} } as const;
+
+async function setupPod() {
+  const { workspace, user, auth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  const pod = await SpaceFactory.project(workspace, user.id);
+
+  return { workspace, user, auth, pod };
+}
+
+function gcsObject(
+  workspaceId: string,
+  podId: string,
+  relPath: string,
+  contentType = "text/plain"
+) {
+  return {
+    name: `w/${workspaceId}/pods/${podId}/files/${relPath}`,
+    metadata: {
+      contentType,
+      size: "100",
+      updated: new Date().toISOString(),
+    },
+  };
+}
+
+async function publishFunction(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { slug, fileName }: { slug: string; fileName: string }
+) {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: pod.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(auth, {
+    space: pod,
+    file,
+    slug,
+    description: `Function ${slug}.`,
+    inputSchema: EMPTY_SCHEMA,
+    outputSchema: EMPTY_SCHEMA,
+    executionMode: "fast",
+  });
+}
+
+function taskListFiles(workspaceId: string, podId: string) {
+  return [
+    gcsObject(workspaceId, podId, "TaskList/"),
+    gcsObject(workspaceId, podId, "TaskList/functions/add-task.ts"),
+    gcsObject(workspaceId, podId, "TaskList/databases/tasks.db.ts"),
+  ];
+}
+
+async function exportApp(workspaceId: string, podId: string, prefix: string) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/pods/${podId}/apps/${prefix}/export`,
+    { method: "GET" }
+  );
+}
+
+describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("streams a zip holding the app's files and a valid manifest", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    fileStorageMock.setFilesByPrefix(() =>
+      taskListFiles(workspace.sId, pod.sId)
+    );
+    fileStorageMock.setFileContent((filePath) => {
+      if (filePath.endsWith("functions/add-task.ts")) {
+        return "export async function main() {}";
+      }
+      if (filePath.endsWith("databases/tasks.db.ts")) {
+        return "export const tasks = {};";
+      }
+      return null;
+    });
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+    fileStorageMock.setSubdirectoryNames(() => ["tasklist__tasks.db"]);
+
+    const res = await exportApp(workspace.sId, pod.sId, "tasklist");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/zip");
+    expect(res.headers.get("Content-Disposition")).toBe(
+      'attachment; filename="tasklist.podapp.zip"'
+    );
+
+    const zip = new AdmZip(Buffer.from(await res.arrayBuffer()));
+    const entryNames = zip
+      .getEntries()
+      .filter((entry) => !entry.isDirectory)
+      .map((entry) => entry.entryName)
+      .sort();
+    expect(entryNames).toEqual([
+      "files/databases/tasks.db.ts",
+      "files/functions/add-task.ts",
+      "manifest.json",
+    ]);
+
+    const manifestEntry = zip.getEntry("manifest.json");
+    expect(manifestEntry).not.toBeNull();
+    const parsed = PodAppManifestSchema.safeParse(
+      JSON.parse(manifestEntry!.getData().toString("utf-8"))
+    );
+    expect(parsed.success).toBe(true);
+    const manifest: PodAppManifest = parsed.success
+      ? parsed.data
+      : (undefined as never);
+    expect(manifest.name).toBe("TaskList");
+    expect(manifest.functions).toEqual([
+      {
+        name: "add-task",
+        description: "Function tasklist__add-task.",
+        executionMode: "fast",
+      },
+    ]);
+    expect(manifest.databases).toEqual([{ name: "tasks" }]);
+    expect(manifest.frames).toEqual([]);
+    expect(manifest.files.map((f) => f.path).sort()).toEqual([
+      "databases/tasks.db.ts",
+      "functions/add-task.ts",
+    ]);
+
+    expect(
+      zip.getEntry("files/functions/add-task.ts")!.getData().toString("utf-8")
+    ).toBe("export async function main() {}");
+  });
+
+  it("returns 404 for an app the Pod does not have", async () => {
+    const { workspace, pod } = await setupPod();
+
+    const res = await exportApp(workspace.sId, pod.sId, "nosuchapp");
+
+    expect(res.status).toBe(404);
+  });
+
+  it("refuses to export colliding app folders", async () => {
+    const { workspace, pod } = await setupPod();
+    // "Task List" and "Task-List" both normalize to the "task-list" prefix (see
+    // `listPodApps`'s docstring), so they cannot be packaged faithfully.
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "Task List/functions/a.ts"),
+      gcsObject(workspace.sId, pod.sId, "Task-List/functions/b.ts"),
+    ]);
+
+    const res = await exportApp(workspace.sId, pod.sId, "task-list");
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
@@ -2,6 +2,7 @@
 // This directive makes them available in the test environment.
 
 import type { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { FileFactory } from "@app/tests/utils/FileFactory";
@@ -9,8 +10,12 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { PodAppManifest } from "@app/types/api/pod_app_archive";
-import { PodAppManifestSchema } from "@app/types/api/pod_app_archive";
-import { sandboxFunctionContentType } from "@app/types/files";
+import {
+  MAX_POD_APP_ARCHIVE_UNCOMPRESSED_BYTES,
+  PodAppManifestSchema,
+} from "@app/types/api/pod_app_archive";
+import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
+import { DEFAULT_POD_FRAME_TAB_ICON } from "@app/types/pod_frame_tab";
 import { honoApp } from "@front-api/app";
 import AdmZip from "adm-zip";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -72,7 +77,43 @@ function taskListFiles(workspaceId: string, podId: string) {
     gcsObject(workspaceId, podId, "TaskList/"),
     gcsObject(workspaceId, podId, "TaskList/functions/add-task.ts"),
     gcsObject(workspaceId, podId, "TaskList/databases/tasks.db.ts"),
+    gcsObject(workspaceId, podId, "TaskList/TaskList.tsx", frameContentType),
   ];
+}
+
+/**
+ * Creates the Frame's FileResource, published (a bundle root is set) and pinned as a nav tab, so
+ * `exportPodApp`'s Frame branch (fetch by id, read "original" content, capture wasPublished +
+ * pinnedTab) has something real to export.
+ */
+async function publishAndPinFrame(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { workspaceId, fileName }: { workspaceId: string; fileName: string }
+) {
+  const framePath = `pod-${pod.sId}/TaskList/${fileName}`;
+
+  await FileFactory.create(auth, null, {
+    contentType: frameContentType,
+    fileName,
+    fileSize: 100,
+    status: "ready",
+    useCase: "project_context",
+    useCaseMetadata: {
+      spaceId: pod.sId,
+      // Any truthy value marks the Frame published, per `FileResource.isPublishedFrame()`.
+      frameBundleRootPath: `pod-${pod.sId}/TaskList`,
+    },
+    mountFilePath: `w/${workspaceId}/pods/${pod.sId}/files/TaskList/${fileName}`,
+  });
+
+  await ProjectMetadataResource.makeNew(auth, pod, {
+    description: null,
+    frameTabs: [
+      { path: framePath, title: "Tasks", icon: DEFAULT_POD_FRAME_TAB_ICON },
+    ],
+    tabsOrder: [framePath],
+  });
 }
 
 async function exportApp(workspaceId: string, podId: string, prefix: string) {
@@ -88,7 +129,7 @@ describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
     fileStorageMock.reset();
   });
 
-  it("streams a zip holding the app's files and a valid manifest", async () => {
+  it("streams a zip holding the app's files, a published pinned Frame, and a valid manifest", async () => {
     const { workspace, pod, auth } = await setupPod();
     fileStorageMock.setFilesByPrefix(() =>
       taskListFiles(workspace.sId, pod.sId)
@@ -100,13 +141,20 @@ describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
       if (filePath.endsWith("databases/tasks.db.ts")) {
         return "export const tasks = {};";
       }
-      return null;
+      // The Frame's "original" content is read from its FileResource's fileId-keyed storage path
+      // (`files/w/<wId>/<fileId>/original`), not its mount path, so it can't be matched by name
+      // like the two files above; it's the only other content read in this test.
+      return "export default function App() { return null; }";
     });
     await publishFunction(auth, pod, {
       slug: "tasklist__add-task",
       fileName: "add-task.ts",
     });
     fileStorageMock.setSubdirectoryNames(() => ["tasklist__tasks.db"]);
+    await publishAndPinFrame(auth, pod, {
+      workspaceId: workspace.sId,
+      fileName: "TaskList.tsx",
+    });
 
     const res = await exportApp(workspace.sId, pod.sId, "tasklist");
 
@@ -123,6 +171,7 @@ describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
       .map((entry) => entry.entryName)
       .sort();
     expect(entryNames).toEqual([
+      "files/TaskList.tsx",
       "files/databases/tasks.db.ts",
       "files/functions/add-task.ts",
       "manifest.json",
@@ -146,7 +195,15 @@ describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
       },
     ]);
     expect(manifest.databases).toEqual([{ name: "tasks" }]);
-    expect(manifest.frames).toEqual([]);
+    expect(manifest.frames).toEqual([
+      {
+        fileName: "TaskList.tsx",
+        contentType: frameContentType,
+        wasPublished: true,
+        pinnedTab: { title: "Tasks", icon: DEFAULT_POD_FRAME_TAB_ICON },
+      },
+    ]);
+    // The Frame is read through its FileResource, not as a plain file: no entry for it here.
     expect(manifest.files.map((f) => f.path).sort()).toEqual([
       "databases/tasks.db.ts",
       "functions/add-task.ts",
@@ -155,6 +212,9 @@ describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
     expect(
       zip.getEntry("files/functions/add-task.ts")!.getData().toString("utf-8")
     ).toBe("export async function main() {}");
+    expect(
+      zip.getEntry("files/TaskList.tsx")!.getData().toString("utf-8")
+    ).toBe("export default function App() { return null; }");
   });
 
   it("returns 404 for an app the Pod does not have", async () => {
@@ -177,5 +237,28 @@ describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
     const res = await exportApp(workspace.sId, pod.sId, "task-list");
 
     expect(res.status).toBe(400);
+  });
+
+  it("refuses to export an app whose files exceed the uncompressed-size limit", async () => {
+    const { workspace, pod } = await setupPod();
+    // A single oversized entry is enough: the guard sums listed sizes before reading any bytes,
+    // so this never has to actually buffer a huge zip.
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "TaskList/"),
+      {
+        name: `w/${workspace.sId}/pods/${pod.sId}/files/TaskList/functions/huge.ts`,
+        metadata: {
+          contentType: "text/plain",
+          size: String(MAX_POD_APP_ARCHIVE_UNCOMPRESSED_BYTES + 1),
+          updated: new Date().toISOString(),
+        },
+      },
+    ]);
+
+    const res = await exportApp(workspace.sId, pod.sId, "tasklist");
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.message).toMatch(/too large/i);
   });
 });

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
@@ -183,9 +183,10 @@ describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
       JSON.parse(manifestEntry!.getData().toString("utf-8"))
     );
     expect(parsed.success).toBe(true);
-    const manifest: PodAppManifest = parsed.success
-      ? parsed.data
-      : (undefined as never);
+    if (!parsed.success) {
+      throw new Error("manifest failed schema validation");
+    }
+    const manifest: PodAppManifest = parsed.data;
     expect(manifest.name).toBe("TaskList");
     expect(manifest.functions).toEqual([
       {

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
@@ -20,6 +20,7 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { PodAppManifest } from "@app/types/api/pod_app_archive";
 import { MAX_POD_APP_ARCHIVE_SIZE_BYTES } from "@app/types/api/pod_app_archive";
+import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
 import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import {
@@ -286,6 +287,20 @@ describe("POST /api/w/:wId/pods/:podId/apps/import", () => {
     const body = await res.json();
     expect(body.app.prefix).toBe("my-tasks");
     expect(body.app.publishedFunctionSlugs).toEqual(["my-tasks__add-task"]);
+  });
+
+  it("rejects a name override longer than MAX_POD_APP_NAME_LENGTH", async () => {
+    const { workspace, pod } = await setupPod();
+    mockSandboxLeaves();
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifest(), taskListFiles()),
+      "a".repeat(MAX_POD_APP_NAME_LENGTH + 1)
+    );
+
+    expect(res.status).toBe(400);
   });
 
   it("rejects a name colliding with an existing app's prefix", async () => {

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
@@ -4,11 +4,13 @@
 import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
 import {
   PublishFrameError,
   publishFrame,
 } from "@app/lib/api/viz/publish_frame";
 import type { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -17,7 +19,13 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { PodAppManifest } from "@app/types/api/pod_app_archive";
+import { MAX_POD_APP_ARCHIVE_SIZE_BYTES } from "@app/types/api/pod_app_archive";
 import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
+import type { PodFrameTab } from "@app/types/pod_frame_tab";
+import {
+  DEFAULT_POD_FRAME_TAB_ICON,
+  MAX_POD_FRAME_TABS,
+} from "@app/types/pod_frame_tab";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import AdmZip from "adm-zip";
@@ -184,6 +192,18 @@ function taskListFiles(): Record<string, string> {
     "TaskList.tsx": "export default function App() { return null; }",
     "functions/add-task.ts": "export async function main() {}",
     "databases/tasks.db.ts": "export const tasks = {};",
+  };
+}
+
+/** `taskListManifest()` with its Frame recorded as pinned at export time. */
+function taskListManifestWithPinnedTab(): PodAppManifest {
+  const manifest = taskListManifest();
+  return {
+    ...manifest,
+    frames: manifest.frames.map((frame) => ({
+      ...frame,
+      pinnedTab: { title: "Tasks", icon: DEFAULT_POD_FRAME_TAB_ICON },
+    })),
   };
 }
 
@@ -408,5 +428,98 @@ describe("POST /api/w/:wId/pods/:podId/apps/import", () => {
     expect(body.app.prefix).toBe("tasklist");
     expect(body.app.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
     expect(body.app.reconciledDatabaseNames).toEqual(["tasks"]);
+  });
+
+  it("rejects an oversized upload before it reaches the import logic", async () => {
+    const { workspace, pod } = await setupPod();
+
+    // Comfortably past MAX_POD_APP_ARCHIVE_SIZE_BYTES + the route's multipart framing allowance,
+    // so the body-limit middleware rejects it regardless of exactly how much overhead multipart
+    // framing adds.
+    const oversized = Buffer.alloc(MAX_POD_APP_ARCHIVE_SIZE_BYTES + 200 * 1024);
+
+    const res = await importApp(workspace.sId, pod.sId, oversized);
+
+    expect(res.status).toBe(413);
+    const body = await res.json();
+    expect(body.error.type).toBe("content_too_large");
+  });
+
+  it("returns 503 when the sandbox is unavailable", async () => {
+    const { workspace, pod } = await setupPod();
+    mockSandboxLeaves();
+    vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+      new Err(
+        new SandboxFunctionError("sandbox_unavailable", "Sandbox is not ready.")
+      )
+    );
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifest(), taskListFiles())
+    );
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error.type).toBe("service_unavailable");
+  });
+
+  it("pins a Frame's tab when the manifest recorded one", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    mockSandboxLeaves();
+    await ProjectMetadataResource.makeNew(auth, pod, { description: null });
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifestWithPinnedTab(), taskListFiles())
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    const expectedPath = `pod-${pod.sId}/TaskList/TaskList.tsx`;
+    expect(body.app.pinnedTabPaths).toEqual([expectedPath]);
+    expect(body.app.warnings).toEqual([]);
+
+    const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+    expect(metadata?.frameTabs).toEqual([
+      { path: expectedPath, title: "Tasks", icon: DEFAULT_POD_FRAME_TAB_ICON },
+    ]);
+    expect(metadata?.tabsOrder).toContain(expectedPath);
+  });
+
+  it("warns instead of pinning when the Pod is already at the frame-tab cap", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    mockSandboxLeaves();
+    const existingTabs: PodFrameTab[] = Array.from(
+      { length: MAX_POD_FRAME_TABS },
+      (_, i) => ({
+        path: `existing-${i}`,
+        title: `Existing ${i}`,
+        icon: DEFAULT_POD_FRAME_TAB_ICON,
+      })
+    );
+    await ProjectMetadataResource.makeNew(auth, pod, {
+      description: null,
+      frameTabs: existingTabs,
+      tabsOrder: existingTabs.map((tab) => tab.path),
+    });
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifestWithPinnedTab(), taskListFiles())
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.app.pinnedTabPaths).toEqual([]);
+    expect(body.app.warnings).toEqual([
+      `Frame TaskList.tsx: not pinned as a tab (the Pod already has ${MAX_POD_FRAME_TABS}).`,
+    ]);
+
+    const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+    expect(metadata?.frameTabs).toEqual(existingTabs);
   });
 });

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
@@ -1,0 +1,412 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
+// This directive makes them available in the test environment.
+
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
+import {
+  PublishFrameError,
+  publishFrame,
+} from "@app/lib/api/viz/publish_frame";
+import type { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import type { PodAppManifest } from "@app/types/api/pod_app_archive";
+import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import AdmZip from "adm-zip";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(async (_lockName: string, fn: () => unknown) => fn()),
+  distributedLock: vi.fn(async () => "lock-value"),
+  distributedUnlock: vi.fn(async () => undefined),
+}));
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
+
+vi.mock(
+  "@app/lib/api/sandbox_functions/build_on_sandbox",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/sandbox_functions/build_on_sandbox")
+      >();
+
+    return { ...actual, buildSandboxFunctionOnSandbox: vi.fn() };
+  }
+);
+
+vi.mock("@app/lib/api/sandbox_functions/dsbx_db", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/dsbx_db")
+    >();
+
+  return { ...actual, reconcileDatabaseFromPodPath: vi.fn() };
+});
+
+// Publishing a Frame runs the real esbuild bundler over mount reads; mocked so the test exercises
+// the import orchestration rather than the bundler.
+vi.mock("@app/lib/api/viz/publish_frame", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/viz/publish_frame")>();
+
+  return { ...actual, publishFrame: vi.fn() };
+});
+
+const EMPTY_SCHEMA = { type: "object", properties: {} } as const;
+
+function mockSandboxLeaves() {
+  vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+    new Ok({
+      bundleCode: "export default {};",
+      userIdentity: "optional",
+      inputSchema: EMPTY_SCHEMA,
+      outputSchema: EMPTY_SCHEMA,
+    })
+  );
+  vi.mocked(reconcileDatabaseFromPodPath).mockImplementation(
+    async (_auth, { database }) =>
+      new Ok({ database, created: true, statements: [] })
+  );
+  vi.mocked(publishFrame).mockResolvedValue(new Ok({ warnings: [] }));
+  // Frame creation reads its own just-written content back (for the authorized-file-access
+  // allowlist) before `publishFrame` (mocked above) ever runs. The GCS mock's `createReadStream`
+  // only serves content configured here; without it, the read stream never ends.
+  fileStorageMock.setFileContent(() => taskListFiles()["TaskList.tsx"] ?? null);
+}
+
+async function setupPod() {
+  const { workspace, user, auth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  const pod = await SpaceFactory.project(workspace, user.id);
+  const sandbox = await SandboxResource.makeNew(auth, {
+    providerId: "test-provider-id",
+    status: "running",
+    baseImage: "dust-base",
+    version: "0.0.0-test",
+  });
+  vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+    new Ok({ sandbox, freshlyCreated: false })
+  );
+
+  return { workspace, user, auth, pod, sandbox };
+}
+
+function gcsObject(
+  workspaceId: string,
+  podId: string,
+  relPath: string,
+  contentType = "text/plain"
+) {
+  return {
+    name: `w/${workspaceId}/pods/${podId}/files/${relPath}`,
+    metadata: {
+      contentType,
+      size: "100",
+      updated: new Date().toISOString(),
+    },
+  };
+}
+
+async function publishFunction(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { slug, fileName }: { slug: string; fileName: string }
+) {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: pod.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(auth, {
+    space: pod,
+    file,
+    slug,
+    description: `Function ${slug}.`,
+    inputSchema: EMPTY_SCHEMA,
+    outputSchema: EMPTY_SCHEMA,
+    executionMode: "fast",
+  });
+}
+
+function buildArchive(
+  manifest: PodAppManifest,
+  files: Record<string, string>
+): Buffer {
+  const zip = new AdmZip();
+  zip.addFile("manifest.json", Buffer.from(JSON.stringify(manifest), "utf-8"));
+  for (const [relPath, content] of Object.entries(files)) {
+    zip.addFile(`files/${relPath}`, Buffer.from(content, "utf-8"));
+  }
+  return zip.toBuffer();
+}
+
+function taskListManifest(): PodAppManifest {
+  return {
+    formatVersion: 1,
+    name: "TaskList",
+    exportedAt: "2026-08-14T00:00:00.000Z",
+    files: [
+      { path: "functions/add-task.ts", contentType: "text/plain" },
+      { path: "databases/tasks.db.ts", contentType: "text/plain" },
+    ],
+    frames: [
+      {
+        fileName: "TaskList.tsx",
+        contentType: frameContentType,
+        wasPublished: true,
+      },
+    ],
+    functions: [
+      { name: "add-task", description: "Add a task.", executionMode: "fast" },
+    ],
+    databases: [{ name: "tasks" }],
+  };
+}
+
+function taskListFiles(): Record<string, string> {
+  return {
+    "TaskList.tsx": "export default function App() { return null; }",
+    "functions/add-task.ts": "export async function main() {}",
+    "databases/tasks.db.ts": "export const tasks = {};",
+  };
+}
+
+async function importApp(
+  workspaceId: string,
+  podId: string,
+  archive: Buffer,
+  name?: string
+) {
+  const body = new FormData();
+  body.append(
+    "file",
+    new File([new Uint8Array(archive)], "app.podapp.zip", {
+      type: "application/zip",
+    })
+  );
+  if (name !== undefined) {
+    body.append("name", name);
+  }
+
+  return honoApp.request(`/api/w/${workspaceId}/pods/${podId}/apps/import`, {
+    method: "POST",
+    body,
+  });
+}
+
+describe("POST /api/w/:wId/pods/:podId/apps/import", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("imports an archive: writes files, publishes functions, reconciles databases, publishes the Frame", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    mockSandboxLeaves();
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifest(), taskListFiles())
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.app.prefix).toBe("tasklist");
+    expect(body.app.name).toBe("TaskList");
+    expect(body.app.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
+    expect(body.app.reconciledDatabaseNames).toEqual(["tasks"]);
+    expect(body.app.createdFrameNames).toEqual(["TaskList.tsx"]);
+    expect(body.app.publishedFrameNames).toEqual(["TaskList.tsx"]);
+    expect(body.app.warnings).toEqual([]);
+    expect(body.app.skipped).toEqual([]);
+
+    const slugs = (await SandboxFunctionResource.listBySpace(auth, pod)).map(
+      (fn) => fn.slug
+    );
+    expect(slugs).toEqual(["tasklist__add-task"]);
+
+    expect(vi.mocked(reconcileDatabaseFromPodPath)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        database: "tasks",
+        path: `pod-${pod.sId}/TaskList/databases/tasks.db.ts`,
+      })
+    );
+  });
+
+  it("imports under the overriding name, deriving the prefix from it", async () => {
+    const { workspace, pod } = await setupPod();
+    mockSandboxLeaves();
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifest(), taskListFiles()),
+      "My Tasks"
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.app.prefix).toBe("my-tasks");
+    expect(body.app.publishedFunctionSlugs).toEqual(["my-tasks__add-task"]);
+  });
+
+  it("rejects a name colliding with an existing app's prefix", async () => {
+    const { workspace, pod } = await setupPod();
+    mockSandboxLeaves();
+    fileStorageMock.setFilesByPrefix(() => [
+      {
+        name: `w/${workspace.sId}/pods/${pod.sId}/files/TaskList/functions/x.ts`,
+        metadata: {
+          contentType: "text/plain",
+          size: "10",
+          updated: new Date().toISOString(),
+        },
+      },
+    ]);
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifest(), taskListFiles())
+    );
+
+    expect(res.status).toBe(409);
+  });
+
+  it("rejects a zip with an entry escaping files/", async () => {
+    const { workspace, pod } = await setupPod();
+    const zip = new AdmZip();
+    zip.addFile(
+      "manifest.json",
+      Buffer.from(JSON.stringify(taskListManifest()), "utf-8")
+    );
+    zip.addFile("files/../escape.ts", Buffer.from("boom", "utf-8"));
+
+    const res = await importApp(workspace.sId, pod.sId, zip.toBuffer());
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unknown manifest format version", async () => {
+    const { workspace, pod } = await setupPod();
+    const manifest = { ...taskListManifest(), formatVersion: 99 };
+    const zip = new AdmZip();
+    zip.addFile(
+      "manifest.json",
+      Buffer.from(JSON.stringify(manifest), "utf-8")
+    );
+
+    const res = await importApp(workspace.sId, pod.sId, zip.toBuffer());
+
+    expect(res.status).toBe(400);
+  });
+
+  it("records a function whose source is missing from the archive as skipped", async () => {
+    const { workspace, pod } = await setupPod();
+    mockSandboxLeaves();
+    const files = taskListFiles();
+    delete files["functions/add-task.ts"];
+    const manifest = taskListManifest();
+    manifest.files = manifest.files.filter(
+      (f) => f.path !== "functions/add-task.ts"
+    );
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(manifest, files)
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.app.publishedFunctionSlugs).toEqual([]);
+    expect(body.app.skipped).toEqual(["function add-task"]);
+  });
+
+  it("reports a Frame publish failure as a warning without failing the import", async () => {
+    const { workspace, pod } = await setupPod();
+    mockSandboxLeaves();
+    vi.mocked(publishFrame).mockResolvedValue(
+      new Err(
+        new PublishFrameError(
+          "pod_function_not_found",
+          "Unknown function 'oldpod__gone'."
+        )
+      )
+    );
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifest(), taskListFiles())
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.app.createdFrameNames).toEqual(["TaskList.tsx"]);
+    expect(body.app.publishedFrameNames).toEqual([]);
+    expect(body.app.warnings).toEqual([
+      "Frame TaskList.tsx: Unknown function 'oldpod__gone'.",
+    ]);
+  });
+
+  it("round-trips: an exported app imports into another pod", async () => {
+    const { workspace, pod, auth, user } = await setupPod();
+    mockSandboxLeaves();
+    fileStorageMock.setFilesByPrefix((prefix) =>
+      prefix.includes(pod.sId)
+        ? [
+            gcsObject(workspace.sId, pod.sId, "TaskList/"),
+            gcsObject(workspace.sId, pod.sId, "TaskList/functions/add-task.ts"),
+            gcsObject(workspace.sId, pod.sId, "TaskList/databases/tasks.db.ts"),
+          ]
+        : []
+    );
+    fileStorageMock.setFileContent((filePath) =>
+      filePath.includes(pod.sId) && filePath.endsWith(".ts")
+        ? "export const x = 1;"
+        : null
+    );
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+    fileStorageMock.setSubdirectoryNames((prefix) =>
+      prefix.includes(pod.sId) ? ["tasklist__tasks.db"] : []
+    );
+
+    const exportRes = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/tasklist/export`,
+      { method: "GET" }
+    );
+    expect(exportRes.status).toBe(200);
+    const archive = Buffer.from(await exportRes.arrayBuffer());
+
+    const podB = await SpaceFactory.project(workspace, user.id);
+
+    const importRes = await importApp(workspace.sId, podB.sId, archive);
+    expect(importRes.status).toBe(201);
+    const body = await importRes.json();
+    expect(body.app.prefix).toBe("tasklist");
+    expect(body.app.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
+    expect(body.app.reconciledDatabaseNames).toEqual(["tasks"]);
+  });
+});

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/import.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/import.ts
@@ -1,0 +1,95 @@
+import { importPodApp } from "@app/lib/api/projects/app_archive";
+import type { ImportPodAppResponseBody } from "@app/types/api/pod_app_archive";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
+import { withSpace } from "@front-api/middlewares/with_space";
+
+// Mounted at /api/w/:wId/pods/:podId/apps/import.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  withSpace({ requireCanWrite: true, routeParam: "podId" }),
+  async (ctx): HandlerResult<ImportPodAppResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+
+    let body: Awaited<ReturnType<typeof ctx.req.parseBody>>;
+    try {
+      body = await ctx.req.parseBody();
+    } catch (err) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: `File upload failed: ${normalizeError(err).message}`,
+        },
+      });
+    }
+
+    const uploaded = body.file;
+    if (!(uploaded instanceof File)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "A 'file' field holding the archive is required.",
+        },
+      });
+    }
+    const name = typeof body.name === "string" ? body.name : undefined;
+
+    const zipBuffer = Buffer.from(await uploaded.arrayBuffer());
+
+    const importResult = await importPodApp(auth, space, { zipBuffer, name });
+    if (importResult.isErr()) {
+      switch (importResult.error.code) {
+        case "name_taken":
+          return apiError(ctx, {
+            status_code: 409,
+            api_error: {
+              type: "invalid_request_error",
+              message: importResult.error.message,
+            },
+          });
+        case "not_a_pod":
+        case "invalid_archive":
+        case "invalid_name":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: importResult.error.message,
+            },
+          });
+        case "sandbox_unavailable":
+          // Publishing and reconciling need a live sandbox; the import is safe to retry.
+          return apiError(ctx, {
+            status_code: 503,
+            api_error: {
+              type: "service_unavailable",
+              message: importResult.error.message,
+            },
+          });
+        case "internal":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: importResult.error.message,
+            },
+          });
+        default:
+          assertNever(importResult.error.code);
+      }
+    }
+
+    return ctx.json({ app: importResult.value }, 201);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/import.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/import.ts
@@ -1,11 +1,18 @@
 import { importPodApp } from "@app/lib/api/projects/app_archive";
 import type { ImportPodAppResponseBody } from "@app/types/api/pod_app_archive";
+import { MAX_POD_APP_ARCHIVE_SIZE_BYTES } from "@app/types/api/pod_app_archive";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { bodyLimit } from "@front-api/middlewares/body_limit";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { withSpace } from "@front-api/middlewares/with_space";
+
+// Multipart framing (boundary markers, per-part headers, the optional `name` field) adds a small
+// amount of overhead on top of the archive's own bytes; this covers it without materially raising
+// the effective cap.
+const MULTIPART_FRAMING_OVERHEAD_BYTES = 64 * 1024;
 
 // Mounted at /api/w/:wId/pods/:podId/apps/import.
 const app = workspaceApp();
@@ -13,6 +20,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
+  bodyLimit(MAX_POD_APP_ARCHIVE_SIZE_BYTES + MULTIPART_FRAMING_OVERHEAD_BYTES),
   withSpace({ requireCanWrite: true, routeParam: "podId" }),
   async (ctx): HandlerResult<ImportPodAppResponseBody> => {
     const auth = ctx.get("auth");
@@ -22,6 +30,14 @@ app.post(
     try {
       body = await ctx.req.parseBody();
     } catch (err) {
+      // Without a Content-Length header, `bodyLimit(...)` enforces the cap by erroring the
+      // request stream mid-read rather than rejecting upfront; that surfaces here as a thrown
+      // error while reading the body. Let it propagate so the middleware's own `c.error` check
+      // (right after `next()`) turns it into its 413 response instead of this route reporting a
+      // generic 400 parse failure.
+      if (err instanceof Error && err.name === "BodyLimitError") {
+        throw err;
+      }
       return apiError(ctx, {
         status_code: 400,
         api_error: {
@@ -67,7 +83,9 @@ app.post(
             },
           });
         case "sandbox_unavailable":
-          // Publishing and reconciling need a live sandbox; the import is safe to retry.
+          // Publishing and reconciling need a live sandbox. Whatever was already written (folder,
+          // Frames) stays visible in the Apps tab; retrying needs the partial app deleted first,
+          // since the folder name is now taken.
           return apiError(ctx, {
             status_code: 503,
             api_error: {

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -73,6 +73,7 @@ app.get(
           });
         case "not_a_pod":
         case "colliding_folders":
+        case "too_large":
           return apiError(ctx, {
             status_code: 400,
             api_error: {

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -1,3 +1,4 @@
+import { exportPodApp } from "@app/lib/api/projects/app_archive";
 import {
   clonePodApp,
   deletePodApp,
@@ -42,6 +43,62 @@ app.get(
     }
 
     return ctx.json({ apps: appsResult.value });
+  }
+);
+
+/** @ignoreswagger */
+app.get(
+  "/:prefix/export",
+  validate("param", DeletePodAppParamsSchema),
+  withSpace({ requireCanRead: true, routeParam: "podId" }),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { prefix } = ctx.req.valid("param");
+
+    const exportResult = await exportPodApp(auth, space, prefix);
+    if (exportResult.isErr()) {
+      switch (exportResult.error.code) {
+        case "not_found":
+          return apiError(ctx, {
+            status_code: 404,
+            api_error: {
+              type: "space_not_found",
+              message: exportResult.error.message,
+            },
+          });
+        case "not_a_pod":
+        case "colliding_folders":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: exportResult.error.message,
+            },
+          });
+        case "internal":
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: exportResult.error.message,
+            },
+          });
+        default:
+          assertNever(exportResult.error.code);
+      }
+    }
+
+    const { fileName, content } = exportResult.value;
+
+    // Raw Response, matching the conversation file download route: the body is binary, not JSON.
+    return new Response(new Uint8Array(content), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/zip",
+        "Content-Disposition": `attachment; filename="${fileName}"`,
+      },
+    });
   }
 );
 

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -20,8 +20,12 @@ import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 
+import importRoute from "./import";
+
 // Mounted under /api/w/:wId/pods/:podId/apps.
 const app = workspaceApp();
+
+app.route("/import", importRoute);
 
 /** @ignoreswagger */
 app.get(

--- a/front/components/pod/apps/ImportPodAppDialog.tsx
+++ b/front/components/pod/apps/ImportPodAppDialog.tsx
@@ -1,0 +1,194 @@
+import { useImportPodApp } from "@app/lib/swr/pods";
+import type { PodAppImportSummary } from "@app/types/api/pod_app_archive";
+import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
+import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Spinner,
+  Upload01,
+} from "@dust-tt/sparkle";
+import type { ChangeEvent } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+interface ImportPodAppDialogProps {
+  owner: LightWorkspaceType;
+  podId: string;
+  existingPrefixes: string[];
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ImportPodAppDialog({
+  owner,
+  podId,
+  existingPrefixes,
+  isOpen,
+  onClose,
+}: ImportPodAppDialogProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [name, setName] = useState("");
+  const [isImporting, setIsImporting] = useState(false);
+  const [report, setReport] = useState<PodAppImportSummary | null>(null);
+  const doImport = useImportPodApp({ owner, podId });
+
+  const trimmedName = name.trim();
+  const prefix = useMemo(
+    () => (trimmedName ? normalizeAppPrefix(trimmedName) : null),
+    [trimmedName]
+  );
+  const nameError = useMemo(() => {
+    if (!trimmedName) {
+      // Empty is fine: the server falls back to the archive's own name.
+      return null;
+    }
+    if (!prefix) {
+      return "Use at least one letter or digit.";
+    }
+    if (trimmedName.includes("/")) {
+      return "An app name cannot contain '/'.";
+    }
+    if (existingPrefixes.includes(prefix)) {
+      return `This Pod already has an app named '${prefix}'.`;
+    }
+    return null;
+  }, [existingPrefixes, trimmedName, prefix]);
+
+  const onImport = useCallback(async () => {
+    if (!file) {
+      return;
+    }
+    setIsImporting(true);
+    const result = await doImport(file, trimmedName || undefined);
+    setIsImporting(false);
+    if (result.isOk()) {
+      const summary = result.value;
+      if (summary.warnings.length > 0 || summary.skipped.length > 0) {
+        // Keep the dialog open so the issues are read before they scroll away.
+        setReport(summary);
+      } else {
+        onClose();
+      }
+    }
+  }, [doImport, file, trimmedName, onClose]);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Import an app</DialogTitle>
+        </DialogHeader>
+        {isImporting ? (
+          <DialogContainer className="flex flex-col items-center gap-3 py-8">
+            <Spinner variant="dark" size="md" />
+            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+              Importing. Each function is rebuilt on the Pod's Computer, so this
+              can take a while.
+            </p>
+          </DialogContainer>
+        ) : report ? (
+          <>
+            <DialogContainer className="flex flex-col gap-4">
+              <ContentMessage
+                variant="warning"
+                title={`${report.name} imported with issues`}
+              >
+                <ul className="list-disc pl-4">
+                  {[...report.warnings, ...report.skipped].map((issue) => (
+                    <li key={issue}>{issue}</li>
+                  ))}
+                </ul>
+              </ContentMessage>
+            </DialogContainer>
+            <DialogFooter
+              rightButtonProps={{
+                label: "Done",
+                variant: "primary",
+                onClick: onClose,
+              }}
+            />
+          </>
+        ) : (
+          <>
+            <DialogContainer className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1">
+                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+                  App archive (.zip)
+                </span>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".zip"
+                  className="hidden"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setFile(e.target.files?.[0] ?? null)
+                  }
+                />
+                <Button
+                  label={file ? file.name : "Choose archive"}
+                  icon={Upload01}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+                  App name (optional)
+                </span>
+                <Input
+                  name="import-app-name"
+                  value={name}
+                  placeholder="Defaults to the archive's app name"
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setName(e.target.value)
+                  }
+                  maxLength={MAX_POD_APP_NAME_LENGTH}
+                  message={nameError ?? undefined}
+                  messageStatus={nameError ? "error" : undefined}
+                  containerClassName="w-full"
+                />
+              </div>
+              <ContentMessage variant="info" title="The import starts empty">
+                Databases are created from the archive's schemas but hold no
+                data. Missing secrets or configuration in this workspace will
+                surface when the app runs.
+              </ContentMessage>
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: onClose,
+              }}
+              rightButtonProps={{
+                label: "Import app",
+                variant: "primary",
+                disabled: file === null || nameError !== null,
+                onClick: () => {
+                  void onImport();
+                },
+              }}
+            />
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/pod/apps/ImportPodAppDialog.tsx
+++ b/front/components/pod/apps/ImportPodAppDialog.tsx
@@ -110,9 +110,11 @@ export function ImportPodAppDialog({
                 title={`${report.name} imported with issues`}
               >
                 <ul className="list-disc pl-4">
-                  {[...report.warnings, ...report.skipped].map((issue) => (
-                    <li key={issue}>{issue}</li>
-                  ))}
+                  {[...report.warnings, ...report.skipped].map(
+                    (issue, index) => (
+                      <li key={`${index}-${issue}`}>{issue}</li>
+                    )
+                  )}
                 </ul>
               </ContentMessage>
             </DialogContainer>

--- a/front/components/pod/apps/PodAppTile.tsx
+++ b/front/components/pod/apps/PodAppTile.tsx
@@ -20,7 +20,7 @@ interface PodAppTileProps {
   defaultIcon: CustomResourceIconType;
   onOpenFrame: (frame: PodAppFrame) => void;
   /** Download this app as a portable archive. Available to every viewer with read access. */
-  onDownload?: () => Promise<void>;
+  onDownload: () => Promise<void>;
   /** Absent when the viewer cannot edit (no write access). */
   onClone?: () => void;
   /** Absent when the viewer cannot edit (no write access). */
@@ -63,9 +63,6 @@ export function PodAppTile({
 
   const [isDownloading, setIsDownloading] = useState(false);
   const handleDownload = useCallback(async () => {
-    if (!onDownload) {
-      return;
-    }
     setIsDownloading(true);
     await onDownload();
     setIsDownloading(false);
@@ -76,35 +73,31 @@ export function PodAppTile({
       size="sm"
       onClick={openableFrame ? () => onOpenFrame(openableFrame) : undefined}
       action={
-        (onDownload || onClone || onDelete) && (
-          <div className="flex gap-1">
-            {onDownload && (
-              <CardActionButton
-                size="icon"
-                icon={Download01}
-                tooltip="Download this app as a portable archive"
-                onClick={() => void handleDownload()}
-                isLoading={isDownloading}
-              />
-            )}
-            {onClone && (
-              <CardActionButton
-                size="icon"
-                icon={GitBranch01}
-                tooltip="Clone this app into a new folder, with empty databases"
-                onClick={onClone}
-              />
-            )}
-            {onDelete && (
-              <CardActionButton
-                size="icon"
-                icon={Trash01}
-                tooltip="Delete this app and everything it owns"
-                onClick={onDelete}
-              />
-            )}
-          </div>
-        )
+        <div className="flex gap-1">
+          <CardActionButton
+            size="icon"
+            icon={Download01}
+            tooltip="Download this app as a portable archive"
+            onClick={() => void handleDownload()}
+            isLoading={isDownloading}
+          />
+          {onClone && (
+            <CardActionButton
+              size="icon"
+              icon={GitBranch01}
+              tooltip="Clone this app into a new folder, with empty databases"
+              onClick={onClone}
+            />
+          )}
+          {onDelete && (
+            <CardActionButton
+              size="icon"
+              icon={Trash01}
+              tooltip="Delete this app and everything it owns"
+              onClick={onDelete}
+            />
+          )}
+        </div>
       }
     >
       <div className="flex min-w-0 grow items-center gap-3">

--- a/front/components/pod/apps/PodAppTile.tsx
+++ b/front/components/pod/apps/PodAppTile.tsx
@@ -8,15 +8,19 @@ import {
   Card,
   CardActionButton,
   Chip,
+  Download01,
   GitBranch01,
   Trash01,
 } from "@dust-tt/sparkle";
+import { useCallback, useState } from "react";
 
 interface PodAppTileProps {
   app: PodApp;
   iconByFramePath: Map<string, CustomResourceIconType>;
   defaultIcon: CustomResourceIconType;
   onOpenFrame: (frame: PodAppFrame) => void;
+  /** Download this app as a portable archive. Available to every viewer with read access. */
+  onDownload?: () => Promise<void>;
   /** Absent when the viewer cannot edit (no write access). */
   onClone?: () => void;
   /** Absent when the viewer cannot edit (no write access). */
@@ -47,6 +51,7 @@ export function PodAppTile({
   iconByFramePath,
   defaultIcon,
   onOpenFrame,
+  onDownload,
   onClone,
   onDelete,
 }: PodAppTileProps) {
@@ -56,13 +61,32 @@ export function PodAppTile({
   const openableFrame = frame?.fileId ? frame : null;
   const isDraft = app.functions.length === 0 && app.databases.length === 0;
 
+  const [isDownloading, setIsDownloading] = useState(false);
+  const handleDownload = useCallback(async () => {
+    if (!onDownload) {
+      return;
+    }
+    setIsDownloading(true);
+    await onDownload();
+    setIsDownloading(false);
+  }, [onDownload]);
+
   return (
     <Card
       size="sm"
       onClick={openableFrame ? () => onOpenFrame(openableFrame) : undefined}
       action={
-        (onClone || onDelete) && (
+        (onDownload || onClone || onDelete) && (
           <div className="flex gap-1">
+            {onDownload && (
+              <CardActionButton
+                size="icon"
+                icon={Download01}
+                tooltip="Download this app as a portable archive"
+                onClick={() => void handleDownload()}
+                isLoading={isDownloading}
+              />
+            )}
             {onClone && (
               <CardActionButton
                 size="icon"

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -1,13 +1,15 @@
 import { ClonePodAppDialog } from "@app/components/pod/apps/ClonePodAppDialog";
 import { DeletePodAppDialog } from "@app/components/pod/apps/DeletePodAppDialog";
+import { ImportPodAppDialog } from "@app/components/pod/apps/ImportPodAppDialog";
 import { PodAppTile } from "@app/components/pod/apps/PodAppTile";
 import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
-import { usePodApps } from "@app/lib/swr/pods";
+import { useDownloadPodApp, usePodApps } from "@app/lib/swr/pods";
 import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
 import type { PodType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
+  Button,
   CardGrid,
   ContentMessage,
   ScrollArea,
@@ -33,12 +35,14 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
   });
 
   const canEdit = pod.isEditor && !pod.archivedAt;
+  const downloadPodApp = useDownloadPodApp({ owner, podId: pod.sId });
 
   const [framePreview, setFramePreview] = useState<PodAppFrame | null>(null);
   const [appPendingDeletion, setAppPendingDeletion] = useState<PodApp | null>(
     null
   );
   const [appPendingClone, setAppPendingClone] = useState<PodApp | null>(null);
+  const [isImportOpen, setIsImportOpen] = useState(false);
 
   const iconByFramePath = useMemo(
     () =>
@@ -46,6 +50,27 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
         (pod.frameTabs ?? []).map((tab) => [tab.path, tab.icon])
       ),
     [pod.frameTabs]
+  );
+
+  const importButton = canEdit && (
+    <div className="flex justify-end">
+      <Button
+        label="Import app"
+        variant="outline"
+        size="sm"
+        onClick={() => setIsImportOpen(true)}
+      />
+    </div>
+  );
+
+  const importDialog = isImportOpen && (
+    <ImportPodAppDialog
+      owner={owner}
+      podId={pod.sId}
+      existingPrefixes={apps.map((candidate) => candidate.prefix)}
+      isOpen
+      onClose={() => setIsImportOpen(false)}
+    />
   );
 
   if (isPodAppsLoading) {
@@ -69,12 +94,16 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
 
   if (apps.length === 0) {
     return (
-      <div className="flex h-full w-full items-center justify-center px-6 py-8">
-        <p className="max-w-md text-center copy-sm text-muted-foreground dark:text-muted-foreground-night">
-          No app in this Pod yet. Ask an agent in this Pod to build one — a
-          Frame with the functions and databases behind it — and it will show up
-          here.
-        </p>
+      <div className="flex h-full w-full flex-col gap-4 px-6 py-8">
+        {importButton}
+        <div className="flex flex-1 items-center justify-center">
+          <p className="max-w-md text-center copy-sm text-muted-foreground dark:text-muted-foreground-night">
+            No app in this Pod yet. Ask an agent in this Pod to build one — a
+            Frame with the functions and databases behind it — and it will show
+            up here.
+          </p>
+        </div>
+        {importDialog}
       </div>
     );
   }
@@ -87,6 +116,7 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
     <div className="h-full min-h-0 w-full flex-1 overflow-hidden">
       <ScrollArea className="h-full">
         <div className="flex flex-col gap-4 px-6 py-5">
+          {importButton}
           {collidingApps.map((app) => (
             <ContentMessage
               key={app.prefix}
@@ -108,6 +138,7 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
                 iconByFramePath={iconByFramePath}
                 defaultIcon={DEFAULT_POD_APP_ICON}
                 onOpenFrame={setFramePreview}
+                onDownload={() => downloadPodApp(app)}
                 onClone={canEdit ? () => setAppPendingClone(app) : undefined}
                 onDelete={
                   canEdit ? () => setAppPendingDeletion(app) : undefined
@@ -140,6 +171,8 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
           onClose={() => setAppPendingDeletion(null)}
         />
       )}
+
+      {importDialog}
 
       <PodFrameSheet
         owner={owner}

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -15,6 +15,7 @@ import {
   ScrollArea,
   Spinner,
 } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 
 interface PodAppsTabProps {
@@ -63,26 +64,25 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
     </div>
   );
 
-  const importDialog = isImportOpen && (
-    <ImportPodAppDialog
-      owner={owner}
-      podId={pod.sId}
-      existingPrefixes={apps.map((candidate) => candidate.prefix)}
-      isOpen
-      onClose={() => setIsImportOpen(false)}
-    />
+  const collidingApps = apps.filter(
+    (app) => app.collidingFolderNames.length > 0
   );
 
+  // Computed as a variable (rather than returned from separate early-return branches) so
+  // `ImportPodAppDialog` below always sits at the same position in the returned tree. If it were
+  // rendered inside each branch instead, a mutation that flips `apps.length` between 0 and >0
+  // mid-import (the first-ever import into an empty pod) would swap which branch renders and React
+  // would unmount/remount the dialog, wiping its local state (the post-import warnings report)
+  // exactly on that path.
+  let body: ReactNode;
   if (isPodAppsLoading) {
-    return (
+    body = (
       <div className="flex h-full w-full items-center justify-center">
         <Spinner />
       </div>
     );
-  }
-
-  if (isPodAppsError) {
-    return (
+  } else if (isPodAppsError) {
+    body = (
       <div className="px-6 py-8">
         <ContentMessage variant="warning" title="Could not load apps">
           Something went wrong while listing this Pod's apps. Try reloading the
@@ -90,10 +90,8 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
         </ContentMessage>
       </div>
     );
-  }
-
-  if (apps.length === 0) {
-    return (
+  } else if (apps.length === 0) {
+    body = (
       <div className="flex h-full w-full flex-col gap-4 px-6 py-8">
         {importButton}
         <div className="flex flex-1 items-center justify-center">
@@ -103,92 +101,100 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
             up here.
           </p>
         </div>
-        {importDialog}
+      </div>
+    );
+  } else {
+    body = (
+      <div className="h-full min-h-0 w-full flex-1 overflow-hidden">
+        <ScrollArea className="h-full">
+          <div className="flex flex-col gap-4 px-6 py-5">
+            {importButton}
+            {collidingApps.map((app) => (
+              <ContentMessage
+                key={app.prefix}
+                variant="warning"
+                title="Colliding app folders"
+              >
+                {app.collidingFolderNames.join(", ")} all resolve to the same
+                app name (<span className="font-mono">{app.prefix}</span>), so
+                they share the same published functions and databases. Rename
+                all but one, then re-publish its functions.
+              </ContentMessage>
+            ))}
+
+            <CardGrid>
+              {apps.map((app) => (
+                <PodAppTile
+                  key={app.prefix}
+                  app={app}
+                  iconByFramePath={iconByFramePath}
+                  defaultIcon={DEFAULT_POD_APP_ICON}
+                  onOpenFrame={setFramePreview}
+                  onDownload={() => downloadPodApp(app)}
+                  onClone={canEdit ? () => setAppPendingClone(app) : undefined}
+                  onDelete={
+                    canEdit ? () => setAppPendingDeletion(app) : undefined
+                  }
+                />
+              ))}
+            </CardGrid>
+          </div>
+        </ScrollArea>
+
+        {appPendingClone && (
+          <ClonePodAppDialog
+            key={`clone-${appPendingClone.prefix}`}
+            owner={owner}
+            podId={pod.sId}
+            app={appPendingClone}
+            existingPrefixes={apps.map((candidate) => candidate.prefix)}
+            isOpen
+            onClose={() => setAppPendingClone(null)}
+          />
+        )}
+
+        {appPendingDeletion && (
+          <DeletePodAppDialog
+            key={appPendingDeletion.prefix}
+            owner={owner}
+            podId={pod.sId}
+            app={appPendingDeletion}
+            isOpen
+            onClose={() => setAppPendingDeletion(null)}
+          />
+        )}
+
+        <PodFrameSheet
+          owner={owner}
+          fileId={framePreview?.fileId ?? null}
+          framePath={framePreview?.path ?? null}
+          fileName={framePreview?.fileName}
+          podId={pod.sId}
+          pinnedFramePath={pod.pinnedFramePath ?? null}
+          frameTabs={pod.frameTabs ?? []}
+          tabsOrder={pod.tabsOrder ?? []}
+          isEditor={pod.isEditor}
+          isMember={pod.isMember}
+          isArchived={!!pod.archivedAt}
+          isOpen={framePreview !== null}
+          onClose={() => setFramePreview(null)}
+        />
       </div>
     );
   }
 
-  const collidingApps = apps.filter(
-    (app) => app.collidingFolderNames.length > 0
-  );
-
   return (
-    <div className="h-full min-h-0 w-full flex-1 overflow-hidden">
-      <ScrollArea className="h-full">
-        <div className="flex flex-col gap-4 px-6 py-5">
-          {importButton}
-          {collidingApps.map((app) => (
-            <ContentMessage
-              key={app.prefix}
-              variant="warning"
-              title="Colliding app folders"
-            >
-              {app.collidingFolderNames.join(", ")} all resolve to the same app
-              name (<span className="font-mono">{app.prefix}</span>), so they
-              share the same published functions and databases. Rename all but
-              one, then re-publish its functions.
-            </ContentMessage>
-          ))}
-
-          <CardGrid>
-            {apps.map((app) => (
-              <PodAppTile
-                key={app.prefix}
-                app={app}
-                iconByFramePath={iconByFramePath}
-                defaultIcon={DEFAULT_POD_APP_ICON}
-                onOpenFrame={setFramePreview}
-                onDownload={() => downloadPodApp(app)}
-                onClone={canEdit ? () => setAppPendingClone(app) : undefined}
-                onDelete={
-                  canEdit ? () => setAppPendingDeletion(app) : undefined
-                }
-              />
-            ))}
-          </CardGrid>
-        </div>
-      </ScrollArea>
-
-      {appPendingClone && (
-        <ClonePodAppDialog
-          key={`clone-${appPendingClone.prefix}`}
+    <>
+      {body}
+      {isImportOpen && (
+        <ImportPodAppDialog
           owner={owner}
           podId={pod.sId}
-          app={appPendingClone}
           existingPrefixes={apps.map((candidate) => candidate.prefix)}
           isOpen
-          onClose={() => setAppPendingClone(null)}
+          onClose={() => setIsImportOpen(false)}
         />
       )}
-
-      {appPendingDeletion && (
-        <DeletePodAppDialog
-          key={appPendingDeletion.prefix}
-          owner={owner}
-          podId={pod.sId}
-          app={appPendingDeletion}
-          isOpen
-          onClose={() => setAppPendingDeletion(null)}
-        />
-      )}
-
-      {importDialog}
-
-      <PodFrameSheet
-        owner={owner}
-        fileId={framePreview?.fileId ?? null}
-        framePath={framePreview?.path ?? null}
-        fileName={framePreview?.fileName}
-        podId={pod.sId}
-        pinnedFramePath={pod.pinnedFramePath ?? null}
-        frameTabs={pod.frameTabs ?? []}
-        tabsOrder={pod.tabsOrder ?? []}
-        isEditor={pod.isEditor}
-        isMember={pod.isMember}
-        isArchived={!!pod.archivedAt}
-        isOpen={framePreview !== null}
-        onClose={() => setFramePreview(null)}
-      />
-    </div>
+    </>
   );
 }

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -356,8 +356,12 @@ function parsePodAppArchive(
  * Mirrors `clonePodApp`'s pipeline and ordering with the archive as the source. Failures after the
  * files are written are reported per item (`warnings`/`skipped`) rather than aborting: a partially
  * published app is visible in the Apps tab and fixable, whereas aborting would hide work already
- * done. The exceptions are sandbox unavailability (nothing later can succeed; the whole import is
- * retryable) and file writes themselves.
+ * done. The exceptions are sandbox unavailability (nothing later can succeed) and file writes
+ * themselves. Aborting on `sandbox_unavailable` leaves the partial app (folder, any Frames already
+ * created) visible in the Apps tab, same as any other partial failure; because the folder already
+ * exists, retrying the same import hits `name_taken` rather than resuming. Recovering means either
+ * deleting the partial app first and re-importing, or finishing it in place (publish the remaining
+ * functions/databases by hand).
  *
  * The archive carries no source identity, so importing into the origin pod, another pod or another
  * workspace is the same operation. A Frame hard-coding `<podId>/<slug>` function references keeps

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -1,21 +1,41 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
+import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { getFileContent } from "@app/lib/api/files/utils";
 import { listPodApps } from "@app/lib/api/projects/apps";
+import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
+import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
+import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
+import { publishFrame } from "@app/lib/api/viz/publish_frame";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
-import type { PodAppManifest } from "@app/types/api/pod_app_archive";
+import type {
+  PodAppImportSummary,
+  PodAppManifest,
+} from "@app/types/api/pod_app_archive";
 import {
+  MAX_POD_APP_ARCHIVE_ENTRY_COUNT,
+  MAX_POD_APP_ARCHIVE_SIZE_BYTES,
+  MAX_POD_APP_ARCHIVE_UNCOMPRESSED_BYTES,
   POD_APP_ARCHIVE_FILES_PREFIX,
   POD_APP_ARCHIVE_FORMAT_VERSION,
   POD_APP_ARCHIVE_MANIFEST_FILE,
+  PodAppManifestSchema,
 } from "@app/types/api/pod_app_archive";
+import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { isInteractiveContentType } from "@app/types/files";
+import {
+  MAX_POD_FRAME_TABS,
+  normalizeTabsOrder,
+} from "@app/types/pod_frame_tab";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import AdmZip from "adm-zip";
+import { fromError } from "zod-validation-error";
 
 export type PodAppExportErrorCode =
   | "not_a_pod"
@@ -184,5 +204,426 @@ export async function exportPodApp(
   return new Ok({
     fileName: `${app.prefix}.podapp.zip`,
     content: zip.toBuffer(),
+  });
+}
+
+export type PodAppImportErrorCode =
+  | "not_a_pod"
+  | "invalid_archive"
+  | "invalid_name"
+  | "name_taken"
+  | "sandbox_unavailable"
+  | "internal";
+
+export class PodAppImportError extends Error {
+  constructor(
+    readonly code: PodAppImportErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "PodAppImportError";
+  }
+}
+
+/** The archive's validated content: the parsed manifest and each file's bytes by relative path. */
+type ParsedArchive = {
+  manifest: PodAppManifest;
+  fileBuffers: Map<string, Buffer>;
+};
+
+/**
+ * Validate and unpack an archive buffer. Rejects zip-slip entries (`..`, absolute paths,
+ * backslashes), entries outside `manifest.json`/`files/`, oversized archives, and manifests that
+ * fail schema validation — all before anything touches the pod.
+ */
+function parsePodAppArchive(
+  zipBuffer: Buffer
+): Result<ParsedArchive, PodAppImportError> {
+  if (zipBuffer.length > MAX_POD_APP_ARCHIVE_SIZE_BYTES) {
+    return new Err(
+      new PodAppImportError(
+        "invalid_archive",
+        `Archive exceeds ${MAX_POD_APP_ARCHIVE_SIZE_BYTES} bytes.`
+      )
+    );
+  }
+
+  let zip: AdmZip;
+  try {
+    zip = new AdmZip(zipBuffer);
+  } catch (err) {
+    return new Err(
+      new PodAppImportError(
+        "invalid_archive",
+        `Not a readable zip: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const entries = zip.getEntries().filter((entry) => !entry.isDirectory);
+  if (entries.length > MAX_POD_APP_ARCHIVE_ENTRY_COUNT) {
+    return new Err(
+      new PodAppImportError(
+        "invalid_archive",
+        `Archive holds more than ${MAX_POD_APP_ARCHIVE_ENTRY_COUNT} files.`
+      )
+    );
+  }
+
+  const totalUncompressedBytes = entries.reduce(
+    (total, entry) => total + entry.header.size,
+    0
+  );
+  if (totalUncompressedBytes > MAX_POD_APP_ARCHIVE_UNCOMPRESSED_BYTES) {
+    return new Err(
+      new PodAppImportError(
+        "invalid_archive",
+        `Archive expands past ${MAX_POD_APP_ARCHIVE_UNCOMPRESSED_BYTES} bytes.`
+      )
+    );
+  }
+
+  const fileBuffers = new Map<string, Buffer>();
+  let manifestBuffer: Buffer | null = null;
+
+  for (const entry of entries) {
+    const name = entry.entryName;
+    const segments = name.split("/");
+    if (
+      name.startsWith("/") ||
+      name.includes("\\") ||
+      segments.some((segment) => segment === ".." || segment === "")
+    ) {
+      return new Err(
+        new PodAppImportError("invalid_archive", `Unsafe entry path '${name}'.`)
+      );
+    }
+
+    if (name === POD_APP_ARCHIVE_MANIFEST_FILE) {
+      manifestBuffer = entry.getData();
+    } else if (name.startsWith(POD_APP_ARCHIVE_FILES_PREFIX)) {
+      fileBuffers.set(
+        name.slice(POD_APP_ARCHIVE_FILES_PREFIX.length),
+        entry.getData()
+      );
+    } else {
+      return new Err(
+        new PodAppImportError(
+          "invalid_archive",
+          `Unexpected entry '${name}': only manifest.json and files/ are allowed.`
+        )
+      );
+    }
+  }
+
+  if (!manifestBuffer) {
+    return new Err(
+      new PodAppImportError("invalid_archive", "Archive has no manifest.json.")
+    );
+  }
+
+  let manifestJson: unknown;
+  try {
+    manifestJson = JSON.parse(manifestBuffer.toString("utf-8"));
+  } catch (err) {
+    return new Err(
+      new PodAppImportError(
+        "invalid_archive",
+        `manifest.json is not valid JSON: ${normalizeError(err).message}`
+      )
+    );
+  }
+
+  const validation = PodAppManifestSchema.safeParse(manifestJson);
+  if (!validation.success) {
+    return new Err(
+      new PodAppImportError(
+        "invalid_archive",
+        fromError(validation.error).toString()
+      )
+    );
+  }
+
+  return new Ok({ manifest: validation.data, fileBuffers });
+}
+
+/**
+ * Import a Pod app archive into a pod: write its files into a new folder, recreate its Frames
+ * through `createPodFrameFile`, re-publish its functions from their new paths (which is what gives
+ * them the new folder's prefix and re-derives their schemas), reconcile its databases **empty**
+ * from the copied schema files, then publish the Frames that were published at export time.
+ *
+ * Mirrors `clonePodApp`'s pipeline and ordering with the archive as the source. Failures after the
+ * files are written are reported per item (`warnings`/`skipped`) rather than aborting: a partially
+ * published app is visible in the Apps tab and fixable, whereas aborting would hide work already
+ * done. The exceptions are sandbox unavailability (nothing later can succeed; the whole import is
+ * retryable) and file writes themselves.
+ *
+ * The archive carries no source identity, so importing into the origin pod, another pod or another
+ * workspace is the same operation. A Frame hard-coding `<podId>/<slug>` function references keeps
+ * pointing at the source pod; `publishFrame`'s validation surfaces those as warnings here.
+ */
+export async function importPodApp(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { zipBuffer, name }: { zipBuffer: Buffer; name?: string }
+): Promise<Result<PodAppImportSummary, PodAppImportError>> {
+  if (!pod.isProject()) {
+    return new Err(
+      new PodAppImportError("not_a_pod", "Apps only exist on Pod spaces.")
+    );
+  }
+
+  const parseResult = parsePodAppArchive(zipBuffer);
+  if (parseResult.isErr()) {
+    return parseResult;
+  }
+  const { manifest, fileBuffers } = parseResult.value;
+
+  const folderName = (name ?? manifest.name).trim();
+  const prefix = normalizeAppPrefix(folderName);
+  if (!prefix) {
+    return new Err(
+      new PodAppImportError(
+        "invalid_name",
+        `'${folderName}' has no letters or digits to name an app with.`
+      )
+    );
+  }
+  if (folderName.includes("/")) {
+    return new Err(
+      new PodAppImportError("invalid_name", "An app name cannot contain '/'.")
+    );
+  }
+
+  const appsResult = await listPodApps(auth, pod);
+  if (appsResult.isErr()) {
+    return new Err(new PodAppImportError("internal", appsResult.error.message));
+  }
+  if (appsResult.value.some((app) => app.prefix === prefix)) {
+    return new Err(
+      new PodAppImportError(
+        "name_taken",
+        `This Pod already has an app named '${prefix}'.`
+      )
+    );
+  }
+
+  const fsResult = await DustFileSystem.forPod(auth, pod);
+  if (fsResult.isErr()) {
+    return new Err(
+      new PodAppImportError("internal", "Failed to initialise file system.")
+    );
+  }
+  const dustFs = fsResult.value;
+
+  const podRoot = `${SCOPED_PREFIX_POD}${pod.sId}`;
+  const destFolderPath = `${podRoot}/${folderName}`;
+
+  const warnings: string[] = [];
+  const skipped: string[] = [];
+
+  // 1. Plain files. Only paths the manifest declares are written: an undeclared zip entry has no
+  // content type and no standing, so it is skipped rather than guessed at.
+  const writtenRelPaths = new Set<string>();
+  let importedFileCount = 0;
+  for (const manifestFile of manifest.files) {
+    const buffer = fileBuffers.get(manifestFile.path);
+    if (!buffer) {
+      skipped.push(`file ${manifestFile.path}`);
+      continue;
+    }
+
+    const writeResult = await dustFs.write(
+      `${destFolderPath}/${manifestFile.path}`,
+      buffer,
+      manifestFile.contentType
+    );
+    if (writeResult.isErr()) {
+      return new Err(
+        new PodAppImportError("internal", writeResult.error.message)
+      );
+    }
+    writtenRelPaths.add(manifestFile.path);
+    importedFileCount += 1;
+  }
+
+  for (const relPath of fileBuffers.keys()) {
+    const declared =
+      manifest.files.some((f) => f.path === relPath) ||
+      manifest.frames.some((f) => f.fileName === relPath);
+    if (!declared) {
+      skipped.push(`file ${relPath}`);
+    }
+  }
+
+  // 2. Frames, recreated so the import owns publishable files rather than bare objects.
+  const createdFrames: { fileName: string; file: FileResource }[] = [];
+  for (const frame of manifest.frames) {
+    const buffer = fileBuffers.get(frame.fileName);
+    if (!buffer) {
+      skipped.push(`frame ${frame.fileName}`);
+      continue;
+    }
+
+    const createResult = await createPodFrameFile(auth, {
+      space: pod,
+      folderName,
+      fileName: frame.fileName,
+      contentType: frame.contentType,
+      content: buffer.toString("utf-8"),
+    });
+    if (createResult.isErr()) {
+      return new Err(
+        new PodAppImportError("internal", createResult.error.message)
+      );
+    }
+    createdFrames.push({ fileName: frame.fileName, file: createResult.value });
+    importedFileCount += 1;
+  }
+
+  // 3. Functions, re-published from their new paths. Same source-name convention as clone: a
+  // function's source is the file directly under `functions/` named after it.
+  const functionSourceByName = new Map<string, string>();
+  for (const relPath of writtenRelPaths) {
+    const segments = relPath.split("/");
+    if (segments.length !== 2 || segments[0] !== "functions") {
+      continue;
+    }
+    const dotIndex = segments[1].lastIndexOf(".");
+    const baseName =
+      dotIndex <= 0 ? segments[1] : segments[1].slice(0, dotIndex);
+    functionSourceByName.set(baseName, `${destFolderPath}/${relPath}`);
+  }
+
+  const publishedFunctionSlugs: string[] = [];
+  for (const fn of manifest.functions) {
+    const sourcePath = functionSourceByName.get(fn.name);
+    if (!sourcePath) {
+      skipped.push(`function ${fn.name}`);
+      continue;
+    }
+
+    const publishResult = await publishSandboxFunction(auth, {
+      space: pod,
+      slug: fn.name,
+      description: fn.description,
+      path: sourcePath,
+      executionMode: fn.executionMode,
+    });
+    if (publishResult.isErr()) {
+      if (publishResult.error.code === "sandbox_unavailable") {
+        return new Err(
+          new PodAppImportError(
+            "sandbox_unavailable",
+            publishResult.error.message
+          )
+        );
+      }
+      warnings.push(`Function ${fn.name}: ${publishResult.error.message}`);
+      continue;
+    }
+    publishedFunctionSlugs.push(publishResult.value.slug);
+  }
+
+  // 4. Databases, reconciled empty from the copied schema files. Data never travels.
+  const reconciledDatabaseNames: string[] = [];
+  for (const database of manifest.databases) {
+    const schemaRelPath = `databases/${database.name}.db.ts`;
+    if (!writtenRelPaths.has(schemaRelPath)) {
+      skipped.push(`database ${database.name}`);
+      continue;
+    }
+
+    const reconcileResult = await reconcileDatabaseFromPodPath(auth, {
+      space: pod,
+      database: database.name,
+      path: `${destFolderPath}/${schemaRelPath}`,
+    });
+    if (reconcileResult.isErr()) {
+      if (reconcileResult.error.code === "sandbox_unavailable") {
+        return new Err(
+          new PodAppImportError(
+            "sandbox_unavailable",
+            reconcileResult.error.message
+          )
+        );
+      }
+      warnings.push(
+        `Database ${database.name}: ${reconcileResult.error.message}`
+      );
+      continue;
+    }
+    reconciledDatabaseNames.push(reconcileResult.value.database);
+  }
+
+  // 5. Frames that were published at export time are re-published, functions now in place so
+  // `publishFrame`'s reference validation checks against them. A failure is the import's built-in
+  // diagnostic for references the target cannot satisfy, so it lands in warnings.
+  const publishedFrameNames: string[] = [];
+  const pinnedTabPaths: string[] = [];
+  const frameByFileName = new Map(
+    manifest.frames.map((frame) => [frame.fileName, frame])
+  );
+  for (const created of createdFrames) {
+    const frame = frameByFileName.get(created.fileName);
+    if (!frame || !frame.wasPublished) {
+      continue;
+    }
+
+    const publishResult = await publishFrame(auth, {
+      file: created.file,
+      reader: createMountFrameSourceReader(dustFs, destFolderPath),
+      entryRelPath: created.fileName,
+      rootScopedPath: destFolderPath,
+    });
+    if (publishResult.isErr()) {
+      warnings.push(
+        `Frame ${created.fileName}: ${publishResult.error.message}`
+      );
+      continue;
+    }
+    publishedFrameNames.push(created.fileName);
+
+    if (frame.pinnedTab) {
+      const framePath = `${destFolderPath}/${created.fileName}`;
+      const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+      const currentTabs = metadata?.frameTabs ?? [];
+      if (!metadata || currentTabs.length >= MAX_POD_FRAME_TABS) {
+        warnings.push(
+          `Frame ${created.fileName}: not pinned as a tab (the Pod already has ${MAX_POD_FRAME_TABS}).`
+        );
+        continue;
+      }
+      const frameTabs = [
+        ...currentTabs,
+        {
+          path: framePath,
+          title: frame.pinnedTab.title,
+          icon: frame.pinnedTab.icon,
+        },
+      ];
+      await metadata.updateFrameTabs(
+        frameTabs,
+        normalizeTabsOrder(
+          [...(metadata.tabsOrder ?? []), framePath],
+          frameTabs.map((tab) => tab.path)
+        )
+      );
+      pinnedTabPaths.push(framePath);
+    }
+  }
+
+  return new Ok({
+    prefix,
+    name: folderName,
+    importedFileCount,
+    createdFrameNames: createdFrames.map((frame) => frame.fileName),
+    publishedFunctionSlugs,
+    reconciledDatabaseNames,
+    publishedFrameNames,
+    pinnedTabPaths,
+    warnings,
+    skipped,
   });
 }

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -1,7 +1,13 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { getFileContent } from "@app/lib/api/files/utils";
-import { listPodApps } from "@app/lib/api/projects/apps";
+import {
+  APP_DATABASES_SUBFOLDER,
+  APP_FUNCTIONS_SUBFOLDER,
+  listPodApps,
+  POD_DATABASE_SCHEMA_FILE_SUFFIX,
+  stripExtension,
+} from "@app/lib/api/projects/apps";
 import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
@@ -479,11 +485,12 @@ export async function importPodApp(
     importedFileCount += 1;
   }
 
+  const declaredRelPaths = new Set([
+    ...manifest.files.map((f) => f.path),
+    ...manifest.frames.map((f) => f.fileName),
+  ]);
   for (const relPath of fileBuffers.keys()) {
-    const declared =
-      manifest.files.some((f) => f.path === relPath) ||
-      manifest.frames.some((f) => f.fileName === relPath);
-    if (!declared) {
+    if (!declaredRelPaths.has(relPath)) {
       skipped.push(`file ${relPath}`);
     }
   }
@@ -518,13 +525,13 @@ export async function importPodApp(
   const functionSourceByName = new Map<string, string>();
   for (const relPath of writtenRelPaths) {
     const segments = relPath.split("/");
-    if (segments.length !== 2 || segments[0] !== "functions") {
+    if (segments.length !== 2 || segments[0] !== APP_FUNCTIONS_SUBFOLDER) {
       continue;
     }
-    const dotIndex = segments[1].lastIndexOf(".");
-    const baseName =
-      dotIndex <= 0 ? segments[1] : segments[1].slice(0, dotIndex);
-    functionSourceByName.set(baseName, `${destFolderPath}/${relPath}`);
+    functionSourceByName.set(
+      stripExtension(segments[1]),
+      `${destFolderPath}/${relPath}`
+    );
   }
 
   const publishedFunctionSlugs: string[] = [];
@@ -560,7 +567,7 @@ export async function importPodApp(
   // 4. Databases, reconciled empty from the copied schema files. Data never travels.
   const reconciledDatabaseNames: string[] = [];
   for (const database of manifest.databases) {
-    const schemaRelPath = `databases/${database.name}.db.ts`;
+    const schemaRelPath = `${APP_DATABASES_SUBFOLDER}/${database.name}${POD_DATABASE_SCHEMA_FILE_SUFFIX}`;
     if (!writtenRelPaths.has(schemaRelPath)) {
       skipped.push(`database ${database.name}`);
       continue;
@@ -596,6 +603,9 @@ export async function importPodApp(
   const frameByFileName = new Map(
     manifest.frames.map((frame) => [frame.fileName, frame])
   );
+  // Fetched once: updateFrameTabs mutates this same instance, so successive pins in the loop see
+  // each other's appended tabs without refetching.
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
   for (const created of createdFrames) {
     const frame = frameByFileName.get(created.fileName);
     if (!frame || !frame.wasPublished) {
@@ -618,7 +628,6 @@ export async function importPodApp(
 
     if (frame.pinnedTab) {
       const framePath = `${destFolderPath}/${created.fileName}`;
-      const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
       const currentTabs = metadata?.frameTabs ?? [];
       if (!metadata || currentTabs.length >= MAX_POD_FRAME_TABS) {
         warnings.push(

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -25,6 +25,7 @@ import {
   POD_APP_ARCHIVE_MANIFEST_FILE,
   PodAppManifestSchema,
 } from "@app/types/api/pod_app_archive";
+import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
 import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { isInteractiveContentType } from "@app/types/files";
 import {
@@ -41,6 +42,7 @@ export type PodAppExportErrorCode =
   | "not_a_pod"
   | "not_found"
   | "colliding_folders"
+  | "too_large"
   | "internal";
 
 export class PodAppExportError extends Error {
@@ -113,6 +115,23 @@ export async function exportPodApp(
   const fileEntries: FileSystemFileEntry[] = listResult.value.flatMap(
     (entry) => (entry.isDirectory ? [] : [entry])
   );
+
+  // Fail before reading any bytes: an archive this large would only be rejected by
+  // `parsePodAppArchive`'s own uncompressed-size guard on import, and buffering it all into a
+  // zip here first wastes the memory for nothing.
+  const totalSizeBytes = fileEntries.reduce(
+    (total, entry) => total + entry.sizeBytes,
+    0
+  );
+  if (totalSizeBytes > MAX_POD_APP_ARCHIVE_UNCOMPRESSED_BYTES) {
+    return new Err(
+      new PodAppExportError(
+        "too_large",
+        `'${prefix}' is too large to export: its files total ${totalSizeBytes} bytes, ` +
+          `over the ${MAX_POD_APP_ARCHIVE_UNCOMPRESSED_BYTES}-byte limit.`
+      )
+    );
+  }
 
   const zip = new AdmZip();
   const manifestFiles: PodAppManifest["files"] = [];
@@ -385,6 +404,14 @@ export async function importPodApp(
   const { manifest, fileBuffers } = parseResult.value;
 
   const folderName = (name ?? manifest.name).trim();
+  if (folderName.length > MAX_POD_APP_NAME_LENGTH) {
+    return new Err(
+      new PodAppImportError(
+        "invalid_name",
+        `'${folderName}' is longer than ${MAX_POD_APP_NAME_LENGTH} characters.`
+      )
+    );
+  }
   const prefix = normalizeAppPrefix(folderName);
   if (!prefix) {
     return new Err(

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -1,0 +1,188 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { getFileContent } from "@app/lib/api/files/utils";
+import { listPodApps } from "@app/lib/api/projects/apps";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { FileSystemFileEntry } from "@app/types/api/file_system/types";
+import type { PodAppManifest } from "@app/types/api/pod_app_archive";
+import {
+  POD_APP_ARCHIVE_FILES_PREFIX,
+  POD_APP_ARCHIVE_FORMAT_VERSION,
+  POD_APP_ARCHIVE_MANIFEST_FILE,
+} from "@app/types/api/pod_app_archive";
+import { isInteractiveContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import AdmZip from "adm-zip";
+
+export type PodAppExportErrorCode =
+  | "not_a_pod"
+  | "not_found"
+  | "colliding_folders"
+  | "internal";
+
+export class PodAppExportError extends Error {
+  constructor(
+    readonly code: PodAppExportErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "PodAppExportError";
+  }
+}
+
+/**
+ * Package a Pod app as a portable zip: the app folder's files verbatim under `files/`, plus a
+ * `manifest.json` carrying publish metadata the files cannot (function descriptions and execution
+ * modes, Frame publish state and pinned-tab metadata, per-file content types).
+ *
+ * Reads only GCS and Postgres — like `listPodApps`, exporting never wakes a sleeping pod. Bundles
+ * are never exported: an import re-publishes from source, which is also what re-derives input and
+ * output schemas.
+ *
+ * A Frame whose FileResource exists is exported through `getFileContent(_, _, "original")` so the
+ * source (not the built bundle) is what travels; a Frame source with no FileResource row yet is
+ * exported as a plain file, faithfully preserving its unpublishable state.
+ */
+export async function exportPodApp(
+  auth: Authenticator,
+  pod: SpaceResource,
+  prefix: string
+): Promise<Result<{ fileName: string; content: Buffer }, PodAppExportError>> {
+  if (!pod.isProject()) {
+    return new Err(
+      new PodAppExportError("not_a_pod", "Apps only exist on Pod spaces.")
+    );
+  }
+
+  const appsResult = await listPodApps(auth, pod);
+  if (appsResult.isErr()) {
+    return new Err(new PodAppExportError("internal", appsResult.error.message));
+  }
+
+  const app = appsResult.value.find((candidate) => candidate.prefix === prefix);
+  if (!app || !app.folderPath) {
+    return new Err(
+      new PodAppExportError("not_found", `No app '${prefix}' in this Pod.`)
+    );
+  }
+  if (app.collidingFolderNames.length > 0) {
+    return new Err(
+      new PodAppExportError(
+        "colliding_folders",
+        `Folders ${app.collidingFolderNames.join(", ")} all resolve to '${prefix}'. ` +
+          "Rename all but one before exporting."
+      )
+    );
+  }
+
+  const fsResult = await DustFileSystem.forPod(auth, pod);
+  if (fsResult.isErr()) {
+    return new Err(
+      new PodAppExportError("internal", "Failed to initialise file system.")
+    );
+  }
+  const dustFs = fsResult.value;
+
+  const listResult = await dustFs.list(app.folderPath);
+  if (listResult.isErr()) {
+    return new Err(new PodAppExportError("internal", listResult.error.message));
+  }
+  const fileEntries: FileSystemFileEntry[] = listResult.value.flatMap(
+    (entry) => (entry.isDirectory ? [] : [entry])
+  );
+
+  const zip = new AdmZip();
+  const manifestFiles: PodAppManifest["files"] = [];
+
+  // Frames with a FileResource are read through it below; everything else is read as bytes. A
+  // top-level Frame with no row falls through to this loop on purpose.
+  const framePathsWithResource = new Set(
+    app.frames.flatMap((frame) => (frame.fileId ? [frame.path] : []))
+  );
+
+  for (const entry of fileEntries) {
+    if (framePathsWithResource.has(entry.path)) {
+      continue;
+    }
+
+    const relPath = entry.path.slice(app.folderPath.length + 1);
+    const contentResult = await dustFs.readBuffer(entry.path);
+    if (contentResult.isErr() || contentResult.value === null) {
+      return new Err(
+        new PodAppExportError("internal", `Could not read '${relPath}'.`)
+      );
+    }
+
+    zip.addFile(
+      `${POD_APP_ARCHIVE_FILES_PREFIX}${relPath}`,
+      contentResult.value
+    );
+    manifestFiles.push({ path: relPath, contentType: entry.contentType });
+  }
+
+  const metadata = await ProjectMetadataResource.fetchBySpace(auth, pod);
+  const tabByPath = new Map(
+    (metadata?.frameTabs ?? []).map((tab) => [tab.path, tab])
+  );
+
+  const manifestFrames: PodAppManifest["frames"] = [];
+  for (const frame of app.frames) {
+    if (!frame.fileId) {
+      continue;
+    }
+    const file = await FileResource.fetchById(auth, frame.fileId);
+    if (!file || !isInteractiveContentType(file.contentType)) {
+      continue;
+    }
+    const content = await getFileContent(auth, file, "original");
+    if (content === null) {
+      return new Err(
+        new PodAppExportError(
+          "internal",
+          `Could not read the source of Frame '${frame.fileName}'.`
+        )
+      );
+    }
+
+    zip.addFile(
+      `${POD_APP_ARCHIVE_FILES_PREFIX}${frame.fileName}`,
+      Buffer.from(content, "utf-8")
+    );
+    const pinnedTab = tabByPath.get(frame.path);
+    manifestFrames.push({
+      fileName: frame.fileName,
+      contentType: file.contentType,
+      wasPublished: frame.isPublished,
+      ...(pinnedTab
+        ? { pinnedTab: { title: pinnedTab.title, icon: pinnedTab.icon } }
+        : {}),
+    });
+  }
+
+  const manifest: PodAppManifest = {
+    formatVersion: POD_APP_ARCHIVE_FORMAT_VERSION,
+    name: app.name,
+    exportedAt: new Date().toISOString(),
+    files: manifestFiles,
+    frames: manifestFrames,
+    functions: app.functions.map((fn) => ({
+      name: fn.name,
+      description: fn.description,
+      executionMode: fn.executionMode,
+    })),
+    databases: app.databases.map((db) => ({ name: db.name })),
+  };
+
+  zip.addFile(
+    POD_APP_ARCHIVE_MANIFEST_FILE,
+    Buffer.from(JSON.stringify(manifest, null, 2), "utf-8")
+  );
+
+  return new Ok({
+    fileName: `${app.prefix}.podapp.zip`,
+    content: zip.toBuffer(),
+  });
+}

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -47,10 +47,10 @@ import { Err, Ok } from "@app/types/shared/result";
 const POD_DATABASE_FILE_SUFFIX = ".db";
 
 /** The app subfolder holding one drizzle schema file per database. */
-const APP_DATABASES_SUBFOLDER = "databases";
+export const APP_DATABASES_SUBFOLDER = "databases";
 
 /** The app subfolder holding one source file per published function. */
-const APP_FUNCTIONS_SUBFOLDER = "functions";
+export const APP_FUNCTIONS_SUBFOLDER = "functions";
 
 /** Subfolders whose presence marks a pod-root folder as app-shaped. */
 const APP_SHAPED_SUBFOLDERS = [
@@ -59,7 +59,7 @@ const APP_SHAPED_SUBFOLDERS = [
 ];
 
 /** Suffix of a database's schema file, e.g. `chat.db.ts` declares the `chat` database. */
-const POD_DATABASE_SCHEMA_FILE_SUFFIX = ".db.ts";
+export const POD_DATABASE_SCHEMA_FILE_SUFFIX = ".db.ts";
 
 /**
  * A folder's accumulated file-system facts, before published functions and databases are joined in.
@@ -73,7 +73,7 @@ type AppFolder = {
 };
 
 /** Drop the last extension from a file name, e.g. `add-task.ts` -> `add-task`. */
-function stripExtension(fileName: string): string {
+export function stripExtension(fileName: string): string {
   const dotIndex = fileName.lastIndexOf(".");
 
   return dotIndex <= 0 ? fileName : fileName.slice(0, dotIndex);

--- a/front/lib/api/viz/publish_frame.ts
+++ b/front/lib/api/viz/publish_frame.ts
@@ -15,7 +15,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-type PublishFrameErrorCode =
+export type PublishFrameErrorCode =
   | "allowlist_failed"
   | "build_failed"
   | "entry_not_found"
@@ -27,7 +27,7 @@ type PublishFrameErrorCode =
   | "pod_function_schema_invalid"
   | "pod_scope_not_found";
 
-class PublishFrameError extends Error {
+export class PublishFrameError extends Error {
   constructor(
     readonly code: PublishFrameErrorCode,
     message: string

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -26,6 +26,7 @@ import type {
   FileSystemEntry,
   GetSpaceFilesResponseBody,
 } from "@app/types/api/file_system/types";
+import type { ImportPodAppResponseBody } from "@app/types/api/pod_app_archive";
 import type {
   ClonePodAppResponseBody,
   GetPodAppsResponseBody,
@@ -193,6 +194,121 @@ export function useClonePodApp({
       sendNotification({
         type: "error",
         title: `Failed to clone ${app.name ?? app.prefix}`,
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function getPodAppExportUrl(
+  owner: LightWorkspaceType,
+  podId: string,
+  prefix: string
+): string {
+  return `/api/w/${owner.sId}/pods/${podId}/apps/${encodeURIComponent(prefix)}/export`;
+}
+
+export function useDownloadPodApp({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  return async (app: PodApp): Promise<void> => {
+    const appName = app.name ?? app.prefix;
+
+    try {
+      const res = await clientFetch(
+        getPodAppExportUrl(owner, podId, app.prefix)
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: `Failed to download ${appName}`,
+          description: errorData.message,
+        });
+        return;
+      }
+
+      // Fetch-then-blob (rather than a bare <a href> to the endpoint) so the download carries
+      // the same auth context as every other API call, matching `useFileDownload`.
+      const blob = await res.blob();
+      const blobUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = blobUrl;
+      anchor.download = `${app.prefix}.podapp.zip`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(blobUrl);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: `Failed to download ${appName}`,
+        description: errorMessage,
+      });
+    }
+  };
+}
+
+export function useImportPodApp({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutatePodApps } = usePodApps({ owner, podId, disabled: true });
+
+  return async (
+    file: File,
+    name?: string
+  ): Promise<Result<ImportPodAppResponseBody["app"], Error>> => {
+    try {
+      const body = new FormData();
+      body.append("file", file);
+      if (name !== undefined && name.trim().length > 0) {
+        body.append("name", name.trim());
+      }
+
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/pods/${podId}/apps/import`,
+        { method: "POST", body }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to import app",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      const { app }: ImportPodAppResponseBody = await res.json();
+      const hasIssues = app.warnings.length > 0 || app.skipped.length > 0;
+      sendNotification({
+        type: hasIssues ? "info" : "success",
+        title: `${app.name} imported`,
+        description: `${app.publishedFunctionSlugs.length} function(s) published, ${app.reconciledDatabaseNames.length} database(s) created empty${hasIssues ? `, ${app.warnings.length + app.skipped.length} issue(s) to review` : ""}.`,
+      });
+      await mutatePodApps();
+
+      return new Ok(app);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to import app",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/types/api/pod_app_archive.ts
+++ b/front/types/api/pod_app_archive.ts
@@ -1,0 +1,84 @@
+import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
+import { SANDBOX_FUNCTION_EXECUTION_MODES } from "@app/types/api/sandbox_functions";
+import type { InteractiveContentFileContentType } from "@app/types/files";
+import { isInteractiveContentType } from "@app/types/files";
+import { PodFrameTabSchema } from "@app/types/pod_frame_tab";
+import { z } from "zod";
+
+/**
+ * A Pod app archive is a zip holding the app folder's files verbatim under `files/` plus a
+ * `manifest.json` carrying what the files cannot: publish metadata and per-file content types.
+ * Nothing in the archive encodes the source pod or workspace, so an archive imports identically
+ * into any pod anywhere.
+ */
+
+export const POD_APP_ARCHIVE_FORMAT_VERSION = 1;
+export const POD_APP_ARCHIVE_MANIFEST_FILE = "manifest.json";
+export const POD_APP_ARCHIVE_FILES_PREFIX = "files/";
+
+export const MAX_POD_APP_ARCHIVE_SIZE_BYTES = 20 * 1024 * 1024;
+export const MAX_POD_APP_ARCHIVE_ENTRY_COUNT = 1000;
+/** Zip-bomb guard: cap on the sum of declared uncompressed entry sizes. */
+export const MAX_POD_APP_ARCHIVE_UNCOMPRESSED_BYTES = 100 * 1024 * 1024;
+
+/** A non-Frame file in the archive. `path` is relative to the app folder, e.g. `functions/add.ts`. */
+const PodAppManifestFileSchema = z.object({
+  path: z.string().min(1),
+  contentType: z.string().min(1),
+});
+
+const PodAppManifestFrameSchema = z.object({
+  /** Frames only live at the top of the app folder, so the file name is the path. */
+  fileName: z.string().min(1),
+  contentType: z.custom<InteractiveContentFileContentType>(
+    isInteractiveContentType,
+    { message: "Not an interactive content type." }
+  ),
+  wasPublished: z.boolean(),
+  /** The nav-tab metadata to re-pin with, when the Frame was pinned at export time. */
+  pinnedTab: PodFrameTabSchema.omit({ path: true }).optional(),
+});
+
+const PodAppManifestFunctionSchema = z.object({
+  /** Bare name (`list-tasks`); the slug is re-derived from the target folder name at publish. */
+  name: z.string().min(1),
+  description: z.string(),
+  executionMode: z.enum(SANDBOX_FUNCTION_EXECUTION_MODES),
+});
+
+const PodAppManifestDatabaseSchema = z.object({
+  /** App-relative name (`tasks`), declared by `databases/<name>.db.ts`. */
+  name: z.string().min(1),
+});
+
+export const PodAppManifestSchema = z.object({
+  formatVersion: z.literal(POD_APP_ARCHIVE_FORMAT_VERSION),
+  name: z.string().min(1).max(MAX_POD_APP_NAME_LENGTH),
+  exportedAt: z.string(),
+  files: z.array(PodAppManifestFileSchema),
+  frames: z.array(PodAppManifestFrameSchema),
+  functions: z.array(PodAppManifestFunctionSchema),
+  databases: z.array(PodAppManifestDatabaseSchema),
+});
+
+export type PodAppManifest = z.infer<typeof PodAppManifestSchema>;
+
+/** What an import created, as the business layer reports it and the endpoint returns it. */
+export type PodAppImportSummary = {
+  prefix: string;
+  name: string;
+  importedFileCount: number;
+  createdFrameNames: string[];
+  publishedFunctionSlugs: string[];
+  reconciledDatabaseNames: string[];
+  publishedFrameNames: string[];
+  pinnedTabPaths: string[];
+  /** Steps that were attempted and failed non-fatally (e.g. a Frame that would not publish). */
+  warnings: string[];
+  /** Functions or databases the archive had no source for, so they were not recreated. */
+  skipped: string[];
+};
+
+export type ImportPodAppResponseBody = {
+  app: PodAppImportSummary;
+};


### PR DESCRIPTION
Export Action on an app:
<img width="1073" height="377" alt="Screenshot 2026-08-14 at 16 22 15" src="https://github.com/user-attachments/assets/2f40eef7-6702-4f69-9453-7fb53a7ef7c7" />

Import button in the app tab brings this up:
<img width="449" height="393" alt="Screenshot 2026-08-14 at 16 23 12" src="https://github.com/user-attachments/assets/0286e8a9-bab1-401e-834a-642dc5749503" />


## Summary

Makes Pod apps portable: an app can be downloaded from a pod as a self-contained zip archive and uploaded into any other pod — including a pod in a different workspace, region, or instance. The archive contains no source identity, so import behaves identically regardless of where it came from.

## Archive format

A plain zip (`<prefix>.podapp.zip`): the app folder's files byte-for-byte under `files/` (without the folder name itself — the name, and thus the prefix, is chosen at import time, like clone), plus a `manifest.json` carrying what the files can't: `formatVersion` (evolution slot), app name, per-file content types, per-function publish metadata (`description`, `executionMode`), per-Frame publish state and pinned-tab metadata, and database names. No sIds, no bundles (always rebuilt at publish, which also re-derives schemas), no database data, no share tokens, no env var values.

## Export

`GET /api/w/:wId/pods/:podId/apps/:prefix/export` (`requireCanRead`). Reads only GCS and Postgres — exporting never wakes a sleeping pod. Frames are exported from their original source (not the built bundle). Rejects colliding folder names and apps whose summed file size exceeds the archive cap.

## Import

`POST /api/w/:wId/pods/:podId/apps/import` (`requireCanWrite`, multipart `file` + optional `name`, `bodyLimit`-gated). Mirrors `clonePodApp`'s pipeline with the archive as the source: validate fully before writing anything (size/entry-count/uncompressed caps, zip-slip rejection, manifest schema) → prefix collision check → write files → recreate Frames via `createPodFrameFile` → re-publish functions from their new paths (which re-derives slugs and schemas under the new prefix) → reconcile databases empty from the copied schema files → publish Frames that were published at export (surfacing `validateFramePodFunctionReferences` errors, e.g. hard-coded cross-pod refs, as warnings) → re-pin tabs under the `MAX_POD_FRAME_TABS` cap.

Per-item failures land in the returned summary's `warnings`/`skipped` instead of aborting (a partially imported app is visible in the Apps tab and fixable); only sandbox unavailability aborts (503). Missing env vars/secrets/egress domains in the target workspace surface at runtime, as designed — a `requirements` manifest section is a possible follow-up.

## UI

Download action on each app tile (any reader), and an Import dialog in the Apps tab (editors, reachable from the empty state too) with optional rename, prefix-collision validation, busy state, and a report view listing warnings/skipped items before the dialog closes.

## Testing

37 endpoint tests across the apps routes (5 files), including: real-AdmZip export assertions (manifest contents, file bytes, published+pinned Frame capture), an export→import round-trip into a second pod, zip-slip and format-version rejection, oversized-body 413 and oversized-app 400, name collision 409, sandbox-unavailable 503, skipped/warning reporting, and tab-pin cap behavior.