### PR TITLE
Add filesystem namespace creation

### DIFF
--- a/front/lib/api/file_system/namespace.test.ts
+++ b/front/lib/api/file_system/namespace.test.ts
@@ -290,7 +290,7 @@ describe("filesystem namespace creation", () => {
     }
     const root = requireNode(initialized.value.roots?.[0]);
 
-    const unauthorized = await applyFileSystemOperation(
+    const writeDenied = await applyFileSystemOperation(
       authenticator,
       readOnlyScope(conversationId),
       {
@@ -331,9 +331,7 @@ describe("filesystem namespace creation", () => {
       mode: 0o644,
     });
 
-    expect(unauthorized.isErr() && unauthorized.error.code).toBe(
-      "unauthorized"
-    );
+    expect(writeDenied.isErr() && writeDenied.error.code).toBe("unauthorized");
     expect(invalidName.isErr() && invalidName.error.code).toBe(
       "invalid_operation"
     );

--- a/front/lib/api/file_system/namespace.test.ts
+++ b/front/lib/api/file_system/namespace.test.ts
@@ -26,6 +26,17 @@ function readableScope(conversationId: string, podId?: string) {
   ]);
 }
 
+function readOnlyScope(conversationId: string) {
+  return new FileSystemScope([
+    {
+      kind: "conversation",
+      id: conversationId,
+      name: `conversation-${conversationId}`,
+      permissions: { canRead: true, canWrite: false },
+    },
+  ]);
+}
+
 function requireNode(node: FileSystemNodeType | undefined): FileSystemNodeType {
   if (!node) {
     throw new Error("Missing filesystem node.");
@@ -123,5 +134,209 @@ describe("filesystem namespace reads", () => {
     });
 
     expect(result.isErr() && result.error.code).toBe("not_found");
+  });
+});
+
+describe("filesystem namespace creation", () => {
+  it("creates empty directories and files with stable node identities", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const conversationId = `conversation-${randomUUID()}`;
+    const scope = readableScope(conversationId);
+    const initialized = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+    if (initialized.isErr()) {
+      throw initialized.error;
+    }
+    const root = requireNode(initialized.value.roots?.[0]);
+
+    const directory = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "src",
+      kind: "directory",
+      mode: 0o755,
+    });
+    if (directory.isErr()) {
+      throw directory.error;
+    }
+    const directoryNode = requireNode(directory.value.node ?? undefined);
+
+    const file = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: directoryNode.id,
+      name: "index.ts",
+      kind: "file",
+      mode: 0o644,
+    });
+    if (file.isErr()) {
+      throw file.error;
+    }
+    const fileNode = requireNode(file.value.node ?? undefined);
+
+    expect(directoryNode).toEqual(
+      expect.objectContaining({
+        parentId: root.id,
+        rootKind: "conversation",
+        rootId: conversationId,
+        name: "src",
+        kind: "directory",
+        mode: 0o755,
+      })
+    );
+    expect(fileNode).toEqual(
+      expect.objectContaining({
+        parentId: directoryNode.id,
+        rootKind: "conversation",
+        rootId: conversationId,
+        name: "index.ts",
+        kind: "file",
+        mode: 0o644,
+        size: 0,
+        blobId: null,
+        contentRevision: 0,
+      })
+    );
+
+    const lookup = await applyFileSystemOperation(authenticator, scope, {
+      operation: "lookup",
+      parentId: directoryNode.id,
+      name: "index.ts",
+    });
+    expect(lookup.isOk() && lookup.value.node?.id).toBe(fileNode.id);
+  });
+
+  it("returns the same node when a create request is retried", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initialized = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+    if (initialized.isErr()) {
+      throw initialized.error;
+    }
+    const root = requireNode(initialized.value.roots?.[0]);
+    const request = {
+      operation: "create" as const,
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "retry.txt",
+      kind: "file" as const,
+      mode: 0o644,
+    };
+
+    const first = await applyFileSystemOperation(authenticator, scope, request);
+    const retry = await applyFileSystemOperation(authenticator, scope, request);
+    const directory = await applyFileSystemOperation(authenticator, scope, {
+      operation: "readDir",
+      nodeId: root.id,
+      afterName: null,
+      limit: 32,
+    });
+
+    expect(first.isOk() && first.value.node?.id).toBeDefined();
+    expect(retry.isOk() && retry.value.node?.id).toBe(
+      first.isOk() ? first.value.node?.id : undefined
+    );
+    expect(
+      directory.isOk() &&
+        directory.value.nodes?.filter((node) => node.name === request.name)
+    ).toHaveLength(1);
+  });
+
+  it("does not replace an existing name", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initialized = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+    if (initialized.isErr()) {
+      throw initialized.error;
+    }
+    const root = requireNode(initialized.value.roots?.[0]);
+
+    const first = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "existing",
+      kind: "file",
+      mode: 0o644,
+    });
+    const conflict = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "existing",
+      kind: "directory",
+      mode: 0o755,
+    });
+
+    expect(first.isOk()).toBe(true);
+    expect(conflict.isErr() && conflict.error.code).toBe("already_exists");
+  });
+
+  it("requires a writable directory and a valid name", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const conversationId = `conversation-${randomUUID()}`;
+    const scope = readableScope(conversationId);
+    const initialized = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+    if (initialized.isErr()) {
+      throw initialized.error;
+    }
+    const root = requireNode(initialized.value.roots?.[0]);
+
+    const unauthorized = await applyFileSystemOperation(
+      authenticator,
+      readOnlyScope(conversationId),
+      {
+        operation: "create",
+        requestId: randomUUID(),
+        parentId: root.id,
+        name: "blocked.txt",
+        kind: "file",
+        mode: 0o644,
+      }
+    );
+    const invalidName = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "nested/file.txt",
+      kind: "file",
+      mode: 0o644,
+    });
+    const file = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "parent.txt",
+      kind: "file",
+      mode: 0o644,
+    });
+    if (file.isErr()) {
+      throw file.error;
+    }
+    const fileNode = requireNode(file.value.node ?? undefined);
+    const fileAsParent = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: fileNode.id,
+      name: "child.txt",
+      kind: "file",
+      mode: 0o644,
+    });
+
+    expect(unauthorized.isErr() && unauthorized.error.code).toBe(
+      "unauthorized"
+    );
+    expect(invalidName.isErr() && invalidName.error.code).toBe(
+      "invalid_operation"
+    );
+    expect(fileAsParent.isErr() && fileAsParent.error.code).toBe("not_found");
   });
 });

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -5,6 +5,7 @@ import type {
 } from "@app/lib/api/file_system/namespace_types";
 import { FileSystemOperationError } from "@app/lib/api/file_system/namespace_types";
 import type { Authenticator } from "@app/lib/auth";
