### PR TITLE
feat: summary cards on the automations analytics page

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/index.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/index.ts
@@ -1,8 +1,10 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import overview from "./overview";
 import triggers from "./triggers";
 
 const app = workspaceApp();
 
+app.route("/overview", overview);
 app.route("/triggers", triggers);
 
 export default app;

--- a/front-api/routes/w/[wId]/analytics/automations/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/overview.test.ts
@@ -20,8 +20,8 @@ const OVERVIEW: GetAutomationsOverviewResponse = {
     startDate: "2026-07-01T00:00:00.000Z",
     endDate: "2026-08-01T00:00:00.000Z",
   },
-  credits: 8453,
-  workspaceCredits: 24000,
+  automationCredits: 8453,
+  workspaceTotalCredits: 24000,
   triggers: {
     enabled: 142,
     total: 152,

--- a/front-api/routes/w/[wId]/analytics/automations/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/overview.test.ts
@@ -1,0 +1,95 @@
+import type { GetAutomationsOverviewResponse } from "@app/lib/api/analytics/automations/overview";
+import { fetchAutomationsOverview } from "@app/lib/api/analytics/automations/overview";
+import { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Err, Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/analytics/automations/overview"), async (orig) => {
+  const mod = await orig();
+  return {
+    ...mod,
+    fetchAutomationsOverview: vi.fn(),
+  };
+});
+
+const OVERVIEW: GetAutomationsOverviewResponse = {
+  period: {
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+  },
+  credits: 8453,
+  workspaceCredits: 24000,
+  triggers: {
+    enabled: 142,
+    total: 152,
+  },
+};
+
+async function setupTest({
+  role = "admin",
+}: {
+  role?: MembershipRoleType;
+} = {}) {
+  return createPrivateApiMockRequest({ role });
+}
+
+function postOverviewRequest(wId: string, body: Record<string, unknown> = {}) {
+  return honoApp.request(`/api/w/${wId}/analytics/automations/overview`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/analytics/automations/overview", () => {
+  it("returns 403 for managers", async () => {
+    const { workspace } = await setupTest({ role: "manager" });
+
+    const response = await postOverviewRequest(workspace.sId);
+
+    expect(response.status).toBe(403);
+    expect(vi.mocked(fetchAutomationsOverview)).not.toHaveBeenCalled();
+  });
+
+  it("returns the overview for admins, defaulting to the current cycle", async () => {
+    vi.mocked(fetchAutomationsOverview).mockResolvedValue(new Ok(OVERVIEW));
+    const { workspace } = await setupTest();
+
+    const response = await postOverviewRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(OVERVIEW);
+  });
+
+  it("returns 400 on a negative days period", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await postOverviewRequest(workspace.sId, {
+      period: "days",
+      days: -7,
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+    expect(vi.mocked(fetchAutomationsOverview)).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the search fails", async () => {
+    vi.mocked(fetchAutomationsOverview).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { workspace } = await setupTest();
+
+    const response = await postOverviewRequest(workspace.sId);
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      error: { type: "internal_server_error" },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/analytics/automations/overview.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/overview.ts
@@ -1,0 +1,53 @@
+import type { GetAutomationsOverviewResponse } from "@app/lib/api/analytics/automations/overview";
+import { fetchAutomationsOverview } from "@app/lib/api/analytics/automations/overview";
+import { AutomationsOverviewBodySchema } from "@app/lib/api/analytics/automations/schema";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
+import logger from "@app/logger/logger";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+export type { GetAutomationsOverviewResponse };
+
+// Mounted at /api/w/:wId/analytics/automations/overview.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  validate("json", AutomationsOverviewBodySchema),
+  async (ctx): HandlerResult<GetAutomationsOverviewResponse> => {
+    const auth = ctx.get("auth");
+    const periodQuery = ctx.req.valid("json");
+
+    const period = await resolveConsumptionPeriod(
+      auth,
+      toConsumptionPeriodInput(periodQuery)
+    );
+
+    const result = await fetchAutomationsOverview(auth, { period });
+    if (result.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          err: result.error,
+        },
+        "[AutomationsAnalytics] Failed to retrieve overview."
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to retrieve overview.",
+        },
+      });
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -1,3 +1,4 @@
+import { AutomationsOverview } from "@app/components/workspace/analytics/automations/AutomationsOverview";
 import { AutomationsTriggersTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersTable";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
@@ -52,6 +53,7 @@ export function AnalyticsAutomationsPage() {
         }
       />
       <div className="flex flex-col gap-8 pb-8 pt-4">
+        <AutomationsOverview workspaceId={owner.sId} period={period} />
         <AutomationsTriggersTable workspaceId={owner.sId} period={period} />
       </div>
     </Page.Vertical>

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -1,3 +1,5 @@
+import { ValueCard } from "@dust-tt/sparkle";
+
 interface SummaryCardProps {
   label: string;
   value: string;
@@ -6,16 +8,15 @@ interface SummaryCardProps {
 
 export function SummaryCard({ label, value, hint }: SummaryCardProps) {
   return (
-    <div className="flex flex-1 flex-col justify-center gap-1 rounded-xl border border-border bg-panel-background p-4">
-      <span className="text-xs font-semibold text-muted-foreground">
-        {label}
-      </span>
-      <div className="flex flex-col">
-        <span className="truncate text-base font-semibold text-foreground">
-          {value}
-        </span>
-        {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
-      </div>
-    </div>
+    <ValueCard
+      className="flex-1"
+      title={label}
+      content={
+        <div className="flex flex-col gap-1">
+          <div className="truncate text-2xl text-foreground">{value}</div>
+          {hint && <div className="text-xs text-muted-foreground">{hint}</div>}
+        </div>
+      }
+    />
   );
 }

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -1,0 +1,21 @@
+interface SummaryCardProps {
+  label: string;
+  value: string;
+  hint: string | null;
+}
+
+export function SummaryCard({ label, value, hint }: SummaryCardProps) {
+  return (
+    <div className="flex flex-1 flex-col justify-center gap-1 rounded-xl border border-border bg-panel-background p-4">
+      <span className="text-xs font-semibold text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex flex-col">
+        <span className="truncate text-base font-semibold text-foreground">
+          {value}
+        </span>
+        {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+      </div>
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -1,5 +1,3 @@
-import { ValueCard } from "@dust-tt/sparkle";
-
 interface SummaryCardProps {
   label: string;
   value: string;
@@ -8,15 +6,16 @@ interface SummaryCardProps {
 
 export function SummaryCard({ label, value, hint }: SummaryCardProps) {
   return (
-    <ValueCard
-      className="flex-1"
-      title={label}
-      content={
-        <div className="flex flex-col gap-1">
-          <div className="truncate text-2xl text-foreground">{value}</div>
-          {hint && <div className="text-xs text-muted-foreground">{hint}</div>}
-        </div>
-      }
-    />
+    <div className="flex flex-1 flex-col justify-center gap-1 rounded-xl border border-border bg-panel-background p-4">
+      <span className="text-xs font-semibold text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex flex-col">
+        <span className="truncate text-base font-semibold text-foreground">
+          {value}
+        </span>
+        {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
+      </div>
+    </div>
   );
 }

--- a/front/components/workspace/analytics/automations/AutomationsOverview.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsOverview.tsx
@@ -17,7 +17,7 @@ export function AutomationsOverview({
 
   if (isOverviewLoading) {
     return (
-      <div className="h-24 w-full animate-pulse rounded-xl bg-muted-background" />
+      <div className="h-24 w-full animate-pulse rounded-2xl bg-muted-background" />
     );
   }
 
@@ -25,17 +25,17 @@ export function AutomationsOverview({
     return null;
   }
 
-  const { credits, workspaceCredits, triggers } = overview;
+  const { automationCredits, workspaceTotalCredits, triggers } = overview;
   const disabledCount = triggers.total - triggers.enabled;
 
   return (
     <div className="flex items-stretch gap-6">
       <SummaryCard
         label="Credits spent"
-        value={formatCredits(credits)}
+        value={formatCredits(automationCredits)}
         hint={
-          workspaceCredits > 0
-            ? `${Math.round((credits / workspaceCredits) * 100)}% of workspace usage`
+          workspaceTotalCredits > 0
+            ? `${Math.round((automationCredits / workspaceTotalCredits) * 100)}% of workspace usage`
             : null
         }
       />

--- a/front/components/workspace/analytics/automations/AutomationsOverview.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsOverview.tsx
@@ -1,0 +1,49 @@
+import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
+import { useAutomationsOverview } from "@app/hooks/useAutomationsOverview";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { formatCredits } from "@app/lib/client/credits";
+
+interface AutomationsOverviewProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+}
+
+export function AutomationsOverview({
+  workspaceId,
+  period,
+}: AutomationsOverviewProps) {
+  const { overview, isOverviewLoading, isOverviewError } =
+    useAutomationsOverview({ workspaceId, period });
+
+  if (isOverviewLoading) {
+    return (
+      <div className="h-24 w-full animate-pulse rounded-xl bg-muted-background" />
+    );
+  }
+
+  if (isOverviewError || !overview) {
+    return null;
+  }
+
+  const { credits, workspaceCredits, triggers } = overview;
+  const disabledCount = triggers.total - triggers.enabled;
+
+  return (
+    <div className="flex items-stretch gap-6">
+      <SummaryCard
+        label="Credits spent"
+        value={formatCredits(credits)}
+        hint={
+          workspaceCredits > 0
+            ? `${Math.round((credits / workspaceCredits) * 100)}% of workspace usage`
+            : null
+        }
+      />
+      <SummaryCard
+        label="Active triggers"
+        value={`${triggers.enabled.toLocaleString()} / ${triggers.total.toLocaleString()}`}
+        hint={disabledCount > 0 ? `${disabledCount} disabled` : null}
+      />
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/automations/AutomationsOverview.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsOverview.tsx
@@ -17,7 +17,7 @@ export function AutomationsOverview({
 
   if (isOverviewLoading) {
     return (
-      <div className="h-24 w-full animate-pulse rounded-2xl bg-muted-background" />
+      <div className="h-24 w-full animate-pulse rounded-xl bg-muted-background" />
     );
   }
 

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -1,3 +1,4 @@
+import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
@@ -26,28 +27,6 @@ function cycleElapsedPercent({
   const endMs = new Date(endDate).getTime();
   const elapsedRatio = (Date.now() - startMs) / (endMs - startMs);
   return Math.round(Math.min(Math.max(elapsedRatio, 0), 1) * 100);
-}
-
-interface SummaryCardProps {
-  label: string;
-  value: string;
-  hint: string | null;
-}
-
-function SummaryCard({ label, value, hint }: SummaryCardProps) {
-  return (
-    <div className="flex flex-1 flex-col justify-center gap-1 rounded-xl border border-border bg-panel-background p-4">
-      <span className="text-xs font-semibold text-muted-foreground">
-        {label}
-      </span>
-      <div className="flex flex-col">
-        <span className="truncate text-base font-semibold text-foreground">
-          {value}
-        </span>
-        {hint && <span className="text-xs text-muted-foreground">{hint}</span>}
-      </div>
-    </div>
-  );
 }
 
 interface ConsumptionSummaryProps {

--- a/front/hooks/useAutomationsOverview.ts
+++ b/front/hooks/useAutomationsOverview.ts
@@ -1,0 +1,34 @@
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
+import type { GetAutomationsOverviewResponse } from "@app/lib/api/analytics/automations/overview";
+import type { AutomationsOverviewBody } from "@app/lib/api/analytics/automations/schema";
+
+export function useAutomationsOverview({
+  workspaceId,
+  period,
+  disabled,
+}: {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  disabled?: boolean;
+}) {
+  const url = `/api/w/${workspaceId}/analytics/automations/overview`;
+  const body: AutomationsOverviewBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+  };
+
+  const { data, error, isLoading, isValidating } = useConsumptionQuery<
+    AutomationsOverviewBody,
+    GetAutomationsOverviewResponse
+  >({ url, body, disabled });
+
+  return {
+    overview: data ?? null,
+    isOverviewLoading: !error && isLoading,
+    isOverviewError: error,
+    isOverviewValidating: isValidating,
+  };
+}

--- a/front/lib/api/analytics/automations/overview.ts
+++ b/front/lib/api/analytics/automations/overview.ts
@@ -1,0 +1,87 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  buildConsumptionScopeQuery,
+  CREDIT_MICRO_FIELD,
+  TRIGGER_ID_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type AutomationsOverview = {
+  period: ConsumptionPeriod;
+  credits: number;
+  // Every credit the workspace spent over the period, automations included, so
+  // the automation share can be read against it.
+  workspaceCredits: number;
+  triggers: {
+    enabled: number;
+    total: number;
+  };
+};
+
+export type GetAutomationsOverviewResponse = AutomationsOverview;
+
+const CREDIT_AGG = "credit_micro";
+const AUTOMATION_AGG = "automations";
+
+type OverviewAggs = {
+  [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
+  [AUTOMATION_AGG]?: {
+    [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
+  };
+};
+
+export async function fetchAutomationsOverview(
+  auth: Authenticator,
+  { period }: { period: ConsumptionPeriod }
+): Promise<Result<AutomationsOverview, ElasticsearchError>> {
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+  });
+
+  const [searchResult, triggerCounts] = await Promise.all([
+    searchConsumptionAnalytics<never, OverviewAggs>(query, {
+      aggregations: {
+        [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+        [AUTOMATION_AGG]: {
+          filter: { exists: { field: TRIGGER_ID_FIELD } },
+          aggs: {
+            [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+          },
+        },
+      },
+      size: 0,
+    }),
+    TriggerResource.countByStatus(auth),
+  ]);
+  if (searchResult.isErr()) {
+    return searchResult;
+  }
+
+  const aggregations = searchResult.value.aggregations;
+
+  return new Ok({
+    period,
+    credits: microCreditsToCredits(
+      aggregations?.[AUTOMATION_AGG]?.[CREDIT_AGG]?.value ?? 0
+    ),
+    workspaceCredits: microCreditsToCredits(
+      aggregations?.[CREDIT_AGG]?.value ?? 0
+    ),
+    triggers: {
+      enabled: triggerCounts.enabled,
+      total: Object.values(triggerCounts).reduce(
+        (sum, count) => sum + count,
+        0
+      ),
+    },
+  });
+}

--- a/front/lib/api/analytics/automations/overview.ts
+++ b/front/lib/api/analytics/automations/overview.ts
@@ -15,10 +15,9 @@ import type { estypes } from "@elastic/elasticsearch";
 
 export type AutomationsOverview = {
   period: ConsumptionPeriod;
-  credits: number;
-  // Every credit the workspace spent over the period, automations included, so
-  // the automation share can be read against it.
-  workspaceCredits: number;
+  automationCredits: number;
+  // Automations included, so the automation share can be read against it.
+  workspaceTotalCredits: number;
   triggers: {
     enabled: number;
     total: number;
@@ -27,13 +26,14 @@ export type AutomationsOverview = {
 
 export type GetAutomationsOverviewResponse = AutomationsOverview;
 
-const CREDIT_AGG = "credit_micro";
-const AUTOMATION_AGG = "automations";
+const WORKSPACE_TOTAL_AGG = "workspace_credit_micro";
+const AUTOMATIONS_AGG = "automations";
+const AUTOMATION_CREDIT_AGG = "automation_credit_micro";
 
 type OverviewAggs = {
-  [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
-  [AUTOMATION_AGG]?: {
-    [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
+  [WORKSPACE_TOTAL_AGG]?: estypes.AggregationsSumAggregate;
+  [AUTOMATIONS_AGG]?: {
+    [AUTOMATION_CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   };
 };
 
@@ -50,17 +50,17 @@ export async function fetchAutomationsOverview(
   const [searchResult, triggerCounts] = await Promise.all([
     searchConsumptionAnalytics<never, OverviewAggs>(query, {
       aggregations: {
-        [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
-        [AUTOMATION_AGG]: {
+        [WORKSPACE_TOTAL_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+        [AUTOMATIONS_AGG]: {
           filter: { exists: { field: TRIGGER_ID_FIELD } },
           aggs: {
-            [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+            [AUTOMATION_CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
           },
         },
       },
       size: 0,
     }),
-    TriggerResource.countByStatus(auth),
+    TriggerResource.countForWorkspace(auth),
   ]);
   if (searchResult.isErr()) {
     return searchResult;
@@ -70,18 +70,12 @@ export async function fetchAutomationsOverview(
 
   return new Ok({
     period,
-    credits: microCreditsToCredits(
-      aggregations?.[AUTOMATION_AGG]?.[CREDIT_AGG]?.value ?? 0
+    automationCredits: microCreditsToCredits(
+      aggregations?.[AUTOMATIONS_AGG]?.[AUTOMATION_CREDIT_AGG]?.value ?? 0
     ),
-    workspaceCredits: microCreditsToCredits(
-      aggregations?.[CREDIT_AGG]?.value ?? 0
+    workspaceTotalCredits: microCreditsToCredits(
+      aggregations?.[WORKSPACE_TOTAL_AGG]?.value ?? 0
     ),
-    triggers: {
-      enabled: triggerCounts.enabled,
-      total: Object.values(triggerCounts).reduce(
-        (sum, count) => sum + count,
-        0
-      ),
-    },
+    triggers: triggerCounts,
   });
 }

--- a/front/lib/api/analytics/automations/schema.ts
+++ b/front/lib/api/analytics/automations/schema.ts
@@ -3,6 +3,12 @@ import { z } from "zod";
 
 export const DEFAULT_AUTOMATION_TRIGGERS_LIMIT = 25;
 
+export const AutomationsOverviewBodySchema = ConsumptionPeriodSchema;
+
+export type AutomationsOverviewBody = z.infer<
+  typeof AutomationsOverviewBodySchema
+>;
+
 export const AutomationTriggersBodySchema = ConsumptionPeriodSchema.extend({
   limit: z
     .number()

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -3,6 +3,7 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import * as temporalClient from "@app/temporal/triggers/schedule_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -409,6 +410,52 @@ describe("TriggerResource", () => {
 
       mockCreateOrUpdateWorkflow.mockRestore();
       mockDeleteWorkflow.mockRestore();
+    });
+  });
+
+  describe("countByStatus", () => {
+    it("counts the workspace's triggers per status", async () => {
+      const mockCreateOrUpdateWorkflow = vi
+        .spyOn(temporalClient, "createOrUpdateAgentSchedule")
+        .mockResolvedValue(new Ok("workflow-id"));
+
+      const { authenticator } = await createResourceTest({ role: "admin" });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+
+      for (const status of ["enabled", "enabled", "disabled"] as const) {
+        await TriggerFactory.schedule(authenticator, {
+          agentConfigurationId: agentConfig.sId,
+          status,
+          configuration: { cron: "0 9 * * 1", timezone: "UTC" },
+        });
+      }
+      await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+        status: "downgraded",
+      });
+
+      expect(await TriggerResource.countByStatus(authenticator)).toEqual({
+        enabled: 2,
+        disabled: 1,
+        relocating: 0,
+        downgraded: 1,
+      });
+
+      mockCreateOrUpdateWorkflow.mockRestore();
+    });
+
+    it("counts zero for a workspace without triggers", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      expect(await TriggerResource.countByStatus(authenticator)).toEqual({
+        enabled: 0,
+        disabled: 0,
+        relocating: 0,
+        downgraded: 0,
+      });
     });
   });
 });

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -413,8 +413,8 @@ describe("TriggerResource", () => {
     });
   });
 
-  describe("countByStatus", () => {
-    it("counts the workspace's triggers per status", async () => {
+  describe("countForWorkspace", () => {
+    it("counts the workspace's enabled triggers and its total", async () => {
       const mockCreateOrUpdateWorkflow = vi
         .spyOn(temporalClient, "createOrUpdateAgentSchedule")
         .mockResolvedValue(new Ok("workflow-id"));
@@ -437,11 +437,9 @@ describe("TriggerResource", () => {
         status: "downgraded",
       });
 
-      expect(await TriggerResource.countByStatus(authenticator)).toEqual({
+      expect(await TriggerResource.countForWorkspace(authenticator)).toEqual({
         enabled: 2,
-        disabled: 1,
-        relocating: 0,
-        downgraded: 1,
+        total: 4,
       });
 
       mockCreateOrUpdateWorkflow.mockRestore();
@@ -450,11 +448,9 @@ describe("TriggerResource", () => {
     it("counts zero for a workspace without triggers", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
 
-      expect(await TriggerResource.countByStatus(authenticator)).toEqual({
+      expect(await TriggerResource.countForWorkspace(authenticator)).toEqual({
         enabled: 0,
-        disabled: 0,
-        relocating: 0,
-        downgraded: 0,
+        total: 0,
       });
     });
   });

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -28,7 +28,10 @@ import type {
   TriggerType,
   WebhookConfig,
 } from "@app/types/assistant/triggers";
-import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
+import {
+  getTriggerStatusOwner,
+  isValidTriggerStatus,
+} from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -263,6 +266,30 @@ export class TriggerResource extends BaseResource<TriggerModel> {
 
   static listByWorkspace(auth: Authenticator) {
     return this.baseFetch(auth);
+  }
+
+  static async countByStatus(
+    auth: Authenticator
+  ): Promise<Record<TriggerStatus, number>> {
+    const rows = await this.model.count({
+      where: { workspaceId: auth.getNonNullableWorkspace().id },
+      group: ["status"],
+    });
+
+    const counts: Record<TriggerStatus, number> = {
+      enabled: 0,
+      disabled: 0,
+      relocating: 0,
+      downgraded: 0,
+    };
+    for (const row of rows) {
+      const { status } = row;
+      if (typeof status === "string" && isValidTriggerStatus(status)) {
+        counts[status] = row.count;
+      }
+    }
+
+    return counts;
   }
 
   static async listBySpace(

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -28,10 +28,7 @@ import type {
   TriggerType,
   WebhookConfig,
 } from "@app/types/assistant/triggers";
-import {
-  getTriggerStatusOwner,
-  isValidTriggerStatus,
-} from "@app/types/assistant/triggers";
+import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -268,28 +265,17 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return this.baseFetch(auth);
   }
 
-  static async countByStatus(
+  static async countForWorkspace(
     auth: Authenticator
-  ): Promise<Record<TriggerStatus, number>> {
-    const rows = await this.model.count({
-      where: { workspaceId: auth.getNonNullableWorkspace().id },
-      group: ["status"],
-    });
+  ): Promise<{ enabled: number; total: number }> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
 
-    const counts: Record<TriggerStatus, number> = {
-      enabled: 0,
-      disabled: 0,
-      relocating: 0,
-      downgraded: 0,
-    };
-    for (const row of rows) {
-      const { status } = row;
-      if (typeof status === "string" && isValidTriggerStatus(status)) {
-        counts[status] = row.count;
-      }
-    }
+    const [enabled, total] = await Promise.all([
+      this.model.count({ where: { workspaceId, status: "enabled" } }),
+      this.model.count({ where: { workspaceId } }),
+    ]);
 
-    return counts;
+    return { enabled, total };
   }
 
   static async listBySpace(


### PR DESCRIPTION
## Description

Thsi PR adds two cards on top of the /analytics/automations page, same shape as the ones on the consumption page:

- **Credits spent**: what automations burned over the period, hinted with their share of total workspace spend.
- **Active triggers**: enabled over total, hinted with how many are not running.

Backend is one new admin endpoint, `POST /api/w/:wId/analytics/automations/overview`. It runs a single Elasticsearch query over the period and gets both the workspace total and the automation share from a `filter` sub-aggregation on `trigger_id` existence.

`SummaryCard` moved out of `ConsumptionOverview.tsx` into the shared analytics folder so both pages render the same card.

<img width="1380" height="1506" alt="Capture d’écran 2026-08-17 à 18 48 32" src="https://github.com/user-attachments/assets/9e5355a8-8b2c-46c3-992f-53d9fa74a52b" />

## Tests

Unit tests

## Risk

Low. 

## Deploy Plan

Deploy front.