### PR TITLE
[front] feat: default stake on published pod functions

### DIFF
--- a/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
@@ -69,6 +69,9 @@ async function publishFunction(
     inputSchema: EMPTY_SCHEMA,
     outputSchema: EMPTY_SCHEMA,
     executionMode: "fast",
+    // Deliberately not the default, so the manifest assertion proves the stake is carried rather
+    // than re-derived from the column default on the way out.
+    defaultStake: "never_ask",
   });
 }
 
@@ -193,6 +196,7 @@ describe("GET /api/w/:wId/pods/:podId/apps/:prefix/export", () => {
         name: "add-task",
         description: "Function tasklist__add-task.",
         executionMode: "fast",
+        defaultStake: "never_ask",
       },
     ]);
     expect(manifest.databases).toEqual([{ name: "tasks" }]);

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
@@ -21,6 +21,7 @@ import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { PodAppManifest } from "@app/types/api/pod_app_archive";
 import { MAX_POD_APP_ARCHIVE_SIZE_BYTES } from "@app/types/api/pod_app_archive";
 import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
+import { DEFAULT_SANDBOX_FUNCTION_STAKE } from "@app/types/api/sandbox_functions";
 import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
 import type { PodFrameTab } from "@app/types/pod_frame_tab";
 import {
@@ -270,6 +271,56 @@ describe("POST /api/w/:wId/pods/:podId/apps/import", () => {
         path: `pod-${pod.sId}/TaskList/databases/tasks.db.ts`,
       })
     );
