### PR TITLE
[front] Rate-limiter backup for the programmatic spend cap

### DIFF
--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -91,6 +91,7 @@ function creditStateChipColor(
 
 interface PokeCreditStatesCardProps {
   owner: WorkspaceType;
+  creditUsageConfig: PokeCreditUsageConfig | null;
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
@@ -103,6 +104,7 @@ interface PokeCreditStatesCardProps {
 
 function PokeCreditStatesCard({
   owner,
+  creditUsageConfig,
   poolCreditState,
   programmaticCreditState,
   programmaticWarningReached,
@@ -139,6 +141,12 @@ function PokeCreditStatesCard({
           {programmaticWarningReached && (
             <Chip size="xs" color="warning" label="near limit" />
           )}
+          <span className="text-xs text-muted-foreground">
+            cap:{" "}
+            {creditUsageConfig
+              ? `${formatCredits(creditUsageConfig.programmaticMonthlyCapAwuCredits)} credits`
+              : "—"}
+          </span>
           <SpendCountersInline
             esConsumedAwuCredits={programmaticEsConsumedAwuCredits}
             rateLimiterAwuCredits={programmaticSpendLimitRateCapCount}
@@ -342,6 +350,7 @@ export function PokeUsageTab({
     <div className="flex flex-col gap-4">
       <PokeCreditStatesCard
         owner={owner}
+        creditUsageConfig={creditUsageConfig}
         poolCreditState={poolCreditState}
         programmaticCreditState={programmaticCreditState}
         programmaticWarningReached={programmaticWarningReached}

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -45,6 +45,9 @@ interface SpendCountersInlineProps {
   metronomeConsumedAwuCredits: number | null;
 }
 
+const formatCreditsOrDash = (value: number | null): string =>
+  value !== null ? formatCredits(value) : "—";
+
 // The three spend figures for a cap dimension shown together to spot
 // divergence: ES = Elasticsearch-derived, RL = Redis rate-limiter counter (the
 // value enforcement reads), MT = Metronome-derived. Mirrors the
@@ -54,12 +57,11 @@ function SpendCountersInline({
   rateLimiterAwuCredits,
   metronomeConsumedAwuCredits,
 }: SpendCountersInlineProps) {
-  const fmt = (value: number | null) =>
-    value !== null ? formatCredits(value) : "—";
   return (
     <span className="text-xs text-muted-foreground">
-      ES {fmt(esConsumedAwuCredits)} / RL {fmt(rateLimiterAwuCredits)} / MT{" "}
-      {fmt(metronomeConsumedAwuCredits)}
+      ES {formatCreditsOrDash(esConsumedAwuCredits)} / RL{" "}
+      {formatCreditsOrDash(rateLimiterAwuCredits)} / MT{" "}
+      {formatCreditsOrDash(metronomeConsumedAwuCredits)}
     </span>
   );
 }

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -30,11 +30,38 @@ interface PokeUsageTabProps {
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
   programmaticSpendLimitRateCapCount: number | null;
+  programmaticEsConsumedAwuCredits: number | null;
+  programmaticMetronomeConsumedAwuCredits: number | null;
   creditUsageConfig: PokeCreditUsageConfig | null;
   poolAlert: MetronomeAlertRef | null;
   programmaticAlerts: PokeProgrammaticAlerts;
   usageCapAlert: MetronomeAlertRef | null;
   defaultAlerts: DefaultMetronomeAlerts;
+}
+
+interface SpendCountersInlineProps {
+  esConsumedAwuCredits: number | null;
+  rateLimiterAwuCredits: number | null;
+  metronomeConsumedAwuCredits: number | null;
+}
+
+// The three spend figures for a cap dimension shown together to spot
+// divergence: ES = Elasticsearch-derived, RL = Redis rate-limiter counter (the
+// value enforcement reads), MT = Metronome-derived. Mirrors the
+// "Consumed (ES / RL / MT)" column in the members table.
+function SpendCountersInline({
+  esConsumedAwuCredits,
+  rateLimiterAwuCredits,
+  metronomeConsumedAwuCredits,
+}: SpendCountersInlineProps) {
+  const fmt = (value: number | null) =>
+    value !== null ? formatCredits(value) : "—";
+  return (
+    <span className="text-xs text-muted-foreground">
+      ES / RL / MT: {fmt(esConsumedAwuCredits)} / {fmt(rateLimiterAwuCredits)} /{" "}
+      {fmt(metronomeConsumedAwuCredits)}
+    </span>
+  );
 }
 
 type CreditStateChipColor = "success" | "warning" | "warning" | "info";
@@ -68,6 +95,8 @@ interface PokeCreditStatesCardProps {
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
   programmaticSpendLimitRateCapCount: number | null;
+  programmaticEsConsumedAwuCredits: number | null;
+  programmaticMetronomeConsumedAwuCredits: number | null;
   poolAlert: MetronomeAlertRef | null;
   programmaticAlerts: PokeProgrammaticAlerts;
 }
@@ -78,6 +107,8 @@ function PokeCreditStatesCard({
   programmaticCreditState,
   programmaticWarningReached,
   programmaticSpendLimitRateCapCount,
+  programmaticEsConsumedAwuCredits,
+  programmaticMetronomeConsumedAwuCredits,
   poolAlert,
   programmaticAlerts,
 }: PokeCreditStatesCardProps) {
@@ -108,12 +139,13 @@ function PokeCreditStatesCard({
           {programmaticWarningReached && (
             <Chip size="xs" color="warning" label="near limit" />
           )}
-          <span className="text-xs text-muted-foreground">
-            rate limiter:{" "}
-            {programmaticSpendLimitRateCapCount !== null
-              ? `${formatCredits(programmaticSpendLimitRateCapCount)} credits`
-              : "—"}
-          </span>
+          <SpendCountersInline
+            esConsumedAwuCredits={programmaticEsConsumedAwuCredits}
+            rateLimiterAwuCredits={programmaticSpendLimitRateCapCount}
+            metronomeConsumedAwuCredits={
+              programmaticMetronomeConsumedAwuCredits
+            }
+          />
           <AlertChip alert={programmaticAlerts.cap} label="cap alert" />
           <AlertChip alert={programmaticAlerts.warning} label="warning (80%)" />
           <AlertChip alert={programmaticAlerts.low} label="low (-100)" />
@@ -292,6 +324,8 @@ export function PokeUsageTab({
   programmaticCreditState,
   programmaticWarningReached,
   programmaticSpendLimitRateCapCount,
+  programmaticEsConsumedAwuCredits,
+  programmaticMetronomeConsumedAwuCredits,
   creditUsageConfig,
   poolAlert,
   programmaticAlerts,
@@ -312,6 +346,10 @@ export function PokeUsageTab({
         programmaticCreditState={programmaticCreditState}
         programmaticWarningReached={programmaticWarningReached}
         programmaticSpendLimitRateCapCount={programmaticSpendLimitRateCapCount}
+        programmaticEsConsumedAwuCredits={programmaticEsConsumedAwuCredits}
+        programmaticMetronomeConsumedAwuCredits={
+          programmaticMetronomeConsumedAwuCredits
+        }
         poolAlert={poolAlert}
         programmaticAlerts={programmaticAlerts}
       />

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -29,6 +29,7 @@ interface PokeUsageTabProps {
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
+  programmaticSpendLimitRateCapCount: number | null;
   creditUsageConfig: PokeCreditUsageConfig | null;
   poolAlert: MetronomeAlertRef | null;
   programmaticAlerts: PokeProgrammaticAlerts;
@@ -66,6 +67,7 @@ interface PokeCreditStatesCardProps {
   poolCreditState: WorkspacePoolCreditState;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
+  programmaticSpendLimitRateCapCount: number | null;
   poolAlert: MetronomeAlertRef | null;
   programmaticAlerts: PokeProgrammaticAlerts;
 }
@@ -75,6 +77,7 @@ function PokeCreditStatesCard({
   poolCreditState,
   programmaticCreditState,
   programmaticWarningReached,
+  programmaticSpendLimitRateCapCount,
   poolAlert,
   programmaticAlerts,
 }: PokeCreditStatesCardProps) {
@@ -105,6 +108,12 @@ function PokeCreditStatesCard({
           {programmaticWarningReached && (
             <Chip size="xs" color="warning" label="near limit" />
           )}
+          <span className="text-xs text-muted-foreground">
+            rate limiter:{" "}
+            {programmaticSpendLimitRateCapCount !== null
+              ? `${formatCredits(programmaticSpendLimitRateCapCount)} credits`
+              : "—"}
+          </span>
           <AlertChip alert={programmaticAlerts.cap} label="cap alert" />
           <AlertChip alert={programmaticAlerts.warning} label="warning (80%)" />
           <AlertChip alert={programmaticAlerts.low} label="low (-100)" />
@@ -282,6 +291,7 @@ export function PokeUsageTab({
   poolCreditState,
   programmaticCreditState,
   programmaticWarningReached,
+  programmaticSpendLimitRateCapCount,
   creditUsageConfig,
   poolAlert,
   programmaticAlerts,
@@ -301,6 +311,7 @@ export function PokeUsageTab({
         poolCreditState={poolCreditState}
         programmaticCreditState={programmaticCreditState}
         programmaticWarningReached={programmaticWarningReached}
+        programmaticSpendLimitRateCapCount={programmaticSpendLimitRateCapCount}
         poolAlert={poolAlert}
         programmaticAlerts={programmaticAlerts}
       />

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -58,7 +58,7 @@ function SpendCountersInline({
     value !== null ? formatCredits(value) : "—";
   return (
     <span className="text-xs text-muted-foreground">
-      ES / RL / MT: {fmt(esConsumedAwuCredits)} / {fmt(rateLimiterAwuCredits)} /{" "}
+      ES {fmt(esConsumedAwuCredits)} / RL {fmt(rateLimiterAwuCredits)} / MT{" "}
       {fmt(metronomeConsumedAwuCredits)}
     </span>
   );

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -143,6 +143,7 @@ export function WorkspacePage() {
     defaultAlerts,
     programmaticCreditState,
     programmaticWarningReached,
+    programmaticSpendLimitRateCapCount,
     seatPlan,
     stripeSubscription,
     stripeCustomerId,
@@ -370,6 +371,9 @@ export function WorkspacePage() {
                   poolCreditState={poolCreditState}
                   programmaticCreditState={programmaticCreditState}
                   programmaticWarningReached={programmaticWarningReached}
+                  programmaticSpendLimitRateCapCount={
+                    programmaticSpendLimitRateCapCount
+                  }
                   creditUsageConfig={creditUsageConfig}
                   poolAlert={poolAlert}
                   programmaticAlerts={programmaticAlerts}

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -144,6 +144,8 @@ export function WorkspacePage() {
     programmaticCreditState,
     programmaticWarningReached,
     programmaticSpendLimitRateCapCount,
+    programmaticEsConsumedAwuCredits,
+    programmaticMetronomeConsumedAwuCredits,
     seatPlan,
     stripeSubscription,
     stripeCustomerId,
@@ -373,6 +375,12 @@ export function WorkspacePage() {
                   programmaticWarningReached={programmaticWarningReached}
                   programmaticSpendLimitRateCapCount={
                     programmaticSpendLimitRateCapCount
+                  }
+                  programmaticEsConsumedAwuCredits={
+                    programmaticEsConsumedAwuCredits
+                  }
+                  programmaticMetronomeConsumedAwuCredits={
+                    programmaticMetronomeConsumedAwuCredits
                   }
                   creditUsageConfig={creditUsageConfig}
                   poolAlert={poolAlert}

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -65,6 +65,7 @@ import {
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
 import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
+import { isProgrammaticSpendLimitRateCapReached } from "@app/lib/api/credits/programmatic_usage_limit";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { isApiKeySpendLimitRateCapReached } from "@app/lib/api/keys/spend_limit";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
@@ -2646,17 +2647,22 @@ export async function checkMessagesLimit(
 
     // Programmatic monthly cap: block programmatic calls when the cap is reached.
     if (isProgrammaticUsage(auth, { userMessageOrigin: context.origin })) {
+      // The Redis fixed-window backups are flag-gated while we validate the
+      // counters; usage is recorded regardless (in credit_cost), so the flag
+      // only controls blocking.
+      const featureFlags = await getFeatureFlags(auth);
+      const spendCapEnabled = featureFlags.includes(
+        "enforce_user_spend_limit_rate_cap"
+      );
+
       // Per-API-key credit cap: block when this key's credit state is "capped"
       // (driven by the Metronome per-key cap alert / reconcile), or when the
-      // Redis fixed-window backup reports the cap reached. The backup is
-      // flag-gated while we validate the counter; usage is recorded regardless
-      // (in credit_cost), so the flag only controls blocking.
+      // Redis fixed-window backup reports the cap reached.
       const key = auth.key();
       if (key) {
-        const featureFlags = await getFeatureFlags(auth);
         const capReached =
           (await isApiKeyCapped(owner.sId, key.id)) ||
-          (featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
+          (spendCapEnabled &&
             (await isApiKeySpendLimitRateCapReached(auth, {
               keyModelId: key.id,
             })));
@@ -2672,7 +2678,12 @@ export async function checkMessagesLimit(
         }
       }
 
-      const programmaticBlocked = await isProgrammaticApiBlocked(owner.sId);
+      // Workspace programmatic monthly cap: the Metronome-driven state
+      // (`isProgrammaticApiBlocked`) OR the Redis fixed-window backup.
+      const programmaticBlocked =
+        (await isProgrammaticApiBlocked(owner.sId)) ||
+        (spendCapEnabled &&
+          (await isProgrammaticSpendLimitRateCapReached(auth)));
       if (programmaticBlocked) {
         return new Err({
           status_code: 429,

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -3,6 +3,7 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { isToolExecutionStatusBillable } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
+import { recordProgrammaticSpendLimitUsage } from "@app/lib/api/credits/programmatic_usage_limit";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { recordApiKeySpendLimitUsage } from "@app/lib/api/keys/spend_limit";
 import type { ToolCostCategory } from "@app/lib/api/mcp";
@@ -326,29 +327,35 @@ export async function computeAndStoreAgentMessageCredits(
     });
   }
 
-  // Record against the per-user spend-cap backup (Redis fixed-window counter
-  // over the contract billing cycle).
-  if (user && recordedCostDelta > 0) {
+  // Record against the spend-cap backups (Redis fixed-window counters over the
+  // contract billing cycle).
+  if (recordedCostDelta > 0) {
     const featureFlags = await getFeatureFlags(auth);
     if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
-      await recordUserSpendLimitUsage(auth, {
-        user,
-        incrementBy: recordedCostDelta,
-        cycle: spendLimitCycleOverrideForAuth(auth),
-      });
-    }
-  }
+      // Per-user cap.
+      if (user) {
+        await recordUserSpendLimitUsage(auth, {
+          user,
+          incrementBy: recordedCostDelta,
+          cycle: spendLimitCycleOverrideForAuth(auth),
+        });
+      }
 
-  // Record against the per-API-key spend-cap backup (Redis fixed-window counter
-  // over the contract billing cycle).
-  const apiKey = auth.key();
-  if (apiKey && recordedCostDelta > 0) {
-    const featureFlags = await getFeatureFlags(auth);
-    if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
-      await recordApiKeySpendLimitUsage(auth, {
-        keyModelId: apiKey.id,
-        incrementBy: recordedCostDelta,
-      });
+      // Per-API-key cap, for calls authenticated with an API key.
+      const apiKey = auth.key();
+      if (apiKey) {
+        await recordApiKeySpendLimitUsage(auth, {
+          keyModelId: apiKey.id,
+          incrementBy: recordedCostDelta,
+        });
+      }
+
+      // Workspace programmatic cap, for programmatic calls.
+      if (isProgrammaticUsage(auth, { userMessageOrigin: messageOrigin })) {
+        await recordProgrammaticSpendLimitUsage(auth, {
+          incrementBy: recordedCostDelta,
+        });
+      }
     }
   }
 

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -130,6 +130,15 @@ export const makeApiKeySpendLimitAwuCreditsRateLimitKey = (keyId: number) => {
   return `api_key:${keyId}:spend_limit_awu_credit_count`;
 };
 
+// Fixed-window counter backing the workspace programmatic monthly spend cap
+// (programmatic-only AWU usage). Workspace-scoped; bucketed on the Metronome
+// contract billing cycle via `makeSpendLimitCycleWindowBounds`.
+export const makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace = (
+  owner: LightWorkspaceType
+) => {
+  return `workspace:${owner.id}:programmatic_spend_limit_awu_credit_count`;
+};
+
 export const makeProgrammaticUsageRateLimitKeyForWorkspace = (
   owner: LightWorkspaceType
 ) => {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1,5 +1,6 @@
 import {
   makeApiKeySpendLimitAwuCreditsRateLimitKey,
+  makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace,
   makeSpendLimitAwuCreditsRateLimitKeyForUser,
   makeSpendLimitCycleWindowBounds,
 } from "@app/lib/api/assistant/rate_limits";
@@ -25,6 +26,7 @@ import {
   CONTRACT_CREDIT_TYPE_FREE_SEAT,
   getCreditTypeAwuId,
   toFreeMetronomeUserId,
+  USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import { getPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
@@ -506,6 +508,64 @@ export async function getEsConsumedAwuCreditsForApiKey(
     cycle,
   });
   return consumedByApiKeyName.get(apiKeyName) ?? 0;
+}
+
+/**
+ * The workspace's Elasticsearch-derived *programmatic* AWU consumption for the
+ * current billing cycle (summed over `usage_type = programmatic`) — the same
+ * dimension the Metronome programmatic cap alert is scoped to. Used to lazily
+ * seed / resync the programmatic spend-cap counter. Returns 0 when there is no
+ * usage or the analytics read fails.
+ */
+export async function getEsConsumedProgrammaticAwuCredits(
+  auth: Authenticator,
+  { cycle }: { cycle?: BillingCycle }
+): Promise<number> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const resolvedCycle = cycle ?? (await resolveMetronomeCycle(workspace));
+  if (!resolvedCycle) {
+    return 0;
+  }
+  const { cycleStart, cycleEnd } = resolvedCycle;
+
+  const result = await searchAnalytics<
+    never,
+    { credits?: estypes.AggregationsSumAggregate }
+  >(
+    {
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          { term: { usage_type: USAGE_TYPE_PROGRAMMATIC } },
+          {
+            range: {
+              timestamp: {
+                gte: cycleStart.toISOString(),
+                lte: cycleEnd.toISOString(),
+              },
+            },
+          },
+        ],
+      },
+    },
+    {
+      aggregations: { credits: { sum: { field: "cost.billable_awu" } } },
+      size: 0,
+    }
+  );
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, workspaceId: workspace.sId },
+      "[MembersUsage] Failed to read programmatic consumed credits from analytics index"
+    );
+    return 0;
+  }
+
+  return Math.max(
+    0,
+    Math.round(result.value.aggregations?.credits?.value ?? 0)
+  );
 }
 
 async function fetchPerUserUsageCreditsForMembersTable({
@@ -1084,6 +1144,48 @@ export async function resyncApiKeySpendLimitCountersFromEsUsage(
   );
 
   return new Ok({ updatedKeyCount: results.filter(Boolean).length });
+}
+
+/**
+ * Backfill/repair the workspace programmatic spend-cap counter from
+ * Elasticsearch, overwriting it (SET) with the programmatic AWU consumption for
+ * the current cycle. No-op (not seeded) when there is no positive programmatic
+ * cap — that case defers to the programmatic credit-state machine, not the
+ * counter.
+ */
+export async function resyncProgrammaticSpendLimitCounterFromEsUsage(
+  auth: Authenticator
+): Promise<Result<{ programmaticCounterSeeded: boolean }, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const cap = config?.programmaticMonthlyCapAwuCredits ?? 0;
+  if (cap <= 0) {
+    return new Ok({ programmaticCounterSeeded: false });
+  }
+
+  const cycle = await resolveMetronomeCycle(workspace);
+  if (!cycle) {
+    return new Err(
+      new Error("No active Metronome billing period to resync against.")
+    );
+  }
+  const bounds = makeSpendLimitCycleWindowBounds(
+    cycle.cycleStart,
+    cycle.cycleEnd
+  );
+
+  const consumed = await getEsConsumedProgrammaticAwuCredits(auth, { cycle });
+  const setResult = await setFixedWindowCount({
+    key: makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(
+      workspace
+    ),
+    bounds,
+    value: Math.max(0, Math.round(consumed)),
+    logger,
+  });
+  return new Ok({ programmaticCounterSeeded: setResult.isOk() });
 }
 
 export type GetMemberUsageResponseBody = {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -516,18 +516,20 @@ export async function getEsConsumedAwuCreditsForApiKey(
  * programmatic usage is identified with `getProgrammaticUsageFilterClause`
  * (auth_method=api_key / no or programmatic context_origin) — the same split the
  * analytics dashboards use. Used to lazily seed / resync the programmatic
- * spend-cap counter. Returns 0 when there is no usage or the analytics read
- * fails.
+ * spend-cap counter. Returns the consumption, or `null` when it can't be
+ * determined (no billing cycle, or the analytics read failed) — callers must
+ * treat `null` as "unknown", never as 0, so a transient ES outage doesn't erase
+ * a live counter on resync.
  */
 export async function getEsConsumedProgrammaticAwuCredits(
   auth: Authenticator,
   { cycle }: { cycle?: BillingCycle }
-): Promise<number> {
+): Promise<number | null> {
   const workspace = auth.getNonNullableWorkspace();
 
   const resolvedCycle = cycle ?? (await resolveMetronomeCycle(workspace));
   if (!resolvedCycle) {
-    return 0;
+    return null;
   }
   const { cycleStart, cycleEnd } = resolvedCycle;
 
@@ -561,7 +563,7 @@ export async function getEsConsumedProgrammaticAwuCredits(
       { err: result.error, workspaceId: workspace.sId },
       "[MembersUsage] Failed to read programmatic consumed credits from analytics index"
     );
-    return 0;
+    return null;
   }
 
   return Math.max(
@@ -1179,6 +1181,15 @@ export async function resyncProgrammaticSpendLimitCounterFromEsUsage(
   );
 
   const consumed = await getEsConsumedProgrammaticAwuCredits(auth, { cycle });
+  if (consumed === null) {
+    // The Elasticsearch read failed: skip the SET so a transient outage can't
+    // overwrite a valid live counter with 0 and disable the backup cap.
+    return new Err(
+      new Error(
+        "Failed to read programmatic consumption from Elasticsearch; skipped resync to avoid erasing the counter."
+      )
+    );
+  }
   const setResult = await setFixedWindowCount({
     key: makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(
       workspace

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -6,6 +6,7 @@ import {
 } from "@app/lib/api/assistant/rate_limits";
 import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import { getProgrammaticUsageFilterClause } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
 import { listPerUserCreditBalanceAlertsForWorkspace } from "@app/lib/metronome/alerts/per_user_credit_balance";
@@ -26,7 +27,6 @@ import {
   CONTRACT_CREDIT_TYPE_FREE_SEAT,
   getCreditTypeAwuId,
   toFreeMetronomeUserId,
-  USAGE_TYPE_PROGRAMMATIC,
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import { getPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
@@ -512,10 +512,12 @@ export async function getEsConsumedAwuCreditsForApiKey(
 
 /**
  * The workspace's Elasticsearch-derived *programmatic* AWU consumption for the
- * current billing cycle (summed over `usage_type = programmatic`) — the same
- * dimension the Metronome programmatic cap alert is scoped to. Used to lazily
- * seed / resync the programmatic spend-cap counter. Returns 0 when there is no
- * usage or the analytics read fails.
+ * current billing cycle. `usage_type` is not a stored analytics field, so
+ * programmatic usage is identified with `getProgrammaticUsageFilterClause`
+ * (auth_method=api_key / no or programmatic context_origin) — the same split the
+ * analytics dashboards use. Used to lazily seed / resync the programmatic
+ * spend-cap counter. Returns 0 when there is no usage or the analytics read
+ * fails.
  */
 export async function getEsConsumedProgrammaticAwuCredits(
   auth: Authenticator,
@@ -537,7 +539,7 @@ export async function getEsConsumedProgrammaticAwuCredits(
       bool: {
         filter: [
           { term: { workspace_id: workspace.sId } },
-          { term: { usage_type: USAGE_TYPE_PROGRAMMATIC } },
+          getProgrammaticUsageFilterClause(),
           {
             range: {
               timestamp: {

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -1,7 +1,9 @@
+import { makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace } from "@app/lib/api/assistant/rate_limits";
 import {
   buildAuditLogTarget,
   emitAuditLogEvent,
 } from "@app/lib/api/audit/workos_audit";
+import { getEsConsumedProgrammaticAwuCredits } from "@app/lib/api/credits/members_usage";
 import { reconcileProgrammatic } from "@app/lib/api/metronome/reconcile_credit_state";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
@@ -11,6 +13,14 @@ import {
 } from "@app/lib/metronome/alerts/programmatic_cap";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
+import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
+import {
+  addFixedWindowCount,
+  getFixedWindowCount,
+  setFixedWindowCount,
+} from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -132,4 +142,116 @@ export async function syncProgrammaticUsageLimit({
   });
 
   return new Ok(undefined);
+}
+
+/**
+ * Reads the workspace programmatic spend-cap counter, lazily seeding it from
+ * Elasticsearch (programmatic-only AWU for the current cycle) on a 0 read.
+ * Mirrors the per-user / per-key lazy seed. Returns the effective count, or
+ * `null` on a Redis read error (caller fails open).
+ */
+async function readProgrammaticSpendLimitCountWithLazySeed(
+  auth: Authenticator,
+  { redisKey, bounds }: { redisKey: string; bounds: FixedWindowBounds }
+): Promise<number | null> {
+  const countResult = await getFixedWindowCount({ key: redisKey, bounds });
+  if (countResult.isErr()) {
+    return null;
+  }
+  if (countResult.value > 0) {
+    return countResult.value;
+  }
+
+  const consumed = Math.max(
+    0,
+    Math.round(await getEsConsumedProgrammaticAwuCredits(auth, {}))
+  );
+  if (consumed > 0) {
+    await setFixedWindowCount({
+      key: redisKey,
+      bounds,
+      value: consumed,
+      logger,
+    });
+  }
+  return consumed;
+}
+
+/**
+ * Synchronous, Metronome-independent enforcement of the workspace programmatic
+ * spend cap, read at message-send time from the Redis fixed-window counter over
+ * the current contract billing cycle. Runs alongside the Metronome-driven
+ * `isProgrammaticApiBlocked` as a faster, independent backup.
+ *
+ * Only enforces a *positive* cap: a cap of 0 means "always depleted", which is
+ * owned by the programmatic credit-state machine (`isProgrammaticApiBlocked`),
+ * not a threshold — so the backup defers to it there. Returns `false` (does not
+ * block) with no positive cap, no billing period, or on a Redis read error
+ * (fail-open).
+ */
+export async function isProgrammaticSpendLimitRateCapReached(
+  auth: Authenticator
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const threshold = config?.programmaticMonthlyCapAwuCredits ?? 0;
+  if (threshold <= 0) {
+    return false;
+  }
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return false;
+  }
+
+  const count = await readProgrammaticSpendLimitCountWithLazySeed(auth, {
+    redisKey:
+      makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(workspace),
+    bounds,
+  });
+  if (count === null) {
+    logger.error(
+      { workspaceId: workspace.sId },
+      "[ProgrammaticSpendLimitRateCap] Failed to read fixed-window count; allowing message"
+    );
+    return false;
+  }
+
+  return count >= threshold;
+}
+
+/**
+ * Adds `incrementBy` AWU credits to the workspace programmatic spend-cap counter
+ * for the current contract billing cycle. Records for every workspace (the cap
+ * is resolved at enforcement/read time, not here). `incrementBy` is the
+ * newly-accrued delta for a message. No-op when the billing period can't be
+ * resolved.
+ */
+export async function recordProgrammaticSpendLimitUsage(
+  auth: Authenticator,
+  { incrementBy }: { incrementBy: number }
+): Promise<void> {
+  // Only whole positive credits are recordable (the counter is an integer
+  // INCRBY); skip anything else rather than letting it reach the counter.
+  if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
+    return;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return;
+  }
+
+  await addFixedWindowCount({
+    key: makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(
+      workspace
+    ),
+    bounds,
+    incrementBy,
+    logger,
+  });
 }

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -162,18 +162,18 @@ async function readProgrammaticSpendLimitCountWithLazySeed(
     return countResult.value;
   }
 
-  const consumed = Math.max(
-    0,
-    Math.round(await getEsConsumedProgrammaticAwuCredits(auth, {}))
-  );
-  if (consumed > 0) {
-    await setFixedWindowCount({
-      key: redisKey,
-      bounds,
-      value: consumed,
-      logger,
-    });
+  const consumed = await getEsConsumedProgrammaticAwuCredits(auth, {});
+  // `null` means the ES read failed (or no cycle) — treat as unknown and skip
+  // the seed rather than writing 0 (fail-open read).
+  if (consumed === null || consumed <= 0) {
+    return 0;
   }
+  await setFixedWindowCount({
+    key: redisKey,
+    bounds,
+    value: consumed,
+    logger,
+  });
   return consumed;
 }
 

--- a/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
+++ b/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
@@ -1,5 +1,6 @@
 import {
   resyncApiKeySpendLimitCountersFromEsUsage,
+  resyncProgrammaticSpendLimitCounterFromEsUsage,
   resyncSpendLimitCountersFromEsUsage,
 } from "@app/lib/api/credits/members_usage";
 import { createPlugin } from "@app/lib/api/poke/types";
@@ -11,12 +12,13 @@ export const resyncSpendLimitCountersPlugin = createPlugin({
     name: "Resync Spend-Limit Counters from Usage",
     description:
       "Overwrite the Redis fixed-window spend-cap counters (each member's " +
-      "per-user counter and each capped API key's per-key counter) for the " +
-      "current cycle with their Elasticsearch-derived AWU consumption. Use to " +
-      "backfill the counters after enabling the cap, or to repair drift (they " +
-      "otherwise only accrue from live messages). Resyncs the cycle the " +
-      "workspace is enforced on: the Metronome contract billing period on " +
-      "credit-priced plans, the UTC calendar month elsewhere.",
+      "per-user counter, each capped API key's per-key counter, and the " +
+      "workspace programmatic counter) for the current cycle with their " +
+      "Elasticsearch-derived AWU consumption. Use to backfill the counters " +
+      "after enabling the cap, or to repair drift (they otherwise only accrue " +
+      "from live messages). Resyncs the cycle the workspace is enforced on: " +
+      "the Metronome contract billing period on credit-priced plans, the UTC " +
+      "calendar month elsewhere.",
     resourceTypes: ["workspaces"],
     args: {},
     requiredRoles: ["billing"],
@@ -33,12 +35,20 @@ export const resyncSpendLimitCountersPlugin = createPlugin({
       return new Err(new Error(apiKeyResult.error.message));
     }
 
+    const programmaticResult =
+      await resyncProgrammaticSpendLimitCounterFromEsUsage(auth);
+    if (programmaticResult.isErr()) {
+      return new Err(new Error(programmaticResult.error.message));
+    }
+
     return new Ok({
       display: "text",
       value:
         `Resynced spend-limit counters from usage for ` +
-        `${userResult.value.updatedUserCount} user(s) and ` +
-        `${apiKeyResult.value.updatedKeyCount} API key(s).`,
+        `${userResult.value.updatedUserCount} user(s), ` +
+        `${apiKeyResult.value.updatedKeyCount} API key(s), and the ` +
+        `workspace programmatic counter ` +
+        `(${programmaticResult.value.programmaticCounterSeeded ? "seeded" : "no positive cap"}).`,
     });
   },
 });

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -1,3 +1,4 @@
+import { makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace } from "@app/lib/api/assistant/rate_limits";
 import config from "@app/lib/api/config";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { getSeatPlan } from "@app/lib/api/credits/seat_plan";
@@ -19,6 +20,8 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
+import { getFixedWindowCount } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
   WorkspacePoolCreditState,
@@ -87,6 +90,10 @@ export type PokeWorkspaceInfo = {
   defaultAlerts: DefaultMetronomeAlerts;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
+  // Current value of the Redis fixed-window programmatic spend-cap counter for
+  // the contract billing cycle (the rate-limiter backup). Null when there is no
+  // billing period to bucket on or the read failed.
+  programmaticSpendLimitRateCapCount: number | null;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   stripeCustomerId: string | null;
   stripeSubscription: PokeStripeSubscriptionWire | null;
@@ -137,6 +144,21 @@ export async function getPokeWorkspaceInfo(
 
   const creditUsageConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  // Current values of the Redis fixed-window spend-cap counters for the contract
+  // billing cycle (the rate-limiter backups), surfaced in Poke for debugging.
+  // Null when there is no billing period to bucket on or a read fails.
+  const spendLimitBounds = await resolveSpendLimitCycleBounds(owner);
+  let programmaticSpendLimitRateCapCount: number | null = null;
+  if (spendLimitBounds) {
+    const countResult = await getFixedWindowCount({
+      key: makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(owner),
+      bounds: spendLimitBounds,
+    });
+    programmaticSpendLimitRateCapCount = countResult.isOk()
+      ? countResult.value
+      : null;
+  }
 
   // Resolve the Metronome alert ids backing each credit dimension so Poke can
   // deep-link to the dashboard. Best-effort: any failure degrades to null
@@ -243,6 +265,7 @@ export async function getPokeWorkspaceInfo(
     programmaticWarningReached: await isWorkspaceProgrammaticWarningReached(
       owner.sId
     ),
+    programmaticSpendLimitRateCapCount,
     stripeCustomerId,
     stripeSubscription: stripeSubscription
       ? {

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -1,5 +1,6 @@
 import { makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace } from "@app/lib/api/assistant/rate_limits";
 import config from "@app/lib/api/config";
+import { getEsConsumedProgrammaticAwuCredits } from "@app/lib/api/credits/members_usage";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { getSeatPlan } from "@app/lib/api/credits/seat_plan";
 import { getWorkspacePlanLimitOverrides } from "@app/lib/api/plan_limit_overrides";
@@ -11,6 +12,7 @@ import type { DefaultMetronomeAlerts } from "@app/lib/metronome/alerts/default_a
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getCachedWorkspaceMetronomeAlerts } from "@app/lib/metronome/alerts/workspace_alerts";
 import { getMetronomeCustomerStripeCustomerId } from "@app/lib/metronome/client";
+import { fetchProgrammaticAwuSpend } from "@app/lib/metronome/programmatic_awu_usage";
 import { isWorkspaceProgrammaticWarningReached } from "@app/lib/metronome/user_block";
 import type { PlanLimitOverride } from "@app/lib/plans/plan_limit_overrides";
 import { getCustomerId, getStripeSubscription } from "@app/lib/plans/stripe";
@@ -90,10 +92,13 @@ export type PokeWorkspaceInfo = {
   defaultAlerts: DefaultMetronomeAlerts;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
-  // Current value of the Redis fixed-window programmatic spend-cap counter for
-  // the contract billing cycle (the rate-limiter backup). Null when there is no
-  // billing period to bucket on or the read failed.
+  // Programmatic spend for the current billing cycle across the three sources,
+  // for debugging the rate-limiter backup: the Redis fixed-window counter (RL),
+  // the Elasticsearch-derived consumption (ES), and the Metronome-derived
+  // consumption (MT). Each null when it can't be resolved.
   programmaticSpendLimitRateCapCount: number | null;
+  programmaticEsConsumedAwuCredits: number | null;
+  programmaticMetronomeConsumedAwuCredits: number | null;
   programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
   stripeCustomerId: string | null;
   stripeSubscription: PokeStripeSubscriptionWire | null;
@@ -145,9 +150,11 @@ export async function getPokeWorkspaceInfo(
   const creditUsageConfig =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
 
-  // Current values of the Redis fixed-window spend-cap counters for the contract
-  // billing cycle (the rate-limiter backups), surfaced in Poke for debugging.
-  // Null when there is no billing period to bucket on or a read fails.
+  // Spend-cap dimensions for the contract billing cycle, surfaced in Poke for
+  // debugging: the Redis fixed-window rate-limiter counter (RL, the value
+  // enforcement reads), the Elasticsearch-derived consumption (ES), and the
+  // Metronome-derived consumption (MT). Each is null when it can't be resolved
+  // (no billing period, no Metronome customer, or a read failure).
   const spendLimitBounds = await resolveSpendLimitCycleBounds(owner);
   let programmaticSpendLimitRateCapCount: number | null = null;
   if (spendLimitBounds) {
@@ -157,6 +164,19 @@ export async function getPokeWorkspaceInfo(
     });
     programmaticSpendLimitRateCapCount = countResult.isOk()
       ? countResult.value
+      : null;
+  }
+  const programmaticEsConsumedAwuCredits = spendLimitBounds
+    ? await getEsConsumedProgrammaticAwuCredits(auth, {})
+    : null;
+  let programmaticMetronomeConsumedAwuCredits: number | null = null;
+  if (workspaceResource.metronomeCustomerId) {
+    const spendResult = await fetchProgrammaticAwuSpend({
+      workspaceId: owner.sId,
+      metronomeCustomerId: workspaceResource.metronomeCustomerId,
+    });
+    programmaticMetronomeConsumedAwuCredits = spendResult.isOk()
+      ? spendResult.value
       : null;
   }
 
@@ -266,6 +286,8 @@ export async function getPokeWorkspaceInfo(
       owner.sId
     ),
     programmaticSpendLimitRateCapCount,
+    programmaticEsConsumedAwuCredits,
+    programmaticMetronomeConsumedAwuCredits,
     stripeCustomerId,
     stripeSubscription: stripeSubscription
       ? {

--- a/front/lib/metronome/programmatic_credit_state_machine.test.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.test.ts
@@ -28,7 +28,8 @@ vi.mock("@app/lib/metronome/user_block", () => ({
     mockSetWorkspaceProgrammaticCreditStatus,
 }));
 
-vi.mock("@app/lib/utils/cache", () => ({
+vi.mock("@app/lib/utils/cache", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@app/lib/utils/cache")>()),
   invalidateCacheAfterCommit: mockInvalidateCacheAfterCommit,
 }));
 


### PR DESCRIPTION
## Description

Second PR of the pool-cap rate-limiter stack. Adds a Redis fixed-window backup for the Metronome **workspace programmatic monthly spend cap**, following the per-API-key pattern: record programmatic AWU usage into a workspace-scoped counter over the contract billing cycle, and enforce it synchronously at message send alongside the Metronome-driven `isProgrammaticApiBlocked`.

Stacked on #30641.

- Reuses the existing `enforce_user_spend_limit_rate_cap` flag for recording + enforcement.
- Threshold is `programmaticMonthlyCapAwuCredits`. **Only a positive cap is enforced from the counter**: a cap of 0 means "always depleted", owned by the programmatic credit-state machine (`isProgrammaticApiBlocked`), so the backup defers to it there and never over-blocks.
- Lazy-seed from Elasticsearch (summed over `usage_type = programmatic`) on a Redis miss.
- Reader/recorder in `lib/api/credits/programmatic_usage_limit.ts`; ES seed + resync in `members_usage.ts`; the shared `resync-spend-limit-counters` poke plugin resyncs the programmatic counter too.
- Consolidated the spend-cap recording blocks in `credit_cost.ts` to fetch the feature flag once.

## Tests

- `npx tsgo --noEmit` passes; `biome check` clean.
- No new automated tests (internal message-send path, not an endpoint). Intended manual validation: enable the flag on a dust-internal workspace, run the `resync-spend-limit-counters` poke plugin, confirm the programmatic counter matches ES and that a workspace at/over its programmatic cap is blocked with the existing 429.

## Risk

- **Low, fail-open by design** (no positive cap, no billing period, Redis error → allow).
- **Off by default** (`dust_only` flag). No behavior change when off.
- When on, it is a *backup* OR-ed with the existing Metronome-driven block, returning the same 429 — it cannot block where a positive-threshold alert would not.
- Safe to roll back via revert.

## Deploy Plan

1. Merge after #30641; deploy `front` normally. No migration.
2. Flag stays `dust_only` and off — no runtime effect on merge.
3. Validate on a dust-internal workspace (enable flag → run poke resync → compare counter vs Metronome for a cycle) before relying on the Redis path to block.
