### PR TITLE
[front] Bind group permission IDs as an array

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -963,11 +963,6 @@ export class Authenticator {
       ? allGroups.map((g) => g.id)
       : [];
     const keyGroupModelIds = allGroups.map((g) => g.id);
-    // Unscoped system keys represent nearly every group in their workspace. Bind those ids as one
-    // Postgres array so Sequelize does not expand thousands of placeholders into the query text.
-    // Explicitly scoped system keys keep the regular group-id lookup.
-    const useBoundArrayPermissionLookup =
-      key.isSystem && requestedGroupIds === undefined;
 
     let permissions: GroupPermissions;
     let keyPermissions: GroupPermissions;
@@ -977,7 +972,6 @@ export class Authenticator {
       permissions = await this.resolvePermissions({
         workspace,
         groupModelIds: workspaceGroupModelIds,
-        useBoundArrayPermissionLookup,
       });
       keyPermissions = permissions;
     } else {
@@ -985,12 +979,10 @@ export class Authenticator {
         this.resolvePermissions({
           workspace,
           groupModelIds: workspaceGroupModelIds,
-          useBoundArrayPermissionLookup,
         }),
         this.resolvePermissions({
           workspace: keyWorkspace,
           groupModelIds: keyGroupModelIds,
-          useBoundArrayPermissionLookup,
         }),
       ]);
     }
