### PR TITLE
[front] Store resolved verbs (not group refs) in GroupPermissions

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -60,7 +60,6 @@ import type { PlanType, SubscriptionType } from "@app/types/plan";
 import type { ProvidersHealth } from "@app/types/provider_credential";
 import type {
   AccessControlList,
-  GroupGrant,
   WithAccessControl,
 } from "@app/types/resource_permissions";
 import { isDevelopment } from "@app/types/shared/env";
@@ -1260,7 +1259,7 @@ export class Authenticator {
 
     return this.hasPermissionForAcl(verb, {
       roles: [{ role: "admin", permissions: [verb] }],
-      groups: this.getGroupPermissions(resourceType, WHOLE_TYPE_RESOURCE_ID),
+      grantedVerbs: this.getGrantedVerbs(resourceType, WHOLE_TYPE_RESOURCE_ID),
       workspaceId: workspace.id,
     });
   }
@@ -1474,15 +1473,16 @@ export class Authenticator {
   }
 
   /**
-   * The caller's governance grants on `(resourceType, resourceId)`, as group→verb entries, folding
-   * in the type-wide (-1) grants. Caller-scoped (only the caller's groups). Resources fold this into
-   * their `AccessControlList`; pass `WHOLE_TYPE_RESOURCE_ID` for a workspace-wide capability.
+   * The verbs the caller holds on `(resourceType, resourceId)`, resolved from their governance
+   * grants (folding in the type-wide (-1) grants). Caller-scoped and pre-resolved — resources fold
+   * this into their `AccessControlList` as `grantedVerbs`, which the checker uses directly with no
+   * group-membership step. Pass `WHOLE_TYPE_RESOURCE_ID` for a workspace-wide capability.
    */
