### PR TITLE
[front] Rate-limiter backup for the per-API-key spend cap

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -65,6 +65,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
+import { isApiKeySpendLimitRateCapReached } from "@app/lib/api/keys/spend_limit";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
 import {
   checkProgrammaticUsageLimits,
@@ -2603,17 +2604,29 @@ export async function checkMessagesLimit(
     // Programmatic monthly cap: block programmatic calls when the cap is reached.
     if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
       // Per-API-key credit cap: block when this key's credit state is "capped"
-      // (driven by the Metronome per-key cap alert / reconcile).
+      // (driven by the Metronome per-key cap alert / reconcile), or when the
+      // Redis fixed-window backup reports the cap reached. The backup is
+      // flag-gated while we validate the counter; usage is recorded regardless
+      // (in credit_cost), so the flag only controls blocking.
       const key = auth.key();
-      if (key && (await isApiKeyCapped(owner.sId, key.id))) {
-        return new Err({
-          status_code: 429,
-          api_error: {
-            type: "rate_limit_error",
-            message:
-              "This API key has reached its credit spend limit. Please increase the limit in the Developers > API Keys section of the Dust dashboard.",
-          },
-        });
+      if (key) {
+        const featureFlags = await getFeatureFlags(auth);
+        const capReached =
+          (await isApiKeyCapped(owner.sId, key.id)) ||
+          (featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
+            (await isApiKeySpendLimitRateCapReached(auth, {
+              keyModelId: key.id,
+            })));
+        if (capReached) {
+          return new Err({
+            status_code: 429,
+            api_error: {
+              type: "rate_limit_error",
+              message:
+                "This API key has reached its credit spend limit. Please increase the limit in the Developers > API Keys section of the Dust dashboard.",
+            },
+          });
+        }
       }
 
       const programmaticBlocked = await isProgrammaticApiBlocked(owner.sId);

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -4,6 +4,7 @@ import { isToolExecutionStatusBillable } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { recordApiKeySpendLimitUsage } from "@app/lib/api/keys/spend_limit";
 import type { ToolCostCategory } from "@app/lib/api/mcp";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import { recordUserSpendLimitUsage } from "@app/lib/api/users/spend_limit";
@@ -326,13 +327,7 @@ export async function computeAndStoreAgentMessageCredits(
   }
 
   // Record against the per-user spend-cap backup (Redis fixed-window counter
-  // over the contract billing cycle). Independent of the plan-level fair-use
-  // limiter above. Gated behind the same feature flag as enforcement so the
-  // counter only accrues where the backup is active; enforcement happens
-  // pre-message in `checkMessagesLimit`.
-  // The cycle override keeps the counter on the same window
-  // enforcement reads: the contract billing period on credit-priced plans, the
-  // UTC calendar month elsewhere (no contract to anchor on).
+  // over the contract billing cycle).
   if (user && recordedCostDelta > 0) {
     const featureFlags = await getFeatureFlags(auth);
     if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
@@ -340,6 +335,19 @@ export async function computeAndStoreAgentMessageCredits(
         user,
         incrementBy: recordedCostDelta,
         cycle: spendLimitCycleOverrideForAuth(auth),
+      });
+    }
+  }
+
+  // Record against the per-API-key spend-cap backup (Redis fixed-window counter
+  // over the contract billing cycle).
+  const apiKey = auth.key();
+  if (apiKey && recordedCostDelta > 0) {
+    const featureFlags = await getFeatureFlags(auth);
+    if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
+      await recordApiKeySpendLimitUsage(auth, {
+        keyModelId: apiKey.id,
+        incrementBy: recordedCostDelta,
       });
     }
   }

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -111,6 +111,15 @@ export const makeSpendLimitCycleWindowBounds = (
   };
 };
 
