### PR TITLE
Cut over workspace resource cache key

### DIFF
--- a/front-api/lib/api/poke/cache_catalog.test.ts
+++ b/front-api/lib/api/poke/cache_catalog.test.ts
@@ -10,11 +10,17 @@ describe("Poke cache catalog", () => {
     const activeSeats = getPokeCacheOperations("workspace_active_seats");
 
     expect(workspace?.buildKey({ wId: "workspace-1" })).toBe(
-      "cacheWithRedis-_fetchByIdUncached-workspace:v2:workspace-1"
+      "cacheWithRedis-workspace_by_sid-v3:workspace-1"
     );
-    expect(workspace?.keyPattern).toBe(
-      "cacheWithRedis-_fetchByIdUncached-workspace:v2:*"
-    );
+    expect(workspace?.keyPattern).toBe("cacheWithRedis-workspace_by_sid-v3:*");
+    expect(workspace?.buildKeysToDelete({ wId: "workspace-1" })).toEqual([
+      "cacheWithRedis-workspace_by_sid-v3:workspace-1",
+      "cacheWithRedis-_fetchByIdUncached-workspace:v2:workspace-1",
+    ]);
+    expect(workspace?.keyPatternsToDelete).toEqual([
+      "cacheWithRedis-workspace_by_sid-v3:*",
+      "cacheWithRedis-_fetchByIdUncached-workspace:v2:*",
+    ]);
     expect(activeSeats?.buildKey({ workspaceId: "workspace-1" })).toBe(
       "cacheWithRedis-_countActiveSeatsInWorkspaceUncached-count-active-seats-in-workspace:workspace-1"
     );

--- a/front-api/lib/api/poke/cache_catalog.ts
+++ b/front-api/lib/api/poke/cache_catalog.ts
@@ -24,7 +24,11 @@ function legacyCacheOperations(): CacheOperations[] {
       supportsBulkInvalidation: resource.resolverKeyPattern !== undefined,
     },
     buildKey: (params) => buildCacheKey(resource, params),
+    buildKeysToDelete: (params) => [buildCacheKey(resource, params)],
     keyPattern: buildCacheKeyPattern(resource),
+    keyPatternsToDelete: [buildCacheKeyPattern(resource)].filter(
+      (pattern): pattern is string => pattern !== null
+    ),
   }));
 }
 

--- a/front-api/routes/poke/cache/index.test.ts
+++ b/front-api/routes/poke/cache/index.test.ts
@@ -1,8 +1,8 @@
-import { getRedisCacheClient } from "@app/lib/api/redis";
+import { getRedisCacheClient, runOnRedisCache } from "@app/lib/api/redis";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { honoApp } from "@front-api/app";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const WORKSPACE_MODEL_ID = 42;
 const GROUP_MODEL_ID = 7;
@@ -56,5 +56,41 @@ describe("Poke cache: group permissions", () => {
     expect(await lookupResponse.json()).toMatchObject({
       cacheRedis: { value: null },
     });
+  });
+});
+
+const workspaceId = "cache-cutover-test-workspace";
+const newKey = `cacheWithRedis-workspace_by_sid-v3:${workspaceId}`;
+const previousKey = `cacheWithRedis-_fetchByIdUncached-workspace:v2:${workspaceId}`;
+
+describe("DELETE /api/poke/cache", () => {
+  const deleteKey = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(runOnRedisCache).mockImplementation(async (_options, fn) =>
+      fn({ del: deleteKey } as never)
+    );
+  });
+
+  it("deletes the new and previous keys", async () => {
+    await createPrivateApiMockRequest({
+      method: "DELETE",
+      isSuperUser: true,
+    });
+    const query = new URLSearchParams({
+      resourceId: "workspace_by_sid",
+      params: JSON.stringify({ wId: workspaceId }),
+      redisInstance: "cache",
+    });
+
+    const response = await honoApp.request(`/api/poke/cache?${query}`, {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+    expect(deleteKey).toHaveBeenCalledTimes(2);
+    expect(deleteKey).toHaveBeenCalledWith(newKey);
+    expect(deleteKey).toHaveBeenCalledWith(previousKey);
   });
 });

