### PR TITLE
Admin governance: centralize skill editor management on the resource

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/editors.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/editors.ts
@@ -1,5 +1,4 @@
 import { findSkillEditorsWithoutSpaceAccess } from "@app/lib/api/skills/space_requirements";
-import type { GroupResource } from "@app/lib/resources/group_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -28,7 +27,7 @@ const ParamsSchema = z.object({
 async function loadSkillAndEditorGroup(
   ctx: Context,
   sId: string
-): Promise<{ skill: SkillResource; editorGroup: GroupResource } | Response> {
+): Promise<SkillResource | Response> {
   const auth = ctx.get("auth");
 
   const skill = await SkillResource.fetchById(auth, sId);
@@ -53,7 +52,7 @@ async function loadSkillAndEditorGroup(
     });
   }
 
-  return { skill, editorGroup };
+  return skill;
 }
 
 // Mounted at /api/w/:wId/skills/:sId/editors.
@@ -64,13 +63,12 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { sId } = ctx.req.valid("param");
 
-  const loaded = await loadSkillAndEditorGroup(ctx, sId);
-  if (loaded instanceof Response) {
-    return loaded;
+  const skill = await loadSkillAndEditorGroup(ctx, sId);
+  if (skill instanceof Response) {
+    return skill;
   }
-  const { editorGroup } = loaded;
 
-  const members = await editorGroup.getActiveMembers(auth);
+  const members = (await skill.listEditors(auth)) ?? [];
   const memberUsers = members.map((m) => m.toJSON());
 
   // biome-ignore lint/plugin/noDirectRoleCheck: non-admins receive only minimal essential user data (LightUserType)
@@ -91,11 +89,10 @@ app.patch(
     const auth = ctx.get("auth");
     const { sId } = ctx.req.valid("param");
 
-    const loaded = await loadSkillAndEditorGroup(ctx, sId);
-    if (loaded instanceof Response) {
-      return loaded;
+    const skillRes = await loadSkillAndEditorGroup(ctx, sId);
+    if (skillRes instanceof Response) {
+      return skillRes;
     }
-    const { skill: skillRes, editorGroup } = loaded;
 
     if (!skillRes.canAdministrate(auth)) {
       return apiError(ctx, {
@@ -112,9 +109,6 @@ app.patch(
     const usersToAddResources = await UserResource.fetchByIds(addEditorIds);
     const usersToRemoveResources =
       await UserResource.fetchByIds(removeEditorIds);
-
-    const usersToAdd = usersToAddResources.map((u) => u.toJSON());
-    const usersToRemove = usersToRemoveResources.map((u) => u.toJSON());
 
     if (
       usersToAddResources.length !== addEditorIds.length ||
@@ -158,20 +152,8 @@ app.patch(
       });
     }
 
-    // Check authorization for modifying group members.
-    if (!editorGroup.canAdministrate(auth)) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "You are not authorized to modify the skill editors group.",
-        },
-      });
-    }
-
-    const addRes = await editorGroup.dangerouslyAddMembers(auth, {
-      users: usersToAdd,
-    });
+    // Through the resource: it keeps the per-user grants in sync with the group membership.
+    const addRes = await skillRes.addEditors(auth, usersToAddResources);
     if (addRes.isErr()) {
       switch (addRes.error.code) {
         case "unauthorized":
@@ -222,9 +204,10 @@ app.patch(
       }
     }
 
-    const removeRes = await editorGroup.dangerouslyRemoveMembers(auth, {
-      users: usersToRemove,
-    });
+    const removeRes = await skillRes.removeEditors(
+      auth,
+      usersToRemoveResources
+    );
     if (removeRes.isErr()) {
       switch (removeRes.error.code) {
         case "unauthorized":
@@ -266,7 +249,7 @@ app.patch(
       }
     }
 
-    const updatedMembers = await editorGroup.getActiveMembers(auth);
+    const updatedMembers = (await skillRes.listEditors(auth)) ?? [];
     const updatedEditors = updatedMembers.map((m) => m.toJSON());
 
     // biome-ignore lint/plugin/noDirectRoleCheck: non-admins receive only minimal essential user data (LightUserType)

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -411,9 +411,7 @@ app.patch(
 
     // Adding a restricted space can lock out editors that are already on the skill. `updateSkill`
     // also makes the caller an editor, so they are part of the set to validate.
-    const editors = skill.editorGroup
-      ? await skill.editorGroup.getActiveMembers(auth)
-      : [];
+    const editors = (await skill.listEditors(auth)) ?? [];
     const requestedSpaces = await SpaceResource.fetchByModelIds(
       auth,
       requestedSpaceIds

--- a/front/lib/api/poke/plugins/skills/skill_editors.ts
+++ b/front/lib/api/poke/plugins/skills/skill_editors.ts
@@ -39,10 +39,7 @@ export const updateSkillEditorsPlugin = createPlugin({
       activeOnly: true,
     });
 
-    const editorGroup = resource.editorGroup;
-    const currentEditors = editorGroup
-      ? await editorGroup.getActiveMembers(auth)
-      : [];
+    const currentEditors = (await resource.listEditors(auth)) ?? [];
     const editorIds = new Set(currentEditors.map((editor) => editor.sId));
 
     return new Ok({
@@ -69,7 +66,7 @@ export const updateSkillEditorsPlugin = createPlugin({
     const selectedMemberIds = members || [];
 
     // Get current editors.
-    const currentEditors = await editorGroup.getActiveMembers(auth);
+    const currentEditors = (await resource.listEditors(auth)) ?? [];
     const currentEditorIds = new Set(
       currentEditors.map((editor) => editor.sId)
     );
@@ -98,14 +95,17 @@ export const updateSkillEditorsPlugin = createPlugin({
       userResources.map((user) => [user.sId, user.toJSON()])
     );
 
-    // Add new editors.
+    // Go through the resource rather than the group directly: it keeps the per-user grants in sync
+    // with the editor-group membership (see `SkillResource.writeEditorUserGrants`).
+    const userResourceMap = new Map(
+      userResources.map((user) => [user.sId, user])
+    );
+
     if (usersToAdd.length > 0) {
-      const usersToAddTypes = removeNulls(
-        usersToAdd.map((id) => userMap.get(id))
+      const addResult = await resource.upsertEditors(
+        auth,
+        removeNulls(usersToAdd.map((id) => userResourceMap.get(id)))
       );
-      const addResult = await editorGroup.dangerouslyAddMembers(auth, {
-        users: usersToAddTypes,
-      });
       if (addResult.isErr()) {
         return new Err(
           new Error(`Failed to add editors: ${addResult.error.message}`)
@@ -113,14 +113,11 @@ export const updateSkillEditorsPlugin = createPlugin({
       }
     }
 
-    // Remove editors.
     if (usersToRemove.length > 0) {
-      const usersToRemoveTypes = removeNulls(
-        usersToRemove.map((id) => userMap.get(id))
+      const removeResult = await resource.removeEditors(
+        auth,
+        removeNulls(usersToRemove.map((id) => userResourceMap.get(id)))
       );
-      const removeResult = await editorGroup.dangerouslyRemoveMembers(auth, {
-        users: usersToRemoveTypes,
-      });
       if (removeResult.isErr()) {
         return new Err(
           new Error(`Failed to remove editors: ${removeResult.error.message}`)

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -12,6 +12,7 @@ import {
 } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import { hasAll } from "@app/lib/matcher/operators/array";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
@@ -2549,6 +2550,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
+  /**
+   * The skill's editors. Together with `batchListEditors`, the only place editors are read from:
+   * callers must not reach into `editorGroup` themselves, so that changing where editors are
+   * stored is a change to these two methods alone.
+   *
+   * Returns null when the skill has no editor group (global/system skills).
+   */
   async listEditors(auth: Authenticator): Promise<UserResource[] | null> {
     return this.editorGroup?.getActiveMembers(auth) ?? null;
   }
@@ -2579,11 +2587,112 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return new Ok(undefined);
     }
 
-    const addResult = await this.editorGroup.dangerouslyAddMembers(auth, {
-      users: usersToAdd.map((u) => u.toJSON()),
-    });
+    const addResult = await this.addEditors(auth, usersToAdd);
     if (addResult.isErr()) {
       return new Err(new Error(addResult.error.message));
+    }
+
+    return new Ok(undefined);
+  }
+
+  /**
+   * Adds editors, surfacing the group's typed errors so callers can map them (the editors endpoint
+   * turns them into status codes). Authorizes the caller, then mirrors the underlying group
+   * operation one-to-one — `upsertEditors` is the wrapper that additionally skips users who are
+   * already editors.
+   */
+  async addEditors(
+    auth: Authenticator,
+    users: UserResource[]
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    if (users.length === 0) {
+      return new Ok(undefined);
+    }
+
+    if (!this.canAdministrate(auth)) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "User is not authorized to update skill editors."
+        )
+      );
+    }
+
+    if (!this.editorGroup) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "The skill does not have an editors group."
+        )
+      );
+    }
+
+    const addResult = await this.editorGroup.dangerouslyAddMembers(auth, {
+      users: users.map((u) => u.toJSON()),
+    });
+    if (addResult.isErr()) {
+      return addResult;
+    }
+
+    return new Ok(undefined);
+  }
+
+  /**
+   * Removes editors. Like `addEditors`: authorizes the caller, then surfaces the group's typed
+   * errors for the caller to map.
+   */
+  async removeEditors(
+    auth: Authenticator,
+    users: UserResource[]
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    if (users.length === 0) {
+      return new Ok(undefined);
+    }
+
+    if (!this.canAdministrate(auth)) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "User is not authorized to update skill editors."
+        )
+      );
+    }
+
+    if (!this.editorGroup) {
+      return new Err(
+        new DustError(
+          "unauthorized",
+          "The skill does not have an editors group."
+        )
+      );
+    }
+
+    const removeResult = await this.editorGroup.dangerouslyRemoveMembers(auth, {
+      users: users.map((u) => u.toJSON()),
+    });
+    if (removeResult.isErr()) {
+      return removeResult;
     }
 
     return new Ok(undefined);
@@ -2855,7 +2964,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * Batch list editors for multiple skills. Keyed by skill sId.
+   * Batch list editors for multiple skills. Keyed by skill sId. The batched counterpart of
+   * `listEditors` — see it for why editors are only ever read through these two methods.
    */
   static async batchListEditors(
     auth: Authenticator,

--- a/front/scripts/seed/factories/seedSkill.ts
+++ b/front/scripts/seed/factories/seedSkill.ts
@@ -83,7 +83,7 @@ async function addSkillEditors(
 
   // The owner is already in the group, and adding an existing member is an error.
   const activeMemberIds = new Set(
-    (await editorGroup.getActiveMembers(auth)).map((member) => member.sId)
+    ((await skill.listEditors(auth)) ?? []).map((member) => member.sId)
   );
   const usersToAdd = editors.filter(
     (editor) => !activeMemberIds.has(editor.sId)


### PR DESCRIPTION
## Description

Centralize calls to list/add/remove editors so we can mor easily swap it later on

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low, easy to revert

## Deploy Plan

deploy front