### PR TITLE
  Add POSIX rename and move to the filesystem namespace

### DIFF
--- a/front/lib/api/file_system/namespace.test.ts
+++ b/front/lib/api/file_system/namespace.test.ts
@@ -4,6 +4,8 @@ import { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
 import type { FileSystemNodeType } from "@app/lib/api/file_system/namespace_types";
 import { FILE_SYSTEM_CONTENT_MAX_BYTES } from "@app/lib/api/file_system/namespace_types";
 import type { Authenticator } from "@app/lib/auth";
+import { FileSystemBlobCleanupResource } from "@app/lib/resources/file_system_blob_cleanup_resource";
+import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { beforeEach, describe, expect, it } from "vitest";
@@ -74,6 +76,34 @@ async function createEmptyFile(
     name,
     kind: "file",
     mode: 0o644,
+  });
+  if (createdRes.isErr()) {
+    throw createdRes.error;
+  }
+
+  return requireNode(createdRes.value.node ?? undefined);
+}
+
+async function createNode(
+  auth: Authenticator,
+  scope: FileSystemScope,
+  {
+    parentId,
+    name,
+    kind,
+  }: {
+    parentId: number;
+    name: string;
+    kind: "directory" | "file";
+  }
+): Promise<FileSystemNodeType> {
+  const createdRes = await applyFileSystemOperation(auth, scope, {
+    operation: "create",
+    requestId: randomUUID(),
+    parentId,
+    name,
+    kind,
+    mode: kind === "directory" ? 0o755 : 0o644,
   });
   if (createdRes.isErr()) {
     throw createdRes.error;
@@ -376,6 +406,535 @@ describe("filesystem namespace creation", () => {
     expect(fileAsParent.isErr() && fileAsParent.error.code).toBe("not_found");
   });
 });
