### PR TITLE
[front] fix: update app archive filesystem type import

### DIFF
--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -1,5 +1,4 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
-import { SCOPED_PREFIX_POD } from "@app/lib/api/file_system/types";
 import { getFileContent } from "@app/lib/api/files/utils";
 import {
   APP_DATABASES_SUBFOLDER,
@@ -33,6 +32,7 @@ import {
 } from "@app/types/api/pod_app_archive";
 import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
 import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
+import { SCOPED_PREFIX_POD } from "@app/types/file_system";
 import { isInteractiveContentType } from "@app/types/files";
 import {
   MAX_POD_FRAME_TABS,


### PR DESCRIPTION
## Description

Lint on main fails because the Pod app archive code still imports filesystem types from their previous location (two commits got crossed).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- No deploy.
