### PR TITLE
feat: automations analytics page scaffolding 

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -15,6 +15,13 @@ const AnalyticsConsumptionPage = withSuspense(
     ),
   "AnalyticsConsumptionPage"
 );
+const AnalyticsAutomationsPage = withSuspense(
+  () =>
+    import(
+      "@dust-tt/front/components/pages/workspace/AnalyticsAutomationsPage"
+    ),
+  "AnalyticsAutomationsPage"
+);
 const APIKeysPage = withSuspense(
   () =>
     import("@dust-tt/front/components/pages/workspace/developers/APIKeysPage"),
@@ -114,6 +121,10 @@ export const adminRoutes: RouteObject[] = [
       {
         path: "analytics/consumption",
         element: <AnalyticsConsumptionPage />,
+      },
+      {
+        path: "analytics/automations",
+        element: <AnalyticsAutomationsPage />,
       },
       { path: "usage", element: <UsagePage /> },
       { path: "governance", element: <GovernancePage /> },

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -15,6 +15,7 @@ import {
   BarChart01,
   Brackets,
   Brain,
+  Clock,
   CreditCard01,
   File04,
   Fingerprint04,
@@ -97,6 +98,7 @@ type SubNavigationAdminId =
   | "sandbox"
   | "analytics"
   | "analytics_consumption"
+  | "analytics_automations"
   | "credits_usage"
   | "usage"
   | "self_improving_skills";
@@ -109,6 +111,7 @@ const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   model_providers: ["/w/[wId]/model-providers"],
   analytics: ["/w/[wId]/analytics"],
   analytics_consumption: ["/w/[wId]/analytics/consumption"],
+  analytics_automations: ["/w/[wId]/analytics/automations"],
   subscription: ["/w/[wId]/subscription"],
   billing: ["/w/[wId]/billing"],
   api_keys: ["/w/[wId]/developers/api-keys"],
@@ -228,6 +231,7 @@ export const getTopNavigationTabs = (
           "/w/[wId]/billing",
           "/w/[wId]/analytics",
           "/w/[wId]/analytics/consumption",
+          "/w/[wId]/analytics/automations",
           "/w/[wId]/actions",
           "/w/[wId]/developers/credits-usage",
           "/w/[wId]/developers/providers",
@@ -402,6 +406,18 @@ export const subNavigationAdmin = ({
               disabled: !hasAdminRole,
             },
           ]),
+      ...(featureFlags.includes("enable_analytics_automations")
+        ? [
+            {
+              id: "analytics_automations" as const,
+              label: "Automation",
+              icon: Clock,
+              href: `/w/${owner.sId}/analytics/automations`,
+              current: isCurrent("analytics_automations"),
+              disabled: !hasManagerRole,
+            },
+          ]
+        : []),
     ],
   });
 

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -1,0 +1,44 @@
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { cn, Page } from "@dust-tt/sparkle";
+
+export function AnalyticsAutomationsPage() {
+  const { hasFeature } = useFeatureFlags();
+  const isEnabled = hasFeature("enable_analytics_automations");
+
+  if (!isEnabled) {
+    return (
+      <Page.Vertical align="stretch" gap="xl">
+        <Page.Header title={<Page.H variant="h3">Automation</Page.H>} />
+        <div
+          className={cn(
+            "flex flex-col gap-2 rounded-xl border p-6",
+            "border-border bg-muted"
+          )}
+        >
+          <p className="text-sm text-muted-foreground">
+            This page is not enabled for this workspace.
+          </p>
+        </div>
+      </Page.Vertical>
+    );
+  }
+
+  return (
+    <Page.Vertical align="stretch" gap="none">
+      <Page.Header
+        title={
+          <div className="flex max-w-[700px] flex-col gap-1">
+            <Page.H variant="h3">Automation</Page.H>
+            <Page.P variant="secondary">
+              Everything that runs on its own: what it costs, how often, and who
+              set it up.
+            </Page.P>
+          </div>
+        }
+      />
+      <div className="flex flex-col gap-8 pb-8 pt-4">
+        <Page.P variant="secondary">Coming soon.</Page.P>
+      </div>
+    </Page.Vertical>
+  );
+}

--- a/front/scripts/seed/README.md
+++ b/front/scripts/seed/README.md
@@ -16,7 +16,7 @@ DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/<folder>/seed.ts --execute
 
 ## Folders
 
