### PR TITLE
[dsbx] pod: tools.call() delegates to dsbx tools --json

### DIFF
--- a/cli/dust-sandbox/pod/package.json
+++ b/cli/dust-sandbox/pod/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust/pod",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "description": "Runtime library for code running in a Dust pod sandbox.",
   "type": "module",

--- a/cli/dust-sandbox/pod/tools.test.ts
+++ b/cli/dust-sandbox/pod/tools.test.ts
@@ -1,5 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import {
+  DSBX_PATH_ENV,
   runWithInvocationEnv,
   TOOLS_API_URL_ENV,
   TOOLS_SANDBOX_TOKEN_ENV,
@@ -9,139 +14,112 @@ import {
 } from "@dust/pod";
 
 const BASE_URL = "https://front.test/api/v1/w/w_test";
-
-// The server-view resolution cache is keyed by token and persists for the
-// process (module state), so every test uses a unique token to stay isolated.
-let tokenCounter = 0;
-function uniqueToken(): string {
-  tokenCounter += 1;
-  return `sandbox-token-${tokenCounter}`;
-}
-
-interface RecordedRequest {
-  method: string;
-  url: string;
-  headers: Record<string, string>;
-  body: unknown;
-}
-
-type FetchHandler = (request: RecordedRequest) => Response | Promise<Response>;
-
-let requests: RecordedRequest[];
-let handler: FetchHandler;
-
-const realFetch = globalThis.fetch;
-
-function jsonResponse(status: number, body: unknown): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  });
-}
-
-function serverViewsResponse(views: { sId: string; name: string }[]): Response {
-  return jsonResponse(200, {
-    serverViews: views.map(({ sId, name }) => ({
-      sId,
-      server: { name, sId: `srv_${name}`, tools: [] },
-    })),
-  });
-}
+const TOKEN = "sandbox-token";
 
 /**
- * Route requests like the front sandbox-actions API: GET /sandbox/actions
- * lists server views, POST /sandbox/actions/call creates an action, GET
- * /sandbox/actions/{aId} polls it. Tests override `handler` (or the
- * per-route helpers' response queues) to shape each scenario.
+ * A fake dsbx executable: a shell script that records its argv, stdin, and
+ * the credentials it received, then plays back the scenario files sitting
+ * next to it (stdout, stderr, exit_code, sleep_seconds). Each test gets a
+ * fresh temp dir so scenarios and recordings never bleed across tests.
  */
