### PR TITLE
[sparkle] fix: keep tab focus rings visible

### DIFF
--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -51,7 +51,8 @@ const buttonVariants = cva(
     // `transform` stays in the transition list for the `press` scale.
     "transition-[color,background-color,border-color,transform] duration-100 ease-out",
     "motion-reduce:transition-none",
-    "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-0",
+    "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring focus-visible:ring-offset-0",
+    "group-focus-visible/button-link:ring-2 group-focus-visible/button-link:ring-inset group-focus-visible/button-link:ring-ring",
     // data-disabled is set only when truly disabled (not loading), so loading buttons
     // keep their full-color active look while :disabled guards block interaction for both.
     "data-[disabled]:shadow-none",
@@ -451,6 +452,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     return href && isInteractive ? (
       <LinkWrapper
+        className="group/button-link outline-hidden"
         href={href}
         target={target}
         rel={rel}

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -452,7 +452,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 
     return href && isInteractive ? (
       <LinkWrapper
-        className="group/button-link outline-hidden"
+        className="group/button-link focus-visible:outline-hidden"
         href={href}
         target={target}
         rel={rel}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -123,7 +123,7 @@ const NavigationListItem = React.forwardRef<
         {...props}
       >
         <LinkWrapper
-          className="group/nav-item outline-hidden"
+          className="group/nav-item focus-visible:outline-hidden"
           href={disabled ? undefined : href}
           target={target}
           rel={rel}

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -123,6 +123,7 @@ const NavigationListItem = React.forwardRef<
         {...props}
       >
         <LinkWrapper
+          className="group/nav-item outline-hidden"
           href={disabled ? undefined : href}
           target={target}
           rel={rel}
@@ -136,6 +137,7 @@ const NavigationListItem = React.forwardRef<
               "text-muted-foreground font-medium",
               "box-border flex items-center w-full gap-1.5 cursor-pointer select-none",
               "items-center outline-hidden rounded-lg text-sm p-2 transition-colors duration-150 motion-reduce:transition-none",
+              "group-focus-visible/nav-item:ring-2 group-focus-visible/nav-item:ring-inset group-focus-visible/nav-item:ring-ring",
               "data-[disabled]:pointer-events-none",
               !disabled &&
                 (keepHoverOnMoreMenu

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -11,7 +11,6 @@ const Tabs = TabsPrimitive.Root;
 const tabsTriggerVariants = cva(
   [
     "relative",
-    "focus-visible:ring-inset",
     "after:absolute after:bottom-[-10px] after:left-1/2 after:h-[2px]",
     "after:w-full after:-translate-x-1/2",
     "after:bg-foreground after:opacity-0 data-[state=active]:after:opacity-100",

--- a/sparkle/src/components/Tabs.tsx
+++ b/sparkle/src/components/Tabs.tsx
@@ -11,6 +11,7 @@ const Tabs = TabsPrimitive.Root;
 const tabsTriggerVariants = cva(
   [
     "relative",
+    "focus-visible:ring-inset",
     "after:absolute after:bottom-[-10px] after:left-1/2 after:h-[2px]",
     "after:w-full after:-translate-x-1/2",
     "after:bg-foreground after:opacity-0 data-[state=active]:after:opacity-100",


### PR DESCRIPTION
## Description

Observed in [this screenshot](https://dust4ai.slack.com/archives/C0BJ3T5SA0L/p1786952116269309) of the new analytics page.

Tab focus rings are clipped by the horizontal scroll viewport, leaving focused tabs with a broken outline.

This PR renders focus rings inside shared buttons and navigation items so they remain fully visible within clipped or  scrollable containers, without changing layout or scrolling behavior.

Before
<img width="980" height="162" alt="image" src="https://github.com/user-attachments/assets/0e387aec-c596-4115-8175-e02b6bacf0a9" />

After
<img width="1105" height="172" alt="image" src="https://github.com/user-attachments/assets/ae90cf3d-1a93-4385-8e76-58dc6257797e" />

## Tests

- Tested locally + preview, went to the new analytics page to check.

## Risk

- Low.

## Deploy Plan

- Deploy front.
