### PR TITLE
Toggle attribution table filter button to remove active filters

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -8,6 +8,7 @@ import { UsageFilterSummary } from "@app/components/workspace/analytics/UsageFil
 import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
 import {
   addUsageFilterFromAttributionRow,
+  removeUsageFilterFromAttributionRow,
   setUsageFilterFromAttributionRow,
   toConsumptionScopeFilter,
 } from "@app/components/workspace/analytics/usageFilter";
@@ -128,6 +129,15 @@ export function AnalyticsConsumptionPage() {
           onAddFilter={(selectedRow) => {
             setFilter((current) =>
               addUsageFilterFromAttributionRow(current, dimension, selectedRow)
+            );
+          }}
+          onRemoveFilter={(selectedRow) => {
+            setFilter((current) =>
+              removeUsageFilterFromAttributionRow(
+                current,
+                dimension,
+                selectedRow
+              )
             );
           }}
           dimension={dimension}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -26,6 +26,7 @@ import type { ConsumptionDimension } from "./consumptionDimensions";
 export type AttributionRowData = ConsumptionTopRow & {
   onClick: () => void;
   onAddFilter: () => void;
+  onRemoveFilter: () => void;
 };
 
 const ATTRIBUTION_SKELETON_ROW_COUNT = 10;

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -64,6 +64,7 @@ function ControlledAttributionTable({
         setDimension(nextDimension);
       }}
       onAddFilter={vi.fn()}
+      onRemoveFilter={vi.fn()}
       onViewAll={vi.fn()}
     />
   );
@@ -97,6 +98,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -154,6 +156,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -180,6 +183,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -205,6 +209,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -300,6 +305,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -322,6 +328,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="model"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -368,6 +375,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -395,6 +403,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -428,6 +437,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="agent"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );
@@ -470,6 +480,7 @@ describe("ConsumptionAttributionTable", () => {
         dimension="skill"
         onDimensionChange={vi.fn()}
         onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
         onViewAll={vi.fn()}
       />
     );

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -453,6 +453,80 @@ describe("ConsumptionAttributionTable", () => {
     });
   });
 
