### PR TITLE
feat: seed script for the automations analytics page

### DIFF
--- a/front/scripts/seed/README.md
+++ b/front/scripts/seed/README.md
@@ -17,6 +17,7 @@ DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/<folder>/seed.ts --execute
 ## Folders
 
 - `analytics/` - Creates members, teams, skills, agents and triggers, then fills the consumption index behind the "Analytics (new)" page
+- `automations/` - Creates schedule/webhook triggers and fills the consumption index with runs attributed to them, for the "Automation" analytics page
 - `basics/` - Creates a custom agent with skills and sample conversations
 - `byok/` - Setup workspace to test Bring your own key
 - `governance/` - Creates users and skills for testing admin governance

--- a/front/scripts/seed/automations/seed.ts
+++ b/front/scripts/seed/automations/seed.ts
@@ -1,0 +1,89 @@
+import { makeScript } from "@app/scripts/helpers";
+import type {
+  TriggerAsset,
+  WebhookSourceAsset,
+} from "@app/scripts/seed/factories";
+import {
+  createSeedContext,
+  seedAgents,
+  seedConsumptionAnalytics,
+  seedTriggers,
+  seedWebhookSources,
+} from "@app/scripts/seed/factories";
+import type { AgentAsset } from "@app/scripts/seed/factories/types";
+import * as fs from "fs";
+import * as path from "path";
+
+interface Assets {
+  agents: AgentAsset[];
+  triggers: TriggerAsset[];
+  webhookSources: WebhookSourceAsset[];
+}
+
+function loadAssets(): Assets {
+  // Reuses the triggers seed's own assets instead of duplicating them.
+  const triggersAssetsDir = path.join(__dirname, "..", "triggers", "assets");
+  const basicsAssetsDir = path.join(__dirname, "..", "basics", "assets");
+  const read = (dir: string, file: string) =>
+    JSON.parse(fs.readFileSync(path.join(dir, file), "utf-8"));
+
+  return {
+    agents: read(basicsAssetsDir, "agent.json"),
+    triggers: read(triggersAssetsDir, "triggers.json"),
+    webhookSources: read(triggersAssetsDir, "webhook-sources.json"),
+  };
+}
+
+makeScript(
+  {
+    daysBack: {
+      type: "number",
+      default: 90,
+      description: "Size of the window the consumption is spread over",
+    },
+    messagesPerDay: {
+      type: "number",
+      default: 12,
+      description: "Base number of agent messages per day",
+    },
+  },
+  async ({ daysBack, messagesPerDay, execute }, logger) => {
+    const {
+      agents: agentAssets,
+      triggers: triggerAssets,
+      webhookSources: webhookSourceAssets,
+    } = loadAssets();
+
+    const ctx = await createSeedContext({ execute, logger });
+
+    logger.info("Seeding agents...");
+    const createdAgents = await seedAgents(ctx, agentAssets);
+
+    logger.info("Seeding webhook sources...");
+    const createdWebhookSources = await seedWebhookSources(
+      ctx,
+      webhookSourceAssets
+    );
+
+    logger.info("Seeding triggers...");
+    const createdTriggers = await seedTriggers(
+      ctx,
+      triggerAssets,
+      createdAgents,
+      {
+        webhookSources: createdWebhookSources,
+      }
+    );
+
+    logger.info(
+      "Seeding consumption analytics attributed to those triggers..."
+    );
+    await seedConsumptionAnalytics(ctx, {
+      daysBack,
+      messagesPerDay,
+      triggerIds: [...createdTriggers.values()].map((trigger) => trigger.sId),
+    });
+
+    logger.info("Automations seed completed");
+  }
+);


### PR DESCRIPTION
## Description

Adds `front/scripts/seed/automations/seed.ts` and documents it in the seed-script README. The script reuses the existing `basics` and `triggers` assets, creates the referenced agents, webhook sources, and schedule/webhook triggers, then populates consumption analytics for the created trigger IDs. `daysBack` (default: 90) and `messagesPerDay` (default: 12) can be configured through the script arguments.

This provides local data for exercising the automations analytics page, including its trigger table and per-trigger breakdowns, without manually creating database or consumption-index records. The change is limited to seed tooling and does not alter runtime product behavior.

## Tests

The supplied manual test plan is:

````bash
DEV_WORKSPACE_SID=<workspace> npx tsx scripts/seed/automations/seed.ts --execute
````

After running the seed, verify that `/w/<workspace>/analytics/automations` displays populated trigger rows and per-trigger breakdowns. No execution result was included with the PR.

## Risk

The script writes test agents, webhook sources, triggers, and consumption analytics into the workspace selected by `DEV_WORKSPACE_SID`; running it with the wrong workspace could pollute that workspace with seed data. The script is opt-in and requires `--execute` for writes. Because this change adds seed tooling only, it has no direct production runtime blast radius. The change does not add cleanup behavior for data created by the script.

## Deploy Plan


## Open Questions

Please confirm the workspace used for validation and record whether the seed command and analytics-page verification completed successfully.