+import { FileSystemMutationResource } from "@app/lib/resources/file_system_mutation_resource";
 import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -93,6 +94,16 @@ export async function applyFileSystemOperation(
             nodes: result.value.nodes.map((node) => node.toJSON()),
             nextAfterName: result.value.nextAfterName,
           });
+    }
+
+    case "create": {
+      const node = await FileSystemMutationResource.createNode(
+        auth,
+        scope,
+        request
+      );
+
+      return node.isErr() ? node : new Ok({ node: node.value.toJSON() });
     }
 
     default:

--- a/front/lib/api/file_system/namespace_scope.ts
+++ b/front/lib/api/file_system/namespace_scope.ts
@@ -20,4 +20,11 @@ export class FileSystemScope {
       (root) => root.kind === kind && root.id === id && root.permissions.canRead
     );
   }
+
+  canWrite(kind: FileSystemRootKind, id: string): boolean {
+    return this.roots.some(
+      (root) =>
+        root.kind === kind && root.id === id && root.permissions.canWrite
+    );
+  }
 }

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -7,6 +7,15 @@ export const FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS = {
   max: 256,
 } as const;
 
+export const FILE_SYSTEM_NAME_MAX_BYTES = 255;
+
+export const FILE_SYSTEM_MODE_LIMITS = {
+  min: 0,
+  max: 0o7777,
+} as const;
+
+export const FILE_SYSTEM_REQUEST_ID_MAX_LENGTH = 255;
+
 /** The stable file or directory identity returned by the namespace. */
 export type FileSystemNodeType = {
   id: number;
@@ -33,6 +42,14 @@ export type FileSystemOperation =
       nodeId: number;
       afterName: string | null;
       limit: number;
+    }
+  | {
+      operation: "create";
+      requestId: string;
+      parentId: number;
+      name: string;
+      kind: FileSystemNodeKind;
+      mode: number;
     };
 
 export type FileSystemOperationResponse = {
@@ -42,7 +59,11 @@ export type FileSystemOperationResponse = {
   nextAfterName?: string | null;
 };
 
-export type FileSystemOperationErrorCode = "invalid_operation" | "not_found";
+export type FileSystemOperationErrorCode =
+  | "already_exists"
+  | "invalid_operation"
+  | "not_found"
+  | "unauthorized";
 
 export class FileSystemOperationError extends Error {
   constructor(

--- a/front/lib/resources/file_system_mutation_resource.ts
+++ b/front/lib/resources/file_system_mutation_resource.ts
@@ -1,0 +1,213 @@
+import type { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
+import type { FileSystemOperation } from "@app/lib/api/file_system/namespace_types";
+import {
+  FILE_SYSTEM_REQUEST_ID_MAX_LENGTH,
+  FileSystemOperationError,
+} from "@app/lib/api/file_system/namespace_types";
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { FileSystemMutationModel } from "@app/lib/resources/storage/models/file_system_mutation";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { Attributes, Transaction } from "sequelize";
+import { UniqueConstraintError } from "sequelize";
+import { z } from "zod";
+
+type CreateRequest = Extract<FileSystemOperation, { operation: "create" }>;
+
+const CreateMutationResponseSchema = z.object({
+  nodeId: z.number().int().positive(),
+});
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface FileSystemMutationResource
+  extends ReadonlyAttributesType<FileSystemMutationModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class FileSystemMutationResource extends BaseResource<FileSystemMutationModel> {
+  static model: ModelStaticWorkspaceAware<FileSystemMutationModel> =
+    FileSystemMutationModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<FileSystemMutationModel>,
+    blob: Attributes<FileSystemMutationModel>
+  ) {
+    super(model, blob);
+  }
+
+  override delete(): Promise<Result<undefined, Error>> {
+    // Receipts are removed by a retention job, never by request handling.
+    throw new Error("Filesystem mutation receipts cannot be deleted directly.");
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    requestId: string,
+    transaction?: Transaction
+  ): Promise<FileSystemMutationResource | null> {
+    const row = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        requestId,
+      },
+      transaction,
+    });
+
+    return row ? new this(this.model, row.get()) : null;
+  }
+
+  private async createdNode(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    transaction?: Transaction
+  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+    if (this.kind !== "create") {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "That request ID belongs to a different filesystem operation."
+        )
+      );
+    }
+
+    const parsed = CreateMutationResponseSchema.safeParse(this.response);
+    if (!parsed.success) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "The saved filesystem response is invalid."
+        )
+      );
+    }
+
+    const node = await FileSystemNodeResource.fetchById(
+      auth,
+      scope,
+      parsed.data.nodeId,
+      { transaction }
+    );
+    return node
+      ? new Ok(node)
+      : new Err(
+          new FileSystemOperationError(
+            "not_found",
+            "The node created by this request is no longer available."
+          )
+        );
+  }
+
+  static async createNode(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    request: CreateRequest
+  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+    if (
+      request.requestId.length === 0 ||
+      request.requestId.length > FILE_SYSTEM_REQUEST_ID_MAX_LENGTH
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          `Request ID must be between 1 and ${FILE_SYSTEM_REQUEST_ID_MAX_LENGTH} characters.`
+        )
+      );
+    }
+
+    try {
+      return await withTransaction(async (transaction) => {
+        // A lost response may cause the daemon to retry the same request. The
+        // lock keeps both attempts from creating a node before either receipt exists.
+        await this.lockRequest(auth, request.requestId, transaction);
+
+        const existing = await this.baseFetch(
+          auth,
+          request.requestId,
+          transaction
+        );
+        if (existing) {
+          return existing.createdNode(auth, scope, transaction);
+        }
+
+        // Locking the parent serializes two different requests for the same
+        // name. It also gives createChild the current root after a parent move.
+        const parent = await FileSystemNodeResource.fetchById(
+          auth,
+          scope,
+          request.parentId,
+          { transaction, forUpdate: true }
+        );
+        if (!parent) {
+          return new Err(
+            new FileSystemOperationError(
+              "not_found",
+              "The parent directory was not found."
+            )
+          );
+        }
+
+        const created = await parent.createChild(
+          auth,
+          scope,
+          request,
+          transaction
+        );
+        if (created.isErr()) {
+          return created;
+        }
+
+        await this.model.create(
+          {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            completedAt: new Date(),
+            requestId: request.requestId,
+            kind: "create",
+            response: { nodeId: created.value.id },
+          },
+          { transaction }
+        );
+
+        return created;
+      });
+    } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        // The unique index is the final guard for both request IDs and names.
+        // Re-check the receipt so a retry racing an older server still succeeds.
+        return withTransaction(async (transaction) => {
+          const existing = await this.baseFetch(
+            auth,
+            request.requestId,
+            transaction
+          );
+          return existing
+            ? existing.createdNode(auth, scope, transaction)
+            : new Err(
+                new FileSystemOperationError(
+                  "already_exists",
+                  `${request.name} already exists.`
+                )
+              );
+        });
+      }
+      throw error;
+    }
+  }
+
+  private static async lockRequest(
+    auth: Authenticator,
+    requestId: string,
+    transaction: Transaction
+  ): Promise<void> {
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const key = `file_system_create:${workspaceModelId}:${requestId}`;
+    // biome-ignore lint/plugin/noRawSql: PostgreSQL advisory locks have no Sequelize equivalent.
+    await frontSequelize.query("SELECT pg_advisory_xact_lock(hashtext(:key))", {
+      replacements: { key },
+      transaction,
+    });
+  }
+}

