### PR TITLE
Handle terminal Snowflake and Microsoft connector errors

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.test.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.test.ts
@@ -1,0 +1,26 @@
+import { ThirdPartyConfigurationError } from "@connectors/lib/error";
+import { GraphError } from "@microsoft/microsoft-graph-client";
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  Next,
+} from "@temporalio/worker";
+import { describe, expect, it, vi } from "vitest";
+
+import { MicrosoftCastKnownErrorsInterceptor } from "./cast_known_errors";
+
+describe("MicrosoftCastKnownErrorsInterceptor", () => {
+  it("classifies a missing SharePoint license as a terminal configuration error", async () => {
+    const error = new GraphError(400, "Tenant does not have a SPO license.");
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new MicrosoftCastKnownErrorsInterceptor().execute(
+        { args: [], headers: {} } satisfies ActivityExecuteInput,
+        next
+      )
+    ).rejects.toEqual(new ThirdPartyConfigurationError(error));
+  });
+});

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -1,5 +1,8 @@
 import { MicrosoftThrottlingError } from "@connectors/connectors/microsoft/lib/errors";
-import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  ThirdPartyConfigurationError,
+} from "@connectors/lib/error";
 import { GraphError } from "@microsoft/microsoft-graph-client";
 import { ApplicationFailure } from "@temporalio/common";
 import type {
@@ -86,6 +89,16 @@ export function isBillingPolicyError(err: unknown): err is GraphError {
   );
 }
 
+export function isMissingSharePointLicenseError(
+  err: unknown
+): err is GraphError {
+  return (
+    err instanceof GraphError &&
+    err.statusCode === 400 &&
+    err.message.includes("Tenant does not have a SPO license")
+  );
+}
+
 // Identifies JSON parsing errors that may occur when Microsoft's API returns
 // malformed JSON or error responses that are not properly formatted.
 export function isJSONParsingError(err: unknown): err is Error {
@@ -118,6 +131,9 @@ export class MicrosoftCastKnownErrorsInterceptor
       // TODO(2025-02-12): add an error type for Microsoft client errors and catch them at strategic locations (e.g. API call to instantiate a client)
       if (isMicrosoftSignInError(err)) {
         throw new ExternalOAuthTokenError(err);
+      }
+      if (isMissingSharePointLicenseError(err)) {
+        throw new ThirdPartyConfigurationError(err);
       }
       throw err;
     }

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.test.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { isSnowflakeDatabaseUnavailableError } from "./snowflake_api";
+
+describe("isSnowflakeDatabaseUnavailableError", () => {
+  it.each([
+    "002043",
+    "003030",
+  ])("recognizes database-scoped error code %s", (code) => {
+    const error = Object.assign(new Error("Database unavailable"), { code });
+
+    expect(isSnowflakeDatabaseUnavailableError(error)).toBe(true);
+  });
+
+  it("does not skip an expired listing trial", () => {
+    const error = Object.assign(
+      new Error("Listing trial time limit exceeded"),
+      {
+        code: "090693",
+      }
+    );
+
+    expect(isSnowflakeDatabaseUnavailableError(error)).toBe(false);
+  });
+});

