### PR TITLE
Ungate Slack auto-respond without mention

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/linked_slack_channels.ts
@@ -1,6 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import config from "@app/lib/api/config";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
@@ -40,20 +39,6 @@ app.patch(
     const auth = ctx.get("auth");
     const { aId } = ctx.req.valid("param");
     const body = ctx.req.valid("json");
-
-    if (body.auto_respond_without_mention) {
-      const featureFlags = await getFeatureFlags(auth);
-      if (!featureFlags.includes("slack_enhanced_default_agent")) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "feature_flag_not_found",
-            message:
-              "The auto respond without mention feature is not enabled for this workspace.",
-          },
-        });
-      }
-    }
 
     const [slackDataSource] = await DataSourceResource.listByConnectorProvider(
       auth,

--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -1,6 +1,5 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useSlackUserPrivateChannels } from "@app/lib/swr/assistants";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import type { DataSourceType } from "@app/types/data_source";
@@ -292,7 +291,6 @@ export function SlackSettingsSheet({
   slackDataSource,
 }: SlackSettingsSheetProps) {
   const { owner } = useAgentBuilderContext();
-  const { hasFeature } = useFeatureFlags();
 
   const {
     field: { onChange, value: slackChannels },
@@ -434,7 +432,7 @@ export function SlackSettingsSheet({
             disabled: !hasUnsavedChanges,
           }}
         >
-          {hasFeature("slack_enhanced_default_agent") && isAdmin(owner) && (
+          {isAdmin(owner) && (
             <div className="flex flex-col gap-3 border-t p-4">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex min-w-0 flex-1 flex-col gap-1">

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -163,11 +163,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to noop model in the agent builder",
     stage: "dust_only",
   },
-  slack_enhanced_default_agent: {
-    description:
-      "Enhanced default agent feature for Slack channels - auto-respond to all messages in channel",
-    stage: "on_demand",
-  },
   slack_message_splitting: {
     description:
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -789,7 +789,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "servicenow_tool"
   | "shopify_tool"
   | "show_debug_tools"
-  | "slack_enhanced_default_agent"
   | "slack_message_splitting"
   | "run_tools_from_prompt"
   | "usage_data_api"


### PR DESCRIPTION
## Summary
- Remove the `slack_enhanced_default_agent` feature flag so Slack channel auto-respond (reply to all messages, not just @mentions) is available in every workspace.
- Admins still control the setting in agent Slack channel settings; the API no longer 403s when the flag is off.
- This has been in the wild for over a year so likely overdue

## Testing
No new functionality

## Deploy
1. Deploy front

## Risk
Low, but does release feature to all