--- a/front/lib/resources/file_system_mutation_resource.ts
+++ b/front/lib/resources/file_system_mutation_resource.ts
@@ -7,7 +7,6 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
-import { frontSequelize } from "@app/lib/resources/storage";
 import { FileSystemMutationModel } from "@app/lib/resources/storage/models/file_system_mutation";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -120,10 +119,6 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
 
     try {
       return await withTransaction(async (transaction) => {
-        // A lost response may cause the daemon to retry the same request. The
-        // lock keeps both attempts from creating a node before either receipt exists.
-        await this.lockRequest(auth, request.requestId, transaction);
-
         const existing = await this.baseFetch(
           auth,
           request.requestId,
@@ -148,6 +143,17 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
               "The parent directory was not found."
             )
           );
+        }
+
+        // Another request can create the receipt while this one waits for the
+        // parent lock. Re-check it before creating a second node.
+        const concurrent = await this.baseFetch(
+          auth,
+          request.requestId,
+          transaction
+        );
+        if (concurrent) {
+          return concurrent.createdNode(auth, scope, transaction);
         }
 
         const created = await parent.createChild(
@@ -195,19 +201,5 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
       }
       throw error;
     }
-  }
-
-  private static async lockRequest(
-    auth: Authenticator,
-    requestId: string,
-    transaction: Transaction
-  ): Promise<void> {
-    const workspaceModelId = auth.getNonNullableWorkspace().id;
-    const key = `file_system_create:${workspaceModelId}:${requestId}`;
-    // biome-ignore lint/plugin/noRawSql: PostgreSQL advisory locks have no Sequelize equivalent.
-    await frontSequelize.query("SELECT pg_advisory_xact_lock(hashtext(:key))", {
-      replacements: { key },
-      transaction,
-    });
   }
 }

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -4,6 +4,8 @@ import type {
   FileSystemOperation,
 } from "@app/lib/api/file_system/namespace_types";
 import {
+  FILE_SYSTEM_MODE_LIMITS,
+  FILE_SYSTEM_NAME_MAX_BYTES,
   FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS,
   FileSystemOperationError,
 } from "@app/lib/api/file_system/namespace_types";
