### PR TITLE
[front] fix: align chart heights in new analytics page + ui polish

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -1,3 +1,4 @@
+import { CHART_HEIGHT } from "@app/components/charts/constants";
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
@@ -17,7 +18,13 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
-import { cn, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
+import {
+  cn,
+  LoadingBlock,
+  Page,
+  SafeSuspense,
+  safeLazy,
+} from "@dust-tt/sparkle";
 import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
 
 import { useMemo, useState } from "react";
@@ -33,7 +40,27 @@ const ConsumptionChart = safeLazy(
 );
 
 function ChartFallback() {
-  return <div className="h-64 animate-pulse rounded-lg bg-muted-background" />;
+  return (
+    <div aria-hidden="true" className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <LoadingBlock className="h-5 w-28" />
+        <LoadingBlock className="h-[42px] w-40 rounded-2xl" />
+      </div>
+      <div className="rounded-lg border border-border bg-background p-4">
+        <div className="border-b border-border pb-3">
+          <LoadingBlock className="h-6 w-36" />
+        </div>
+        <LoadingBlock
+          className="mt-3 w-full"
+          style={{ height: CHART_HEIGHT }}
+        />
+        <div className="mt-3 flex h-5 items-center gap-6">
+          <LoadingBlock className="h-4 w-32" />
+          <LoadingBlock className="h-4 w-36" />
+        </div>
+      </div>
+    </div>
+  );
 }
 
 export function AnalyticsConsumptionPage() {

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -44,7 +44,9 @@ function ChartFallback() {
     <div aria-hidden="true" className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <LoadingBlock className="h-5 w-28" />
-        <LoadingBlock className="h-[42px] w-40 rounded-2xl" />
+        <div className="rounded-2xl border border-border-dark bg-background p-1">
+          <LoadingBlock className="h-8 w-36 rounded-xl" />
+        </div>
       </div>
       <div className="rounded-lg border border-border bg-background p-4">
         <div className="border-b border-border pb-3">

--- a/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
@@ -179,12 +179,17 @@ export function ConsumptionBurnUpChart({
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
+      showHeaderDivider
     >
       <LineChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>
-        <CartesianGrid vertical={false} className="stroke-border" />
+        <CartesianGrid
+          vertical={false}
+          strokeDasharray="4 4"
+          className="stroke-border"
+        />
         <XAxis
           dataKey="timestamp"
-          className="text-xs text-muted-foreground"
+          className="text-xs text-faint"
           tickLine={false}
           axisLine={false}
           tickMargin={8}
@@ -194,13 +199,14 @@ export function ConsumptionBurnUpChart({
           }
         />
         <YAxis
-          className="text-xs text-muted-foreground"
+          className="text-xs text-faint"
           tickLine={false}
           axisLine={false}
           tickMargin={8}
           tickFormatter={formatCreditsCompact}
         />
         <Tooltip
+          cursor={false}
           content={ConsumptionBurnUpTooltip}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
         />


### PR DESCRIPTION
## Description

The cumulative consumption chart is shorter and visually heavier than the daily chart when switching between modes.

This PR gives it the same header divider and spacing so both chart cards keep a consistent height. It also matches the daily chart's dashed grid, subtle axis labels, and hover behavior.

Also adds a skeleton of the same height.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
