### PR TITLE
Add file and directory removal to the filesystem

### DIFF
--- a/front/lib/api/file_system/namespace.test.ts
+++ b/front/lib/api/file_system/namespace.test.ts
@@ -935,6 +935,279 @@ describe("filesystem namespace rename", () => {
   });
 });
 
+describe("filesystem namespace removal", () => {
+  it("removes a file, retires its blob, and replays the request", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const root = requireNode(initializedRes.value.roots?.[0]);
+    const file = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "remove-me.txt",
+      kind: "file",
+    });
+    const preparedRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "prepareContentUpload",
+      nodeId: file.id,
+      expectedBlobId: null,
+      expectedSizeBytes: 14,
+      contentType: "text/plain",
+    });
+    if (preparedRes.isErr() || !preparedRes.value.upload) {
+      throw new Error("Failed to prepare file content.");
+    }
+    const committedRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "commitContentUpload",
+      nodeId: file.id,
+      expectedBlobId: null,
+      blobId: preparedRes.value.upload.blobId,
+      expectedSizeBytes: preparedRes.value.upload.expectedSizeBytes,
+      contentType: preparedRes.value.upload.contentType,
+    });
+    if (committedRes.isErr() || !committedRes.value.node?.blobId) {
+      throw new Error("Failed to commit file content.");
+    }
+    const fileResource = await FileSystemNodeResource.fetchById(
+      authenticator,
+      scope,
+      file.id
+    );
+    if (!fileResource) {
+      throw new Error("Missing file resource.");
+    }
+    const blobId = committedRes.value.node.blobId;
+    const request = {
+      operation: "remove" as const,
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: file.name,
+      kind: "file" as const,
+    };
+
+    const removedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      request
+    );
+    const retriedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      request
+    );
+    const reusedRequestIdRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { ...request, name: "another-file.txt" }
+    );
+    const lookupRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "lookup",
+      parentId: root.id,
+      name: file.name,
+    });
+    const getAttrRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "getAttr",
+      nodeId: file.id,
+    });
+    const cleanup = await FileSystemBlobCleanupResource.fetchForBlob(
+      authenticator,
+      fileResource,
+      { blobId }
+    );
+
+    expect(removedRes.isOk() && removedRes.value).toEqual({});
+    expect(retriedRes.isOk() && retriedRes.value).toEqual({});
+    expect(reusedRequestIdRes.isErr() && reusedRequestIdRes.error.code).toBe(
+      "invalid_operation"
+    );
+    expect(lookupRes.isOk() && lookupRes.value.node).toBeNull();
+    expect(getAttrRes.isErr() && getAttrRes.error.code).toBe("not_found");
+    expect(cleanup).toMatchObject({ nodeId: file.id, blobId });
+  });
+
+  it("removes an empty directory and rejects the wrong kind", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const root = requireNode(initializedRes.value.roots?.[0]);
+    const emptyDirectory = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "empty",
+      kind: "directory",
+    });
+    const directory = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "directory",
+      kind: "directory",
+    });
+    const file = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "file.txt",
+      kind: "file",
+    });
+
+    const removedDirectoryRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "remove",
+        requestId: randomUUID(),
+        parentId: root.id,
+        name: emptyDirectory.name,
+        kind: "directory",
+      }
+    );
+    const directoryAsFileRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "remove",
+        requestId: randomUUID(),
+        parentId: root.id,
+        name: directory.name,
+        kind: "file",
+      }
+    );
+    const fileAsDirectoryRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "remove",
+        requestId: randomUUID(),
+        parentId: root.id,
+        name: file.name,
+        kind: "directory",
+      }
+    );
+    const removedDirectoryAttrRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "getAttr", nodeId: emptyDirectory.id }
+    );
+    const directoryAttrRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "getAttr", nodeId: directory.id }
+    );
+    const fileAttrRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "getAttr",
+      nodeId: file.id,
+    });
+
+    expect(removedDirectoryRes.isOk()).toBe(true);
+    expect(
+      removedDirectoryAttrRes.isErr() && removedDirectoryAttrRes.error.code
+    ).toBe("not_found");
+    expect(directoryAsFileRes.isErr() && directoryAsFileRes.error.code).toBe(
+      "is_directory"
+    );
+    expect(fileAsDirectoryRes.isErr() && fileAsDirectoryRes.error.code).toBe(
+      "not_directory"
+    );
+    expect(directoryAttrRes.isOk() && directoryAttrRes.value.node?.id).toBe(
+      directory.id
+    );
+    expect(fileAttrRes.isOk() && fileAttrRes.value.node?.id).toBe(file.id);
+  });
+
+  it("rejects non-empty directories, missing names, and read-only roots", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const conversationId = `conversation-${randomUUID()}`;
+    const scope = readableScope(conversationId);
+    const initializedRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      { operation: "initialize" }
+    );
+    if (initializedRes.isErr()) {
+      throw initializedRes.error;
+    }
+    const root = requireNode(initializedRes.value.roots?.[0]);
+    const directory = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "non-empty",
+      kind: "directory",
+    });
+    const child = await createNode(authenticator, scope, {
+      parentId: directory.id,
+      name: "child.txt",
+      kind: "file",
+    });
+    const file = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: "read-only.txt",
+      kind: "file",
+    });
+
+    const nonEmptyRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "remove",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: directory.name,
+      kind: "directory",
+    });
+    const missingRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "remove",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "missing.txt",
+      kind: "file",
+    });
+    const invalidNameRes = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "remove",
+        requestId: randomUUID(),
+        parentId: root.id,
+        name: "..",
+        kind: "directory",
+      }
+    );
+    const readOnlyRes = await applyFileSystemOperation(
+      authenticator,
+      readOnlyScope(conversationId),
+      {
+        operation: "remove",
+        requestId: randomUUID(),
+        parentId: root.id,
+        name: file.name,
+        kind: "file",
+      }
+    );
+    const childAttrRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "getAttr",
+      nodeId: child.id,
+    });
+    const fileAttrRes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "getAttr",
+      nodeId: file.id,
+    });
+
+    expect(nonEmptyRes.isErr() && nonEmptyRes.error.code).toBe("not_empty");
+    expect(missingRes.isErr() && missingRes.error.code).toBe("not_found");
+    expect(invalidNameRes.isErr() && invalidNameRes.error.code).toBe(
+      "invalid_operation"
+    );
+    expect(readOnlyRes.isErr() && readOnlyRes.error.code).toBe("unauthorized");
+    expect(childAttrRes.isOk() && childAttrRes.value.node?.id).toBe(child.id);
+    expect(fileAttrRes.isOk() && fileAttrRes.value.node?.id).toBe(file.id);
+  });
+});
+
 describe("filesystem content", () => {
   it("commits one immutable blob and returns it for reads", async () => {
     const { authenticator, workspace } = await createResourceTest({

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -106,6 +106,16 @@ export async function applyFileSystemOperation(
       return node.isErr() ? node : new Ok({ node: node.value.toJSON() });
     }
 
+    case "remove": {
+      const removedRes = await FileSystemMutationResource.removeNode(
+        auth,
+        scope,
+        request
+      );
+
+      return removedRes.isErr() ? removedRes : new Ok({});
+    }
+
     case "rename": {
       const nodeRes = await FileSystemMutationResource.renameNode(
         auth,

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -90,6 +90,13 @@ export type FileSystemOperation =
       mode: number;
     }
   | {
+      operation: "remove";
+      requestId: string;
+      parentId: number;
+      name: string;
+      kind: FileSystemNodeKind;
+    }
+  | {
       operation: "rename";
       requestId: string;
       sourceParentId: number;

--- a/front/lib/resources/file_system_mutation_resource.ts
+++ b/front/lib/resources/file_system_mutation_resource.ts
@@ -23,10 +23,18 @@ import { UniqueConstraintError } from "sequelize";
 import { z } from "zod";
 
 type CreateRequest = Extract<FileSystemOperation, { operation: "create" }>;
+type RemoveRequest = Extract<FileSystemOperation, { operation: "remove" }>;
 type RenameRequest = Extract<FileSystemOperation, { operation: "rename" }>;
 
 const CreateMutationResponseSchema = z.object({
   nodeId: z.number().int().positive(),
+});
+const RemoveMutationResponseSchema = z.object({
+  parentId: z.number().int().positive(),
+  name: z.string(),
+  nodeKind: FileSystemNodeSchema.shape.kind,
+  rootKind: FileSystemNodeSchema.shape.rootKind,
+  rootId: FileSystemNodeSchema.shape.rootId,
 });
 const RenameMutationResponseSchema = z.object({
   node: FileSystemNodeSchema,
@@ -103,10 +111,9 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
     const workspaceId = auth.getNonNullableWorkspace().id;
     const key = `${FILE_SYSTEM_NAMESPACE_LOCK_PREFIX}:${workspaceId}`;
 
-    // Creates take a shared lock, so different creates can run at the same
-    // time. Rename takes an exclusive lock and waits for current creates. Without
-    // it, a child created during a cross-root move could keep the old rootKind
-    // and rootId.
+    // Creates and removes take a shared lock, so they can run at the same time.
+    // Rename takes an exclusive lock and waits for them. Without it, a child
+    // created during a cross-root move could keep the old rootKind and rootId.
     const query =
       mode === "shared"
         ? "SELECT pg_advisory_xact_lock_shared(hashtextextended(:key, 0))"
@@ -206,6 +213,60 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
     // Return the result saved by the first request. Fetching the node again
     // could return a later move, or nothing if another rename replaced it.
     return new Ok(parsed.data.node);
+  }
+
+  private async removedNode(
+    scope: FileSystemScope,
+    request: RemoveRequest
+  ): Promise<Result<undefined, FileSystemOperationError>> {
+    if (this.kind !== "remove") {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "That request ID belongs to a different filesystem operation."
+        )
+      );
+    }
+
+    const parsed = RemoveMutationResponseSchema.safeParse(this.response);
+    if (!parsed.success) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "The saved filesystem response is invalid."
+        )
+      );
+    }
+    if (
+      parsed.data.parentId !== request.parentId ||
+      parsed.data.name !== request.name ||
+      parsed.data.nodeKind !== request.kind
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "That request ID belongs to a different removal."
+        )
+      );
+    }
+    if (!scope.canRead(parsed.data.rootKind, parsed.data.rootId)) {
+      return new Err(
+        new FileSystemOperationError(
+          "not_found",
+          "The parent directory was not found."
+        )
+      );
+    }
+    if (!scope.canWrite(parsed.data.rootKind, parsed.data.rootId)) {
+      return new Err(
+        new FileSystemOperationError(
+          "unauthorized",
+          "You do not have write access to the parent directory."
+        )
+      );
+    }
+
+    return new Ok(undefined);
   }
 
   static async createNode(
@@ -394,5 +455,99 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
 
       return new Ok(node);
     });
+  }
+
+  static async removeNode(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    request: RemoveRequest
+  ): Promise<Result<undefined, FileSystemOperationError>> {
+    const requestIdRes = this.validateRequestId(request.requestId);
+    if (requestIdRes.isErr()) {
+      return requestIdRes;
+    }
+
+    try {
+      return await withTransaction(async (transaction) => {
+        // Take this before locking any file or directory row.
+        await this.lockNamespace(auth, { mode: "shared", transaction });
+        const existing = await this.baseFetch(
+          auth,
+          request.requestId,
+          transaction
+        );
+        if (existing) {
+          return existing.removedNode(scope, request);
+        }
+
+        const parent = await FileSystemNodeResource.fetchById(
+          auth,
+          scope,
+          request.parentId,
+          { transaction, forUpdate: true }
+        );
+        if (!parent) {
+          return new Err(
+            new FileSystemOperationError(
+              "not_found",
+              "The parent directory was not found."
+            )
+          );
+        }
+
+        // A matching request can finish while this one waits for the parent.
+        const concurrent = await this.baseFetch(
+          auth,
+          request.requestId,
+          transaction
+        );
+        if (concurrent) {
+          return concurrent.removedNode(scope, request);
+        }
+
+        const removedRes = await parent.removeChild(auth, scope, {
+          name: request.name,
+          kind: request.kind,
+          transaction,
+        });
+        if (removedRes.isErr()) {
+          return removedRes;
+        }
+
+        await this.model.create(
+          {
+            workspaceId: auth.getNonNullableWorkspace().id,
+            completedAt: new Date(),
+            requestId: request.requestId,
+            kind: "remove",
+            response: {
+              parentId: request.parentId,
+              name: request.name,
+              nodeKind: request.kind,
+              rootKind: parent.rootKind,
+              rootId: parent.rootId,
+            },
+          },
+          { transaction }
+        );
+
+        return new Ok(undefined);
+      });
+    } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        return withTransaction(async (transaction) => {
+          const existing = await this.baseFetch(
+            auth,
+            request.requestId,
+            transaction
+          );
+          if (existing) {
+            return existing.removedNode(scope, request);
+          }
+          throw error;
+        });
+      }
+      throw error;
+    }
   }
 }

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -48,6 +48,10 @@ type ReadDirRequest = Extract<FileSystemOperation, { operation: "readDir" }>;
 type ReadDirOptions = Pick<ReadDirRequest, "afterName" | "limit">;
 type CreateRequest = Extract<FileSystemOperation, { operation: "create" }>;
 type CreateOptions = Pick<CreateRequest, "kind" | "mode" | "name">;