+// Fixed-window counter backing the admin-configured per-API-key spend cap.
+// Keyed by the key model id (the calling key is active, and key names are
+// unique among active keys, so id and name are 1:1 here). Bucketed on the
+// Metronome contract billing cycle via `makeSpendLimitCycleWindowBounds`, like
+// the per-user key above.
+export const makeApiKeySpendLimitAwuCreditsRateLimitKey = (keyId: number) => {
+  return `api_key:${keyId}:spend_limit_awu_credit_count`;
+};
+
 export const makeProgrammaticUsageRateLimitKeyForWorkspace = (
   owner: LightWorkspaceType
 ) => {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,4 +1,5 @@
 import {
+  makeApiKeySpendLimitAwuCreditsRateLimitKey,
   makeSpendLimitAwuCreditsRateLimitKeyForUser,
   makeSpendLimitCycleWindowBounds,
 } from "@app/lib/api/assistant/rate_limits";
@@ -45,6 +46,7 @@ import type { BillingFrequency } from "@app/lib/metronome/types";
 import { isUserAwuWarned } from "@app/lib/metronome/user_block";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { spendLimitCycleOverrideForAuth } from "@app/lib/spend_limits/cycle";
@@ -411,6 +413,109 @@ export async function getEsConsumedAwuCreditsForUser(
     cycle,
   });
   return consumedByUserId.get(user.sId) ?? 0;
