### PR TITLE
[Activation] Personalize recommendation email delivery

### DIFF
--- a/front/lib/notifications/email-templates/activation-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/activation-new-conversation.tsx
@@ -205,7 +205,7 @@ const ActivationNewConversationEmailTemplate = ({
             borderRadius: "6px",
           }}
         >
-          Start building
+          {action.label}
         </a>
       </p>
     </EmailLayout>

--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -5,6 +5,7 @@ import {
   filterMembersByNotifyCondition,
   notifyActivationConversationAgentReplied,
 } from "@app/lib/notifications/triggers/project-new-conversation";
+import { getActivationNewConversationEmailSubject } from "@app/lib/notifications/workflows/activation-new-conversation";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
@@ -18,6 +19,7 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { NotificationCondition } from "@app/types/notification_preferences";
 import {
+  ACTIVATION_NEW_CONVERSATION_TRIGGER_ID,
   CONVERSATION_NOTIFICATION_METADATA_KEYS,
   DEFAULT_NOTIFICATION_CONDITION,
   FOR_YOU_NOTIFICATION_METADATA_KEY,
@@ -25,15 +27,35 @@ import {
 import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
+const { mockTriggerBulk } = vi.hoisted(() => ({
+  mockTriggerBulk: vi.fn().mockResolvedValue({ result: [] }),
+}));
+
 // Mock Novu client so tests can assert whether the activation email was triggered.
 vi.mock(import("@app/lib/notifications"), async (importOriginal) => {
   const mod = await importOriginal();
   return {
     ...mod,
     getNovuClient: vi.fn().mockResolvedValue({
-      triggerBulk: vi.fn().mockResolvedValue({ result: [] }),
+      triggerBulk: mockTriggerBulk,
     }),
   };
+});
+
+describe("getActivationNewConversationEmailSubject", () => {
+  test("uses the recommendation name", () => {
+    expect(
+      getActivationNewConversationEmailSubject(
+        "  Prepare the weekly\ncustomer review  "
+      )
+    ).toBe("[Dust] Recommendation For You: Prepare the weekly customer review");
+  });
+
+  test("falls back when no recommendation name is available", () => {
+    expect(getActivationNewConversationEmailSubject(null)).toBe(
+      "[Dust] Recommendation For You: A recommendation for you"
+    );
+  });
 });
 
 describe("filterMembersByNotifyCondition", () => {
@@ -309,6 +331,7 @@ describe("notifyActivationConversationAgentReplied", () => {
     await ActivationPodResource.makeNew(auth, { pod, user });
 
     vi.mocked(getNovuClient).mockClear();
+    mockTriggerBulk.mockClear();
   });
 
   // A conversation Dust opened with a nudge: its opening message carries the
@@ -339,6 +362,25 @@ describe("notifyActivationConversationAgentReplied", () => {
     });
 
     expect(vi.mocked(getNovuClient)).toHaveBeenCalled();
+  });
+
+  test("uses a stable Novu transaction for repeated completions of the same nudge conversation", async () => {
+    const conversation = await createNudgeConversation();
+
+    await notifyActivationConversationAgentReplied(auth, {
+      conversationId: conversation.sId,
+    });
+    await notifyActivationConversationAgentReplied(auth, {
+      conversationId: conversation.sId,
+    });
+
+    expect(mockTriggerBulk).toHaveBeenCalledTimes(2);
+    const firstEvent = mockTriggerBulk.mock.calls[0][0].events[0];
+    const secondEvent = mockTriggerBulk.mock.calls[1][0].events[0];
+    expect(firstEvent.transactionId).toBe(
+      `${ACTIVATION_NEW_CONVERSATION_TRIGGER_ID}-${workspace.sId}-${conversation.sId}-${user.sId}`
+    );
+    expect(secondEvent.transactionId).toBe(firstEvent.transactionId);
   });
 
   test("does not trigger the activation email for a conversation the user starts", async () => {

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -9,6 +9,7 @@ import {
   getActivationRecommendation,
   getConversationDetails,
 } from "@app/lib/notifications/helpers";
+import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { FOR_YOU_EMAIL_UTM } from "@app/lib/tracking/campaigns";
 import { getGetStartedRoute } from "@app/lib/utils/router";
@@ -24,6 +25,18 @@ import { z } from "zod";
 // to the target user as a dedicated, standalone email. It has no digest step, so a
 // conversation sent this way is never also bundled into the unread digest for the same activity.
 
+const ACTIVATION_NEW_CONVERSATION_EMAIL_SUBJECT_FALLBACK =
+  "A recommendation for you";
+
+export function getActivationNewConversationEmailSubject(
+  recommendationName: string | null
+): string {
+  const normalizedName = recommendationName?.replace(/\s+/g, " ").trim();
+  return `[Dust] Recommendation For You: ${
+    normalizedName || ACTIVATION_NEW_CONVERSATION_EMAIL_SUBJECT_FALLBACK
+  }`;
+}
+
 const activationNewConversationPayloadSchema = z.object({
   workspaceId: z.string(),
   conversationId: z.string(),
@@ -34,7 +47,8 @@ type activationNewConversationPayloadType = z.infer<
 >;
 
 const activationNewConversationDetailsSchema = z.object({
-  subject: z.string(),
+  recommendationName: z.string().nullable(),
+  actionLabel: z.string(),
   workspaceName: z.string(),
   podName: z.string(),
   goal: z.string().nullable(),
@@ -84,7 +98,8 @@ const getActivationNewConversationDetails = async ({
     // Only reached for a deleted conversation, in which case the email step is
     // already skipped, so this value is never actually delivered.
     return {
-      subject: "A new conversation",
+      recommendationName: null,
+      actionLabel: "Start building",
       workspaceName: "your workspace",
       podName: "your pod",
       goal: null,
@@ -96,9 +111,20 @@ const getActivationNewConversationDetails = async ({
     subscriberId: subscriberId ?? "",
     payload,
   });
+  const recommendations = subscriberId
+    ? await ActivationRecommendationResource.fetchByConversationSId(
+        await Authenticator.fromUserIdAndWorkspaceId(
+          subscriberId,
+          payload.workspaceId
+        ),
+        payload.conversationId
+      )
+    : [];
 
   return {
-    subject: detailsResult.value.subject,
+    recommendationName:
+      recommendations[0]?.title ?? detailsResult.value.subject,
+    actionLabel: recommendations[0]?.ctaLabel?.trim() || "Start building",
     workspaceName: detailsResult.value.workspaceName,
     podName: detailsResult.value.projectName ?? "your pod",
     goal,
@@ -140,13 +166,15 @@ export const activationNewConversationWorkflow = workflow(
           podName: details.podName,
           goal: details.goal,
           action: {
-            label: details.subject,
+            label: details.actionLabel,
             url: forYouUrl,
           },
         });
 
         return {
-          subject: `[Dust] Recommendation For You: ${details.subject}`,
+          subject: getActivationNewConversationEmailSubject(
+            details.recommendationName
+          ),
           body,
         };
       },
@@ -183,10 +211,16 @@ export const triggerActivationNewConversationEmail = async (
       conversationId: conversation.sId,
     };
 
+    // A nudge conversation should produce exactly one email. Agent-loop
+    // finalization and Temporal activities are both retryable, so use the
+    // conversation and recipient as Novu's stable deduplication boundary.
+    const transactionId = `${ACTIVATION_NEW_CONVERSATION_TRIGGER_ID}-${payload.workspaceId}-${payload.conversationId}-${userToNotify.sId}`;
+
     const r = await novuClient.triggerBulk({
       events: [
         {
           workflowId: ACTIVATION_NEW_CONVERSATION_TRIGGER_ID,
+          transactionId,
           to: {
             subscriberId: userToNotify.sId,
             email: userToNotify.email,


### PR DESCRIPTION
## Summary
- Use the activation recommendation title and CTA label in the customer-facing email which is already prompted to have the correct format
- deduplicate retryable notification triggers with a stable Novu transaction ID

## Testing
New unit tests

## Risk
Low - fixing idempotency issue

## Deploy
1. Deploy front