### PR TITLE
[front] Cache system key workspace permission grants

### DIFF
--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -62,6 +62,7 @@ export type RedisUsageTagsType =
   | "email_context"
   | "otp_challenge"
   | "force_reload_commits"
+  | "group_permissions_cache"
   | "key_usage_tracking"
   | "lock"
   | "sandbox_exec_tokens"

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -973,6 +973,10 @@ export class Authenticator {
       ? allGroups.map((g) => g.id)
       : [];
     const keyGroupModelIds = allGroups.map((g) => g.id);
+    const isUnscopedSystemKey = key.isSystem && requestedGroupIds === undefined;
+    const useWorkspacePermissionCache =
+      isUnscopedSystemKey &&
+      (await isSystemKeyPermissionCacheEnabled(keyWorkspace.id));
 
     let permissions: GroupPermissions;
     let keyPermissions: GroupPermissions;
@@ -982,6 +986,7 @@ export class Authenticator {
       permissions = await this.resolvePermissions({
         workspace,
         groupModelIds: workspaceGroupModelIds,
+        useWorkspacePermissionCache,
       });
       keyPermissions = permissions;
     } else {
@@ -989,10 +994,12 @@ export class Authenticator {
         this.resolvePermissions({
           workspace,
           groupModelIds: workspaceGroupModelIds,
+          useWorkspacePermissionCache,
         }),
         this.resolvePermissions({
           workspace: keyWorkspace,
           groupModelIds: keyGroupModelIds,
+          useWorkspacePermissionCache,
         }),
       ]);
     }
