### PR TITLE
Add executable bit updates to the filesystem namespace

### DIFF
--- a/front/lib/api/file_system/namespace.test.ts
+++ b/front/lib/api/file_system/namespace.test.ts
@@ -693,3 +693,105 @@ describe("filesystem content", () => {
     );
   });
 });
+
+describe("filesystem executable bits", () => {
+  it("changes executable bits without changing the other mode bits", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = readableScope(`conversation-${randomUUID()}`);
+    const initialized = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+    if (initialized.isErr()) {
+      throw initialized.error;
+    }
+    const root = requireNode(initialized.value.roots?.[0]);
+    const created = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "script.sh",
+      kind: "file",
+      mode: 0o644,
+    });
+    if (created.isErr()) {
+      throw created.error;
+    }
+    const file = requireNode(created.value.node ?? undefined);
+
+    const madeExecutable = await applyFileSystemOperation(
+      authenticator,
+      scope,
+      {
+        operation: "setExecutableBits",
+        nodeId: file.id,
+        executableBits: 0o111,
+      }
+    );
+    const retry = await applyFileSystemOperation(authenticator, scope, {
+      operation: "setExecutableBits",
+      nodeId: file.id,
+      executableBits: 0o111,
+    });
+    const cleared = await applyFileSystemOperation(authenticator, scope, {
+      operation: "setExecutableBits",
+      nodeId: file.id,
+      executableBits: 0,
+    });
+
+    expect(madeExecutable.isOk() && madeExecutable.value.node?.mode).toBe(
+      0o755
+    );
+    expect(retry.isOk() && retry.value.node?.mode).toBe(0o755);
+    expect(cleared.isOk() && cleared.value.node?.mode).toBe(0o644);
+  });
+
+  it("rejects non-executable mode changes and requires write access", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const conversationId = `conversation-${randomUUID()}`;
+    const scope = readableScope(conversationId);
+    const initialized = await applyFileSystemOperation(authenticator, scope, {
+      operation: "initialize",
+    });
+    if (initialized.isErr()) {
+      throw initialized.error;
+    }
+    const root = requireNode(initialized.value.roots?.[0]);
+    const created = await applyFileSystemOperation(authenticator, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: root.id,
+      name: "script.sh",
+      kind: "file",
+      mode: 0o644,
+    });
+    if (created.isErr()) {
+      throw created.error;
+    }
+    const file = requireNode(created.value.node ?? undefined);
+
+    const readBitChange = await applyFileSystemOperation(authenticator, scope, {
+      operation: "setExecutableBits",
+      nodeId: file.id,
+      executableBits: 0o400,
+    });
+    const writeDenied = await applyFileSystemOperation(
+      authenticator,
+      readOnlyScope(conversationId),
+      {
+        operation: "setExecutableBits",
+        nodeId: file.id,
+        executableBits: 0o100,
+      }
+    );
+    const attributes = await applyFileSystemOperation(authenticator, scope, {
+      operation: "getAttr",
+      nodeId: file.id,
+    });
+
+    expect(readBitChange.isErr() && readBitChange.error.code).toBe(
+      "invalid_operation"
+    );
+    expect(writeDenied.isErr() && writeDenied.error.code).toBe("unauthorized");
+    expect(attributes.isOk() && attributes.value.node?.mode).toBe(0o644);
+  });
+});

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -169,6 +169,27 @@ export async function applyFileSystemOperation(
         : new Ok({ node: committedRes.value.toJSON() });
     }
 
+    case "setExecutableBits": {
+      const node = await FileSystemNodeResource.fetchById(
+        auth,
+        scope,
+        request.nodeId
+      );
+      if (!node) {
+        return new Err(
+          new FileSystemOperationError("not_found", "The inode was not found.")
+        );
+      }
+
+      const updatedNode = await node.setExecutableBits(auth, scope, {
+        executableBits: request.executableBits,
+      });
+
+      return updatedNode.isErr()
+        ? updatedNode
+        : new Ok({ node: updatedNode.value.toJSON() });
+    }
+
     default:
       return assertNever(request);
   }

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -14,6 +14,8 @@ export const FILE_SYSTEM_MODE_LIMITS = {
   max: 0o7777,
 } as const;
 