+
+describe("filesystem namespace rename", () => {
+  it("renames a file without changing its identity and replays the same request", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const root = requireNode(initializedRes.value.roots?.[0]);
+    const source = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "before.txt",
+      kind: "file",
+    });
+    const request = {
+      operation: "rename" as const,
+      requestId: randomUUID(),
+      sourceParentId: root.id,
+      sourceName: source.name,
+      destinationParentId: root.id,
+      destinationName: "after.txt",
+    };
+
+    const renamedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      request
+    );
+    const retriedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      request
+    );
+    const oldPathRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "lookup",
+      parentId: root.id,
+      name: source.name,
+    });
+    const newPathRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "lookup",
+      parentId: root.id,
+      name: request.destinationName,
+    });
+    const noOpRes = await applyFileSystemOperation(authenticator, scope, {
+      ...request,
+      requestId: randomUUID(),
+      sourceName: request.destinationName,
+    });
+    const reusedRequestIdRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { ...request, destinationName: "somewhere-else.txt" }
+    );
+    const replacement = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "replacement.txt",
+      kind: "file",
+    });
+    const replacementRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "rename",
+        requestId: randomUUID(),
+        sourceParentId: root.id,
+        sourceName: replacement.name,
+        destinationParentId: root.id,
+        destinationName: request.destinationName,
+      }
+    );
+    const replayedAfterReplacementRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      request
+    );
+    const replacedSourceRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "getAttr", nodeId: source.id }
+    );
+
+    expect(renamedRes.isOk() && renamedRes.value.node).toMatchObject({
+      id: source.id,
+      parentId: root.id,
+      name: request.destinationName,
+    });
+    expect(retriedRes.isOk() && retriedRes.value.node).toMatchObject({
+      id: source.id,
+      name: request.destinationName,
+    });
+    expect(oldPathRes.isOk() && oldPathRes.value.node).toBeNull();
+    expect(newPathRes.isOk() && newPathRes.value.node?.id).toBe(source.id);
+    expect(noOpRes.isOk() && noOpRes.value.node?.id).toBe(source.id);
+    expect(reusedRequestIdRes.isErr() && reusedRequestIdRes.error.code).toBe(
+      "invalid_operation"
+    );
+    expect(replacementRes.isOk() && replacementRes.value.node?.id).toBe(
+      replacement.id
+    );
+    expect(replacedSourceRes.isErr() && replacedSourceRes.error.code).toBe(
+      "not_found"
+    );
+    expect(
+      replayedAfterReplacementRes.isOk() &&
+        replayedAfterReplacementRes.value.node
+    ).toEqual(renamedRes.isOk() ? renamedRes.value.node : undefined);
+  });
+
+  it("moves a directory tree between conversation and Pod roots", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const conversationId = `conversation-${randomUUID()}`;
+    const podId = `pod-${randomUUID()}`;
+    const scope = readableScope(conversationId, podId);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const conversationRoot = requireNode(initializedRes.value.roots?.[0]);
+    const podRoot = requireNode(initializedRes.value.roots?.[1]);
+    const directory = await createNode(authenticator, scope, {
+      parentId: conversationRoot.id,
+      name: "project",
+      kind: "directory",
+    });
+    const nestedDirectory = await createNode(authenticator, scope, {
+      parentId: directory.id,
+      name: "src",
+      kind: "directory",
+    });
+    const file = await createNode(authenticator, scope, {
+      parentId: nestedDirectory.id,
+      name: "index.ts",
+      kind: "file",
+    });
+
+    const movedRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "rename",
+      requestId: randomUUID(),
+      sourceParentId: conversationRoot.id,
+      sourceName: directory.name,
+      destinationParentId: podRoot.id,
+      destinationName: directory.name,
+    });
+    const movedDirectoryRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "getAttr", nodeId: directory.id }
+    );
+    const movedNestedDirectoryRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "getAttr", nodeId: nestedDirectory.id }
+    );
+    const movedFileRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "getAttr",
+      nodeId: file.id,
+    });
+    const oldScopeRes = await applyFileSystemOperation(
+      authenticator,
+      readableScope(conversationId),
+      { operation: "getAttr", nodeId: file.id }
+    );
+
+    expect(movedRes.isOk() && movedRes.value.node).toMatchObject({
+      id: directory.id,
+      parentId: podRoot.id,
+      rootKind: "pod",
+      rootId: podId,
+    });
+    for (const nodeRes of [
+      movedDirectoryRes,
+      movedNestedDirectoryRes,
+      movedFileRes,
+    ]) {
+      expect(nodeRes.isOk() && nodeRes.value.node).toMatchObject({
+        rootKind: "pod",
+        rootId: podId,
+      });
+    }
+    expect(
+      movedNestedDirectoryRes.isOk() && movedNestedDirectoryRes.value.node
+    ).toMatchObject({ id: nestedDirectory.id });
+    expect(movedFileRes.isOk() && movedFileRes.value.node).toMatchObject({
+      id: file.id,
+      blobId: file.blobId,
+      contentRevision: file.contentRevision,
+    });
+    expect(oldScopeRes.isErr() && oldScopeRes.error.code).toBe("not_found");
+  });
+
+  it("atomically replaces a file and retires the replaced content", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const root = requireNode(initializedRes.value.roots?.[0]);
+    const source = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "temporary.txt",
+      kind: "file",
+    });
+    const destination = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "document.txt",
+      kind: "file",
+    });
+    const preparedRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "prepareContentUpload",
+      nodeId: destination.id,
+      expectedBlobId: null,
+      expectedSizeBytes: 14,
+      contentType: "text/plain",
+    });
+    if (preparedRes.isErr() || !preparedRes.value.upload) {
+      throw new Error("Failed to prepare destination content.");
+    }
+    const committedRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "commitContentUpload",
+      nodeId: destination.id,
+      expectedBlobId: null,
+      blobId: preparedRes.value.upload.blobId,
+      expectedSizeBytes: preparedRes.value.upload.expectedSizeBytes,
+      contentType: preparedRes.value.upload.contentType,
+    });
+    if (committedRes.isErr() || !committedRes.value.node?.blobId) {
+      throw new Error("Failed to commit destination content.");
+    }
+    const destinationResource = await FileSystemNodeResource.fetchById(
+      authenticator,
+      scope,
+      destination.id
+    );
+    if (!destinationResource) {
+      throw new Error("Missing destination resource.");
+    }
+    const replacedBlobId = committedRes.value.node.blobId;
+
+    const renamedRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "rename",
+      requestId: randomUUID(),
+      sourceParentId: root.id,
+      sourceName: source.name,
+      destinationParentId: root.id,
+      destinationName: destination.name,
+    });
+    const replacedNodeRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "getAttr", nodeId: destination.id }
+    );
+    const cleanup = await FileSystemBlobCleanupResource.fetchForBlob(
+      authenticator,
+      destinationResource,
+      { blobId: replacedBlobId }
+    );
+
+    expect(renamedRes.isOk() && renamedRes.value.node).toMatchObject({
+      id: source.id,
+      name: destination.name,
+      blobId: source.blobId,
+    });
+    expect(replacedNodeRes.isErr() && replacedNodeRes.error.code).toBe(
+      "not_found"
+    );
+    expect(cleanup).toMatchObject({
+      nodeId: destination.id,
+      blobId: replacedBlobId,
+    });
+  });
+
+  it("replaces an empty directory with the source directory", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const root = requireNode(initializedRes.value.roots?.[0]);
+    const source = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "source",
+      kind: "directory",
+    });
+    const destination = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "destination",
+      kind: "directory",
+    });
+
+    const renamedRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "rename",
+      requestId: randomUUID(),
+      sourceParentId: root.id,
+      sourceName: source.name,
+      destinationParentId: root.id,
+      destinationName: destination.name,
+    });
+    const replacedNodeRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "getAttr", nodeId: destination.id }
+    );
+
+    expect(renamedRes.isOk() && renamedRes.value.node).toMatchObject({
+      id: source.id,
+      name: destination.name,
+    });
+    expect(replacedNodeRes.isErr() && replacedNodeRes.error.code).toBe(
+      "not_found"
+    );
+  });
+
+  it("rejects directory cycles and incompatible replacements", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const root = requireNode(initializedRes.value.roots?.[0]);
+    const directory = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "directory",
+      kind: "directory",
+    });
+    const childDirectory = await createNode(authenticator, scope, {
+      parentId: directory.id,
+      name: "child",
+      kind: "directory",
+    });
+    await createNode(authenticator, scope, {
+      parentId: childDirectory.id,
+      name: "nested.txt",
+      kind: "file",
+    });
+    const file = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "file.txt",
+      kind: "file",
+    });
+    const nonEmptyDestination = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "destination",
+      kind: "directory",
+    });
+    await createNode(authenticator, scope, {
+      parentId: nonEmptyDestination.id,
+      name: "existing.txt",
+      kind: "file",
+    });
+
+    const cycleRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "rename",
+      requestId: randomUUID(),
+      sourceParentId: root.id,
+      sourceName: directory.name,
+      destinationParentId: childDirectory.id,
+      destinationName: directory.name,
+    });
+    const fileOverDirectoryRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "rename",
+        requestId: randomUUID(),
+        sourceParentId: root.id,
+        sourceName: file.name,
+        destinationParentId: root.id,
+        destinationName: nonEmptyDestination.name,
+      }
+    );
+    const directoryOverFileRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "rename",
+        requestId: randomUUID(),
+        sourceParentId: root.id,
+        sourceName: directory.name,
+        destinationParentId: root.id,
+        destinationName: file.name,
+      }
+    );
+    const nonEmptyDirectoryRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "rename",
+        requestId: randomUUID(),
+        sourceParentId: directory.id,
+        sourceName: childDirectory.name,
+        destinationParentId: root.id,
+        destinationName: nonEmptyDestination.name,
+      }
+    );
+    const directoryLookupRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "lookup", parentId: root.id, name: directory.name }
+    );
+    const fileLookupRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "lookup",
+      parentId: root.id,
+      name: file.name,
+    });
+    const destinationLookupRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "lookup",
+        parentId: root.id,
+        name: nonEmptyDestination.name,
+      }
+    );
+
+    expect(cycleRes.isErr() && cycleRes.error.code).toBe("invalid_operation");
+    expect(
+      fileOverDirectoryRes.isErr() && fileOverDirectoryRes.error.code
+    ).toBe("is_directory");
+    expect(
+      directoryOverFileRes.isErr() && directoryOverFileRes.error.code
+    ).toBe("not_directory");
+    expect(
+      nonEmptyDirectoryRes.isErr() && nonEmptyDirectoryRes.error.code
+    ).toBe("not_empty");
+    expect(directoryLookupRes.isOk() && directoryLookupRes.value.node?.id).toBe(
+      directory.id
+    );
+    expect(fileLookupRes.isOk() && fileLookupRes.value.node?.id).toBe(file.id);
+    expect(
+      destinationLookupRes.isOk() && destinationLookupRes.value.node?.id
+    ).toBe(nonEmptyDestination.id);
+  });
+
+  it("requires write access to the destination root", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const conversationId = `conversation-${randomUUID()}`;
+    const podId = `pod-${randomUUID()}`;
+    const writableScope = readableScope(conversationId, podId);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      writableScope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const conversationRoot = requireNode(initializedRes.value.roots?.[0]);
+    const podRoot = requireNode(initializedRes.value.roots?.[1]);
+    const source = await createNode(authenticator, writableScope, {
+      parentId: conversationRoot.id,
+      name: "private.txt",
+      kind: "file",
+    });
+    const destinationReadOnlyScope = new FileSystemScope([
+      {
+        kind: "conversation",
+        id: conversationId,
+        name: `conversation-${conversationId}`,
+        permissions: { canRead: true, canWrite: true },
+      },
+      {
+        kind: "pod",
+        id: podId,
+        name: `pod-${podId}`,
+        permissions: { canRead: true, canWrite: false },
+      },
+    ]);
+
+    const deniedRes = await applyFileSystemOperation(
+      authenticator,
+      destinationReadOnlyScope,
+      {
+        operation: "rename",
+        requestId: randomUUID(),
+        sourceParentId: conversationRoot.id,
+        sourceName: source.name,
+        destinationParentId: podRoot.id,
+        destinationName: source.name,
+      }
+    );
+    const sourceLookupRes = await applyFileSystemOperation(
+      authenticator,
+      writableScope,
+      {
+        operation: "lookup",
+        parentId: conversationRoot.id,
+        name: source.name,
+      }
+    );
+    const destinationLookupRes = await applyFileSystemOperation(
+      authenticator,
+      writableScope,
+      { operation: "lookup", parentId: podRoot.id, name: source.name }
+    );
+
+    expect(deniedRes.isErr() && deniedRes.error.code).toBe("unauthorized");
+    expect(sourceLookupRes.isOk() && sourceLookupRes.value.node?.id).toBe(
+      source.id
+    );
+    expect(
+      destinationLookupRes.isOk() && destinationLookupRes.value.node
+    ).toBeNull();
+  });
+});
+
 describe("filesystem content", () => {
   it("commits one immutable blob and returns it for reads", async () => {
     const { authenticator, workspace } = await createResourceTest({

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -106,6 +106,16 @@ export async function applyFileSystemOperation(
       return node.isErr() ? node : new Ok({ node: node.value.toJSON() });
     }
 
+    case "rename": {
+      const nodeRes = await FileSystemMutationResource.renameNode(
+        auth,
+        scope,
+        request
+      );
+
+      return nodeRes.isErr() ? nodeRes : new Ok({ node: nodeRes.value });
+    }
+
     case "getContent": {
       const node = await FileSystemNodeResource.fetchById(
         auth,

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -1,6 +1,16 @@
 import type { FileSystemRootKind } from "@app/lib/api/file_system/namespace_scope";
+import { z } from "zod";
 
 export type FileSystemNodeKind = "directory" | "file";
+
+const FileSystemRootKinds = [
+  "conversation",
+  "pod",
+] as const satisfies readonly FileSystemRootKind[];
+const FileSystemNodeKinds = [
+  "directory",
+  "file",
+] as const satisfies readonly FileSystemNodeKind[];
 
 export const FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS = {
   min: 1,
@@ -24,21 +34,27 @@ export const FILE_SYSTEM_CONTENT_TYPE_MAX_LENGTH = 255;
 export const FILE_SYSTEM_CONTENT_MAX_BYTES = 350 * 1024 * 1024;
 
 /** The stable file or directory identity returned by the namespace. */
-export type FileSystemNodeType = {
-  id: number;
-  parentId: number | null;
-  rootKind: FileSystemRootKind;
-  rootId: string;
-  name: string;
-  kind: FileSystemNodeKind;
-  mode: number;
-  size: number;
-  contentType: string | null;
-  blobId: string | null;
-  contentRevision: number;
-  createdAtMs: number;
-  modifiedAtMs: number;
-};
+export const FileSystemNodeSchema = z.object({
+  id: z.number().int().positive(),
+  parentId: z.number().int().positive().nullable(),
+  rootKind: z.enum(FileSystemRootKinds),
+  rootId: z.string().min(1),
+  name: z.string(),
+  kind: z.enum(FileSystemNodeKinds),
+  mode: z
+    .number()
+    .int()
+    .min(FILE_SYSTEM_MODE_LIMITS.min)
+    .max(FILE_SYSTEM_MODE_LIMITS.max),
+  size: z.number().int().nonnegative(),
+  contentType: z.string().nullable(),
+  blobId: z.string().uuid().nullable(),
+  contentRevision: z.number().int().nonnegative(),
+  createdAtMs: z.number(),
+  modifiedAtMs: z.number(),
+});
+
+export type FileSystemNodeType = z.infer<typeof FileSystemNodeSchema>;
 
 export type FileSystemContentType = {
   blobId: string | null;
@@ -72,6 +88,14 @@ export type FileSystemOperation =
       name: string;
       kind: FileSystemNodeKind;
       mode: number;
+    }
+  | {
+      operation: "rename";
+      requestId: string;
+      sourceParentId: number;
+      sourceName: string;
+      destinationParentId: number;
+      destinationName: string;
     }
   | { operation: "getContent"; nodeId: number }
   | {
@@ -108,6 +132,9 @@ export type FileSystemOperationResponse = {
 export type FileSystemOperationErrorCode =
   | "already_exists"
   | "invalid_operation"
+  | "is_directory"
+  | "not_directory"
+  | "not_empty"
   | "not_found"
   | "stale"
   | "unauthorized";

--- a/front/lib/resources/file_system_mutation_resource.ts
+++ b/front/lib/resources/file_system_mutation_resource.ts
@@ -103,9 +103,9 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
     const workspaceId = auth.getNonNullableWorkspace().id;
     const key = `${FILE_SYSTEM_NAMESPACE_LOCK_PREFIX}:${workspaceId}`;
 
-    // Creates share this lock and remain concurrent. Rename takes it
-    // exclusively because moving a directory across roots rewrites every
-    // descendant's cached root fields and must not miss a concurrent child.
+    // Creates take a shared lock, so different creates can run at the same
+    // time. Rename takes an exclusive lock because a cross-root directory move
+    // must include every child created before the move starts.
     const query =
       mode === "shared"
         ? "SELECT pg_advisory_xact_lock_shared(hashtextextended(:key, 0))"
@@ -202,8 +202,8 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
       );
     }
 
-    // Replay the result that committed with the rename. Fetching the node here
-    // would return a later move, or nothing if a later rename replaced it.
+    // Return the result saved by the first request. Fetching the node again
+    // could return a later move, or nothing if another rename replaced it.
     return new Ok(parsed.data.node);
   }
 
@@ -219,8 +219,8 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
 
     try {
       return await withTransaction(async (transaction) => {
-        // This must be the first lock in every namespace mutation. Rename must
-        // stay disabled until every deployed create path participates.
+        // Take this before locking any file or directory row. Do not enable
+        // rename until every running Front server uses this create code.
         await this.lockNamespace(auth, { mode: "shared", transaction });
         const existing = await this.baseFetch(
           auth,
@@ -317,8 +317,8 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
     }
 
     return withTransaction(async (transaction) => {
-      // Take the exclusive namespace lock before any node row lock. This
-      // also gives the recursive root update a stable tree to work from.
+      // Take this before locking any file or directory row. It blocks creates
+      // until the directory move and its child updates have committed.
       await this.lockNamespace(auth, { mode: "exclusive", transaction });
 
       const existing = await this.baseFetch(
@@ -362,8 +362,8 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
         );
       }
 
-      // The Node Resource owns the complete rename. This transaction also
-      // stores the receipt below, so the two changes commit together.
+      // The move and the saved response use the same transaction: both commit,
+      // or neither does.
       const movedRes = await sourceParent.renameChild(auth, scope, {
         sourceName: request.sourceName,
         destinationParent,

--- a/front/lib/resources/file_system_mutation_resource.ts
+++ b/front/lib/resources/file_system_mutation_resource.ts
@@ -104,8 +104,9 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
     const key = `${FILE_SYSTEM_NAMESPACE_LOCK_PREFIX}:${workspaceId}`;
 
     // Creates take a shared lock, so different creates can run at the same
-    // time. Rename takes an exclusive lock because a cross-root directory move
-    // must include every child created before the move starts.
+    // time. Rename takes an exclusive lock and waits for current creates. Without
+    // it, a child created during a cross-root move could keep the old rootKind
+    // and rootId.
     const query =
       mode === "shared"
         ? "SELECT pg_advisory_xact_lock_shared(hashtextextended(:key, 0))"

--- a/front/lib/resources/file_system_mutation_resource.ts
+++ b/front/lib/resources/file_system_mutation_resource.ts
@@ -1,12 +1,17 @@
 import type { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
-import type { FileSystemOperation } from "@app/lib/api/file_system/namespace_types";
+import type {
+  FileSystemNodeType,
+  FileSystemOperation,
+} from "@app/lib/api/file_system/namespace_types";
 import {
   FILE_SYSTEM_REQUEST_ID_MAX_LENGTH,
+  FileSystemNodeSchema,
   FileSystemOperationError,
 } from "@app/lib/api/file_system/namespace_types";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { FileSystemMutationModel } from "@app/lib/resources/storage/models/file_system_mutation";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -18,10 +23,20 @@ import { UniqueConstraintError } from "sequelize";
 import { z } from "zod";
 
 type CreateRequest = Extract<FileSystemOperation, { operation: "create" }>;
+type RenameRequest = Extract<FileSystemOperation, { operation: "rename" }>;
 
 const CreateMutationResponseSchema = z.object({
   nodeId: z.number().int().positive(),
 });
+const RenameMutationResponseSchema = z.object({
+  node: FileSystemNodeSchema,
+  sourceParentId: z.number().int().positive(),
+  sourceName: z.string(),
+  destinationParentId: z.number().int().positive(),
+  destinationName: z.string(),
+});
+
+const FILE_SYSTEM_NAMESPACE_LOCK_PREFIX = "file_system_namespace";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface FileSystemMutationResource
@@ -58,6 +73,48 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
     });
 
     return row ? new this(this.model, row.get()) : null;
+  }
+
+  private static validateRequestId(
+    requestId: string
+  ): Result<undefined, FileSystemOperationError> {
+    if (
+      requestId.length === 0 ||
+      requestId.length > FILE_SYSTEM_REQUEST_ID_MAX_LENGTH
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          `Request ID must be between 1 and ${FILE_SYSTEM_REQUEST_ID_MAX_LENGTH} characters.`
+        )
+      );
+    }
+
+    return new Ok(undefined);
+  }
+
+  private static async lockNamespace(
+    auth: Authenticator,
+    {
+      mode,
+      transaction,
+    }: { mode: "exclusive" | "shared"; transaction: Transaction }
+  ): Promise<void> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const key = `${FILE_SYSTEM_NAMESPACE_LOCK_PREFIX}:${workspaceId}`;
+
+    // Creates share this lock and remain concurrent. Rename takes it
+    // exclusively because moving a directory across roots rewrites every
+    // descendant's cached root fields and must not miss a concurrent child.
+    const query =
+      mode === "shared"
+        ? "SELECT pg_advisory_xact_lock_shared(hashtextextended(:key, 0))"
+        : "SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))";
+    // biome-ignore lint/plugin/noRawSql: PostgreSQL advisory locks have no Sequelize equivalent.
+    await frontSequelize.query(query, {
+      replacements: { key },
+      transaction,
+    });
   }
 
   private async createdNode(
@@ -100,25 +157,71 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
         );
   }
 
+  private async renamedNode(
+    scope: FileSystemScope,
+    request: RenameRequest
+  ): Promise<Result<FileSystemNodeType, FileSystemOperationError>> {
+    if (this.kind !== "rename") {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "That request ID belongs to a different filesystem operation."
+        )
+      );
+    }
+
+    const parsed = RenameMutationResponseSchema.safeParse(this.response);
+    if (!parsed.success) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "The saved filesystem response is invalid."
+        )
+      );
+    }
+    if (
+      parsed.data.sourceParentId !== request.sourceParentId ||
+      parsed.data.sourceName !== request.sourceName ||
+      parsed.data.destinationParentId !== request.destinationParentId ||
+      parsed.data.destinationName !== request.destinationName
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "That request ID belongs to a different rename."
+        )
+      );
+    }
+
+    if (!scope.canRead(parsed.data.node.rootKind, parsed.data.node.rootId)) {
+      return new Err(
+        new FileSystemOperationError(
+          "not_found",
+          "The node renamed by this request is no longer available."
+        )
+      );
+    }
+
+    // Replay the result that committed with the rename. Fetching the node here
+    // would return a later move, or nothing if a later rename replaced it.
+    return new Ok(parsed.data.node);
+  }
+
   static async createNode(
     auth: Authenticator,
     scope: FileSystemScope,
     request: CreateRequest
   ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
-    if (
-      request.requestId.length === 0 ||
-      request.requestId.length > FILE_SYSTEM_REQUEST_ID_MAX_LENGTH
-    ) {
-      return new Err(
-        new FileSystemOperationError(
-          "invalid_operation",
-          `Request ID must be between 1 and ${FILE_SYSTEM_REQUEST_ID_MAX_LENGTH} characters.`
-        )
-      );
+    const requestIdRes = this.validateRequestId(request.requestId);
+    if (requestIdRes.isErr()) {
+      return requestIdRes;
     }
 
     try {
       return await withTransaction(async (transaction) => {
+        // This must be the first lock in every namespace mutation. Rename must
+        // stay disabled until every deployed create path participates.
+        await this.lockNamespace(auth, { mode: "shared", transaction });
         const existing = await this.baseFetch(
           auth,
           request.requestId,
@@ -201,5 +304,95 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
       }
       throw error;
     }
+  }
+
+  static async renameNode(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    request: RenameRequest
+  ): Promise<Result<FileSystemNodeType, FileSystemOperationError>> {
+    const requestIdRes = this.validateRequestId(request.requestId);
+    if (requestIdRes.isErr()) {
+      return requestIdRes;
+    }
+
+    return withTransaction(async (transaction) => {
+      // Take the exclusive namespace lock before any node row lock. This
+      // also gives the recursive root update a stable tree to work from.
+      await this.lockNamespace(auth, { mode: "exclusive", transaction });
+
+      const existing = await this.baseFetch(
+        auth,
+        request.requestId,
+        transaction
+      );
+      if (existing) {
+        return existing.renamedNode(scope, request);
+      }
+
+      const sourceParent = await FileSystemNodeResource.fetchById(
+        auth,
+        scope,
+        request.sourceParentId,
+        { transaction, forUpdate: true }
+      );
+      if (!sourceParent) {
+        return new Err(
+          new FileSystemOperationError(
+            "not_found",
+            "The source directory was not found."
+          )
+        );
+      }
+      const destinationParent =
+        request.destinationParentId === sourceParent.id
+          ? sourceParent
+          : await FileSystemNodeResource.fetchById(
+              auth,
+              scope,
+              request.destinationParentId,
+              { transaction, forUpdate: true }
+            );
+      if (!destinationParent) {
+        return new Err(
+          new FileSystemOperationError(
+            "not_found",
+            "The destination directory was not found."
+          )
+        );
+      }
+
+      // The Node Resource owns the complete rename. This transaction also
+      // stores the receipt below, so the two changes commit together.
+      const movedRes = await sourceParent.renameChild(auth, scope, {
+        sourceName: request.sourceName,
+        destinationParent,
+        destinationName: request.destinationName,
+        transaction,
+      });
+      if (movedRes.isErr()) {
+        return movedRes;
+      }
+      const node = movedRes.value.toJSON();
+
+      await this.model.create(
+        {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          completedAt: new Date(),
+          requestId: request.requestId,
+          kind: "rename",
+          response: {
+            node,
+            sourceParentId: request.sourceParentId,
+            sourceName: request.sourceName,
+            destinationParentId: request.destinationParentId,
+            destinationName: request.destinationName,
+          },
+        },
+        { transaction }
+      );
+
+      return new Ok(node);
+    });
   }
 }

--- a/front/lib/resources/file_system_mutation_resource.ts
+++ b/front/lib/resources/file_system_mutation_resource.ts
@@ -220,8 +220,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
 
     try {
       return await withTransaction(async (transaction) => {
-        // Take this before locking any file or directory row. Do not enable
-        // rename until every running Front server uses this create code.
+        // Take this before locking any file or directory row.
         await this.lockNamespace(auth, { mode: "shared", transaction });
         const existing = await this.baseFetch(
           auth,

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -493,11 +493,11 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     possibleDescendant: FileSystemNodeResource,
     transaction: Transaction
   ): Promise<boolean> {
-    // Deliberate recursive CTE: the adjacency-list model only stores parentId,
-    // so preventing a directory cycle requires walking toward the root. This
-    // is O(directory depth), not O(subtree size). This is one of the few places
-    // where recursive SQL is allowed; do not reuse it for ordinary reads.
-    // biome-ignore lint/plugin/noRawSql: Recursive tree traversal has no Sequelize equivalent.
+    // Each row only stores its parentId. To stop a directory from being moved
+    // inside itself, this query follows parentId until it reaches a root. Its
+    // work grows with the number of parent directories, not the number of
+    // children. Keep recursive SQL out of normal reads.
+    // biome-ignore lint/plugin/noRawSql: Sequelize cannot follow parentId until the root.
     const rows = await frontSequelize.query<{ found: number }>(
       `
         WITH RECURSIVE ancestors AS (
@@ -536,8 +536,8 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       return true;
     }
 
-    // Check the tree structure directly. A child with stale cached root fields
-    // must still keep this directory from being replaced and cascade-deleted.
+    // Look for children by parentId, without filtering on rootKind or rootId.
+    // Wrong copied root values must never let us delete a non-empty directory.
     const child = await this.model.findOne({
       attributes: ["id"],
       where: { workspaceId: this.workspaceId, parentId: this.id },
@@ -570,14 +570,13 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     destinationParent: FileSystemNodeResource,
     transaction: Transaction
   ): Promise<void> {
-    // Deliberate recursive CTE: rootKind/rootId are copied onto each node so
-    // ordinary authorization stays a simple indexed lookup. A cross-root move
-    // therefore has to update the whole subtree. This is O(descendants) and
-    // runs under the exclusive namespace lock. If these moves become frequent
-    // or trees become large, change the data model instead of adding more
-    // recursive writes or tuning this query into a wider tree API.
-    // Do not touch updatedAt: moving an ancestor did not modify child contents.
-    // biome-ignore lint/plugin/noRawSql: Recursive tree updates have no Sequelize equivalent.
+    // Every row stores rootKind and rootId so permission checks do not need to
+    // follow parentId. A cross-root move must therefore update every child of
+    // the moved directory. The workspace lock blocks creates and other renames
+    // until this finishes. If large moves become slow, reconsider copying the
+    // root onto every row instead of adding more recursive SQL.
+    // Do not change updatedAt: moving a parent did not change a child's bytes.
+    // biome-ignore lint/plugin/noRawSql: Sequelize cannot update a whole directory tree.
     await frontSequelize.query(
       `
         WITH RECURSIVE subtree AS (

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -25,6 +25,7 @@ import {
 import { isGCSNotFoundError } from "@app/lib/file_storage/types";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileSystemBlobCleanupResource } from "@app/lib/resources/file_system_blob_cleanup_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { FileSystemNodeModel } from "@app/lib/resources/storage/models/file_system_node";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -40,13 +41,27 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes, Transaction } from "sequelize";
-import { Op } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 import { z } from "zod";
 
 type ReadDirRequest = Extract<FileSystemOperation, { operation: "readDir" }>;
 type ReadDirOptions = Pick<ReadDirRequest, "afterName" | "limit">;
 type CreateRequest = Extract<FileSystemOperation, { operation: "create" }>;
 type CreateOptions = Pick<CreateRequest, "kind" | "mode" | "name">;
+type RenameRequest = Extract<FileSystemOperation, { operation: "rename" }>;
+type RenameChildOptions = Pick<
+  RenameRequest,
+  "destinationName" | "sourceName"
+> & {
+  destinationParent: FileSystemNodeResource;
+  transaction: Transaction;
+};
+type MoveOptions = Pick<
+  RenameChildOptions,
+  "destinationName" | "transaction"
+> & {
+  destinationParent: FileSystemNodeResource;
+};
 type PrepareContentUploadRequest = Extract<
   FileSystemOperation,
   { operation: "prepareContentUpload" }
@@ -216,6 +231,29 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     return node ?? null;
   }
 
+  private static validateName(
+    name: string
+  ): Result<undefined, FileSystemOperationError> {
+    const nameLengthBytes = Buffer.byteLength(name, "utf8");
+    if (
+      name === "." ||
+      name === ".." ||
+      name.includes("/") ||
+      name.includes("\0") ||
+      nameLengthBytes === 0 ||
+      nameLengthBytes > FILE_SYSTEM_NAME_MAX_BYTES
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          `A file name must be between 1 and ${FILE_SYSTEM_NAME_MAX_BYTES} bytes and cannot contain a slash or null byte.`
+        )
+      );
+    }
+
+    return new Ok(undefined);
+  }
+
   private isReadableBy(auth: Authenticator, scope: FileSystemScope): boolean {
     return (
       this.workspaceId === auth.getNonNullableWorkspace().id &&
@@ -234,7 +272,10 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     auth: Authenticator,
     scope: FileSystemScope,
     name: string,
-    transaction?: Transaction
+    {
+      transaction,
+      forUpdate = false,
+    }: { transaction?: Transaction; forUpdate?: boolean } = {}
   ): Promise<FileSystemNodeResource | null> {
     const [child] = await FileSystemNodeResource.baseFetch(
       auth,
@@ -243,10 +284,53 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
         where: { parentId: this.id, name },
         limit: 1,
       },
-      { transaction }
+      { transaction, forUpdate }
     );
 
     return child ?? null;
+  }
+
+  private checkWritableDirectory(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    { description }: { description: string }
+  ): Result<undefined, FileSystemOperationError> {
+    if (!this.isReadableBy(auth, scope) || this.kind !== "directory") {
+      return new Err(
+        new FileSystemOperationError(
+          "not_found",
+          `The ${description} directory was not found.`
+        )
+      );
+    }
+    if (!this.isWritableBy(auth, scope)) {
+      return new Err(
+        new FileSystemOperationError(
+          "unauthorized",
+          `You do not have write access to the ${description} directory.`
+        )
+      );
+    }
+
+    return new Ok(undefined);
+  }
+
+  private async fetchChildForUpdate(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    { name, transaction }: { name: string; transaction: Transaction }
+  ): Promise<Result<FileSystemNodeResource | null, FileSystemOperationError>> {
+    const nameRes = FileSystemNodeResource.validateName(name);
+    if (nameRes.isErr()) {
+      return nameRes;
+    }
+
+    return new Ok(
+      await this.fetchChildByName(auth, scope, name, {
+        transaction,
+        forUpdate: true,
+      })
+    );
   }
 
   async createChild(
@@ -255,36 +339,15 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     request: CreateOptions,
     transaction: Transaction
   ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
-    if (!this.isReadableBy(auth, scope) || this.kind !== "directory") {
-      return new Err(
-        new FileSystemOperationError(
-          "not_found",
-          "The parent directory was not found."
-        )
-      );
+    const accessRes = this.checkWritableDirectory(auth, scope, {
+      description: "parent",
+    });
+    if (accessRes.isErr()) {
+      return accessRes;
     }
-    if (!this.isWritableBy(auth, scope)) {
-      return new Err(
-        new FileSystemOperationError(
-          "unauthorized",
-          "You do not have write access to this directory."
-        )
-      );
-    }
-    if (
-      request.name === "." ||
-      request.name === ".." ||
-      request.name.includes("/") ||
-      request.name.includes("\0") ||
-      Buffer.byteLength(request.name, "utf8") === 0 ||
-      Buffer.byteLength(request.name, "utf8") > FILE_SYSTEM_NAME_MAX_BYTES
-    ) {
-      return new Err(
-        new FileSystemOperationError(
-          "invalid_operation",
-          `A file name must be between 1 and ${FILE_SYSTEM_NAME_MAX_BYTES} bytes and cannot contain a slash or null byte.`
-        )
-      );
+    const nameRes = FileSystemNodeResource.validateName(request.name);
+    if (nameRes.isErr()) {
+      return nameRes;
     }
     if (
       !Number.isInteger(request.mode) ||
@@ -299,12 +362,9 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       );
     }
 
-    const existing = await this.fetchChildByName(
-      auth,
-      scope,
-      request.name,
-      transaction
-    );
+    const existing = await this.fetchChildByName(auth, scope, request.name, {
+      transaction,
+    });
     if (existing) {
       return new Err(
         new FileSystemOperationError(
@@ -427,6 +487,257 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       nextAfterName:
         nodes.length > options.limit ? (page.at(-1)?.name ?? null) : null,
     });
+  }
+
+  private async isAncestorOf(
+    possibleDescendant: FileSystemNodeResource,
+    transaction: Transaction
+  ): Promise<boolean> {
+    // Deliberate recursive CTE: the adjacency-list model only stores parentId,
+    // so preventing a directory cycle requires walking toward the root. This
+    // is O(directory depth), not O(subtree size). This is one of the few places
+    // where recursive SQL is allowed; do not reuse it for ordinary reads.
+    // biome-ignore lint/plugin/noRawSql: Recursive tree traversal has no Sequelize equivalent.
+    const rows = await frontSequelize.query<{ found: number }>(
+      `
+        WITH RECURSIVE ancestors AS (
+          SELECT "id", "parentId"
+          FROM "file_system_nodes"
+          WHERE "workspaceId" = :workspaceId AND "id" = :nodeId
+
+          UNION
+
+          SELECT parent."id", parent."parentId"
+          FROM "file_system_nodes" parent
+          JOIN ancestors child ON parent."id" = child."parentId"
+          WHERE parent."workspaceId" = :workspaceId
+        )
+        SELECT 1 AS "found"
+        FROM ancestors
+        WHERE "id" = :ancestorId
+        LIMIT 1
+      `,
+      {
+        type: QueryTypes.SELECT,
+        transaction,
+        replacements: {
+          workspaceId: this.workspaceId,
+          nodeId: possibleDescendant.id,
+          ancestorId: this.id,
+        },
+      }
+    );
+
+    return rows.length > 0;
+  }
+
+  private async isEmptyDirectory(transaction: Transaction): Promise<boolean> {
+    if (this.kind !== "directory") {
+      return true;
+    }
+
+    // Check the tree structure directly. A child with stale cached root fields
+    // must still keep this directory from being replaced and cascade-deleted.
+    const child = await this.model.findOne({
+      attributes: ["id"],
+      where: { workspaceId: this.workspaceId, parentId: this.id },
+      transaction,
+    });
+    return child === null;
+  }
+
+  private async destroyReplacedNode(
+    auth: Authenticator,
+    transaction: Transaction
+  ): Promise<void> {
+    if (this.blobId !== null) {
+      await FileSystemBlobCleanupResource.retireBlob(auth, this, {
+        blobId: this.blobId,
+        transaction,
+      });
+    }
+
+    const deletedCount = await this.model.destroy({
+      where: { workspaceId: this.workspaceId, id: this.id },
+      transaction,
+    });
+    if (deletedCount !== 1) {
+      throw new Error(`Failed to replace filesystem node ${this.id}.`);
+    }
+  }
+
+  private async moveDescendantsToRoot(
+    destinationParent: FileSystemNodeResource,
+    transaction: Transaction
+  ): Promise<void> {
+    // Deliberate recursive CTE: rootKind/rootId are copied onto each node so
+    // ordinary authorization stays a simple indexed lookup. A cross-root move
+    // therefore has to update the whole subtree. This is O(descendants) and
+    // runs under the exclusive namespace lock. If these moves become frequent
+    // or trees become large, change the data model instead of adding more
+    // recursive writes or tuning this query into a wider tree API.
+    // Do not touch updatedAt: moving an ancestor did not modify child contents.
+    // biome-ignore lint/plugin/noRawSql: Recursive tree updates have no Sequelize equivalent.
+    await frontSequelize.query(
+      `
+        WITH RECURSIVE subtree AS (
+          SELECT "id"
+          FROM "file_system_nodes"
+          WHERE "workspaceId" = :workspaceId AND "id" = :sourceNodeId
+
+          UNION
+
+          SELECT child."id"
+          FROM "file_system_nodes" child
+          JOIN subtree parent ON child."parentId" = parent."id"
+          WHERE child."workspaceId" = :workspaceId
+        )
+        UPDATE "file_system_nodes"
+        SET "rootKind" = :rootKind, "rootId" = :rootId
+        WHERE "workspaceId" = :workspaceId
+          AND "id" IN (SELECT "id" FROM subtree)
+          AND "id" <> :sourceNodeId
+      `,
+      {
+        transaction,
+        replacements: {
+          workspaceId: this.workspaceId,
+          sourceNodeId: this.id,
+          rootKind: destinationParent.rootKind,
+          rootId: destinationParent.rootId,
+        },
+      }
+    );
+  }
+
+  private async moveTo(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    options: MoveOptions
+  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+    const nameRes = FileSystemNodeResource.validateName(
+      options.destinationName
+    );
+    if (nameRes.isErr()) {
+      return nameRes;
+    }
+
+    if (
+      this.parentId === options.destinationParent.id &&
+      this.name === options.destinationName
+    ) {
+      return new Ok(this);
+    }
+
+    if (
+      this.kind === "directory" &&
+      (await this.isAncestorOf(options.destinationParent, options.transaction))
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "A directory cannot be moved inside itself."
+        )
+      );
+    }
+
+    const destination = await options.destinationParent.fetchChildByName(
+      auth,
+      scope,
+      options.destinationName,
+      { transaction: options.transaction, forUpdate: true }
+    );
+    if (destination?.kind === "directory" && this.kind === "file") {
+      return new Err(
+        new FileSystemOperationError(
+          "is_directory",
+          "A file cannot replace a directory."
+        )
+      );
+    }
+    if (destination?.kind === "file" && this.kind === "directory") {
+      return new Err(
+        new FileSystemOperationError(
+          "not_directory",
+          "A directory cannot replace a file."
+        )
+      );
+    }
+    if (
+      destination &&
+      !(await destination.isEmptyDirectory(options.transaction))
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "not_empty",
+          "The destination directory is not empty."
+        )
+      );
+    }
+
+    if (destination) {
+      await destination.destroyReplacedNode(auth, options.transaction);
+    }
+
+    const changesRoot =
+      this.rootKind !== options.destinationParent.rootKind ||
+      this.rootId !== options.destinationParent.rootId;
+    if (this.kind === "directory" && changesRoot) {
+      await this.moveDescendantsToRoot(
+        options.destinationParent,
+        options.transaction
+      );
+    }
+
+    await this.update(
+      {
+        parentId: options.destinationParent.id,
+        name: options.destinationName,
+        rootKind: options.destinationParent.rootKind,
+        rootId: options.destinationParent.rootId,
+      },
+      options.transaction
+    );
+
+    return new Ok(this);
+  }
+
+  async renameChild(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    options: RenameChildOptions
+  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+    const sourceAccessRes = this.checkWritableDirectory(auth, scope, {
+      description: "source",
+    });
+    if (sourceAccessRes.isErr()) {
+      return sourceAccessRes;
+    }
+    const destinationAccessRes =
+      options.destinationParent.checkWritableDirectory(auth, scope, {
+        description: "destination",
+      });
+    if (destinationAccessRes.isErr()) {
+      return destinationAccessRes;
+    }
+
+    const sourceRes = await this.fetchChildForUpdate(auth, scope, {
+      name: options.sourceName,
+      transaction: options.transaction,
+    });
+    if (sourceRes.isErr()) {
+      return sourceRes;
+    }
+    if (!sourceRes.value) {
+      return new Err(
+        new FileSystemOperationError(
+          "not_found",
+          `${options.sourceName} was not found.`
+        )
+      );
+    }
+
+    return sourceRes.value.moveTo(auth, scope, options);
   }
 
   private checkContentAccess(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See design doc [here](https://app.notion.com/p/dust-tt/Design-Doc-Robust-Dust-File-System-3bb28599d94180ca8bfddcbd2ab7b2c3).

This PR adds rename and move support to the filesystem namespace. A node can move within a directory, between directories, or between Conversation and Pod roots while keeping the same stable identity.

Rename follows normal POSIX behavior. An existing file is replaced atomically, and an existing empty directory can be replaced by another directory. Replaced file content is handed to the existing blob cleanup flow. Type mismatches, non-empty destination directories, invalid names, and directory cycles are rejected without partially changing the tree.

Moving a directory between roots updates the cached root information for every descendant. This keeps authorization checks simple and fast during normal reads. It **sadly** requires a recursive tree update during the move. The code documents this as a narrow exception and calls out that we should revisit the data model if large cross-root moves become common. We could also define a max depth on this new file system. A second recursive query walks a directory’s parents to prevent cycles.

Namespace writes use a workspace-scoped PostgreSQL lock. Creates take a shared lock and can still run concurrently. Rename takes the lock exclusively so it cannot miss a child being created while a directory tree is changing roots. The lock is taken before node row locks to keep ordering consistent and avoid deadlocks. Reads and content transfers do not take this lock.

Rename requests are idempotent. The mutation receipt stores the exact committed response, validated with Zod when replayed. If the caller loses the response and retries after the node has since moved or been replaced again, it still receives the result of its original rename rather than the node’s newer state.

This PR only adds the namespace operation in Front. Wiring it into the filesystem daemon comes later. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
