### PR TITLE
[front] feat: pod identity bits on the public share frame path

### DIFF
--- a/front-api/routes/v1/public/frames/[token]/index.test.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.test.ts
@@ -79,35 +79,35 @@ describe("GET /api/v1/public/frames/[token]", () => {
     return honoApp.request(`/api/v1/public/frames/${token}`, { headers });
   };
 
+  // A shared Frame that lives in an app folder must resolve its app's functions by bare name just
+  // as it does when opened from the Pod, so the response has to tell it which app it belongs to.
+  const createPodAppFrame = async () => {
+    const pod = await SpaceFactory.project(workspace, user.id);
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameContentType,
+      fileName: "TaskList.tsx",
+      fileSize: 100,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+      mountFilePath: `w/${workspace.sId}/pods/${pod.sId}/files/TaskList/TaskList.tsx`,
+    });
+
+    await file.setShareScope(auth, "workspace_and_emails");
+    const shareInfo = await file.getShareInfo();
+    const token = shareInfo!.shareUrl.split("/").at(-1)!;
+
+    // The Authenticator caches its group memberships, and `auth` predates this pod, so it would
+    // not be able to read it. Rebuild one that can.
+    const podAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    return { pod, file, token, podAuth };
+  };
+
   describe("framePath for a Pod app Frame", () => {
-    // A shared Frame that lives in an app folder must resolve its app's functions by bare name just
-    // as it does when opened from the Pod, so the response has to tell it which app it belongs to.
-    const createPodAppFrame = async () => {
-      const pod = await SpaceFactory.project(workspace, user.id);
-      const file = await FileFactory.create(auth, user, {
-        contentType: frameContentType,
-        fileName: "TaskList.tsx",
-        fileSize: 100,
-        status: "ready",
-        useCase: "project_context",
-        useCaseMetadata: { spaceId: pod.sId },
-        mountFilePath: `w/${workspace.sId}/pods/${pod.sId}/files/TaskList/TaskList.tsx`,
-      });
-
-      await file.setShareScope(auth, "workspace_and_emails");
-      const shareInfo = await file.getShareInfo();
-      const token = shareInfo!.shareUrl.split("/").at(-1)!;
-
-      // The Authenticator caches its group memberships, and `auth` predates this pod, so it would
-      // not be able to read it. Rebuild one that can.
-      const podAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        user.sId,
-        workspace.sId
-      );
-
-      return { pod, file, token, podAuth };
-    };
-
     it("returns the scoped path for a viewer who can read the Pod", async () => {
       const { pod, token, podAuth } = await createPodAppFrame();
       vi.mocked(resolveOptionalAuth).mockResolvedValue(podAuth);
@@ -136,6 +136,41 @@ describe("GET /api/v1/public/frames/[token]", () => {
       // Such a viewer cannot invoke the Pod's functions either, so there is no reason to hand them
       // the Pod's layout.
       expect(body.framePath).toBeNull();
+    });
+  });
+
+  describe("pod identity for a Pod Frame", () => {
+    // The share page is not a pod host, so these flags are how a shared Frame learns the viewer's
+    // standing in the Pod (e.g. to show member-only affordances instead of a guest view).
+    it("reports the standing of a viewer in the Pod", async () => {
+      // createPodAppFrame makes the viewer the pod's creator, who lands in its editor group.
+      const { token, podAuth } = await createPodAppFrame();
+      vi.mocked(resolveOptionalAuth).mockResolvedValue(podAuth);
+
+      const response = await requestFrame(token);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.isPodMember).toBe(true);
+      expect(body.isPodEditor).toBe(true);
+    });
+
+    it("reports no standing for a viewer outside the Pod", async () => {
+      const { file, token } = await createPodAppFrame();
+      vi.mocked(resolveOptionalAuth).mockResolvedValue(null);
+
+      const sessionToken = await createGrantAndSession(
+        file,
+        "external@example.com"
+      );
+      const response = await requestFrame(token, {
+        cookies: { dust_frame_session: sessionToken },
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.isPodMember).toBe(false);
+      expect(body.isPodEditor).toBe(false);
     });
   });
 

--- a/front-api/routes/v1/public/frames/[token]/index.ts
+++ b/front-api/routes/v1/public/frames/[token]/index.ts
@@ -201,6 +201,21 @@ app.get(
     const space =
       spaceId && auth ? await SpaceResource.fetchById(auth, spaceId) : null;
     const canRead = space && space.isProject() && auth && space.canRead(auth);
+    // Standing of the viewer in the Pod hosting the Frame, mirroring what pod hosts thread into
+    // the frame identity (podInfo.isMember / podInfo.isEditor). Display-only: invocations
+    // re-authorize server-side.
+    const isPodMember = !!(
+      space &&
+      space.isProject() &&
+      auth &&
+      space.isMember(auth)
+    );
+    const isPodEditor = !!(
+      space &&
+      space.isProject() &&
+      auth &&
+      space.canAdministrate(auth)
+    );
 
     // Generate access token for viz rendering.
     const accessToken = generateVizAccessToken({
@@ -229,6 +244,8 @@ app.get(
       // Lets the frame enable member-only tools (e.g. callFunction) client-side;
       // real authorization still happens server-side on invocation.
       isAuthenticatedMember: !!user,
+      isPodMember,
+      isPodEditor,
       // Lets a shared Frame in an app folder resolve bare function references, exactly as it does
       // when opened from the Pod. Withheld from viewers who cannot read the Pod, who cannot invoke
       // its functions either.

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.test.ts
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
     viewer: unknown;
   } | null,
   isAuthenticatedMember: true,
+  isPodEditor: false,
+  isPodMember: false,
   isUserLoading: true,
   user: null as typeof user | null,
 }));
@@ -45,6 +47,8 @@ vi.mock("@app/lib/swr/frames", () => ({
     error: null,
     accessToken: "token",
     isAuthenticatedMember: mocks.isAuthenticatedMember,
+    isPodMember: mocks.isPodMember,
+    isPodEditor: mocks.isPodEditor,
   }),
 }));
 
