### PR TITLE
[sparkle] Tag components with a11y issues via badges + sync script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37706,6 +37706,13 @@
         "url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
       }
     },
+    "node_modules/map-or-similar": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
+      "integrity": "sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/map-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
@@ -39037,6 +39044,16 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "*"
+      }
+    },
+    "node_modules/memoizerific": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
+      "integrity": "sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "map-or-similar": "^1.5.0"
       }
     },
     "node_modules/meow": {
@@ -53062,6 +53079,22 @@
         }
       }
     },
+    "node_modules/storybook-addon-tag-badges": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-tag-badges/-/storybook-addon-tag-badges-3.1.0.tgz",
+      "integrity": "sha512-sVWVyUT8woEmSKDsePJtSFCP9RFojrmsibD11dL0/+pkn7HrkhaJC96uz3mnqt78OuO7qflFMLF1Bqg3JwnrJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "memoizerific": "^1.11.3"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "storybook": "^10.0.0"
+      }
+    },
     "node_modules/storybook/node_modules/semver": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
@@ -58602,6 +58635,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "storybook": "10.4.1",
+        "storybook-addon-tag-badges": "^3.1.0",
         "tailwindcss": "^4.3.0",
         "tsc-alias": "^1.8.10",
         "tw-animate-css": "^1.4.0",

