### PR TITLE
feat: remove write permission from project viewer

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1963,13 +1963,21 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     if (this.isProject()) {
-      return groups.map((group) => ({
-        id: group.groupId,
-        permissions:
-          group.groupSpaceKind === "project_editor"
-            ? ["admin", "read", "write"]
-            : ["read", "write"],
-      }));
+      return groups.map((group) => {
+        switch (group.groupSpaceKind) {
+          case "project_editor":
+            return {
+              id: group.groupId,
+              permissions: ["admin", "read", "write"],
+            };
+          case "member":
+            return { id: group.groupId, permissions: ["read", "write"] };
+          case "project_viewer":
+            return { id: group.groupId, permissions: ["read"] };
+          default:
+            assertNever(group.groupSpaceKind);
+        }
+      });
     }
 
     // Restricted regular space.


### PR DESCRIPTION
## Description

This PR fixes a viewer-to-write permission escalation by mapping `project_viewer`, which represents the global group on project spaces, to read-only access instead of read and write.

More context https://dust4ai.slack.com/archives/C0B2L7PT56C/p1786613391762769

## Tests

Manually.

## Risks

Low. Ordinary workspace users on open Pods will lose unintended write access. Explicit project editors and Pod members retain their existing write access. Easy to revert.

## Deploy Plan

Standard deployment.