-- `analytics/` - Creates members, teams, skills and agents, then fills the consumption index behind the "Analytics (new)" page
+- `analytics/` - Creates members, teams, skills, agents and triggers, then fills the consumption index behind the "Analytics (new)" page
 - `basics/` - Creates a custom agent with skills and sample conversations
 - `byok/` - Setup workspace to test Bring your own key
 - `governance/` - Creates users and skills for testing admin governance

--- a/front/scripts/seed/analytics/assets/triggers.json
+++ b/front/scripts/seed/analytics/assets/triggers.json
@@ -1,0 +1,115 @@
+[
+  {
+    "name": "Morning pipeline sweep",
+    "kind": "schedule",
+    "agentName": "PipelineWatch",
+    "customPrompt": "Review the pipeline and list the deals that slipped since yesterday.",
+    "status": "disabled",
+    "configuration": {
+      "cron": "0 7 * * 1-5",
+      "timezone": "Europe/Paris"
+    }
+  },
+  {
+    "name": "Hourly support triage",
+    "kind": "schedule",
+    "agentName": "SupportTriager",
+    "customPrompt": "Triage the tickets opened in the last hour and flag the ones breaching SLA.",
+    "status": "disabled",
+    "configuration": {
+      "cron": "0 * * * *",
+      "timezone": "UTC"
+    }
+  },
+  {
+    "name": "Release notes draft",
+    "kind": "schedule",
+    "agentName": "ReleaseScribe",
+    "customPrompt": "Draft the release notes for everything merged since the last release.",
+    "status": "disabled",
+    "configuration": {
+      "cron": "0 17 * * 4",
+      "timezone": "Europe/Paris"
+    }
+  },
+  {
+    "name": "Daily meeting recap",
+    "kind": "schedule",
+    "agentName": "MeetingRecap",
+    "customPrompt": "Summarize today's meetings and list the action items per owner.",
+    "status": "disabled",
+    "configuration": {
+      "cron": "0 18 * * 1-5",
+      "timezone": "Europe/Paris"
+    }
+  },
+  {
+    "name": "Weekly revenue digest",
+    "kind": "schedule",
+    "agentName": "DataAnalyst",
+    "customPrompt": "Compare this week's revenue to the previous one and explain the gap.",
+    "status": "disabled",
+    "configuration": {
+      "cron": "0 9 * * 1",
+      "timezone": "Europe/Paris"
+    }
+  },
+  {
+    "name": "Onboarding nudge",
+    "kind": "schedule",
+    "agentName": "OnboardingBuddy",
+    "customPrompt": "Check who joined last week and send them their next onboarding step.",
+    "status": "disabled",
+    "configuration": {
+      "cron": "0 10 * * 2",
+      "timezone": "Europe/Paris"
+    }
+  },
+  {
+    "name": "Contract renewal watch",
+    "kind": "schedule",
+    "agentName": "ContractReader",
+    "customPrompt": "List the contracts renewing in the next 30 days and their notice periods.",
+    "status": "disabled",
+    "configuration": {
+      "cron": "0 8 1 * *",
+      "timezone": "Europe/Paris"
+    }
+  },
+  {
+    "name": "Incident postmortem starter",
+    "kind": "webhook",
+    "agentName": "IncidentBuddy",
+    "webhookSourceName": "Analytics Linear",
+    "customPrompt": "An incident issue was updated. Draft the postmortem skeleton.",
+    "status": "disabled",
+    "configuration": {
+      "includePayload": true,
+      "event": "Issue"
+    }
+  },
+  {
+    "name": "PR summary",
+    "kind": "webhook",
+    "agentName": "ReleaseScribe",
+    "webhookSourceName": "Analytics GitHub",
+    "customPrompt": "A pull request was opened. Summarize what it changes for the release notes.",
+    "status": "disabled",
+    "configuration": {
+      "includePayload": true,
+      "event": "pull_request"
+    }
+  },
+  {
+    "name": "Doc freshness check",
+    "kind": "webhook",
+    "agentName": "DocFinder",
+    "webhookSourceName": "Analytics GitHub",
+    "customPrompt": "Code changed. Flag the docs pages that now describe stale behaviour.",
+    "status": "disabled",
+    "configuration": {
+      "includePayload": true,
+      "event": "push"
+    }
+  }
+]

