### PR TITLE
Add filesystem namespace reads

### DIFF
--- a/front/lib/api/file_system/namespace.test.ts
+++ b/front/lib/api/file_system/namespace.test.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { applyFileSystemOperation } from "@app/lib/api/file_system/namespace";
 import { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
-import type { FileSystemNode } from "@app/lib/api/file_system/namespace_types";
+import type { FileSystemNodeType } from "@app/lib/api/file_system/namespace_types";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
@@ -26,7 +26,7 @@ function readableScope(conversationId: string, podId?: string) {
   ]);
 }
 
-function requireNode(node: FileSystemNode | undefined): FileSystemNode {
+function requireNode(node: FileSystemNodeType | undefined): FileSystemNodeType {
   if (!node) {
     throw new Error("Missing filesystem node.");
   }

--- a/front/lib/api/file_system/namespace.test.ts
+++ b/front/lib/api/file_system/namespace.test.ts
@@ -1,0 +1,127 @@
+import { randomUUID } from "node:crypto";
+import { applyFileSystemOperation } from "@app/lib/api/file_system/namespace";
+import { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
+import type { FileSystemNode } from "@app/lib/api/file_system/namespace_types";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+function readableScope(conversationId: string, podId?: string) {
+  return new FileSystemScope([
+    {
+      kind: "conversation",
+      id: conversationId,
+      name: `conversation-${conversationId}`,
+      permissions: { canRead: true, canWrite: true },
+    },
+    ...(podId
+      ? [
+          {
+            kind: "pod" as const,
+            id: podId,
+            name: `pod-${podId}`,
+            permissions: { canRead: true, canWrite: true },
+          },
+        ]
+      : []),
+  ]);
+}
+
+function requireNode(node: FileSystemNode | undefined): FileSystemNode {
+  if (!node) {
+    throw new Error("Missing filesystem node.");
+  }
+  return node;
+}
+
+describe("filesystem namespace reads", () => {
+  it("initializes stable conversation and Pod roots", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(
+      `conversation-${randomUUID()}`,
+      `pod-${randomUUID()}`
+    );
+
+    const first = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+    const second = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(second.isOk()).toBe(true);
+    if (first.isErr() || second.isErr()) {
+      return;
+    }
+    expect(first.value.roots).toHaveLength(2);
+    expect(second.value.roots?.map((root) => root.id)).toEqual(
+      first.value.roots?.map((root) => root.id)
+    );
+    expect(first.value.roots).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "directory",
+          rootKind: "conversation",
+        }),
+        expect.objectContaining({ kind: "directory", rootKind: "pod" }),
+      ])
+    );
+  });
+
+  it("reads an initialized root", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initialized = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+    if (initialized.isErr()) {
+      throw initialized.error;
+    }
+    const root = requireNode(initialized.value.roots?.[0]);
+
+    const attributes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "getAttr",
+      nodeId: root.id,
+    });
+    const directory = await applyFileSystemOperation(authenticator, scope, {
+      operation: "readDir",
+      nodeId: root.id,
+      afterName: null,
+      limit: 32,
+    });
+    const missing = await applyFileSystemOperation(authenticator, scope, {
+      operation: "lookup",
+      parentId: root.id,
+      name: "missing.txt",
+    });
+
+    expect(attributes.isOk() && attributes.value.node).toEqual(root);
+    expect(directory.isOk() && directory.value).toEqual({
+      nodes: [],
+      nextAfterName: null,
+    });
+    expect(missing.isOk() && missing.value.node).toBeNull();
+  });
+
+  it("does not read a node outside the selected roots", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const firstScope = readableScope(`conversation-${randomUUID()}`);
+    const secondScope = readableScope(`conversation-${randomUUID()}`);
+    const initialized = await applyFileSystemOperation(
+      authenticator,
+      firstScope,
+      { operation: "initialize" }
+    );
+    if (initialized.isErr()) {
+      throw initialized.error;
+    }
+    const root = requireNode(initialized.value.roots?.[0]);
+
+    const result = await applyFileSystemOperation(authenticator, secondScope, {
+      operation: "getAttr",
+      nodeId: root.id,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("not_found");
+  });
+});

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -11,7 +11,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type {
-  FileSystemNode,
+  FileSystemNodeType,
   FileSystemOperation,
   FileSystemOperationResponse,
 } from "./namespace_types";

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -1,0 +1,55 @@
+import type { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
+import type {
+  FileSystemOperation,
+  FileSystemOperationError,
+  FileSystemOperationResponse,
+} from "@app/lib/api/file_system/namespace_types";
+import type { Authenticator } from "@app/lib/auth";
+import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type {
+  FileSystemNode,
+  FileSystemOperation,
+  FileSystemOperationResponse,
+} from "./namespace_types";
+export { FileSystemOperationError } from "./namespace_types";
+
+/** Run one filesystem read after the caller has selected the allowed roots. */
+export async function applyFileSystemOperation(
+  auth: Authenticator,
+  scope: FileSystemScope,
+  request: FileSystemOperation
+): Promise<Result<FileSystemOperationResponse, FileSystemOperationError>> {
+  switch (request.operation) {
+    case "initialize": {
+      const roots = await FileSystemNodeResource.ensureRoots(auth, scope);
+      return new Ok({ roots });
+    }
+    case "lookup": {
+      const node = await FileSystemNodeResource.lookup(
+        auth,
+        scope,
+        request.parentId,
+        request.name
+      );
+      return node.isErr() ? node : new Ok({ node: node.value });
+    }
+    case "getAttr": {
+      const node = await FileSystemNodeResource.getAttr(
+        auth,
+        scope,
+        request.nodeId
+      );
+      return node.isErr() ? node : new Ok({ node: node.value });
+    }
+    case "readDir": {
+      const result = await FileSystemNodeResource.readDir(auth, scope, request);
+      return result.isErr() ? result : new Ok(result.value);
+    }
+    default:
+      return assertNever(request);
+  }
+}

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -26,8 +26,10 @@ export async function applyFileSystemOperation(
   switch (request.operation) {
     case "initialize": {
       const roots = await FileSystemNodeResource.ensureRoots(auth, scope);
-      return new Ok({ roots });
+
+      return new Ok({ roots: roots.map((root) => root.toJSON()) });
     }
+
     case "lookup": {
       const node = await FileSystemNodeResource.lookup(
         auth,
@@ -35,20 +37,33 @@ export async function applyFileSystemOperation(
         request.parentId,
         request.name
       );
-      return node.isErr() ? node : new Ok({ node: node.value });
+
+      return node.isErr()
+        ? node
+        : new Ok({ node: node.value?.toJSON() ?? null });
     }
+
     case "getAttr": {
       const node = await FileSystemNodeResource.getAttr(
         auth,
         scope,
         request.nodeId
       );
-      return node.isErr() ? node : new Ok({ node: node.value });
+
+      return node.isErr() ? node : new Ok({ node: node.value.toJSON() });
     }
+
     case "readDir": {
       const result = await FileSystemNodeResource.readDir(auth, scope, request);
-      return result.isErr() ? result : new Ok(result.value);
+
+      return result.isErr()
+        ? result
+        : new Ok({
+            nodes: result.value.nodes.map((node) => node.toJSON()),
+            nextAfterName: result.value.nextAfterName,
+          });
     }
+
     default:
       return assertNever(request);
   }

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -1,13 +1,13 @@
 import type { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
 import type {
   FileSystemOperation,
-  FileSystemOperationError,
   FileSystemOperationResponse,
 } from "@app/lib/api/file_system/namespace_types";
+import { FileSystemOperationError } from "@app/lib/api/file_system/namespace_types";
 import type { Authenticator } from "@app/lib/auth";
 import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type {
@@ -31,12 +31,21 @@ export async function applyFileSystemOperation(
     }
 
     case "lookup": {
-      const node = await FileSystemNodeResource.lookup(
+      const parent = await FileSystemNodeResource.fetchById(
         auth,
         scope,
-        request.parentId,
-        request.name
+        request.parentId
       );
+      if (!parent) {
+        return new Err(
+          new FileSystemOperationError(
+            "not_found",
+            "The parent directory was not found."
+          )
+        );
+      }
+
+      const node = await parent.lookupChild(auth, scope, request.name);
 
       return node.isErr()
         ? node
@@ -44,17 +53,39 @@ export async function applyFileSystemOperation(
     }
 
     case "getAttr": {
-      const node = await FileSystemNodeResource.getAttr(
+      const node = await FileSystemNodeResource.fetchById(
         auth,
         scope,
         request.nodeId
       );
+      if (!node) {
+        return new Err(
+          new FileSystemOperationError("not_found", "The inode was not found.")
+        );
+      }
 
-      return node.isErr() ? node : new Ok({ node: node.value.toJSON() });
+      return new Ok({ node: node.toJSON() });
     }
 
     case "readDir": {
-      const result = await FileSystemNodeResource.readDir(auth, scope, request);
+      const directory = await FileSystemNodeResource.fetchById(
+        auth,
+        scope,
+        request.nodeId
+      );
+      if (!directory) {
+        return new Err(
+          new FileSystemOperationError(
+            "not_found",
+            "The directory was not found."
+          )
+        );
+      }
+
+      const result = await directory.readDir(auth, scope, {
+        afterName: request.afterName,
+        limit: request.limit,
+      });
 
       return result.isErr()
         ? result

--- a/front/lib/api/file_system/namespace_scope.ts
+++ b/front/lib/api/file_system/namespace_scope.ts
@@ -14,4 +14,10 @@ export class FileSystemScope {
   readableRoots(): readonly FileSystemAllowedRoot[] {
     return this.roots.filter((root) => root.permissions.canRead);
   }
+
+  canRead(kind: FileSystemRootKind, id: string): boolean {
+    return this.roots.some(
+      (root) => root.kind === kind && root.id === id && root.permissions.canRead
+    );
+  }
 }

--- a/front/lib/api/file_system/namespace_scope.ts
+++ b/front/lib/api/file_system/namespace_scope.ts
@@ -1,0 +1,17 @@
+export type FileSystemRootKind = "conversation" | "pod";
+
+export type FileSystemAllowedRoot = {
+  kind: FileSystemRootKind;
+  id: string;
+  name: string;
+  permissions: { canRead: boolean; canWrite: boolean };
+};
+
+/** Roots selected by the caller after checking access to them. */
+export class FileSystemScope {
+  constructor(readonly roots: readonly FileSystemAllowedRoot[]) {}
+
+  readableRoots(): readonly FileSystemAllowedRoot[] {
+    return this.roots.filter((root) => root.permissions.canRead);
+  }
+}

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -2,6 +2,11 @@ import type { FileSystemRootKind } from "@app/lib/api/file_system/namespace_scop
 
 export type FileSystemNodeKind = "directory" | "file";
 
+export const FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS = {
+  min: 1,
+  max: 256,
+} as const;
+
 /** The stable file or directory identity returned by the namespace. */
 export type FileSystemNode = {
   id: number;

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -1,0 +1,49 @@
+import type { FileSystemRootKind } from "@app/lib/api/file_system/namespace_scope";
+
+export type FileSystemNodeKind = "directory" | "file";
+
+/** The stable file or directory identity returned by the namespace. */
+export type FileSystemNode = {
+  id: number;
+  parentId: number | null;
+  rootKind: FileSystemRootKind;
+  rootId: string;
+  name: string;
+  kind: FileSystemNodeKind;
+  mode: number;
+  size: number;
+  contentType: string | null;
+  blobId: string | null;
+  contentRevision: number;
+  createdAtMs: number;
+  modifiedAtMs: number;
+};
+
+export type FileSystemOperation =
+  | { operation: "initialize" }
+  | { operation: "lookup"; parentId: number; name: string }
+  | { operation: "getAttr"; nodeId: number }
+  | {
+      operation: "readDir";
+      nodeId: number;
+      afterName: string | null;
+      limit: number;
+    };
+
+export type FileSystemOperationResponse = {
+  roots?: FileSystemNode[];
+  node?: FileSystemNode | null;
+  nodes?: FileSystemNode[];
+  nextAfterName?: string | null;
+};
+
+export type FileSystemOperationErrorCode = "invalid_operation" | "not_found";
+
+export class FileSystemOperationError extends Error {
+  constructor(
+    readonly code: FileSystemOperationErrorCode,
+    message: string
+  ) {
+    super(message);
+  }
+}

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -8,7 +8,7 @@ export const FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS = {
 } as const;
 
 /** The stable file or directory identity returned by the namespace. */
-export type FileSystemNode = {
+export type FileSystemNodeType = {
   id: number;
   parentId: number | null;
   rootKind: FileSystemRootKind;
@@ -36,9 +36,9 @@ export type FileSystemOperation =
     };
 
 export type FileSystemOperationResponse = {
-  roots?: FileSystemNode[];
-  node?: FileSystemNode | null;
-  nodes?: FileSystemNode[];
+  roots?: FileSystemNodeType[];
+  node?: FileSystemNodeType | null;
+  nodes?: FileSystemNodeType[];
   nextAfterName?: string | null;
 };
 

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -1,6 +1,6 @@
 import type { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
 import type {
-  FileSystemNode,
+  FileSystemNodeType,
   FileSystemOperation,
 } from "@app/lib/api/file_system/namespace_types";
 import {
@@ -206,7 +206,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
 
   // Node rendering.
 
-  toJSON(): FileSystemNode {
+  toJSON(): FileSystemNodeType {
     return {
       id: this.id,
       parentId: this.parentId,

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -5,32 +5,55 @@ import type {
 } from "@app/lib/api/file_system/namespace_types";
 import { FileSystemOperationError } from "@app/lib/api/file_system/namespace_types";
 import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileSystemNodeModel } from "@app/lib/resources/storage/models/file_system_node";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { WhereOptions } from "sequelize";
+import type { Attributes, WhereOptions } from "sequelize";
 import { Op } from "sequelize";
 
 type ReadDirRequest = Extract<FileSystemOperation, { operation: "readDir" }>;
 
-/** All Sequelize access for filesystem nodes lives in this Resource. */
-export class FileSystemNodeResource {
-  private static render(node: FileSystemNodeModel): FileSystemNode {
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface FileSystemNodeResource
+  extends ReadonlyAttributesType<FileSystemNodeModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
+  static model: ModelStaticWorkspaceAware<FileSystemNodeModel> =
+    FileSystemNodeModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<FileSystemNodeModel>,
+    blob: Attributes<FileSystemNodeModel>
+  ) {
+    super(model, blob);
+  }
+
+  toJSON(): FileSystemNode {
     return {
-      id: node.id,
-      parentId: node.parentId,
-      rootKind: node.rootKind,
-      rootId: node.rootId,
-      name: node.name,
-      kind: node.kind,
-      mode: node.mode,
-      size: Number(node.size),
-      contentType: node.contentType,
-      blobId: node.blobId,
-      contentRevision: node.contentRevision,
-      createdAtMs: node.createdAt.getTime(),
-      modifiedAtMs: node.updatedAt.getTime(),
+      id: this.id,
+      parentId: this.parentId,
+      rootKind: this.rootKind,
+      rootId: this.rootId,
+      name: this.name,
+      kind: this.kind,
+      mode: this.mode,
+      size: Number(this.size),
+      contentType: this.contentType,
+      blobId: this.blobId,
+      contentRevision: this.contentRevision,
+      createdAtMs: this.createdAt.getTime(),
+      modifiedAtMs: this.updatedAt.getTime(),
     };
+  }
+
+  override delete(): Promise<Result<undefined, Error>> {
+    // Removing a node also updates the mutation journal and blob cleanup queue.
+    // It must go through the filesystem mutation operation added later.
+    throw new Error("Filesystem nodes cannot be deleted directly.");
   }
 
   private static allowedWhere(
@@ -54,14 +77,14 @@ export class FileSystemNodeResource {
   static async ensureRoots(
     auth: Authenticator,
     scope: FileSystemScope
-  ): Promise<FileSystemNode[]> {
+  ): Promise<FileSystemNodeResource[]> {
     const readableRoots = scope.readableRoots();
     if (readableRoots.length === 0) {
       return [];
     }
 
     const workspaceId = auth.getNonNullableWorkspace().id;
-    await FileSystemNodeModel.bulkCreate(
+    await this.model.bulkCreate(
       readableRoots.map((root) => ({
         workspaceId,
         parentId: null,
@@ -78,7 +101,7 @@ export class FileSystemNodeResource {
       { ignoreDuplicates: true }
     );
 
-    const rows = await FileSystemNodeModel.findAll({
+    const rows = await this.model.findAll({
       where: {
         workspaceId,
         parentId: null,
@@ -97,7 +120,7 @@ export class FileSystemNodeResource {
       if (!row) {
         throw new Error(`Filesystem root ${root.kind}:${root.id} is missing.`);
       }
-      return this.render(row);
+      return new this(this.model, row.get());
     });
   }
 
@@ -105,15 +128,16 @@ export class FileSystemNodeResource {
     auth: Authenticator,
     scope: FileSystemScope,
     nodeId: number
-  ): Promise<FileSystemNodeModel | null> {
+  ): Promise<FileSystemNodeResource | null> {
     const allowedWhere = this.allowedWhere(auth, scope);
     if (!allowedWhere) {
       return null;
     }
 
-    return FileSystemNodeModel.findOne({
+    const row = await this.model.findOne({
       where: { ...allowedWhere, id: nodeId },
     });
+    return row ? new this(this.model, row.get()) : null;
   }
 
   static async lookup(
@@ -121,7 +145,7 @@ export class FileSystemNodeResource {
     scope: FileSystemScope,
     parentId: number,
     name: string
-  ): Promise<Result<FileSystemNode | null, FileSystemOperationError>> {
+  ): Promise<Result<FileSystemNodeResource | null, FileSystemOperationError>> {
     const parent = await this.fetch(auth, scope, parentId);
     if (!parent || parent.kind !== "directory") {
       return new Err(
@@ -136,20 +160,20 @@ export class FileSystemNodeResource {
     if (!allowedWhere) {
       return new Ok(null);
     }
-    const node = await FileSystemNodeModel.findOne({
+    const node = await this.model.findOne({
       where: { ...allowedWhere, parentId: parent.id, name },
     });
-    return new Ok(node ? this.render(node) : null);
+    return new Ok(node ? new this(this.model, node.get()) : null);
   }
 
   static async getAttr(
     auth: Authenticator,
     scope: FileSystemScope,
     nodeId: number
-  ): Promise<Result<FileSystemNode, FileSystemOperationError>> {
+  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
     const node = await this.fetch(auth, scope, nodeId);
     return node
-      ? new Ok(this.render(node))
+      ? new Ok(node)
       : new Err(
           new FileSystemOperationError("not_found", "The inode was not found.")
         );
@@ -161,7 +185,7 @@ export class FileSystemNodeResource {
     request: ReadDirRequest
   ): Promise<
     Result<
-      { nodes: FileSystemNode[]; nextAfterName: string | null },
+      { nodes: FileSystemNodeResource[]; nextAfterName: string | null },
       FileSystemOperationError
     >
   > {
@@ -192,7 +216,7 @@ export class FileSystemNodeResource {
     if (!allowedWhere) {
       return new Ok({ nodes: [], nextAfterName: null });
     }
-    const rows = await FileSystemNodeModel.findAll({
+    const rows = await this.model.findAll({
       where: {
         ...allowedWhere,
         parentId: directory.id,
@@ -204,7 +228,7 @@ export class FileSystemNodeResource {
     const page = rows.slice(0, request.limit);
 
     return new Ok({
-      nodes: page.map((row) => this.render(row)),
+      nodes: page.map((row) => new this(this.model, row.get())),
       nextAfterName:
         rows.length > request.limit ? (page.at(-1)?.name ?? null) : null,
     });

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -3,18 +3,23 @@ import type {
   FileSystemNode,
   FileSystemOperation,
 } from "@app/lib/api/file_system/namespace_types";
-import { FileSystemOperationError } from "@app/lib/api/file_system/namespace_types";
+import {
+  FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS,
+  FileSystemOperationError,
+} from "@app/lib/api/file_system/namespace_types";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileSystemNodeModel } from "@app/lib/resources/storage/models/file_system_node";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { Attributes, WhereOptions } from "sequelize";
+import type { Attributes } from "sequelize";
 import { Op } from "sequelize";
 
 type ReadDirRequest = Extract<FileSystemOperation, { operation: "readDir" }>;
+type ReadDirOptions = Pick<ReadDirRequest, "afterName" | "limit">;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface FileSystemNodeResource
@@ -32,46 +37,36 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     super(model, blob);
   }
 
-  toJSON(): FileSystemNode {
-    return {
-      id: this.id,
-      parentId: this.parentId,
-      rootKind: this.rootKind,
-      rootId: this.rootId,
-      name: this.name,
-      kind: this.kind,
-      mode: this.mode,
-      size: Number(this.size),
-      contentType: this.contentType,
-      blobId: this.blobId,
-      contentRevision: this.contentRevision,
-      createdAtMs: this.createdAt.getTime(),
-      modifiedAtMs: this.updatedAt.getTime(),
-    };
-  }
-
   override delete(): Promise<Result<undefined, Error>> {
     // Removing a node also updates the mutation journal and blob cleanup queue.
     // It must go through the filesystem mutation operation added later.
     throw new Error("Filesystem nodes cannot be deleted directly.");
   }
 
-  private static allowedWhere(
+  private static async baseFetch(
     auth: Authenticator,
-    scope: FileSystemScope
-  ): WhereOptions<FileSystemNodeModel> | null {
+    scope: FileSystemScope,
+    options: ResourceFindOptions<FileSystemNodeModel> = {}
+  ): Promise<FileSystemNodeResource[]> {
     const readableRoots = scope.readableRoots();
     if (readableRoots.length === 0) {
-      return null;
+      return [];
     }
 
-    return {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      [Op.or]: readableRoots.map((root) => ({
-        rootKind: root.kind,
-        rootId: root.id,
-      })),
-    };
+    const { where, ...otherOptions } = options;
+    const rows = await this.model.findAll({
+      ...otherOptions,
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        [Op.or]: readableRoots.map((root) => ({
+          rootKind: root.kind,
+          rootId: root.id,
+        })),
+      },
+    });
+
+    return rows.map((row) => new this(this.model, row.get()));
   }
 
   static async ensureRoots(
@@ -101,53 +96,49 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       { ignoreDuplicates: true }
     );
 
-    const rows = await this.model.findAll({
-      where: {
-        workspaceId,
-        parentId: null,
-        [Op.or]: readableRoots.map((root) => ({
-          rootKind: root.kind,
-          rootId: root.id,
-        })),
-      },
+    const roots = await this.baseFetch(auth, scope, {
+      where: { parentId: null },
     });
-    const rowsByRoot = new Map(
-      rows.map((row) => [`${row.rootKind}:${row.rootId}`, row])
+    const rootsByKey = new Map(
+      roots.map((root) => [`${root.rootKind}:${root.rootId}`, root])
     );
 
-    return readableRoots.map((root) => {
-      const row = rowsByRoot.get(`${root.kind}:${root.id}`);
-      if (!row) {
-        throw new Error(`Filesystem root ${root.kind}:${root.id} is missing.`);
+    return readableRoots.map((allowedRoot) => {
+      const root = rootsByKey.get(`${allowedRoot.kind}:${allowedRoot.id}`);
+      if (!root) {
+        throw new Error(
+          `Filesystem root ${allowedRoot.kind}:${allowedRoot.id} is missing.`
+        );
       }
-      return new this(this.model, row.get());
+      return root;
     });
   }
 
-  private static async fetch(
+  static async fetchById(
     auth: Authenticator,
     scope: FileSystemScope,
     nodeId: number
   ): Promise<FileSystemNodeResource | null> {
-    const allowedWhere = this.allowedWhere(auth, scope);
-    if (!allowedWhere) {
-      return null;
-    }
-
-    const row = await this.model.findOne({
-      where: { ...allowedWhere, id: nodeId },
+    const [node] = await this.baseFetch(auth, scope, {
+      where: { id: nodeId },
+      limit: 1,
     });
-    return row ? new this(this.model, row.get()) : null;
+    return node ?? null;
   }
 
-  static async lookup(
+  private isReadableBy(auth: Authenticator, scope: FileSystemScope): boolean {
+    return (
+      this.workspaceId === auth.getNonNullableWorkspace().id &&
+      scope.canRead(this.rootKind, this.rootId)
+    );
+  }
+
+  async lookupChild(
     auth: Authenticator,
     scope: FileSystemScope,
-    parentId: number,
     name: string
   ): Promise<Result<FileSystemNodeResource | null, FileSystemOperationError>> {
-    const parent = await this.fetch(auth, scope, parentId);
-    if (!parent || parent.kind !== "directory") {
+    if (!this.isReadableBy(auth, scope) || this.kind !== "directory") {
       return new Err(
         new FileSystemOperationError(
           "not_found",
@@ -156,33 +147,18 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       );
     }
 
-    const allowedWhere = this.allowedWhere(auth, scope);
-    if (!allowedWhere) {
-      return new Ok(null);
-    }
-    const node = await this.model.findOne({
-      where: { ...allowedWhere, parentId: parent.id, name },
+    const [node] = await FileSystemNodeResource.baseFetch(auth, scope, {
+      where: { parentId: this.id, name },
+      limit: 1,
     });
-    return new Ok(node ? new this(this.model, node.get()) : null);
+
+    return new Ok(node ?? null);
   }
 
-  static async getAttr(
+  async readDir(
     auth: Authenticator,
     scope: FileSystemScope,
-    nodeId: number
-  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
-    const node = await this.fetch(auth, scope, nodeId);
-    return node
-      ? new Ok(node)
-      : new Err(
-          new FileSystemOperationError("not_found", "The inode was not found.")
-        );
-  }
-
-  static async readDir(
-    auth: Authenticator,
-    scope: FileSystemScope,
-    request: ReadDirRequest
+    options: ReadDirOptions
   ): Promise<
     Result<
       { nodes: FileSystemNodeResource[]; nextAfterName: string | null },
@@ -190,20 +166,19 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     >
   > {
     if (
-      !Number.isInteger(request.limit) ||
-      request.limit < 1 ||
-      request.limit > 256
+      !Number.isInteger(options.limit) ||
+      options.limit < FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS.min ||
+      options.limit > FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS.max
     ) {
       return new Err(
         new FileSystemOperationError(
           "invalid_operation",
-          "Directory page size must be between 1 and 256."
+          `Directory page size must be between ${FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS.min} and ${FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS.max}.`
         )
       );
     }
 
-    const directory = await this.fetch(auth, scope, request.nodeId);
-    if (!directory || directory.kind !== "directory") {
+    if (!this.isReadableBy(auth, scope) || this.kind !== "directory") {
       return new Err(
         new FileSystemOperationError(
           "not_found",
@@ -212,25 +187,40 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       );
     }
 
-    const allowedWhere = this.allowedWhere(auth, scope);
-    if (!allowedWhere) {
-      return new Ok({ nodes: [], nextAfterName: null });
-    }
-    const rows = await this.model.findAll({
+    const nodes = await FileSystemNodeResource.baseFetch(auth, scope, {
       where: {
-        ...allowedWhere,
-        parentId: directory.id,
-        ...(request.afterName ? { name: { [Op.gt]: request.afterName } } : {}),
+        parentId: this.id,
+        ...(options.afterName ? { name: { [Op.gt]: options.afterName } } : {}),
       },
       order: [["name", "ASC"]],
-      limit: request.limit + 1,
+      limit: options.limit + 1,
     });
-    const page = rows.slice(0, request.limit);
+    const page = nodes.slice(0, options.limit);
 
     return new Ok({
-      nodes: page.map((row) => new this(this.model, row.get())),
+      nodes: page,
       nextAfterName:
-        rows.length > request.limit ? (page.at(-1)?.name ?? null) : null,
+        nodes.length > options.limit ? (page.at(-1)?.name ?? null) : null,
     });
+  }
+
+  // Node rendering.
+
+  toJSON(): FileSystemNode {
+    return {
+      id: this.id,
+      parentId: this.parentId,
+      rootKind: this.rootKind,
+      rootId: this.rootId,
+      name: this.name,
+      kind: this.kind,
+      mode: this.mode,
+      size: Number(this.size),
+      contentType: this.contentType,
+      blobId: this.blobId,
+      contentRevision: this.contentRevision,
+      createdAtMs: this.createdAt.getTime(),
+      modifiedAtMs: this.updatedAt.getTime(),
+    };
   }
 }

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -1,0 +1,212 @@
+import type { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
+import type {
+  FileSystemNode,
+  FileSystemOperation,
+} from "@app/lib/api/file_system/namespace_types";
+import { FileSystemOperationError } from "@app/lib/api/file_system/namespace_types";
+import type { Authenticator } from "@app/lib/auth";
+import { FileSystemNodeModel } from "@app/lib/resources/storage/models/file_system_node";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { WhereOptions } from "sequelize";
+import { Op } from "sequelize";
+
+type ReadDirRequest = Extract<FileSystemOperation, { operation: "readDir" }>;
+
+/** All Sequelize access for filesystem nodes lives in this Resource. */
+export class FileSystemNodeResource {
+  private static render(node: FileSystemNodeModel): FileSystemNode {
+    return {
+      id: node.id,
+      parentId: node.parentId,
+      rootKind: node.rootKind,
+      rootId: node.rootId,
+      name: node.name,
+      kind: node.kind,
+      mode: node.mode,
+      size: Number(node.size),
+      contentType: node.contentType,
+      blobId: node.blobId,
+      contentRevision: node.contentRevision,
+      createdAtMs: node.createdAt.getTime(),
+      modifiedAtMs: node.updatedAt.getTime(),
+    };
+  }
+
+  private static allowedWhere(
+    auth: Authenticator,
+    scope: FileSystemScope
+  ): WhereOptions<FileSystemNodeModel> | null {
+    const readableRoots = scope.readableRoots();
+    if (readableRoots.length === 0) {
+      return null;
+    }
+
+    return {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      [Op.or]: readableRoots.map((root) => ({
+        rootKind: root.kind,
+        rootId: root.id,
+      })),
+    };
+  }
+
+  static async ensureRoots(
+    auth: Authenticator,
+    scope: FileSystemScope
+  ): Promise<FileSystemNode[]> {
+    const readableRoots = scope.readableRoots();
+    if (readableRoots.length === 0) {
+      return [];
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    await FileSystemNodeModel.bulkCreate(
+      readableRoots.map((root) => ({
+        workspaceId,
+        parentId: null,
+        rootKind: root.kind,
+        rootId: root.id,
+        name: root.name,
+        kind: "directory" as const,
+        mode: 0o755,
+        size: 0,
+        contentType: null,
+        blobId: null,
+        contentRevision: 0,
+      })),
+      { ignoreDuplicates: true }
+    );
+
+    const rows = await FileSystemNodeModel.findAll({
+      where: {
+        workspaceId,
+        parentId: null,
+        [Op.or]: readableRoots.map((root) => ({
+          rootKind: root.kind,
+          rootId: root.id,
+        })),
+      },
+    });
+    const rowsByRoot = new Map(
+      rows.map((row) => [`${row.rootKind}:${row.rootId}`, row])
+    );
+
+    return readableRoots.map((root) => {
+      const row = rowsByRoot.get(`${root.kind}:${root.id}`);
+      if (!row) {
+        throw new Error(`Filesystem root ${root.kind}:${root.id} is missing.`);
+      }
+      return this.render(row);
+    });
+  }
+
+  private static async fetch(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    nodeId: number
+  ): Promise<FileSystemNodeModel | null> {
+    const allowedWhere = this.allowedWhere(auth, scope);
+    if (!allowedWhere) {
+      return null;
+    }
+
+    return FileSystemNodeModel.findOne({
+      where: { ...allowedWhere, id: nodeId },
+    });
+  }
+
+  static async lookup(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    parentId: number,
+    name: string
+  ): Promise<Result<FileSystemNode | null, FileSystemOperationError>> {
+    const parent = await this.fetch(auth, scope, parentId);
+    if (!parent || parent.kind !== "directory") {
+      return new Err(
+        new FileSystemOperationError(
+          "not_found",
+          "The parent directory was not found."
+        )
+      );
+    }
+
+    const allowedWhere = this.allowedWhere(auth, scope);
+    if (!allowedWhere) {
+      return new Ok(null);
+    }
+    const node = await FileSystemNodeModel.findOne({
+      where: { ...allowedWhere, parentId: parent.id, name },
+    });
+    return new Ok(node ? this.render(node) : null);
+  }
+
+  static async getAttr(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    nodeId: number
+  ): Promise<Result<FileSystemNode, FileSystemOperationError>> {
+    const node = await this.fetch(auth, scope, nodeId);
+    return node
+      ? new Ok(this.render(node))
+      : new Err(
+          new FileSystemOperationError("not_found", "The inode was not found.")
+        );
+  }
+
+  static async readDir(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    request: ReadDirRequest
+  ): Promise<
+    Result<
+      { nodes: FileSystemNode[]; nextAfterName: string | null },
+      FileSystemOperationError
+    >
+  > {
+    if (
+      !Number.isInteger(request.limit) ||
+      request.limit < 1 ||
+      request.limit > 256
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "Directory page size must be between 1 and 256."
+        )
+      );
+    }
+
+    const directory = await this.fetch(auth, scope, request.nodeId);
+    if (!directory || directory.kind !== "directory") {
+      return new Err(
+        new FileSystemOperationError(
+          "not_found",
+          "The directory was not found."
+        )
+      );
+    }
+
+    const allowedWhere = this.allowedWhere(auth, scope);
+    if (!allowedWhere) {
+      return new Ok({ nodes: [], nextAfterName: null });
+    }
+    const rows = await FileSystemNodeModel.findAll({
+      where: {
+        ...allowedWhere,
+        parentId: directory.id,
+        ...(request.afterName ? { name: { [Op.gt]: request.afterName } } : {}),
+      },
+      order: [["name", "ASC"]],
+      limit: request.limit + 1,
+    });
+    const page = rows.slice(0, request.limit);
+
+    return new Ok({
+      nodes: page.map((row) => this.render(row)),
+      nextAfterName:
+        rows.length > request.limit ? (page.at(-1)?.name ?? null) : null,
+    });
+  }
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See design document [here](https://app.notion.com/p/dust-tt/Design-Doc-Robust-Dust-File-System-3bb28599d94180ca8bfddcbd2ab7b2c3)

Dust’s new filesystem keeps its namespace in PostgreSQL. Each file or directory is represented by a stable node. Its parent and name determine where it appears, while its node ID remains unchanged when it is renamed or moved. The node also records its Conversation or Pod root and the metadata needed by the filesystem.

Access is restricted through a `FileSystemScope`, built after permissions have been checked. All reads are filtered by both workspace and the Conversation or Pod roots present in that scope.

This PR introduces the read side of the namespace.

`Namespace` is the entry point for filesystem operations. `FileSystemNodeResource` owns all database access, while the scope and operation types live in small supporting files.

Initialization creates the requested Conversation and Pod roots when needed. It is safe to retry and returns the same node IDs. Root creation is batched so adding more mounts does not produce one query per root.

Three read operations are currently supported:

### lookup

Finds a child from its parent node ID and name. It returns `null` when the child does not exist, and `not_found` when the parent is missing, outside the allowed scope, or not a directory.

### getAttr

Returns the stored metadata for a node: its parent, root, name, kind, mode, size, blob pointer, content revision and timestamps. Nodes outside the allowed scope are treated as not found.

### readDir

Lists the direct children of a directory in name order. Results are paginated using `afterName`, with page sizes limited to max 256 entries.

This PR deliberately stops before writes. Create, content updates, rename/move and delete will follow as separate changes. It also does not expose an HTTP endpoint or connect the namespace to the FUSE daemon yet.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
