### PR TITLE
[front] enh: polish new analytics UI

### DIFF
--- a/front/components/charts/ChartContainer.tsx
+++ b/front/components/charts/ChartContainer.tsx
@@ -1,4 +1,7 @@
-import type { LegendItem } from "@app/components/charts/ChartLegend";
+import type {
+  ChartLegendAlignment,
+  LegendItem,
+} from "@app/components/charts/ChartLegend";
 import { ChartLegend } from "@app/components/charts/ChartLegend";
 import { CHART_HEIGHT } from "@app/components/charts/constants";
 import {
@@ -28,7 +31,7 @@ interface ChartContainerProps {
   height?: number;
   description?: string;
   legendItems?: LegendItem[];
-  legendClassName?: string;
+  legendAlignment?: ChartLegendAlignment;
   isAllowFullScreen?: boolean;
   showHeaderDivider?: boolean;
 }
@@ -45,7 +48,7 @@ export function ChartContainer({
   height,
   description,
   legendItems,
-  legendClassName,
+  legendAlignment,
   isAllowFullScreen,
   showHeaderDivider,
 }: ChartContainerProps) {
@@ -107,7 +110,7 @@ export function ChartContainer({
             </ResponsiveContainer>
             {bottomControls}
             {legendItems && (
-              <ChartLegend items={legendItems} className={legendClassName} />
+              <ChartLegend items={legendItems} alignment={legendAlignment} />
             )}
           </>
         )}
@@ -141,7 +144,7 @@ export function ChartContainer({
                   {legendItems && (
                     <ChartLegend
                       items={legendItems}
-                      className={legendClassName}
+                      alignment={legendAlignment}
                     />
                   )}
                 </div>

--- a/front/components/charts/ChartContainer.tsx
+++ b/front/components/charts/ChartContainer.tsx
@@ -28,6 +28,7 @@ interface ChartContainerProps {
   height?: number;
   description?: string;
   legendItems?: LegendItem[];
+  legendClassName?: string;
   isAllowFullScreen?: boolean;
   showHeaderDivider?: boolean;
 }
@@ -44,6 +45,7 @@ export function ChartContainer({
   height,
   description,
   legendItems,
+  legendClassName,
   isAllowFullScreen,
   showHeaderDivider,
 }: ChartContainerProps) {
@@ -104,7 +106,9 @@ export function ChartContainer({
               {children}
             </ResponsiveContainer>
             {bottomControls}
-            {legendItems && <ChartLegend items={legendItems} />}
+            {legendItems && (
+              <ChartLegend items={legendItems} className={legendClassName} />
+            )}
           </>
         )}
       </div>
@@ -134,7 +138,12 @@ export function ChartContainer({
                     {children}
                   </ResponsiveContainer>
                   {bottomControls}
-                  {legendItems && <ChartLegend items={legendItems} />}
+                  {legendItems && (
+                    <ChartLegend
+                      items={legendItems}
+                      className={legendClassName}
+                    />
+                  )}
                 </div>
               </div>
             </SheetContainer>

--- a/front/components/charts/ChartLegend.tsx
+++ b/front/components/charts/ChartLegend.tsx
@@ -1,4 +1,5 @@
 import { LegendDot } from "@app/components/charts/ChartTooltip";
+import { cn } from "@dust-tt/sparkle";
 
 export type LegendEntry = {
   key: string;
@@ -38,11 +39,17 @@ export interface LegendItem {
 
 interface ChartLegendProps {
   items: LegendItem[];
+  className?: string;
 }
 
-export function ChartLegend({ items }: ChartLegendProps) {
+export function ChartLegend({ items, className }: ChartLegendProps) {
   return (
-    <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-2">
+    <div
+      className={cn(
+        "mt-3 flex flex-wrap items-center gap-x-6 gap-y-2",
+        className
+      )}
+    >
       {items.map((item) => (
         <div
           key={item.key}

--- a/front/components/charts/ChartLegend.tsx
+++ b/front/components/charts/ChartLegend.tsx
@@ -37,17 +37,25 @@ export interface LegendItem {
   isActive?: boolean;
 }
 
+export type ChartLegendAlignment = "left" | "center" | "right";
+
+const ALIGNMENT_CLASSES: Record<ChartLegendAlignment, string> = {
+  left: "justify-start",
+  center: "justify-center",
+  right: "justify-end",
+};
+
 interface ChartLegendProps {
   items: LegendItem[];
-  className?: string;
+  alignment?: ChartLegendAlignment;
 }
 
-export function ChartLegend({ items, className }: ChartLegendProps) {
+export function ChartLegend({ items, alignment = "left" }: ChartLegendProps) {
   return (
     <div
       className={cn(
         "mt-3 flex flex-wrap items-center gap-x-6 gap-y-2",
-        className
+        ALIGNMENT_CLASSES[alignment]
       )}
     >
       {items.map((item) => (

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -70,6 +70,8 @@ export function UsageFilterPanel({
   const [activeTier, setActiveTier] =
     useState<ModelsTierName>(DEFAULT_MODEL_TIER);
   const [searchText, setSearchText] = useState("");
+  const [contentScrollContainer, setContentScrollContainer] =
+    useState<HTMLDivElement | null>(null);
   const selectedGroups = useToggleSelectionList<UsageFilterGroup>();
 
   const draftScopeFilter = useMemo(
@@ -170,9 +172,21 @@ export function UsageFilterPanel({
     }
   };
 
+  const resetContentScroll = () => {
+    if (contentScrollContainer) {
+      contentScrollContainer.scrollTop = 0;
+    }
+  };
+
   const handleCategoryChange = (category: UsageFilterCategory) => {
     setActiveCategory(category);
     setSearchText("");
+    resetContentScroll();
+  };
+
+  const handleSearchChange = (search: string) => {
+    setSearchText(search);
+    resetContentScroll();
   };
 
   const activeCategorySelectionCount = draftFilter[activeCategory]?.length ?? 0;
@@ -217,56 +231,68 @@ export function UsageFilterPanel({
             <SearchInput
               name="usage-filter-search"
               value={searchText}
-              onChange={setSearchText}
+              onChange={handleSearchChange}
               placeholder={`Search ${USAGE_FILTER_CATEGORY_LABEL[activeCategory].toLowerCase()}`}
             />
-            {activeCategory === "member" && (
-              <UsageFilterMemberGroupsControls
-                groups={groups}
-                selectedGroups={selectedGroups.items}
-                onAddGroup={selectedGroups.add}
-                onRemoveGroup={selectedGroups.remove}
-              />
-            )}
-            {activeCategory === "model" && (
-              <UsageFilterModelComplexityControls
-                moreModelsCatalog={categoryOptions.model}
-                selectedModelIds={selectedIdsForActiveCategory}
-                onToggleModel={(model) => toggleOption("model", model)}
-                activeTier={activeTier}
-                onTierChange={setActiveTier}
-              />
-            )}
-            {activeCategory === "agent" && (
-              <UsageFilterAgentScopeControls
-                scopes={USAGE_FILTER_AGENT_SCOPES}
-                activeScope={activeScope}
-                onScopeChange={setActiveScope}
-              />
-            )}
-            {isFacetsError ? (
-              <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
-                Failed to load filters.
-              </div>
-            ) : (
-              <UsageFilterOptionCheckboxList
-                key={optionListKey}
-                category={activeCategory}
-                categoryLabel={USAGE_FILTER_CATEGORY_LABEL[activeCategory]}
-                options={filteredOptions}
-                selectedIds={selectedIdsForActiveCategory}
-                onToggleOption={(option) =>
-                  toggleOption(activeCategory, option)
-                }
-                onSelectAll={() =>
-                  selectAllFiltered(activeCategory, unselectedEnabledOptions)
-                }
-                selectAllLabel="Select all"
-                hasSelectableOptions={unselectedEnabledOptions.length > 0}
-                isLoading={isFacetsLoading}
-                isUpdating={isFacetsValidating}
-              />
-            )}
+            <div
+              ref={setContentScrollContainer}
+              className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2"
+            >
+              {activeCategory === "member" && (
+                <UsageFilterMemberGroupsControls
+                  groups={groups}
+                  selectedGroups={selectedGroups.items}
+                  onAddGroup={selectedGroups.add}
+                  onRemoveGroup={selectedGroups.remove}
+                />
+              )}
+              {activeCategory === "model" && (
+                <UsageFilterModelComplexityControls
+                  moreModelsCatalog={categoryOptions.model}
+                  selectedModelIds={selectedIdsForActiveCategory}
+                  onToggleModel={(model) => toggleOption("model", model)}
+                  activeTier={activeTier}
+                  onTierChange={(tier) => {
+                    setActiveTier(tier);
+                    resetContentScroll();
+                  }}
+                />
+              )}
+              {activeCategory === "agent" && (
+                <UsageFilterAgentScopeControls
+                  scopes={USAGE_FILTER_AGENT_SCOPES}
+                  activeScope={activeScope}
+                  onScopeChange={(scope) => {
+                    setActiveScope(scope);
+                    resetContentScroll();
+                  }}
+                />
+              )}
+              {isFacetsError ? (
+                <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+                  Failed to load filters.
+                </div>
+              ) : (
+                <UsageFilterOptionCheckboxList
+                  key={optionListKey}
+                  category={activeCategory}
+                  categoryLabel={USAGE_FILTER_CATEGORY_LABEL[activeCategory]}
+                  options={filteredOptions}
+                  selectedIds={selectedIdsForActiveCategory}
+                  onToggleOption={(option) =>
+                    toggleOption(activeCategory, option)
+                  }
+                  onSelectAll={() =>
+                    selectAllFiltered(activeCategory, unselectedEnabledOptions)
+                  }
+                  selectAllLabel="Select all"
+                  hasSelectableOptions={unselectedEnabledOptions.length > 0}
+                  isLoading={isFacetsLoading}
+                  isUpdating={isFacetsValidating}
+                  scrollContainer={contentScrollContainer}
+                />
+              )}
+            </div>
           </div>
           <UsageFilterSelectionSummary
             categoriesWithSelection={categoriesWithSelection}

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -211,7 +211,7 @@ export function UsageFilterPanel({
             activeCategory={activeCategory}
             onCategoryChange={handleCategoryChange}
           />
-          <div className="flex h-full w-72 flex-col gap-2 p-2">
+          <div className="flex h-full w-80 flex-col gap-2 p-2">
             <UsageFilterSection
               title={USAGE_FILTER_CATEGORY_LABEL[activeCategory]}
               action={

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -17,6 +17,7 @@ import { UsageFilterFooter } from "@app/components/workspace/analytics/usageFilt
 import { UsageFilterMemberGroupsControls } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterMemberGroupsControls";
 import { UsageFilterModelComplexityControls } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls";
 import { UsageFilterOptionCheckboxList } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList";
+import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import { UsageFilterSelectionSummary } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSelectionSummary";
 import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilter";
 import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
@@ -29,7 +30,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   FilterFunnel01,
-  NavigationListLabel,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -211,10 +211,9 @@ export function UsageFilterPanel({
             activeCategory={activeCategory}
             onCategoryChange={handleCategoryChange}
           />
-          <div className="flex h-full w-72 flex-col gap-2 p-2">
-            <NavigationListLabel
-              label={USAGE_FILTER_CATEGORY_LABEL[activeCategory]}
-              className="bg-transparent pt-1.5 pb-0 font-medium"
+          <div className="flex h-full w-72 flex-col gap-4 p-2">
+            <UsageFilterSection
+              title={USAGE_FILTER_CATEGORY_LABEL[activeCategory]}
               action={
                 <Button
                   label="Clear"
@@ -227,16 +226,17 @@ export function UsageFilterPanel({
                   }
                 />
               }
-            />
-            <SearchInput
-              name="usage-filter-search"
-              value={searchText}
-              onChange={handleSearchChange}
-              placeholder={`Search ${USAGE_FILTER_CATEGORY_LABEL[activeCategory].toLowerCase()}`}
-            />
+            >
+              <SearchInput
+                name="usage-filter-search"
+                value={searchText}
+                onChange={handleSearchChange}
+                placeholder={`Search ${USAGE_FILTER_CATEGORY_LABEL[activeCategory].toLowerCase()}`}
+              />
+            </UsageFilterSection>
             <div
               ref={setContentScrollContainer}
-              className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2"
+              className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-2"
             >
               {activeCategory === "member" && (
                 <UsageFilterMemberGroupsControls

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -211,7 +211,7 @@ export function UsageFilterPanel({
             activeCategory={activeCategory}
             onCategoryChange={handleCategoryChange}
           />
-          <div className="flex h-full w-72 flex-col gap-4 p-2">
+          <div className="flex h-full w-72 flex-col gap-2 p-2">
             <UsageFilterSection
               title={USAGE_FILTER_CATEGORY_LABEL[activeCategory]}
               action={
@@ -236,7 +236,7 @@ export function UsageFilterPanel({
             </UsageFilterSection>
             <div
               ref={setContentScrollContainer}
-              className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-2"
+              className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
             >
               {activeCategory === "member" && (
                 <UsageFilterMemberGroupsControls

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -377,34 +377,33 @@ function buildColumns({
       id: "filter",
       header: "",
       enableSorting: false,
-      meta: { className: "w-12", headerAlign: "right" },
+      meta: { className: "w-12 p-0", headerAlign: "right" },
       cell: (info) => {
         const row = info.row.original;
         const isFilterSelected = selectedIdSet.has(row.id);
         return (
-          <DataTable.CellContent className="w-full justify-end">
-            <Button
-              icon={isFilterSelected ? XCircle : FilterFunnel01}
-              variant="ghost-secondary"
-              size="xs"
-              tooltip={
-                isFilterSelected ? "Remove from filters" : "Add to filters"
+          <Button
+            icon={isFilterSelected ? XCircle : FilterFunnel01}
+            variant="ghost-secondary"
+            size="xs"
+            className="h-12 w-full rounded-none"
+            tooltip={
+              isFilterSelected ? "Remove from filters" : "Add to filters"
+            }
+            aria-label={
+              isFilterSelected
+                ? `Remove ${row.name} from filters`
+                : `Add ${row.name} to filters`
+            }
+            onClick={(event) => {
+              event.stopPropagation();
+              if (isFilterSelected) {
+                row.onRemoveFilter();
+              } else {
+                row.onAddFilter();
               }
-              aria-label={
-                isFilterSelected
-                  ? `Remove ${row.name} from filters`
-                  : `Add ${row.name} to filters`
-              }
-              onClick={(event) => {
-                event.stopPropagation();
-                if (isFilterSelected) {
-                  row.onRemoveFilter();
-                } else {
-                  row.onAddFilter();
-                }
-              }}
-            />
-          </DataTable.CellContent>
+            }}
+          />
         );
       },
     },

--- a/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
@@ -179,6 +179,7 @@ export function ConsumptionBurnUpChart({
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
+      legendClassName="justify-center"
       showHeaderDivider
     >
       <LineChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>

--- a/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
@@ -179,7 +179,7 @@ export function ConsumptionBurnUpChart({
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
-      legendClassName="justify-center"
+      legendAlignment="center"
       showHeaderDivider
     >
       <LineChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -278,7 +278,7 @@ function ConsumptionDailyChart({
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
-      legendClassName="justify-center"
+      legendAlignment="center"
       showHeaderDivider
     >
       <BarChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -319,28 +319,34 @@ function ConsumptionDailyChart({
             ifOverflow="extendDomain"
           />
         )}
-        {orderedGroups.map((group) => (
-          <Bar
-            key={group.groupKey}
-            dataKey={(datum: ConsumptionTimeseriesPoint) =>
-              datum.values[group.groupKey] ?? 0
-            }
-            name={group.name}
-            stackId="credits"
-            isAnimationActive={false}
-          >
-            {chartData.map((datum) => (
-              <Cell
-                key={datum.timestamp}
-                fill="currentColor"
-                className={cn(
-                  colorByGroupKey.get(group.groupKey),
-                  datum.timestamp === partialTimestamp && PARTIAL_BAR_OPACITY
-                )}
-              />
-            ))}
-          </Bar>
-        ))}
+        {orderedGroups.map((group, rank) => {
+          const colorClassName = getConsumptionChartColor(rank);
+
+          return (
+            <Bar
+              // Recharts keeps each mounted Bar in its original stack slot, so
+              // identify bars by color rank rather than the group occupying it.
+              key={colorClassName}
+              dataKey={(datum: ConsumptionTimeseriesPoint) =>
+                datum.values[group.groupKey] ?? 0
+              }
+              name={group.name}
+              stackId="credits"
+              isAnimationActive={false}
+            >
+              {chartData.map((datum) => (
+                <Cell
+                  key={datum.timestamp}
+                  fill="currentColor"
+                  className={cn(
+                    colorClassName,
+                    datum.timestamp === partialTimestamp && PARTIAL_BAR_OPACITY
+                  )}
+                />
+              ))}
+            </Bar>
+          );
+        })}
       </BarChart>
     </ChartContainer>
   );

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -260,6 +260,7 @@ function ConsumptionDailyChart({
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
+      legendClassName="justify-center"
       showHeaderDivider
     >
       <BarChart data={chartData} margin={{ ...CHART_MARGIN, top: 24 }}>

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -100,7 +100,8 @@ const CONSUMPTION_CHART_COLORS = [
   "text-blue-50",
 ] as const;
 
-// Reserve the final color for the optional "Others" series.
+// Request the top five categories, leaving the sixth shade available when the
+// endpoint adds an aggregate "Others" category.
 const CONSUMPTION_CHART_BREAKDOWN_COUNT = CONSUMPTION_CHART_COLORS.length - 1;
 
 function getConsumptionChartColor(index: number): string {
@@ -205,19 +206,36 @@ function ConsumptionDailyChart({
     });
 
   const groups = useMemo(() => timeseries?.groups ?? [], [timeseries]);
+  const chartData = useMemo(() => timeseries?.points ?? [], [timeseries]);
 
-  // Colors are assigned darkest-to-lightest by rank, so the biggest consumer
-  // keeps the strongest color as long as it stays on top.
+  const orderedGroups = useMemo(() => {
+    const totalByGroupKey = new Map<string, number>();
+    for (const datum of chartData) {
+      for (const [groupKey, credits] of Object.entries(datum.values)) {
+        totalByGroupKey.set(
+          groupKey,
+          (totalByGroupKey.get(groupKey) ?? 0) + credits
+        );
+      }
+    }
+
+    return [...groups].sort(
+      (a, b) =>
+        (totalByGroupKey.get(b.groupKey) ?? 0) -
+        (totalByGroupKey.get(a.groupKey) ?? 0)
+    );
+  }, [chartData, groups]);
+
+  // Colors are assigned darkest-to-lightest by total consumption, including
+  // the aggregate "Others" category.
   const colorByGroupKey = useMemo(() => {
     return new Map(
-      groups.map((group, index) => [
+      orderedGroups.map((group, index) => [
         group.groupKey,
         getConsumptionChartColor(index),
       ])
     );
-  }, [groups]);
-
-  const chartData = useMemo(() => timeseries?.points ?? [], [timeseries]);
+  }, [orderedGroups]);
 
   const partialTimestamp = useMemo(
     () => findPartialTimestamp(chartData),
@@ -228,15 +246,15 @@ function ConsumptionDailyChart({
     (props: TooltipContentProps<number, string>) => (
       <ConsumptionDailyTooltip
         {...props}
-        groups={groups}
+        groups={orderedGroups}
         colorByGroupKey={colorByGroupKey}
         partialTimestamp={partialTimestamp}
       />
     ),
-    [groups, colorByGroupKey, partialTimestamp]
+    [orderedGroups, colorByGroupKey, partialTimestamp]
   );
 
-  const legendItems: LegendItem[] = groups.map((group) => ({
+  const legendItems: LegendItem[] = orderedGroups.map((group) => ({
     key: group.groupKey,
     label: group.name,
     colorClassName: colorByGroupKey.get(group.groupKey) ?? "",
@@ -301,7 +319,7 @@ function ConsumptionDailyChart({
             ifOverflow="extendDomain"
           />
         )}
-        {groups.map((group) => (
+        {orderedGroups.map((group) => (
           <Bar
             key={group.groupKey}
             dataKey={(datum: ConsumptionTimeseriesPoint) =>

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -97,7 +97,7 @@ const CONSUMPTION_CHART_COLORS = [
   "text-blue-700",
   "text-blue-600",
   "text-blue-500",
-  "text-blue-50",
+  "text-blue-400",
 ] as const;
 
 // Request the top five categories, leaving the sixth shade available when the

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -71,7 +71,7 @@ function TodayPartialLabel({ viewBox }: TodayPartialLabelProps) {
           width={rectWidth}
           height={rectHeight}
           rx={4}
-          className="fill-gray-700"
+          className="fill-muted-foreground"
         />
       )}
       <text

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
@@ -17,7 +17,7 @@ export function UsageFilterAgentScopeControls({
     <>
       <NavigationListLabel
         label="Scopes"
-        className="bg-transparent font-medium pt-2 pb-0"
+        className="bg-transparent px-0 pt-2 pb-0 font-medium"
       />
       <div className="flex items-center gap-1">
         {scopes.map((scope) => (

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls.tsx
@@ -1,6 +1,7 @@
 import type { UsageFilterAgentScope } from "@app/components/workspace/analytics/usageFilter";
 import { USAGE_FILTER_SCOPE_LABEL } from "@app/components/workspace/analytics/usageFilter";
-import { Button, NavigationListLabel } from "@dust-tt/sparkle";
+import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
+import { Button } from "@dust-tt/sparkle";
 
 interface UsageFilterAgentScopeControlsProps {
   scopes: readonly UsageFilterAgentScope[];
@@ -14,11 +15,7 @@ export function UsageFilterAgentScopeControls({
   onScopeChange,
 }: UsageFilterAgentScopeControlsProps) {
   return (
-    <>
-      <NavigationListLabel
-        label="Scopes"
-        className="bg-transparent px-0 pt-2 pb-0 font-medium"
-      />
+    <UsageFilterSection title="Scopes">
       <div className="flex items-center gap-1">
         {scopes.map((scope) => (
           <Button
@@ -31,6 +28,6 @@ export function UsageFilterAgentScopeControls({
           />
         ))}
       </div>
-    </>
+    </UsageFilterSection>
   );
 }

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterMemberGroupsControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterMemberGroupsControls.tsx
@@ -1,10 +1,10 @@
 import type { UsageFilterGroup } from "@app/components/workspace/analytics/usageFilter";
+import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import {
   Button,
   Chip,
   NavigationList,
   NavigationListItem,
-  NavigationListLabel,
   Plus,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -34,20 +34,18 @@ export function UsageFilterMemberGroupsControls({
   };
 
   return (
-    <>
-      <NavigationListLabel
-        label="Groups"
-        className="bg-transparent px-0 pt-2 pb-0 font-medium"
-        action={
-          <Button
-            label="Add group"
-            icon={Plus}
-            size="xmini"
-            variant="ghost-secondary"
-            onClick={() => setIsAddGroupOpen((current) => !current)}
-          />
-        }
-      />
+    <UsageFilterSection
+      title="Groups"
+      action={
+        <Button
+          label="Add group"
+          icon={Plus}
+          size="xmini"
+          variant="ghost-secondary"
+          onClick={() => setIsAddGroupOpen((current) => !current)}
+        />
+      }
+    >
       {isAddGroupOpen && (
         <NavigationList className="max-h-32">
           {availableGroups.length > 0 ? (
@@ -81,6 +79,6 @@ export function UsageFilterMemberGroupsControls({
           ))}
         </div>
       )}
-    </>
+    </UsageFilterSection>
   );
 }

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterMemberGroupsControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterMemberGroupsControls.tsx
@@ -37,7 +37,7 @@ export function UsageFilterMemberGroupsControls({
     <>
       <NavigationListLabel
         label="Groups"
-        className="bg-transparent font-medium pt-2 pb-0"
+        className="bg-transparent px-0 pt-2 pb-0 font-medium"
         action={
           <Button
             label="Add group"

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -209,22 +209,24 @@ export function UsageFilterModelComplexityControls({
         </DropdownMenu>
       }
     >
-      <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-        Price tier of all the models actually billed — not only the Basic /
-        Standard / Premium options offered in the model picker.
-      </p>
-      <div className="flex items-center gap-1">
-        {MODELS_TIER_NAMES.map((tier) => (
-          <Button
-            key={tier}
-            label={getModelsTierDisplayName(tier)}
-            icon={MODEL_TIER_ICON[tier]}
-            size="xs"
-            variant={activeTier === tier ? "primary" : "outline"}
-            aria-pressed={activeTier === tier}
-            onClick={() => onTierChange(tier)}
-          />
-        ))}
+      <div className="flex flex-col gap-2 px-2">
+        <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+          Price tier of all the models actually billed — not only the Basic /
+          Standard / Premium options offered in the model picker.
+        </p>
+        <div className="flex items-center gap-1">
+          {MODELS_TIER_NAMES.map((tier) => (
+            <Button
+              key={tier}
+              label={getModelsTierDisplayName(tier)}
+              icon={MODEL_TIER_ICON[tier]}
+              size="xs"
+              variant={activeTier === tier ? "primary" : "outline"}
+              aria-pressed={activeTier === tier}
+              onClick={() => onTierChange(tier)}
+            />
+          ))}
+        </div>
       </div>
     </UsageFilterSection>
   );

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -111,7 +111,7 @@ export function UsageFilterModelComplexityControls({
     <>
       <NavigationListLabel
         label="Complexity"
-        className="bg-transparent font-medium pt-2 pb-0"
+        className="bg-transparent px-0 pt-2 pb-0 font-medium"
         action={
           <DropdownMenu
             open={isMoreModelsOpen}

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -211,7 +211,7 @@ export function UsageFilterModelComplexityControls({
     >
       <div className="flex flex-col gap-2 px-2">
         <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-          Price tier of all the models actually billed — not only the Basic /
+          Price tier of all the models actually billed, not only the Basic /
           Standard / Premium options offered in the model picker.
         </p>
         <div className="flex items-center gap-1">

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -2,6 +2,7 @@ import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { UsageFilterModelOption } from "@app/components/workspace/analytics/usageFilter";
 import { UsageFilterAvailabilityStatus } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterAvailabilityStatus";
+import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import {
   getModelsTierDisplayName,
@@ -26,7 +27,6 @@ import {
   DropdownMenuSearchbar,
   DropdownMenuTrigger,
   Icon,
-  NavigationListLabel,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 import { Fragment, useState } from "react";
@@ -108,113 +108,107 @@ export function UsageFilterModelComplexityControls({
     model.disabled && !selectedModelIds.has(model.id);
 
   return (
-    <>
-      <NavigationListLabel
-        label="Complexity"
-        className="bg-transparent px-0 pt-2 pb-0 font-medium"
-        action={
-          <DropdownMenu
-            open={isMoreModelsOpen}
-            onOpenChange={handleMoreModelsOpenChange}
-          >
-            <DropdownMenuTrigger asChild>
-              <Button
-                label="More models"
-                size="xmini"
-                variant="ghost-secondary"
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              <DropdownMenuSearchbar
-                name="usage-filter-more-models-search"
-                placeholder="Search for model"
-                value={moreModelsSearch}
-                onChange={setMoreModelsSearch}
-              />
-              {isSearchingMoreModels ? (
-                moreModelsSearchResults.length > 0 ? (
-                  moreModelsSearchResults.map((model) => (
-                    <DropdownMenuItem
-                      key={model.id}
-                      label={model.name}
-                      icon={
-                        model.lab
-                          ? getModelMakerLogo(model.lab, isDark)
-                          : undefined
+    <UsageFilterSection
+      title="Complexity"
+      action={
+        <DropdownMenu
+          open={isMoreModelsOpen}
+          onOpenChange={handleMoreModelsOpenChange}
+        >
+          <DropdownMenuTrigger asChild>
+            <Button
+              label="More models"
+              size="xmini"
+              variant="ghost-secondary"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuSearchbar
+              name="usage-filter-more-models-search"
+              placeholder="Search for model"
+              value={moreModelsSearch}
+              onChange={setMoreModelsSearch}
+            />
+            {isSearchingMoreModels ? (
+              moreModelsSearchResults.length > 0 ? (
+                moreModelsSearchResults.map((model) => (
+                  <DropdownMenuItem
+                    key={model.id}
+                    label={model.name}
+                    icon={
+                      model.lab
+                        ? getModelMakerLogo(model.lab, isDark)
+                        : undefined
+                    }
+                    aria-disabled={isModelSelectionDisabled(model)}
+                    className={
+                      isModelSelectionDisabled(model) ? "opacity-50" : undefined
+                    }
+                    endComponent={getModelSelectionStatus({
+                      isSelected: selectedModelIds.has(model.id),
+                      isUnavailable: model.disabled,
+                    })}
+                    onClick={() => {
+                      if (!isModelSelectionDisabled(model)) {
+                        onToggleModel(model);
                       }
-                      aria-disabled={isModelSelectionDisabled(model)}
-                      className={
-                        isModelSelectionDisabled(model)
-                          ? "opacity-50"
-                          : undefined
-                      }
-                      endComponent={getModelSelectionStatus({
-                        isSelected: selectedModelIds.has(model.id),
-                        isUnavailable: model.disabled,
-                      })}
-                      onClick={() => {
-                        if (!isModelSelectionDisabled(model)) {
-                          onToggleModel(model);
-                        }
-                      }}
-                      onSelect={(e) => e.preventDefault()}
-                    />
-                  ))
-                ) : (
-                  <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
-                    No models found
-                  </div>
-                )
-              ) : (
-                moreModelsGroups.map(({ lab, models }) => (
-                  <Fragment key={lab}>
-                    <DropdownMenuItem
-                      label={getModelMakerDisplayName(lab)}
-                      icon={getModelMakerLogo(lab, isDark)}
-                      endComponent={
-                        <Icon
-                          visual={
-                            expandedModelLab === lab
-                              ? ChevronDown
-                              : ChevronRight
-                          }
-                          size="xs"
-                        />
-                      }
-                      onClick={() => handleToggleExpandedModelLab(lab)}
-                      aria-expanded={expandedModelLab === lab}
-                      onSelect={(e) => e.preventDefault()}
-                    />
-                    {expandedModelLab === lab &&
-                      models.map((model) => (
-                        <DropdownMenuItem
-                          key={model.id}
-                          label={model.name}
-                          aria-disabled={isModelSelectionDisabled(model)}
-                          className={
-                            isModelSelectionDisabled(model)
-                              ? "pl-8 opacity-50"
-                              : "pl-8"
-                          }
-                          endComponent={getModelSelectionStatus({
-                            isSelected: selectedModelIds.has(model.id),
-                            isUnavailable: model.disabled,
-                          })}
-                          onClick={() => {
-                            if (!isModelSelectionDisabled(model)) {
-                              onToggleModel(model);
-                            }
-                          }}
-                          onSelect={(e) => e.preventDefault()}
-                        />
-                      ))}
-                  </Fragment>
+                    }}
+                    onSelect={(e) => e.preventDefault()}
+                  />
                 ))
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
-      />
+              ) : (
+                <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+                  No models found
+                </div>
+              )
+            ) : (
+              moreModelsGroups.map(({ lab, models }) => (
+                <Fragment key={lab}>
+                  <DropdownMenuItem
+                    label={getModelMakerDisplayName(lab)}
+                    icon={getModelMakerLogo(lab, isDark)}
+                    endComponent={
+                      <Icon
+                        visual={
+                          expandedModelLab === lab ? ChevronDown : ChevronRight
+                        }
+                        size="xs"
+                      />
+                    }
+                    onClick={() => handleToggleExpandedModelLab(lab)}
+                    aria-expanded={expandedModelLab === lab}
+                    onSelect={(e) => e.preventDefault()}
+                  />
+                  {expandedModelLab === lab &&
+                    models.map((model) => (
+                      <DropdownMenuItem
+                        key={model.id}
+                        label={model.name}
+                        aria-disabled={isModelSelectionDisabled(model)}
+                        className={
+                          isModelSelectionDisabled(model)
+                            ? "pl-8 opacity-50"
+                            : "pl-8"
+                        }
+                        endComponent={getModelSelectionStatus({
+                          isSelected: selectedModelIds.has(model.id),
+                          isUnavailable: model.disabled,
+                        })}
+                        onClick={() => {
+                          if (!isModelSelectionDisabled(model)) {
+                            onToggleModel(model);
+                          }
+                        }}
+                        onSelect={(e) => e.preventDefault()}
+                      />
+                    ))}
+                </Fragment>
+              ))
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+    >
       <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
         Price tier of all the models actually billed — not only the Basic /
         Standard / Premium options offered in the model picker.
@@ -232,6 +226,6 @@ export function UsageFilterModelComplexityControls({
           />
         ))}
       </div>
-    </>
+    </UsageFilterSection>
   );
 }

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList.tsx
@@ -6,12 +6,12 @@ import type {
 import { FILTER_PICKER_PAGE_SIZE } from "@app/components/workspace/analytics/usageFilterPanel/constants";
 import { UsageFilterAvailabilityStatus } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterAvailabilityStatus";
 import { UsageFilterOptionIcon } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon";
+import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import {
   Button,
   Checkbox,
   Label,
   LoadingBlock,
-  NavigationListLabel,
   Spinner,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
@@ -67,25 +67,23 @@ export function UsageFilterOptionCheckboxList({
   const loadMore = () =>
     setVisibleCount((current) => current + FILTER_PICKER_PAGE_SIZE);
   return (
-    <>
-      <NavigationListLabel
-        label={`All ${categoryLabel}`}
-        className="bg-transparent px-0 font-medium"
-        action={
-          <div className="flex items-center gap-2">
-            {isUpdating && (
-              <span className="text-xs text-muted-foreground">Updating…</span>
-            )}
-            <Button
-              label={selectAllLabel}
-              size="xmini"
-              variant="ghost-secondary"
-              onClick={onSelectAll}
-              disabled={!hasSelectableOptions || isUpdating}
-            />
-          </div>
-        }
-      />
+    <UsageFilterSection
+      title={`All ${categoryLabel}`}
+      action={
+        <div className="flex items-center gap-2">
+          {isUpdating && (
+            <span className="text-xs text-muted-foreground">Updating…</span>
+          )}
+          <Button
+            label={selectAllLabel}
+            size="xmini"
+            variant="ghost-secondary"
+            onClick={onSelectAll}
+            disabled={!hasSelectableOptions || isUpdating}
+          />
+        </div>
+      }
+    >
       <div
         aria-busy={isLoading || isUpdating}
         className="flex flex-col gap-0.5"
@@ -159,6 +157,6 @@ export function UsageFilterOptionCheckboxList({
           </div>
         )}
       </div>
-    </>
+    </UsageFilterSection>
   );
 }

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList.tsx
@@ -20,7 +20,7 @@ function UsageFilterOptionListSkeleton() {
   return (
     <div aria-hidden="true" className="flex flex-col gap-0.5">
       {["w-24", "w-32", "w-20", "w-36", "w-28", "w-24"].map((width, index) => (
-        <div key={index} className="flex items-center gap-2 py-1">
+        <div key={index} className="flex items-center gap-2 px-2 py-1">
           <LoadingBlock className="h-4 w-4 shrink-0 rounded" />
           <LoadingBlock className="h-4 w-4 shrink-0 rounded" />
           <LoadingBlock className={`h-3 ${width}`} />
@@ -100,7 +100,10 @@ export function UsageFilterOptionCheckboxList({
                 ? `${checkboxId}-availability`
                 : undefined;
               return (
-                <div key={option.id} className="flex items-center gap-2 py-1">
+                <div
+                  key={option.id}
+                  className="flex items-center gap-2 px-2 py-1"
+                >
                   <Checkbox
                     id={checkboxId}
                     checked={checked}

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList.tsx
@@ -20,7 +20,7 @@ function UsageFilterOptionListSkeleton() {
   return (
     <div aria-hidden="true" className="flex flex-col gap-0.5">
       {["w-24", "w-32", "w-20", "w-36", "w-28", "w-24"].map((width, index) => (
-        <div key={index} className="flex items-center gap-2 py-1 pl-1 pr-2">
+        <div key={index} className="flex items-center gap-2 py-1">
           <LoadingBlock className="h-4 w-4 shrink-0 rounded" />
           <LoadingBlock className="h-4 w-4 shrink-0 rounded" />
           <LoadingBlock className={`h-3 ${width}`} />
@@ -42,6 +42,7 @@ interface UsageFilterOptionCheckboxListProps {
   isLoadingMore?: boolean;
   isLoading?: boolean;
   isUpdating?: boolean;
+  scrollContainer: HTMLDivElement | null;
 }
 
 export function UsageFilterOptionCheckboxList({
@@ -56,12 +57,8 @@ export function UsageFilterOptionCheckboxList({
   isLoadingMore = false,
   isLoading = false,
   isUpdating = false,
+  scrollContainer,
 }: UsageFilterOptionCheckboxListProps) {
-  // Tracked as state so InfiniteScroll re-renders once the node
-  // mounts and can attach its scroll listener directly to it.
-  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(
-    null
-  );
   // Reset on category/search/scope change by remounting this component with
   // a fresh `key` from the parent instead of tracking a reset key here.
   const [visibleCount, setVisibleCount] = useState(FILTER_PICKER_PAGE_SIZE);
@@ -73,7 +70,7 @@ export function UsageFilterOptionCheckboxList({
     <>
       <NavigationListLabel
         label={`All ${categoryLabel}`}
-        className="bg-transparent font-medium"
+        className="bg-transparent px-0 font-medium"
         action={
           <div className="flex items-center gap-2">
             {isUpdating && (
@@ -90,9 +87,8 @@ export function UsageFilterOptionCheckboxList({
         }
       />
       <div
-        ref={setScrollContainer}
         aria-busy={isLoading || isUpdating}
-        className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto"
+        className="flex flex-col gap-0.5"
       >
         {isLoading && options.length === 0 ? (
           <UsageFilterOptionListSkeleton />
@@ -106,10 +102,7 @@ export function UsageFilterOptionCheckboxList({
                 ? `${checkboxId}-availability`
                 : undefined;
               return (
-                <div
-                  key={option.id}
-                  className="flex items-center gap-2 py-1 pl-1 pr-2"
-                >
+                <div key={option.id} className="flex items-center gap-2 py-1">
                   <Checkbox
                     id={checkboxId}
                     checked={checked}

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterSection.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterSection.tsx
@@ -13,8 +13,8 @@ export function UsageFilterSection({
 }: UsageFilterSectionProps) {
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-center justify-between gap-2 text-sm font-medium text-muted-foreground">
-        <span className="min-w-0 truncate">{title}</span>
+      <div className="flex items-center text-sm font-medium text-muted-foreground">
+        <span className="min-w-0 flex-1 truncate px-2 py-1.5">{title}</span>
         {action && <div className="shrink-0">{action}</div>}
       </div>
       {children}

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterSection.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterSection.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+interface UsageFilterSectionProps {
+  title: string;
+  action?: ReactNode;
+  children: ReactNode;
+}
+
+export function UsageFilterSection({
+  title,
+  action,
+  children,
+}: UsageFilterSectionProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-2 text-sm font-medium text-muted-foreground">
+        <span className="min-w-0 truncate">{title}</span>
+        {action && <div className="shrink-0">{action}</div>}
+      </div>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

This is a follow-up to the [design qa](https://dust4ai.slack.com/archives/C0BJ3T5SA0L/p1786968667351589).

Addresses the following items:
1. Make the entire usage filter content area scrollable and align its sections and controls
2. Use `muted-foreground` for the `Today (partial)` chart label
3. Center the chart legend labels
4. Make the attribution table filter cell fully clickable
5. Fix color attribution in the chart

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