--- a/front/scripts/seed/analytics/assets/webhook-sources.json
+++ b/front/scripts/seed/analytics/assets/webhook-sources.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "Analytics GitHub",
+    "provider": "github",
+    "subscribedEvents": ["push", "pull_request", "issues"],
+    "description": "Receives GitHub repository events for code changes and issues.",
+    "icon": "GithubLogo"
+  },
+  {
+    "name": "Analytics Linear",
+    "provider": "linear",
+    "subscribedEvents": ["Issue", "Comment"],
+    "description": "Receives Linear issue and comment updates.",
+    "icon": "LinearLogo"
+  }
+]

--- a/front/scripts/seed/analytics/seed.ts
+++ b/front/scripts/seed/analytics/seed.ts
@@ -3,7 +3,9 @@ import { seedHiddenAgent } from "@app/scripts/seed/analytics/hiddenAgent";
 import type {
   AgentAsset,
   SkillAsset,
+  TriggerAsset,
   UserAsset,
+  WebhookSourceAsset,
 } from "@app/scripts/seed/factories";
 import {
   createSeedContext,
@@ -11,7 +13,9 @@ import {
   seedConsumptionAnalytics,
   seedGroup,
   seedSkill,
+  seedTriggers,
   seedUsers,
+  seedWebhookSources,
 } from "@app/scripts/seed/factories";
 import { removeNulls } from "@app/types/shared/utils/general";
 import * as fs from "fs";
@@ -20,7 +24,9 @@ import * as path from "path";
 interface Assets {
   agents: AgentAsset[];
   skills: SkillAsset[];
+  triggers: TriggerAsset[];
   users: UserAsset[];
+  webhookSources: WebhookSourceAsset[];
 }
 
 function loadAssets(): Assets {
@@ -30,7 +36,9 @@ function loadAssets(): Assets {
   return {
     agents: read("agents.json"),
     skills: read("skills.json"),
+    triggers: read("triggers.json"),
     users: read("users.json"),
+    webhookSources: read("webhook-sources.json"),
   };
 }
 
@@ -53,7 +61,7 @@ makeScript(
     },
   },
   async ({ daysBack, messagesPerDay, execute }, logger) => {
-    const { agents, skills, users } = loadAssets();
+    const { agents, skills, triggers, users, webhookSources } = loadAssets();
 
     const ctx = await createSeedContext({ execute, logger });
 
@@ -94,16 +102,33 @@ makeScript(
     // 4. Enough agents for the rankings to have a long tail and an "others"
     // series in the chart.
     logger.info("Seeding agents...");
-    await seedAgents(ctx, agents, { skills: removeNulls(createdSkills) });
+    const createdAgents = await seedAgents(ctx, agents, {
+      skills: removeNulls(createdSkills),
+    });
 
     logger.info("Seeding the hidden agent...");
     await seedHiddenAgent(ctx, {
       owner: createdUsers.get(HIDDEN_AGENT_OWNER_ID),
     });
 
-    // 5. The consumption documents themselves.
+    // 5. Triggers, which the automated share of the consumption is attributed
+    // to. They stay disabled: the seed fabricates their consumption rather than
+    // letting Temporal actually run them.
+    logger.info("Seeding webhook sources...");
+    const createdWebhookSources = await seedWebhookSources(ctx, webhookSources);
+
+    logger.info("Seeding triggers...");
+    const createdTriggers = await seedTriggers(ctx, triggers, createdAgents, {
+      webhookSources: createdWebhookSources,
+    });
+
+    // 6. The consumption documents themselves.
     logger.info("Seeding consumption analytics...");
-    await seedConsumptionAnalytics(ctx, { daysBack, messagesPerDay });
+    await seedConsumptionAnalytics(ctx, {
+      daysBack,
+      messagesPerDay,
+      triggerIds: [...createdTriggers.values()].map((trigger) => trigger.sId),
+    });
 
     logger.info("Analytics seed completed");
   }

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -48,7 +48,6 @@ const MS_PER_HOUR = 60 * 60 * 1000;
 const LLM_CREDIT_RANGE = { min: 0.2, max: 8 };
 const TOOL_DIRECT_CREDIT_RANGE = { min: 0.01, max: 0.4 };
 const TOOL_MODEL_CREDIT_RANGE = { min: 0.01, max: 0.2 };
-const TRIGGER_COUNT = 3;
 const MAX_LLM_STEPS = 3;
 const MAX_TOOL_CALLS = 3;
 // Share of messages that delegate to a sub-agent.
@@ -58,13 +57,16 @@ const SUB_AGENT_RATE = 0.15;
 const FIRST_HOUR_UTC = 7;
 const LAST_HOUR_UTC = 20;
 
+// Automations are a third of the workspace's consumption, so the Automation
+// page has a ranking with a head and a tail rather than a handful of rows.
 const ORIGIN_WEIGHTS: { origin: UserMessageOrigin; weight: number }[] = [
-  { origin: "web", weight: 60 },
-  { origin: "slack", weight: 15 },
-  { origin: "api", weight: 8 },
-  { origin: "extension", weight: 6 },
-  { origin: "cli_programmatic", weight: 4 },
-  { origin: "triggered", weight: 4 },
+  { origin: "web", weight: 40 },
+  { origin: "triggered", weight: 22 },
+  { origin: "slack", weight: 12 },
+  { origin: "triggered_programmatic", weight: 8 },
+  { origin: "api", weight: 7 },
+  { origin: "extension", weight: 5 },
+  { origin: "cli_programmatic", weight: 3 },
   { origin: "gsheet", weight: 2 },
   { origin: "email", weight: 1 },
 ];
@@ -83,6 +85,7 @@ const TRIGGERED_ORIGINS: UserMessageOrigin[] = [
 export interface SeedConsumptionAnalyticsOptions {
   daysBack?: number;
   messagesPerDay?: number;
+  triggerIds?: string[];
 }
 
 // Deterministic PRNG (mulberry32): the same workspace always gets the same
@@ -151,10 +154,12 @@ type ConsumptionPools = {
   models: ModelConfigurationType[];
   toolServerNames: string[];
   skillIds: string[];
+  triggerIds: string[];
 };
 
 async function loadConsumptionPools(
-  ctx: SeedContext
+  ctx: SeedContext,
+  triggerIds: string[]
 ): Promise<ConsumptionPools> {
   const { auth } = ctx;
 
@@ -189,6 +194,7 @@ async function loadConsumptionPools(
     ),
     toolServerNames: catalog.tool.map((entry) => entry.value),
     skillIds: catalog.skill.map((entry) => entry.value),
+    triggerIds,
   };
 }
 
@@ -201,6 +207,7 @@ type SeedMessage = {
   model: ModelConfigurationType;
   origin: UserMessageOrigin;
   toolCallCount: number;
+  triggerId: string | null;
   user: AgentMessageConsumptionAnalyticsUser;
 };
 
@@ -246,11 +253,18 @@ function planDayMessages(
     );
     const agentId = pickByRank(random, pools.agentIds);
     const conversationId = seedId("seedconv", index);
+    const origin = pickOrigin(random);
+    // The trigger lives on the conversation, so every message of a triggered
+    // run carries the same one.
     const shared = {
       completedAt: new Date(completedAtMs),
       conversationId,
       model: pickByRank(random, pools.models),
-      origin: pickOrigin(random),
+      origin,
+      triggerId:
+        TRIGGERED_ORIGINS.includes(origin) && pools.triggerIds.length > 0
+          ? pickByRank(random, pools.triggerIds)
+          : null,
       user: pickByRank(random, pools.users),
     };
 
@@ -334,9 +348,7 @@ function makeBaseFields(
     space_id: null,
     status: "succeeded",
     step_index: stepIndex,
-    trigger_id: TRIGGERED_ORIGINS.includes(message.origin)
-      ? seedId("seedtrigger", randomInt(random, 0, TRIGGER_COUNT - 1))
-      : null,
+    trigger_id: message.triggerId,
     usage_type: isProgrammatic ? "programmatic" : "user",
     user: message.user,
     workspace_id: workspaceId,
@@ -523,11 +535,12 @@ export async function seedConsumptionAnalytics(
   {
     daysBack = DEFAULT_DAYS_BACK,
     messagesPerDay = DEFAULT_MESSAGES_PER_DAY,
+    triggerIds = [],
   }: SeedConsumptionAnalyticsOptions = {}
 ): Promise<void> {
   const { workspace, execute, logger } = ctx;
 
-  const pools = await loadConsumptionPools(ctx);
+  const pools = await loadConsumptionPools(ctx, triggerIds);
   if (
     pools.agentIds.length === 0 ||
     pools.users.length === 0 ||
@@ -540,6 +553,11 @@ export async function seedConsumptionAnalytics(
   if (pools.toolServerNames.length === 0) {
     logger.warn(
       "No MCP server in the workspace: the Tools and Skills tabs will be empty."
+    );
+  }
+  if (pools.triggerIds.length === 0) {
+    logger.warn(
+      "No trigger passed in: the triggered consumption will carry no trigger."
     );
   }
 
@@ -594,6 +612,7 @@ export async function seedConsumptionAnalytics(
       skillCount: pools.skillIds.length,
       toolCount: pools.toolServerNames.length,
       totalCredits,
+      triggerCount: pools.triggerIds.length,
     },
     "Indexed consumption documents"
   );

--- a/front/scripts/seed/factories/seedTriggers.ts
+++ b/front/scripts/seed/factories/seedTriggers.ts
@@ -1,7 +1,7 @@
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 
 import type { CreatedWebhookSourceView } from "./seedWebhookSources";
-import type { CreatedAgent, SeedContext } from "./types";
+import type { CreatedAgent, CreatedTrigger, SeedContext } from "./types";
 
 export interface ScheduleTriggerAsset {
   name: string;
@@ -40,11 +40,12 @@ export async function seedTriggers(
   triggerAssets: TriggerAsset[],
   agents: Map<string, CreatedAgent>,
   options: SeedTriggersOptions = {}
-): Promise<void> {
+): Promise<Map<string, CreatedTrigger>> {
   const { auth, execute, logger } = ctx;
   const workspace = auth.getNonNullableWorkspace();
   const user = auth.getNonNullableUser();
   const { webhookSources } = options;
+  const createdTriggers = new Map<string, CreatedTrigger>();
 
   for (const asset of triggerAssets) {
     const agent = agents.get(asset.agentName);
@@ -80,6 +81,10 @@ export async function seedTriggers(
     );
     const existingTrigger = existing.find((t) => t.name === asset.name);
     if (existingTrigger) {
+      createdTriggers.set(asset.name, {
+        sId: existingTrigger.sId,
+        name: asset.name,
+      });
       logger.info(
         { name: asset.name, agentName: asset.agentName },
         "Trigger already exists, skipping"
@@ -105,6 +110,11 @@ export async function seedTriggers(
         throw result.error;
       }
 
+      createdTriggers.set(asset.name, {
+        sId: result.value.sId,
+        name: asset.name,
+      });
+
       logger.info(
         { name: asset.name, kind: asset.kind, agentName: asset.agentName },
         "Trigger created"
@@ -116,4 +126,6 @@ export async function seedTriggers(
       );
     }
   }
+
+  return createdTriggers;
 }

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -96,6 +96,11 @@ export interface CreatedAgent {
   name: string;
 }
 
+export interface CreatedTrigger {
+  sId: string;
+  name: string;
+}
+
 export type SuggestionAsset = AgentSuggestionData & {
   agentName: string;
   analysis: string | null;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -155,6 +155,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to the new consumption-based Analytics dashboard, built alongside the current one while it is brought to parity.",
     stage: "dust_only",
   },
+  enable_analytics_automations: {
+    description:
+      "Access to the Automation analytics page, breaking down what triggers and programmatic runs cost.",
+    stage: "dust_only",
+  },
   xai_feature: {
     description: "Access to xAI models in the agent builder",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -794,6 +794,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "usage_data_api"
   | "usage_page_read_only"
   | "enable_analytics_consumption"
+  | "enable_analytics_automations"
   | "pricing_groups"
   | "workspace_analytics"
   | "xai_feature"


### PR DESCRIPTION
## Description

Scaffolds `/analytics/automations`, the page that will break down what triggers and programmatic runs cost. It sits in the **API & Programmatic** group of the Settings tab, behind the new `enable_analytics_automations` flag.

The analytics seed now creates 10 triggers (7 schedule, 3 webhook). Origin weights were rebalanced so automations are about a third of the consumption instead of 4%, which gives the page some data to display.

## Tests

Ran `scripts/seed/analytics/seed.ts` against a hive dev workspace, dry run and `--execute`.

Loaded the page with the flag on and off.

## Risk

Low.

## Deploy Plan

Deploy front.