### PR TITLE
[front] poc: Add metabase private in-cluster mcp server

### DIFF
--- a/front-api/routes/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front-api/routes/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -1,6 +1,7 @@
 import { getDefaultRemoteMCPServerByURL } from "@app/lib/actions/mcp_internal_actions/remote_servers";
 import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
 import { MCPOAuthProvider } from "@app/lib/actions/mcp_oauth_provider";
+import { isInClusterMCPUrlAllowed } from "@app/lib/api/mcp/in_cluster";
 import { validateExternalUrl } from "@app/lib/api/url_safety";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import type { DiscoverOAuthMetadataResponseBody } from "@app/types/api/oauth/providers/mcp";
@@ -35,15 +36,17 @@ app.post(
     const auth = ctx.get("auth");
     const { url, customHeaders } = ctx.req.valid("json");
 
-    const urlError = await validateExternalUrl(url);
-    if (urlError) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: urlError,
-        },
-      });
+    if (!(await isInClusterMCPUrlAllowed(auth, url))) {
+      const urlError = await validateExternalUrl(url);
+      if (urlError) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: urlError,
+          },
+        });
+      }
     }
 
     const headers = headersArrayToRecord(customHeaders);

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -34,11 +34,13 @@ import {
 } from "@app/lib/actions/mcp_oauth_provider";
 import type { ToolContext } from "@app/lib/actions/types";
 import { ClientSideRedisMCPTransport } from "@app/lib/api/actions/mcp_client_side";
+import { internalAgent } from "@app/lib/api/internal_fetch";
 import type {
   MCPServerType,
   MCPToolType,
   ToolDisplayLabels,
 } from "@app/lib/api/mcp";
+import { isInClusterMCPUrlAllowed } from "@app/lib/api/mcp/in_cluster";
 import { invalidateOAuthConnectionAccessTokenCache } from "@app/lib/api/oauth_access_token";
 import { isHostUnderVerifiedDomain } from "@app/lib/api/workspace_has_domains";
 import type { Authenticator } from "@app/lib/auth";
@@ -69,6 +71,7 @@ import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
+import type { Dispatcher } from "undici";
 import { z } from "zod";
 
 const DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS = 25_000;
