### PR TITLE
[front] perf: speed up MCP server facet loading in new analytics

### DIFF
--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -1,4 +1,7 @@
-import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import {
+  getMcpServerDisplayName,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
 import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
 import { SOURCE_ORIGIN_LABELS } from "@app/lib/api/analytics/source_labels";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
@@ -8,6 +11,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import type { MCPServerViewDisplayMetadata } from "@app/lib/resources/mcp_server_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -65,21 +69,20 @@ function traceFacetCatalogLoad<T>(
 }
 
 function toolFacetCatalogEntries(
-  mcpServerViews: MCPServerViewResource[]
+  mcpServerViews: MCPServerViewDisplayMetadata[]
 ): ConsumptionFacetCatalogEntry[] {
   const entries = mcpServerViews.flatMap<ConsumptionFacetCatalogEntry>(
     (view) => {
-      const server = view.getServerDisplayMetadata();
       if (view.serverType === "internal") {
         return [
           {
-            value: server.name,
+            value: view.serverName,
             label: getMcpServerDisplayName({
               sId: view.mcpServerId,
-              name: server.name,
+              name: view.serverName,
             }),
             pictureUrl: null,
-            icon: server.icon,
+            icon: view.icon,
           },
         ];
       }
@@ -92,10 +95,16 @@ function toolFacetCatalogEntries(
       // indexed data and would show a disabled duplicate in the UI.
       return [
         {
-          value: view.name ?? server.name,
-          label: view.getDisplayName(),
+          value: view.viewName ?? view.serverName,
+          label: getMcpServerViewDisplayName({
+            name: view.viewName,
+            server: {
+              sId: view.mcpServerId,
+              name: view.serverName,
+            },
+          }),
           pictureUrl: null,
-          icon: server.icon,
+          icon: view.icon,
         },
       ];
     }
@@ -165,7 +174,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
     "mcp_servers",
     "tool",
     requestedDimension,
-    () => MCPServerViewResource.listByWorkspace(auth)
+    () => MCPServerViewResource.listDisplayMetadataByWorkspace(auth)
   );
   const skills = await traceFacetCatalogLoad(
     "skills",

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -806,7 +806,7 @@ describe("MCPServerViewResource", () => {
     });
   });
 
-  describe("toolsMetadata", () => {
+  describe("display and tool metadata", () => {
     let workspace: WorkspaceType;
     let adminAuth: Authenticator;
 
@@ -815,6 +815,32 @@ describe("MCPServerViewResource", () => {
       adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       await SpaceFactory.defaults(adminAuth);
       await FeatureFlagFactory.basic(adminAuth, "dev_mcp_actions");
+    });
+
+    it("lists display metadata for internal and remote servers", async () => {
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        { name: "ashby", useCase: null }
+      );
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+
+      const metadata =
+        await MCPServerViewResource.listDisplayMetadataByWorkspace(adminAuth);
+
+      expect(metadata).toContainEqual({
+        serverType: "internal",
+        viewName: null,
+        mcpServerId: internalServer.id,
+        serverName: internalServer.toJSON().name,
+        icon: internalServer.toJSON().icon,
+      });
+      expect(metadata).toContainEqual({
+        serverType: "remote",
+        viewName: null,
+        mcpServerId: remoteServer.sId,
+        serverName: remoteServer.cachedName,
+        icon: remoteServer.icon,
+      });
     });
 
     it("should populate toolsMetadata for internal server views", async () => {

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -97,6 +97,14 @@ type MCPServerViewCreationResult = {
   affectedAgents?: AffectedAgent[];
 };
 
+export type MCPServerViewDisplayMetadata = {
+  serverType: "internal" | "remote";
+  viewName: string | null;
+  mcpServerId: string;
+  serverName: string;
+  icon: CustomResourceIconType | InternalAllowedIconType;
+};
+
 export type GetMCPServerViewsResponseBody = {
   success: boolean;
   serverViews: MCPServerViewType[];
@@ -698,6 +706,69 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   ): Promise<MCPServerViewResource[]> {
     const { includeHeavyAttributes, ...findOptions } = options ?? {};
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
+  }
+
+  /** Lists names and icons without hydrating spaces, credentials, or tools. */
+  static async listDisplayMetadataByWorkspace(
+    auth: Authenticator
+  ): Promise<MCPServerViewDisplayMetadata[]> {
+    const views = await this.model.findAll({
+      attributes: [
+        "serverType",
+        "name",
+        "internalMCPServerId",
+        "remoteMCPServerId",
+      ],
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+    });
+
+    const remoteServerModelIds = [
+      ...new Set(removeNulls(views.map((view) => view.remoteMCPServerId))),
+    ];
+    const remoteServers = await RemoteMCPServerResource.fetchByModelIds(
+      auth,
+      remoteServerModelIds
+    );
+    const remoteServersById = new Map(
+      remoteServers.map((server) => [server.id, server])
+    );
+
+    return removeNulls(
+      views.map((view): MCPServerViewDisplayMetadata | null => {
+        if (view.serverType === "remote" && view.remoteMCPServerId) {
+          const server = remoteServersById.get(view.remoteMCPServerId);
+          return server
+            ? {
+                serverType: view.serverType,
+                viewName: view.name,
+                mcpServerId: server.sId,
+                serverName: server.cachedName,
+                icon: server.icon,
+              }
+            : null;
+        }
+
+        if (view.serverType === "internal" && view.internalMCPServerId) {
+          const server = getInternalMCPServerNameAndWorkspaceId(
+            view.internalMCPServerId
+          );
+          if (server.isErr()) {
+            return null;
+          }
+          const { serverInfo } =
+            INTERNAL_MCP_SERVERS[server.value.name].metadata;
+          return {
+            serverType: view.serverType,
+            viewName: view.name,
+            mcpServerId: view.internalMCPServerId,
+            serverName: serverInfo.name,
+            icon: serverInfo.icon,
+          };
+        }
+
+        return null;
+      })
+    );
   }
 
   static async resolveDisplayMetadataByNames(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -708,7 +708,6 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     return this.baseFetch(auth, findOptions, { includeHeavyAttributes });
   }
 
-  /** Lists names and icons without hydrating spaces, credentials, or tools. */
   static async listDisplayMetadataByWorkspace(
     auth: Authenticator
   ): Promise<MCPServerViewDisplayMetadata[]> {


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/10069.

The MCP server facet is currently loading MCP server views using `listByWorkspace` to get names and icons.
This method is actually very inefficient, but for the wrong reasons (not for permission check): it does several joins/separate queries that are not always useful and hard to opt-out from in the current state of things, fetching twice on `mcp_server_views` for instance.

To get things moving without having to refactor this too much, this PR adds a small resource method that uses at most 2 queries instead of 7: one for views and one for remote servers, and reads the data for internal server metadata directly from the object we have already defined in the code. I'll optimize the common code path later (quite large blast radius).

Next step is to add some resource-level caching on the resources fetched for the facets here.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
