### PR TITLE
fix(front): knowledge picker dead-clicks on childless data source views

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
@@ -350,17 +350,21 @@ export function DataSourceList({
           ? selectionState === "partial"
           : !hideCheckbox;
 
+        const handleRowClick = () => {
+          if (item.onClick) {
+            item.onClick();
+            return;
+          }
+          if (shouldShowCheckbox) {
+            void handleSelectionChange(item, selectionState !== true);
+          }
+        };
+
         return (
           <Fragment key={item.id}>
             <div
               className="flex cursor-pointer items-center justify-between rounded-md p-3 hover:bg-muted/60"
-              onClick={() => {
-                if (item.onClick) {
-                  item.onClick();
-                } else if (shouldShowCheckbox) {
-                  void handleSelectionChange(item, selectionState !== true);
-                }
-              }}
+              onClick={handleRowClick}
             >
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 {shouldShowCheckbox ? (

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
@@ -10,7 +10,7 @@ import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { getDisplayTitleForDataSourceViewContentNode } from "@app/lib/providers/content_nodes_display";
 import { useInfiniteDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
-import { Spinner } from "@dust-tt/sparkle";
+import { ArrowLeft, EmptyCTA, EmptyCTAButton, Spinner } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React, { useCallback, useMemo } from "react";
 
@@ -22,7 +22,8 @@ interface DataSourceNodeTableProps {
 
 export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
   const { owner } = useAgentBuilderContext();
-  const { navigationHistory, addNodeEntry } = useDataSourceBuilderContext();
+  const { navigationHistory, addNodeEntry, navigateTo } =
+    useDataSourceBuilderContext();
 
   const traversedNode = getLatestNodeFromNavigationHistory(navigationHistory);
   const dataSourceView =
@@ -81,6 +82,22 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
       <div className="flex justify-center p-4">
         <Spinner size="md" />
       </div>
+    );
+  }
+
+  if (isTopLevelInView && listItems.length === 0) {
+    return (
+      <EmptyCTA
+        message="No pages found in this website."
+        action={
+          <EmptyCTAButton
+            variant="primary"
+            icon={ArrowLeft}
+            label="Go back"
+            onClick={() => navigateTo(navigationHistory.length - 2)}
+          />
+        }
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- Clicking a top-level data source view with zero root content nodes (e.g. a website with nothing crawled) navigated into a blank screen with no way back — now shows an empty state with a "Go back" action.
- Row clicks in the knowledge picker now fall back to toggling selection when there is nothing to navigate into, fixing the same silent dead-click on non-expandable leaf nodes deeper in the tree.

## Tests
- `npx tsgo --noEmit` in `front`
- Opened Agent Builder → Add knowledge → a space → Websites, click a website with zero root pages: confirm the empty state + "Go back" button instead of a blank screen
- Clicked a website with children: confirm navigation still works unchanged
- Clicked a non-expandable leaf content node's label (not the checkbox): confirm it toggles selection

### Before 
<img width="757" height="373" alt="image" src="https://github.com/user-attachments/assets/4c5be2b2-3b30-4d85-b6f3-ee58fa3c9b22" />


### After
<img width="762" height="421" alt="image" src="https://github.com/user-attachments/assets/e42b9ec6-da54-4da9-b21b-95c7764c2789" />


