### PR TITLE
[front] enh: add inline references to Poke skill suggestions

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/skills/suggestions.test.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/suggestions.test.ts
@@ -1,14 +1,38 @@
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { serializeSkillTag } from "@app/lib/skills/format";
+import { serializeToolTag } from "@app/lib/tools/format";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
 describe("POST /api/poke/workspaces/:wId/skills/suggestions", () => {
-  it("stores instructions in the Skill Builder HTML format", async () => {
-    const { workspace } = await createPrivateApiMockRequest({
+  it("stores inline tool and skill references", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
       method: "POST",
       isSuperUser: true,
       role: "admin",
     });
+
+    const serverView =
+      await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+        auth,
+        "agent_memory"
+      );
+    expect(serverView).not.toBeNull();
+    if (!serverView) {
+      return;
+    }
+    const referencedSkillId = "frames";
+    const instructions = `Search with ${serializeToolTag({
+      icon: null,
+      id: serverView.sId,
+      name: "Source search",
+    })}, then use ${serializeSkillTag({
+      icon: null,
+      id: referencedSkillId,
+      name: "Frames",
+    })}.`;
 
     const response = await honoApp.request(
       `/api/poke/workspaces/${workspace.sId}/skills/suggestions`,
@@ -16,23 +40,36 @@ describe("POST /api/poke/workspaces/:wId/skills/suggestions", () => {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          name: "Source verification",
+          name: "Source research",
           userFacingDescription: "Verifies sources before answering.",
           agentFacingDescription: "Use when an answer needs verified sources.",
-          instructions: "Verify every source before answering.",
+          instructions,
           icon: "MagnifyingGlassIcon",
-          mcpServerViewIds: [],
+          mcpServerViewIds: [serverView.sId],
         }),
       }
     );
 
     expect(response.status).toBe(201);
     const data = await response.json();
-    expect(data.skill.instructions).toBe(
-      "Verify every source before answering."
+    expect(data.skill.instructions).toBe(instructions);
+    expect(data.skill.instructionsHtml).toContain(serverView.sId);
+    expect(data.skill.instructionsHtml).toContain(referencedSkillId);
+    expect(data.skill.tools).toEqual(
+      expect.arrayContaining([expect.objectContaining({ sId: serverView.sId })])
     );
-    expect(data.skill.instructionsHtml).toContain(
-      "Verify every source before answering."
-    );
+
+    const createdSkill = await SkillResource.fetchById(auth, data.skill.sId);
+    expect(createdSkill).not.toBeNull();
+    if (!createdSkill) {
+      return;
+    }
+
+    const childSkills = await SkillResource.batchFetchChildSkills(auth, [
+      createdSkill,
+    ]);
+    expect(
+      childSkills.get(createdSkill.sId)?.map((skill) => skill.sId)
+    ).toEqual([referencedSkillId]);
   });
 });

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -106,6 +106,7 @@ interface SkillInstructionsSkillReferencesOptions {
 
 interface UseSkillInstructionsEditorProps {
   content: string;
+  enableSlashCommands?: boolean;
   htmlContent?: string;
   isReadOnly: boolean;
   skillReferences?: SkillInstructionsSkillReferencesOptions;
@@ -116,12 +117,14 @@ interface UseSkillInstructionsEditorProps {
 
 function buildSkillInstructionsEditableExtensions({
   currentSkillIdRef,
+  enableSlashCommands,
   onSelectRef,
   onSkillDetailsRef,
   onToolDetailsRef,
   owner,
 }: {
   currentSkillIdRef: React.RefObject<string | null>;
+  enableSlashCommands: boolean;
   onSelectRef: React.RefObject<
     ((item: SlashCommand, editor: Editor, range: Range) => void) | undefined
   >;
@@ -134,13 +137,17 @@ function buildSkillInstructionsEditableExtensions({
   owner?: LightWorkspaceType;
 }) {
   return [
-    SlashCommandExtension.configure({
-      currentSkillIdRef,
-      onSelectRef,
-      onSkillDetailsRef,
-      onToolDetailsRef,
-      owner,
-    }),
+    ...(enableSlashCommands
+      ? [
+          SlashCommandExtension.configure({
+            currentSkillIdRef,
+            onSelectRef,
+            onSkillDetailsRef,
+            onToolDetailsRef,
+            owner,
+          }),
+        ]
+      : []),
     AgentInstructionDiffExtension,
     Placeholder.configure({
       placeholder: "What does this skill do? How should it behave?",
@@ -155,6 +162,7 @@ function buildSkillInstructionsEditableExtensions({
 
 export function useSkillInstructionsEditor({
   content,
+  enableSlashCommands = true,
   htmlContent,
   isReadOnly,
   skillReferences,
@@ -188,12 +196,13 @@ export function useSkillInstructionsEditor({
     () =>
       buildSkillInstructionsEditableExtensions({
         currentSkillIdRef,
+        enableSlashCommands,
         onSelectRef,
         onSkillDetailsRef,
         onToolDetailsRef,
         owner,
       }),
-    [currentSkillId, owner]
+    [currentSkillId, enableSlashCommands, owner]
   );
 
   const extensions = useMemo(

--- a/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
+++ b/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
@@ -1,15 +1,49 @@
+import { editorVariants } from "@app/components/editor/editorStyles";
+import {
+  isSkillSlashCommand,
+  isToolSlashCommand,
+  SELECT_SKILL_SLASH_COMMAND_ACTION,
+  SELECT_TOOL_SLASH_COMMAND_ACTION,
+} from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
+import { buildCapabilitySlashCommandItems } from "@app/components/editor/extensions/shared/slash_suggestion/buildSlashCommandItems";
+import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
+import {
+  SkillInstructionsEditorContent,
+  useSkillInstructionsEditor,
+} from "@app/components/editor/SkillInstructionsEditor";
+import {
+  getMcpServerViewDisplayName,
+  isToolWithKnowledge,
+} from "@app/lib/actions/mcp_helper";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import type { PokeMCPServerViewListItemType } from "@app/lib/api/poke/mcp_server_views";
+import { postProcessMarkdown } from "@app/lib/editor/skill_instructions_preprocessing";
 import {
   SKILL_INSTRUCTIONS_LABEL,
   SKILL_INVOCATION_LABEL,
 } from "@app/lib/skills/labels";
-import { useCreatePokeSkillSuggestion } from "@app/poke/swr/skills";
+import { extractToolTags } from "@app/lib/tools/format";
+import { usePokeMCPServerViews } from "@app/poke/swr/mcp_server_views";
+import {
+  useCreatePokeSkillSuggestion,
+  usePokeSkills,
+} from "@app/poke/swr/skills";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   ActionIcons,
   Button,
+  cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   IconPicker,
   Input,
   Label,
+  Plus,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -18,9 +52,12 @@ import {
   SheetContent,
   SheetHeader,
   SheetTitle,
+  Spinner,
   TextArea,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import type { Editor } from "@tiptap/core";
+import type { Transaction } from "@tiptap/pm/state";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const DEFAULT_ICON: keyof typeof ActionIcons = "ActionListCheckIcon";
 
@@ -47,6 +84,98 @@ export function CreateSkillSuggestionSheet({
   const [agentFacingDescription, setAgentFacingDescription] = useState("");
   const [instructions, setInstructions] = useState("");
   const [icon, setIcon] = useState<string | null>(null);
+  const [capabilitySearchText, setCapabilitySearchText] = useState("");
+
+  const { data: skills, isLoading: isSkillsLoading } = usePokeSkills({
+    owner,
+    disabled: !show,
+  });
+  const { data: mcpServerViews, isLoading: isMCPServerViewsLoading } =
+    usePokeMCPServerViews({
+      owner,
+      disabled: !show,
+      globalSpaceOnly: true,
+    });
+
+  const activeSkills = useMemo(
+    () => skills.filter((skill) => skill.status === "active"),
+    [skills]
+  );
+
+  const selectableMCPServerViews = useMemo(() => {
+    const serverViewCountByServerId = new Map<string, number>();
+    for (const view of mcpServerViews) {
+      serverViewCountByServerId.set(
+        view.server.sId,
+        (serverViewCountByServerId.get(view.server.sId) ?? 0) + 1
+      );
+    }
+
+    return mcpServerViews
+      .filter((view) => {
+        const { availability } = view.server;
+        return (
+          (availability === "manual" || availability === "auto") &&
+          !isToolWithKnowledge(view) &&
+          getMCPServerRequirements(view).noRequirement
+        );
+      })
+      .map((view) => ({
+        ...view,
+        label:
+          (serverViewCountByServerId.get(view.server.sId) ?? 0) > 1
+            ? `${getMcpServerViewDisplayName(view)} (${view.space.name})`
+            : getMcpServerViewDisplayName(view),
+      }));
+  }, [mcpServerViews]);
+
+  const capabilityItems = useMemo(
+    () =>
+      buildCapabilitySlashCommandItems({
+        query: capabilitySearchText,
+        skills: activeSkills,
+        tools: selectableMCPServerViews,
+      }),
+    [activeSkills, capabilitySearchText, selectableMCPServerViews]
+  );
+  const skillItems = capabilityItems.filter(
+    (item) => item.action === SELECT_SKILL_SLASH_COMMAND_ACTION
+  );
+  const toolItems = capabilityItems.filter(
+    (item) => item.action === SELECT_TOOL_SLASH_COMMAND_ACTION
+  );
+  const isCapabilitiesLoading = isSkillsLoading || isMCPServerViewsLoading;
+
+  const handleInstructionsUpdate = useCallback(
+    ({ editor, transaction }: { editor: Editor; transaction: Transaction }) => {
+      if (transaction.docChanged) {
+        setInstructions(postProcessMarkdown(editor.getMarkdown()).trim());
+      }
+    },
+    []
+  );
+
+  const { editor } = useSkillInstructionsEditor({
+    content: "",
+    enableSlashCommands: false,
+    isReadOnly: false,
+    onUpdate: handleInstructionsUpdate,
+  });
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    editor.setOptions({
+      editorProps: {
+        attributes: {
+          "aria-label": SKILL_INSTRUCTIONS_LABEL,
+          class: cn(editorVariants(), "min-h-48 max-h-[50vh]"),
+        },
+      },
+    });
+  }, [editor]);
 
   const resetForm = () => {
     setName("");
@@ -54,6 +183,8 @@ export function CreateSkillSuggestionSheet({
     setAgentFacingDescription("");
     setInstructions("");
     setIcon(null);
+    setCapabilitySearchText("");
+    editor?.commands.clearContent();
   };
 
   const handleClose = () => {
@@ -67,16 +198,55 @@ export function CreateSkillSuggestionSheet({
   });
 
   const handleSubmit = async () => {
+    const serializedInstructions = editor
+      ? postProcessMarkdown(editor.getMarkdown()).trim()
+      : instructions.trim();
+
     setIsSubmitting(true);
     await createSkillSuggestion({
       name: name.trim(),
       userFacingDescription: userFacingDescription.trim(),
       agentFacingDescription: agentFacingDescription.trim(),
-      instructions: instructions.trim(),
+      instructions: serializedInstructions,
       icon: icon ?? null,
-      mcpServerViewIds: [],
+      mcpServerViewIds: [
+        ...new Set(
+          extractToolTags(serializedInstructions).map((tag) => tag.id)
+        ),
+      ],
     });
     setIsSubmitting(false);
+  };
+
+  const handleInsertCapability = (item: SlashCommand) => {
+    if (!editor || editor.isDestroyed) {
+      return;
+    }
+
+    if (isSkillSlashCommand(item)) {
+      editor
+        .chain()
+        .focus()
+        .insertSkillNode({
+          skillId: item.data.skill.sId,
+          skillIcon: item.data.skill.icon,
+          skillName: item.data.skill.name,
+        })
+        .run();
+      return;
+    }
+
+    if (isToolSlashCommand<PokeMCPServerViewListItemType>(item)) {
+      editor
+        .chain()
+        .focus()
+        .insertToolNode({
+          mcpServerViewId: item.data.tool.id,
+          toolIcon: item.data.tool.icon,
+          toolName: item.data.tool.name,
+        })
+        .run();
+    }
   };
 
   const selectedIconName = isValidIcon(icon) ? icon : DEFAULT_ICON;
@@ -159,14 +329,85 @@ export function CreateSkillSuggestionSheet({
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label htmlFor="instructions">{SKILL_INSTRUCTIONS_LABEL}</Label>
-              <TextArea
-                id="instructions"
-                value={instructions}
-                onChange={(e) => setInstructions(e.target.value)}
-                minRows={8}
-                placeholder="What does this skill do? How should it behave?"
-              />
+              <div className="flex items-center justify-between">
+                <Label>{SKILL_INSTRUCTIONS_LABEL}</Label>
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      icon={Plus}
+                      variant="outline"
+                      label="Add"
+                      isSelect
+                      size="xs"
+                      disabled={!editor || isCapabilitiesLoading}
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    className="w-80"
+                    onAnimationEnd={() => setCapabilitySearchText("")}
+                  >
+                    <DropdownMenuSearchbar
+                      autoFocus
+                      placeholder="Search tools and skills..."
+                      name="capability-search"
+                      value={capabilitySearchText}
+                      onChange={setCapabilitySearchText}
+                    />
+                    <DropdownMenuSeparator />
+                    <div className="max-h-72 overflow-auto">
+                      {isCapabilitiesLoading ? (
+                        <div className="flex items-center justify-center py-4">
+                          <Spinner size="sm" />
+                        </div>
+                      ) : capabilityItems.length === 0 ? (
+                        <div className="p-3 text-center text-sm text-muted-foreground">
+                          No tools or skills found.
+                        </div>
+                      ) : (
+                        <>
+                          {skillItems.length > 0 && (
+                            <>
+                              <DropdownMenuLabel label="Skills" />
+                              {skillItems.map((item) => (
+                                <DropdownMenuItem
+                                  key={item.id}
+                                  label={item.label}
+                                  description={item.description}
+                                  icon={item.icon}
+                                  onSelect={() => handleInsertCapability(item)}
+                                />
+                              ))}
+                            </>
+                          )}
+                          {skillItems.length > 0 && toolItems.length > 0 && (
+                            <DropdownMenuSeparator />
+                          )}
+                          {toolItems.length > 0 && (
+                            <>
+                              <DropdownMenuLabel label="Tools" />
+                              {toolItems.map((item) => (
+                                <DropdownMenuItem
+                                  key={item.id}
+                                  label={item.label}
+                                  description={item.description}
+                                  icon={item.icon}
+                                  onSelect={() => handleInsertCapability(item)}
+                                />
+                              ))}
+                            </>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+              <div className="group relative overflow-hidden rounded-xl p-px">
+                <SkillInstructionsEditorContent
+                  editor={editor}
+                  isReadOnly={false}
+                />
+              </div>
             </div>
 
             <div className="flex justify-end gap-2">
@@ -185,7 +426,8 @@ export function CreateSkillSuggestionSheet({
                   !name.trim() ||
                   !userFacingDescription.trim() ||
                   !agentFacingDescription.trim() ||
-                  !instructions.trim()
+                  !instructions.trim() ||
+                  !editor
                 }
               />
             </div>

--- a/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
+++ b/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
@@ -353,7 +353,7 @@ export function CreateSkillSuggestionSheet({
                       value={capabilitySearchText}
                       onChange={setCapabilitySearchText}
                     />
-                    <DropdownMenuSeparator />
+                    <DropdownMenuSeparator className="my-0" />
                     <div className="max-h-72 overflow-auto">
                       {isCapabilitiesLoading ? (
                         <div className="flex items-center justify-center py-4">
@@ -369,7 +369,7 @@ export function CreateSkillSuggestionSheet({
                             <>
                               <DropdownMenuLabel
                                 label="Skills"
-                                className="pl-3"
+                                className="py-1 pl-3"
                               />
                               {skillItems.map((item) => (
                                 <DropdownMenuItem
@@ -378,19 +378,20 @@ export function CreateSkillSuggestionSheet({
                                   label={item.label}
                                   description={item.description}
                                   icon={item.icon}
+                                  truncateText
                                   onSelect={() => handleInsertCapability(item)}
                                 />
                               ))}
                             </>
                           )}
                           {skillItems.length > 0 && toolItems.length > 0 && (
-                            <DropdownMenuSeparator />
+                            <DropdownMenuSeparator className="my-0" />
                           )}
                           {toolItems.length > 0 && (
                             <>
                               <DropdownMenuLabel
                                 label="Tools"
-                                className="pl-3"
+                                className="py-1 pl-3"
                               />
                               {toolItems.map((item) => (
                                 <DropdownMenuItem
@@ -399,6 +400,7 @@ export function CreateSkillSuggestionSheet({
                                   label={item.label}
                                   description={item.description}
                                   icon={item.icon}
+                                  truncateText
                                   onSelect={() => handleInsertCapability(item)}
                                 />
                               ))}

--- a/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
+++ b/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
@@ -367,10 +367,14 @@ export function CreateSkillSuggestionSheet({
                         <>
                           {skillItems.length > 0 && (
                             <>
-                              <DropdownMenuLabel label="Skills" />
+                              <DropdownMenuLabel
+                                label="Skills"
+                                className="pl-3"
+                              />
                               {skillItems.map((item) => (
                                 <DropdownMenuItem
                                   key={item.id}
+                                  className="pl-3"
                                   label={item.label}
                                   description={item.description}
                                   icon={item.icon}
@@ -384,10 +388,14 @@ export function CreateSkillSuggestionSheet({
                           )}
                           {toolItems.length > 0 && (
                             <>
-                              <DropdownMenuLabel label="Tools" />
+                              <DropdownMenuLabel
+                                label="Tools"
+                                className="pl-3"
+                              />
                               {toolItems.map((item) => (
                                 <DropdownMenuItem
                                   key={item.id}
+                                  className="pl-3"
                                   label={item.label}
                                   description={item.description}
                                   icon={item.icon}


### PR DESCRIPTION
## Description

Follow-up to #30632 

This PR allows adding skills and tools to the skill suggestions pushed from Poke.
Replaces a plain input for the skill instructions field with a rich skill editor + adds a Poke-backed picker that inserts tools and skills as inline references at the cursor.

<img width="691" height="593" alt="image" src="https://github.com/user-attachments/assets/bad5c75f-6907-430b-b526-4cbb93128bdb" />

## Tests

- Added tests.
- Tested locally.

## Risk

- Low. Poke only.

## Deploy Plan

- Deploy front.