+type RemoveRequest = Extract<FileSystemOperation, { operation: "remove" }>;
+type RemoveChildOptions = Pick<RemoveRequest, "kind" | "name"> & {
+  transaction: Transaction;
+};
 type RenameRequest = Extract<FileSystemOperation, { operation: "rename" }>;
 type RenameChildOptions = Pick<
   RenameRequest,
@@ -106,8 +110,8 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
   }
 
   override delete(): Promise<Result<undefined, Error>> {
-    // Removing a node also updates the mutation journal and blob cleanup queue.
-    // It must go through the filesystem mutation operation added later.
+    // Removing a node must also save the successful request and queue its blob
+    // for deletion, so it must go through the filesystem remove operation.
     throw new Error("Filesystem nodes cannot be deleted directly.");
   }
 
@@ -546,7 +550,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     return child === null;
   }
 
-  private async destroyReplacedNode(
+  private async destroyAndRetireBlob(
     auth: Authenticator,
     transaction: Transaction
   ): Promise<void> {
@@ -562,8 +566,63 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       transaction,
     });
     if (deletedCount !== 1) {
-      throw new Error(`Failed to replace filesystem node ${this.id}.`);
+      throw new Error(`Failed to remove filesystem node ${this.id}.`);
     }
+  }
+
+  async removeChild(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    options: RemoveChildOptions
+  ): Promise<Result<undefined, FileSystemOperationError>> {
+    const accessRes = this.checkWritableDirectory(auth, scope, {
+      description: "parent",
+    });
+    if (accessRes.isErr()) {
+      return accessRes;
+    }
+
+    const childRes = await this.fetchChildForUpdate(auth, scope, {
+      name: options.name,
+      transaction: options.transaction,
+    });
+    if (childRes.isErr()) {
+      return childRes;
+    }
+    const child = childRes.value;
+    if (!child) {
+      return new Err(
+        new FileSystemOperationError(
+          "not_found",
+          `${options.name} was not found.`
+        )
+      );
+    }
+
+    if (options.kind === "file" && child.kind === "directory") {
+      return new Err(
+        new FileSystemOperationError(
+          "is_directory",
+          "A directory cannot be removed as a file."
+        )
+      );
+    }
+    if (options.kind === "directory" && child.kind === "file") {
+      return new Err(
+        new FileSystemOperationError(
+          "not_directory",
+          "A file cannot be removed as a directory."
+        )
+      );
+    }
+    if (!(await child.isEmptyDirectory(options.transaction))) {
+      return new Err(
+        new FileSystemOperationError("not_empty", "The directory is not empty.")
+      );
+    }
+
+    await child.destroyAndRetireBlob(auth, options.transaction);
+    return new Ok(undefined);
   }
 
   private async moveDescendantsToRoot(
@@ -675,7 +734,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     }
 
     if (destination) {
-      await destination.destroyReplacedNode(auth, options.transaction);
+      await destination.destroyAndRetireBlob(auth, options.transaction);
     }
 
     const changesRoot =


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See design doc [here](https://app.notion.com/p/dust-tt/Design-Doc-Robust-Dust-File-System-3bb28599d94180ca8bfddcbd2ab7b2c3).

This PR adds removal support to the new filesystem. A request provides the parent ID, name, and expected kind. The FUSE daemon will use file for Linux `[unlink](https://man7.org/linux/man-pages/man2/unlink.2.html)` and directory for `[rmdir](https://man7.org/linux/man-pages/man2/rmdir.2.html)`.

Removing a file deletes its node and queues its blob for deletion in the same PostgreSQL transaction. The blob remains available until previously issued download URLs have expired. Removing an empty directory deletes its node without running recursive SQL.

The operation follows Linux behavior. Removing a directory as a file returns `is_directory`, removing a file as a directory returns `not_directory`, and removing a non-empty directory returns `not_empty`. Missing names, invalid names, and read-only roots also fail without deleting anything. Recursive commands such as `rm -rf` will remove children individually before removing their parent.

Create and remove take the same shared workspace lock, so work in different directories can still run at the same time. The parent and target rows are locked while checking and deleting them. This prevents a child from being added after an empty-directory check. It also makes removal wait while a cross-root directory move is running.

A successful removal is saved in the existing filesystem request table. If the response is lost, retrying the same request returns success without trying to delete the missing node again. Reusing the request ID with another parent, name, or kind is rejected.

This PR only adds the front operation. Calling it from the FUSE daemon comes later!

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
