### PR TITLE
feat: wire filter panel into the automations analytics page

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/triggers.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.ts
@@ -21,7 +21,7 @@ app.post(
   validate("json", AutomationTriggersBodySchema),
   async (ctx): HandlerResult<GetAutomationTriggersResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -32,6 +32,7 @@ app.post(
       period,
       limit,
       offset,
+      filter,
     });
     if (result.isErr()) {
       logger.error(

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -1,11 +1,15 @@
+import { AutomationsFilterPanel } from "@app/components/workspace/analytics/automations/AutomationsFilterPanel";
+import { AutomationsFilterSummary } from "@app/components/workspace/analytics/automations/AutomationsFilterSummary";
 import { AutomationsOverview } from "@app/components/workspace/analytics/automations/AutomationsOverview";
 import { AutomationsTriggersTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersTable";
+import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
+import { toAutomationsTriggersFilter } from "@app/components/workspace/analytics/automationsFilter";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { cn, Page } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 export function AnalyticsAutomationsPage() {
   const owner = useWorkspace();
@@ -13,6 +17,11 @@ export function AnalyticsAutomationsPage() {
   const isEnabled = hasFeature("enable_analytics_automations");
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
+  );
+  const [filter, setFilter] = useState<AutomationsFilter>({});
+  const triggersFilter = useMemo(
+    () => toAutomationsTriggersFilter(filter),
+    [filter]
   );
 
   if (!isEnabled) {
@@ -54,7 +63,25 @@ export function AnalyticsAutomationsPage() {
       />
       <div className="flex flex-col gap-8 pb-8 pt-4">
         <AutomationsOverview workspaceId={owner.sId} period={period} />
-        <AutomationsTriggersTable workspaceId={owner.sId} period={period} />
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-end">
+            <AutomationsFilterPanel
+              owner={owner}
+              filter={filter}
+              onFilterChange={setFilter}
+            />
+          </div>
+          <AutomationsFilterSummary
+            filter={filter}
+            onFilterChange={setFilter}
+          />
+        </div>
+        <AutomationsTriggersTable
+          key={JSON.stringify(triggersFilter)}
+          workspaceId={owner.sId}
+          period={period}
+          filter={triggersFilter}
+        />
       </div>
     </Page.Vertical>
   );

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -1,15 +1,12 @@
-import { AutomationsFilterPanel } from "@app/components/workspace/analytics/automations/AutomationsFilterPanel";
-import { AutomationsFilterSummary } from "@app/components/workspace/analytics/automations/AutomationsFilterSummary";
 import { AutomationsOverview } from "@app/components/workspace/analytics/automations/AutomationsOverview";
 import { AutomationsTriggersTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersTable";
 import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
-import { toAutomationsTriggersFilter } from "@app/components/workspace/analytics/automationsFilter";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { cn, Page } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 
 export function AnalyticsAutomationsPage() {
   const owner = useWorkspace();
@@ -19,10 +16,6 @@ export function AnalyticsAutomationsPage() {
     DEFAULT_CONSUMPTION_PERIOD
   );
   const [filter, setFilter] = useState<AutomationsFilter>({});
-  const triggersFilter = useMemo(
-    () => toAutomationsTriggersFilter(filter),
-    [filter]
-  );
 
   if (!isEnabled) {
     return (
@@ -63,24 +56,11 @@ export function AnalyticsAutomationsPage() {
       />
       <div className="flex flex-col gap-8 pb-8 pt-4">
         <AutomationsOverview workspaceId={owner.sId} period={period} />
-        <div className="flex flex-col gap-2">
-          <div className="flex items-center justify-end">
-            <AutomationsFilterPanel
-              owner={owner}
-              filter={filter}
-              onFilterChange={setFilter}
-            />
-          </div>
-          <AutomationsFilterSummary
-            filter={filter}
-            onFilterChange={setFilter}
-          />
-        </div>
         <AutomationsTriggersTable
-          key={JSON.stringify(triggersFilter)}
-          workspaceId={owner.sId}
+          owner={owner}
           period={period}
-          filter={triggersFilter}
+          filter={filter}
+          onFilterChange={setFilter}
         />
       </div>
     </Page.Vertical>

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -1,7 +1,11 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { getIcon } from "@app/components/resources/resources_icons";
+import { AutomationsFilterPanel } from "@app/components/workspace/analytics/automations/AutomationsFilterPanel";
+import { AutomationsFilterSummary } from "@app/components/workspace/analytics/automations/AutomationsFilterSummary";
 import type { TriggerRowData as BaseTriggerRowData } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
 import { AutomationsTriggersRowsTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
+import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
+import { toAutomationsTriggersFilter } from "@app/components/workspace/analytics/automationsFilter";
 import {
   AvatarNameCell,
   CreditsCell,
@@ -9,13 +13,13 @@ import {
 } from "@app/components/workspace/analytics/creditsTableCells";
 import { useAutomationsTriggers } from "@app/hooks/useAutomationsTriggers";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import type { AutomationTriggersFilter } from "@app/lib/api/analytics/automations/schema";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { useUpdateTriggerStatus } from "@app/lib/swr/agent_triggers";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
 import type { TriggerStatus } from "@app/types/assistant/triggers";
 import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
   Button,
@@ -291,21 +295,39 @@ function buildColumns({
 }
 
 interface AutomationsTriggersTableProps {
-  workspaceId: string;
+  owner: LightWorkspaceType;
   period: ConsumptionPeriodSelection;
-  filter?: AutomationTriggersFilter;
+  filter: AutomationsFilter;
+  onFilterChange: (next: AutomationsFilter) => void;
 }
 
 export function AutomationsTriggersTable({
-  workspaceId,
+  owner,
   period,
   filter,
+  onFilterChange,
 }: AutomationsTriggersTableProps) {
+  const workspaceId = owner.sId;
+  const triggersFilter = useMemo(
+    () => toAutomationsTriggersFilter(filter),
+    [filter]
+  );
+
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: TRIGGERS_PAGE_SIZE,
   });
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+
+  // A filter change invalidates the current page and any expanded row.
+  // Reset during render (https://react.dev/learn/you-might-not-need-an-effect)
+  // instead of an effect keyed on `filter`.
+  const [prevFilter, setPrevFilter] = useState(filter);
+  if (prevFilter !== filter) {
+    setPrevFilter(filter);
+    setPagination((current) => ({ ...current, pageIndex: 0 }));
+    setExpandedRowId(null);
+  }
 
   const {
     triggers,
@@ -317,7 +339,7 @@ export function AutomationsTriggersTable({
   } = useAutomationsTriggers({
     workspaceId,
     period,
-    filter,
+    filter: triggersFilter,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
   });
@@ -408,6 +430,19 @@ export function AutomationsTriggersTable({
 
   return (
     <div className="rounded-lg border border-border bg-panel-background p-4">
+      <div className="mb-4 flex flex-col gap-2">
+        <div className="flex items-center justify-end">
+          <AutomationsFilterPanel
+            owner={owner}
+            filter={filter}
+            onFilterChange={onFilterChange}
+          />
+        </div>
+        <AutomationsFilterSummary
+          filter={filter}
+          onFilterChange={onFilterChange}
+        />
+      </div>
       <TriggersTableBody
         isLoading={isTriggersLoading}
         isError={!!isTriggersError}

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -9,6 +9,7 @@ import {
 } from "@app/components/workspace/analytics/creditsTableCells";
 import { useAutomationsTriggers } from "@app/hooks/useAutomationsTriggers";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { AutomationTriggersFilter } from "@app/lib/api/analytics/automations/schema";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { useUpdateTriggerStatus } from "@app/lib/swr/agent_triggers";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
@@ -292,11 +293,13 @@ function buildColumns({
 interface AutomationsTriggersTableProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  filter?: AutomationTriggersFilter;
 }
 
 export function AutomationsTriggersTable({
   workspaceId,
   period,
+  filter,
 }: AutomationsTriggersTableProps) {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -314,6 +317,7 @@ export function AutomationsTriggersTable({
   } = useAutomationsTriggers({
     workspaceId,
     period,
+    filter,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
   });

--- a/front/hooks/useAutomationsTriggers.ts
+++ b/front/hooks/useAutomationsTriggers.ts
@@ -1,7 +1,10 @@
 import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
-import type { AutomationTriggersBody } from "@app/lib/api/analytics/automations/schema";
+import type {
+  AutomationTriggersBody,
+  AutomationTriggersFilter,
+} from "@app/lib/api/analytics/automations/schema";
 import type {
   AutomationTriggerRow,
   GetAutomationTriggersResponse,
@@ -13,12 +16,14 @@ export function useAutomationsTriggers({
   period,
   limit,
   offset = 0,
+  filter,
   disabled,
 }: {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   limit: number;
   offset?: number;
+  filter?: AutomationTriggersFilter;
   disabled?: boolean;
 }) {
   const url = `/api/w/${workspaceId}/analytics/automations/triggers`;
@@ -28,6 +33,7 @@ export function useAutomationsTriggers({
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
     limit,
     offset,
+    filter,
   };
 
   const { data, error, isLoading, isValidating } = useConsumptionQuery<

--- a/front/lib/api/analytics/automations/schema.ts
+++ b/front/lib/api/analytics/automations/schema.ts
@@ -9,6 +9,16 @@ export type AutomationsOverviewBody = z.infer<
   typeof AutomationsOverviewBodySchema
 >;
 
+export const AutomationTriggersFilterSchema = z.object({
+  agentIds: z.array(z.string()).optional(),
+  editorIds: z.array(z.string()).optional(),
+  kinds: z.array(z.enum(["schedule", "webhook"])).optional(),
+});
+
+export type AutomationTriggersFilter = z.infer<
+  typeof AutomationTriggersFilterSchema
+>;
+
 export const AutomationTriggersBodySchema = ConsumptionPeriodSchema.extend({
   limit: z
     .number()
@@ -17,6 +27,7 @@ export const AutomationTriggersBodySchema = ConsumptionPeriodSchema.extend({
     .max(100)
     .default(DEFAULT_AUTOMATION_TRIGGERS_LIMIT),
   offset: z.number().int().nonnegative().default(0),
+  filter: AutomationTriggersFilterSchema.optional(),
 });
 
 export type AutomationTriggersBody = z.infer<

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -2,7 +2,9 @@ import type {
   CustomResourceIconType,
   InternalAllowedIconType,
 } from "@app/components/resources/resources_icon_names";
+import type { AutomationTriggersFilter } from "@app/lib/api/analytics/automations/schema";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
@@ -105,6 +107,23 @@ function median(values: number[]): number {
 }
 
 /**
+ * Trigger kind isn't indexed in the consumption Elasticsearch documents, so
+ * a kind filter is resolved to a concrete set of trigger ids up front and
+ * applied as a terms filter on TRIGGER_ID_FIELD. Returns null when no kind
+ * filter is requested (no restriction).
+ */
+async function resolveTriggerIdsForKindFilter(
+  auth: Authenticator,
+  kinds: TriggerKind[] | undefined
+): Promise<string[] | null> {
+  if (!kinds || kinds.length === 0) {
+    return null;
+  }
+  const triggers = await TriggerResource.listByWorkspaceAndKinds(auth, kinds);
+  return triggers.map((trigger) => trigger.sId);
+}
+
+/**
  * The period's triggers ranked by gross credits, highest first. The
  * underlying terms aggregation is capped at CARDINALITY_PRECISION_THRESHOLD
  * buckets (the same approximation boundary used for the total trigger
@@ -119,10 +138,12 @@ async function fetchTriggersRanking(
     period,
     limit,
     offset,
+    filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset: number;
+    filter?: AutomationTriggersFilter;
   }
 ): Promise<
   Result<
@@ -135,10 +156,28 @@ async function fetchTriggersRanking(
     ElasticsearchError
   >
 > {
+  const scopeFilter: ConsumptionScopeFilter = {};
+  if (filter?.agentIds?.length) {
+    scopeFilter.agents = filter.agentIds;
+  }
+  if (filter?.editorIds?.length) {
+    scopeFilter.users = filter.editorIds;
+  }
+
+  const triggerIdsForKindFilter = await resolveTriggerIdsForKindFilter(
+    auth,
+    filter?.kinds
+  );
+
   const query = buildConsumptionScopeQuery({
     auth,
     startDate: period.startDate,
     endDate: period.endDate,
+    filter: scopeFilter,
+    extraFilters:
+      triggerIdsForKindFilter !== null
+        ? [{ terms: { [TRIGGER_ID_FIELD]: triggerIdsForKindFilter } }]
+        : [],
   });
 
   const result = await searchConsumptionAnalytics<never, TriggerAggs>(query, {
@@ -225,16 +264,19 @@ export async function fetchAutomationTriggers(
     period,
     limit,
     offset,
+    filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset: number;
+    filter?: AutomationTriggersFilter;
   }
 ): Promise<Result<AutomationTriggers, ElasticsearchError>> {
   const rankingResult = await fetchTriggersRanking(auth, {
     period,
     limit,
     offset,
+    filter,
   });
   if (rankingResult.isErr()) {
     return rankingResult;

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -24,6 +24,7 @@ import {
 import type {
   ScheduleConfig,
   TriggerExecutionMode,
+  TriggerKind,
   TriggerStatus,
   TriggerType,
   WebhookConfig,
@@ -276,6 +277,15 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     ]);
 
     return { enabled, total };
+  }
+
+  static listByWorkspaceAndKinds(
+    auth: Authenticator,
+    kinds: TriggerKind[]
+  ): Promise<TriggerResource[]> {
+    return this.baseFetch(auth, {
+      where: { kind: { [Op.in]: kinds } },
+    });
   }
 
   static async listBySpace(


### PR DESCRIPTION
## Description

Adds the automation analytics filter panel and applied-filter summary to the triggers table. The page now supports filtering by agent, editor, and trigger kind (`schedule` or `webhook`), and threads the selected filters through the client hook, request schema, API route, and trigger-ranking query.

Agent and editor filters are translated into the existing consumption scope filters. Because trigger kind is not indexed in the consumption Elasticsearch documents, kind selections are first resolved to trigger IDs and then applied as a trigger-ID terms filter. With no filters selected, the existing unfiltered query path is preserved.

## Tests


## Risk

Low. This is a read-only analytics change with an optional request field, so existing unfiltered requests remain compatible. The main additional query cost is the workspace trigger lookup required when filtering by kind, followed by the Elasticsearch terms filter.

## Deploy Plan

- Deploy front