--- a/sparkle/.storybook/main.ts
+++ b/sparkle/.storybook/main.ts
@@ -17,6 +17,7 @@ const config: StorybookConfig = {
     "@storybook/addon-docs",
     "@storybook/addon-a11y",
     "@storybook/addon-vitest",
+    "storybook-addon-tag-badges",
   ],
 
   viteFinal: async (config) => {

--- a/sparkle/.storybook/manager.ts
+++ b/sparkle/.storybook/manager.ts
@@ -1,5 +1,9 @@
 import { addons } from "storybook/manager-api";
 import { create } from "storybook/theming/create";
+import {
+  defaultConfig,
+  type TagBadgeParameters,
+} from "storybook-addon-tag-badges/manager-helpers";
 
 // Served from `.storybook/assets` via the `/brand` staticDir in main.ts.
 const dustTheme = create({
@@ -14,4 +18,37 @@ const dustTheme = create({
   fontCode: "'Geist Mono', monospace",
 });
 
-addons.setConfig({ theme: dustTheme });
+addons.setConfig({
+  theme: dustTheme,
+  tagBadges: [
+    // Components whose stories have known axe-core violations (see the
+    // Accessibility panel). Remove the tag from a story file once fixed.
+    {
+      tags: "a11y-issues",
+      badge: {
+        text: "A11y",
+        style: { backgroundColor: "#FEE2E2", color: "#B91C1C" },
+        tooltip: "Has known accessibility violations",
+      },
+      display: {
+        sidebar: [{ type: "component", skipInherited: false }],
+        toolbar: false,
+        mdx: true,
+      },
+    },
+    {
+      tags: "needs-work",
+      badge: {
+        text: "WIP",
+        style: { backgroundColor: "#FEF3C7", color: "#92400E" },
+        tooltip: "Stories are AI-generated and not yet reviewed",
+      },
+      display: {
+        sidebar: [{ type: "component", skipInherited: false }],
+        toolbar: false,
+        mdx: true,
+      },
+    },
+    ...defaultConfig,
+  ] satisfies TagBadgeParameters,
+});

--- a/sparkle/.storybook/manager.ts
+++ b/sparkle/.storybook/manager.ts
@@ -26,7 +26,7 @@ addons.setConfig({
     {
       tags: "a11y-issues",
       badge: {
-        text: "🔴 a11y",
+        text: "a11y",
         style: { backgroundColor: "#FEE2E2", color: "#B91C1C" },
         tooltip: "Has known accessibility violations",
       },

--- a/sparkle/.storybook/manager.ts
+++ b/sparkle/.storybook/manager.ts
@@ -26,7 +26,7 @@ addons.setConfig({
     {
       tags: "a11y-issues",
       badge: {
-        text: "A11y",
+        text: "🔴 a11y",
         style: { backgroundColor: "#FEE2E2", color: "#B91C1C" },
         tooltip: "Has known accessibility violations",
       },

--- a/sparkle/.storybook/preview.ts
+++ b/sparkle/.storybook/preview.ts
@@ -7,6 +7,11 @@ import { create } from "storybook/theming/create";
 
 const preview: Preview = {
   parameters: {
+    // Surface axe violations as warnings in the test widget without failing
+    // runs. Components with known violations carry the "a11y-issues" tag
+    // (badge configured in manager.ts). `npm run a11y:sync` re-runs the suite
+    // in strict mode (VITE_A11Y_STRICT=1 → violations fail) to refresh tags.
+    a11y: { test: import.meta.env.VITE_A11Y_STRICT ? "error" : "todo" },
     docs: {
       // Render docs pages in the system fonts (Geist is loaded by fonts.css).
       theme: create({

--- a/sparkle/AGENTS.md
+++ b/sparkle/AGENTS.md
@@ -1,0 +1,63 @@
+Sparkle is Dust's design system: a published npm package (`@dust-tt/sparkle`) of React
+components, icons, and logos, documented and tested through Storybook.
+
+# Layout
+
+```
+sparkle/
+├── src/
+│   ├── components/ # Hand-written components
+│   ├── hooks/, lib/ # Hand-written support code
+│   ├── icons/, logo/ # Generated SVG modules (~2,900 files, see build_icons.sh)
+│   ├── stories/ # ALL Storybook stories live here — never colocate next to components
+│   └── styles/ # Tailwind 4 CSS config (theme.css holds the design tokens)
+├── .storybook/ # Storybook config (main.ts, preview.ts, manager.ts)
+├── scripts/ # Build and maintenance scripts
+└── vitest.config.ts # Story test runner (browser mode)
+```
+
+Stories must live in `src/stories/`, not next to components: `package.json` `files` publishes
+`src/` but excludes only `src/stories/`, so colocated stories would ship in the npm tarball.
+
+# Storybook
+
+- `npm run storybook` — dev server on :6006. A static build is deployed as the prod instance.
+- `npm run build-storybook` — static build; also the cheapest way to catch story compile errors.
+- Addons: themes, docs, a11y, vitest, tag-badges. Suite packages are pinned to one exact
+  version (no `^`) because Storybook addons peer-lock to the exact core version; bump them all
+  together, and only to versions older than the repo `.npmrc` `min-release-age` cooldown.
+
+# Story tests
+
+Stories run as real browser tests (vitest browser mode + Playwright Chromium), configured in
+`vitest.config.ts`. One-time setup per machine: `npx playwright install chromium`.
+
+- In-UI: the testing widget at the bottom of the Storybook sidebar (dev server only — it needs
+  the local Vitest process, so it does not exist on the deployed instance).
+- CLI: `npx vitest run --project=storybook [story file...]` — full suite takes ~2 minutes.
+- Intentionally NOT wired into CI.
+- Do not enable the widget's Coverage toggle on full-suite runs: it OOMs the dev-server
+  process. Use the CLI with `--coverage` instead (coverage is scoped in `vitest.config.ts`
+  because remapping the generated icon/logo modules exhausts the Node heap).
+
+# Accessibility workflow
+
+Every story gets an axe-core Accessibility panel (a11y addon). Violations are warnings, not
+failures (`a11y: { test: "todo" }` in `.storybook/preview.ts`).
+
+Components with known violations carry an `"a11y-issues"` tag on their story meta, rendered as
+a red "A11y" sidebar badge (tag-badges addon, configured in `.storybook/manager.ts`).
+
+These tags are maintained by a script — do not add or remove them by hand:
+
+```
+npm run a11y:sync
+```
+
+It re-runs the suite in strict mode (`VITE_A11Y_STRICT=1` makes violations fail), then adds the
+tag to story files with violations and removes it from files that are now clean
+(`scripts/sync-a11y-tags.mjs`). Run it after a11y fixes and commit the diff. The prod Storybook
+only reflects the tags committed at build time, so keep them in sync.
+
+To fix a badged component: open it in Storybook, read the violations in the Accessibility
+panel, fix the component, then run the sync and commit the tag removal it produces.

--- a/sparkle/CLAUDE.md
+++ b/sparkle/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/sparkle/README.md
+++ b/sparkle/README.md
@@ -1,7 +1,36 @@
 # Sparkle
 
+Dust's design system, published as `@dust-tt/sparkle` and documented through Storybook.
+
 ## Build icons
 
 ```
 ./build_icons.sh
 ```
+
+## Storybook
+
+```
+npm run storybook        # dev server on http://localhost:6006
+npm run build-storybook  # static build (what gets deployed)
+```
+
+Stories live in `src/stories/` and run as real browser tests via the testing widget at the
+bottom of the Storybook sidebar (dev server only), or from the CLI:
+
+```
+npx playwright install chromium                # one-time setup per machine
+npx vitest run --project=storybook             # full suite, ~2 minutes
+```
+
+## Accessibility
+
+Every story has an axe-core Accessibility panel. Components with known violations carry an
+`a11y-issues` tag, shown as a red "A11y" badge in the sidebar. The tags are maintained by a
+script — after fixing (or changing) components, refresh them and commit the diff:
+
+```
+npm run a11y:sync
+```
+
+See `AGENTS.md` for the full workflow and conventions.

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -12,6 +12,7 @@
     "build:cjs": "node scripts/build-cjs.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "a11y:sync": "node scripts/sync-a11y-tags.mjs",
     "watch": "npm-watch"
   },
   "watch": {
@@ -78,6 +79,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "storybook": "10.4.1",
+    "storybook-addon-tag-badges": "^3.1.0",
     "tailwindcss": "^4.3.0",
     "tsc-alias": "^1.8.10",
     "tw-animate-css": "^1.4.0",

--- a/sparkle/scripts/sync-a11y-tags.mjs
+++ b/sparkle/scripts/sync-a11y-tags.mjs
@@ -8,6 +8,10 @@ import { fileURLToPath } from "url";
 // and syncs the "a11y-issues" tag on story metas: added to files with at
 // least one violating story, removed from files that are now clean. Commit
 // the resulting diff. Usage: `npm run a11y:sync`.
+//
+// GEN8 note: console is used deliberately — this is a standalone Node script
+// where the app logger is not available, matching the sibling build-cjs.mjs
+// and the front/scripts convention.
 
 const TAG = "a11y-issues";
 

--- a/sparkle/scripts/sync-a11y-tags.mjs
+++ b/sparkle/scripts/sync-a11y-tags.mjs
@@ -1,0 +1,157 @@
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+
+// Re-runs the Storybook test suite in strict a11y mode (axe violations fail)
+// and syncs the "a11y-issues" tag on story metas: added to files with at
+// least one violating story, removed from files that are now clean. Commit
+// the resulting diff. Usage: `npm run a11y:sync`.
+
+const TAG = "a11y-issues";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, "..");
+const storiesDir = path.resolve(rootDir, "src/stories");
+
+const reportPath = path.join(
+  fs.mkdtempSync(path.join(os.tmpdir(), "a11y-sync-")),
+  "report.json"
+);
+
+console.log("Running story tests in strict a11y mode (takes a few minutes)…");
+const run = spawnSync(
+  "npx",
+  [
+    "vitest",
+    "run",
+    "--project=storybook",
+    "--reporter=json",
+    `--outputFile=${reportPath}`,
+  ],
+  {
+    cwd: rootDir,
+    stdio: ["ignore", "ignore", "inherit"],
+    env: {
+      ...process.env,
+      VITE_A11Y_STRICT: "1",
+      // The full sweep needs more heap than the Node default.
+      NODE_OPTIONS: process.env.NODE_OPTIONS ?? "--max-old-space-size=8192",
+    },
+  }
+);
+
+// vitest exits non-zero when tests fail, which is expected here; only a
+// missing report means the run itself broke.
+if (!fs.existsSync(reportPath)) {
+  console.error("vitest did not produce a report; aborting.", run.error ?? "");
+  process.exit(1);
+}
+
+const report = JSON.parse(fs.readFileSync(reportPath, "utf-8"));
+const failingFiles = new Set(
+  report.testResults
+    .filter((tr) => tr.assertionResults.some((a) => a.status === "failed"))
+    .map((tr) => path.resolve(tr.name))
+);
+
+// Locates the meta object (`const meta = {` or `export default {`) and, at
+// its top level, the `tags:` and `title:` lines. Depth-tracking is textual;
+// it relies on the stories' consistent 2-space formatting (biome-enforced).
+function locateMeta(lines) {
+  const start = lines.findIndex((l) =>
+    /^(const meta(:.*)? = \{|export default \{)/.test(l)
+  );
+  if (start === -1) {
+    return null;
+  }
+  let depth = 0;
+  let tagsLine = null;
+  let titleLine = null;
+  for (let i = start; i < lines.length; i++) {
+    const l = lines[i];
+    if (depth === 1) {
+      if (tagsLine === null && /^\s{2}tags: \[/.test(l)) {
+        tagsLine = i;
+      }
+      if (titleLine === null && /^\s{2}title: /.test(l)) {
+        titleLine = i;
+      }
+    }
+    for (const ch of l) {
+      if (ch === "{" || ch === "[") {
+        depth++;
+      } else if (ch === "}" || ch === "]") {
+        depth--;
+      }
+    }
+    if (depth === 0 && i > start) {
+      break;
+    }
+  }
+  return { tagsLine, titleLine };
+}
+
+const added = [];
+const removed = [];
+const manual = [];
+
+for (const file of fs.readdirSync(storiesDir)) {
+  if (!/\.stories\.tsx?$/.test(file)) {
+    continue;
+  }
+  const filePath = path.join(storiesDir, file);
+  const source = fs.readFileSync(filePath, "utf-8");
+  const lines = source.split("\n");
+  const meta = locateMeta(lines);
+  if (!meta || (meta.tagsLine === null && meta.titleLine === null)) {
+    manual.push(file);
+    continue;
+  }
+
+  const shouldTag = failingFiles.has(filePath);
+  const hasTag =
+    meta.tagsLine !== null && lines[meta.tagsLine].includes(`"${TAG}"`);
+
+  if (shouldTag && !hasTag) {
+    if (meta.tagsLine !== null) {
+      lines[meta.tagsLine] = lines[meta.tagsLine].replace(
+        "tags: [",
+        `tags: ["${TAG}", `
+      );
+    } else {
+      lines.splice(meta.titleLine + 1, 0, `  tags: ["${TAG}"],`);
+    }
+    added.push(file);
+  } else if (!shouldTag && hasTag) {
+    const line = lines[meta.tagsLine];
+    if (new RegExp(`^\\s{2}tags: \\["${TAG}"\\],?\\s*$`).test(line)) {
+      // Tag was the only entry: drop the whole line.
+      lines.splice(meta.tagsLine, 1);
+    } else {
+      lines[meta.tagsLine] = line
+        .replace(`"${TAG}", `, "")
+        .replace(`, "${TAG}"`, "");
+    }
+    removed.push(file);
+  } else {
+    continue;
+  }
+  fs.writeFileSync(filePath, lines.join("\n"));
+}
+
+console.log(
+  `Components with a11y violations: ${failingFiles.size}. ` +
+    `Tags added: ${added.length}, removed: ${removed.length}.`
+);
+for (const f of added) {
+  console.log(`  + ${f}`);
+}
+for (const f of removed) {
+  console.log(`  - ${f}`);
+}
+if (manual.length > 0) {
+  console.log("Could not parse meta, update manually:", manual.join(", "));
+}
+console.log("Review the diff and commit it to update the sidebar badges.");

--- a/sparkle/src/stories/ActionBlock.stories.tsx
+++ b/sparkle/src/stories/ActionBlock.stories.tsx
@@ -16,6 +16,7 @@ import {
 
 const meta = {
   title: "Product/Conversation/ActionBlock",
+  tags: ["a11y-issues"],
   component: ActionCardBlock,
   parameters: {
     layout: "fullscreen",

--- a/sparkle/src/stories/ActionCard.stories.tsx
+++ b/sparkle/src/stories/ActionCard.stories.tsx
@@ -7,6 +7,7 @@ import { BookOpen01, SearchMd, Terminal } from "@sparkle/icons/v2-stroke";
 
 const meta: Meta<typeof ActionCard> = {
   title: "Product/Agent/ActionCard",
+  tags: ["a11y-issues"],
   component: ActionCard,
   parameters: {
     docs: {

--- a/sparkle/src/stories/AssistantCard.stories.tsx
+++ b/sparkle/src/stories/AssistantCard.stories.tsx
@@ -15,6 +15,7 @@ import {
 
 const meta: Meta<typeof AssistantCard> = {
   title: "Product/Agent/AssistantCard",
+  tags: ["a11y-issues"],
   component: AssistantCard,
   parameters: {
     docs: {

--- a/sparkle/src/stories/AttachmentChip.stories.tsx
+++ b/sparkle/src/stories/AttachmentChip.stories.tsx
@@ -25,7 +25,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
 } satisfies Meta<typeof AttachmentChip>;
 
 export default meta;

--- a/sparkle/src/stories/Avatar.stories.tsx
+++ b/sparkle/src/stories/Avatar.stories.tsx
@@ -28,7 +28,7 @@ const ICONS = {
 const meta = {
   title: "Data Display/Avatar",
   component: Avatar,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/AvatarSet.stories.tsx
+++ b/sparkle/src/stories/AvatarSet.stories.tsx
@@ -5,6 +5,7 @@ import { Avatar } from "@sparkle/components";
 
 const meta = {
   title: "Assets/Avatars/AvatarSet",
+  tags: ["a11y-issues"],
   component: Avatar,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -25,7 +25,7 @@ const ICONS = {
 const meta = {
   title: "Actions/Button",
   component: Button,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/ButtonGroup.stories.tsx
+++ b/sparkle/src/stories/ButtonGroup.stories.tsx
@@ -37,7 +37,7 @@ const DefaultButtons = ({
 const meta = {
   title: "Actions/ButtonGroup",
   component: ButtonGroup,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/Card.stories.tsx
+++ b/sparkle/src/stories/Card.stories.tsx
@@ -22,7 +22,7 @@ import { Brackets } from "@sparkle/icons/v2-stroke";
 const meta = {
   title: "Data Display/Card",
   component: Card,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/Checkbox.stories.tsx
+++ b/sparkle/src/stories/Checkbox.stories.tsx
@@ -22,6 +22,7 @@ type ExtendedCheckboxProps = CheckboxProps & {
 
 const meta = {
   title: "Forms & Inputs/Checkbox",
+  tags: ["a11y-issues"],
   component: Checkbox as React.ComponentType<ExtendedCheckboxProps>,
   parameters: {
     layout: "centered",

--- a/sparkle/src/stories/Chip.stories.tsx
+++ b/sparkle/src/stories/Chip.stories.tsx
@@ -13,7 +13,7 @@ const ICONS = {
 const meta = {
   title: "Data Display/Chip",
   component: Chip,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     layout: "padded",
     docs: {

--- a/sparkle/src/stories/Citation.stories.tsx
+++ b/sparkle/src/stories/Citation.stories.tsx
@@ -24,6 +24,7 @@ import {
 
 const meta = {
   title: "Product/Conversation/Citation",
+  tags: ["a11y-issues"],
   component: Citation,
   parameters: {
     docs: {

--- a/sparkle/src/stories/CodeBlock.stories.tsx
+++ b/sparkle/src/stories/CodeBlock.stories.tsx
@@ -5,6 +5,7 @@ import { CodeBlock } from "../index_with_tw_base";
 
 const meta: Meta<typeof CodeBlock> = {
   title: "Product/Conversation/CodeBlock",
+  tags: ["a11y-issues"],
   component: CodeBlock,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Collapsible.stories.tsx
+++ b/sparkle/src/stories/Collapsible.stories.tsx
@@ -10,6 +10,7 @@ import {
 
 const meta = {
   title: "Layout/Collapsible",
+  tags: ["a11y-issues"],
   component: Collapsible,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Container.stories.tsx
+++ b/sparkle/src/stories/Container.stories.tsx
@@ -5,6 +5,7 @@ import { Container } from "../index_with_tw_base";
 
 const meta = {
   title: "Layout/Container",
+  tags: ["a11y-issues"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/ContextItem.stories.tsx
+++ b/sparkle/src/stories/ContextItem.stories.tsx
@@ -24,6 +24,7 @@ import {
 
 const meta = {
   title: "Lists/ContextItem",
+  tags: ["a11y-issues"],
   component: ContextItem,
   parameters: {
     docs: {

--- a/sparkle/src/stories/ConversationListItem.stories.tsx
+++ b/sparkle/src/stories/ConversationListItem.stories.tsx
@@ -10,7 +10,7 @@ import {
 const meta = {
   title: "Lists/ConversationListItem",
   component: ConversationListItem,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/ConversationMessage.stories.tsx
+++ b/sparkle/src/stories/ConversationMessage.stories.tsx
@@ -25,6 +25,7 @@ import {
 
 const meta = {
   title: "Product/Conversation/ConversationMessage",
+  tags: ["a11y-issues"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/DataTable.stories.tsx
+++ b/sparkle/src/stories/DataTable.stories.tsx
@@ -29,6 +29,7 @@ import { Folder } from "@sparkle/icons/v2-stroke";
 
 const meta = {
   title: "Data Display/DataTable",
+  tags: ["a11y-issues"],
   component: DataTable,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -73,7 +73,7 @@ import {
 const meta = {
   title: "Forms & Inputs/Dropdown",
   component: DropdownMenu,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/Hover3D.stories.tsx
+++ b/sparkle/src/stories/Hover3D.stories.tsx
@@ -7,6 +7,7 @@ import { Div3D, GithubLogo, Hover3D, Icon } from "../index_with_tw_base";
 
 const meta = {
   title: "Effects & Motion/Hover3D",
+  tags: ["a11y-issues"],
   component: Hover3D,
   parameters: {
     docs: {

--- a/sparkle/src/stories/HoveringBar.stories.tsx
+++ b/sparkle/src/stories/HoveringBar.stories.tsx
@@ -18,6 +18,7 @@ import {
 
 const meta = {
   title: "Lab/HoveringBar",
+  tags: ["a11y-issues"],
   component: HoveringBar,
   parameters: {
     docs: {

--- a/sparkle/src/stories/IconButton.stories.tsx
+++ b/sparkle/src/stories/IconButton.stories.tsx
@@ -4,6 +4,7 @@ import { Settings01, IconButton } from "../index_with_tw_base";
 
 const meta = {
   title: "Actions/IconButton",
+  tags: ["a11y-issues"],
   component: IconButton,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Input.stories.tsx
+++ b/sparkle/src/stories/Input.stories.tsx
@@ -10,7 +10,7 @@ const MESSAGE_STATUSES = ["info", "default", "error"] as const;
 const meta = {
   title: "Forms & Inputs/Input",
   component: Input,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/InputWithSave.stories.tsx
+++ b/sparkle/src/stories/InputWithSave.stories.tsx
@@ -5,6 +5,7 @@ import { InputWithSave } from "../index_with_tw_base";
 
 const meta = {
   title: "Forms & Inputs/InputWithSave",
+  tags: ["a11y-issues"],
   component: InputWithSave,
   parameters: {
     layout: "padded",

--- a/sparkle/src/stories/Label.stories.tsx
+++ b/sparkle/src/stories/Label.stories.tsx
@@ -6,6 +6,7 @@ import { Checkbox, Label } from "../index_with_tw_base";
 
 const meta = {
   title: "Forms & Inputs/Label",
+  tags: ["a11y-issues"],
   component: Label,
   parameters: {
     docs: {

--- a/sparkle/src/stories/LegacyButton.stories.tsx
+++ b/sparkle/src/stories/LegacyButton.stories.tsx
@@ -22,7 +22,7 @@ const ICONS = {
 const meta = {
   title: "Actions/LegacyButton",
   component: Button,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/LegacyInput.stories.tsx
+++ b/sparkle/src/stories/LegacyInput.stories.tsx
@@ -8,7 +8,7 @@ const MESSAGE_STATUSES = ["info", "default", "error"] as const;
 const meta = {
   title: "Forms & Inputs/LegacyInput",
   component: Input,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/LegacyInputWithSave.stories.tsx
+++ b/sparkle/src/stories/LegacyInputWithSave.stories.tsx
@@ -5,6 +5,7 @@ import { InputWithSave } from "../index_with_tw_base";
 
 const meta = {
   title: "Forms & Inputs/LegacyInputWithSave",
+  tags: ["a11y-issues"],
   component: InputWithSave,
   parameters: {
     layout: "padded",

--- a/sparkle/src/stories/LegacySplitButton.stories.tsx
+++ b/sparkle/src/stories/LegacySplitButton.stories.tsx
@@ -9,6 +9,7 @@ import { ArrowUp, ChevronDown } from "@sparkle/icons/v2-stroke";
 
 const meta: Meta<React.ComponentProps<typeof LegacyFlexSplitButton>> = {
   title: "Actions/LegacySplitButton",
+  tags: ["a11y-issues"],
   component: LegacyFlexSplitButton,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Markdown.stories.tsx
+++ b/sparkle/src/stories/Markdown.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   decorators: [(Story) => <Story />],
   argTypes: {
     textColor: {

--- a/sparkle/src/stories/Motion.stories.tsx
+++ b/sparkle/src/stories/Motion.stories.tsx
@@ -5,7 +5,7 @@ import { TokenChip, useCssVar, withThemedSurface } from "./foundations-helpers";
 
 const meta = {
   title: "Foundations/Motion",
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   decorators: [withThemedSurface],
   parameters: {
     layout: "padded",

--- a/sparkle/src/stories/NavigationList.stories.tsx
+++ b/sparkle/src/stories/NavigationList.stories.tsx
@@ -29,6 +29,7 @@ import type { NavigationListItemStatus } from "../components/NavigationList";
 
 const meta = {
   title: "Navigation/NavigationList",
+  tags: ["a11y-issues"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/NotificationButton.stories.tsx
+++ b/sparkle/src/stories/NotificationButton.stories.tsx
@@ -6,6 +6,7 @@ import { InfoCircle } from "@sparkle/icons";
 
 const meta = {
   title: "Feedback & Status/NotificationButton",
+  tags: ["a11y-issues"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/OptionCard.stories.tsx
+++ b/sparkle/src/stories/OptionCard.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
 } satisfies Meta<typeof OptionCard>;
 
 export default meta;

--- a/sparkle/src/stories/Page.stories.tsx
+++ b/sparkle/src/stories/Page.stories.tsx
@@ -15,6 +15,7 @@ import { MessageChatSquare } from "@sparkle/icons/v2-stroke";
 
 const meta = {
   title: "Layout/Page",
+  tags: ["a11y-issues"],
   component: Page,
   parameters: {
     docs: {

--- a/sparkle/src/stories/PaginatedCitationsGrid.stories.tsx
+++ b/sparkle/src/stories/PaginatedCitationsGrid.stories.tsx
@@ -5,6 +5,7 @@ import { File02, PaginatedCitationsGrid } from "../index_with_tw_base";
 
 const meta = {
   title: "Product/Conversation/PaginatedCitationsGrid",
+  tags: ["a11y-issues"],
   component: PaginatedCitationsGrid,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Pagination.stories.tsx
+++ b/sparkle/src/stories/Pagination.stories.tsx
@@ -26,7 +26,7 @@ const meta: Meta<typeof Pagination> = {
       />
     );
   },
-  tags: ["ai-generated", "needs-work"],
+  tags: ["a11y-issues", "ai-generated", "needs-work"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/Popover.stories.tsx
+++ b/sparkle/src/stories/Popover.stories.tsx
@@ -15,6 +15,7 @@ import {
 
 const meta = {
   title: "Overlays/Popover",
+  tags: ["a11y-issues"],
   component: Popover,
   parameters: {
     docs: {

--- a/sparkle/src/stories/PriceTable.stories.tsx
+++ b/sparkle/src/stories/PriceTable.stories.tsx
@@ -5,6 +5,7 @@ import { Button, Hoverable, PriceTable } from "../index_with_tw_base";
 
 const meta = {
   title: "Data Display/PriceTable",
+  tags: ["a11y-issues"],
   component: PriceTable,
   parameters: {
     docs: {

--- a/sparkle/src/stories/RadioGroup.stories.tsx
+++ b/sparkle/src/stories/RadioGroup.stories.tsx
@@ -15,6 +15,7 @@ import {
 
 const meta = {
   title: "Forms & Inputs/RadioGroup",
+  tags: ["a11y-issues"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/ScrollArea.stories.tsx
+++ b/sparkle/src/stories/ScrollArea.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
 } satisfies Meta<typeof ScrollArea>;
 
 export default meta;

--- a/sparkle/src/stories/SettingsList.stories.tsx
+++ b/sparkle/src/stories/SettingsList.stories.tsx
@@ -5,6 +5,7 @@ import { Input, SettingsList, SliderToggle } from "../index_with_tw_base";
 
 const meta = {
   title: "Lists/SettingsList",
+  tags: ["a11y-issues"],
   component: SettingsList,
   parameters: {
     docs: {

--- a/sparkle/src/stories/SidebarLayout.stories.tsx
+++ b/sparkle/src/stories/SidebarLayout.stories.tsx
@@ -17,6 +17,7 @@ import {
 
 const meta = {
   title: "Lab/SidebarLayout",
+  tags: ["a11y-issues"],
   component: SidebarLayout,
   parameters: {
     docs: {

--- a/sparkle/src/stories/SplitButton.stories.tsx
+++ b/sparkle/src/stories/SplitButton.stories.tsx
@@ -7,6 +7,7 @@ import { Button, FlexSplitButton } from "../index_with_tw_base";
 
 const meta: Meta<React.ComponentProps<typeof FlexSplitButton>> = {
   title: "Actions/SplitButton",
+  tags: ["a11y-issues"],
   component: FlexSplitButton,
   parameters: {
     docs: {

--- a/sparkle/src/stories/SystemAvatarSet.stories.tsx
+++ b/sparkle/src/stories/SystemAvatarSet.stories.tsx
@@ -4,6 +4,7 @@ import { Avatar } from "../index_with_tw_base";
 
 export default {
   title: "Assets/Avatars/SystemAvatarSet",
+  tags: ["a11y-issues"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/Tabs.stories.tsx
+++ b/sparkle/src/stories/Tabs.stories.tsx
@@ -15,7 +15,7 @@ import {
 const meta = {
   title: "Navigation/Tabs",
   component: Tabs,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/TextArea.stories.tsx
+++ b/sparkle/src/stories/TextArea.stories.tsx
@@ -5,6 +5,7 @@ import { TextArea } from "../index_with_tw_base";
 
 const meta = {
   title: "Forms & Inputs/TextArea",
+  tags: ["a11y-issues"],
   component: TextArea,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Toolbar.stories.tsx
+++ b/sparkle/src/stories/Toolbar.stories.tsx
@@ -174,7 +174,7 @@ function handleOverlayClose(
 const meta = {
   title: "Navigation/Toolbar",
   component: Toolbar,
-  tags: ["autodocs"],
+  tags: ["a11y-issues", "autodocs"],
   parameters: {
     docs: {
       description: {

--- a/sparkle/src/stories/Tooltip.stories.tsx
+++ b/sparkle/src/stories/Tooltip.stories.tsx
@@ -14,6 +14,7 @@ import {
 
 const meta = {
   title: "Overlays/Tooltip",
+  tags: ["a11y-issues"],
   component: TooltipProvider,
   parameters: {
     docs: {

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -26,6 +26,7 @@ import {
 
 const meta = {
   title: "Data Display/Tree",
+  tags: ["a11y-issues"],
   component: Tree,
   parameters: {
     docs: {


### PR DESCRIPTION
## Description

Adds accessibility violation tracking in the Sparkle Storybook via the `storybook-addon-tag-badges` package. Components with known axe-core violations are tagged `"a11y-issues"` and display a red 🔴 a11y badge in the sidebar; the existing `"needs-work"` tag gets a WIP badge. A new `npm run a11y:sync` script (`scripts/sync-a11y-tags.mjs`) re-runs the test suite in strict mode (`VITE_A11Y_STRICT=1`) and automatically adds/removes the `a11y-issues` tag per story file so badges stay accurate. 51 components (109 stories) were tagged in this initial sweep. The default a11y behavior remains non-blocking (`a11y.test: "todo"`). The workflow is documented in a new `sparkle/AGENTS.md`.

## Tests

Tested manually via the Storybook dev server: badges appear correctly in the sidebar. The `a11y:sync` script was run to generate the initial set of tagged components.

## Risk

Low. Changes are confined to Storybook configuration and dev tooling; no production code is affected. Adds two new dev dependencies (`storybook-addon-tag-badges`, `memoizerific`).

## Deploy Plan

Deploy sparkle (dev/Storybook tooling only — no npm package change).