### PR TITLE
[front] enh: rework inline tool approval UI

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -114,6 +114,9 @@ export function ToolValidationCard({
 
   const toolOverride = getToolOverride(validationRequest.metadata);
   const isSubmitting = isValidating || submittingDecision !== null;
+  const {
+    metadata: { agentName, mcpServerName },
+  } = validationRequest;
 
   return (
     <Card
@@ -125,7 +128,9 @@ export function ToolValidationCard({
       <div className="flex items-center justify-between gap-3 px-5 pt-4">
         <div className="flex min-w-0 items-center gap-3">
           <Avatar icon={icon ?? PieChart01} size="sm" />
-          <div className="heading-base min-w-0 wrap-break-word">{`Allow ${validationRequest.metadata.agentName} to use ${asDisplayName(validationRequest.metadata.mcpServerName)}?`}</div>
+          <div className="heading-base min-w-0 wrap-break-word">
+            {`Allow ${agentName} to use ${asDisplayName(mcpServerName)}?`}
+          </div>
         </div>
         {approvalProgress && <ApprovalProgress {...approvalProgress} />}
       </div>

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -193,7 +193,6 @@ export function ToolValidationCard({
             <Button
               label="Decline"
               variant="outline"
-              size="md"
               icon={XClose}
               disabled={isSubmitting}
               isLoading={submittingDecision === "rejected"}
@@ -202,7 +201,6 @@ export function ToolValidationCard({
             <Button
               label={toolOverride?.approveLabel ?? "Allow"}
               variant="highlight"
-              size="md"
               icon={Check}
               disabled={isSubmitting}
               isLoading={submittingDecision === "approved"}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -94,10 +94,7 @@ export function ToolValidationCard({
   };
 
   const toolOverride = getToolOverride(validationRequest.metadata);
-  const alwaysAllowLabel = getToolValidationAlwaysAllowLabel(validationRequest);
   const isSubmitting = isValidating || submittingDecision !== null;
-  const alwaysAllowInputId = `never-ask-again-${validationRequest.actionId}`;
-  const hasDetails = Object.keys(validationRequest.inputs).length > 0;
 
   return (
     <Card
@@ -130,7 +127,7 @@ export function ToolValidationCard({
         </div>
         {canCurrentUserRespond ? (
           <>
-            {hasDetails && (
+            {Object.keys(validationRequest.inputs).length > 0 && (
               <ToolValidationDetails
                 blockedAction={validationRequest}
                 user={currentUser}
@@ -161,18 +158,20 @@ export function ToolValidationCard({
           {(validationRequest.stake === "low" ||
             validationRequest.stake === "medium") && (
             <Label
-              htmlFor={alwaysAllowInputId}
+              htmlFor={`never-ask-again-${validationRequest.actionId}`}
               className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
             >
               <Checkbox
-                id={alwaysAllowInputId}
+                id={`never-ask-again-${validationRequest.actionId}`}
                 checked={neverAskAgain}
                 disabled={isSubmitting}
                 onCheckedChange={(check) => {
                   setNeverAskAgain(!!check);
                 }}
               />
-              <span className="font-normal">{alwaysAllowLabel}</span>
+              <span className="font-normal">
+                {getToolValidationAlwaysAllowLabel(validationRequest)}
+              </span>
             </Label>
           )}
           <div className="flex gap-2 sm:ml-auto">

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -100,7 +100,7 @@ export function ToolValidationCard({
     <Card
       variant="secondary"
       containerClassName="w-full max-w-xl"
-      className="flex-col p-0"
+      className="flex-col p-0 shadow"
       isPulsing={isPulsing}
     >
       <div className="flex items-center justify-between gap-3 px-5 pt-4">

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -193,7 +193,7 @@ export function ToolValidationCard({
             <Button
               label="Decline"
               variant="outline"
-              size="xs"
+              size="md"
               icon={XClose}
               disabled={isSubmitting}
               isLoading={submittingDecision === "rejected"}
@@ -202,7 +202,7 @@ export function ToolValidationCard({
             <Button
               label={toolOverride?.approveLabel ?? "Allow"}
               variant="highlight"
-              size="xs"
+              size="md"
               icon={Check}
               disabled={isSubmitting}
               isLoading={submittingDecision === "approved"}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -34,12 +34,31 @@ type ToolValidationRequest = Pick<
   | "argumentsRequiringApproval"
 >;
 
+type ApprovalProgressProps = {
+  current: number;
+  total: number;
+};
+
+function ApprovalProgress({ current, total }: ApprovalProgressProps) {
+  if (total <= 1) {
+    return null;
+  }
+
+  return (
+    <div className="heading-xs shrink-0 text-muted-foreground">
+      <span className="sr-only">
+        Approval {current} of {total}
+      </span>
+      <span aria-hidden="true">
+        {current}/{total}
+      </span>
+    </div>
+  );
+}
+
 interface ToolValidationCardProps {
   validationRequest: ToolValidationRequest;
-  approvalProgress?: {
-    current: number;
-    total: number;
-  };
+  approvalProgress?: ApprovalProgressProps;
   triggeringUser: UserType | null;
   // The viewer looking at the card. Passed in rather than read from `AuthContext` because shared
   // frames render this card outside of any AuthProvider.
@@ -108,16 +127,7 @@ export function ToolValidationCard({
           <Avatar icon={icon ?? PieChart01} size="sm" />
           <div className="heading-base min-w-0 wrap-break-word">{`Allow ${validationRequest.metadata.agentName} to use ${asDisplayName(validationRequest.metadata.mcpServerName)}?`}</div>
         </div>
-        {approvalProgress && approvalProgress.total > 1 && (
-          <div className="heading-xs shrink-0 text-muted-foreground">
-            <span className="sr-only">
-              Approval {approvalProgress.current} of {approvalProgress.total}
-            </span>
-            <span aria-hidden="true">
-              {approvalProgress.current}/{approvalProgress.total}
-            </span>
-          </div>
-        )}
+        {approvalProgress && <ApprovalProgress {...approvalProgress} />}
       </div>
 
       <div className="flex flex-col gap-4 px-5 py-4">

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -1,23 +1,25 @@
 import {
   getToolOverride,
   getToolValidationAlwaysAllowLabel,
-  getToolValidationTitle,
 } from "@app/components/actions/blocked/toolValidationLabels";
 import { ToolValidationDetails } from "@app/components/assistant/conversation/ToolValidationDetails";
 import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import {
+  Avatar,
   Button,
+  Card,
   Check,
   Checkbox,
-  ContentMessage,
   Label,
+  PieChart01,
   XClose,
 } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 // Display data needed to render a tool validation card, for both agent-loop and sandbox-function
 // blocked tool executions.
@@ -34,6 +36,10 @@ type ToolValidationRequest = Pick<
 
 interface ToolValidationCardProps {
   validationRequest: ToolValidationRequest;
+  approvalProgress?: {
+    current: number;
+    total: number;
+  };
   triggeringUser: UserType | null;
   // The viewer looking at the card. Passed in rather than read from `AuthContext` because shared
   // frames render this card outside of any AuthProvider.
@@ -49,6 +55,7 @@ interface ToolValidationCardProps {
 
 export function ToolValidationCard({
   validationRequest,
+  approvalProgress,
   triggeringUser,
   currentUser,
   owner,
@@ -59,106 +66,137 @@ export function ToolValidationCard({
   onValidate,
 }: ToolValidationCardProps) {
   const [neverAskAgain, setNeverAskAgain] = useState(false);
+  const [submittingDecision, setSubmittingDecision] = useState<
+    "approved" | "rejected" | null
+  >(null);
 
-  const canCurrentUserRespond = useMemo(
-    () =>
-      canCurrentUserRespondToParentUserMessage({
-        parentUserId: validationRequest.userId,
-        currentUserId: currentUser.sId,
-      }),
-    [validationRequest.userId, currentUser.sId]
-  );
+  const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
+    parentUserId: validationRequest.userId,
+    currentUserId: currentUser.sId,
+  });
 
   const icon = validationRequest.metadata.icon
     ? getIcon(validationRequest.metadata.icon)
     : undefined;
 
   const handleValidation = async (approved: "approved" | "rejected") => {
-    const success = await onValidate(
-      approved === "approved" && neverAskAgain ? "always_approved" : approved
-    );
-    if (success) {
-      setNeverAskAgain(false);
+    setSubmittingDecision(approved);
+    try {
+      const success = await onValidate(
+        approved === "approved" && neverAskAgain ? "always_approved" : approved
+      );
+      if (success) {
+        setNeverAskAgain(false);
+      }
+    } finally {
+      setSubmittingDecision(null);
     }
   };
 
   const toolOverride = getToolOverride(validationRequest.metadata);
-  const title = getToolValidationTitle(
-    validationRequest,
-    canCurrentUserRespond
-  );
   const alwaysAllowLabel = getToolValidationAlwaysAllowLabel(validationRequest);
+  const isSubmitting = isValidating || submittingDecision !== null;
+  const alwaysAllowInputId = `never-ask-again-${validationRequest.actionId}`;
+  const hasDetails = Object.keys(validationRequest.inputs).length > 0;
 
   return (
-    <ContentMessage
-      title={title}
-      variant="primary"
-      className="flex w-full flex-col gap-3 sm:w-80 sm:min-w-125"
-      icon={icon}
+    <Card
+      variant="secondary"
+      containerClassName="w-full max-w-xl"
+      className="flex-col p-0"
+      isPulsing={isPulsing}
     >
-      {canCurrentUserRespond ? (
-        <>
-          <ToolValidationDetails
-            blockedAction={validationRequest}
-            user={currentUser}
-            owner={owner}
-            conversationId={conversationId}
-            defaultExpanded={toolOverride?.detailsExpanded}
-          />
-          {errorMessage && (
-            <div className="mt-2 text-sm font-medium text-warning-800">
-              {errorMessage}
-            </div>
-          )}
-          <div className="flex flex-col gap-3 sm:mt-3">
-            {(validationRequest.stake === "low" ||
-              validationRequest.stake === "medium") && (
-              <Label
-                htmlFor="never-ask-again"
-                className="flex w-fit cursor-pointer flex-row items-center gap-2 py-1 pr-2 text-xs"
-              >
-                <Checkbox
-                  id="never-ask-again"
-                  checked={neverAskAgain}
-                  onCheckedChange={(check) => {
-                    setNeverAskAgain(!!check);
-                  }}
-                />
-                <span className="text-normal font-normal">
-                  {alwaysAllowLabel}
-                </span>
-              </Label>
-            )}
-            <div className="hidden sm:block sm:grow" />
-            <div className="flex flex-row gap-3 self-end">
-              <Button
-                label="Decline"
-                variant="outline"
-                size="xs"
-                icon={XClose}
-                disabled={isValidating}
-                isPulsing={isPulsing}
-                onClick={() => void handleValidation("rejected")}
-              />
-              <Button
-                label={toolOverride?.approveLabel ?? "Allow"}
-                variant="highlight"
-                size="xs"
-                icon={Check}
-                disabled={isValidating}
-                isPulsing={isPulsing}
-                onClick={() => void handleValidation("approved")}
-              />
-            </div>
+      <div className="flex items-center justify-between gap-3 px-5 pt-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <Avatar icon={icon ?? PieChart01} size="sm" />
+          <div className="heading-base min-w-0 wrap-break-word">{`Allow ${validationRequest.metadata.agentName} to use ${asDisplayName(validationRequest.metadata.mcpServerName)}?`}</div>
+        </div>
+        {approvalProgress && approvalProgress.total > 1 && (
+          <div className="heading-xs shrink-0 text-muted-foreground">
+            <span className="sr-only">
+              Approval {approvalProgress.current} of {approvalProgress.total}
+            </span>
+            <span aria-hidden="true">
+              {approvalProgress.current}/{approvalProgress.total}
+            </span>
           </div>
-        </>
-      ) : (
-        <div className="font-sm whitespace-normal wrap-break-word text-foreground">
-          Waiting for{" "}
-          <span className="font-semibold">{triggeringUser?.fullName}</span> to
-          confirm.
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4 px-5 py-4">
+        <div className="text-base">
+          {validationRequest.metadata.displayLabel ??
+            asDisplayName(validationRequest.metadata.toolName)}
+        </div>
+        {canCurrentUserRespond ? (
+          <>
+            {hasDetails && (
+              <ToolValidationDetails
+                blockedAction={validationRequest}
+                user={currentUser}
+                owner={owner}
+                conversationId={conversationId}
+                defaultExpanded={toolOverride?.detailsExpanded}
+              />
+            )}
+            {errorMessage && (
+              <div className="text-sm font-medium text-warning-800">
+                {errorMessage}
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="text-sm wrap-break-word text-muted-foreground">
+            Waiting for{" "}
+            <span className="font-semibold text-foreground">
+              {triggeringUser?.fullName}
+            </span>{" "}
+            to confirm.
+          </div>
+        )}
+      </div>
+
+      {canCurrentUserRespond && (
+        <div className="flex flex-col gap-3 px-4 pb-3 pt-2 sm:flex-row sm:items-center">
+          {(validationRequest.stake === "low" ||
+            validationRequest.stake === "medium") && (
+            <Label
+              htmlFor={alwaysAllowInputId}
+              className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
+            >
+              <Checkbox
+                id={alwaysAllowInputId}
+                checked={neverAskAgain}
+                disabled={isSubmitting}
+                onCheckedChange={(check) => {
+                  setNeverAskAgain(!!check);
+                }}
+              />
+              <span className="font-normal">{alwaysAllowLabel}</span>
+            </Label>
+          )}
+          <div className="flex gap-2 sm:ml-auto">
+            <Button
+              label="Decline"
+              variant="outline"
+              size="xs"
+              icon={XClose}
+              disabled={isSubmitting}
+              isLoading={submittingDecision === "rejected"}
+              onClick={() => void handleValidation("rejected")}
+            />
+            <Button
+              label={toolOverride?.approveLabel ?? "Allow"}
+              variant="highlight"
+              size="xs"
+              icon={Check}
+              disabled={isSubmitting}
+              isLoading={submittingDecision === "approved"}
+              onClick={() => void handleValidation("approved")}
+            />
+          </div>
         </div>
       )}
-    </ContentMessage>
+    </Card>
   );
 }

--- a/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.test.tsx
@@ -85,9 +85,26 @@ function makeAuthBlockedAction(
   };
 }
 
+function makeValidationBlockedAction(
+  actionId: string
+): AgentLoopBlockedToolExecution & {
+  status: "blocked_validation_required";
+} {
+  const { authorizationInfo: _authorizationInfo, ...action } =
+    makeAuthBlockedAction(actionId);
+
+  return {
+    ...action,
+    status: "blocked_validation_required",
+    stake: "low",
+    authorizationInfo: null,
+  };
+}
+
 function Consumer() {
   const {
     getBlockedActionItems,
+    getApprovalProgress,
     getFirstBlockedActionForMessage,
     refreshBlockedActions,
     removeCompletedAction,
@@ -95,6 +112,9 @@ function Consumer() {
 
   const firstAction = getFirstBlockedActionForMessage("msg_1");
   const firstActionItem = getBlockedActionItems("user_1")[0];
+  const approvalProgress = firstAction
+    ? getApprovalProgress({ actionId: firstAction.actionId, userId: "user_1" })
+    : undefined;
 
   return (
     <div>
@@ -104,6 +124,11 @@ function Consumer() {
       </span>
       <span data-testid="blocked-message-id">
         {firstActionItem?.blockedAction.messageId ?? "none"}
+      </span>
+      <span data-testid="approval-progress">
+        {approvalProgress
+          ? `${approvalProgress.current}/${approvalProgress.total}`
+          : "none"}
       </span>
       <button
         type="button"
@@ -155,6 +180,36 @@ describe("BlockedActionsProvider", () => {
     await user.click(screen.getByRole("button", { name: "resolve" }));
 
     expect(screen.getByTestId("first-action")).toHaveTextContent("action_2");
+  });
+
+  it("preserves approval progress as actions are resolved", async () => {
+    const user = userEvent.setup();
+    blockedActionsMock = [
+      makeValidationBlockedAction("action_1"),
+      makeValidationBlockedAction("action_2"),
+      makeValidationBlockedAction("action_3"),
+    ];
+
+    const { rerender } = renderProvider();
+
+    expect(screen.getByTestId("approval-progress")).toHaveTextContent("1/3");
+
+    await user.click(screen.getByRole("button", { name: "resolve" }));
+    expect(screen.getByTestId("approval-progress")).toHaveTextContent("2/3");
+
+    blockedActionsMock = [
+      makeValidationBlockedAction("action_2"),
+      makeValidationBlockedAction("action_3"),
+    ];
+    rerender(
+      <BlockedActionsProvider owner={owner} conversation={conversation}>
+        <Consumer />
+      </BlockedActionsProvider>
+    );
+    expect(screen.getByTestId("approval-progress")).toHaveTextContent("2/3");
+
+    await user.click(screen.getByRole("button", { name: "resolve" }));
+    expect(screen.getByTestId("approval-progress")).toHaveTextContent("3/3");
   });
 
   it("revalidates the blocked actions cache when an action is resolved", async () => {

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -20,8 +20,60 @@ type BlockedActionQueueItem = {
   blockedAction: AgentLoopBlockedToolExecution;
 };
 
+type ApprovalQueueItem = Pick<
+  AgentLoopBlockedToolExecution,
+  "actionId" | "userId"
+> & {
+  messageId: string;
+};
+
+type ApprovalProgress = {
+  current: number;
+  total: number;
+};
+
+type BlockedActionsState = {
+  conversationId: string | null;
+  blockedActionsQueue: BlockedActionQueueItem[];
+  approvalQueue: ApprovalQueueItem[];
+};
+
 const EMPTY_BLOCKED_ACTIONS_QUEUE: BlockedActionQueueItem[] = [];
+const EMPTY_APPROVAL_QUEUE: ApprovalQueueItem[] = [];
 const pulseDurationMs = 3000;
+
+function getApprovalQueueItems(
+  blockedActionsQueue: BlockedActionQueueItem[]
+): ApprovalQueueItem[] {
+  return blockedActionsQueue.flatMap(({ blockedAction, messageId }) =>
+    blockedAction.status === "blocked_validation_required"
+      ? [
+          {
+            actionId: blockedAction.actionId,
+            userId: blockedAction.userId,
+            messageId,
+          },
+        ]
+      : []
+  );
+}
+
+function mergeApprovalQueue(
+  approvalQueue: ApprovalQueueItem[],
+  blockedActionsQueue: BlockedActionQueueItem[]
+): ApprovalQueueItem[] {
+  const activeApprovals = getApprovalQueueItems(blockedActionsQueue);
+  if (activeApprovals.length === 0) {
+    return EMPTY_APPROVAL_QUEUE;
+  }
+
+  // Keep resolved approvals in the batch so remaining actions retain their original positions.
+  const knownActionIds = new Set(approvalQueue.map(({ actionId }) => actionId));
+  return [
+    ...approvalQueue,
+    ...activeApprovals.filter(({ actionId }) => !knownActionIds.has(actionId)),
+  ];
+}
 
 type BlockedActionsContextType = {
   enqueueBlockedAction: (params: {
@@ -37,6 +89,10 @@ type BlockedActionsContextType = {
   hasPendingValidations: (userId: string) => boolean;
   getBlockedActions: (userId: string) => AgentLoopBlockedToolExecution[];
   getBlockedActionItems: (userId: string) => BlockedActionQueueItem[];
+  getApprovalProgress: (params: {
+    actionId: string;
+    userId: string;
+  }) => ApprovalProgress | undefined;
   getFirstBlockedActionForMessage: (
     messageId: string
   ) => AgentLoopBlockedToolExecution | undefined;
@@ -81,9 +137,12 @@ export function BlockedActionsProvider({
   });
 
   // Inlined queue management logic
-  const [blockedActionsQueue, setBlockedActionsQueue] = useState<
-    BlockedActionQueueItem[]
-  >([]);
+  const [{ blockedActionsQueue, approvalQueue }, setBlockedActionsState] =
+    useState<BlockedActionsState>({
+      conversationId,
+      blockedActionsQueue: EMPTY_BLOCKED_ACTIONS_QUEUE,
+      approvalQueue: EMPTY_APPROVAL_QUEUE,
+    });
 
   // State for tracking pulsing state of user manual required actions
   const [pulsingActionIds, setPulsingActionIds] = useState<Set<string>>(
@@ -112,13 +171,23 @@ export function BlockedActionsProvider({
           return [{ blockedAction: action, messageId: outerMessageId }];
         });
 
-      setBlockedActionsQueue(
-        blockedActions.flatMap((action) =>
-          flattenBlockedActions([action], action.messageId)
-        )
+      const nextBlockedActionsQueue = blockedActions.flatMap((action) =>
+        flattenBlockedActions([action], action.messageId)
       );
+      setBlockedActionsState((state) => ({
+        conversationId,
+        blockedActionsQueue: nextBlockedActionsQueue,
+        approvalQueue:
+          state.conversationId === conversationId
+            ? mergeApprovalQueue(state.approvalQueue, nextBlockedActionsQueue)
+            : getApprovalQueueItems(nextBlockedActionsQueue),
+      }));
     } else {
-      setBlockedActionsQueue(EMPTY_BLOCKED_ACTIONS_QUEUE);
+      setBlockedActionsState({
+        conversationId,
+        blockedActionsQueue: EMPTY_BLOCKED_ACTIONS_QUEUE,
+        approvalQueue: EMPTY_APPROVAL_QUEUE,
+      });
     }
   }, [conversationId, blockedActions]);
 
@@ -130,21 +199,39 @@ export function BlockedActionsProvider({
       messageId: string;
       blockedAction: AgentLoopBlockedToolExecution;
     }) => {
-      setBlockedActionsQueue((prevQueue) => {
-        const existingIndex = prevQueue.findIndex(
+      setBlockedActionsState((state) => {
+        const previousQueue =
+          state.conversationId === conversationId
+            ? state.blockedActionsQueue
+            : EMPTY_BLOCKED_ACTIONS_QUEUE;
+        const existingIndex = previousQueue.findIndex(
           (v) => v.blockedAction.actionId === blockedAction.actionId
         );
 
         // If the action is not in the queue, add it.
         // If the action is in the queue, replace it with the new one.
-        return existingIndex === -1
-          ? [...prevQueue, { blockedAction, messageId }]
-          : prevQueue.map((item, index) =>
-              index === existingIndex ? { blockedAction, messageId } : item
-            );
+        const nextBlockedActionsQueue =
+          existingIndex === -1
+            ? [...previousQueue, { blockedAction, messageId }]
+            : previousQueue.map((item, index) =>
+                index === existingIndex ? { blockedAction, messageId } : item
+              );
+        const previousApprovalQueue =
+          state.conversationId === conversationId
+            ? state.approvalQueue
+            : EMPTY_APPROVAL_QUEUE;
+
+        return {
+          conversationId,
+          blockedActionsQueue: nextBlockedActionsQueue,
+          approvalQueue: mergeApprovalQueue(
+            previousApprovalQueue,
+            nextBlockedActionsQueue
+          ),
+        };
       });
     },
-    []
+    [conversationId]
   );
 
   const startPulsingAction = useCallback((actionId: string) => {
@@ -191,9 +278,23 @@ export function BlockedActionsProvider({
     (actionId: string) => {
       stopPulsingAction(actionId);
 
-      setBlockedActionsQueue((prevQueue) =>
-        prevQueue.filter((item) => item.blockedAction.actionId !== actionId)
-      );
+      setBlockedActionsState((state) => {
+        const nextBlockedActionsQueue = state.blockedActionsQueue.filter(
+          (item) => item.blockedAction.actionId !== actionId
+        );
+        const hasPendingApprovals = nextBlockedActionsQueue.some(
+          ({ blockedAction }) =>
+            blockedAction.status === "blocked_validation_required"
+        );
+
+        return {
+          ...state,
+          blockedActionsQueue: nextBlockedActionsQueue,
+          approvalQueue: hasPendingApprovals
+            ? state.approvalQueue
+            : EMPTY_APPROVAL_QUEUE,
+        };
+      });
 
       // Revalidate the blocked actions cache. Resolving an action happens
       // right after the OAuth popup closes, which refocuses the window and
@@ -242,6 +343,25 @@ export function BlockedActionsProvider({
     [getBlockedActionItems]
   );
 
+  const getApprovalProgress = useCallback(
+    ({ actionId, userId }: { actionId: string; userId: string }) => {
+      const userApprovalQueue = approvalQueue.filter((action) =>
+        canCurrentUserRespondToParentUserMessage({
+          parentUserId: action.userId,
+          currentUserId: userId,
+        })
+      );
+      const currentIndex = userApprovalQueue.findIndex(
+        (action) => action.actionId === actionId
+      );
+
+      return currentIndex === -1
+        ? undefined
+        : { current: currentIndex + 1, total: userApprovalQueue.length };
+    },
+    [approvalQueue]
+  );
+
   const { mutateConversations } = useConversations({
     workspaceId: owner.sId,
     options: { disabled: true },
@@ -255,9 +375,25 @@ export function BlockedActionsProvider({
       messageId: string;
       conversationId: string;
     }) => {
-      setBlockedActionsQueue((prevQueue) =>
-        prevQueue.filter((item) => item.messageId !== messageId)
-      );
+      setBlockedActionsState((state) => {
+        const nextBlockedActionsQueue = state.blockedActionsQueue.filter(
+          (item) => item.messageId !== messageId
+        );
+        const hasPendingApprovals = nextBlockedActionsQueue.some(
+          ({ blockedAction }) =>
+            blockedAction.status === "blocked_validation_required"
+        );
+
+        return {
+          ...state,
+          blockedActionsQueue: nextBlockedActionsQueue,
+          approvalQueue: hasPendingApprovals
+            ? state.approvalQueue.filter(
+                (approval) => approval.messageId !== messageId
+              )
+            : EMPTY_APPROVAL_QUEUE,
+        };
+      });
 
       // This is to update the unread inbox state in sidebar menu.
       // We only show the conversation in unread inbox if actionRequired is true (and this happens only when you come back to a conversation
@@ -301,6 +437,7 @@ export function BlockedActionsProvider({
       hasPendingValidations,
       getBlockedActions,
       getBlockedActionItems,
+      getApprovalProgress,
       getFirstBlockedActionForMessage,
       startPulsingAction,
       stopPulsingAction,
@@ -314,6 +451,7 @@ export function BlockedActionsProvider({
       hasPendingValidations,
       getBlockedActions,
       getBlockedActionItems,
+      getApprovalProgress,
       getFirstBlockedActionForMessage,
       startPulsingAction,
       stopPulsingAction,

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -51,6 +51,23 @@ export function MCPToolValidationRequired({
 
   const isPulsing = isActionPulsing(blockedAction.actionId);
 
+  const approvalProgress = useMemo(() => {
+    if (!user) {
+      return undefined;
+    }
+
+    const pendingApprovals = getBlockedActions(user.sId).filter(
+      (action) => action.status === "blocked_validation_required"
+    );
+    const currentIndex = pendingApprovals.findIndex(
+      (action) => action.actionId === blockedAction.actionId
+    );
+
+    return currentIndex === -1
+      ? undefined
+      : { current: currentIndex + 1, total: pendingApprovals.length };
+  }, [blockedAction.actionId, getBlockedActions, user]);
+
   const handleValidationStart = () => {
     // Stop pulsing immediately when the user takes an action.
     stopPulsingAction(blockedAction.actionId);
@@ -135,6 +152,7 @@ export function MCPToolValidationRequired({
   return (
     <ToolValidationCard
       validationRequest={blockedAction}
+      approvalProgress={approvalProgress}
       triggeringUser={triggeringUser}
       currentUser={user}
       owner={owner}

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -31,6 +31,7 @@ export function MCPToolValidationRequired({
 
   const {
     getBlockedActions,
+    getApprovalProgress,
     removeCompletedAction,
     isActionPulsing,
     stopPulsingAction,
@@ -51,22 +52,12 @@ export function MCPToolValidationRequired({
 
   const isPulsing = isActionPulsing(blockedAction.actionId);
 
-  const approvalProgress = useMemo(() => {
-    if (!user) {
-      return undefined;
-    }
-
-    const pendingApprovals = getBlockedActions(user.sId).filter(
-      (action) => action.status === "blocked_validation_required"
-    );
-    const currentIndex = pendingApprovals.findIndex(
-      (action) => action.actionId === blockedAction.actionId
-    );
-
-    return currentIndex === -1
-      ? undefined
-      : { current: currentIndex + 1, total: pendingApprovals.length };
-  }, [blockedAction.actionId, getBlockedActions, user]);
+  const approvalProgress = user
+    ? getApprovalProgress({
+        actionId: blockedAction.actionId,
+        userId: user.sId,
+      })
+    : undefined;
 
   const handleValidationStart = () => {
     // Stop pulsing immediately when the user takes an action.

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionPublishValidationDetails.tsx
@@ -16,7 +16,7 @@ export function SandboxFunctionPublishValidationDetails({
   const sourceFileName = input.path.split("/").pop() || input.path;
 
   return (
-    <div className="flex flex-col gap-3 py-2 pl-7 sm:flex-row">
+    <div className="flex flex-col gap-3 py-2 sm:flex-row">
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         <p className="heading-base wrap-break-word text-foreground">
           {input.slug}

--- a/front/components/assistant/conversation/tool_validation/SandboxFunctionUnpublishValidationDetails.tsx
+++ b/front/components/assistant/conversation/tool_validation/SandboxFunctionUnpublishValidationDetails.tsx
@@ -8,7 +8,7 @@ export function SandboxFunctionUnpublishValidationDetails({
   input,
 }: SandboxFunctionUnpublishValidationDetailsProps) {
   return (
-    <div className="flex flex-col gap-2 py-2 pl-7">
+    <div className="flex flex-col gap-2 py-2">
       <p className="heading-base wrap-break-word text-foreground">
         {input.slug}
       </p>

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -60,10 +60,8 @@ export type MCPValidationOutputType = (typeof MCP_VALIDATION_OUTPUTS)[number];
 export type MCPValidationMetadataType = {
   toolName: string;
   mcpServerName: string;
-  // Deprecated (2026-07-09): no longer read by any client, but still required at parse time by
-  // already-deployed CLI and extension versions. Typed as the literal to force emit sites to the
-  // placeholder constant; remove the field entirely once old clients have cycled out.
-  agentName: "agent";
+  displayLabel?: string;
+  agentName: string;
   pubsubMessageId?: string;
   icon?: InternalAllowedIconType | CustomResourceIconType;
   displayedAs?: "agent" | "server";

--- a/front/lib/actions/tool_approval_events.ts
+++ b/front/lib/actions/tool_approval_events.ts
@@ -5,11 +5,13 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { MCPApproveExecutionEventBase } from "@app/lib/actions/mcp_internal_actions/events";
 import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
+import { getToolDisplayLabels } from "@app/lib/actions/tool_display_labels";
 import type { Authenticator } from "@app/lib/auth";
 
 type ApprovalToolConfiguration = Pick<
   MCPToolConfigurationType,
   | "argumentsRequiringApproval"
+  | "displayLabels"
   | "icon"
   | "mcpServerName"
   | "originalName"
@@ -35,11 +37,19 @@ export async function makeMCPApproveExecutionEventBase(
 ): Promise<MCPApproveExecutionEventBase> {
   const argumentsRequiringApproval =
     toolConfiguration.argumentsRequiringApproval ?? [];
+  const internalMCPServerName = getInternalMCPServerNameFromSId(
+    toolConfiguration.toolServerId
+  );
+  const displayLabels =
+    getToolDisplayLabels({
+      internalMCPServerName,
+      mcpServerName: toolConfiguration.mcpServerName,
+      toolName: toolConfiguration.originalName,
+      inputs: approvalLabelInputs,
+    }) ?? toolConfiguration.displayLabels;
   const approvalArgsLabel = await getApprovalArgsLabel({
     auth,
-    internalMCPServerName: getInternalMCPServerNameFromSId(
-      toolConfiguration.toolServerId
-    ),
+    internalMCPServerName,
     toolName: toolConfiguration.originalName,
     agentName: approvalSubjectName,
     inputs: approvalLabelInputs,
@@ -56,7 +66,8 @@ export async function makeMCPApproveExecutionEventBase(
     metadata: {
       toolName: toolConfiguration.originalName,
       mcpServerName: toolConfiguration.mcpServerName,
-      agentName: "agent",
+      displayLabel: displayLabels?.done,
+      agentName: approvalSubjectName,
       icon: toolConfiguration.icon,
       displayedAs: getInternalMCPServerDisplayedAs(
         toolConfiguration.toolServerId

--- a/front/lib/api/assistant/jit/conversation.ts
+++ b/front/lib/api/assistant/jit/conversation.ts
@@ -42,6 +42,7 @@ export async function getConversationMCPServers(
       name: mcpServerView.name ?? serverDisplayMetadata.name,
       description:
         mcpServerView.description ?? serverDisplayMetadata.description,
+      icon: serverDisplayMetadata.icon,
       dataSources: null,
       tables: null,
       childAgentId: null,

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -1,9 +1,13 @@
+import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/constants";
 import type { LightServerSideMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolGeneratedFilePathType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
+import {
+  AgentMCPActionModel,
+  AgentMCPActionOutputItemModel,
+} from "@app/lib/models/agent/actions/mcp";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import {
   GCS_CONTENT_CACHE_TTL_MS,
@@ -12,12 +16,15 @@ import {
 } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { getNamespace } from "@app/tests/utils/test_cls";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type {
@@ -88,11 +95,13 @@ describe("listBlockedActionsForConversation", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
   let conversation: ConversationType;
+  let globalSpace: SpaceResource;
 
   beforeEach(async () => {
     const setup = await createResourceTest({});
     workspace = setup.workspace;
     auth = setup.authenticator;
+    globalSpace = setup.globalSpace;
 
     conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: "test-agent",
@@ -157,9 +166,24 @@ describe("listBlockedActionsForConversation", () => {
         parentId: userMessageRow.id,
       });
 
-    await createBlockedAction({
+    const remoteServer = await RemoteMCPServerFactory.create(workspace);
+    const mcpServerView = await MCPServerViewFactory.create(
+      workspace,
+      remoteServer.sId,
+      globalSpace
+    );
+    const { action } = await createBlockedAction({
       agentMessageModelId: agentMessageRow.agentMessageId!,
     });
+    await AgentMCPActionModel.update(
+      {
+        toolConfiguration: {
+          ...action.toolConfiguration,
+          mcpServerViewId: mcpServerView.sId,
+        },
+      },
+      { where: { id: action.id, workspaceId: workspace.id } }
+    );
 
     const conversationResource = await ConversationResource.fetchById(
       auth,
@@ -175,7 +199,8 @@ describe("listBlockedActionsForConversation", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].status).toBe("blocked_validation_required");
-    expect(result[0].metadata.agentName).toBe("agent");
+    expect(result[0].metadata.agentName).toBe("Test Agent");
+    expect(result[0].metadata.icon).toBe(DEFAULT_MCP_SERVER_ICON);
   });
 
   it("should only return blocked actions, not succeeded ones", async () => {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -453,11 +453,28 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
 
       const mcpServerId = mcpServerView?.mcpServerId;
       const mcpServerDisplayName = mcpServerView?.getDisplayName();
+      const icon =
+        mcpServerView?.getServerDisplayMetadata().icon ??
+        action.toolConfiguration.icon;
+      const internalMCPServerName = action.toolConfiguration.toolServerId
+        ? getInternalMCPServerNameFromSId(action.toolConfiguration.toolServerId)
+        : null;
 
       const parentUserMessage =
         parentUserMessageById[agentMessage.message.parentId!];
 
       assert(parentUserMessage.userMessage, "Parent user message not found.");
+
+      const displayLabels =
+        getToolDisplayLabels({
+          internalMCPServerName,
+          mcpServerName: action.toolConfiguration.mcpServerName,
+          toolName: action.toolConfiguration.originalName,
+          inputs: {
+            ...action.augmentedInputs,
+            ...(action.userEditedInputs ?? {}),
+          },
+        }) ?? action.toolConfiguration.displayLabels;
 
       const baseActionParams: Omit<
         AgentLoopBlockedToolExecution,
@@ -479,18 +496,15 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
         metadata: {
           toolName: action.toolConfiguration.originalName,
           mcpServerName: action.toolConfiguration.mcpServerName,
-          agentName: "agent",
-          icon: action.toolConfiguration.icon,
+          displayLabel: displayLabels?.done,
+          agentName: agentConfiguration.name,
+          icon,
         },
         argumentsRequiringApproval:
           action.toolConfiguration.argumentsRequiringApproval,
         approvalArgsLabel: await getApprovalArgsLabel({
           auth,
-          internalMCPServerName: action.toolConfiguration.toolServerId
-            ? getInternalMCPServerNameFromSId(
-                action.toolConfiguration.toolServerId
-              )
-            : null,
+          internalMCPServerName,
           toolName: action.toolConfiguration.originalName,
           agentName: agentConfiguration.name,
           inputs: action.augmentedInputs,


### PR DESCRIPTION
## Description

This PR reworks the Inline MCP approval UI, mostly based on the approval dialog we used to have.

Main changes:
- Use a card instead of a content message (bg color, shadow)
- Update the title to mention the agent's name, add a one-liner to explain what action is being taken
- Show queue position
- Improve loading states

Before
<img width="486" height="304" alt="image" src="https://github.com/user-attachments/assets/28b59872-b1da-4bd6-9dbc-6b4c68932356" />

After
<img width="558" height="298" alt="image" src="https://github.com/user-attachments/assets/35541c0f-6558-46c6-b934-93d271ac1c10" />

Next step is to work on the `Details` part.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