+export const FILE_SYSTEM_EXECUTABLE_BITS_MASK = 0o111;
+
 export const FILE_SYSTEM_REQUEST_ID_MAX_LENGTH = 255;
 
 export const FILE_SYSTEM_CONTENT_TYPE_MAX_LENGTH = 255;
@@ -86,6 +88,12 @@ export type FileSystemOperation =
       blobId: string;
       expectedSizeBytes: number;
       contentType: string;
+    }
+  | {
+      operation: "setExecutableBits";
+      nodeId: number;
+      /** The exact user, group, and other execute bits to store. */
+      executableBits: number;
     };
 
 export type FileSystemOperationResponse = {

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -10,6 +10,7 @@ import type {
 import {
   FILE_SYSTEM_CONTENT_MAX_BYTES,
   FILE_SYSTEM_CONTENT_TYPE_MAX_LENGTH,
+  FILE_SYSTEM_EXECUTABLE_BITS_MASK,
   FILE_SYSTEM_MODE_LIMITS,
   FILE_SYSTEM_NAME_MAX_BYTES,
   FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS,
@@ -64,6 +65,14 @@ type CommitContentUploadOptions = Pick<
 >;
 
 const FileSystemBlobIdSchema = z.string().uuid();
+type SetExecutableBitsRequest = Extract<
+  FileSystemOperation,
+  { operation: "setExecutableBits" }
+>;
+type SetExecutableBitsOptions = Pick<
+  SetExecutableBitsRequest,
+  "executableBits"
+>;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface FileSystemNodeResource
@@ -325,6 +334,50 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     }
 
     return new Ok(await this.fetchChildByName(auth, scope, name));
+  }
+
+  async setExecutableBits(
+    auth: Authenticator,
+    scope: FileSystemScope,
+    { executableBits }: SetExecutableBitsOptions
+  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+    if (!this.isReadableBy(auth, scope)) {
+      return new Err(
+        new FileSystemOperationError("not_found", "The inode was not found.")
+      );
+    }
+    if (!this.isWritableBy(auth, scope)) {
+      return new Err(
+        new FileSystemOperationError(
+          "unauthorized",
+          "You do not have write access to this inode."
+        )
+      );
+    }
+    if (
+      !Number.isInteger(executableBits) ||
+      executableBits < 0 ||
+      (executableBits & ~FILE_SYSTEM_EXECUTABLE_BITS_MASK) !== 0
+    ) {
+      return new Err(
+        new FileSystemOperationError(
+          "invalid_operation",
+          "Only user, group, and other executable bits can be changed."
+        )
+      );
+    }
+
+    // Keep read, write, and special bits unchanged.
+    const mode =
+      (this.mode & ~FILE_SYSTEM_EXECUTABLE_BITS_MASK) | executableBits;
+    const [updatedCount] = await this.update({ mode });
+    if (updatedCount !== 1) {
+      return new Err(
+        new FileSystemOperationError("not_found", "The inode was not found.")
+      );
+    }
+
+    return new Ok(this);
   }
 
   async readDir(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See design doc [here](https://app.notion.com/p/dust-tt/Design-Doc-Robust-Dust-File-System-3bb28599d94180ca8bfddcbd2ab7b2c3).

At first, I was not planning to support this, but models often do this on a sandbox:
```
chmod +x ./my_script.sh
./my_script.ts
```

To make sure those changes persist in our filesystem, this PR adds the filesystem operation needed for `chmod +x` and `chmod -x`.

The caller sends the exact user, group, and other executable bits to store. Front preserves the existing read, write, setuid, setgid, and sticky bits. Requests attempting to change anything outside `0o111` (this is JS octal [value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#octal)) for ([doc](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_stat.h.html))  are rejected.

The operation checks that the node belongs to a readable root and that the caller has write access. It updates the existing node, so its inode and path remain unchanged. Retrying the same request is safe.

This deliberately does not add general `chmod` support. The application currently needs executable files in sandboxes, but has no product use for changing read or write permissions (who knows, maybe in the future!).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
