### PR TITLE
[front] Rate-limiter backup for the workspace usage cap

### DIFF
--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -28,6 +28,8 @@ interface PokeUsageTabProps {
   stripeSubscription: PokeStripeSubscriptionWire | null;
   poolCreditState: WorkspacePoolCreditState;
   poolSpendLimitRateCapCount: number | null;
+  poolEsConsumedAwuCredits: number | null;
+  poolMetronomeConsumedAwuCredits: number | null;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
   programmaticSpendLimitRateCapCount: number | null;
@@ -97,6 +99,8 @@ interface PokeCreditStatesCardProps {
   creditUsageConfig: PokeCreditUsageConfig | null;
   poolCreditState: WorkspacePoolCreditState;
   poolSpendLimitRateCapCount: number | null;
+  poolEsConsumedAwuCredits: number | null;
+  poolMetronomeConsumedAwuCredits: number | null;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
   programmaticSpendLimitRateCapCount: number | null;
@@ -111,6 +115,8 @@ function PokeCreditStatesCard({
   creditUsageConfig,
   poolCreditState,
   poolSpendLimitRateCapCount,
+  poolEsConsumedAwuCredits,
+  poolMetronomeConsumedAwuCredits,
   programmaticCreditState,
   programmaticWarningReached,
   programmaticSpendLimitRateCapCount,
@@ -132,12 +138,11 @@ function PokeCreditStatesCard({
             color={creditStateChipColor(poolCreditState)}
             label={poolCreditState}
           />
-          <span className="text-xs text-muted-foreground">
-            rate limiter:{" "}
-            {poolSpendLimitRateCapCount !== null
-              ? `${formatCredits(poolSpendLimitRateCapCount)} credits`
-              : "—"}
-          </span>
+          <SpendCountersInline
+            esConsumedAwuCredits={poolEsConsumedAwuCredits}
+            rateLimiterAwuCredits={poolSpendLimitRateCapCount}
+            metronomeConsumedAwuCredits={poolMetronomeConsumedAwuCredits}
+          />
           <AlertChip alert={poolAlert} label="balance alert" />
           <CreditStateLogsLink machine="pool" workspaceId={owner.sId} />
           <ReconcileCreditStateButton owner={owner} target="pool" />
@@ -341,6 +346,8 @@ export function PokeUsageTab({
   stripeSubscription,
   poolCreditState,
   poolSpendLimitRateCapCount,
+  poolEsConsumedAwuCredits,
+  poolMetronomeConsumedAwuCredits,
   programmaticCreditState,
   programmaticWarningReached,
   programmaticSpendLimitRateCapCount,
@@ -365,6 +372,8 @@ export function PokeUsageTab({
         creditUsageConfig={creditUsageConfig}
         poolCreditState={poolCreditState}
         poolSpendLimitRateCapCount={poolSpendLimitRateCapCount}
+        poolEsConsumedAwuCredits={poolEsConsumedAwuCredits}
+        poolMetronomeConsumedAwuCredits={poolMetronomeConsumedAwuCredits}
         programmaticCreditState={programmaticCreditState}
         programmaticWarningReached={programmaticWarningReached}
         programmaticSpendLimitRateCapCount={programmaticSpendLimitRateCapCount}

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -27,6 +27,7 @@ interface PokeUsageTabProps {
   subscription: SubscriptionType;
   stripeSubscription: PokeStripeSubscriptionWire | null;
   poolCreditState: WorkspacePoolCreditState;
+  poolSpendLimitRateCapCount: number | null;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
   programmaticSpendLimitRateCapCount: number | null;
@@ -95,6 +96,7 @@ interface PokeCreditStatesCardProps {
   owner: WorkspaceType;
   creditUsageConfig: PokeCreditUsageConfig | null;
   poolCreditState: WorkspacePoolCreditState;
+  poolSpendLimitRateCapCount: number | null;
   programmaticCreditState: WorkspaceProgrammaticCreditState;
   programmaticWarningReached: boolean;
   programmaticSpendLimitRateCapCount: number | null;
@@ -108,6 +110,7 @@ function PokeCreditStatesCard({
   owner,
   creditUsageConfig,
   poolCreditState,
+  poolSpendLimitRateCapCount,
   programmaticCreditState,
   programmaticWarningReached,
   programmaticSpendLimitRateCapCount,
@@ -129,6 +132,12 @@ function PokeCreditStatesCard({
             color={creditStateChipColor(poolCreditState)}
             label={poolCreditState}
           />
+          <span className="text-xs text-muted-foreground">
+            rate limiter:{" "}
+            {poolSpendLimitRateCapCount !== null
+              ? `${formatCredits(poolSpendLimitRateCapCount)} credits`
+              : "—"}
+          </span>
           <AlertChip alert={poolAlert} label="balance alert" />
           <CreditStateLogsLink machine="pool" workspaceId={owner.sId} />
           <ReconcileCreditStateButton owner={owner} target="pool" />
@@ -331,6 +340,7 @@ export function PokeUsageTab({
   subscription,
   stripeSubscription,
   poolCreditState,
+  poolSpendLimitRateCapCount,
   programmaticCreditState,
   programmaticWarningReached,
   programmaticSpendLimitRateCapCount,
@@ -354,6 +364,7 @@ export function PokeUsageTab({
         owner={owner}
         creditUsageConfig={creditUsageConfig}
         poolCreditState={poolCreditState}
+        poolSpendLimitRateCapCount={poolSpendLimitRateCapCount}
         programmaticCreditState={programmaticCreditState}
         programmaticWarningReached={programmaticWarningReached}
         programmaticSpendLimitRateCapCount={programmaticSpendLimitRateCapCount}

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -107,6 +107,7 @@ interface PokeCreditStatesCardProps {
   programmaticEsConsumedAwuCredits: number | null;
   programmaticMetronomeConsumedAwuCredits: number | null;
   poolAlert: MetronomeAlertRef | null;
+  usageCapAlert: MetronomeAlertRef | null;
   programmaticAlerts: PokeProgrammaticAlerts;
 }
 
@@ -123,6 +124,7 @@ function PokeCreditStatesCard({
   programmaticEsConsumedAwuCredits,
   programmaticMetronomeConsumedAwuCredits,
   poolAlert,
+  usageCapAlert,
   programmaticAlerts,
 }: PokeCreditStatesCardProps) {
   return (
@@ -138,6 +140,13 @@ function PokeCreditStatesCard({
             color={creditStateChipColor(poolCreditState)}
             label={poolCreditState}
           />
+          <span className="text-xs text-muted-foreground">
+            usage cap:{" "}
+            {creditUsageConfig?.usageCapCredits != null
+              ? `${formatCredits(creditUsageConfig.usageCapCredits)} credits`
+              : "none"}
+          </span>
+          <AlertChip alert={usageCapAlert} label="cap alert" />
           <SpendCountersInline
             esConsumedAwuCredits={poolEsConsumedAwuCredits}
             rateLimiterAwuCredits={poolSpendLimitRateCapCount}
@@ -187,17 +196,13 @@ function PokeCreditStatesCard({
 
 interface PokeCreditConfigCardProps {
   creditUsageConfig: PokeCreditUsageConfig | null;
-  usageCapAlert: MetronomeAlertRef | null;
 }
 
 function PokeCreditConfigCard({
   creditUsageConfig,
-  usageCapAlert,
 }: PokeCreditConfigCardProps) {
   const paygEnabled = creditUsageConfig?.paygEnabled ?? false;
-  const usageCapCredits = creditUsageConfig?.usageCapCredits ?? null;
   const defaultDiscountPercent = creditUsageConfig?.defaultDiscountPercent ?? 0;
-  const hasUsageCap = usageCapCredits !== null && usageCapCredits > 0;
 
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
@@ -212,19 +217,6 @@ function PokeCreditConfigCard({
             color={paygEnabled ? "success" : "warning"}
             label={paygEnabled ? "enabled" : "disabled"}
           />
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">Usage cap</span>
-          <span className="inline-flex items-center gap-1 text-sm font-medium text-foreground">
-            {hasUsageCap ? (
-              <>
-                {formatCredits(usageCapCredits)} credits
-                <AlertChip alert={usageCapAlert} label="alert" />
-              </>
-            ) : (
-              "disabled"
-            )}
-          </span>
         </div>
         <div className="flex items-center gap-2">
           <span className="text-xs text-muted-foreground">
@@ -382,12 +374,10 @@ export function PokeUsageTab({
           programmaticMetronomeConsumedAwuCredits
         }
         poolAlert={poolAlert}
+        usageCapAlert={usageCapAlert}
         programmaticAlerts={programmaticAlerts}
       />
-      <PokeCreditConfigCard
-        creditUsageConfig={creditUsageConfig}
-        usageCapAlert={usageCapAlert}
-      />
+      <PokeCreditConfigCard creditUsageConfig={creditUsageConfig} />
       <PokeDefaultAlertsCard defaultAlerts={defaultAlerts} />
       <PokeCreditPoolCard owner={owner} />
       <PokeTopUpsHistoryTable owner={owner} />

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -138,6 +138,8 @@ export function WorkspacePage() {
     planLimitOverride,
     poolCreditState,
     poolSpendLimitRateCapCount,
+    poolEsConsumedAwuCredits,
+    poolMetronomeConsumedAwuCredits,
     poolAlert,
     programmaticAlerts,
     usageCapAlert,
@@ -373,6 +375,10 @@ export function WorkspacePage() {
                   stripeSubscription={stripeSubscription}
                   poolCreditState={poolCreditState}
                   poolSpendLimitRateCapCount={poolSpendLimitRateCapCount}
+                  poolEsConsumedAwuCredits={poolEsConsumedAwuCredits}
+                  poolMetronomeConsumedAwuCredits={
+                    poolMetronomeConsumedAwuCredits
+                  }
                   programmaticCreditState={programmaticCreditState}
                   programmaticWarningReached={programmaticWarningReached}
                   programmaticSpendLimitRateCapCount={

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -137,6 +137,7 @@ export function WorkspacePage() {
     pendingSubscription,
     planLimitOverride,
     poolCreditState,
+    poolSpendLimitRateCapCount,
     poolAlert,
     programmaticAlerts,
     usageCapAlert,
@@ -371,6 +372,7 @@ export function WorkspacePage() {
                   subscription={activeSubscription}
                   stripeSubscription={stripeSubscription}
                   poolCreditState={poolCreditState}
+                  poolSpendLimitRateCapCount={poolSpendLimitRateCapCount}
                   programmaticCreditState={programmaticCreditState}
                   programmaticWarningReached={programmaticWarningReached}
                   programmaticSpendLimitRateCapCount={

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -66,6 +66,7 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { maybeAutoUpgradeSeat } from "@app/lib/api/credits/auto_seat_upgrade";
 import { isProgrammaticSpendLimitRateCapReached } from "@app/lib/api/credits/programmatic_usage_limit";
+import { isWorkspaceSpendLimitRateCapReached } from "@app/lib/api/credits/usage_configuration";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { isApiKeySpendLimitRateCapReached } from "@app/lib/api/keys/spend_limit";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/programmatic_usage/key_cap";
@@ -2587,7 +2588,24 @@ export async function checkMessagesLimit(
     // `no_seat` gate above is intentionally left outside this exemption since
     // it reflects membership, not credit state.
     if (!isFreeOrigin(context.origin)) {
-      if (blockedReason === "user_cap_reached") {
+      // The Redis fixed-window spend-cap backups are flag-gated while we
+      // validate the counters; usage is recorded regardless (in credit_cost),
+      // so the flag only controls blocking.
+      const featureFlags = await getFeatureFlags(auth);
+      const spendCapEnabled = featureFlags.includes(
+        "enforce_user_spend_limit_rate_cap"
+      );
+
+      // Per-user cap: the Metronome-driven reason OR the Redis fixed-window
+      // backup over the current contract billing cycle. The backup applies to
+      // real users only (API keys are gated by the pool / programmatic caps
+      // instead).
+      if (
+        blockedReason === "user_cap_reached" ||
+        (user &&
+          spendCapEnabled &&
+          (await isUserSpendLimitRateCapReached(auth, { user })))
+      ) {
         return new Err({
           status_code: 403,
           api_error: {
@@ -2596,28 +2614,13 @@ export async function checkMessagesLimit(
           },
         });
       }
-      // Redis fixed-window per-user spend cap: a synchronous backup of the
-      // Metronome per-user cap over the current contract billing cycle. Only
-      // applies to real users (API keys are gated by pool / programmatic caps
-      // instead). Enforcement is gated behind a feature flag while we validate
-      // the counter; usage is recorded regardless (in credit_cost), so the flag
-      // only controls blocking.
-      if (user) {
-        const featureFlags = await getFeatureFlags(auth);
-        if (
-          featureFlags.includes("enforce_user_spend_limit_rate_cap") &&
-          (await isUserSpendLimitRateCapReached(auth, { user }))
-        ) {
-          return new Err({
-            status_code: 403,
-            api_error: {
-              type: "user_cap_reached",
-              message: "You have reached your personal usage cap.",
-            },
-          });
-        }
-      }
-      if (blockedReason === "credits_exhausted") {
+
+      // Workspace usage cap (PAYG pool): the Metronome-driven pool state
+      // (`credits_exhausted`) OR the Redis fixed-window backup.
+      if (
+        blockedReason === "credits_exhausted" ||
+        (spendCapEnabled && (await isWorkspaceSpendLimitRateCapReached(auth)))
+      ) {
         return new Err({
           status_code: 403,
           api_error: {

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -4,6 +4,7 @@ import { isToolExecutionStatusBillable } from "@app/lib/actions/statuses";
 import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import { recordProgrammaticSpendLimitUsage } from "@app/lib/api/credits/programmatic_usage_limit";
+import { recordWorkspaceSpendLimitUsage } from "@app/lib/api/credits/usage_configuration";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import { recordApiKeySpendLimitUsage } from "@app/lib/api/keys/spend_limit";
 import type { ToolCostCategory } from "@app/lib/api/mcp";
@@ -19,6 +20,7 @@ import {
 import { getUsageType } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { spendLimitCycleOverrideForAuth } from "@app/lib/spend_limits/cycle";
@@ -332,6 +334,10 @@ export async function computeAndStoreAgentMessageCredits(
   if (recordedCostDelta > 0) {
     const featureFlags = await getFeatureFlags(auth);
     if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
+      const isProgrammatic = isProgrammaticUsage(auth, {
+        userMessageOrigin: messageOrigin,
+      });
+
       // Per-user cap.
       if (user) {
         await recordUserSpendLimitUsage(auth, {
@@ -351,10 +357,31 @@ export async function computeAndStoreAgentMessageCredits(
       }
 
       // Workspace programmatic cap, for programmatic calls.
-      if (isProgrammaticUsage(auth, { userMessageOrigin: messageOrigin })) {
+      if (isProgrammatic) {
         await recordProgrammaticSpendLimitUsage(auth, {
           incrementBy: recordedCostDelta,
         });
+      }
+
+      // Workspace usage cap (PAYG pool): pool usage only. Programmatic usage is
+      // always pool; user usage counts only for paid seats — free-seat usage
+      // draws from a separate Metronome credit type the pool cap does not
+      // measure.
+      if (isProgrammatic) {
+        await recordWorkspaceSpendLimitUsage(auth, {
+          incrementBy: recordedCostDelta,
+        });
+      } else if (user) {
+        const membership =
+          await MembershipResource.getActiveMembershipOfUserInWorkspace({
+            user,
+            workspace: auth.getNonNullableWorkspace(),
+          });
+        if (membership && membership.seatType !== "free") {
+          await recordWorkspaceSpendLimitUsage(auth, {
+            incrementBy: recordedCostDelta,
+          });
+        }
       }
     }
   }

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -139,6 +139,15 @@ export const makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace = (
   return `workspace:${owner.id}:programmatic_spend_limit_awu_credit_count`;
 };
 
+// Fixed-window counter backing the workspace usage cap (`usageCapCredits`): the
+// PAYG pool cap over all pool (non-free-seat) AWU usage. Workspace-scoped;
+// bucketed on the Metronome contract billing cycle.
+export const makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace = (
+  owner: LightWorkspaceType
+) => {
+  return `workspace:${owner.id}:usage_cap_spend_limit_awu_credit_count`;
+};
+
 export const makeProgrammaticUsageRateLimitKeyForWorkspace = (
   owner: LightWorkspaceType
 ) => {

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -579,18 +579,20 @@ export async function getEsConsumedProgrammaticAwuCredits(
  * programmatic). Free-seat usage is excluded (`must_not is_free_seat`): it draws
  * from the free-seat credit type, a separate Metronome credit type the PAYG
  * usage cap (`usageCapCredits`) does not measure. Used to lazily seed / resync
- * the workspace usage-cap counter. Returns 0 on no usage or an analytics read
- * failure.
+ * the workspace usage-cap counter. Returns the consumption, or `null` when it
+ * can't be determined (no billing cycle, or the analytics read failed) —
+ * callers must treat `null` as "unknown", never as 0, so a transient ES outage
+ * doesn't erase a live counter on resync.
  */
 export async function getEsConsumedWorkspaceAwuCredits(
   auth: Authenticator,
   { cycle }: { cycle?: BillingCycle }
-): Promise<number> {
+): Promise<number | null> {
   const workspace = auth.getNonNullableWorkspace();
 
   const resolvedCycle = cycle ?? (await resolveMetronomeCycle(workspace));
   if (!resolvedCycle) {
-    return 0;
+    return null;
   }
   const { cycleStart, cycleEnd } = resolvedCycle;
 
@@ -627,7 +629,7 @@ export async function getEsConsumedWorkspaceAwuCredits(
       { err: result.error, workspaceId: workspace.sId },
       "[MembersUsage] Failed to read workspace consumed credits from analytics index"
     );
-    return 0;
+    return null;
   }
 
   return Math.max(
@@ -1293,6 +1295,15 @@ export async function resyncWorkspaceSpendLimitCounterFromEsUsage(
   );
 
   const consumed = await getEsConsumedWorkspaceAwuCredits(auth, { cycle });
+  if (consumed === null) {
+    // The Elasticsearch read failed: skip the SET so a transient outage can't
+    // overwrite a valid live counter with 0 and disable the backup cap.
+    return new Err(
+      new Error(
+        "Failed to read workspace pool consumption from Elasticsearch; skipped resync to avoid erasing the counter."
+      )
+    );
+  }
   const setResult = await setFixedWindowCount({
     key: makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace(workspace),
     bounds,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -3,6 +3,7 @@ import {
   makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace,
   makeSpendLimitAwuCreditsRateLimitKeyForUser,
   makeSpendLimitCycleWindowBounds,
+  makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace,
 } from "@app/lib/api/assistant/rate_limits";
 import { computeCreditUsageStatus } from "@app/lib/api/credits/usage_status";
 import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
@@ -564,6 +565,69 @@ export async function getEsConsumedProgrammaticAwuCredits(
       "[MembersUsage] Failed to read programmatic consumed credits from analytics index"
     );
     return null;
+  }
+
+  return Math.max(
+    0,
+    Math.round(result.value.aggregations?.credits?.value ?? 0)
+  );
+}
+
+/**
+ * The workspace's Elasticsearch-derived *pool* AWU consumption for the current
+ * billing cycle — all non-free-seat billable usage (paid-seat users +
+ * programmatic). Free-seat usage is excluded (`must_not is_free_seat`): it draws
+ * from the free-seat credit type, a separate Metronome credit type the PAYG
+ * usage cap (`usageCapCredits`) does not measure. Used to lazily seed / resync
+ * the workspace usage-cap counter. Returns 0 on no usage or an analytics read
+ * failure.
+ */
+export async function getEsConsumedWorkspaceAwuCredits(
+  auth: Authenticator,
+  { cycle }: { cycle?: BillingCycle }
+): Promise<number> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const resolvedCycle = cycle ?? (await resolveMetronomeCycle(workspace));
+  if (!resolvedCycle) {
+    return 0;
+  }
+  const { cycleStart, cycleEnd } = resolvedCycle;
+
+  const result = await searchAnalytics<
+    never,
+    { credits?: estypes.AggregationsSumAggregate }
+  >(
+    {
+      bool: {
+        filter: [
+          { term: { workspace_id: workspace.sId } },
+          {
+            range: {
+              timestamp: {
+                gte: cycleStart.toISOString(),
+                lte: cycleEnd.toISOString(),
+              },
+            },
+          },
+        ],
+        // Paid/pool usage only (`must_not is_free_seat=true` rather than
+        // `is_free_seat=false` so historical docs without the field count as
+        // paid) — mirrors the `paid_credits` split in the per-user query.
+        must_not: [{ term: { is_free_seat: true } }],
+      },
+    },
+    {
+      aggregations: { credits: { sum: { field: "cost.billable_awu" } } },
+      size: 0,
+    }
+  );
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, workspaceId: workspace.sId },
+      "[MembersUsage] Failed to read workspace consumed credits from analytics index"
+    );
+    return 0;
   }
 
   return Math.max(
@@ -1199,6 +1263,43 @@ export async function resyncProgrammaticSpendLimitCounterFromEsUsage(
     logger,
   });
   return new Ok({ programmaticCounterSeeded: setResult.isOk() });
+}
+
+/**
+ * Backfill/repair the workspace usage-cap (`usageCapCredits`) counter from
+ * Elasticsearch, overwriting it (SET) with the pool AWU consumption for the
+ * current cycle. No-op (not seeded) when no usage cap is configured.
+ */
+export async function resyncWorkspaceSpendLimitCounterFromEsUsage(
+  auth: Authenticator
+): Promise<Result<{ workspaceCounterSeeded: boolean }, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  if ((config?.usageCapCredits ?? null) === null) {
+    return new Ok({ workspaceCounterSeeded: false });
+  }
+
+  const cycle = await resolveMetronomeCycle(workspace);
+  if (!cycle) {
+    return new Err(
+      new Error("No active Metronome billing period to resync against.")
+    );
+  }
+  const bounds = makeSpendLimitCycleWindowBounds(
+    cycle.cycleStart,
+    cycle.cycleEnd
+  );
+
+  const consumed = await getEsConsumedWorkspaceAwuCredits(auth, { cycle });
+  const setResult = await setFixedWindowCount({
+    key: makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace(workspace),
+    bounds,
+    value: Math.max(0, Math.round(consumed)),
+    logger,
+  });
+  return new Ok({ workspaceCounterSeeded: setResult.isOk() });
 }
 
 export type GetMemberUsageResponseBody = {

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -1,5 +1,7 @@
+import { makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace } from "@app/lib/api/assistant/rate_limits";
 import { passesBillingGate } from "@app/lib/api/credits/auto_seat_upgrade";
 import { syncMetronomeBalanceThresholdAlert } from "@app/lib/api/credits/balance_threshold_alert";
+import { getEsConsumedWorkspaceAwuCredits } from "@app/lib/api/credits/members_usage";
 import { syncMetronomeSeatCountForWorkspace } from "@app/lib/api/metronome/seat_sync";
 import type { Authenticator } from "@app/lib/auth";
 import { isEnterprisePlanPrefix, isFreePlan } from "@app/lib/plans/plan_codes";
@@ -10,6 +12,13 @@ import {
   DEFAULT_TOP_UP_ENABLED,
   DEFAULT_UPGRADE_REQUEST_EMAIL_ENABLED,
 } from "@app/lib/resources/storage/models/credit_usage_configurations";
+import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
+import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
+import {
+  addFixedWindowCount,
+  getFixedWindowCount,
+  setFixedWindowCount,
+} from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
   CreditUsageConfigurationBody,
@@ -156,4 +165,110 @@ export async function updateUsageConfiguration(
   }
 
   return new Ok(await getUsageConfiguration(auth));
+}
+
+/**
+ * Reads the workspace usage-cap counter, lazily seeding it from Elasticsearch
+ * (pool AWU for the current cycle) on a 0 read. Mirrors the other spend-cap
+ * lazy seeds. Returns the effective count, or `null` on a Redis read error
+ * (caller fails open).
+ */
+async function readWorkspaceSpendLimitCountWithLazySeed(
+  auth: Authenticator,
+  { redisKey, bounds }: { redisKey: string; bounds: FixedWindowBounds }
+): Promise<number | null> {
+  const countResult = await getFixedWindowCount({ key: redisKey, bounds });
+  if (countResult.isErr()) {
+    return null;
+  }
+  if (countResult.value > 0) {
+    return countResult.value;
+  }
+
+  const consumed = Math.max(
+    0,
+    Math.round(await getEsConsumedWorkspaceAwuCredits(auth, {}))
+  );
+  if (consumed > 0) {
+    await setFixedWindowCount({
+      key: redisKey,
+      bounds,
+      value: consumed,
+      logger,
+    });
+  }
+  return consumed;
+}
+
+/**
+ * Synchronous, Metronome-independent enforcement of the workspace usage cap
+ * (`usageCapCredits`, the PAYG pool cap), read at message-send time from the
+ * Redis fixed-window counter over the current contract billing cycle. Runs
+ * alongside the Metronome-driven pool state (`credits_exhausted`) as a faster,
+ * independent backup. Returns `false` (does not block) when no cap is
+ * configured, no billing period can be resolved, or on a Redis read error
+ * (fail-open).
+ */
+export async function isWorkspaceSpendLimitRateCapReached(
+  auth: Authenticator
+): Promise<boolean> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const config =
+    await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);
+  const threshold = config?.usageCapCredits ?? null;
+  if (threshold === null) {
+    return false;
+  }
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return false;
+  }
+
+  const count = await readWorkspaceSpendLimitCountWithLazySeed(auth, {
+    redisKey:
+      makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace(workspace),
+    bounds,
+  });
+  if (count === null) {
+    logger.error(
+      { workspaceId: workspace.sId },
+      "[WorkspaceSpendLimitRateCap] Failed to read fixed-window count; allowing message"
+    );
+    return false;
+  }
+
+  return count >= threshold;
+}
+
+/**
+ * Adds `incrementBy` AWU credits to the workspace usage-cap counter for the
+ * current contract billing cycle. The caller records only *pool* usage
+ * (non-free-seat), matching what `usageCapCredits` measures. No-op when the
+ * billing period can't be resolved.
+ */
+export async function recordWorkspaceSpendLimitUsage(
+  auth: Authenticator,
+  { incrementBy }: { incrementBy: number }
+): Promise<void> {
+  // Only whole positive credits are recordable (the counter is an integer
+  // INCRBY); skip anything else rather than letting it reach the counter.
+  if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
+    return;
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return;
+  }
+
+  await addFixedWindowCount({
+    key: makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace(workspace),
+    bounds,
+    incrementBy,
+    logger,
+  });
 }

--- a/front/lib/api/credits/usage_configuration.ts
+++ b/front/lib/api/credits/usage_configuration.ts
@@ -185,18 +185,18 @@ async function readWorkspaceSpendLimitCountWithLazySeed(
     return countResult.value;
   }
 
-  const consumed = Math.max(
-    0,
-    Math.round(await getEsConsumedWorkspaceAwuCredits(auth, {}))
-  );
-  if (consumed > 0) {
-    await setFixedWindowCount({
-      key: redisKey,
-      bounds,
-      value: consumed,
-      logger,
-    });
+  const consumed = await getEsConsumedWorkspaceAwuCredits(auth, {});
+  // `null` means the ES read failed (or no cycle) — treat as unknown and skip
+  // the seed rather than writing 0 (fail-open read).
+  if (consumed === null || consumed <= 0) {
+    return 0;
   }
+  await setFixedWindowCount({
+    key: redisKey,
+    bounds,
+    value: consumed,
+    logger,
+  });
   return consumed;
 }
 

--- a/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
+++ b/front/lib/api/poke/plugins/workspaces/resync_spend_limit_counters.ts
@@ -2,6 +2,7 @@ import {
   resyncApiKeySpendLimitCountersFromEsUsage,
   resyncProgrammaticSpendLimitCounterFromEsUsage,
   resyncSpendLimitCountersFromEsUsage,
+  resyncWorkspaceSpendLimitCounterFromEsUsage,
 } from "@app/lib/api/credits/members_usage";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { Err, Ok } from "@app/types/shared/result";
@@ -12,9 +13,10 @@ export const resyncSpendLimitCountersPlugin = createPlugin({
     name: "Resync Spend-Limit Counters from Usage",
     description:
       "Overwrite the Redis fixed-window spend-cap counters (each member's " +
-      "per-user counter, each capped API key's per-key counter, and the " +
-      "workspace programmatic counter) for the current cycle with their " +
-      "Elasticsearch-derived AWU consumption. Use to backfill the counters " +
+      "per-user counter, each capped API key's per-key counter, the workspace " +
+      "programmatic counter, and the workspace usage-cap counter) for the " +
+      "current cycle with their Elasticsearch-derived AWU consumption. Use to " +
+      "backfill the counters " +
       "after enabling the cap, or to repair drift (they otherwise only accrue " +
       "from live messages). Resyncs the cycle the workspace is enforced on: " +
       "the Metronome contract billing period on credit-priced plans, the UTC " +
@@ -41,14 +43,22 @@ export const resyncSpendLimitCountersPlugin = createPlugin({
       return new Err(new Error(programmaticResult.error.message));
     }
 
+    const workspaceResult =
+      await resyncWorkspaceSpendLimitCounterFromEsUsage(auth);
+    if (workspaceResult.isErr()) {
+      return new Err(new Error(workspaceResult.error.message));
+    }
+
     return new Ok({
       display: "text",
       value:
         `Resynced spend-limit counters from usage for ` +
         `${userResult.value.updatedUserCount} user(s), ` +
-        `${apiKeyResult.value.updatedKeyCount} API key(s), and the ` +
-        `workspace programmatic counter ` +
-        `(${programmaticResult.value.programmaticCounterSeeded ? "seeded" : "no positive cap"}).`,
+        `${apiKeyResult.value.updatedKeyCount} API key(s), the workspace ` +
+        `programmatic counter ` +
+        `(${programmaticResult.value.programmaticCounterSeeded ? "seeded" : "no positive cap"}), ` +
+        `and the workspace usage-cap counter ` +
+        `(${workspaceResult.value.workspaceCounterSeeded ? "seeded" : "no cap"}).`,
     });
   },
 });

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -1,4 +1,7 @@
-import { makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace } from "@app/lib/api/assistant/rate_limits";
+import {
+  makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace,
+  makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace,
+} from "@app/lib/api/assistant/rate_limits";
 import config from "@app/lib/api/config";
 import { getEsConsumedProgrammaticAwuCredits } from "@app/lib/api/credits/members_usage";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
@@ -80,6 +83,10 @@ export type PokeWorkspaceInfo = {
   // this tells Poke which of them are overridden rather than plan-given.
   planLimitOverride: PlanLimitOverride | null;
   poolCreditState: WorkspacePoolCreditState;
+  // Current value of the Redis fixed-window workspace usage-cap counter for the
+  // contract billing cycle (the rate-limiter backup). Null when there is no
+  // billing period to bucket on or the read failed.
+  poolSpendLimitRateCapCount: number | null;
   seatPlan: SeatPlanResponseBody | null;
   // The Metronome alerts backing each credit dimension — id and current status —
   // for deep-linking and display from Poke. Null when not configured / not
@@ -157,13 +164,22 @@ export async function getPokeWorkspaceInfo(
   // (no billing period, no Metronome customer, or a read failure).
   const spendLimitBounds = await resolveSpendLimitCycleBounds(owner);
   let programmaticSpendLimitRateCapCount: number | null = null;
+  let poolSpendLimitRateCapCount: number | null = null;
   if (spendLimitBounds) {
-    const countResult = await getFixedWindowCount({
+    const programmaticCountResult = await getFixedWindowCount({
       key: makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(owner),
       bounds: spendLimitBounds,
     });
-    programmaticSpendLimitRateCapCount = countResult.isOk()
-      ? countResult.value
+    programmaticSpendLimitRateCapCount = programmaticCountResult.isOk()
+      ? programmaticCountResult.value
+      : null;
+
+    const poolCountResult = await getFixedWindowCount({
+      key: makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace(owner),
+      bounds: spendLimitBounds,
+    });
+    poolSpendLimitRateCapCount = poolCountResult.isOk()
+      ? poolCountResult.value
       : null;
   }
   const programmaticEsConsumedAwuCredits = spendLimitBounds
@@ -277,6 +293,7 @@ export async function getPokeWorkspaceInfo(
     pendingSubscription,
     planLimitOverride,
     poolCreditState: workspaceResource.poolCreditState,
+    poolSpendLimitRateCapCount,
     poolAlert,
     programmaticAlerts,
     usageCapAlert,

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -3,7 +3,11 @@ import {
   makeUsageCapSpendLimitAwuCreditsRateLimitKeyForWorkspace,
 } from "@app/lib/api/assistant/rate_limits";
 import config from "@app/lib/api/config";
-import { getEsConsumedProgrammaticAwuCredits } from "@app/lib/api/credits/members_usage";
+import { getAwuPoolSummary } from "@app/lib/api/credits/awu_pool_summary";
+import {
+  getEsConsumedProgrammaticAwuCredits,
+  getEsConsumedWorkspaceAwuCredits,
+} from "@app/lib/api/credits/members_usage";
 import type { SeatPlanResponseBody } from "@app/lib/api/credits/seat_plan";
 import { getSeatPlan } from "@app/lib/api/credits/seat_plan";
 import { getWorkspacePlanLimitOverrides } from "@app/lib/api/plan_limit_overrides";
@@ -83,10 +87,13 @@ export type PokeWorkspaceInfo = {
   // this tells Poke which of them are overridden rather than plan-given.
   planLimitOverride: PlanLimitOverride | null;
   poolCreditState: WorkspacePoolCreditState;
-  // Current value of the Redis fixed-window workspace usage-cap counter for the
-  // contract billing cycle (the rate-limiter backup). Null when there is no
-  // billing period to bucket on or the read failed.
+  // Workspace usage-cap (pool) spend for the current billing cycle across the
+  // three sources, for debugging the rate-limiter backup: the Redis fixed-window
+  // counter (RL), the Elasticsearch-derived consumption (ES), and the
+  // Metronome-derived consumption (MT). Each null when it can't be resolved.
   poolSpendLimitRateCapCount: number | null;
+  poolEsConsumedAwuCredits: number | null;
+  poolMetronomeConsumedAwuCredits: number | null;
   seatPlan: SeatPlanResponseBody | null;
   // The Metronome alerts backing each credit dimension — id and current status —
   // for deep-linking and display from Poke. Null when not configured / not
@@ -195,6 +202,23 @@ export async function getPokeWorkspaceInfo(
       ? spendResult.value
       : null;
   }
+  const poolEsConsumedAwuCredits = spendLimitBounds
+    ? await getEsConsumedWorkspaceAwuCredits(auth, {})
+    : null;
+  // Pool MT = credits drawn from the pool this cycle = active − remaining, from
+  // the Metronome ledger balances.
+  let poolMetronomeConsumedAwuCredits: number | null = null;
+  if (workspaceResource.metronomeCustomerId) {
+    const poolSummaryResult = await getAwuPoolSummary(auth);
+    if (poolSummaryResult.isOk()) {
+      const { totalActiveCredits, totalRemainingCredits } =
+        poolSummaryResult.value;
+      poolMetronomeConsumedAwuCredits = Math.max(
+        0,
+        Math.round(totalActiveCredits - totalRemainingCredits)
+      );
+    }
+  }
 
   // Resolve the Metronome alert ids backing each credit dimension so Poke can
   // deep-link to the dashboard. Best-effort: any failure degrades to null
@@ -294,6 +318,8 @@ export async function getPokeWorkspaceInfo(
     planLimitOverride,
     poolCreditState: workspaceResource.poolCreditState,
     poolSpendLimitRateCapCount,
+    poolEsConsumedAwuCredits,
+    poolMetronomeConsumedAwuCredits,
     poolAlert,
     programmaticAlerts,
     usageCapAlert,


### PR DESCRIPTION
## Description

Final PR of the pool-cap rate-limiter stack. Adds a Redis fixed-window backup for the Metronome **workspace usage cap** (`usageCapCredits`, the PAYG pool cap): record pool AWU usage into a workspace-scoped counter over the contract billing cycle, and enforce it synchronously at message send alongside the Metronome-driven pool state (`credits_exhausted`).

Stacked on #30654.

- Reuses the existing `enforce_user_spend_limit_rate_cap` flag.
- Threshold is `usageCapCredits` (null = no cap → no enforcement).
- **Pool = non-free-seat usage only.** The cap measures the AWU pool credit type; free-seat usage draws from a separate Metronome credit type. Both the ES seed (`must_not is_free_seat`) and recording (programmatic OR paid-seat user) exclude free-seat usage to match Metronome and avoid over-blocking.
- Lazy-seed from Elasticsearch on a Redis miss; reader/recorder in `lib/api/credits/usage_configuration.ts`; ES seed + resync in `members_usage.ts`; the shared `resync-spend-limit-counters` poke plugin resyncs the usage-cap counter too.

## Tests

- `npx tsgo --noEmit` passes; `biome check` clean.
- No new automated tests (internal message-send path). Intended manual validation: enable the flag on a dust-internal workspace, run the `resync-spend-limit-counters` poke plugin, confirm the usage-cap counter matches ES pool consumption and that a workspace at/over `usageCapCredits` is blocked with the existing 403 `credits_exhausted`.

## Risk

- **Low, fail-open by design** (no cap, no billing period, Redis error → allow).
- **Off by default** (`dust_only` flag). No behavior change when off.
- When on, it is a *backup* OR-ed with the existing `credits_exhausted` pool state, returning the same 403.
- **One assumption to confirm:** the pool cap excludes free-seat usage (free-seat is a separate Metronome credit type). If `usageCapCredits` actually includes free-seat usage, drop the `must_not is_free_seat` filter + the seat check in recording — the current choice under-counts (fails toward under-blocking, the safe direction) in that case.
- Safe to roll back via revert.

## Deploy Plan

1. Merge after #30654; deploy `front` normally. No migration.
2. Flag stays `dust_only` and off — no runtime effect on merge.
3. Validate on a dust-internal workspace (enable flag → run poke resync → compare counter vs Metronome pool consumption for a cycle) before relying on the Redis path to block.