+}
+
+type ApiKeyConsumedCreditsBucket = {
+  key: string;
+  credits?: estypes.AggregationsSumAggregate;
+};
+
+type ApiKeyConsumedCreditsAggs = {
+  by_api_key_name?: estypes.AggregationsMultiBucketAggregateBase<ApiKeyConsumedCreditsBucket>;
+};
+
+/**
+ * Elasticsearch-derived AWU consumption for the current billing cycle, summed
+ * per `api_key_name` — the same dimension the Metronome per-API-key cap alert
+ * aggregates spend on. Used to lazily seed / resync the per-API-key spend-cap
+ * counter. Returns an empty map on no usage or an analytics read failure.
+ */
+async function fetchConsumedAwuCreditsByApiKeyName({
+  workspace,
+  apiKeyNames,
+  cycle,
+}: {
+  workspace: LightWorkspaceType;
+  apiKeyNames: string[];
+  cycle?: BillingCycle;
+}): Promise<Map<string, number>> {
+  if (apiKeyNames.length === 0) {
+    return new Map();
+  }
+
+  const resolvedCycle = cycle ?? (await resolveMetronomeCycle(workspace));
+  if (!resolvedCycle) {
+    return new Map();
+  }
+  const { cycleStart, cycleEnd } = resolvedCycle;
+
+  const result = await searchAnalytics<never, ApiKeyConsumedCreditsAggs>(
+    {
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          { terms: { api_key_name: apiKeyNames } },
+          {
+            range: {
+              timestamp: {
+                gte: cycleStart.toISOString(),
+                lte: cycleEnd.toISOString(),
+              },
+            },
+          },
+        ],
+      },
+    },
+    {
+      aggregations: {
+        by_api_key_name: {
+          terms: {
+            field: "api_key_name",
+            size: Math.max(1, apiKeyNames.length),
+          },
+          aggs: { credits: { sum: { field: "cost.billable_awu" } } },
+        },
+      },
+      size: 0,
+    }
+  );
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, workspaceId: workspace.sId },
+      "[MembersUsage] Failed to read per-API-key consumed credits from analytics index"
+    );
+    return new Map();
+  }
+
+  const consumedByApiKeyName = new Map<string, number>();
+  for (const bucket of bucketsToArray<ApiKeyConsumedCreditsBucket>(
+    result.value.aggregations?.by_api_key_name?.buckets
+  )) {
+    consumedByApiKeyName.set(
+      String(bucket.key),
+      Math.round(bucket.credits?.value ?? 0)
+    );
+  }
+  return consumedByApiKeyName;
+}
+
+/**
+ * A single API key's Elasticsearch-derived AWU consumption for the current
+ * billing cycle, scoped by `api_key_name`. Used to lazily seed the per-API-key
+ * spend-cap counter on a Redis miss. Returns 0 when there is no usage or the
+ * analytics read fails.
+ */
+export async function getEsConsumedAwuCreditsForApiKey(
+  auth: Authenticator,
+  { apiKeyName, cycle }: { apiKeyName: string; cycle?: BillingCycle }
+): Promise<number> {
+  const workspace = auth.getNonNullableWorkspace();
+  const consumedByApiKeyName = await fetchConsumedAwuCreditsByApiKeyName({
+    workspace,
+    apiKeyNames: [apiKeyName],
+    cycle,
+  });
+  return consumedByApiKeyName.get(apiKeyName) ?? 0;
 }
 
 async function fetchPerUserUsageCreditsForMembersTableUncached({
@@ -1060,6 +1165,64 @@ export async function resyncSpendLimitCountersFromEsUsage(
   );
 
   return new Ok({ updatedUserCount: results.filter(Boolean).length });
+}
+
+/**
+ * Backfill/repair the per-API-key spend-cap counters for a workspace from
+ * Elasticsearch, overwriting each capped key's counter (SET) so it matches ES.
+ * Use after enabling the cap or to repair drift (the counter otherwise only
+ * accrues from live messages and starts at 0 mid-cycle). Only keys with a
+ * configured `monthlyCapAwuCredits` are seeded. Returns the number of keys
+ * whose counter was written.
+ */
+export async function resyncApiKeySpendLimitCountersFromEsUsage(
+  auth: Authenticator
+): Promise<Result<{ updatedKeyCount: number }, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const cycle = await resolveMetronomeCycle(workspace);
+  if (!cycle) {
+    return new Err(
+      new Error("No active Metronome billing period to resync against.")
+    );
+  }
+  const bounds = makeSpendLimitCycleWindowBounds(
+    cycle.cycleStart,
+    cycle.cycleEnd
+  );
+
+  const keys = await KeyResource.listNonSystemKeysByWorkspace(workspace);
+  // The cap is per-name (Metronome aggregates spend by `api_key_name`; names
+  // are unique among active keys), so only active, capped keys are seeded.
+  const cappedKeys = keys.filter(
+    (key) => key.isActive && key.monthlyCapAwuCredits !== null
+  );
+  if (cappedKeys.length === 0) {
+    return new Ok({ updatedKeyCount: 0 });
+  }
+
+  const consumedByApiKeyName = await fetchConsumedAwuCreditsByApiKeyName({
+    workspace,
+    apiKeyNames: cappedKeys.map((key) => key.name),
+    cycle,
+  });
+
+  const results = await concurrentExecutor(
+    cappedKeys,
+    async (key) => {
+      const consumed = consumedByApiKeyName.get(key.name) ?? 0;
+      const setResult = await setFixedWindowCount({
+        key: makeApiKeySpendLimitAwuCreditsRateLimitKey(key.id),
+        bounds,
+        value: Math.max(0, Math.round(consumed)),
+        logger,
+      });
+      return setResult.isOk();
+    },
+    { concurrency: 8 }
+  );
+
+  return new Ok({ updatedKeyCount: results.filter(Boolean).length });
 }
 
 export type GetMemberUsageResponseBody = {

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -1,3 +1,5 @@
+import { makeApiKeySpendLimitAwuCreditsRateLimitKey } from "@app/lib/api/assistant/rate_limits";
+import { getEsConsumedAwuCreditsForApiKey } from "@app/lib/api/credits/members_usage";
 import {
   reconcileApiKey,
   reconcileWorkspaceApiKeyCreditStates,
@@ -8,8 +10,15 @@ import {
   upsertMetronomeApiKeyCapAlert,
 } from "@app/lib/metronome/alerts/api_key_caps";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
 import { revertOnSyncFailure } from "@app/lib/spend_limits/revert_on_sync_failure";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
+import {
+  addFixedWindowCount,
+  getFixedWindowCount,
+  setFixedWindowCount,
+} from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
   ApiKeySpendLimit,
@@ -319,4 +328,125 @@ export async function backfillApiKeyCreditCapsForWorkspace(
   });
 
   return { converted };
+}
+
+/**
+ * Reads the per-API-key spend-cap counter, lazily seeding it from Elasticsearch
+ * whenever it reads as 0 — a brand-new cycle (ES ≈ 0, a harmless no-op), the
+ * flag just enabled mid-cycle, or the key evicted under Redis memory pressure.
+ * ES is scoped to the current cycle and summed by `api_key_name`, so the seeded
+ * value is the correct cycle-to-date total in every case. A non-zero count is
+ * already live and used as-is with no ES read. Mirrors the per-user lazy seed
+ * in `lib/api/users/spend_limit.ts`.
+ *
+ * Returns the effective count, or `null` on a Redis read error (caller fails
+ * open). A seed write failure degrades to the ES value rather than throwing.
+ */
+async function readApiKeySpendLimitCountWithLazySeed(
+  auth: Authenticator,
+  {
+    apiKeyName,
+    redisKey,
+    bounds,
+  }: { apiKeyName: string; redisKey: string; bounds: FixedWindowBounds }
+): Promise<number | null> {
+  const countResult = await getFixedWindowCount({ key: redisKey, bounds });
+  if (countResult.isErr()) {
+    return null;
+  }
+  if (countResult.value > 0) {
+    return countResult.value;
+  }
+
+  const consumed = Math.max(
+    0,
+    Math.round(await getEsConsumedAwuCreditsForApiKey(auth, { apiKeyName }))
+  );
+  if (consumed > 0) {
+    await setFixedWindowCount({
+      key: redisKey,
+      bounds,
+      value: consumed,
+      logger,
+    });
+  }
+  return consumed;
+}
+
+/**
+ * Synchronous, Metronome-independent enforcement of the per-API-key spend cap,
+ * read at message-send time from the Redis fixed-window counter over the current
+ * contract billing cycle. The threshold is the key's admin-configured
+ * `monthlyCapAwuCredits`. Runs alongside the Metronome per-key cap
+ * (`isApiKeyCapped`) as a faster, independent backup. Returns `false` (does not
+ * block) when the key is gone, has no cap, the billing period can't be resolved,
+ * or on a Redis read error (fail-open).
+ */
+export async function isApiKeySpendLimitRateCapReached(
+  auth: Authenticator,
+  { keyModelId }: { keyModelId: number }
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const key = await KeyResource.fetchByWorkspaceAndId({
+    workspace,
+    id: keyModelId,
+  });
+  if (!key || key.monthlyCapAwuCredits === null) {
+    return false;
+  }
+  const threshold = key.monthlyCapAwuCredits;
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return false;
+  }
+
+  const count = await readApiKeySpendLimitCountWithLazySeed(auth, {
+    apiKeyName: key.name,
+    redisKey: makeApiKeySpendLimitAwuCreditsRateLimitKey(key.id),
+    bounds,
+  });
+  if (count === null) {
+    logger.error(
+      { workspaceId: workspace.sId, keyName: key.name },
+      "[ApiKeySpendLimitRateCap] Failed to read fixed-window count; allowing message"
+    );
+    return false;
+  }
+
+  return count >= threshold;
+}
+
+/**
+ * Adds `incrementBy` AWU credits to the per-API-key fixed-window spend-cap
+ * counter for the current contract billing cycle. Records for every key (the
+ * cap is resolved at enforcement/read time, not here). `incrementBy` is the
+ * newly-accrued delta for a message (the caller diffs against the previously
+ * recorded amount so repeated finalizes don't over-count). No-op when the
+ * billing period can't be resolved.
+ */
+export async function recordApiKeySpendLimitUsage(
+  auth: Authenticator,
+  { keyModelId, incrementBy }: { keyModelId: number; incrementBy: number }
+): Promise<void> {
+  // Only whole positive credits are recordable (the counter is an integer
+  // INCRBY); skip anything else rather than letting it reach the counter.
+  if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
+    return;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return;
+  }
+
+  await addFixedWindowCount({
+    key: makeApiKeySpendLimitAwuCreditsRateLimitKey(keyModelId),
+    bounds,
+    incrementBy,
+    logger,
+  });
 }

