### PR TITLE
Avervaet/attribution progress bar color

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -1,10 +1,9 @@
-import { CostShareBar } from "@app/components/workspace/analytics/creditsTableCells";
 import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
-import { Button, cn, LoadingBlock } from "@dust-tt/sparkle";
+import { Button, cn, LoadingBlock, ProgressBar } from "@dust-tt/sparkle";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 import { CONSUMPTION_DIMENSION_CONFIG } from "./consumptionDimensions";
 
@@ -112,7 +111,7 @@ function BreakdownColumn({
                     {percentage}%
                   </span>
                 </div>
-                <CostShareBar className="w-full" percentage={percentage} />
+                <ProgressBar className="w-full" percentage={percentage} />
               </div>
             );
           })}

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -1,5 +1,5 @@
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
-import { Avatar, cn, Tooltip } from "@dust-tt/sparkle";
+import { Avatar, ProgressBar, Tooltip } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
 function EmptyCell() {
@@ -30,33 +30,12 @@ export function AvatarNameCell({
   );
 }
 
-interface CostShareBarProps {
-  percentage: number;
-  className?: string;
-}
-
-export function CostShareBar({ percentage, className }: CostShareBarProps) {
-  return (
-    <div
-      className={cn(
-        "h-1.5 overflow-hidden rounded-full bg-muted-background",
-        className
-      )}
-    >
-      <div
-        className="h-full rounded-full bg-primary-light"
-        style={{ width: `${percentage}%` }}
-      />
-    </div>
-  );
-}
-
 export function CostShareCell({ share }: { share: number }) {
   const percentage = Math.round(Math.min(100, share * 100));
 
   return (
     <div className="flex items-center gap-2">
-      <CostShareBar className="w-24" percentage={percentage} />
+      <ProgressBar className="w-24" percentage={percentage} />
       <span className="w-8 text-right text-xs text-muted-foreground tabular-nums">
         {percentage}%
       </span>

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -38,10 +38,13 @@ interface CostShareBarProps {
 export function CostShareBar({ percentage, className }: CostShareBarProps) {
   return (
     <div
-      className={cn("h-1.5 overflow-hidden rounded-full bg-muted", className)}
+      className={cn(
+        "h-1.5 overflow-hidden rounded-full bg-muted-background",
+        className
+      )}
     >
       <div
-        className="h-full rounded-full bg-primary"
+        className="h-full rounded-full bg-primary-light"
         style={{ width: `${percentage}%` }}
       />
     </div>

--- a/sparkle/src/components/ProgressBar.tsx
+++ b/sparkle/src/components/ProgressBar.tsx
@@ -1,0 +1,56 @@
+import { cn } from "@sparkle/lib/utils";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+const progressBarVariants = cva("h-1.5 overflow-hidden rounded-full", {
+  variants: {
+    variant: {
+      default: "bg-muted-background",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
+const progressBarFillVariants = cva("h-full rounded-full", {
+  variants: {
+    variant: {
+      default: "bg-primary-light",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
+export interface ProgressBarProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
+    VariantProps<typeof progressBarVariants> {
+  percentage: number;
+}
+
+export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
+  ({ percentage, variant = "default", className, ...props }, ref) => {
+    const clampedPercentage = Math.min(100, Math.max(0, percentage));
+
+    return (
+      <div
+        ref={ref}
+        role="progressbar"
+        aria-valuenow={clampedPercentage}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className={cn(progressBarVariants({ variant }), className)}
+        {...props}
+      >
+        <div
+          className={progressBarFillVariants({ variant })}
+          style={{ width: `${clampedPercentage}%` }}
+        />
+      </div>
+    );
+  }
+);
+
+ProgressBar.displayName = "ProgressBar";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -243,6 +243,7 @@ export {
   PopoverTrigger,
 } from "./Popover";
 export { PriceTable } from "./PriceTable";
+export { ProgressBar } from "./ProgressBar";
 export { PuzzleSpinner } from "./PuzzleSpinner";
 export { RadioGroup, RadioGroupCustomItem, RadioGroupItem } from "./RadioGroup";
 export { RainbowEffect } from "./RainbowEffect";

--- a/sparkle/src/stories/ProgressBar.stories.tsx
+++ b/sparkle/src/stories/ProgressBar.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { ProgressBar } from "../components/ProgressBar";
+
+const meta = {
+  title: "Data Display/ProgressBar",
+  component: ProgressBar,
+  parameters: {
+    docs: {
+      description: {
+        component: `A thin horizontal bar that communicates a share or completion percentage — e.g. a cost share breakdown or a progress indicator.
+
+**When to use**
+- To show a proportion or completion percentage inline, typically alongside a label or numeric value.
+
+**Guidelines**
+- Pass a \`percentage\` between 0 and 100; out-of-range values are clamped.
+- Control the bar's width via \`className\` (e.g. \`w-24\`, \`w-full\`).`,
+      },
+    },
+  },
+  args: {
+    percentage: 40,
+  },
+  argTypes: {
+    percentage: {
+      control: { type: "number", min: 0, max: 100 },
+    },
+  },
+} satisfies Meta<typeof ProgressBar>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => <ProgressBar {...args} className="w-48" />,
+};
+
+export const Percentages: Story = {
+  render: () => (
+    <div className="flex w-48 flex-col gap-3">
+      {[10, 40, 75, 100].map((percentage) => (
+        <ProgressBar key={percentage} percentage={percentage} />
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
## Description

Updates the consumption attribution and cost-share bars to use a shared `ProgressBar` component from Sparkle. The new component matches the Figma-aligned colors.

The previous analytics-local `CostShareBar` implementation is removed, and both existing consumers now use the shared component. `ProgressBar` is exported from Sparkle and includes Storybook documentation and examples for different percentages.

**Before:**
<img width="1115" height="416" alt="Capture d’écran 2026-08-17 à 09 55 25" src="https://github.com/user-attachments/assets/80ee8a48-f967-4828-a3bd-fe2ca957f831" />

**Now:**
<img width="1124" height="376" alt="Capture d’écran 2026-08-17 à 09 54 37" src="https://github.com/user-attachments/assets/d89e4517-fb93-44a2-bb4a-c15665cbf26d" />

**Sparkle doc:**
<img width="1453" height="817" alt="Capture d’écran 2026-08-17 à 09 55 55" src="https://github.com/user-attachments/assets/bdb4019b-8b95-4745-801e-45cbd28138d3" />
<img width="1507" height="757" alt="Capture d’écran 2026-08-17 à 09 56 17" src="https://github.com/user-attachments/assets/bc7023b0-38c0-40b3-a0ea-027aeb83af72" />

## Tests


## Risk

Low risk and limited to the analytics UI.

## Deploy Plan

- Deploy sparkle storybook
- Deploy front 