### PR TITLE
[Activation] Hide Learning Space from pods

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -467,6 +467,12 @@ export function AgentSidebarMenu({
     workspaceId: owner.sId,
   });
 
+  // Hide the Learning Space pod from the UI. Users can only see "For you"
+  const visibleSummary = useMemo(
+    () => summary.filter(({ space }) => space.sId !== activationPodId),
+    [summary, activationPodId]
+  );
+
   useEffect(() => {
     const handleConversationsUpdated = () => {
       void mutateConversations();
@@ -609,12 +615,12 @@ export function AgentSidebarMenu({
 
   const availablePods = useMemo(
     () =>
-      summary
+      visibleSummary
         .map(({ space }) => space)
         .filter((space) =>
           space.name.toLowerCase().includes(podSearchText.toLowerCase().trim())
         ),
-    [summary, podSearchText]
+    [visibleSummary, podSearchText]
   );
 
   const moveSelectionToPod = useCallback(
@@ -722,7 +728,9 @@ export function AgentSidebarMenu({
   const sidebarTitleFilter = titleFilter;
 
   const starredSection = useMemo(() => {
-    const starredSummary = summary.filter(({ space }) => space.isStarred);
+    const starredSummary = visibleSummary.filter(
+      ({ space }) => space.isStarred
+    );
     const starredCountInSummary = starredSummary.length;
 
     if (starredCountInSummary === 0) {
@@ -762,7 +770,7 @@ export function AgentSidebarMenu({
       </NavigationList>
     );
   }, [
-    summary,
+    visibleSummary,
     owner,
     sidebarTitleFilter,
     moveConversationToPod,
@@ -772,7 +780,9 @@ export function AgentSidebarMenu({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
   const podsSection = useMemo(() => {
-    const nonStarredSummary = summary.filter((pod) => !pod.space.isStarred);
+    const nonStarredSummary = visibleSummary.filter(
+      (pod) => !pod.space.isStarred
+    );
 
     const VISIBLE_PODS = 4;
     const hiddenSummary = nonStarredSummary.slice(VISIBLE_PODS);
@@ -838,7 +848,7 @@ export function AgentSidebarMenu({
     );
   }, [
     owner,
-    summary,
+    visibleSummary,
     setIsCreatePodModalOpen,
     isPodsSectionCollapsed,
     setPodsSectionCollapsed,


### PR DESCRIPTION
## Description
Hide the Learning Space pod from pods. The only way users can access activation is from the special For you page. In-app notifications from the pod still show up in conversations-unread (the same as before).
<img width="694" height="548" alt="Screenshot 2026-08-14 at 17 04 30" src="https://github.com/user-attachments/assets/e541b50e-c777-43bf-90bd-7b084de74705" />

## Tests
Local tests

## Risk
Low risk, solely a UI change.

## Deploy Plan
Deploy front.