### PR TITLE
Fix legacy messages on Auto model streams

### DIFF
--- a/front/types/assistant/agent_run.test.ts
+++ b/front/types/assistant/agent_run.test.ts
@@ -1,0 +1,60 @@
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { getAgentLoopDataWithAuth } from "@app/types/assistant/agent_run";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
+import { describe, expect, it } from "vitest";
+
+describe("getAgentLoopDataWithAuth", () => {
+  it("resolves an auto stream for a legacy message without a stored model", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      model: {
+        providerId: AUTO_MODEL_ID,
+        modelId: AUTO_MODEL_ID,
+      },
+    });
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: userMessageRow, userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+      });
+    const { agentMessage } = await ConversationFactory.createAgentMessage(
+      auth,
+      {
+        workspace,
+        conversation,
+        agentConfig,
+        parentMessageModelId: userMessageRow.id,
+        rank: 1,
+      }
+    );
+
+    expect(agentMessage.resolvedModel).toBeNull();
+
+    const result = await getAgentLoopDataWithAuth(auth, {
+      agentMessageId: agentMessage.sId,
+      agentMessageVersion: agentMessage.version,
+      conversationId: conversation.sId,
+      conversationTitle: conversation.title,
+      userMessageId: userMessage.sId,
+      userMessageVersion: userMessage.version,
+      userMessageOrigin: userMessage.context.origin,
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect(result.value.agentMessage.resolvedModel).toBeNull();
+    expect(result.value.modelInfo.endpoint.modelConfig.modelId).not.toBe(
+      AUTO_MODEL_ID
+    );
+  });
+});

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -4,11 +4,12 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
+import { resolveModel } from "@app/lib/api/assistant/resolve_model";
 import { getStaticReplyForUserMessage } from "@app/lib/api/assistant/static_reply";
 import { legacyModelIdToModel } from "@app/lib/api/llm";
 import { selectPreferredStreamEndpointForWorkspace } from "@app/lib/api/llm/selectPreferredEndpointForWorkspace";
 import type { AuthenticatorType } from "@app/lib/auth";
-import { Authenticator } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { DustNoopNoopGlobalNoopStream } from "@app/lib/llms/stream/endpoints/noop_noop_global_noop";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -29,6 +30,7 @@ import {
   isAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { NOOP_MODEL_ID } from "@app/types/assistant/models/noop";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import type { Result } from "../shared/result";
@@ -341,7 +343,16 @@ export async function getAgentLoopDataWithAuth(
 
   // The resolved model is stored in the agent message.
   // Legacy message will not have a resolved model.
-  const { resolvedModel } = agentMessage;
+  let { resolvedModel } = agentMessage;
+  if (!resolvedModel && isModelStreamId(agentModelConfig.modelId)) {
+    // Legacy messages have no stored model resolution. Global agent configurations ignore the
+    // message's configuration version and may now use a stream, so resolve the stream before
+    // selecting its endpoint.
+    ({ resolvedModel } = await resolveModel(auth, {
+      configuration: agentConfiguration,
+      featureFlags: await getFeatureFlags(auth),
+    }));
+  }
   // Global agents may pin the noop model at run time (static replies from the dust and
   // sidekick agents, see `getStaticReplyForUserMessage`). The model stored on the agent
   // message was resolved at creation time without that context, so it must not override


### PR DESCRIPTION
## Description

Legacy agent messages can have no persisted model resolution. Since `@dust` moved to an Auto stream, `getAgentLoopDataWithAuth` fell through to endpoint lookup with the literal `auto` sentinel, causing both model execution and cancellation finalization to retry indefinitely.

Resolve the current stream to a concrete model only when the message has no stored resolution. Messages with a persisted resolution and legacy messages on concrete models keep their existing behavior. This changes activity code only, so existing Temporal workflow histories remain replay-safe.

## Tests

Added a regression test that loads a legacy null-resolution message on Auto and verifies concrete endpoint selection.

## Risk

Low. The fallback is limited to legacy messages with no resolved model whose current configuration is a model stream. Rollback restores the previous failure behavior for those messages.

## Deploy Plan

Standard Front deploy to both regions. After deploy, verify the three affected cancellation finalizers complete and the agent messages leave `created` status.