-  getGroupPermissions(
+  getGrantedVerbs(
     resourceType: ConcreteResourceType,
     resourceId: number
-  ): GroupGrant[] {
-    return this._permissions.forResource(resourceType, resourceId);
+  ): GrantVerb[] {
+    return this._permissions.resolvedVerbsForResource(resourceType, resourceId);
   }
 
   /**
@@ -1570,12 +1570,14 @@ export class Authenticator {
     return acls.every((acl) => this.hasPermissionForAcl(verb, acl));
   }
 
-  // Single-ACL check. Two paths (OR):
-  // 1. Role: the caller's workspace role grants `verb` (and the ACL is in the caller's workspace).
-  // 2. Group: the caller belongs to a listed group that grants `verb`.
-  // The group-membership check is kept even when the ACL's groups are already caller-scoped (built
-  // from `getGroupPermissions`): it lets the same checker also evaluate ACLs that list every group
-  // (e.g. legacy inline groups), filtering by membership at check time.
+  // Single-ACL check. The grant sources are additive (OR): the caller passes if any of them grants
+  // `verb`. An absent source contributes nothing, so an ACL with no matching source denies.
+  // - Role: the caller's workspace role grants `verb` (and the ACL is in the caller's workspace).
+  // - grantedVerbs: the caller's own governance verbs, already resolved — used directly, no
+  //   membership step (the caller-scoping is baked in when they are resolved).
+  // - groups: legacy group listing, filtered by the caller's membership here at check time. This is
+  //   what lets the same checker also evaluate ACLs that enumerate every group (e.g. the cross-space
+  //   conversation checks).
   private hasPermissionForAcl(
     verb: GrantVerb,
     acl: AccessControlList
@@ -1583,16 +1585,23 @@ export class Authenticator {
     // Role path: gated to the caller's workspace (a role only applies within its own workspace).
     const grantedByRole =
       this.getNonNullableWorkspace().id === acl.workspaceId &&
-      acl.roles.some(
+      (acl.roles ?? []).some(
         (r) => this.role() === r.role && r.permissions.includes(verb)
       );
     if (grantedByRole) {
       return true;
     }
 
-    // Group path: group membership is inherently workspace-scoped, so it needs no workspace gate.
+    // Governance path: the caller's verbs are pre-resolved, so no membership step is needed.
+    if ((acl.grantedVerbs ?? []).includes(verb)) {
+      return true;
+    }
+
+    // Legacy group path: group membership is inherently workspace-scoped, so it needs no gate.
     return this._groupModelIds.some((groupId) =>
-      acl.groups.some((g) => g.id === groupId && g.permissions.includes(verb))
+      (acl.groups ?? []).some(
+        (g) => g.id === groupId && g.permissions.includes(verb)
+      )
     );
   }
 

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -255,15 +255,19 @@ describe("Authenticator.fromKey permission resolution", () => {
       group: excludedGroup,
       grantType: "editor",
       resourceType: "agent",
-      resourceId: 42,
+      // A different agent, so the excluded group's grant is observable by its absence below.
+      resourceId: 99,
     });
 
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
 
-    expect(
-      workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
-    ).toEqual([includedGroup.id]);
+    // The in-scope group's grant on agent 42 is loaded; the out-of-scope group's grant on agent 99
+    // is not — resolved verbs are caller-scoped and carry no group ids.
+    expect(workspaceAuth.getGrantedVerbs("agent", 42).length).toBeGreaterThan(
+      0
+    );
+    expect(workspaceAuth.getGrantedVerbs("agent", 99)).toEqual([]);
   });
 
   it("resolves permissions for explicitly scoped system keys", async () => {
@@ -290,7 +294,8 @@ describe("Authenticator.fromKey permission resolution", () => {
       group: excludedGroup,
       grantType: "editor",
       resourceType: "agent",
-      resourceId: 42,
+      // A different agent, so the excluded group's grant is observable by its absence below.
+      resourceId: 99,
     });
 
     const key = await KeyFactory.system(systemGroup);
@@ -298,8 +303,11 @@ describe("Authenticator.fromKey permission resolution", () => {
       includedGroup.sId,
     ]);
 
-    expect(
-      workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
-    ).toEqual([includedGroup.id]);
+    // The in-scope group's grant on agent 42 is loaded; the out-of-scope group's grant on agent 99
+    // is not — resolved verbs are caller-scoped and carry no group ids.
+    expect(workspaceAuth.getGrantedVerbs("agent", 42).length).toBeGreaterThan(
+      0
+    );
+    expect(workspaceAuth.getGrantedVerbs("agent", 99)).toEqual([]);
   });
 });

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -1,5 +1,6 @@
 import {
   assertValidGrant,
+  GroupPermissions,
   grantTypesForVerb,
   ROLE_REGISTRY,
 } from "@app/lib/resources/group_permission_registry";
@@ -236,5 +237,35 @@ describe("ROLE_REGISTRY invariants", () => {
         expect(roleNames.has(grantType)).toBe(true);
       }
     }
+  });
+});
+
+describe("GroupPermissions.fromJSON", () => {
+  // read = 1 << 0, write = 1 << 1 (see VERB_BIT / GRANT_VERBS order).
+  it("reads the current resolved-mask shape", () => {
+    const perms = GroupPermissions.fromJSON({
+      grants: { agent: { 42: 0b11 } },
+    });
+    expect(perms.resolvedVerbsForResource("agent", 42)).toEqual([
+      "read",
+      "write",
+    ]);
+  });
+
+  it("reads the legacy per-group shape by OR-ing the group masks", () => {
+    // In-flight Temporal payloads serialized before group ids were folded away carry
+    // resourceId -> groupId -> mask; groups 7 and 9 union to read + write.
+    const perms = GroupPermissions.fromJSON({
+      grants: { agent: { 42: { 7: 0b01, 9: 0b10 } } },
+    });
+    expect(perms.resolvedVerbsForResource("agent", 42)).toEqual([
+      "read",
+      "write",
+    ]);
+  });
+
+  it("round-trips the current shape through toJSON", () => {
+    const json = { grants: { agent: { 42: 0b11 } } };
+    expect(GroupPermissions.fromJSON(json).toJSON()).toEqual(json);
   });
 });

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -15,8 +15,6 @@ import {
   isConcreteResourceType,
   WHOLE_TYPE_RESOURCE_ID,
 } from "@app/types/group_permissions";
-import type { GroupGrant } from "@app/types/resource_permissions";
-import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
 /**
@@ -222,24 +220,35 @@ type GrantRow = Pick<
 >;
 
 // JSON-serializable form of GroupPermissions, embedded in a serialized Authenticator so it can be
-// restored without re-querying `group_permissions`. resourceType -> resourceId -> groupId -> verb
-// bitmask (numeric keys become strings after a JSON round-trip; `fromJSON` coerces them back).
+// restored without re-querying `group_permissions`. resourceType -> resourceId -> verb bitmask
+// (numeric keys become strings after a JSON round-trip; `fromJSON` coerces them back).
 export interface GroupPermissionsJSON {
+  grants: Partial<Record<ConcreteResourceType, Record<number, number>>>;
+}
+
+// The shapes `fromJSON` accepts: the current resolved-mask form, plus the legacy per-group form
+// (resourceId -> groupId -> mask) still carried by in-flight Temporal payloads serialized before
+// group ids were folded away. TODO(governance): drop the legacy arm once such payloads have drained.
+interface SerializedGroupPermissions {
   grants: Partial<
-    Record<ConcreteResourceType, Record<number, Record<number, number>>>
+    Record<
+      ConcreteResourceType,
+      Record<number, number | Record<number, number>>
+    >
   >;
 }
 
 /**
- * The governance grants the *caller* holds, resolved once at auth construction and kept group-
- * granular. Keyed by (resourceType, resourceId, groupId) -> verb bitmask: resourceId is
- * WHOLE_TYPE_RESOURCE_ID (-1) for type-wide capabilities (e.g. "create" on "agent") or a resource's
- * model id for instance grants. A type-wide grant satisfies an instance check on any id of that
- * type.
+ * The governance grants the *caller* holds, resolved once at auth construction. Keyed by
+ * (resourceType, resourceId) -> verb bitmask: resourceId is WHOLE_TYPE_RESOURCE_ID (-1) for type-
+ * wide capabilities (e.g. "create" on "agent") or a resource's model id for instance grants. A
+ * type-wide grant satisfies an instance check on any id of that type.
  *
- * Holds only grants — it knows nothing about roles. Admin-by-default access is applied by the
- * Authenticator. Because we only load the caller's groups, this is caller-scoped: `forResource`
- * returns the caller's matching groups, which resources fold into an `AccessControlList`.
+ * The caller's groups are folded away at construction: we only load the caller's groups, so the
+ * mask on each (resourceType, resourceId) is the union of the verbs every one of the caller's
+ * groups confers there. This is why the structure is caller-scoped and holds no group ids — it
+ * answers "what may the caller do on this resource", not "which group grants it". Holds only grants;
+ * admin-by-default access is layered on by the Authenticator.
  *
  * Example — the grant rows of a caller belonging to groups 7 and 9:
  *
@@ -252,21 +261,18 @@ export interface GroupPermissionsJSON {
  * become (with read=1, write=2, admin=4, create=8):
  *
  *   {
- *     space: { 12: { 7: 0b0011, 9: 0b0001 } },
- *     skill: { -1: { 7: 0b1000 } },
+ *     space: { 12: 0b0011 },
+ *     skill: { -1: 0b1000 },
  *   }
  *
- * `member` expands to read + write via the registry, so group 7 holds mask 3 on space 12. The
- * skill row is type-wide (-1), so it answers a "create" check on any skill.
+ * `member` expands to read + write and `reader` to read, so on space 12 the caller's two groups
+ * union to mask 3. The skill row is type-wide (-1), so it answers a "create" check on any skill.
  */
 export class GroupPermissions {
   private constructor(
-    // resourceType -> resourceId -> groupId -> verb bitmask (see VERB_BIT). resourceId
-    // WHOLE_TYPE_RESOURCE_ID (-1) is the type-wide entry.
-    private readonly grants: Map<
-      ConcreteResourceType,
-      Map<number, Map<ModelId, number>>
-    >
+    // resourceType -> resourceId -> verb bitmask (see VERB_BIT), unioned across the caller's groups.
+    // resourceId WHOLE_TYPE_RESOURCE_ID (-1) is the type-wide entry.
+    private readonly grants: Map<ConcreteResourceType, Map<number, number>>
   ) {}
 
   static empty(): GroupPermissions {
@@ -274,14 +280,10 @@ export class GroupPermissions {
   }
 
   static fromGrants(grants: readonly GrantRow[]): GroupPermissions {
-    const map = new Map<
-      ConcreteResourceType,
-      Map<number, Map<ModelId, number>>
-    >();
+    const map = new Map<ConcreteResourceType, Map<number, number>>();
     const add = (
       resourceType: ConcreteResourceType,
       resourceId: number,
-      groupId: ModelId,
       mask: number
     ) => {
       if (mask === 0) {
@@ -292,15 +294,10 @@ export class GroupPermissions {
         byId = new Map();
         map.set(resourceType, byId);
       }
-      let byGroup = byId.get(resourceId);
-      if (!byGroup) {
-        byGroup = new Map();
-        byId.set(resourceId, byGroup);
-      }
-      byGroup.set(groupId, (byGroup.get(groupId) ?? 0) | mask);
+      byId.set(resourceId, (byId.get(resourceId) ?? 0) | mask);
     };
 
-    for (const { groupId, grantType, resourceType, resourceId } of grants) {
+    for (const { grantType, resourceType, resourceId } of grants) {
       // A "*" grant / -1 resourceId are always type-wide; concrete ids are instance-level.
       const level: GrantLevel =
         resourceId === WHOLE_TYPE_RESOURCE_ID ? "type" : "instance";
@@ -318,19 +315,17 @@ export class GroupPermissions {
           grantType === "*"
             ? allVerbsForResourceAtLevel(rt, level)
             : verbsForGrantAtLevel(grantType, rt, level);
-        add(rt, resourceId, groupId, verbsToMask(verbs));
+        add(rt, resourceId, verbsToMask(verbs));
       }
     }
 
     return new GroupPermissions(map);
   }
 
-  // Rebuilds from the serialized form (see toJSON) — no DB access.
-  static fromJSON(json: GroupPermissionsJSON): GroupPermissions {
-    const map = new Map<
-      ConcreteResourceType,
-      Map<number, Map<ModelId, number>>
-    >();
+  // Rebuilds from the serialized form (see toJSON) — no DB access. Reads both the current shape and
+  // the legacy per-group shape (see SerializedGroupPermissions).
+  static fromJSON(json: SerializedGroupPermissions): GroupPermissions {
+    const map = new Map<ConcreteResourceType, Map<number, number>>();
     for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
       if (!isConcreteResourceType(resourceType)) {
         continue;
@@ -339,44 +334,38 @@ export class GroupPermissions {
       if (!byIdRecord) {
         continue;
       }
-      const byId = new Map<number, Map<ModelId, number>>();
-      for (const [resourceId, byGroupRecord] of Object.entries(byIdRecord)) {
-        const byGroup = new Map<ModelId, number>();
-        for (const [groupId, mask] of Object.entries(byGroupRecord)) {
-          byGroup.set(Number(groupId), mask);
-        }
-        byId.set(Number(resourceId), byGroup);
+      const byId = new Map<number, number>();
+      for (const [resourceId, value] of Object.entries(byIdRecord)) {
+        // `value` is the resolved mask in the current shape; tolerate the legacy per-group shape
+        // by OR-ing the group masks together.
+        const mask =
+          typeof value === "number"
+            ? value
+            : Object.values(value).reduce((acc, m) => acc | m, 0);
+        byId.set(Number(resourceId), mask);
       }
       map.set(resourceType, byId);
     }
     return new GroupPermissions(map);
   }
 
-  // The caller's groups' grants on (resourceType, resourceId), folding in the type-wide (-1) grants
-  // so a workspace-wide grant satisfies an instance lookup. Caller-scoped: only groups the caller
-  // belongs to appear (that is all we load).
-  forResource(
+  // The verbs the caller holds on (resourceType, resourceId), folding in the type-wide (-1) grants
+  // so a workspace-wide grant satisfies an instance lookup. Already the union across the caller's
+  // groups (see the class doc), so it is caller-scoped and needs no membership step. Governance-
+  // sourced ACLs carry this as `grantedVerbs`.
+  resolvedVerbsForResource(
     resourceType: ConcreteResourceType,
     resourceId: number
-  ): GroupGrant[] {
+  ): GrantVerb[] {
     const byId = this.grants.get(resourceType);
     if (!byId) {
       return [];
     }
-    const merged = new Map<ModelId, number>();
+    let mask = 0;
     for (const key of new Set([resourceId, WHOLE_TYPE_RESOURCE_ID])) {
-      const byGroup = byId.get(key);
-      if (!byGroup) {
-        continue;
-      }
-      for (const [groupId, mask] of byGroup) {
-        merged.set(groupId, (merged.get(groupId) ?? 0) | mask);
-      }
+      mask |= byId.get(key) ?? 0;
     }
-    return [...merged].map(([id, mask]) => ({
-      id,
-      permissions: maskToVerbs(mask),
-    }));
+    return maskToVerbs(mask);
   }
 
   // The type-wide (-1) verbs the caller's grants confer per resource type — the flat record for the
@@ -385,14 +374,7 @@ export class GroupPermissions {
   toWorkspacePermissions(): WorkspacePermissions {
     const result = emptyWorkspacePermissions();
     for (const [resourceType, byId] of this.grants) {
-      const byGroup = byId.get(WHOLE_TYPE_RESOURCE_ID);
-      if (!byGroup) {
-        continue;
-      }
-      let mask = 0;
-      for (const groupMask of byGroup.values()) {
-        mask |= groupMask;
-      }
+      const mask = byId.get(WHOLE_TYPE_RESOURCE_ID) ?? 0;
       if (mask) {
         result[resourceType] = maskToVerbs(mask);
       }
@@ -400,20 +382,16 @@ export class GroupPermissions {
     return result;
   }
 
-  // Serializes the group-granular grant map for embedding in a serialized Authenticator, so
-  // `fromJSON` can restore it without hitting the DB. Round-trips exactly.
+  // Serializes the resolved grant map for embedding in a serialized Authenticator, so `fromJSON`
+  // can restore it without hitting the DB. Round-trips exactly.
   toJSON(): GroupPermissionsJSON {
     const grants: Partial<
-      Record<ConcreteResourceType, Record<number, Record<number, number>>>
+      Record<ConcreteResourceType, Record<number, number>>
     > = {};
     for (const [resourceType, byId] of this.grants) {
-      const byIdRecord: Record<number, Record<number, number>> = {};
-      for (const [resourceId, byGroup] of byId) {
-        const byGroupRecord: Record<number, number> = {};
-        for (const [groupId, mask] of byGroup) {
-          byGroupRecord[groupId] = mask;
-        }
-        byIdRecord[resourceId] = byGroupRecord;
+      const byIdRecord: Record<number, number> = {};
+      for (const [resourceId, mask] of byId) {
+        byIdRecord[resourceId] = mask;
       }
       grants[resourceType] = byIdRecord;
     }
@@ -425,12 +403,9 @@ export class GroupPermissions {
   toString(): string {
     const parts: string[] = [];
     for (const [resourceType, byId] of this.grants) {
-      const entries = [...byId.entries()].flatMap(([resourceId, byGroup]) => {
+      const entries = [...byId.entries()].map(([resourceId, mask]) => {
         const id = resourceId === WHOLE_TYPE_RESOURCE_ID ? "*" : resourceId;
-        return [...byGroup.entries()].map(
-          ([groupId, mask]) =>
-            `${id}/group:${groupId}: [${maskToVerbs(mask).join(", ")}]`
-        );
+        return `${id}: [${maskToVerbs(mask).join(", ")}]`;
       });
       parts.push(`${resourceType}: { ${entries.join(", ")} }`);
     }

--- a/front/lib/resources/permission_utils.ts
+++ b/front/lib/resources/permission_utils.ts
@@ -25,7 +25,7 @@ export function createSpaceIdToGroupsMap(
     // TODO: Refactor to avoid calling `getAccessControlLists` but still get the right groups.
     const permissions = space.getAccessControlLists(auth);
     const groupIds = permissions.flatMap((permission) =>
-      permission.groups.map((group) =>
+      (permission.groups ?? []).map((group) =>
         GroupResource.modelIdToSId({
           id: group.id,
           workspaceId,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2178,10 +2178,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * The skill's access-control list: the code role rules plus the groups holding a grant on it in
-   * `group_permissions` (written by `writeGroupPermissions` on every mutation of the editor-group
-   * association). The editor group is not read here — membership in it only matters through the
-   * grant it holds.
+   * The skill's access-control list: the code role rules plus the caller's own verbs resolved from
+   * its `group_permissions` grants (written by `writeGroupPermissions` on every mutation of the
+   * editor-group association). The editor group is not read here — membership in it only matters
+   * through the grant it holds.
    */
   getAccessControlLists(auth: Authenticator): AccessControlList[] {
     // Global skills carry no row, so there is no grant to look up (and their synthetic `id` of -1
@@ -2190,7 +2190,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return [
         {
           roles: GLOBAL_SKILL_ROLE_GRANTS,
-          groups: [],
           workspaceId: this.workspaceId,
         },
       ];
@@ -2199,7 +2198,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return [
       {
         roles: SKILL_ROLE_GRANTS,
-        groups: auth.getGroupPermissions("skill", this.id),
+        grantedVerbs: auth.getGrantedVerbs("skill", this.id),
         workspaceId: this.workspaceId,
       },
     ];

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1820,9 +1820,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   /**
-   * The space's access-control list built from governance data: the code role rules plus the groups
-   *  held in `group_permissions`. At the flip this becomes the served `getAccessControlLists(auth)`
-   *  and `legacySpaceGroupGrants` is deleted without touching it.
+   * The space's access-control list built from governance data: the code role rules plus the
+   * caller's own verbs resolved from `group_permissions`. At the flip this becomes the served
+   * `getAccessControlLists(auth)` and `legacySpaceGroupGrants` is deleted without touching it.
    *
    * Until then it is the shadow-compare candidate.
    */
@@ -1831,7 +1831,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       {
         workspaceId: this.workspaceId,
         roles: this.spaceRoleGrants(),
-        groups: auth.getGroupPermissions("space", this.id),
+        grantedVerbs: auth.getGrantedVerbs("space", this.id),
       },
     ];
   }

--- a/front/migrations/20260728_backfill_space_group_permissions.ts
+++ b/front/migrations/20260728_backfill_space_group_permissions.ts
@@ -31,7 +31,7 @@ async function backfillWorkspaceSpaceGroupPermissions(
     async (space) => {
       const desiredGrants = space
         .getAccessControlLists(auth)
-        .flatMap((permission) => permission.groups)
+        .flatMap((permission) => permission.groups ?? [])
         .map((grant) => ({
           groupId: grant.id,
           permissions: grant.permissions,

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -27,21 +27,31 @@ export type RoleGrant = {
 };
 
 /**
- * The access rules for a resource: the roles and groups that confer verbs, scoped to a workspace.
+ * The access rules for a resource: the additive grant sources that confer verbs, scoped to a
+ * workspace. A caller passes an ACL when ANY source grants the verb; a resource passes when the
+ * caller satisfies EVERY ACL it declares (see `Authenticator.hasPermission`). Every source is
+ * optional and an absent source contributes nothing, so an ACL with no matching source denies
+ * (fail-closed) — a missing field is intent, not a bug.
  *
- * A resource builds its own ACL (see each resource's `acl(auth)`) from role rules and/or the
- * caller's governance grants (`Authenticator.getGroupPermissions`). The Authenticator evaluates it
- * with `hasPermission`: a caller passes if their role grants the verb, or they belong to a listed
- * group that grants it. When the groups come from governance grants, the list is caller-scoped
- * (only the caller's groups) — an ACL is a check artifact, not a complete "who has access" listing.
+ * The three sources:
+ * - `roles`: the caller passes if their workspace role grants the verb (only within the ACL's
+ *   workspace).
+ * - `grantedVerbs`: the caller's own verbs on the resource, already resolved from their governance
+ *   grants (`Authenticator.getGrantedVerbs`). Caller-scoped and pre-filtered, so the checker uses it
+ *   directly with no group-membership step. This is the shape governance-sourced ACLs use.
+ * - `groups`: legacy group→verb listing. The checker filters it by the caller's group membership at
+ *   check time, so it also handles ACLs that enumerate every group (e.g. the cross-space
+ *   conversation checks). An ACL is a check artifact, not a complete "who has access" listing.
  *
  * @property roles - Role-based grants: a caller whose workspace role matches gets its verbs
- * @property groups - Group-based grants: a caller in a listed group gets its verbs
+ * @property groups - Legacy group-based grants, filtered by the caller's membership at check time
+ * @property grantedVerbs - The caller's pre-resolved governance verbs on the resource
  * @property workspaceId - The resource's workspace; checks only apply within the caller's workspace
  */
 export type AccessControlList = {
-  roles: RoleGrant[];
-  groups: GroupGrant[];
+  roles?: RoleGrant[];
+  groups?: GroupGrant[];
+  grantedVerbs?: GrantVerb[];
   workspaceId: ModelId;
 };
 


### PR DESCRIPTION
## Description

The Authenticator's `GroupPermissions` kept a per-group mask map — `resourceType → resourceId → groupId → mask` — and `hasPermissionForAcl` re-intersected those groups against the caller's own groups on every check. We only ever load the caller's groups, so that intersection was a no-op for governance grants. This folds the groups away at construction and stores just the caller's resolved verb mask per resource.

Based on `main` (behind the space/skill governance rollout, ahead of the space flip #29763). No user-facing behavior change: the space governance ACL is still shadow-compare only, and the legacy served/conversation paths are untouched.

**Storage** — `space: { 12: { 7: 0b0011, 9: 0b0001 } }` becomes `space: { 12: 0b0011 }`:
- `GroupPermissions` storage, `fromGrants`, `toJSON`, `GroupPermissionsJSON`, `toWorkspacePermissions`, `toString` lose the `groupId` level. `forResource` → `resolvedVerbsForResource` (direct mask lookup), surfaced as `Authenticator.getGrantedVerbs`; `getGroupPermissions` removed.

**ACL shape** — governance-sourced ACLs carry resolved verbs, not group refs:
- `AccessControlList` gains an optional `grantedVerbs`; `roles`/`groups` become optional (additive OR; absent = fail-closed).
- `hasPermissionForAcl` checks `grantedVerbs` directly (no membership step) and keeps the legacy `groups` intersection for the cross-space conversation path (still legacy until the space flip; still uses `_groupModelIds`).
- Serving `grantedVerbs`: the space shadow candidate (`governanceAcls`), the skill served ACL, and the workspace-wide capability check. The served legacy space ACL and the conversation/`permission_utils` path are unchanged.

**Temporal-safe serialization** — `fromJSON` reads **both** shapes. The shadow stage (already in prod) serializes the 3-level shape into Temporal payloads, so the new reader OR-folds the legacy per-group masks. `TODO(governance)`: drop the legacy arm once those payloads drain.

`_groupModelIds` stays for the legacy `groups` ACL path and `hasGroup*`.

## Tests

- `npx tsgo --noEmit` clean; `biome check` clean.
- 420 existing tests passing (registry, space/skill/conversation resources, conversation permissions, spaces JSON round-trip, auth.workspace_permission, auth.fromjson, governance_seeding, shadow) — no behavior change.
- Added 3 unit tests for the dual-read `fromJSON` (current shape, legacy per-group shape, round-trip).
- Reframed the two system-key group-scoping tests onto resolved verbs: the out-of-scope group's grant lands on a different agent so its absence is observable now that group ids are gone.

## Risk

Low.
- No user-facing behavior change: the only governance ACL that changes shape is the space **shadow candidate** (fire-and-forget compare) and the skill served ACL (gated by `isLegacyAclsEnabled`, decision unchanged). Legacy served + conversation paths untouched. Fail-closed: an absent ACL source denies.
- **Serialized-shape transition, handled.** The live shadow build writes the 3-level `GroupPermissionsJSON` into Temporal payloads; `fromJSON` here reads both shapes, so new workers parse in-flight payloads correctly. Residual: during the rolling deploy an old worker could read a new 2-level payload and misparse → fail-closed (never over-grants), transient.

## Deploy Plan

Standard deploy, no migration or flag. Deploy **before** the space flip (#29763) so the simpler shape lands and bakes first; the flip then serves `grantedVerbs` directly. Fresh auths rebuild `GroupPermissions` from the DB on every `resolvePermissions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)