### PR TITLE
[front] fix: resolve remote tool labels by name

### DIFF
--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -6,7 +6,6 @@ import {
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -158,29 +157,17 @@ describe("resolveDimensionLabels", () => {
     });
   });
 
-  it("labels internal and remote tools by server and view name", async () => {
+  it("labels internal and remote tools by server name", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
     const server = await RemoteMCPServerFactory.create(workspace, {
       name: "Customer records",
     });
-    const view = await MCPServerViewResource.getMCPServerViewForSystemSpace(
-      authenticator,
-      server.sId
-    );
-    if (!view) {
-      throw new Error("Expected the remote server system view to exist.");
-    }
-    await view.updateNameAndDescription(
-      authenticator,
-      "customer_records_admin"
-    );
 
     const labels = await resolveDimensionLabels(authenticator, "tool", [
       "image_generation",
       server.cachedName,
-      "customer_records_admin",
     ]);
 
     expect(labels.get("image_generation")).toEqual({
@@ -191,12 +178,6 @@ describe("resolveDimensionLabels", () => {
     });
     expect(labels.get(server.cachedName)).toEqual({
       name: "Customer records",
-      pictureUrl: null,
-      description: null,
-      icon: server.icon,
-    });
-    expect(labels.get("customer_records_admin")).toEqual({
-      name: "Customer Records Admin",
       pictureUrl: null,
       description: null,
       icon: server.icon,

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -6,6 +6,7 @@ import {
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -157,17 +158,29 @@ describe("resolveDimensionLabels", () => {
     });
   });
 
-  it("labels internal tools by name and remote tools by id", async () => {
+  it("labels internal and remote tools by server and view name", async () => {
     const { authenticator, workspace } = await createResourceTest({
       role: "admin",
     });
     const server = await RemoteMCPServerFactory.create(workspace, {
       name: "Customer records",
     });
+    const view = await MCPServerViewResource.getMCPServerViewForSystemSpace(
+      authenticator,
+      server.sId
+    );
+    if (!view) {
+      throw new Error("Expected the remote server system view to exist.");
+    }
+    await view.updateNameAndDescription(
+      authenticator,
+      "customer_records_admin"
+    );
 
     const labels = await resolveDimensionLabels(authenticator, "tool", [
       "image_generation",
-      server.sId,
+      server.cachedName,
+      "customer_records_admin",
     ]);
 
     expect(labels.get("image_generation")).toEqual({
@@ -176,8 +189,14 @@ describe("resolveDimensionLabels", () => {
       description: null,
       icon: getInternalMCPServerIconByName("image_generation"),
     });
-    expect(labels.get(server.sId)).toEqual({
+    expect(labels.get(server.cachedName)).toEqual({
       name: "Customer records",
+      pictureUrl: null,
+      description: null,
+      icon: server.icon,
+    });
+    expect(labels.get("customer_records_admin")).toEqual({
+      name: "Customer Records Admin",
       pictureUrl: null,
       description: null,
       icon: server.icon,

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -21,7 +21,7 @@ import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
  * - "user": user sIds
  * - "group": group sIds
  * - "model": raw model ids
- * - "tool": internal MCP server names or remote MCP server sIds
+ * - "tool": MCP server names
  * - "skill": skill sIds
  * - "source": origin slugs
  */
@@ -118,11 +118,8 @@ export async function resolveDimensionLabels(
       );
 
     case "tool": {
-      // Internal servers are keyed by name, while remote servers are keyed by sId.
-      const metadata = await MCPServerViewResource.resolveDisplayMetadata(
-        auth,
-        keys
-      );
+      const metadata =
+        await MCPServerViewResource.resolveDisplayMetadataByNames(auth, keys);
       return new Map(
         keys.map((key) => {
           const tool = metadata.get(key);

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -21,7 +21,7 @@ import { Ok } from "@app/types/shared/result";
  */
 
 export type ConsumptionTopToolRow = {
-  // The internal MCP server name or remote MCP server sId used by the `tool` filter.
+  // The MCP server name, which is also what the `tool` filter takes.
   serverName: string;
   name: string;
   icon: string | null;

--- a/front/lib/api/assistant/observability/tool_usage.test.ts
+++ b/front/lib/api/assistant/observability/tool_usage.test.ts
@@ -1,0 +1,32 @@
+import { resolveServerDisplayNames } from "@app/lib/api/assistant/observability/tool_usage";
+import logger from "@app/logger/logger";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("resolveServerDisplayNames", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("only parses remote server ids as ids", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const server = await RemoteMCPServerFactory.create(workspace, {
+      name: "Customer records",
+    });
+    const error = vi.spyOn(logger, "error");
+
+    const names = await resolveServerDisplayNames(authenticator, [
+      "image_generation",
+      server.cachedName,
+      server.sId,
+    ]);
+
+    expect(names.get("image_generation")).toBe("Create Images");
+    expect(names.get(server.cachedName)).toBe("Customer Records");
+    expect(names.get(server.sId)).toBe("Customer records");
+    expect(error).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import { isResourceSId } from "@app/lib/resources/string_ids";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
@@ -231,7 +232,13 @@ export async function resolveServerDisplayNames(
   serverNames: string[]
 ): Promise<Map<string, string>> {
   const unique = [...new Set(serverNames)];
-  const remoteServers = await RemoteMCPServerResource.fetchByIds(auth, unique);
+  const remoteServerIds = unique.filter((id) =>
+    isResourceSId("remote_mcp_server", id)
+  );
+  const remoteServers =
+    remoteServerIds.length > 0
+      ? await RemoteMCPServerResource.fetchByIds(auth, remoteServerIds)
+      : [];
   const remoteServerMap = new Map(
     remoteServers.map((server) => [server.sId, server])
   );

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -235,10 +235,10 @@ export async function resolveServerDisplayNames(
   const remoteServerIds = unique.filter((id) =>
     isResourceSId("remote_mcp_server", id)
   );
-  const remoteServers =
-    remoteServerIds.length > 0
-      ? await RemoteMCPServerResource.fetchByIds(auth, remoteServerIds)
-      : [];
+  const remoteServers = await RemoteMCPServerResource.fetchByIds(
+    auth,
+    remoteServerIds
+  );
   const remoteServerMap = new Map(
     remoteServers.map((server) => [server.sId, server])
   );

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -40,6 +40,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
+import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
@@ -54,11 +55,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
-import {
-  getResourceIdFromSId,
-  isResourceSId,
-  makeSId,
-} from "@app/lib/resources/string_ids";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type {
   InferIncludeType,
   ResourceFindOptions,
@@ -83,7 +80,7 @@ import {
 import assert from "assert";
 import uniq from "lodash/uniq";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
-import { Op } from "sequelize";
+import { Op, Sequelize } from "sequelize";
 import { z } from "zod";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -704,8 +701,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
-  static async resolveDisplayMetadata(auth: Authenticator, keys: string[]) {
-    const uniqueKeys = [...new Set(keys)];
+  static async resolveDisplayMetadataByNames(
+    auth: Authenticator,
+    names: string[]
+  ) {
+    const uniqueNames = [...new Set(names)];
     const metadata = new Map<
       string,
       {
@@ -714,31 +714,63 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
     >();
 
-    for (const key of uniqueKeys) {
-      if (isInternalMCPServerName(key)) {
-        metadata.set(key, {
-          name: asDisplayToolName(key),
-          icon: getInternalMCPServerIconByName(key),
+    for (const name of uniqueNames) {
+      if (isInternalMCPServerName(name)) {
+        metadata.set(name, {
+          name: asDisplayToolName(name),
+          icon: getInternalMCPServerIconByName(name),
         });
       }
     }
 
-    const remoteServerIds = uniqueKeys.filter((key) =>
-      isResourceSId("remote_mcp_server", key)
+    const remoteNames = uniqueNames.filter(
+      (name) => !isInternalMCPServerName(name)
     );
-    if (remoteServerIds.length === 0) {
+    if (remoteNames.length === 0) {
       return metadata;
     }
 
-    const remoteServers = await RemoteMCPServerResource.fetchByIds(
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const views = await this.baseFetch(
       auth,
-      remoteServerIds
+      {
+        where: {
+          serverType: "remote",
+          [Op.or]: [
+            { name: { [Op.in]: remoteNames } },
+            Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
+              [Op.in]: remoteNames,
+            }),
+          ],
+        },
+        includes: [
+          {
+            model: RemoteMCPServerModel,
+            as: "remoteMCPServer",
+            attributes: [],
+            required: true,
+            where: { workspaceId: workspaceModelId },
+          },
+        ],
+      },
+      { includeMetadata: false }
     );
-    for (const server of remoteServers) {
-      metadata.set(server.sId, {
-        name: server.cachedName,
-        icon: server.icon,
-      });
+
+    const requestedNames = new Set(uniqueNames);
+    for (const view of views) {
+      const server = view.getRemoteMCPServerResource();
+      if (view.name && requestedNames.has(view.name)) {
+        metadata.set(view.name, {
+          name: asDisplayToolName(view.name),
+          icon: server.icon,
+        });
+      }
+      if (requestedNames.has(server.cachedName)) {
+        metadata.set(server.cachedName, {
+          name: server.cachedName,
+          icon: server.icon,
+        });
+      }
     }
 
     return metadata;

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -40,7 +40,6 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
-import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_server";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
@@ -80,7 +79,7 @@ import {
 import assert from "assert";
 import uniq from "lodash/uniq";
 import type { Attributes, CreationAttributes, Transaction } from "sequelize";
-import { Op, Sequelize } from "sequelize";
+import { Op } from "sequelize";
 import { z } from "zod";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -730,47 +729,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       return metadata;
     }
 
-    const workspaceModelId = auth.getNonNullableWorkspace().id;
-    const views = await this.baseFetch(
+    const remoteServers = await RemoteMCPServerResource.fetchByNames(
       auth,
-      {
-        where: {
-          serverType: "remote",
-          [Op.or]: [
-            { name: { [Op.in]: remoteNames } },
-            Sequelize.where(Sequelize.col("remoteMCPServer.cachedName"), {
-              [Op.in]: remoteNames,
-            }),
-          ],
-        },
-        includes: [
-          {
-            model: RemoteMCPServerModel,
-            as: "remoteMCPServer",
-            attributes: [],
-            required: true,
-            where: { workspaceId: workspaceModelId },
-          },
-        ],
-      },
-      { includeMetadata: false }
+      remoteNames
     );
 
-    const requestedNames = new Set(uniqueNames);
-    for (const view of views) {
-      const server = view.getRemoteMCPServerResource();
-      if (view.name && requestedNames.has(view.name)) {
-        metadata.set(view.name, {
-          name: asDisplayToolName(view.name),
-          icon: server.icon,
-        });
-      }
-      if (requestedNames.has(server.cachedName)) {
-        metadata.set(server.cachedName, {
-          name: server.cachedName,
-          icon: server.icon,
-        });
-      }
+    for (const server of remoteServers) {
+      metadata.set(server.cachedName, {
+        name: server.cachedName,
+        icon: server.icon,
+      });
     }
 
     return metadata;

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -350,6 +350,17 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
     });
   }
 
+  static async fetchByNames(
+    auth: Authenticator,
+    names: string[]
+  ): Promise<RemoteMCPServerResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        cachedName: { [Op.in]: names },
+      },
+    });
+  }
+
   static async fetchById(
     auth: Authenticator,
     id: string,


### PR DESCRIPTION
## Description

Remote tool usage is stored with server names. The label resolver was looking for remote server ids, so remote tool icons were missing.

Resolve internal tool metadata in memory and fetch remote servers by name. Only use id lookup when the input is a remote server id.

## Tests

- Added coverage for internal and remote server names.
- Added coverage for server names mixed with remote server ids.

## Risk

- Low. This only changes analytics tool labels.

## Deploy Plan

- Deploy front.
