### PR TITLE
[Activation] Exclude archived learning spaces

### DIFF
--- a/front-api/routes/w/[wId]/activation-pod/index.test.ts
+++ b/front-api/routes/w/[wId]/activation-pod/index.test.ts
@@ -1,4 +1,5 @@
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -25,8 +26,11 @@ describe("GET /api/w/:wId/activation-pod", () => {
 
     const user = auth.getNonNullableUser();
     const [userResource] = await UserResource.fetchByModelIds([user.id]);
-    const podSpace = await SpaceFactory.regular(workspace);
+    const podSpace = await SpaceFactory.project(workspace);
 
+    await ProjectMetadataResource.makeNew(auth, podSpace, {
+      description: null,
+    });
     await ActivationPodResource.makeNew(auth, {
       pod: podSpace,
       user: userResource,
@@ -37,5 +41,27 @@ describe("GET /api/w/:wId/activation-pod", () => {
 
     const body = await response.json();
     expect(body).toEqual({ podId: podSpace.sId });
+  });
+
+  it("returns null when the user's activation pod is archived", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest();
+
+    const user = auth.getNonNullableUser();
+    const [userResource] = await UserResource.fetchByModelIds([user.id]);
+    const podSpace = await SpaceFactory.project(workspace);
+    await ActivationPodResource.makeNew(auth, {
+      pod: podSpace,
+      user: userResource,
+    });
+    await ProjectMetadataResource.makeNew(auth, podSpace, {
+      description: null,
+      archivedAt: new Date(),
+    });
+
+    const response = await getActivationPod(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toEqual({ podId: null });
   });
 });

--- a/front/lib/api/activation/pods.test.ts
+++ b/front/lib/api/activation/pods.test.ts
@@ -1,0 +1,39 @@
+import { listActivationPodsByUser } from "@app/lib/api/activation/pods";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { describe, expect, it } from "vitest";
+
+describe("listActivationPodsByUser", () => {
+  it("omits users whose only activation pod is archived", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    await ActivationPodResource.makeNew(authenticator, { pod, user });
+    await ProjectMetadataResource.makeNew(authenticator, pod, {
+      description: null,
+      archivedAt: new Date(),
+    });
+
+    const byUser = await listActivationPodsByUser(authenticator);
+
+    expect(byUser.has(user.id)).toBe(false);
+  });
+
+  it("includes users with a live activation pod", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    await ActivationPodResource.makeNew(authenticator, { pod, user });
+    await ProjectMetadataResource.makeNew(authenticator, pod, {
+      description: null,
+    });
+
+    const byUser = await listActivationPodsByUser(authenticator);
+
+    expect(byUser.get(user.id)?.pod.sId).toBe(pod.sId);
+  });
+});

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -37,12 +37,11 @@ export async function getActivationPodInfo(
     return { podId: null };
   }
 
-  const [space] = await SpaceResource.fetchByModelIds(auth, [
-    activationPod.spaceId,
-  ]);
-
   return {
-    podId: space?.sId ?? null,
+    podId: SpaceResource.modelIdToSId({
+      id: activationPod.spaceId,
+      workspaceId: activationPod.workspaceId,
+    }),
   };
 }
 

--- a/front/lib/models/activation/activation_pod.ts
+++ b/front/lib/models/activation/activation_pod.ts
@@ -1,9 +1,10 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import type { CreationOptional, ForeignKey } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
 // One row = one Activation Pod: a Pod (project space) provisioned by the
 // activation flow. Canonical record for a pod's owner.
@@ -17,6 +18,8 @@ export class ActivationPodModel extends WorkspaceAwareModel<ActivationPodModel> 
   declare userId: ForeignKey<UserModel["id"]>;
   // Whether the Pod uses the compact UI variant.
   declare isCompactUIView: CreationOptional<boolean>;