@@ -1297,18 +1304,25 @@ export class Authenticator {
   static async resolvePermissions({
     workspace,
     groupModelIds,
+    useWorkspacePermissionCache = false,
   }: {
     workspace?: WorkspaceResource | null;
     groupModelIds: ModelId[];
+    useWorkspacePermissionCache?: boolean;
   }): Promise<GroupPermissions> {
     if (!workspace) {
       return GroupPermissions.empty();
     }
 
     const lightWorkspace = renderLightWorkspaceType({ workspace });
-    const grants = await GroupPermissionResource.listForGroups(lightWorkspace, {
-      groupModelIds,
-    });
+    const grants = useWorkspacePermissionCache
+      ? await GroupPermissionResource.listForGroupsFromWorkspaceCache(
+          lightWorkspace,
+          groupModelIds
+        )
+      : await GroupPermissionResource.listForGroups(lightWorkspace, {
+          groupModelIds,
+        });
 
     return GroupPermissions.fromGrants(grants);
   }
@@ -1974,6 +1988,25 @@ export async function prodAPICredentialsForOwner(
     apiKey: systemAPIKeyRes.value.secret,
     workspaceId: owner.sId,
   };
+}
+
+const SYSTEM_KEY_PERMISSION_CACHE_FEATURE =
+  "system_key_permission_cache" as const satisfies WhitelistableFeature;
+
+async function isSystemKeyPermissionCacheEnabled(
+  workspaceModelId: ModelId
+): Promise<boolean> {
+  const globalFlag = (await GlobalFeatureFlagResource.listAll()).find(
+    (flag) => flag.name === SYSTEM_KEY_PERMISSION_CACHE_FEATURE
+  );
+
+  return (
+    globalFlag !== undefined &&
+    GlobalFeatureFlagResource.isInRollout(
+      workspaceModelId,
+      globalFlag.rolloutPercentage
+    )
+  );
 }
 
 export async function getFeatureFlagsForWorkspace(

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
@@ -230,7 +231,26 @@ describe("Authenticator.fromKey permission resolution", () => {
     vi.restoreAllMocks();
   });
 
-  it("resolves permissions for unscoped system keys", async () => {
+  it("keeps the cache disabled until its global rollout starts", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const { systemGroup } = await GroupFactory.defaults(workspace);
+    const databaseLookupSpy = vi.spyOn(
+      GroupPermissionResource,
+      "listForGroups"
+    );
+    const workspaceCacheSpy = vi.spyOn(
+      GroupPermissionResource,
+      "listForGroupsFromWorkspaceCache"
+    );
+    const key = await KeyFactory.system(systemGroup);
+
+    await Authenticator.fromKey(key, workspace.sId);
+
+    expect(databaseLookupSpy).toHaveBeenCalledTimes(1);
+    expect(workspaceCacheSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses the workspace grant cache for unscoped system keys", async () => {
     const workspace = await WorkspaceFactory.basic();
     const { systemGroup } = await GroupFactory.defaults(workspace);
     const adminAuth = await Authenticator.internalAdminForWorkspace(
@@ -258,12 +278,23 @@ describe("Authenticator.fromKey permission resolution", () => {
       // A different agent, so the excluded group's grant is observable by its absence below.
       resourceId: 99,
     });
+    await GlobalFeatureFlagResource.setRolloutPercentage(
+      "system_key_permission_cache",
+      100
+    );
 
+    const workspaceCacheSpy = vi.spyOn(
+      GroupPermissionResource,
+      "listForGroupsFromWorkspaceCache"
+    );
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
 
-    // The in-scope group's grant on agent 42 is loaded; the out-of-scope group's grant on agent 99
-    // is not — resolved verbs are caller-scoped and carry no group ids.
+    // The workspace snapshot cache serves this unscoped system key when the rollout is enabled.
+    expect(workspaceCacheSpy).toHaveBeenCalledTimes(1);
+    // The in-scope group's grant on agent 42 is loaded; the out-of-scope (agent_editors) group's
+    // grant on agent 99 is filtered out of the snapshot — resolved verbs are caller-scoped and
+    // carry no group ids.
     expect(workspaceAuth.getGrantedVerbs("agent", 42).length).toBeGreaterThan(
       0
     );
@@ -297,12 +328,23 @@ describe("Authenticator.fromKey permission resolution", () => {
       // A different agent, so the excluded group's grant is observable by its absence below.
       resourceId: 99,
     });
+    await GlobalFeatureFlagResource.setRolloutPercentage(
+      "system_key_permission_cache",
+      100
+    );
 
+    const workspaceCacheSpy = vi.spyOn(
+      GroupPermissionResource,
+      "listForGroupsFromWorkspaceCache"
+    );
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId, [
       includedGroup.sId,
     ]);
 
+    // A scoped key routes through the ordinary database lookup, never the workspace cache — even
+    // with the rollout enabled, because the cache only serves unscoped system keys.
+    expect(workspaceCacheSpy).not.toHaveBeenCalled();
     // The in-scope group's grant on agent 42 is loaded; the out-of-scope group's grant on agent 99
     // is not — resolved verbs are caller-scoped and carry no group ids.
     expect(workspaceAuth.getGrantedVerbs("agent", 42).length).toBeGreaterThan(

--- a/front/lib/resources/group_permission_cache.test.ts
+++ b/front/lib/resources/group_permission_cache.test.ts
@@ -1,0 +1,346 @@
+import type { CacheableFunction, JsonSerializable } from "@app/lib/utils/cache";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+const cacheMisses = vi.hoisted(() => ({ count: 0 }));
+const cacheLoad = vi.hoisted(() => ({
+  blocker: null as Promise<void> | null,
+  resultReady: null as (() => void) | null,
+}));
+const generationCache = vi.hoisted(() => ({
+  values: new Map<string, number>(),
+  calls: 0,
+  blocker: null as Promise<void> | null,
+  advanceOnRead: false,
+}));
+
+vi.mock("@app/lib/api/redis", () => ({
+  getRedisCacheClient: vi.fn().mockResolvedValue({
+    get: vi.fn().mockImplementation((key: string) => {
+      let generation = generationCache.values.get(key);
+      if (generationCache.advanceOnRead) {
+        generation = (generation ?? 0) + 1;
+        generationCache.values.set(key, generation);
+      }
+      return Promise.resolve(generation?.toString() ?? null);
+    }),
+    eval: vi
+      .fn()
+      .mockImplementation(
+        async (
+          _script: string,
+          { keys: [generationKey] }: { keys: string[] }
+        ) => {
+          generationCache.calls += 1;
+          await generationCache.blocker;
+          generationCache.values.set(
+            generationKey,
+            (generationCache.values.get(generationKey) ?? 0) + 1
+          );
+          return generationCache.values.get(generationKey);
+        }
+      ),
+  }),
+}));
+
+vi.mock("@app/lib/utils/cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/utils/cache")>();
+  return {
+    ...actual,
+    cacheWithRedis: vi
+      .fn()
+      .mockImplementation(
+        <T, Args extends unknown[]>(
+          fn: CacheableFunction<JsonSerializable<T>, Args>,
+          resolver: (...args: Args) => string,
+          options: { cacheId?: string }
+        ) => {
+          return async (...args: Args): Promise<JsonSerializable<T>> => {
+            const key = `cacheWithRedis-${options.cacheId ?? fn.name}-${resolver(...args)}`;
+            const cached = inMemoryCache.get(key);
+            if (cached) {
+              return JSON.parse(cached) as JsonSerializable<T>;
+            }
+            cacheMisses.count += 1;
+            const result = await fn(...args);
+            cacheLoad.resultReady?.();
+            await cacheLoad.blocker;
+            inMemoryCache.set(key, JSON.stringify(result));
+            return result;
+          };
+        }
+      ),
+  };
+});
+
+import { Authenticator } from "@app/lib/auth";
+import {
+  WORKSPACE_GRANTS_CACHE_ID,
+  workspaceGrantsCacheKeyResolver,
+} from "@app/lib/resources/group_permission_cache";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { getNamespace } from "@app/tests/utils/test_cls";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+function workspaceGrantsCacheKey(workspaceModelId: number): string {
+  const generation =
+    generationCache.values.get(
+      `workspace-group-permissions-generation:${workspaceModelId}`
+    ) ?? 0;
+  return `cacheWithRedis-${WORKSPACE_GRANTS_CACHE_ID}-${workspaceGrantsCacheKeyResolver(workspaceModelId, generation)}`;
+}
+
+describe("GroupPermissionResource workspace cache", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let groupA: GroupResource;
+  let groupB: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(workspace);
+    groupA = await GroupFactory.regularManual(workspace, "A");
+    groupB = await GroupFactory.regularManual(workspace, "B");
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    inMemoryCache.clear();
+    cacheMisses.count = 0;
+    cacheLoad.blocker = null;
+    cacheLoad.resultReady = null;
+    generationCache.values.clear();
+    generationCache.calls = 0;
+    generationCache.blocker = null;
+    generationCache.advanceOnRead = false;
+  });
+
+  it("shares one workspace snapshot while filtering the current group ids", async () => {
+    await GroupPermissionResource.grant(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    });
+    await GroupPermissionResource.grant(auth, {
+      group: groupB,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 2,
+    });
+
+    const grantsForA =
+      await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+        groupA.id,
+      ]);
+    const grantsForB =
+      await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+        groupB.id,
+      ]);
+
+    expect(cacheMisses.count).toBe(1);
+    expect(grantsForA.map((grant) => grant.groupModelId)).toEqual([groupA.id]);
+    expect(grantsForB.map((grant) => grant.groupModelId)).toEqual([groupB.id]);
+    expect(inMemoryCache.size).toBe(1);
+  });
+
+  it("advances the snapshot generation after a grant transaction commits", async () => {
+    await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+      groupA.id,
+    ]);
+    const cacheKey = workspaceGrantsCacheKey(workspace.id);
+    expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+    const parentTransaction =
+      getNamespace("test-namespace")?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+    const transaction = await frontSequelize.transaction({
+      transaction: parentTransaction,
+    });
+
+    await GroupPermissionResource.grant(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+      transaction,
+    });
+    expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+    await transaction.commit();
+    expect(inMemoryCache.has(cacheKey)).toBe(true);
+    expect(workspaceGrantsCacheKey(workspace.id)).not.toBe(cacheKey);
+    expect(inMemoryCache.has(workspaceGrantsCacheKey(workspace.id))).toBe(
+      false
+    );
+
+    const grants =
+      await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+        groupA.id,
+      ]);
+    expect(grants).toMatchObject([{ groupModelId: groupA.id, resourceId: 1 }]);
+  });
+
+  it("keeps the snapshot when a grant transaction rolls back", async () => {
+    await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+      groupA.id,
+    ]);
+    const cacheKey = workspaceGrantsCacheKey(workspace.id);
+
+    const parentTransaction =
+      getNamespace("test-namespace")?.get("transaction");
+    expect(parentTransaction).toBeDefined();
+    const transaction = await frontSequelize.transaction({
+      transaction: parentTransaction,
+    });
+
+    await GroupPermissionResource.grant(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+      transaction,
+    });
+    await transaction.rollback();
+
+    expect(inMemoryCache.has(cacheKey)).toBe(true);
+    expect(
+      await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+        groupA.id,
+      ])
+    ).toEqual([]);
+  });
+
+  it("advances the snapshot generation after revoking a grant", async () => {
+    await GroupPermissionResource.grant(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    });
+    await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+      groupA.id,
+    ]);
+
+    await GroupPermissionResource.revoke(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    });
+
+    expect(inMemoryCache.has(workspaceGrantsCacheKey(workspace.id))).toBe(
+      false
+    );
+  });
+
+  it("retries when a revocation commits during a cache fill", async () => {
+    await GroupPermissionResource.grant(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    });
+
+    let releaseCacheLoad: () => void = () => {};
+    cacheLoad.blocker = new Promise<void>((resolve) => {
+      releaseCacheLoad = resolve;
+    });
+    let signalCacheResultReady: () => void = () => {};
+    const cacheResultReady = new Promise<void>((resolve) => {
+      signalCacheResultReady = resolve;
+    });
+    cacheLoad.resultReady = signalCacheResultReady;
+
+    const grantsPromise =
+      GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+        groupA.id,
+      ]);
+    await cacheResultReady;
+
+    await GroupPermissionResource.revoke(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    });
+    releaseCacheLoad();
+
+    await expect(grantsPromise).resolves.toEqual([]);
+    expect(cacheMisses.count).toBe(2);
+  });
+
+  it("falls back to the database query during continuous generation churn", async () => {
+    await GroupPermissionResource.grant(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    });
+    const databaseLookup = vi.spyOn(GroupPermissionResource, "listForGroups");
+    generationCache.advanceOnRead = true;
+
+    const grants =
+      await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+        groupA.id,
+      ]);
+
+    expect(databaseLookup).toHaveBeenCalledTimes(1);
+    expect(grants).toMatchObject([{ groupModelId: groupA.id, resourceId: 1 }]);
+  });
+
+  it("waits for a generation advance without an explicit transaction", async () => {
+    await GroupPermissionResource.grant(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    });
+    await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+      groupA.id,
+    ]);
+
+    generationCache.calls = 0;
+    let releaseGenerationAdvance: () => void = () => {};
+    generationCache.blocker = new Promise<void>((resolve) => {
+      releaseGenerationAdvance = resolve;
+    });
+    let revokeSettled = false;
+    const revokePromise = GroupPermissionResource.revoke(auth, {
+      group: groupA,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    }).then(() => {
+      revokeSettled = true;
+    });
+
+    await vi.waitFor(() => expect(generationCache.calls).toBe(1));
+    expect(revokeSettled).toBe(false);
+
+    releaseGenerationAdvance();
+    await revokePromise;
+    expect(inMemoryCache.has(workspaceGrantsCacheKey(workspace.id))).toBe(
+      false
+    );
+  });
+
+  it("invalidates the snapshot when group deletion removes grants", async () => {
+    await GroupPermissionResource.grant(auth, {
+      group: groupB,
+      grantType: "reader",
+      resourceType: "space",
+      resourceId: 1,
+    });
+    await GroupPermissionResource.listForGroupsFromWorkspaceCache(workspace, [
+      groupB.id,
+    ]);
+
+    const deleteResult = await groupB.delete(auth);
+
+    expect(deleteResult.isOk()).toBe(true);
+    expect(inMemoryCache.has(workspaceGrantsCacheKey(workspace.id))).toBe(
+      false
+    );
+  });
+});

