### PR TITLE
[front] Share pod apps as workspace agent toolsets

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -1,4 +1,10 @@
 import { exportPodApp } from "@app/lib/api/projects/app_archive";
+import type { PodAppShareError } from "@app/lib/api/projects/app_shares";
+import {
+  sharePodApp,
+  unsharePodApp,
+  updatePodAppShare,
+} from "@app/lib/api/projects/app_shares";
 import {
   clonePodApp,
   deletePodApp,
@@ -7,11 +13,15 @@ import {
 import type {
   ClonePodAppResponseBody,
   DeletePodAppResponseBody,
+  DeletePodAppShareResponseBody,
   GetPodAppsResponseBody,
+  SharePodAppResponseBody,
 } from "@app/types/api/pod_apps";
 import {
   ClonePodAppRequestBodySchema,
   DeletePodAppParamsSchema,
+  SharePodAppRequestBodySchema,
+  UpdatePodAppShareRequestBodySchema,
 } from "@app/types/api/pod_apps";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -228,6 +238,126 @@ app.post(
     }
 
     return ctx.json({ app: cloneResult.value }, 201);
+  }
+);
+
+function podAppShareApiError(
+  ctx: Parameters<typeof apiError>[0],
+  error: PodAppShareError
+) {
+  switch (error.code) {
+    case "not_a_pod":
+    case "no_functions":
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: error.message,
+        },
+      });
+    case "not_found":
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "space_not_found",
+          message: error.message,
+        },
+      });
+    case "not_shared":
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message: error.message,
+        },
+      });
+    case "name_taken":
+    case "already_shared":
+      return apiError(ctx, {
+        status_code: 409,
+        api_error: {
+          type: "invalid_request_error",
+          message: error.message,
+        },
+      });
+    case "internal":
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: error.message,
+        },
+      });
+    default:
+      return assertNever(error.code);
+  }
+}
+
+/** @ignoreswagger */
+app.post(
+  "/:prefix/share",
+  validate("param", DeletePodAppParamsSchema),
+  validate("json", SharePodAppRequestBodySchema),
+  withSpace({ requireCanAdministrate: true, routeParam: "podId" }),
+  async (ctx): HandlerResult<SharePodAppResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { prefix } = ctx.req.valid("param");
+    const { name, description } = ctx.req.valid("json");
+
+    const shareResult = await sharePodApp(auth, space, {
+      prefix,
+      name,
+      description,
+    });
+    if (shareResult.isErr()) {
+      return podAppShareApiError(ctx, shareResult.error);
+    }
+
+    return ctx.json({ share: shareResult.value }, 201);
+  }
+);
+
+/** @ignoreswagger */
+app.patch(
+  "/:prefix/share",
+  validate("param", DeletePodAppParamsSchema),
+  validate("json", UpdatePodAppShareRequestBodySchema),
+  withSpace({ requireCanAdministrate: true, routeParam: "podId" }),
+  async (ctx): HandlerResult<SharePodAppResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { prefix } = ctx.req.valid("param");
+    const { name, description } = ctx.req.valid("json");
+
+    const updateResult = await updatePodAppShare(auth, space, prefix, {
+      name,
+      description,
+    });
+    if (updateResult.isErr()) {
+      return podAppShareApiError(ctx, updateResult.error);
+    }
+
+    return ctx.json({ share: updateResult.value });
+  }
+);
+
+/** @ignoreswagger */
+app.delete(
+  "/:prefix/share",
+  validate("param", DeletePodAppParamsSchema),
+  withSpace({ requireCanAdministrate: true, routeParam: "podId" }),
+  async (ctx): HandlerResult<DeletePodAppShareResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+    const { prefix } = ctx.req.valid("param");
+
+    const unshareResult = await unsharePodApp(auth, space, prefix);
+    if (unshareResult.isErr()) {
+      return podAppShareApiError(ctx, unshareResult.error);
+    }
+
+    return ctx.json({ success: true } as const);
   }
 );
 

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/share.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/share.test.ts
@@ -117,7 +117,7 @@ describe("POST /api/w/:wId/pods/:podId/apps/:prefix/share", () => {
     expect(res.status).toBe(201);
     const body = await res.json();
     expect(body.share).toEqual({
-      appPrefix: "tasklist",
+      appName: "tasklist",
       toolsetName: "Task List",
       description: "Task management tools.",
     });
@@ -129,7 +129,7 @@ describe("POST /api/w/:wId/pods/:podId/apps/:prefix/share", () => {
     const listBody = await listRes.json();
     expect(listBody.apps).toHaveLength(1);
     expect(listBody.apps[0].share).toEqual({
-      appPrefix: "tasklist",
+      appName: "tasklist",
       toolsetName: "Task List",
       description: "Task management tools.",
     });
@@ -210,7 +210,7 @@ describe("PATCH /api/w/:wId/pods/:podId/apps/:prefix/share", () => {
     const body = await res.json();
     expect(body.share.description).toBe("Better description.");
 
-    const shareRow = await PodAppShareResource.fetchByPodAndAppPrefix(
+    const shareRow = await PodAppShareResource.fetchByPodAndAppName(
       auth,
       pod,
       "tasklist"
@@ -249,7 +249,7 @@ describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix/share", () => {
       description: "Task management tools.",
     });
     expect(created.status).toBe(201);
-    const shareRow = await PodAppShareResource.fetchByPodAndAppPrefix(
+    const shareRow = await PodAppShareResource.fetchByPodAndAppName(
       auth,
       pod,
       "tasklist"
@@ -265,7 +265,7 @@ describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix/share", () => {
     expect(await res.json()).toEqual({ success: true });
 
     expect(
-      await PodAppShareResource.fetchByPodAndAppPrefix(auth, pod, "tasklist")
+      await PodAppShareResource.fetchByPodAndAppName(auth, pod, "tasklist")
     ).toBeNull();
 
     const adminAuth = await Authenticator.internalAdminForWorkspace(
@@ -340,7 +340,7 @@ describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix with an active share", () 
 
     expect(res.status).toBe(200);
     expect(
-      await PodAppShareResource.fetchByPodAndAppPrefix(auth, pod, "tasklist")
+      await PodAppShareResource.fetchByPodAndAppName(auth, pod, "tasklist")
     ).toBeNull();
   });
 });

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/share.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/share.test.ts
@@ -1,0 +1,346 @@
+import { ensurePodSandboxReady } from "@app/lib/api/sandbox/lifecycle";
+import { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import assert from "assert";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(async (_lockName: string, fn: () => unknown) => fn()),
+}));
+
+vi.mock("@app/lib/api/sandbox/lifecycle", () => ({
+  ensurePodSandboxReady: vi.fn(),
+}));
+
+const EMPTY_SCHEMA = { type: "object", properties: {} } as const;
+
+async function setupPod() {
+  const { workspace, user, auth } = await createPrivateApiMockRequest({
+    role: "admin",
+  });
+  const pod = await SpaceFactory.project(workspace, user.id);
+
+  return { workspace, user, auth, pod };
+}
+
+function gcsObject(
+  workspaceId: string,
+  podId: string,
+  relPath: string,
+  contentType = "text/plain"
+) {
+  return {
+    name: `w/${workspaceId}/pods/${podId}/files/${relPath}`,
+    metadata: {
+      contentType,
+      size: "100",
+      updated: new Date().toISOString(),
+    },
+  };
+}
+
+async function publishFunction(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { slug, fileName }: { slug: string; fileName: string }
+) {
+  const file = await FileFactory.create(auth, null, {
+    contentType: sandboxFunctionContentType,
+    fileName,
+    fileSize: 100,
+    status: "created",
+    useCase: "project_context",
+    useCaseMetadata: { spaceId: pod.sId },
+  });
+
+  return SandboxFunctionResource.makeNew(auth, {
+    space: pod,
+    file,
+    slug,
+    description: `Function ${slug}.`,
+    inputSchema: EMPTY_SCHEMA,
+    outputSchema: EMPTY_SCHEMA,
+  });
+}
+
+function shareUrl(workspaceId: string, podId: string, prefix: string) {
+  return `/api/w/${workspaceId}/pods/${podId}/apps/${prefix}/share`;
+}
+
+async function share(
+  workspaceId: string,
+  podId: string,
+  prefix: string,
+  body: { name?: string; description: string }
+) {
+  return honoApp.request(shareUrl(workspaceId, podId, prefix), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/pods/:podId/apps/:prefix/share", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("shares the app and surfaces it on the apps listing", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "TaskList/"),
+      gcsObject(workspace.sId, pod.sId, "TaskList/functions/add-task.ts"),
+    ]);
+
+    const res = await share(workspace.sId, pod.sId, "tasklist", {
+      name: "Task List",
+      description: "Task management tools.",
+    });
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.share).toEqual({
+      appPrefix: "tasklist",
+      toolsetName: "Task List",
+      description: "Task management tools.",
+    });
+
+    const listRes = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json();
+    expect(listBody.apps).toHaveLength(1);
+    expect(listBody.apps[0].share).toEqual({
+      appPrefix: "tasklist",
+      toolsetName: "Task List",
+      description: "Task management tools.",
+    });
+  });
+
+  it("rejects a duplicate share with 409", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+
+    const first = await share(workspace.sId, pod.sId, "tasklist", {
+      description: "Task management tools.",
+    });
+    expect(first.status).toBe(201);
+
+    const second = await share(workspace.sId, pod.sId, "tasklist", {
+      description: "Task management tools.",
+    });
+    expect(second.status).toBe(409);
+  });
+
+  it("rejects an app with no published functions with 400", async () => {
+    const { workspace, pod } = await setupPod();
+
+    const res = await share(workspace.sId, pod.sId, "tasklist", {
+      description: "Task management tools.",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a workspace member who is not a pod editor with 404", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const editor = await UserFactory.basic();
+    const pod = await SpaceFactory.project(workspace, editor.id);
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+
+    const res = await share(workspace.sId, pod.sId, "tasklist", {
+      description: "Task management tools.",
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/w/:wId/pods/:podId/apps/:prefix/share", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("updates the description", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+    const created = await share(workspace.sId, pod.sId, "tasklist", {
+      description: "Task management tools.",
+    });
+    expect(created.status).toBe(201);
+
+    const res = await honoApp.request(
+      shareUrl(workspace.sId, pod.sId, "tasklist"),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: "Better description." }),
+      }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.share.description).toBe("Better description.");
+
+    const shareRow = await PodAppShareResource.fetchByPodAndAppPrefix(
+      auth,
+      pod,
+      "tasklist"
+    );
+    expect(shareRow?.description).toBe("Better description.");
+  });
+
+  it("404s when the app is not shared", async () => {
+    const { workspace, pod } = await setupPod();
+
+    const res = await honoApp.request(
+      shareUrl(workspace.sId, pod.sId, "tasklist"),
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description: "Whatever." }),
+      }
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix/share", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("revokes the share and soft-deletes the toolset views", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+    const created = await share(workspace.sId, pod.sId, "tasklist", {
+      description: "Task management tools.",
+    });
+    expect(created.status).toBe(201);
+    const shareRow = await PodAppShareResource.fetchByPodAndAppPrefix(
+      auth,
+      pod,
+      "tasklist"
+    );
+    assert(shareRow, "Expected a share row");
+
+    const res = await honoApp.request(
+      shareUrl(workspace.sId, pod.sId, "tasklist"),
+      { method: "DELETE" }
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+
+    expect(
+      await PodAppShareResource.fetchByPodAndAppPrefix(auth, pod, "tasklist")
+    ).toBeNull();
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    expect(
+      await MCPServerViewResource.listByMCPServer(
+        adminAuth,
+        shareRow.internalMCPServerId
+      )
+    ).toEqual([]);
+  });
+
+  it("404s when the app is not shared", async () => {
+    const { workspace, pod } = await setupPod();
+
+    const res = await honoApp.request(
+      shareUrl(workspace.sId, pod.sId, "tasklist"),
+      { method: "DELETE" }
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/w/:wId/pods/:podId/apps/:prefix with an active share", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.reset();
+  });
+
+  it("revokes the share when the app is deleted", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    const sandbox = await SandboxResource.makeNew(auth, {
+      providerId: "test-provider-id",
+      status: "running",
+      baseImage: "dust-base",
+      version: "0.0.0-test",
+    });
+    vi.mocked(ensurePodSandboxReady).mockResolvedValue(
+      new Ok({ sandbox, freshlyCreated: false })
+    );
+    vi.spyOn(sandbox, "execRoot").mockResolvedValue(
+      new Ok({ exitCode: 0, stdout: "", stderr: "" })
+    );
+    vi.spyOn(sandbox, "exec").mockResolvedValue(
+      new Ok({
+        exitCode: 0,
+        stdout: `${JSON.stringify({ ok: true })}\n`,
+        stderr: "",
+      })
+    );
+
+    await publishFunction(auth, pod, {
+      slug: "tasklist__add-task",
+      fileName: "add-task.ts",
+    });
+    fileStorageMock.setFilesByPrefix(() => [
+      gcsObject(workspace.sId, pod.sId, "TaskList/"),
+      gcsObject(workspace.sId, pod.sId, "TaskList/functions/add-task.ts"),
+    ]);
+    fileStorageMock.setSubdirectoryNames(() => []);
+
+    const created = await share(workspace.sId, pod.sId, "tasklist", {
+      description: "Task management tools.",
+    });
+    expect(created.status).toBe(201);
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps/tasklist`,
+      { method: "DELETE" }
+    );
+
+    expect(res.status).toBe(200);
+    expect(
+      await PodAppShareResource.fetchByPodAndAppPrefix(auth, pod, "tasklist")
+    ).toBeNull();
+  });
+});

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -115,6 +115,7 @@ import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { MembershipUpgradeRequestModel } from "@app/lib/resources/storage/models/membership_upgrade_requests";
 import { OnboardingTaskModel } from "@app/lib/resources/storage/models/onboarding_tasks";
 import { PluginRunModel } from "@app/lib/resources/storage/models/plugin_runs";
+import { PodAppShareModel } from "@app/lib/resources/storage/models/pod_app_share";
 import { ProgrammaticUsageConfigurationModel } from "@app/lib/resources/storage/models/programmatic_usage_configurations";
 import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import {
@@ -188,6 +189,7 @@ export function loadAllModels() {
     FileSystemBlobCleanupModel,
     SandboxFunctionModel,
     SandboxFunctionInvocationModel,
+    PodAppShareModel,
     ShareableFileModel,
     AuthorizedFileAccessModel,
     SharingGrantModel,

--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -142,7 +142,7 @@ function getDefaultToolSettings({
   const metadata = toolMetadataByName[tool.name];
   const defaultPermission = getDefaultInternalToolStakeLevel(
     mcpServerView.server,
-    tool.name
+    tool
   );
 
   return {

--- a/front/components/actions/mcp/forms/mcpServerFormSchema.ts
+++ b/front/components/actions/mcp/forms/mcpServerFormSchema.ts
@@ -8,7 +8,9 @@ import {
   isRemoteMCPServerType,
   requiresBearerTokenConfiguration,
 } from "@app/lib/actions/mcp_helper";
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
+  getInternalMCPServerNameAndWorkspaceId,
   getInternalMCPServerToolArgumentsRequiringApproval,
   INTERNAL_MCP_SERVERS,
   isInternalMCPServerName,
@@ -78,35 +80,62 @@ export type MCPServerFormValues = ServerSettings & {
 
 export function getDefaultInternalToolStakeLevel(
   server: MCPServerViewType["server"],
-  toolName: string
+  tool: { name: string; stake?: MCPToolStakeLevelType }
 ): MCPToolStakeLevelType {
-  if (isRemoteMCPServerType(server) || !isInternalMCPServerName(server.name)) {
+  if (isRemoteMCPServerType(server)) {
     return FALLBACK_MCP_TOOL_STAKE_LEVEL;
+  }
+
+  const serverName = internalServerNameFromServer(server);
+  if (!serverName) {
+    return tool.stake ?? FALLBACK_MCP_TOOL_STAKE_LEVEL;
   }
 
   const {
     metadata: { tools },
     availability,
-  } = INTERNAL_MCP_SERVERS[server.name];
+  } = INTERNAL_MCP_SERVERS[serverName];
 
+  // The tool's self-declared stake covers dynamically-listed tools (e.g. pod app toolsets),
+  // which have no static registry entry.
   return (
-    tools.find((tool) => tool.name === toolName)?.stake ??
+    tools.find((t) => t.name === tool.name)?.stake ??
+    tool.stake ??
     (availability === "manual"
       ? FALLBACK_MCP_TOOL_STAKE_LEVEL
       : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL)
   );
 }
 
+/**
+ * The registry identity of an internal server. Decoded from the sId because `server.name` can
+ * carry a per-instance display override (pod app toolsets) and is not a reliable registry key.
+ */
+function internalServerNameFromServer(
+  server: MCPServerViewType["server"]
+): InternalMCPServerNameType | null {
+  const decoded = getInternalMCPServerNameAndWorkspaceId(server.sId);
+  if (decoded.isOk()) {
+    return decoded.value.name;
+  }
+  return isInternalMCPServerName(server.name) ? server.name : null;
+}
+
 export function canToolUseMediumStakeLevel(
   server: MCPServerViewType["server"],
   toolName: string
 ): boolean {
-  if (isRemoteMCPServerType(server) || !isInternalMCPServerName(server.name)) {
+  if (isRemoteMCPServerType(server)) {
+    return false;
+  }
+
+  const serverName = internalServerNameFromServer(server);
+  if (!serverName) {
     return false;
   }
 
   return Boolean(
-    getInternalMCPServerToolArgumentsRequiringApproval(server.name, toolName)
+    getInternalMCPServerToolArgumentsRequiringApproval(serverName, toolName)
       ?.length
   );
 }
@@ -124,7 +153,7 @@ export function getMCPServerFormDefaults(
     const metadata = view.toolsMetadata?.find((m) => m.toolName === tool.name);
     const defaultPermission =
       metadata?.permission ??
-      getDefaultInternalToolStakeLevel(view.server, tool.name);
+      getDefaultInternalToolStakeLevel(view.server, tool);
     toolSettings[tool.name] = {
       enabled: metadata?.enabled ?? true,
       permission: defaultPermission,

--- a/front/components/pod/apps/PodAppTile.tsx
+++ b/front/components/pod/apps/PodAppTile.tsx
@@ -153,7 +153,7 @@ export function PodAppTile({
               <Chip
                 size="xs"
                 color="success"
-                label="Shared"
+                label="Tools"
                 className="shrink-0"
               />
             )}

--- a/front/components/pod/apps/PodAppTile.tsx
+++ b/front/components/pod/apps/PodAppTile.tsx
@@ -10,6 +10,7 @@ import {
   Chip,
   Download01,
   GitBranch01,
+  Share01,
   Spinner,
   Trash01,
 } from "@dust-tt/sparkle";
@@ -26,6 +27,8 @@ interface PodAppTileProps {
   onClone?: () => void;
   /** Absent when the viewer cannot edit (no write access). */
   onDelete?: () => void;
+  /** Absent when the viewer cannot edit (no write access). */
+  onShare?: () => void;
   /** Deletion is in flight: the tile stays put, inert, until the app is actually gone. */
   isDeleting: boolean;
 }
@@ -57,6 +60,7 @@ export function PodAppTile({
   onDownload,
   onClone,
   onDelete,
+  onShare,
   isDeleting,
 }: PodAppTileProps) {
   // The tile surfaces a single Frame — the app's first — as apps almost always have exactly one.
@@ -93,6 +97,14 @@ export function PodAppTile({
               onClick={() => void handleDownload()}
               isLoading={isDownloading}
             />
+            {onShare && (
+              <CardActionButton
+                size="icon"
+                icon={Share01}
+                tooltip="Share this app's functions as agent tools"
+                onClick={onShare}
+              />
+            )}
             {onClone && (
               <CardActionButton
                 size="icon"
@@ -134,6 +146,14 @@ export function PodAppTile({
                 size="xs"
                 color="primary"
                 label="Draft"
+                className="shrink-0"
+              />
+            )}
+            {app.share && !isDeleting && (
+              <Chip
+                size="xs"
+                color="success"
+                label="Shared"
                 className="shrink-0"
               />
             )}

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -4,6 +4,7 @@ import { ImportPodAppDialog } from "@app/components/pod/apps/ImportPodAppDialog"
 import { PendingPodAppTile } from "@app/components/pod/apps/PendingPodAppTile";
 import { PodAppImportReportDialog } from "@app/components/pod/apps/PodAppImportReportDialog";
 import { PodAppTile } from "@app/components/pod/apps/PodAppTile";
+import { SharePodAppDialog } from "@app/components/pod/apps/SharePodAppDialog";
 import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
 import {
@@ -79,6 +80,7 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
     null
   );
   const [appPendingClone, setAppPendingClone] = useState<PodApp | null>(null);
+  const [appPendingShare, setAppPendingShare] = useState<PodApp | null>(null);
   const [isImportOpen, setIsImportOpen] = useState(false);
   const [importReport, setImportReport] = useState<PodAppImportSummary | null>(
     null
@@ -287,6 +289,11 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
                             ? () => setAppPendingDeletion(entry.app)
                             : undefined
                         }
+                        onShare={
+                          canEdit
+                            ? () => setAppPendingShare(entry.app)
+                            : undefined
+                        }
                         isDeleting={deletingPrefixSet.has(entry.app.prefix)}
                       />
                     );
@@ -348,6 +355,16 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
           isOpen
           onClose={() => setAppPendingDeletion(null)}
           onSubmit={() => void onDelete(appPendingDeletion)}
+        />
+      )}
+      {appPendingShare && (
+        <SharePodAppDialog
+          key={`share-${appPendingShare.prefix}`}
+          owner={owner}
+          podId={pod.sId}
+          app={appPendingShare}
+          isOpen
+          onClose={() => setAppPendingShare(null)}
         />
       )}
       {isImportOpen && (

--- a/front/components/pod/apps/SharePodAppDialog.tsx
+++ b/front/components/pod/apps/SharePodAppDialog.tsx
@@ -1,0 +1,212 @@
+import {
+  useSharePodApp,
+  useUnsharePodApp,
+  useUpdatePodAppShare,
+} from "@app/lib/swr/pods";
+import type { PodApp } from "@app/types/api/pod_apps";
+import {
+  MAX_POD_APP_NAME_LENGTH,
+  MAX_POD_APP_SHARE_DESCRIPTION_LENGTH,
+} from "@app/types/api/pod_apps";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Chip,
+  ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Spinner,
+  TextArea,
+} from "@dust-tt/sparkle";
+import type { ChangeEvent } from "react";
+import { useCallback, useState } from "react";
+
+interface SharePodAppDialogProps {
+  owner: LightWorkspaceType;
+  podId: string;
+  app: PodApp;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Share (or edit the sharing of) a pod app as a workspace toolset: every published function of
+ * the app becomes an agent tool, discoverable by name and description.
+ */
+export function SharePodAppDialog({
+  owner,
+  podId,
+  app,
+  isOpen,
+  onClose,
+}: SharePodAppDialogProps) {
+  const appName = app.name ?? app.prefix;
+  const isEditing = app.share !== null;
+
+  const [name, setName] = useState(app.share?.toolsetName ?? appName);
+  const [description, setDescription] = useState(
+    app.share?.description ??
+      app.functions.map((fn) => `${fn.name}: ${fn.description}`).join("\n")
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const doShare = useSharePodApp({ owner, podId });
+  const doUpdate = useUpdatePodAppShare({ owner, podId });
+  const doUnshare = useUnsharePodApp({ owner, podId });
+
+  const trimmedName = name.trim();
+  const trimmedDescription = description.trim();
+  const canSubmit = trimmedName.length > 0 && trimmedDescription.length > 0;
+
+  const onSubmit = useCallback(async () => {
+    setIsSubmitting(true);
+    const result = isEditing
+      ? await doUpdate(app, {
+          name: trimmedName,
+          description: trimmedDescription,
+        })
+      : await doShare(app, {
+          name: trimmedName,
+          description: trimmedDescription,
+        });
+    setIsSubmitting(false);
+    if (result.isOk()) {
+      onClose();
+    }
+  }, [
+    app,
+    doShare,
+    doUpdate,
+    isEditing,
+    onClose,
+    trimmedDescription,
+    trimmedName,
+  ]);
+
+  const onStopSharing = useCallback(async () => {
+    setIsSubmitting(true);
+    const result = await doUnshare(app);
+    setIsSubmitting(false);
+    if (result.isOk()) {
+      onClose();
+    }
+  }, [app, doUnshare, onClose]);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>
+            {isEditing ? `Sharing of ${appName}` : `Share ${appName} as tools`}
+          </DialogTitle>
+        </DialogHeader>
+        {isSubmitting ? (
+          <DialogContainer className="flex flex-col items-center gap-3 py-8">
+            <Spinner variant="dark" size="md" />
+          </DialogContainer>
+        ) : (
+          <>
+            <DialogContainer className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1">
+                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+                  Toolset name
+                </span>
+                <Input
+                  name="share-toolset-name"
+                  value={name}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setName(e.target.value)
+                  }
+                  maxLength={MAX_POD_APP_NAME_LENGTH}
+                  containerClassName="w-full"
+                />
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+                  Description
+                </span>
+                <TextArea
+                  value={description}
+                  onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                    setDescription(e.target.value)
+                  }
+                  maxLength={MAX_POD_APP_SHARE_DESCRIPTION_LENGTH}
+                  rows={4}
+                />
+                <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+                  Agents use this description to decide when to use the toolset
+                  — make it specific.
+                </span>
+              </div>
+
+              <div className="flex flex-col gap-1">
+                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+                  Functions shared as tools
+                </span>
+                <div className="flex flex-col gap-1">
+                  {app.functions.map((fn) => (
+                    <div
+                      key={fn.slug}
+                      className="flex items-center gap-2 copy-sm"
+                    >
+                      <span className="font-mono">{fn.name}</span>
+                      {fn.userIdentity === "pod_member_required" && (
+                        <Chip
+                          size="xs"
+                          color="warning"
+                          label="Pod members only"
+                        />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <ContentMessage variant="info" title="Workspace-wide tools">
+                Agents across the workspace can attach or enable this toolset.
+                Functions run on this Pod's Computer, against its databases.
+              </ContentMessage>
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={
+                isEditing
+                  ? {
+                      label: "Stop sharing",
+                      variant: "warning",
+                      onClick: () => {
+                        void onStopSharing();
+                      },
+                    }
+                  : {
+                      label: "Cancel",
+                      variant: "outline",
+                      onClick: onClose,
+                    }
+              }
+              rightButtonProps={{
+                label: isEditing ? "Save" : "Share as tools",
+                variant: "primary",
+                disabled: !canSubmit,
+                onClick: () => {
+                  void onSubmit();
+                },
+              }}
+            />
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/poke/mcp_server_views/tools_config.tsx
+++ b/front/components/poke/mcp_server_views/tools_config.tsx
@@ -180,7 +180,7 @@ export function ToolsConfigTable({ mcpServerView }: ToolsConfigTableProps) {
       const override = overridesByName.get(tool.name);
       const defaultPermission = getDefaultInternalToolStakeLevel(
         mcpServerView.server,
-        tool.name
+        tool
       );
       const permission = override?.permission ?? defaultPermission;
 

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -1431,8 +1431,11 @@ export async function buildToolConfigurationsFromRawTools(
   const toolsWithStakesRetryPoliciesAndTimeout = allToolsRaw
     .filter(({ name }) => !(toolsEnabled[name] === false)) // Include tools that are enabled (true) or not explicitly disabled (undefined).
     .map((tool) => {
+      // Admin overrides and static registry stakes first, then the stake the tool declares for
+      // itself (dynamically-listed internal tools have no static entry), then the fallback.
       const configuredStakeLevel =
         toolsStakes[tool.name] ||
+        tool.stake ||
         (availability === "manual"
           ? FALLBACK_MCP_TOOL_STAKE_LEVEL
           : FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL);

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -220,7 +220,12 @@ export function getMcpServerDisplayName(
 
     const serverConfig = INTERNAL_MCP_SERVERS[res.value.name];
 
-    if (serverConfig.isPreview === true) {
+    // Pod app toolsets carry a user-authored per-instance name; the preview label is about the
+    // server type and would read as if the user's own toolset were unreleased.
+    if (
+      serverConfig.isPreview === true &&
+      res.value.name !== "pod_app_toolset"
+    ) {
       displayName += " (Preview)";
     }
     // Only matches the old internal Notion server; the new official Notion is a remote

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1781,6 +1781,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "toolCostCategory": "basic",
     },
   },
+  "pod_app_toolset": {},
   "pod_manager": {
     "add_content_node": {
       "freeUsage": true,
@@ -3200,6 +3201,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "create_plan": "never_ask",
     "edit_plan": "never_ask",
   },
+  "pod_app_toolset": {},
   "pod_manager": {
     "add_content_node": "never_ask",
     "add_message_to_conversation": "medium",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -59,6 +59,7 @@ import { OPENAI_USAGE_SERVER } from "@app/lib/api/actions/servers/openai_usage/m
 import { OUTLOOK_CALENDAR_SERVER } from "@app/lib/api/actions/servers/outlook/calendar_metadata";
 import { OUTLOOK_MAIL_SERVER } from "@app/lib/api/actions/servers/outlook/mail_metadata";
 import { PLAN_MODE_SERVER } from "@app/lib/api/actions/servers/plan_mode/metadata";
+import { POD_APP_TOOLSET_SERVER } from "@app/lib/api/actions/servers/pod_app_toolset/metadata";
 import { POD_MANAGER_SERVER } from "@app/lib/api/actions/servers/pod_manager/metadata";
 import { POD_TASKS_SERVER } from "@app/lib/api/actions/servers/pod_tasks/metadata";
 import { POKE_SERVER } from "@app/lib/api/actions/servers/poke/metadata";
@@ -240,6 +241,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "poke",
   "sandbox",
   "sandbox_functions",
+  "pod_app_toolset",
   "ask_user_question",
   "wakeups",
   "plan_mode",
@@ -1104,6 +1106,19 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
     timeoutMs: undefined,
     metadata: SANDBOX_FUNCTIONS_SERVER,
   },
+  pod_app_toolset: {
+    id: 1047,
+    availability: "manual",
+    allowMultipleInstances: true,
+    isPreview: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("sandbox_functions");
+    },
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: POD_APP_TOOLSET_SERVER,
+  },
   user_mentions: {
     id: 1026,
     availability: "auto_hidden_builder",
@@ -1383,6 +1398,7 @@ type DynamicInternalMCPToolNameOverrides = {
   missing_action_catcher: string;
   run_agent: string;
   run_dust_app: string;
+  pod_app_toolset: string;
   search: "find_tags";
 };
 

--- a/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
+++ b/front/lib/actions/mcp_internal_actions/internal_mcp_server_availability.snapshot.json
@@ -86,6 +86,7 @@
     { "name": "clari_copilot", "id": 1030 },
     { "name": "workday", "id": 1038 },
     { "name": "servicenow", "id": 1042 },
-    { "name": "shopify", "id": 1046 }
+    { "name": "shopify", "id": 1046 },
+    { "name": "pod_app_toolset", "id": 1047 }
   ]
 }

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -53,6 +53,7 @@ import { default as openaiUsageServer } from "@app/lib/api/actions/servers/opena
 import { default as outlookCalendarServer } from "@app/lib/api/actions/servers/outlook/calendar_server";
 import { default as outlookMailServer } from "@app/lib/api/actions/servers/outlook/mail_server";
 import { default as planModeServer } from "@app/lib/api/actions/servers/plan_mode";
+import { default as podAppToolsetServer } from "@app/lib/api/actions/servers/pod_app_toolset";
 import { default as podManagerServer } from "@app/lib/api/actions/servers/pod_manager";
 import { default as podTasksServer } from "@app/lib/api/actions/servers/pod_tasks";
 import { default as pokeServer } from "@app/lib/api/actions/servers/poke";
@@ -291,6 +292,8 @@ export async function getInternalMCPServer(
       return sandboxServer(auth, toolContext);
     case "sandbox_functions":
       return sandboxFunctionsServer(auth, toolContext);
+    case "pod_app_toolset":
+      return podAppToolsetServer(auth, mcpServerId, toolContext);
     case "wakeups":
       return wakeupsServer(auth, toolContext);
     case "plan_mode":

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -899,6 +899,7 @@ export function extractMetadataFromTools(tools: Tool[]): MCPToolType[] {
       // TODO: the types are slightly incompatible: we have an unknown as the values of `properties`
       //  whereas JSONSchema expects a JSONSchema7Definition.
       inputSchema: inputSchema as JSONSchema,
+      ...(dustMeta?.stake ? { stake: dustMeta.stake } : {}),
       ...(dustMeta?.displayLabels
         ? { displayLabels: dustMeta.displayLabels }
         : {}),

--- a/front/lib/api/actions/servers/pod_app_toolset/index.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/index.ts
@@ -1,0 +1,57 @@
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { ToolContext } from "@app/lib/actions/types";
+import { isAgentLoopRunContext } from "@app/lib/actions/types";
+import { POD_APP_TOOLSET_SERVER_NAME } from "@app/lib/api/actions/servers/pod_app_toolset/metadata";
+import {
+  callPodAppTool,
+  listPodAppTools,
+} from "@app/lib/api/actions/servers/pod_app_toolset/tools";
+import type { Authenticator } from "@app/lib/auth";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import assert from "assert";
+
+/**
+ * One instance of this server per shared pod app: the instance's sId is bound to a PodAppShare
+ * row, and every published function of the shared app becomes one tool.
+ *
+ * Tools serve their function's stored JSON Schema verbatim, which the zod-based `registerTool`
+ * wrapper cannot express — so this server installs its own low-level list/call handlers. Never
+ * call `registerTool` on it: the SDK forbids mixing the two, and `_meta.dust` is emitted by the
+ * listing handler instead.
+ */
+function createServer(
+  auth: Authenticator,
+  mcpServerId: string,
+  toolContext?: ToolContext
+): McpServer {
+  const server = makeInternalMCPServer(POD_APP_TOOLSET_SERVER_NAME);
+
+  server.server.registerCapabilities({ tools: { listChanged: true } });
+
+  server.server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools: await listPodAppTools(auth, mcpServerId) };
+  });
+
+  server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const runContext = toolContext?.runContext;
+    assert(runContext, "Tool handlers require a tool run context.");
+    const timezone = isAgentLoopRunContext(runContext)
+      ? runContext.userMessage.context.timezone
+      : runContext.invocation.context?.timezone;
+    return callPodAppTool(
+      auth,
+      mcpServerId,
+      request.params.name,
+      request.params.arguments ?? {},
+      timezone === undefined ? undefined : { timezone }
+    );
+  });
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/pod_app_toolset/metadata.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/metadata.ts
@@ -2,9 +2,6 @@ import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_
 
 export const POD_APP_TOOLSET_SERVER_NAME = "pod_app_toolset" as const;
 
-/** Default stake of a shared app's tools; admins can override per tool. */
-export const POD_APP_TOOL_DEFAULT_STAKE = "low" as const;
-
 // Tools are fully dynamic: one tool per published function of the shared pod app bound to each
 // server instance, resolved at listing time from the PodAppShare row. The static list is empty.
 export const POD_APP_TOOLSET_SERVER = {

--- a/front/lib/api/actions/servers/pod_app_toolset/metadata.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/metadata.ts
@@ -1,0 +1,17 @@
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+
+export const POD_APP_TOOLSET_SERVER_NAME = "pod_app_toolset" as const;
+
+// Tools are fully dynamic: one tool per published function of the shared pod app bound to each
+// server instance, resolved at listing time from the PodAppShare row. The static list is empty.
+export const POD_APP_TOOLSET_SERVER = {
+  serverInfo: {
+    name: POD_APP_TOOLSET_SERVER_NAME,
+    version: "1.0.0",
+    description: "Functions from a shared pod app, exposed as agent tools.",
+    icon: "CommandLineIcon",
+    authorization: null,
+    documentationUrl: null,
+  },
+  tools: [],
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/pod_app_toolset/metadata.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/metadata.ts
@@ -2,6 +2,9 @@ import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_
 
 export const POD_APP_TOOLSET_SERVER_NAME = "pod_app_toolset" as const;
 
+/** Default stake of a shared app's tools; admins can override per tool. */
+export const POD_APP_TOOL_DEFAULT_STAKE = "low" as const;
+
 // Tools are fully dynamic: one tool per published function of the shared pod app bound to each
 // server instance, resolved at listing time from the PodAppShare row. The static list is empty.
 export const POD_APP_TOOLSET_SERVER = {

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.test.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.test.ts
@@ -1,0 +1,202 @@
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { listPodAppTools } from "@app/lib/api/actions/servers/pod_app_toolset/tools";
+import { Authenticator } from "@app/lib/auth";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { PodAppShareFactory } from "@app/tests/utils/PodAppShareFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
+import { sandboxFunctionContentType } from "@app/types/files";
+import type { WorkspaceType } from "@app/types/user";
+import assert from "assert";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(
+    async (_lockName: string, callback: () => Promise<unknown>) => callback()
+  ),
+}));
+
+const inputSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    query: { type: "string", description: "What to look for." },
+  },
+  required: ["query"],
+};
+
+const outputSchema: JSONSchema = {
+  type: "object",
+  properties: { items: { type: "array" } },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fileStorageMock.reset();
+});
+
+async function setupSharedApp() {
+  const { authenticator: adminAuth, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const pod = await SpaceFactory.project(workspace);
+
+  const makeFunction = async (
+    slug: string,
+    fileName: string,
+    userIdentity?: SandboxFunctionUserIdentityPolicy
+  ) => {
+    const file = await FileFactory.create(adminAuth, null, {
+      contentType: sandboxFunctionContentType,
+      fileName,
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    return SandboxFunctionResource.makeNew(adminAuth, {
+      space: pod,
+      file,
+      slug,
+      description: `Function ${slug}.`,
+      userIdentity,
+      inputSchema,
+      outputSchema,
+    });
+  };
+
+  const mcpServerId = internalMCPServerNameToSId({
+    name: "pod_app_toolset",
+    workspaceId: workspace.id,
+    prefix: 123456,
+  });
+  const share = await PodAppShareFactory.create(adminAuth, {
+    space: pod,
+    appPrefix: "notes",
+    internalMCPServerId: mcpServerId,
+  });
+
+  const outsider = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, outsider, { role: "user" });
+  const outsiderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    outsider.sId,
+    workspace.sId
+  );
+  assert(outsiderAuth, "Expected an authenticator for the outsider");
+
+  return {
+    adminAuth,
+    workspace,
+    pod,
+    share,
+    mcpServerId,
+    makeFunction,
+    outsiderAuth,
+  };
+}
+
+async function addPodMember(
+  adminAuth: Authenticator,
+  workspace: WorkspaceType,
+  pod: SpaceResource
+) {
+  const member = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, member, { role: "user" });
+  const memberGroupReference = pod.groups.find((group) =>
+    group.isRegularAuto()
+  );
+  assert(memberGroupReference, "Expected a member group on the pod");
+  const [memberGroup] = await pod.fetchGroupResources(adminAuth, {
+    groupReferences: [memberGroupReference],
+  });
+  const addResult = await memberGroup.dangerouslyAddMember(adminAuth, {
+    user: member.toJSON(),
+  });
+  assert(addResult.isOk(), "Expected member group membership to be added");
+  const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    member.sId,
+    workspace.sId
+  );
+  assert(memberAuth, "Expected an authenticator for the pod member");
+  return memberAuth;
+}
+
+describe("pod_app_toolset listPodAppTools", () => {
+  it("lists one tool per published function with the stored JSON Schema verbatim", async () => {
+    const { mcpServerId, makeFunction, outsiderAuth } = await setupSharedApp();
+    await makeFunction("notes__list", "list.ts");
+    await makeFunction("notes__add-note", "add-note.ts");
+    await makeFunction("other__fn", "fn.ts");
+
+    const tools = await listPodAppTools(outsiderAuth, mcpServerId);
+
+    expect(tools.map(({ name }) => name).sort()).toEqual(["add-note", "list"]);
+    const listTool = tools.find(({ name }) => name === "list");
+    expect(listTool?.description).toBe("Function notes__list.");
+    expect(listTool?.inputSchema).toEqual(inputSchema);
+    expect(listTool?._meta).toEqual({
+      dust: {
+        stake: "low",
+        displayLabels: {
+          running: "Calling list...",
+          done: "Called list",
+        },
+      },
+    });
+  });
+
+  it("filters functions whose policy the caller can never satisfy", async () => {
+    const { adminAuth, mcpServerId, makeFunction, outsiderAuth } =
+      await setupSharedApp();
+    await makeFunction("notes__list", "list.ts");
+    await makeFunction(
+      "notes__members-only",
+      "members-only.ts",
+      "pod_member_required"
+    );
+    await makeFunction(
+      "notes__interactive",
+      "interactive.ts",
+      "interactive_workspace_user_required"
+    );
+
+    const outsiderTools = await listPodAppTools(outsiderAuth, mcpServerId);
+    expect(outsiderTools.map(({ name }) => name)).toEqual(["list"]);
+
+    // The workspace admin here is not a pod member either (admin standing is not membership),
+    // so pod_member_required is filtered for them too.
+    const adminTools = await listPodAppTools(adminAuth, mcpServerId);
+    expect(adminTools.map(({ name }) => name)).toEqual(["list"]);
+  });
+
+  it("lists pod_member_required functions for pod members", async () => {
+    const { adminAuth, workspace, pod, mcpServerId, makeFunction } =
+      await setupSharedApp();
+    await makeFunction(
+      "notes__members-only",
+      "members-only.ts",
+      "pod_member_required"
+    );
+
+    const memberAuth = await addPodMember(adminAuth, workspace, pod);
+    const memberTools = await listPodAppTools(memberAuth, mcpServerId);
+    expect(memberTools.map(({ name }) => name)).toEqual(["members-only"]);
+  });
+
+  it("returns no tools for an unknown server id", async () => {
+    const { workspace, outsiderAuth } = await setupSharedApp();
+
+    const unknownServerId = internalMCPServerNameToSId({
+      name: "pod_app_toolset",
+      workspaceId: workspace.id,
+      prefix: 654321,
+    });
+    expect(await listPodAppTools(outsiderAuth, unknownServerId)).toEqual([]);
+  });
+});

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.test.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.test.ts
@@ -1,5 +1,9 @@
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
-import { listPodAppTools } from "@app/lib/api/actions/servers/pod_app_toolset/tools";
+import {
+  callPodAppTool,
+  listPodAppTools,
+} from "@app/lib/api/actions/servers/pod_app_toolset/tools";
+import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -12,6 +16,7 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
+import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -21,6 +26,10 @@ vi.mock("@app/lib/lock", () => ({
   executeWithLock: vi.fn(
     async (_lockName: string, callback: () => Promise<unknown>) => callback()
   ),
+}));
+
+vi.mock("@app/lib/api/sandbox_functions/call_sandbox_function", () => ({
+  callSandboxFunction: vi.fn(),
 }));
 
 const inputSchema: JSONSchema = {
@@ -198,5 +207,76 @@ describe("pod_app_toolset listPodAppTools", () => {
       prefix: 654321,
     });
     expect(await listPodAppTools(outsiderAuth, unknownServerId)).toEqual([]);
+  });
+});
+
+describe("pod_app_toolset callPodAppTool", () => {
+  it("resolves the function through the share and returns its result", async () => {
+    const { mcpServerId, makeFunction, outsiderAuth } = await setupSharedApp();
+    await makeFunction("notes__list", "list.ts");
+    vi.mocked(callSandboxFunction).mockResolvedValue(new Ok({ items: [1, 2] }));
+
+    const result = await callPodAppTool(
+      outsiderAuth,
+      mcpServerId,
+      "list",
+      { query: "x" },
+      { timezone: "Europe/Paris" }
+    );
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify({ items: [1, 2] }, null, 2) },
+    ]);
+    expect(vi.mocked(callSandboxFunction)).toHaveBeenCalledWith(
+      outsiderAuth,
+      expect.objectContaining({ slug: "notes__list" }),
+      { query: "x" },
+      { timezone: "Europe/Paris" }
+    );
+  });
+
+  it("reports an unknown tool name as an error result", async () => {
+    const { mcpServerId, outsiderAuth } = await setupSharedApp();
+
+    const result = await callPodAppTool(outsiderAuth, mcpServerId, "nope", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: 'No function "nope" in this toolset.' },
+    ]);
+    expect(vi.mocked(callSandboxFunction)).not.toHaveBeenCalled();
+  });
+
+  it("reports a revoked share as an error result", async () => {
+    const { adminAuth, share, mcpServerId, makeFunction, outsiderAuth } =
+      await setupSharedApp();
+    await makeFunction("notes__list", "list.ts");
+    await share.revoke(adminAuth);
+
+    const result = await callPodAppTool(outsiderAuth, mcpServerId, "list", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      { type: "text", text: "No shared app is bound to this toolset anymore." },
+    ]);
+  });
+
+  it("surfaces function errors with their code and message", async () => {
+    const { mcpServerId, makeFunction, outsiderAuth } = await setupSharedApp();
+    await makeFunction("notes__list", "list.ts");
+    vi.mocked(callSandboxFunction).mockResolvedValue(
+      new Err({ code: "invocation_failed", message: "boom" })
+    );
+
+    const result = await callPodAppTool(outsiderAuth, mcpServerId, "list", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: 'Function "list" returned an error (invocation_failed): boom',
+      },
+    ]);
   });
 });

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.test.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.test.ts
@@ -14,7 +14,10 @@ import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { PodAppShareFactory } from "@app/tests/utils/PodAppShareFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import type { SandboxFunctionUserIdentityPolicy } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionStake,
+  SandboxFunctionUserIdentityPolicy,
+} from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import type { WorkspaceType } from "@app/types/user";
@@ -59,7 +62,8 @@ async function setupSharedApp() {
   const makeFunction = async (
     slug: string,
     fileName: string,
-    userIdentity?: SandboxFunctionUserIdentityPolicy
+    userIdentity?: SandboxFunctionUserIdentityPolicy,
+    defaultStake?: SandboxFunctionStake
   ) => {
     const file = await FileFactory.create(adminAuth, null, {
       contentType: sandboxFunctionContentType,
@@ -75,6 +79,7 @@ async function setupSharedApp() {
       slug,
       description: `Function ${slug}.`,
       userIdentity,
+      defaultStake,
       inputSchema,
       outputSchema,
     });
@@ -196,6 +201,20 @@ describe("pod_app_toolset listPodAppTools", () => {
     const memberAuth = await addPodMember(adminAuth, workspace, pod);
     const memberTools = await listPodAppTools(memberAuth, mcpServerId);
     expect(memberTools.map(({ name }) => name)).toEqual(["members-only"]);
+  });
+
+  it("lists each tool with its function's declared default stake", async () => {
+    const { mcpServerId, makeFunction, outsiderAuth } = await setupSharedApp();
+    await makeFunction("notes__list", "list.ts");
+    await makeFunction("notes__wipe", "wipe.ts", undefined, "high");
+
+    const tools = await listPodAppTools(outsiderAuth, mcpServerId);
+
+    const stakeByName = new Map(
+      tools.map((tool) => [tool.name, tool._meta?.dust])
+    );
+    expect(stakeByName.get("list")).toMatchObject({ stake: "low" });
+    expect(stakeByName.get("wipe")).toMatchObject({ stake: "high" });
   });
 
   it("returns no tools for an unknown server id", async () => {

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.test.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.test.ts
@@ -87,7 +87,7 @@ async function setupSharedApp() {
   });
   const share = await PodAppShareFactory.create(adminAuth, {
     space: pod,
-    appPrefix: "notes",
+    appName: "notes",
     internalMCPServerId: mcpServerId,
   });
 

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.ts
@@ -1,4 +1,3 @@
-import { POD_APP_TOOL_DEFAULT_STAKE } from "@app/lib/api/actions/servers/pod_app_toolset/metadata";
 import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
 import {
   SANDBOX_FUNCTION_SLUG_SEPARATOR,
@@ -96,7 +95,7 @@ export async function listPodAppTools(
         inputSchema: asToolInputSchema(sandboxFunction.inputSchema),
         _meta: {
           dust: {
-            stake: POD_APP_TOOL_DEFAULT_STAKE,
+            stake: sandboxFunction.defaultStake,
             displayLabels: {
               running: `Calling ${name}...`,
               done: `Called ${name}`,

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.ts
@@ -1,4 +1,8 @@
-import { sandboxFunctionNameFromSlug } from "@app/lib/api/sandbox_functions/slug";
+import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
+import {
+  SANDBOX_FUNCTION_SLUG_SEPARATOR,
+  sandboxFunctionNameFromSlug,
+} from "@app/lib/api/sandbox_functions/slug";
 import type { Authenticator } from "@app/lib/auth";
 import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -102,6 +106,10 @@ export async function listPodAppTools(
     });
 }
 
+function errorResult(text: string): CallToolResult {
+  return { content: [{ type: "text", text }], isError: true };
+}
+
 export async function callPodAppTool(
   auth: Authenticator,
   mcpServerId: string,
@@ -109,6 +117,38 @@ export async function callPodAppTool(
   args: Record<string, unknown>,
   context?: SandboxFunctionInvocationContext
 ): Promise<CallToolResult> {
-  // Implemented in the next task.
-  throw new Error("Not implemented");
+  const resolved = await resolveShare(auth, mcpServerId);
+  if (!resolved) {
+    return errorResult("No shared app is bound to this toolset anymore.");
+  }
+  const { share } = resolved;
+
+  const slug = `${share.appPrefix}${SANDBOX_FUNCTION_SLUG_SEPARATOR}${toolName}`;
+  const sandboxFunction =
+    await SandboxFunctionResource.fetchBySlugWithPodAppShare(auth, share, slug);
+  if (!sandboxFunction) {
+    return errorResult(`No function "${toolName}" in this toolset.`);
+  }
+
+  const result = await callSandboxFunction(
+    auth,
+    sandboxFunction,
+    args,
+    context
+  );
+  if (result.isErr()) {
+    const { code, message } = result.error;
+    return errorResult(
+      `Function "${toolName}" returned an error (${code}): ${message}`
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(result.value, null, 2) ?? "null",
+      },
+    ],
+  };
 }

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.ts
@@ -1,0 +1,114 @@
+import { sandboxFunctionNameFromSlug } from "@app/lib/api/sandbox_functions/slug";
+import type { Authenticator } from "@app/lib/auth";
+import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type {
+  SandboxFunctionInvocationContext,
+  SandboxFunctionUserIdentityPolicy,
+} from "@app/types/api/sandbox_functions";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
+import { ToolSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+
+async function resolveShare(
+  auth: Authenticator,
+  mcpServerId: string
+): Promise<{ share: PodAppShareResource; space: SpaceResource } | null> {
+  const share = await PodAppShareResource.fetchByInternalMCPServerId(
+    auth,
+    mcpServerId
+  );
+  if (!share) {
+    return null;
+  }
+  return { share, space: share.space };
+}
+
+/**
+ * Whether the current caller can ever satisfy a function's userIdentity policy from the agent
+ * loop. A courtesy filter for listing only — the policy itself is re-checked at invocation.
+ */
+function isCallableFromAgentLoop(
+  userIdentity: SandboxFunctionUserIdentityPolicy,
+  isPodMember: boolean
+): boolean {
+  switch (userIdentity) {
+    case "optional":
+    case "workspace_user_required":
+      return true;
+    // Agent-loop invocations are never interactive sessions.
+    case "interactive_workspace_user_required":
+      return false;
+    case "pod_member_required":
+      return isPodMember;
+    default:
+      // Retired or unknown policies deny, matching authorizeSandboxFunctionInvocation.
+      assertNeverAndIgnore(userIdentity);
+      return false;
+  }
+}
+
+/**
+ * The stored JSON Schema, narrowed to the MCP wire shape. Published functions always carry an
+ * object-typed input schema (publish extracts it from the author's zod object); the SDK schema
+ * validates that invariant rather than a cast assuming it.
+ */
+function asToolInputSchema(schema: JSONSchema): Tool["inputSchema"] {
+  return ToolSchema.shape.inputSchema.parse(schema);
+}
+
+export async function listPodAppTools(
+  auth: Authenticator,
+  mcpServerId: string
+): Promise<Tool[]> {
+  const resolved = await resolveShare(auth, mcpServerId);
+  if (!resolved) {
+    return [];
+  }
+  const { share, space } = resolved;
+
+  const sandboxFunctions = await SandboxFunctionResource.listByPodAppShare(
+    auth,
+    share
+  );
+  const isPodMember = space.isMember(auth);
+
+  return sandboxFunctions
+    .filter((sandboxFunction) =>
+      // A null stored policy means "optional", matching authorizeSandboxFunctionInvocation.
+      isCallableFromAgentLoop(
+        sandboxFunction.userIdentity ?? "optional",
+        isPodMember
+      )
+    )
+    .map((sandboxFunction) => {
+      const name = sandboxFunctionNameFromSlug(sandboxFunction.slug);
+      return {
+        name,
+        description: sandboxFunction.description,
+        inputSchema: asToolInputSchema(sandboxFunction.inputSchema),
+        _meta: {
+          dust: {
+            stake: "low",
+            displayLabels: {
+              running: `Calling ${name}...`,
+              done: `Called ${name}`,
+            },
+          },
+        },
+      };
+    });
+}
+
+export async function callPodAppTool(
+  auth: Authenticator,
+  mcpServerId: string,
+  toolName: string,
+  args: Record<string, unknown>,
+  context?: SandboxFunctionInvocationContext
+): Promise<CallToolResult> {
+  // Implemented in the next task.
+  throw new Error("Not implemented");
+}

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.ts
@@ -1,3 +1,4 @@
+import { POD_APP_TOOL_DEFAULT_STAKE } from "@app/lib/api/actions/servers/pod_app_toolset/metadata";
 import { callSandboxFunction } from "@app/lib/api/sandbox_functions/call_sandbox_function";
 import {
   SANDBOX_FUNCTION_SLUG_SEPARATOR,
@@ -95,7 +96,7 @@ export async function listPodAppTools(
         inputSchema: asToolInputSchema(sandboxFunction.inputSchema),
         _meta: {
           dust: {
-            stake: "low",
+            stake: POD_APP_TOOL_DEFAULT_STAKE,
             displayLabels: {
               running: `Calling ${name}...`,
               done: `Called ${name}`,

--- a/front/lib/api/actions/servers/pod_app_toolset/tools.ts
+++ b/front/lib/api/actions/servers/pod_app_toolset/tools.ts
@@ -123,7 +123,7 @@ export async function callPodAppTool(
   }
   const { share } = resolved;
 
-  const slug = `${share.appPrefix}${SANDBOX_FUNCTION_SLUG_SEPARATOR}${toolName}`;
+  const slug = `${share.appName}${SANDBOX_FUNCTION_SLUG_SEPARATOR}${toolName}`;
   const sandboxFunction =
     await SandboxFunctionResource.fetchBySlugWithPodAppShare(auth, share, slug);
   if (!sandboxFunction) {

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -74,6 +74,10 @@ export type MCPToolType = {
   name: string;
   description: string;
   inputSchema?: JSONSchema;
+  // The stake the tool declares for itself (via `_meta.dust`). Used as the default when no
+  // admin override exists — the only stake channel for dynamically-listed internal tools,
+  // which have no static registry entry to carry it.
+  stake?: MCPToolStakeLevelType;
   // Optional for remote MCP servers (external sources may not have this).
   // Mandatory for internal MCP servers (enforced via ServerMetadata type).
   displayLabels?: ToolDisplayLabels;

--- a/front/lib/api/projects/app_shares.test.ts
+++ b/front/lib/api/projects/app_shares.test.ts
@@ -1,0 +1,269 @@
+import {
+  sharePodApp,
+  unsharePodApp,
+  updatePodAppShare,
+} from "@app/lib/api/projects/app_shares";
+import { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { sandboxFunctionContentType } from "@app/types/files";
+import assert from "assert";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(
+    async (_lockName: string, callback: () => Promise<unknown>) => callback()
+  ),
+}));
+
+const EMPTY_SCHEMA: JSONSchema = { type: "object", properties: {} };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fileStorageMock.reset();
+});
+
+async function setup() {
+  const { workspace, user } = await createResourceTest({ role: "admin" });
+  const pod = await SpaceFactory.project(workspace, user.id);
+  // Rebuild the authenticator after pod creation so it carries the editor group membership.
+  const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  assert(editorAuth, "Expected an authenticator for the pod editor");
+
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+
+  const publishFunction = async (pod: SpaceResource, slug: string) => {
+    const file = await FileFactory.create(editorAuth, null, {
+      contentType: sandboxFunctionContentType,
+      fileName: `${slug}.ts`,
+      fileSize: 100,
+      status: "created",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: pod.sId },
+    });
+    return SandboxFunctionResource.makeNew(editorAuth, {
+      space: pod,
+      file,
+      slug,
+      description: `Function ${slug}.`,
+      inputSchema: EMPTY_SCHEMA,
+      outputSchema: EMPTY_SCHEMA,
+    });
+  };
+
+  return { workspace, pod, editorAuth, adminAuth, publishFunction };
+}
+
+describe("sharePodApp", () => {
+  it("creates the share row and the system + global views", async () => {
+    const { pod, editorAuth, adminAuth, publishFunction } = await setup();
+    await publishFunction(pod, "tasklist__add-task");
+
+    const result = await sharePodApp(editorAuth, pod, {
+      prefix: "tasklist",
+      name: "Task List",
+      description: "Task management tools.",
+    });
+
+    assert(result.isOk(), "Expected sharePodApp to succeed");
+    expect(result.value).toEqual({
+      appPrefix: "tasklist",
+      toolsetName: "Task List",
+      description: "Task management tools.",
+    });
+
+    const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+      editorAuth,
+      pod,
+      "tasklist"
+    );
+    assert(share, "Expected a share row");
+    expect(share.toolsetName).toBe("Task List");
+
+    const views = await MCPServerViewResource.listByMCPServer(
+      adminAuth,
+      share.internalMCPServerId
+    );
+    expect(views.map((view) => view.space.kind).sort()).toEqual([
+      "global",
+      "system",
+    ]);
+    for (const view of views) {
+      expect(view.name).toBe("Task List");
+      expect(view.description).toBe("Task management tools.");
+    }
+  });
+
+  it("rejects an app with no published functions", async () => {
+    const { pod, editorAuth } = await setup();
+
+    const result = await sharePodApp(editorAuth, pod, {
+      prefix: "tasklist",
+      description: "Task management tools.",
+    });
+
+    assert(result.isErr(), "Expected sharePodApp to fail");
+    expect(result.error.code).toBe("no_functions");
+  });
+
+  it("rejects sharing the same app twice", async () => {
+    const { pod, editorAuth, publishFunction } = await setup();
+    await publishFunction(pod, "tasklist__add-task");
+
+    const first = await sharePodApp(editorAuth, pod, {
+      prefix: "tasklist",
+      description: "Task management tools.",
+    });
+    expect(first.isOk()).toBe(true);
+
+    const second = await sharePodApp(editorAuth, pod, {
+      prefix: "tasklist",
+      description: "Task management tools.",
+    });
+    assert(second.isErr(), "Expected the second share to fail");
+    expect(second.error.code).toBe("already_shared");
+  });
+
+  it("rejects a toolset name already used in the workspace", async () => {
+    const { workspace, pod, editorAuth, publishFunction } = await setup();
+    await publishFunction(pod, "tasklist__add-task");
+
+    const otherPod = await SpaceFactory.project(
+      workspace,
+      editorAuth.getNonNullableUser().id
+    );
+    const otherEditorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      editorAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+    assert(otherEditorAuth, "Expected an authenticator");
+    await publishFunction(otherPod, "notes__list");
+
+    const first = await sharePodApp(editorAuth, pod, {
+      prefix: "tasklist",
+      name: "Shared Tools",
+      description: "Task management tools.",
+    });
+    expect(first.isOk()).toBe(true);
+
+    const second = await sharePodApp(otherEditorAuth, otherPod, {
+      prefix: "notes",
+      name: "Shared Tools",
+      description: "Note tools.",
+    });
+    assert(second.isErr(), "Expected the name conflict to fail");
+    expect(second.error.code).toBe("name_taken");
+  });
+});
+
+describe("unsharePodApp", () => {
+  it("soft-deletes the share row and both views", async () => {
+    const { pod, editorAuth, adminAuth, publishFunction } = await setup();
+    await publishFunction(pod, "tasklist__add-task");
+    const shared = await sharePodApp(editorAuth, pod, {
+      prefix: "tasklist",
+      description: "Task management tools.",
+    });
+    expect(shared.isOk()).toBe(true);
+    const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+      editorAuth,
+      pod,
+      "tasklist"
+    );
+    assert(share, "Expected a share row");
+
+    const result = await unsharePodApp(editorAuth, pod, "tasklist");
+    expect(result.isOk()).toBe(true);
+
+    expect(
+      await PodAppShareResource.fetchByPodAndAppPrefix(
+        editorAuth,
+        pod,
+        "tasklist"
+      )
+    ).toBeNull();
+    expect(
+      await MCPServerViewResource.listByMCPServer(
+        adminAuth,
+        share.internalMCPServerId
+      )
+    ).toEqual([]);
+  });
+
+  it("reports an unshared app", async () => {
+    const { pod, editorAuth } = await setup();
+
+    const result = await unsharePodApp(editorAuth, pod, "tasklist");
+    assert(result.isErr(), "Expected unshare to fail");
+    expect(result.error.code).toBe("not_shared");
+  });
+});
+
+describe("updatePodAppShare", () => {
+  it("updates the name and description on the row and both views", async () => {
+    const { pod, editorAuth, adminAuth, publishFunction } = await setup();
+    await publishFunction(pod, "tasklist__add-task");
+    const shared = await sharePodApp(editorAuth, pod, {
+      prefix: "tasklist",
+      name: "Task List",
+      description: "Task management tools.",
+    });
+    expect(shared.isOk()).toBe(true);
+
+    const result = await updatePodAppShare(editorAuth, pod, "tasklist", {
+      name: "Better Tasks",
+      description: "Improved.",
+    });
+    assert(result.isOk(), "Expected update to succeed");
+    expect(result.value).toEqual({
+      appPrefix: "tasklist",
+      toolsetName: "Better Tasks",
+      description: "Improved.",
+    });
+
+    const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+      editorAuth,
+      pod,
+      "tasklist"
+    );
+    assert(share, "Expected a share row");
+    const views = await MCPServerViewResource.listByMCPServer(
+      adminAuth,
+      share.internalMCPServerId
+    );
+    expect(views).toHaveLength(2);
+    for (const view of views) {
+      expect(view.name).toBe("Better Tasks");
+      expect(view.description).toBe("Improved.");
+    }
+  });
+
+  it("keeping the same name is not a conflict", async () => {
+    const { pod, editorAuth, publishFunction } = await setup();
+    await publishFunction(pod, "tasklist__add-task");
+    const shared = await sharePodApp(editorAuth, pod, {
+      prefix: "tasklist",
+      name: "Task List",
+      description: "Task management tools.",
+    });
+    expect(shared.isOk()).toBe(true);
+
+    const result = await updatePodAppShare(editorAuth, pod, "tasklist", {
+      name: "Task List",
+      description: "Same name, new description.",
+    });
+    expect(result.isOk()).toBe(true);
+  });
+});

--- a/front/lib/api/projects/app_shares.test.ts
+++ b/front/lib/api/projects/app_shares.test.ts
@@ -79,12 +79,12 @@ describe("sharePodApp", () => {
 
     assert(result.isOk(), "Expected sharePodApp to succeed");
     expect(result.value).toEqual({
-      appPrefix: "tasklist",
+      appName: "tasklist",
       toolsetName: "Task List",
       description: "Task management tools.",
     });
 
-    const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+    const share = await PodAppShareResource.fetchByPodAndAppName(
       editorAuth,
       pod,
       "tasklist"
@@ -177,7 +177,7 @@ describe("unsharePodApp", () => {
       description: "Task management tools.",
     });
     expect(shared.isOk()).toBe(true);
-    const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+    const share = await PodAppShareResource.fetchByPodAndAppName(
       editorAuth,
       pod,
       "tasklist"
@@ -188,7 +188,7 @@ describe("unsharePodApp", () => {
     expect(result.isOk()).toBe(true);
 
     expect(
-      await PodAppShareResource.fetchByPodAndAppPrefix(
+      await PodAppShareResource.fetchByPodAndAppName(
         editorAuth,
         pod,
         "tasklist"
@@ -228,12 +228,12 @@ describe("updatePodAppShare", () => {
     });
     assert(result.isOk(), "Expected update to succeed");
     expect(result.value).toEqual({
-      appPrefix: "tasklist",
+      appName: "tasklist",
       toolsetName: "Better Tasks",
       description: "Improved.",
     });
 
-    const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+    const share = await PodAppShareResource.fetchByPodAndAppName(
       editorAuth,
       pod,
       "tasklist"

--- a/front/lib/api/projects/app_shares.test.ts
+++ b/front/lib/api/projects/app_shares.test.ts
@@ -4,6 +4,7 @@ import {
   updatePodAppShare,
 } from "@app/lib/api/projects/app_shares";
 import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
@@ -104,6 +105,29 @@ describe("sharePodApp", () => {
       expect(view.name).toBe("Task List");
       expect(view.description).toBe("Task management tools.");
     }
+
+    // The server instance itself carries the toolset identity and the live tool list, so admin
+    // and picker surfaces render the real name and per-tool settings.
+    const instance = await InternalMCPServerInMemoryResource.fetchById(
+      adminAuth,
+      share.internalMCPServerId
+    );
+    assert(instance, "Expected the server instance to resolve");
+    const serverJSON = instance.toJSON();
+    expect(serverJSON.name).toBe("Task List");
+    expect(serverJSON.description).toBe("Task management tools.");
+    expect(serverJSON.tools).toEqual([
+      {
+        name: "add-task",
+        description: "Function tasklist__add-task.",
+        inputSchema: EMPTY_SCHEMA,
+        stake: "low",
+        displayLabels: {
+          running: "Calling add-task...",
+          done: "Called add-task",
+        },
+      },
+    ]);
   });
 
   it("rejects an app with no published functions", async () => {

--- a/front/lib/api/projects/app_shares.ts
+++ b/front/lib/api/projects/app_shares.ts
@@ -1,0 +1,288 @@
+import { appPrefixFromSlug } from "@app/lib/api/sandbox_functions/slug";
+import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { PodAppShareSummary } from "@app/types/api/pod_apps";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+export type PodAppShareErrorCode =
+  | "not_a_pod"
+  | "not_found"
+  | "no_functions"
+  | "name_taken"
+  | "already_shared"
+  | "not_shared"
+  | "internal";
+
+export class PodAppShareError extends Error {
+  constructor(
+    readonly code: PodAppShareErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "PodAppShareError";
+  }
+}
+
+/**
+ * View and server-instance mutations are admin-gated at the resource layer, while sharing is a
+ * pod editor's gesture: the caller's editorship is checked here (and by the route's withSpace),
+ * then the workspace-level artifacts are created under an internal admin authenticator.
+ */
+async function internalAdminAuth(auth: Authenticator): Promise<Authenticator> {
+  return Authenticator.internalAdminForWorkspace(
+    auth.getNonNullableWorkspace().sId
+  );
+}
+
+function toSummary(share: PodAppShareResource): PodAppShareSummary {
+  return {
+    appPrefix: share.appPrefix,
+    toolsetName: share.toolsetName,
+    description: share.description,
+  };
+}
+
+/**
+ * Share a pod app to the workspace as an agent toolset: mint a pod_app_toolset server instance,
+ * create its system + global views, and record the binding. Not one DB transaction — the
+ * instance/view APIs are not transactional — so the share row comes last and a failure cleans
+ * the views up for a clean retry.
+ */
+export async function sharePodApp(
+  auth: Authenticator,
+  pod: SpaceResource,
+  {
+    prefix,
+    name,
+    description,
+  }: { prefix: string; name?: string; description: string }
+): Promise<Result<PodAppShareSummary, PodAppShareError>> {
+  if (!pod.isProject()) {
+    return new Err(new PodAppShareError("not_a_pod", "Not a pod."));
+  }
+  if (!pod.canAdministrate(auth)) {
+    return new Err(
+      new PodAppShareError("not_found", `No app "${prefix}" in this pod.`)
+    );
+  }
+
+  const existing = await PodAppShareResource.fetchByPodAndAppPrefix(
+    auth,
+    pod,
+    prefix
+  );
+  if (existing) {
+    return new Err(
+      new PodAppShareError("already_shared", "This app is already shared.")
+    );
+  }
+
+  const sandboxFunctions = await SandboxFunctionResource.listBySpace(auth, pod);
+  const appFunctions = sandboxFunctions.filter(
+    (sandboxFunction) => appPrefixFromSlug(sandboxFunction.slug) === prefix
+  );
+  if (appFunctions.length === 0) {
+    return new Err(
+      new PodAppShareError(
+        "no_functions",
+        "This app has no published functions to share."
+      )
+    );
+  }
+
+  const toolsetName = name ?? prefix;
+  const adminAuth = await internalAdminAuth(auth);
+  const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(adminAuth);
+  const { hasConflict } =
+    await MCPServerViewResource.hasNameConflictInSpaceByName(
+      adminAuth,
+      toolsetName,
+      globalSpace
+    );
+  if (hasConflict) {
+    return new Err(
+      new PodAppShareError(
+        "name_taken",
+        `A tool named "${toolsetName}" already exists in this workspace.`
+      )
+    );
+  }
+
+  const server = await InternalMCPServerInMemoryResource.makeNew(adminAuth, {
+    name: "pod_app_toolset",
+    useCase: null,
+    viewName: toolsetName,
+    viewDescription: description,
+  });
+
+  try {
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        adminAuth,
+        server.id
+      );
+    if (!systemView) {
+      throw new Error("Missing system view after server creation.");
+    }
+    await MCPServerViewResource.create(adminAuth, {
+      systemView,
+      space: globalSpace,
+    });
+
+    const share = await PodAppShareResource.makeNew(auth, {
+      space: pod,
+      appPrefix: prefix,
+      internalMCPServerId: server.id,
+      toolsetName,
+      description,
+    });
+
+    return new Ok(toSummary(share));
+  } catch (error) {
+    // Best-effort cleanup: without the share row the views are orphans; remove them so a retry
+    // can start clean.
+    const views = await MCPServerViewResource.listByMCPServer(
+      adminAuth,
+      server.id
+    );
+    for (const view of views) {
+      await view.delete(adminAuth, { hardDelete: true });
+    }
+    logger.error(
+      { error: normalizeError(error), podId: pod.sId, prefix },
+      "Failed to create pod app share; cleaned up views."
+    );
+    return new Err(
+      new PodAppShareError("internal", normalizeError(error).message)
+    );
+  }
+}
+
+export async function unsharePodApp(
+  auth: Authenticator,
+  pod: SpaceResource,
+  prefix: string
+): Promise<Result<undefined, PodAppShareError>> {
+  const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+    auth,
+    pod,
+    prefix
+  );
+  if (!share) {
+    return new Err(
+      new PodAppShareError("not_shared", "This app is not shared.")
+    );
+  }
+  if (!pod.canAdministrate(auth)) {
+    return new Err(
+      new PodAppShareError("not_found", `No app "${prefix}" in this pod.`)
+    );
+  }
+
+  const adminAuth = await internalAdminAuth(auth);
+  const views = await MCPServerViewResource.listByMCPServer(
+    adminAuth,
+    share.internalMCPServerId
+  );
+  for (const view of views) {
+    await view.delete(adminAuth, { hardDelete: false });
+  }
+  await share.revoke(auth);
+
+  return new Ok(undefined);
+}
+
+export async function updatePodAppShare(
+  auth: Authenticator,
+  pod: SpaceResource,
+  prefix: string,
+  { name, description }: { name?: string; description?: string }
+): Promise<Result<PodAppShareSummary, PodAppShareError>> {
+  const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+    auth,
+    pod,
+    prefix
+  );
+  if (!share) {
+    return new Err(
+      new PodAppShareError("not_shared", "This app is not shared.")
+    );
+  }
+  if (!pod.canAdministrate(auth)) {
+    return new Err(
+      new PodAppShareError("not_found", `No app "${prefix}" in this pod.`)
+    );
+  }
+
+  const adminAuth = await internalAdminAuth(auth);
+  const views = await MCPServerViewResource.listByMCPServer(
+    adminAuth,
+    share.internalMCPServerId
+  );
+
+  if (name && name !== share.toolsetName) {
+    const globalSpace =
+      await SpaceResource.fetchWorkspaceGlobalSpace(adminAuth);
+    const globalView = views.find((view) => view.space.kind === "global");
+    const { hasConflict } =
+      await MCPServerViewResource.hasNameConflictInSpaceByName(
+        adminAuth,
+        name,
+        globalSpace,
+        [],
+        { excludedMCPServerViewId: globalView?.sId }
+      );
+    if (hasConflict) {
+      return new Err(
+        new PodAppShareError(
+          "name_taken",
+          `A tool named "${name}" already exists in this workspace.`
+        )
+      );
+    }
+  }
+
+  for (const view of views) {
+    const updateResult = await view.updateNameAndDescription(
+      adminAuth,
+      name,
+      description
+    );
+    if (updateResult.isErr()) {
+      return new Err(
+        new PodAppShareError("internal", updateResult.error.message)
+      );
+    }
+  }
+  await share.updateShareDetails({ toolsetName: name, description });
+
+  return new Ok(toSummary(share));
+}
+
+/**
+ * Scrub-time cleanup, called when a pod is deleted: hard-delete every share row of the pod and
+ * the server views bound to them.
+ */
+export async function scrubPodAppSharesForSpace(
+  auth: Authenticator,
+  space: SpaceResource
+): Promise<void> {
+  const shares = await PodAppShareResource.deleteAllForSpace(auth, space);
+  // O(n) view fetches acceptable: a pod holds a handful of shared apps at most.
+  for (const share of shares) {
+    const views = await MCPServerViewResource.listByMCPServer(
+      auth,
+      share.internalMCPServerId
+    );
+    for (const view of views) {
+      await view.delete(auth, { hardDelete: true });
+    }
+  }
+}

--- a/front/lib/api/projects/app_shares.ts
+++ b/front/lib/api/projects/app_shares.ts
@@ -65,7 +65,7 @@ export async function sharePodApp(
     );
   }
 
-  const existing = await PodAppShareResource.fetchByPodAndAppPrefix(
+  const existing = await PodAppShareResource.fetchByPodAndAppName(
     auth,
     pod,
     prefix
@@ -130,7 +130,7 @@ export async function sharePodApp(
 
     const share = await PodAppShareResource.makeNew(auth, {
       space: pod,
-      appPrefix: prefix,
+      appName: prefix,
       internalMCPServerId: server.id,
       toolsetName,
       description,
@@ -162,7 +162,7 @@ export async function unsharePodApp(
   pod: SpaceResource,
   prefix: string
 ): Promise<Result<undefined, PodAppShareError>> {
-  const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+  const share = await PodAppShareResource.fetchByPodAndAppName(
     auth,
     pod,
     prefix
@@ -197,7 +197,7 @@ export async function updatePodAppShare(
   prefix: string,
   { name, description }: { name?: string; description?: string }
 ): Promise<Result<PodAppShareSummary, PodAppShareError>> {
-  const share = await PodAppShareResource.fetchByPodAndAppPrefix(
+  const share = await PodAppShareResource.fetchByPodAndAppName(
     auth,
     pod,
     prefix

--- a/front/lib/api/projects/app_shares.ts
+++ b/front/lib/api/projects/app_shares.ts
@@ -41,14 +41,6 @@ async function internalAdminAuth(auth: Authenticator): Promise<Authenticator> {
   );
 }
 
-function toSummary(share: PodAppShareResource): PodAppShareSummary {
-  return {
-    appPrefix: share.appPrefix,
-    toolsetName: share.toolsetName,
-    description: share.description,
-  };
-}
-
 /**
  * Share a pod app to the workspace as an agent toolset: mint a pod_app_toolset server instance,
  * create its system + global views, and record the binding. Not one DB transaction — the
@@ -144,7 +136,7 @@ export async function sharePodApp(
       description,
     });
 
-    return new Ok(toSummary(share));
+    return new Ok(share.toJSON());
   } catch (error) {
     // Best-effort cleanup: without the share row the views are orphans; remove them so a retry
     // can start clean.
@@ -263,7 +255,7 @@ export async function updatePodAppShare(
   }
   await share.updateShareDetails({ toolsetName: name, description });
 
-  return new Ok(toSummary(share));
+  return new Ok(share.toJSON());
 }
 
 /**

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -356,9 +356,7 @@ export async function listPodApps(
       PodAppShareResource.listBySpace(auth, pod),
     ]);
 
-  const shareByPrefix = new Map(
-    shares.map((share) => [share.appPrefix, share])
-  );
+  const shareByPrefix = new Map(shares.map((share) => [share.appName, share]));
 
   const functionsByPrefix = groupFunctionsByAppPrefix(sandboxFunctions);
   const pinnedFramePaths = new Set(

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -21,6 +21,7 @@ import { unpublishSandboxFunction } from "@app/lib/api/sandbox_functions/unpubli
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { FileResource } from "@app/lib/resources/file_resource";
+import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
@@ -347,11 +348,17 @@ export async function listPodApps(
     return new Err(listResult.error);
   }
 
-  const [sandboxFunctions, databaseOnDiskNames, metadata] = await Promise.all([
-    SandboxFunctionResource.listBySpace(auth, pod),
-    listPodDatabaseOnDiskNames(auth, pod),
-    ProjectMetadataResource.fetchBySpace(auth, pod),
-  ]);
+  const [sandboxFunctions, databaseOnDiskNames, metadata, shares] =
+    await Promise.all([
+      SandboxFunctionResource.listBySpace(auth, pod),
+      listPodDatabaseOnDiskNames(auth, pod),
+      ProjectMetadataResource.fetchBySpace(auth, pod),
+      PodAppShareResource.listBySpace(auth, pod),
+    ]);
+
+  const shareByPrefix = new Map(
+    shares.map((share) => [share.appPrefix, share])
+  );
 
   const functionsByPrefix = groupFunctionsByAppPrefix(sandboxFunctions);
   const pinnedFramePaths = new Set(
@@ -425,6 +432,7 @@ export async function listPodApps(
       ),
       collidingFolderNames:
         prefixFolders.length > 1 ? prefixFolders.map((f) => f.name) : [],
+      share: shareByPrefix.get(prefix)?.toJSON() ?? null,
     });
   }
 

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -1,5 +1,6 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { getFileContent } from "@app/lib/api/files/utils";
+import { unsharePodApp } from "@app/lib/api/projects/app_shares";
 import { deleteProjectFile } from "@app/lib/api/projects/context";
 import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import {
@@ -558,6 +559,15 @@ export async function deletePodApp(
         await metadata.removeFramePath(frame.path);
       }
     }
+  }
+
+  // 5bis. Revoke the app's workspace share (toolset views + share row) before the folder goes.
+  // Idempotent and retry-safe, like every step before the folder delete.
+  const unshareResult = await unsharePodApp(auth, pod, prefix);
+  if (unshareResult.isErr() && unshareResult.error.code !== "not_shared") {
+    return new Err(
+      new PodAppDeleteError("internal", unshareResult.error.message)
+    );
   }
 
   // 6. Source folder last. `deleteProjectFile` recurses and deletes each FileResource underneath,

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -115,11 +115,13 @@ export class InternalMCPServerInMemoryResource {
       name,
       useCase,
       viewName,
+      viewDescription,
       oauthScope,
     }: {
       name: InternalMCPServerNameType;
       useCase: MCPOAuthUseCase | null;
       viewName?: string;
+      viewDescription?: string;
       oauthScope?: string | null;
     }
   ) {
@@ -237,6 +239,7 @@ export class InternalMCPServerInMemoryResource {
       oauthScope: oauthScope ?? null,
       isRestrictedToSkills: false,
       ...(viewName ? { name: viewName } : {}),
+      ...(viewDescription ? { description: viewDescription } : {}),
     });
 
     return server;

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -24,8 +24,10 @@ import {
   isAutoInternalMCPServerName,
   matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import { POD_APP_TOOL_DEFAULT_STAKE } from "@app/lib/api/actions/servers/pod_app_toolset/metadata";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
+import { sandboxFunctionNameFromSlug } from "@app/lib/api/sandbox_functions/slug";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -34,6 +36,8 @@ import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_serv
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { RemoteMCPServerToolMetadataModel } from "@app/lib/models/agent/actions/remote_mcp_server_tool_metadata";
 import { destroyMCPServerViewDependencies } from "@app/lib/resources/mcp_server_view_helper";
+import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
@@ -82,6 +86,80 @@ export class InternalMCPServerInMemoryResource {
   ) {
     this.metadata = metadata;
     this.internalServerCredential = internalServerCredential;
+  }
+
+  /**
+   * Per-instance metadata overrides for pod_app_toolset instances. Their identity lives outside
+   * the static registry: the toolset name/description come from the system-space view (set when
+   * the app was shared) and the tools are the shared app's published functions. Without this,
+   * admin and picker surfaces would render a generic, tool-less "Pod App Toolset".
+   */
+  private static async buildPodAppToolsetOverrides(
+    auth: Authenticator,
+    instances: { id: string; name: InternalMCPServerNameType }[]
+  ): Promise<
+    Map<string, { name?: string; description?: string; tools: MCPToolType[] }>
+  > {
+    const overrides = new Map<
+      string,
+      { name?: string; description?: string; tools: MCPToolType[] }
+    >();
+
+    const podAppToolsetIds = instances
+      .filter(({ name }) => name === "pod_app_toolset")
+      .map(({ id }) => id);
+    if (podAppToolsetIds.length === 0) {
+      return overrides;
+    }
+
+    const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
+    const systemViews = await MCPServerViewModel.findAll({
+      attributes: ["internalMCPServerId", "name", "description"],
+      where: {
+        serverType: "internal",
+        internalMCPServerId: { [Op.in]: podAppToolsetIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
+        vaultId: systemSpace.id,
+      },
+    });
+    const systemViewById = new Map(
+      systemViews.map((view) => [view.internalMCPServerId, view])
+    );
+
+    // O(n) queries acceptable: a workspace holds a handful of shared apps at most, and callers
+    // hydrate instances for a single workspace at a time.
+    for (const id of podAppToolsetIds) {
+      const share = await PodAppShareResource.fetchByInternalMCPServerId(
+        auth,
+        id
+      );
+      const systemView = systemViewById.get(id);
+      const sandboxFunctions = share
+        ? await SandboxFunctionResource.listByPodAppShare(auth, share)
+        : [];
+
+      overrides.set(id, {
+        ...(systemView?.name ? { name: systemView.name } : {}),
+        ...(systemView?.description
+          ? { description: systemView.description }
+          : {}),
+        tools: sandboxFunctions.map((sandboxFunction) => {
+          const toolName = sandboxFunctionNameFromSlug(sandboxFunction.slug);
+          return {
+            name: toolName,
+            description: sandboxFunction.description,
+            inputSchema: sandboxFunction.inputSchema,
+            stake: POD_APP_TOOL_DEFAULT_STAKE,
+            displayLabels: {
+              running: `Calling ${toolName}...`,
+              done: `Called ${toolName}`,
+            },
+          };
+        }),
+      });
+    }
+
+    return overrides;
   }
 
   private static async computeEnabledServerNames(
@@ -384,6 +462,11 @@ export class InternalMCPServerInMemoryResource {
       ])
     );
 
+    const podAppToolsetOverrides = await this.buildPodAppToolsetOverrides(
+      auth,
+      resolvedIds
+    );
+
     return resolvedIds.map(({ id, name }) => {
       if (!enabledServerNames.has(name)) {
         logger.info(
@@ -400,6 +483,7 @@ export class InternalMCPServerInMemoryResource {
         metadata: {
           ...serverMetadata.serverInfo,
           tools: serverMetadata.tools,
+          ...(podAppToolsetOverrides.get(id) ?? {}),
         },
         internalServerCredential: credentialsById.get(id) ?? null,
       });
@@ -499,6 +583,11 @@ export class InternalMCPServerInMemoryResource {
       ])
     );
 
+    const podAppToolsetOverrides = await this.buildPodAppToolsetOverrides(
+      auth,
+      resolvedIds
+    );
+
     return resolvedIds.map(({ id, name }) => {
       if (!enabledServerNames.has(name)) {
         logger.info(
@@ -515,6 +604,7 @@ export class InternalMCPServerInMemoryResource {
         metadata: {
           ...serverMetadata.serverInfo,
           tools: serverMetadata.tools,
+          ...(podAppToolsetOverrides.get(id) ?? {}),
         },
         internalServerCredential: credentialsById.get(id) ?? null,
       });

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -24,7 +24,6 @@ import {
   isAutoInternalMCPServerName,
   matchesInternalMCPServerName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import { POD_APP_TOOL_DEFAULT_STAKE } from "@app/lib/api/actions/servers/pod_app_toolset/metadata";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
 import type { MCPServerType, MCPToolType } from "@app/lib/api/mcp";
 import { sandboxFunctionNameFromSlug } from "@app/lib/api/sandbox_functions/slug";
@@ -149,7 +148,7 @@ export class InternalMCPServerInMemoryResource {
             name: toolName,
             description: sandboxFunction.description,
             inputSchema: sandboxFunction.inputSchema,
-            stake: POD_APP_TOOL_DEFAULT_STAKE,
+            stake: sandboxFunction.defaultStake,
             displayLabels: {
               running: `Calling ${toolName}...`,
               done: `Called ${toolName}`,

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -1307,7 +1307,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       name,
       description,
       editedAt: new Date(),
-      editedByUserId: auth.getNonNullableUser().id,
+      // Internal-admin authenticators (e.g. the pod app share flow) carry no user.
+      editedByUserId: auth.user()?.id ?? null,
     });
     return new Ok(affectedCount);
   }

--- a/front/lib/resources/pod_app_share_resource.test.ts
+++ b/front/lib/resources/pod_app_share_resource.test.ts
@@ -1,0 +1,173 @@
+import { Authenticator } from "@app/lib/auth";
+import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { PodAppShareFactory } from "@app/tests/utils/PodAppShareFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+async function setup() {
+  const { workspace, user } = await createResourceTest({ role: "admin" });
+  const pod = await SpaceFactory.project(workspace, user.id);
+  // Rebuild the authenticator after pod creation so it carries the editor group membership.
+  const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+
+  const outsider = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, outsider, { role: "user" });
+  const outsiderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    outsider.sId,
+    workspace.sId
+  );
+
+  return { workspace, pod, editorAuth, outsiderAuth };
+}
+
+describe("PodAppShareResource", () => {
+  it("creates and fetches a share by pod/app and by server id", async () => {
+    const { pod, editorAuth } = await setup();
+
+    const share = await PodAppShareFactory.create(editorAuth, {
+      space: pod,
+      appPrefix: "notes",
+      internalMCPServerId: "ims_abc123",
+      toolsetName: "Notes",
+      description: "Note-taking tools.",
+    });
+
+    expect(share.appPrefix).toBe("notes");
+    expect(share.toolsetName).toBe("Notes");
+    expect(share.space.id).toBe(pod.id);
+
+    const byPrefix = await PodAppShareResource.fetchByPodAndAppPrefix(
+      editorAuth,
+      pod,
+      "notes"
+    );
+    expect(byPrefix?.id).toBe(share.id);
+
+    const byServerId = await PodAppShareResource.fetchByInternalMCPServerId(
+      editorAuth,
+      "ims_abc123"
+    );
+    expect(byServerId?.id).toBe(share.id);
+    expect(byServerId?.space.id).toBe(pod.id);
+  });
+
+  it("rejects creation by a non-editor and on a non-project space", async () => {
+    const { pod, outsiderAuth, editorAuth } = await setup();
+
+    await expect(
+      PodAppShareFactory.create(outsiderAuth, {
+        space: pod,
+        appPrefix: "notes",
+      })
+    ).rejects.toThrow("Only pod editors");
+
+    const { globalSpace } = await createResourceTest({ role: "admin" });
+    assert(globalSpace, "Expected a global space");
+    await expect(
+      PodAppShareFactory.create(editorAuth, {
+        space: globalSpace,
+        appPrefix: "notes",
+      })
+    ).rejects.toThrow("can only belong to pods");
+  });
+
+  it("revoke soft-deletes and allows re-sharing the same app", async () => {
+    const { pod, editorAuth } = await setup();
+
+    const share = await PodAppShareFactory.create(editorAuth, {
+      space: pod,
+      appPrefix: "notes",
+      internalMCPServerId: "ims_first",
+    });
+
+    await share.revoke(editorAuth);
+
+    expect(
+      await PodAppShareResource.fetchByPodAndAppPrefix(editorAuth, pod, "notes")
+    ).toBeNull();
+    expect(
+      await PodAppShareResource.fetchByInternalMCPServerId(
+        editorAuth,
+        "ims_first"
+      )
+    ).toBeNull();
+
+    // The partial unique index only covers active rows, so re-sharing succeeds.
+    const reshared = await PodAppShareFactory.create(editorAuth, {
+      space: pod,
+      appPrefix: "notes",
+      internalMCPServerId: "ims_second",
+    });
+    expect(reshared.appPrefix).toBe("notes");
+  });
+
+  it("revoke is editor-gated", async () => {
+    const { pod, editorAuth, outsiderAuth } = await setup();
+
+    const share = await PodAppShareFactory.create(editorAuth, {
+      space: pod,
+      appPrefix: "notes",
+    });
+
+    await expect(share.revoke(outsiderAuth)).rejects.toThrow(
+      "Only pod editors"
+    );
+  });
+
+  it("lists only the pod's active shares", async () => {
+    const { workspace, pod, editorAuth } = await setup();
+
+    const otherPod = await SpaceFactory.project(workspace);
+    const adminAuth = editorAuth;
+
+    const shareA = await PodAppShareFactory.create(adminAuth, {
+      space: pod,
+      appPrefix: "notes",
+      internalMCPServerId: "ims_a",
+    });
+    const shareB = await PodAppShareFactory.create(adminAuth, {
+      space: pod,
+      appPrefix: "tasks",
+      internalMCPServerId: "ims_b",
+    });
+    await shareB.revoke(adminAuth);
+
+    const listed = await PodAppShareResource.listBySpace(adminAuth, pod);
+    expect(listed.map(({ id }) => id)).toEqual([shareA.id]);
+
+    expect(await PodAppShareResource.listBySpace(adminAuth, otherPod)).toEqual(
+      []
+    );
+  });
+
+  it("updateShareDetails updates the mirror columns", async () => {
+    const { pod, editorAuth } = await setup();
+
+    const share = await PodAppShareFactory.create(editorAuth, {
+      space: pod,
+      appPrefix: "notes",
+    });
+
+    await share.updateShareDetails({
+      toolsetName: "Better Notes",
+      description: "Improved.",
+    });
+    expect(share.toolsetName).toBe("Better Notes");
+    expect(share.description).toBe("Improved.");
+
+    const fetched = await PodAppShareResource.fetchByPodAndAppPrefix(
+      editorAuth,
+      pod,
+      "notes"
+    );
+    expect(fetched?.toolsetName).toBe("Better Notes");
+    expect(fetched?.description).toBe("Improved.");
+  });
+});

--- a/front/lib/resources/pod_app_share_resource.test.ts
+++ b/front/lib/resources/pod_app_share_resource.test.ts
@@ -33,17 +33,17 @@ describe("PodAppShareResource", () => {
 
     const share = await PodAppShareFactory.create(editorAuth, {
       space: pod,
-      appPrefix: "notes",
+      appName: "notes",
       internalMCPServerId: "ims_abc123",
       toolsetName: "Notes",
       description: "Note-taking tools.",
     });
 
-    expect(share.appPrefix).toBe("notes");
+    expect(share.appName).toBe("notes");
     expect(share.toolsetName).toBe("Notes");
     expect(share.space.id).toBe(pod.id);
 
-    const byPrefix = await PodAppShareResource.fetchByPodAndAppPrefix(
+    const byPrefix = await PodAppShareResource.fetchByPodAndAppName(
       editorAuth,
       pod,
       "notes"
@@ -64,7 +64,7 @@ describe("PodAppShareResource", () => {
     await expect(
       PodAppShareFactory.create(outsiderAuth, {
         space: pod,
-        appPrefix: "notes",
+        appName: "notes",
       })
     ).rejects.toThrow("Only pod editors");
 
@@ -73,7 +73,7 @@ describe("PodAppShareResource", () => {
     await expect(
       PodAppShareFactory.create(editorAuth, {
         space: globalSpace,
-        appPrefix: "notes",
+        appName: "notes",
       })
     ).rejects.toThrow("can only belong to pods");
   });
@@ -83,14 +83,14 @@ describe("PodAppShareResource", () => {
 
     const share = await PodAppShareFactory.create(editorAuth, {
       space: pod,
-      appPrefix: "notes",
+      appName: "notes",
       internalMCPServerId: "ims_first",
     });
 
     await share.revoke(editorAuth);
 
     expect(
-      await PodAppShareResource.fetchByPodAndAppPrefix(editorAuth, pod, "notes")
+      await PodAppShareResource.fetchByPodAndAppName(editorAuth, pod, "notes")
     ).toBeNull();
     expect(
       await PodAppShareResource.fetchByInternalMCPServerId(
@@ -102,10 +102,10 @@ describe("PodAppShareResource", () => {
     // The partial unique index only covers active rows, so re-sharing succeeds.
     const reshared = await PodAppShareFactory.create(editorAuth, {
       space: pod,
-      appPrefix: "notes",
+      appName: "notes",
       internalMCPServerId: "ims_second",
     });
-    expect(reshared.appPrefix).toBe("notes");
+    expect(reshared.appName).toBe("notes");
   });
 
   it("revoke is editor-gated", async () => {
@@ -113,7 +113,7 @@ describe("PodAppShareResource", () => {
 
     const share = await PodAppShareFactory.create(editorAuth, {
       space: pod,
-      appPrefix: "notes",
+      appName: "notes",
     });
 
     await expect(share.revoke(outsiderAuth)).rejects.toThrow(
@@ -129,12 +129,12 @@ describe("PodAppShareResource", () => {
 
     const shareA = await PodAppShareFactory.create(adminAuth, {
       space: pod,
-      appPrefix: "notes",
+      appName: "notes",
       internalMCPServerId: "ims_a",
     });
     const shareB = await PodAppShareFactory.create(adminAuth, {
       space: pod,
-      appPrefix: "tasks",
+      appName: "tasks",
       internalMCPServerId: "ims_b",
     });
     await shareB.revoke(adminAuth);
@@ -152,7 +152,7 @@ describe("PodAppShareResource", () => {
 
     const share = await PodAppShareFactory.create(editorAuth, {
       space: pod,
-      appPrefix: "notes",
+      appName: "notes",
     });
 
     await share.updateShareDetails({
@@ -162,7 +162,7 @@ describe("PodAppShareResource", () => {
     expect(share.toolsetName).toBe("Better Notes");
     expect(share.description).toBe("Improved.");
 
-    const fetched = await PodAppShareResource.fetchByPodAndAppPrefix(
+    const fetched = await PodAppShareResource.fetchByPodAndAppName(
       editorAuth,
       pod,
       "notes"

--- a/front/lib/resources/pod_app_share_resource.ts
+++ b/front/lib/resources/pod_app_share_resource.ts
@@ -5,6 +5,7 @@ import { PodAppShareModel } from "@app/lib/resources/storage/models/pod_app_shar
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { PodAppShareSummary } from "@app/types/api/pod_apps";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import assert from "assert";
@@ -194,6 +195,14 @@ export class PodAppShareResource extends BaseResource<PodAppShareModel> {
       "Only pod editors can unshare a pod app."
     );
     await this.delete(auth, {});
+  }
+
+  toJSON(): PodAppShareSummary {
+    return {
+      appPrefix: this.appPrefix,
+      toolsetName: this.toolsetName,
+      description: this.description,
+    };
   }
 
   async delete(

--- a/front/lib/resources/pod_app_share_resource.ts
+++ b/front/lib/resources/pod_app_share_resource.ts
@@ -1,0 +1,177 @@
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { PodAppShareModel } from "@app/lib/resources/storage/models/pod_app_share";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticSoftDeletable } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import assert from "assert";
+import type { Attributes, Transaction } from "sequelize";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface PodAppShareResource
+  extends ReadonlyAttributesType<PodAppShareModel> {}
+
+/**
+ * The record that a pod app is shared to the workspace as an agent toolset. Rows are readable by
+ * any workspace user (the binding itself is not sensitive); everything security-relevant is gated
+ * where functions get resolved (SandboxFunctionResource) and where shares get mutated (makeNew and
+ * revoke assert pod editorship).
+ */
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class PodAppShareResource extends BaseResource<PodAppShareModel> {
+  static model: ModelStaticSoftDeletable<PodAppShareModel> = PodAppShareModel;
+  declare readonly model: ModelStaticSoftDeletable<PodAppShareModel>;
+
+  readonly space: SpaceResource;
+
+  constructor(
+    model: ModelStaticSoftDeletable<PodAppShareModel>,
+    blob: Attributes<PodAppShareModel>,
+    space: SpaceResource
+  ) {
+    super(PodAppShareModel, blob);
+    this.space = space;
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    {
+      space,
+      appPrefix,
+      internalMCPServerId,
+      toolsetName,
+      description,
+    }: {
+      space: SpaceResource;
+      appPrefix: string;
+      internalMCPServerId: string;
+      toolsetName: string;
+      description: string;
+    }
+  ): Promise<PodAppShareResource> {
+    assert(space.isProject(), "Pod app shares can only belong to pods.");
+    assert(
+      space.canAdministrate(auth),
+      "Only pod editors can share a pod app."
+    );
+    assert(
+      space.workspaceId === auth.getNonNullableWorkspace().id,
+      "The pod must belong to the authenticated workspace."
+    );
+
+    const share = await this.model.create({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      spaceId: space.id,
+      appPrefix,
+      internalMCPServerId,
+      sharedByUserId: auth.user()?.id ?? null,
+      toolsetName,
+      description,
+    });
+
+    return new this(this.model, share.get(), space);
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options: ResourceFindOptions<PodAppShareModel> = {}
+  ): Promise<PodAppShareResource[]> {
+    const { where, ...rest } = options;
+    const shares = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      ...rest,
+    });
+
+    const spaces = await SpaceResource.fetchByModelIds(
+      auth,
+      Array.from(new Set(shares.map((share) => share.get().spaceId)))
+    );
+    const spacesById = new Map(
+      spaces
+        .filter((space) => space.isProject())
+        .map((space) => [space.id, space])
+    );
+
+    return shares.flatMap((share) => {
+      const blob = share.get();
+      const space = spacesById.get(blob.spaceId);
+      if (!space) {
+        return [];
+      }
+      return [new this(this.model, blob, space)];
+    });
+  }
+
+  static async fetchByPodAndAppPrefix(
+    auth: Authenticator,
+    space: SpaceResource,
+    appPrefix: string
+  ): Promise<PodAppShareResource | null> {
+    if (!space.isProject()) {
+      return null;
+    }
+    const [share] = await this.baseFetch(auth, {
+      where: { spaceId: space.id, appPrefix },
+    });
+    return share ?? null;
+  }
+
+  static async fetchByInternalMCPServerId(
+    auth: Authenticator,
+    internalMCPServerId: string
+  ): Promise<PodAppShareResource | null> {
+    const [share] = await this.baseFetch(auth, {
+      where: { internalMCPServerId },
+    });
+    return share ?? null;
+  }
+
+  static async listBySpace(
+    auth: Authenticator,
+    space: SpaceResource
+  ): Promise<PodAppShareResource[]> {
+    if (!space.isProject()) {
+      return [];
+    }
+    return this.baseFetch(auth, { where: { spaceId: space.id } });
+  }
+
+  async updateShareDetails({
+    toolsetName,
+    description,
+  }: {
+    toolsetName?: string;
+    description?: string;
+  }): Promise<void> {
+    await this.update({
+      ...(toolsetName !== undefined ? { toolsetName } : {}),
+      ...(description !== undefined ? { description } : {}),
+    });
+  }
+
+  async revoke(auth: Authenticator): Promise<void> {
+    assert(
+      this.space.canAdministrate(auth),
+      "Only pod editors can unshare a pod app."
+    );
+    await this.delete(auth, {});
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction }
+  ): Promise<Result<undefined, Error>> {
+    await this.model.destroy({
+      where: { id: this.id, workspaceId: auth.getNonNullableWorkspace().id },
+      transaction,
+      hardDelete: false,
+    });
+    return new Ok(undefined);
+  }
+}

--- a/front/lib/resources/pod_app_share_resource.ts
+++ b/front/lib/resources/pod_app_share_resource.ts
@@ -77,7 +77,14 @@ export class PodAppShareResource extends BaseResource<PodAppShareModel> {
 
   private static async baseFetch(
     auth: Authenticator,
-    options: ResourceFindOptions<PodAppShareModel> = {}
+    {
+      includeDeletedSpace,
+      ...options
+    }: ResourceFindOptions<PodAppShareModel> & {
+      // Pods are soft-deleted before being scrubbed; without this, shares of a pod being
+      // deleted resolve to no space and are silently dropped here.
+      includeDeletedSpace?: boolean;
+    } = {}
   ): Promise<PodAppShareResource[]> {
     const { where, ...rest } = options;
     const shares = await this.model.findAll({
@@ -90,7 +97,8 @@ export class PodAppShareResource extends BaseResource<PodAppShareModel> {
 
     const spaces = await SpaceResource.fetchByModelIds(
       auth,
-      Array.from(new Set(shares.map((share) => share.get().spaceId)))
+      Array.from(new Set(shares.map((share) => share.get().spaceId))),
+      { includeDeleted: includeDeletedSpace }
     );
     const spacesById = new Map(
       spaces
@@ -140,6 +148,31 @@ export class PodAppShareResource extends BaseResource<PodAppShareModel> {
       return [];
     }
     return this.baseFetch(auth, { where: { spaceId: space.id } });
+  }
+
+  /**
+   * Scrub-time cleanup: hard-deletes every share row of the pod (revoked ones included — the
+   * spaceId FK is ON DELETE RESTRICT, so soft-deleted rows would block the space scrub) and
+   * returns what was active so the caller can clean up the bound server views.
+   */
+  static async deleteAllForSpace(
+    auth: Authenticator,
+    space: SpaceResource
+  ): Promise<PodAppShareResource[]> {
+    const shares = await this.baseFetch(auth, {
+      where: { spaceId: space.id },
+      includeDeletedSpace: true,
+    });
+
+    await this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: space.id,
+      },
+      hardDelete: true,
+    });
+
+    return shares;
   }
 
   async updateShareDetails({

--- a/front/lib/resources/pod_app_share_resource.ts
+++ b/front/lib/resources/pod_app_share_resource.ts
@@ -41,13 +41,13 @@ export class PodAppShareResource extends BaseResource<PodAppShareModel> {
     auth: Authenticator,
     {
       space,
-      appPrefix,
+      appName,
       internalMCPServerId,
       toolsetName,
       description,
     }: {
       space: SpaceResource;
-      appPrefix: string;
+      appName: string;
       internalMCPServerId: string;
       toolsetName: string;
       description: string;
@@ -66,7 +66,7 @@ export class PodAppShareResource extends BaseResource<PodAppShareModel> {
     const share = await this.model.create({
       workspaceId: auth.getNonNullableWorkspace().id,
       spaceId: space.id,
-      appPrefix,
+      appName,
       internalMCPServerId,
       sharedByUserId: auth.user()?.id ?? null,
       toolsetName,
@@ -117,16 +117,16 @@ export class PodAppShareResource extends BaseResource<PodAppShareModel> {
     });
   }
 
-  static async fetchByPodAndAppPrefix(
+  static async fetchByPodAndAppName(
     auth: Authenticator,
     space: SpaceResource,
-    appPrefix: string
+    appName: string
   ): Promise<PodAppShareResource | null> {
     if (!space.isProject()) {
       return null;
     }
     const [share] = await this.baseFetch(auth, {
-      where: { spaceId: space.id, appPrefix },
+      where: { spaceId: space.id, appName },
     });
     return share ?? null;
   }
@@ -199,7 +199,7 @@ export class PodAppShareResource extends BaseResource<PodAppShareModel> {
 
   toJSON(): PodAppShareSummary {
     return {
-      appPrefix: this.appPrefix,
+      appName: this.appName,
       toolsetName: this.toolsetName,
       description: this.description,
     };

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -10,6 +10,7 @@ import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { PodAppShareFactory } from "@app/tests/utils/PodAppShareFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { SandboxFunctionStake } from "@app/types/api/sandbox_functions";
@@ -712,5 +713,108 @@ describe("SandboxFunctionResource", () => {
     await expect(
       SandboxFunctionResource.fetchById(adminAuth, sandboxFunction.sId)
     ).resolves.toMatchObject({ id: sandboxFunction.id });
+  });
+});
+
+describe("SandboxFunctionResource pod app share gate", () => {
+  async function setupSharedApp() {
+    const { authenticator: adminAuth, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace);
+
+    const makeFunction = async (slug: string, fileName: string) => {
+      const file = await FileFactory.create(adminAuth, null, {
+        contentType: sandboxFunctionContentType,
+        fileName,
+        fileSize: 100,
+        status: "created",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: pod.sId },
+      });
+      return SandboxFunctionResource.makeNew(adminAuth, {
+        space: pod,
+        file,
+        slug,
+        description: `Function ${slug}.`,
+        inputSchema,
+        outputSchema,
+      });
+    };
+
+    await makeFunction("notes__list", "list.ts");
+    await makeFunction("other__fn", "fn.ts");
+
+    const share = await PodAppShareFactory.create(adminAuth, {
+      space: pod,
+      appPrefix: "notes",
+    });
+
+    const outsider = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, outsider, { role: "user" });
+    const outsiderAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      outsider.sId,
+      workspace.sId
+    );
+    assert(outsiderAuth, "Expected an authenticator for the outsider");
+
+    return { adminAuth, pod, share, outsiderAuth };
+  }
+
+  it("resolves a shared app's functions for a workspace user without pod access", async () => {
+    const { share, outsiderAuth } = await setupSharedApp();
+
+    const listed = await SandboxFunctionResource.listByPodAppShare(
+      outsiderAuth,
+      share
+    );
+    expect(listed.map(({ slug }) => slug)).toEqual(["notes__list"]);
+
+    const fetched = await SandboxFunctionResource.fetchBySlugWithPodAppShare(
+      outsiderAuth,
+      share,
+      "notes__list"
+    );
+    expect(fetched?.slug).toBe("notes__list");
+  });
+
+  it("does not resolve functions of a different app in the same pod", async () => {
+    const { share, outsiderAuth } = await setupSharedApp();
+
+    expect(
+      await SandboxFunctionResource.fetchBySlugWithPodAppShare(
+        outsiderAuth,
+        share,
+        "other__fn"
+      )
+    ).toBeNull();
+  });
+
+  it("does not widen the default fetchers", async () => {
+    const { pod, outsiderAuth } = await setupSharedApp();
+
+    expect(
+      await SandboxFunctionResource.fetchBySpaceAndSlug(
+        outsiderAuth,
+        pod,
+        "notes__list"
+      )
+    ).toBeNull();
+    expect(
+      await SandboxFunctionResource.fetchByIdOrSlug(
+        outsiderAuth,
+        `${pod.sId}/notes__list`
+      )
+    ).toBeNull();
+  });
+
+  it("pod members still resolve through their own access", async () => {
+    const { adminAuth, share } = await setupSharedApp();
+
+    const listed = await SandboxFunctionResource.listByPodAppShare(
+      adminAuth,
+      share
+    );
+    expect(listed.map(({ slug }) => slug)).toEqual(["notes__list"]);
   });
 });

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -747,7 +747,7 @@ describe("SandboxFunctionResource pod app share gate", () => {
 
     const share = await PodAppShareFactory.create(adminAuth, {
       space: pod,
-      appPrefix: "notes",
+      appName: "notes",
     });
 
     const outsider = await UserFactory.basic();

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -12,6 +12,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { executeWithLock } from "@app/lib/lock";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
+import type { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
 import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -306,10 +307,16 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     auth: Authenticator,
     {
       includeDeletedSpace,
+      podAppShare,
       dangerouslyBypassSpacePermissionFilter = false,
       ...options
     }: ResourceFindOptions<SandboxFunctionModel> & {
       includeDeletedSpace?: boolean;
+      // An active workspace share of the function's app widens resolution for workspace users,
+      // the way the frame-share capability does for frame viewers. Opt-in: only the
+      // pod_app_toolset MCP server's handlers pass it. Per-function userIdentity policies still
+      // apply at invocation.
+      podAppShare?: PodAppShareResource;
       // Reserved for resolution paths whose authorization is established before the fetch:
       // fetchByIdForExecution and the tool workflow (an invocation row), and fetchInAppFolder
       // (a validated frame share capability, enforced by its own query constraints).
@@ -344,6 +351,13 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         .map((space) => [space.id, space])
     );
 
+    const podAppShareSpace =
+      podAppShare && auth.isUser()
+        ? (spaces.find(
+            (space) => space.isProject() && space.id === podAppShare.spaceId
+          ) ?? null)
+        : null;
+
     const files = await FileResource.fetchByModelIdsWithAuth(
       auth,
       Array.from(
@@ -362,8 +376,15 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
+      // Three prioritized gates: the caller's own access, the app a workspace share grants,
+      // then the pre-authorized bypass (spacesById is only built for it).
+      const podAppShareGrantsFunction =
+        podAppShareSpace?.id === blob.spaceId &&
+        appPrefixFromSlug(blob.slug) === podAppShare?.appPrefix;
       const space =
-        accessibleSpacesById.get(blob.spaceId) ?? spacesById?.get(blob.spaceId);
+        accessibleSpacesById.get(blob.spaceId) ??
+        (podAppShareGrantsFunction ? podAppShareSpace : undefined) ??
+        spacesById?.get(blob.spaceId);
       const file = filesById.get(blob.fileId);
       if (!space || !file) {
         return [];
@@ -491,6 +512,42 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     const [sandboxFunction] = await this.baseFetch(auth, {
       where: { spaceId: space.id, slug },
+    });
+
+    return sandboxFunction ?? null;
+  }
+
+  /**
+   * The functions a workspace share exposes: the shared app's published functions, resolvable by
+   * any workspace user. Only the pod_app_toolset MCP server should call this.
+   */
+  static async listByPodAppShare(
+    auth: Authenticator,
+    share: PodAppShareResource
+  ): Promise<SandboxFunctionResource[]> {
+    const sandboxFunctions = await this.baseFetch(auth, {
+      where: { spaceId: share.spaceId },
+      podAppShare: share,
+    });
+
+    return sandboxFunctions.filter(
+      (sandboxFunction) =>
+        appPrefixFromSlug(sandboxFunction.slug) === share.appPrefix
+    );
+  }
+
+  static async fetchBySlugWithPodAppShare(
+    auth: Authenticator,
+    share: PodAppShareResource,
+    slug: string
+  ): Promise<SandboxFunctionResource | null> {
+    if (appPrefixFromSlug(slug) !== share.appPrefix) {
+      return null;
+    }
+
+    const [sandboxFunction] = await this.baseFetch(auth, {
+      where: { spaceId: share.spaceId, slug },
+      podAppShare: share,
     });
 
     return sandboxFunction ?? null;

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -768,6 +768,8 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description: this.description,
       executionMode: this.executionMode,
       defaultStake: this.defaultStake,
+      // A null stored policy means "optional", matching authorizeSandboxFunctionInvocation.
+      userIdentity: this.userIdentity ?? "optional",
     };
   }
 

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -380,7 +380,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       // then the pre-authorized bypass (spacesById is only built for it).
       const podAppShareGrantsFunction =
         podAppShareSpace?.id === blob.spaceId &&
-        appPrefixFromSlug(blob.slug) === podAppShare?.appPrefix;
+        appPrefixFromSlug(blob.slug) === podAppShare?.appName;
       const space =
         accessibleSpacesById.get(blob.spaceId) ??
         (podAppShareGrantsFunction ? podAppShareSpace : undefined) ??
@@ -532,7 +532,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     return sandboxFunctions.filter(
       (sandboxFunction) =>
-        appPrefixFromSlug(sandboxFunction.slug) === share.appPrefix
+        appPrefixFromSlug(sandboxFunction.slug) === share.appName
     );
   }
 
@@ -541,7 +541,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
     share: PodAppShareResource,
     slug: string
   ): Promise<SandboxFunctionResource | null> {
-    if (appPrefixFromSlug(slug) !== share.appPrefix) {
+    if (appPrefixFromSlug(slug) !== share.appName) {
       return null;
     }
 

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -2377,6 +2377,7 @@ const KNOWN_SPACE_RELATED_MODELS = [
   "group_vaults",
   "mcp_server_view",
   "workspace_sandbox_env_var",
+  "pod_app_share",
   "sandbox_function",
   "sandbox_owner",
   "project_metadata",

--- a/front/lib/resources/storage/models/pod_app_share.ts
+++ b/front/lib/resources/storage/models/pod_app_share.ts
@@ -1,0 +1,108 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import {
+  DANGEROUSLY_UNBOUNDED_TEXT,
+  DataTypes,
+} from "@app/lib/resources/storage/data_types";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
+
+/**
+ * Records that a pod app (identified by its normalized app prefix) is shared to the workspace as
+ * an agent toolset. `internalMCPServerId` is the sId of the dedicated `pod_app_toolset` internal
+ * MCP server instance whose views expose the app's functions; the row is the binding between the
+ * instance and the app. `toolsetName` mirrors the views' display name so listings never need a
+ * per-share view fetch. Soft-deleted on unshare so a revoked share keeps history.
+ */
+export class PodAppShareModel extends SoftDeletableWorkspaceAwareModel<PodAppShareModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare spaceId: ForeignKey<SpaceModel["id"]>;
+  declare appPrefix: string;
+  declare internalMCPServerId: string;
+  declare sharedByUserId: ForeignKey<UserModel["id"]> | null;
+  declare toolsetName: string;
+  declare description: string;
+
+  declare space: NonAttribute<SpaceModel>;
+}
+
+PodAppShareModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+    },
+    spaceId: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+    },
+    appPrefix: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    internalMCPServerId: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    toolsetName: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    description: {
+      type: DANGEROUSLY_UNBOUNDED_TEXT,
+      allowNull: false,
+    },
+  },
+  {
+    modelName: "pod_app_share",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId", "spaceId", "appPrefix"],
+        where: { deletedAt: null },
+        unique: true,
+        concurrently: true,
+        name: "pod_app_shares_workspace_space_app_prefix_active",
+      },
+      {
+        fields: ["workspaceId", "internalMCPServerId"],
+        where: { deletedAt: null },
+        unique: true,
+        concurrently: true,
+        name: "pod_app_shares_workspace_internal_mcp_server_active",
+      },
+      { fields: ["spaceId"], concurrently: true },
+    ],
+  }
+);
+
+PodAppShareModel.belongsTo(SpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  onDelete: "RESTRICT",
+  as: "space",
+});
+SpaceModel.hasMany(PodAppShareModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  as: "podAppShares",
+});
+
+PodAppShareModel.belongsTo(UserModel, {
+  foreignKey: { name: "sharedByUserId", allowNull: true },
+  onDelete: "SET NULL",
+  as: "sharedByUser",
+});
+UserModel.hasMany(PodAppShareModel, {
+  foreignKey: { name: "sharedByUserId", allowNull: true },
+});

--- a/front/lib/resources/storage/models/pod_app_share.ts
+++ b/front/lib/resources/storage/models/pod_app_share.ts
@@ -9,7 +9,7 @@ import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wra
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
 /**
- * Records that a pod app (identified by its normalized app prefix) is shared to the workspace as
+ * Records that a pod app (identified by its normalized app name — the slug prefix) is shared to the workspace as
  * an agent toolset. `internalMCPServerId` is the sId of the dedicated `pod_app_toolset` internal
  * MCP server instance whose views expose the app's functions; the row is the binding between the
  * instance and the app. `toolsetName` mirrors the views' display name so listings never need a
@@ -20,7 +20,7 @@ export class PodAppShareModel extends SoftDeletableWorkspaceAwareModel<PodAppSha
   declare updatedAt: CreationOptional<Date>;
 
   declare spaceId: ForeignKey<SpaceModel["id"]>;
-  declare appPrefix: string;
+  declare appName: string;
   declare internalMCPServerId: string;
   declare sharedByUserId: ForeignKey<UserModel["id"]> | null;
   declare toolsetName: string;
@@ -48,7 +48,7 @@ PodAppShareModel.init(
       type: DataTypes.BIGINT,
       allowNull: false,
     },
-    appPrefix: {
+    appName: {
       type: DataTypes.STRING(255),
       allowNull: false,
     },
@@ -70,11 +70,11 @@ PodAppShareModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        fields: ["workspaceId", "spaceId", "appPrefix"],
+        fields: ["workspaceId", "spaceId", "appName"],
         where: { deletedAt: null },
         unique: true,
         concurrently: true,
-        name: "pod_app_shares_workspace_space_app_prefix_active",
+        name: "pod_app_shares_workspace_space_app_name_active",
       },
       {
         fields: ["workspaceId", "internalMCPServerId"],

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -31,6 +31,7 @@ import type {
   ClonePodAppResponseBody,
   GetPodAppsResponseBody,
   PodApp,
+  SharePodAppResponseBody,
 } from "@app/types/api/pod_apps";
 import type {
   GetPodMetadataResponseBody,
@@ -194,6 +195,168 @@ export function useClonePodApp({
       sendNotification({
         type: "error",
         title: `Failed to clone ${app.name ?? app.prefix}`,
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useSharePodApp({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutatePodApps } = usePodApps({ owner, podId, disabled: true });
+
+  return async (
+    app: PodApp,
+    { name, description }: { name?: string; description: string }
+  ): Promise<Result<SharePodAppResponseBody["share"], Error>> => {
+    const appName = app.name ?? app.prefix;
+
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/pods/${podId}/apps/${encodeURIComponent(app.prefix)}/share`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, description }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: `Failed to share ${appName}`,
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      const { share }: SharePodAppResponseBody = await res.json();
+      sendNotification({
+        type: "success",
+        title: `${share.toolsetName} shared as tools`,
+        description:
+          "Agents across the workspace can now use this app's functions.",
+      });
+      await mutatePodApps();
+
+      return new Ok(share);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: `Failed to share ${appName}`,
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useUpdatePodAppShare({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutatePodApps } = usePodApps({ owner, podId, disabled: true });
+
+  return async (
+    app: PodApp,
+    { name, description }: { name?: string; description?: string }
+  ): Promise<Result<SharePodAppResponseBody["share"], Error>> => {
+    const appName = app.name ?? app.prefix;
+
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/pods/${podId}/apps/${encodeURIComponent(app.prefix)}/share`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, description }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: `Failed to update sharing of ${appName}`,
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      const { share }: SharePodAppResponseBody = await res.json();
+      sendNotification({
+        type: "success",
+        title: `${share.toolsetName} sharing updated`,
+      });
+      await mutatePodApps();
+
+      return new Ok(share);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: `Failed to update sharing of ${appName}`,
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useUnsharePodApp({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutatePodApps } = usePodApps({ owner, podId, disabled: true });
+
+  return async (app: PodApp): Promise<Result<void, Error>> => {
+    const appName = app.name ?? app.prefix;
+
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/pods/${podId}/apps/${encodeURIComponent(app.prefix)}/share`,
+        { method: "DELETE" }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: `Failed to stop sharing ${appName}`,
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: `${appName} is no longer shared`,
+      });
+      await mutatePodApps();
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: `Failed to stop sharing ${appName}`,
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/migrations/pre-deploy/20260817102135_create_pod_app_shares.sql
+++ b/front/migrations/pre-deploy/20260817102135_create_pod_app_shares.sql
@@ -5,15 +5,15 @@ CREATE TABLE "pod_app_shares" (
   "deletedAt" TIMESTAMP WITH TIME ZONE,
   "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
   "spaceId" BIGINT NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
-  "appPrefix" VARCHAR(255) NOT NULL,
+  "appName" VARCHAR(255) NOT NULL,
   "internalMCPServerId" VARCHAR(255) NOT NULL,
   "sharedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
   "toolsetName" VARCHAR(255) NOT NULL,
   "description" TEXT NOT NULL
 );
 
-CREATE UNIQUE INDEX "pod_app_shares_workspace_space_app_prefix_active" ON "pod_app_shares"
-  ("workspaceId", "spaceId", "appPrefix") WHERE "deletedAt" IS NULL;
+CREATE UNIQUE INDEX "pod_app_shares_workspace_space_app_name_active" ON "pod_app_shares"
+  ("workspaceId", "spaceId", "appName") WHERE "deletedAt" IS NULL;
 CREATE UNIQUE INDEX "pod_app_shares_workspace_internal_mcp_server_active" ON "pod_app_shares"
   ("workspaceId", "internalMCPServerId") WHERE "deletedAt" IS NULL;
 CREATE INDEX "pod_app_shares_space_id" ON "pod_app_shares" ("spaceId");

--- a/front/migrations/pre-deploy/20260817102135_create_pod_app_shares.sql
+++ b/front/migrations/pre-deploy/20260817102135_create_pod_app_shares.sql
@@ -1,0 +1,19 @@
+CREATE TABLE "pod_app_shares" (
+  "id" BIGSERIAL PRIMARY KEY,
+  "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "deletedAt" TIMESTAMP WITH TIME ZONE,
+  "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "spaceId" BIGINT NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+  "appPrefix" VARCHAR(255) NOT NULL,
+  "internalMCPServerId" VARCHAR(255) NOT NULL,
+  "sharedByUserId" BIGINT REFERENCES "users" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+  "toolsetName" VARCHAR(255) NOT NULL,
+  "description" TEXT NOT NULL
+);
+
+CREATE UNIQUE INDEX "pod_app_shares_workspace_space_app_prefix_active" ON "pod_app_shares"
+  ("workspaceId", "spaceId", "appPrefix") WHERE "deletedAt" IS NULL;
+CREATE UNIQUE INDEX "pod_app_shares_workspace_internal_mcp_server_active" ON "pod_app_shares"
+  ("workspaceId", "internalMCPServerId") WHERE "deletedAt" IS NULL;
+CREATE INDEX "pod_app_shares_space_id" ON "pod_app_shares" ("spaceId");

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -2,6 +2,7 @@ import { hardDeleteApp } from "@app/lib/api/apps";
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
 import config from "@app/lib/api/config";
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
+import { scrubPodAppSharesForSpace } from "@app/lib/api/projects/app_shares";
 import { deletePodStatePrefix } from "@app/lib/api/sandbox/db";
 import { hardDeleteSpace } from "@app/lib/api/spaces";
 import { deleteWebhookSource } from "@app/lib/api/webhook_source";
@@ -175,6 +176,10 @@ export async function scrubSpaceActivity({
     if (deleteSandboxFunctionsResult.isErr()) {
       throw deleteSandboxFunctionsResult.error;
     }
+
+    // App shares FK the space with ON DELETE RESTRICT, so their rows (and the toolset views
+    // bound to them) must be gone before the space can be hard-deleted.
+    await scrubPodAppSharesForSpace(auth, space);
 
     // Destroy the pod sandbox at the provider and drop its ownership row. The
     // FK from sandbox_owners to spaces is `onDelete: "RESTRICT"`, so the row

--- a/front/tests/utils/PodAppShareFactory.ts
+++ b/front/tests/utils/PodAppShareFactory.ts
@@ -7,7 +7,7 @@ export class PodAppShareFactory {
     auth: Authenticator,
     opts: {
       space: SpaceResource;
-      appPrefix: string;
+      appName: string;
       internalMCPServerId?: string;
       toolsetName?: string;
       description?: string;
@@ -15,11 +15,11 @@ export class PodAppShareFactory {
   ): Promise<PodAppShareResource> {
     return PodAppShareResource.makeNew(auth, {
       space: opts.space,
-      appPrefix: opts.appPrefix,
+      appName: opts.appName,
       internalMCPServerId:
-        opts.internalMCPServerId ?? `ims_test_${opts.appPrefix}`,
-      toolsetName: opts.toolsetName ?? opts.appPrefix,
-      description: opts.description ?? `Toolset for ${opts.appPrefix}.`,
+        opts.internalMCPServerId ?? `ims_test_${opts.appName}`,
+      toolsetName: opts.toolsetName ?? opts.appName,
+      description: opts.description ?? `Toolset for ${opts.appName}.`,
     });
   }
 }

--- a/front/tests/utils/PodAppShareFactory.ts
+++ b/front/tests/utils/PodAppShareFactory.ts
@@ -1,0 +1,25 @@
+import type { Authenticator } from "@app/lib/auth";
+import { PodAppShareResource } from "@app/lib/resources/pod_app_share_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+
+export class PodAppShareFactory {
+  static async create(
+    auth: Authenticator,
+    opts: {
+      space: SpaceResource;
+      appPrefix: string;
+      internalMCPServerId?: string;
+      toolsetName?: string;
+      description?: string;
+    }
+  ): Promise<PodAppShareResource> {
+    return PodAppShareResource.makeNew(auth, {
+      space: opts.space,
+      appPrefix: opts.appPrefix,
+      internalMCPServerId:
+        opts.internalMCPServerId ?? `ims_test_${opts.appPrefix}`,
+      toolsetName: opts.toolsetName ?? opts.appPrefix,
+      description: opts.description ?? `Toolset for ${opts.appPrefix}.`,
+    });
+  }
+}

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -99,7 +99,7 @@ export const MAX_POD_APP_SHARE_DESCRIPTION_LENGTH = 2048;
 
 /** How a shared app surfaces on listings and share endpoints. */
 export type PodAppShareSummary = {
-  appPrefix: string;
+  appName: string;
   toolsetName: string;
   description: string;
 };

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -1,6 +1,7 @@
 import type {
   SandboxFunctionExecutionMode,
   SandboxFunctionStake,
+  SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import { z } from "zod";
 
@@ -35,6 +36,8 @@ export type PodAppFunction = {
   executionMode: SandboxFunctionExecutionMode;
   /** The approval level a tool derived from this function starts at. */
   defaultStake: SandboxFunctionStake;
+  /** Who may invoke the function; `pod_member_required` stays members-only even when shared. */
+  userIdentity: SandboxFunctionUserIdentityPolicy;
 };
 
 export type PodAppDatabase = {
@@ -64,6 +67,8 @@ export type PodApp = {
    * share published slugs and databases, so the UI warns instead of merging them quietly.
    */
   collidingFolderNames: string[];
+  /** Non-null when the app is shared to the workspace as an agent toolset. */
+  share: PodAppShareSummary | null;
 };
 
 export type GetPodAppsResponseBody = {

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -89,6 +89,38 @@ export const ClonePodAppRequestBodySchema = z.object({
   name: z.string().min(1).max(MAX_POD_APP_NAME_LENGTH),
 });
 
+/** Max length of the sharer-provided toolset description, which agents use for discovery. */
+export const MAX_POD_APP_SHARE_DESCRIPTION_LENGTH = 2048;
+
+/** How a shared app surfaces on listings and share endpoints. */
+export type PodAppShareSummary = {
+  appPrefix: string;
+  toolsetName: string;
+  description: string;
+};
+
+export const SharePodAppRequestBodySchema = z.object({
+  name: z.string().min(1).max(MAX_POD_APP_NAME_LENGTH).optional(),
+  description: z.string().min(1).max(MAX_POD_APP_SHARE_DESCRIPTION_LENGTH),
+});
+
+export const UpdatePodAppShareRequestBodySchema = z.object({
+  name: z.string().min(1).max(MAX_POD_APP_NAME_LENGTH).optional(),
+  description: z
+    .string()
+    .min(1)
+    .max(MAX_POD_APP_SHARE_DESCRIPTION_LENGTH)
+    .optional(),
+});
+
+export type SharePodAppResponseBody = {
+  share: PodAppShareSummary;
+};
+
+export type DeletePodAppShareResponseBody = {
+  success: true;
+};
+
 /** What a clone created, as the business layer reports it and the endpoint returns it. */
 export type PodAppCloneSummary = {
   prefix: string;


### PR DESCRIPTION
## What

Lets pod editors share a pod app (a folder of published functions) as a named toolset that agents across the workspace can use — sort of like an MCP server, without leaving the pod. Builds on the frame-share capability work merged in #30532. Design doc: [Sharing pod functions as tools](https://app.notion.com/p/dust-tt/Sharing-pod-functions-as-tools-3bf28599d94180a59721f8a78752a61d).

- **Agent builders** can attach the toolset from the existing tools picker; each published function shows up as an individually-named tool with its real input schema.
- **Any agent** can discover and enable the toolset on demand via the existing `discover_tools` / `toolsets__enable` catalog (works out of the box since the views live in the global space with no required configuration).

Everything is workspace-internal: no external exposure, no direct human invocation surface, and cross-pod frame calls are explicitly out of scope for this iteration.

## How

A shared app is one instance of a new `pod_app_toolset` internal MCP server (standard multi-instance machinery, distinct sId per instance) plus the usual system/global `MCPServerView` pair, bound to `(pod, appName)` by a new `PodAppShareModel` row.

- **Tool listing**: the server installs low-level MCP list/call handlers so each function's stored JSON Schema is served verbatim (the zod-based `registerTool` wrapper can't express raw JSON Schema). Tools are listed fresh on every agent step, so republishing a function propagates instantly. Functions whose `userIdentity` policy the caller can never satisfy (`pod_member_required` for non-members, `interactive_workspace_user_required` in agent loops) are filtered from listings; the policy is still re-checked at invocation.
- **Resolution gate**: `SandboxFunctionResource.baseFetch` gains an opt-in `podAppShare` gate (same pattern as the frame-share capability), passed only by the toolset server's handlers. The HTTP invocation route, frames, and every other existing resolution path are unchanged — regression-tested.
- **Execution**: calls feed the existing invocation pipeline unchanged; functions run on the owning pod's sandbox against its databases, and the invoker's identity is passed as today (`isPodMember: false` for outsiders).
- **Permissions**: sharing/unsharing is gated on pod editorship; the admin-gated view/instance mutations run under `internalAdminForWorkspace`. Unsharing soft-deletes the views and the share row; deleting the app or scrubbing the pod cascades the revocation (the share FK is `ON DELETE RESTRICT`, so scrub hard-deletes the rows).
- **Stake**: each shared tool starts at its function's author-declared `defaultStake` (the field introduced with #30532), overridable per tool by admins. This surfaced a latent gap: `extractMetadataFromTools` dropped the `_meta.dust.stake` that dynamically-listed tools declare, so they silently fell back to High. The stake now threads through `MCPToolType` with precedence admin override → static registry stake → tool's self-declared stake → fallback (no behavior change for existing servers: static internal tools always hit the registry stake first, and `run_dust_app`'s dynamic tools declared the same value as their fallback).
- **Admin/picker surfaces**: `pod_app_toolset` instances overlay their system view's name/description and their live tool list onto the in-memory server metadata, so the space "add tools" picker shows the real toolset name (not "Pod App Toolset (Preview)") and the Spaces/Tools detail panel lists the functions with working per-tool stake/disable. The client-side default-stake helpers now resolve registry identity from the sId instead of `server.name`, which the name overlay would otherwise have broken.
- **UI**: "Share as tools" action + dialog on the pod Apps tab (toolset name, description with discovery guidance, function list flagging members-only functions, edit + stop-sharing modes) and a "Tools" chip on shared app tiles.

The whole feature sits behind the existing `sandbox_functions` feature flag; the new server is `isPreview`.

## Notes

- Share creation is a sequenced operation with cleanup-on-failure rather than one DB transaction — the instance/view APIs aren't transactional.
- No revoke-on-folder-rename hook: no rename event exists, and published functions keep their old-prefix slugs after a rename, so the toolset keeps working over the already-published functions; future republishes land under the new prefix.
- Deferred (see design doc): cross-pod frame calls, audit logging for share/unshare, sharing into specific restricted spaces, per-function opt-out.

## Testing

Functional tests throughout: resource-level (share lifecycle, the opt-in gate incl. "default fetchers not widened"), the toolset server (verbatim schema listing, policy filtering for members/non-members, per-function default stakes, call routing with mocked invocation), the business layer (share/unshare/update incl. view lifecycle and name conflicts, instance metadata overlay), and endpoint tests (POST/PATCH/DELETE share, listing status, non-editor 404, app-deletion cascade). Migration applied locally; availability snapshot and metadata snapshots updated; space-scrub model guard registered.
