### PR TITLE
Skip seat sync writes after subscription end

### DIFF
--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -1822,6 +1822,30 @@ export async function syncSeatCount({
     for (const { sub, seatType } of seatSubscriptions) {
       const subscriptionId = sub.id!;
       const quantityMode = sub.quantity_management_mode ?? "QUANTITY_ONLY";
+      const subscriptionEndingBeforeMs = sub.ending_before
+        ? Date.parse(sub.ending_before)
+        : undefined;
+
+      const shouldSkipTimestamp = (tMs: number): boolean => {
+        if (
+          subscriptionEndingBeforeMs === undefined ||
+          tMs < subscriptionEndingBeforeMs
+        ) {
+          return false;
+        }
+        logger.info(
+          {
+            workspaceId: workspace.sId,
+            contractId,
+            subscriptionId,
+            seatType,
+            tMs,
+            endingBefore: sub.ending_before,
+          },
+          "[Metronome] Skipping seat reconciliation at or after subscription end"
+        );
+        return true;
+      };
 
       if (quantityMode === "SEAT_BASED") {
         // One reconcile per distinct effective moment. `desiredSIds` and the
@@ -1832,6 +1856,9 @@ export async function syncSeatCount({
         // membership unchanged therefore only moves the *unassigned* seats (the
         // floor top-up), since the assigned real users stay the same.
         for (const tMs of effectiveTimestampsMs) {
+          if (shouldSkipTimestamp(tMs)) {
+            continue;
+          }
           const isImmediateBase = tMs === baseMs && !startingAt;
           // Immediate base sync: let Metronome default to "now" for both the
           // write (`starting_at`) and the read (`covering_date`). Any other
@@ -1884,6 +1911,9 @@ export async function syncSeatCount({
         // unbilled.
         let lastQuantity: number | undefined;
         for (const tMs of effectiveTimestampsMs) {
+          if (shouldSkipTimestamp(tMs)) {
+            continue;
+          }
           const isImmediateBase = tMs === baseMs && !startingAt;
           const segmentStartingAt = isImmediateBase
             ? startingAt

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -477,6 +477,23 @@ describe("syncSeatCount min clamping", () => {
 
 describe("syncSeatCount subscription end boundary", () => {
   const sourceEndingBefore = "2026-09-10T10:00:00.000Z";
+  const boundaryCases = [
+    {
+      name: "exactly at",
+      transitionAt: "2026-09-10T10:00:00.000Z",
+      updatesSource: false,
+    },
+    {
+      name: "one millisecond after",
+      transitionAt: "2026-09-10T10:00:00.001Z",
+      updatesSource: false,
+    },
+    {
+      name: "one millisecond before",
+      transitionAt: "2026-09-10T09:59:59.999Z",
+      updatesSource: true,
+    },
+  ];
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -517,25 +534,9 @@ describe("syncSeatCount subscription end boundary", () => {
     vi.useRealTimers();
   });
 
-  it.each([
-    {
-      name: "exactly at",
-      transitionAt: "2026-09-10T10:00:00.000Z",
-      removesFromSource: false,
-    },
-    {
-      name: "one millisecond after",
-      transitionAt: "2026-09-10T10:00:00.001Z",
-      removesFromSource: false,
-    },
-    {
-      name: "one millisecond before",
-      transitionAt: "2026-09-10T09:59:59.999Z",
-      removesFromSource: true,
-    },
-  ])("$name the source subscription end", async ({
+  it.each(boundaryCases)("$name the SEAT_BASED source end", async ({
     transitionAt,
-    removesFromSource,
+    updatesSource,
   }) => {
     mockGetScheduledFutureMemberships.mockResolvedValue([
       {
@@ -577,11 +578,66 @@ describe("syncSeatCount subscription end boundary", () => {
       removeSeatIds: ["u1"],
       startingAt: transitionAt,
     });
-    if (removesFromSource) {
+    if (updatesSource) {
       expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(sourceRemoval);
     } else {
       expect(mockUpdateSubscriptionSeats).not.toHaveBeenCalledWith(
         sourceRemoval
+      );
+    }
+  });
+
+  it.each(boundaryCases)("$name the QUANTITY_ONLY source end", async ({
+    transitionAt,
+    updatesSource,
+  }) => {
+    mockGetScheduledFutureMemberships.mockResolvedValue([
+      {
+        ...membership("u1", "pro_yearly"),
+        startAt: new Date(transitionAt),
+      },
+    ]);
+
+    const result = await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
+      contract: makeContract([
+        {
+          id: "sub_pro",
+          productId: "pro-product",
+          mode: "QUANTITY_ONLY",
+          endingBefore: sourceEndingBefore,
+        },
+        {
+          id: "sub_pro_yearly",
+          productId: "pro-yearly-product",
+          mode: "QUANTITY_ONLY",
+        },
+      ]),
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockUpdateSubscriptionQuantity).toHaveBeenCalledWith({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      subscriptionId: "sub_pro_yearly",
+      quantity: 1,
+      startingAt: transitionAt,
+    });
+    const sourceUpdate = {
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      subscriptionId: "sub_pro",
+      quantity: 0,
+      startingAt: transitionAt,
+    };
+    if (updatesSource) {
+      expect(mockUpdateSubscriptionQuantity).toHaveBeenCalledWith(sourceUpdate);
+    } else {
+      expect(mockUpdateSubscriptionQuantity).not.toHaveBeenCalledWith(
+        sourceUpdate
       );
     }
   });

--- a/front/lib/metronome/seats_sync.test.ts
+++ b/front/lib/metronome/seats_sync.test.ts
@@ -3,7 +3,7 @@ import { syncSeatCount } from "@app/lib/metronome/seats";
 import type { MembershipSeatType } from "@app/types/memberships";
 import { Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockGetProductSeatTypes,
@@ -94,13 +94,19 @@ vi.mock("@app/lib/utils/cache", () => ({
 const WORKSPACE = { sId: "ws_1", id: 1 } as unknown as LightWorkspaceType;
 
 function makeContract(
-  subs: Array<{ id: string; productId: string; mode: string }>
+  subs: Array<{
+    id: string;
+    productId: string;
+    mode: string;
+    endingBefore?: string;
+  }>
 ): CachedContract {
   return {
-    subscriptions: subs.map(({ id, productId, mode }) => ({
+    subscriptions: subs.map(({ id, productId, mode, endingBefore }) => ({
       id,
       quantity_management_mode: mode,
       subscription_rate: { product: { id: productId, name: id } },
+      ending_before: endingBefore,
     })),
   } as unknown as CachedContract;
 }
@@ -466,5 +472,117 @@ describe("syncSeatCount min clamping", () => {
         startingAt: scheduledAt.toISOString(),
       })
     );
+  });
+});
+
+describe("syncSeatCount subscription end boundary", () => {
+  const sourceEndingBefore = "2026-09-10T10:00:00.000Z";
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-10T09:00:00.000Z"));
+    vi.clearAllMocks();
+    mockGetProductSeatTypes.mockResolvedValue(
+      new Map([
+        ["pro-product", "pro"],
+        ["pro-yearly-product", "pro_yearly"],
+      ])
+    );
+    mockGetActiveMemberships.mockResolvedValue({
+      memberships: [membership("u1", "pro")],
+      total: 1,
+    });
+    mockFetchSeatLimits.mockResolvedValue(new Map());
+    mockUpdateSubscriptionQuantity.mockResolvedValue(new Ok(undefined));
+    mockUpdateSubscriptionSeats.mockResolvedValue(new Ok(undefined));
+    mockGetSeatState.mockImplementation(
+      ({ subscriptionId }: { subscriptionId: string }) =>
+        Promise.resolve(
+          new Ok({
+            assignedSeatIds: subscriptionId === "sub_pro" ? ["u1"] : [],
+            unassignedSeats: 0,
+          })
+        )
+    );
+    mockListPerUserCreditUserIds.mockResolvedValue(new Ok(new Set()));
+    mockListPerUserCreditBalances.mockResolvedValue(new Ok(new Map()));
+    mockAddPerUserCredit.mockResolvedValue(new Ok(null));
+    mockRevokePerUserCustomerCredit.mockResolvedValue(new Ok(undefined));
+    mockUpsertPerUserCreditAlerts.mockResolvedValue(new Ok(undefined));
+    mockClearPerUserCreditAlerts.mockResolvedValue(new Ok(undefined));
+    mockListSeatBalances.mockResolvedValue(new Ok([]));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    {
+      name: "exactly at",
+      transitionAt: "2026-09-10T10:00:00.000Z",
+      removesFromSource: false,
+    },
+    {
+      name: "one millisecond after",
+      transitionAt: "2026-09-10T10:00:00.001Z",
+      removesFromSource: false,
+    },
+    {
+      name: "one millisecond before",
+      transitionAt: "2026-09-10T09:59:59.999Z",
+      removesFromSource: true,
+    },
+  ])("$name the source subscription end", async ({
+    transitionAt,
+    removesFromSource,
+  }) => {
+    mockGetScheduledFutureMemberships.mockResolvedValue([
+      {
+        ...membership("u1", "pro_yearly"),
+        startAt: new Date(transitionAt),
+      },
+    ]);
+
+    const result = await syncSeatCount({
+      metronomeCustomerId: "cus_1",
+      contractId: "con_1",
+      workspace: WORKSPACE,
+      planCode: "CP_BUSINESS_PLAN",
+      contract: makeContract([
+        {
+          id: "sub_pro",
+          productId: "pro-product",
+          mode: "SEAT_BASED",
+          endingBefore: sourceEndingBefore,
+        },
+        {
+          id: "sub_pro_yearly",
+          productId: "pro-yearly-product",
+          mode: "SEAT_BASED",
+        },
+      ]),
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromSubscriptionId: "sub_pro_yearly",
+        addSeatIds: ["u1"],
+        startingAt: transitionAt,
+      })
+    );
+    const sourceRemoval = expect.objectContaining({
+      fromSubscriptionId: "sub_pro",
+      removeSeatIds: ["u1"],
+      startingAt: transitionAt,
+    });
+    if (removesFromSource) {
+      expect(mockUpdateSubscriptionSeats).toHaveBeenCalledWith(sourceRemoval);
+    } else {
+      expect(mockUpdateSubscriptionSeats).not.toHaveBeenCalledWith(
+        sourceRemoval
+      );
+    }
   });
 });


### PR DESCRIPTION
## Description

Seat reconciliation now ignores a subscription at timestamps equal to or later than its `ending_before`. This prevents Metronome from rejecting removals scheduled exactly at an expired source boundary, while destination subscriptions still receive their additions.

## Tests

Added SEAT_BASED and QUANTITY_ONLY regression coverage for transitions exactly at, 1 ms before, and 1 ms after the source subscription end, including the destination update.

## Risk

Low. The guard only suppresses writes outside a subscription's valid `[starting_at, ending_before)` interval. Rollback restores the prior behavior.

## Deploy Plan

Standard deploy. After deployment, terminate the existing retrying workflow and rerun Poke's Sync Metronome seats.