### PR TITLE
feat(models): unify model tier vocabulary and gate streams on their tier

### DIFF
--- a/front/components/editor/extensions/shared/slash_suggestion/PickModelSubMenuDropdown.tsx
+++ b/front/components/editor/extensions/shared/slash_suggestion/PickModelSubMenuDropdown.tsx
@@ -48,7 +48,7 @@ export const PickModelSubMenuDropdown = forwardRef<
     const lockPremiumEfforts = !isCreditPricedPlan(subscription.plan);
     const { isDark } = useTheme();
 
-    const { models, isModelsLoading } = useModels({
+    const { models, streams, isModelsLoading } = useModels({
       owner,
       disabled: !hasModelsPicker,
     });
@@ -65,8 +65,9 @@ export const PickModelSubMenuDropdown = forwardRef<
           lockPremiumEfforts,
           models,
           query,
+          streams,
         }),
-      [getModelIcon, lockPremiumEfforts, models, query]
+      [getModelIcon, lockPremiumEfforts, models, query, streams]
     );
 
     const handleSelect = (item: SlashCommand) => {

--- a/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
@@ -1,6 +1,7 @@
 import { buildPickModelSlashCommandItems } from "@app/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import { CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import { AUTO_COMPLEX_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import { GPT_4_1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import { describe, expect, it } from "vitest";
@@ -20,12 +21,13 @@ describe("buildPickModelSlashCommandItems", () => {
       lockPremiumEfforts: false,
       models: [asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG)],
       query: "",
+      streams: null,
     });
 
     expect(items.map((item) => item.label)).toEqual([
-      "Fast",
+      "Basic",
       "Standard",
-      "Complex",
+      "Premium",
       `${CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.displayName} Light`,
       `${CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.displayName} Medium`,
       `${CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.displayName} High`,
@@ -43,6 +45,7 @@ describe("buildPickModelSlashCommandItems", () => {
       lockPremiumEfforts: false,
       models: [asSelectable(GPT_4_1_MODEL_CONFIG)],
       query: "",
+      streams: null,
     });
 
     expect(
@@ -66,6 +69,7 @@ describe("buildPickModelSlashCommandItems", () => {
           asSelectable(GPT_4_1_MODEL_CONFIG),
         ],
         query: "claude",
+        streams: null,
       }).map((item) => item.data.selection.toSend?.modelId)
     ).toEqual([
       CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.modelId,
@@ -74,16 +78,36 @@ describe("buildPickModelSlashCommandItems", () => {
     ]);
   });
 
-  it("omits premium efforts and the Complex tier when gated", () => {
+  it("omits a tier whose stream is above the member's model-tier cap", () => {
+    const items = buildPickModelSlashCommandItems({
+      getModelIcon: () => Icon,
+      lockPremiumEfforts: false,
+      models: [
+        asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG),
+        { ...AUTO_COMPLEX_MODEL_CONFIG, isSelectable: false },
+      ],
+      query: "",
+      streams: null,
+    });
+
+    expect(
+      items
+        .filter((item) => item.data.selection.display.kind === "tier")
+        .map((item) => item.label)
+    ).toEqual(["Basic", "Standard"]);
+  });
+
+  it("omits premium efforts and the Premium tier when gated", () => {
     const items = buildPickModelSlashCommandItems({
       getModelIcon: () => Icon,
       lockPremiumEfforts: true,
       models: [asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG)],
       query: "",
+      streams: null,
     });
 
     expect(items.map((item) => item.label)).toEqual([
-      "Fast",
+      "Basic",
       "Standard",
       `${CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.displayName} Light`,
       `${CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG.displayName} Medium`,

--- a/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.ts
@@ -10,11 +10,15 @@ import {
   buildTierSelection,
   getEffortStops,
   getModelWithReasoningEffortLabel,
+  getTierLockReason,
+  getTierResolvedModelLabel,
   isPremiumModel,
-  isTierLocked,
   MODEL_TIERS,
 } from "@app/components/model_picker/modelPickerUtils";
-import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import type {
+  EnabledModelConfigurationType,
+  ModelStreamResolutionsType,
+} from "@app/types/api/assistant/models";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
@@ -61,13 +65,17 @@ function matchesQuery(item: SlashCommand, normalizedQuery: string): boolean {
 
 function buildTierSlashCommandItems({
   lockPremiumEfforts,
+  streamModels,
+  streams,
 }: {
   lockPremiumEfforts: boolean;
+  streamModels: EnabledModelConfigurationType[];
+  streams: ModelStreamResolutionsType | null;
 }): SelectModelSlashCommand[] {
   const items: SelectModelSlashCommand[] = [];
 
   for (const tier of MODEL_TIERS) {
-    if (isTierLocked(tier.id, { lockPremiumEfforts })) {
+    if (getTierLockReason(tier.id, { lockPremiumEfforts, streamModels })) {
       continue;
     }
 
@@ -79,7 +87,7 @@ function buildTierSlashCommandItems({
     items.push({
       action: SELECT_MODEL_SLASH_COMMAND_ACTION,
       data: { selection },
-      description: tier.description,
+      description: getTierResolvedModelLabel(tier.id, streams),
       icon: TIER_ICON[tier.id],
       id: `tier-${tier.id}`,
       label: tier.name,
@@ -94,19 +102,26 @@ export function buildPickModelSlashCommandItems({
   lockPremiumEfforts,
   models,
   query,
+  streams,
 }: {
   getModelIcon: (model: EnabledModelConfigurationType) => ComponentType;
   lockPremiumEfforts: boolean;
   models: EnabledModelConfigurationType[];
   query: string;
+  streams: ModelStreamResolutionsType | null;
 }): SelectModelSlashCommand[] {
   const normalizedQuery = query.trim().toLowerCase();
   const selectableModels = models.filter(
     (model) => !isModelStreamId(model.modelId) && model.isSelectable
   );
+  const streamModels = models.filter((model) => isModelStreamId(model.modelId));
 
   const items: SelectModelSlashCommand[] = [
-    ...buildTierSlashCommandItems({ lockPremiumEfforts }),
+    ...buildTierSlashCommandItems({
+      lockPremiumEfforts,
+      streamModels,
+      streams,
+    }),
   ];
 
   for (const model of selectableModels) {

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -11,9 +11,9 @@ import {
   getModelEffortTier,
   getModelTier,
   getModelWithReasoningEffortLabel,
+  getTierLockReason,
   isPremiumModel,
   isSameSelection,
-  isTierLocked,
   resolveShownSelection,
 } from "@app/components/model_picker/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
@@ -112,7 +112,7 @@ export function ModelPicker({
 
   const [userOverride, setUserOverride] = useState<Selection | null>(null);
 
-  const { models } = useModels({
+  const { models, streams } = useModels({
     owner,
     disabled: !hasModelsPicker,
   });
@@ -158,6 +158,13 @@ export function ModelPicker({
       models.filter(
         (model) => !isModelStreamId(model.modelId) && model.isSelectable
       ),
+    [models]
+  );
+
+  // Meta-models backing the tier rows: their `isSelectable` tells whether the
+  // member's model-tier cap allows the stream at all.
+  const streamModels = useMemo(
+    () => models.filter((model) => isModelStreamId(model.modelId)),
     [models]
   );
 
@@ -208,7 +215,7 @@ export function ModelPicker({
     Date.now() - lastModelInteractionAtMsRef.current < 300;
 
   const onSelectTier = (tierId: ModelTierId) => {
-    if (isTierLocked(tierId, { lockPremiumEfforts })) {
+    if (getTierLockReason(tierId, { lockPremiumEfforts, streamModels })) {
       return;
     }
     commit({
@@ -305,6 +312,8 @@ export function ModelPicker({
         lockPremiumEfforts={lockPremiumEfforts}
         makerGroups={makerGroups}
         allModels={allModels}
+        streamModels={streamModels}
+        streams={streams}
         search={search}
         onSearchChange={setSearch}
         moreModelsExpanded={moreModelsExpanded}

--- a/front/components/model_picker/ModelPickerContent.tsx
+++ b/front/components/model_picker/ModelPickerContent.tsx
@@ -6,11 +6,16 @@ import type {
   Selection,
 } from "@app/components/model_picker/modelPickerUtils";
 import {
+  getModelLockTooltip,
+  getTierLockReason,
+  getTierResolvedModelLabel,
   isTierDisplayed,
-  isTierLocked,
   MODEL_TIERS,
-  PREMIUM_MODEL_LOCKED_TOOLTIP,
 } from "@app/components/model_picker/modelPickerUtils";
+import type {
+  EnabledModelConfigurationType,
+  ModelStreamResolutionsType,
+} from "@app/types/api/assistant/models";
 import type {
   ModelConfigurationType,
   ModelMakerIdType,
@@ -29,7 +34,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
-// Tier trigger icons: rising bars from Fast to Complex.
+// Tier trigger icons: rising bars from Basic to Premium.
 const TIER_ICON: Record<ModelTierId, ComponentType> = {
   fast: BarLow,
   standard: BarHalf,
@@ -47,6 +52,8 @@ interface ModelPickerContentProps {
   lockPremiumEfforts: boolean;
   makerGroups: MakerGroup[];
   allModels: ModelConfigurationType[];
+  streamModels: EnabledModelConfigurationType[];
+  streams: ModelStreamResolutionsType | null;
   search: string;
   onSearchChange: (value: string) => void;
   moreModelsExpanded: boolean;
@@ -68,6 +75,8 @@ export function ModelPickerContent({
   lockPremiumEfforts,
   makerGroups,
   allModels,
+  streamModels,
+  streams,
   search,
   onSearchChange,
   moreModelsExpanded,
@@ -80,21 +89,28 @@ export function ModelPickerContent({
   onRevert,
 }: ModelPickerContentProps) {
   return (
-    <DropdownMenuContent className="w-72" align="start" side={side}>
+    <DropdownMenuContent
+      className="w-84 max-w-(--radix-dropdown-menu-content-available-width)"
+      align="start"
+      side={side}
+    >
       <DropdownMenuLabel label="Model" />
 
       {MODEL_TIERS.map((tier) => {
         const isSelected = isTierDisplayed(tier.id, shown.display);
         const isDefault = isTierDisplayed(tier.id, agentDefault.display);
-        const locked = isTierLocked(tier.id, { lockPremiumEfforts });
-        if (locked) {
+        const lockReason = getTierLockReason(tier.id, {
+          lockPremiumEfforts,
+          streamModels,
+        });
+        if (lockReason) {
           return (
             <DropdownMenuItem
               key={tier.id}
               icon={TIER_ICON[tier.id]}
               label={tier.name}
               disabled
-              tooltip={PREMIUM_MODEL_LOCKED_TOOLTIP}
+              tooltip={getModelLockTooltip(lockReason)}
               endComponent={
                 <Icon
                   visual={Lock01}
@@ -118,8 +134,8 @@ export function ModelPickerContent({
                   onRevert={onRevert}
                 />
               ) : (
-                <span className="whitespace-nowrap text-xs text-muted-foreground">
-                  {tier.description}
+                <span className="whitespace-nowrap text-xs text-faint">
+                  {getTierResolvedModelLabel(tier.id, streams)}
                 </span>
               )
             }

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -1,4 +1,5 @@
 import {
+  getDefaultTierId,
   getEffortStops,
   getInitialEffort,
   getModelEffortTier,
@@ -17,6 +18,7 @@ import {
   AUTO_COMPLEX_MODEL_CONFIG,
   AUTO_COMPLEX_MODEL_ID,
   AUTO_FAST_MODEL_ID,
+  AUTO_MODEL_ID,
 } from "@app/types/assistant/models/auto";
 import { GEMINI_2_5_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import { O1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
@@ -154,6 +156,31 @@ describe("modelPickerUtils premium gating", () => {
       expect(
         getTierLockReason("standard", { ...UNGATED, streamModels: [] })
       ).toBeNull();
+    });
+  });
+
+  describe("getDefaultTierId", () => {
+    const streamModel = (
+      modelId: ModelStreamIdType,
+      isSelectable: boolean
+    ): EnabledModelConfigurationType => ({
+      ...AUTO_COMPLEX_MODEL_CONFIG,
+      modelId,
+      providerId: modelId,
+      isSelectable,
+    });
+
+    it("falls back to Basic when Standard is above the member's cap", () => {
+      expect(getDefaultTierId([streamModel(AUTO_MODEL_ID, false)])).toBe(
+        "fast"
+      );
+    });
+
+    it("keeps Standard when the member can run it, or while the payload is in flight", () => {
+      expect(getDefaultTierId([streamModel(AUTO_MODEL_ID, true)])).toBe(
+        "standard"
+      );
+      expect(getDefaultTierId([])).toBe("standard");
     });
   });
 

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -2,14 +2,22 @@ import {
   getEffortStops,
   getInitialEffort,
   getModelEffortTier,
+  getTierLockReason,
   isPremiumModel,
 } from "@app/components/model_picker/modelPickerUtils";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
   CLAUDE_OPUS_4_8_MODEL_ID,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
+import {
+  AUTO_COMPLEX_MODEL_CONFIG,
+  AUTO_COMPLEX_MODEL_ID,
+  AUTO_FAST_MODEL_ID,
+} from "@app/types/assistant/models/auto";
 import { GEMINI_2_5_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import { O1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelIdType } from "@app/types/assistant/models/types";
@@ -104,6 +112,48 @@ describe("modelPickerUtils premium gating", () => {
         isPremiumModel(CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG, UNGATED)
       ).toBe(false);
       expect(isPremiumModel(O1_MODEL_CONFIG, UNGATED)).toBe(false);
+    });
+  });
+
+  describe("getTierLockReason", () => {
+    const streamModel = (
+      modelId: ModelStreamIdType,
+      isSelectable: boolean
+    ): EnabledModelConfigurationType => ({
+      ...AUTO_COMPLEX_MODEL_CONFIG,
+      modelId,
+      providerId: modelId,
+      isSelectable,
+    });
+
+    it("locks a tier whose stream is above the member's cap", () => {
+      expect(
+        getTierLockReason("complex", {
+          ...UNGATED,
+          streamModels: [streamModel(AUTO_COMPLEX_MODEL_ID, false)],
+        })
+      ).toBe("model_tier");
+      expect(
+        getTierLockReason("fast", {
+          ...UNGATED,
+          streamModels: [streamModel(AUTO_FAST_MODEL_ID, true)],
+        })
+      ).toBeNull();
+    });
+
+    it("locks the Premium tier on a legacy plan whatever the cap", () => {
+      expect(
+        getTierLockReason("complex", {
+          ...GATED,
+          streamModels: [streamModel(AUTO_COMPLEX_MODEL_ID, true)],
+        })
+      ).toBe("premium");
+    });
+
+    it("does not lock a tier whose stream is absent from the payload", () => {
+      expect(
+        getTierLockReason("standard", { ...UNGATED, streamModels: [] })
+      ).toBeNull();
     });
   });
 

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -123,6 +123,15 @@ export function getTierLockReason(
 
   return null;
 }
+export function getDefaultTierId(
+  streamModels: EnabledModelConfigurationType[]
+): ModelTierId {
+  const standard = streamModels.find(
+    (model) => model.modelId === AUTO_MODEL_ID
+  );
+
+  return standard && !standard.isSelectable ? "fast" : "standard";
+}
 
 // Per reasoning-effort blurbs surfaced in the effort slider tooltip.
 const REASONING_EFFORT_INFO: Record<ReasoningEffort, string> = {
@@ -470,14 +479,14 @@ function resolveAgentDefault({
   models,
 }: {
   agentModel: AgentModelConfigurationType | null;
-  models: ModelConfigurationType[];
+  models: EnabledModelConfigurationType[];
 }): Selection {
-  const standardDefault: Selection = {
-    display: { kind: "tier", tierId: "standard" },
+  const tierDefault: Selection = {
+    display: { kind: "tier", tierId: getDefaultTierId(models) },
     toSend: undefined,
   };
   if (!agentModel) {
-    return standardDefault;
+    return tierDefault;
   }
   if (isModelStreamId(agentModel.modelId)) {
     return {
@@ -490,7 +499,7 @@ function resolveAgentDefault({
   }
   const model = findAgentModel(models, agentModel);
   if (!model) {
-    return standardDefault;
+    return tierDefault;
   }
 
   // Keep `toSend` undefined so the agent runs its own configured model/effort
@@ -514,7 +523,7 @@ export function resolveShownSelection({
   agentModel: AgentModelConfigurationType | null;
   lastRequestedModel: ModelSelectionType | null;
   sessionSticky?: ModelSelectionType | null;
-  models: ModelConfigurationType[];
+  models: EnabledModelConfigurationType[];
 }): { shown: Selection; agentDefault: Selection } {
   const agentDefault = resolveAgentDefault({ agentModel, models });
   const shown =

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -4,6 +4,10 @@ import {
   STATIC_MODEL_TIERS,
 } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import type {
+  EnabledModelConfigurationType,
+  ModelStreamResolutionsType,
+} from "@app/types/api/assistant/models";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
 import {
@@ -38,38 +42,34 @@ const MODEL_TIER_LOCKED_TOOLTIP =
   "Contact your administrator to get access.";
 
 // The three primary picks of the model picker. Each tier is backed by a
-// meta-model that is resolved to a concrete model at message-send time:
-//   - Fast     -> auto_fast (curated pool of small, cheap models)
-//   - Standard -> auto       (Dust picks any available model — the old "Auto")
-//   - Complex  -> auto_complex  (curated pool of powerful models)
+// meta-model that is resolved to a concrete model at message-send time. Tier ids
+// keep the meta-model wording; `name` is what users see:
+//   - "Basic"     -> auto_fast (curated pool of small, cheap models)
+//   - "Standard"  -> auto       (Dust picks any available model — the old "Auto")
+//   - "Premium"   -> auto_complex  (curated pool of powerful models)
 export type ModelTierId = "fast" | "standard" | "complex";
 
 interface ModelTierDefinition {
   id: ModelTierId;
   metaModelId: ModelStreamIdType;
   name: string;
-  // Short right-aligned blurb shown next to the tier name.
-  description: string;
 }
 
 export const MODEL_TIERS: ModelTierDefinition[] = [
   {
     id: "fast",
     metaModelId: AUTO_FAST_MODEL_ID,
-    name: "Fast",
-    description: "Quick, low cost",
+    name: "Basic",
   },
   {
     id: "standard",
     metaModelId: AUTO_MODEL_ID,
     name: "Standard",
-    description: "Best for most",
   },
   {
     id: "complex",
     metaModelId: AUTO_COMPLEX_MODEL_ID,
-    name: "Complex",
-    description: "Slower, most capable",
+    name: "Premium",
   },
 ];
 
@@ -92,11 +92,36 @@ export function getModelTier(tierId: ModelTierId): ModelTierDefinition {
 
 const PREMIUM_MODEL_TIER_IDS: ModelTierId[] = ["complex"];
 
-export function isTierLocked(
+// A tier row is locked either because the workspace is on a legacy plan without
+// premium access, or because the stream's own model tier is above the member's
+// cap — the server refuses such a selection, so the picker must not offer it.
+export function getTierLockReason(
   tierId: ModelTierId,
-  { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
-): boolean {
-  return lockPremiumEfforts && PREMIUM_MODEL_TIER_IDS.includes(tierId);
+  {
+    lockPremiumEfforts,
+    streamModels,
+  }: {
+    lockPremiumEfforts: boolean;
+    streamModels: EnabledModelConfigurationType[];
+  }
+): ModelLockReason | null {
+  if (lockPremiumEfforts && PREMIUM_MODEL_TIER_IDS.includes(tierId)) {
+    return "premium";
+  }
+
+  const { metaModelId } = getModelTier(tierId);
+  const streamModel = streamModels.find(
+    (model) => model.modelId === metaModelId
+  );
+  // Absent means we can't tell yet: the tier rows render before the models
+  // payload lands (`useModels` returns an empty list while it is in flight), so
+  // locking on absence would flash every row locked on each open. Default to
+  // unlocked — the server refuses an out-of-tier stream at send time anyway.
+  if (streamModel && !streamModel.isSelectable) {
+    return "model_tier";
+  }
+
+  return null;
 }
 
 // Per reasoning-effort blurbs surfaced in the effort slider tooltip.
@@ -109,6 +134,19 @@ const REASONING_EFFORT_INFO: Record<ReasoningEffort, string> = {
 
 export function getReasoningEffortLabel(effort: ReasoningEffort): string {
   return effort === "none" ? "None" : capitalize(effort);
+}
+
+export function getTierResolvedModelLabel(
+  tierId: ModelTierId,
+  streams: ModelStreamResolutionsType | null
+): string | undefined {
+  const resolution = streams?.[getModelTier(tierId).metaModelId];
+  if (!resolution) {
+    return undefined;
+  }
+  return resolution.reasoningEffort === "none"
+    ? resolution.displayName
+    : `${resolution.displayName} ${getReasoningEffortLabel(resolution.reasoningEffort)}`;
 }
 
 // What the picker is currently showing, decoupled from the payload we send:

--- a/front/components/providers/model_configs.ts
+++ b/front/components/providers/model_configs.ts
@@ -6,7 +6,11 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
-import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
+import {
+  AUTO_COMPLEX_MODEL_CONFIG,
+  AUTO_FAST_MODEL_CONFIG,
+  AUTO_MODEL_CONFIG,
+} from "@app/types/assistant/models/auto";
 import {
   FIREWORKS_DEEPSEEK_V4_FLASH_0731_MODEL_CONFIG,
   FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG,
@@ -68,5 +72,7 @@ export const USED_MODEL_CONFIGS: readonly ModelConfig[] = [
   FIREWORKS_GLM_5P2_MODEL_CONFIG,
   GROK_4_6_MODEL_CONFIG,
   GROK_4_5_MODEL_CONFIG,
+  AUTO_FAST_MODEL_CONFIG,
   AUTO_MODEL_CONFIG,
+  AUTO_COMPLEX_MODEL_CONFIG,
 ] as const;

--- a/front/components/workspace/ModelTiersInfoModal.tsx
+++ b/front/components/workspace/ModelTiersInfoModal.tsx
@@ -113,8 +113,8 @@ function ModelTiersInfoDialog({ isOpen, onClose }: ModelTiersInfoDialogProps) {
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             Each tier groups <b>model + reasoning-effort</b> options based on
             cost. A member capped at a tier can use that tier and every cheaper
-            one — “Up to Balanced” means Balanced and Cost Efficient. Open a
-            tier to see what's inside.
+            one — “Up to Standard” means Standard and Basic. Open a tier to see
+            what's inside.
           </p>
           <div className="flex flex-col gap-2">
             {tiers.map((tier) => (

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -3,7 +3,6 @@ import type {
   UsageFilterAgentScope,
   UsageFilterCategory,
   UsageFilterGroup,
-  UsageModelTier,
 } from "@app/components/workspace/analytics/usageFilter";
 import {
   toConsumptionScopeFilter,
@@ -23,6 +22,7 @@ import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilt
 import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import { useGroups } from "@app/lib/swr/groups";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -37,7 +37,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
-const DEFAULT_MODEL_TIER: UsageModelTier = "standard";
+const DEFAULT_MODEL_TIER: ModelsTierName = "balanced";
 
 interface UsageFilterPanelProps {
   owner: LightWorkspaceType;
@@ -68,7 +68,7 @@ export function UsageFilterPanel({
     useState<UsageFilterCategory>("agent");
   const [activeScope, setActiveScope] = useState<UsageFilterAgentScope>("all");
   const [activeTier, setActiveTier] =
-    useState<UsageModelTier>(DEFAULT_MODEL_TIER);
+    useState<ModelsTierName>(DEFAULT_MODEL_TIER);
   const [searchText, setSearchText] = useState("");
   const selectedGroups = useToggleSelectionList<UsageFilterGroup>();
 

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -9,10 +9,7 @@ import { AGENT_CONFIGURATION_SCOPES } from "@app/types/assistant/agent";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import type { ConnectorProvider } from "@app/types/data_source";
 import { isConnectorProvider } from "@app/types/data_source";
-import {
-  assertNever,
-  assertNeverAndIgnore,
-} from "@app/types/shared/utils/assert_never";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const USAGE_FILTER_CATEGORIES = [
   "agent",
@@ -64,16 +61,6 @@ export const USAGE_FILTER_SCOPE_LABEL: Record<UsageFilterAgentScope, string> = {
   all: "All",
 };
 
-export const USAGE_MODEL_TIERS = ["fast", "standard", "complex"] as const;
-
-export type UsageModelTier = (typeof USAGE_MODEL_TIERS)[number];
-
-export const USAGE_MODEL_TIER_LABEL: Record<UsageModelTier, string> = {
-  fast: "Fast",
-  standard: "Standard",
-  complex: "Complex",
-};
-
 interface UsageFilterOptionBase {
   id: string;
   name: string;
@@ -105,9 +92,9 @@ export interface UsageFilterModelOption extends UsageFilterOptionBase {
   kind: "model";
   lab?: ModelMakerIdType;
   // Undefined for a model outside the static tier table — it doesn't match
-  // any Fast/Standard/Complex quick filter, so it's absent from the main
+  // any Basic/Standard/Premium quick filter, so it's absent from the main
   // checklist but still reachable through the "More models" browse dropdown.
-  tier: UsageModelTier | undefined;
+  tier: ModelsTierName | undefined;
 }
 
 export interface UsageFilterToolOption extends UsageFilterOptionBase {
@@ -328,28 +315,4 @@ export function toConsumptionScopeFilter(
   }
 
   return scopeFilter;
-}
-
-// Maps the backend's reasoning-effort-aware pricing tier onto the filter
-// panel's simpler Fast/Standard/Complex bucket. Null propagates (a model
-// outside the static tier table, or a raw catalog entry with no config match)
-// as "no bucket", so it's excluded from every quick-filter tier rather than
-// landing in one arbitrarily.
-export function usageModelTierFromModelsTierName(
-  tier: ModelsTierName | null | undefined
-): UsageModelTier | undefined {
-  if (tier === null || tier === undefined) {
-    return undefined;
-  }
-  switch (tier) {
-    case "cost_efficient":
-      return "fast";
-    case "balanced":
-      return "standard";
-    case "premium":
-      return "complex";
-    default:
-      assertNeverAndIgnore(tier);
-      return undefined;
-  }
 }

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -1,14 +1,12 @@
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import type {
-  UsageFilterModelOption,
-  UsageModelTier,
-} from "@app/components/workspace/analytics/usageFilter";
-import {
-  USAGE_MODEL_TIER_LABEL,
-  USAGE_MODEL_TIERS,
-} from "@app/components/workspace/analytics/usageFilter";
+import type { UsageFilterModelOption } from "@app/components/workspace/analytics/usageFilter";
 import { UsageFilterAvailabilityStatus } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterAvailabilityStatus";
+import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import {
+  getModelsTierDisplayName,
+  MODELS_TIER_NAMES,
+} from "@app/lib/api/assistant/token_pricing/tiers";
 import {
   getModelMakerDisplayName,
   MODEL_MAKER_IDS,
@@ -33,18 +31,18 @@ import {
 import type { ComponentType } from "react";
 import { Fragment, useState } from "react";
 
-const MODEL_TIER_ICON: Record<UsageModelTier, ComponentType> = {
-  fast: BarLow,
-  standard: BarHalf,
-  complex: BarFull,
+const MODEL_TIER_ICON: Record<ModelsTierName, ComponentType> = {
+  cost_efficient: BarLow,
+  balanced: BarHalf,
+  premium: BarFull,
 };
 
 interface UsageFilterModelComplexityControlsProps {
   moreModelsCatalog: UsageFilterModelOption[];
   selectedModelIds: Set<string>;
   onToggleModel: (model: UsageFilterModelOption) => void;
-  activeTier: UsageModelTier;
-  onTierChange: (tier: UsageModelTier) => void;
+  activeTier: ModelsTierName;
+  onTierChange: (tier: ModelsTierName) => void;
 }
 
 function getModelSelectionStatus({
@@ -217,11 +215,15 @@ export function UsageFilterModelComplexityControls({
           </DropdownMenu>
         }
       />
+      <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+        Price tier of all the models actually billed — not only the Basic /
+        Standard / Premium options offered in the model picker.
+      </p>
       <div className="flex items-center gap-1">
-        {USAGE_MODEL_TIERS.map((tier) => (
+        {MODELS_TIER_NAMES.map((tier) => (
           <Button
             key={tier}
-            label={USAGE_MODEL_TIER_LABEL[tier]}
+            label={getModelsTierDisplayName(tier)}
             icon={MODEL_TIER_ICON[tier]}
             size="xs"
             variant={activeTier === tier ? "primary" : "outline"}

--- a/front/hooks/useConsumptionFacets.ts
+++ b/front/hooks/useConsumptionFacets.ts
@@ -9,7 +9,6 @@ import type {
   UsageFilterSourceOption,
   UsageFilterToolOption,
 } from "@app/components/workspace/analytics/usageFilter";
-import { usageModelTierFromModelsTierName } from "@app/components/workspace/analytics/usageFilter";
 import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { normalizedConsumptionFilter } from "@app/lib/analytics/consumption_period";
@@ -69,7 +68,7 @@ function toFacetOptions(
       ...baseOption(facet),
       kind: "model",
       lab: facet.maker,
-      tier: usageModelTierFromModelsTierName(facet.tier),
+      tier: facet.tier ?? undefined,
     })),
     tool: data.facets.tool.map<UsageFilterToolOption>((facet) => ({
       ...baseOption(facet),

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -48,7 +48,6 @@ import {
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
-import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import {
   FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG,
@@ -87,8 +86,9 @@ interface DustLikeGlobalAgentArgs {
   // Workspace feature flags, forwarded to model selection so it runs the exact
   // same model availability check that is enforced when a message is posted.
   featureFlags: WhitelistableFeature[];
-  // When set, the @dust agent defaults to the Auto (Standard) meta-model. This
-  preferAutoDefaultModel?: boolean;
+  // When set, the @dust agent defaults to this stream meta-model (the highest
+  // one the member's model-tier cap allows) instead of Claude Sonnet 4.6.
+  autoDefaultModelConfig?: ModelConfigurationType | null;
   // When set, the @dust agent defaults to GPT 5.6 Luna (high reasoning) instead
   // of Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_6_luna_default` flag.
   preferGpt56LunaDefaultModel?: boolean;
@@ -479,8 +479,8 @@ export function _getDustGlobalAgent(
     CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
   let preferredReasoningEffort: ReasoningEffort = "medium";
 
-  if (args.preferAutoDefaultModel) {
-    preferredModelConfiguration = AUTO_MODEL_CONFIG;
+  if (args.autoDefaultModelConfig) {
+    preferredModelConfiguration = args.autoDefaultModelConfig;
     preferredReasoningEffort = "none";
   } else if (args.preferSonnet5DefaultModel) {
     preferredModelConfiguration = CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG;

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -1,13 +1,20 @@
 import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
 import { Authenticator } from "@app/lib/auth";
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import {
   CLAUDE_OPUS_5_MODEL_ID,
   CLAUDE_SONNET_5_MODEL_ID,
 } from "@app/types/assistant/models/anthropic";
+import {
+  AUTO_FAST_MODEL_ID,
+  AUTO_MODEL_ID,
+} from "@app/types/assistant/models/auto";
 import { GEMINI_3_1_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import {
   GPT_5_6_LUNA_MODEL_ID,
@@ -503,5 +510,40 @@ describe("getGlobalAgents Deep Dive model routing", () => {
       modelId: GEMINI_3_1_PRO_MODEL_ID,
       reasoningEffort: "light",
     });
+  });
+});
+
+// @dust is not editable by members, so a Basic-capped member defaulted to the
+// Standard stream would get an agent that only ever fails the tier check.
+describe("getGlobalAgents Dust Auto default", () => {
+  it.each([
+    ["premium", AUTO_MODEL_ID],
+    ["cost_efficient", AUTO_FAST_MODEL_ID],
+  ] as const)("defaults @dust to %s member's highest allowed stream", async (tierName, expectedModelId) => {
+    const workspace = await WorkspaceFactory.basic();
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "user" });
+    await ModelsTierResource.setUserMaxAllowedTier(adminAuth, {
+      userId: user.sId,
+      tierName,
+    });
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agents = await getGlobalAgents(
+      auth,
+      [GLOBAL_AGENTS_SID.DUST],
+      "light"
+    );
+
+    expect(agents).toHaveLength(1);
+    expect(agents[0].model).toMatchObject({ modelId: expectedModelId });
   });
 });

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -117,6 +117,7 @@ import {
 import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
+import { getDefaultStreamConfigForAuth } from "@app/lib/model_tiers/enabled_models";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import type {
@@ -130,7 +131,10 @@ import {
   isGlobalAgentId,
 } from "@app/types/assistant/assistant";
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
-import type { ModelProviderIdType } from "@app/types/assistant/models/types";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+} from "@app/types/assistant/models/types";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import { isWorkspaceAnalyticsEnabled } from "@app/types/user";
@@ -146,7 +150,7 @@ function getGlobalAgent({
   hasSandbox,
   globalAgentContext,
   excludeProviders,
-  preferAutoDefaultModel,
+  autoDefaultModelConfig,
   preferGpt56LunaDefaultModel,
   preferSonnet5DefaultModel,
   featureFlags,
@@ -161,7 +165,7 @@ function getGlobalAgent({
   hasSandbox: boolean;
   globalAgentContext?: GlobalAgentContext;
   excludeProviders: ReadonlySet<ModelProviderIdType>;
-  preferAutoDefaultModel: boolean;
+  autoDefaultModelConfig: ModelConfigurationType | null;
   preferGpt56LunaDefaultModel: boolean;
   preferSonnet5DefaultModel: boolean;
   featureFlags: WhitelistableFeature[];
@@ -383,7 +387,7 @@ function getGlobalAgent({
         featureFlags,
         globalAgentContext,
         excludeProviders,
-        preferAutoDefaultModel,
+        autoDefaultModelConfig,
         preferGpt56LunaDefaultModel,
         preferSonnet5DefaultModel,
       });
@@ -1200,6 +1204,10 @@ export async function getGlobalAgents(
       ? await buildSidekickContext(auth, agentsIdsToFetch)
       : null;
 
+  const autoDefaultModelConfig = flags.includes("models_picker")
+    ? await getDefaultStreamConfigForAuth(auth)
+    : null;
+
   // For now we retrieve them all
   // We will store them in the database later to allow admin enable them or not
   const agentCandidates = agentsIdsToFetch.map((sId) =>
@@ -1214,7 +1222,7 @@ export async function getGlobalAgents(
       hasSandbox: isComputerFeatureEnabled(flags),
       globalAgentContext: options?.globalAgentContext,
       excludeProviders,
-      preferAutoDefaultModel: flags.includes("models_picker"),
+      autoDefaultModelConfig,
       preferGpt56LunaDefaultModel: flags.includes(
         "dust_agent_gpt_5_6_luna_default"
       ),

--- a/front/lib/api/assistant/models.test.ts
+++ b/front/lib/api/assistant/models.test.ts
@@ -274,7 +274,7 @@ describe("resolveModel", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await FeatureFlagFactory.basic(auth, "models_picker");
 
-    const getModelForStreamSpy = vi.spyOn(enabledModels, "getModelForStream");
+    const resolveStreamModelSpy = vi.spyOn(enabledModels, "resolveStreamModel");
 
     const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       configuration: makeAgentConfiguration({
@@ -285,9 +285,12 @@ describe("resolveModel", () => {
     });
 
     // `auto` is a stream like `auto_fast` / `auto_complex`: it routes through
-    // getModelForStream and resolves to its first available candidate, which
+    // resolveStreamModel and resolves to its first available candidate, which
     // is Luna at `high` reasoning.
-    expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
+    expect(resolveStreamModelSpy).toHaveBeenCalledWith(
+      expect.any(Array),
+      AUTO_MODEL_ID
+    );
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({
@@ -302,7 +305,7 @@ describe("resolveModel", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await FeatureFlagFactory.basic(auth, "models_picker");
 
-    const getModelForStreamSpy = vi.spyOn(enabledModels, "getModelForStream");
+    const resolveStreamModelSpy = vi.spyOn(enabledModels, "resolveStreamModel");
 
     const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       selection: {
@@ -316,7 +319,10 @@ describe("resolveModel", () => {
       featureFlags: ["models_picker"],
     });
 
-    expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
+    expect(resolveStreamModelSpy).toHaveBeenCalledWith(
+      expect.any(Array),
+      AUTO_MODEL_ID
+    );
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({
@@ -330,7 +336,7 @@ describe("resolveModel", () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-    const getModelForStreamSpy = vi.spyOn(enabledModels, "getModelForStream");
+    const resolveStreamModelSpy = vi.spyOn(enabledModels, "resolveStreamModel");
 
     const { resolvedModel, modelResolutionMethod } = await resolveModel(auth, {
       configuration: makeAgentConfiguration({
@@ -340,7 +346,10 @@ describe("resolveModel", () => {
       featureFlags: [],
     });
 
-    expect(getModelForStreamSpy).toHaveBeenCalledWith(auth, AUTO_MODEL_ID);
+    expect(resolveStreamModelSpy).toHaveBeenCalledWith(
+      expect.any(Array),
+      AUTO_MODEL_ID
+    );
     expect(modelResolutionMethod).toBe("auto");
     expect(resolvedModel.modelId).not.toBe(AUTO_MODEL_ID);
     expect(resolvedModel).toEqual({

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -2,8 +2,8 @@ import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_pref
 import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  getAutoModelForAuth,
-  getModelForStream,
+  getEnabledModelsForAuth,
+  resolveStreamModel,
 } from "@app/lib/model_tiers/enabled_models";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -84,7 +84,7 @@ export async function resolveModel(
           }
         );
 
-  // Effort chosen by a stream tier (Fast/Standard/Complex) for its resolved
+  // Effort chosen by a stream tier (Basic/Standard/Premium) for its resolved
   // model. When set, it takes precedence over any effort carried by the
   // (sentinel) selection.
   let streamEffort: ReasoningEffort | undefined;
@@ -93,23 +93,18 @@ export async function resolveModel(
   // ordered candidate pool and pick the first one available to the workspace.
   if (enabled && isModelStreamId(enabled.modelId)) {
     const streamId = enabled.modelId;
-    const resolved = await getModelForStream(auth, streamId);
-    if (resolved) {
-      enabled = resolved.model;
-      streamEffort = resolved.reasoningEffort;
-    } else {
-      // None of the stream's candidates are available: fall back to a preferred
-      // large model supported by the workspace.
-      // FIXME(review): getAutoModelForAuth re-runs getEnabledModelsForAuth even
-      // though getModelForStream just fetched the same list — consider threading
-      // the already-fetched available models through to avoid the double query.
-      enabled = await getAutoModelForAuth(auth);
+    const models = await getEnabledModelsForAuth(auth);
+    const resolution = resolveStreamModel(models, streamId);
+    enabled = resolution.model;
+
+    if (resolution.fromPool) {
+      streamEffort = resolution.reasoningEffort;
+      modelResolutionMethod = streamId;
     }
-    // FIXME(review): on the fallback branch above the model did NOT come from the
-    // stream, yet we still record modelResolutionMethod as the streamId. This
-    // mislabels analytics/telemetry (a plain fallback pick attributed to e.g.
-    // "auto_complex").
-    modelResolutionMethod = streamId;
+    // Otherwise none of the stream's candidates were available and `enabled`
+    // comes from the generic preferred-large-model fallback, not from the
+    // stream: keep the original "user"/"agent" attribution so analytics don't
+    // credit the pick to e.g. "auto_complex", and honor the requested effort.
   }
 
   // Should never happen as we should at least fallback to our selection of PREFERRED_LARGE_MODEL_CONFIGS.

--- a/front/lib/api/assistant/token_pricing/tiers.test.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.test.ts
@@ -73,13 +73,13 @@ describe("token_pricing/tiers", () => {
     ).toBe("premium");
   });
 
-  it("classifies Grok 4.6 medium and high reasoning as premium", () => {
+  it("classifies Grok 4.6 high reasoning as premium", () => {
     expect(ModelsTierResource.getTierForModel(GROK_4_6_MODEL_ID, "light")).toBe(
       "balanced"
     );
     expect(
       ModelsTierResource.getTierForModel(GROK_4_6_MODEL_ID, "medium")
-    ).toBe("premium");
+    ).toBe("balanced");
     expect(ModelsTierResource.getTierForModel(GROK_4_6_MODEL_ID, "high")).toBe(
       "premium"
     );

--- a/front/lib/api/assistant/token_pricing/tiers.ts
+++ b/front/lib/api/assistant/token_pricing/tiers.ts
@@ -19,6 +19,19 @@ export function isModelsTierName(value: unknown): value is ModelsTierName {
   return MODELS_TIER_NAMES.includes(value as ModelsTierName);
 }
 
+// Single source of truth for how tiers are named to users. The same three words
+// name the model-picker streams (`auto_fast`/`auto`/`auto_complex`) and the
+// analytics usage filter, so a tier means the same thing everywhere.
+const MODELS_TIER_DISPLAY_NAMES: Record<ModelsTierName, string> = {
+  cost_efficient: "Basic",
+  balanced: "Standard",
+  premium: "Premium",
+};
+
+export function getModelsTierDisplayName(tierName: ModelsTierName): string {
+  return MODELS_TIER_DISPLAY_NAMES[tierName];
+}
+
 export type ModelTierSelection = {
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
@@ -36,7 +49,7 @@ export const MODELS_TIERS: readonly ModelsTierDefinition[] = [
     id: 1,
     name: "cost_efficient",
     description:
-      "Cost efficient models sacrificing on performance to cut on price while remaining acceptable to use Dust with.",
+      "Basic, cost efficient models sacrificing on performance to cut on price while remaining acceptable to use Dust with.",
   },
   {
     id: 2,
@@ -332,7 +345,7 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
     high: "premium",
   },
   "gemini-3.6-flash": {
-    light: "balanced",
+    light: "cost_efficient",
     medium: "balanced",
     high: "premium",
   },
@@ -397,7 +410,7 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   },
   "grok-4.6": {
     light: "balanced",
-    medium: "premium",
+    medium: "balanced",
     high: "premium",
   },
   "grok-4-latest": {
@@ -421,13 +434,17 @@ export const STATIC_MODEL_TIERS: StaticModelTiersLookup = {
   noop: {
     none: "balanced",
   },
+  // Streams are meta-models: they never bill at their own tier, they resolve to
+  // a concrete candidate at message-send time. They are tiered as the tier they
+  // are named after, so a member capped below a stream cannot pick it at all —
+  // rather than picking it and silently getting a cheaper model.
   auto: {
     none: "balanced",
   },
   auto_fast: {
-    none: "balanced",
+    none: "cost_efficient",
   },
   auto_complex: {
-    none: "balanced",
+    none: "premium",
   },
 } satisfies StaticModelTiersMap;

--- a/front/lib/client/model_tiers.ts
+++ b/front/lib/client/model_tiers.ts
@@ -1,8 +1,8 @@
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import { getModelsTierDisplayName } from "@app/lib/api/assistant/token_pricing/tiers";
 import { resolveAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
 import { expandTiersUpTo } from "@app/lib/model_tiers/tier_order";
 import type { ModelsTierDefinition } from "@app/lib/resources/models_tier_resource";
-import { formatAsDisplayName } from "@app/types/shared/utils/string_utils";
 
 type ResolvedModelTiersForUser = ReturnType<typeof resolveAllowedModelTiers>;
 
@@ -51,7 +51,7 @@ export function formatModelTiersSummary(
     return "--";
   }
 
-  return `Up to ${formatAsDisplayName(maxTierName)}`;
+  return `Up to ${getModelsTierDisplayName(maxTierName)}`;
 }
 
 export function formatUserModelTierInheritLabel({

--- a/front/lib/client/model_tiers_explainer.ts
+++ b/front/lib/client/model_tiers_explainer.ts
@@ -6,6 +6,7 @@ import {
   STATIC_MODEL_TIERS,
 } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getTierIndex } from "@app/lib/model_tiers/tier_order";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { isStaticModelId } from "@app/types/assistant/models/models";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
@@ -46,6 +47,7 @@ export function getModelTierExplainer(): ModelTierExplainerTier[] {
     for (const config of USED_MODEL_CONFIGS) {
       if (
         HIDDEN_PROVIDER_IDS.has(config.providerId) ||
+        isModelStreamId(config.modelId) ||
         !isStaticModelId(config.modelId)
       ) {
         continue;

--- a/front/lib/client/model_tiers_explainer.ts
+++ b/front/lib/client/model_tiers_explainer.ts
@@ -1,6 +1,7 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import {
+  getModelsTierDisplayName,
   MODELS_TIERS,
   STATIC_MODEL_TIERS,
 } from "@app/lib/api/assistant/token_pricing/tiers";
@@ -8,7 +9,6 @@ import { getTierIndex } from "@app/lib/model_tiers/tier_order";
 import { isStaticModelId } from "@app/types/assistant/models/models";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";
-import { formatAsDisplayName } from "@app/types/shared/utils/string_utils";
 
 export interface ModelTierExplainerEntry {
   displayName: string;
@@ -70,7 +70,7 @@ export function getModelTierExplainer(): ModelTierExplainerTier[] {
 
     return {
       name: tier.name,
-      displayName: formatAsDisplayName(tier.name),
+      displayName: getModelsTierDisplayName(tier.name),
       description: tier.description,
       priceLevel: getTierIndex(tier.name) + 1,
       models,

--- a/front/lib/model_tiers/access.test.ts
+++ b/front/lib/model_tiers/access.test.ts
@@ -5,7 +5,10 @@ import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG } from "@app/types/assistant/models/anthropic";
+import {
+  CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
+  CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
+} from "@app/types/assistant/models/anthropic";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("getModelTierAccessErrorForAgentConfiguration", () => {
@@ -96,5 +99,26 @@ describe("getModelTierAccessErrorForAgentConfiguration", () => {
     });
 
     expect(error).toBeNull();
+  });
+
+  // A stream only ever resolves to a candidate within the member's cap, so
+  // checking the resolved model alone would let a member run a stream above it.
+  it.each([
+    ["auto_complex", "model_tier_not_enabled"],
+    ["auto", null],
+    ["auto_fast", null],
+  ] as const)("tier-checks the %s stream itself, not the model it resolved to", async (modelResolutionMethod, expectedCode) => {
+    const auth = await restrictedUserAuth();
+
+    const error = await getModelTierAccessErrorForAgentConfiguration(auth, {
+      agentName: "test-agent",
+      // Haiku 4.5 is cost_efficient at every effort: a plausible candidate for
+      // any stream, and always within a `balanced` member's cap.
+      model: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
+      featureFlags: ["models_picker"],
+      modelResolutionMethod,
+    });
+
+    expect(error?.code ?? null).toBe(expectedCode);
   });
 });

--- a/front/lib/model_tiers/access.ts
+++ b/front/lib/model_tiers/access.ts
@@ -4,8 +4,10 @@ import type {
   AgentConfigurationScope,
   GenericErrorContent,
 } from "@app/types/assistant/agent";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import type {
   ModelConfigurationType,
+  ModelResolutionMethodType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
@@ -37,12 +39,14 @@ export async function getModelTierAccessErrorForAgentConfiguration(
     reasoningEffort,
     featureFlags,
     agentScope,
+    modelResolutionMethod,
   }: {
     agentName: string;
     model: ModelConfigurationType;
     reasoningEffort?: ReasoningEffort;
     featureFlags: WhitelistableFeature[];
     agentScope?: AgentConfigurationScope;
+    modelResolutionMethod?: ModelResolutionMethodType | null;
   }
 ): Promise<GenericErrorContent | null> {
   if (!featureFlags.includes("models_picker")) {
@@ -58,13 +62,18 @@ export async function getModelTierAccessErrorForAgentConfiguration(
     return null;
   }
 
-  const effectiveReasoningEffort =
-    reasoningEffort ??
-    getMinimumReasoningEffort(model.supportedReasoningEfforts);
-  const tierName = ModelsTierResource.getTierForModel(
-    model.modelId,
-    effectiveReasoningEffort
-  );
+  // A stream only ever resolves to a candidate within the member's cap, so the
+  // resolved model can never reveal that the member was not allowed to run the
+  // stream in the first place. Tier-check the stream itself instead: it is
+  // tiered as the tier it is named after, at its only effort (`none`).
+  const tierName =
+    modelResolutionMethod && isModelStreamId(modelResolutionMethod)
+      ? ModelsTierResource.getTierForModel(modelResolutionMethod, "none")
+      : ModelsTierResource.getTierForModel(
+          model.modelId,
+          reasoningEffort ??
+            getMinimumReasoningEffort(model.supportedReasoningEfforts)
+        );
 
   if (!tierName) {
     return null;

--- a/front/lib/model_tiers/enabled_models.test.ts
+++ b/front/lib/model_tiers/enabled_models.test.ts
@@ -1,6 +1,8 @@
 import { Authenticator } from "@app/lib/auth";
 import {
-  getModelForStream,
+  getDefaultModelFromEnabledModels,
+  getEnabledModelsForAuth,
+  resolveStreamModel,
   withModelSelectability,
 } from "@app/lib/model_tiers/enabled_models";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
@@ -13,7 +15,13 @@ import {
   CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG,
   CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
 } from "@app/types/assistant/models/anthropic";
-import { MODEL_STREAMS } from "@app/types/assistant/models/auto";
+import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
+import {
+  AUTO_COMPLEX_MODEL_CONFIG,
+  AUTO_FAST_MODEL_CONFIG,
+  AUTO_MODEL_CONFIG,
+  MODEL_STREAMS,
+} from "@app/types/assistant/models/auto";
 import { GPT_5_6_LUNA_MODEL_ID } from "@app/types/assistant/models/openai";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -142,6 +150,45 @@ describe("withModelSelectability", () => {
     });
   });
 
+  it("gates each stream on the tier it is named after", async () => {
+    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+    const auth = await userAuthForTierCap("balanced");
+
+    const models = await withModelSelectability(auth, {
+      models: [
+        AUTO_FAST_MODEL_CONFIG,
+        AUTO_MODEL_CONFIG,
+        AUTO_COMPLEX_MODEL_CONFIG,
+      ],
+    });
+
+    // Under a balanced cap the Basic and Standard streams stay selectable, but
+    // the Premium stream is out of reach.
+    expect(models.map((m) => [m.modelId, m.isSelectable])).toEqual([
+      [AUTO_FAST_MODEL_CONFIG.modelId, true],
+      [AUTO_MODEL_CONFIG.modelId, true],
+      [AUTO_COMPLEX_MODEL_CONFIG.modelId, false],
+    ]);
+  });
+
+  it("defaults a Basic-capped member to the Basic stream", async () => {
+    await FeatureFlagFactory.basic(adminAuth, "models_picker");
+    const auth = await userAuthForTierCap("cost_efficient");
+
+    const models = await withModelSelectability(auth, {
+      models: [
+        CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG,
+        AUTO_FAST_MODEL_CONFIG,
+        AUTO_MODEL_CONFIG,
+        AUTO_COMPLEX_MODEL_CONFIG,
+      ],
+    });
+
+    expect(getDefaultModelFromEnabledModels(models).modelId).toBe(
+      AUTO_FAST_MODEL_CONFIG.modelId
+    );
+  });
+
   it("keeps custom (non-tiered) models selectable when models_picker is enabled and the user is tier-capped", async () => {
     await FeatureFlagFactory.basic(adminAuth, "models_picker");
     const auth = await userAuthForTierCap("cost_efficient");
@@ -156,7 +203,7 @@ describe("withModelSelectability", () => {
   });
 });
 
-describe("getModelForStream", () => {
+describe("resolveStreamModel", () => {
   let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
   let adminAuth: Authenticator;
 
@@ -177,58 +224,78 @@ describe("getModelForStream", () => {
     return Authenticator.fromUserIdAndWorkspaceId(user.sId, workspace.sId);
   }
 
+  async function resolveStreamForAuth(
+    auth: Authenticator,
+    streamId: ModelStreamIdType
+  ) {
+    const models = await getEnabledModelsForAuth(auth);
+    return resolveStreamModel(models, streamId);
+  }
+
   it("routes the Auto stream to its first available candidate + effort", async () => {
-    const resolved = await getModelForStream(adminAuth, "auto");
+    const resolved = await resolveStreamForAuth(adminAuth, "auto");
 
-    expect(resolved).not.toBeNull();
+    expect(resolved.fromPool).toBe(true);
     // In a full workspace every candidate is available, so the first one wins.
-    expect(resolved?.model.modelId).toBe(GPT_5_6_LUNA_MODEL_ID);
-    expect(resolved?.reasoningEffort).toBe("high");
+    expect(resolved.model.modelId).toBe(GPT_5_6_LUNA_MODEL_ID);
+    expect(resolved.reasoningEffort).toBe("high");
   });
 
-  it("routes the Fast stream to its first available candidate + effort", async () => {
-    const resolved = await getModelForStream(adminAuth, "auto_fast");
+  it("routes the Basic stream to its first available candidate + effort", async () => {
+    const resolved = await resolveStreamForAuth(adminAuth, "auto_fast");
 
-    expect(resolved).not.toBeNull();
+    expect(resolved.fromPool).toBe(true);
     // In a full workspace every candidate is available, so the first one wins.
-    expect(resolved?.model.modelId).toBe(GPT_5_6_LUNA_MODEL_ID);
-    expect(resolved?.reasoningEffort).toBe("light");
+    expect(resolved.model.modelId).toBe(GPT_5_6_LUNA_MODEL_ID);
+    expect(resolved.reasoningEffort).toBe("light");
   });
 
-  it("routes the Complex stream to its first available candidate + effort", async () => {
-    const resolved = await getModelForStream(adminAuth, "auto_complex");
+  it("routes the Premium stream to its first available candidate + effort", async () => {
+    const resolved = await resolveStreamForAuth(adminAuth, "auto_complex");
 
-    expect(resolved).not.toBeNull();
-    expect(resolved?.model.modelId).toBe(
+    expect(resolved.fromPool).toBe(true);
+    expect(resolved.model.modelId).toBe(
       CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG.modelId
     );
-    expect(resolved?.reasoningEffort).toBe("high");
+    expect(resolved.reasoningEffort).toBe("high");
   });
 
-  it("keeps a cost-effective candidate in the Complex stream for cost_efficient-capped users", async () => {
+  it("keeps a Basic-tier candidate in the Premium stream for cost_efficient-capped users", async () => {
     const auth = await userAuthForTierCap("cost_efficient");
 
     // Every premium/balanced candidate is unavailable under a cost_efficient
-    // cap, so the stream must still resolve to its cost-effective floor rather
-    // than returning null and dropping out of the Complex stream entirely.
-    const resolved = await getModelForStream(auth, "auto_complex");
+    // cap, so the stream must still resolve to its Basic-tier floor rather
+    // than falling out of the Premium stream entirely.
+    const resolved = await resolveStreamForAuth(auth, "auto_complex");
 
-    expect(resolved).not.toBeNull();
-    expect(resolved?.model.modelId).toBe(
+    expect(resolved.fromPool).toBe(true);
+    expect(resolved.model.modelId).toBe(
       CLAUDE_OPUS_5_DEFAULT_MODEL_CONFIG.modelId
     );
-    expect(resolved?.reasoningEffort).toBe("high");
+    expect(resolved.reasoningEffort).toBe("high");
   });
 
   it("only ever resolves to a candidate declared in the stream", async () => {
     for (const streamId of ["auto", "auto_fast", "auto_complex"] as const) {
-      const resolved = await getModelForStream(adminAuth, streamId);
+      const resolved = await resolveStreamForAuth(adminAuth, streamId);
       const candidate = MODEL_STREAMS[streamId].find(
         (c) =>
-          c.modelId === resolved?.model.modelId &&
-          c.reasoningEffort === resolved?.reasoningEffort
+          c.modelId === resolved.model.modelId &&
+          c.reasoningEffort === resolved.reasoningEffort
       );
       expect(candidate).toBeDefined();
     }
+  });
+
+  it("falls back to a preferred large model when no candidate is available", async () => {
+    const models = await getEnabledModelsForAuth(adminAuth);
+    const resolved = resolveStreamModel(
+      // Nothing is selectable, so no stream candidate can match.
+      models.map((m) => ({ ...m, isSelectable: false })),
+      "auto_complex"
+    );
+
+    expect(resolved.fromPool).toBe(false);
+    expect(resolved.model.isSelectable).toBe(true);
   });
 });

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -5,9 +5,18 @@ import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
-import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import type {
+  EnabledModelConfigurationType,
+  ModelStreamResolutionsType,
+  ModelStreamResolutionType,
+} from "@app/types/api/assistant/models";
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
-import { AUTO_MODEL_ID, MODEL_STREAMS } from "@app/types/assistant/models/auto";
+import {
+  AUTO_COMPLEX_MODEL_ID,
+  AUTO_FAST_MODEL_ID,
+  AUTO_MODEL_ID,
+  MODEL_STREAMS,
+} from "@app/types/assistant/models/auto";
 import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import type {
   ModelConfigurationType,
@@ -102,9 +111,15 @@ export function getDefaultModelFromEnabledModels(
   models: EnabledModelConfigurationType[]
 ): EnabledModelConfigurationType {
   const selectableModels = models.filter((m) => m.isSelectable);
-  const autoModel = selectableModels.find((m) => m.modelId === AUTO_MODEL_ID);
-  if (autoModel) {
-    return autoModel;
+
+  // Streams are tiered as the tier they are named after, so the Standard stream
+  // is out of reach for a Basic-capped member: fall back to the Basic stream
+  // before giving up on streams entirely.
+  for (const streamId of [AUTO_MODEL_ID, AUTO_FAST_MODEL_ID]) {
+    const streamModel = selectableModels.find((m) => m.modelId === streamId);
+    if (streamModel) {
+      return streamModel;
+    }
   }
 
   return {
@@ -113,31 +128,21 @@ export function getDefaultModelFromEnabledModels(
   };
 }
 
-export async function getAutoModelForAuth(
-  auth: Authenticator
-): Promise<EnabledModelConfigurationType | null> {
-  const availableModels = await getEnabledModelsForAuth(auth);
-  return {
-    ...pickPreferredLargeModel(availableModels.filter((m) => m.isSelectable)),
-  };
-}
-
-// Resolve a stream tier (Fast/Standard/Complex) to a concrete model + reasoning effort.
-// Walks the stream's ordered candidate pool and picks the first one available
-// (selectable) to the workspace that supports the requested effort. Returns null
-// when none of the stream's candidates are available — the caller falls back to
-// the auto model.
-export async function getModelForStream(
-  auth: Authenticator,
-  streamId: ModelStreamIdType
-): Promise<{
+export interface StreamResolutionType {
   model: EnabledModelConfigurationType;
   reasoningEffort: ReasoningEffort;
-} | null> {
-  const availableModels = await getEnabledModelsForAuth(auth);
+  // False = none of candidates were available, we fell back to a large model
+  fromPool: boolean;
+}
 
+// Walks a stream's ordered candidate pool and picks the first one available
+// or a fallback large model
+export function resolveStreamModel(
+  models: EnabledModelConfigurationType[],
+  streamId: ModelStreamIdType
+): StreamResolutionType {
   for (const candidate of MODEL_STREAMS[streamId]) {
-    const model = availableModels.find(
+    const model = models.find(
       (m) =>
         m.isSelectable &&
         m.providerId === candidate.providerId &&
@@ -145,20 +150,56 @@ export async function getModelForStream(
         m.supportedReasoningEfforts[candidate.reasoningEffort]
     );
     if (model) {
-      return { model, reasoningEffort: candidate.reasoningEffort };
+      return {
+        model,
+        reasoningEffort: candidate.reasoningEffort,
+        fromPool: true,
+      };
     }
   }
 
-  return null;
+  const fallback = pickPreferredLargeModel(
+    models.filter((m) => m.isSelectable)
+  );
+  return {
+    model: { ...fallback, isSelectable: true },
+    reasoningEffort: fallback.defaultReasoningEffort,
+    fromPool: false,
+  };
+}
+
+function toStreamResolution(
+  models: EnabledModelConfigurationType[],
+  streamId: ModelStreamIdType
+): ModelStreamResolutionType {
+  const { model, reasoningEffort } = resolveStreamModel(models, streamId);
+  return {
+    providerId: model.providerId,
+    modelId: model.modelId,
+    displayName: model.displayName,
+    reasoningEffort,
+  };
+}
+
+export function getStreamResolutions(
+  models: EnabledModelConfigurationType[]
+): ModelStreamResolutionsType {
+  return {
+    [AUTO_MODEL_ID]: toStreamResolution(models, AUTO_MODEL_ID),
+    [AUTO_FAST_MODEL_ID]: toStreamResolution(models, AUTO_FAST_MODEL_ID),
+    [AUTO_COMPLEX_MODEL_ID]: toStreamResolution(models, AUTO_COMPLEX_MODEL_ID),
+  };
 }
 
 export async function getModelsForAuth(auth: Authenticator): Promise<{
   models: EnabledModelConfigurationType[];
   defaultModel: EnabledModelConfigurationType;
+  streams: ModelStreamResolutionsType;
 }> {
   const models = await getEnabledModelsForAuth(auth);
   return {
     models,
     defaultModel: getDefaultModelFromEnabledModels(models),
+    streams: getStreamResolutions(models),
   };
 }

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -13,7 +13,9 @@ import type {
 import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
 import {
   AUTO_COMPLEX_MODEL_ID,
+  AUTO_FAST_MODEL_CONFIG,
   AUTO_FAST_MODEL_ID,
+  AUTO_MODEL_CONFIG,
   AUTO_MODEL_ID,
   MODEL_STREAMS,
 } from "@app/types/assistant/models/auto";
@@ -105,6 +107,16 @@ export async function getEnabledModelsForAuth(
 ): Promise<EnabledModelConfigurationType[]> {
   const availableModels = await getAvailableModelsForWorkspace(auth);
   return withModelSelectability(auth, { models: availableModels });
+}
+
+export async function getDefaultStreamConfigForAuth(
+  auth: Authenticator
+): Promise<ModelConfigurationType> {
+  const { tiers } = await ModelsTierResource.resolveAllowedTierNames(auth);
+
+  return tiers.includes("balanced")
+    ? AUTO_MODEL_CONFIG
+    : AUTO_FAST_MODEL_CONFIG;
 }
 
 export function getDefaultModelFromEnabledModels(

--- a/front/lib/model_tiers/tier_order.ts
+++ b/front/lib/model_tiers/tier_order.ts
@@ -1,6 +1,8 @@
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
-import { MODELS_TIER_NAMES } from "@app/lib/api/assistant/token_pricing/tiers";
-import { formatAsDisplayName } from "@app/types/shared/utils/string_utils";
+import {
+  getModelsTierDisplayName,
+  MODELS_TIER_NAMES,
+} from "@app/lib/api/assistant/token_pricing/tiers";
 
 export const DEFAULT_MAX_MODEL_TIER: ModelsTierName = "premium";
 
@@ -49,5 +51,5 @@ export function formatMaxTierDescription(
     return undefined;
   }
 
-  return `Includes ${lowerTiers.map(formatAsDisplayName).join(", ")}`;
+  return `Includes ${lowerTiers.map(getModelsTierDisplayName).join(", ")}`;
 }

--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -22,6 +22,7 @@ export function useModels({
   return {
     models: data?.models ?? emptyArray(),
     defaultModel: data?.defaultModel ?? null,
+    streams: data?.streams ?? null,
     isModelsLoading: !error && !data && !disabled,
     isModelsError: !!error,
   };

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -481,6 +481,7 @@ export async function runModel(
         reasoningEffort: modelInfo.reasoningEffort,
         featureFlags,
         agentScope: agentConfiguration.scope,
+        modelResolutionMethod: agentMessage.modelResolutionMethod,
       }
     );
     if (accessError) {

--- a/front/types/api/assistant/models.ts
+++ b/front/types/api/assistant/models.ts
@@ -1,10 +1,28 @@
-import type { ModelConfigurationType } from "@app/types/assistant/models/types";
+import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
+import type {
+  ModelConfigurationType,
+  ModelProviderIdType,
+  ReasoningEffort,
+} from "@app/types/assistant/models/types";
 
 export type EnabledModelConfigurationType = ModelConfigurationType & {
   isSelectable: boolean;
 };
 
+export type ModelStreamResolutionType = {
+  providerId: ModelProviderIdType;
+  modelId: string;
+  displayName: string;
+  reasoningEffort: ReasoningEffort;
+};
+
+export type ModelStreamResolutionsType = Record<
+  ModelStreamIdType,
+  ModelStreamResolutionType
+>;
+
 export type GetEnabledModelsResponseType = {
   models: EnabledModelConfigurationType[];
   defaultModel: EnabledModelConfigurationType;
+  streams: ModelStreamResolutionsType;
 };

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -13,11 +13,7 @@ import {
   MISTRAL_MEDIUM_3_5_MODEL_ID,
   MISTRAL_SMALL_MODEL_ID,
 } from "./mistral";
-import {
-  GPT_5_5_MODEL_ID,
-  GPT_5_6_LUNA_MODEL_ID,
-  GPT_5_6_SOL_MODEL_ID,
-} from "./openai";
+import { GPT_5_6_LUNA_MODEL_ID, GPT_5_6_SOL_MODEL_ID } from "./openai";
 import type {
   ModelConfigurationType,
   ModelProviderIdType,
@@ -47,7 +43,7 @@ export function isModelStreamId(modelId: string): modelId is ModelStreamIdType {
 // at. Ordered by preference — the router picks the first candidate available to
 // the workspace. Efforts default to each model's own default; they are only
 // overridden when a stream deliberately wants a different effort (e.g. `light`
-// for the Fast stream, `high` for the Complex stream).
+// for the Basic stream, `high` for the Premium stream).
 export interface ModelStreamCandidate {
   providerId: ModelProviderIdType;
   modelId: string;
@@ -57,8 +53,8 @@ export interface ModelStreamCandidate {
 export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
   {
     // Plain `auto` spans the whole preferred catalog at each model's default
-    // reasoning effort. The last candidate (Sonnet at `light`) is the
-    // cost-effective floor so tier-capped users still resolve within the stream.
+    // reasoning effort. The last candidate (Sonnet at `light`) is the Basic-tier
+    // floor so tier-capped users still resolve within the stream.
     [AUTO_MODEL_ID]: [
       {
         providerId: "openai",
@@ -68,11 +64,6 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
       {
         providerId: "anthropic",
         modelId: CLAUDE_SONNET_4_6_MODEL_ID,
-        reasoningEffort: "medium",
-      },
-      {
-        providerId: "openai",
-        modelId: GPT_5_5_MODEL_ID,
         reasoningEffort: "medium",
       },
       {
@@ -98,7 +89,7 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
       {
         providerId: "xai",
         modelId: GROK_4_6_MODEL_ID,
-        reasoningEffort: "high",
+        reasoningEffort: "medium",
       },
       {
         providerId: "xai",
@@ -167,7 +158,7 @@ export const MODEL_STREAMS: Record<ModelStreamIdType, ModelStreamCandidate[]> =
         modelId: MISTRAL_LARGE_MODEL_ID,
         reasoningEffort: "none",
       },
-      // Cost-effective floor
+      // Basic-tier floor
       {
         providerId: "anthropic",
         modelId: CLAUDE_SONNET_4_6_MODEL_ID,
@@ -226,12 +217,12 @@ export const AUTO_MODEL_CONFIG: ModelConfigurationType = makeMetaModelConfig(
 
 export const AUTO_FAST_MODEL_CONFIG: ModelConfigurationType =
   makeMetaModelConfig(AUTO_FAST_MODEL_ID, {
-    displayName: "Fast",
+    displayName: "Basic",
     description: "Quick, low cost",
   });
 
 export const AUTO_COMPLEX_MODEL_CONFIG: ModelConfigurationType =
   makeMetaModelConfig(AUTO_COMPLEX_MODEL_ID, {
-    displayName: "Complex",
+    displayName: "Premium",
     description: "Slower, most capable",
   });


### PR DESCRIPTION
## Description

Three different vocabularies described the same three model buckets: the pricing tiers
(`cost_efficient` / `balanced` / `premium`, shown as "Cost Efficient" / "Balanced" / "Premium"),
the model picker's streams (Fast / Standard / Complex), and the usage page's complexity filter
(Fast / Standard / Complex). This PR settles on one — **Basic / Standard / Premium** — and makes a
stream mean the tier it is named after.

It also displays the name of the model the tier will resolve to instead of description.

<img width="381" height="247" alt="Screenshot 2026-08-14 at 14 10 02" src="https://github.com/user-attachments/assets/5cf5d383-8a71-40ee-85be-2fdac4a6e1a8" />

**Vocabulary**

- `getModelsTierDisplayName()` in `token_pricing/tiers.ts` is now the single source of truth for
  tier labels, replacing `formatAsDisplayName(tierName)` at its three call sites ("Up to X"
  summary, "Includes …" description, tier explainer cards).
- The picker's streams are renamed Fast → Basic and Complex → Premium, and each tier row now shows
  the model it currently resolves to instead of a static blurb (the `/api/w/[wId]/models` payload
  carries a new `streams` field for this).
- The usage page's `UsageModelTier` was a 1:1 restatement of `ModelsTierName`, so it is deleted
  along with `USAGE_MODEL_TIER_LABEL` and `usageModelTierFromModelsTierName`; the filter panel uses
  `ModelsTierName` directly. A hint above the buttons spells out that these group the concrete
  models actually billed, not the picker's identically-named streams.

**Stream / tier alignment**

The stream pools contained candidates from other tiers, so a stream could resolve to a model priced
above what its name promised:

- `gemini-3.6-flash` at `light` moves from `balanced` to `cost_efficient` (Basic pool).
- `grok-4.6` at `medium` moves from `premium` to `balanced`, and the Standard pool now enters it at
  `medium` rather than `high`.
- `gpt-5.5` at `medium` (premium) is dropped from the Standard pool entirely.

**Gating**

The three meta-models were all tiered `balanced`, which meant a Basic-capped member was rejected on
*every* stream — the picker offered them while `validatePublicModelSelection` and
`getModelTierAccessErrorForAgentConfiguration` refused them. Each stream is now tiered as the tier
it is named after (`auto_fast` → cost_efficient, `auto` → balanced, `auto_complex` → premium), and
the UI follows: `isTierLocked` becomes `getTierLockReason`, returning the existing `ModelLockReason`
union so a tier row locked by the member's cap gets the tier tooltip rather than the legacy-plan
one. The `/` slash menu drops those tiers the same way it already dropped premium-gated ones.
Members capped below Standard now default to the Basic stream rather than falling through to a
concrete model.

## Tests

Covered by unit/integration tests (63 passing across the touched suites):

- `getTierLockReason` — locked by cap, locked by legacy plan, unlocked when the stream is absent
  from the payload (the picker renders before `useModels` resolves, so absence must not lock).
- `buildPickModelSlashCommandItems` — a tier above the member's cap is omitted.
- `enabled_models` — per-stream selectability under a `balanced` cap, and the Basic-capped default.
- `tiers` — the `grok-4.6` reclassification.

Worth a manual pass in the picker with a tier-capped member: the tier rows they cannot use should
be locked with the "model tier" tooltip, and their default should land on Basic.

## Risk

An agent **configured** on `auto_complex` now fails for non-premium members with "Model tier not
enabled", exactly as an agent configured on Opus does — unless it is published and the workspace
allows restricted models for published agents. That is the intended consequence of gating streams
on their tier, but it is the one behaviour change that reaches beyond the picker.

The `grok-4.6@medium` and `gemini-3.6-flash@light` reclassifications also widen who can select
those combinations directly, since both moved to a cheaper tier.

## Deploy Plan

Nothing specific — no migration, no config change.
