### PR TITLE
refactor: extract reusable analytics filter-panel components

### DIFF
--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -300,8 +300,13 @@ export function UsageFilterPanel({
                   renderIcon={(option) => (
                     <UsageFilterOptionIcon option={option} />
                   )}
-                  isLoading={isFacetsLoading}
-                  isUpdating={isFacetsValidating}
+                  status={
+                    isFacetsLoading
+                      ? "loading"
+                      : isFacetsValidating
+                        ? "updating"
+                        : "idle"
+                  }
                   scrollContainer={contentScrollContainer}
                 />
               )}

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -1,8 +1,13 @@
+import { FilterCategoryNav } from "@app/components/workspace/analytics/filterPanel/FilterCategoryNav";
+import { FilterFooter } from "@app/components/workspace/analytics/filterPanel/FilterFooter";
+import { FilterOptionCheckboxList } from "@app/components/workspace/analytics/filterPanel/FilterOptionCheckboxList";
+import { FilterSelectionSummary } from "@app/components/workspace/analytics/filterPanel/FilterSelectionSummary";
 import type {
   UsageFilter,
   UsageFilterAgentScope,
   UsageFilterCategory,
   UsageFilterGroup,
+  UsageFilterOption,
 } from "@app/components/workspace/analytics/usageFilter";
 import {
   toConsumptionScopeFilter,
@@ -12,13 +17,10 @@ import {
   usageFilterSelectionCount,
 } from "@app/components/workspace/analytics/usageFilter";
 import { UsageFilterAgentScopeControls } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterAgentScopeControls";
-import { UsageFilterCategoryNav } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterCategoryNav";
-import { UsageFilterFooter } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterFooter";
 import { UsageFilterMemberGroupsControls } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterMemberGroupsControls";
 import { UsageFilterModelComplexityControls } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls";
-import { UsageFilterOptionCheckboxList } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionCheckboxList";
+import { UsageFilterOptionIcon } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon";
 import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
-import { UsageFilterSelectionSummary } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSelectionSummary";
 import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilter";
 import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
@@ -162,6 +164,13 @@ export function UsageFilterPanel({
       ),
     [draftFilter]
   );
+  const categorySelectionCounts = useMemo(() => {
+    const counts: Partial<Record<UsageFilterCategory, number>> = {};
+    for (const category of USAGE_FILTER_CATEGORIES) {
+      counts[category] = draftFilter[category]?.length ?? 0;
+    }
+    return counts;
+  }, [draftFilter]);
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
@@ -205,9 +214,10 @@ export function UsageFilterPanel({
       </PopoverTrigger>
       <PopoverContent fullWidth align="end" className="w-auto rounded-2xl p-0">
         <div className="flex h-96 flex-row divide-x divide-border">
-          <UsageFilterCategoryNav
+          <FilterCategoryNav
             categories={USAGE_FILTER_CATEGORIES}
-            draftFilter={draftFilter}
+            categoryLabels={USAGE_FILTER_CATEGORY_LABEL}
+            selectionCounts={categorySelectionCounts}
             activeCategory={activeCategory}
             onCategoryChange={handleCategoryChange}
           />
@@ -273,9 +283,9 @@ export function UsageFilterPanel({
                   Failed to load filters.
                 </div>
               ) : (
-                <UsageFilterOptionCheckboxList
+                <FilterOptionCheckboxList
                   key={optionListKey}
-                  category={activeCategory}
+                  idPrefix={`usage-filter-option-${activeCategory}`}
                   categoryLabel={USAGE_FILTER_CATEGORY_LABEL[activeCategory]}
                   options={filteredOptions}
                   selectedIds={selectedIdsForActiveCategory}
@@ -287,6 +297,9 @@ export function UsageFilterPanel({
                   }
                   selectAllLabel="Select all"
                   hasSelectableOptions={unselectedEnabledOptions.length > 0}
+                  renderIcon={(option) => (
+                    <UsageFilterOptionIcon option={option} />
+                  )}
                   isLoading={isFacetsLoading}
                   isUpdating={isFacetsValidating}
                   scrollContainer={contentScrollContainer}
@@ -294,14 +307,16 @@ export function UsageFilterPanel({
               )}
             </div>
           </div>
-          <UsageFilterSelectionSummary
+          <FilterSelectionSummary<UsageFilterCategory, UsageFilterOption>
             categoriesWithSelection={categoriesWithSelection}
-            draftFilter={draftFilter}
+            categoryLabels={USAGE_FILTER_CATEGORY_LABEL}
+            filter={draftFilter}
             onClearCategory={clearCategory}
             onRemoveOption={removeOption}
+            renderIcon={(option) => <UsageFilterOptionIcon option={option} />}
           />
         </div>
-        <UsageFilterFooter
+        <FilterFooter
           onClearAll={clearAllCategories}
           onCancel={() => setIsOpen(false)}
           onApply={() => {

--- a/front/components/workspace/analytics/UsageFilterSummary.tsx
+++ b/front/components/workspace/analytics/UsageFilterSummary.tsx
@@ -1,108 +1,26 @@
-import type {
-  UsageFilter,
-  UsageFilterSummary as UsageFilterSummaryType,
-} from "@app/components/workspace/analytics/usageFilter";
+import { FilterSummaryChips } from "@app/components/workspace/analytics/filterPanel/FilterSummaryChips";
+import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
 import {
   clearUsageFilterCategory,
   getUsageFilterSummaries,
 } from "@app/components/workspace/analytics/usageFilter";
-import { Button, Chip } from "@dust-tt/sparkle";
-import { AnimatePresence, m, useReducedMotion } from "framer-motion";
-import { Fragment } from "react";
 
 interface UsageFilterSummaryProps {
   filter: UsageFilter;
   onFilterChange: (filter: UsageFilter) => void;
 }
 
-function SummaryLabel({
-  categoryLabel,
-  options,
-}: Pick<UsageFilterSummaryType, "categoryLabel" | "options">) {
-  return (
-    <span className="min-w-0 truncate text-xs font-medium">
-      <span className="font-bold">{categoryLabel}</span>
-      <span> is </span>
-      {options.map((option, index) => (
-        <Fragment key={option.id}>
-          {index > 0 && <span> or </span>}
-          <span className="font-bold">{option.name}</span>
-        </Fragment>
-      ))}
-    </span>
-  );
-}
-
 export function UsageFilterSummary({
   filter,
   onFilterChange,
 }: UsageFilterSummaryProps) {
-  const summaries = getUsageFilterSummaries(filter);
-  const shouldReduceMotion = useReducedMotion();
-  const transition = shouldReduceMotion
-    ? { duration: 0 }
-    : { duration: 0.18, ease: "easeOut" as const };
-
   return (
-    <AnimatePresence initial={false}>
-      {summaries.length > 0 && (
-        <m.div
-          key="usage-filter-summary"
-          initial={
-            shouldReduceMotion ? false : { opacity: 0, scale: 0.98, y: -4 }
-          }
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          exit={
-            shouldReduceMotion ? undefined : { opacity: 0, scale: 0.98, y: -4 }
-          }
-          transition={transition}
-          className="mt-2 origin-top"
-        >
-          <div className="flex flex-wrap items-center gap-2">
-            <AnimatePresence initial={false}>
-              {summaries.map((summary) => (
-                <m.div
-                  key={summary.category}
-                  layout={!shouldReduceMotion}
-                  initial={
-                    shouldReduceMotion ? false : { opacity: 0, scale: 0.96 }
-                  }
-                  animate={{ opacity: 1, scale: 1 }}
-                  exit={
-                    shouldReduceMotion ? undefined : { opacity: 0, scale: 0.96 }
-                  }
-                  transition={transition}
-                  className="max-w-full"
-                >
-                  <Chip
-                    size="xs"
-                    color="highlight"
-                    className="max-w-full"
-                    onRemove={() =>
-                      onFilterChange(
-                        clearUsageFilterCategory(filter, summary.category)
-                      )
-                    }
-                  >
-                    <SummaryLabel
-                      categoryLabel={summary.categoryLabel}
-                      options={summary.options}
-                    />
-                  </Chip>
-                </m.div>
-              ))}
-            </AnimatePresence>
-            <m.div layout={!shouldReduceMotion} transition={transition}>
-              <Button
-                label="Clear all"
-                size="xs"
-                variant="ghost-secondary"
-                onClick={() => onFilterChange({})}
-              />
-            </m.div>
-          </div>
-        </m.div>
-      )}
-    </AnimatePresence>
+    <FilterSummaryChips
+      summaries={getUsageFilterSummaries(filter)}
+      onClearCategory={(category) =>
+        onFilterChange(clearUsageFilterCategory(filter, category))
+      }
+      onClearAll={() => onFilterChange({})}
+    />
   );
 }

--- a/front/components/workspace/analytics/filterPanel/FilterAvailabilityStatus.tsx
+++ b/front/components/workspace/analytics/filterPanel/FilterAvailabilityStatus.tsx
@@ -1,13 +1,15 @@
-interface UsageFilterAvailabilityStatusProps {
+interface FilterAvailabilityStatusProps {
   id?: string;
+  label?: string;
 }
 
-export function UsageFilterAvailabilityStatus({
+export function FilterAvailabilityStatus({
   id,
-}: UsageFilterAvailabilityStatusProps) {
+  label = "No activity",
+}: FilterAvailabilityStatusProps) {
   return (
     <span id={id} className="ml-auto shrink-0 text-xs font-normal text-faint">
-      No activity
+      {label}
       <span className="sr-only"> for the selected period and filters</span>
     </span>
   );

--- a/front/components/workspace/analytics/filterPanel/FilterCategoryNav.tsx
+++ b/front/components/workspace/analytics/filterPanel/FilterCategoryNav.tsx
@@ -1,8 +1,3 @@
-import type {
-  UsageFilter,
-  UsageFilterCategory,
-} from "@app/components/workspace/analytics/usageFilter";
-import { USAGE_FILTER_CATEGORY_LABEL } from "@app/components/workspace/analytics/usageFilter";
 import {
   Counter,
   NavigationList,
@@ -10,19 +5,21 @@ import {
   NavigationListLabel,
 } from "@dust-tt/sparkle";
 
-interface UsageFilterCategoryNavProps {
-  categories: readonly UsageFilterCategory[];
-  draftFilter: UsageFilter;
-  activeCategory: UsageFilterCategory;
-  onCategoryChange: (category: UsageFilterCategory) => void;
+interface FilterCategoryNavProps<Category extends string> {
+  categories: readonly Category[];
+  categoryLabels: Record<Category, string>;
+  selectionCounts: Partial<Record<Category, number>>;
+  activeCategory: Category;
+  onCategoryChange: (category: Category) => void;
 }
 
-export function UsageFilterCategoryNav({
+export function FilterCategoryNav<Category extends string>({
   categories,
-  draftFilter,
+  categoryLabels,
+  selectionCounts,
   activeCategory,
   onCategoryChange,
-}: UsageFilterCategoryNavProps) {
+}: FilterCategoryNavProps<Category>) {
   return (
     <div className="flex h-full w-44 flex-col p-2">
       <NavigationListLabel
@@ -31,7 +28,7 @@ export function UsageFilterCategoryNav({
       />
       <NavigationList role="tablist" className="min-h-0 flex-1">
         {categories.map((category) => {
-          const selectionCount = draftFilter[category]?.length ?? 0;
+          const selectionCount = selectionCounts[category] ?? 0;
           return (
             <button
               type="button"
@@ -45,7 +42,7 @@ export function UsageFilterCategoryNav({
                 selected={category === activeCategory}
                 avatar={
                   <span className="label-sm grow overflow-hidden text-ellipsis whitespace-nowrap primary-dark">
-                    {USAGE_FILTER_CATEGORY_LABEL[category]}
+                    {categoryLabels[category]}
                   </span>
                 }
                 suffix={

--- a/front/components/workspace/analytics/filterPanel/FilterFooter.tsx
+++ b/front/components/workspace/analytics/filterPanel/FilterFooter.tsx
@@ -1,16 +1,16 @@
 import { Button } from "@dust-tt/sparkle";
 
-interface UsageFilterFooterProps {
+interface FilterFooterProps {
   onClearAll: () => void;
   onCancel: () => void;
   onApply: () => void;
 }
 
-export function UsageFilterFooter({
+export function FilterFooter({
   onClearAll,
   onCancel,
   onApply,
-}: UsageFilterFooterProps) {
+}: FilterFooterProps) {
   return (
     <div className="flex items-center justify-between border-t border-border p-2">
       <Button

--- a/front/components/workspace/analytics/filterPanel/FilterOptionCheckboxList.tsx
+++ b/front/components/workspace/analytics/filterPanel/FilterOptionCheckboxList.tsx
@@ -27,6 +27,12 @@ function FilterOptionListSkeleton() {
   );
 }
 
+export type FilterOptionListStatus =
+  | "idle"
+  | "loading"
+  | "loading-more"
+  | "updating";
+
 interface FilterOptionCheckboxListProps<Option extends FilterOptionBase> {
   idPrefix: string;
   categoryLabel: string;
@@ -37,9 +43,7 @@ interface FilterOptionCheckboxListProps<Option extends FilterOptionBase> {
   selectAllLabel: string;
   hasSelectableOptions: boolean;
   renderIcon?: (option: Option) => ReactNode;
-  isLoadingMore?: boolean;
-  isLoading?: boolean;
-  isUpdating?: boolean;
+  status?: FilterOptionListStatus;
   scrollContainer: HTMLDivElement | null;
 }
 
@@ -53,11 +57,12 @@ export function FilterOptionCheckboxList<Option extends FilterOptionBase>({
   selectAllLabel,
   hasSelectableOptions,
   renderIcon,
-  isLoadingMore = false,
-  isLoading = false,
-  isUpdating = false,
+  status = "idle",
   scrollContainer,
 }: FilterOptionCheckboxListProps<Option>) {
+  const isLoading = status === "loading";
+  const isUpdating = status === "updating";
+  const isLoadingMore = status === "loading-more";
   // Reset on category/search/scope change by remounting this component with
   // a fresh `key` from the parent instead of tracking a reset key here.
   const [visibleCount, setVisibleCount] = useState(FILTER_PICKER_PAGE_SIZE);

--- a/front/components/workspace/analytics/filterPanel/FilterOptionCheckboxList.tsx
+++ b/front/components/workspace/analytics/filterPanel/FilterOptionCheckboxList.tsx
@@ -1,11 +1,7 @@
 import { InfiniteScroll } from "@app/components/InfiniteScroll";
-import type {
-  UsageFilterCategory,
-  UsageFilterOption,
-} from "@app/components/workspace/analytics/usageFilter";
-import { FILTER_PICKER_PAGE_SIZE } from "@app/components/workspace/analytics/usageFilterPanel/constants";
-import { UsageFilterAvailabilityStatus } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterAvailabilityStatus";
-import { UsageFilterOptionIcon } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon";
+import { FILTER_PICKER_PAGE_SIZE } from "@app/components/workspace/analytics/filterPanel/constants";
+import { FilterAvailabilityStatus } from "@app/components/workspace/analytics/filterPanel/FilterAvailabilityStatus";
+import type { FilterOptionBase } from "@app/components/workspace/analytics/filterPanel/filterState";
 import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import {
   Button,
@@ -14,9 +10,10 @@ import {
   LoadingBlock,
   Spinner,
 } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useState } from "react";
 
-function UsageFilterOptionListSkeleton() {
+function FilterOptionListSkeleton() {
   return (
     <div aria-hidden="true" className="flex flex-col gap-0.5">
       {["w-24", "w-32", "w-20", "w-36", "w-28", "w-24"].map((width, index) => (
@@ -30,23 +27,24 @@ function UsageFilterOptionListSkeleton() {
   );
 }
 
-interface UsageFilterOptionCheckboxListProps {
-  category: UsageFilterCategory;
+interface FilterOptionCheckboxListProps<Option extends FilterOptionBase> {
+  idPrefix: string;
   categoryLabel: string;
-  options: UsageFilterOption[];
+  options: Option[];
   selectedIds: Set<string>;
-  onToggleOption: (option: UsageFilterOption) => void;
+  onToggleOption: (option: Option) => void;
   onSelectAll: () => void;
   selectAllLabel: string;
   hasSelectableOptions: boolean;
+  renderIcon?: (option: Option) => ReactNode;
   isLoadingMore?: boolean;
   isLoading?: boolean;
   isUpdating?: boolean;
   scrollContainer: HTMLDivElement | null;
 }
 
-export function UsageFilterOptionCheckboxList({
-  category,
+export function FilterOptionCheckboxList<Option extends FilterOptionBase>({
+  idPrefix,
   categoryLabel,
   options,
   selectedIds,
@@ -54,11 +52,12 @@ export function UsageFilterOptionCheckboxList({
   onSelectAll,
   selectAllLabel,
   hasSelectableOptions,
+  renderIcon,
   isLoadingMore = false,
   isLoading = false,
   isUpdating = false,
   scrollContainer,
-}: UsageFilterOptionCheckboxListProps) {
+}: FilterOptionCheckboxListProps<Option>) {
   // Reset on category/search/scope change by remounting this component with
   // a fresh `key` from the parent instead of tracking a reset key here.
   const [visibleCount, setVisibleCount] = useState(FILTER_PICKER_PAGE_SIZE);
@@ -89,13 +88,13 @@ export function UsageFilterOptionCheckboxList({
         className="flex flex-col gap-0.5"
       >
         {isLoading && options.length === 0 ? (
-          <UsageFilterOptionListSkeleton />
+          <FilterOptionListSkeleton />
         ) : displayedOptions.length > 0 ? (
           <>
             {displayedOptions.map((option) => {
               const checked = selectedIds.has(option.id);
               const disabled = option.disabled && !checked;
-              const checkboxId = `usage-filter-option-${category}-${option.id}`;
+              const checkboxId = `${idPrefix}-${option.id}`;
               const availabilityDescriptionId = option.disabled
                 ? `${checkboxId}-availability`
                 : undefined;
@@ -118,7 +117,7 @@ export function UsageFilterOptionCheckboxList({
                       }
                     }}
                   />
-                  <UsageFilterOptionIcon option={option} />
+                  {renderIcon?.(option)}
                   <Label
                     htmlFor={checkboxId}
                     className={
@@ -130,9 +129,7 @@ export function UsageFilterOptionCheckboxList({
                     <span className="block truncate">{option.name}</span>
                   </Label>
                   {option.disabled && (
-                    <UsageFilterAvailabilityStatus
-                      id={availabilityDescriptionId}
-                    />
+                    <FilterAvailabilityStatus id={availabilityDescriptionId} />
                   )}
                 </div>
               );

--- a/front/components/workspace/analytics/filterPanel/FilterSelectionSummary.tsx
+++ b/front/components/workspace/analytics/filterPanel/FilterSelectionSummary.tsx
@@ -1,9 +1,7 @@
 import type {
-  UsageFilter,
-  UsageFilterCategory,
-} from "@app/components/workspace/analytics/usageFilter";
-import { USAGE_FILTER_CATEGORY_LABEL } from "@app/components/workspace/analytics/usageFilter";
-import { UsageFilterOptionIcon } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon";
+  CategoryFilter,
+  FilterOptionBase,
+} from "@app/components/workspace/analytics/filterPanel/filterState";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import {
   Button,
@@ -16,28 +14,39 @@ import {
   NavigationListLabel,
   XClose,
 } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useState } from "react";
 
-interface UsageFilterSelectionSummaryProps {
-  categoriesWithSelection: UsageFilterCategory[];
-  draftFilter: UsageFilter;
-  onClearCategory: (category: UsageFilterCategory) => void;
-  onRemoveOption: (category: UsageFilterCategory, id: string) => void;
+interface FilterSelectionSummaryProps<
+  Category extends string,
+  Option extends FilterOptionBase,
+> {
+  categoriesWithSelection: Category[];
+  categoryLabels: Record<Category, string>;
+  filter: CategoryFilter<Category, Option>;
+  onClearCategory: (category: Category) => void;
+  onRemoveOption: (category: Category, id: string) => void;
+  renderIcon?: (option: Option) => ReactNode;
 }
 
-export function UsageFilterSelectionSummary({
+export function FilterSelectionSummary<
+  Category extends string,
+  Option extends FilterOptionBase,
+>({
   categoriesWithSelection,
-  draftFilter,
+  categoryLabels,
+  filter,
   onClearCategory,
   onRemoveOption,
-}: UsageFilterSelectionSummaryProps) {
+  renderIcon,
+}: FilterSelectionSummaryProps<Category, Option>) {
   // Sections are open by default; a category lands here once the user
   // collapses it.
-  const [collapsedCategories, setCollapsedCategories] = useState<
-    Set<UsageFilterCategory>
-  >(new Set());
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<Category>>(
+    new Set()
+  );
 
-  const handleToggleCategoryOpen = (category: UsageFilterCategory) => {
+  const handleToggleCategoryOpen = (category: Category) => {
     setCollapsedCategories((current) => {
       const next = new Set(current);
       if (next.has(category)) {
@@ -50,7 +59,7 @@ export function UsageFilterSelectionSummary({
   };
 
   const selectionCount = categoriesWithSelection.reduce(
-    (total, category) => total + (draftFilter[category]?.length ?? 0),
+    (total, category) => total + (filter[category]?.length ?? 0),
     0
   );
 
@@ -68,7 +77,7 @@ export function UsageFilterSelectionSummary({
               <div key={category}>
                 <NavigationListLabel
                   className="bg-transparent font-medium"
-                  label={`${USAGE_FILTER_CATEGORY_LABEL[category]} (${draftFilter[category]?.length ?? 0})`}
+                  label={`${categoryLabels[category]} (${filter[category]?.length ?? 0})`}
                   action={
                     <div className="flex items-center gap-1">
                       <Button
@@ -89,12 +98,12 @@ export function UsageFilterSelectionSummary({
                 />
                 <Collapsible open={isCategoryOpen}>
                   <CollapsibleContent>
-                    {(draftFilter[category] ?? []).map((option) => (
+                    {(filter[category] ?? []).map((option) => (
                       <NavigationListItem
                         key={`${category}:${option.id}`}
                         avatar={
                           <div className="flex grow items-center gap-2 overflow-hidden">
-                            <UsageFilterOptionIcon option={option} />
+                            {renderIcon?.(option)}
                             <span className="label-sm overflow-hidden text-ellipsis whitespace-nowrap primary-dark">
                               {option.name}
                             </span>

--- a/front/components/workspace/analytics/filterPanel/FilterSummaryChips.tsx
+++ b/front/components/workspace/analytics/filterPanel/FilterSummaryChips.tsx
@@ -1,0 +1,98 @@
+import type { FilterSummary } from "@app/components/workspace/analytics/filterPanel/filterState";
+import { Button, Chip } from "@dust-tt/sparkle";
+import { AnimatePresence, m, useReducedMotion } from "framer-motion";
+import { Fragment } from "react";
+
+function SummaryLabel({
+  categoryLabel,
+  options,
+}: Pick<FilterSummary<string>, "categoryLabel" | "options">) {
+  return (
+    <span className="min-w-0 truncate text-xs font-medium">
+      <span className="font-bold">{categoryLabel}</span>
+      <span> is </span>
+      {options.map((option, index) => (
+        <Fragment key={option.id}>
+          {index > 0 && <span> or </span>}
+          <span className="font-bold">{option.name}</span>
+        </Fragment>
+      ))}
+    </span>
+  );
+}
+
+interface FilterSummaryChipsProps<Category extends string> {
+  summaries: FilterSummary<Category>[];
+  onClearCategory: (category: Category) => void;
+  onClearAll: () => void;
+}
+
+export function FilterSummaryChips<Category extends string>({
+  summaries,
+  onClearCategory,
+  onClearAll,
+}: FilterSummaryChipsProps<Category>) {
+  const shouldReduceMotion = useReducedMotion();
+  const transition = shouldReduceMotion
+    ? { duration: 0 }
+    : { duration: 0.18, ease: "easeOut" as const };
+
+  return (
+    <AnimatePresence initial={false}>
+      {summaries.length > 0 && (
+        <m.div
+          key="filter-summary-chips"
+          initial={
+            shouldReduceMotion ? false : { opacity: 0, scale: 0.98, y: -4 }
+          }
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={
+            shouldReduceMotion ? undefined : { opacity: 0, scale: 0.98, y: -4 }
+          }
+          transition={transition}
+          className="mt-2 origin-top"
+        >
+          <div className="flex flex-wrap items-center gap-2">
+            <AnimatePresence initial={false}>
+              {summaries.map((summary) => (
+                <m.div
+                  key={summary.category}
+                  layout={!shouldReduceMotion}
+                  initial={
+                    shouldReduceMotion ? false : { opacity: 0, scale: 0.96 }
+                  }
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={
+                    shouldReduceMotion ? undefined : { opacity: 0, scale: 0.96 }
+                  }
+                  transition={transition}
+                  className="max-w-full"
+                >
+                  <Chip
+                    size="xs"
+                    color="highlight"
+                    className="max-w-full"
+                    onRemove={() => onClearCategory(summary.category)}
+                  >
+                    <SummaryLabel
+                      categoryLabel={summary.categoryLabel}
+                      options={summary.options}
+                    />
+                  </Chip>
+                </m.div>
+              ))}
+            </AnimatePresence>
+            <m.div layout={!shouldReduceMotion} transition={transition}>
+              <Button
+                label="Clear all"
+                size="xs"
+                variant="ghost-secondary"
+                onClick={onClearAll}
+              />
+            </m.div>
+          </div>
+        </m.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/front/components/workspace/analytics/filterPanel/constants.ts
+++ b/front/components/workspace/analytics/filterPanel/constants.ts
@@ -1,0 +1,1 @@
+export const FILTER_PICKER_PAGE_SIZE = 50;

--- a/front/components/workspace/analytics/filterPanel/constants.ts
+++ b/front/components/workspace/analytics/filterPanel/constants.ts
@@ -1,1 +1,1 @@
-export const FILTER_PICKER_PAGE_SIZE = 50;
+export const FILTER_PICKER_PAGE_SIZE = 100;

--- a/front/components/workspace/analytics/filterPanel/filterState.ts
+++ b/front/components/workspace/analytics/filterPanel/filterState.ts
@@ -1,0 +1,113 @@
+// Generic filter-selection state, shared by every analytics filter panel
+// (consumption, automations, ...). Each panel picks its own category union
+// and option shape; these helpers only assume `{id}`-shaped options keyed by
+// a category.
+
+export interface FilterOptionBase {
+  id: string;
+  name: string;
+  disabled: boolean;
+}
+
+export type CategoryFilter<
+  Category extends string,
+  Option extends FilterOptionBase,
+> = Partial<Record<Category, Option[]>>;
+
+export interface FilterSummary<Category extends string> {
+  category: Category;
+  categoryLabel: string;
+  options: Array<{ id: string; name: string }>;
+}
+
+export function getFilterSummaries<
+  Category extends string,
+  Option extends FilterOptionBase,
+>(
+  filter: CategoryFilter<Category, Option>,
+  categories: readonly Category[],
+  categoryLabels: Record<Category, string>
+): FilterSummary<Category>[] {
+  return categories.flatMap((category) => {
+    const options = filter[category];
+    if (!options?.length) {
+      return [];
+    }
+
+    return [
+      {
+        category,
+        categoryLabel: categoryLabels[category],
+        options: options.map(({ id, name }) => ({ id, name })),
+      },
+    ];
+  });
+}
+
+export function filterSelectionCount<
+  Category extends string,
+  Option extends FilterOptionBase,
+>(
+  filter: CategoryFilter<Category, Option>,
+  categories: readonly Category[]
+): number {
+  return categories.reduce(
+    (count, category) => count + (filter[category]?.length ?? 0),
+    0
+  );
+}
+
+export function toggleFilterOption<
+  Category extends string,
+  Option extends FilterOptionBase,
+>(
+  filter: CategoryFilter<Category, Option>,
+  category: Category,
+  option: Option
+): CategoryFilter<Category, Option> {
+  const current = filter[category] ?? [];
+  const isSelected = current.some((e) => e.id === option.id);
+  const next = isSelected
+    ? current.filter((e) => e.id !== option.id)
+    : [...current, option];
+  return { ...filter, [category]: next.length > 0 ? next : undefined };
+}
+
+export function removeFilterOption<
+  Category extends string,
+  Option extends FilterOptionBase,
+>(
+  filter: CategoryFilter<Category, Option>,
+  category: Category,
+  id: string
+): CategoryFilter<Category, Option> {
+  const next = (filter[category] ?? []).filter((e) => e.id !== id);
+  return { ...filter, [category]: next.length > 0 ? next : undefined };
+}
+
+export function clearFilterCategory<
+  Category extends string,
+  Option extends FilterOptionBase,
+>(
+  filter: CategoryFilter<Category, Option>,
+  category: Category
+): CategoryFilter<Category, Option> {
+  return { ...filter, [category]: undefined };
+}
+
+export function selectAllFilterOptions<
+  Category extends string,
+  Option extends FilterOptionBase,
+>(
+  filter: CategoryFilter<Category, Option>,
+  category: Category,
+  options: Option[]
+): CategoryFilter<Category, Option> {
+  const current = filter[category] ?? [];
+  const currentIds = new Set(current.map((e) => e.id));
+  const additions = options.filter((e) => !currentIds.has(e.id));
+  if (additions.length === 0) {
+    return filter;
+  }
+  return { ...filter, [category]: [...current, ...additions] };
+}

--- a/front/components/workspace/analytics/filterPanel/useFilterDraft.ts
+++ b/front/components/workspace/analytics/filterPanel/useFilterDraft.ts
@@ -1,0 +1,54 @@
+import type {
+  CategoryFilter,
+  FilterOptionBase,
+} from "@app/components/workspace/analytics/filterPanel/filterState";
+import {
+  clearFilterCategory,
+  removeFilterOption,
+  selectAllFilterOptions,
+  toggleFilterOption,
+} from "@app/components/workspace/analytics/filterPanel/filterState";
+import { useCallback, useState } from "react";
+
+// Selections are staged in a local draft while a filter panel is open and
+// only propagated to the caller when the user applies them.
+export function useFilterDraft<
+  Category extends string,
+  Option extends FilterOptionBase,
+>(initialFilter: CategoryFilter<Category, Option>) {
+  const [draftFilter, setDraftFilter] =
+    useState<CategoryFilter<Category, Option>>(initialFilter);
+
+  const clearAllCategories = useCallback(() => {
+    setDraftFilter({});
+  }, []);
+
+  const clearCategory = useCallback((category: Category) => {
+    setDraftFilter((prev) => clearFilterCategory(prev, category));
+  }, []);
+
+  const toggleOption = useCallback((category: Category, option: Option) => {
+    setDraftFilter((prev) => toggleFilterOption(prev, category, option));
+  }, []);
+
+  const removeOption = useCallback((category: Category, id: string) => {
+    setDraftFilter((prev) => removeFilterOption(prev, category, id));
+  }, []);
+
+  const selectAllFiltered = useCallback(
+    (category: Category, options: Option[]) => {
+      setDraftFilter((prev) => selectAllFilterOptions(prev, category, options));
+    },
+    []
+  );
+
+  return {
+    draftFilter,
+    setDraftFilter,
+    clearAllCategories,
+    clearCategory,
+    toggleOption,
+    removeOption,
+    selectAllFiltered,
+  };
+}

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -1,7 +1,7 @@
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { FilterAvailabilityStatus } from "@app/components/workspace/analytics/filterPanel/FilterAvailabilityStatus";
 import type { UsageFilterModelOption } from "@app/components/workspace/analytics/usageFilter";
-import { UsageFilterAvailabilityStatus } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterAvailabilityStatus";
 import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import {
@@ -58,7 +58,7 @@ function getModelSelectionStatus({
 
   return (
     <div className="flex items-center gap-2">
-      {isUnavailable && <UsageFilterAvailabilityStatus />}
+      {isUnavailable && <FilterAvailabilityStatus />}
       {isSelected && (
         <Icon visual={Check} size="sm" className="text-muted-foreground" />
       )}

--- a/front/components/workspace/analytics/usageFilterPanel/constants.ts
+++ b/front/components/workspace/analytics/usageFilterPanel/constants.ts
@@ -1,2 +1,0 @@
-// Chunk size for the infinite scroll
-export const FILTER_PICKER_PAGE_SIZE = 100;


### PR DESCRIPTION
## Description

Extracts the reusable analytics filter-panel building blocks from the consumption usage-filter implementation into a generic `filterPanel/` module. The new components cover category navigation, option checkboxes, selection summaries, footer actions, availability status, and summary chips; shared filter-state types and helpers provide category/option-generic selection, clearing, removal, and select-all behavior.

This provides the reusable UI groundwork for the analytics automations page. The following stacked PR, [#30645](https://github.com/dust-tt/dust/pull/30645), builds an `AutomationsFilterPanel` for agent, member, and type filters on top of these generic components; the preceding stacked PR, [#30624](https://github.com/dust-tt/dust/pull/30624), adds the automations analytics trigger-breakdown row that the page will support.

## Tests
- Local testing

## Risk

Low This is a front-end refactor only. The main compatibility surface is the consumption analytics filter UI, which now uses the extracted generic components.  Reverting this PR restores the previous component structure and constant.

## Deploy Plan

- Deploy front