--- a/front-api/routes/poke/cache/index.ts
+++ b/front-api/routes/poke/cache/index.ts
@@ -25,7 +25,9 @@ app.route("/catalog", catalog);
 
 function resolveCacheKey(
   ctx: Context
-): { cacheKey: string } | { err: ReturnType<typeof apiError> } {
+):
+  | { cacheKey: string; cacheKeysToDelete: string[] }
+  | { err: ReturnType<typeof apiError> } {
   const resourceId = ctx.req.query("resourceId");
   const rawKey = ctx.req.query("rawKey");
   const params = ctx.req.query("params");
@@ -90,7 +92,10 @@ function resolveCacheKey(
     }
 
     try {
-      return { cacheKey: operations.buildKey(parsedParams) };
+      return {
+        cacheKey: operations.buildKey(parsedParams),
+        cacheKeysToDelete: operations.buildKeysToDelete(parsedParams),
+      };
     } catch {
       return {
         err: apiError(ctx, {
@@ -105,7 +110,7 @@ function resolveCacheKey(
   }
 
   if (isString(rawKey)) {
-    return { cacheKey: rawKey };
+    return { cacheKey: rawKey, cacheKeysToDelete: [rawKey] };
   }
 
   return {
@@ -188,7 +193,7 @@ app.delete("/", async (ctx): HandlerResult<DeletePokeCacheResponseBody> => {
   if ("err" in r) {
     return r.err;
   }
-  const { cacheKey } = r;
+  const { cacheKey, cacheKeysToDelete } = r;
 
   const redisInstance = ctx.req.query("redisInstance");
   if (redisInstance !== "cache" && redisInstance !== "stream") {
@@ -205,11 +210,11 @@ app.delete("/", async (ctx): HandlerResult<DeletePokeCacheResponseBody> => {
   const runFn = redisInstance === "cache" ? runOnRedisCache : runOnRedis;
 
   await runFn({ origin: "poke_cache_invalidation" }, async (client) => {
-    await client.del(cacheKey);
+    await Promise.all(cacheKeysToDelete.map((key) => client.del(key)));
   });
 
   logger.info(
-    { redisKey: cacheKey, redisInstance },
+    { redisKeys: cacheKeysToDelete, redisInstance },
     "Poke cache invalidation performed"
   );
 
@@ -249,8 +254,8 @@ app.delete(
       });
     }
 
-    const pattern = operations.keyPattern;
-    if (!pattern) {
+    const patterns = operations.keyPatternsToDelete;
+    if (patterns.length === 0) {
       return apiError(ctx, {
         status_code: 400,
         api_error: {
@@ -265,14 +270,16 @@ app.delete(
       async (client) => {
         let count = 0;
         let batch: string[] = [];
-        for await (const key of client.scanIterator({
-          MATCH: pattern,
-          COUNT: DELETE_ALL_BATCH_SIZE,
-        })) {
-          batch.push(key);
-          if (batch.length >= DELETE_ALL_BATCH_SIZE) {
-            count += await client.del(batch);
-            batch = [];
+        for (const pattern of patterns) {
+          for await (const key of client.scanIterator({
+            MATCH: pattern,
+            COUNT: DELETE_ALL_BATCH_SIZE,
+          })) {
+            batch.push(key);
+            if (batch.length >= DELETE_ALL_BATCH_SIZE) {
+              count += await client.del(batch);
+              batch = [];
+            }
           }
         }
         if (batch.length > 0) {
@@ -283,12 +290,12 @@ app.delete(
     );
 
     logger.info(
-      { redisKeyPattern: pattern, deletedCount },
+      { redisKeyPatterns: patterns, deletedCount },
       "Poke cache bulk invalidation performed"
     );
 
     return ctx.json({
-      pattern,
+      pattern: operations.keyPattern ?? patterns[0],
       deletedCount,
     });
   }

--- a/front/lib/api/resources/cached_resource_lookup.ts
+++ b/front/lib/api/resources/cached_resource_lookup.ts
@@ -22,15 +22,17 @@ type CacheKeyDefinition<Input> = {
   keyPattern: string;
 };
 
-type ReadFromKeyFirstDefinition<Input> = CacheKeyDefinition<Input> & {
-  mirrorToCanonicalOnHit?: boolean;
+type CacheKeyMigrationDefinition<Input> = {
+  previousKey: CacheKeyDefinition<Input>;
+  readFrom: "previous" | "new";
+  copyToOtherKey: "after_load" | "after_read";
 };
 
 type CachedResourceLookupDefinition<Input, Snapshot, Resource> = {
   id: string;
   version: number;
   key: (input: Input) => string;
-  readFromKeyFirst?: ReadFromKeyFirstDefinition<Input>;
+  migration?: CacheKeyMigrationDefinition<Input>;
   loadFromDatabase: (
     input: Input,
     transaction?: Transaction
@@ -107,7 +109,7 @@ export function defineCachedResourceLookup<Input, Snapshot, Resource>({
   id,
   version,
   key,
-  readFromKeyFirst,
+  migration,
   loadFromDatabase,
   toSnapshot,
   fromSnapshot,
@@ -117,18 +119,26 @@ export function defineCachedResourceLookup<Input, Snapshot, Resource>({
   Resource
 >): OperableCachedResourceLookup<Input, Resource> {
   const versionedKey = (input: Input) => `v${version}:${key(input)}`;
-  const readFromKeyFirstOptions = readFromKeyFirst
+  const migrationOptions = migration
     ? {
-        cacheId: readFromKeyFirst.cacheId,
-        resolver: readFromKeyFirst.key,
-        mirrorToCanonicalOnHit: readFromKeyFirst.mirrorToCanonicalOnHit,
+        previousKey: {
+          cacheId: migration.previousKey.cacheId,
+          resolver: migration.previousKey.key,
+        },
+        readFrom: migration.readFrom,
+        copyToOtherKey: migration.copyToOtherKey,
       }
     : undefined;
-  const operationsCacheKey = readFromKeyFirst ?? {
+  const newCacheKey = {
     cacheId: id,
     key: versionedKey,
     keyPattern: `v${version}:*`,
   };
+  const operationsCacheKey =
+    migration?.readFrom === "previous" ? migration.previousKey : newCacheKey;
+  const cacheKeysToDelete = migration
+    ? [newCacheKey, migration.previousKey]
+    : [newCacheKey];
 
   const loadSnapshotFromDatabase = async (
     input: Input
@@ -147,7 +157,7 @@ export function defineCachedResourceLookup<Input, Snapshot, Resource>({
     {
       cacheId: id,
       cacheNullValues: false,
-      readFromKeyFirst: readFromKeyFirstOptions,
+      migration: migrationOptions,
     }
   );
   const invalidateSnapshot = invalidateCacheWithRedis(
@@ -155,7 +165,7 @@ export function defineCachedResourceLookup<Input, Snapshot, Resource>({
     versionedKey,
     {
       cacheId: id,
-      readFromKeyFirst: readFromKeyFirstOptions,
+      migration: migrationOptions,
     }
   );
   const invalidateSnapshots = batchInvalidateCacheWithRedis(
@@ -163,7 +173,7 @@ export function defineCachedResourceLookup<Input, Snapshot, Resource>({
     versionedKey,
     {
       cacheId: id,
-      readFromKeyFirst: readFromKeyFirstOptions,
+      migration: migrationOptions,
     }
   );
 
@@ -217,9 +227,19 @@ export function defineCachedResourceLookup<Input, Snapshot, Resource>({
             operationsCacheKey.cacheId,
             operationsCacheKey.key(toLookupInput(input))
           ),
+        buildKeysToDelete: (input) =>
+          cacheKeysToDelete.map((cacheKey) =>
+            buildCacheWithRedisKey(
+              cacheKey.cacheId,
+              cacheKey.key(toLookupInput(input))
+            )
+          ),
         keyPattern: buildCacheWithRedisKey(
           operationsCacheKey.cacheId,
           operationsCacheKey.keyPattern
+        ),
+        keyPatternsToDelete: cacheKeysToDelete.map((cacheKey) =>
+          buildCacheWithRedisKey(cacheKey.cacheId, cacheKey.keyPattern)
         ),
       }),
   };

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -18,10 +18,13 @@ vi.mock("@app/lib/utils/cache", () => ({
       options?: {
         cacheId?: string;
         cacheNullValues?: boolean;
-        readFromKeyFirst?: {
-          cacheId: string;
-          resolver: (...args: Args) => string;
-          mirrorToCanonicalOnHit?: boolean;
+        migration?: {
+          previousKey: {
+            cacheId: string;
+            resolver: (...args: Args) => string;
+          };
+          readFrom: "previous" | "new";
+          copyToOtherKey: "after_load" | "after_read";
         };
       }
     ) => {
@@ -29,14 +32,23 @@ vi.mock("@app/lib/utils/cache", () => ({
         if (cacheReadFailure.current) {
           throw cacheReadFailure.current;
         }
-        const key = `cacheWithRedis-${options?.cacheId ?? fn.name}-${resolver(...args)}`;
-        const readKey = options?.readFromKeyFirst
-          ? `cacheWithRedis-${options.readFromKeyFirst.cacheId}-${options.readFromKeyFirst.resolver(...args)}`
-          : key;
+        const newKey = `cacheWithRedis-${options?.cacheId ?? fn.name}-${resolver(...args)}`;
+        const previousKey = options?.migration
+          ? `cacheWithRedis-${options.migration.previousKey.cacheId}-${options.migration.previousKey.resolver(...args)}`
+          : null;
+        const readKey =
+          options?.migration?.readFrom === "previous" && previousKey
+            ? previousKey
+            : newKey;
+        const otherKey = previousKey
+          ? readKey === newKey
+            ? previousKey
+            : newKey
+          : null;
         const cached = inMemoryCache.get(readKey);
         if (cached) {
-          if (options?.readFromKeyFirst?.mirrorToCanonicalOnHit !== false) {
-            inMemoryCache.set(key, cached);
+          if (otherKey && options?.migration?.copyToOtherKey === "after_read") {
+            inMemoryCache.set(otherKey, cached);
           }
           return JSON.parse(cached) as JsonSerializable<T>;
         }
@@ -44,7 +56,9 @@ vi.mock("@app/lib/utils/cache", () => ({
         if ((options?.cacheNullValues ?? true) || result !== null) {
           const serializedResult = JSON.stringify(result);
           inMemoryCache.set(readKey, serializedResult);
-          inMemoryCache.set(key, serializedResult);
+          if (otherKey) {
+            inMemoryCache.set(otherKey, serializedResult);
+          }
         }
         return result;
       };
@@ -56,20 +70,22 @@ vi.mock("@app/lib/utils/cache", () => ({
       resolver: (...args: Args) => string,
       options?: {
         cacheId?: string;
-        readFromKeyFirst?: {
-          cacheId: string;
-          resolver: (...args: Args) => string;
+        migration?: {
+          previousKey: {
+            cacheId: string;
+            resolver: (...args: Args) => string;
+          };
         };
       }
     ) => {
       return (...args: Args): Promise<void> => {
-        const key = `cacheWithRedis-${options?.cacheId ?? fn.name}-${resolver(...args)}`;
-        inMemoryCache.delete(key);
-        deletedKeys.push(key);
-        if (options?.readFromKeyFirst) {
-          const readKey = `cacheWithRedis-${options.readFromKeyFirst.cacheId}-${options.readFromKeyFirst.resolver(...args)}`;
-          inMemoryCache.delete(readKey);
-          deletedKeys.push(readKey);
+        const newKey = `cacheWithRedis-${options?.cacheId ?? fn.name}-${resolver(...args)}`;
+        inMemoryCache.delete(newKey);
+        deletedKeys.push(newKey);
+        if (options?.migration) {
+          const previousKey = `cacheWithRedis-${options.migration.previousKey.cacheId}-${options.migration.previousKey.resolver(...args)}`;
+          inMemoryCache.delete(previousKey);
+          deletedKeys.push(previousKey);
         }
         return Promise.resolve();
       };

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -197,11 +197,14 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     id: "workspace_by_sid",
     version: WORKSPACE_CACHE_KEY_VERSION,
     key: (workspaceId: string) => workspaceId,
-    readFromKeyFirst: {
-      cacheId: "_fetchByIdUncached",
-      key: (workspaceId: string) => `workspace:v2:${workspaceId}`,
-      keyPattern: "workspace:v2:*",
-      mirrorToCanonicalOnHit: false,
+    migration: {
+      previousKey: {
+        cacheId: "_fetchByIdUncached",
+        key: (workspaceId: string) => `workspace:v2:${workspaceId}`,
+        keyPattern: "workspace:v2:*",
+      },
+      readFrom: "new",
+      copyToOtherKey: "after_read",
     },
     loadFromDatabase: WorkspaceResource.fetchByIdFromDatabase,
     toSnapshot: (workspace) => workspace.toCacheSnapshot(),

--- a/front/lib/utils/cache.test.ts
+++ b/front/lib/utils/cache.test.ts
@@ -211,7 +211,7 @@ describe("cacheWithRedis", () => {
       );
     });
 
-    it("reads the migration key first and synchronizes the canonical key", async () => {
+    it("reads the new key and copies the hit to the previous key", async () => {
       const mockFn = vi.fn().mockResolvedValue({ data: "fresh" });
       mockRedisClient.get.mockResolvedValue(
         JSON.stringify({ data: "from-previous-key" })
@@ -221,9 +221,13 @@ describe("cacheWithRedis", () => {
       const cachedFn = cacheWithRedis(mockFn, (arg: string) => `v3:${arg}`, {
         cacheId: "workspace_by_sid",
         ttlMs: 60_000,
-        readFromKeyFirst: {
-          cacheId: "_fetchByIdUncached",
-          resolver: (arg: string) => `workspace:v2:${arg}`,
+        migration: {
+          previousKey: {
+            cacheId: "_fetchByIdUncached",
+            resolver: (arg: string) => `workspace:v2:${arg}`,
+          },
+          readFrom: "new",
+          copyToOtherKey: "after_read",
         },
       });
       const result = await cachedFn("workspace-1");
@@ -231,16 +235,16 @@ describe("cacheWithRedis", () => {
       expect(result).toEqual({ data: "from-previous-key" });
       expect(mockFn).not.toHaveBeenCalled();
       expect(mockRedisClient.get).toHaveBeenCalledWith(
-        "cacheWithRedis-_fetchByIdUncached-workspace:v2:workspace-1"
+        "cacheWithRedis-workspace_by_sid-v3:workspace-1"
       );
       expect(mockRedisClient.set).toHaveBeenCalledWith(
-        "cacheWithRedis-workspace_by_sid-v3:workspace-1",
+        "cacheWithRedis-_fetchByIdUncached-workspace:v2:workspace-1",
         JSON.stringify({ data: "from-previous-key" }),
         { PX: 60_000 }
       );
     });
 
-    it("does not mirror an incompatible migration-key hit", async () => {
+    it("can read the previous key without copying a cache hit", async () => {
       const mockFn = vi.fn().mockResolvedValue({ data: "fresh" });
       mockRedisClient.get.mockResolvedValue(
         JSON.stringify({ data: "legacy-semantics" })
@@ -248,10 +252,13 @@ describe("cacheWithRedis", () => {
 
       const cachedFn = cacheWithRedis(mockFn, (arg: string) => `v3:${arg}`, {
         cacheId: "workspace_by_sid",
-        readFromKeyFirst: {
-          cacheId: "_fetchByIdUncached",
-          resolver: (arg: string) => `workspace:v2:${arg}`,
-          mirrorToCanonicalOnHit: false,
+        migration: {
+          previousKey: {
+            cacheId: "_fetchByIdUncached",
+            resolver: (arg: string) => `workspace:v2:${arg}`,
+          },
+          readFrom: "previous",
+          copyToOtherKey: "after_load",
         },
       });
       const result = await cachedFn("workspace-1");
@@ -268,10 +275,13 @@ describe("cacheWithRedis", () => {
 
       const cachedFn = cacheWithRedis(mockFn, (arg: string) => `v3:${arg}`, {
         cacheId: "workspace_by_sid",
-        readFromKeyFirst: {
-          cacheId: "_fetchByIdUncached",
-          resolver: (arg: string) => `workspace:v2:${arg}`,
-          mirrorToCanonicalOnHit: false,
+        migration: {
+          previousKey: {
+            cacheId: "_fetchByIdUncached",
+            resolver: (arg: string) => `workspace:v2:${arg}`,
+          },
+          readFrom: "previous",
+          copyToOtherKey: "after_load",
         },
       });
       const result = await cachedFn("workspace-1");
@@ -630,9 +640,13 @@ describe("invalidateCacheWithRedis", () => {
       (arg: string) => `v3:${arg}`,
       {
         cacheId: "workspace_by_sid",
-        readFromKeyFirst: {
-          cacheId: "_fetchByIdUncached",
-          resolver: (arg: string) => `workspace:v2:${arg}`,
+        migration: {
+          previousKey: {
+            cacheId: "_fetchByIdUncached",
+            resolver: (arg: string) => `workspace:v2:${arg}`,
+          },
+          readFrom: "new",
+          copyToOtherKey: "after_read",
         },
       }
     );
@@ -787,9 +801,13 @@ describe("batchInvalidateCacheWithRedis", () => {
       (arg: string) => `v2:${arg}`,
       {
         cacheId: "canonical",
-        readFromKeyFirst: {
-          cacheId: "previous",
-          resolver: (arg) => `v1:${arg}`,
+        migration: {
+          previousKey: {
+            cacheId: "previous",
+            resolver: (arg) => `v1:${arg}`,
+          },
+          readFrom: "new",
+          copyToOtherKey: "after_read",
         },
       }
     );

--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -34,15 +34,15 @@ export type CacheableFunction<T, Args extends unknown[]> = (
 
 type KeyResolver<Args extends unknown[]> = (...args: Args) => string;
 
-/**
- * During a rolling key migration, this key remains the source of truth. Reads use it instead of
- * the canonical key and mirror compatible values by default. Invalidation removes both keys.
- */
-type ReadFromKeyFirst<Args extends unknown[]> = {
-  cacheId: string;
-  resolver: KeyResolver<Args>;
-  // Disable when a legacy hit cannot safely represent the canonical payload semantics.
-  mirrorToCanonicalOnHit?: boolean;
+// `readFrom` chooses the key used for reads. Fresh loads write both keys.
+// `after_read` also copies cache hits to the other key.
+type CacheKeyMigration<Args extends unknown[]> = {
+  previousKey: {
+    cacheId: string;
+    resolver: KeyResolver<Args>;
+  };
+  readFrom: "previous" | "new";
+  copyToOtherKey: "after_load" | "after_read";
 };
 
 export function buildCacheWithRedisKey(
@@ -63,7 +63,7 @@ function getCacheKey<T, Args extends unknown[]>(
 
 // Wrapper function to cache the result of a function with Redis.
 // Usage:
-// const cachedFn = cacheWithRedis(fn, (fnArg1, fnArg2, ...) => `${fnArg1}-${fnArg2}`, 60 * 10 * 1000);
+// const cachedFn = cacheWithRedis(fn, (fnArg1, fnArg2, ...) => `${fnArg1}-${fnArg2}`, 60 * 10 * 1000)
 
 // if caching big objects, there is a possible race condition (multiple calls to
 // caching), therefore, we use a lock
@@ -77,7 +77,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     useDistributedLock?: boolean;
     skipIfLocked?: false;
     cacheNullValues?: boolean;
-    readFromKeyFirst?: ReadFromKeyFirst<Args>;
+    migration?: CacheKeyMigration<Args>;
   }
 ): (...args: Args) => Promise<JsonSerializable<T>>;
 
@@ -91,7 +91,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     useDistributedLock?: boolean;
     skipIfLocked?: false;
     cacheNullValues: false;
-    readFromKeyFirst?: ReadFromKeyFirst<Args>;
+    migration?: CacheKeyMigration<Args>;
   }
 ): (...args: Args) => Promise<JsonSerializable<T> | null>;
 
@@ -106,7 +106,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     // When true and the distributed lock is taken, return null immediately.
     skipIfLocked: true;
     cacheNullValues?: boolean;
-    readFromKeyFirst?: ReadFromKeyFirst<Args>;
+    migration?: CacheKeyMigration<Args>;
   }
 ): (...args: Args) => Promise<JsonSerializable<T> | null>;
 
@@ -121,7 +121,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     useDistributedLock = false,
     skipIfLocked = false,
     cacheNullValues = true,
-    readFromKeyFirst,
+    migration,
   }: {
     cacheId?: string;
     ttlMs?: number | ((...args: Args) => number);
@@ -132,7 +132,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
     // When false, null/undefined results are not cached. This prevents stale
     // null entries from masking records that exist in the database.
     cacheNullValues?: boolean;
-    readFromKeyFirst?: ReadFromKeyFirst<Args>;
+    migration?: CacheKeyMigration<Args>;
   }
 ): (...args: Args) => Promise<JsonSerializable<T> | null> {
   // A static ttlMs is validated eagerly, same as before. A function ttlMs can only be
@@ -147,15 +147,22 @@ export function cacheWithRedis<T, Args extends unknown[]>(
       throw new Error("ttlMs should be less than 24 hours");
     }
 
-    const key = getCacheKey(fn, resolver, args, cacheId);
-    const readKey = readFromKeyFirst
+    const newKey = getCacheKey(fn, resolver, args, cacheId);
+    const previousKey = migration
       ? getCacheKey(
           fn,
-          readFromKeyFirst.resolver,
+          migration.previousKey.resolver,
           args,
-          readFromKeyFirst.cacheId
+          migration.previousKey.cacheId
         )
-      : key;
+      : null;
+    const readKey =
+      migration?.readFrom === "previous" && previousKey ? previousKey : newKey;
+    const otherKey = previousKey
+      ? readKey === newKey
+        ? previousKey
+        : newKey
+      : null;
 
     const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
 
@@ -167,21 +174,22 @@ export function cacheWithRedis<T, Args extends unknown[]>(
       }
     };
 
-    const synchronizeCanonicalKey = async (
+    const copyToOtherKey = async (
       value: string,
       { fromCacheHit }: { fromCacheHit: boolean }
     ): Promise<void> => {
-      if (
-        readKey !== key &&
-        (!fromCacheHit || readFromKeyFirst?.mirrorToCanonicalOnHit !== false)
-      ) {
-        await setValue(key, value);
+      if (!otherKey) {
+        return;
       }
+      if (fromCacheHit && migration?.copyToOtherKey !== "after_read") {
+        return;
+      }
+      await setValue(otherKey, value);
     };
 
     let cacheVal = await redisCli.get(readKey);
     if (cacheVal) {
-      await synchronizeCanonicalKey(cacheVal, { fromCacheHit: true });
+      await copyToOtherKey(cacheVal, { fromCacheHit: true });
       return JSON.parse(cacheVal) as JsonSerializable<T>;
     }
 
@@ -205,7 +213,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
             );
             cacheVal = await redisCli.get(readKey);
             if (cacheVal) {
-              await synchronizeCanonicalKey(cacheVal, { fromCacheHit: true });
+              await copyToOtherKey(cacheVal, { fromCacheHit: true });
               return JSON.parse(cacheVal) as JsonSerializable<T>;
             }
             lockValue = await distributedLock(redisCli, readKey);
@@ -216,7 +224,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
       }
       cacheVal = await redisCli.get(readKey);
       if (cacheVal) {
-        await synchronizeCanonicalKey(cacheVal, { fromCacheHit: true });
+        await copyToOtherKey(cacheVal, { fromCacheHit: true });
         return JSON.parse(cacheVal) as JsonSerializable<T>;
       }
 
@@ -224,7 +232,7 @@ export function cacheWithRedis<T, Args extends unknown[]>(
       if (cacheNullValues || result != null) {
         const serializedResult = JSON.stringify(result);
         await setValue(readKey, serializedResult);
-        await synchronizeCanonicalKey(serializedResult, {
+        await copyToOtherKey(serializedResult, {
           fromCacheHit: false,
         });
       }
@@ -270,22 +278,22 @@ export function invalidateCacheWithRedis<T, Args extends unknown[]>(
   _options?: {
     cacheId?: string;
     redisUri?: string;
-    readFromKeyFirst?: ReadFromKeyFirst<Args>;
+    migration?: CacheKeyMigration<Args>;
   }
 ): (...args: Args) => Promise<void> {
   return async function (...args: Args): Promise<void> {
     const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
 
-    const key = getCacheKey(fn, resolver, args, _options?.cacheId);
-    const readKey = _options?.readFromKeyFirst
+    const newKey = getCacheKey(fn, resolver, args, _options?.cacheId);
+    const previousKey = _options?.migration
       ? getCacheKey(
           fn,
-          _options.readFromKeyFirst.resolver,
+          _options.migration.previousKey.resolver,
           args,
-          _options.readFromKeyFirst.cacheId
+          _options.migration.previousKey.cacheId
         )
-      : key;
-    await redisCli.del(readKey === key ? key : [key, readKey]);
+      : null;
+    await redisCli.del(previousKey ? [newKey, previousKey] : newKey);
   };
 }
 
@@ -296,7 +304,7 @@ export function batchInvalidateCacheWithRedis<T, Args extends unknown[]>(
   _options?: {
     cacheId?: string;
     redisUri?: string;
-    readFromKeyFirst?: ReadFromKeyFirst<Args>;
+    migration?: CacheKeyMigration<Args>;
   }
 ): (argsList: Args[]) => Promise<void> {
   return async function (argsList: Args[]): Promise<void> {
@@ -309,13 +317,13 @@ export function batchInvalidateCacheWithRedis<T, Args extends unknown[]>(
     const keys = new Set<string>();
     for (const args of argsList) {
       keys.add(getCacheKey(fn, resolver, args, _options?.cacheId));
-      if (_options?.readFromKeyFirst) {
+      if (_options?.migration) {
         keys.add(
           getCacheKey(
             fn,
-            _options.readFromKeyFirst.resolver,
+            _options.migration.previousKey.resolver,
             args,
-            _options.readFromKeyFirst.cacheId
+            _options.migration.previousKey.cacheId
           )
         );
       }

--- a/front/lib/utils/cache_operations.ts
+++ b/front/lib/utils/cache_operations.ts
@@ -17,7 +17,9 @@ export type CacheOperationDescription = {
 export type CacheOperations = {
   description: CacheOperationDescription;
   buildKey: (params: Record<string, string>) => string;
+  buildKeysToDelete: (params: Record<string, string>) => string[];
   keyPattern: string | null;
+  keyPatternsToDelete: string[];
 };
 
 export function defineCacheOperations<Input>({
@@ -26,14 +28,18 @@ export function defineCacheOperations<Input>({
   params,
   inputSchema,
   buildKey,
+  buildKeysToDelete,
   keyPattern,
+  keyPatternsToDelete,
 }: {
   id: string;
   label: string;
   params: CacheOperationParam[];
   inputSchema: z.ZodType<Input>;
   buildKey: (input: Input) => string;
+  buildKeysToDelete?: (input: Input) => string[];
   keyPattern: string | null;
+  keyPatternsToDelete?: string[];
 }): CacheOperations {
   return {
     description: {
@@ -43,6 +49,12 @@ export function defineCacheOperations<Input>({
       supportsBulkInvalidation: keyPattern !== null,
     },
     buildKey: (rawParams) => buildKey(inputSchema.parse(rawParams)),
+    buildKeysToDelete: (rawParams) => {
+      const input = inputSchema.parse(rawParams);
+      return buildKeysToDelete ? buildKeysToDelete(input) : [buildKey(input)];
+    },
     keyPattern,
+    keyPatternsToDelete:
+      keyPatternsToDelete ?? (keyPattern === null ? [] : [keyPattern]),
   };
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This is the second step of the Workspace cache-key migration. The first PR https://github.com/dust-tt/dust/pull/30270 keeps the previous key as the read source while populating both keys. This PR cuts reads over to the new versioned key.

This must only be deployed after the first PR is fully deployed.

## What changes

Workspace reads now use the new key. Cache hits are copied to the previous key so old application instances and an immediate rollback can still read current data. Database loads continue to populate both keys, and application invalidation removes both.

The cached Workspace snapshot continues to store the raw provider list. Provider kill switches are applied after reading the snapshot, preventing temporary kill-switch state from being stored in the new cache.

Poke now looks up the key currently used for reads. Exact and bulk deletion remove both the new and previous keys so deleted entries cannot reappear from the rollback copy.

Took the opportunity to "productize" the cache migration by making the state is explicit about which key is read and when cache hits are copied. This keeps future resource migrations inside the cache layer.

## Rollout and rollback

To roll back, revert this PR. The previous key remains populated throughout the cutover, so the first migration state can resume reading it without a cache-wide flush.

## Risk

During this temporary phase, cache hits also write the previous key. This increases Redis writes for Workspace reads until the cleanup PR is deployed.

The main correctness risk is deleting or updating only one key. Both application invalidation and Poke deletion are covered to ensure both keys are removed together.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
