### PR TITLE
feat: log userId in shadow compare permissions

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2203,6 +2203,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         skillId: this.sId,
         permission,
         workspaceId: this.workspaceId,
+        // Null for non-user callers (internal auth); API keys skip shadow-compare entirely.
+        userId: auth.user()?.sId ?? null,
       }
     );
   }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -2107,6 +2107,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         spaceId: this.sId,
         permission,
         workspaceId: this.workspaceId,
+        // Null for non-user callers (API keys, internal auth).
+        userId: auth.user()?.sId ?? null,
       }
     );
   }


### PR DESCRIPTION
## Description

This PR adds the authenticated user ID to skill and space permission checks so shadow-compare logs can identify the user associated with each comparison.

## Tests

## Risks

Low.

## Deploy Plan

Standard deployment.