### PR TITLE
move Tools and Triggers into its own modal

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -2,6 +2,7 @@ import type { CreditUsageState } from "@app/components/app/CreditUsage";
 import { CreditUsage } from "@app/components/app/CreditUsage";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
+import { UserToolsAndTriggersDialog } from "@app/components/me/UserToolsAndTriggersDialog";
 import { UserSettingsPopover } from "@app/components/UserSettingsPopover";
 import { WorkspacePickerRadioGroup } from "@app/components/WorkspacePicker";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
@@ -55,6 +56,7 @@ import {
   MessageTextCircle01,
   Separator,
   Shapes,
+  ShapesPlus,
   SlackLogo,
   Star01,
   Terminal,
@@ -78,6 +80,7 @@ export function UserMenu({
   const router = useAppRouter();
   const { featureFlags } = useFeatureFlags();
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [toolsAndTriggersOpen, setToolsAndTriggersOpen] = useState(false);
 
   const sendNotification = useSendNotification();
   const devMode = useDevMode();
@@ -235,6 +238,11 @@ export function UserMenu({
         onOpenChange={setSettingsOpen}
         owner={owner}
       />
+      <UserToolsAndTriggersDialog
+        open={toolsAndTriggersOpen}
+        onOpenChange={setToolsAndTriggersOpen}
+        owner={owner}
+      />
       <DropdownMenu>
         <DropdownMenuTrigger className="hover:bg-hover data-[state=open]:bg-selected rounded-xl p-2 m-2">
           <div className="group flex cursor-pointer items-center justify-between gap-2">
@@ -381,11 +389,18 @@ export function UserMenu({
 
           <DropdownMenuLabel label="Account" />
           {subscription?.plan.limits.canUseProduct && (
-            <DropdownMenuItem
-              label="Personal Settings"
-              icon={User01}
-              onSelect={() => setSettingsOpen(true)}
-            />
+            <>
+              <DropdownMenuItem
+                label="Personal Settings"
+                icon={User01}
+                onSelect={() => setSettingsOpen(true)}
+              />
+              <DropdownMenuItem
+                label="Tools and Triggers"
+                icon={ShapesPlus}
+                onSelect={() => setToolsAndTriggersOpen(true)}
+              />
+            </>
           )}
 
           <DropdownMenuItem

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -10,8 +10,6 @@ import {
   SoundNotificationPreferences,
   useSoundNotificationPreferencesForm,
 } from "@app/components/me/SoundNotificationPreferences";
-import { UserToolsTable } from "@app/components/me/UserToolsTable";
-import { UserTriggersTable } from "@app/components/me/UserTriggersTable";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { MyAwuUsageFromAnalyticsChart } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
@@ -72,19 +70,16 @@ import {
   Page,
   Separator,
   Settings01,
-  ShapesPlus,
   SliderToggle,
   Spinner,
   Stars02,
   Sun,
   Tabs,
-  TabsContent,
   TabsList,
   TabsTrigger,
   Tooltip,
   User01,
   XClose,
-  Zap,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ExternalLinkIcon } from "lucide-react";
@@ -99,7 +94,6 @@ type SettingsSection =
   | "customization"
   | "notifications"
   | "memory"
-  | "tools"
   | "invitations";
 
 interface UserSettingsPopoverProps {
@@ -773,27 +767,6 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
   );
 }
 
-// ─── Tools & Triggers ─────────────────────────────────────────────────────────
-
-function ToolsSection({ owner }: { owner: WorkspaceType }) {
-  return (
-    <SectionContent title="Tools and Triggers">
-      <Tabs defaultValue="tools">
-        <TabsList border>
-          <TabsTrigger value="tools" label="Tools" icon={Zap} />
-          <TabsTrigger value="triggers" label="Triggers" icon={Bell01} />
-        </TabsList>
-        <TabsContent value="tools">
-          <UserToolsTable owner={owner} />
-        </TabsContent>
-        <TabsContent value="triggers">
-          <UserTriggersTable owner={owner} />
-        </TabsContent>
-      </Tabs>
-    </SectionContent>
-  );
-}
-
 // ─── Invitations ──────────────────────────────────────────────────────────────
 
 interface InvitationsSectionProps {
@@ -944,7 +917,6 @@ const NAV_ITEMS: Array<{
   { section: "customization", icon: Settings01, label: "Customization" },
   { section: "memory", icon: Brain, label: "Memory" },
   { section: "notifications", icon: Bell01, label: "Notifications" },
-  { section: "tools", icon: ShapesPlus, label: "Tools and Triggers" },
   { section: "invitations", icon: Mail01, label: "Invitations" },
 ];
 
@@ -1060,7 +1032,6 @@ export function UserSettingsPopover({
               <NotificationsSection owner={owner} />
             )}
             {activeSection === "memory" && <MemorySection owner={owner} />}
-            {activeSection === "tools" && <ToolsSection owner={owner} />}
             {activeSection === "invitations" && (
               <InvitationsSection
                 invitations={pendingInvitations}

--- a/front/components/me/UserToolsAndTriggersDialog.tsx
+++ b/front/components/me/UserToolsAndTriggersDialog.tsx
@@ -1,0 +1,54 @@
+import { UserToolsTable } from "@app/components/me/UserToolsTable";
+import { UserTriggersTable } from "@app/components/me/UserTriggersTable";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Bell01,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  Zap,
+} from "@dust-tt/sparkle";
+
+interface UserToolsAndTriggersDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  owner: LightWorkspaceType;
+}
+
+export function UserToolsAndTriggersDialog({
+  open,
+  onOpenChange,
+  owner,
+}: UserToolsAndTriggersDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      {/* The portal has no forceMount, so this subtree unmounts when the dialog
+       * closes. The tables' SWR hooks need no `disabled` gating. */}
+      <DialogContent size="2xl" height="xl">
+        <DialogHeader>
+          <DialogTitle>Tools and Triggers</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <Tabs defaultValue="tools">
+            <TabsList border>
+              <TabsTrigger value="tools" label="Tools" icon={Zap} />
+              <TabsTrigger value="triggers" label="Triggers" icon={Bell01} />
+            </TabsList>
+            <TabsContent value="tools">
+              <UserToolsTable owner={owner} />
+            </TabsContent>
+            <TabsContent value="triggers">
+              <UserTriggersTable owner={owner} />
+            </TabsContent>
+          </Tabs>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Description

"Tools and Triggers" was a section inside the Personal Settings modal. It is now
its own entry in the user menu, opening its own modal.

- New `UserToolsAndTriggersDialog`, standard dialog layout (`DialogHeader` + `DialogContainer`), keeping the existing Tools / Triggers tabs.
- Removed the `tools` section from `UserSettingsPopover` (nav item, section component, render branch).
- New "Tools and Triggers" item in the user menu, under Account right after "Personal Settings", behind the same `canUseProduct` gate.

`UserToolsTable` and `UserTriggersTable` are unchanged.

## Tests

Locally.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front; 