### PR TITLE
Add the sandbox filesystem endpoint and scoped token

### DIFF
--- a/front-api/middlewares/sandbox_auth.ts
+++ b/front-api/middlewares/sandbox_auth.ts
@@ -1,6 +1,7 @@
 import type { SandboxTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import {
   isSandboxExecTokenPayload,
+  isSandboxFileSystemTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
   verifySandboxExecToken,
 } from "@app/lib/api/sandbox/access_tokens";
@@ -17,7 +18,7 @@ import { createMiddleware } from "hono/factory";
 
 import { apiError } from "./utils";
 
-type SandboxTokenKind = "action" | "function_invocation";
+type SandboxTokenKind = "action" | "filesystem" | "function_invocation";
 type SandboxAuthOptions = {
   allowedTokenKinds: SandboxTokenKind[];
 };
@@ -30,6 +31,9 @@ function getSandboxTokenKind(
   }
   if (isSandboxFunctionInvocationTokenPayload(claims)) {
     return "function_invocation";
+  }
+  if (isSandboxFileSystemTokenPayload(claims)) {
+    return "filesystem";
   }
   return null;
 }

--- a/front-api/routes/v1/w/[wId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front-api/routes/v1/w/[wId]/data_sources/[dsId]/tables/csv.test.ts
@@ -65,7 +65,9 @@ const mockFileContent = {
   },
 };
 