--- a/front/lib/resources/group_permission_cache.ts
+++ b/front/lib/resources/group_permission_cache.ts
@@ -1,0 +1,75 @@
+import { getRedisCacheClient } from "@app/lib/api/redis";
+import { invalidateCacheAfterCommit } from "@app/lib/utils/cache";
+import type {
+  GrantType,
+  GroupPermissionResourceType,
+} from "@app/types/group_permissions";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Transaction } from "sequelize";
+
+export interface CachedWorkspaceGrant {
+  groupModelId: ModelId;
+  grantType: GrantType;
+  resourceType: GroupPermissionResourceType;
+  resourceId: number;
+}
+
+export const WORKSPACE_GRANTS_CACHE_ID = "workspace_group_permissions";
+export const WORKSPACE_GRANTS_CACHE_TTL_MS = 60 * 1000;
+const WORKSPACE_GRANTS_GENERATION_TTL_MS = 5 * WORKSPACE_GRANTS_CACHE_TTL_MS;
+
+export const workspaceGrantsCacheKeyResolver = (
+  workspaceModelId: ModelId,
+  generation: number
+): string => `workspace-group-permissions:${workspaceModelId}:${generation}`;
+
+const workspaceGrantsGenerationKey = (workspaceModelId: ModelId): string =>
+  `workspace-group-permissions-generation:${workspaceModelId}`;
+
+export async function getWorkspaceGrantsCacheGeneration(
+  workspaceModelId: ModelId
+): Promise<number> {
+  const redis = await getRedisCacheClient({
+    origin: "group_permissions_cache",
+  });
+  const generation = await redis.get(
+    workspaceGrantsGenerationKey(workspaceModelId)
+  );
+
+  return generation === null ? 0 : Number.parseInt(generation, 10);
+}
+
+async function advanceWorkspaceGrantsCacheGeneration(
+  workspaceModelId: ModelId
+): Promise<void> {
+  const redis = await getRedisCacheClient({
+    origin: "group_permissions_cache",
+  });
+  const key = workspaceGrantsGenerationKey(workspaceModelId);
+
+  await redis.eval(
+    `
+      local generation = redis.call("incr", KEYS[1])
+      redis.call("pexpire", KEYS[1], ARGV[1])
+      return generation
+    `,
+    {
+      keys: [key],
+      arguments: [WORKSPACE_GRANTS_GENERATION_TTL_MS.toString()],
+    }
+  );
+}
+
+export async function advanceWorkspaceGrantsCacheGenerationAfterCommit(
+  workspaceModelId: ModelId,
+  transaction?: Transaction
+): Promise<void> {
+  if (transaction) {
+    invalidateCacheAfterCommit(transaction, () =>
+      advanceWorkspaceGrantsCacheGeneration(workspaceModelId)
+    );
+    return;
+  }
+
+  await advanceWorkspaceGrantsCacheGeneration(workspaceModelId);
+}

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -211,12 +211,13 @@ function maskToVerbs(mask: number): GrantVerb[] {
   return GRANT_VERBS.filter((verb) => (mask & (VERB_BIT.get(verb) ?? 0)) !== 0);
 }
 
