### PR TITLE
[front] Refresh group_permissions grants for user-less auths

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -373,7 +373,13 @@ export class Authenticator {
   }
 
   async refresh({ transaction }: { transaction?: Transaction } = {}) {
-    if (this._user && this._workspace) {
+    if (!this._workspace) {
+      return;
+    }
+
+    // Reload group memberships for user-backed auths. Key auths carry a fixed group set derived
+    // from the key (not from live membership), so their `_groupModelIds` are left as-is.
+    if (this._user) {
       this._groupModelIds = Authenticator.isMember(this._role)
         ? await GroupResource.dangerouslyListUserGroupsForAuth({
             user: this._user,
@@ -381,12 +387,20 @@ export class Authenticator {
             transaction,
           })
         : [];
-      // Group memberships changed, so capabilities may have changed too: re-resolve them.
-      this._permissions = await Authenticator.resolvePermissions({
-        workspace: this._workspace,
-        groupModelIds: this._groupModelIds,
-      });
     }
+
+    // Re-resolve grants from the current group set. Grants on those groups can change (backfill,
+    // updatePermissions, create_pod, ...) even when the membership set does not, so this must run
+    // for every auth — including auths that have no user (API/system keys, internal auths), which
+    // the `_user` gate above skips. The agent loop freezes a serialized (user-less) key auth at
+    // workflow start and refreshes it per step (see `fromJsonWithRefrehedGroups`); without this it
+    // would keep a stale grant snapshot and deny access to resources granted mid-run. System keys
+    // scan the workspace grant set to avoid sending their whole group list to Postgres.
+    this._permissions = await Authenticator.resolvePermissions({
+      workspace: this._workspace,
+      groupModelIds: this._groupModelIds,
+      scanWorkspacePermissions: this.isSystemKey(),
+    });
   }
 
   /**

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -313,3 +313,37 @@ describe("Authenticator.fromKey permission resolution", () => {
     ).toEqual([includedGroup.id]);
   });
 });
+
+describe("Authenticator.refresh permission resolution", () => {
+  it("re-resolves grants for a user-less (system key) auth", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const { systemGroup } = await GroupFactory.defaults(workspace);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const group = await GroupFactory.regularManual(workspace, "eng");
+
+    // A system-key auth has no user; its grant snapshot is resolved once at build time. The agent
+    // loop freezes it at workflow start and refreshes it on every step.
+    const key = await KeyFactory.system(systemGroup);
+    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
+    expect(workspaceAuth.getGroupPermissions("agent", 42)).toEqual([]);
+
+    // A grant lands on one of the key's groups AFTER the auth was built (mirrors a backfill or an
+    // updatePermissions write arriving mid-run).
+    await GroupPermissionResource.grant(adminAuth, {
+      group,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: 42,
+    });
+
+    // refresh() must observe the new grant even though the auth has no user. Before the fix the
+    // `_user`-gated body skipped user-less auths entirely, leaving the stale (empty) snapshot.
+    await workspaceAuth.refresh();
+
+    expect(
+      workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
+    ).toEqual([group.id]);
+  });
+});


### PR DESCRIPTION
## Description

`Authenticator.refresh()` did not re-resolve `group_permissions` grants for **user-less** auths (API keys, system keys, internal auths), because the whole body was gated on `if (this._user && this._workspace)`. Programmatic agent loops run on a user-less auth, and the agent loop freezes its auth at workflow start and rebuilds it per step via `fromJsonWithRefrehedGroups → refresh()`. For a user-less auth that `refresh()` was a **no-op**, so the loop kept a **stale grant snapshot** for its whole run.

This surfaced in `group_permissions` shadow mode (#9479): a programmatic agent-loop worker logged `group_permissions_shadow_mismatch` ~60× over a single run — `legacyResult: true` (legacy re-reads the live `group_vaults` associations every call) vs `candidateResult: false` (the table-backed candidate read the frozen snapshot, taken before the space's grant was backfilled). The `group_permissions` row was present and correct; the caller's snapshot just never refreshed.

### The fix (`refresh()`)

- The **membership reload** (`dangerouslyListUserGroupsForAuth`) stays gated on `_user` — key auths derive their group set from the key, not from live membership, so their `_groupModelIds` are left untouched.
- The **grant re-resolution** (`resolvePermissions`) now runs for **every** auth that has a workspace, including user-less/key auths. Grants on a group can change (backfill, `updatePermissions`, `create_pod`, …) even when the membership set does not, so a refreshed auth must observe them. System keys keep the `scanWorkspacePermissions` path so they don't send their whole group list to Postgres.

### Why this matters for the flip (#9480)

In shadow mode this is harmless (served result unchanged). **After** the per-space flip, a user-less agent loop that spans a grant write would be wrongly **denied** access to that space until the loop ends — because its frozen grant snapshot never refreshes. Legacy avoided this by re-reading `group_vaults` live. This fix is a prerequisite for enabling the flip.

## Risk

Low. `refresh()` already re-resolved grants for user auths; this extends the same re-resolution to user-less auths (and drops the redundant `_user` gate around the permissions read). User-auth behavior is unchanged.

## Tests

New `Authenticator.refresh permission resolution` case in `auth.workspace_permission.test.ts`: builds a user-less system-key auth, writes a grant to one of its groups **after** construction, calls `refresh()`, and asserts `getGroupPermissions` now returns it (fails on the old no-op refresh). `auth.workspace_permission` (14) and `auth.fromjson` (2) suites pass; `tsgo` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