@@ -101,9 +104,13 @@ function extractMCPErrorMessage(errorMessage: string): string {
 // disconnected and waiting further won't help.
 const CLIENT_SIDE_CONNECT_TIMEOUT_MS = 5_000;
 
-type MCPProxyKind = "static_ip_proxy" | "untrusted_egress_proxy" | "direct";
+type MCPProxyKind =
+  | "static_ip_proxy"
+  | "untrusted_egress_proxy"
+  | "in_cluster"
+  | "direct";
 type MCPProxyConfig = {
-  dispatcher?: ReturnType<typeof getUntrustedEgressAgent>;
+  dispatcher?: Dispatcher;
   fetch?: FetchLike;
   proxyKind: MCPProxyKind;
 };
@@ -164,9 +171,18 @@ export type MCPConnectionParams =
  */
 async function createMCPProxyConfig(
   auth: Authenticator,
-  host: string
+  url: URL
 ): Promise<MCPProxyConfig> {
   const workspace = auth.getNonNullableWorkspace();
+  const host = url.hostname;
+
+  if (await isInClusterMCPUrlAllowed(auth, url)) {
+    return {
+      dispatcher: internalAgent,
+      fetch: createProxyFetch(internalAgent),
+      proxyKind: "in_cluster" as const,
+    };
+  }
 
   // Check if workspace should use static IP:
   // 1. Legacy hardcoded check for specific workspaces
@@ -593,7 +609,7 @@ export async function connectToMCPServer(
             dispatcher,
             fetch: proxyFetch,
             proxyKind,
-          } = await createMCPProxyConfig(auth, url.hostname);
+          } = await createMCPProxyConfig(auth, url);
 
           try {
             const req = {
@@ -692,7 +708,7 @@ export async function connectToMCPServer(
       }
       const { dispatcher, fetch: proxyFetch } = await createMCPProxyConfig(
         auth,
-        url.hostname
+        url
       );
       const req = {
         requestInit: {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -522,6 +522,18 @@ const config = {
       "UNTRUSTED_EGRESS_PROXY_PORT"
     );
   },
+  getInClusterMCPHosts: (): string[] => {
+    const hosts = EnvironmentConfig.getOptionalEnvVariable(
+      "MCP_IN_CLUSTER_HOSTS"
+    );
+    if (!hosts) {
+      return [];
+    }
+    return hosts
+      .split(",")
+      .map((host) => host.trim().toLowerCase())
+      .filter((host) => host.length > 0);
+  },
   getElasticsearchConfig: (): {
     url: string;
     username: string;

--- a/front/lib/api/internal_fetch.ts
+++ b/front/lib/api/internal_fetch.ts
@@ -8,7 +8,7 @@ const { dns } = interceptors;
 // - dns: caches DNS resolutions to avoid repeated dns.lookup() calls that saturate the
 //   libuv thread pool and drive up event loop utilisation.
 // - retry: retries on transient network errors; only fires on idempotent methods for 5xx.
-const _internalAgent = new Agent({
+export const internalAgent = new Agent({
   keepAliveTimeout: 30_000,
   keepAliveMaxTimeout: 600_000,
 }).compose(
@@ -24,5 +24,5 @@ export function internalFetch(
 ): Promise<globalThis.Response> {
   // @ts-expect-error - globalThis.RequestInit and undici.RequestInit are structurally
   // compatible at runtime; the mismatch is only that DOM RequestInit lacks `dispatcher`.
-  return undiciFetch(url, { ...(init ?? {}), dispatcher: _internalAgent });
+  return undiciFetch(url, { ...(init ?? {}), dispatcher: internalAgent });
 }

--- a/front/lib/api/mcp/in_cluster.test.ts
+++ b/front/lib/api/mcp/in_cluster.test.ts
@@ -1,0 +1,111 @@
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isInClusterMCPUrlAllowed } from "./in_cluster";
+
+const ALLOWED_HOSTS = ["some-service.some-namespace.svc.cluster.local"];
+const ALLOWED_URL = "http://some-service.some-namespace.svc.cluster.local/mcp";
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getInClusterMCPHosts: () => ALLOWED_HOSTS,
+  },
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  hasFeatureFlag: vi.fn(),
+}));
+
+const auth = {} as Authenticator;
+
+function setFlag(enabled: boolean) {
+  vi.mocked(hasFeatureFlag).mockResolvedValue(enabled);
+}
+
+describe("isInClusterMCPUrlAllowed", () => {
+  beforeEach(() => {
+    setFlag(true);
+  });
+
+  it("allows an allowlisted host when the workspace is flagged", async () => {
+    await expect(isInClusterMCPUrlAllowed(auth, ALLOWED_URL)).resolves.toBe(
+      true
+    );
+  });
+
+  it("rejects an allowlisted host when the workspace is not flagged", async () => {
+    setFlag(false);
+    await expect(isInClusterMCPUrlAllowed(auth, ALLOWED_URL)).resolves.toBe(
+      false
+    );
+  });
+
+  it("matches regardless of scheme or case", async () => {
+    await expect(
+      isInClusterMCPUrlAllowed(
+        auth,
+        "https://Some-Service.Some-Namespace.svc.cluster.local/mcp"
+      )
+    ).resolves.toBe(true);
+  });
+
+  it("rejects a host that merely ends with an allowlisted suffix", async () => {
+    await expect(
+      isInClusterMCPUrlAllowed(
+        auth,
+        "http://evil.some-service.some-namespace.svc.cluster.local/mcp"
+      )
+    ).resolves.toBe(false);
+    await expect(
+      isInClusterMCPUrlAllowed(
+        auth,
+        "http://not-some-service.some-namespace.svc.cluster.local"
+      )
+    ).resolves.toBe(false);
+  });
+
+  it("rejects other in-cluster services", async () => {
+    await expect(
+      isInClusterMCPUrlAllowed(
+        auth,
+        "http://kubernetes.default.svc.cluster.local"
+      )
+    ).resolves.toBe(false);
+    await expect(
+      isInClusterMCPUrlAllowed(auth, "http://169.254.169.254/latest/meta-data")
+    ).resolves.toBe(false);
+    await expect(
+      isInClusterMCPUrlAllowed(auth, "http://127.0.0.1:1111/mcp")
+    ).resolves.toBe(false);
+  });
+
+  it("rejects an allowlisted host on an unlisted port", async () => {
+    await expect(
+      isInClusterMCPUrlAllowed(
+        auth,
+        "http://some-service.some-namespace.svc.cluster.local:9000/mcp"
+      )
+    ).resolves.toBe(false);
+  });
+
+  it("rejects an unparseable url", async () => {
+    await expect(
+      isInClusterMCPUrlAllowed(
+        auth,
+        "some-service.some-namespace.svc.cluster.local"
+      )
+    ).resolves.toBe(false);
+  });
+
+  it("evaluates the flag before looking at the url at all", async () => {
+    setFlag(false);
+    const getInClusterMCPHosts = vi.spyOn(config, "getInClusterMCPHosts");
+
+    await expect(isInClusterMCPUrlAllowed(auth, ALLOWED_URL)).resolves.toBe(
+      false
+    );
+    expect(getInClusterMCPHosts).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/mcp/in_cluster.ts
+++ b/front/lib/api/mcp/in_cluster.ts
@@ -1,0 +1,39 @@
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
+
+// Two gates, both required: the workspace must be flagged, and the host must be named in
+// config. The allowlist is global, so on its own it would let any workspace admin reach an
+// in-cluster service.
+export async function isInClusterMCPUrlAllowed(
+  auth: Authenticator,
+  url: string | URL
+): Promise<boolean> {
+  if (
+    !(await hasFeatureFlag(
+      auth,
+      "dust_internal_dangerous_in_cluster_mcp_servers"
+    ))
+  ) {
+    return false;
+  }
+
+  const allowedHosts = config.getInClusterMCPHosts();
+  if (allowedHosts.length === 0) {
+    return false;
+  }
+
+  let parsed: URL;
+  if (url instanceof URL) {
+    parsed = url;
+  } else {
+    try {
+      parsed = new URL(url);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_) {
+      return false;
+    }
+  }
+
+  return allowedHosts.includes(parsed.host.toLowerCase());
+}

--- a/front/lib/egress/server.ts
+++ b/front/lib/egress/server.ts
@@ -1,6 +1,6 @@
 import config from "@app/lib/api/config";
 import { EnvironmentConfig } from "@app/types/shared/utils/config";
-import type { RequestInfo, RequestInit, Response } from "undici";
+import type { Dispatcher, RequestInfo, RequestInit, Response } from "undici";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 
 export function getUntrustedEgressAgent(): ProxyAgent | undefined {
@@ -49,14 +49,14 @@ export function untrustedFetch(
 }
 
 /**
- * Creates a fetch function that routes all requests through the given proxy agent.
+ * Creates a fetch function that routes all requests through the given dispatcher.
  *
  * Used by MCP transports: the MCP SDK does NOT forward `requestInit.dispatcher`
  * to its internal EventSource/GET connections. Passing this as `opts.fetch`
- * ensures ALL fetch calls (SSE GET + POST) go through the proxy.
+ * ensures ALL fetch calls (SSE GET + POST) go through the dispatcher.
  */
 export function createProxyFetch(
-  agent: ProxyAgent
+  agent: Dispatcher
 ): (
   input: string | URL,
   init?: globalThis.RequestInit

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -186,6 +186,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "NetSuite MCP tool for querying records and interacting with your NetSuite account",
     stage: "on_demand",
   },
+  dust_internal_dangerous_in_cluster_mcp_servers: {
+    description:
+      "EXPERIMENTAL FEATURE. DUST INTERNAL ONLY. Allow remote MCP servers pointing at hosts on the MCP_IN_CLUSTER_HOSTS allowlist, reached in-cluster instead of through the untrusted egress proxy.",
+    stage: "dust_only",
+  },
   discord_bot: {
     description:
       "Discord bot integration for workspace-level Discord integration",

--- a/front/vite.setup.ts
+++ b/front/vite.setup.ts
@@ -262,7 +262,8 @@ vi.mock("@app/lib/api/sandbox", () => ({
 
 // Mock internal fetch (undici-based) so tests can intercept CoreAPI/OAuthAPI calls
 // without needing real network access. Tests override with vi.mocked(internalFetch).mockImplementation(...).
-vi.mock("@app/lib/api/internal_fetch", () => ({
+vi.mock("@app/lib/api/internal_fetch", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/api/internal_fetch")>()),
   internalFetch: vi.fn(),
 }));
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -754,6 +754,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dummy_feature_for_flag_testing"
   | "dust_agent_gpt_5_6_luna_default"
   | "dust_agent_sonnet_5_default"
+  | "dust_internal_dangerous_in_cluster_mcp_servers"
   | "dust_internal_global_agents"
   | "fireworks_new_model_feature"
   | "google_sheets_tool"


### PR DESCRIPTION
## Description

Add the ability to bypass egress limitations to reach in-cluster IPs from an external MCP server instance, avoiding routing through the internet. 
This is an experimental feature targeted only to be used by our workspace for now.

Alternatives considered:

* IAP-aware mcp server => ❌ too big, you need to overfit for each IAP, there are tens if not hundreds around.
* Tunneling => worth doing one day, but scope too big. That being said some parts of this small change can be re-used.

## Tests

Tested locally

## Risk

Low, internal feature


## Deploy Plan

- In US, add the secret MCP_IN_CLUSTER_HOSTS with the correct value in front
- deploy front