--- a/connectors/src/connectors/snowflake/lib/snowflake_api.ts
+++ b/connectors/src/connectors/snowflake/lib/snowflake_api.ts
@@ -470,7 +470,7 @@ export const fetchTree = async (
       connection,
     });
     if (schemasRes.isErr()) {
-      if (isSnowflakeObjectNotFoundError(schemasRes.error)) {
+      if (isSnowflakeDatabaseUnavailableError(schemasRes.error)) {
         localLogger.warn(
           { database: db.name },
           "Database no longer exists or is inaccessible, skipping."
@@ -488,7 +488,7 @@ export const fetchTree = async (
       connection,
     });
     if (tablesRes.isErr()) {
-      if (isSnowflakeObjectNotFoundError(tablesRes.error)) {
+      if (isSnowflakeDatabaseUnavailableError(tablesRes.error)) {
         localLogger.warn(
           { database: db.name },
           "Database no longer exists or is inaccessible, skipping."
@@ -821,12 +821,16 @@ async function _closeConnection(
 }
 
 /**
- * Snowflake error code 002043: "Object does not exist, or operation cannot be
- * performed." Raised when a database or schema has been dropped / made
- * inaccessible after SHOW DATABASES returned it.
+ * Raised when a database has been dropped, made inaccessible, or its share was
+ * revoked after SHOW DATABASES returned it. These are database-scoped failures,
+ * so the rest of the account can still be synchronized.
  */
-function isSnowflakeObjectNotFoundError(err: Error): boolean {
-  return "code" in err && (err as Error & { code: string }).code === "002043";
+export function isSnowflakeDatabaseUnavailableError(err: Error): boolean {
+  return (
+    "code" in err &&
+    typeof err.code === "string" &&
+    ["002043", "003030"].includes(err.code)
+  );
 }
 
 /**

--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.test.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.test.ts
@@ -1,0 +1,31 @@
+import { ThirdPartyConfigurationError } from "@connectors/lib/error";
+import type {
+  ActivityExecuteInput,
+  ActivityInboundCallsInterceptor,
+  Next,
+} from "@temporalio/worker";
+import { describe, expect, it, vi } from "vitest";
+
+import { SnowflakeCastKnownErrorsInterceptor } from "./cast_known_errors";
+
+describe("SnowflakeCastKnownErrorsInterceptor", () => {
+  it("classifies an expired listing trial as a terminal configuration error", async () => {
+    const error = Object.assign(
+      new Error("Listing trial time limit exceeded"),
+      {
+        code: "090693",
+        name: "OperationFailedError",
+      }
+    );
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(
+      new SnowflakeCastKnownErrorsInterceptor().execute(
+        { args: [], headers: {} } satisfies ActivityExecuteInput,
+        next
+      )
+    ).rejects.toEqual(new ThirdPartyConfigurationError(error));
+  });
+});

--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -1,4 +1,7 @@
-import { ExternalOAuthTokenError } from "@connectors/lib/error";
+import {
+  ExternalOAuthTokenError,
+  ThirdPartyConfigurationError,
+} from "@connectors/lib/error";
 import type {
   ActivityExecuteInput,
   ActivityInboundCallsInterceptor,
@@ -168,6 +171,15 @@ function isSnowflakeInvalidJwtError(
   );
 }
 
+function isSnowflakeListingTrialExpiredError(err: unknown): err is Error {
+  return (
+    err instanceof Error &&
+    "code" in err &&
+    typeof err.code === "string" &&
+    err.code === "090693"
+  );
+}
+
 export class SnowflakeCastKnownErrorsInterceptor
   implements ActivityInboundCallsInterceptor
 {
@@ -191,6 +203,9 @@ export class SnowflakeCastKnownErrorsInterceptor
         isSnowflakeInvalidJwtError(err)
       ) {
         throw new ExternalOAuthTokenError(err);
+      }
+      if (isSnowflakeListingTrialExpiredError(err)) {
+        throw new ThirdPartyConfigurationError(err);
       }
       throw err;
     }

--- a/connectors/src/lib/error.ts
+++ b/connectors/src/lib/error.ts
@@ -115,6 +115,18 @@ export class RemoteDatabaseConnectionNotReadonlyError extends Error {
   }
 }
 
+// An external provider configuration prevents the connector from making
+// progress and requires customer action before synchronization can resume.
+export class ThirdPartyConfigurationError extends Error {
+  declare cause?: Error;
+
+  constructor(readonly innerError?: Error) {
+    super(innerError?.message);
+    this.cause = innerError;
+    this.name = "ThirdPartyConfigurationError";
+  }
+}
+
 export class WorkspaceQuotaExceededError extends Error {
   constructor() {
     super(

--- a/connectors/src/lib/temporal_monitoring.test.ts
+++ b/connectors/src/lib/temporal_monitoring.test.ts
@@ -63,7 +63,10 @@ vi.mock("dd-trace", () => ({
 
 import logger from "@connectors/logger/logger";
 
-import { RemoteDatabaseConnectionNotReadonlyError } from "./error";
+import {
+  RemoteDatabaseConnectionNotReadonlyError,
+  ThirdPartyConfigurationError,
+} from "./error";
 import { ActivityInboundLogInterceptor } from "./temporal_monitoring";
 
 const temporalLogger = {
@@ -189,6 +192,34 @@ describe("ActivityInboundLogInterceptor", () => {
     );
     expect(mocks.pauseAndStop).toHaveBeenCalledWith({
       reason: "Stopped on workspace_can_use_product_required_error",
+    });
+  });
+
+  it("marks third-party configuration failures and pauses the connector", async () => {
+    const interceptor = new ActivityInboundLogInterceptor(
+      makeActivityContext(),
+      logger,
+      "snowflake"
+    );
+    const error = new ThirdPartyConfigurationError(
+      new Error("Provider configuration requires user action")
+    );
+    const input = {
+      args: [],
+      headers: {},
+    } satisfies ActivityExecuteInput;
+    const next = vi.fn(async () => {
+      throw error;
+    }) satisfies Next<ActivityInboundCallsInterceptor, "execute">;
+
+    await expect(interceptor.execute(input, next)).rejects.toBe(error);
+
+    expect(mocks.syncFailed).toHaveBeenCalledWith(
+      42,
+      "third_party_internal_error"
+    );
+    expect(mocks.pauseAndStop).toHaveBeenCalledWith({
+      reason: "Stopped on ThirdPartyConfigurationError",
     });
   });
 });

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -20,6 +20,7 @@ import {
   ExternalOAuthTokenError,
   ProviderTransientError,
   RemoteDatabaseConnectionNotReadonlyError,
+  ThirdPartyConfigurationError,
   WorkspaceQuotaExceededError,
 } from "./error";
 import { syncFailed } from "./sync_status";
@@ -66,6 +67,15 @@ function categorizeFinalConnectorError(err: unknown): {
       connectorErrorType: "workspace_quota_exceeded",
       logMessage:
         "Stopping connector manager because of quota exceeded for the workspace.",
+      pauseReason: `Stopped on ${err.name}`,
+    };
+  }
+
+  if (err instanceof ThirdPartyConfigurationError) {
+    return {
+      connectorErrorType: "third_party_internal_error",
+      logMessage:
+        "Stopping connector manager because the third-party configuration requires user action.",
       pauseReason: `Stopped on ${err.name}`,
     };
   }


### PR DESCRIPTION
## Description

- Skip Snowflake databases that return `003030` after a share is revoked, matching the existing per-database handling for `002043`.
- Treat Snowflake `090693` expired listings and Microsoft Graph's missing SharePoint license response as terminal provider configuration errors. The existing activity interceptor marks the sync failed, pauses the connector, and stops its workflow instead of retrying forever.

## Tests

Added focused tests for the three provider responses and for the shared failed-sync, pause, and stop behavior.

## Risk

A revoked Snowflake database is removed from the sync tree and its stale content can be garbage collected, matching the existing inaccessible-database behavior. Terminal configuration errors pause the whole connector until it is manually resumed after the customer fixes the provider configuration. Rollback is a normal revert; connectors paused before rollback remain paused until resumed.

## Deploy Plan

Deploy Connectors normally in both regions. Verify connector 32646 completes while skipping the revoked database, and connectors 13993 and 49139 become failed and paused with no further Temporal attempts. Monitor the three workflow IDs and connector error logs after rollout.