@@ -15,11 +17,13 @@ import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrapp
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import type { Attributes } from "sequelize";
+import type { Attributes, Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 type ReadDirRequest = Extract<FileSystemOperation, { operation: "readDir" }>;
 type ReadDirOptions = Pick<ReadDirRequest, "afterName" | "limit">;
+type CreateRequest = Extract<FileSystemOperation, { operation: "create" }>;
+type CreateOptions = Pick<CreateRequest, "kind" | "mode" | "name">;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface FileSystemNodeResource
@@ -46,7 +50,11 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
   private static async baseFetch(
     auth: Authenticator,
     scope: FileSystemScope,
-    options: ResourceFindOptions<FileSystemNodeModel> = {}
+    options: ResourceFindOptions<FileSystemNodeModel> = {},
+    {
+      transaction,
+      forUpdate = false,
+    }: { transaction?: Transaction; forUpdate?: boolean } = {}
   ): Promise<FileSystemNodeResource[]> {
     const readableRoots = scope.readableRoots();
     if (readableRoots.length === 0) {
@@ -64,6 +72,8 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
           rootId: root.id,
         })),
       },
+      transaction,
+      ...(transaction && forUpdate ? { lock: transaction.LOCK.UPDATE } : {}),
     });
 
     return rows.map((row) => new this(this.model, row.get()));
