### PR TITLE
feat: enabled toggle on the automations analytics table

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
@@ -27,6 +27,7 @@ const TRIGGERS: GetAutomationTriggersResponse = {
       triggerId: "trg1",
       name: "Competitor watch",
       kind: "schedule",
+      status: "enabled",
       agent: {
         agentId: "agent1",
         name: "deep-dive",
@@ -50,6 +51,7 @@ const TRIGGERS: GetAutomationTriggersResponse = {
       triggerId: "trg2",
       name: "Inbound triage",
       kind: "webhook",
+      status: "disabled",
       agent: {
         agentId: "agent2",
         name: "support",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/index.ts
@@ -1,10 +1,12 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
+import status from "./status";
 import webhookRequests from "./webhook_requests";
 
 // Mounted under /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId.
 const app = workspaceApp();
 
+app.route("/status", status);
 app.route("/webhook_requests", webhookRequests);
 
 export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/status.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/status.test.ts
@@ -1,0 +1,271 @@
+import { Authenticator } from "@app/lib/auth";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { TriggerStatus } from "@app/types/assistant/triggers";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function patchStatus(
+  workspace: { sId: string },
+  aId: string,
+  tId: string,
+  body: unknown
+) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/${aId}/triggers/${tId}/status`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+// A second workspace member whose triggers the session user does not edit.
+async function createOtherEditorAuth(workspace: WorkspaceType) {
+  const otherUser = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+  return Authenticator.fromUserIdAndWorkspaceId(otherUser.sId, workspace.sId);
+}
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId/status", () => {
+  it("lets the editor enable their own disabled trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, {
+      status: "enabled",
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("enabled");
+  });
+
+  it("lets an admin disable another member's enabled trigger, locking it", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const editorAuth = await createOtherEditorAuth(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth);
+    const trigger = await TriggerFactory.webhook(editorAuth, {
+      agentConfigurationId: agent.sId,
+      status: "enabled",
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, {
+      status: "disabled",
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(editorAuth, trigger.sId);
+    expect(updated?.status).toBe("disabled_by_admin");
+  });
+
+  it("stores a plain disabled status when the editor pauses their own trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      status: "enabled",
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, {
+      status: "disabled",
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("disabled");
+  });
+
+  it.each<{ target: "enabled" | "disabled" }>([
+    { target: "enabled" },
+    { target: "disabled" },
+  ])("rejects a non-admin editor setting an admin-locked trigger to $target", async ({
+    target,
+  }) => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      status: "disabled_by_admin",
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, {
+      status: target,
+    });
+
+    expect(response.status).toBe(403);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("disabled_by_admin");
+  });
+
+  it("lets an admin re-enable an admin-locked trigger", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const editorAuth = await createOtherEditorAuth(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth);
+    const trigger = await TriggerFactory.webhook(editorAuth, {
+      agentConfigurationId: agent.sId,
+      status: "disabled_by_admin",
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, {
+      status: "enabled",
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(editorAuth, trigger.sId);
+    expect(updated?.status).toBe("enabled");
+  });
+
+  it("rejects a member who is neither admin nor editor", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const editorAuth = await createOtherEditorAuth(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth);
+    const trigger = await TriggerFactory.webhook(editorAuth, {
+      agentConfigurationId: agent.sId,
+      status: "enabled",
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, {
+      status: "disabled",
+    });
+
+    expect(response.status).toBe(403);
+    const updated = await TriggerResource.fetchById(editorAuth, trigger.sId);
+    expect(updated?.status).toBe("enabled");
+  });
+
+  it.each<{ status: TriggerStatus; target: "enabled" | "disabled" }>([
+    { status: "relocating", target: "enabled" },
+    { status: "relocating", target: "disabled" },
+    { status: "downgraded", target: "enabled" },
+    { status: "downgraded", target: "disabled" },
+  ])("rejects toggling a $status trigger to $target", async ({
+    status,
+    target,
+  }) => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      status,
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, {
+      status: target,
+    });
+
+    expect(response.status).toBe(400);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe(status);
+  });
+
+  it("returns 404 for an unknown trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const response = await patchStatus(workspace, agent.sId, "unknown", {
+      status: "enabled",
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when the trigger belongs to another agent", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const otherAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Other Test Agent",
+    });
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: otherAgent.sId,
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, {
+      status: "enabled",
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it.each<{ body: unknown }>([
+    { body: { status: "relocating" } },
+    { body: { status: "disabled_by_admin" } },
+  ])("rejects a status outside enabled/disabled ($body)", async ({ body }) => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+    });
+
+    const response = await patchStatus(workspace, agent.sId, trigger.sId, body);
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/status.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/status.ts
@@ -1,0 +1,115 @@
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import logger from "@app/logger/logger";
+import { PatchTriggerStatusRequestBodySchema } from "@app/types/api/assistant/configuration/triggers";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+  tId: z.string(),
+});
+
+// Mounted at /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId/status.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.patch(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PatchTriggerStatusRequestBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId, tId } = ctx.req.valid("param");
+    const { status } = ctx.req.valid("json");
+
+    const trigger = await TriggerResource.fetchById(auth, tId);
+    if (!trigger) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "trigger_not_found",
+          message: "Trigger not found.",
+        },
+      });
+    }
+
+    if (trigger.agentConfigurationId !== aId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Trigger does not belong to the specified agent configuration.",
+        },
+      });
+    }
+
+    if (!auth.isAdmin() && trigger.editor !== auth.getNonNullableUser().id) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message:
+            "Only admins or the editor of the trigger can change its status.",
+        },
+      });
+    }
+
+    if (trigger.isSystemStatusTransitionTo(status)) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "This trigger's status is managed by Dust and cannot be changed.",
+        },
+      });
+    }
+
+    if (!trigger.canUpdateStatusTo(auth, status)) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "You don't have permission to change this trigger's status.",
+        },
+      });
+    }
+
+    let result;
+    switch (status) {
+      case "enabled":
+        result = await trigger.enable(auth);
+        break;
+      case "disabled":
+        result = await trigger.disable(
+          auth,
+          auth.isAdmin() ? "disabled_by_admin" : "disabled"
+        );
+        break;
+      default:
+        assertNever(status);
+    }
+
+    if (result.isErr()) {
+      logger.error(
+        { error: result.error, aId, tId, targetStatus: status },
+        "Error updating trigger status"
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to update the trigger status.",
+        },
+      });
+    }
+
+    return ctx.body(null, 204);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.test.ts
@@ -1,8 +1,10 @@
 import { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { faker } from "@faker-js/faker";
 import { honoApp } from "@front-api/app";
@@ -264,5 +266,211 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers (spaceI
     });
 
     expect(response.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers (disabled_by_admin)", () => {
+  async function createAdminLockedTrigger(
+    workspace: { sId: string },
+    aId: string
+  ) {
+    const trigger = await createScheduleTrigger(workspace, aId, null);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const resource = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    const disableRes = await resource?.disable(adminAuth, "disabled_by_admin");
+    expect(disableRes?.isOk()).toBe(true);
+    return trigger;
+  }
+
+  it("rejects a non-admin editor re-enabling an admin-locked trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createAdminLockedTrigger(workspace, agent.sId);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, status: "enabled" }],
+    });
+
+    expect(response.status).toBe(403);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("disabled_by_admin");
+  });
+
+  it("rejects a non-admin editor re-enabling a relocating trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const resource = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    const disableRes = await resource?.disable(adminAuth, "relocating");
+    expect(disableRes?.isOk()).toBe(true);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, status: "enabled" }],
+    });
+
+    expect(response.status).toBe(400);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("relocating");
+  });
+
+  it("rejects even an admin moving a trigger out of a system-owned status", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const resource = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    const disableRes = await resource?.disable(adminAuth, "downgraded");
+    expect(disableRes?.isOk()).toBe(true);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, status: "enabled" }],
+    });
+
+    expect(response.status).toBe(400);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("downgraded");
+  });
+
+  it("rejects even an admin moving a trigger into a system-owned status", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, status: "relocating" }],
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("lets an editor save other fields of a system-disabled trigger, status echoed unchanged", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const resource = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    const disableRes = await resource?.disable(adminAuth, "downgraded");
+    expect(disableRes?.isOk()).toBe(true);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [
+        {
+          ...trigger,
+          sId: trigger.sId,
+          name: "renamed-downgraded-trigger",
+          status: "downgraded",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.name).toBe("renamed-downgraded-trigger");
+    expect(updated?.status).toBe("downgraded");
+  });
+
+  it("keeps the update()/enable() asymmetry restore jobs rely on", async () => {
+    // update() refuses system-status transitions for everyone, while enable()
+    // allows them for admins: this is what lets enableAllForWorkspace restore
+    // downgraded/relocating triggers. Do not "unify" these paths.
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      status: "downgraded",
+    });
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const updateRes = await TriggerResource.update(adminAuth, trigger.sId, {
+      status: "enabled",
+    });
+    expect(updateRes.isErr()).toBe(true);
+
+    const enableRes = await trigger.enable(adminAuth);
+    expect(enableRes?.isOk()).toBe(true);
+    const restored = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    expect(restored?.status).toBe("enabled");
+  });
+
+  it("lets a non-admin editor edit other fields of an admin-locked trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createAdminLockedTrigger(workspace, agent.sId);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [
+        {
+          ...trigger,
+          sId: trigger.sId,
+          name: "renamed-trigger",
+          status: "disabled_by_admin",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.name).toBe("renamed-trigger");
+    expect(updated?.status).toBe("disabled_by_admin");
   });
 });

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -222,6 +222,34 @@ app.patch(
       }
 
       const validatedTrigger = triggerValidation.data;
+
+      const nextStatus = validatedTrigger.status ?? "enabled";
+      if (triggerToUpdate.isSystemStatusTransitionTo(nextStatus)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "This trigger's status is managed by Dust and cannot be changed.",
+          },
+        });
+      }
+
+      const canUpdateStatus = triggerToUpdate.canUpdateStatusTo(
+        auth,
+        nextStatus
+      );
+      if (!canUpdateStatus) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "You don't have permission to change this trigger's status.",
+          },
+        });
+      }
+
       const webhookSourceViewId = isWebhookTriggerData(validatedTrigger)
         ? getResourceIdFromSId(validatedTrigger.webhookSourceViewId)
         : null;

--- a/front/components/me/UserTriggersTable.tsx
+++ b/front/components/me/UserTriggersTable.tsx
@@ -1,15 +1,14 @@
+import { TriggerStatusChip } from "@app/components/triggers/TriggerStatusChip";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useDeleteTrigger, useUserTriggers } from "@app/lib/swr/agent_triggers";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import { getTriggerDescription } from "@app/lib/utils/trigger_description";
 import type { GetUserTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
-import type { TriggerStatus } from "@app/types/assistant/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
   Button,
-  Chip,
   DataTable,
   Dialog,
   DialogContainer,
@@ -28,15 +27,6 @@ import { useCallback, useMemo, useState } from "react";
 // `onClick` satisfies DataTable's row shape, which is otherwise a weak type.
 type UserTriggerRow = GetUserTriggersResponseBody["triggers"][number] & {
   onClick?: () => void;
-};
-
-type ChipColor = React.ComponentProps<typeof Chip>["color"];
-
-const STATUS_CHIP_COLORS: Record<TriggerStatus, ChipColor> = {
-  enabled: "success",
-  disabled: "primary",
-  relocating: "info",
-  downgraded: "warning",
 };
 
 interface UserTriggersTableProps {
@@ -150,14 +140,11 @@ export function UserTriggersTable({ owner }: UserTriggersTableProps) {
         header: "Status",
         cell: ({ row }) => (
           <DataTable.CellContent>
-            <Chip size="xs" color={STATUS_CHIP_COLORS[row.original.status]}>
-              {row.original.status.charAt(0).toUpperCase() +
-                row.original.status.slice(1)}
-            </Chip>
+            <TriggerStatusChip status={row.original.status} />
           </DataTable.CellContent>
         ),
         meta: {
-          className: "w-28",
+          className: "w-36",
         },
       },
       {

--- a/front/components/triggers/TriggerStatusChip.tsx
+++ b/front/components/triggers/TriggerStatusChip.tsx
@@ -1,0 +1,33 @@
+import type { TriggerStatus } from "@app/types/assistant/triggers";
+import { Chip } from "@dust-tt/sparkle";
+import type React from "react";
+
+type ChipColor = React.ComponentProps<typeof Chip>["color"];
+
+const STATUS_CHIP_COLORS: Record<TriggerStatus, ChipColor> = {
+  enabled: "success",
+  disabled: "primary",
+  disabled_by_admin: "warning",
+  relocating: "info",
+  downgraded: "warning",
+};
+
+export const TRIGGER_STATUS_LABELS: Record<TriggerStatus, string> = {
+  enabled: "Enabled",
+  disabled: "Disabled",
+  disabled_by_admin: "Disabled by admin",
+  relocating: "Relocating",
+  downgraded: "Downgraded",
+};
+
+interface TriggerStatusChipProps {
+  status: TriggerStatus;
+}
+
+export function TriggerStatusChip({ status }: TriggerStatusChipProps) {
+  return (
+    <Chip size="xs" color={STATUS_CHIP_COLORS[status]}>
+      {TRIGGER_STATUS_LABELS[status]}
+    </Chip>
+  );
+}

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -1,3 +1,4 @@
+import { ConfirmContext } from "@app/components/Confirm";
 import { getIcon } from "@app/components/resources/resources_icons";
 import {
   AvatarNameCell,
@@ -7,7 +8,10 @@ import {
 import { useAutomationsTriggers } from "@app/hooks/useAutomationsTriggers";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
+import { useUpdateTriggerStatus } from "@app/lib/swr/agent_triggers";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
+import type { TriggerStatus } from "@app/types/assistant/triggers";
+import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
   Avatar,
@@ -15,15 +19,20 @@ import {
   DataTable,
   DataTableLoadingSkeleton,
   Icon,
+  SliderToggle,
   Tooltip,
 } from "@dust-tt/sparkle";
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import type { ComponentProps, Dispatch, SetStateAction } from "react";
-import { useState } from "react";
+import { useCallback, useContext, useMemo, useState } from "react";
 
 const TRIGGERS_PAGE_SIZE = 25;
 
 interface TriggerRowData extends AutomationTriggerRow {
+  displayStatus: TriggerStatus;
+  isStatusPending: boolean;
+  onToggleStatus: () => void;
+  // onClick satisfies DataTable's row shape, which is otherwise a weak type.
   onClick?: () => void;
 }
 
@@ -49,6 +58,43 @@ function TypeCell({ trigger }: { trigger: AutomationTriggerRow }) {
       );
     default:
       assertNeverAndIgnore(trigger.kind);
+      return null;
+  }
+}
+
+function RunningCell({ row }: { row: TriggerRowData }) {
+  switch (row.displayStatus) {
+    // The page is admin-only, so an admin-locked trigger stays toggleable here.
+    case "enabled":
+    case "disabled":
+    case "disabled_by_admin":
+      return (
+        <SliderToggle
+          selected={row.displayStatus === "enabled"}
+          disabled={row.isStatusPending}
+          onClick={row.onToggleStatus}
+        />
+      );
+    case "relocating":
+    case "downgraded":
+      return (
+        <Tooltip
+          label={
+            row.displayStatus === "relocating"
+              ? "Disabled while the workspace is being relocated."
+              : "Disabled following a plan downgrade."
+          }
+          trigger={
+            // A disabled SliderToggle needs a wrapper to be a valid Tooltip
+            // trigger.
+            <div>
+              <SliderToggle selected={false} disabled />
+            </div>
+          }
+        />
+      );
+    default:
+      assertNeverAndIgnore(row.displayStatus);
       return null;
   }
 }
@@ -195,6 +241,17 @@ const columns: ColumnDef<TriggerRowData>[] = [
       </DataTable.CellContent>
     ),
   },
+  {
+    id: "status",
+    header: "Enabled",
+    enableSorting: false,
+    meta: { className: "w-24", headerAlign: "left" },
+    cell: (info) => (
+      <DataTable.CellContent className="w-full justify-start">
+        <RunningCell row={info.row.original} />
+      </DataTable.CellContent>
+    ),
+  },
 ];
 
 interface AutomationsTriggersTableProps {
@@ -219,12 +276,92 @@ export function AutomationsTriggersTable({
       offset: pagination.pageIndex * pagination.pageSize,
     });
 
+  const confirm = useContext(ConfirmContext);
+  const updateTriggerStatus = useUpdateTriggerStatus({ workspaceId });
+
+  // The table data comes from an expensive Elasticsearch query, so instead of
+  // revalidating after a toggle we track the new statuses locally.
+  const [statusOverrides, setStatusOverrides] = useState<
+    Record<string, TriggerStatus>
+  >({});
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(new Set());
+
+  // Refetched rows (pagination, period change) already carry any status we
+  // wrote, so overrides only need to live until the next fetch. Reset during
+  // render (https://react.dev/learn/you-might-not-need-an-effect). A fetch
+  // that straddles a toggle can briefly show the pre-toggle status; the next
+  // fetch self-heals it.
+  const [prevTriggers, setPrevTriggers] = useState(triggers);
+  if (prevTriggers !== triggers) {
+    setPrevTriggers(triggers);
+    setStatusOverrides({});
+  }
+
+  const handleToggle = useCallback(
+    async (trigger: AutomationTriggerRow, currentStatus: TriggerStatus) => {
+      if (getTriggerStatusOwner(currentStatus) === "system") {
+        return;
+      }
+      const nextStatus = currentStatus === "enabled" ? "disabled" : "enabled";
+
+      if (nextStatus === "disabled") {
+        const confirmed = await confirm({
+          title: "Disable this automation?",
+          message: `"${trigger.name}" will stop running for ${trigger.editor.name}. Only an admin will be able to re-enable it.`,
+          validateVariant: "warning",
+          validateLabel: "Disable",
+          cancelLabel: "Cancel",
+        });
+        if (!confirmed) {
+          return;
+        }
+      }
+
+      setPendingIds((ids) => new Set([...ids, trigger.triggerId]));
+      const success = await updateTriggerStatus({
+        agentConfigurationId: trigger.agent.agentId,
+        triggerId: trigger.triggerId,
+        status: nextStatus,
+      });
+      if (success) {
+        // This page is admin-only, so a disable is stored server-side as
+        // disabled_by_admin.
+        setStatusOverrides((overrides) => ({
+          ...overrides,
+          [trigger.triggerId]:
+            nextStatus === "disabled" ? "disabled_by_admin" : "enabled",
+        }));
+      }
+      setPendingIds((ids) => {
+        const next = new Set(ids);
+        next.delete(trigger.triggerId);
+        return next;
+      });
+    },
+    [confirm, updateTriggerStatus]
+  );
+
+  const rows: TriggerRowData[] = useMemo(
+    () =>
+      triggers.map((trigger) => {
+        const displayStatus =
+          statusOverrides[trigger.triggerId] ?? trigger.status;
+        return {
+          ...trigger,
+          displayStatus,
+          isStatusPending: pendingIds.has(trigger.triggerId),
+          onToggleStatus: () => void handleToggle(trigger, displayStatus),
+        };
+      }),
+    [triggers, statusOverrides, pendingIds, handleToggle]
+  );
+
   return (
     <div className="rounded-lg border border-border bg-panel-background p-4">
       <TriggersTableBody
         isLoading={isTriggersLoading}
         isError={!!isTriggersError}
-        triggers={triggers}
+        rows={rows}
         totalCount={totalCount}
         pagination={pagination}
         setPagination={setPagination}
@@ -236,7 +373,7 @@ export function AutomationsTriggersTable({
 interface TriggersTableBodyProps {
   isLoading: boolean;
   isError: boolean;
-  triggers: AutomationTriggerRow[];
+  rows: TriggerRowData[];
   totalCount: number;
   pagination: PaginationState;
   setPagination: Dispatch<SetStateAction<PaginationState>>;
@@ -245,7 +382,7 @@ interface TriggersTableBodyProps {
 function TriggersTableBody({
   isLoading,
   isError,
-  triggers,
+  rows,
   totalCount,
   pagination,
   setPagination,
@@ -264,7 +401,7 @@ function TriggersTableBody({
     );
   }
 
-  if (triggers.length === 0) {
+  if (rows.length === 0) {
     return (
       <div className="text-sm text-muted-foreground">
         No automation ran over this period.
@@ -276,7 +413,7 @@ function TriggersTableBody({
     <div className="overflow-x-auto">
       <DataTable<TriggerRowData>
         className="min-w-200"
-        data={triggers}
+        data={rows}
         columns={columns}
         totalRowCount={totalCount}
         pagination={pagination}

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -24,7 +24,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
-import type { TriggerKind } from "@app/types/assistant/triggers";
+import type { TriggerKind, TriggerStatus } from "@app/types/assistant/triggers";
 import { isScheduleTrigger } from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -36,6 +36,7 @@ export type AutomationTriggerRow = {
   triggerId: string;
   name: string;
   kind: TriggerKind;
+  status: TriggerStatus;
   agent: {
     agentId: string;
     name: string;
@@ -251,6 +252,7 @@ export async function fetchAutomationTriggers(
       triggerId: trigger.sId,
       name: trigger.name,
       kind: trigger.kind,
+      status: trigger.status,
       agent: {
         agentId: trigger.agentConfigurationId,
         name: agentLabel?.name ?? trigger.agentConfigurationId,

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -28,6 +28,7 @@ import type {
   TriggerType,
   WebhookConfig,
 } from "@app/types/assistant/triggers";
+import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -120,6 +121,27 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       id: this.id,
       workspaceId: this.workspaceId,
     });
+  }
+
+  canUpdateStatusTo(auth: Authenticator, to: TriggerStatus): boolean {
+    if (this.status === to) {
+      return true;
+    }
+    // Editor-owned statuses are open to the editor; anything else needs an
+    // admin (system transitions additionally never go through update(), see
+    // isSystemStatusTransitionTo).
+    return [this.status, to].every(
+      (s) => getTriggerStatusOwner(s) === "editor" || auth.isAdmin()
+    );
+  }
+
+  // The editing path never crosses system-owned statuses; only restore jobs
+  // do, via enable()/disable().
+  isSystemStatusTransitionTo(to: TriggerStatus): boolean {
+    return (
+      this.status !== to &&
+      [this.status, to].some((s) => getTriggerStatusOwner(s) === "system")
+    );
   }
 
   private static async baseFetch(
@@ -366,6 +388,26 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     ) {
       return new Err(
         new Error("Only the editor of the trigger can update the trigger")
+      );
+    }
+
+    if (
+      blob.status !== undefined &&
+      trigger.isSystemStatusTransitionTo(blob.status)
+    ) {
+      return new Err(
+        new Error(
+          "This trigger's status is managed by Dust and cannot be changed"
+        )
+      );
+    }
+
+    if (
+      blob.status !== undefined &&
+      !trigger.canUpdateStatusTo(auth, blob.status)
+    ) {
+      return new Err(
+        new Error("You don't have permission to change this trigger's status")
       );
     }
 
@@ -804,6 +846,12 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       return new Ok(undefined);
     }
 
+    if (!this.canUpdateStatusTo(auth, "enabled")) {
+      return new Err(
+        new Error("You don't have permission to change this trigger's status")
+      );
+    }
+
     const previousStatus = this.status;
 
     try {
@@ -864,6 +912,12 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     targetStatus: Exclude<TriggerStatus, "enabled"> = "disabled"
   ): Promise<Result<undefined, Error>> {
+    if (!this.canUpdateStatusTo(auth, targetStatus)) {
+      return new Err(
+        new Error("You don't have permission to change this trigger's status")
+      );
+    }
+
     // Even when the status is already the target, we still reconcile the
     // Temporal workflow below: a previous disable may have flipped the status
     // but failed (or been interrupted) before removing the schedule, leaving an

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -11,6 +11,7 @@ import type { GetTriggerEstimationResponseBody } from "@app/lib/triggers/trigger
 import type {
   GetTriggersResponseBody,
   GetUserTriggersResponseBody,
+  PatchTriggerStatusRequestBody,
   PatchTriggersRequestBody,
   PostTextAsCronRuleRequestBody,
   PostTextAsCronRuleResponseBody,
@@ -243,6 +244,68 @@ export function useUpdateTrigger({
   );
 
   return updateTrigger;
+}
+
+export function useUpdateTriggerStatus({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const updateTriggerStatus = useCallback(
+    async ({
+      agentConfigurationId,
+      triggerId,
+      status,
+    }: {
+      agentConfigurationId: string;
+      triggerId: string;
+      status: PatchTriggerStatusRequestBody["status"];
+    }): Promise<boolean> => {
+      try {
+        const response = await clientFetch(
+          `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/triggers/${triggerId}/status`,
+          {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ status }),
+          }
+        );
+
+        if (response.ok) {
+          sendNotification({
+            type: "success",
+            title:
+              status === "enabled" ? "Trigger enabled" : "Trigger disabled",
+            description:
+              status === "enabled"
+                ? "The trigger is now running."
+                : "The trigger is no longer running.",
+          });
+          return true;
+        } else {
+          const errorData = await getErrorFromResponse(response);
+          sendNotification({
+            type: "error",
+            title: "Failed to update trigger",
+            description: `Error: ${errorData.message}`,
+          });
+          return false;
+        }
+      } catch {
+        sendNotification({
+          type: "error",
+          title: "Failed to update trigger",
+          description: "An unexpected error occurred. Please try again.",
+        });
+        return false;
+      }
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return updateTriggerStatus;
 }
 
 function responseToScheduleConfig(

--- a/front/types/api/assistant/configuration/triggers.ts
+++ b/front/types/api/assistant/configuration/triggers.ts
@@ -37,6 +37,13 @@ export type PatchTriggersRequestBody = z.infer<
   typeof PatchTriggersRequestBodySchema
 >;
 
+export const PatchTriggerStatusRequestBodySchema = z.object({
+  status: z.enum(["enabled", "disabled"]),
+});
+export type PatchTriggerStatusRequestBody = z.infer<
+  typeof PatchTriggerStatusRequestBodySchema
+>;
+
 export const PostTriggersRequestBodySchema = z.object({
   triggers: z.array(TriggerSchema),
 });

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -1,3 +1,4 @@
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { z } from "zod";
 
 export type CronScheduleConfig = {
@@ -71,6 +72,7 @@ export type TriggerExecutionMode = "fair_use" | "programmatic";
 export const TRIGGER_STATUSES = [
   "enabled",
   "disabled",
+  "disabled_by_admin",
   "relocating",
   "downgraded",
 ] as const;
@@ -78,6 +80,30 @@ export type TriggerStatus = (typeof TRIGGER_STATUSES)[number];
 
 export function isValidTriggerStatus(status: string): status is TriggerStatus {
   return (TRIGGER_STATUSES as readonly string[]).includes(status);
+}
+
+// Who may set or clear a status: the trigger's editor, only an admin, or only
+// Dust's bulk jobs (workspace relocation, plan downgrade).
+export type TriggerStatusOwner = "editor" | "admin" | "system";
+
+export function getTriggerStatusOwner(
+  status: TriggerStatus
+): TriggerStatusOwner {
+  switch (status) {
+    case "enabled":
+    case "disabled":
+      return "editor";
+    case "disabled_by_admin":
+      return "admin";
+    case "relocating":
+    case "downgraded":
+      return "system";
+    default:
+      // Called from client components: a status shipped server-first must not
+      // crash old clients. Unknown statuses are treated as locked.
+      assertNeverAndIgnore(status);
+      return "system";
+  }
 }
 
 export const WEBHOOK_REQUEST_TRIGGER_STATUSES = [


### PR DESCRIPTION
## Description

Adds an "Enabled" column to the admin-only Automations analytics table: a SliderToggle per trigger, confirm dialog on disable (which admin-locks the trigger), instant enable. The table's Elasticsearch query is not revalidated after a toggle — a local per-row status override (cleared on refetch) reflects the change instead. `relocating`/`downgraded` render a disabled toggle with a tooltip.

Part 3/4, stacked on #30661 and the status endpoint PR.

## Tests

Analytics fixture updated for the new `status` row field; toggle behavior manually tested on the dev workspace (enable, confirm-on-disable, cancel, lock visible to the editor).

## Risk

Additive row field on a private analytics endpoint; UI is behind the `enable_analytics_automations` feature flag.