### PR TITLE
Restrict default agent picker to private channels only returned by Slack API

### DIFF
--- a/front/components/agent_builder/settings/SlackSettingsSheet.tsx
+++ b/front/components/agent_builder/settings/SlackSettingsSheet.tsx
@@ -1,5 +1,6 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { buildDefaultAgentSlackPickerChannels } from "@app/components/agent_builder/settings/buildDefaultAgentSlackPickerChannels";
 import { useSlackUserPrivateChannels } from "@app/lib/swr/assistants";
 import { useConnectorPermissions } from "@app/lib/swr/connectors";
 import type { DataSourceType } from "@app/types/data_source";
@@ -29,8 +30,6 @@ import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { useController } from "react-hook-form";
-
-const SLACK_CHANNEL_INTERNAL_ID_PREFIX = "slack-channel-";
 
 type SlackChannel = {
   slackChannelId: string;
@@ -117,46 +116,14 @@ function SlackChannelsList({
       disabled,
     });
 
-  const publicChannels = useMemo(() => {
-    if (!resources) {
-      return [];
-    }
-
-    return resources
-      .filter((resource) =>
-        resource.internalId.startsWith(SLACK_CHANNEL_INTERNAL_ID_PREFIX)
-      )
-      .map((resource) => ({
-        slackChannelId: resource.internalId.substring(
-          SLACK_CHANNEL_INTERNAL_ID_PREFIX.length
-        ),
-        slackChannelName: resource.title,
-        sourceUrl: resource.sourceUrl,
-        isPrivate: false as const,
-      }));
-  }, [resources]);
-
-  const mergedChannels = useMemo(() => {
-    const byId = new Map<string, SlackChannel>();
-
-    for (const channel of publicChannels) {
-      byId.set(channel.slackChannelId, channel);
-    }
-
-    for (const channel of privateChannels) {
-      // Prefer the private-channel entry so admins see the lock affordance.
-      byId.set(channel.slackChannelId, {
-        slackChannelId: channel.slackChannelId,
-        slackChannelName: channel.slackChannelName,
-        sourceUrl: channel.sourceUrl,
-        isPrivate: true,
-      });
-    }
-
-    return Array.from(byId.values()).sort((a, b) =>
-      a.slackChannelName.localeCompare(b.slackChannelName)
-    );
-  }, [publicChannels, privateChannels]);
+  const mergedChannels = useMemo(
+    () =>
+      buildDefaultAgentSlackPickerChannels({
+        connectorResources: resources ?? [],
+        privateChannels,
+      }),
+    [resources, privateChannels]
+  );
 
   const filteredChannels = useMemo(() => {
     if (searchQuery.trim() === "") {

--- a/front/components/agent_builder/settings/buildDefaultAgentSlackPickerChannels.test.ts
+++ b/front/components/agent_builder/settings/buildDefaultAgentSlackPickerChannels.test.ts
@@ -1,0 +1,89 @@
+import { buildDefaultAgentSlackPickerChannels } from "@app/components/agent_builder/settings/buildDefaultAgentSlackPickerChannels";
+import { describe, expect, it } from "vitest";
+
+function connectorChannel({
+  id,
+  title,
+  providerVisibility,
+}: {
+  id: string;
+  title: string;
+  providerVisibility: "public" | "private" | null;
+}) {
+  return {
+    internalId: `slack-channel-${id}`,
+    title,
+    sourceUrl: `https://app.slack.com/client/T1/${id}`,
+    providerVisibility,
+  };
+}
+
+describe("buildDefaultAgentSlackPickerChannels", () => {
+  it("keeps public connector channels and drops connector-listed private channels", () => {
+    const channels = buildDefaultAgentSlackPickerChannels({
+      connectorResources: [
+        connectorChannel({
+          id: "Cpub",
+          title: "#general",
+          providerVisibility: "public",
+        }),
+        connectorChannel({
+          id: "Cpriv",
+          title: "#secret",
+          providerVisibility: "private",
+        }),
+      ],
+      privateChannels: [],
+    });
+
+    expect(channels).toEqual([
+      {
+        slackChannelId: "Cpub",
+        slackChannelName: "#general",
+        sourceUrl: "https://app.slack.com/client/T1/Cpub",
+        isPrivate: false,
+      },
+    ]);
+  });
+
+  it("adds private channels the admin and Dust bot both belong to", () => {
+    const channels = buildDefaultAgentSlackPickerChannels({
+      connectorResources: [
+        connectorChannel({
+          id: "Cpub",
+          title: "#general",
+          providerVisibility: "public",
+        }),
+        connectorChannel({
+          id: "Cpriv",
+          title: "#secret",
+          providerVisibility: "private",
+        }),
+      ],
+      privateChannels: [
+        {
+          slackChannelId: "Cpriv",
+          slackChannelName: "#secret",
+          sourceUrl: "https://app.slack.com/client/T1/Cpriv",
+        },
+        {
+          slackChannelId: "Cmine",
+          slackChannelName: "#mine",
+          sourceUrl: "https://app.slack.com/client/T1/Cmine",
+        },
+      ],
+    });
+
+    expect(channels.map((c) => c.slackChannelId)).toEqual([
+      "Cpub",
+      "Cmine",
+      "Cpriv",
+    ]);
+    expect(channels.find((c) => c.slackChannelId === "Cpriv")?.isPrivate).toBe(
+      true
+    );
+    expect(channels.find((c) => c.slackChannelId === "Cmine")?.isPrivate).toBe(
+      true
+    );
+  });
+});

--- a/front/components/agent_builder/settings/buildDefaultAgentSlackPickerChannels.ts
+++ b/front/components/agent_builder/settings/buildDefaultAgentSlackPickerChannels.ts
@@ -1,0 +1,66 @@
+export const SLACK_CHANNEL_INTERNAL_ID_PREFIX = "slack-channel-";
+
+type SlackPickerChannel = {
+  slackChannelId: string;
+  slackChannelName: string;
+  sourceUrl?: string | null;
+  isPrivate: boolean;
+};
+
+type SlackPickerConnectorResource = {
+  internalId: string;
+  title: string;
+  sourceUrl?: string | null;
+  providerVisibility: "public" | "private" | null;
+};
+
+type SlackPickerPrivateChannel = {
+  slackChannelId: string;
+  slackChannelName: string;
+  sourceUrl?: string | null;
+};
+
+// Public write channels Dust can post in, plus private channels this admin and
+// the Dust bot both belong to. Connector-listed private channels are excluded
+// so we never show another admin's private channels.
+export function buildDefaultAgentSlackPickerChannels({
+  connectorResources,
+  privateChannels,
+}: {
+  connectorResources: SlackPickerConnectorResource[];
+  privateChannels: SlackPickerPrivateChannel[];
+}): SlackPickerChannel[] {
+  const byId = new Map<string, SlackPickerChannel>();
+
+  for (const resource of connectorResources) {
+    if (
+      !resource.internalId.startsWith(SLACK_CHANNEL_INTERNAL_ID_PREFIX) ||
+      resource.providerVisibility === "private"
+    ) {
+      continue;
+    }
+
+    const slackChannelId = resource.internalId.substring(
+      SLACK_CHANNEL_INTERNAL_ID_PREFIX.length
+    );
+    byId.set(slackChannelId, {
+      slackChannelId,
+      slackChannelName: resource.title,
+      sourceUrl: resource.sourceUrl,
+      isPrivate: false,
+    });
+  }
+
+  for (const channel of privateChannels) {
+    byId.set(channel.slackChannelId, {
+      slackChannelId: channel.slackChannelId,
+      slackChannelName: channel.slackChannelName,
+      sourceUrl: channel.sourceUrl,
+      isPrivate: true,
+    });
+  }
+
+  return Array.from(byId.values()).sort((a, b) =>
+    a.slackChannelName.localeCompare(b.slackChannelName)
+  );
+}


### PR DESCRIPTION
## Summary
- The default-agent Slack picker was showing every private channel Dust had joined (when `index_private_slack_channel` is on), including channels the current admin is not in.
- It now shows public Dust-write channels plus private channels this admin and the Dust bot both belong to.

## Testing
* New unit tests, can't test fully locally because i don't have a multi-user Slack workspace

## Risk
Low

## Deploy
1. Deploy front