### PR TITLE
feat: per-trigger breakdown row on the automations triggers table

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/index.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/index.ts
@@ -1,10 +1,12 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import overview from "./overview";
+import triggerBreakdown from "./trigger-breakdown";
 import triggers from "./triggers";
 
 const app = workspaceApp();
 
 app.route("/overview", overview);
 app.route("/triggers", triggers);
+app.route("/trigger-breakdown", triggerBreakdown);
 
 export default app;

--- a/front-api/routes/w/[wId]/analytics/automations/trigger-breakdown.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/trigger-breakdown.test.ts
@@ -1,0 +1,112 @@
+import type { GetAutomationTriggerBreakdownResponse } from "@app/lib/api/analytics/automations/breakdown";
+import { fetchAutomationTriggerBreakdown } from "@app/lib/api/analytics/automations/breakdown";
+import { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Err, Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  import("@app/lib/api/analytics/automations/breakdown"),
+  async (orig) => {
+    const mod = await orig();
+    return {
+      ...mod,
+      fetchAutomationTriggerBreakdown: vi.fn(),
+    };
+  }
+);
+
+const BREAKDOWN: GetAutomationTriggerBreakdownResponse = {
+  period: {
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+  },
+  creditDestination: {
+    dimension: "tool",
+    key: "web_search_browse",
+    name: "Web search browse",
+    icon: null,
+    credits: 2154,
+    share: 0.88,
+  },
+};
+
+async function setupTest({
+  role = "admin",
+}: {
+  role?: MembershipRoleType;
+} = {}) {
+  return createPrivateApiMockRequest({ role });
+}
+
+function postBreakdownRequest(wId: string, body: Record<string, unknown>) {
+  return honoApp.request(
+    `/api/w/${wId}/analytics/automations/trigger-breakdown`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("POST /api/w/:wId/analytics/automations/trigger-breakdown", () => {
+  it("returns 403 for managers", async () => {
+    const { workspace } = await setupTest({ role: "manager" });
+
+    const response = await postBreakdownRequest(workspace.sId, {
+      triggerId: "trg1",
+    });
+
+    expect(response.status).toBe(403);
+    expect(vi.mocked(fetchAutomationTriggerBreakdown)).not.toHaveBeenCalled();
+  });
+
+  it("returns the breakdown for admins", async () => {
+    vi.mocked(fetchAutomationTriggerBreakdown).mockResolvedValue(
+      new Ok(BREAKDOWN)
+    );
+    const { workspace } = await setupTest();
+
+    const response = await postBreakdownRequest(workspace.sId, {
+      triggerId: "trg1",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(BREAKDOWN);
+    expect(vi.mocked(fetchAutomationTriggerBreakdown)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ triggerId: "trg1" })
+    );
+  });
+
+  it("returns 400 when triggerId is missing", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await postBreakdownRequest(workspace.sId, {});
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+    expect(vi.mocked(fetchAutomationTriggerBreakdown)).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the search fails", async () => {
+    vi.mocked(fetchAutomationTriggerBreakdown).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { workspace } = await setupTest();
+
+    const response = await postBreakdownRequest(workspace.sId, {
+      triggerId: "trg1",
+    });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: { type: "internal_server_error" },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/analytics/automations/trigger-breakdown.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/trigger-breakdown.ts
@@ -1,0 +1,57 @@
+import type { GetAutomationTriggerBreakdownResponse } from "@app/lib/api/analytics/automations/breakdown";
+import { fetchAutomationTriggerBreakdown } from "@app/lib/api/analytics/automations/breakdown";
+import { AutomationTriggerBreakdownBodySchema } from "@app/lib/api/analytics/automations/schema";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
+import logger from "@app/logger/logger";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+export type { GetAutomationTriggerBreakdownResponse };
+
+// Mounted at /api/w/:wId/analytics/automations/trigger-breakdown.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", AutomationTriggerBreakdownBodySchema),
+  async (ctx): HandlerResult<GetAutomationTriggerBreakdownResponse> => {
+    const auth = ctx.get("auth");
+    const { triggerId, ...periodQuery } = ctx.req.valid("json");
+
+    const period = await resolveConsumptionPeriod(
+      auth,
+      toConsumptionPeriodInput(periodQuery)
+    );
+
+    const result = await fetchAutomationTriggerBreakdown(auth, {
+      triggerId,
+      period,
+    });
+    if (result.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          triggerId,
+          err: result.error,
+        },
+        "[AutomationsAnalytics] Failed to retrieve trigger breakdown."
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to retrieve trigger breakdown.",
+        },
+      });
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
@@ -22,6 +22,8 @@ const TRIGGERS: GetAutomationTriggersResponse = {
     endDate: "2026-08-01T00:00:00.000Z",
   },
   totalCount: 2,
+  medianRunCount: 366,
+  medianCostPerRun: 3.4,
   triggers: [
     {
       triggerId: "trg1",

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.test.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.test.tsx
@@ -1,0 +1,67 @@
+import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AutomationsTriggerBreakdown } from "./AutomationsTriggerBreakdown";
+
+vi.mock(import("@app/hooks/useAutomationsTriggerBreakdown"), () => ({
+  useAutomationsTriggerBreakdown: vi.fn(() => ({
+    creditDestination: null,
+    isBreakdownLoading: false,
+    isBreakdownError: false,
+    isBreakdownValidating: false,
+  })),
+}));
+
+const PERIOD = { kind: "days", days: 30 } as const;
+
+const TRIGGER: AutomationTriggerRow = {
+  triggerId: "trg1",
+  name: "Competitor watch",
+  kind: "schedule",
+  agent: {
+    agentId: "agent1",
+    name: "deep-dive",
+    pictureUrl: null,
+    description: null,
+    modelId: null,
+    modelDisplayName: null,
+  },
+  editor: { name: "Nic Siegle", email: null, pictureUrl: null },
+  scheduleDescription: "Every day at 9:00",
+  webhookSourceName: null,
+  webhookIcon: null,
+  runCount: 0,
+  credits: 0,
+  status: "enabled",
+};
+
+describe("AutomationsTriggerBreakdown", () => {
+  it("shows no comparison for a trigger with zero run count, instead of an Infinity ratio", () => {
+    render(
+      <AutomationsTriggerBreakdown
+        workspaceId="w1"
+        trigger={TRIGGER}
+        period={PERIOD}
+        medianRunCount={366}
+        medianCostPerRun={3.4}
+      />
+    );
+
+    expect(screen.getAllByText("no comparison available")).toHaveLength(2);
+    expect(screen.queryByText(/Infinity/)).not.toBeInTheDocument();
+  });
+
+  it("compares a trigger's stats against a non-zero median", () => {
+    render(
+      <AutomationsTriggerBreakdown
+        workspaceId="w1"
+        trigger={{ ...TRIGGER, runCount: 720, credits: 2448 }}
+        period={PERIOD}
+        medianRunCount={360}
+        medianCostPerRun={1}
+      />
+    );
+
+    expect(screen.getByText("2x more than most")).toBeInTheDocument();
+  });
+});

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
@@ -29,22 +29,33 @@ function StatBlock({
   label,
   primaryText,
   caption,
+  captionTooltipLabel,
 }: {
   label: string;
   primaryText: ReactNode;
   caption: string;
+  captionTooltipLabel?: string;
 }) {
   return (
     <div className="flex min-w-0 flex-col gap-2">
       <h4 className="text-xs font-semibold text-muted-foreground">{label}</h4>
       <div className="flex min-w-0 items-baseline gap-2 text-xs">
         <div className="truncate">{primaryText}</div>
-        <Tooltip
-          trigger={
-            <span className="truncate text-muted-foreground">{caption}</span>
-          }
-          label={CAPTION_TOOLTIP_LABEL}
-        />
+        {captionTooltipLabel ? (
+          <Tooltip
+            tooltipTriggerAsChild
+            trigger={
+              <span className="ml-auto truncate text-muted-foreground">
+                {caption}
+              </span>
+            }
+            label={captionTooltipLabel}
+          />
+        ) : (
+          <span className="ml-auto truncate text-muted-foreground">
+            {caption}
+          </span>
+        )}
       </div>
     </div>
   );
@@ -137,6 +148,7 @@ export function AutomationsTriggerBreakdown({
           </>
         }
         caption={ratioCaption(trigger.runCount, medianRunCount)}
+        captionTooltipLabel={CAPTION_TOOLTIP_LABEL}
       />
       <StatBlock
         label="What each run costs"

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
@@ -2,21 +2,14 @@ import { useAutomationsTriggerBreakdown } from "@app/hooks/useAutomationsTrigger
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { formatCredits } from "@app/lib/client/credits";
-import { LoadingBlock, ProgressBar } from "@dust-tt/sparkle";
+import { LoadingBlock, Tooltip } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
-// A trigger at 2x its comparison's median fills the bar; further outliers
-// (a trigger running 24x more than most) still just cap at 100%.
-const RATIO_BAR_SCALE = 2;
+const CAPTION_TOOLTIP_LABEL =
+  "Compared to the median across all triggers for this period.";
+
 const RATIO_MORE_THRESHOLD = 1.5;
 const RATIO_LESS_THRESHOLD = 1 / RATIO_MORE_THRESHOLD;
-
-function ratioPercentage(value: number, median: number): number {
-  if (median <= 0) {
-    return 0;
-  }
-  return Math.round(Math.min(100, (value / median / RATIO_BAR_SCALE) * 100));
-}
 
 function ratioCaption(value: number, median: number): string {
   if (median <= 0) {
@@ -35,23 +28,23 @@ function ratioCaption(value: number, median: number): string {
 function StatBlock({
   label,
   primaryText,
-  percentage,
   caption,
 }: {
   label: string;
   primaryText: ReactNode;
-  percentage: number;
   caption: string;
 }) {
   return (
     <div className="flex min-w-0 flex-col gap-2">
       <h4 className="text-xs font-semibold text-muted-foreground">{label}</h4>
-      <div className="flex flex-col gap-1">
-        <div className="truncate text-xs">{primaryText}</div>
-        <ProgressBar className="w-full" percentage={percentage} />
-        <span className="truncate text-xs text-muted-foreground">
-          {caption}
-        </span>
+      <div className="flex min-w-0 items-baseline gap-2 text-xs">
+        <div className="truncate">{primaryText}</div>
+        <Tooltip
+          trigger={
+            <span className="truncate text-muted-foreground">{caption}</span>
+          }
+          label={CAPTION_TOOLTIP_LABEL}
+        />
       </div>
     </div>
   );
@@ -75,9 +68,8 @@ function CreditDestinationBlock({
         <h4 className="text-xs font-semibold text-muted-foreground">
           Where the credits go
         </h4>
-        <div className="flex flex-col gap-1">
+        <div className="flex items-baseline gap-2">
           <LoadingBlock className="h-4 w-24" />
-          <LoadingBlock className="h-1.5 w-full rounded-full" />
           <LoadingBlock className="h-3 w-20" />
         </div>
       </div>
@@ -109,7 +101,6 @@ function CreditDestinationBlock({
           {creditDestination.name}
         </span>
       }
-      percentage={percentage}
       caption={`${percentage}% of its credits`}
     />
   );
@@ -145,7 +136,6 @@ export function AutomationsTriggerBreakdown({
             <span className="text-muted-foreground">times</span>
           </>
         }
-        percentage={ratioPercentage(trigger.runCount, medianRunCount)}
         caption={ratioCaption(trigger.runCount, medianRunCount)}
       />
       <StatBlock
@@ -158,7 +148,6 @@ export function AutomationsTriggerBreakdown({
             <span className="text-muted-foreground">credits</span>
           </>
         }
-        percentage={ratioPercentage(costPerRun, medianCostPerRun)}
         caption={ratioCaption(costPerRun, medianCostPerRun)}
       />
       <CreditDestinationBlock

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
@@ -1,0 +1,171 @@
+import { useAutomationsTriggerBreakdown } from "@app/hooks/useAutomationsTriggerBreakdown";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
+import { formatCredits } from "@app/lib/client/credits";
+import { LoadingBlock, ProgressBar } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+// A trigger at 2x its comparison's median fills the bar; further outliers
+// (a trigger running 24x more than most) still just cap at 100%.
+const RATIO_BAR_SCALE = 2;
+const RATIO_MORE_THRESHOLD = 1.5;
+const RATIO_LESS_THRESHOLD = 1 / RATIO_MORE_THRESHOLD;
+
+function ratioPercentage(value: number, median: number): number {
+  if (median <= 0) {
+    return 0;
+  }
+  return Math.round(Math.min(100, (value / median / RATIO_BAR_SCALE) * 100));
+}
+
+function ratioCaption(value: number, median: number): string {
+  if (median <= 0) {
+    return "no comparison available";
+  }
+  const ratio = value / median;
+  if (ratio >= RATIO_MORE_THRESHOLD) {
+    return `${Math.round(ratio)}x more than most`;
+  }
+  if (ratio <= RATIO_LESS_THRESHOLD) {
+    return `${Math.round(1 / ratio)}x less than most`;
+  }
+  return "about typical";
+}
+
+function StatBlock({
+  label,
+  primaryText,
+  percentage,
+  caption,
+}: {
+  label: string;
+  primaryText: ReactNode;
+  percentage: number;
+  caption: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      <h4 className="text-xs font-semibold text-muted-foreground">{label}</h4>
+      <div className="flex flex-col gap-1">
+        <div className="truncate text-xs">{primaryText}</div>
+        <ProgressBar className="w-full" percentage={percentage} />
+        <span className="truncate text-xs text-muted-foreground">
+          {caption}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CreditDestinationBlock({
+  workspaceId,
+  triggerId,
+  period,
+}: {
+  workspaceId: string;
+  triggerId: string;
+  period: ConsumptionPeriodSelection;
+}) {
+  const { creditDestination, isBreakdownLoading, isBreakdownError } =
+    useAutomationsTriggerBreakdown({ workspaceId, triggerId, period });
+
+  if (isBreakdownLoading) {
+    return (
+      <div className="flex min-w-0 flex-col gap-2">
+        <h4 className="text-xs font-semibold text-muted-foreground">
+          Where the credits go
+        </h4>
+        <div className="flex flex-col gap-1">
+          <LoadingBlock className="h-4 w-24" />
+          <LoadingBlock className="h-1.5 w-full rounded-full" />
+          <LoadingBlock className="h-3 w-20" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isBreakdownError || !creditDestination) {
+    return (
+      <div className="flex min-w-0 flex-col gap-2">
+        <h4 className="text-xs font-semibold text-muted-foreground">
+          Where the credits go
+        </h4>
+        <span className="text-xs text-muted-foreground">
+          {isBreakdownError
+            ? "Failed to load breakdown."
+            : "No attributed consumption."}
+        </span>
+      </div>
+    );
+  }
+
+  const percentage = Math.round(Math.min(100, creditDestination.share * 100));
+
+  return (
+    <StatBlock
+      label="Where the credits go"
+      primaryText={
+        <span className="font-semibold text-foreground">
+          {creditDestination.name}
+        </span>
+      }
+      percentage={percentage}
+      caption={`${percentage}% of its credits`}
+    />
+  );
+}
+
+interface AutomationsTriggerBreakdownProps {
+  workspaceId: string;
+  trigger: AutomationTriggerRow;
+  period: ConsumptionPeriodSelection;
+  medianRunCount: number;
+  medianCostPerRun: number;
+}
+
+export function AutomationsTriggerBreakdown({
+  workspaceId,
+  trigger,
+  period,
+  medianRunCount,
+  medianCostPerRun,
+}: AutomationsTriggerBreakdownProps) {
+  const costPerRun =
+    trigger.runCount > 0 ? trigger.credits / trigger.runCount : 0;
+
+  return (
+    <div className="grid grid-cols-3 gap-16 border-b border-separator px-2 pb-6 pt-4">
+      <StatBlock
+        label="How often it runs"
+        primaryText={
+          <>
+            <span className="font-semibold text-foreground">
+              {trigger.runCount.toLocaleString()}
+            </span>{" "}
+            <span className="text-muted-foreground">times</span>
+          </>
+        }
+        percentage={ratioPercentage(trigger.runCount, medianRunCount)}
+        caption={ratioCaption(trigger.runCount, medianRunCount)}
+      />
+      <StatBlock
+        label="What each run costs"
+        primaryText={
+          <>
+            <span className="font-semibold text-foreground">
+              {formatCredits(costPerRun)}
+            </span>{" "}
+            <span className="text-muted-foreground">credits</span>
+          </>
+        }
+        percentage={ratioPercentage(costPerRun, medianCostPerRun)}
+        caption={ratioCaption(costPerRun, medianCostPerRun)}
+      />
+      <CreditDestinationBlock
+        workspaceId={workspaceId}
+        triggerId={trigger.triggerId}
+        period={period}
+      />
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
@@ -12,7 +12,7 @@ const RATIO_MORE_THRESHOLD = 1.5;
 const RATIO_LESS_THRESHOLD = 1 / RATIO_MORE_THRESHOLD;
 
 function ratioCaption(value: number, median: number): string {
-  if (median <= 0) {
+  if (value <= 0 || median <= 0) {
     return "no comparison available";
   }
   const ratio = value / median;

--- a/front/components/workspace/analytics/automations/AutomationsTriggersRowsTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersRowsTable.tsx
@@ -1,0 +1,142 @@
+import { AutomationsTriggerBreakdown } from "@app/components/workspace/analytics/automations/AutomationsTriggerBreakdown";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronSelectorVertical,
+  Collapsible,
+  CollapsibleContent,
+  cn,
+  DataTable,
+  Icon,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { Fragment } from "react";
+
+export type TriggerRowData = AutomationTriggerRow & {
+  onClick: () => void;
+};
+
+interface AutomationsTriggersRowsTableProps<T extends TriggerRowData> {
+  data: T[];
+  columns: ColumnDef<T>[];
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  expandedRowId: string | null;
+  medianRunCount: number;
+  medianCostPerRun: number;
+}
+
+export function AutomationsTriggersRowsTable<T extends TriggerRowData>({
+  data,
+  columns,
+  workspaceId,
+  period,
+  expandedRowId,
+  medianRunCount,
+  medianCostPerRun,
+}: AutomationsTriggersRowsTableProps<T>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <DataTable.Root className="min-w-150">
+      <DataTable.Header>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <DataTable.Row key={headerGroup.id} widthClassName="w-full">
+            {headerGroup.headers.map((header) => (
+              <DataTable.Head
+                column={header.column}
+                key={header.id}
+                onClick={
+                  header.column.getCanSort()
+                    ? header.column.getToggleSortingHandler()
+                    : undefined
+                }
+                className={cn(header.column.getCanSort() && "cursor-pointer")}
+              >
+                <div
+                  className={cn(
+                    "flex items-center space-x-1 whitespace-nowrap",
+                    header.column.columnDef.meta?.headerAlign === "right" &&
+                      "justify-end"
+                  )}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                  {header.column.getCanSort() && (
+                    <Icon
+                      visual={
+                        header.column.getIsSorted() === "asc"
+                          ? ArrowUp
+                          : header.column.getIsSorted() === "desc"
+                            ? ArrowDown
+                            : ChevronSelectorVertical
+                      }
+                      size="xs"
+                      className="ml-1"
+                    />
+                  )}
+                </div>
+              </DataTable.Head>
+            ))}
+          </DataTable.Row>
+        ))}
+      </DataTable.Header>
+      <DataTable.Body>
+        {table.getRowModel().rows.map((row) => (
+          <Fragment key={row.id}>
+            <DataTable.Row
+              widthClassName="w-full"
+              onClick={row.original.onClick}
+              rowData={row.original}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <DataTable.Cell column={cell.column} key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </DataTable.Cell>
+              ))}
+            </DataTable.Row>
+            <tr>
+              <td className="max-w-0" colSpan={row.getVisibleCells().length}>
+                <Collapsible open={expandedRowId === row.original.triggerId}>
+                  <CollapsibleContent
+                    animated={false}
+                    className={cn(
+                      "transition-none ease-enter motion-reduce:animate-none",
+                      "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+                      "data-[state=open]:slide-in-from-top-1 data-[state=open]:duration-enter",
+                      "data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
+                      "data-[state=closed]:slide-out-to-top-1 data-[state=closed]:duration-exit"
+                    )}
+                  >
+                    <AutomationsTriggerBreakdown
+                      workspaceId={workspaceId}
+                      trigger={row.original}
+                      period={period}
+                      medianRunCount={medianRunCount}
+                      medianCostPerRun={medianCostPerRun}
+                    />
+                  </CollapsibleContent>
+                </Collapsible>
+              </td>
+            </tr>
+          </Fragment>
+        ))}
+      </DataTable.Body>
+    </DataTable.Root>
+  );
+}

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -1,5 +1,7 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { getIcon } from "@app/components/resources/resources_icons";
+import type { TriggerRowData as BaseTriggerRowData } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
+import { AutomationsTriggersRowsTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
 import {
   AvatarNameCell,
   CreditsCell,
@@ -15,10 +17,14 @@ import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Avatar,
+  Button,
+  ChevronDown,
+  ChevronUp,
   Clock,
   DataTable,
   DataTableLoadingSkeleton,
   Icon,
+  Pagination,
   SliderToggle,
   Tooltip,
 } from "@dust-tt/sparkle";
@@ -28,12 +34,10 @@ import { useCallback, useContext, useMemo, useState } from "react";
 
 const TRIGGERS_PAGE_SIZE = 25;
 
-interface TriggerRowData extends AutomationTriggerRow {
+interface TriggerRowData extends BaseTriggerRowData {
   displayStatus: TriggerStatus;
   isStatusPending: boolean;
   onToggleStatus: () => void;
-  // onClick satisfies DataTable's row shape, which is otherwise a weak type.
-  onClick?: () => void;
 }
 
 function TypeCell({ trigger }: { trigger: AutomationTriggerRow }) {
@@ -173,86 +177,117 @@ function EditorCell({ editor }: { editor: AutomationTriggerRow["editor"] }) {
   );
 }
 
-const columns: ColumnDef<TriggerRowData>[] = [
-  {
-    id: "name",
-    accessorKey: "name",
-    header: "Name",
-    meta: { className: "w-56", headerAlign: "left" },
-    cell: (info) => (
-      <DataTable.CellContent className="w-full justify-start text-left">
-        <span className="truncate text-sm">{info.row.original.name}</span>
-      </DataTable.CellContent>
-    ),
-  },
-  {
-    id: "agent",
-    header: "Agent",
-    enableSorting: false,
-    meta: { className: "w-44", headerAlign: "left" },
-    cell: (info) => (
-      <DataTable.CellContent className="w-full justify-start">
-        <AgentCell agent={info.row.original.agent} />
-      </DataTable.CellContent>
-    ),
-  },
-  {
-    id: "editor",
-    header: "Editor",
-    enableSorting: false,
-    meta: { className: "w-16", headerAlign: "center" },
-    cell: (info) => (
-      <DataTable.CellContent className="w-full justify-center">
-        <EditorCell editor={info.row.original.editor} />
-      </DataTable.CellContent>
-    ),
-  },
-  {
-    id: "type",
-    header: "Type",
-    enableSorting: false,
-    meta: { headerAlign: "left" },
-    cell: (info) => (
-      <DataTable.CellContent className="w-full justify-start">
-        <TypeCell trigger={info.row.original} />
-      </DataTable.CellContent>
-    ),
-  },
-  {
-    id: "runCount",
-    accessorKey: "runCount",
-    header: "Runs",
-    meta: { className: "w-20", headerAlign: "right" },
-    cell: (info) => (
-      <DataTable.BasicCellContent
-        className="justify-end text-right tabular-nums"
-        label={info.row.original.runCount.toLocaleString()}
-      />
-    ),
-  },
-  {
-    id: "credits",
-    accessorKey: "credits",
-    header: "Credits",
-    meta: { className: "w-24", headerAlign: "right" },
-    cell: (info) => (
-      <DataTable.CellContent className="w-full justify-end text-right">
-        <CreditsCell credits={info.row.original.credits} />
-      </DataTable.CellContent>
-    ),
-  },
-  {
-    id: "status",
-    header: "Enabled",
-    enableSorting: false,
-    meta: { className: "w-24", headerAlign: "left" },
-    cell: (info) => (
-      <DataTable.CellContent className="w-full justify-start">
-        <RunningCell row={info.row.original} />
-      </DataTable.CellContent>
-    ),
-  },
-];
+function buildColumns({
+  expandedRowId,
+}: {
+  expandedRowId: string | null;
+}): ColumnDef<TriggerRowData>[] {
+  return [
+    {
+      id: "name",
+      accessorKey: "name",
+      header: "Name",
+      meta: { className: "w-56", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-start text-left">
+          <span className="truncate text-sm">{info.row.original.name}</span>
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "agent",
+      header: "Agent",
+      enableSorting: false,
+      meta: { className: "w-44", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-start">
+          <AgentCell agent={info.row.original.agent} />
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "editor",
+      header: "Editor",
+      enableSorting: false,
+      meta: { className: "w-16", headerAlign: "center" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-center">
+          <EditorCell editor={info.row.original.editor} />
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "type",
+      header: "Type",
+      enableSorting: false,
+      meta: { headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-start">
+          <TypeCell trigger={info.row.original} />
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "runCount",
+      accessorKey: "runCount",
+      header: "Runs",
+      meta: { className: "w-20", headerAlign: "right" },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          className="justify-end text-right tabular-nums"
+          label={info.row.original.runCount.toLocaleString()}
+        />
+      ),
+    },
+    {
+      id: "credits",
+      accessorKey: "credits",
+      header: "Credits",
+      meta: { className: "w-24", headerAlign: "right" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-end text-right">
+          <CreditsCell credits={info.row.original.credits} />
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "status",
+      header: "Enabled",
+      enableSorting: false,
+      meta: { className: "w-24", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-start">
+          <RunningCell row={info.row.original} />
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "details",
+      header: "",
+      enableSorting: false,
+      meta: { className: "w-12", headerAlign: "right" },
+      cell: (info) => {
+        const row = info.row.original;
+        const isExpanded = expandedRowId === row.triggerId;
+        return (
+          <DataTable.CellContent className="w-full justify-end">
+            <Button
+              icon={isExpanded ? ChevronUp : ChevronDown}
+              variant="ghost-secondary"
+              size="xs"
+              aria-label={`${isExpanded ? "Collapse" : "Expand"} breakdown for ${row.name}`}
+              aria-expanded={isExpanded}
+              onClick={(event) => {
+                event.stopPropagation();
+                row.onClick();
+              }}
+            />
+          </DataTable.CellContent>
+        );
+      },
+    },
+  ];
+}
 
 interface AutomationsTriggersTableProps {
   workspaceId: string;
@@ -267,14 +302,21 @@ export function AutomationsTriggersTable({
     pageIndex: 0,
     pageSize: TRIGGERS_PAGE_SIZE,
   });
+  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
 
-  const { triggers, totalCount, isTriggersLoading, isTriggersError } =
-    useAutomationsTriggers({
-      workspaceId,
-      period,
-      limit: pagination.pageSize,
-      offset: pagination.pageIndex * pagination.pageSize,
-    });
+  const {
+    triggers,
+    totalCount,
+    medianRunCount,
+    medianCostPerRun,
+    isTriggersLoading,
+    isTriggersError,
+  } = useAutomationsTriggers({
+    workspaceId,
+    period,
+    limit: pagination.pageSize,
+    offset: pagination.pageIndex * pagination.pageSize,
+  });
 
   const confirm = useContext(ConfirmContext);
   const updateTriggerStatus = useUpdateTriggerStatus({ workspaceId });
@@ -351,9 +393,13 @@ export function AutomationsTriggersTable({
           displayStatus,
           isStatusPending: pendingIds.has(trigger.triggerId),
           onToggleStatus: () => void handleToggle(trigger, displayStatus),
+          onClick: () =>
+            setExpandedRowId((current) =>
+              current === trigger.triggerId ? null : trigger.triggerId
+            ),
         };
       }),
-    [triggers, statusOverrides, pendingIds, handleToggle]
+    [triggers, statusOverrides, pendingIds, handleToggle, setExpandedRowId]
   );
 
   return (
@@ -363,8 +409,13 @@ export function AutomationsTriggersTable({
         isError={!!isTriggersError}
         rows={rows}
         totalCount={totalCount}
+        medianRunCount={medianRunCount}
+        medianCostPerRun={medianCostPerRun}
         pagination={pagination}
         setPagination={setPagination}
+        workspaceId={workspaceId}
+        period={period}
+        expandedRowId={expandedRowId}
       />
     </div>
   );
@@ -375,8 +426,13 @@ interface TriggersTableBodyProps {
   isError: boolean;
   rows: TriggerRowData[];
   totalCount: number;
+  medianRunCount: number;
+  medianCostPerRun: number;
   pagination: PaginationState;
   setPagination: Dispatch<SetStateAction<PaginationState>>;
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  expandedRowId: string | null;
 }
 
 function TriggersTableBody({
@@ -384,9 +440,19 @@ function TriggersTableBody({
   isError,
   rows,
   totalCount,
+  medianRunCount,
+  medianCostPerRun,
   pagination,
   setPagination,
+  workspaceId,
+  period,
+  expandedRowId,
 }: TriggersTableBodyProps) {
+  const columns = useMemo(
+    () => buildColumns({ expandedRowId }),
+    [expandedRowId]
+  );
+
   if (isLoading) {
     return (
       <DataTableLoadingSkeleton showSelectionColumn={false} showTrailingCell />
@@ -410,15 +476,29 @@ function TriggersTableBody({
   }
 
   return (
-    <div className="overflow-x-auto">
-      <DataTable<TriggerRowData>
-        className="min-w-200"
-        data={rows}
-        columns={columns}
-        totalRowCount={totalCount}
-        pagination={pagination}
-        setPagination={setPagination}
-      />
+    <div>
+      <div className="overflow-x-auto">
+        <AutomationsTriggersRowsTable
+          data={rows}
+          columns={columns}
+          workspaceId={workspaceId}
+          period={period}
+          expandedRowId={expandedRowId}
+          medianRunCount={medianRunCount}
+          medianCostPerRun={medianCostPerRun}
+        />
+      </div>
+      {totalCount > pagination.pageSize && (
+        <div className="mt-2 p-1">
+          <Pagination
+            size="xs"
+            showDetails={false}
+            pagination={pagination}
+            setPagination={setPagination}
+            rowCount={totalCount}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -399,7 +399,7 @@ export function AutomationsTriggersTable({
             ),
         };
       }),
-    [triggers, statusOverrides, pendingIds, handleToggle, setExpandedRowId]
+    [triggers, statusOverrides, pendingIds, handleToggle]
   );
 
   return (

--- a/front/hooks/useAutomationsTriggerBreakdown.ts
+++ b/front/hooks/useAutomationsTriggerBreakdown.ts
@@ -1,0 +1,36 @@
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { GetAutomationTriggerBreakdownResponse } from "@app/lib/api/analytics/automations/breakdown";
+import type { AutomationTriggerBreakdownBody } from "@app/lib/api/analytics/automations/schema";
+
+export function useAutomationsTriggerBreakdown({
+  workspaceId,
+  triggerId,
+  period,
+  disabled,
+}: {
+  workspaceId: string;
+  triggerId: string;
+  period: ConsumptionPeriodSelection;
+  disabled?: boolean;
+}) {
+  const url = `/api/w/${workspaceId}/analytics/automations/trigger-breakdown`;
+  const body: AutomationTriggerBreakdownBody = {
+    triggerId,
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+  };
+
+  const { data, error, isLoading, isValidating } = useConsumptionQuery<
+    AutomationTriggerBreakdownBody,
+    GetAutomationTriggerBreakdownResponse
+  >({ url, body, disabled });
+
+  return {
+    creditDestination: data?.creditDestination ?? null,
+    isBreakdownLoading: !error && isLoading,
+    isBreakdownError: error,
+    isBreakdownValidating: isValidating,
+  };
+}

--- a/front/hooks/useAutomationsTriggerBreakdown.ts
+++ b/front/hooks/useAutomationsTriggerBreakdown.ts
@@ -1,5 +1,6 @@
 import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
 import type { GetAutomationTriggerBreakdownResponse } from "@app/lib/api/analytics/automations/breakdown";
 import type { AutomationTriggerBreakdownBody } from "@app/lib/api/analytics/automations/schema";
 

--- a/front/hooks/useAutomationsTriggers.ts
+++ b/front/hooks/useAutomationsTriggers.ts
@@ -38,6 +38,8 @@ export function useAutomationsTriggers({
   return {
     triggers: data?.triggers ?? emptyArray<AutomationTriggerRow>(),
     totalCount: data?.totalCount ?? 0,
+    medianRunCount: data?.medianRunCount ?? 0,
+    medianCostPerRun: data?.medianCostPerRun ?? 0,
     isTriggersLoading: !error && isLoading,
     isTriggersError: error,
     isTriggersValidating: isValidating,

--- a/front/lib/api/analytics/automations/breakdown.test.ts
+++ b/front/lib/api/analytics/automations/breakdown.test.ts
@@ -1,0 +1,187 @@
+import { fetchAutomationTriggerBreakdown } from "@app/lib/api/analytics/automations/breakdown";
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  ElasticsearchError,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+
+vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, resolveDimensionLabels: vi.fn() };
+});
+
+const PERIOD: ConsumptionPeriod = {
+  startDate: "2026-07-01T00:00:00.000Z",
+  endDate: "2026-08-01T00:00:00.000Z",
+};
+
+function bucket(key: string, creditMicro: number) {
+  return { key, credit_micro: { value: creditMicro } };
+}
+
+function mockAggs({
+  tool = [],
+  model = [],
+  skill = [],
+  totalMicro,
+}: {
+  tool?: unknown[];
+  model?: unknown[];
+  skill?: unknown[];
+  totalMicro: number;
+}) {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      aggregations: {
+        by_tool: { buckets: tool },
+        by_model: { buckets: model },
+        by_skill: { buckets: skill },
+        total_credit_micro: { value: totalMicro },
+      },
+    }) as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+  );
+}
+
+function mockLabel(key: string, name: string) {
+  vi.mocked(resolveDimensionLabels).mockResolvedValue(
+    new Map([[key, { name, pictureUrl: null, description: null }]])
+  );
+}
+
+async function setup() {
+  const workspace = await WorkspaceFactory.basic();
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  return { auth };
+}
+
+describe("fetchAutomationTriggerBreakdown", () => {
+  afterEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+    vi.mocked(resolveDimensionLabels).mockReset();
+  });
+
+  it("picks the tool dimension when it has the largest bucket", async () => {
+    const { auth } = await setup();
+    mockAggs({
+      tool: [bucket("web_search", 6_000_000)],
+      model: [bucket("claude-opus-5", 3_000_000)],
+      skill: [bucket("skl_1", 1_000_000)],
+      totalMicro: 10_000_000,
+    });
+    mockLabel("web_search", "Web Search");
+
+    const result = await fetchAutomationTriggerBreakdown(auth, {
+      triggerId: "trg1",
+      period: PERIOD,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.creditDestination).toEqual({
+      dimension: "tool",
+      key: "web_search",
+      name: "Web Search",
+      icon: null,
+      credits: 6,
+      share: 0.6,
+    });
+    expect(resolveDimensionLabels).toHaveBeenCalledWith(auth, "tool", [
+      "web_search",
+    ]);
+  });
+
+  it("picks the model dimension when it outranks tool and skill", async () => {
+    const { auth } = await setup();
+    mockAggs({
+      tool: [bucket("web_search", 1_000_000)],
+      model: [bucket("claude-opus-5", 7_000_000)],
+      skill: [bucket("skl_1", 2_000_000)],
+      totalMicro: 10_000_000,
+    });
+    mockLabel("claude-opus-5", "Claude Opus 5");
+
+    const result = await fetchAutomationTriggerBreakdown(auth, {
+      triggerId: "trg1",
+      period: PERIOD,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.creditDestination).toMatchObject({
+      dimension: "model",
+      key: "claude-opus-5",
+      credits: 7,
+    });
+  });
+
+  it("picks the skill dimension when it outranks tool and model", async () => {
+    const { auth } = await setup();
+    mockAggs({
+      tool: [bucket("web_search", 1_000_000)],
+      model: [bucket("claude-opus-5", 2_000_000)],
+      skill: [bucket("skl_1", 8_000_000)],
+      totalMicro: 10_000_000,
+    });
+    mockLabel("skl_1", "Research");
+
+    const result = await fetchAutomationTriggerBreakdown(auth, {
+      triggerId: "trg1",
+      period: PERIOD,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.creditDestination).toMatchObject({
+      dimension: "skill",
+      key: "skl_1",
+      credits: 8,
+    });
+  });
+
+  it("returns no destination when the trigger has no attributed consumption", async () => {
+    const { auth } = await setup();
+    mockAggs({ totalMicro: 0 });
+
+    const result = await fetchAutomationTriggerBreakdown(auth, {
+      triggerId: "trg1",
+      period: PERIOD,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.creditDestination).toBeNull();
+    expect(resolveDimensionLabels).not.toHaveBeenCalled();
+  });
+
+  it("returns the search error unchanged when the query fails", async () => {
+    const { auth } = await setup();
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+
+    const result = await fetchAutomationTriggerBreakdown(auth, {
+      triggerId: "trg1",
+      period: PERIOD,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/analytics/automations/breakdown.ts
+++ b/front/lib/api/analytics/automations/breakdown.ts
@@ -1,0 +1,153 @@
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  buildConsumptionScopeQuery,
+  CONSUMPTION_DIMENSION_FIELDS,
+  CREDIT_MICRO_FIELD,
+  TRIGGER_ID_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+// The dimensions a trigger's credits can be attributed to, ranked against each
+// other to find the single biggest destination.
+const CREDIT_DESTINATION_DIMENSIONS = ["tool", "model", "skill"] as const;
+type CreditDestinationDimension =
+  (typeof CREDIT_DESTINATION_DIMENSIONS)[number];
+
+export type AutomationTriggerCreditDestination = {
+  dimension: CreditDestinationDimension;
+  key: string;
+  name: string;
+  icon: string | null;
+  credits: number;
+  // Share of this trigger's own credits over the period, not the workspace's.
+  share: number;
+};
+
+export type AutomationTriggerBreakdown = {
+  period: ConsumptionPeriod;
+  creditDestination: AutomationTriggerCreditDestination | null;
+};
+
+export type GetAutomationTriggerBreakdownResponse = AutomationTriggerBreakdown;
+
+const CREDIT_AGG = "credit_micro";
+const TOTAL_CREDIT_AGG = "total_credit_micro";
+const TOOL_AGG = "by_tool";
+const MODEL_AGG = "by_model";
+const SKILL_AGG = "by_skill";
+
+type DestinationBucket = {
+  key: string;
+  [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
+};
+
+type DestinationAggs = {
+  [TOOL_AGG]?: estypes.AggregationsMultiBucketAggregateBase<DestinationBucket>;
+  [MODEL_AGG]?: estypes.AggregationsMultiBucketAggregateBase<DestinationBucket>;
+  [SKILL_AGG]?: estypes.AggregationsMultiBucketAggregateBase<DestinationBucket>;
+  [TOTAL_CREDIT_AGG]?: estypes.AggregationsSumAggregate;
+};
+
+function topBucketAggregation(
+  dimension: CreditDestinationDimension
+): estypes.AggregationsAggregationContainer {
+  return {
+    terms: {
+      field: CONSUMPTION_DIMENSION_FIELDS[dimension],
+      size: 1,
+      order: { [CREDIT_AGG]: "desc" },
+    },
+    aggs: { [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } } },
+  };
+}
+
+/**
+ * The single biggest destination of a trigger's credits over a period, picked
+ * across the tool/model/skill dimensions by whichever has the largest top
+ * bucket. Distinct from the consumption attribution table's per-dimension
+ * ranking: this only ever surfaces one winner, scoped to one trigger.
+ */
+export async function fetchAutomationTriggerBreakdown(
+  auth: Authenticator,
+  { triggerId, period }: { triggerId: string; period: ConsumptionPeriod }
+): Promise<Result<AutomationTriggerBreakdown, ElasticsearchError>> {
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+    extraFilters: [{ term: { [TRIGGER_ID_FIELD]: triggerId } }],
+  });
+
+  const result = await searchConsumptionAnalytics<never, DestinationAggs>(
+    query,
+    {
+      aggregations: {
+        [TOOL_AGG]: topBucketAggregation("tool"),
+        [MODEL_AGG]: topBucketAggregation("model"),
+        [SKILL_AGG]: topBucketAggregation("skill"),
+        [TOTAL_CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+      },
+      size: 0,
+    }
+  );
+  if (result.isErr()) {
+    return result;
+  }
+
+  const aggs = result.value.aggregations;
+  const totalCredits = microCreditsToCredits(
+    aggs?.[TOTAL_CREDIT_AGG]?.value ?? 0
+  );
+
+  const candidates = (
+    [
+      [TOOL_AGG, "tool"],
+      [MODEL_AGG, "model"],
+      [SKILL_AGG, "skill"],
+    ] as const
+  ).flatMap(([aggName, dimension]) => {
+    const bucket = bucketsToArray<DestinationBucket>(
+      aggs?.[aggName]?.buckets
+    )[0];
+    if (!bucket) {
+      return [];
+    }
+    return [
+      {
+        dimension,
+        key: String(bucket.key),
+        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
+      },
+    ];
+  });
+
+  const top = candidates.sort((a, b) => b.credits - a.credits)[0];
+  if (!top || top.credits === 0) {
+    return new Ok({ period, creditDestination: null });
+  }
+
+  const labels = await resolveDimensionLabels(auth, top.dimension, [top.key]);
+  const label = labels.get(top.key);
+
+  return new Ok({
+    period,
+    creditDestination: {
+      dimension: top.dimension,
+      key: top.key,
+      name: label?.name ?? top.key,
+      icon: label?.icon ?? null,
+      credits: top.credits,
+      share: totalCredits > 0 ? top.credits / totalCredits : 0,
+    },
+  });
+}

--- a/front/lib/api/analytics/automations/schema.ts
+++ b/front/lib/api/analytics/automations/schema.ts
@@ -22,3 +22,12 @@ export const AutomationTriggersBodySchema = ConsumptionPeriodSchema.extend({
 export type AutomationTriggersBody = z.infer<
   typeof AutomationTriggersBodySchema
 >;
+
+export const AutomationTriggerBreakdownBodySchema =
+  ConsumptionPeriodSchema.extend({
+    triggerId: z.string().min(1),
+  });
+
+export type AutomationTriggerBreakdownBody = z.infer<
+  typeof AutomationTriggerBreakdownBodySchema
+>;

--- a/front/lib/api/analytics/automations/triggers.test.ts
+++ b/front/lib/api/analytics/automations/triggers.test.ts
@@ -1,0 +1,133 @@
+import { fetchAutomationTriggers } from "@app/lib/api/analytics/automations/triggers";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+
+const PERIOD: ConsumptionPeriod = {
+  startDate: "2026-07-01T00:00:00.000Z",
+  endDate: "2026-08-01T00:00:00.000Z",
+};
+
+function bucket(triggerId: string, runs: number, creditMicro: number) {
+  return {
+    key: triggerId,
+    credit_micro: { value: creditMicro },
+    runs: { value: runs },
+  };
+}
+
+function mockRanking(buckets: ReturnType<typeof bucket>[]) {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      aggregations: {
+        by_trigger: { buckets },
+        total_count: { value: buckets.length },
+      },
+    }) as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+  );
+}
+
+describe("fetchAutomationTriggers", () => {
+  afterEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("keeps the median baseline stable across pages, including low-credit triggers outside the requested page", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const highCreditTrigger = await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "High credit trigger",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+    const lowCreditTrigger = await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Low credit trigger",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    // The ranking terms aggregation is not paginated in Elasticsearch: it
+    // always returns every active trigger (up to the cardinality
+    // threshold), so a low-credit trigger ranked outside page 1 still
+    // contributes to the median regardless of the requested offset/limit.
+    const buckets = [
+      bucket(highCreditTrigger.sId, 100, 100_000_000),
+      bucket(lowCreditTrigger.sId, 10, 100_000),
+    ];
+    mockRanking(buckets);
+
+    const page1 = await fetchAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 1,
+      offset: 0,
+    });
+    mockRanking(buckets);
+    const page2 = await fetchAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 1,
+      offset: 1,
+    });
+
+    expect(page1.isOk()).toBe(true);
+    expect(page2.isOk()).toBe(true);
+    if (!page1.isOk() || !page2.isOk()) {
+      return;
+    }
+
+    // Both pages see the same page-independent median, derived from the
+    // full active set rather than just the triggers ranked on that page.
+    expect(page1.value.medianRunCount).toBe(page2.value.medianRunCount);
+    expect(page1.value.medianCostPerRun).toBe(page2.value.medianCostPerRun);
+    expect(page1.value.medianRunCount).toBe(55);
+
+    expect(page1.value.triggers).toHaveLength(1);
+    expect(page1.value.triggers[0].triggerId).toBe(highCreditTrigger.sId);
+    expect(page2.value.triggers).toHaveLength(1);
+    expect(page2.value.triggers[0].triggerId).toBe(lowCreditTrigger.sId);
+  });
+
+  it("keeps a zero run-count trigger out of the median without dividing by zero", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const activeTrigger = await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+    const neverRanTrigger = await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    mockRanking([
+      bucket(activeTrigger.sId, 10, 50_000_000),
+      // A trigger with credits attributed but no completed run yet.
+      bucket(neverRanTrigger.sId, 0, 0),
+    ]);
+
+    const result = await fetchAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(Number.isFinite(result.value.medianRunCount)).toBe(true);
+    expect(Number.isFinite(result.value.medianCostPerRun)).toBe(true);
+    expect(result.value.medianRunCount).toBe(10);
+    expect(result.value.medianCostPerRun).toBe(5);
+  });
+});

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -63,6 +63,11 @@ export type AutomationTriggers = {
   // CARDINALITY_PRECISION_THRESHOLD.
   totalCount: number;
   triggers: AutomationTriggerRow[];
+  // Median run count / cost per run across the ranked triggers that ran at
+  // least once over the period, so a single row's breakdown can say how it
+  // compares to the rest of the workspace's automations.
+  medianRunCount: number;
+  medianCostPerRun: number;
 };
 
 export type GetAutomationTriggersResponse = AutomationTriggers;
@@ -88,10 +93,25 @@ type RankedTrigger = {
   credits: number;
 };
 
+function median(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[mid - 1] + sorted[mid]) / 2
+    : sorted[mid];
+}
+
 /**
  * The period's triggers ranked by gross credits, highest first. Ranking and
  * paging both happen in Elasticsearch, so neither grows with the number of
  * triggers the workspace holds.
+ *
+ * Median run count / cost per run are derived from this same ranked set
+ * (the top `offset + limit` triggers by credits), so they approximate the
+ * workspace's typical trigger rather than covering every trigger ever run.
  */
 async function fetchTriggersRanking(
   auth: Authenticator,
@@ -105,7 +125,15 @@ async function fetchTriggersRanking(
     offset: number;
   }
 ): Promise<
-  Result<{ ranking: RankedTrigger[]; totalCount: number }, ElasticsearchError>
+  Result<
+    {
+      ranking: RankedTrigger[];
+      totalCount: number;
+      medianRunCount: number;
+      medianCostPerRun: number;
+    },
+    ElasticsearchError
+  >
 > {
   const query = buildConsumptionScopeQuery({
     auth,
@@ -143,15 +171,23 @@ async function fetchTriggersRanking(
   const buckets = bucketsToArray<TriggerBucket>(
     result.value.aggregations?.by_trigger?.buckets
   );
+  const ranked = buckets.map((bucket) => ({
+    triggerId: String(bucket.key),
+    runCount: Math.round(bucket[RUNS_AGG]?.value ?? 0),
+    credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
+  }));
+  // Triggers that never ran have nothing to compare a "how often" or "per
+  // run cost" stat against, so the baseline only looks at the ones that did.
+  const activeRanked = ranked.filter((r) => r.runCount > 0);
 
   return new Ok({
-    ranking: buckets.slice(offset, offset + limit).map((bucket) => ({
-      triggerId: String(bucket.key),
-      runCount: Math.round(bucket[RUNS_AGG]?.value ?? 0),
-      credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-    })),
+    ranking: ranked.slice(offset, offset + limit),
     totalCount: Math.round(
       result.value.aggregations?.[TOTAL_COUNT_AGG]?.value ?? 0
+    ),
+    medianRunCount: median(activeRanked.map((r) => r.runCount)),
+    medianCostPerRun: median(
+      activeRanked.map((r) => r.credits / r.runCount)
     ),
   });
 }
@@ -205,7 +241,8 @@ export async function fetchAutomationTriggers(
   if (rankingResult.isErr()) {
     return rankingResult;
   }
-  const { ranking, totalCount } = rankingResult.value;
+  const { ranking, totalCount, medianRunCount, medianCostPerRun } =
+    rankingResult.value;
 
   const triggers = await TriggerResource.fetchByIds(
     auth,
@@ -280,5 +317,7 @@ export async function fetchAutomationTriggers(
     period,
     totalCount,
     triggers: rows,
+    medianRunCount,
+    medianCostPerRun,
   });
 }

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -105,13 +105,13 @@ function median(values: number[]): number {
 }
 
 /**
- * The period's triggers ranked by gross credits, highest first. Ranking and
- * paging both happen in Elasticsearch, so neither grows with the number of
- * triggers the workspace holds.
- *
- * Median run count / cost per run are derived from this same ranked set
- * (the top `offset + limit` triggers by credits), so they approximate the
- * workspace's typical trigger rather than covering every trigger ever run.
+ * The period's triggers ranked by gross credits, highest first. The
+ * underlying terms aggregation is capped at CARDINALITY_PRECISION_THRESHOLD
+ * buckets (the same approximation boundary used for the total trigger
+ * count below), so both the requested page and the median baseline are
+ * sliced/derived from that same, page-independent set — a trigger's stats
+ * always compare against the full active set, never just the triggers
+ * ranked ahead of it.
  */
 async function fetchTriggersRanking(
   auth: Authenticator,
@@ -146,7 +146,7 @@ async function fetchTriggersRanking(
       by_trigger: {
         terms: {
           field: TRIGGER_ID_FIELD,
-          size: offset + limit,
+          size: CARDINALITY_PRECISION_THRESHOLD,
           order: { [CREDIT_AGG]: "desc" },
         },
         aggs: {

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -186,9 +186,7 @@ async function fetchTriggersRanking(
       result.value.aggregations?.[TOTAL_COUNT_AGG]?.value ?? 0
     ),
     medianRunCount: median(activeRanked.map((r) => r.runCount)),
-    medianCostPerRun: median(
-      activeRanked.map((r) => r.credits / r.runCount)
-    ),
+    medianCostPerRun: median(activeRanked.map((r) => r.credits / r.runCount)),
   });
 }
 


### PR DESCRIPTION
## Description

Adds an expandable breakdown row to each trigger in the automations analytics table. The breakdown shows how often the trigger ran and its average credits per run, with both metrics compared against the workspace median across triggers that ran during the selected period. It also identifies the single largest credit destination for that trigger across tools, models, and skills, including the destination's share of the trigger's own credits.

**Visual:**
<img width="1167" height="389" alt="Capture d’écran 2026-08-18 à 09 20 11" src="https://github.com/user-attachments/assets/cfac9442-118a-4356-9149-d59d759fe83e" />

## Tests

Tested localy

## Risk

Low. The feature adds read-only Elasticsearch aggregation queries for trigger-specific consumption data and exposes them through an admin-only endpoint. 

The main operational risk is additional analytics-query load when trigger breakdowns are requested, including aggregations across tool, model, and skill dimensions.

## Deploy Plan

- Deploy front