--- a/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
+++ b/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
@@ -1,4 +1,7 @@
-import { resyncSpendLimitCountersFromEsUsage } from "@app/lib/api/credits/members_usage";
+import {
+  resyncApiKeySpendLimitCountersFromEsUsage,
+  resyncSpendLimitCountersFromEsUsage,
+} from "@app/lib/api/credits/members_usage";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -7,25 +10,35 @@ export const resyncSpendLimitCountersPlugin = createPlugin({
     id: "resync-spend-limit-counters",
     name: "Resync Spend-Limit Counters from Usage",
     description:
-      "Overwrite each member's Redis fixed-window per-user spend-cap counter " +
-      "for the current cycle with their Elasticsearch-derived AWU consumption. " +
-      "Use to backfill the counter after enabling the cap, or to repair drift " +
-      "(the counter otherwise only accrues from live messages). Resyncs the " +
-      "cycle the workspace is enforced on: the Metronome contract billing " +
-      "period on credit-priced plans, the UTC calendar month elsewhere.",
+      "Overwrite the Redis fixed-window spend-cap counters (each member's " +
+      "per-user counter and each capped API key's per-key counter) for the " +
+      "current cycle with their Elasticsearch-derived AWU consumption. Use to " +
+      "backfill the counters after enabling the cap, or to repair drift (they " +
+      "otherwise only accrue from live messages). Resyncs the cycle the " +
+      "workspace is enforced on: the Metronome contract billing period on " +
+      "credit-priced plans, the UTC calendar month elsewhere.",
     resourceTypes: ["workspaces"],
     args: {},
     requiredRoles: ["billing"],
   },
 
   execute: async (auth, _resource, _args) => {
-    const result = await resyncSpendLimitCountersFromEsUsage(auth);
-    if (result.isErr()) {
-      return new Err(new Error(result.error.message));
+    const userResult = await resyncSpendLimitCountersFromEsUsage(auth);
+    if (userResult.isErr()) {
+      return new Err(new Error(userResult.error.message));
     }
+
+    const apiKeyResult = await resyncApiKeySpendLimitCountersFromEsUsage(auth);
+    if (apiKeyResult.isErr()) {
+      return new Err(new Error(apiKeyResult.error.message));
+    }
+
     return new Ok({
       display: "text",
-      value: `Resynced spend-limit counters for ${result.value.updatedUserCount} user(s) from usage.`,
+      value:
+        `Resynced spend-limit counters from usage for ` +
+        `${userResult.value.updatedUserCount} user(s) and ` +
+        `${apiKeyResult.value.updatedKeyCount} API key(s).`,
     });
   },
 });

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -23,12 +23,14 @@ import {
   upsertMetronomePerUserCapAlert,
   upsertMetronomePerUserWarningAlert,
 } from "@app/lib/metronome/alerts/spend_limits";
