### PR TITLE
[front] fix: populate instructions for Poke skill suggestions

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.test.ts
@@ -1,0 +1,38 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+describe("POST /api/poke/workspaces/:wId/skills/suggestions", () => {
+  it("stores instructions in the Skill Builder HTML format", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      isSuperUser: true,
+      role: "admin",
+    });
+
+    const response = await honoApp.request(
+      `/api/poke/workspaces/${workspace.sId}/skills/suggestions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Source verification",
+          userFacingDescription: "Verifies sources before answering.",
+          agentFacingDescription: "Use when an answer needs verified sources.",
+          instructions: "Verify every source before answering.",
+          icon: "MagnifyingGlassIcon",
+          mcpServerViewIds: [],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(201);
+    const data = await response.json();
+    expect(data.skill.instructions).toBe(
+      "Verify every source before answering."
+    );
+    expect(data.skill.instructionsHtml).toContain(
+      "Verify every source before answering."
+    );
+  });
+});

--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,4 +1,5 @@
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
+import { convertMarkdownToBlockHtml } from "@app/lib/reinforcement/skill_instructions_html";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import {
   SKILL_INSTRUCTIONS_LABEL,
@@ -64,6 +65,7 @@ app.post(
         userFacingDescription,
         agentFacingDescription,
         instructions,
+        instructionsHtml: convertMarkdownToBlockHtml(instructions),
         icon: skillIcon,
         availability: DEFAULT_SKILL_AVAILABILITY,
       },


### PR DESCRIPTION
## Description

Skills suggested through Poke currently store only Markdown instructions. Skill Builder reads the editor HTML representation, so accepting one opens with an empty Instructions field.

This PR fixes that by converting the submitted Markdown to its HTML representation when creating the suggestion.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