-function installFetchMock(): void {
-  const mocked: typeof fetch = Object.assign(
-    async (input: string | URL | Request, init?: RequestInit) => {
-      const url =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? input.toString()
-            : input.url;
-      const headers: Record<string, string> = {};
-      for (const [key, value] of new Headers(init?.headers).entries()) {
-        headers[key] = value;
-      }
-      const request: RecordedRequest = {
-        method: init?.method ?? "GET",
-        url,
-        headers,
-        body:
-          typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
-      };
-      requests.push(request);
-      return handler(request);
-    },
-    { preconnect: realFetch.preconnect }
-  );
-  globalThis.fetch = mocked;
+interface FakeDsbx {
+  readonly dir: string;
+  readonly path: string;
 }
 
-/** Sequence responses: each call consumes the next entry; the last repeats. */
-function sequence(...responses: (Response | Error)[]): FetchHandler {
-  let index = 0;
-  return () => {
-    const step = responses[Math.min(index, responses.length - 1)];
-    index += 1;
-    if (step instanceof Error) {
-      throw step;
-    }
-    // Response bodies are single-use; clone so a repeated final entry works.
-    return step.clone();
-  };
-}
-
-/**
- * Standard happy-path routing: resolution finds `serverName`, the call
- * returns `actionId`, and polling replays `pollResponses` in order (last
- * repeats).
- */
-function routeToolCall({
-  serverName,
-  viewId,
-  actionId,
-  pollResponses,
+function makeFakeDsbx({
+  stdout,
+  stderr,
+  exitCode,
+  sleepSeconds,
 }: {
-  serverName: string;
-  viewId: string;
-  actionId: string;
-  pollResponses: (Response | Error)[];
-}): void {
-  const poll = sequence(...pollResponses);
-  handler = (request) => {
-    if (request.method === "GET" && request.url.includes("?server=")) {
-      return serverViewsResponse([{ sId: viewId, name: serverName }]);
-    }
-    if (request.method === "POST" && request.url.endsWith("/actions/call")) {
-      return jsonResponse(202, { status: "pending", actionId });
-    }
-    if (request.method === "GET" && request.url.endsWith(`/${actionId}`)) {
-      return poll(request);
-    }
-    throw new Error(`Unexpected request: ${request.method} ${request.url}`);
-  };
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  sleepSeconds?: number;
+} = {}): FakeDsbx {
+  const dir = mkdtempSync(join(tmpdir(), "fake-dsbx-"));
+  const path = join(dir, "dsbx");
+  writeFileSync(
+    path,
+    [
+      "#!/bin/sh",
+      'dir="$(dirname "$0")"',
+      'printf \'%s\\n\' "$@" > "$dir/argv"',
+      'cat > "$dir/stdin"',
+      'printf \'%s\' "$DUST_API_URL" > "$dir/env_api_url"',
+      'printf \'%s\' "$DUST_SANDBOX_TOKEN" > "$dir/env_token"',
+      'if [ -f "$dir/sleep_seconds" ]; then sleep "$(cat "$dir/sleep_seconds")"; fi',
+      'if [ -f "$dir/stderr" ]; then cat "$dir/stderr" >&2; fi',
+      'if [ -f "$dir/stdout" ]; then cat "$dir/stdout"; fi',
+      'if [ -f "$dir/exit_code" ]; then exit "$(cat "$dir/exit_code")"; fi',
+      "exit 0",
+    ].join("\n"),
+    { mode: 0o755 }
+  );
+  chmodSync(path, 0o755);
+  if (stdout !== undefined) {
+    writeFileSync(join(dir, "stdout"), stdout);
+  }
+  if (stderr !== undefined) {
+    writeFileSync(join(dir, "stderr"), stderr);
+  }
+  if (exitCode !== undefined) {
+    writeFileSync(join(dir, "exit_code"), String(exitCode));
+  }
+  if (sleepSeconds !== undefined) {
+    writeFileSync(join(dir, "sleep_seconds"), String(sleepSeconds));
+  }
+  return { dir, path };
 }
 
-function successPoll(
-  output: unknown[],
-  {
-    actionStatus = "succeeded",
-    structuredContent,
-  }: { actionStatus?: string; structuredContent?: unknown } = {}
-): Response {
-  return jsonResponse(200, {
-    status: "success",
-    action: {
-      status: actionStatus,
-      output,
-      ...(structuredContent === undefined ? {} : { structuredContent }),
-    },
+function recorded(fake: FakeDsbx, name: string): string {
+  return readFileSync(join(fake.dir, name), "utf8");
+}
+
+function resultJson(overrides: Partial<Record<string, unknown>> = {}): string {
+  return JSON.stringify({
+    content: [{ type: "text", text: "3 results" }],
+    isError: false,
+    ...overrides,
   });
+}
+
+function envelopeJson(error: Record<string, unknown>): string {
+  return JSON.stringify({ error });
+}
+
+/** Run tools.call inside an invocation context wired to the fake binary. */
+function callThroughFake(
+  fake: FakeDsbx,
+  {
+    server = "slack",
+    tool = "search",
+    args,
+    timeoutMs,
+    env,
+  }: {
+    server?: string;
+    tool?: string;
+    args?: Record<string, unknown>;
+    timeoutMs?: number;
+    env?: Record<string, string>;
+  } = {}
+): Promise<ToolCallResult> {
+  return runWithInvocationEnv(
+    env ?? {
+      [TOOLS_API_URL_ENV]: BASE_URL,
+      [TOOLS_SANDBOX_TOKEN_ENV]: TOKEN,
+      [DSBX_PATH_ENV]: fake.path,
+    },
+    () =>
+      tools.call(
+        server,
+        tool,
+        args,
+        timeoutMs === undefined ? undefined : { timeoutMs }
+      )
+  );
 }
 
 async function expectToolCallError(
@@ -155,425 +133,244 @@ async function expectToolCallError(
       return err;
     }
   }
-  throw new Error("Expected the call to throw a ToolCallError");
+  throw new Error("expected the call to throw a ToolCallError");
 }
 
-beforeEach(() => {
-  requests = [];
-  handler = () => {
-    throw new Error("No fetch handler installed for this test");
-  };
-  installFetchMock();
-  process.env[TOOLS_API_URL_ENV] = BASE_URL;
-  process.env[TOOLS_SANDBOX_TOKEN_ENV] = uniqueToken();
-});
-
-afterEach(() => {
-  globalThis.fetch = realFetch;
-  delete process.env[TOOLS_API_URL_ENV];
-  delete process.env[TOOLS_SANDBOX_TOKEN_ENV];
-});
-
 describe("tools.call", () => {
-  test("resolves the server, POSTs JSON args verbatim, and returns the result", async () => {
-    routeToolCall({
-      serverName: "slack_personal",
-      viewId: "msv_1",
-      actionId: "act_1",
-      pollResponses: [successPoll([{ type: "text", text: "hello" }])],
+  test("spawns dsbx with the delegation argv and returns the parsed result", async () => {
+    const fake = makeFakeDsbx({ stdout: resultJson() });
+    const result = await callThroughFake(fake, {
+      args: { query: "budget", count: 2, filter: { status: "active" } },
     });
 
-    const args = {
-      query: "release notes",
-      limit: 20,
-      exhaustive: false,
-      channels: ["C123", "C456"],
-      filter: { after: "2026-01-01" },
-    };
-    const result = await tools.call("slack_personal", "search_messages", args);
-
-    expect(result).toBeInstanceOf(ToolCallResult);
     expect(result.isError).toBe(false);
-    expect(result.content).toEqual([{ type: "text", text: "hello" }]);
-    expect(result.structuredContent).toBeUndefined();
-
-    // Wire shape: server resolution, then the call with args as a real JSON
-    // object (numbers stay numbers, booleans stay booleans, no __file__).
-    const [listRequest, callRequest] = requests;
-    expect(listRequest?.url).toBe(
-      `${BASE_URL}/sandbox/actions?server=slack_personal&light=true`
+    expect(result.text()).toBe("3 results");
+    expect(recorded(fake, "argv")).toBe(
+      "tools\n--json\n--args-json\n-\nslack\nsearch\n"
     );
-    expect(callRequest?.url).toBe(`${BASE_URL}/sandbox/actions/call`);
-    expect(callRequest?.body).toEqual({
-      serverViewId: "msv_1",
-      toolName: "search_messages",
-      arguments: args,
+    // Args travel over stdin as one verbatim JSON object: no argv limits, no
+    // scalar coercion.
+    expect(JSON.parse(recorded(fake, "stdin"))).toEqual({
+      query: "budget",
+      count: 2,
+      filter: { status: "active" },
     });
-    expect(callRequest?.headers["authorization"]).toBe(
-      `Bearer ${process.env[TOOLS_SANDBOX_TOKEN_ENV]}`
-    );
+    expect(recorded(fake, "env_api_url")).toBe(BASE_URL);
+    expect(recorded(fake, "env_token")).toBe(TOKEN);
   });
 
-  test("omitted args are sent as an empty object", async () => {
-    routeToolCall({
-      serverName: "fathom",
-      viewId: "msv_f",
-      actionId: "act_f",
-      pollResponses: [successPoll([])],
-    });
-
-    await tools.call("fathom", "list_meetings");
-
-    const callRequest = requests.find((r) => r.method === "POST");
-    expect(callRequest?.body).toEqual({
-      serverViewId: "msv_f",
-      toolName: "list_meetings",
-      arguments: {},
-    });
+  test("omitted args are sent as an empty JSON object", async () => {
+    const fake = makeFakeDsbx({ stdout: resultJson() });
+    await callThroughFake(fake);
+    expect(recorded(fake, "stdin")).toBe("{}");
   });
 
-  test("keeps polling while the action is pending", async () => {
-    routeToolCall({
-      serverName: "hubspot",
-      viewId: "msv_h",
-      actionId: "act_h",
-      pollResponses: [
-        jsonResponse(202, { status: "pending", actionId: "act_h" }),
-        successPoll([{ type: "text", text: "done" }]),
-      ],
+  test("a tool-level error resolves with isError true instead of throwing", async () => {
+    // dsbx exits 1 when the tool reported an error, with the result payload
+    // still on stdout.
+    const fake = makeFakeDsbx({
+      stdout: resultJson({
+        content: [{ type: "text", text: "tool exploded" }],
+        isError: true,
+      }),
+      exitCode: 1,
     });
-
-    const result = await tools.call("hubspot", "search_crm_objects", {
-      query: "acme",
-    });
-
-    expect(result.text()).toBe("done");
-    const polls = requests.filter((r) => r.url.endsWith("/act_h"));
-    expect(polls.length).toBe(2);
-  });
-
-  test("an errored action resolves with isError true instead of throwing", async () => {
-    routeToolCall({
-      serverName: "hubspot",
-      viewId: "msv_h",
-      actionId: "act_err",
-      pollResponses: [
-        successPoll([{ type: "text", text: "boom" }], {
-          actionStatus: "errored",
-        }),
-      ],
-    });
-
-    const result = await tools.call("hubspot", "search_crm_objects", {});
+    const result = await callThroughFake(fake);
     expect(result.isError).toBe(true);
-    expect(result.text()).toBe("boom");
-  });
-
-  test("a rejected action throws a terminal `rejected` error", async () => {
-    routeToolCall({
-      serverName: "hubspot",
-      viewId: "msv_h",
-      actionId: "act_rej",
-      pollResponses: [jsonResponse(403, { status: "rejected" })],
-    });
-
-    const error = await expectToolCallError(
-      tools.call("hubspot", "search_crm_objects", {})
-    );
-    expect(error.code).toBe("rejected");
-    expect(error.retryable).toBe(false);
+    expect(result.text()).toBe("tool exploded");
   });
 
   test("passes structuredContent through when the platform delivers one", async () => {
-    const structured = { meetings: [{ id: 1 }], nextCursor: null };
-    routeToolCall({
-      serverName: "fathom",
-      viewId: "msv_f",
-      actionId: "act_s",
-      pollResponses: [
-        successPoll([{ type: "text", text: "1 meeting" }], {
-          structuredContent: structured,
-        }),
-      ],
+    const fake = makeFakeDsbx({
+      stdout: resultJson({ structuredContent: { rows: [1, 2] } }),
     });
-
-    const result = await tools.call("fathom", "list_meetings", {});
-    expect(result.structuredContent).toEqual(structured);
-    expect(result.json()).toEqual(structured);
+    const result = await callThroughFake(fake);
+    expect(result.structuredContent).toEqual({ rows: [1, 2] });
+    expect(result.json()).toEqual({ rows: [1, 2] });
   });
 });
 
 describe("environment handling", () => {
   test("throws missing_env without DUST_API_URL", async () => {
-    delete process.env[TOOLS_API_URL_ENV];
-    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    const fake = makeFakeDsbx({ stdout: resultJson() });
+    const error = await expectToolCallError(
+      callThroughFake(fake, {
+        env: { [TOOLS_SANDBOX_TOKEN_ENV]: TOKEN, [DSBX_PATH_ENV]: fake.path },
+      })
+    );
     expect(error.code).toBe("missing_env");
     expect(error.retryable).toBe(false);
     expect(error.message).toContain(TOOLS_API_URL_ENV);
-    expect(requests.length).toBe(0);
   });
 
   test("throws missing_env without DUST_SANDBOX_TOKEN", async () => {
-    delete process.env[TOOLS_SANDBOX_TOKEN_ENV];
-    const error = await expectToolCallError(tools.call("slack", "search", {}));
+    const fake = makeFakeDsbx({ stdout: resultJson() });
+    const error = await expectToolCallError(
+      callThroughFake(fake, {
+        env: { [TOOLS_API_URL_ENV]: BASE_URL, [DSBX_PATH_ENV]: fake.path },
+      })
+    );
     expect(error.code).toBe("missing_env");
     expect(error.message).toContain(TOOLS_SANDBOX_TOKEN_ENV);
   });
 
-  test("reads the invocation context env, not process.env, inside a context", async () => {
-    routeToolCall({
-      serverName: "slack",
-      viewId: "msv_ctx",
-      actionId: "act_ctx",
-      pollResponses: [successPoll([])],
-    });
-
-    const contextToken = uniqueToken();
-    await runWithInvocationEnv(
-      {
-        [TOOLS_API_URL_ENV]: BASE_URL,
-        [TOOLS_SANDBOX_TOKEN_ENV]: contextToken,
-      },
-      () => tools.call("slack", "search", {})
-    );
-
-    // Every request authenticates with the context token even though
-    // process.env carries a different one.
-    for (const request of requests) {
-      expect(request.headers["authorization"]).toBe(`Bearer ${contextToken}`);
+  test("the child gets the invocation's credentials, not process.env's", async () => {
+    // In a resident worker one process serves concurrent invocations;
+    // process.env may carry another (scrubbed or stale) token. The spawn env
+    // must carry the invocation context's values.
+    const processToken = process.env[TOOLS_SANDBOX_TOKEN_ENV];
+    process.env[TOOLS_SANDBOX_TOKEN_ENV] = "process-env-token";
+    try {
+      const fake = makeFakeDsbx({ stdout: resultJson() });
+      await callThroughFake(fake, {
+        env: {
+          [TOOLS_API_URL_ENV]: BASE_URL,
+          [TOOLS_SANDBOX_TOKEN_ENV]: "invocation-token",
+          [DSBX_PATH_ENV]: fake.path,
+        },
+      });
+      expect(recorded(fake, "env_token")).toBe("invocation-token");
+    } finally {
+      if (processToken === undefined) {
+        delete process.env[TOOLS_SANDBOX_TOKEN_ENV];
+      } else {
+        process.env[TOOLS_SANDBOX_TOKEN_ENV] = processToken;
+      }
     }
   });
 });
 
-describe("server-name resolution", () => {
-  test("throws server_not_found when the server is not available", async () => {
-    handler = () => serverViewsResponse([]);
-    const error = await expectToolCallError(
-      tools.call("nonexistent", "some_tool", {})
-    );
-    expect(error.code).toBe("server_not_found");
-    expect(error.retryable).toBe(false);
-    expect(error.message).toContain("nonexistent");
-  });
-
-  test("caches resolution per invocation token", async () => {
-    routeToolCall({
-      serverName: "slack",
-      viewId: "msv_c",
-      actionId: "act_c",
-      pollResponses: [successPoll([])],
-    });
-
-    await tools.call("slack", "search", {});
-    await tools.call("slack", "list", {});
-
-    const listings = requests.filter((r) => r.url.includes("?server="));
-    expect(listings.length).toBe(1);
-  });
-
-  test("a new invocation token re-resolves", async () => {
-    routeToolCall({
-      serverName: "slack",
-      viewId: "msv_c",
-      actionId: "act_c",
-      pollResponses: [successPoll([])],
-    });
-
-    await tools.call("slack", "search", {});
-    process.env[TOOLS_SANDBOX_TOKEN_ENV] = uniqueToken();
-    await tools.call("slack", "search", {});
-
-    const listings = requests.filter((r) => r.url.includes("?server="));
-    expect(listings.length).toBe(2);
-  });
-
-  test("a failed resolution is not cached", async () => {
-    let listCalls = 0;
-    handler = (request) => {
-      if (request.url.includes("?server=")) {
-        listCalls += 1;
-        if (listCalls === 1) {
-          return jsonResponse(500, {
-            error: { type: "internal_server_error", message: "boom" },
-          });
-        }
-        return serverViewsResponse([{ sId: "msv_r", name: "slack" }]);
-      }
-      if (request.method === "POST") {
-        return jsonResponse(202, { status: "pending", actionId: "act_r" });
-      }
-      return successPoll([]);
-    };
-
-    const first = await expectToolCallError(tools.call("slack", "search", {}));
-    expect(first.code).toBe("server_error");
-    expect(first.retryable).toBe(true);
-
-    const result = await tools.call("slack", "search", {});
-    expect(result.isError).toBe(false);
-    expect(listCalls).toBe(2);
-  });
-
-  test("a network failure during resolution is retryable", async () => {
-    handler = () => {
-      throw new TypeError("Unable to connect");
-    };
-    const error = await expectToolCallError(tools.call("slack", "search", {}));
-    expect(error.code).toBe("network_error");
-    expect(error.retryable).toBe(true);
-  });
-});
-
-describe("HTTP error classification", () => {
-  async function callFailingWith(status: number, body: unknown) {
-    handler = (request) => {
-      if (request.url.includes("?server=")) {
-        return serverViewsResponse([{ sId: "msv_e", name: "slack" }]);
-      }
-      return jsonResponse(status, body);
-    };
-    return expectToolCallError(tools.call("slack", "search", {}));
-  }
-
-  test("401 -> invalid_token, terminal (per-invocation JWT)", async () => {
-    const error = await callFailingWith(401, {
-      error: {
-        type: "invalid_sandbox_token_error",
-        message: "The sandbox token is invalid or expired.",
-      },
-    });
-    expect(error.code).toBe("invalid_token");
-    expect(error.retryable).toBe(false);
-    expect(error.status).toBe(401);
-  });
-
-  test("403 -> permission_denied surfacing front's message", async () => {
-    const error = await callFailingWith(403, {
-      error: {
-        type: "invalid_request_error",
+describe("error envelope classification", () => {
+  test("a typed envelope surfaces code, message, retryable, and status", async () => {
+    const fake = makeFakeDsbx({
+      stdout: envelopeJson({
+        code: "fast_function_called_tools",
         message:
-          "This Pod function is published as fast and cannot call tools. " +
-          "Publish it with executionMode `durable` to let it call tools.",
-      },
+          "This Pod function is published as fast and cannot call tools.",
+        retryable: false,
+        status: 403,
+      }),
+      exitCode: 12,
     });
-    expect(error.code).toBe("permission_denied");
+    const error = await expectToolCallError(callThroughFake(fake));
+    expect(error.code).toBe("fast_function_called_tools");
     expect(error.retryable).toBe(false);
+    expect(error.status).toBe(403);
     expect(error.message).toContain("published as fast");
   });
 
-  test("400 -> invalid_request", async () => {
-    const error = await callFailingWith(400, {
-      error: { type: "invalid_request_error", message: "Unknown tool." },
+  test("rate_limited stays retryable", async () => {
+    const fake = makeFakeDsbx({
+      stdout: envelopeJson({
+        code: "rate_limited",
+        message: "Too many requests.",
+        retryable: true,
+        status: 429,
+      }),
+      exitCode: 13,
     });
-    expect(error.code).toBe("invalid_request");
-    expect(error.retryable).toBe(false);
-  });
-
-  test("404 -> not_found", async () => {
-    const error = await callFailingWith(404, {
-      error: { type: "invalid_request_error", message: "No such view." },
-    });
-    expect(error.code).toBe("not_found");
-    expect(error.retryable).toBe(false);
-  });
-
-  test("429 -> rate_limited, retryable", async () => {
-    const error = await callFailingWith(429, {
-      error: { type: "rate_limit_error", message: "Slow down." },
-    });
+    const error = await expectToolCallError(callThroughFake(fake));
     expect(error.code).toBe("rate_limited");
     expect(error.retryable).toBe(true);
+    expect(error.status).toBe(429);
   });
 
-  test("a non-JSON error body is classified by status with a snippet", async () => {
-    handler = (request) => {
-      if (request.url.includes("?server=")) {
-        return serverViewsResponse([{ sId: "msv_e", name: "slack" }]);
-      }
-      return new Response("Bad Gateway", { status: 502 });
-    };
-    const error = await expectToolCallError(tools.call("slack", "search", {}));
-    expect(error.code).toBe("server_error");
+  test("tool_output_unavailable carries no status and stays retryable", async () => {
+    const fake = makeFakeDsbx({
+      stdout: envelopeJson({
+        code: "tool_output_unavailable",
+        message: "offloaded tool output never became readable",
+        retryable: true,
+      }),
+      exitCode: 15,
+    });
+    const error = await expectToolCallError(callThroughFake(fake));
+    expect(error.code).toBe("tool_output_unavailable");
     expect(error.retryable).toBe(true);
-    expect(error.message).toContain("Bad Gateway");
+    expect(error.status).toBeUndefined();
   });
 
-  test("a network failure on the POST is not retryable (call may exist)", async () => {
-    handler = (request) => {
-      if (request.url.includes("?server=")) {
-        return serverViewsResponse([{ sId: "msv_e", name: "slack" }]);
-      }
-      throw new TypeError("socket closed");
-    };
-    const error = await expectToolCallError(tools.call("slack", "search", {}));
-    expect(error.code).toBe("network_error");
-    expect(error.retryable).toBe(false);
+  test("an envelope code this client does not know degrades to unknown", async () => {
+    // The envelope contract is append-only: a newer dsbx may emit codes this
+    // client has never heard of. Message and retryable flag still carry.
+    const fake = makeFakeDsbx({
+      stdout: envelopeJson({
+        code: "code_from_the_future",
+        message: "something new",
+        retryable: true,
+      }),
+      exitCode: 10,
+    });
+    const error = await expectToolCallError(callThroughFake(fake));
+    expect(error.code).toBe("unknown");
+    expect(error.retryable).toBe(true);
+    expect(error.message).toBe("something new");
   });
 
-  test("an unparseable success body is invalid_response", async () => {
-    handler = (request) => {
-      if (request.url.includes("?server=")) {
-        return serverViewsResponse([{ sId: "msv_e", name: "slack" }]);
-      }
-      return new Response("not json", { status: 200 });
-    };
-    const error = await expectToolCallError(tools.call("slack", "search", {}));
-    expect(error.code).toBe("invalid_response");
+  test("dsbx-side validation failures arrive as unknown with the message", async () => {
+    // e.g. a typo'd server name: dsbx bails before any tool call and emits
+    // the generic envelope.
+    const fake = makeFakeDsbx({
+      stdout: envelopeJson({
+        code: "unknown",
+        message: "server 'slak' not found",
+        retryable: false,
+      }),
+      exitCode: 1,
+    });
+    const error = await expectToolCallError(callThroughFake(fake));
+    expect(error.code).toBe("unknown");
     expect(error.retryable).toBe(false);
+    expect(error.message).toContain("server 'slak' not found");
   });
 });
 
-describe("polling resilience", () => {
-  test("retries transient network errors while polling, then succeeds", async () => {
-    routeToolCall({
-      serverName: "slack",
-      viewId: "msv_p",
-      actionId: "act_p",
-      pollResponses: [
-        new TypeError("connection reset"),
-        successPoll([{ type: "text", text: "recovered" }]),
-      ],
-    });
-
-    const result = await tools.call("slack", "search", {});
-    expect(result.text()).toBe("recovered");
-    const polls = requests.filter((r) => r.url.endsWith("/act_p"));
-    expect(polls.length).toBe(2);
+describe("process failures", () => {
+  test("an unparseable stdout on exit 0 is invalid_response", async () => {
+    const fake = makeFakeDsbx({ stdout: "not json at all" });
+    const error = await expectToolCallError(callThroughFake(fake));
+    expect(error.code).toBe("invalid_response");
+    expect(error.retryable).toBe(false);
+    expect(error.message).toContain("not json at all");
   });
 
-  test("an API error while polling is terminal, not retried", async () => {
-    routeToolCall({
-      serverName: "slack",
-      viewId: "msv_p",
-      actionId: "act_term",
-      pollResponses: [
-        jsonResponse(404, {
-          error: { type: "action_not_found", message: "Action not found." },
-        }),
-      ],
+  test("a non-zero exit without an envelope is exec_error with the stderr tail", async () => {
+    // e.g. a clap usage error (exit 2): stderr prose, no stdout contract.
+    const fake = makeFakeDsbx({
+      stderr: "error: unexpected argument",
+      exitCode: 2,
     });
-
-    const error = await expectToolCallError(tools.call("slack", "search", {}));
-    expect(error.code).toBe("not_found");
-    const polls = requests.filter((r) => r.url.endsWith("/act_term"));
-    expect(polls.length).toBe(1);
+    const error = await expectToolCallError(callThroughFake(fake));
+    expect(error.code).toBe("exec_error");
+    expect(error.retryable).toBe(false);
+    expect(error.message).toContain("exited 2");
+    expect(error.message).toContain("unexpected argument");
   });
 
-  test("times out when the action stays pending past the deadline", async () => {
-    routeToolCall({
-      serverName: "slack",
-      viewId: "msv_p",
-      actionId: "act_slow",
-      pollResponses: [
-        jsonResponse(202, { status: "pending", actionId: "act_slow" }),
-      ],
-    });
-
+  test("a missing dsbx binary is exec_error naming the path", async () => {
     const error = await expectToolCallError(
-      tools.call("slack", "search", {}, { timeoutMs: 0 })
+      runWithInvocationEnv(
+        {
+          [TOOLS_API_URL_ENV]: BASE_URL,
+          [TOOLS_SANDBOX_TOKEN_ENV]: TOKEN,
+          [DSBX_PATH_ENV]: "/nonexistent/dsbx-test-12345",
+        },
+        () => tools.call("slack", "search", {})
+      )
+    );
+    expect(error.code).toBe("exec_error");
+    expect(error.retryable).toBe(false);
+    expect(error.message).toContain("/nonexistent/dsbx-test-12345");
+  });
+
+  test("kills the child and throws timeout past timeoutMs", async () => {
+    const fake = makeFakeDsbx({ stdout: resultJson(), sleepSeconds: 30 });
+    const error = await expectToolCallError(
+      callThroughFake(fake, { timeoutMs: 150 })
     );
     expect(error.code).toBe("timeout");
     expect(error.retryable).toBe(false);
+    expect(error.message).toContain("slack.search");
   });
 });
 

--- a/cli/dust-sandbox/pod/tools.test.ts
+++ b/cli/dust-sandbox/pod/tools.test.ts
@@ -32,11 +32,14 @@ function makeFakeDsbx({
   stderr,
   exitCode,
   sleepSeconds,
+  holdPipeSeconds,
 }: {
   stdout?: string;
   stderr?: string;
   exitCode?: number;
   sleepSeconds?: number;
+  /** Leave a background child holding the stdout pipe open after exit. */
+  holdPipeSeconds?: number;
 } = {}): FakeDsbx {
   const dir = mkdtempSync(join(tmpdir(), "fake-dsbx-"));
   const path = join(dir, "dsbx");
@@ -52,6 +55,9 @@ function makeFakeDsbx({
       'if [ -f "$dir/sleep_seconds" ]; then sleep "$(cat "$dir/sleep_seconds")"; fi',
       'if [ -f "$dir/stderr" ]; then cat "$dir/stderr" >&2; fi',
       'if [ -f "$dir/stdout" ]; then cat "$dir/stdout"; fi',
+      // The background sleep inherits the stdout fd, keeping the pipe open
+      // after this script exits.
+      'if [ -f "$dir/hold_pipe_seconds" ]; then sleep "$(cat "$dir/hold_pipe_seconds")" & fi',
       'if [ -f "$dir/exit_code" ]; then exit "$(cat "$dir/exit_code")"; fi',
       "exit 0",
     ].join("\n"),
@@ -69,6 +75,9 @@ function makeFakeDsbx({
   }
   if (sleepSeconds !== undefined) {
     writeFileSync(join(dir, "sleep_seconds"), String(sleepSeconds));
+  }
+  if (holdPipeSeconds !== undefined) {
+    writeFileSync(join(dir, "hold_pipe_seconds"), String(holdPipeSeconds));
   }
   return { dir, path };
 }
@@ -371,6 +380,17 @@ describe("process failures", () => {
     expect(error.code).toBe("timeout");
     expect(error.retryable).toBe(false);
     expect(error.message).toContain("slack.search");
+  });
+
+  test("throws timeout when an exited child's pipe never reaches EOF", async () => {
+    // The child exits promptly but a stray descendant inherited the stdout
+    // fd: the drain must be bounded by the same deadline, not hang forever.
+    const fake = makeFakeDsbx({ stdout: resultJson(), holdPipeSeconds: 30 });
+    const error = await expectToolCallError(
+      callThroughFake(fake, { timeoutMs: 150 })
+    );
+    expect(error.code).toBe("timeout");
+    expect(error.retryable).toBe(false);
   });
 });
 

--- a/cli/dust-sandbox/pod/tools.ts
+++ b/cli/dust-sandbox/pod/tools.ts
@@ -18,8 +18,10 @@
 // process.env.
 //
 // Tool outputs above front's offload threshold are resolved by dsbx itself
-// under `--json`: blocks arrive with their full archived content already
-// substituted, never the truncated snippet.
+// under `--json` when the image's dsbx carries that behavior (dsbx > 0.1.49):
+// blocks arrive with their full archived content already substituted. With an
+// older dsbx, offloaded blocks keep their snippet and descriptor, and
+// resolveToolTextContent (./tool_output.ts) still applies.
 
 import { z } from "zod";
 
@@ -36,10 +38,14 @@ export const DSBX_PATH_ENV = "DUST_DSBX_PATH";
 
 const DEFAULT_DSBX_PATH = "/opt/bin/dsbx";
 
-// Default wait cap, matching dsbx's own 10-minute poll ceiling
-// (src/api/client.rs). dsbx enforces its cap internally; this local deadline
-// only fires if the child process itself wedges.
-const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+// Default wait cap: dsbx's own 10-minute poll ceiling (src/api/client.rs)
+// plus a grace margin. dsbx's clock starts after its list+POST round-trips,
+// so the margin lets it hit its ceiling first and report the failure through
+// its typed envelope; the local deadline only fires when the child process
+// itself wedges.
+const DSBX_POLL_CEILING_MS = 10 * 60 * 1000;
+const DEFAULT_TIMEOUT_GRACE_MS = 30 * 1000;
+const DEFAULT_TIMEOUT_MS = DSBX_POLL_CEILING_MS + DEFAULT_TIMEOUT_GRACE_MS;
 
 const STDERR_TAIL_MAX_CHARS = 2000;
 
@@ -174,9 +180,9 @@ export class ToolCallResult {
 export interface ToolCallOptions {
   /**
    * Cap on the total time spent waiting for the tool result. Defaults to
-   * dsbx's own 10-minute ceiling; values above it never fire because dsbx
-   * gives up first. The invocation's own execution deadline is typically
-   * tighter.
+   * dsbx's own 10-minute ceiling plus a small grace margin, so dsbx's typed
+   * timeout reporting wins over the local kill. The invocation's own
+   * execution deadline is typically tighter.
    */
   timeoutMs?: number;
 }
@@ -276,7 +282,12 @@ function spawnDsbx({ dsbxPath, argv, env, stdinBody }: DsbxSpawnParams) {
   }
 }
 
-/** Spawn dsbx and wait for it to exit, killing it past `timeoutMs`. */
+/**
+ * Spawn dsbx and wait for it to exit and its pipes to drain, both under the
+ * same `timeoutMs` deadline: a child that wedges is killed, and a pipe still
+ * held open after exit (an fd inherited by a stray descendant) cannot hang
+ * the call either.
+ */
 async function runDsbx({
   timeoutMs,
   ...spawnParams
@@ -291,20 +302,31 @@ async function runDsbx({
   const stderrPromise = new Response(proc.stderr).text().catch(() => "");
 
   let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    proc.kill("SIGKILL");
-  }, timeoutMs);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<"deadline">((resolve) => {
+    timer = setTimeout(() => {
+      timedOut = true;
+      // No-op when the child already exited and only a pipe is still open.
+      proc.kill("SIGKILL");
+      resolve("deadline");
+    }, timeoutMs);
+  });
 
   try {
     const exitCode = await proc.exited;
-    if (timedOut) {
-      // The pipes can be held open past the kill by processes the child
-      // spawned; the output is discarded anyway, so don't wait for EOF.
-      return { exitCode, stdout: "", stderr: "", timedOut };
+    if (!timedOut) {
+      const drained = await Promise.race([
+        Promise.all([stdoutPromise, stderrPromise]),
+        deadline,
+      ]);
+      if (drained !== "deadline") {
+        const [stdout, stderr] = drained;
+        return { exitCode, stdout, stderr, timedOut: false };
+      }
     }
-    const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
-    return { exitCode, stdout, stderr, timedOut };
+    // Timed out before exit or before EOF; whatever output exists is
+    // incomplete and discarded.
+    return { exitCode, stdout: "", stderr: "", timedOut: true };
   } finally {
     clearTimeout(timer);
   }

--- a/cli/dust-sandbox/pod/tools.ts
+++ b/cli/dust-sandbox/pod/tools.ts
@@ -1,21 +1,25 @@
 // Typed client for calling workspace tools (MCP servers) from pod function
 // code.
 //
-// `tools.call(server, tool, args)` POSTs `sandbox/actions/call` with the
-// arguments as a real JSON object and polls `sandbox/actions/{aId}` until the
-// action completes, mirroring the dsbx CLI transport (src/api/client.rs)
-// without shelling out: no argv size limits, no scalar coercion, no stdout
-// parsing, and the wait is async so a resident worker serving concurrent
-// invocations is never blocked on a child process.
+// `tools.call(server, tool, args)` delegates to the dsbx CLI: it spawns
+// `dsbx tools --json --args-json - <server> <tool>` and parses the stdout
+// contract. The POST+poll transport, its retry policy, and offloaded-output
+// resolution are implemented exactly once, in dsbx (src/api/client.rs and
+// src/commands/tools/); this file only owns process plumbing. The spawn is
+// fully async (awaiting the child never blocks the event loop), so a resident
+// worker serving concurrent invocations is never stalled on a tool call.
+// Arguments travel over stdin as one JSON object (`--args-json -`): no argv
+// size limits, no scalar coercion.
 //
 // Auth and routing come from the invocation environment (DUST_API_URL is
 // workspace-scoped, DUST_SANDBOX_TOKEN is minted per invocation), read through
-// podEnv() so concurrent invocations in one process stay isolated.
+// podEnv() and passed explicitly to the child, so concurrent invocations in
+// one process stay isolated even though the child inherits the rest of
+// process.env.
 //
-// Tool outputs above front's offload threshold arrive as a truncated snippet
-// block plus an archive pointer into the pod filesystem. text()/json() return
-// the blocks as delivered; transparent archive resolution will build on the
-// resolveToolTextContent helper once it lands in this package.
+// Tool outputs above front's offload threshold are resolved by dsbx itself
+// under `--json`: blocks arrive with their full archived content already
+// substituted, never the truncated snippet.
 
 import { z } from "zod";
 
@@ -24,36 +28,53 @@ import { podEnv } from "./context.ts";
 export const TOOLS_API_URL_ENV = "DUST_API_URL";
 export const TOOLS_SANDBOX_TOKEN_ENV = "DUST_SANDBOX_TOKEN";
 
-// Poll cadence mirrors the dsbx CLI client (src/api/client.rs): 500 ms
-// interval, 10-minute hard cap so a wedged action cannot pin an invocation
-// forever, and bounded retries with exponential backoff on transient network
-// errors (re-polling an action id is idempotent).
-const POLL_INTERVAL_MS = 500;
-const POLL_MAX_DURATION_MS = 10 * 60 * 1000;
-const HTTP_REQUEST_TIMEOUT_MS = 30 * 1000;
-const POLL_MAX_CONSECUTIVE_NETWORK_ERRORS = 30;
-const POLL_RETRY_BACKOFF_BASE_MS = 500;
-const POLL_RETRY_BACKOFF_CAP_MS = 5 * 1000;
+/**
+ * Override of the dsbx executable path, for tests and local use. Production
+ * pods resolve the default absolute path baked into the sandbox image.
+ */
+export const DSBX_PATH_ENV = "DUST_DSBX_PATH";
 
-// Server-name resolution is cached per invocation: the sandbox token is minted
-// once per invocation, so keying by token scopes entries to exactly one
-// invocation on both the cold and warm paths. FIFO eviction keeps the map
-// bounded in a long-lived resident worker.
-const SERVER_VIEW_CACHE_MAX_ENTRIES = 256;
+const DEFAULT_DSBX_PATH = "/opt/bin/dsbx";
 
+// Default wait cap, matching dsbx's own 10-minute poll ceiling
+// (src/api/client.rs). dsbx enforces its cap internally; this local deadline
+// only fires if the child process itself wedges.
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+const STDERR_TAIL_MAX_CHARS = 2000;
+
+/**
+ * Error codes thrown by tools.call().
+ *
+ * Most values mirror the dsbx `tools --json` error envelope
+ * (`ApiErrorCode::as_str` and `OffloadResolutionError` in the CLI); that
+ * contract is append-only, and an envelope code this client does not know yet
+ * is surfaced as `unknown` with the envelope's message and retryable flag
+ * intact. The rest (`missing_env`, `exec_error`, `invalid_response`,
+ * `timeout`) are local to this client's process plumbing.
+ */
 export type ToolCallErrorCode =
-  | "missing_env"
-  | "server_not_found"
-  | "invalid_token"
-  | "permission_denied"
-  | "rejected"
+  | "invalid_sandbox_token"
+  | "fast_function_called_tools"
   | "invalid_request"
-  | "not_found"
   | "rate_limited"
   | "server_error"
-  | "network_error"
+  | "tool_output_unavailable"
+  | "unknown"
+  | "missing_env"
+  | "exec_error"
   | "invalid_response"
   | "timeout";
+
+const ENVELOPE_ERROR_CODES: readonly ToolCallErrorCode[] = [
+  "invalid_sandbox_token",
+  "fast_function_called_tools",
+  "invalid_request",
+  "rate_limited",
+  "server_error",
+  "tool_output_unavailable",
+  "unknown",
+];
 
 /**
  * Transport-level failure of a tool call. Tool-level failures (the tool ran
@@ -61,11 +82,8 @@ export type ToolCallErrorCode =
  * with `isError: true`.
  *
  * `retryable` means "issuing the same tools.call() again is safe and has a
- * chance of succeeding". It is false when the failure is deterministic
- * (bad request, unknown server), when the invocation's token cannot recover
- * (tokens are minted once per invocation and expire on their own schedule),
- * and when the underlying action may already exist or still be running
- * (a retry would start a duplicate tool call).
+ * chance of succeeding". For envelope-carried failures it is dsbx's own
+ * classification; local failures are never retryable except where noted.
  */
 export class ToolCallError extends Error {
   override readonly name = "ToolCallError";
@@ -155,51 +173,31 @@ export class ToolCallResult {
 
 export interface ToolCallOptions {
   /**
-   * Cap on the total time spent waiting for the tool result. Defaults to the
-   * 10-minute poll ceiling. The invocation's own execution deadline is
-   * typically tighter.
+   * Cap on the total time spent waiting for the tool result. Defaults to
+   * dsbx's own 10-minute ceiling; values above it never fire because dsbx
+   * gives up first. The invocation's own execution deadline is typically
+   * tighter.
    */
   timeoutMs?: number;
 }
 
-interface ToolsClientConfig {
-  readonly baseUrl: string;
-  readonly token: string;
-}
-
-const serverViewsResponseSchema = z.object({
-  serverViews: z.array(
-    z.object({
-      sId: z.string(),
-      server: z.object({ name: z.string() }),
-    })
-  ),
+// The two stdout shapes of `dsbx tools --json`: a CallToolResult on
+// completion (exit 0, or 1 when the tool reported an error), an error
+// envelope on transport failure. Both are append-only contracts.
+const resultSchema = z.object({
+  content: z.array(z.unknown()),
+  isError: z.boolean(),
+  structuredContent: z.unknown().optional(),
 });
 
-const callPostResponseSchema = z.object({
-  status: z.literal("pending"),
-  actionId: z.string(),
-});
-
-const apiErrorEnvelopeSchema = z.object({
+const errorEnvelopeSchema = z.object({
   error: z.object({
-    type: z.string().optional(),
-    message: z.string().optional(),
+    code: z.string(),
+    message: z.string(),
+    retryable: z.boolean(),
+    status: z.number().optional(),
   }),
 });
-
-const pollResponseSchema = z.discriminatedUnion("status", [
-  z.object({ status: z.literal("pending") }),
-  z.object({ status: z.literal("rejected") }),
-  z.object({
-    status: z.literal("success"),
-    action: z.object({
-      status: z.string(),
-      output: z.array(z.unknown()).nullish(),
-      structuredContent: z.unknown().optional(),
-    }),
-  }),
-]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -207,10 +205,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function errorMessageOf(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function tryParseJson(text: string): unknown {
@@ -233,304 +227,86 @@ function requiredEnv(name: string): string {
   return value;
 }
 
-/**
- * Classify a failing (or unparseable) HTTP response into a ToolCallError.
- * Front error bodies are `{error: {type, message}}`; the message is surfaced
- * verbatim when present so the caller sees the platform's explanation (e.g.
- * the fast-function tool refusal).
- */
-function errorFromResponse(
-  context: string,
-  status: number,
-  bodyText: string
-): ToolCallError {
-  let detail = bodyText.slice(0, 500);
-  const envelope = apiErrorEnvelopeSchema.safeParse(tryParseJson(bodyText));
-  if (envelope.success) {
-    const { type, message } = envelope.data.error;
-    detail = message ?? type ?? detail;
-  }
-
-  if (status >= 200 && status < 300) {
-    return new ToolCallError(
-      "invalid_response",
-      `${context} returned an unparseable body: ${detail}`,
-      { retryable: false, status }
-    );
-  }
-
-  const message = `${context} returned ${status}: ${detail}`;
-  if (status === 401) {
-    // Tokens are minted once per invocation with a short expiry; a fresh one
-    // only exists in a fresh invocation, so retrying here is futile.
-    return new ToolCallError("invalid_token", message, {
-      retryable: false,
-      status,
-    });
-  }
-  if (status === 403) {
-    return new ToolCallError("permission_denied", message, {
-      retryable: false,
-      status,
-    });
-  }
-  if (status === 404) {
-    return new ToolCallError("not_found", message, {
-      retryable: false,
-      status,
-    });
-  }
-  if (status === 429) {
-    return new ToolCallError("rate_limited", message, {
-      retryable: true,
-      status,
-    });
-  }
-  if (status >= 500) {
-    return new ToolCallError("server_error", message, {
-      retryable: true,
-      status,
-    });
-  }
-  return new ToolCallError("invalid_request", message, {
-    retryable: false,
-    status,
-  });
+/** Map an envelope code onto the known union; future dsbx codes degrade to
+ * `unknown` (message and retryable flag still carried verbatim). */
+function classifyEnvelopeCode(code: string): ToolCallErrorCode {
+  return ENVELOPE_ERROR_CODES.find((known) => known === code) ?? "unknown";
 }
 
-interface HttpResponse {
-  readonly status: number;
-  readonly ok: boolean;
-  readonly bodyText: string;
+function stderrTail(stderr: string): string {
+  const trimmed = stderr.trim();
+  if (trimmed.length === 0) {
+    return "";
+  }
+  return `; stderr: ${trimmed.slice(-STDERR_TAIL_MAX_CHARS)}`;
+}
+
+interface DsbxRun {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly timedOut: boolean;
+}
+
+interface DsbxSpawnParams {
+  dsbxPath: string;
+  argv: string[];
+  env: Record<string, string | undefined>;
+  stdinBody: string;
 }
 
 /**
- * One HTTP round-trip. Network failures (DNS, refused connection, per-request
- * timeout) reject with the underlying error; callers classify them because
- * retryability depends on the request's idempotency.
+ * Bun.spawn throws synchronously when the executable cannot be started
+ * (missing binary, permission denied); that surfaces as `exec_error`.
  */
-async function httpRequest(
-  config: ToolsClientConfig,
-  method: "GET" | "POST",
-  path: string,
-  body?: unknown
-): Promise<HttpResponse> {
-  const response = await fetch(`${config.baseUrl}/${path}`, {
-    method,
-    headers: {
-      authorization: `Bearer ${config.token}`,
-      "content-type": "application/json",
-    },
-    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-    signal: AbortSignal.timeout(HTTP_REQUEST_TIMEOUT_MS),
-  });
-  const bodyText = await response.text();
-  return { status: response.status, ok: response.ok, bodyText };
-}
-
-const serverViewIdCache = new Map<string, Promise<string>>();
-
-function resolveServerViewId(
-  config: ToolsClientConfig,
-  server: string
-): Promise<string> {
-  const key = `${config.token}\u0000${server}`;
-  const cached = serverViewIdCache.get(key);
-  if (cached !== undefined) {
-    return cached;
-  }
-
-  const promise = fetchServerViewId(config, server);
-  serverViewIdCache.set(key, promise);
-  // Failures are not cached: a transient listing error must not poison every
-  // later call of the invocation.
-  promise.catch(() => serverViewIdCache.delete(key));
-  while (serverViewIdCache.size > SERVER_VIEW_CACHE_MAX_ENTRIES) {
-    const oldest = serverViewIdCache.keys().next().value;
-    if (oldest === undefined) {
-      break;
-    }
-    serverViewIdCache.delete(oldest);
-  }
-  return promise;
-}
-
-async function fetchServerViewId(
-  config: ToolsClientConfig,
-  server: string
-): Promise<string> {
-  const path = `sandbox/actions?server=${encodeURIComponent(server)}&light=true`;
-  let response: HttpResponse;
+function spawnDsbx({ dsbxPath, argv, env, stdinBody }: DsbxSpawnParams) {
   try {
-    response = await httpRequest(config, "GET", path);
-  } catch (err) {
-    // Listing is read-only, so re-calling after a network failure is safe.
-    throw new ToolCallError(
-      "network_error",
-      `GET ${path} failed: ${errorMessageOf(err)}`,
-      { retryable: true }
-    );
-  }
-  if (!response.ok) {
-    throw errorFromResponse(`GET ${path}`, response.status, response.bodyText);
-  }
-
-  const parsed = serverViewsResponseSchema.safeParse(
-    tryParseJson(response.bodyText)
-  );
-  if (!parsed.success) {
-    throw errorFromResponse(`GET ${path}`, response.status, response.bodyText);
-  }
-
-  const view = parsed.data.serverViews.find((v) => v.server.name === server);
-  if (view === undefined) {
-    throw new ToolCallError(
-      "server_not_found",
-      `Server '${server}' not found: it is not available to this pod.`,
-      { retryable: false }
-    );
-  }
-  return view.sId;
-}
-
-async function postToolCall(
-  config: ToolsClientConfig,
-  {
-    serverViewId,
-    toolName,
-    args,
-  }: {
-    serverViewId: string;
-    toolName: string;
-    args: Record<string, unknown>;
-  }
-): Promise<string> {
-  const path = "sandbox/actions/call";
-  let response: HttpResponse;
-  try {
-    response = await httpRequest(config, "POST", path, {
-      serverViewId,
-      toolName,
-      arguments: args,
+    return Bun.spawn([dsbxPath, ...argv], {
+      env,
+      stdin: new TextEncoder().encode(stdinBody),
+      stdout: "pipe",
+      stderr: "pipe",
     });
   } catch (err) {
-    // The POST is not idempotent (each one creates an action) and a request
-    // that failed in flight may still have been processed, so a blind retry
-    // could run the tool twice.
     throw new ToolCallError(
-      "network_error",
-      `POST ${path} failed: ${errorMessageOf(err)}`,
+      "exec_error",
+      `Failed to spawn dsbx at ${dsbxPath}: ${errorMessageOf(err)}`,
       { retryable: false }
     );
   }
-  if (!response.ok) {
-    throw errorFromResponse(`POST ${path}`, response.status, response.bodyText);
-  }
-
-  const parsed = callPostResponseSchema.safeParse(
-    tryParseJson(response.bodyText)
-  );
-  if (!parsed.success) {
-    throw errorFromResponse(`POST ${path}`, response.status, response.bodyText);
-  }
-  return parsed.data.actionId;
 }
 
-function timeoutError(actionId: string, timeoutMs: number): ToolCallError {
-  // The action may still complete server-side; retrying would start a
-  // duplicate tool call on top of it.
-  return new ToolCallError(
-    "timeout",
-    `Timed out waiting for action ${actionId} after ${timeoutMs} ms.`,
-    { retryable: false }
-  );
-}
+/** Spawn dsbx and wait for it to exit, killing it past `timeoutMs`. */
+async function runDsbx({
+  timeoutMs,
+  ...spawnParams
+}: DsbxSpawnParams & { timeoutMs: number }): Promise<DsbxRun> {
+  const proc = spawnDsbx(spawnParams);
 
-async function pollActionResult(
-  config: ToolsClientConfig,
-  {
-    actionId,
-    deadlineMs,
-    timeoutMs,
-  }: { actionId: string; deadlineMs: number; timeoutMs: number }
-): Promise<ToolCallResult> {
-  const path = `sandbox/actions/${actionId}`;
-  let consecutiveNetworkErrors = 0;
+  // Start draining both pipes before awaiting exit so a chatty child can
+  // never fill a pipe buffer and deadlock against us waiting on exited. A
+  // read failure degrades to an empty capture rather than masking the exit
+  // outcome.
+  const stdoutPromise = new Response(proc.stdout).text().catch(() => "");
+  const stderrPromise = new Response(proc.stderr).text().catch(() => "");
 
-  for (;;) {
-    let response: HttpResponse;
-    try {
-      response = await httpRequest(config, "GET", path);
-      consecutiveNetworkErrors = 0;
-    } catch (err) {
-      // Transient network errors are retried: action ids are durable and
-      // re-polling one is idempotent. HTTP-level errors below are terminal.
-      consecutiveNetworkErrors += 1;
-      if (consecutiveNetworkErrors > POLL_MAX_CONSECUTIVE_NETWORK_ERRORS) {
-        throw new ToolCallError(
-          "network_error",
-          `Polling action ${actionId} failed after ` +
-            `${POLL_MAX_CONSECUTIVE_NETWORK_ERRORS} consecutive network ` +
-            `errors: ${errorMessageOf(err)}`,
-          // The tool call may still be running server-side.
-          { retryable: false }
-        );
-      }
-      if (Date.now() >= deadlineMs) {
-        throw timeoutError(actionId, timeoutMs);
-      }
-      const backoffMs = Math.min(
-        POLL_RETRY_BACKOFF_BASE_MS *
-          2 ** Math.min(consecutiveNetworkErrors - 1, 4),
-        POLL_RETRY_BACKOFF_CAP_MS
-      );
-      await sleep(backoffMs);
-      continue;
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill("SIGKILL");
+  }, timeoutMs);
+
+  try {
+    const exitCode = await proc.exited;
+    if (timedOut) {
+      // The pipes can be held open past the kill by processes the child
+      // spawned; the output is discarded anyway, so don't wait for EOF.
+      return { exitCode, stdout: "", stderr: "", timedOut };
     }
-
-    const parsed = pollResponseSchema.safeParse(
-      tryParseJson(response.bodyText)
-    );
-    if (!parsed.success) {
-      // Error envelopes (and anything else unparseable) end the poll: the
-      // classifier maps front's `{error: {...}}` bodies to a typed error.
-      throw errorFromResponse(
-        `GET ${path}`,
-        response.status,
-        response.bodyText
-      );
-    }
-
-    const poll = parsed.data;
-    switch (poll.status) {
-      case "pending": {
-        if (Date.now() >= deadlineMs) {
-          throw timeoutError(actionId, timeoutMs);
-        }
-        await sleep(POLL_INTERVAL_MS);
-        continue;
-      }
-      case "rejected":
-        throw new ToolCallError(
-          "rejected",
-          `Action ${actionId} was rejected.`,
-          { retryable: false }
-        );
-      case "success":
-        return new ToolCallResult({
-          content: poll.action.output ?? [],
-          isError: poll.action.status === "errored",
-          structuredContent: poll.action.structuredContent,
-        });
-      default: {
-        const exhaustive: never = poll;
-        throw new ToolCallError(
-          "invalid_response",
-          `Unexpected poll status: ${JSON.stringify(exhaustive)}`,
-          { retryable: false }
-        );
-      }
-    }
+    const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+    return { exitCode, stdout, stderr, timedOut };
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -552,19 +328,71 @@ export const tools = {
     args?: Record<string, unknown>,
     options?: ToolCallOptions
   ): Promise<ToolCallResult> {
-    const config: ToolsClientConfig = {
-      baseUrl: requiredEnv(TOOLS_API_URL_ENV).replace(/\/+$/, ""),
-      token: requiredEnv(TOOLS_SANDBOX_TOKEN_ENV),
-    };
-    const timeoutMs = options?.timeoutMs ?? POLL_MAX_DURATION_MS;
-    const deadlineMs = Date.now() + timeoutMs;
+    const apiUrl = requiredEnv(TOOLS_API_URL_ENV);
+    const token = requiredEnv(TOOLS_SANDBOX_TOKEN_ENV);
+    const dsbxPath = podEnv(DSBX_PATH_ENV) ?? DEFAULT_DSBX_PATH;
+    const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-    const serverViewId = await resolveServerViewId(config, server);
-    const actionId = await postToolCall(config, {
-      serverViewId,
-      toolName: tool,
-      args: args ?? {},
+    const run = await runDsbx({
+      dsbxPath,
+      argv: ["tools", "--json", "--args-json", "-", server, tool],
+      // The invocation's credentials override whatever the process env holds:
+      // in a resident worker, process.env is scrubbed of tokens and each
+      // invocation carries its own.
+      env: {
+        ...process.env,
+        [TOOLS_API_URL_ENV]: apiUrl,
+        [TOOLS_SANDBOX_TOKEN_ENV]: token,
+      },
+      stdinBody: JSON.stringify(args ?? {}),
+      timeoutMs,
     });
-    return pollActionResult(config, { actionId, deadlineMs, timeoutMs });
+
+    if (run.timedOut) {
+      // The underlying action may still complete server-side; retrying would
+      // start a duplicate tool call on top of it.
+      throw new ToolCallError(
+        "timeout",
+        `Tool call ${server}.${tool} timed out after ${timeoutMs} ms.`,
+        { retryable: false }
+      );
+    }
+
+    const parsed = tryParseJson(run.stdout);
+
+    const envelope = errorEnvelopeSchema.safeParse(parsed);
+    if (envelope.success) {
+      const { code, message, retryable, status } = envelope.data.error;
+      throw new ToolCallError(classifyEnvelopeCode(code), message, {
+        retryable,
+        status,
+      });
+    }
+
+    const result = resultSchema.safeParse(parsed);
+    if (result.success) {
+      // Exit code 1 with a result payload is a tool-level error, already
+      // carried by isError; any other exit code cannot produce this shape.
+      return new ToolCallResult({
+        content: result.data.content,
+        isError: result.data.isError,
+        structuredContent: result.data.structuredContent,
+      });
+    }
+
+    if (run.exitCode === 0) {
+      throw new ToolCallError(
+        "invalid_response",
+        `dsbx exited 0 but its output is not a tool result: ` +
+          `${run.stdout.slice(0, 500)}${stderrTail(run.stderr)}`,
+        { retryable: false }
+      );
+    }
+    throw new ToolCallError(
+      "exec_error",
+      `dsbx exited ${run.exitCode} without a machine-readable ` +
+        `error${stderrTail(run.stderr)}`,
+      { retryable: false }
+    );
   },
 };

--- a/front/lib/api/sandbox/image/pod_package.ts
+++ b/front/lib/api/sandbox/image/pod_package.ts
@@ -9,7 +9,7 @@ import path from "path";
 // external and resolve through NODE_PATH, like zod) and copy a flat
 // {package.json, index.js} into the image's global node_modules.
 export const POD_PACKAGE_NAME = "@dust/pod";
-export const POD_PACKAGE_VERSION = "0.2.0";
+export const POD_PACKAGE_VERSION = "0.3.0";
 export const POD_PACKAGE_IMAGE_DIR = `/opt/npm-global/lib/node_modules/${POD_PACKAGE_NAME}`;
 
 let podPackageSrcDir: string | undefined;

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,7 +94,7 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.85",
+      tag: "0.8.86",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -673,7 +673,7 @@ describe("sandbox image registry", () => {
         expect.objectContaining({ name: "drizzle-orm", version: "0.45.2" }),
         expect.objectContaining({ name: "drizzle-kit", version: "0.31.10" }),
         expect.objectContaining({ name: "@libsql/client", version: "0.17.4" }),
-        expect.objectContaining({ name: "@dust/pod", version: "0.2.0" }),
+        expect.objectContaining({ name: "@dust/pod", version: "0.3.0" }),
       ])
     );
   });

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,7 +26,7 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.85";
+const DUST_BASE_IMAGE_VERSION = "0.8.86";
 const DSBX_CLI_VERSION = "0.1.51";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is


### PR DESCRIPTION
## Description

Follow-up to #30393. `@dust/pod`'s `tools.call()` duplicated the Rust CLI's server resolution, POST/poll transport, retries, and error handling, while still returning snippets for offloaded tool output.

`tools.call()` now delegates to:

```text
dsbx tools --json --args-json - <server> <tool>
```

Arguments are sent as one JSON object over stdin. The invocation-scoped API URL and sandbox token are passed explicitly to the child, and `Bun.spawn` keeps concurrent resident-worker invocations non-blocking. A 10m30s deadline covers both process exit and pipe draining.

The public API is unchanged except for `ToolCallErrorCode`, which now mirrors the CLI's typed JSON envelope plus local process errors. Unknown future CLI codes degrade to `unknown` while preserving the message and retryability. `@dust/pod` is bumped from 0.2.0 to 0.3.0.

## Tests

A fake `dsbx` executable covers argv/stdin delegation, invocation credential isolation, success and tool-level errors, structured output, typed and future error envelopes, malformed output, missing binary, non-zero exits, process timeout, and pipe-drain timeout. The pod and image registry suites pass.

## Risk

Low. The repository has no `tools.call()` consumers outside this package's tests. The main behavior change is that offloaded outputs are now fully resolved by `dsbx`; failures to read them surface as typed `tool_output_unavailable` errors. Delegation adds one server-view GET per call because the CLI does not share the former in-process cache.

Rollback is selecting the previous sandbox image.

## Deploy plan

- [x] Bump `DUST_BASE_IMAGE_VERSION` from 0.8.85 to 0.8.86 in this PR so the vendored `@dust/pod` 0.3.0 produces a new image.
- [x] Merge, then run the Sandbox Image Registry workflow from `main` for EU and US.
- [x] After the Front deploy, use `/poke/kill` for older `dust-base` sandboxes so existing conversations recreate on 0.8.86.

No `dsbx` release or pin bump is needed: 0.1.51 is already released, pinned by `DSBX_CLI_VERSION`, and contains #30393.