@@ -72,6 +76,8 @@ afterEach(() => {
   cleanup();
   mocks.iframeProps = null;
   mocks.isAuthenticatedMember = true;
+  mocks.isPodEditor = false;
+  mocks.isPodMember = false;
   mocks.isUserLoading = true;
   mocks.user = null;
 });
@@ -80,6 +86,8 @@ describe("getPublicFrameUserIdentity", () => {
   it("scopes a server-confirmed member to the Frame workspace", () => {
     expect(getPublicFrameUserIdentity(user, true, "w_current")).toEqual({
       workspaceId: "w_current",
+      isPodMember: false,
+      isPodEditor: false,
       user: {
         sId: "usr_123",
         firstName: "Ada",
@@ -87,6 +95,15 @@ describe("getPublicFrameUserIdentity", () => {
         fullName: "Ada Lovelace",
         image: null,
       },
+    });
+  });
+
+  it("forwards the viewer's pod standing", () => {
+    expect(
+      getPublicFrameUserIdentity(user, true, "w_current", true, true)
+    ).toMatchObject({
+      isPodMember: true,
+      isPodEditor: true,
     });
   });
 
@@ -123,6 +140,7 @@ describe("PublicFrameRenderer", () => {
   it("enables function calls with the matching member identity", () => {
     mocks.isUserLoading = false;
     mocks.user = user;
+    mocks.isPodMember = true;
 
     render(
       createElement(PublicFrameRenderer, {
@@ -138,6 +156,8 @@ describe("PublicFrameRenderer", () => {
       canInvokeFunctions: true,
       scopedUserIdentity: {
         workspaceId: "w_current",
+        isPodMember: true,
+        isPodEditor: false,
         user: expect.objectContaining({ sId: "usr_123" }),
       },
       // Blocked-action cards run without an AuthProvider on a shared frame, so they get the

--- a/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/PublicFrameRenderer.tsx
@@ -32,7 +32,11 @@ interface PublicFrameViewer extends WorkspaceUserIdentity {
 export function getPublicFrameUserIdentity(
   user: PublicFrameViewer | null,
   isAuthenticatedMember: boolean,
-  workspaceId: string
+  workspaceId: string,
+  // Standing of the viewer in the Pod hosting the Frame, resolved server-side by the public frame
+  // endpoint. Display-only: invocations are re-authorized server-side.
+  isPodMember = false,
+  isPodEditor = false
 ): ScopedWorkspaceUserIdentity | undefined {
   if (
     !isAuthenticatedMember ||
@@ -44,6 +48,8 @@ export function getPublicFrameUserIdentity(
 
   return {
     workspaceId,
+    isPodMember,
+    isPodEditor,
     user: {
       sId: user.sId,
       firstName: user.firstName,
@@ -71,6 +77,8 @@ export function PublicFrameRenderer({
     error,
     accessToken,
     isAuthenticatedMember,
+    isPodMember,
+    isPodEditor,
     framePath,
   } = usePublicFrame({
     shareToken,
@@ -88,7 +96,9 @@ export function PublicFrameRenderer({
   const publicUserIdentity = getPublicFrameUserIdentity(
     user,
     isAuthenticatedMember,
-    workspaceId
+    workspaceId,
+    isPodMember,
+    isPodEditor
   );
   // The shared frame has no AuthProvider, so the viewer context the blocked-action cards need is
   // built from the workspace the viewer is a member of.

--- a/front/lib/swr/frames.ts
+++ b/front/lib/swr/frames.ts
@@ -38,6 +38,8 @@ export function usePublicFrame({ shareToken }: { shareToken: string | null }) {
     accessToken: data?.accessToken ?? null,
     isFrameLoading: !error && !data,
     isAuthenticatedMember: data?.isAuthenticatedMember ?? false,
+    isPodMember: data?.isPodMember ?? false,
+    isPodEditor: data?.isPodEditor ?? false,
     error,
     mutateFrame: mutate,
   };

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3207,6 +3207,11 @@ export const PublicFrameResponseBodySchema = z.object({
   // functions by bare name. Only sent to a viewer who can read the Pod: nobody else can invoke a pod
   // function anyway, so there is no reason to hand out the Pod's layout.
   framePath: z.string().nullable().optional(),
+  // Standing of the authenticated viewer in the Pod hosting the Frame, so the share page can
+  // thread the same identity bits pod hosts do. Display-only: invocations re-authorize
+  // server-side. Absent means false.
+  isPodMember: z.boolean().optional(),
+  isPodEditor: z.boolean().optional(),
 });
 
 export type PublicFrameResponseBodyType = z.infer<


### PR DESCRIPTION
## Description

Follow-up to #30583. `isPodMember` and `isPodEditor` were not actually working client side, and were always false.

With this fix, we get the correct value and the frame can display conditional UI.

We're just missing changes to the skills so agent knows how to use this. Coming up in follow-up PR.

## Tests

Added

## Risk

Low: additive response fields, display-only client threading, no authorization change.

## Deploy Plan

Deploy front.