### PR TITLE
Handle unsupported Notion formula results

### DIFF
--- a/connectors/src/connectors/notion/lib/notion_api.test.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePropertyValue } from "./notion_api";
+
+describe("parsePropertyValue", () => {
+  it("returns null for unsupported formula results", () => {
+    expect(
+      parsePropertyValue({
+        id: "formula-property",
+        type: "formula",
+        formula: {
+          type: "unsupported",
+          unsupported: {},
+        },
+      })
+    ).toBeNull();
+  });
+
+  it("keeps rendering supported formula results", () => {
+    expect(
+      parsePropertyValue({
+        id: "formula-property",
+        type: "formula",
+        formula: {
+          type: "number",
+          number: 42,
+        },
+      })
+    ).toBe("42");
+  });
+});

--- a/connectors/src/connectors/notion/lib/notion_api.ts
+++ b/connectors/src/connectors/notion/lib/notion_api.ts
@@ -37,6 +37,21 @@ const logger = mainLogger.child({ provider: "notion" });
 const NOTION_SEARCH_PAGE_SIZE = 90;
 const MIN_NOTION_SEARCH_PAGE_SIZE_ON_RENDERING_BUDGET_ERROR = 10;
 
+// Notion can return this formula result even though @notionhq/client@2 does not
+// include it in FormulaPropertyResponse.
+type UnsupportedFormulaPageProperty = {
+  id: string;
+  type: "formula";
+  formula: {
+    type: "unsupported";
+    unsupported: Record<string, never>;
+  };
+};
+
+type NotionPageProperty =
+  | PageObjectProperties[PropertyKeys]
+  | UnsupportedFormulaPageProperty;
+
 const notionClientLogger = (
   level: LogLevel,
   message: string,
@@ -966,7 +981,7 @@ export async function validateAccessToken(notionAccessToken: string) {
 }
 
 export function parsePropertyValue(
-  property: PageObjectProperties[PropertyKeys]
+  property: NotionPageProperty
 ): string | string[] | null {
   const parseDateProp = (d?: { start: string; end: string | null } | null) => {
     if (d?.start && d?.end) {
@@ -1068,6 +1083,8 @@ export function parsePropertyValue(
             return parseDateProp(property.formula.date);
           case "number":
             return `${property.formula.number}`;
+          case "unsupported":
+            return null;
           default:
             assertNever(property.formula);
         }


### PR DESCRIPTION
## Description

Treat Notion formula results with `type: "unsupported"` as empty property values. Notion emits this variant, but the pinned SDK v2 does not model it, so exhaustiveness checking currently retries the entire page render.

## Tests

Added regression coverage for unsupported and supported formula results. Tested locally with the targeted Vitest suite.

## Risk

Low. Only unsupported formula metadata is omitted while the rest of the page still syncs. Safe to roll back.

## Deploy Plan

Standard deploy.