@@ -117,12 +127,18 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
   static async fetchById(
     auth: Authenticator,
     scope: FileSystemScope,
-    nodeId: number
+    nodeId: number,
+    options: { transaction?: Transaction; forUpdate?: boolean } = {}
   ): Promise<FileSystemNodeResource | null> {
-    const [node] = await this.baseFetch(auth, scope, {
-      where: { id: nodeId },
-      limit: 1,
-    });
+    const [node] = await this.baseFetch(
+      auth,
+      scope,
+      {
+        where: { id: nodeId },
+        limit: 1,
+      },
+      options
+    );
     return node ?? null;
   }
 
@@ -130,6 +146,103 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     return (
       this.workspaceId === auth.getNonNullableWorkspace().id &&
       scope.canRead(this.rootKind, this.rootId)
+    );
+  }
+
+  private isWritableBy(auth: Authenticator, scope: FileSystemScope): boolean {
+    return (
+      this.workspaceId === auth.getNonNullableWorkspace().id &&
+      scope.canWrite(this.rootKind, this.rootId)
+    );
+  }
+
+  async createChild(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    request: CreateOptions,
+    transaction: Transaction
+  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+    if (!this.isReadableBy(auth, scope) || this.kind !== "directory") {
+      return new Err(
+        new FileSystemOperationError(
+          "not_found",
+          "The parent directory was not found."
+        )
+      );
+    }
+    if (!this.isWritableBy(auth, scope)) {
+      return new Err(
+        new FileSystemOperationError(
+          "unauthorized",
+          "You do not have write access to this directory."
+        )
+      );
+    }
+    if (
+      request.name === "." ||
+      request.name === ".." ||
+      request.name.includes("/") ||
+      request.name.includes("\0") ||
+      Buffer.byteLength(request.name, "utf8") === 0 ||
+      Buffer.byteLength(request.name, "utf8") > FILE_SYSTEM_NAME_MAX_BYTES
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          `A file name must be between 1 and ${FILE_SYSTEM_NAME_MAX_BYTES} bytes and cannot contain a slash or null byte.`
+        )
+      );
+    }
+    if (
+      !Number.isInteger(request.mode) ||
+      request.mode < FILE_SYSTEM_MODE_LIMITS.min ||
+      request.mode > FILE_SYSTEM_MODE_LIMITS.max
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          `File mode must be between ${FILE_SYSTEM_MODE_LIMITS.min} and ${FILE_SYSTEM_MODE_LIMITS.max}.`
+        )
+      );
+    }
+
+    const [existing] = await FileSystemNodeResource.baseFetch(
+      auth,
+      scope,
+      {
+        where: { parentId: this.id, name: request.name },
+        limit: 1,
+      },
+      { transaction }
+    );
+    if (existing) {
+      return new Err(
+        new FileSystemOperationError(
+          "already_exists",
+          `${request.name} already exists.`
+        )
+      );
+    }
+
+    const row = await FileSystemNodeResource.model.create(
+      {
+        workspaceId: this.workspaceId,
+        parentId: this.id,
+        rootKind: this.rootKind,
+        rootId: this.rootId,
+        name: request.name,
+        kind: request.kind,
+        mode: request.mode,
+        size: 0,
+        contentType: null,
+        blobId: null,
+        contentRevision: 0,
+      },
+      { transaction }
+    );
+
+    return new Ok(
+      new FileSystemNodeResource(FileSystemNodeResource.model, row.get())
     );
   }
 

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -79,6 +79,31 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     return rows.map((row) => new this(this.model, row.get()));
   }
 
