### PR TITLE
[front] fix permission check MCP metadata fetch

### DIFF
--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -711,8 +711,11 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
   static async listDisplayMetadataByWorkspace(
     auth: Authenticator
   ): Promise<MCPServerViewDisplayMetadata[]> {
-    const views = await this.model.findAll({
+    const views = await this.baseFetchWithAuthorization(auth, {
       attributes: [
+        "id",
+        "workspaceId",
+        "vaultId",
         "serverType",
         "name",
         "internalMCPServerId",


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/30587#discussion_r3794896164.

The MCP server display metadata used for the facets in the new analytics did not check permissions correctly.

`listDisplayMetadataByWorkspace` now uses `baseFetchWithAuthorization` instead of a direct lookup. This change compensates for the fact that `RemoteMCPServerResource` actually does not enforce any permission check itself (only `MCPServerViewResource` can, we don't actually need the resource `RemoteMCPServerResource` as the underlying model should only be accessible via MCP server views).

## Tests

- Covered by existing tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