-import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { currentCalendarMonthCycleUtc } from "@app/lib/spend_limits/cycle";
+import {
+  currentCalendarMonthCycleUtc,
+  resolveSpendLimitCycleBounds,
+} from "@app/lib/spend_limits/cycle";
 import { revertOnSyncFailure } from "@app/lib/spend_limits/revert_on_sync_failure";
 import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
@@ -46,7 +48,6 @@ import { normalizeToPoolLimitSeatType } from "@app/types/memberships";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { LightWorkspaceType } from "@app/types/user";
 
 export const MIN_USER_SPEND_LIMIT_AWU_CREDITS = 0;
 export const MAX_USER_SPEND_LIMIT_AWU_CREDITS = 2_000_000;
@@ -490,30 +491,6 @@ export async function expireUserSpendLimitOverride(
   });
 
   return new Ok({ reverted: true, previousAwuCredits });
-}
-
-// Fixed-window bounds for the current Metronome contract billing cycle (the
-// window the per-user spend cap is bucketed on). `null` when no billing period
-// can be resolved — callers treat that as a no-op (fail-open, matching the rest
-// of the rate-limiter callers).
-async function resolveSpendLimitCycleBounds(
-  workspace: LightWorkspaceType
-): Promise<FixedWindowBounds | null> {
-  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
-    workspace.sId
-  );
-  if (periodResult.isErr() || !periodResult.value) {
-    logger.warn(
-      {
-        workspaceId: workspace.sId,
-        err: periodResult.isErr() ? periodResult.error : undefined,
-      },
-      "[SpendLimitRateCap] Could not resolve contract billing period; skipping fixed-window cap"
-    );
-    return null;
-  }
-  const { cycleStart, cycleEnd } = periodResult.value;
-  return makeSpendLimitCycleWindowBounds(cycleStart, cycleEnd);
 }
 
 /**

--- a/front/lib/spend_limits/cycle.ts
+++ b/front/lib/spend_limits/cycle.ts
@@ -1,6 +1,11 @@
+import { makeSpendLimitCycleWindowBounds } from "@app/lib/api/assistant/rate_limits";
 import type { Authenticator } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
 import { isCreditPricedPlan } from "@app/types/plan";
+import type { LightWorkspaceType } from "@app/types/user";
 
 /**
  * The UTC calendar month containing `now`, used as the per-user spend-cap cycle
@@ -39,4 +44,29 @@ export function spendLimitCycleOverrideForAuth(
   }
 
   return currentCalendarMonthCycleUtc();
+}
+
+// Fixed-window bounds for the current Metronome contract billing cycle (the
+// window the pool-level spend caps are bucketed on). `null` when no billing
+// period can be resolved — callers treat that as a no-op (fail-open, matching
+// the rest of the rate-limiter callers). Shared by the per-user, per-API-key,
+// programmatic and workspace spend-cap backups.
+export async function resolveSpendLimitCycleBounds(
+  workspace: LightWorkspaceType
+): Promise<FixedWindowBounds | null> {
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isErr() || !periodResult.value) {
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        err: periodResult.isErr() ? periodResult.error : undefined,
+      },
+      "[SpendLimitRateCap] Could not resolve contract billing period; skipping fixed-window cap"
+    );
+    return null;
+  }
+  const { cycleStart, cycleEnd } = periodResult.value;
+  return makeSpendLimitCycleWindowBounds(cycleStart, cycleEnd);
 }

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -339,7 +339,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   enforce_user_spend_limit_rate_cap: {
     description:
-      "Enable the per-user spend-cap backup: record per-user AWU usage into the Redis fixed-window counter and enforce it at message send (blocks with user_cap_reached). When off, usage is neither recorded nor enforced.",
+      "Enable the Redis fixed-window spend-cap backups (per-user, per-API-key, programmatic, and workspace usage cap): record AWU usage into the counters and enforce them at message send. When off, usage is neither recorded nor enforced.",
     stage: "dust_only",
   },
   editable_tool_inputs: {


### PR DESCRIPTION
## Description

Adds a Redis fixed-window backup for the Metronome **per-API-key spend cap**, mirroring the per-user spend-cap backup shipped previously. It records AWU usage per calling API key into a fixed-window counter over the contract billing cycle, and enforces it synchronously at message send alongside the existing Metronome-driven `isApiKeyCapped`.

First PR of a 3-PR stack backing the pool-level Metronome spend caps with Redis rate-limiters (per-API-key → programmatic → workspace usage cap).

- Gated behind the **existing** `enforce_user_spend_limit_rate_cap` flag (reused for all spend-cap backups; description broadened) — one flag flip enables the per-user, per-key, programmatic and workspace backups together.
- Counter keyed by key model id; threshold is the key's `monthlyCapAwuCredits`.
- Lazy-seed from Elasticsearch (summed by `api_key_name`) on a Redis miss, so flipping the flag mid-cycle backfills the cycle-to-date total. Seeding by name also bridges key rotation.
- Extends the existing `resync-spend-limit-counters` poke plugin to also resync the per-key counters (one plugin resyncs all spend-cap counters).
- Promotes `resolveSpendLimitCycleBounds` to `lib/spend_limits/cycle.ts` so the per-user and per-key backups share one cycle-window resolver.

## Tests

- `npx tsgo --noEmit` passes; `biome check` clean.
- No new automated tests in this PR — the enforcement path is internal (message-send), not an endpoint. Can add counter/seed coverage to `front/lib/api/keys/spend_limit.test.ts` if desired.
- Intended manual validation: enable the flag on a dust-internal workspace, run the `resync-spend-limit-counters` poke plugin, and confirm the per-key counter matches ES `Consumed (ES)` and that a key at/over its cap is blocked with the existing 429.

## Risk

- **Low, fail-open by design.** Every failure mode (no cap, no billing period, Redis read error, missing key) returns "not reached" and allows the message.
- **Off by default** — behind `enforce_user_spend_limit_rate_cap` (`dust_only`). No behavior change when the flag is off (nothing recorded, nothing enforced).
- When on, this is a *backup* to the Metronome per-key cap already enforced today (`isApiKeyCapped`), OR-ed with it — it can only add blocks the Metronome path would also eventually apply, returning the same existing 429 `rate_limit_error`.
- Shared refactor (`resolveSpendLimitCycleBounds` moved to `cycle.ts`) is a pure move; the per-user path is unchanged behaviorally.
- Safe to roll back (revert): the flag stays off elsewhere and the counter keys are self-expiring.

## Deploy Plan

1. Merge; deploy `front` normally. No migration.
2. Flag remains `dust_only` and off — no runtime effect on merge.
3. To validate: enable `enforce_user_spend_limit_rate_cap` on a dust-internal workspace, then run the `resync-spend-limit-counters` poke plugin to seed counters from ES for the current cycle.
4. Compare the per-key counter against Metronome for a cycle before relying on the Redis path to block.