+
+  declare projectMetadata?: NonAttribute<ProjectMetadataModel>;
 }
 
 ActivationPodModel.init(
@@ -53,6 +56,13 @@ ActivationPodModel.belongsTo(SpaceModel, {
 });
 SpaceModel.hasOne(ActivationPodModel, {
   foreignKey: { name: "spaceId", allowNull: false },
+});
+
+ActivationPodModel.belongsTo(ProjectMetadataModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  targetKey: "spaceId",
+  as: "projectMetadata",
+  constraints: false,
 });
 
 ActivationPodModel.belongsTo(UserModel, {

--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -6,6 +6,7 @@ import {
   notifyActivationConversationAgentReplied,
 } from "@app/lib/notifications/triggers/project-new-conversation";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
@@ -306,6 +307,9 @@ describe("notifyActivationConversationAgentReplied", () => {
       description: "Test",
     });
 
+    await ProjectMetadataResource.makeNew(auth, pod, {
+      description: null,
+    });
     await ActivationPodResource.makeNew(auth, { pod, user });
 
     vi.mocked(getNovuClient).mockClear();

--- a/front/lib/resources/activation_pod_resource.test.ts
+++ b/front/lib/resources/activation_pod_resource.test.ts
@@ -1,11 +1,27 @@
 import { Authenticator } from "@app/lib/auth";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it } from "vitest";
+
+async function makeActivationPod(
+  auth: Authenticator,
+  pod: SpaceResource,
+  user: UserResource,
+  { archivedAt = null }: { archivedAt?: Date | null } = {}
+) {
+  await ProjectMetadataResource.makeNew(auth, pod, {
+    description: null,
+    archivedAt,
+  });
+  return ActivationPodResource.makeNew(auth, { pod, user });
+}
 
 describe("ActivationPodResource", () => {
   let workspace: WorkspaceType;
@@ -21,7 +37,7 @@ describe("ActivationPodResource", () => {
   describe("listWorkspaceModelIdsWithActivationPods", () => {
     it("returns the workspace of an activation pod", async () => {
       const user = await UserFactory.basic();
-      await ActivationPodResource.makeNew(auth, { pod: projectSpace, user });
+      await makeActivationPod(auth, projectSpace, user);
 
       const workspaceIds =
         await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
@@ -34,14 +50,8 @@ describe("ActivationPodResource", () => {
       const userA = await UserFactory.basic();
       const userB = await UserFactory.basic();
 
-      await ActivationPodResource.makeNew(auth, {
-        pod: projectSpace,
-        user: userA,
-      });
-      await ActivationPodResource.makeNew(auth, {
-        pod: secondProjectSpace,
-        user: userB,
-      });
+      await makeActivationPod(auth, projectSpace, userA);
+      await makeActivationPod(auth, secondProjectSpace, userB);
 
       const workspaceIds =
         await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
@@ -58,10 +68,7 @@ describe("ActivationPodResource", () => {
 
     it("excludes workspaces whose only pod has been deleted", async () => {
       const user = await UserFactory.basic();
-      const pod = await ActivationPodResource.makeNew(auth, {
-        pod: projectSpace,
-        user,
-      });
+      const pod = await makeActivationPod(auth, projectSpace, user);
       await pod.delete(auth, {});
 
       const otherWorkspace = await WorkspaceFactory.basic();
@@ -70,16 +77,85 @@ describe("ActivationPodResource", () => {
       );
       const otherProjectSpace = await SpaceFactory.project(otherWorkspace);
       const otherUser = await UserFactory.basic();
-      await ActivationPodResource.makeNew(otherAuth, {
-        pod: otherProjectSpace,
-        user: otherUser,
-      });
+      await makeActivationPod(otherAuth, otherProjectSpace, otherUser);
 
       const workspaceIds =
         await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
 
       expect(workspaceIds).not.toContain(workspace.id);
       expect(workspaceIds).toContain(otherWorkspace.id);
+    });
+
+    it("excludes workspaces whose only activation pod is archived", async () => {
+      const user = await UserFactory.basic();
+      await makeActivationPod(auth, projectSpace, user, {
+        archivedAt: new Date(),
+      });
+
+      const workspaceIds =
+        await ActivationPodResource.listWorkspaceModelIdsWithActivationPods();
+
+      expect(workspaceIds).not.toContain(workspace.id);
+    });
+  });
+
+  describe("fetchByUser", () => {
+    it("returns the user's live activation pod", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      await makeActivationPod(userAuth, projectSpace, user);
+
+      const fetched = await ActivationPodResource.fetchByUser(userAuth);
+      expect(fetched?.spaceId).toBe(projectSpace.id);
+    });
+
+    it("returns null when the user's only activation pod is archived", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      await makeActivationPod(userAuth, projectSpace, user, {
+        archivedAt: new Date(),
+      });
+
+      expect(await ActivationPodResource.fetchByUser(userAuth)).toBeNull();
+    });
+
+    it("skips a newer archived pod in favor of an older live one", async () => {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+      await makeActivationPod(userAuth, projectSpace, user);
+
+      const archivedSpace = await SpaceFactory.project(workspace);
+      await makeActivationPod(userAuth, archivedSpace, user, {
+        archivedAt: new Date(),
+      });
+
+      const fetched = await ActivationPodResource.fetchByUser(userAuth);
+      expect(fetched?.spaceId).toBe(projectSpace.id);
+    });
+  });
+
+  describe("fetchBySpace", () => {
+    it("returns null for an archived pod", async () => {
+      const user = await UserFactory.basic();
+      await makeActivationPod(auth, projectSpace, user, {
+        archivedAt: new Date(),
+      });
+
+      expect(
+        await ActivationPodResource.fetchBySpace(auth, projectSpace)
+      ).toBeNull();
     });
   });
 });

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -3,7 +3,6 @@ import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
-import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
@@ -72,18 +71,11 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     return {
       include: [
         {
-          model: SpaceModel,
+          model: ProjectMetadataModel,
+          as: "projectMetadata",
           attributes: [],
           required: true,
-          include: [
-            {
-              model: ProjectMetadataModel,
-              as: "projectMetadata",
-              attributes: [],
-              required: true,
-              where: { archivedAt: null },
-            },
-          ],
+          where: { archivedAt: null },
         },
       ],
     };

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -2,6 +2,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
@@ -65,7 +67,29 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     return new this(this.model, model.get());
   }
 
-  // Fetches the ActivationPod for a given Pod, if one exists.
+  // An Activation Pod must be a non-archived Pod
+  private static get unarchivedQuery() {
+    return {
+      include: [
+        {
+          model: SpaceModel,
+          attributes: [],
+          required: true,
+          include: [
+            {
+              model: ProjectMetadataModel,
+              as: "projectMetadata",
+              attributes: [],
+              required: true,
+              where: { archivedAt: null },
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  // Fetches the ActivationPod for a given Pod, if one exists and is not archived.
   static async fetchBySpace(
     auth: Authenticator,
     pod: SpaceResource
@@ -74,22 +98,45 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     return activationPod ?? null;
   }
 
-  // Fetches the calling user's activation Pod. A user can technically have more
-  // than one over time; we return the most recent, treated as "their" learning
-  // space for surfaces like the Get Started page.
-  static async fetchByUser(
-    auth: Authenticator
+  // Cleanup paths still need the canonical row after a Pod was archived or
+  // its metadata was removed.
+  static async fetchBySpaceIncludingArchived(
+    auth: Authenticator,
+    pod: SpaceResource
   ): Promise<ActivationPodResource | null> {
-    const user = auth.getNonNullableUser();
     const activationPod = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: pod.id,
+      },
+    });
+
+    return activationPod ? new this(this.model, activationPod.get()) : null;
+  }
+
+  // The calling user's Activation Pods, newest first. Archived pods are omitted.
+  static async listByUser(
+    auth: Authenticator
+  ): Promise<ActivationPodResource[]> {
+    const user = auth.getNonNullableUser();
+    const activationPods = await this.model.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         userId: user.id,
       },
+      include: this.unarchivedQuery.include,
       order: [["createdAt", "DESC"]],
     });
 
-    return activationPod ? new this(this.model, activationPod.get()) : null;
+    return activationPods.map((pod) => new this(this.model, pod.get()));
+  }
+
+  // Fetches the calling user's most recent live Activation Pod.
+  static async fetchByUser(
+    auth: Authenticator
+  ): Promise<ActivationPodResource | null> {
+    const [activationPod] = await this.listByUser(auth);
+    return activationPod ?? null;
   }
 
   // Batch variant of fetchBySpace, avoiding one query per pod (e.g. when the
@@ -107,17 +154,21 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
         workspaceId: auth.getNonNullableWorkspace().id,
         spaceId: spaceModelIds,
       },
+      include: this.unarchivedQuery.include,
     });
 
     return activationPods.map((pod) => new this(this.model, pod.get()));
   }
 
-  // Lists every ActivationPod in the calling workspace.
+  // Lists every live Activation Pod in the calling workspace.
   static async listForWorkspace(
     auth: Authenticator
   ): Promise<ActivationPodResource[]> {
     const activationPods = await this.model.findAll({
-      where: { workspaceId: auth.getNonNullableWorkspace().id },
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      include: this.unarchivedQuery.include,
     });
 
     return activationPods.map((pod) => new this(this.model, pod.get()));
@@ -130,7 +181,10 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
   // schedule.
   static async listWorkspaceModelIdsWithActivationPods(): Promise<ModelId[]> {
     const rows = await this.model.findAll({
-      attributes: [[fn("DISTINCT", col("workspaceId")), "workspaceId"]],
+      attributes: [
+        [fn("DISTINCT", col(`${this.model.name}.workspaceId`)), "workspaceId"],
+      ],
+      include: this.unarchivedQuery.include,
       raw: true,
       // WORKSPACE_ISOLATION_BYPASS: nightly reconcile scan across all workspaces
       // to find which ones have a live activation pod (see

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -271,7 +271,8 @@ export async function scrubSpaceActivity({
     await UserProjectPreferencesResource.deleteAllBySpace(auth, space.id);
   }
 
-  const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
+  const activationPod =
+    await ActivationPodResource.fetchBySpaceIncludingArchived(auth, space);
   if (activationPod) {
     await ActivationRecommendationResource.deleteAllForActivationPod(
       auth,


### PR DESCRIPTION
## Summary
- Treat archived Pods as inactive across For You, activation scheduling, and notification lookups
- Done by filtering via an inner join in resource class

## Testing
- Archived pod, validated not treating as active

## Risk
Low (solving existing bug)

## Deploy
1. Deploy front