-// The grant fields `fromGrants` reads. `GroupPermissionResource` satisfies this structurally, so
-// callers pass resources directly (no DTO conversion); typed as a Pick to avoid coupling to the
-// full resource and to keep the reference type-only.
+// The grant fields `fromGrants` reads — group ids are folded away, so only the grant tuple is
+// needed. Both `GroupPermissionResource` and the cache DTO `CachedWorkspaceGrant` satisfy this
+// structurally, so callers pass either directly (no DTO conversion); typed as a Pick to keep the
+// reference type-only.
 type GrantRow = Pick<
   GroupPermissionResource,
-  "groupId" | "grantType" | "resourceType" | "resourceId"
+  "grantType" | "resourceType" | "resourceId"
 >;
 
 // JSON-serializable form of GroupPermissions, embedded in a serialized Authenticator so it can be

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -1,11 +1,20 @@
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import type { CachedWorkspaceGrant } from "@app/lib/resources/group_permission_cache";
+import {
+  advanceWorkspaceGrantsCacheGenerationAfterCommit,
+  getWorkspaceGrantsCacheGeneration,
+  WORKSPACE_GRANTS_CACHE_ID,
+  WORKSPACE_GRANTS_CACHE_TTL_MS,
+  workspaceGrantsCacheKeyResolver,
+} from "@app/lib/resources/group_permission_cache";
 import { assertValidGrant } from "@app/lib/resources/group_permission_registry";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { cacheWithRedis } from "@app/lib/utils/cache";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   CapabilitySpec,
