### PR TITLE
feat: filter panel for the automations analytics page

### DIFF
--- a/front/components/workspace/analytics/automations/AutomationsFilterOptionIcon.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterOptionIcon.tsx
@@ -1,0 +1,36 @@
+import type { AutomationsFilterOption } from "@app/components/workspace/analytics/automationsFilter";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { Avatar } from "@dust-tt/sparkle";
+
+interface AutomationsFilterOptionIconProps {
+  option: AutomationsFilterOption;
+}
+
+export function AutomationsFilterOptionIcon({
+  option,
+}: AutomationsFilterOptionIconProps) {
+  switch (option.category) {
+    case "agent":
+      return (
+        <Avatar
+          name={option.name}
+          visual={option.image ?? undefined}
+          size="xxs"
+        />
+      );
+    case "member":
+      return (
+        <Avatar
+          name={option.name}
+          visual={option.image ?? undefined}
+          size="xxs"
+          isRounded
+        />
+      );
+    case "type":
+      return null;
+    default:
+      assertNeverAndIgnore(option.category);
+      return null;
+  }
+}

--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -58,6 +58,8 @@ export function AutomationsFilterPanel({
   const [activeCategory, setActiveCategory] =
     useState<AutomationsFilterCategory>("agent");
   const [searchText, setSearchText] = useState("");
+  const [contentScrollContainer, setContentScrollContainer] =
+    useState<HTMLDivElement | null>(null);
 
   const isAgentCategoryActive = isOpen && activeCategory === "agent";
   const { agentConfigurations, isAgentConfigurationsLoading } =
@@ -147,9 +149,21 @@ export function AutomationsFilterPanel({
     }
   };
 
+  const resetContentScroll = () => {
+    if (contentScrollContainer) {
+      contentScrollContainer.scrollTop = 0;
+    }
+  };
+
   const handleCategoryChange = (category: AutomationsFilterCategory) => {
     setActiveCategory(category);
     setSearchText("");
+    resetContentScroll();
+  };
+
+  const handleSearchChange = (search: string) => {
+    setSearchText(search);
+    resetContentScroll();
   };
 
   const activeCategorySelectionCount = draftFilter[activeCategory]?.length ?? 0;
@@ -195,21 +209,31 @@ export function AutomationsFilterPanel({
             <SearchInput
               name="automations-filter-search"
               value={searchText}
-              onChange={setSearchText}
+              onChange={handleSearchChange}
               placeholder={`Search ${AUTOMATIONS_FILTER_CATEGORY_LABEL[activeCategory].toLowerCase()}`}
             />
-            <FilterOptionCheckboxList
-              key={`${isOpen}|${activeCategory}|${searchText}`}
-              idPrefix={`automations-filter-option-${activeCategory}`}
-              categoryLabel={AUTOMATIONS_FILTER_CATEGORY_LABEL[activeCategory]}
-              options={filteredOptions}
-              selectedIds={selectedIdsForActiveCategory}
-              onToggleOption={(option) => toggleOption(activeCategory, option)}
-              renderIcon={(option) => (
-                <AutomationsFilterOptionIcon option={option} />
-              )}
-              status={isOptionsLoading ? "loading" : "idle"}
-            />
+            <div
+              ref={setContentScrollContainer}
+              className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
+            >
+              <FilterOptionCheckboxList
+                key={`${isOpen}|${activeCategory}|${searchText}`}
+                idPrefix={`automations-filter-option-${activeCategory}`}
+                categoryLabel={
+                  AUTOMATIONS_FILTER_CATEGORY_LABEL[activeCategory]
+                }
+                options={filteredOptions}
+                selectedIds={selectedIdsForActiveCategory}
+                onToggleOption={(option) =>
+                  toggleOption(activeCategory, option)
+                }
+                renderIcon={(option) => (
+                  <AutomationsFilterOptionIcon option={option} />
+                )}
+                status={isOptionsLoading ? "loading" : "idle"}
+                scrollContainer={contentScrollContainer}
+              />
+            </div>
           </div>
           <FilterSelectionSummary<
             AutomationsFilterCategory,

--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -54,7 +54,6 @@ export function AutomationsFilterPanel({
     clearCategory,
     toggleOption,
     removeOption,
-    selectAllFiltered,
   } = useAutomationsFilter(filter);
   const [activeCategory, setActiveCategory] =
     useState<AutomationsFilterCategory>("agent");
@@ -124,12 +123,6 @@ export function AutomationsFilterPanel({
       new Set((draftFilter[activeCategory] ?? []).map((option) => option.id)),
     [draftFilter, activeCategory]
   );
-  const unselectedOptions = filteredOptions.filter(
-    (option) => !selectedIdsForActiveCategory.has(option.id)
-  );
-  const hasSelectableOptions =
-    activeCategory !== "member" && unselectedOptions.length > 0;
-
   const appliedSelectionCount = automationsFilterSelectionCount(filter);
   const categoriesWithSelection = useMemo(
     () =>
@@ -212,15 +205,10 @@ export function AutomationsFilterPanel({
               options={filteredOptions}
               selectedIds={selectedIdsForActiveCategory}
               onToggleOption={(option) => toggleOption(activeCategory, option)}
-              onSelectAll={() =>
-                selectAllFiltered(activeCategory, unselectedOptions)
-              }
-              selectAllLabel="Select all"
-              hasSelectableOptions={hasSelectableOptions}
               renderIcon={(option) => (
                 <AutomationsFilterOptionIcon option={option} />
               )}
-              isLoading={isOptionsLoading}
+              status={isOptionsLoading ? "loading" : "idle"}
             />
           </div>
           <FilterSelectionSummary<

--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -1,0 +1,249 @@
+import { AutomationsFilterOptionIcon } from "@app/components/workspace/analytics/automations/AutomationsFilterOptionIcon";
+import type {
+  AutomationsFilter,
+  AutomationsFilterCategory,
+  AutomationsFilterOption,
+} from "@app/components/workspace/analytics/automationsFilter";
+import {
+  AUTOMATIONS_FILTER_CATEGORIES,
+  AUTOMATIONS_FILTER_CATEGORY_LABEL,
+  automationsFilterSelectionCount,
+} from "@app/components/workspace/analytics/automationsFilter";
+import { FilterCategoryNav } from "@app/components/workspace/analytics/filterPanel/FilterCategoryNav";
+import { FilterFooter } from "@app/components/workspace/analytics/filterPanel/FilterFooter";
+import { FilterOptionCheckboxList } from "@app/components/workspace/analytics/filterPanel/FilterOptionCheckboxList";
+import { FilterSelectionSummary } from "@app/components/workspace/analytics/filterPanel/FilterSelectionSummary";
+import { useAutomationsFilter } from "@app/components/workspace/analytics/useAutomationsFilter";
+import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import { useSearchMembers } from "@app/lib/swr/memberships";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  FilterFunnel01,
+  NavigationListLabel,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+  SearchInput,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+const MEMBERS_PAGE_SIZE = 25;
+
+const TYPE_OPTIONS: AutomationsFilterOption[] = [
+  { id: "schedule", name: "Schedule", disabled: false, category: "type" },
+  { id: "webhook", name: "Webhook", disabled: false, category: "type" },
+];
+
+interface AutomationsFilterPanelProps {
+  owner: LightWorkspaceType;
+  filter: AutomationsFilter;
+  onFilterChange: (next: AutomationsFilter) => void;
+}
+
+export function AutomationsFilterPanel({
+  owner,
+  filter,
+  onFilterChange,
+}: AutomationsFilterPanelProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const {
+    draftFilter,
+    setDraftFilter,
+    clearAllCategories,
+    clearCategory,
+    toggleOption,
+    removeOption,
+    selectAllFiltered,
+  } = useAutomationsFilter(filter);
+  const [activeCategory, setActiveCategory] =
+    useState<AutomationsFilterCategory>("agent");
+  const [searchText, setSearchText] = useState("");
+
+  const isAgentCategoryActive = isOpen && activeCategory === "agent";
+  const { agentConfigurations, isAgentConfigurationsLoading } =
+    useAgentConfigurations({
+      workspaceId: owner.sId,
+      agentsGetView: isAgentCategoryActive ? "manage" : null,
+      sort: "alphabetical",
+    });
+
+  const isMemberCategoryActive = isOpen && activeCategory === "member";
+  const { members, isLoading: isMembersLoading } = useSearchMembers({
+    workspaceId: owner.sId,
+    searchTerm: isMemberCategoryActive ? searchText : "",
+    pageIndex: 0,
+    pageSize: MEMBERS_PAGE_SIZE,
+    disabled: !isMemberCategoryActive,
+  });
+
+  const categoryOptions = useMemo<
+    Record<AutomationsFilterCategory, AutomationsFilterOption[]>
+  >(
+    () => ({
+      agent: agentConfigurations.map((agent) => ({
+        id: agent.sId,
+        name: agent.name,
+        disabled: false,
+        image: agent.pictureUrl,
+        category: "agent",
+      })),
+      member: members.map((member) => ({
+        id: member.sId,
+        name: member.fullName,
+        disabled: false,
+        image: member.image,
+        category: "member",
+      })),
+      type: TYPE_OPTIONS,
+    }),
+    [agentConfigurations, members]
+  );
+
+  const isOptionsLoading =
+    (activeCategory === "agent" && isAgentConfigurationsLoading) ||
+    (activeCategory === "member" && isMembersLoading);
+
+  const activeOptions = categoryOptions[activeCategory];
+  // Member search is applied server-side; agent and type options are
+  // filtered client-side against the small, already-fetched list.
+  const filteredOptions = useMemo(() => {
+    if (activeCategory === "member") {
+      return activeOptions;
+    }
+    const search = searchText.trim().toLowerCase();
+    return search
+      ? activeOptions.filter((option) =>
+          option.name.toLowerCase().includes(search)
+        )
+      : activeOptions;
+  }, [activeOptions, activeCategory, searchText]);
+
+  const selectedIdsForActiveCategory = useMemo(
+    () =>
+      new Set((draftFilter[activeCategory] ?? []).map((option) => option.id)),
+    [draftFilter, activeCategory]
+  );
+  const unselectedOptions = filteredOptions.filter(
+    (option) => !selectedIdsForActiveCategory.has(option.id)
+  );
+
+  const appliedSelectionCount = automationsFilterSelectionCount(filter);
+  const categoriesWithSelection = useMemo(
+    () =>
+      AUTOMATIONS_FILTER_CATEGORIES.filter(
+        (category) => (draftFilter[category]?.length ?? 0) > 0
+      ),
+    [draftFilter]
+  );
+  const categorySelectionCounts = useMemo(() => {
+    const counts: Partial<Record<AutomationsFilterCategory, number>> = {};
+    for (const category of AUTOMATIONS_FILTER_CATEGORIES) {
+      counts[category] = draftFilter[category]?.length ?? 0;
+    }
+    return counts;
+  }, [draftFilter]);
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    if (open) {
+      setDraftFilter(filter);
+      setSearchText("");
+    }
+  };
+
+  const handleCategoryChange = (category: AutomationsFilterCategory) => {
+    setActiveCategory(category);
+    setSearchText("");
+  };
+
+  const activeCategorySelectionCount = draftFilter[activeCategory]?.length ?? 0;
+
+  return (
+    <PopoverRoot open={isOpen} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          icon={FilterFunnel01}
+          label="Filters"
+          size="sm"
+          variant="outline"
+          isCounter={appliedSelectionCount > 0}
+          counterValue={String(appliedSelectionCount)}
+        />
+      </PopoverTrigger>
+      <PopoverContent fullWidth align="end" className="w-auto rounded-2xl p-0">
+        <div className="flex h-96 flex-row divide-x divide-border">
+          <FilterCategoryNav
+            categories={AUTOMATIONS_FILTER_CATEGORIES}
+            categoryLabels={AUTOMATIONS_FILTER_CATEGORY_LABEL}
+            selectionCounts={categorySelectionCounts}
+            activeCategory={activeCategory}
+            onCategoryChange={handleCategoryChange}
+          />
+          <div className="flex h-full w-72 flex-col gap-2 p-2">
+            <NavigationListLabel
+              label={AUTOMATIONS_FILTER_CATEGORY_LABEL[activeCategory]}
+              className="bg-transparent pt-1.5 pb-0 font-medium"
+              action={
+                <Button
+                  label="Clear"
+                  size="xmini"
+                  variant="ghost-secondary"
+                  onClick={() => clearCategory(activeCategory)}
+                  disabled={activeCategorySelectionCount === 0}
+                  className={
+                    activeCategorySelectionCount === 0 ? "invisible" : undefined
+                  }
+                />
+              }
+            />
+            <SearchInput
+              name="automations-filter-search"
+              value={searchText}
+              onChange={setSearchText}
+              placeholder={`Search ${AUTOMATIONS_FILTER_CATEGORY_LABEL[activeCategory].toLowerCase()}`}
+            />
+            <FilterOptionCheckboxList
+              key={`${isOpen}|${activeCategory}|${searchText}`}
+              idPrefix={`automations-filter-option-${activeCategory}`}
+              categoryLabel={AUTOMATIONS_FILTER_CATEGORY_LABEL[activeCategory]}
+              options={filteredOptions}
+              selectedIds={selectedIdsForActiveCategory}
+              onToggleOption={(option) => toggleOption(activeCategory, option)}
+              onSelectAll={() =>
+                selectAllFiltered(activeCategory, unselectedOptions)
+              }
+              selectAllLabel="Select all"
+              hasSelectableOptions={unselectedOptions.length > 0}
+              renderIcon={(option) => (
+                <AutomationsFilterOptionIcon option={option} />
+              )}
+              isLoading={isOptionsLoading}
+            />
+          </div>
+          <FilterSelectionSummary<
+            AutomationsFilterCategory,
+            AutomationsFilterOption
+          >
+            categoriesWithSelection={categoriesWithSelection}
+            categoryLabels={AUTOMATIONS_FILTER_CATEGORY_LABEL}
+            filter={draftFilter}
+            onClearCategory={clearCategory}
+            onRemoveOption={removeOption}
+            renderIcon={(option) => (
+              <AutomationsFilterOptionIcon option={option} />
+            )}
+          />
+        </div>
+        <FilterFooter
+          onClearAll={clearAllCategories}
+          onCancel={() => setIsOpen(false)}
+          onApply={() => {
+            onFilterChange(draftFilter);
+            setIsOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </PopoverRoot>
+  );
+}

--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -64,18 +64,26 @@ export function AutomationsFilterPanel({
   const { agentConfigurations, isAgentConfigurationsLoading } =
     useAgentConfigurations({
       workspaceId: owner.sId,
-      agentsGetView: isAgentCategoryActive ? "manage" : null,
+      agentsGetView: isAgentCategoryActive ? "analytics" : null,
       sort: "alphabetical",
     });
 
   const isMemberCategoryActive = isOpen && activeCategory === "member";
-  const { members, isLoading: isMembersLoading } = useSearchMembers({
+  const {
+    members,
+    totalMembersCount,
+    isLoading: isMembersLoading,
+  } = useSearchMembers({
     workspaceId: owner.sId,
     searchTerm: isMemberCategoryActive ? searchText : "",
     pageIndex: 0,
     pageSize: MEMBERS_PAGE_SIZE,
     disabled: !isMemberCategoryActive,
   });
+  // Members are fetched as a single fixed-size page (same pattern as
+  // AnalyticsFilterDropdown), so "Select all" can only be offered once that
+  // page covers every matching member.
+  const hasAllMatchingMembersLoaded = members.length >= totalMembersCount;
 
   const categoryOptions = useMemo<
     Record<AutomationsFilterCategory, AutomationsFilterOption[]>
@@ -127,6 +135,9 @@ export function AutomationsFilterPanel({
   const unselectedOptions = filteredOptions.filter(
     (option) => !selectedIdsForActiveCategory.has(option.id)
   );
+  const hasSelectableOptions =
+    unselectedOptions.length > 0 &&
+    (activeCategory !== "member" || hasAllMatchingMembersLoaded);
 
   const appliedSelectionCount = automationsFilterSelectionCount(filter);
   const categoriesWithSelection = useMemo(
@@ -214,7 +225,7 @@ export function AutomationsFilterPanel({
                 selectAllFiltered(activeCategory, unselectedOptions)
               }
               selectAllLabel="Select all"
-              hasSelectableOptions={unselectedOptions.length > 0}
+              hasSelectableOptions={hasSelectableOptions}
               renderIcon={(option) => (
                 <AutomationsFilterOptionIcon option={option} />
               )}

--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -69,21 +69,13 @@ export function AutomationsFilterPanel({
     });
 
   const isMemberCategoryActive = isOpen && activeCategory === "member";
-  const {
-    members,
-    totalMembersCount,
-    isLoading: isMembersLoading,
-  } = useSearchMembers({
+  const { members, isLoading: isMembersLoading } = useSearchMembers({
     workspaceId: owner.sId,
     searchTerm: isMemberCategoryActive ? searchText : "",
     pageIndex: 0,
     pageSize: MEMBERS_PAGE_SIZE,
     disabled: !isMemberCategoryActive,
   });
-  // Members are fetched as a single fixed-size page (same pattern as
-  // AnalyticsFilterDropdown), so "Select all" can only be offered once that
-  // page covers every matching member.
-  const hasAllMatchingMembersLoaded = members.length >= totalMembersCount;
 
   const categoryOptions = useMemo<
     Record<AutomationsFilterCategory, AutomationsFilterOption[]>
@@ -136,8 +128,7 @@ export function AutomationsFilterPanel({
     (option) => !selectedIdsForActiveCategory.has(option.id)
   );
   const hasSelectableOptions =
-    unselectedOptions.length > 0 &&
-    (activeCategory !== "member" || hasAllMatchingMembersLoaded);
+    activeCategory !== "member" && unselectedOptions.length > 0;
 
   const appliedSelectionCount = automationsFilterSelectionCount(filter);
   const categoriesWithSelection = useMemo(

--- a/front/components/workspace/analytics/automations/AutomationsFilterSummary.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterSummary.tsx
@@ -1,0 +1,24 @@
+import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
+import { getAutomationsFilterSummaries } from "@app/components/workspace/analytics/automationsFilter";
+import { FilterSummaryChips } from "@app/components/workspace/analytics/filterPanel/FilterSummaryChips";
+import { clearFilterCategory } from "@app/components/workspace/analytics/filterPanel/filterState";
+
+interface AutomationsFilterSummaryProps {
+  filter: AutomationsFilter;
+  onFilterChange: (filter: AutomationsFilter) => void;
+}
+
+export function AutomationsFilterSummary({
+  filter,
+  onFilterChange,
+}: AutomationsFilterSummaryProps) {
+  return (
+    <FilterSummaryChips
+      summaries={getAutomationsFilterSummaries(filter)}
+      onClearCategory={(category) =>
+        onFilterChange(clearFilterCategory(filter, category))
+      }
+      onClearAll={() => onFilterChange({})}
+    />
+  );
+}

--- a/front/components/workspace/analytics/automationsFilter.test.ts
+++ b/front/components/workspace/analytics/automationsFilter.test.ts
@@ -1,0 +1,121 @@
+import {
+  automationsFilterSelectionCount,
+  getAutomationsFilterSummaries,
+  toAutomationsTriggersFilter,
+} from "@app/components/workspace/analytics/automationsFilter";
+import { describe, expect, it } from "vitest";
+
+const agentOption = {
+  id: "agent-1",
+  name: "@dust",
+  category: "agent" as const,
+  disabled: false,
+  image: null,
+};
+
+const memberOption = {
+  id: "member-1",
+  name: "Ada",
+  category: "member" as const,
+  disabled: false,
+  image: null,
+};
+
+describe("toAutomationsTriggersFilter", () => {
+  it("maps every selected category to its triggers filter field", () => {
+    expect(
+      toAutomationsTriggersFilter({
+        agent: [agentOption],
+        member: [memberOption],
+        type: [
+          {
+            id: "schedule",
+            name: "Schedule",
+            category: "type",
+            disabled: false,
+          },
+          { id: "webhook", name: "Webhook", category: "type", disabled: false },
+        ],
+      })
+    ).toEqual({
+      agentIds: ["agent-1"],
+      editorIds: ["member-1"],
+      kinds: ["schedule", "webhook"],
+    });
+  });
+
+  it("omits empty selections", () => {
+    expect(toAutomationsTriggersFilter({})).toEqual({});
+    expect(
+      toAutomationsTriggersFilter({ agent: [], member: [], type: [] })
+    ).toEqual({});
+  });
+
+  it("drops type ids that are not valid trigger kinds", () => {
+    expect(
+      toAutomationsTriggersFilter({
+        type: [
+          {
+            id: "schedule",
+            name: "Schedule",
+            category: "type",
+            disabled: false,
+          },
+          {
+            id: "not-a-kind",
+            name: "Unknown",
+            category: "type",
+            disabled: false,
+          },
+        ],
+      })
+    ).toEqual({ kinds: ["schedule"] });
+  });
+
+  it("only maps the selected categories, leaving the others out", () => {
+    expect(toAutomationsTriggersFilter({ agent: [agentOption] })).toEqual({
+      agentIds: ["agent-1"],
+    });
+  });
+});
+
+describe("automationsFilterSelectionCount", () => {
+  it("sums the selection count across all categories", () => {
+    expect(
+      automationsFilterSelectionCount({
+        agent: [agentOption],
+        member: [memberOption],
+      })
+    ).toBe(2);
+  });
+
+  it("is zero for an empty filter", () => {
+    expect(automationsFilterSelectionCount({})).toBe(0);
+  });
+});
+
+describe("getAutomationsFilterSummaries", () => {
+  it("flattens selected options into ordered, human-readable categories", () => {
+    expect(
+      getAutomationsFilterSummaries({
+        agent: [agentOption],
+        member: [memberOption],
+      })
+    ).toEqual([
+      {
+        category: "agent",
+        categoryLabel: "Agent",
+        options: [{ id: "agent-1", name: "@dust" }],
+      },
+      {
+        category: "member",
+        categoryLabel: "Member",
+        options: [{ id: "member-1", name: "Ada" }],
+      },
+    ]);
+  });
+
+  it("omits empty categories", () => {
+    expect(getAutomationsFilterSummaries({ type: [] })).toEqual([]);
+  });
+});

--- a/front/components/workspace/analytics/automationsFilter.ts
+++ b/front/components/workspace/analytics/automationsFilter.ts
@@ -1,0 +1,84 @@
+import type {
+  CategoryFilter,
+  FilterOptionBase,
+} from "@app/components/workspace/analytics/filterPanel/filterState";
+import {
+  filterSelectionCount,
+  getFilterSummaries,
+} from "@app/components/workspace/analytics/filterPanel/filterState";
+import type { TriggerKind } from "@app/types/assistant/triggers";
+
+export const AUTOMATIONS_FILTER_CATEGORIES = [
+  "agent",
+  "member",
+  "type",
+] as const;
+
+export type AutomationsFilterCategory =
+  (typeof AUTOMATIONS_FILTER_CATEGORIES)[number];
+
+export const AUTOMATIONS_FILTER_CATEGORY_LABEL: Record<
+  AutomationsFilterCategory,
+  string
+> = {
+  agent: "Agents",
+  member: "Members",
+  type: "Type",
+};
+
+export const AUTOMATIONS_FILTER_CATEGORY_SINGULAR_LABEL: Record<
+  AutomationsFilterCategory,
+  string
+> = {
+  agent: "Agent",
+  member: "Member",
+  type: "Type",
+};
+
+export interface AutomationsFilterOption extends FilterOptionBase {
+  category: AutomationsFilterCategory;
+  image?: string | null;
+}
+
+export type AutomationsFilter = CategoryFilter<
+  AutomationsFilterCategory,
+  AutomationsFilterOption
+>;
+
+export function getAutomationsFilterSummaries(filter: AutomationsFilter) {
+  return getFilterSummaries(
+    filter,
+    AUTOMATIONS_FILTER_CATEGORIES,
+    AUTOMATIONS_FILTER_CATEGORY_SINGULAR_LABEL
+  );
+}
+
+export function automationsFilterSelectionCount(
+  filter: AutomationsFilter
+): number {
+  return filterSelectionCount(filter, AUTOMATIONS_FILTER_CATEGORIES);
+}
+
+export type AutomationsTriggersFilter = {
+  agentIds?: string[];
+  editorIds?: string[];
+  kinds?: TriggerKind[];
+};
+
+function isTriggerKind(id: string): id is TriggerKind {
+  return id === "schedule" || id === "webhook";
+}
+
+export function toAutomationsTriggersFilter(
+  filter: AutomationsFilter
+): AutomationsTriggersFilter {
+  const agentIds = filter.agent?.map((option) => option.id);
+  const editorIds = filter.member?.map((option) => option.id);
+  const kinds = filter.type?.map((option) => option.id).filter(isTriggerKind);
+
+  return {
+    ...(agentIds && agentIds.length > 0 ? { agentIds } : {}),
+    ...(editorIds && editorIds.length > 0 ? { editorIds } : {}),
+    ...(kinds && kinds.length > 0 ? { kinds } : {}),
+  };
+}

--- a/front/components/workspace/analytics/filterPanel/FilterOptionCheckboxList.tsx
+++ b/front/components/workspace/analytics/filterPanel/FilterOptionCheckboxList.tsx
@@ -2,12 +2,12 @@ import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { FILTER_PICKER_PAGE_SIZE } from "@app/components/workspace/analytics/filterPanel/constants";
 import { FilterAvailabilityStatus } from "@app/components/workspace/analytics/filterPanel/FilterAvailabilityStatus";
 import type { FilterOptionBase } from "@app/components/workspace/analytics/filterPanel/filterState";
-import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import {
   Button,
   Checkbox,
   Label,
   LoadingBlock,
+  NavigationListLabel,
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
@@ -39,12 +39,12 @@ interface FilterOptionCheckboxListProps<Option extends FilterOptionBase> {
   options: Option[];
   selectedIds: Set<string>;
   onToggleOption: (option: Option) => void;
-  onSelectAll: () => void;
-  selectAllLabel: string;
-  hasSelectableOptions: boolean;
+  onSelectAll?: () => void;
+  selectAllLabel?: string;
+  hasSelectableOptions?: boolean;
   renderIcon?: (option: Option) => ReactNode;
   status?: FilterOptionListStatus;
-  scrollContainer: HTMLDivElement | null;
+  scrollContainer?: HTMLDivElement | null;
 }
 
 export function FilterOptionCheckboxList<Option extends FilterOptionBase>({
@@ -58,7 +58,7 @@ export function FilterOptionCheckboxList<Option extends FilterOptionBase>({
   hasSelectableOptions,
   renderIcon,
   status = "idle",
-  scrollContainer,
+  scrollContainer = null,
 }: FilterOptionCheckboxListProps<Option>) {
   const isLoading = status === "loading";
   const isUpdating = status === "updating";
@@ -71,23 +71,27 @@ export function FilterOptionCheckboxList<Option extends FilterOptionBase>({
   const loadMore = () =>
     setVisibleCount((current) => current + FILTER_PICKER_PAGE_SIZE);
   return (
-    <UsageFilterSection
-      title={`All ${categoryLabel}`}
-      action={
-        <div className="flex items-center gap-2">
-          {isUpdating && (
-            <span className="text-xs text-muted-foreground">Updating…</span>
-          )}
-          <Button
-            label={selectAllLabel}
-            size="xmini"
-            variant="ghost-secondary"
-            onClick={onSelectAll}
-            disabled={!hasSelectableOptions || isUpdating}
-          />
-        </div>
-      }
-    >
+    <>
+      <NavigationListLabel
+        label={`All ${categoryLabel}`}
+        className="bg-transparent font-medium"
+        action={
+          <div className="flex items-center gap-2">
+            {isUpdating && (
+              <span className="text-xs text-muted-foreground">Updating…</span>
+            )}
+            {onSelectAll && (
+              <Button
+                label={selectAllLabel}
+                size="xmini"
+                variant="ghost-secondary"
+                onClick={onSelectAll}
+                disabled={!hasSelectableOptions || isUpdating}
+              />
+            )}
+          </div>
+        }
+      />
       <div
         aria-busy={isLoading || isUpdating}
         className="flex flex-col gap-0.5"
@@ -162,6 +166,6 @@ export function FilterOptionCheckboxList<Option extends FilterOptionBase>({
           </div>
         )}
       </div>
-    </UsageFilterSection>
+    </>
   );
 }

--- a/front/components/workspace/analytics/useAutomationsFilter.ts
+++ b/front/components/workspace/analytics/useAutomationsFilter.ts
@@ -1,0 +1,12 @@
+import type {
+  AutomationsFilter,
+  AutomationsFilterCategory,
+  AutomationsFilterOption,
+} from "@app/components/workspace/analytics/automationsFilter";
+import { useFilterDraft } from "@app/components/workspace/analytics/filterPanel/useFilterDraft";
+
+export function useAutomationsFilter(initialFilter: AutomationsFilter) {
+  return useFilterDraft<AutomationsFilterCategory, AutomationsFilterOption>(
+    initialFilter
+  );
+}


### PR DESCRIPTION
## Description

Adds the reusable filter UI and state model for the Automations analytics page. The new `AutomationsFilterPanel` supports filtering by agent, member, and trigger type (`Schedule` or `Webhook`) using the generic analytics filter-panel components. 

This PR adds the panel, filter state, and conversion helpers but does not wire them into the analytics page yet; no existing page behavior is changed until that integration is added.

Visuals: 
<img width="968" height="590" alt="Capture d’écran 2026-08-18 à 10 01 44" src="https://github.com/user-attachments/assets/691b9213-3549-4ad2-b1c5-a1b265cae93c" />
<img width="986" height="611" alt="Capture d’écran 2026-08-18 à 10 01 41" src="https://github.com/user-attachments/assets/82589318-46ea-4b91-b12d-0146a29beecc" />
<img width="981" height="625" alt="Capture d’écran 2026-08-18 à 10 01 37" src="https://github.com/user-attachments/assets/d8bab922-ea60-4ce0-bc74-0bf346296c86" />


## Tests


## Risk

Low runtime risk because the changes add new components and filter utilities without wiring them into the existing page or changing current data fetching or API behavior. 

## Deploy Plan

- Deploy front