### PR TITLE
Admin governance: switch skills to new permissions

### DIFF
--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -76,6 +76,13 @@ const KILL_SWITCH_DEFINITIONS: Record<KillSwitchType, KillSwitchDefinition> = {
     note: "Enqueues keep succeeding and in-flight upserts finish. Use to shed Qdrant write load (e.g. during resharding).",
     icon: PauseCircle,
   },
+  use_legacy_acls: {
+    title: "Legacy ACLs",
+    description:
+      "Serve skill permission checks from the legacy editor-group ACLs instead of the group_permissions table.",
+    note: "Revert path for the governance migration. Takes up to 60s to apply on each pod, as permission checks read the switch from an in-process cache.",
+    icon: RefreshCw02,
+  },
 };
 
 const PANEL_HEADING_CLASSES =

--- a/front/lib/api/permissions/legacy_acls.ts
+++ b/front/lib/api/permissions/legacy_acls.ts
@@ -1,0 +1,47 @@
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// How long a pod may serve a stale value of the kill switch.
+const REFRESH_INTERVAL_MS = 60 * 1000;
+
+let cachedValue = false;
+let lastRefreshStartedAt = 0;
+let refreshing = false;
+
+/**
+ * Whether to serve permission decisions from the legacy inline-group ACLs instead of the
+ * `group_permissions` table — the revert path for the governance migration, toggled from Poke.
+ *
+ * Read synchronously because permission checks are: `canWrite` runs inside `toJSON` and inside
+ * array predicates. The kill switch itself lives in Redis, so this keeps the last known value in
+ * process and refreshes it in the background at most every REFRESH_INTERVAL_MS. Consequences:
+ * enabling it in Poke takes effect within that window on each pod, and a pod serves the new path
+ * until its first refresh resolves (a few ms after boot).
+ *
+ * Temporary — delete along with the legacy path once the table is trusted.
+ */
+export function isLegacyAclsEnabled(): boolean {
+  const now = Date.now();
+  if (!refreshing && now - lastRefreshStartedAt > REFRESH_INTERVAL_MS) {
+    refreshing = true;
+    lastRefreshStartedAt = now;
+
+    void KillSwitchResource.isKillSwitchEnabled("use_legacy_acls")
+      .then((enabled) => {
+        cachedValue = enabled;
+      })
+      .catch((err) => {
+        // Keep the last known value: a Redis blip must not flip permission behaviour.
+        logger.error(
+          { err: normalizeError(err) },
+          "Failed to refresh the use_legacy_acls kill switch"
+        );
+      })
+      .finally(() => {
+        refreshing = false;
+      });
+  }
+
+  return cachedValue;
+}

--- a/front/lib/poke/types.ts
+++ b/front/lib/poke/types.ts
@@ -6,6 +6,7 @@ export const KILL_SWITCH_TYPES = [
   "global_disable_firecrawl",
   "global_dust_agents_fallback",
   "pause_upsert_queue",
+  "use_legacy_acls",
 ] as const;
 export type KillSwitchType = (typeof KILL_SWITCH_TYPES)[number];
 export function isKillSwitchType(type: string): type is KillSwitchType {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { isLegacyAclsEnabled } from "@app/lib/api/permissions/legacy_acls";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
@@ -16,12 +17,11 @@ import { GlobalSkillsRegistry } from "@app/lib/resources/skill/code_defined/glob
 import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { serializeSkillTag } from "@app/lib/skills/format";
-import logger from "@app/logger/logger";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
@@ -35,6 +35,10 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/permissions/legacy_acls", () => ({
+  isLegacyAclsEnabled: vi.fn(() => false),
+}));
 
 describe("SkillResource", () => {
   let testContext: Awaited<ReturnType<typeof createResourceTest>>;
@@ -2798,14 +2802,15 @@ describe("SkillResource", () => {
     });
   });
 