+  private static async makeNew(
+    parent: FileSystemNodeResource,
+    request: CreateOptions,
+    transaction: Transaction
+  ): Promise<FileSystemNodeResource> {
+    const row = await this.model.create(
+      {
+        workspaceId: parent.workspaceId,
+        parentId: parent.id,
+        rootKind: parent.rootKind,
+        rootId: parent.rootId,
+        name: request.name,
+        kind: request.kind,
+        mode: request.mode,
+        size: 0,
+        contentType: null,
+        blobId: null,
+        contentRevision: 0,
+      },
+      { transaction }
+    );
+
+    return new this(this.model, row.get());
+  }
+
   static async ensureRoots(
     auth: Authenticator,
     scope: FileSystemScope
@@ -156,6 +181,25 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     );
   }
 
+  private async fetchChildByName(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    name: string,
+    transaction?: Transaction
+  ): Promise<FileSystemNodeResource | null> {
+    const [child] = await FileSystemNodeResource.baseFetch(
+      auth,
+      scope,
+      {
+        where: { parentId: this.id, name },
+        limit: 1,
+      },
+      { transaction }
+    );
+
+    return child ?? null;
+  }
+
   async createChild(
     auth: Authenticator,
     scope: FileSystemScope,
@@ -206,14 +250,11 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       );
     }
 
-    const [existing] = await FileSystemNodeResource.baseFetch(
+    const existing = await this.fetchChildByName(
       auth,
       scope,
-      {
-        where: { parentId: this.id, name: request.name },
-        limit: 1,
-      },
-      { transaction }
+      request.name,
+      transaction
     );
     if (existing) {
       return new Err(
@@ -224,25 +265,8 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       );
     }
 
-    const row = await FileSystemNodeResource.model.create(
-      {
-        workspaceId: this.workspaceId,
-        parentId: this.id,
-        rootKind: this.rootKind,
-        rootId: this.rootId,
-        name: request.name,
-        kind: request.kind,
-        mode: request.mode,
-        size: 0,
-        contentType: null,
-        blobId: null,
-        contentRevision: 0,
-      },
-      { transaction }
-    );
-
     return new Ok(
-      new FileSystemNodeResource(FileSystemNodeResource.model, row.get())
+      await FileSystemNodeResource.makeNew(this, request, transaction)
     );
   }
 
@@ -260,12 +284,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       );
     }
 
-    const [node] = await FileSystemNodeResource.baseFetch(auth, scope, {
-      where: { parentId: this.id, name },
-      limit: 1,
-    });
-
-    return new Ok(node ?? null);
+    return new Ok(await this.fetchChildByName(auth, scope, name));
   }
 
   async readDir(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See design document [here](https://app.notion.com/p/dust-tt/Design-Doc-Robust-Dust-File-System-3bb28599d94180ca8bfddcbd2ab7b2c3)

Dust’s filesystem namespace gives every file and directory a stable node. Its parent and name determine where it appears, while its node ID remains unchanged throughout its lifetime.

The previous PR (https://github.com/dust-tt/dust/pull/30582) introduced namespace initialization and reads. This PR adds the first write operation: creating a node.

## What this PR adds

`createNode` creates either an empty file or a directory beneath an existing directory.

The parent is fetched once as a `FileSystemNodeResource`, which then owns the creation of its child. The operation checks that the parent exists, is a directory, and belongs to a writable Conversation or Pod root.

The node and its mutation receipt are created in the same database transaction. Retrying the same mutation is therefore safe and returns the result of the first attempt without creating another node.

Names must be unique within a directory. Creating a different node at an existing name returns a conflict instead of replacing it.

New files contain no bytes yet. Uploading content and attaching a GCS blob will come in a later PR. Rename, move and delete are also outside this change.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