-vi.mock("@app/lib/file_storage", async () => {
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
   const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"
   );
@@ -74,6 +76,7 @@ vi.mock("@app/lib/file_storage", async () => {
     createReadStream: () => Readable.from([mockFileContent.content]),
   });
   return {
+    ...original,
     ...fileStorageMock.mock(),
     getUpsertQueueBucket: vi.fn(() => ({ file: mockFile })),
     getPrivateUploadBucket: vi.fn(() => ({ file: mockFile })),

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/[aId]/index.test.ts
@@ -9,30 +9,35 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // In-memory GCS mock: writes persist content that reads can return.
 const gcsStore = new Map<string, Buffer>();
 
-vi.mock("@app/lib/file_storage", () => ({
-  getPrivateUploadBucket: vi.fn(() => ({
-    file: vi.fn((path: string) => ({
-      save: vi.fn(async (data: Buffer) => {
-        gcsStore.set(path, data);
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
+  return {
+    ...original,
+    getPrivateUploadBucket: vi.fn(() => ({
+      file: vi.fn((path: string) => ({
+        save: vi.fn(async (data: Buffer) => {
+          gcsStore.set(path, data);
+        }),
+        download: vi.fn(async () => {
+          const buf = gcsStore.get(path);
+          if (!buf) {
+            throw new Error(`GCS file not found: ${path}`);
+          }
+          return [buf];
+        }),
+      })),
+      delete: vi.fn(async (path: string) => {
+        gcsStore.delete(path);
       }),
-      download: vi.fn(async () => {
-        const buf = gcsStore.get(path);
-        if (!buf) {
-          throw new Error(`GCS file not found: ${path}`);
+      uploadBufferToBucket: vi.fn(
+        async ({ buffer, filePath }: { buffer: Buffer; filePath: string }) => {
+          gcsStore.set(filePath, buffer);
         }
-        return [buf];
-      }),
+      ),
     })),
-    delete: vi.fn(async (path: string) => {
-      gcsStore.delete(path);
-    }),
-    uploadBufferToBucket: vi.fn(
-      async ({ buffer, filePath }: { buffer: Buffer; filePath: string }) => {
-        gcsStore.set(filePath, buffer);
-      }
-    ),
-  })),
-}));
+  };
+});
 
 function getSandboxAction(
   workspace: { sId: string },

--- a/front-api/routes/v1/w/[wId]/sandbox/filesystem.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/filesystem.test.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from "node:crypto";
+import { FileSystemOperationResponseSchema } from "@app/lib/api/file_system/namespace";
+import { generateSandboxFileSystemToken } from "@app/lib/api/sandbox/access_tokens";
+import { createSandboxTokenTestContext } from "@app/tests/utils/SandboxTokenFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function requestFileSystem(
+  workspaceId: string,
+  token: string,
+  operation: object
+) {
+  return honoApp.request(`/api/v1/w/${workspaceId}/sandbox/filesystem`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(operation),
+  });
+}
+
+describe("POST /api/v1/w/[wId]/sandbox/filesystem", () => {
+  it("uses only the roots and permissions signed into the token", async () => {
+    const context = await createSandboxTokenTestContext();
+    const pod = await SpaceFactory.project(
+      context.workspace,
+      context.auth.getNonNullableUser().id
+    );
+    const token = await generateSandboxFileSystemToken(context.auth, {
+      sandbox: context.sandbox,
+      roots: [
+        {
+          kind: "conversation",
+          id: context.conversation.sId,
+          permissions: { canRead: true, canWrite: true },
+        },
+        {
+          kind: "pod",
+          id: pod.sId,
+          permissions: { canRead: true, canWrite: false },
+        },
+      ],
+    });
+
+    const initializeResponse = await requestFileSystem(
+      context.workspace.sId,
+      token,
+      { operation: "initialize" }
+    );
+    expect(initializeResponse.status).toBe(200);
+    const initialized = FileSystemOperationResponseSchema.parse(
+      await initializeResponse.json()
+    );
+    const conversationRoot = initialized.roots?.find(
+      (root) => root.rootKind === "conversation"
+    );
+    const podRoot = initialized.roots?.find((root) => root.rootKind === "pod");
+    if (!conversationRoot || !podRoot) {
+      throw new Error("Expected conversation and Pod filesystem roots.");
+    }
+
+    const createResponse = await requestFileSystem(
+      context.workspace.sId,
+      token,
+      {
+        operation: "create",
+        requestId: randomUUID(),
+        parentId: conversationRoot.id,
+        name: "script.sh",
+        kind: "file",
+        mode: 0o644,
+      }
+    );
+    expect(createResponse.status).toBe(200);
+    const created = FileSystemOperationResponseSchema.parse(
+      await createResponse.json()
+    );
+    if (!created.node) {
+      throw new Error("Expected the created file.");
+    }
+
+    const executableResponse = await requestFileSystem(
+      context.workspace.sId,
+      token,
+      {
+        operation: "setExecutableBits",
+        nodeId: created.node.id,
+        executableBits: 0o111,
+      }
+    );
+    expect(executableResponse.status).toBe(200);
+    expect(
+      FileSystemOperationResponseSchema.parse(await executableResponse.json())
+        .node?.mode
+    ).toBe(0o755);
+
+    const podWriteResponse = await requestFileSystem(
+      context.workspace.sId,
+      token,
+      {
+        operation: "create",
+        requestId: randomUUID(),
+        parentId: podRoot.id,
+        name: "blocked.txt",
+        kind: "file",
+        mode: 0o644,
+      }
+    );
+    expect(podWriteResponse.status).toBe(403);
+    expect(podWriteResponse.headers.get("x-dust-filesystem-error")).toBe(
+      "unauthorized"
+    );
+  });
+
+  it("rejects malformed filesystem operations before running them", async () => {
+    const context = await createSandboxTokenTestContext();
+    const token = await generateSandboxFileSystemToken(context.auth, {
+      sandbox: context.sandbox,
+      roots: [
+        {
+          kind: "conversation",
+          id: context.conversation.sId,
+          permissions: { canRead: true, canWrite: true },
+        },
+      ],
+    });
+
+    const response = await requestFileSystem(context.workspace.sId, token, {
+      operation: "setExecutableBits",
+      nodeId: 1,
+      executableBits: 0o200,
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects regular sandbox action tokens", async () => {
+    const context = await createSandboxTokenTestContext();
+
+    const response = await requestFileSystem(
+      context.workspace.sId,
+      context.token,
+      { operation: "initialize" }
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("does not let filesystem tokens call sandbox action endpoints", async () => {
+    const context = await createSandboxTokenTestContext();
+    const token = await generateSandboxFileSystemToken(context.auth, {
+      sandbox: context.sandbox,
+      roots: [
+        {
+          kind: "conversation",
+          id: context.conversation.sId,
+          permissions: { canRead: true, canWrite: true },
+        },
+      ],
+    });
+
+    const response = await honoApp.request(
+      `/api/v1/w/${context.workspace.sId}/sandbox/actions`,
+      { headers: { authorization: `Bearer ${token}` } }
+    );
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/v1/w/[wId]/sandbox/filesystem.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/filesystem.ts
@@ -6,6 +6,7 @@ import {
 import type { FileSystemOperationErrorCode } from "@app/lib/api/file_system/namespace_types";
 import { fileSystemScopeFromSandboxClaims } from "@app/lib/api/file_system/sandbox_scope";
 import { isSandboxFileSystemTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
@@ -31,6 +32,8 @@ function statusForFileSystemError(
     case "not_empty":
     case "stale":
       return 409;
+    default:
+      return assertNever(code);
   }
 }
 

--- a/front-api/routes/v1/w/[wId]/sandbox/filesystem.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/filesystem.ts
@@ -1,5 +1,6 @@
 import {
   applyFileSystemOperation,
+  type FileSystemOperationResponse,
   FileSystemOperationSchema,
 } from "@app/lib/api/file_system/namespace";
 import type { FileSystemOperationErrorCode } from "@app/lib/api/file_system/namespace_types";
@@ -7,7 +8,7 @@ import { fileSystemScopeFromSandboxClaims } from "@app/lib/api/file_system/sandb
 import { isSandboxFileSystemTokenPayload } from "@app/lib/api/sandbox/access_tokens";
 import { sandboxApp } from "@front-api/middlewares/ctx";
 import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
-import { apiError } from "@front-api/middlewares/utils";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
 const app = sandboxApp();
@@ -37,37 +38,41 @@ function statusForFileSystemError(
  * @ignoreswagger
  * Internal syscall endpoint used only by the Dust filesystem daemon.
  */
-app.post("/", validate("json", FileSystemOperationSchema), async (ctx) => {
-  const claims = ctx.get("sandboxClaims");
-  if (!isSandboxFileSystemTokenPayload(claims)) {
-    return apiError(ctx, {
-      status_code: 403,
-      api_error: {
-        type: "invalid_request_error",
-        message: "This sandbox token cannot access the filesystem.",
-      },
-    });
-  }
+app.post(
+  "/",
+  validate("json", FileSystemOperationSchema),
+  async (ctx): HandlerResult<FileSystemOperationResponse> => {
+    const claims = ctx.get("sandboxClaims");
+    if (!isSandboxFileSystemTokenPayload(claims)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "This sandbox token cannot access the filesystem.",
+        },
+      });
+    }
 
-  const operationRes = await applyFileSystemOperation(
-    ctx.get("auth"),
-    fileSystemScopeFromSandboxClaims(claims),
-    ctx.req.valid("json")
-  );
-  if (operationRes.isErr()) {
-    // The daemon uses this code for errno. The body remains the normal Dust
-    // error shape so logs and manual requests stay readable.
-    ctx.header("x-dust-filesystem-error", operationRes.error.code);
-    return apiError(ctx, {
-      status_code: statusForFileSystemError(operationRes.error.code),
-      api_error: {
-        type: "invalid_request_error",
-        message: operationRes.error.message,
-      },
-    });
-  }
+    const operationRes = await applyFileSystemOperation(
+      ctx.get("auth"),
+      fileSystemScopeFromSandboxClaims(claims),
+      ctx.req.valid("json")
+    );
+    if (operationRes.isErr()) {
+      // The daemon uses this code for errno. The body remains the normal Dust
+      // error shape so logs and manual requests stay readable.
+      ctx.header("x-dust-filesystem-error", operationRes.error.code);
+      return apiError(ctx, {
+        status_code: statusForFileSystemError(operationRes.error.code),
+        api_error: {
+          type: "invalid_request_error",
+          message: operationRes.error.message,
+        },
+      });
+    }
 
-  return ctx.json(operationRes.value, 200);
-});
+    return ctx.json(operationRes.value, 200);
+  }
+);
 
 export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/filesystem.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/filesystem.ts
@@ -1,0 +1,73 @@
+import {
+  applyFileSystemOperation,
+  FileSystemOperationSchema,
+} from "@app/lib/api/file_system/namespace";
+import type { FileSystemOperationErrorCode } from "@app/lib/api/file_system/namespace_types";
+import { fileSystemScopeFromSandboxClaims } from "@app/lib/api/file_system/sandbox_scope";
+import { isSandboxFileSystemTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+import { sandboxApp } from "@front-api/middlewares/ctx";
+import { sandboxAuth } from "@front-api/middlewares/sandbox_auth";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+const app = sandboxApp();
+
+app.use("*", sandboxAuth({ allowedTokenKinds: ["filesystem"] }));
+
+function statusForFileSystemError(
+  code: FileSystemOperationErrorCode
+): 400 | 403 | 404 | 409 {
+  switch (code) {
+    case "invalid_operation":
+      return 400;
+    case "unauthorized":
+      return 403;
+    case "not_found":
+      return 404;
+    case "already_exists":
+    case "is_directory":
+    case "not_directory":
+    case "not_empty":
+    case "stale":
+      return 409;
+  }
+}
+
+/**
+ * @ignoreswagger
+ * Internal syscall endpoint used only by the Dust filesystem daemon.
+ */
+app.post("/", validate("json", FileSystemOperationSchema), async (ctx) => {
+  const claims = ctx.get("sandboxClaims");
+  if (!isSandboxFileSystemTokenPayload(claims)) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_request_error",
+        message: "This sandbox token cannot access the filesystem.",
+      },
+    });
+  }
+
+  const operationRes = await applyFileSystemOperation(
+    ctx.get("auth"),
+    fileSystemScopeFromSandboxClaims(claims),
+    ctx.req.valid("json")
+  );
+  if (operationRes.isErr()) {
+    // The daemon uses this code for errno. The body remains the normal Dust
+    // error shape so logs and manual requests stay readable.
+    ctx.header("x-dust-filesystem-error", operationRes.error.code);
+    return apiError(ctx, {
+      status_code: statusForFileSystemError(operationRes.error.code),
+      api_error: {
+        type: "invalid_request_error",
+        message: operationRes.error.message,
+      },
+    });
+  }
+
+  return ctx.json(operationRes.value, 200);
+});
+
+export default app;

--- a/front-api/routes/v1/w/[wId]/sandbox/index.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/index.ts
@@ -1,6 +1,7 @@
 import { sandboxApp } from "@front-api/middlewares/ctx";
 
 import actions from "./actions";
+import filesystem from "./filesystem";
 import sandboxFunctions from "./sandbox-functions";
 
 // Mounted at /api/v1/w/:wId/sandbox. This sub-tree is mounted before
@@ -10,6 +11,7 @@ import sandboxFunctions from "./sandbox-functions";
 const app = sandboxApp();
 
 app.route("/actions", actions);
+app.route("/filesystem", filesystem);
 app.route("/sandbox-functions", sandboxFunctions);
 
 export default app;

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -65,7 +65,9 @@ const mockFileContent = {
   },
 };
 
-vi.mock("@app/lib/file_storage", async () => {
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
   const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"
   );
@@ -74,6 +76,7 @@ vi.mock("@app/lib/file_storage", async () => {
     createReadStream: () => Readable.from([mockFileContent.content]),
   });
   return {
+    ...original,
     ...fileStorageMock.mock(),
     getUpsertQueueBucket: vi.fn(() => ({ file: mockFile })),
     getPrivateUploadBucket: vi.fn(() => ({ file: mockFile })),

--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.test.ts
@@ -37,11 +37,14 @@ vi.mock("@app/lib/utils/statsd", () => ({
   }),
 }));
 
-vi.mock("@app/lib/file_storage", async () => {
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
   const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"
   );
   return {
+    ...original,
     ...fileStorageMock.mock(),
     getWebhookRequestsBucket: () => ({
       uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),

--- a/front-api/routes/w/[wId]/data_sources/[dsId]/files.test.ts
+++ b/front-api/routes/w/[wId]/data_sources/[dsId]/files.test.ts
@@ -52,11 +52,14 @@ const mockFileContent = {
   },
 };
 
-vi.mock("@app/lib/file_storage", async () => {
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
   const { fileStorageMock } = await import(
     "@app/tests/utils/mocks/file_storage"
   );
   return {
+    ...original,
     ...fileStorageMock.mock(),
     getUpsertQueueBucket: vi.fn(() => ({
       file: () => ({

--- a/front-api/routes/w/[wId]/files/[fileId]/signed-url.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/signed-url.test.ts
@@ -8,7 +8,9 @@ const { mockGetSignedUrl } = vi.hoisted(() => ({
   mockGetSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
 }));
 
-vi.mock("@app/lib/file_storage", () => {
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
   const createMockFileStorage = () => ({
     file: vi.fn(() => ({
       copy: vi.fn().mockResolvedValue(undefined),
@@ -20,6 +22,7 @@ vi.mock("@app/lib/file_storage", () => {
   });
 
   return {
+    ...original,
     FileStorage: vi.fn().mockImplementation(createMockFileStorage),
     getPrivateUploadBucket: vi.fn(createMockFileStorage),
     getPublicUploadBucket: vi.fn(createMockFileStorage),

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -16,7 +16,11 @@ export type {
   FileSystemOperation,
   FileSystemOperationResponse,
 } from "./namespace_types";
-export { FileSystemOperationError } from "./namespace_types";
+export {
+  FileSystemOperationError,
+  FileSystemOperationResponseSchema,
+  FileSystemOperationSchema,
+} from "./namespace_types";
 
 /** Run one filesystem read after the caller has selected the allowed roots. */
 export async function applyFileSystemOperation(
@@ -201,13 +205,13 @@ export async function applyFileSystemOperation(
         );
       }
 
-      const updatedNode = await node.setExecutableBits(auth, scope, {
+      const updatedNodeRes = await node.setExecutableBits(auth, scope, {
         executableBits: request.executableBits,
       });
 
-      return updatedNode.isErr()
-        ? updatedNode
-        : new Ok({ node: updatedNode.value.toJSON() });
+      return updatedNodeRes.isErr()
+        ? updatedNodeRes
+        : new Ok({ node: updatedNodeRes.value.toJSON() });
     }
 
     default:

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -56,85 +56,139 @@ export const FileSystemNodeSchema = z.object({
 
 export type FileSystemNodeType = z.infer<typeof FileSystemNodeSchema>;
 
-export type FileSystemContentType = {
-  blobId: string | null;
-  downloadUrl: string | null;
-  size: number;
-  contentType: string | null;
-};
+export const FileSystemContentSchema = z.object({
+  blobId: z.string().uuid().nullable(),
+  downloadUrl: z.string().nullable(),
+  size: z.number().int().nonnegative(),
+  contentType: z.string().nullable(),
+});
 
-export type FileSystemContentUploadType = {
-  blobId: string;
-  uploadUrl: string;
-  contentType: string;
-  expectedSizeBytes: number;
-  headers: Record<string, string>;
-};
+export type FileSystemContentType = z.infer<typeof FileSystemContentSchema>;
 
-export type FileSystemOperation =
-  | { operation: "initialize" }
-  | { operation: "lookup"; parentId: number; name: string }
-  | { operation: "getAttr"; nodeId: number }
-  | {
-      operation: "readDir";
-      nodeId: number;
-      afterName: string | null;
-      limit: number;
-    }
-  | {
-      operation: "create";
-      requestId: string;
-      parentId: number;
-      name: string;
-      kind: FileSystemNodeKind;
-      mode: number;
-    }
-  | {
-      operation: "remove";
-      requestId: string;
-      parentId: number;
-      name: string;
-      kind: FileSystemNodeKind;
-    }
-  | {
-      operation: "rename";
-      requestId: string;
-      sourceParentId: number;
-      sourceName: string;
-      destinationParentId: number;
-      destinationName: string;
-    }
-  | { operation: "getContent"; nodeId: number }
-  | {
-      operation: "prepareContentUpload";
-      nodeId: number;
-      expectedBlobId: string | null;
-      expectedSizeBytes: number;
-      contentType: string;
-    }
-  | {
-      operation: "commitContentUpload";
-      nodeId: number;
-      expectedBlobId: string | null;
-      blobId: string;
-      expectedSizeBytes: number;
-      contentType: string;
-    }
-  | {
-      operation: "setExecutableBits";
-      nodeId: number;
-      /** The exact user, group, and other execute bits to store. */
-      executableBits: number;
-    };
+export const FileSystemContentUploadSchema = z.object({
+  blobId: z.string().uuid(),
+  uploadUrl: z.string(),
+  contentType: z.string(),
+  expectedSizeBytes: z.number().int().nonnegative(),
+  headers: z.record(z.string(), z.string()),
+});
 
-export type FileSystemOperationResponse = {
-  roots?: FileSystemNodeType[];
-  node?: FileSystemNodeType | null;
-  nodes?: FileSystemNodeType[];
-  nextAfterName?: string | null;
-  content?: FileSystemContentType;
-  upload?: FileSystemContentUploadType;
-};
+export type FileSystemContentUploadType = z.infer<
+  typeof FileSystemContentUploadSchema
+>;
+
+const FileSystemNodeIdSchema = z.number().int().positive();
+const FileSystemNameSchema = z.string().min(1).max(FILE_SYSTEM_NAME_MAX_BYTES);
+const FileSystemRequestIdSchema = z
+  .string()
+  .min(1)
+  .max(FILE_SYSTEM_REQUEST_ID_MAX_LENGTH);
+const FileSystemModeSchema = z
+  .number()
+  .int()
+  .min(FILE_SYSTEM_MODE_LIMITS.min)
+  .max(FILE_SYSTEM_MODE_LIMITS.max);
+const FileSystemContentTypeSchema = z
+  .string()
+  .min(1)
+  .max(FILE_SYSTEM_CONTENT_TYPE_MAX_LENGTH);
+const FileSystemContentSizeSchema = z
+  .number()
+  .int()
+  .min(0)
+  .max(FILE_SYSTEM_CONTENT_MAX_BYTES);
+
+export const FileSystemOperationSchema = z.discriminatedUnion("operation", [
+  z.object({ operation: z.literal("initialize") }),
+  z.object({
+    operation: z.literal("lookup"),
+    parentId: FileSystemNodeIdSchema,
+    name: FileSystemNameSchema,
+  }),
+  z.object({
+    operation: z.literal("getAttr"),
+    nodeId: FileSystemNodeIdSchema,
+  }),
+  z.object({
+    operation: z.literal("readDir"),
+    nodeId: FileSystemNodeIdSchema,
+    afterName: z.string().max(FILE_SYSTEM_NAME_MAX_BYTES).nullable(),
+    limit: z
+      .number()
+      .int()
+      .min(FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS.min)
+      .max(FILE_SYSTEM_READ_DIR_PAGE_SIZE_LIMITS.max),
+  }),
+  z.object({
+    operation: z.literal("create"),
+    requestId: FileSystemRequestIdSchema,
+    parentId: FileSystemNodeIdSchema,
+    name: FileSystemNameSchema,
+    kind: z.enum(FileSystemNodeKinds),
+    mode: FileSystemModeSchema,
+  }),
+  z.object({
+    operation: z.literal("remove"),
+    requestId: FileSystemRequestIdSchema,
+    parentId: FileSystemNodeIdSchema,
+    name: FileSystemNameSchema,
+    kind: z.enum(FileSystemNodeKinds),
+  }),
+  z.object({
+    operation: z.literal("rename"),
+    requestId: FileSystemRequestIdSchema,
+    sourceParentId: FileSystemNodeIdSchema,
+    sourceName: FileSystemNameSchema,
+    destinationParentId: FileSystemNodeIdSchema,
+    destinationName: FileSystemNameSchema,
+  }),
+  z.object({
+    operation: z.literal("getContent"),
+    nodeId: FileSystemNodeIdSchema,
+  }),
+  z.object({
+    operation: z.literal("prepareContentUpload"),
+    nodeId: FileSystemNodeIdSchema,
+    expectedBlobId: z.string().uuid().nullable(),
+    expectedSizeBytes: FileSystemContentSizeSchema,
+    contentType: FileSystemContentTypeSchema,
+  }),
+  z.object({
+    operation: z.literal("commitContentUpload"),
+    nodeId: FileSystemNodeIdSchema,
+    expectedBlobId: z.string().uuid().nullable(),
+    blobId: z.string().uuid(),
+    expectedSizeBytes: FileSystemContentSizeSchema,
+    contentType: FileSystemContentTypeSchema,
+  }),
+  z.object({
+    operation: z.literal("setExecutableBits"),
+    nodeId: FileSystemNodeIdSchema,
+    // Only these three bits may be sent. Read and write bits stay unchanged.
+    executableBits: z
+      .number()
+      .int()
+      .refine(
+        (bits) => bits >= 0 && (bits & ~FILE_SYSTEM_EXECUTABLE_BITS_MASK) === 0,
+        "Only user, group, and other executable bits can be changed."
+      ),
+  }),
+]);
+
+export type FileSystemOperation = z.infer<typeof FileSystemOperationSchema>;
+
+export const FileSystemOperationResponseSchema = z.object({
+  roots: z.array(FileSystemNodeSchema).optional(),
+  node: FileSystemNodeSchema.nullable().optional(),
+  nodes: z.array(FileSystemNodeSchema).optional(),
+  nextAfterName: z.string().nullable().optional(),
+  content: FileSystemContentSchema.optional(),
+  upload: FileSystemContentUploadSchema.optional(),
+});
+
+export type FileSystemOperationResponse = z.infer<
+  typeof FileSystemOperationResponseSchema
+>;
 
 export type FileSystemOperationErrorCode =
   | "already_exists"

--- a/front/lib/api/file_system/sandbox_scope.ts
+++ b/front/lib/api/file_system/sandbox_scope.ts
@@ -1,0 +1,16 @@
+import { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
+import type { SandboxFileSystemTokenPayload } from "@app/lib/api/sandbox/access_tokens";
+
+/** Build the mounted roots from signed token claims, never from request data. */
+export function fileSystemScopeFromSandboxClaims(
+  claims: SandboxFileSystemTokenPayload
+): FileSystemScope {
+  return new FileSystemScope(
+    claims.fileSystemRoots.map((root) => ({
+      kind: root.kind,
+      id: root.id,
+      name: `${root.kind}-${root.id}`,
+      permissions: root.permissions,
+    }))
+  );
+}

--- a/front/lib/api/sandbox/access_tokens.test.ts
+++ b/front/lib/api/sandbox/access_tokens.test.ts
@@ -1,7 +1,9 @@
 import {
   generateSandboxExecToken,
+  generateSandboxFileSystemToken,
   generateSandboxFunctionInvocationToken,
   isSandboxExecTokenPayload,
+  isSandboxFileSystemTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
   SANDBOX_TOKEN_PREFIX,
   verifySandboxExecToken,
@@ -237,6 +239,36 @@ describe("sandbox access tokens", () => {
     expect(payload.spaceId).toBe(pod.sId);
     expect(payload.sandboxFunctionId).toBe("sfn_test");
     expect(payload.invocationId).toBe("test-invocation-id");
+  });
+
+  it("round-trips a filesystem token with its exact roots", async () => {
+    const { auth, conversation, sandbox } = await setupTest();
+    const pod = await SpaceFactory.project(auth.getNonNullableWorkspace());
+    const roots = [
+      {
+        kind: "conversation" as const,
+        id: conversation.sId,
+        permissions: { canRead: true, canWrite: true },
+      },
+      {
+        kind: "pod" as const,
+        id: pod.sId,
+        permissions: { canRead: true, canWrite: false },
+      },
+    ];
+
+    const token = await generateSandboxFileSystemToken(auth, {
+      sandbox,
+      roots,
+    });
+    const payload = await verifySandboxExecToken(token);
+
+    expect(payload && isSandboxFileSystemTokenPayload(payload)).toBe(true);
+    if (!payload || !isSandboxFileSystemTokenPayload(payload)) {
+      return;
+    }
+    expect(payload.fileSystemRoots).toEqual(roots);
+    expect(payload.execId).toBe("filesystem");
   });
 
   it("tampered token is rejected", async () => {

--- a/front/lib/api/sandbox/access_tokens.ts
+++ b/front/lib/api/sandbox/access_tokens.ts
@@ -22,6 +22,31 @@ function isDefined<T>(value: T | undefined): value is T {
   return value !== undefined;
 }
 
+const SandboxFileSystemRootSchema = z
+  .object({
+    kind: z.enum(["conversation", "pod"]),
+    id: z.string().min(1),
+    permissions: z.object({
+      canRead: z.boolean(),
+      canWrite: z.boolean(),
+    }),
+  })
+  .refine(
+    (root) => !root.permissions.canWrite || root.permissions.canRead,
+    "A writable filesystem root must also be readable."
+  );
+
+const SandboxFileSystemRootsSchema = z
+  .array(SandboxFileSystemRootSchema)
+  .min(1)
+  .max(2)
+  .refine(
+    (roots) => new Set(roots.map((root) => root.kind)).size === roots.length,
+    "A filesystem token cannot contain the same root kind twice."
+  );
+
+export type SandboxFileSystemRoot = z.infer<typeof SandboxFileSystemRootSchema>;
+
 const SandboxTokenPayloadSchema = z
   .object({
     wId: z.string(),
@@ -36,6 +61,8 @@ const SandboxTokenPayloadSchema = z
     spaceId: z.string().optional(),
     sandboxFunctionId: z.string().optional(),
     invocationId: z.string().optional(),
+    filesystem: z.literal(true).optional(),
+    fileSystemRoots: SandboxFileSystemRootsSchema.optional(),
     // Set for a fast Pod function, published on the promise that it does not call tools. A tool
     // call can wait on the user for as long as they take, which a fast invocation has no way to
     // survive, so the token it runs under cannot make one.
@@ -51,6 +78,14 @@ const SandboxTokenPayloadSchema = z
     const hasAction =
       payload.cId !== undefined && actionClaims.every(isDefined);
     const hasInvocation = invocationClaims.every(isDefined);
+    const hasFileSystem =
+      payload.filesystem === true &&
+      payload.fileSystemRoots !== undefined &&
+      payload.cId === undefined &&
+      !actionClaims.some(isDefined) &&
+      !invocationClaims.some(isDefined) &&
+      payload.aV === undefined &&
+      payload.noTools === undefined;
 
     if (actionClaims.some(isDefined) && !hasAction) {
       ctx.addIssue({
@@ -64,11 +99,23 @@ const SandboxTokenPayloadSchema = z
         message: "Incomplete sandbox function invocation token claims.",
       });
     }
-    if (!hasAction && !hasInvocation) {
+    if (
+      (payload.filesystem === true || payload.fileSystemRoots !== undefined) &&
+      !hasFileSystem
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Invalid sandbox filesystem token claims.",
+      });
+    }
+    const tokenKindCount = [hasAction, hasInvocation, hasFileSystem].filter(
+      Boolean
+    ).length;
+    if (tokenKindCount !== 1) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "Sandbox token payload must include action or function invocation claims.",
+          "Sandbox token payload must include exactly one supported claim set.",
       });
     }
   });
@@ -87,6 +134,11 @@ export type SandboxFunctionInvocationTokenPayload = SandboxTokenPayload & {
   spaceId: string;
   sandboxFunctionId: string;
   invocationId: string;
+};
+
+export type SandboxFileSystemTokenPayload = SandboxTokenPayload & {
+  filesystem: true;
+  fileSystemRoots: SandboxFileSystemRoot[];
 };
 
 export function isSandboxExecTokenPayload(
@@ -169,6 +221,24 @@ export function isSandboxFunctionInvocationTokenPayload(
     payload.spaceId !== undefined &&
     payload.sandboxFunctionId !== undefined &&
     payload.invocationId !== undefined
+  );
+}
+
+export function isSandboxFileSystemTokenPayload(
+  payload: SandboxTokenPayload
+): payload is SandboxFileSystemTokenPayload {
+  return (
+    payload.filesystem === true &&
+    payload.fileSystemRoots !== undefined &&
+    payload.cId === undefined &&
+    payload.aId === undefined &&
+    payload.aV === undefined &&
+    payload.mId === undefined &&
+    payload.actionId === undefined &&
+    payload.spaceId === undefined &&
+    payload.sandboxFunctionId === undefined &&
+    payload.invocationId === undefined &&
+    payload.noTools === undefined
   );
 }
 
@@ -318,6 +388,39 @@ export async function generateSandboxFunctionInvocationToken(
   const token = jwt.sign(payload, secret, {
     algorithm: "HS256",
     expiresIn: expiryMs / 1000, // expiresIn is in seconds
+  });
+
+  return `${SANDBOX_TOKEN_PREFIX}${token}`;
+}
+
+export async function generateSandboxFileSystemToken(
+  auth: Authenticator,
+  {
+    sandbox,
+    roots,
+    expiryMs = EXEC_TOKEN_REDIS_TTL_SECONDS * 1000,
+  }: {
+    sandbox: SandboxResource;
+    roots: SandboxFileSystemRoot[];
+    expiryMs?: number;
+  }
+): Promise<string> {
+  const fileSystemRoots = SandboxFileSystemRootsSchema.parse(roots);
+
+  const payload: SandboxFileSystemTokenPayload = {
+    wId: auth.getNonNullableWorkspace().sId,
+    uId: auth.user()?.sId,
+    sbId: sandbox.sId,
+    execId: "filesystem",
+    filesystem: true,
+    fileSystemRoots,
+  };
+
+  await registerExecToken(payload);
+
+  const token = jwt.sign(payload, config.getSandboxJwtSecret(), {
+    algorithm: "HS256",
+    expiresIn: expiryMs / 1000,
   });
 
   return `${SANDBOX_TOKEN_PREFIX}${token}`;

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -7,6 +7,7 @@ import type {
 } from "@app/lib/api/sandbox/access_tokens";
 import {
   isSandboxExecTokenPayload,
+  isSandboxFileSystemTokenPayload,
   isSandboxFunctionInvocationTokenPayload,
   SANDBOX_TOKEN_PREFIX,
 } from "@app/lib/api/sandbox/access_tokens";
@@ -659,6 +660,11 @@ export class Authenticator {
         return new Err(groupModelIdsRes.error);
       }
       groupModelIdSets.push(groupModelIdsRes.value);
+    }
+    if (isSandboxFileSystemTokenPayload(claims)) {
+      // This token kind is accepted only by the filesystem route. File access
+      // comes from its signed conversation and Pod roots, not workspace groups.
+      groupModelIdSets.push([]);
     }
     if (groupModelIdSets.length === 0) {
       return new Err({

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -82,6 +82,14 @@ type CommitContentUploadOptions = Pick<
   CommitContentUploadRequest,
   "blobId" | "contentType" | "expectedBlobId" | "expectedSizeBytes"
 >;
+type SetExecutableBitsRequest = Extract<
+  FileSystemOperation,
+  { operation: "setExecutableBits" }
+>;
+type SetExecutableBitsOptions = Pick<
+  SetExecutableBitsRequest,
+  "executableBits"
+>;
 
 const FileSystemBlobIdSchema = z.string().uuid();
 type SetExecutableBitsRequest = Extract<

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -82,15 +82,6 @@ type CommitContentUploadOptions = Pick<
   CommitContentUploadRequest,
   "blobId" | "contentType" | "expectedBlobId" | "expectedSizeBytes"
 >;
-type SetExecutableBitsRequest = Extract<
-  FileSystemOperation,
-  { operation: "setExecutableBits" }
->;
-type SetExecutableBitsOptions = Pick<
-  SetExecutableBitsRequest,
-  "executableBits"
->;
-
 const FileSystemBlobIdSchema = z.string().uuid();
 type SetExecutableBitsRequest = Extract<
   FileSystemOperation,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See design doc [here](https://app.notion.com/p/dust-tt/Design-Doc-Robust-Dust-File-System-3bb28599d94180ca8bfddcbd2ab7b2c3).

This PR adds the private HTTP endpoint used by the Dust filesystem daemon. The daemon sends one filesystem operation at a time. This API validates it, applies it through the namespace resources, and returns the node or content response.

It also adds a filesystem-specific sandbox token. The token contains the exact roots mounted in the sandbox: at most one Conversation and one Pod, with separate `read` and `write` permissions. A request cannot add another root or make a read-only root writable.

Filesystem tokens only work on this endpoint. Existing action and function tokens are rejected, and filesystem tokens cannot call other sandbox endpoints.

Requests and responses are validated with Zod. Filesystem errors also include an error header that the Rust daemon uses to return the matching Linux error.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
