### PR TITLE
[front] perf: speed up agent fetching in consumption facet loading

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
@@ -212,7 +212,7 @@ app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
     limit,
     sort,
     // Stripped to stay under Next.js' 4MB API response limit.
-    omitInstructions: true,
+    omitHeavyAttributes: true,
   });
   if (withUsage === "true") {
     const mentionCounts = await runOnRedis(

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -4,11 +4,13 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
 import { SOURCE_ORIGIN_LABELS } from "@app/lib/api/analytics/source_labels";
-import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { filterAgentsByRequestedSpaces } from "@app/lib/api/assistant/configuration/agent";
+import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import type { MCPServerViewDisplayMetadata } from "@app/lib/resources/mcp_server_view_resource";
@@ -21,6 +23,7 @@ import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
+import { Op } from "sequelize";
 
 export type ConsumptionFacetCatalogEntry = {
   value: string;
@@ -115,6 +118,45 @@ function toolFacetCatalogEntries(
   return [...new Map(entries.map((entry) => [entry.value, entry])).values()];
 }
 
+async function listAgentFacetCatalogEntries(
+  auth: Authenticator
+): Promise<ConsumptionFacetCatalogEntry[]> {
+  const isManager = auth.isManager();
+  const [workspaceAgents, globalAgents] = await Promise.all([
+    AgentConfigurationModel.findAll({
+      attributes: [
+        "sId",
+        "name",
+        "pictureUrl",
+        "scope",
+        ...(!isManager ? ["requestedSpaceIds"] : []),
+      ],
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        status: "active",
+        ...(!isManager
+          ? { scope: { [Op.in]: ["workspace", "published", "visible"] } }
+          : {}),
+      },
+    }),
+    getGlobalAgents(auth, undefined, "extra_light"),
+  ]);
+
+  const visibleWorkspaceAgents = isManager
+    ? workspaceAgents
+    : await filterAgentsByRequestedSpaces(auth, workspaceAgents);
+
+  return [
+    ...globalAgents.filter((agent) => agent.status === "active"),
+    ...visibleWorkspaceAgents,
+  ].map((agent) => ({
+    value: agent.sId,
+    label: agent.name,
+    pictureUrl: agent.pictureUrl,
+    scope: agent.scope,
+  }));
+}
+
 /** Lists current workspace entities that can be selected as consumption filters. */
 async function listConsumptionFacetCatalogWithoutTracing(
   auth: Authenticator,
@@ -124,78 +166,42 @@ async function listConsumptionFacetCatalogWithoutTracing(
   // workspace catalogs and is known to perform poorly on large workspaces.
   // Move most facet metadata into Elasticsearch so this endpoint can query ES
   // instead of loading several unbounded database-backed catalogs.
-  const members = await traceFacetCatalogLoad(
-    "members",
-    "user",
-    requestedDimension,
-    async () => {
-      const result = await getMembers(auth, { activeOnly: true });
-      return result.members;
-    }
-  );
-  const apiKeys = await traceFacetCatalogLoad(
-    "api_keys",
-    "api_key",
-    requestedDimension,
-    () =>
-      KeyResource.listNonSystemKeysByWorkspace(auth.getNonNullableWorkspace())
-  );
-  const groups = await traceFacetCatalogLoad(
-    "groups",
-    "group",
-    requestedDimension,
-    () =>
-      GroupResource.listAllWorkspaceGroups(auth, {
-        groupKinds: [...MANAGEABLE_GROUP_KINDS],
-      })
-  );
-  const agents = await traceFacetCatalogLoad(
-    "agents",
-    "agent",
-    requestedDimension,
-    () =>
-      getAgentConfigurationsForView({
-        auth,
-        agentsGetView: "analytics",
-        variant: "extra_light",
-        omitInstructions: true,
-      })
-  );
-  const models = await traceFacetCatalogLoad(
-    "models",
-    "model",
-    requestedDimension,
-    async () => {
-      const result = await getModelsForAuth(auth);
-      return result.models;
-    }
-  );
-  const mcpServerViews = await traceFacetCatalogLoad(
-    "mcp_servers",
-    "tool",
-    requestedDimension,
-    () => MCPServerViewResource.listDisplayMetadataByWorkspace(auth)
-  );
-  const skills = await traceFacetCatalogLoad(
-    "skills",
-    "skill",
-    requestedDimension,
-    () =>
-      SkillResource.listByWorkspace(auth, {
-        status: "active",
-        withInstructions: false,
-        withTools: false,
-        withFileAttachments: false,
-      })
-  );
+  const [members, apiKeys, groups, agents, models, mcpServerViews, skills] =
+    await Promise.all([
+      traceFacetCatalogLoad("members", "user", requestedDimension, async () => {
+        const result = await getMembers(auth, { activeOnly: true });
+        return result.members;
+      }),
+      traceFacetCatalogLoad("api_keys", "api_key", requestedDimension, () =>
+        KeyResource.listNonSystemKeysByWorkspace(auth.getNonNullableWorkspace())
+      ),
+      traceFacetCatalogLoad("groups", "group", requestedDimension, () =>
+        GroupResource.listAllWorkspaceGroups(auth, {
+          groupKinds: [...MANAGEABLE_GROUP_KINDS],
+        })
+      ),
+      traceFacetCatalogLoad("agents", "agent", requestedDimension, () =>
+        listAgentFacetCatalogEntries(auth)
+      ),
+      traceFacetCatalogLoad("models", "model", requestedDimension, async () => {
+        const result = await getModelsForAuth(auth);
+        return result.models;
+      }),
+      traceFacetCatalogLoad("mcp_servers", "tool", requestedDimension, () =>
+        MCPServerViewResource.listDisplayMetadataByWorkspace(auth)
+      ),
+      traceFacetCatalogLoad("skills", "skill", requestedDimension, () =>
+        SkillResource.listByWorkspace(auth, {
+          status: "active",
+          withInstructions: false,
+          withTools: false,
+          withFileAttachments: false,
+        })
+      ),
+    ]);
 
   return {
-    agent: agents.map((agent) => ({
-      value: agent.sId,
-      label: agent.name,
-      pictureUrl: agent.pictureUrl,
-      scope: agent.scope,
-    })),
+    agent: agents,
     user: members.map((member) => ({
       value: member.sId,
       label: member.fullName,

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -124,45 +124,71 @@ async function listConsumptionFacetCatalogWithoutTracing(
   // workspace catalogs and is known to perform poorly on large workspaces.
   // Move most facet metadata into Elasticsearch so this endpoint can query ES
   // instead of loading several unbounded database-backed catalogs.
-  const [members, apiKeys, groups, agents, models, mcpServerViews, skills] =
-    await Promise.all([
-      traceFacetCatalogLoad("members", "user", requestedDimension, async () => {
-        const result = await getMembers(auth, { activeOnly: true });
-        return result.members;
-      }),
-      traceFacetCatalogLoad("api_keys", "api_key", requestedDimension, () =>
-        KeyResource.listNonSystemKeysByWorkspace(auth.getNonNullableWorkspace())
-      ),
-      traceFacetCatalogLoad("groups", "group", requestedDimension, () =>
-        GroupResource.listAllWorkspaceGroups(auth, {
-          groupKinds: [...MANAGEABLE_GROUP_KINDS],
-        })
-      ),
-      traceFacetCatalogLoad("agents", "agent", requestedDimension, () =>
-        getAgentConfigurationsForView({
-          auth,
-          agentsGetView: "analytics",
-          variant: "extra_light",
-          omitInstructions: true,
-          omitHeavyAttributes: true,
-        })
-      ),
-      traceFacetCatalogLoad("models", "model", requestedDimension, async () => {
-        const result = await getModelsForAuth(auth);
-        return result.models;
-      }),
-      traceFacetCatalogLoad("mcp_servers", "tool", requestedDimension, () =>
-        MCPServerViewResource.listDisplayMetadataByWorkspace(auth)
-      ),
-      traceFacetCatalogLoad("skills", "skill", requestedDimension, () =>
-        SkillResource.listByWorkspace(auth, {
-          status: "active",
-          withInstructions: false,
-          withTools: false,
-          withFileAttachments: false,
-        })
-      ),
-    ]);
+  const members = await traceFacetCatalogLoad(
+    "members",
+    "user",
+    requestedDimension,
+    async () => {
+      const result = await getMembers(auth, { activeOnly: true });
+      return result.members;
+    }
+  );
+  const apiKeys = await traceFacetCatalogLoad(
+    "api_keys",
+    "api_key",
+    requestedDimension,
+    () =>
+      KeyResource.listNonSystemKeysByWorkspace(auth.getNonNullableWorkspace())
+  );
+  const groups = await traceFacetCatalogLoad(
+    "groups",
+    "group",
+    requestedDimension,
+    () =>
+      GroupResource.listAllWorkspaceGroups(auth, {
+        groupKinds: [...MANAGEABLE_GROUP_KINDS],
+      })
+  );
+  const agents = await traceFacetCatalogLoad(
+    "agents",
+    "agent",
+    requestedDimension,
+    () =>
+      getAgentConfigurationsForView({
+        auth,
+        agentsGetView: "analytics",
+        variant: "extra_light",
+        omitInstructions: true,
+        omitHeavyAttributes: true,
+      })
+  );
+  const models = await traceFacetCatalogLoad(
+    "models",
+    "model",
+    requestedDimension,
+    async () => {
+      const result = await getModelsForAuth(auth);
+      return result.models;
+    }
+  );
+  const mcpServerViews = await traceFacetCatalogLoad(
+    "mcp_servers",
+    "tool",
+    requestedDimension,
+    () => MCPServerViewResource.listDisplayMetadataByWorkspace(auth)
+  );
+  const skills = await traceFacetCatalogLoad(
+    "skills",
+    "skill",
+    requestedDimension,
+    () =>
+      SkillResource.listByWorkspace(auth, {
+        status: "active",
+        withInstructions: false,
+        withTools: false,
+        withFileAttachments: false,
+      })
+  );
 
   return {
     agent: agents.map((agent) => ({

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -144,11 +144,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
           agentsGetView: "analytics",
           variant: "extra_light",
           omitInstructions: true,
-          excludeAttributes: [
-            "description",
-            "instructionsHtml",
-            "responseFormat",
-          ],
+          omitHeavyAttributes: true,
         })
       ),
       traceFacetCatalogLoad("models", "model", requestedDimension, async () => {

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -158,7 +158,6 @@ async function listConsumptionFacetCatalogWithoutTracing(
         auth,
         agentsGetView: "analytics",
         variant: "extra_light",
-        omitInstructions: true,
         omitHeavyAttributes: true,
       })
   );

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -4,13 +4,11 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
 import { SOURCE_ORIGIN_LABELS } from "@app/lib/api/analytics/source_labels";
-import { filterAgentsByRequestedSpaces } from "@app/lib/api/assistant/configuration/agent";
-import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_agents";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
-import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import type { MCPServerViewDisplayMetadata } from "@app/lib/resources/mcp_server_view_resource";
@@ -23,7 +21,6 @@ import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
-import { Op } from "sequelize";
 
 export type ConsumptionFacetCatalogEntry = {
   value: string;
@@ -118,45 +115,6 @@ function toolFacetCatalogEntries(
   return [...new Map(entries.map((entry) => [entry.value, entry])).values()];
 }
 
-async function listAgentFacetCatalogEntries(
-  auth: Authenticator
-): Promise<ConsumptionFacetCatalogEntry[]> {
-  const isManager = auth.isManager();
-  const [workspaceAgents, globalAgents] = await Promise.all([
-    AgentConfigurationModel.findAll({
-      attributes: [
-        "sId",
-        "name",
-        "pictureUrl",
-        "scope",
-        ...(!isManager ? ["requestedSpaceIds"] : []),
-      ],
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        status: "active",
-        ...(!isManager
-          ? { scope: { [Op.in]: ["workspace", "published", "visible"] } }
-          : {}),
-      },
-    }),
-    getGlobalAgents(auth, undefined, "extra_light"),
-  ]);
-
-  const visibleWorkspaceAgents = isManager
-    ? workspaceAgents
-    : await filterAgentsByRequestedSpaces(auth, workspaceAgents);
-
-  return [
-    ...globalAgents.filter((agent) => agent.status === "active"),
-    ...visibleWorkspaceAgents,
-  ].map((agent) => ({
-    value: agent.sId,
-    label: agent.name,
-    pictureUrl: agent.pictureUrl,
-    scope: agent.scope,
-  }));
-}
-
 /** Lists current workspace entities that can be selected as consumption filters. */
 async function listConsumptionFacetCatalogWithoutTracing(
   auth: Authenticator,
@@ -181,7 +139,17 @@ async function listConsumptionFacetCatalogWithoutTracing(
         })
       ),
       traceFacetCatalogLoad("agents", "agent", requestedDimension, () =>
-        listAgentFacetCatalogEntries(auth)
+        getAgentConfigurationsForView({
+          auth,
+          agentsGetView: "analytics",
+          variant: "extra_light",
+          omitInstructions: true,
+          excludeAttributes: [
+            "description",
+            "instructionsHtml",
+            "responseFormat",
+          ],
+        })
       ),
       traceFacetCatalogLoad("models", "model", requestedDimension, async () => {
         const result = await getModelsForAuth(auth);
@@ -201,7 +169,12 @@ async function listConsumptionFacetCatalogWithoutTracing(
     ]);
 
   return {
-    agent: agents,
+    agent: agents.map((agent) => ({
+      value: agent.sId,
+      label: agent.name,
+      pictureUrl: agent.pictureUrl,
+      scope: agent.scope,
+    })),
     user: members.map((member) => ({
       value: member.sId,
       label: member.fullName,

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -366,9 +366,35 @@ async function fetchWorkspaceAgentConfigurationsForView(
   });
 }
 
-export async function getAgentConfigurationsForView<
-  V extends AgentFetchVariant,
->({
+type AgentConfigurationsForViewBaseArgs = {
+  auth: Authenticator;
+  agentsGetView: AgentsGetViewType;
+  agentPrefix?: string;
+  limit?: number;
+  sort?: SortStrategyType;
+  dangerouslySkipPermissionFiltering?: boolean;
+};
+
+type FullAgentConfigurationsForViewArgs = AgentConfigurationsForViewBaseArgs & {
+  variant: "full";
+  omitInstructions?: never;
+  omitHeavyAttributes?: never;
+};
+
+type LightAgentConfigurationsForViewArgs =
+  AgentConfigurationsForViewBaseArgs & {
+    variant: Exclude<AgentFetchVariant, "full">;
+    omitInstructions?: boolean;
+    omitHeavyAttributes?: boolean;
+  };
+
+export function getAgentConfigurationsForView(
+  args: FullAgentConfigurationsForViewArgs
+): Promise<AgentConfigurationType[]>;
+export function getAgentConfigurationsForView(
+  args: LightAgentConfigurationsForViewArgs
+): Promise<LightAgentConfigurationType[]>;
+export async function getAgentConfigurationsForView({
   auth,
   agentsGetView,
   agentPrefix,
@@ -378,19 +404,7 @@ export async function getAgentConfigurationsForView<
   dangerouslySkipPermissionFiltering,
   omitInstructions,
   omitHeavyAttributes,
-}: {
-  auth: Authenticator;
-  agentsGetView: AgentsGetViewType;
-  agentPrefix?: string;
-  variant: V;
-  limit?: number;
-  sort?: SortStrategyType;
-  dangerouslySkipPermissionFiltering?: boolean;
-  omitInstructions?: boolean;
-  omitHeavyAttributes?: boolean;
-}): Promise<
-  V extends "full" ? AgentConfigurationType[] : LightAgentConfigurationType[]
-> {
+}: FullAgentConfigurationsForViewArgs | LightAgentConfigurationsForViewArgs) {
   const owner = auth.workspace();
   if (!owner || !auth.isUser()) {
     throw new Error("Unexpected `auth` without `workspace`.");
@@ -419,12 +433,6 @@ export async function getAgentConfigurationsForView<
       agentsGetView === "favorites")
   ) {
     throw new Error(`'${agentsGetView}' view is specific to a user.`);
-  }
-
-  // Omission options are incompatible with the "full" variant since callers of
-  // "full" inherently want the complete agent configuration.
-  if ((omitInstructions || omitHeavyAttributes) && variant === "full") {
-    throw new Error("Omission options cannot be combined with variant 'full'.");
   }
 
   const shouldOmitInstructions = omitInstructions || omitHeavyAttributes;

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -25,7 +25,6 @@ import type { WorkspaceType } from "@app/types/user";
 import { Op, Sequelize } from "sequelize";
 
 const HEAVY_AGENT_CONFIGURATION_ATTRIBUTES = [
-  "description",
   "instructions",
   "instructionsHtml",
   "responseFormat",

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -85,12 +85,12 @@ async function fetchGlobalAgentConfigurationForView(
     agentPrefix,
     agentsGetView,
     variant,
-    omitInstructions,
+    omitHeavyAttributes,
   }: {
     agentPrefix?: string;
     agentsGetView: AgentsGetViewType;
     variant: AgentFetchVariant;
-    omitInstructions?: boolean;
+    omitHeavyAttributes?: boolean;
   }
 ) {
   const globalAgentIdsToFetch = determineGlobalAgentIdsToFetch(agentsGetView);
@@ -100,7 +100,7 @@ async function fetchGlobalAgentConfigurationForView(
     variant
   );
   // Global agents have `instructions` baked in; strip when not needed.
-  const normalizedGlobalAgents = omitInstructions
+  const normalizedGlobalAgents = omitHeavyAttributes
     ? allGlobalAgents.map((a) => ({ ...a, instructions: null }))
     : allGlobalAgents;
   const matchingGlobalAgents = normalizedGlobalAgents.filter(
@@ -135,7 +135,6 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     limit,
     owner,
     sort,
-    omitInstructions,
     omitHeavyAttributes,
   }: {
     agentPrefix?: string;
@@ -144,7 +143,6 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     limit?: number;
     owner: WorkspaceType;
     sort?: SortStrategyType;
-    omitInstructions?: boolean;
     omitHeavyAttributes?: boolean;
   }
 ): Promise<AgentConfigurationModel[]> {
@@ -158,9 +156,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
 
   const attributesToExclude = omitHeavyAttributes
     ? HEAVY_AGENT_CONFIGURATION_ATTRIBUTES
-    : omitInstructions
-      ? (["instructions"] as const)
-      : [];
+    : [];
   const excludeAttributesFromSelect =
     attributesToExclude.length > 0
       ? { attributes: { exclude: [...new Set(attributesToExclude)] } }
@@ -312,7 +308,6 @@ async function fetchWorkspaceAgentConfigurationsForView(
     sort,
     variant,
     dangerouslySkipPermissionFiltering,
-    omitInstructions,
     omitHeavyAttributes,
   }: {
     agentPrefix?: string;
@@ -321,7 +316,6 @@ async function fetchWorkspaceAgentConfigurationsForView(
     sort?: SortStrategyType;
     variant: AgentFetchVariant;
     dangerouslySkipPermissionFiltering?: boolean;
-    omitInstructions?: boolean;
     omitHeavyAttributes?: boolean;
   }
 ) {
@@ -344,7 +338,6 @@ async function fetchWorkspaceAgentConfigurationsForView(
       limit,
       owner,
       sort,
-      omitInstructions,
       omitHeavyAttributes,
     }
   );
@@ -376,14 +369,12 @@ type AgentConfigurationsForViewBaseArgs = {
 
 type FullAgentConfigurationsForViewArgs = AgentConfigurationsForViewBaseArgs & {
   variant: "full";
-  omitInstructions?: never;
   omitHeavyAttributes?: never;
 };
 
 type LightAgentConfigurationsForViewArgs =
   AgentConfigurationsForViewBaseArgs & {
     variant: Exclude<AgentFetchVariant, "full">;
-    omitInstructions?: boolean;
     omitHeavyAttributes?: boolean;
   };
 
@@ -401,7 +392,6 @@ export async function getAgentConfigurationsForView({
   limit,
   sort,
   dangerouslySkipPermissionFiltering,
-  omitInstructions,
   omitHeavyAttributes,
 }: FullAgentConfigurationsForViewArgs | LightAgentConfigurationsForViewArgs) {
   const owner = auth.workspace();
@@ -434,8 +424,6 @@ export async function getAgentConfigurationsForView({
     throw new Error(`'${agentsGetView}' view is specific to a user.`);
   }
 
-  const shouldOmitInstructions = omitInstructions || omitHeavyAttributes;
-
   const applySortAndLimit = makeApplySortAndLimit(sort, limit);
 
   if (agentsGetView === "global") {
@@ -443,7 +431,7 @@ export async function getAgentConfigurationsForView({
       agentPrefix,
       agentsGetView,
       variant,
-      omitInstructions: shouldOmitInstructions,
+      omitHeavyAttributes,
     });
 
     return applySortAndLimit(allGlobalAgents);
@@ -456,7 +444,7 @@ export async function getAgentConfigurationsForView({
       agentPrefix,
       agentsGetView,
       variant,
-      omitInstructions: shouldOmitInstructions,
+      omitHeavyAttributes,
     }),
     fetchWorkspaceAgentConfigurationsForView(auth, owner, {
       agentPrefix,
@@ -465,7 +453,6 @@ export async function getAgentConfigurationsForView({
       sort,
       variant,
       dangerouslySkipPermissionFiltering,
-      omitInstructions: shouldOmitInstructions,
       omitHeavyAttributes,
     }),
   ]);

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -22,10 +22,13 @@ import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
-import type { Attributes } from "sequelize";
 import { Op, Sequelize } from "sequelize";
 
-type AgentConfigurationAttribute = keyof Attributes<AgentConfigurationModel>;
+const HEAVY_AGENT_CONFIGURATION_ATTRIBUTES = [
+  "description",
+  "instructionsHtml",
+  "responseFormat",
+] as const;
 
 const sortStrategies: Record<SortStrategyType, SortStrategy> = {
   alphabetical: {
@@ -133,7 +136,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     owner,
     sort,
     omitInstructions,
-    excludeAttributes = [],
+    omitHeavyAttributes,
   }: {
     agentPrefix?: string;
     agentsGetView: Exclude<AgentsGetViewType, "global">;
@@ -142,7 +145,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     owner: WorkspaceType;
     sort?: SortStrategyType;
     omitInstructions?: boolean;
-    excludeAttributes?: readonly AgentConfigurationAttribute[];
+    omitHeavyAttributes?: boolean;
   }
 ): Promise<AgentConfigurationModel[]> {
   const sortStrategy = sort && sortStrategies[sort];
@@ -153,9 +156,9 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
   };
 
-  const attributesToExclude: AgentConfigurationAttribute[] = [
+  const attributesToExclude = [
     ...(omitInstructions ? (["instructions"] as const) : []),
-    ...excludeAttributes,
+    ...(omitHeavyAttributes ? HEAVY_AGENT_CONFIGURATION_ATTRIBUTES : []),
   ];
   const excludeAttributesFromSelect =
     attributesToExclude.length > 0
@@ -309,7 +312,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     variant,
     dangerouslySkipPermissionFiltering,
     omitInstructions,
-    excludeAttributes,
+    omitHeavyAttributes,
   }: {
     agentPrefix?: string;
     agentsGetView: Exclude<AgentsGetViewType, "global">;
@@ -318,7 +321,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     variant: AgentFetchVariant;
     dangerouslySkipPermissionFiltering?: boolean;
     omitInstructions?: boolean;
-    excludeAttributes?: readonly AgentConfigurationAttribute[];
+    omitHeavyAttributes?: boolean;
   }
 ) {
   const user = auth.user();
@@ -341,7 +344,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
       owner,
       sort,
       omitInstructions,
-      excludeAttributes,
+      omitHeavyAttributes,
     }
   );
 
@@ -372,7 +375,7 @@ export async function getAgentConfigurationsForView<
   sort,
   dangerouslySkipPermissionFiltering,
   omitInstructions,
-  excludeAttributes,
+  omitHeavyAttributes,
 }: {
   auth: Authenticator;
   agentsGetView: AgentsGetViewType;
@@ -382,7 +385,7 @@ export async function getAgentConfigurationsForView<
   sort?: SortStrategyType;
   dangerouslySkipPermissionFiltering?: boolean;
   omitInstructions?: boolean;
-  excludeAttributes?: readonly AgentConfigurationAttribute[];
+  omitHeavyAttributes?: boolean;
 }): Promise<
   V extends "full" ? AgentConfigurationType[] : LightAgentConfigurationType[]
 > {
@@ -454,7 +457,7 @@ export async function getAgentConfigurationsForView<
       variant,
       dangerouslySkipPermissionFiltering,
       omitInstructions,
-      excludeAttributes,
+      omitHeavyAttributes,
     }),
   ]);
 

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -26,6 +26,7 @@ import { Op, Sequelize } from "sequelize";
 
 const HEAVY_AGENT_CONFIGURATION_ATTRIBUTES = [
   "description",
+  "instructions",
   "instructionsHtml",
   "responseFormat",
 ] as const;
@@ -156,10 +157,11 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
   };
 
-  const attributesToExclude = [
-    ...(omitInstructions ? (["instructions"] as const) : []),
-    ...(omitHeavyAttributes ? HEAVY_AGENT_CONFIGURATION_ATTRIBUTES : []),
-  ];
+  const attributesToExclude = omitHeavyAttributes
+    ? HEAVY_AGENT_CONFIGURATION_ATTRIBUTES
+    : omitInstructions
+      ? (["instructions"] as const)
+      : [];
   const excludeAttributesFromSelect =
     attributesToExclude.length > 0
       ? { attributes: { exclude: [...new Set(attributesToExclude)] } }
@@ -419,13 +421,13 @@ export async function getAgentConfigurationsForView<
     throw new Error(`'${agentsGetView}' view is specific to a user.`);
   }
 
-  // `omitInstructions` is incompatible with the "full" variant since callers of
-  // "full" inherently want the instructions text.
-  if (omitInstructions && variant === "full") {
-    throw new Error(
-      "`omitInstructions` cannot be combined with variant 'full'."
-    );
+  // Omission options are incompatible with the "full" variant since callers of
+  // "full" inherently want the complete agent configuration.
+  if ((omitInstructions || omitHeavyAttributes) && variant === "full") {
+    throw new Error("Omission options cannot be combined with variant 'full'.");
   }
+
+  const shouldOmitInstructions = omitInstructions || omitHeavyAttributes;
 
   const applySortAndLimit = makeApplySortAndLimit(sort, limit);
 
@@ -434,7 +436,7 @@ export async function getAgentConfigurationsForView<
       agentPrefix,
       agentsGetView,
       variant,
-      omitInstructions,
+      omitInstructions: shouldOmitInstructions,
     });
 
     return applySortAndLimit(allGlobalAgents);
@@ -447,7 +449,7 @@ export async function getAgentConfigurationsForView<
       agentPrefix,
       agentsGetView,
       variant,
-      omitInstructions,
+      omitInstructions: shouldOmitInstructions,
     }),
     fetchWorkspaceAgentConfigurationsForView(auth, owner, {
       agentPrefix,
@@ -456,7 +458,7 @@ export async function getAgentConfigurationsForView<
       sort,
       variant,
       dangerouslySkipPermissionFiltering,
-      omitInstructions,
+      omitInstructions: shouldOmitInstructions,
       omitHeavyAttributes,
     }),
   ]);

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -27,7 +27,6 @@ import { Op, Sequelize } from "sequelize";
 const HEAVY_AGENT_CONFIGURATION_ATTRIBUTES = [
   "instructions",
   "instructionsHtml",
-  "responseFormat",
 ] as const;
 
 const sortStrategies: Record<SortStrategyType, SortStrategy> = {

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -22,7 +22,10 @@ import { compareAgentsForSort } from "@app/types/assistant/assistant";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
+import type { Attributes } from "sequelize";
 import { Op, Sequelize } from "sequelize";
+
+type AgentConfigurationAttribute = keyof Attributes<AgentConfigurationModel>;
 
 const sortStrategies: Record<SortStrategyType, SortStrategy> = {
   alphabetical: {
@@ -130,6 +133,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     owner,
     sort,
     omitInstructions,
+    excludeAttributes = [],
   }: {
     agentPrefix?: string;
     agentsGetView: Exclude<AgentsGetViewType, "global">;
@@ -138,6 +142,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     owner: WorkspaceType;
     sort?: SortStrategyType;
     omitInstructions?: boolean;
+    excludeAttributes?: readonly AgentConfigurationAttribute[];
   }
 ): Promise<AgentConfigurationModel[]> {
   const sortStrategy = sort && sortStrategies[sort];
@@ -148,15 +153,19 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
     ...(agentPrefix ? { name: { [Op.iLike]: `${agentPrefix}%` } } : {}),
   };
 
-  // `instructions` can be many KB per agent; skip it when not needed.
-  const excludeInstructionsAttributes = omitInstructions
-    ? { attributes: { exclude: ["instructions"] } }
-    : {};
+  const attributesToExclude: AgentConfigurationAttribute[] = [
+    ...(omitInstructions ? (["instructions"] as const) : []),
+    ...excludeAttributes,
+  ];
+  const excludeAttributesFromSelect =
+    attributesToExclude.length > 0
+      ? { attributes: { exclude: [...new Set(attributesToExclude)] } }
+      : {};
 
   const baseAgentsSequelizeQuery = {
     limit,
     order: sortStrategy?.dbOrder,
-    ...excludeInstructionsAttributes,
+    ...excludeAttributesFromSelect,
   };
 
   const baseConditionsAndScopesIn = (scopes: string[]) => ({
@@ -218,7 +227,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
         );
 
         return AgentConfigurationModel.findAll({
-          ...excludeInstructionsAttributes,
+          ...excludeAttributesFromSelect,
           where: {
             workspaceId: owner.id,
             id: {
@@ -300,6 +309,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     variant,
     dangerouslySkipPermissionFiltering,
     omitInstructions,
+    excludeAttributes,
   }: {
     agentPrefix?: string;
     agentsGetView: Exclude<AgentsGetViewType, "global">;
@@ -308,6 +318,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
     variant: AgentFetchVariant;
     dangerouslySkipPermissionFiltering?: boolean;
     omitInstructions?: boolean;
+    excludeAttributes?: readonly AgentConfigurationAttribute[];
   }
 ) {
   const user = auth.user();
@@ -330,6 +341,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
       owner,
       sort,
       omitInstructions,
+      excludeAttributes,
     }
   );
 
@@ -360,6 +372,7 @@ export async function getAgentConfigurationsForView<
   sort,
   dangerouslySkipPermissionFiltering,
   omitInstructions,
+  excludeAttributes,
 }: {
   auth: Authenticator;
   agentsGetView: AgentsGetViewType;
@@ -369,6 +382,7 @@ export async function getAgentConfigurationsForView<
   sort?: SortStrategyType;
   dangerouslySkipPermissionFiltering?: boolean;
   omitInstructions?: boolean;
+  excludeAttributes?: readonly AgentConfigurationAttribute[];
 }): Promise<
   V extends "full" ? AgentConfigurationType[] : LightAgentConfigurationType[]
 > {
@@ -440,6 +454,7 @@ export async function getAgentConfigurationsForView<
       variant,
       dangerouslySkipPermissionFiltering,
       omitInstructions,
+      excludeAttributes,
     }),
   ]);
 

--- a/front/lib/api/mcp_server/tools/agents/list.ts
+++ b/front/lib/api/mcp_server/tools/agents/list.ts
@@ -35,7 +35,7 @@ export function registerAgentsListTool(server: McpServer) {
         auth,
         agentsGetView: "list",
         variant: "extra_light",
-        omitInstructions: true,
+        omitHeavyAttributes: true,
       });
 
       const accessibleAgents = agents.filter((agent) => agent.canRead);

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -412,7 +412,7 @@ export const activationManagementPlugin = createPlugin({
         auth,
         agentsGetView: "published",
         variant: "light",
-        omitInstructions: true,
+        omitHeavyAttributes: true,
       }),
       GroupResource.listAllWorkspaceGroups(auth, {
         groupKinds: [...MANAGEABLE_GROUP_KINDS],


### PR DESCRIPTION
## Description

Loading consumption facets can be slow on large workspaces, and in some examples the agents part is the longest (trace [here](https://app.datadoghq.eu/apm/traces?query=operation_name%3Ahono.request%20service%3Afront%20%40span.kind%3Aserver%20resource_name%3A%22POST%20%2Fapi%2Fw%2F%3AwId%2Fanalytics%2Fconsumption%2Ffacets%22&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&spanID=5513054968455158536&spanType=all&storage=hot&timeHint=1786983685909&trace=AwAAAaAQhx8VlIexLAAAABhBYUFRaHpkR0FBQ3BuWEVlZ1J0MU04TlgAAAAkMDFhMDEwODktMGYzZi00NTNmLTljMWYtZGVmNzU4MjU1NjNlAAQ-JA&trace_group_by_from=a&trace_group_by_metrics=a&traceID=6a8335040000000057c3a9e3311c463b&traceQuery=&view=spans&start=1787030506947&end=1787034106947&paused=false)).

Looking further into this, the query on `agent_configurations` is the main bottleneck. It's well indexed, no join, but it does select a few columns that are TOASTed (instructions and instructionsHTML). This PR removes those fields from the query done to populate the facets.

Will actually also speed up the Manage Agents page.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