+  it("toggles the filter button between add and remove", () => {
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [
+        {
+          id: "agent-id",
+          name: "Research agent",
+          pictureUrl: null,
+          description: null,
+          icon: null,
+          modelId: null,
+          modelDisplayName: null,
+          credits: 100,
+          avgCredits: 10,
+        },
+      ],
+      totalCredits: 100,
+      totalCount: 1,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    });
+
+    const onAddFilter = vi.fn();
+    const onRemoveFilter = vi.fn();
+
+    const { rerender } = render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        onDimensionChange={vi.fn()}
+        onAddFilter={onAddFilter}
+        onRemoveFilter={onRemoveFilter}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    const addButton = screen.getByRole("button", {
+      name: "Add Research agent to filters",
+    });
+    fireEvent.click(addButton);
+    expect(onAddFilter).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-id" })
+    );
+    expect(onRemoveFilter).not.toHaveBeenCalled();
+
+    rerender(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        filter={{ agents: ["agent-id"] }}
+        onDimensionChange={vi.fn()}
+        onAddFilter={onAddFilter}
+        onRemoveFilter={onRemoveFilter}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    const removeButton = screen.getByRole("button", {
+      name: "Remove Research agent from filters",
+    });
+    expect(
+      screen.queryByRole("button", { name: "Add Research agent to filters" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(removeButton);
+    expect(onRemoveFilter).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-id" })
+    );
+    expect(onAddFilter).toHaveBeenCalledTimes(1);
+  });
+
   it("renders the skill identity and description without a model", () => {
     mockUseConsumptionTop.mockReturnValue({
       rows: [

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -43,6 +43,7 @@ import {
   TabsList,
   TabsTrigger,
   Tooltip,
+  XCircle,
 } from "@dust-tt/sparkle";
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import type { Transition, Variants } from "framer-motion";
@@ -382,21 +383,24 @@ function buildColumns({
         return (
           <DataTable.CellContent className="w-full justify-end">
             <Button
-              icon={FilterFunnel01}
+              icon={isFilterSelected ? XCircle : FilterFunnel01}
               variant="ghost-secondary"
               size="xs"
-              disabled={isFilterSelected}
               tooltip={
-                isFilterSelected ? "Already in filters" : "Add to filters"
+                isFilterSelected ? "Remove from filters" : "Add to filters"
               }
               aria-label={
                 isFilterSelected
-                  ? `${row.name} is already in filters`
+                  ? `Remove ${row.name} from filters`
                   : `Add ${row.name} to filters`
               }
               onClick={(event) => {
                 event.stopPropagation();
-                row.onAddFilter();
+                if (isFilterSelected) {
+                  row.onRemoveFilter();
+                } else {
+                  row.onAddFilter();
+                }
               }}
             />
           </DataTable.CellContent>
@@ -412,6 +416,7 @@ interface AttributionRowsProps {
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
   onAddFilter: (row: ConsumptionTopRow) => void;
+  onRemoveFilter: (row: ConsumptionTopRow) => void;
   search: string;
   onViewAll: (
     dimension: ConsumptionDimension,
@@ -425,6 +430,7 @@ function AttributionRows({
   period,
   filter,
   onAddFilter,
+  onRemoveFilter,
   search,
   onViewAll,
 }: AttributionRowsProps) {
@@ -490,8 +496,9 @@ function AttributionRows({
         onClick: () =>
           setExpandedRowId((current) => (current === row.id ? null : row.id)),
         onAddFilter: () => onAddFilter(row),
+        onRemoveFilter: () => onRemoveFilter(row),
       })),
-    [rows, onAddFilter]
+    [rows, onAddFilter, onRemoveFilter]
   );
   const isLoading = isTopLoading;
   const skeletonRowCount =
@@ -597,6 +604,7 @@ interface ConsumptionAttributionTableProps {
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
   onAddFilter: (row: ConsumptionTopRow) => void;
+  onRemoveFilter: (row: ConsumptionTopRow) => void;
   // Owned by the page: the selected tab also drives the chart's breakdown.
   dimension: ConsumptionDimension;
   onDimensionChange: (dimension: ConsumptionDimension) => void;
@@ -611,6 +619,7 @@ export function ConsumptionAttributionTable({
   period,
   filter,
   onAddFilter,
+  onRemoveFilter,
   dimension,
   onDimensionChange,
   onViewAll,
@@ -721,6 +730,7 @@ export function ConsumptionAttributionTable({
                     period={period}
                     filter={filter}
                     onAddFilter={onAddFilter}
+                    onRemoveFilter={onRemoveFilter}
                     search={debouncedValue}
                     onViewAll={onViewAll}
                   />

--- a/front/components/workspace/analytics/usageFilter.test.ts
+++ b/front/components/workspace/analytics/usageFilter.test.ts
@@ -1,6 +1,7 @@
 import {
   addUsageFilterFromAttributionRow,
   getUsageFilterSummaries,
+  removeUsageFilterFromAttributionRow,
   setUsageFilterFromAttributionRow,
   toConsumptionScopeFilter,
 } from "@app/components/workspace/analytics/usageFilter";
@@ -231,5 +232,91 @@ describe("addUsageFilterFromAttributionRow", () => {
     const twice = addUsageFilterFromAttributionRow(once, "user", row);
 
     expect(twice).toEqual(once);
+  });
+});
+
+describe("removeUsageFilterFromAttributionRow", () => {
+  const row = {
+    id: "selected-member",
+    name: "Ada",
+    pictureUrl: null,
+  };
+
+  it.each<{ dimension: ConsumptionScopeDimension }>([
+    { dimension: "agent" },
+    { dimension: "user" },
+    { dimension: "group" },
+    { dimension: "model" },
+    { dimension: "tool" },
+    { dimension: "skill" },
+    { dimension: "source" },
+    { dimension: "api_key" },
+  ])("removes a previously added $dimension row, clearing the category", ({
+    dimension,
+  }) => {
+    const added = addUsageFilterFromAttributionRow({}, dimension, row);
+
+    expect(toConsumptionScopeFilter(added)).not.toEqual({});
+
+    const removed = removeUsageFilterFromAttributionRow(added, dimension, row);
+
+    expect(toConsumptionScopeFilter(removed)).toEqual({});
+  });
+
+  it("removes only the targeted row, preserving other selections", () => {
+    const filter = addUsageFilterFromAttributionRow(
+      {
+        member: [
+          {
+            id: "other-member",
+            name: "Grace",
+            kind: "member",
+            image: null,
+            disabled: false,
+          },
+        ],
+      },
+      "user",
+      row
+    );
+
+    const removed = removeUsageFilterFromAttributionRow(filter, "user", row);
+
+    expect(removed.member?.map(({ id }) => id)).toEqual(["other-member"]);
+  });
+
+  it("preserves other categories when clearing the targeted one", () => {
+    const filter = addUsageFilterFromAttributionRow(
+      {
+        tool: [
+          {
+            id: "tool-1",
+            name: "Web search",
+            kind: "tool",
+            icon: null,
+            disabled: false,
+          },
+        ],
+      },
+      "user",
+      row
+    );
+
+    const removed = removeUsageFilterFromAttributionRow(filter, "user", row);
+
+    expect(removed.member).toBeUndefined();
+    expect(removed.tool?.map(({ id }) => id)).toEqual(["tool-1"]);
+  });
+
+  it("is a no-op when the row is not selected", () => {
+    const filter = addUsageFilterFromAttributionRow({}, "user", {
+      id: "other-member",
+      name: "Grace",
+      pictureUrl: null,
+    });
+
+    const removed = removeUsageFilterFromAttributionRow(filter, "user", row);
+
+    expect(removed).toEqual(filter);
   });
 });

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -291,6 +291,15 @@ export function addUsageFilterFromAttributionRow(
   );
 }
 
+export function removeUsageFilterFromAttributionRow(
+  filter: UsageFilter,
+  dimension: ConsumptionScopeDimension,
+  row: AttributionFilterRow
+): UsageFilter {
+  const option = usageFilterOptionFromAttributionRow(dimension, row);
+  return removeUsageFilterOption(filter, option.kind, option.id);
+}
+
 // Maps an attribution row to the filter UI option shape, replacing that
 // dimension while preserving the other filters.
 export function setUsageFilterFromAttributionRow(


### PR DESCRIPTION
## Description

The per-row filter action in the workspace analytics consumption attribution table was disabled once a row had been added to the active filters, so users could not remove that filter from the table itself. The action now toggles based on the row's filter state: it shows the filter-funnel icon and “Add to filters” for unfiltered rows, and an X icon with “Remove from filters” for filtered rows.

**Before:**
<img width="1132" height="263" alt="Capture d’écran 2026-08-17 à 10 38 03" src="https://github.com/user-attachments/assets/02a37b4c-169f-40a5-b46e-98232c1c51e4" />

**After:**
<img width="1104" height="222" alt="Capture d’écran 2026-08-17 à 10 37 44" src="https://github.com/user-attachments/assets/9f8e30f9-c639-4921-96eb-5f604c7eab5d" />


## Tests


- Added `usageFilter.test.ts` coverage for removal across all supported dimensions, preserving other selections and categories, and handling the no-op case when the row is not selected.

## Risk

Low. The change is confined to the consumption attribution table's filter interaction and reuses the existing usage-filter removal logic.

## Deploy Plan

- Deploy front