### PR TITLE
[front] fix: filter-out unknown models from client-side

### DIFF
--- a/front/lib/swr/models.ts
+++ b/front/lib/swr/models.ts
@@ -1,5 +1,9 @@
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { GetEnabledModelsResponseType } from "@app/types/api/assistant/models";
+import type {
+  EnabledModelConfigurationType,
+  GetEnabledModelsResponseType,
+} from "@app/types/api/assistant/models";
+import { isStaticModelId } from "@app/types/assistant/models/models";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 
@@ -20,7 +24,9 @@ export function useModels({
   );
 
   return {
-    models: data?.models ?? emptyArray(),
+    models:
+      data?.models.filter((model) => isStaticModelId(model.modelId)) ??
+      emptyArray<EnabledModelConfigurationType>(),
     defaultModel: data?.defaultModel ?? null,
     streams: data?.streams ?? null,
     isModelsLoading: !error && !data && !disabled,


### PR DESCRIPTION
## Description

We rely on a client-side collection of models to process the backend's payload.
Because of that, any client lagging behind in terms of this collection will crash.
This means 100% of browser extension clients will, until we deploy a new version.

This PR filters out models not in the collection. Not ideal, but much better than a extension-wide crash.

Fixes https://github.com/dust-tt/tasks/issues/10077

## Tests

Tested locally - front-spa, not extension but fairly trivial change so highly confident.

## Risk

Low

## Deploy Plan

Merge
Publish new app