@@ -28,8 +37,11 @@ import assert from "assert";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { literal, Op } from "sequelize";
 
+const MAX_WORKSPACE_GRANTS_GENERATION_READ_ATTEMPTS = 3;
+
 /**
- * All writes to `group_permissions` go through this resource — never a raw model write elsewhere.
+ * Permission-specific writes to `group_permissions` go through this resource. Group deletion also
+ * removes its rows in GroupResource, where it shares this resource's cache invalidation helper.
  * This file covers instance-level grants and reads; wildcard / type-level writes (resourceId = -1,
  * "*") land through dedicated named methods in a follow-up so a defaulted -1 can never silently
  * grant a whole type.
@@ -106,6 +118,36 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     super(GroupPermissionModel, blob);
   }
 
+  private static async listWorkspaceGrantsUncached(
+    workspaceModelId: ModelId,
+    _generation: number
+  ): Promise<CachedWorkspaceGrant[]> {
+    const rows = await GroupPermissionModel.findAll({
+      attributes: ["groupId", "grantType", "resourceType", "resourceId"],
+      where: { workspaceId: workspaceModelId },
+    });
+
+    return rows.map(
+      ({ groupId: groupModelId, grantType, resourceType, resourceId }) => ({
+        groupModelId,
+        grantType,
+        resourceType,
+        resourceId,
+      })
+    );
+  }
+
+  private static listWorkspaceGrantsCached = cacheWithRedis(
+    GroupPermissionResource.listWorkspaceGrantsUncached,
+    workspaceGrantsCacheKeyResolver,
+    {
+      cacheId: WORKSPACE_GRANTS_CACHE_ID,
+      cacheNullValues: false,
+      ttlMs: WORKSPACE_GRANTS_CACHE_TTL_MS,
+      useDistributedLock: true,
+    }
+  );
+
   // A group is scoped to a single workspace, and every grant is scoped to the caller's workspace.
   // The DB only FKs groupId to groups.id (not to the workspace), so we enforce the match here to
   // keep a group from workspace B out of workspace A's grants.
@@ -163,7 +205,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
         );
       }
 
-      const [row] = await GroupPermissionModel.findOrCreate({
+      const [row, created] = await GroupPermissionModel.findOrCreate({
         where: {
           workspaceId,
           groupId: group.id,
@@ -173,6 +215,10 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
         },
         transaction: t,
       });
+
+      if (created) {
+        await advanceWorkspaceGrantsCacheGenerationAfterCommit(workspaceId, t);
+      }
 
       return new this(GroupPermissionModel, row.get());
     }, transaction);
@@ -441,9 +487,10 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       resourceId > 0,
       "revoke() is instance-level; use revokeTypeWide for type-wide grants."
     );
-    await GroupPermissionModel.destroy({
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const deleted = await GroupPermissionModel.destroy({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: workspaceModelId,
         groupId: group.id,
         grantType,
         resourceType,
@@ -451,6 +498,12 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       },
       transaction,
     });
+    if (deleted > 0) {
+      await advanceWorkspaceGrantsCacheGenerationAfterCommit(
+        workspaceModelId,
+        transaction
+      );
+    }
   }
 
   // Read grants for the given groups, optionally narrowed by grant type / resource type /
@@ -482,6 +535,52 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     return rows.map((row) => new this(GroupPermissionModel, row.get()));
   }
 
+  // System keys can represent nearly every group in a workspace. Cache the compact workspace
+  // grant snapshot independently of the caller's group set, then intersect with the current group
+  // ids on every request. This keeps group membership changes out of this cache's lifecycle.
+  static async listForGroupsFromWorkspaceCache(
+    workspace: LightWorkspaceType,
+    groupModelIds: ModelId[]
+  ): Promise<CachedWorkspaceGrant[]> {
+    if (groupModelIds.length === 0) {
+      return [];
+    }
+
+    const groupModelIdSet = new Set(groupModelIds);
+    for (
+      let attempt = 0;
+      attempt < MAX_WORKSPACE_GRANTS_GENERATION_READ_ATTEMPTS;
+      attempt++
+    ) {
+      const generationBefore = await getWorkspaceGrantsCacheGeneration(
+        workspace.id
+      );
+      const grants = await this.listWorkspaceGrantsCached(
+        workspace.id,
+        generationBefore
+      );
+      const generationAfter = await getWorkspaceGrantsCacheGeneration(
+        workspace.id
+      );
+
+      if (generationBefore === generationAfter) {
+        return grants.filter((grant) =>
+          groupModelIdSet.has(grant.groupModelId)
+        );
+      }
+    }
+
+    const grants = await this.listForGroups(workspace, { groupModelIds });
+    return grants.map(
+      ({ groupId: groupModelId, grantType, resourceType, resourceId }) => ({
+        groupModelId,
+        grantType,
+        resourceType,
+        resourceId,
+      })
+    );
+  }
+
   // Deletion-integrity hook: drop every grant (across all groups) targeting one resource. There is
   // no FK on the resource side, so callers invoke this when a resource is deleted. Guards against
   // wiping the type-wide wildcard rows.
@@ -502,14 +601,22 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       "deleteAllForResource targets a concrete resource; it must not clear type-wide grants."
     );
 
-    return GroupPermissionModel.destroy({
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const deleted = await GroupPermissionModel.destroy({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: workspaceModelId,
         resourceType,
         resourceId,
       },
       transaction,
     });
+    if (deleted > 0) {
+      await advanceWorkspaceGrantsCacheGenerationAfterCommit(
+        workspaceModelId,
+        transaction
+      );
+    }
+    return deleted;
   }
 
   static async listForWorkspace(
@@ -530,20 +637,28 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       return;
     }
 
-    await GroupPermissionModel.destroy({
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const deleted = await GroupPermissionModel.destroy({
       where: {
         id: ids,
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: workspaceModelId,
       },
     });
+    if (deleted > 0) {
+      await advanceWorkspaceGrantsCacheGenerationAfterCommit(workspaceModelId);
+    }
   }
 
   // Workspace-scrub hook: drop every grant for the workspace. Must run before groups and the
   // workspace row are torn down, since both FKs are ON DELETE RESTRICT.
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
-    await GroupPermissionModel.destroy({
-      where: { workspaceId: auth.getNonNullableWorkspace().id },
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const deleted = await GroupPermissionModel.destroy({
+      where: { workspaceId: workspaceModelId },
     });
+    if (deleted > 0) {
+      await advanceWorkspaceGrantsCacheGenerationAfterCommit(workspaceModelId);
+    }
   }
 
   // Grant a permission for the whole resource type (resourceId = -1). Single-group convenience over
@@ -599,6 +714,10 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       })),
       { ignoreDuplicates: true, transaction }
     );
+    await advanceWorkspaceGrantsCacheGenerationAfterCommit(
+      workspaceId,
+      transaction
+    );
   }
 
   // Revoke a group's type-wide grant. No-op if absent.
@@ -606,9 +725,10 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     auth: Authenticator,
     { group, grantType, resourceType, transaction }: TypeWideGrantSpec
   ): Promise<void> {
-    await GroupPermissionModel.destroy({
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const deleted = await GroupPermissionModel.destroy({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: workspaceModelId,
         groupId: group.id,
         grantType,
         resourceType,
@@ -616,6 +736,12 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       },
       transaction,
     });
+    if (deleted > 0) {
+      await advanceWorkspaceGrantsCacheGenerationAfterCommit(
+        workspaceModelId,
+        transaction
+      );
+    }
   }
 
   // Batch of instance-level grants (one INSERT, unique index dedupes). Each is validated; -1 is
@@ -663,6 +789,10 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
         resourceId,
       })),
       { ignoreDuplicates: true, transaction }
+    );
+    await advanceWorkspaceGrantsCacheGenerationAfterCommit(
+      workspaceId,
+      transaction
     );
   }
 
@@ -763,15 +893,22 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     { grantType, resourceType }: CapabilitySpec,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
-    await GroupPermissionModel.destroy({
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const deleted = await GroupPermissionModel.destroy({
       where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: workspaceModelId,
         grantType,
         resourceType,
         resourceId: WHOLE_TYPE_RESOURCE_ID,
       },
       transaction,
     });
+    if (deleted > 0) {
+      await advanceWorkspaceGrantsCacheGenerationAfterCommit(
+        workspaceModelId,
+        transaction
+      );
+    }
   }
 
   // Serialize concurrent writes on the same grant tuple. The transaction-scoped advisory lock
@@ -873,13 +1010,20 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    await this.model.destroy({
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const deleted = await this.model.destroy({
       where: {
         id: this.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
+        workspaceId: workspaceModelId,
       },
       transaction,
     });
+    if (deleted > 0) {
+      await advanceWorkspaceGrantsCacheGenerationAfterCommit(
+        workspaceModelId,
+        transaction
+      );
+    }
 
     return new Ok(undefined);
   }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -3,6 +3,7 @@ import { DustError } from "@app/lib/error";
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { advanceWorkspaceGrantsCacheGenerationAfterCommit } from "@app/lib/resources/group_permission_cache";
 import type { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -2517,13 +2518,19 @@ export class GroupResource extends BaseResource<GroupModel> {
         transaction,
       });
 
-      await GroupPermissionModel.destroy({
+      const deletedGroupPermissions = await GroupPermissionModel.destroy({
         where: {
           groupId: this.id,
           workspaceId: owner.id,
         },
         transaction,
       });
+      if (deletedGroupPermissions > 0) {
+        await advanceWorkspaceGrantsCacheGenerationAfterCommit(
+          owner.id,
+          transaction
+        );
+      }
 
       await this.model.destroy({
         where: {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -332,6 +332,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",
     stage: "dust_only",
   },
+  system_key_permission_cache: {
+    description:
+      "Resolve unscoped system-key group permissions from a generation-versioned workspace cache after all writers have deployed.",
+    stage: "dust_only",
+  },
   user_memory: {
     description:
       "Enable the user_memory internal MCP server: agents can store and retrieve per-user memory in a user-scoped filesystem.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -761,6 +761,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "fireworks_new_model_feature"
   | "google_sheets_tool"
   | "group_permissions_shadow"
+  | "system_key_permission_cache"
   | "http_client_tool"
   | "index_private_slack_channel"
   | "labs_mcp_actions_dashboard"


### PR DESCRIPTION
## Description

Stacked on #30642.

Cache one compact `group_permissions` snapshot per workspace generation for unscoped system keys when the default-off rollout flag is enabled. Every other permission resolution uses the ordinary bound-array database lookup from #30642. Each cached request filters the workspace snapshot against its current group IDs, so membership and scoped-key behavior stay outside the cache. Snapshots store only `groupModelId`, `grantType`, `resourceType`, and `resourceId`, and expire after 60 seconds.

Writers atomically advance a short-lived Redis generation after commit. Readers verify the generation before and after a cache fill, retry on a concurrent mutation, and fall back to the ordinary database lookup during continuous churn. The rollout gate lets writer invalidation reach every pod before cached reads are activated.

## Tests

Added DB-backed coverage for shared cache hits, caller-specific filtering, the default-off rollout gate, commit and rollback behavior, awaited generation advances, revoke and group-deletion invalidation, a revocation racing a delayed cache fill, and database fallback under generation churn. Preserved the SQL-shape regression coverage from #30642. Ran 123 focused resource, Authenticator, governance, and feature-flag tests locally. Ran Biome on all changed files and the Front TypeScript check.

## Risk

If Redis generation advancement fails after a database commit, an already-populated snapshot can remain stale for at most its 60-second TTL. Old generation snapshots also remain for at most 60 seconds, bounding key growth. Disable the global flag and wait 60 seconds to restore the ordinary database path before rolling back this PR.

## Deploy Plan

Merge and deploy #30642 first. Deploy this PR to every Front and front-sse pod in both regions while `system_key_permission_cache` remains disabled. After the rollout is complete, enable the global flag gradually, then monitor Redis errors, Front DB CPU, cache fallbacks, and `group_permissions` query volume. For rollback, disable the flag, wait 60 seconds for flag caches to expire, and then revert.