### PR TITLE
[sparkle] fix: make navigation items keyboard accessible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53867,6 +53867,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/tabbable": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+      "integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+      "license": "MIT"
+    },
     "node_modules/table-layout": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
@@ -58603,6 +58609,7 @@
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
         "sonner": "^1.7.4",
+        "tabbable": "^6.5.0",
         "tailwind-merge": "^2.5.3",
         "tailwind-scrollbar-hide": "^1.1.7",
         "unist-util-visit": "^5.0.0"

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -143,6 +143,7 @@
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "sonner": "^1.7.4",
+    "tabbable": "^6.5.0",
     "tailwind-merge": "^2.5.3",
     "tailwind-scrollbar-hide": "^1.1.7",
     "unist-util-visit": "^5.0.0"

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -27,6 +27,7 @@ import { cn } from "@sparkle/lib/utils";
 import { cva } from "class-variance-authority";
 import * as React from "react";
 import { useMemo, useRef } from "react";
+import { tabbable } from "tabbable";
 
 const ITEM_VARIANTS = ["default", "warning"] as const;
 
@@ -312,6 +313,52 @@ const OPEN_SEARCHABLE_MENU_ITEM_SELECTOR = [
   '[data-radix-menu-content][data-state=open] [role="menuitemradio"]',
 ].join(", ");
 
+type TabbableElement = ReturnType<typeof tabbable>[number];
+
+function getDropdownMenuTrigger(content: HTMLElement): HTMLElement | null {
+  return content.ownerDocument.getElementById(
+    content.getAttribute("aria-labelledby") ?? ""
+  );
+}
+
+function handleDropdownMenuTab(
+  event: React.KeyboardEvent<HTMLDivElement>,
+  onExit: (element: TabbableElement) => void
+): void {
+  const content = event.currentTarget;
+  const trigger = getDropdownMenuTrigger(content);
+  if (!trigger) {
+    return;
+  }
+
+  const tabbableElements = tabbable(content.ownerDocument.body).filter(
+    (element) =>
+      !element.closest('[data-radix-menu-content][data-state="open"]')
+  );
+  const triggerIndex = tabbableElements.indexOf(trigger);
+  if (triggerIndex === -1) {
+    return;
+  }
+
+  const nextIndex = event.shiftKey
+    ? (triggerIndex - 1 + tabbableElements.length) % tabbableElements.length
+    : (triggerIndex + 1) % tabbableElements.length;
+  const nextElement = tabbableElements[nextIndex];
+
+  // Radix suppresses Tab inside menus. Close through its Escape path so
+  // controlled roots receive onOpenChange, then transfer focus after unmount.
+  event.preventDefault();
+  event.stopPropagation();
+  onExit(nextElement);
+  content.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    })
+  );
+}
+
 function getFirstDropdownMenuItem(container: ParentNode): HTMLElement | null {
   return container.querySelector<HTMLElement>(SEARCHABLE_MENU_ITEM_SELECTOR);
 }
@@ -398,6 +445,7 @@ const DropdownMenuContent = React.forwardRef<
   ) => {
     const viewportRef = useRef<HTMLDivElement>(null);
     const itemElementsRef = useRef(new Map<string, HTMLElement>());
+    const tabExitTargetRef = useRef<TabbableElement | null>(null);
 
     const handleKeyDownCapture = (e: React.KeyboardEvent<HTMLDivElement>) => {
       onKeyDownCapture?.(e);
@@ -427,6 +475,13 @@ const DropdownMenuContent = React.forwardRef<
         return;
       }
 
+      if (e.key === "Tab") {
+        handleDropdownMenuTab(e, (element) => {
+          tabExitTargetRef.current = element;
+        });
+        return;
+      }
+
       if (isDropdownTextEntryElement(document.activeElement)) {
         return;
       }
@@ -450,7 +505,13 @@ const DropdownMenuContent = React.forwardRef<
 
     const handleCloseAutoFocus = React.useCallback(
       (event: Event) => {
-        if (preventAutoFocusOnClose) {
+        const tabExitTarget = tabExitTargetRef.current;
+        tabExitTargetRef.current = null;
+
+        if (tabExitTarget) {
+          event.preventDefault();
+          tabExitTarget.focus();
+        } else if (preventAutoFocusOnClose) {
           event.preventDefault();
         }
         onCloseAutoFocus?.(event);

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -1,6 +1,7 @@
 import { DropdownMenuCheckboxItemProps } from "@radix-ui/react-dropdown-menu";
 import type { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
+import { expect, waitFor, within } from "storybook/test";
 
 import { Spinner } from "@sparkle/components";
 import {
@@ -137,6 +138,55 @@ export const SimpleDropdown: Story = {
         </DropdownMenuContent>
       </DropdownMenu>
     );
+  },
+};
+
+export const KeyboardNavigation: Story = {
+  render: () => (
+    <div className="flex gap-2">
+      <button type="button">Before dropdown</button>
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open Keyboard Dropdown</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem label="First item" />
+          <DropdownMenuItem label="Second item" />
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <button type="button">After dropdown</button>
+    </div>
+  ),
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const beforeButton = canvas.getByRole("button", {
+      name: "Before dropdown",
+    });
+    const trigger = canvas.getByRole("button", {
+      name: "Open Keyboard Dropdown",
+    });
+    const afterButton = canvas.getByRole("button", {
+      name: "After dropdown",
+    });
+    trigger.focus();
+    await userEvent.keyboard("{Enter}");
+
+    const documentBody = within(canvasElement.ownerDocument.body);
+    const menuItems = await documentBody.findAllByRole("menuitem");
+    await expect(menuItems[0]).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect(menuItems[1]).toHaveFocus();
+
+    await userEvent.tab();
+    await waitFor(() => expect(afterButton).toHaveFocus());
+
+    await userEvent.tab({ shift: true });
+    await expect(trigger).toHaveFocus();
+    await userEvent.keyboard("{Enter}");
+    await expect(
+      (await documentBody.findAllByRole("menuitem"))[0]
+    ).toHaveFocus();
+
+    await userEvent.tab({ shift: true });
+    await waitFor(() => expect(beforeButton).toHaveFocus());
   },
 };
 


### PR DESCRIPTION
## Description

`NavigationListItem` rows are driven by an `onClick`, and rendered as non-focusable divs, so keyboard users cannot reach them with a tab, which is an a11y issue.

This PR fixes that by rendering click-only rows as native buttons (except for non-interactive rows). The button rows support Tab, Enter, and Space and use the same focus ring as link-backed navigation items.

## Tests

- Tested locally.

## Risk

- Medium. Relatively widely used.

## Deploy Plan

- Deploy front.