-  describe("group_permissions shadow-compare", () => {
-    // A skill's editor group grants [read, write, admin]; a "user" role grants only read, so write
-    // and admin flow purely through the group — isolating the group-vs-table check.
+  describe("group_permissions as the source of truth", () => {
+    // A skill's editor group grants [read, write, admin] through its group_permissions row; a
+    // "user" role grants only read, so write and admin flow purely through the grant.
     //
     // Returns a `buildEditorAuth` thunk rather than a ready authenticator: an Authenticator
     // snapshots its grants at construction, so callers must build it AFTER any grant mutation.
     async function setupSkillWithEditor(name: string): Promise<{
       skill: SkillResource;
+      editor: UserResource;
       buildEditorAuth: () => Promise<Authenticator>;
     }> {
       const skill = await SkillFactory.create(testContext.authenticator, {
@@ -2823,6 +2828,7 @@ describe("SkillResource", () => {
 
       return {
         skill,
+        editor,
         buildEditorAuth: () =>
           Authenticator.fromUserIdAndWorkspaceId(
             editor.sId,
@@ -2831,77 +2837,76 @@ describe("SkillResource", () => {
       };
     }
 
-    // Simulates a skill created before the dual-write shipped: the association exists but the
-    // table holds no grant for it.
-    async function clearSkillGrants(skill: SkillResource): Promise<void> {
+    it("grants write and admin to an editor through the table", async () => {
+      const { skill, buildEditorAuth } =
+        await setupSkillWithEditor("Governed Skill");
+      const editorAuth = await buildEditorAuth();
+
+      expect(skill.canWrite(editorAuth)).toBe(true);
+      expect(skill.canAdministrate(editorAuth)).toBe(true);
+    });
+
+    it("denies an editor whose grant is missing, despite group membership", async () => {
+      // The decision now comes from group_permissions alone: dropping the row revokes access even
+      // though the user is still a member of the editor group.
+      const { skill, editor, buildEditorAuth } =
+        await setupSkillWithEditor("Ungranted Skill");
       await GroupPermissionResource.deleteAllForResource(
         testContext.authenticator,
         { resourceType: "skill", resourceId: skill.id }
       );
-    }
 
-    it("logs a mismatch when the table diverges from the editor-group rules", async () => {
+      const editorAuth = await buildEditorAuth();
+
+      // Membership is untouched — only the grant is gone.
+      const members = await skill.editorGroup!.getActiveMembers(editorAuth);
+      expect(members.map((m) => m.sId)).toContain(editor.sId);
+      expect(skill.canWrite(editorAuth)).toBe(false);
+      expect(skill.canAdministrate(editorAuth)).toBe(false);
+    });
+
+    it("falls back to the editor group when the use_legacy_acls kill switch is on", async () => {
       const { skill, buildEditorAuth } = await setupSkillWithEditor(
-        "Shadow Mismatch Skill"
+        "Legacy Switch Skill"
       );
-      await clearSkillGrants(skill);
-      await FeatureFlagFactory.basic(
+      await GroupPermissionResource.deleteAllForResource(
         testContext.authenticator,
-        "group_permissions_shadow"
+        { resourceType: "skill", resourceId: skill.id }
       );
-
       const editorAuth = await buildEditorAuth();
-      const warn = vi.spyOn(logger, "warn");
 
-      // Served result is unchanged: the editor group still grants write via code.
+      // No grant row: the table-backed path denies.
+      expect(skill.canWrite(editorAuth)).toBe(false);
+
+      // The kill-switch restores the pre-migration decision, taken from group membership.
+      vi.mocked(isLegacyAclsEnabled).mockReturnValue(true);
       expect(skill.canWrite(editorAuth)).toBe(true);
-
-      await vi.waitFor(() =>
-        expect(warn).toHaveBeenCalledWith(
-          expect.objectContaining({
-            resource: "skill",
-            skillId: skill.sId,
-            permission: "write",
-          }),
-          "group_permissions_shadow_mismatch"
-        )
-      );
+      expect(skill.canAdministrate(editorAuth)).toBe(true);
     });
 
-    it("keeps the governance role rules in sync with the editor-group ACL", async () => {
-      // `governanceAcls` restates the role rules so it can stand alone at the flip; they must stay
-      // identical to what the skill_editors group declares while both paths coexist.
-      const { skill, buildEditorAuth } = await setupSkillWithEditor(
-        "Shadow Role Rules Skill"
-      );
-      const editorAuth = await buildEditorAuth();
+    it("keeps a non-editor out, and lets a workspace admin administrate but not write", async () => {
+      const { skill } = await setupSkillWithEditor("Role Rules Skill");
 
-      const byRole = (grants: { role: string }[]) =>
-        [...grants].sort((a, b) => a.role.localeCompare(b.role));
+      const authFor = async (role: "user" | "admin") => {
+        const user = await UserFactory.basic();
+        await MembershipFactory.associate(testContext.workspace, user, {
+          role,
+        });
+        return Authenticator.fromUserIdAndWorkspaceId(
+          user.sId,
+          testContext.workspace.sId
+        );
+      };
 
-      expect(byRole(skill.governanceAcls(editorAuth)[0].roles)).toEqual(
-        byRole(skill.editorGroup!.getAccessControlLists(editorAuth)[0].roles)
-      );
-    });
+      const otherAuth = await authFor("user");
+      expect(skill.canWrite(otherAuth)).toBe(false);
+      expect(skill.canAdministrate(otherAuth)).toBe(false);
 
-    it("never logs a mismatch while the flag is off", async () => {
-      const { skill, buildEditorAuth } = await setupSkillWithEditor(
-        "Shadow Flag Off Skill"
-      );
-      await clearSkillGrants(skill);
-
-      const editorAuth = await buildEditorAuth();
-      const warn = vi.spyOn(logger, "warn");
-
-      expect(skill.canWrite(editorAuth)).toBe(true);
-
-      // Flush the fire-and-forget; with the flag off it short-circuits before comparing.
-      await new Promise((resolve) => setImmediate(resolve));
-      await new Promise((resolve) => setImmediate(resolve));
-      expect(warn).not.toHaveBeenCalledWith(
-        expect.anything(),
-        "group_permissions_shadow_mismatch"
-      );
+      // An admin who is not an editor: the role rules grant admin (manage the editor list) but
+      // never write — editing the skill itself stays with its editors.
+      const adminAuth = await authFor("admin");
+      expect(skill.canAdministrate(adminAuth)).toBe(true);
+      expect(skill.canWrite(adminAuth)).toBe(false);
     });
   });
 });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -5,6 +5,7 @@ import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/ag
 import { getEffectiveSpaceIdsForAgentRun } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { updateConversationRequirementsForSkills } from "@app/lib/api/assistant/conversation/skill_permissions";
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
+import { isLegacyAclsEnabled } from "@app/lib/api/permissions/legacy_acls";
 import {
   filterUsersWithSharedMembership,
   hasSharedMembership,
@@ -265,6 +266,15 @@ const SKILL_EDITOR_GRANT_TYPE = "editor" as const;
 
 const SKILL_ROLE_GRANTS: RoleGrant[] = [
   { role: "admin", permissions: ["read", "admin"] },
+  { role: "manager", permissions: ["read"] },
+  { role: "user", permissions: ["read"] },
+  { role: "builder", permissions: ["read"] },
+];
+
+// Code-defined global/system skills: everyone in the workspace reads them, nobody edits them — they
+// have no row and no editor group, so no grant can ever point at them.
+const GLOBAL_SKILL_ROLE_GRANTS: RoleGrant[] = [
+  { role: "admin", permissions: ["read"] },
   { role: "manager", permissions: ["read"] },
   { role: "user", permissions: ["read"] },
   { role: "builder", permissions: ["read"] },
@@ -2135,14 +2145,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return true;
     }
 
-    if (!this.editorGroup) {
-      return false;
-    }
-
-    const legacyAcls = this.editorGroup.getAccessControlLists(auth);
-    this.shadowCompareSkillPermission(auth, legacyAcls, "write");
-
-    return auth.hasPermissionForAcls("write", legacyAcls);
+    return this.hasSkillPermission(auth, "write");
   }
 
   canAdministrate(auth: Authenticator): boolean {
@@ -2152,25 +2155,47 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return true;
     }
 
-    if (!this.editorGroup) {
-      return false;
+    return this.hasSkillPermission(auth, "admin");
+  }
+
+  // Serves the decision from `group_permissions` (see `getAccessControlLists`), unless the
+  // `use_legacy_acls` kill switch is on — then it falls back to the pre-migration path, where the
+  // editor group is listed inline in its own ACL and membership decides. Remove the fallback (and
+  // the switch) once the table is trusted.
+  private hasSkillPermission(auth: Authenticator, verb: GrantVerb): boolean {
+    if (isLegacyAclsEnabled()) {
+      if (!this.editorGroup) {
+        return false;
+      }
+
+      return auth.hasPermissionForAcls(
+        verb,
+        this.editorGroup.getAccessControlLists(auth)
+      );
     }
 
-    const legacyAcls = this.editorGroup.getAccessControlLists(auth);
-    this.shadowCompareSkillPermission(auth, legacyAcls, "admin");
-
-    return auth.hasPermissionForAcls("admin", legacyAcls);
+    return auth.hasPermission(verb, this);
   }
 
   /**
-   * The skill's access-control list built from governance data: the code role rules plus the
-   * groups held in `group_permissions`. Stands on its own — it reads nothing from the editor-group
-   * association — so at the flip (#9480) this becomes the served `getAccessControlLists(auth)` and
-   * the legacy path is deleted without touching it.
-   *
-   * Until then it is the shadow-compare candidate.
+   * The skill's access-control list: the code role rules plus the groups holding a grant on it in
+   * `group_permissions` (written by `writeGroupPermissions` on every mutation of the editor-group
+   * association). The editor group is not read here — membership in it only matters through the
+   * grant it holds.
    */
-  governanceAcls(auth: Authenticator): AccessControlList[] {
+  getAccessControlLists(auth: Authenticator): AccessControlList[] {
+    // Global skills carry no row, so there is no grant to look up (and their synthetic `id` of -1
+    // is the type-wide sentinel, which would resolve the workspace-wide capability grants instead).
+    if (this.globalSId) {
+      return [
+        {
+          roles: GLOBAL_SKILL_ROLE_GRANTS,
+          groups: [],
+          workspaceId: this.workspaceId,
+        },
+      ];
+    }
+
     return [
       {
         roles: SKILL_ROLE_GRANTS,
@@ -2178,35 +2203,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         workspaceId: this.workspaceId,
       },
     ];
-  }
-
-  // Shadow-compare (#9479): while the `group_permissions_shadow` flag is on for the workspace, check
-  // whether the governance ACL yields the same decision as the legacy editor-group ACL. Legacy is
-  // the editor group's own `getAccessControlLists(auth)` (the group listed inline); the candidate is
-  // `governanceAcls`, built independently from the table. Delegates the flag lookup + compare + log
-  // to the Authenticator as fire-and-forget — never changes the served result.
-  //
-  // Callers skip this for API keys (code-ruled: any key may write any skill, which the table has no
-  // way to express) and for skills without an editor group (global/system skills, not part of the
-  // migration).
-  private shadowCompareSkillPermission(
-    auth: Authenticator,
-    legacyAcls: AccessControlList[],
-    permission: GrantVerb
-  ): void {
-    auth.shadowComparePermission(
-      permission,
-      legacyAcls,
-      this.governanceAcls(auth),
-      {
-        resource: "skill",
-        skillId: this.sId,
-        permission,
-        workspaceId: this.workspaceId,
-        // Null for non-user callers (internal auth); API keys skip shadow-compare entirely.
-        userId: auth.user()?.sId ?? null,
-      }
-    );
   }
 
   // The group grants a skill confers, derived from its `group_skills` association: the editor


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/9472

After a few days of shadow comparing permissions everything wen all right so we switch to the new model.
Adds a global switch to go back to old system for now it case needed.


## Tests
updated unit tests

## Risk

wrong access computed with new model, but there is a global switch to go back in case it's needed

<img width="1666" height="260" alt="image" src="https://github.com/user-attachments/assets/366eff07-2d59-4192-a403-5a11c9a72da7" />


## Deploy Plan

deploy front