### PR TITLE
feat(dust-hive): toggle several feature flags in one go

### DIFF
--- a/x/henry/dust-hive/completions/dust-hive.bash
+++ b/x/henry/dust-hive/completions/dust-hive.bash
@@ -41,27 +41,39 @@ _dust_hive_path_is_at_or_inside() {
   [[ "$candidate" == "$parent" || "$candidate" == "$parent"/* ]]
 }
 
+_dust_hive_env_worktree_path() {
+  local env_name="${1:?usage: _dust_hive_env_worktree_path <env>}"
+  local metadata="$HOME/.dust-hive/envs/$env_name/metadata.json"
+  local repo_root worktree_path
+
+  [[ -f "$metadata" ]] || return
+
+  worktree_path="$(_dust_hive_json_string "$metadata" "worktreePath")"
+  if [[ -z "$worktree_path" ]]; then
+    repo_root="$(_dust_hive_json_string "$metadata" "repoRoot")"
+    [[ -n "$repo_root" ]] || return
+    worktree_path="$repo_root/.hives/$env_name"
+    if [[ ! -d "$worktree_path" && -d "$HOME/dust-hive/$env_name" ]]; then
+      worktree_path="$HOME/dust-hive/$env_name"
+    fi
+  fi
+
+  echo "$worktree_path"
+}
+
 _dust_hive_current_env_from_metadata() {
   local cwd="$PWD"
-  local env_dir env_name metadata repo_root worktree_path
+  local env_dir env_name worktree_path
   local best_env="" best_len=0 path_len
 
   [[ -d "$HOME/.dust-hive/envs" ]] || return
 
   while IFS= read -r env_dir; do
     env_name="${env_dir##*/}"
-    metadata="$env_dir/metadata.json"
-    [[ -f "$metadata" ]] || continue
+    [[ -f "$env_dir/metadata.json" ]] || continue
 
-    worktree_path="$(_dust_hive_json_string "$metadata" "worktreePath")"
-    if [[ -z "$worktree_path" ]]; then
-      repo_root="$(_dust_hive_json_string "$metadata" "repoRoot")"
-      [[ -n "$repo_root" ]] || continue
-      worktree_path="$repo_root/.hives/$env_name"
-      if [[ ! -d "$worktree_path" && -d "$HOME/dust-hive/$env_name" ]]; then
-        worktree_path="$HOME/dust-hive/$env_name"
-      fi
-    fi
+    worktree_path="$(_dust_hive_env_worktree_path "$env_name")"
+    [[ -n "$worktree_path" ]] || continue
 
     if _dust_hive_path_is_at_or_inside "$worktree_path" "$cwd"; then
       path_len=${#worktree_path}
@@ -123,8 +135,8 @@ _dust_hive_envs() {
   _dust_hive_filter_selected_envs "${result[@]}"
 }
 
-_dust_hive_env_already_selected() {
-  local candidate="${1:?usage: _dust_hive_env_already_selected <name>}"
+_dust_hive_word_already_used() {
+  local candidate="${1:?usage: _dust_hive_word_already_used <name>}"
   local start=1
   local comp_cword="${COMP_CWORD:-0}"
   local i word
@@ -146,7 +158,7 @@ _dust_hive_filter_selected_envs() {
   local env
 
   for env in "$@"; do
-    _dust_hive_env_already_selected "$env" || printf '%s\n' "$env"
+    _dust_hive_word_already_used "$env" || printf '%s\n' "$env"
   done
 }
 
@@ -273,6 +285,59 @@ _dust_hive_startable_envs() {
 
 _dust_hive_stoppable_envs() {
   _dust_hive_envs_by_states cold warm
+}
+
+_dust_hive_first_positional() {
+  local comp_cword="${COMP_CWORD:-0}"
+  local start=1
+  local i word
+
+  if [[ -n "${cmd_index:-}" ]] && (( cmd_index > 0 )); then
+    start=$(( cmd_index + 1 ))
+  fi
+
+  for (( i=start; i<comp_cword; i++ )); do
+    word="${COMP_WORDS[$i]}"
+    [[ "$word" == -* ]] && continue
+    printf '%s\n' "$word"
+    return
+  done
+}
+
+_dust_hive_feature_flags_file() {
+  local roots=()
+  local env_name worktree_path repo_root root
+
+  for env_name in "$(_dust_hive_first_positional)" "$(_dust_hive_current_env)"; do
+    [[ -n "$env_name" ]] || continue
+
+    worktree_path="$(_dust_hive_env_worktree_path "$env_name")"
+    [[ -n "$worktree_path" ]] && roots+=("$worktree_path")
+
+    repo_root="$(_dust_hive_json_string "$HOME/.dust-hive/envs/$env_name/metadata.json" "repoRoot")"
+    [[ -n "$repo_root" ]] && roots+=("$repo_root")
+  done
+
+  for root in "${roots[@]}"; do
+    if [[ -f "$root/front/types/shared/feature_flags.ts" ]]; then
+      printf '%s\n' "$root/front/types/shared/feature_flags.ts"
+      return
+    fi
+  done
+}
+
+# Parse flag names out of the source file; invoking the Bun CLI here would be too slow.
+_dust_hive_flags() {
+  local file
+  file="$(_dust_hive_feature_flags_file)"
+  [[ -n "$file" ]] || return
+
+  local flag
+  while IFS= read -r flag; do
+    _dust_hive_word_already_used "$flag" || printf '%s\n' "$flag"
+  done < <(
+    command sed -nE '/WHITELISTABLE_FEATURES_CONFIG = \{/,/^\} as const/ s/^  ([A-Za-z0-9_]+):[[:space:]]*\{[[:space:]]*$/\1/p' "$file" 2>/dev/null
+  )
 }
 
 _dust_hive_complete() {
@@ -513,6 +578,8 @@ _dust_hive_complete() {
           done
           if (( pos == 0 )); then
             COMPREPLY=($(compgen -W "$(_dust_hive_warm_envs)" -- "$cur"))
+          else
+            COMPREPLY=($(compgen -W "$(_dust_hive_flags)" -- "$cur"))
           fi
           ;;
       esac

--- a/x/henry/dust-hive/completions/dust-hive.zsh
+++ b/x/henry/dust-hive/completions/dust-hive.zsh
@@ -47,27 +47,39 @@ _dust_hive_path_is_at_or_inside() {
   [[ "$candidate" == "$parent" || "$candidate" == "$parent"/* ]]
 }
 
+_dust_hive_env_worktree_path() {
+  local env_name="${1:?usage: _dust_hive_env_worktree_path <env>}"
+  local metadata="$HOME/.dust-hive/envs/$env_name/metadata.json"
+  local repo_root worktree_path
+
+  [[ -f "$metadata" ]] || return
+
+  worktree_path="$(_dust_hive_json_string "$metadata" "worktreePath")"
+  if [[ -z "$worktree_path" ]]; then
+    repo_root="$(_dust_hive_json_string "$metadata" "repoRoot")"
+    [[ -n "$repo_root" ]] || return
+    worktree_path="$repo_root/.hives/$env_name"
+    if [[ ! -d "$worktree_path" && -d "$HOME/dust-hive/$env_name" ]]; then
+      worktree_path="$HOME/dust-hive/$env_name"
+    fi
+  fi
+
+  echo "$worktree_path"
+}
+
 _dust_hive_current_env_from_metadata() {
   local cwd="$PWD"
-  local env_dir env_name metadata repo_root worktree_path
+  local env_dir env_name worktree_path
   local best_env="" best_len=0 path_len
 
   [[ -d "$HOME/.dust-hive/envs" ]] || return
 
   while IFS= read -r env_dir; do
     env_name="${env_dir##*/}"
-    metadata="$env_dir/metadata.json"
-    [[ -f "$metadata" ]] || continue
+    [[ -f "$env_dir/metadata.json" ]] || continue
 
-    worktree_path="$(_dust_hive_json_string "$metadata" "worktreePath")"
-    if [[ -z "$worktree_path" ]]; then
-      repo_root="$(_dust_hive_json_string "$metadata" "repoRoot")"
-      [[ -n "$repo_root" ]] || continue
-      worktree_path="$repo_root/.hives/$env_name"
-      if [[ ! -d "$worktree_path" && -d "$HOME/dust-hive/$env_name" ]]; then
-        worktree_path="$HOME/dust-hive/$env_name"
-      fi
-    fi
+    worktree_path="$(_dust_hive_env_worktree_path "$env_name")"
+    [[ -n "$worktree_path" ]] || continue
 
     if _dust_hive_path_is_at_or_inside "$worktree_path" "$cwd"; then
       path_len=${#worktree_path}
@@ -114,8 +126,8 @@ _dust_hive_envs() {
   _dust_hive_describe_envs "${envs[@]}"
 }
 
-_dust_hive_env_already_selected() {
-  local candidate="${1:?usage: _dust_hive_env_already_selected <name>}"
+_dust_hive_word_already_used() {
+  local candidate="${1:?usage: _dust_hive_word_already_used <name>}"
   local i word
 
   for (( i = 1; i < CURRENT; i++ )); do
@@ -134,7 +146,7 @@ _dust_hive_describe_envs() {
   local env
   local -a filtered_envs=()
   for env in "${envs[@]}"; do
-    _dust_hive_env_already_selected "$env" || filtered_envs+=("$env")
+    _dust_hive_word_already_used "$env" || filtered_envs+=("$env")
   done
   envs=("${filtered_envs[@]}")
   (( $#envs )) || return
@@ -262,6 +274,63 @@ _dust_hive_stoppable_envs() {
 
 _dust_hive_service() {
   _describe 'service' _dust_hive_services
+}
+
+_dust_hive_first_positional() {
+  local i word
+
+  for (( i = 2; i < CURRENT; i++ )); do
+    word="${words[i]}"
+    [[ "$word" == -* ]] && continue
+    echo "$word"
+    return
+  done
+}
+
+_dust_hive_feature_flags_file() {
+  local -a roots=()
+  local env_name worktree_path repo_root root
+
+  for env_name in "$(_dust_hive_first_positional)" "$(_dust_hive_current_env)"; do
+    [[ -n "$env_name" ]] || continue
+
+    worktree_path="$(_dust_hive_env_worktree_path "$env_name")"
+    [[ -n "$worktree_path" ]] && roots+=("$worktree_path")
+
+    repo_root="$(_dust_hive_json_string "$HOME/.dust-hive/envs/$env_name/metadata.json" "repoRoot")"
+    [[ -n "$repo_root" ]] && roots+=("$repo_root")
+  done
+
+  for root in "${roots[@]}"; do
+    if [[ -f "$root/front/types/shared/feature_flags.ts" ]]; then
+      echo "$root/front/types/shared/feature_flags.ts"
+      return
+    fi
+  done
+}
+
+# Parse flag names out of the source file; invoking the Bun CLI here would be too slow.
+_dust_hive_flag_names() {
+  local file
+  file="$(_dust_hive_feature_flags_file)"
+  [[ -n "$file" ]] || return
+
+  command sed -nE '/WHITELISTABLE_FEATURES_CONFIG = \{/,/^\} as const/ s/^  ([A-Za-z0-9_]+):[[:space:]]*\{[[:space:]]*$/\1/p' "$file" 2>/dev/null
+}
+
+_dust_hive_flags() {
+  local -a flags
+  flags=(${(f)"$(_dust_hive_flag_names)"})
+  (( $#flags )) || return
+
+  local flag
+  local -a remaining=()
+  for flag in "${flags[@]}"; do
+    _dust_hive_word_already_used "$flag" || remaining+=("$flag")
+  done
+  (( $#remaining )) || return
+
+  _describe -V 'feature flag' remaining
 }
 
 _dust-hive() {
@@ -480,10 +549,10 @@ _dust-hive() {
           ;;
         flag)
           _arguments \
-            '1::name:_dust_hive_warm_envs' \
-            '2::flag name:' \
-            '-d[Disable the flag]' \
-            '--disable[Disable the flag]'
+            '1:name:_dust_hive_warm_envs' \
+            '*:feature flag:_dust_hive_flags' \
+            '-d[Disable the flags]' \
+            '--disable[Disable the flags]'
           ;;
       esac
       ;;

--- a/x/henry/dust-hive/src/commands/flag.ts
+++ b/x/henry/dust-hive/src/commands/flag.ts
@@ -32,67 +32,33 @@ async function getAvailableFlags(frontPath: string): Promise<FlagInfo[]> {
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function flagCommand(
-  nameArg: string | undefined,
-  flagNameArg: string | undefined,
-  options?: { disable?: boolean }
-): Promise<Result<void>> {
-  const skipRestore = !flagNameArg;
-  const envResult = await requireEnvironment(nameArg, "flag", {
-    skipRestoreTerminal: skipRestore,
+async function selectFlags(availableFlags: FlagInfo[], disable: boolean): Promise<string[]> {
+  const result = await p.multiselect({
+    message: `Select feature flags to ${disable ? "disable" : "enable"} (space to toggle, enter to confirm)`,
+    initialValues: [],
+    required: true,
+    options: availableFlags.map((f) => ({
+      value: f.name,
+      label: f.name,
+      hint: f.description,
+    })),
   });
-  if (!envResult.ok) return envResult;
 
-  const env = envResult.value;
-
-  // Check if environment is warm
-  const stateInfo = await getStateInfo(env);
-  if (stateInfo.state !== "warm") {
-    restoreTerminal();
-    return Err(
-      new CommandError(
-        `Environment '${env.name}' is not warm (current state: ${stateInfo.state}). Run 'dust-hive warm ${env.name}' first.`
-      )
-    );
+  if (p.isCancel(result)) {
+    return [];
   }
 
-  const worktreePath = getEnvironmentWorktreeDir(env.metadata);
-  const frontPath = path.join(worktreePath, "front");
+  return result as string[];
+}
 
-  // Resolve flag name — interactive select if not provided
-  let flagName = flagNameArg;
-  if (!flagName) {
-    const availableFlags = await getAvailableFlags(frontPath);
-
-    if (availableFlags.length === 0) {
-      restoreTerminal();
-      return Err(
-        new CommandError("Could not read feature flags from front/types/shared/feature_flags.ts")
-      );
-    }
-
-    const selected = await p.select({
-      message: "Select a feature flag",
-      options: availableFlags.map((f) => ({
-        value: f.name,
-        label: f.name,
-        hint: f.description,
-      })),
-    });
-
-    restoreTerminal();
-
-    if (p.isCancel(selected)) {
-      return Err(new CommandError("No flag selected"));
-    }
-
-    flagName = selected as string;
-  }
-
-  const disable = Boolean(options?.disable);
-  const action = disable ? "Disabling" : "Enabling";
-
-  logger.info(`${action} feature flag '${flagName}' on workspace ${WORKSPACE_ID}...`);
+async function toggleFlag(
+  frontPath: string,
+  flagName: string,
+  disable: boolean
+): Promise<Result<void>> {
+  logger.info(
+    `${disable ? "Disabling" : "Enabling"} feature flag '${flagName}' on workspace ${WORKSPACE_ID}...`
+  );
   console.log();
 
   const args = [
@@ -120,11 +86,94 @@ export async function flagCommand(
   const exitCode = await proc.exited;
 
   if (exitCode !== 0) {
-    return Err(new CommandError(`toggle_feature_flags.ts failed with exit code ${exitCode}`));
+    return Err(
+      new CommandError(
+        `toggle_feature_flags.ts failed for '${flagName}' with exit code ${exitCode}`
+      )
+    );
   }
 
   console.log();
   logger.success(`Feature flag '${flagName}' ${disable ? "disabled" : "enabled"} successfully`);
+
+  return Ok(undefined);
+}
+
+export async function flagCommand(
+  nameArg: string | undefined,
+  flagNameArgs: string[] | undefined,
+  options?: { disable?: boolean }
+): Promise<Result<void>> {
+  const requestedFlags = flagNameArgs ?? [];
+  const skipRestore = requestedFlags.length === 0;
+  const envResult = await requireEnvironment(nameArg, "flag", {
+    skipRestoreTerminal: skipRestore,
+  });
+  if (!envResult.ok) return envResult;
+
+  const env = envResult.value;
+
+  // Check if environment is warm
+  const stateInfo = await getStateInfo(env);
+  if (stateInfo.state !== "warm") {
+    restoreTerminal();
+    return Err(
+      new CommandError(
+        `Environment '${env.name}' is not warm (current state: ${stateInfo.state}). Run 'dust-hive warm ${env.name}' first.`
+      )
+    );
+  }
+
+  const worktreePath = getEnvironmentWorktreeDir(env.metadata);
+  const frontPath = path.join(worktreePath, "front");
+
+  const availableFlags = await getAvailableFlags(frontPath);
+  if (availableFlags.length === 0) {
+    restoreTerminal();
+    return Err(
+      new CommandError("Could not read feature flags from front/types/shared/feature_flags.ts")
+    );
+  }
+
+  const disable = Boolean(options?.disable);
+
+  // Resolve flag names — interactive multi-select if none provided
+  let flagNames: string[];
+  if (requestedFlags.length > 0) {
+    flagNames = requestedFlags;
+  } else {
+    const selected = await selectFlags(availableFlags, disable);
+    restoreTerminal();
+
+    if (selected.length === 0) {
+      return Err(new CommandError("No flag selected"));
+    }
+
+    flagNames = selected;
+  }
+
+  // Validate every flag before toggling any, so a typo cannot leave a partial toggle behind.
+  const availableNames = new Set(availableFlags.map((f) => f.name));
+  const unknownFlags = flagNames.filter((flagName) => !availableNames.has(flagName));
+  if (unknownFlags.length > 0) {
+    return Err(
+      new CommandError(
+        `Unknown feature flag(s): ${unknownFlags.join(", ")}. Run 'dust-hive flag ${env.name}' with no flag name to pick from the list.`
+      )
+    );
+  }
+
+  for (const flagName of flagNames) {
+    const toggleResult = await toggleFlag(frontPath, flagName, disable);
+    if (!toggleResult.ok) return toggleResult;
+  }
+
+  if (flagNames.length > 1) {
+    console.log();
+    logger.success(
+      `All ${flagNames.length} feature flags ${disable ? "disabled" : "enabled"} successfully`
+    );
+  }
 
   return Ok(undefined);
 }

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -428,15 +428,15 @@ cli
   );
 
 cli
-  .command("flag [name] [flagName]", "Toggle a feature flag on the workspace")
-  .option("-d, --disable", "Disable the flag (default is enable)")
+  .command("flag [name] [...flagNames]", "Toggle feature flags on the workspace")
+  .option("-d, --disable", "Disable the flags (default is enable)")
   .action(
     async (
       name: string | undefined,
-      flagName: string | undefined,
+      flagNames: string[] | undefined,
       options: { disable?: boolean }
     ) => {
-      await prepareAndRun(flagCommand(name, flagName, { disable: Boolean(options.disable) }));
+      await prepareAndRun(flagCommand(name, flagNames, { disable: Boolean(options.disable) }));
     }
   );
 


### PR DESCRIPTION
## Description

Setting up a fresh hive env sometimes means turning on several flags at once. `dh flag` only accepted one, so you ran it once per flag, and you had to go through the picker UI or know the flag name by heart.

This PR moves the interactive picker to a multiselect instead of a single select, and zsh/bash completion offers flag names parsed out of the target worktree's `front/types/shared/feature_flags.ts`.

`toggle_feature_flags.ts` still runs once per flag.

## Tests

Manual, against a warm env:
- `dh flag <env> allow_sso audit_logs`
- `dh flag <env>` with no names, picked two flags in the multiselect

`bun run check` passes.

## Risk

None.

## Deploy Plan

None