@@ -1295,25 +1287,18 @@ export class Authenticator {
   static async resolvePermissions({
     workspace,
     groupModelIds,
-    useBoundArrayPermissionLookup = false,
   }: {
     workspace?: WorkspaceResource | null;
     groupModelIds: ModelId[];
-    useBoundArrayPermissionLookup?: boolean;
   }): Promise<GroupPermissions> {
     if (!workspace) {
       return GroupPermissions.empty();
     }
 
     const lightWorkspace = renderLightWorkspaceType({ workspace });
-    const grants = useBoundArrayPermissionLookup
-      ? await GroupPermissionResource.listForGroupsWithBoundArray(
-          lightWorkspace,
-          groupModelIds
-        )
-      : await GroupPermissionResource.listForGroups(lightWorkspace, {
-          groupModelIds,
-        });
+    const grants = await GroupPermissionResource.listForGroups(lightWorkspace, {
+      groupModelIds,
+    });
 
     return GroupPermissions.fromGrants(grants);
   }

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1307,7 +1307,7 @@ export class Authenticator {
 
     const lightWorkspace = renderLightWorkspaceType({ workspace });
     const grants = scanWorkspacePermissions
-      ? await GroupPermissionResource.listForGroupsFromWorkspaceScan(
+      ? await GroupPermissionResource.listForGroupsWithBoundArray(
           lightWorkspace,
           groupModelIds
         )

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -963,10 +963,10 @@ export class Authenticator {
       ? allGroups.map((g) => g.id)
       : [];
     const keyGroupModelIds = allGroups.map((g) => g.id);
-    // Unscoped system keys represent nearly every group in their workspace. Resolve their grants
-    // from the workspace grant set so large workspaces do not send thousands of group ids to
-    // Postgres on every request. Explicitly scoped system keys keep the group-id query.
-    const scanWorkspacePermissions =
+    // Unscoped system keys represent nearly every group in their workspace. Bind those ids as one
+    // Postgres array so Sequelize does not expand thousands of placeholders into the query text.
+    // Explicitly scoped system keys keep the regular group-id lookup.
+    const useBoundArrayPermissionLookup =
       key.isSystem && requestedGroupIds === undefined;
 
     let permissions: GroupPermissions;
@@ -977,7 +977,7 @@ export class Authenticator {
       permissions = await this.resolvePermissions({
         workspace,
         groupModelIds: workspaceGroupModelIds,
-        scanWorkspacePermissions,
+        useBoundArrayPermissionLookup,
       });
       keyPermissions = permissions;
     } else {
@@ -985,12 +985,12 @@ export class Authenticator {
         this.resolvePermissions({
           workspace,
           groupModelIds: workspaceGroupModelIds,
-          scanWorkspacePermissions,
+          useBoundArrayPermissionLookup,
         }),
         this.resolvePermissions({
           workspace: keyWorkspace,
           groupModelIds: keyGroupModelIds,
-          scanWorkspacePermissions,
+          useBoundArrayPermissionLookup,
         }),
       ]);
     }
@@ -1295,18 +1295,18 @@ export class Authenticator {
   static async resolvePermissions({
     workspace,
     groupModelIds,
-    scanWorkspacePermissions = false,
+    useBoundArrayPermissionLookup = false,
   }: {
     workspace?: WorkspaceResource | null;
     groupModelIds: ModelId[];
-    scanWorkspacePermissions?: boolean;
+    useBoundArrayPermissionLookup?: boolean;
   }): Promise<GroupPermissions> {
     if (!workspace) {
       return GroupPermissions.empty();
     }
 
     const lightWorkspace = renderLightWorkspaceType({ workspace });
-    const grants = scanWorkspacePermissions
+    const grants = useBoundArrayPermissionLookup
       ? await GroupPermissionResource.listForGroupsWithBoundArray(
           lightWorkspace,
           groupModelIds

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -230,7 +230,7 @@ describe("Authenticator.fromKey permission resolution", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses a workspace grant scan for unscoped system keys", async () => {
+  it("uses the bound-array lookup for unscoped system keys", async () => {
     const workspace = await WorkspaceFactory.basic();
     const { systemGroup } = await GroupFactory.defaults(workspace);
     const adminAuth = await Authenticator.internalAdminForWorkspace(
@@ -258,14 +258,14 @@ describe("Authenticator.fromKey permission resolution", () => {
       resourceId: 42,
     });
 
-    const workspaceScanSpy = vi.spyOn(
+    const boundArrayLookupSpy = vi.spyOn(
       GroupPermissionResource,
-      "listForGroupsFromWorkspaceScan"
+      "listForGroupsWithBoundArray"
     );
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
 
-    expect(workspaceScanSpy).toHaveBeenCalledTimes(1);
+    expect(boundArrayLookupSpy).toHaveBeenCalledTimes(1);
     expect(
       workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
     ).toEqual([includedGroup.id]);
@@ -298,16 +298,16 @@ describe("Authenticator.fromKey permission resolution", () => {
       resourceId: 42,
     });
 
-    const workspaceScanSpy = vi.spyOn(
+    const boundArrayLookupSpy = vi.spyOn(
       GroupPermissionResource,
-      "listForGroupsFromWorkspaceScan"
+      "listForGroupsWithBoundArray"
     );
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId, [
       includedGroup.sId,
     ]);
 
-    expect(workspaceScanSpy).not.toHaveBeenCalled();
+    expect(boundArrayLookupSpy).not.toHaveBeenCalled();
     expect(
       workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
     ).toEqual([includedGroup.id]);

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -230,7 +230,7 @@ describe("Authenticator.fromKey permission resolution", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses the bound-array lookup for unscoped system keys", async () => {
+  it("resolves permissions for unscoped system keys", async () => {
     const workspace = await WorkspaceFactory.basic();
     const { systemGroup } = await GroupFactory.defaults(workspace);
     const adminAuth = await Authenticator.internalAdminForWorkspace(
@@ -258,20 +258,15 @@ describe("Authenticator.fromKey permission resolution", () => {
       resourceId: 42,
     });
 
-    const boundArrayLookupSpy = vi.spyOn(
-      GroupPermissionResource,
-      "listForGroupsWithBoundArray"
-    );
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
 
-    expect(boundArrayLookupSpy).toHaveBeenCalledTimes(1);
     expect(
       workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
     ).toEqual([includedGroup.id]);
   });
 
-  it("keeps explicitly scoped system keys on the group-id lookup", async () => {
+  it("resolves permissions for explicitly scoped system keys", async () => {
     const workspace = await WorkspaceFactory.basic();
     const { systemGroup } = await GroupFactory.defaults(workspace);
     const adminAuth = await Authenticator.internalAdminForWorkspace(
@@ -298,16 +293,11 @@ describe("Authenticator.fromKey permission resolution", () => {
       resourceId: 42,
     });
 
-    const boundArrayLookupSpy = vi.spyOn(
-      GroupPermissionResource,
-      "listForGroupsWithBoundArray"
-    );
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId, [
       includedGroup.sId,
     ]);
 
-    expect(boundArrayLookupSpy).not.toHaveBeenCalled();
     expect(
       workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
     ).toEqual([includedGroup.id]);

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -174,7 +174,7 @@ describe("GroupPermissionResource", () => {
     });
   });
 
-  describe("listForGroupsWithBoundArray", () => {
+  describe("listForGroups", () => {
     it("filters in Postgres through one bound bigint array", async () => {
       await GroupPermissionResource.grant(auth, {
         group: groupA,
@@ -201,9 +201,9 @@ describe("GroupPermissionResource", () => {
 
       let grants: GroupPermissionResource[];
       try {
-        grants = await GroupPermissionResource.listForGroupsWithBoundArray(
+        grants = await GroupPermissionResource.listForGroups(
           auth.getNonNullableWorkspace(),
-          [groupA.id]
+          { groupModelIds: [groupA.id] }
         );
       } finally {
         frontSequelize.removeHook("afterQuery", captureQueryHook);
@@ -215,6 +215,58 @@ describe("GroupPermissionResource", () => {
       );
       expect(capturedQuery?.sql).not.toContain('"groupId" IN (');
       expect(capturedQuery?.bind).toEqual({ groupModelIds: [groupA.id] });
+    });
+
+    it("keeps a large group set in one bind and applies optional filters", async () => {
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        grantType: "reader",
+        resourceType: "space",
+        resourceId: 1,
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: groupB,
+        grantType: "member",
+        resourceType: "space",
+        resourceId: 2,
+      });
+
+      const groupModelIds = [
+        groupA.id,
+        groupB.id,
+        ...Array.from({ length: 8_192 }, (_, index) => 1_000_000 + index),
+      ];
+      let capturedQuery: { sql: string; bind: unknown } | undefined;
+      const captureQueryHook = "capture-large-group-permission-query";
+      const captureQuery = (options: QueryOptions, query: AbstractQuery) => {
+        const sql = Reflect.get(query, "sql");
+        if (isString(sql) && sql.includes('FROM "group_permissions"')) {
+          capturedQuery = { sql, bind: options.bind };
+        }
+      };
+      frontSequelize.addHook("afterQuery", captureQueryHook, captureQuery);
+
+      let grants: GroupPermissionResource[];
+      try {
+        grants = await GroupPermissionResource.listForGroups(
+          auth.getNonNullableWorkspace(),
+          {
+            groupModelIds,
+            grantType: "member",
+            resourceType: "space",
+            resourceId: 2,
+          }
+        );
+      } finally {
+        frontSequelize.removeHook("afterQuery", captureQueryHook);
+      }
+
+      expect(grants.map((grant) => grant.groupId)).toEqual([groupB.id]);
+      expect(capturedQuery?.sql).toContain(
+        '"group_permissions"."groupId" = ANY ($1::bigint[])'
+      );
+      expect(capturedQuery?.sql).not.toContain('"groupId" IN (');
+      expect(capturedQuery?.bind).toEqual({ groupModelIds });
     });
   });
 

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -1,10 +1,14 @@
 import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { isString } from "@app/types/shared/utils/general";
+import type { QueryOptions } from "sequelize";
+import type { AbstractQuery } from "sequelize/types/dialects/abstract/query";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("GroupPermissionResource", () => {
@@ -167,6 +171,50 @@ describe("GroupPermissionResource", () => {
         }
       );
       expect(grants).toEqual([]);
+    });
+  });
+
+  describe("listForGroupsWithBoundArray", () => {
+    it("filters in Postgres through one bound bigint array", async () => {
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        grantType: "reader",
+        resourceType: "space",
+        resourceId: 1,
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: groupB,
+        grantType: "reader",
+        resourceType: "space",
+        resourceId: 2,
+      });
+
+      let capturedQuery: { sql: string; bind: unknown } | undefined;
+      const captureQueryHook = "capture-bound-group-permission-query";
+      const captureQuery = (options: QueryOptions, query: AbstractQuery) => {
+        const sql = Reflect.get(query, "sql");
+        if (isString(sql) && sql.includes('FROM "group_permissions"')) {
+          capturedQuery = { sql, bind: options.bind };
+        }
+      };
+      frontSequelize.addHook("afterQuery", captureQueryHook, captureQuery);
+
+      let grants: GroupPermissionResource[];
+      try {
+        grants = await GroupPermissionResource.listForGroupsWithBoundArray(
+          auth.getNonNullableWorkspace(),
+          [groupA.id]
+        );
+      } finally {
+        frontSequelize.removeHook("afterQuery", captureQueryHook);
+      }
+
+      expect(grants.map((grant) => grant.groupId)).toEqual([groupA.id]);
+      expect(capturedQuery?.sql).toContain(
+        '"group_permissions"."groupId" = ANY ($1::bigint[])'
+      );
+      expect(capturedQuery?.sql).not.toContain('"groupId" IN (');
+      expect(capturedQuery?.bind).toEqual({ groupModelIds: [groupA.id] });
     });
   });
 

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -23,7 +23,7 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
-import { Op } from "sequelize";
+import { literal, Op } from "sequelize";
 
 /**
  * All writes to `group_permissions` go through this resource — never a raw model write elsewhere.
@@ -419,12 +419,9 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     return rows.map((row) => new this(GroupPermissionModel, row.get()));
   }
 
-  // System keys can represent nearly every group in a workspace. Expanding those group ids into
-  // an IN clause on every authenticated request is much more expensive than reading the usually
-  // small workspace grant set through its workspace-leading index and filtering it in memory.
-  // Keep the exact caller group semantics by intersecting with the ids already resolved for the
-  // Authenticator.
-  static async listForGroupsFromWorkspaceScan(
+  // System keys can represent nearly every group in a workspace. Bind their group ids as one
+  // Postgres array so Sequelize does not expand thousands of placeholders into the query text.
+  static async listForGroupsWithBoundArray(
     workspace: LightWorkspaceType,
     groupModelIds: ModelId[]
   ): Promise<GroupPermissionResource[]> {
@@ -432,14 +429,17 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       return [];
     }
 
-    const groupModelIdSet = new Set(groupModelIds);
     const rows = await GroupPermissionModel.findAll({
-      where: { workspaceId: workspace.id },
+      where: {
+        workspaceId: workspace.id,
+        groupId: {
+          [Op.any]: literal("$groupModelIds::bigint[]"),
+        },
+      },
+      bind: { groupModelIds },
     });
 
-    return rows
-      .filter((row) => groupModelIdSet.has(row.groupId))
-      .map((row) => new this(GroupPermissionModel, row.get()));
+    return rows.map((row) => new this(GroupPermissionModel, row.get()));
   }
 
   // Deletion-integrity hook: drop every grant (across all groups) targeting one resource. There is

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -409,32 +409,12 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     const rows = await GroupPermissionModel.findAll({
       where: {
         workspaceId: workspace.id,
-        groupId: groupModelIds,
-        ...(grantType !== undefined ? { grantType } : {}),
-        ...(resourceType !== undefined ? { resourceType } : {}),
-        ...(resourceId !== undefined ? { resourceId } : {}),
-      },
-    });
-
-    return rows.map((row) => new this(GroupPermissionModel, row.get()));
-  }
-
-  // System keys can represent nearly every group in a workspace. Bind their group ids as one
-  // Postgres array so Sequelize does not expand thousands of placeholders into the query text.
-  static async listForGroupsWithBoundArray(
-    workspace: LightWorkspaceType,
-    groupModelIds: ModelId[]
-  ): Promise<GroupPermissionResource[]> {
-    if (groupModelIds.length === 0) {
-      return [];
-    }
-
-    const rows = await GroupPermissionModel.findAll({
-      where: {
-        workspaceId: workspace.id,
         groupId: {
           [Op.any]: literal("$groupModelIds::bigint[]"),
         },
+        ...(grantType !== undefined ? { grantType } : {}),
+        ...(resourceType !== undefined ? { resourceType } : {}),
+        ...(resourceId !== undefined ? { resourceId } : {}),
       },
       bind: { groupModelIds },
     });


### PR DESCRIPTION
## Description

Replace the unscoped system-key workspace scan with the regular group-filtered lookup, and make that lookup bind every group set as one PostgreSQL `bigint[]` consumed by `ANY`.

This keeps query text stable for both small and very large group sets, avoids Sequelize expanding thousands of `IN` placeholders, and prevents the workspace scan that returned 7.61M rows in one minute during the EU DB incident. Optional grant and resource filters continue to apply in Postgres.

## Tests

Added DB-backed coverage for small and 8,194-ID group sets, the single array bind SQL shape, absence of an expanded `IN` clause, optional filters, empty group sets, and scoped and unscoped system-key permission semantics.

Ran the focused Vitest suite: 42 tests passed. Ran Biome on all changed files and the Front TypeScript check.

## Risk

Low. Permission semantics and empty-list behavior are unchanged. The database now receives the same group IDs as one typed array. Roll back this PR to restore the previous lookup behavior.

## Deploy Plan

Deploy Front and front-sse together. Monitor Front DB CPU and `group_permissions` query fingerprints in both regions.