### PR TITLE
[front] fix: remove filtering on new analytics page header values

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -85,11 +85,7 @@ export function AnalyticsConsumptionPage() {
         }
       />
       <div className="flex flex-col gap-8 pb-8 pt-4">
-        <ConsumptionOverview
-          workspaceId={owner.sId}
-          period={period}
-          filter={scopeFilter}
-        />
+        <ConsumptionOverview workspaceId={owner.sId} period={period} />
         <LazyMotion features={domMax}>
           <div className="flex flex-col gap-4">
             <div className="sticky top-0 z-30 -mb-4 flex flex-col bg-panel-background pb-4 pt-4">

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -3,7 +3,6 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionOverview as ConsumptionOverviewType } from "@app/lib/api/analytics/consumption/overview";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
@@ -113,13 +112,11 @@ function ConsumptionSummary({
 interface ConsumptionOverviewProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
-  filter?: ConsumptionScopeFilter;
 }
 
 export function ConsumptionOverview({
   workspaceId,
   period: periodSelection,
-  filter,
 }: ConsumptionOverviewProps) {
   const { overview, isOverviewLoading, isOverviewError } =
     useConsumptionOverview({ workspaceId, period: periodSelection });

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -122,7 +122,7 @@ export function ConsumptionOverview({
   filter,
 }: ConsumptionOverviewProps) {
   const { overview, isOverviewLoading, isOverviewError } =
-    useConsumptionOverview({ workspaceId, period: periodSelection, filter });
+    useConsumptionOverview({ workspaceId, period: periodSelection });
 
   if (isOverviewLoading) {
     return (


### PR DESCRIPTION
## Description

The header on the new analytics page changes when we change the filter.
As it's positioned above the filter it should remain the same.

This PR fixes that.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
