### PR TITLE
perf: merge consumption top-N ranking + vs-prev queries into one ES call

### DIFF
--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,6 +1,7 @@
 import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
 import { fetchConsumptionTopApiKeys } from "@app/lib/api/analytics/consumption/top_api_keys";
 import { fetchConsumptionTopGroups } from "@app/lib/api/analytics/consumption/top_groups";
@@ -41,10 +42,48 @@ const PERIOD: ConsumptionPeriod = {
   endDate: "2026-08-01T00:00:00.000Z",
 };
 
+// The query is a single request spanning both periods (see
+// fetchConsumptionTopGroups), so tests that assert on the date range need
+// this to build the expected union bound.
+const PREVIOUS_PERIOD = previousConsumptionPeriod(PERIOD);
+
 function esResponse(aggregations: unknown) {
   return new Ok({ aggregations }) as Awaited<
     ReturnType<typeof searchConsumptionAnalytics>
   >;
+}
+
+// A ranked bucket, with its current- and previous-period nested filter aggs.
+// `previousCreditMicro` defaults to `creditMicro` so growth reads as flat,
+// matching what most tests want; pass `previousDocCount: 0` for "no prior
+// consumption at all" (null vs-prev).
+function bucket({
+  key,
+  docCount,
+  creditMicro,
+  messages,
+  previousCreditMicro = creditMicro,
+  previousDocCount = docCount,
+}: {
+  key: string;
+  docCount: number;
+  creditMicro: number;
+  messages?: number;
+  previousCreditMicro?: number;
+  previousDocCount?: number;
+}) {
+  return {
+    key,
+    current_period: {
+      doc_count: docCount,
+      credit_micro: { value: creditMicro },
+      ...(messages !== undefined ? { messages: { value: messages } } : {}),
+    },
+    previous_period: {
+      doc_count: previousDocCount,
+      credit_micro: { value: previousCreditMicro },
+    },
+  };
 }
 
 function mockAggs({
@@ -60,12 +99,12 @@ function mockAggs({
 }) {
   const ranking = {
     by_group: { buckets },
-    total_count: { value: totalCount },
+    total_count: { count: { value: totalCount } },
   };
   vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
     esResponse({
       ...(filtered ? { ranking } : ranking),
-      total_credit_micro: { value: totalMicro },
+      total_credit_micro: { value: { value: totalMicro } },
     })
   );
 }
@@ -87,16 +126,11 @@ async function setup() {
   return { auth };
 }
 
-// The last search the code under test issued, as [query, options].
+// The last search the code under test issued — one call per fetch, since the
+// ranking and the vs-prev credits now share a single Elasticsearch request.
 function lastSearchCall() {
   const calls = vi.mocked(searchConsumptionAnalytics).mock.calls;
   return calls[calls.length - 1];
-}
-
-// The ranking search — always the first call, since a second call for the
-// previous-period comparison follows it whenever the ranking has keys.
-function rankingSearchCall() {
-  return vi.mocked(searchConsumptionAnalytics).mock.calls[0];
 }
 
 describe("consumption top rankings", () => {
@@ -106,7 +140,7 @@ describe("consumption top rankings", () => {
     vi.mocked(resolveDimensionLabels).mockReset();
   });
 
-  it("ranks agents on gross credits and averages over distinct messages", async () => {
+  it("ranks agents on gross credits and averages over distinct messages, in a single request", async () => {
     const { auth } = await setup();
     vi.mocked(resolveDimensionLabels).mockResolvedValue(
       new Map([
@@ -124,12 +158,12 @@ describe("consumption top rankings", () => {
     );
     mockAggs({
       buckets: [
-        {
+        bucket({
           key: "agent1",
-          doc_count: 7,
-          credit_micro: { value: 3_000_000 },
-          messages: { value: 2 },
-        },
+          docCount: 7,
+          creditMicro: 3_000_000,
+          messages: 2,
+        }),
       ],
       totalMicro: 5_000_000,
     });
@@ -156,8 +190,8 @@ describe("consumption top rankings", () => {
         modelId: "claude-4-sonnet",
         modelDisplayName: "Claude 4 Sonnet",
         credits: 3,
-        // The mocked search response is reused for the previous-period
-        // query too, so the previous credits come out equal.
+        // The mocked bucket reuses the current period's credits for the
+        // previous one, so growth comes out flat.
         previousCredits: 3,
         // The 7 documents of the bucket belong to 2 messages.
         messageCount: 2,
@@ -165,27 +199,57 @@ describe("consumption top rankings", () => {
       },
     ]);
 
-    // Ranked on agent.id by gross credits, with a per-message cardinality
-    // sub-agg — a message spans several documents.
-    const [query, options] = rankingSearchCall();
+    // A single call: the query spans the union of both periods, and the
+    // ranking/vs-prev split happens through nested filter aggregations.
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query, options] = lastSearchCall();
     expect(query.bool?.filter).toContainEqual({
-      range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
+      range: {
+        completed_at: { gte: PREVIOUS_PERIOD.startDate, lt: PERIOD.endDate },
+      },
     });
+
+    // Ranked on agent.id by current-period gross credits, with a per-message
+    // cardinality sub-agg — a message spans several documents.
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "agent.id",
       size: 10,
-      order: { credit_micro: "desc" },
+      order: { "current_period>credit_micro": "desc" },
     });
-    expect(
-      options?.aggregations?.by_group?.aggs?.credit_micro?.sum?.field
-    ).toBe("credit_micro");
-    expect(
-      options?.aggregations?.by_group?.aggs?.messages?.cardinality?.field
-    ).toBe("agent_message_id");
-    expect(options?.aggregations?.total_credit_micro?.sum?.field).toBe(
+    const byGroupAggs = options?.aggregations?.by_group?.aggs;
+    expect(byGroupAggs?.current_period?.filter).toEqual({
+      range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
+    });
+    expect(byGroupAggs?.current_period?.aggs?.credit_micro?.sum?.field).toBe(
       "credit_micro"
     );
-    expect(options?.aggregations?.total_count?.cardinality).toEqual({
+    expect(
+      byGroupAggs?.current_period?.aggs?.messages?.cardinality?.field
+    ).toBe("agent_message_id");
+    expect(byGroupAggs?.previous_period?.filter).toEqual({
+      range: {
+        completed_at: {
+          gte: PREVIOUS_PERIOD.startDate,
+          lt: PREVIOUS_PERIOD.endDate,
+        },
+      },
+    });
+    expect(byGroupAggs?.previous_period?.aggs?.credit_micro?.sum?.field).toBe(
+      "credit_micro"
+    );
+
+    expect(options?.aggregations?.total_credit_micro?.filter).toEqual({
+      range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
+    });
+    expect(
+      options?.aggregations?.total_credit_micro?.aggs?.value?.sum?.field
+    ).toBe("credit_micro");
+    expect(options?.aggregations?.total_count?.filter).toEqual({
+      range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
+    });
+    expect(
+      options?.aggregations?.total_count?.aggs?.count?.cardinality
+    ).toEqual({
       field: "agent.id",
       precision_threshold: 40_000,
     });
@@ -197,30 +261,30 @@ describe("consumption top rankings", () => {
     mockLabels({ agent2: "Agent 2", agent3: "Agent 3" });
     mockAggs({
       buckets: [
-        {
+        bucket({
           key: "agent1",
-          doc_count: 1,
-          credit_micro: { value: 4_000_000 },
-          messages: { value: 1 },
-        },
-        {
+          docCount: 1,
+          creditMicro: 4_000_000,
+          messages: 1,
+        }),
+        bucket({
           key: "agent2",
-          doc_count: 1,
-          credit_micro: { value: 3_000_000 },
-          messages: { value: 1 },
-        },
-        {
+          docCount: 1,
+          creditMicro: 3_000_000,
+          messages: 1,
+        }),
+        bucket({
           key: "agent3",
-          doc_count: 1,
-          credit_micro: { value: 2_000_000 },
-          messages: { value: 1 },
-        },
-        {
+          docCount: 1,
+          creditMicro: 2_000_000,
+          messages: 1,
+        }),
+        bucket({
           key: "agent4",
-          doc_count: 1,
-          credit_micro: { value: 1_000_000 },
-          messages: { value: 1 },
-        },
+          docCount: 1,
+          creditMicro: 1_000_000,
+          messages: 1,
+        }),
       ],
       totalMicro: 10_000_000,
     });
@@ -241,11 +305,48 @@ describe("consumption top rankings", () => {
     ]);
     expect(result.value.hasMore).toBe(true);
     expect(result.value.totalCount).toBe(4);
-    expect(rankingSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject(
-      {
-        size: 3,
-      }
-    );
+    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
+      size: 3,
+    });
+  });
+
+  it("drops candidate buckets with no current-period activity", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "Agent 1" });
+    mockAggs({
+      buckets: [
+        bucket({
+          key: "agent1",
+          docCount: 1,
+          creditMicro: 1_000_000,
+          messages: 1,
+        }),
+        // Only ever active in the previous period: a terms candidate the
+        // union-range query surfaces, but it must not show up in the ranking.
+        bucket({
+          key: "agent_stale",
+          docCount: 0,
+          creditMicro: 0,
+          previousCreditMicro: 5_000_000,
+          previousDocCount: 3,
+        }),
+      ],
+      totalCount: 1,
+      totalMicro: 1_000_000,
+    });
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
+      "agent1",
+    ]);
   });
 
   it.each([
@@ -338,11 +439,11 @@ describe("consumption top rankings", () => {
     );
     mockAggs({
       buckets: [
-        {
+        bucket({
           key: "web_search_browse",
-          doc_count: 4,
-          credit_micro: { value: 2_000_000 },
-        },
+          docCount: 4,
+          creditMicro: 2_000_000,
+        }),
       ],
       totalMicro: 10_000_000,
     });
@@ -375,7 +476,9 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "tool.server_name",
     });
-    expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
+    expect(
+      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.messages
+    ).toBeUndefined();
   });
 
   it("ranks API key names on gross credits per distinct message", async () => {
@@ -390,12 +493,12 @@ describe("consumption top rankings", () => {
     mockLabels({ "Production key": "Production key" });
     mockAggs({
       buckets: [
-        {
+        bucket({
           key: "Production key",
-          doc_count: 6,
-          credit_micro: { value: 3_000_000 },
-          messages: { value: 2 },
-        },
+          docCount: 6,
+          creditMicro: 3_000_000,
+          messages: 2,
+        }),
       ],
       totalMicro: 5_000_000,
       filtered: true,
@@ -416,15 +519,13 @@ describe("consumption top rankings", () => {
         apiKeyName: "Production key",
         name: "Production key",
         credits: 3,
-        // The filtered ranking's response nests buckets under `ranking`,
-        // which the previous-period query doesn't produce, so no match.
-        previousCredits: null,
+        previousCredits: 3,
         messageCount: 2,
         avgCreditsPerMessage: 1.5,
       },
     ]);
 
-    const [, options] = rankingSearchCall();
+    const [, options] = lastSearchCall();
     expect(listConsumptionFacetCatalogDimension).toHaveBeenCalledWith(
       auth,
       "api_key"
@@ -438,8 +539,8 @@ describe("consumption top rankings", () => {
       }
     );
     expect(
-      options?.aggregations?.ranking?.aggs?.by_group?.aggs?.messages
-        ?.cardinality?.field
+      options?.aggregations?.ranking?.aggs?.by_group?.aggs?.current_period?.aggs
+        ?.messages?.cardinality?.field
     ).toBe("agent_message_id");
   });
 
@@ -459,9 +560,7 @@ describe("consumption top rankings", () => {
       ])
     );
     mockAggs({
-      buckets: [
-        { key: "skl_1", doc_count: 5, credit_micro: { value: 2_500_000 } },
-      ],
+      buckets: [bucket({ key: "skl_1", docCount: 5, creditMicro: 2_500_000 })],
       totalMicro: 10_000_000,
     });
 
@@ -491,19 +590,21 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "tool.attributed_skill_ids",
     });
-    expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
+    expect(
+      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.messages
+    ).toBeUndefined();
   });
 
   it("ranks users, groups and models per message on their own key", async () => {
     const { auth } = await setup();
     mockAggs({
       buckets: [
-        {
+        bucket({
           key: "key1",
-          doc_count: 6,
-          credit_micro: { value: 2_000_000 },
-          messages: { value: 4 },
-        },
+          docCount: 6,
+          creditMicro: 2_000_000,
+          messages: 4,
+        }),
       ],
       totalMicro: 2_000_000,
     });
@@ -578,12 +679,12 @@ describe("consumption top rankings", () => {
     mockLabels({ web: "Conversation" });
     mockAggs({
       buckets: [
-        {
+        bucket({
           key: "web",
-          doc_count: 10,
-          credit_micro: { value: 4_000_000 },
-          messages: { value: 4 },
-        },
+          docCount: 10,
+          creditMicro: 4_000_000,
+          messages: 4,
+        }),
       ],
       totalMicro: 4_000_000,
     });
@@ -635,12 +736,12 @@ describe("consumption top rankings", () => {
     mockLabels({});
     mockAggs({
       buckets: [
-        {
+        bucket({
           key: "agent_gone",
-          doc_count: 1,
-          credit_micro: { value: 1_000_000 },
-          messages: { value: 1 },
-        },
+          docCount: 1,
+          creditMicro: 1_000_000,
+          messages: 1,
+        }),
       ],
       totalMicro: 1_000_000,
     });
@@ -667,12 +768,12 @@ describe("consumption top rankings", () => {
     mockLabels({ agent1: "@dust" });
     mockAggs({
       buckets: [
-        {
+        bucket({
           key: "agent1",
-          doc_count: 0,
-          credit_micro: { value: 1_000_000 },
-          messages: { value: 0 },
-        },
+          docCount: 1,
+          creditMicro: 1_000_000,
+          messages: 0,
+        }),
       ],
       totalMicro: 1_000_000,
     });
@@ -689,29 +790,22 @@ describe("consumption top rankings", () => {
     expect(result.value.agents[0].avgCreditsPerMessage).toBe(0);
   });
 
-  it("still returns the ranking when the previous-period lookup fails", async () => {
+  it("reports null vs-prev growth for a group with no prior consumption", async () => {
     const { auth } = await setup();
     mockLabels({ agent1: "@dust" });
-    // The ranking query succeeds, then the previous-period query fails.
-    vi.mocked(searchConsumptionAnalytics).mockResolvedValueOnce(
-      esResponse({
-        by_group: {
-          buckets: [
-            {
-              key: "agent1",
-              doc_count: 1,
-              credit_micro: { value: 3_000_000 },
-              messages: { value: 1 },
-            },
-          ],
-        },
-        total_count: { value: 1 },
-        total_credit_micro: { value: 3_000_000 },
-      })
-    );
-    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
-      new Err(new ElasticsearchError("connection_error", "boom"))
-    );
+    mockAggs({
+      buckets: [
+        bucket({
+          key: "agent1",
+          docCount: 1,
+          creditMicro: 3_000_000,
+          messages: 1,
+          previousDocCount: 0,
+          previousCreditMicro: 0,
+        }),
+      ],
+      totalMicro: 3_000_000,
+    });
 
     const result = await fetchConsumptionTopAgents(auth, {
       period: PERIOD,
@@ -724,5 +818,20 @@ describe("consumption top rankings", () => {
     }
     expect(result.value.agents[0].credits).toBe(3);
     expect(result.value.agents[0].previousCredits).toBeNull();
+  });
+
+  it("fails the ranking when the merged Elasticsearch request errors", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "@dust" });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Err(new ElasticsearchError("connection_error", "boom"))
+    );
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(false);
   });
 });

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -10,6 +10,7 @@ import type {
 import {
   AGENT_MESSAGE_ID_FIELD,
   buildConsumptionScopeQuery,
+  COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
   CONSUMPTION_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
@@ -21,7 +22,6 @@ import {
 } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { microCreditsToCredits } from "@app/lib/credits/units";
-import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -55,15 +55,24 @@ export type ConsumptionTopGroups = {
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
 const TOTAL_COUNT_AGG = "total_count";
+// Nested filter aggregations that isolate the current and previous period
+// within a single query spanning both, so the ranking and the vs-prev
+// credits come back in one Elasticsearch round trip.
+const CURRENT_PERIOD_AGG = "current_period";
+const PREVIOUS_PERIOD_AGG = "previous_period";
 const CARDINALITY_PRECISION_THRESHOLD = 40_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
 
-type GroupBucket = {
-  key: string;
-  doc_count: number;
+type PeriodBucket = estypes.AggregationsSingleBucketAggregateBase & {
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
+};
+
+type GroupBucket = {
+  key: string;
+  [CURRENT_PERIOD_AGG]?: PeriodBucket;
+  [PREVIOUS_PERIOD_AGG]?: PeriodBucket;
 };
 
 function subAggs(unit: ConsumptionTopUnit) {
@@ -75,29 +84,43 @@ function subAggs(unit: ConsumptionTopUnit) {
   };
 }
 
+function periodRangeFilter(
+  period: ConsumptionPeriod
+): estypes.QueryDslQueryContainer {
+  return {
+    range: {
+      [COMPLETED_AT_FIELD]: { gte: period.startDate, lt: period.endDate },
+    },
+  };
+}
+
 type RankingAggs = {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
-  [TOTAL_COUNT_AGG]?: estypes.AggregationsCardinalityAggregate;
+  [TOTAL_COUNT_AGG]?: estypes.AggregationsSingleBucketAggregateBase & {
+    count?: estypes.AggregationsCardinalityAggregate;
+  };
 };
 
 type TopAggs = RankingAggs & {
   ranking?: estypes.AggregationsSingleBucketAggregateBase & RankingAggs;
-  total_credit_micro?: estypes.AggregationsSumAggregate;
+  total_credit_micro?: estypes.AggregationsSingleBucketAggregateBase & {
+    value?: estypes.AggregationsSumAggregate;
+  };
 };
 
 function countFromBucket(
-  bucket: GroupBucket,
+  current: PeriodBucket | undefined,
   unit: ConsumptionTopUnit
 ): number {
   switch (unit) {
     case "message":
-      return Math.round(bucket[MESSAGES_AGG]?.value ?? 0);
+      return Math.round(current?.[MESSAGES_AGG]?.value ?? 0);
     case "invocation":
       // One tool document is one invocation, so the bucket counts itself. A
       // multi-valued dimension (a tool call attributed to several skills) puts
       // the same document in several buckets, which is the intent: each skill is
       // credited with the invocation it is responsible for.
-      return bucket.doc_count;
+      return current?.doc_count ?? 0;
     default:
       assertNever(unit);
   }
@@ -170,30 +193,55 @@ function buildConsumptionTopAggregations({
   limit,
   offset,
   searchFilter,
+  period,
+  previousPeriod,
 }: {
   dimension: ConsumptionScopeDimension;
   limit: number;
   offset: number;
   searchFilter: estypes.QueryDslQueryContainer | null;
+  period: ConsumptionPeriod;
+  previousPeriod: ConsumptionPeriod;
 }): Record<string, estypes.AggregationsAggregationContainer> {
   const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
   const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
 
   // TODO(2026-08-14 aubin): Add pagination beyond the maximum bucket count.
   const requestedBucketCount = offset + limit;
+  // The query spans both periods (see fetchConsumptionTopGroups), so a term
+  // active only in the previous period can otherwise consume a terms
+  // candidate slot ahead of a real current-period contender. Padding
+  // shard_size makes that far less likely without changing what's returned.
+  const shardSize = requestedBucketCount * 3 + 50;
+
   const rankingAggregations = {
     by_group: {
       terms: {
         field: dimensionField,
         size: requestedBucketCount,
-        order: { [CREDIT_AGG]: "desc" },
+        shard_size: shardSize,
+        order: { [`${CURRENT_PERIOD_AGG}>${CREDIT_AGG}`]: "desc" },
       },
-      aggs: subAggs(unit),
+      aggs: {
+        [CURRENT_PERIOD_AGG]: {
+          filter: periodRangeFilter(period),
+          aggs: subAggs(unit),
+        },
+        [PREVIOUS_PERIOD_AGG]: {
+          filter: periodRangeFilter(previousPeriod),
+          aggs: { [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } } },
+        },
+      },
     },
     [TOTAL_COUNT_AGG]: {
-      cardinality: {
-        field: dimensionField,
-        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+      filter: periodRangeFilter(period),
+      aggs: {
+        count: {
+          cardinality: {
+            field: dimensionField,
+            precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+          },
+        },
       },
     },
   } satisfies Record<string, estypes.AggregationsAggregationContainer>;
@@ -209,75 +257,11 @@ function buildConsumptionTopAggregations({
 
   return {
     ...rankingRootAggregations,
-    total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+    total_credit_micro: {
+      filter: periodRangeFilter(period),
+      aggs: { value: { sum: { field: CREDIT_MICRO_FIELD } } },
+    },
   };
-}
-
-type PreviousCreditsAggs = {
-  by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
-};
-
-// Sums credits per key over `previousPeriod`, scoped to exactly the keys
-// passed in (the current page's ranking) rather than re-ranking that window,
-// since we only need those keys' prior credits to compute their growth.
-async function fetchConsumptionPreviousCredits(
-  auth: Authenticator,
-  {
-    dimension,
-    previousPeriod,
-    filter,
-    keys,
-  }: {
-    dimension: ConsumptionScopeDimension;
-    previousPeriod: ConsumptionPeriod;
-    filter?: ConsumptionScopeFilter;
-    keys: string[];
-  }
-): Promise<Result<Map<string, number>, ElasticsearchError>> {
-  if (keys.length === 0) {
-    return new Ok(new Map());
-  }
-
-  const query = buildConsumptionScopeQuery({
-    auth,
-    startDate: previousPeriod.startDate,
-    endDate: previousPeriod.endDate,
-    filter,
-  });
-
-  const result = await searchConsumptionAnalytics<never, PreviousCreditsAggs>(
-    query,
-    {
-      aggregations: {
-        by_group: {
-          terms: {
-            field: CONSUMPTION_DIMENSION_FIELDS[dimension],
-            include: keys,
-            size: keys.length,
-          },
-          aggs: { [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } } },
-        },
-      },
-      size: 0,
-    }
-  );
-
-  if (result.isErr()) {
-    return result;
-  }
-
-  const buckets = bucketsToArray<GroupBucket>(
-    result.value.aggregations?.by_group?.buckets
-  );
-
-  return new Ok(
-    new Map(
-      buckets.map((bucket) => [
-        String(bucket.key),
-        microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-      ])
-    )
-  );
 }
 
 /**
@@ -307,9 +291,15 @@ export async function fetchConsumptionTopGroups(
     search,
   });
 
+  const previousPeriod = previousConsumptionPeriod(period);
+
+  // A single query over the union of both periods, so the ranking and the
+  // vs-prev credits come back in one Elasticsearch round trip instead of two.
+  // previousPeriod.endDate is always period.startDate (see
+  // previousConsumptionPeriod), so the union range is contiguous.
   const query = buildConsumptionScopeQuery({
     auth,
-    startDate: period.startDate,
+    startDate: previousPeriod.startDate,
     endDate: period.endDate,
     filter,
   });
@@ -319,6 +309,8 @@ export async function fetchConsumptionTopGroups(
     limit,
     offset,
     searchFilter,
+    period,
+    previousPeriod,
   });
 
   const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
@@ -333,49 +325,34 @@ export async function fetchConsumptionTopGroups(
   const ranking = searchFilter
     ? result.value.aggregations?.ranking
     : result.value.aggregations;
-  const rankedGroups = bucketsToArray<GroupBucket>(
-    ranking?.by_group?.buckets
-  ).map((bucket) => ({
-    key: String(bucket.key),
-    credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-    count: countFromBucket(bucket, CONSUMPTION_DIMENSION_UNIT[dimension]),
-  }));
-  const totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
+  const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
+  const rankedGroups = bucketsToArray<GroupBucket>(ranking?.by_group?.buckets)
+    // A bucket with no current-period activity only exists to let its
+    // previous-period volume compete for a terms candidate slot; it never
+    // belongs in the ranking itself.
+    .filter((bucket) => (bucket[CURRENT_PERIOD_AGG]?.doc_count ?? 0) > 0)
+    .map((bucket) => {
+      const current = bucket[CURRENT_PERIOD_AGG];
+      const previous = bucket[PREVIOUS_PERIOD_AGG];
+      return {
+        key: String(bucket.key),
+        credits: microCreditsToCredits(current?.[CREDIT_AGG]?.value ?? 0),
+        count: countFromBucket(current, unit),
+        previousCredits:
+          previous && previous.doc_count > 0
+            ? microCreditsToCredits(previous[CREDIT_AGG]?.value ?? 0)
+            : null,
+      };
+    });
+  const totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.count?.value ?? 0);
   const pagedGroups = rankedGroups.slice(offset, offset + limit);
 
-  const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
-    dimension,
-    previousPeriod: previousConsumptionPeriod(period),
-    filter,
-    keys: pagedGroups.map((group) => group.key),
-  });
-  // The prior-period lookup only feeds the vs-prev display column: a failure
-  // there should not take down the current-period ranking, which already
-  // succeeded. Fall back to unknown growth for every group instead.
-  if (previousCreditsResult.isErr()) {
-    logger.warn(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        dimension,
-        err: previousCreditsResult.error,
-      },
-      "[ConsumptionAnalytics] Failed to fetch previous-period credits, " +
-        "falling back to null vs-prev values."
-    );
-  }
-  const previousCreditsByKey = previousCreditsResult.isOk()
-    ? previousCreditsResult.value
-    : new Map<string, number>();
-
   return new Ok({
-    groups: pagedGroups.map((group) => ({
-      ...group,
-      previousCredits: previousCreditsByKey.get(group.key) ?? null,
-    })),
+    groups: pagedGroups,
     hasMore: totalCount > offset + limit,
     totalCount,
     totalCredits: microCreditsToCredits(
-      result.value.aggregations?.total_credit_micro?.value ?? 0
+      result.value.aggregations?.total_credit_micro?.value?.value ?? 0
     ),
   });
 }


### PR DESCRIPTION
## Summary
- `fetchConsumptionTopGroups` (backing every consumption Top-N widget: agents, users, models, tools, skills, sources, api keys, groups) issued two sequential Elasticsearch requests — the ranking query, then a second query for the period-over-period ("vs prev") comparison.
- Merged both into a single query spanning the union of the current and previous periods, using nested `filter` aggregations to isolate each period's credits/count within the same `terms` ranking. Halves the ES round-trip count for every attribution table and breakdown column on the consumption analytics page.
- `total_count` and `total_credit_micro` are now scoped via a `current_period` filter agg too, since the outer query date range now spans both periods.
- Padded `shard_size` on the ranking `terms` agg, since a term active only in the previous period can now appear as a candidate bucket; those buckets are filtered out of the final ranking in code so results are unaffected.

## Known tradeoff
Previously, a failure fetching vs-prev credits didn't take down the ranking (it fell back to null growth for every row). Since both are now one request, a failure there fails the whole ranking. Given this is read-only analytics tooling (not a mutation path), this seemed like an acceptable tradeoff for halving the query count, but flagging explicitly for review.

## Test plan
- [x] `front/lib/api/analytics/consumption/top.test.ts` updated for the new single-request aggregation shape (16 tests), plus new coverage for stale-candidate filtering and the merged-failure path.
- [x] `npx tsgo --noEmit` passes across `front`.
- [x] Full `lib/api/analytics/consumption` test suite passes (66 tests).