### PR TITLE
[front] enh: move approval details to a dialog

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -22,6 +22,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogTrigger,
   Label,
   PieChart01,
   XClose,
@@ -93,9 +94,6 @@ export function ToolValidationCard({
 }: ToolValidationCardProps) {
   const [neverAskAgain, setNeverAskAgain] = useState(false);
   const toolOverride = getToolOverride(validationRequest.metadata);
-  const [detailsOpen, setDetailsOpen] = useState(
-    toolOverride?.detailsOpen ?? false
-  );
   const [submittingDecision, setSubmittingDecision] = useState<
     "approved" | "rejected" | null
   >(null);
@@ -118,7 +116,6 @@ export function ToolValidationCard({
       );
       if (success) {
         setNeverAskAgain(false);
-        setDetailsOpen(false);
       }
     } finally {
       setSubmittingDecision(null);
@@ -152,14 +149,91 @@ export function ToolValidationCard({
         <div className="flex shrink-0 items-center gap-2">
           {approvalProgress && <ApprovalProgress {...approvalProgress} />}
           {hasDetails && (
-            <Button
-              label="Review details"
-              variant="ghost"
-              size="sm"
-              className="min-h-11 sm:min-h-0"
-              disabled={isSubmitting}
-              onClick={() => setDetailsOpen(true)}
-            />
+            <Dialog defaultOpen={toolOverride?.detailsOpen ?? false}>
+              <DialogTrigger asChild>
+                <Button
+                  label="Review details"
+                  variant="ghost"
+                  size="sm"
+                  className="min-h-11 sm:min-h-0"
+                  disabled={isSubmitting}
+                />
+              </DialogTrigger>
+              <DialogContent
+                size="lg"
+                className="gap-4 p-5"
+                preventAutoFocusOnClose={false}
+              >
+                <DialogHeader className="gap-1 p-0">
+                  <div className="flex items-center justify-between gap-4 pr-8">
+                    <DialogTitle
+                      visual={<Avatar icon={icon ?? PieChart01} size="sm" />}
+                    >
+                      {approvalTitle}
+                    </DialogTitle>
+                    {approvalProgress && (
+                      <ApprovalProgress {...approvalProgress} />
+                    )}
+                  </div>
+                  <DialogDescription className="pl-11">
+                    {displayLabel}
+                  </DialogDescription>
+                </DialogHeader>
+                <DialogContainer className="p-0">
+                  <ToolValidationDetails
+                    blockedAction={validationRequest}
+                    user={currentUser}
+                    owner={owner}
+                    conversationId={conversationId}
+                  />
+                  {errorMessage && (
+                    <div className="mt-2 text-sm font-medium text-warning-800">
+                      {errorMessage}
+                    </div>
+                  )}
+                </DialogContainer>
+                <DialogFooter className="flex-col items-stretch gap-3 p-0">
+                  {["low", "medium"].includes(
+                    validationRequest.stake ?? ""
+                  ) && (
+                    <Label
+                      htmlFor={`never-ask-again-dialog-${validationRequest.actionId}`}
+                      className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
+                    >
+                      <Checkbox
+                        id={`never-ask-again-dialog-${validationRequest.actionId}`}
+                        checked={neverAskAgain}
+                        disabled={isSubmitting}
+                        onCheckedChange={(check) => {
+                          setNeverAskAgain(!!check);
+                        }}
+                      />
+                      <span className="font-normal">
+                        {getToolValidationAlwaysAllowLabel(validationRequest)}
+                      </span>
+                    </Label>
+                  )}
+                  <div className="flex justify-end gap-2">
+                    <Button
+                      label="Decline"
+                      variant="outline"
+                      icon={XClose}
+                      disabled={isSubmitting}
+                      isLoading={submittingDecision === "rejected"}
+                      onClick={() => void handleValidation("rejected")}
+                    />
+                    <Button
+                      label={toolOverride?.approveLabel ?? "Allow"}
+                      variant="highlight"
+                      icon={Check}
+                      disabled={isSubmitting}
+                      isLoading={submittingDecision === "approved"}
+                      onClick={() => void handleValidation("approved")}
+                    />
+                  </div>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           )}
         </div>
       </div>
@@ -168,90 +242,6 @@ export function ToolValidationCard({
         <div className="text-base">{displayLabel}</div>
         {canCurrentUserRespond ? (
           <>
-            {hasDetails && (
-              <Dialog
-                open={detailsOpen}
-                onOpenChange={(open) => {
-                  if (!isSubmitting) {
-                    setDetailsOpen(open);
-                  }
-                }}
-              >
-                <DialogContent
-                  size="lg"
-                  className="gap-4 p-5"
-                  preventAutoFocusOnClose={false}
-                >
-                  <DialogHeader className="gap-1 p-0">
-                    <div className="flex items-center justify-between gap-4 pr-8">
-                      <DialogTitle
-                        visual={<Avatar icon={icon ?? PieChart01} size="sm" />}
-                      >
-                        {approvalTitle}
-                      </DialogTitle>
-                      {approvalProgress && (
-                        <ApprovalProgress {...approvalProgress} />
-                      )}
-                    </div>
-                    <DialogDescription className="pl-11">
-                      {displayLabel}
-                    </DialogDescription>
-                  </DialogHeader>
-                  <DialogContainer className="p-0">
-                    <ToolValidationDetails
-                      blockedAction={validationRequest}
-                      user={currentUser}
-                      owner={owner}
-                      conversationId={conversationId}
-                    />
-                    {errorMessage && (
-                      <div className="mt-2 text-sm font-medium text-warning-800">
-                        {errorMessage}
-                      </div>
-                    )}
-                  </DialogContainer>
-                  <DialogFooter className="flex-col items-stretch gap-3 p-0">
-                    {(validationRequest.stake === "low" ||
-                      validationRequest.stake === "medium") && (
-                      <Label
-                        htmlFor={`never-ask-again-dialog-${validationRequest.actionId}`}
-                        className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
-                      >
-                        <Checkbox
-                          id={`never-ask-again-dialog-${validationRequest.actionId}`}
-                          checked={neverAskAgain}
-                          disabled={isSubmitting}
-                          onCheckedChange={(check) => {
-                            setNeverAskAgain(!!check);
-                          }}
-                        />
-                        <span className="font-normal">
-                          {getToolValidationAlwaysAllowLabel(validationRequest)}
-                        </span>
-                      </Label>
-                    )}
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        label="Decline"
-                        variant="outline"
-                        icon={XClose}
-                        disabled={isSubmitting}
-                        isLoading={submittingDecision === "rejected"}
-                        onClick={() => void handleValidation("rejected")}
-                      />
-                      <Button
-                        label={toolOverride?.approveLabel ?? "Allow"}
-                        variant="highlight"
-                        icon={Check}
-                        disabled={isSubmitting}
-                        isLoading={submittingDecision === "approved"}
-                        onClick={() => void handleValidation("approved")}
-                      />
-                    </div>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
-            )}
             {errorMessage && (
               <div className="text-sm font-medium text-warning-800">
                 {errorMessage}
@@ -271,8 +261,7 @@ export function ToolValidationCard({
 
       {canCurrentUserRespond && (
         <div className="flex flex-col gap-3 px-4 pb-3 pt-2 sm:flex-row sm:items-center">
-          {(validationRequest.stake === "low" ||
-            validationRequest.stake === "medium") && (
+          {["low", "medium"].includes(validationRequest.stake ?? "") && (
             <Label
               htmlFor={`never-ask-again-${validationRequest.actionId}`}
               className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -177,7 +177,11 @@ export function ToolValidationCard({
                   }
                 }}
               >
-                <DialogContent size="lg" preventAutoFocusOnClose={false}>
+                <DialogContent
+                  size="lg"
+                  className="gap-4"
+                  preventAutoFocusOnClose={false}
+                >
                   <DialogHeader className="gap-1">
                     <div className="flex items-center justify-between gap-4 pr-8">
                       <DialogTitle
@@ -193,7 +197,7 @@ export function ToolValidationCard({
                       {displayLabel}
                     </DialogDescription>
                   </DialogHeader>
-                  <DialogContainer className="pb-3 pt-4">
+                  <DialogContainer className="py-0">
                     <ToolValidationDetails
                       blockedAction={validationRequest}
                       user={currentUser}
@@ -206,7 +210,7 @@ export function ToolValidationCard({
                       </div>
                     )}
                   </DialogContainer>
-                  <DialogFooter className="flex-col items-stretch gap-3 px-5 pb-4 pt-3">
+                  <DialogFooter className="flex-col items-stretch gap-3 px-5 pb-4 pt-0">
                     {(validationRequest.stake === "low" ||
                       validationRequest.stake === "medium") && (
                       <Label

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -22,7 +22,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
   Label,
   PieChart01,
   XClose,
@@ -133,6 +132,8 @@ export function ToolValidationCard({
   const displayLabel =
     validationRequest.metadata.displayLabel ??
     asDisplayName(validationRequest.metadata.toolName);
+  const hasDetails =
+    canCurrentUserRespond && Object.keys(validationRequest.inputs).length > 0;
 
   return (
     <Card
@@ -148,14 +149,26 @@ export function ToolValidationCard({
             {approvalTitle}
           </div>
         </div>
-        {approvalProgress && <ApprovalProgress {...approvalProgress} />}
+        <div className="flex shrink-0 items-center gap-2">
+          {approvalProgress && <ApprovalProgress {...approvalProgress} />}
+          {hasDetails && (
+            <Button
+              label="Review details"
+              variant="ghost"
+              size="sm"
+              className="min-h-11 sm:min-h-0"
+              disabled={isSubmitting}
+              onClick={() => setDetailsOpen(true)}
+            />
+          )}
+        </div>
       </div>
 
       <div className="flex flex-col gap-4 px-5 py-4">
         <div className="text-base">{displayLabel}</div>
         {canCurrentUserRespond ? (
           <>
-            {Object.keys(validationRequest.inputs).length > 0 && (
+            {hasDetails && (
               <Dialog
                 open={detailsOpen}
                 onOpenChange={(open) => {
@@ -164,15 +177,6 @@ export function ToolValidationCard({
                   }
                 }}
               >
-                <DialogTrigger asChild>
-                  <Button
-                    label="Review details"
-                    variant="outline"
-                    size="sm"
-                    className="min-h-11 self-start sm:min-h-0"
-                    disabled={isSubmitting}
-                  />
-                </DialogTrigger>
                 <DialogContent size="lg" preventAutoFocusOnClose={false}>
                   <DialogHeader className="gap-1">
                     <div className="flex items-center justify-between gap-4 pr-8">

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -19,7 +19,6 @@ import {
   DialogContainer,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
@@ -89,12 +88,7 @@ interface ToolValidationDetailsDialogProps {
   currentUser: UserType;
   owner: LightWorkspaceType;
   conversationId?: string | null;
-  errorMessage: string | null;
-  neverAskAgain: boolean;
   isSubmitting: boolean;
-  submittingDecision: "approved" | "rejected" | null;
-  onNeverAskAgainChange: (checked: boolean) => void;
-  onValidate: (approved: "approved" | "rejected") => Promise<void>;
 }
 
 function ToolValidationDetailsDialog({
@@ -106,12 +100,7 @@ function ToolValidationDetailsDialog({
   currentUser,
   owner,
   conversationId,
-  errorMessage,
-  neverAskAgain,
   isSubmitting,
-  submittingDecision,
-  onNeverAskAgainChange,
-  onValidate,
 }: ToolValidationDetailsDialogProps) {
   const toolOverride = getToolOverride(validationRequest.metadata);
 
@@ -149,50 +138,7 @@ function ToolValidationDetailsDialog({
             owner={owner}
             conversationId={conversationId}
           />
-          {errorMessage && (
-            <div className="mt-2 text-sm font-medium text-warning-800">
-              {errorMessage}
-            </div>
-          )}
         </DialogContainer>
-        <DialogFooter className="flex-col items-stretch gap-3 p-0">
-          {["low", "medium"].includes(validationRequest.stake ?? "") && (
-            <Label
-              htmlFor={`never-ask-again-dialog-${validationRequest.actionId}`}
-              className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
-            >
-              <Checkbox
-                id={`never-ask-again-dialog-${validationRequest.actionId}`}
-                checked={neverAskAgain}
-                disabled={isSubmitting}
-                onCheckedChange={(check) => {
-                  onNeverAskAgainChange(!!check);
-                }}
-              />
-              <span className="font-normal">
-                {getToolValidationAlwaysAllowLabel(validationRequest)}
-              </span>
-            </Label>
-          )}
-          <div className="flex justify-end gap-2">
-            <Button
-              label="Decline"
-              variant="outline"
-              icon={XClose}
-              disabled={isSubmitting}
-              isLoading={submittingDecision === "rejected"}
-              onClick={() => void onValidate("rejected")}
-            />
-            <Button
-              label={toolOverride?.approveLabel ?? "Allow"}
-              variant="highlight"
-              icon={Check}
-              disabled={isSubmitting}
-              isLoading={submittingDecision === "approved"}
-              onClick={() => void onValidate("approved")}
-            />
-          </div>
-        </DialogFooter>
       </DialogContent>
     </Dialog>
   );
@@ -276,12 +222,7 @@ export function ToolValidationCard({
               currentUser={currentUser}
               owner={owner}
               conversationId={conversationId}
-              errorMessage={errorMessage}
-              neverAskAgain={neverAskAgain}
               isSubmitting={isSubmitting}
-              submittingDecision={submittingDecision}
-              onNeverAskAgainChange={setNeverAskAgain}
-              onValidate={handleValidation}
             />
           )}
         </div>

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -179,10 +179,10 @@ export function ToolValidationCard({
               >
                 <DialogContent
                   size="lg"
-                  className="gap-4"
+                  className="gap-4 p-5"
                   preventAutoFocusOnClose={false}
                 >
-                  <DialogHeader className="gap-1">
+                  <DialogHeader className="gap-1 p-0">
                     <div className="flex items-center justify-between gap-4 pr-8">
                       <DialogTitle
                         visual={<Avatar icon={icon ?? PieChart01} size="sm" />}
@@ -197,7 +197,7 @@ export function ToolValidationCard({
                       {displayLabel}
                     </DialogDescription>
                   </DialogHeader>
-                  <DialogContainer className="py-0">
+                  <DialogContainer className="p-0">
                     <ToolValidationDetails
                       blockedAction={validationRequest}
                       user={currentUser}
@@ -210,7 +210,7 @@ export function ToolValidationCard({
                       </div>
                     )}
                   </DialogContainer>
-                  <DialogFooter className="flex-col items-stretch gap-3 px-5 pb-4 pt-0">
+                  <DialogFooter className="flex-col items-stretch gap-3 p-0">
                     {(validationRequest.stake === "low" ||
                       validationRequest.stake === "medium") && (
                       <Label

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -80,6 +80,124 @@ interface ToolValidationCardProps {
   onValidate: (approved: MCPValidationOutputType) => Promise<boolean>;
 }
 
+interface ToolValidationDetailsDialogProps {
+  validationRequest: ToolValidationRequest;
+  approvalProgress?: ApprovalProgressProps;
+  approvalTitle: string;
+  displayLabel: string;
+  icon: React.ComponentProps<typeof Avatar>["icon"];
+  currentUser: UserType;
+  owner: LightWorkspaceType;
+  conversationId?: string | null;
+  errorMessage: string | null;
+  neverAskAgain: boolean;
+  isSubmitting: boolean;
+  submittingDecision: "approved" | "rejected" | null;
+  onNeverAskAgainChange: (checked: boolean) => void;
+  onValidate: (approved: "approved" | "rejected") => Promise<void>;
+}
+
+function ToolValidationDetailsDialog({
+  validationRequest,
+  approvalProgress,
+  approvalTitle,
+  displayLabel,
+  icon,
+  currentUser,
+  owner,
+  conversationId,
+  errorMessage,
+  neverAskAgain,
+  isSubmitting,
+  submittingDecision,
+  onNeverAskAgainChange,
+  onValidate,
+}: ToolValidationDetailsDialogProps) {
+  const toolOverride = getToolOverride(validationRequest.metadata);
+
+  return (
+    <Dialog defaultOpen={toolOverride?.detailsOpen ?? false}>
+      <DialogTrigger asChild>
+        <Button
+          label="Review details"
+          variant="ghost"
+          size="sm"
+          className="min-h-11 sm:min-h-0"
+          disabled={isSubmitting}
+        />
+      </DialogTrigger>
+      <DialogContent
+        size="lg"
+        className="gap-4 p-5"
+        preventAutoFocusOnClose={false}
+      >
+        <DialogHeader className="gap-1 p-0">
+          <div className="flex items-center justify-between gap-4 pr-8">
+            <DialogTitle visual={<Avatar icon={icon} size="sm" />}>
+              {approvalTitle}
+            </DialogTitle>
+            {approvalProgress && <ApprovalProgress {...approvalProgress} />}
+          </div>
+          <DialogDescription className="pl-11">
+            {displayLabel}
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer className="p-0">
+          <ToolValidationDetails
+            blockedAction={validationRequest}
+            user={currentUser}
+            owner={owner}
+            conversationId={conversationId}
+          />
+          {errorMessage && (
+            <div className="mt-2 text-sm font-medium text-warning-800">
+              {errorMessage}
+            </div>
+          )}
+        </DialogContainer>
+        <DialogFooter className="flex-col items-stretch gap-3 p-0">
+          {["low", "medium"].includes(validationRequest.stake ?? "") && (
+            <Label
+              htmlFor={`never-ask-again-dialog-${validationRequest.actionId}`}
+              className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
+            >
+              <Checkbox
+                id={`never-ask-again-dialog-${validationRequest.actionId}`}
+                checked={neverAskAgain}
+                disabled={isSubmitting}
+                onCheckedChange={(check) => {
+                  onNeverAskAgainChange(!!check);
+                }}
+              />
+              <span className="font-normal">
+                {getToolValidationAlwaysAllowLabel(validationRequest)}
+              </span>
+            </Label>
+          )}
+          <div className="flex justify-end gap-2">
+            <Button
+              label="Decline"
+              variant="outline"
+              icon={XClose}
+              disabled={isSubmitting}
+              isLoading={submittingDecision === "rejected"}
+              onClick={() => void onValidate("rejected")}
+            />
+            <Button
+              label={toolOverride?.approveLabel ?? "Allow"}
+              variant="highlight"
+              icon={Check}
+              disabled={isSubmitting}
+              isLoading={submittingDecision === "approved"}
+              onClick={() => void onValidate("approved")}
+            />
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export function ToolValidationCard({
   validationRequest,
   approvalProgress,
@@ -149,91 +267,22 @@ export function ToolValidationCard({
         <div className="flex shrink-0 items-center gap-2">
           {approvalProgress && <ApprovalProgress {...approvalProgress} />}
           {hasDetails && (
-            <Dialog defaultOpen={toolOverride?.detailsOpen ?? false}>
-              <DialogTrigger asChild>
-                <Button
-                  label="Review details"
-                  variant="ghost"
-                  size="sm"
-                  className="min-h-11 sm:min-h-0"
-                  disabled={isSubmitting}
-                />
-              </DialogTrigger>
-              <DialogContent
-                size="lg"
-                className="gap-4 p-5"
-                preventAutoFocusOnClose={false}
-              >
-                <DialogHeader className="gap-1 p-0">
-                  <div className="flex items-center justify-between gap-4 pr-8">
-                    <DialogTitle
-                      visual={<Avatar icon={icon ?? PieChart01} size="sm" />}
-                    >
-                      {approvalTitle}
-                    </DialogTitle>
-                    {approvalProgress && (
-                      <ApprovalProgress {...approvalProgress} />
-                    )}
-                  </div>
-                  <DialogDescription className="pl-11">
-                    {displayLabel}
-                  </DialogDescription>
-                </DialogHeader>
-                <DialogContainer className="p-0">
-                  <ToolValidationDetails
-                    blockedAction={validationRequest}
-                    user={currentUser}
-                    owner={owner}
-                    conversationId={conversationId}
-                  />
-                  {errorMessage && (
-                    <div className="mt-2 text-sm font-medium text-warning-800">
-                      {errorMessage}
-                    </div>
-                  )}
-                </DialogContainer>
-                <DialogFooter className="flex-col items-stretch gap-3 p-0">
-                  {["low", "medium"].includes(
-                    validationRequest.stake ?? ""
-                  ) && (
-                    <Label
-                      htmlFor={`never-ask-again-dialog-${validationRequest.actionId}`}
-                      className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
-                    >
-                      <Checkbox
-                        id={`never-ask-again-dialog-${validationRequest.actionId}`}
-                        checked={neverAskAgain}
-                        disabled={isSubmitting}
-                        onCheckedChange={(check) => {
-                          setNeverAskAgain(!!check);
-                        }}
-                      />
-                      <span className="font-normal">
-                        {getToolValidationAlwaysAllowLabel(validationRequest)}
-                      </span>
-                    </Label>
-                  )}
-                  <div className="flex justify-end gap-2">
-                    <Button
-                      label="Decline"
-                      variant="outline"
-                      icon={XClose}
-                      disabled={isSubmitting}
-                      isLoading={submittingDecision === "rejected"}
-                      onClick={() => void handleValidation("rejected")}
-                    />
-                    <Button
-                      label={toolOverride?.approveLabel ?? "Allow"}
-                      variant="highlight"
-                      icon={Check}
-                      disabled={isSubmitting}
-                      isLoading={submittingDecision === "approved"}
-                      onClick={() => void handleValidation("approved")}
-                    />
-                  </div>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
+            <ToolValidationDetailsDialog
+              validationRequest={validationRequest}
+              approvalProgress={approvalProgress}
+              approvalTitle={approvalTitle}
+              displayLabel={displayLabel}
+              icon={icon ?? PieChart01}
+              currentUser={currentUser}
+              owner={owner}
+              conversationId={conversationId}
+              errorMessage={errorMessage}
+              neverAskAgain={neverAskAgain}
+              isSubmitting={isSubmitting}
+              submittingDecision={submittingDecision}
+              onNeverAskAgainChange={setNeverAskAgain}
+              onValidate={handleValidation}
+            />
           )}
         </div>
       </div>

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -15,6 +15,14 @@ import {
   Card,
   Check,
   Checkbox,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
   Label,
   PieChart01,
   XClose,
@@ -85,9 +93,14 @@ export function ToolValidationCard({
   onValidate,
 }: ToolValidationCardProps) {
   const [neverAskAgain, setNeverAskAgain] = useState(false);
+  const toolOverride = getToolOverride(validationRequest.metadata);
+  const [detailsOpen, setDetailsOpen] = useState(
+    toolOverride?.detailsOpen ?? false
+  );
   const [submittingDecision, setSubmittingDecision] = useState<
     "approved" | "rejected" | null
   >(null);
+  const isSubmitting = isValidating || submittingDecision !== null;
 
   const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
     parentUserId: validationRequest.userId,
@@ -106,17 +119,20 @@ export function ToolValidationCard({
       );
       if (success) {
         setNeverAskAgain(false);
+        setDetailsOpen(false);
       }
     } finally {
       setSubmittingDecision(null);
     }
   };
 
-  const toolOverride = getToolOverride(validationRequest.metadata);
-  const isSubmitting = isValidating || submittingDecision !== null;
   const {
     metadata: { agentName, mcpServerName },
   } = validationRequest;
+  const approvalTitle = `Allow ${agentName} to use ${asDisplayName(mcpServerName)}?`;
+  const displayLabel =
+    validationRequest.metadata.displayLabel ??
+    asDisplayName(validationRequest.metadata.toolName);
 
   return (
     <Card
@@ -129,27 +145,106 @@ export function ToolValidationCard({
         <div className="flex min-w-0 items-center gap-3">
           <Avatar icon={icon ?? PieChart01} size="sm" />
           <div className="heading-base min-w-0 wrap-break-word">
-            {`Allow ${agentName} to use ${asDisplayName(mcpServerName)}?`}
+            {approvalTitle}
           </div>
         </div>
         {approvalProgress && <ApprovalProgress {...approvalProgress} />}
       </div>
 
       <div className="flex flex-col gap-4 px-5 py-4">
-        <div className="text-base">
-          {validationRequest.metadata.displayLabel ??
-            asDisplayName(validationRequest.metadata.toolName)}
-        </div>
+        <div className="text-base">{displayLabel}</div>
         {canCurrentUserRespond ? (
           <>
             {Object.keys(validationRequest.inputs).length > 0 && (
-              <ToolValidationDetails
-                blockedAction={validationRequest}
-                user={currentUser}
-                owner={owner}
-                conversationId={conversationId}
-                defaultExpanded={toolOverride?.detailsExpanded}
-              />
+              <Dialog
+                open={detailsOpen}
+                onOpenChange={(open) => {
+                  if (!isSubmitting) {
+                    setDetailsOpen(open);
+                  }
+                }}
+              >
+                <DialogTrigger asChild>
+                  <Button
+                    label="Review details"
+                    variant="outline"
+                    size="sm"
+                    className="min-h-11 self-start sm:min-h-0"
+                    disabled={isSubmitting}
+                  />
+                </DialogTrigger>
+                <DialogContent
+                  size="lg"
+                  height="lg"
+                  preventAutoFocusOnClose={false}
+                >
+                  <DialogHeader>
+                    <div className="flex items-start justify-between gap-4 pr-8">
+                      <DialogTitle
+                        visual={<Avatar icon={icon ?? PieChart01} size="sm" />}
+                      >
+                        {approvalTitle}
+                      </DialogTitle>
+                      {approvalProgress && (
+                        <ApprovalProgress {...approvalProgress} />
+                      )}
+                    </div>
+                    <DialogDescription>{displayLabel}</DialogDescription>
+                  </DialogHeader>
+                  <DialogContainer>
+                    <ToolValidationDetails
+                      blockedAction={validationRequest}
+                      user={currentUser}
+                      owner={owner}
+                      conversationId={conversationId}
+                    />
+                    {errorMessage && (
+                      <div className="mt-2 text-sm font-medium text-warning-800">
+                        {errorMessage}
+                      </div>
+                    )}
+                  </DialogContainer>
+                  <DialogFooter className="flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    {(validationRequest.stake === "low" ||
+                      validationRequest.stake === "medium") && (
+                      <Label
+                        htmlFor={`never-ask-again-dialog-${validationRequest.actionId}`}
+                        className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
+                      >
+                        <Checkbox
+                          id={`never-ask-again-dialog-${validationRequest.actionId}`}
+                          checked={neverAskAgain}
+                          disabled={isSubmitting}
+                          onCheckedChange={(check) => {
+                            setNeverAskAgain(!!check);
+                          }}
+                        />
+                        <span className="font-normal">
+                          {getToolValidationAlwaysAllowLabel(validationRequest)}
+                        </span>
+                      </Label>
+                    )}
+                    <div className="flex gap-2 sm:ml-auto">
+                      <Button
+                        label="Decline"
+                        variant="outline"
+                        icon={XClose}
+                        disabled={isSubmitting}
+                        isLoading={submittingDecision === "rejected"}
+                        onClick={() => void handleValidation("rejected")}
+                      />
+                      <Button
+                        label={toolOverride?.approveLabel ?? "Allow"}
+                        variant="highlight"
+                        icon={Check}
+                        disabled={isSubmitting}
+                        isLoading={submittingDecision === "approved"}
+                        onClick={() => void handleValidation("approved")}
+                      />
+                    </div>
+                  </DialogFooter>
+                </DialogContent>
+              </Dialog>
             )}
             {errorMessage && (
               <div className="text-sm font-medium text-warning-800">

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -173,13 +173,9 @@ export function ToolValidationCard({
                     disabled={isSubmitting}
                   />
                 </DialogTrigger>
-                <DialogContent
-                  size="lg"
-                  height="lg"
-                  preventAutoFocusOnClose={false}
-                >
-                  <DialogHeader>
-                    <div className="flex items-start justify-between gap-4 pr-8">
+                <DialogContent size="lg" preventAutoFocusOnClose={false}>
+                  <DialogHeader className="gap-1">
+                    <div className="flex items-center justify-between gap-4 pr-8">
                       <DialogTitle
                         visual={<Avatar icon={icon ?? PieChart01} size="sm" />}
                       >
@@ -189,9 +185,11 @@ export function ToolValidationCard({
                         <ApprovalProgress {...approvalProgress} />
                       )}
                     </div>
-                    <DialogDescription>{displayLabel}</DialogDescription>
+                    <DialogDescription className="pl-11">
+                      {displayLabel}
+                    </DialogDescription>
                   </DialogHeader>
-                  <DialogContainer>
+                  <DialogContainer className="py-3">
                     <ToolValidationDetails
                       blockedAction={validationRequest}
                       user={currentUser}
@@ -204,7 +202,7 @@ export function ToolValidationCard({
                       </div>
                     )}
                   </DialogContainer>
-                  <DialogFooter className="flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <DialogFooter className="flex-col items-stretch gap-3 px-5 pb-4 pt-3">
                     {(validationRequest.stake === "low" ||
                       validationRequest.stake === "medium") && (
                       <Label
@@ -224,7 +222,7 @@ export function ToolValidationCard({
                         </span>
                       </Label>
                     )}
-                    <div className="flex gap-2 sm:ml-auto">
+                    <div className="flex justify-end gap-2">
                       <Button
                         label="Decline"
                         variant="outline"

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -193,7 +193,7 @@ export function ToolValidationCard({
                       {displayLabel}
                     </DialogDescription>
                   </DialogHeader>
-                  <DialogContainer className="py-3">
+                  <DialogContainer className="pb-3 pt-4">
                     <ToolValidationDetails
                       blockedAction={validationRequest}
                       user={currentUser}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -81,7 +81,6 @@ interface ToolValidationCardProps {
 
 interface ToolValidationDetailsDialogProps {
   validationRequest: ToolValidationRequest;
-  approvalProgress?: ApprovalProgressProps;
   approvalTitle: string;
   displayLabel: string;
   icon: React.ComponentProps<typeof Avatar>["icon"];
@@ -93,7 +92,6 @@ interface ToolValidationDetailsDialogProps {
 
 function ToolValidationDetailsDialog({
   validationRequest,
-  approvalProgress,
   approvalTitle,
   displayLabel,
   icon,
@@ -121,12 +119,9 @@ function ToolValidationDetailsDialog({
         preventAutoFocusOnClose={false}
       >
         <DialogHeader className="gap-1 p-0">
-          <div className="flex items-center justify-between gap-4 pr-8">
-            <DialogTitle visual={<Avatar icon={icon} size="sm" />}>
-              {approvalTitle}
-            </DialogTitle>
-            {approvalProgress && <ApprovalProgress {...approvalProgress} />}
-          </div>
+          <DialogTitle visual={<Avatar icon={icon} size="sm" />}>
+            {approvalTitle}
+          </DialogTitle>
           <DialogDescription className="pl-11">
             {displayLabel}
           </DialogDescription>
@@ -215,7 +210,6 @@ export function ToolValidationCard({
           {hasDetails && (
             <ToolValidationDetailsDialog
               validationRequest={validationRequest}
-              approvalProgress={approvalProgress}
               approvalTitle={approvalTitle}
               displayLabel={displayLabel}
               icon={icon ?? PieChart01}

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -27,7 +27,7 @@ type ToolOverride = {
   title?: (inputs: Record<string, unknown>) => string;
   approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
-  detailsExpanded?: boolean;
+  detailsOpen?: boolean;
 };
 
 // Display data needed to compute the title and always-allow label of a tool validation card, for
@@ -60,7 +60,7 @@ const MCP_TOOL_OVERRIDES: Partial<
   sandbox: {
     add_egress_domain: {
       title: () => `Allow agent to add a domain to the Computer?`,
-      detailsExpanded: true,
+      detailsOpen: true,
     },
   },
   [SANDBOX_FUNCTIONS_SERVER_NAME]: {

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -45,7 +45,11 @@ import {
   UPDATE_SKILL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import { useSkill } from "@app/lib/swr/skill_configurations";
-import { isNumber, isString } from "@app/types/shared/utils/general";
+import {
+  isNumber,
+  isString,
+  removeNulls,
+} from "@app/types/shared/utils/general";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { Markdown } from "@dust-tt/sparkle";
 
@@ -127,28 +131,26 @@ export function ToolValidationDetails({
     ? "Loading…"
     : (skill?.name ?? "Unknown skill");
 
-  const displayableInputs: DisplayableInput[] = Object.entries(
-    blockedAction.inputs
-  ).flatMap(([key, value]) => {
-    if (isSkillAuthoringUpdate && key === "sId") {
-      return [{ key, label: "Skill", value: resolvedSkillName, isJson: false }];
-    }
+  const displayableInputs: DisplayableInput[] = removeNulls(
+    Object.entries(blockedAction.inputs).map(([key, value]) => {
+      if (isSkillAuthoringUpdate && key === "sId") {
+        return { key, label: "Skill", value: resolvedSkillName, isJson: false };
+      }
 
-    const displayValue = formatDisplayValue(value);
-    if (displayValue === null) {
-      return [];
-    }
+      const displayValue = formatDisplayValue(value);
+      if (displayValue === null) {
+        return null;
+      }
 
-    return [
-      {
+      return {
         key,
         label: humanizeFieldName(key),
         value: displayValue,
         isJson:
           value !== null && typeof value === "object" && !Array.isArray(value),
-      },
-    ];
-  });
+      };
+    })
+  );
 
   if (
     blockedAction.metadata.mcpServerName === ASHBY_SERVER_NAME &&

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -45,15 +45,9 @@ import {
   UPDATE_SKILL_TOOL_NAME,
 } from "@app/lib/api/actions/servers/skill_authoring/metadata";
 import { useSkill } from "@app/lib/swr/skill_configurations";
-import { isString } from "@app/types/shared/utils/general";
+import { isNumber, isString } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-  Markdown,
-} from "@dust-tt/sparkle";
-import { useMemo } from "react";
+import { Markdown } from "@dust-tt/sparkle";
 
 function humanizeFieldName(name: string): string {
   return name
@@ -74,6 +68,9 @@ function formatDisplayValue(value: unknown): string | null {
   if (typeof value === "boolean") {
     return value ? "Yes" : "No";
   }
+  if (isNumber(value)) {
+    return String(value);
+  }
   if (!isString(value)) {
     return null;
   }
@@ -82,11 +79,11 @@ function formatDisplayValue(value: unknown): string | null {
 }
 
 interface DisplayableInput {
+  key: string;
   label: string;
   value: string;
-  // Whether `value` was produced from an object/array input (as opposed to a
-  // string that merely looks like JSON), so it can be rendered as a
-  // collapsible JSON code block.
+  // Whether `value` was produced from an object/array input rather than a
+  // string that merely looks like JSON.
   isJson: boolean;
 }
 
@@ -97,7 +94,6 @@ interface ToolValidationDetailsProps {
   user: UserType;
   owner: LightWorkspaceType;
   conversationId?: string | null;
-  defaultExpanded?: boolean;
 }
 
 export function ToolValidationDetails({
@@ -105,7 +101,6 @@ export function ToolValidationDetails({
   user,
   owner,
   conversationId,
-  defaultExpanded = false,
 }: ToolValidationDetailsProps) {
   // For skill_authoring `update_skill`, the only identifier the agent passes is
   // the skill `sId`, which is meaningless to a human approving the call. Resolve
@@ -129,23 +124,27 @@ export function ToolValidationDetails({
     ? "Loading…"
     : (skill?.name ?? "Unknown skill");
 
-  const displayableInputs: DisplayableInput[] = useMemo(() => {
-    if (!blockedAction.inputs) {
+  const displayableInputs: DisplayableInput[] = Object.entries(
+    blockedAction.inputs
+  ).flatMap(([key, value]) => {
+    if (isSkillAuthoringUpdate && key === "sId") {
+      return [{ key, label: "Skill", value: resolvedSkillName, isJson: false }];
+    }
+
+    const displayValue = formatDisplayValue(value);
+    if (displayValue === null) {
       return [];
     }
-    return Object.entries(blockedAction.inputs)
-      .map(([key, value]) => {
-        if (isSkillAuthoringUpdate && key === "sId") {
-          return { label: "Skill", value: resolvedSkillName, isJson: false };
-        }
-        return {
-          label: humanizeFieldName(key),
-          value: formatDisplayValue(value),
-          isJson: value !== null && typeof value === "object",
-        };
-      })
-      .filter((entry): entry is DisplayableInput => entry.value !== null);
-  }, [blockedAction.inputs, isSkillAuthoringUpdate, resolvedSkillName]);
+
+    return [
+      {
+        key,
+        label: humanizeFieldName(key),
+        value: displayValue,
+        isJson: value !== null && typeof value === "object",
+      },
+    ];
+  });
 
   if (
     blockedAction.metadata.mcpServerName === ASHBY_SERVER_NAME &&
@@ -260,37 +259,26 @@ export function ToolValidationDetails({
   }
 
   return (
-    <Collapsible defaultOpen={defaultExpanded}>
-      <CollapsibleTrigger>
-        <span className="my-2 font-medium">Details</span>
-      </CollapsibleTrigger>
-      <CollapsibleContent>
-        <div className="max-h-80 space-y-2 overflow-auto rounded-lg bg-muted p-3 text-sm">
-          {displayableInputs.map(({ label, value, isJson }) =>
-            isJson ? (
-              <Collapsible key={label}>
-                <CollapsibleTrigger>
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {label}
-                  </span>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  <Markdown content={`\`\`\`json\n${value}\n\`\`\``} />
-                </CollapsibleContent>
-              </Collapsible>
-            ) : (
-              <div key={label} className="flex flex-col gap-0.5">
-                <span className="text-xs font-medium text-muted-foreground">
-                  {label}
-                </span>
-                <span className="whitespace-pre-wrap wrap-break-word">
-                  {value}
-                </span>
+    <dl className="divide-y divide-separator">
+      {displayableInputs.map(({ key, label, value, isJson }) => (
+        <div
+          key={key}
+          className="grid gap-1 py-3 first:pt-0 last:pb-0 sm:grid-cols-[minmax(0,10rem)_minmax(0,1fr)] sm:gap-4"
+        >
+          <dt className="text-sm font-medium text-muted-foreground">{label}</dt>
+          <dd className="min-w-0 text-sm text-foreground">
+            {isJson ? (
+              <div className="max-w-full overflow-auto">
+                <Markdown content={`\`\`\`json\n${value}\n\`\`\``} />
               </div>
-            )
-          )}
+            ) : (
+              <span className="whitespace-pre-wrap wrap-break-word">
+                {value}
+              </span>
+            )}
+          </dd>
         </div>
-      </CollapsibleContent>
-    </Collapsible>
+      ))}
+    </dl>
   );
 }

--- a/front/components/assistant/conversation/ToolValidationDetails.tsx
+++ b/front/components/assistant/conversation/ToolValidationDetails.tsx
@@ -60,8 +60,11 @@ function formatDisplayValue(value: unknown): string | null {
   if (value === null) {
     return null;
   }
+  if (Array.isArray(value)) {
+    return value.map(String).join(", ");
+  }
   if (typeof value === "object") {
-    // Render objects/arrays as formatted JSON, same as GenericActionDetails.
+    // Render objects as formatted JSON, same as GenericActionDetails.
     // No truncation: the container is overflow-auto.
     return JSON.stringify(value, null, 2);
   }
@@ -82,8 +85,8 @@ interface DisplayableInput {
   key: string;
   label: string;
   value: string;
-  // Whether `value` was produced from an object/array input rather than a
-  // string that merely looks like JSON.
+  // Whether `value` was produced from an object input rather than a string
+  // that merely looks like JSON.
   isJson: boolean;
 }
 
@@ -141,7 +144,8 @@ export function ToolValidationDetails({
         key,
         label: humanizeFieldName(key),
         value: displayValue,
-        isJson: value !== null && typeof value === "object",
+        isJson:
+          value !== null && typeof value === "object" && !Array.isArray(value),
       },
     ];
   });
@@ -263,7 +267,7 @@ export function ToolValidationDetails({
       {displayableInputs.map(({ key, label, value, isJson }) => (
         <div
           key={key}
-          className="grid gap-1 py-3 first:pt-0 last:pb-0 sm:grid-cols-[minmax(0,10rem)_minmax(0,1fr)] sm:gap-4"
+          className="grid gap-1 py-3 first:pt-0 last:pb-0 sm:grid-cols-[minmax(0,8rem)_minmax(0,1fr)] sm:gap-4"
         >
           <dt className="text-sm font-medium text-muted-foreground">{label}</dt>
           <dd className="min-w-0 text-sm text-foreground">


### PR DESCRIPTION
## Description

Approval details currently expand inside the inline card, which 1. constrains longer payloads and 2. gives it a lot of importance as it directly follows the action description, which is the main asset users should rely on to make a decision of accept/deny. This POC keeps the compact approval card and opens the full payload in a large dialog from `Review details`.

This PR moves it to a popover, which allows for a fixed footer position and a richer UI for the details (used to be a jsonviewer).

<img width="630" height="215" alt="image" src="https://github.com/user-attachments/assets/d86150ae-ea0d-4f74-a046-ab46d0870252" />

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