+  });
+
+  it("publishes with the default stake the manifest declares", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    mockSandboxLeaves();
+
+    const manifest = taskListManifest();
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(
+        {
+          ...manifest,
+          functions: manifest.functions.map((fn) => ({
+            ...fn,
+            defaultStake: "never_ask" as const,
+          })),
+        },
+        taskListFiles()
+      )
+    );
+
+    expect(res.status).toBe(201);
+    const published = await SandboxFunctionResource.fetchBySpaceAndSlug(
+      auth,
+      pod,
+      "tasklist__add-task"
+    );
+    expect(published?.defaultStake).toBe("never_ask");
+  });
+
+  // An archive exported before stakes existed carries no `defaultStake`, and still imports: the
+  // field is optional at the same format version, so publish applies its own default.
+  it("publishes with the default stake when the manifest predates the field", async () => {
+    const { workspace, pod, auth } = await setupPod();
+    mockSandboxLeaves();
+
+    const res = await importApp(
+      workspace.sId,
+      pod.sId,
+      buildArchive(taskListManifest(), taskListFiles())
+    );
+
+    expect(res.status).toBe(201);
+    const published = await SandboxFunctionResource.fetchBySpaceAndSlug(
+      auth,
+      pod,
+      "tasklist__add-task"
+    );
+    expect(published?.defaultStake).toBe(DEFAULT_SANDBOX_FUNCTION_STAKE);
   });
 
   it("imports under the overriding name, deriving the prefix from it", async () => {

--- a/front/components/poke/projects/pod_functions/view.tsx
+++ b/front/components/poke/projects/pod_functions/view.tsx
@@ -53,6 +53,10 @@ export function ViewPodFunctionTable({
                 <PokeTableCell>{podFunction.executionMode}</PokeTableCell>
               </PokeTableRow>
               <PokeTableRow>
+                <PokeTableHead>Default stake</PokeTableHead>
+                <PokeTableCell>{podFunction.defaultStake}</PokeTableCell>
+              </PokeTableRow>
+              <PokeTableRow>
                 <PokeTableHead>Bundle file</PokeTableHead>
                 <PokeTableCellWithCopy label={podFunction.fileId} />
               </PokeTableRow>

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -4,6 +4,7 @@ import {
   SANDBOX_FUNCTION_EXECUTION_MODES,
   SANDBOX_FUNCTION_SLUG_REGEX,
   SANDBOX_FUNCTION_SLUG_SEGMENT_REGEX,
+  SANDBOX_FUNCTION_STAKES,
 } from "@app/types/api/sandbox_functions";
 import { z } from "zod";
 
@@ -89,6 +90,15 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
             "user for approval or authentication. Keep the functions a Frame calls on user " +
             "interaction or on a poll `fast`, and isolate `dsbx tools` calls in their own " +
             "`durable` functions."
+        ),
+      defaultStake: z
+        .enum(SANDBOX_FUNCTION_STAKES)
+        .optional()
+        .describe(
+          "How much approval the function should require once it is shared as a tool, derived " +
+            "from what it does rather than from how it is called: `never_ask` for a read that " +
+            "changes nothing, `low` for anything that writes/deletes, and `high` only for something " +
+            "extremely dangerous. Defaults to `low`."
         ),
       domains: z
         .array(z.string())

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -93,12 +93,11 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
         ),
       defaultStake: z
         .enum(SANDBOX_FUNCTION_STAKES)
-        .optional()
         .describe(
           "How much approval the function should require once it is shared as a tool, derived " +
             "from what it does rather than from how it is called: `never_ask` for a read that " +
             "changes nothing, `low` for anything that writes/deletes, and `high` only for something " +
-            "extremely dangerous. Defaults to `low`."
+            "extremely dangerous."
         ),
       domains: z
         .array(z.string())

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -8,8 +8,6 @@ import {
   setupProjectConversation,
 } from "@app/tests/utils/conversation_test_factories";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import type { SandboxFunctionStake } from "@app/types/api/sandbox_functions";
-import { DEFAULT_SANDBOX_FUNCTION_STAKE } from "@app/types/api/sandbox_functions";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -78,6 +76,7 @@ describe("publishHandler", () => {
         description: "Add a task.",
         path: `pod-${projectId}/TaskList/functions/add-task.ts`,
         executionMode: "fast",
+        defaultStake: "low",
       },
       makeExtra(auth, conversation)
     );
@@ -103,6 +102,7 @@ describe("publishHandler", () => {
         description: "Charge a card.",
         path: `pod-${projectId}/Billing/functions/charge.ts`,
         executionMode: "fast",
+        defaultStake: "low",
         domains: ["API.Stripe.COM", "*.stripe.com"],
       },
       makeExtra(auth, conversation)
@@ -131,6 +131,7 @@ describe("publishHandler", () => {
         description: "Greet.",
         path: `pod-${projectId}/App/functions/greet.ts`,
         executionMode: "fast",
+        defaultStake: "low",
       },
       makeExtra(auth, conversation)
     );
@@ -142,29 +143,27 @@ describe("publishHandler", () => {
     expect(firstText(result.value)).not.toContain("Requested");
   });
 
-  it("persists the declared default stake, and defaults it when unstated", async () => {
+  it("persists the declared default stake", async () => {
     const { auth, conversation, projectId } = await setupProjectConversation();
     const pod = await SpaceResource.fetchById(auth, projectId);
     if (!pod) {
       throw new Error("pod not found");
     }
 
-    const publish = async (slug: string, defaultStake?: SandboxFunctionStake) =>
-      publishHandler(
-        {
-          slug,
-          description: "Read a task.",
-          path: `pod-${projectId}/TaskList/functions/${slug}.ts`,
-          executionMode: "fast",
-          defaultStake,
-        },
-        makeExtra(auth, conversation)
-      );
-
-    const declared = await publish("read-task", "never_ask");
-    if (declared.isErr()) {
-      throw declared.error;
+    const result = await publishHandler(
+      {
+        slug: "read-task",
+        description: "Read a task.",
+        path: `pod-${projectId}/TaskList/functions/read-task.ts`,
+        executionMode: "fast",
+        defaultStake: "never_ask",
+      },
+      makeExtra(auth, conversation)
+    );
+    if (result.isErr()) {
+      throw result.error;
     }
+
     expect(
       (
         await SandboxFunctionResource.fetchBySpaceAndSlug(
@@ -174,20 +173,23 @@ describe("publishHandler", () => {
         )
       )?.defaultStake
     ).toBe("never_ask");
+  });
 
-    const unstated = await publish("add-task");
-    if (unstated.isErr()) {
-      throw unstated.error;
-    }
-    expect(
-      (
-        await SandboxFunctionResource.fetchBySpaceAndSlug(
-          auth,
-          pod,
-          "tasklist__add-task"
-        )
-      )?.defaultStake
-    ).toBe(DEFAULT_SANDBOX_FUNCTION_STAKE);
+  it("requires a default stake on every publish", () => {
+    const metadata = SANDBOX_FUNCTIONS_TOOLS_METADATA.find(
+      (tool) => tool.name === "publish"
+    );
+
+    expect(metadata).toBeDefined();
+    expect(metadata?.schema.defaultStake.safeParse(undefined).success).toBe(
+      false
+    );
+    expect(metadata?.schema.defaultStake.safeParse("medium").success).toBe(
+      false
+    );
+    expect(metadata?.schema.defaultStake.safeParse("never_ask").success).toBe(
+      true
+    );
   });
 
   it("accepts a bare function name but not one that already carries a prefix", () => {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.test.ts
@@ -1,11 +1,15 @@
 import { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { publishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   makeExtra,
   setupProjectConversation,
 } from "@app/tests/utils/conversation_test_factories";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import type { SandboxFunctionStake } from "@app/types/api/sandbox_functions";
+import { DEFAULT_SANDBOX_FUNCTION_STAKE } from "@app/types/api/sandbox_functions";
 import { Ok } from "@app/types/shared/result";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -136,6 +140,54 @@ describe("publishHandler", () => {
     }
     expect(firstText(result.value)).not.toContain("Pod allowlist");
     expect(firstText(result.value)).not.toContain("Requested");
+  });
+
+  it("persists the declared default stake, and defaults it when unstated", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    if (!pod) {
+      throw new Error("pod not found");
+    }
+
+    const publish = async (slug: string, defaultStake?: SandboxFunctionStake) =>
+      publishHandler(
+        {
+          slug,
+          description: "Read a task.",
+          path: `pod-${projectId}/TaskList/functions/${slug}.ts`,
+          executionMode: "fast",
+          defaultStake,
+        },
+        makeExtra(auth, conversation)
+      );
+
+    const declared = await publish("read-task", "never_ask");
+    if (declared.isErr()) {
+      throw declared.error;
+    }
+    expect(
+      (
+        await SandboxFunctionResource.fetchBySpaceAndSlug(
+          auth,
+          pod,
+          "tasklist__read-task"
+        )
+      )?.defaultStake
+    ).toBe("never_ask");
+
+    const unstated = await publish("add-task");
+    if (unstated.isErr()) {
+      throw unstated.error;
+    }
+    expect(
+      (
+        await SandboxFunctionResource.fetchBySpaceAndSlug(
+          auth,
+          pod,
+          "tasklist__add-task"
+        )
+      )?.defaultStake
+    ).toBe(DEFAULT_SANDBOX_FUNCTION_STAKE);
   });
 
   it("accepts a bare function name but not one that already carries a prefix", () => {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -9,18 +9,23 @@ import type { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionExecutionMode,
+  SandboxFunctionStake,
+} from "@app/types/api/sandbox_functions";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export async function publishHandler(
   {
+    defaultStake,
     description,
     domains,
     executionMode,
     path,
     slug,
   }: {
+    defaultStake?: SandboxFunctionStake;
     description: string;
     domains?: string[];
     executionMode: SandboxFunctionExecutionMode;
@@ -42,6 +47,7 @@ export async function publishHandler(
     description,
     path,
     executionMode,
+    defaultStake,
   });
   if (result.isErr()) {
     return new Err(toMCPError(result.error));

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -25,7 +25,7 @@ export async function publishHandler(
     path,
     slug,
   }: {
-    defaultStake?: SandboxFunctionStake;
+    defaultStake: SandboxFunctionStake;
     description: string;
     domains?: string[];
     executionMode: SandboxFunctionExecutionMode;

--- a/front/lib/api/poke/projects.ts
+++ b/front/lib/api/poke/projects.ts
@@ -6,6 +6,7 @@ import type {
   SandboxFunctionInvocationOrigin,
   SandboxFunctionInvocationStatus,
   SandboxFunctionMCPActionType,
+  SandboxFunctionStake,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import type { PodMetadataType } from "@app/types/project_metadata";
@@ -71,6 +72,7 @@ export type PokePodFunctionDetails = PokePodFunction & {
   fileId: string;
   userIdentity: SandboxFunctionUserIdentityPolicy | null;
   executionMode: SandboxFunctionExecutionMode;
+  defaultStake: SandboxFunctionStake;
   inputSchema: JSONSchema;
   outputSchema: JSONSchema;
 };

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -217,6 +217,7 @@ export async function exportPodApp(
       name: fn.name,
       description: fn.description,
       executionMode: fn.executionMode,
+      defaultStake: fn.defaultStake,
     })),
     databases: app.databases.map((db) => ({ name: db.name })),
   };
@@ -548,6 +549,7 @@ export async function importPodApp(
       description: fn.description,
       path: sourcePath,
       executionMode: fn.executionMode,
+      defaultStake: fn.defaultStake,
     });
     if (publishResult.isErr()) {
       if (publishResult.error.code === "sandbox_unavailable") {

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -778,8 +778,8 @@ export async function clonePodApp(
   }
 
   // Publish the copy's functions. The source path decides the prefix, so publishing from the copy's
-  // folder is what gives the clone its own functions; description and execution mode are carried over
-  // so the contract is identical.
+  // folder is what gives the clone its own functions; description, execution mode and default stake
+  // are carried over so the contract is identical.
   const publishedFunctionSlugs: string[] = [];
   for (const fn of source.functions) {
     const sourcePath = functionSourceByName.get(fn.name);
@@ -794,6 +794,7 @@ export async function clonePodApp(
       description: fn.description,
       path: sourcePath,
       executionMode: fn.executionMode,
+      defaultStake: fn.defaultStake,
     });
     if (publishResult.isErr()) {
       return new Err(

--- a/front/lib/api/sandbox_functions/publish_sandbox_function.ts
+++ b/front/lib/api/sandbox_functions/publish_sandbox_function.ts
@@ -9,7 +9,10 @@ import {
   SandboxFunctionResource,
 } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionExecutionMode,
+  SandboxFunctionStake,
+} from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -34,12 +37,14 @@ export async function publishSandboxFunction(
     description,
     path: sourcePath,
     executionMode,
+    defaultStake,
   }: {
     space: SpaceResource;
     slug: string;
     description: string;
     path: string;
     executionMode?: SandboxFunctionExecutionMode;
+    defaultStake?: SandboxFunctionStake;
   }
 ): Promise<Result<SandboxFunctionResource, SandboxFunctionError>> {
   // Resolve the model-supplied scoped path (e.g. `pod-{id}/greet.ts`) to its absolute path inside
@@ -95,6 +100,7 @@ export async function publishSandboxFunction(
       description,
       userIdentity,
       executionMode,
+      defaultStake,
       inputSchema,
       outputSchema,
     });
@@ -123,6 +129,7 @@ export async function publishSandboxFunction(
     description,
     userIdentity,
     executionMode,
+    defaultStake,
     bundleSha256: computeSandboxFunctionBundleSha256(bundleCode),
     inputSchema,
     outputSchema,

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -12,6 +12,8 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { SandboxFunctionStake } from "@app/types/api/sandbox_functions";
+import { DEFAULT_SANDBOX_FUNCTION_STAKE } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -498,6 +500,71 @@ describe("SandboxFunctionResource", () => {
     );
     expect(fetched?.userIdentity).toBe("workspace_user_required");
     expect(fetched?.description).toBe("First.");
+  });
+
+  it("defaults the stake, stores a declared one, and restates it on re-publish", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+    const space = await SpaceFactory.project(workspace);
+
+    const makeFunction = async (
+      fileName: string,
+      slug: string,
+      defaultStake?: SandboxFunctionStake
+    ) => {
+      const file = await FileFactory.create(authenticator, null, {
+        contentType: sandboxFunctionContentType,
+        fileName,
+        fileSize: 100,
+        status: "created",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: space.sId },
+      });
+
+      return SandboxFunctionResource.makeNew(authenticator, {
+        space,
+        file,
+        slug,
+        description: "First.",
+        defaultStake,
+        inputSchema,
+        outputSchema,
+      });
+    };
+
+    const unstated = await makeFunction("unstated.ts", "unstated");
+    expect(unstated.defaultStake).toBe(DEFAULT_SANDBOX_FUNCTION_STAKE);
+
+    const declared = await makeFunction("declared.ts", "declared", "never_ask");
+    expect(declared.defaultStake).toBe("never_ask");
+
+    const raised = await declared.updateContent(authenticator, {
+      bundleCode: "v2",
+      description: "Second.",
+      defaultStake: "high",
+      inputSchema,
+      outputSchema,
+    });
+    expect(raised.isOk()).toBe(true);
+    expect(
+      (await SandboxFunctionResource.fetchById(authenticator, declared.sId))
+        ?.defaultStake
+    ).toBe("high");
+
+    // Restated, not carried forward: a re-publish that names no stake falls back to the default
+    // rather than keeping the `high` above, the same rule the execution mode follows.
+    const unstatedRepublish = await declared.updateContent(authenticator, {
+      bundleCode: "v3",
+      description: "Third.",
+      inputSchema,
+      outputSchema,
+    });
+    expect(unstatedRepublish.isOk()).toBe(true);
+    expect(
+      (await SandboxFunctionResource.fetchById(authenticator, declared.sId))
+        ?.defaultStake
+    ).toBe(DEFAULT_SANDBOX_FUNCTION_STAKE);
   });
 
   it("deletes all sandbox functions for a space", async () => {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -30,10 +30,12 @@ import type {
   PostSandboxFunctionInvocationRequestBody,
   SandboxFunctionExecutionMode,
   SandboxFunctionInvocationOrigin,
+  SandboxFunctionStake,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import {
   DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+  DEFAULT_SANDBOX_FUNCTION_STAKE,
   isValidSandboxFunctionSlug,
 } from "@app/types/api/sandbox_functions";
 import { sandboxFunctionContentType } from "@app/types/files";
@@ -139,6 +141,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description,
       userIdentity = "optional",
       executionMode = DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+      defaultStake = DEFAULT_SANDBOX_FUNCTION_STAKE,
       bundleSha256 = null,
       inputSchema,
       outputSchema,
@@ -149,6 +152,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description: string;
       userIdentity?: SandboxFunctionUserIdentityPolicy;
       executionMode?: SandboxFunctionExecutionMode;
+      defaultStake?: SandboxFunctionStake;
       bundleSha256?: string | null;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
@@ -190,6 +194,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
         description,
         userIdentity,
         executionMode,
+        defaultStake,
         bundleSha256,
         inputSchema,
         outputSchema,
@@ -213,6 +218,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description,
       userIdentity = this.userIdentity ?? "optional",
       executionMode = DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+      defaultStake = DEFAULT_SANDBOX_FUNCTION_STAKE,
       inputSchema,
       outputSchema,
     }: {
@@ -220,6 +226,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       description: string;
       userIdentity?: SandboxFunctionUserIdentityPolicy;
       executionMode?: SandboxFunctionExecutionMode;
+      defaultStake?: SandboxFunctionStake;
       inputSchema: JSONSchema;
       outputSchema: JSONSchema;
     }
@@ -259,10 +266,17 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
           // It moves after the upload, and unlike the user identity policy there is no window to
           // guard: whichever mode is in effect while the upload lands, a fast bundle running as
           // durable is harmless and a durable bundle running as fast just fails its tool calls.
+          //
+          // The default stake is restated on the same terms, and for the same reason: a function
+          // that grew a destructive path must not keep the `never_ask` it earned while it was a
+          // read. Nothing gates on the stake until a function is shared as an MCP tool, so it needs
+          // no ordering guard against the upload yet — sharing it will need one, so that a stricter
+          // stake lands before the bundle it applies to, the way the user identity policy does.
           await this.update({
             description,
             userIdentity,
             executionMode,
+            defaultStake,
             // Derived from the exact code the upload above wrote. Landing with the row update
             // (not before the upload) means a warm server can never be told to expect a bundle
             // that is not on disk yet; invocations racing this publish carry the old hash and
@@ -587,6 +601,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       name: sandboxFunctionNameFromSlug(this.slug),
       description: this.description,
       executionMode: this.executionMode,
+      defaultStake: this.defaultStake,
     };
   }
 
@@ -598,6 +613,7 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       fileId: this.file.sId,
       userIdentity: this.userIdentity,
       executionMode: this.executionMode,
+      defaultStake: this.defaultStake,
       inputSchema: this.inputSchema,
       outputSchema: this.outputSchema,
     };

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -12,14 +12,17 @@ import type {
   SandboxFunctionExecutionMode,
   SandboxFunctionInvocationOrigin,
   SandboxFunctionInvocationStatus,
+  SandboxFunctionStake,
   SandboxFunctionUserIdentityPolicy,
 } from "@app/types/api/sandbox_functions";
 import {
   DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
+  DEFAULT_SANDBOX_FUNCTION_STAKE,
   isValidSandboxFunctionSlug,
   SANDBOX_FUNCTION_EXECUTION_MODES,
   SANDBOX_FUNCTION_INVOCATION_ORIGINS,
   SANDBOX_FUNCTION_INVOCATION_STATUSES,
+  SANDBOX_FUNCTION_STAKES,
   SANDBOX_FUNCTION_USER_IDENTITY_POLICIES,
 } from "@app/types/api/sandbox_functions";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -54,6 +57,9 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare description: string;
   declare userIdentity: SandboxFunctionUserIdentityPolicy | null;
   declare executionMode: CreationOptional<SandboxFunctionExecutionMode>;
+  // The approval level a tool derived from this function starts at. A default, not a verdict: it is
+  // what the publisher declared, and an override can sit on top of it.
+  declare defaultStake: CreationOptional<SandboxFunctionStake>;
   // Sha256 hex of the published bundle. Stamped onto every invocation envelope so the in-sandbox
   // warm server can refuse to serve a bundle the publisher has since replaced. Null only for
   // functions last published before the column existed.
@@ -124,6 +130,14 @@ SandboxFunctionModel.init(
       defaultValue: DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE,
       validate: {
         isIn: [SANDBOX_FUNCTION_EXECUTION_MODES],
+      },
+    },
+    defaultStake: {
+      type: DataTypes.STRING(16),
+      allowNull: false,
+      defaultValue: DEFAULT_SANDBOX_FUNCTION_STAKE,
+      validate: {
+        isIn: [SANDBOX_FUNCTION_STAKES],
       },
     },
     bundleSha256: {

--- a/front/migrations/pre-deploy/20260817141519_add_default_stake_to_sandbox_functions.sql
+++ b/front/migrations/pre-deploy/20260817141519_add_default_stake_to_sandbox_functions.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions" ADD COLUMN "defaultStake" character varying(16) COLLATE "pg_catalog"."default" NOT NULL DEFAULT 'low';

--- a/front/types/api/pod_app_archive.ts
+++ b/front/types/api/pod_app_archive.ts
@@ -1,5 +1,8 @@
 import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
-import { SANDBOX_FUNCTION_EXECUTION_MODES } from "@app/types/api/sandbox_functions";
+import {
+  SANDBOX_FUNCTION_EXECUTION_MODES,
+  SANDBOX_FUNCTION_STAKES,
+} from "@app/types/api/sandbox_functions";
 import type { InteractiveContentFileContentType } from "@app/types/files";
 import { isInteractiveContentType } from "@app/types/files";
 import { PodFrameTabSchema } from "@app/types/pod_frame_tab";
@@ -44,6 +47,11 @@ const PodAppManifestFunctionSchema = z.object({
   name: z.string().min(1),
   description: z.string(),
   executionMode: z.enum(SANDBOX_FUNCTION_EXECUTION_MODES),
+  /**
+   * Optional so archives exported before stakes existed still import under the same format version;
+   * publish then applies its own default.
+   */
+  defaultStake: z.enum(SANDBOX_FUNCTION_STAKES).optional(),
 });
 
 const PodAppManifestDatabaseSchema = z.object({

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -1,4 +1,7 @@
-import type { SandboxFunctionExecutionMode } from "@app/types/api/sandbox_functions";
+import type {
+  SandboxFunctionExecutionMode,
+  SandboxFunctionStake,
+} from "@app/types/api/sandbox_functions";
 import { z } from "zod";
 
 /**
@@ -30,6 +33,8 @@ export type PodAppFunction = {
   name: string;
   description: string;
   executionMode: SandboxFunctionExecutionMode;
+  /** The approval level a tool derived from this function starts at. */
+  defaultStake: SandboxFunctionStake;
 };
 
 export type PodAppDatabase = {

--- a/front/types/api/sandbox_functions.ts
+++ b/front/types/api/sandbox_functions.ts
@@ -1,3 +1,4 @@
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type {
   SandboxFunctionMCPApproveExecutionEvent,
   SandboxFunctionToolPersonalAuthRequiredEvent,
@@ -44,6 +45,29 @@ export type SandboxFunctionExecutionMode =
 // durable: the mode that can do everything. Backs both the column default and the publish default.
 export const DEFAULT_SANDBOX_FUNCTION_EXECUTION_MODE: SandboxFunctionExecutionMode =
   "durable";
+
+// How much a caller has to approve before a published function runs, for the day a function is
+// shared as an MCP tool: `never_ask` runs unattended, `low` asks once and can be always-approved,
+// `high` asks on every call.
+//
+// A subset of MCP_TOOL_STAKE_LEVELS, kept assignable to it so sharing a function needs no
+// translation. `medium` is excluded on purpose: it only means anything paired with
+// `argumentsRequiringApproval` (which argument values scope the approval), and a published function
+// has no way to declare those, so a `medium` function would silently approve on an empty argument
+// set.
+export const SANDBOX_FUNCTION_STAKES = [
+  "never_ask",
+  "low",
+  "high",
+] as const satisfies readonly MCPToolStakeLevelType[];
+
+export type SandboxFunctionStake = (typeof SANDBOX_FUNCTION_STAKES)[number];
+
+// Functions published before stakes existed, and publishes that do not state one, ask once. It is
+// the only safe guess for a function nothing has classified: `never_ask` would run an unreviewed
+// write unattended, and `high` would nag on a read. Backs both the column default and the publish
+// default.
+export const DEFAULT_SANDBOX_FUNCTION_STAKE: SandboxFunctionStake = "low";
 
 export const SANDBOX_FUNCTION_INVOCATION_ORIGINS = [
   "interactive_session",


### PR DESCRIPTION
### Description

Groundwork for sharing pod functions as MCP tools. When that lands, something has to say how much approval a function's tool requires — and the moment where that is actually knowable is publish time, while the model that wrote the function still knows what it does. Reading it back later off a name or a JSON schema is guesswork.

So this records it: a `defaultStake` column on `sandbox_functions`, stated on every publish, plumbed everywhere the execution mode already goes. Nothing gates on it yet.

The argument description carries the guidance the model needs (`never_ask` for a read that changes nothing, `low` for writes and deletes, `high` only for something extremely dangerous).

### Risk

Low. Additive pre-deploy column with a default, hand-authored (the generator diffed unrelated local drift). No existing behaviour reads the new field. The one behavioural change is a new required argument on an internal MCP tool, whose schema deploys with the server.

### Deploy Plan

Standard: run the pre-deploy migration, then deploy front.