### PR TITLE
[front] enh: polish medium-stake approval UI

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -14,7 +14,9 @@ import {
   Button,
   Card,
   Check,
+  CheckBoxWithTextAndDescription,
   Checkbox,
+  cn,
   Label,
   PieChart01,
   XClose,
@@ -114,6 +116,11 @@ export function ToolValidationCard({
 
   const toolOverride = getToolOverride(validationRequest.metadata);
   const isSubmitting = isValidating || submittingDecision !== null;
+  const isMediumStake = validationRequest.stake === "medium";
+  const alwaysAllowLabel =
+    validationRequest.stake === "low" || isMediumStake
+      ? getToolValidationAlwaysAllowLabel(validationRequest)
+      : null;
   const {
     metadata: { agentName, mcpServerName },
   } = validationRequest;
@@ -169,27 +176,48 @@ export function ToolValidationCard({
       </div>
 
       {canCurrentUserRespond && (
-        <div className="flex flex-col gap-3 px-4 pb-3 pt-2 sm:flex-row sm:items-center">
-          {(validationRequest.stake === "low" ||
-            validationRequest.stake === "medium") && (
-            <Label
-              htmlFor={`never-ask-again-${validationRequest.actionId}`}
-              className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
-            >
-              <Checkbox
-                id={`never-ask-again-${validationRequest.actionId}`}
-                checked={neverAskAgain}
-                disabled={isSubmitting}
-                onCheckedChange={(check) => {
-                  setNeverAskAgain(!!check);
-                }}
-              />
-              <span className="font-normal">
-                {getToolValidationAlwaysAllowLabel(validationRequest)}
-              </span>
-            </Label>
+        <div
+          className={cn(
+            "flex flex-col gap-3 px-4 pb-3 pt-2",
+            !isMediumStake && "sm:flex-row sm:items-center"
           )}
-          <div className="flex gap-2 sm:ml-auto">
+        >
+          {alwaysAllowLabel &&
+            (isMediumStake ? (
+              <div className="flex min-h-11 items-center px-1">
+                <CheckBoxWithTextAndDescription
+                  id={`never-ask-again-${validationRequest.actionId}`}
+                  text="Don’t ask again"
+                  description={alwaysAllowLabel}
+                  checked={neverAskAgain}
+                  disabled={isSubmitting}
+                  onCheckedChange={(check) => {
+                    setNeverAskAgain(!!check);
+                  }}
+                />
+              </div>
+            ) : (
+              <Label
+                htmlFor={`never-ask-again-${validationRequest.actionId}`}
+                className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
+              >
+                <Checkbox
+                  id={`never-ask-again-${validationRequest.actionId}`}
+                  checked={neverAskAgain}
+                  disabled={isSubmitting}
+                  onCheckedChange={(check) => {
+                    setNeverAskAgain(!!check);
+                  }}
+                />
+                <span className="font-normal">{alwaysAllowLabel}</span>
+              </Label>
+            ))}
+          <div
+            className={cn(
+              "flex gap-2 sm:ml-auto",
+              isMediumStake && "justify-end"
+            )}
+          >
             <Button
               label="Decline"
               variant="outline"

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -21,6 +21,7 @@ import {
 } from "@app/lib/api/actions/servers/pod_tasks/types";
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { WAKEUPS_SERVER_NAME } from "@app/lib/api/actions/servers/wakeups/metadata";
+import { isString } from "@app/types/shared/utils/general";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 
 type ToolOverride = {
@@ -214,18 +215,22 @@ export function getToolValidationAlwaysAllowLabel(
     return data.approvalArgsLabel;
   }
   const args = data.argumentsRequiringApproval ?? [];
-  const argValues = args
+  const approvalParameters = args
     .filter((arg) => data.inputs[arg] != null)
     .map((arg) => {
       const value = data.inputs[arg];
-      if (Array.isArray(value)) {
-        return value.map(String).join(", ");
-      }
-      return JSON.stringify(value);
+      const displayValue = Array.isArray(value)
+        ? value.map(String).join(", ")
+        : isString(value)
+          ? value
+          : JSON.stringify(value);
+      return `${asDisplayName(arg)}: ${displayValue}`;
     });
-  return `Always allow agent to ${asDisplayName(data.metadata.toolName)} ${
-    argValues.length > 0
-      ? ` for the following parameters: ${argValues.join(", ")}`
+  const toolName = asDisplayName(data.metadata.toolName).toLowerCase();
+
+  return `Allow future ${toolName} requests${
+    approvalParameters.length > 0
+      ? ` with ${approvalParameters.join(", ")}`
       : ""
-  }`;
+  }.`;
 }


### PR DESCRIPTION
## Description

Medium-stake approvals currently squeeze a long standing-permission sentence beside `Decline` and `Allow`, making the footer difficult to scan and prone to awkward wrapping.

This PR gives that opt-in its own full-width, two-line control: `Don’t ask again` with the exact permission scope as secondary text, followed by a separate right-aligned action row. Generic parameter-scoped labels now name the approved arguments directly. Low- and high-stake layouts remain unchanged, and this is deliberately separate from #30639.

## Tests

- Not tested manually.

## Risk

- Low. Limited to medium-stake MCP approval presentation and copy.

## Deploy Plan

- Deploy front.
