### PR TITLE
feat: surface trigger status in editor UIs

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.test.ts
@@ -1,8 +1,10 @@
 import { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { faker } from "@faker-js/faker";
 import { honoApp } from "@front-api/app";
@@ -264,5 +266,211 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers (spaceI
     });
 
     expect(response.status).toBe(400);
+  });
+});
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers (disabled_by_admin)", () => {
+  async function createAdminLockedTrigger(
+    workspace: { sId: string },
+    aId: string
+  ) {
+    const trigger = await createScheduleTrigger(workspace, aId, null);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const resource = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    const disableRes = await resource?.disable(adminAuth, "disabled_by_admin");
+    expect(disableRes?.isOk()).toBe(true);
+    return trigger;
+  }
+
+  it("rejects a non-admin editor re-enabling an admin-locked trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createAdminLockedTrigger(workspace, agent.sId);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, status: "enabled" }],
+    });
+
+    expect(response.status).toBe(403);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("disabled_by_admin");
+  });
+
+  it("rejects a non-admin editor re-enabling a relocating trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const resource = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    const disableRes = await resource?.disable(adminAuth, "relocating");
+    expect(disableRes?.isOk()).toBe(true);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, status: "enabled" }],
+    });
+
+    expect(response.status).toBe(400);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("relocating");
+  });
+
+  it("rejects even an admin moving a trigger out of a system-owned status", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const resource = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    const disableRes = await resource?.disable(adminAuth, "downgraded");
+    expect(disableRes?.isOk()).toBe(true);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, status: "enabled" }],
+    });
+
+    expect(response.status).toBe(400);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.status).toBe("downgraded");
+  });
+
+  it("rejects even an admin moving a trigger into a system-owned status", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...trigger, sId: trigger.sId, status: "relocating" }],
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("lets an editor save other fields of a system-disabled trigger, status echoed unchanged", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const resource = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    const disableRes = await resource?.disable(adminAuth, "downgraded");
+    expect(disableRes?.isOk()).toBe(true);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [
+        {
+          ...trigger,
+          sId: trigger.sId,
+          name: "renamed-downgraded-trigger",
+          status: "downgraded",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.name).toBe("renamed-downgraded-trigger");
+    expect(updated?.status).toBe("downgraded");
+  });
+
+  it("keeps the update()/enable() asymmetry restore jobs rely on", async () => {
+    // update() refuses system-status transitions for everyone, while enable()
+    // allows them for admins: this is what lets enableAllForWorkspace restore
+    // downgraded/relocating triggers. Do not "unify" these paths.
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      status: "downgraded",
+    });
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+
+    const updateRes = await TriggerResource.update(adminAuth, trigger.sId, {
+      status: "enabled",
+    });
+    expect(updateRes.isErr()).toBe(true);
+
+    const enableRes = await trigger.enable(adminAuth);
+    expect(enableRes?.isOk()).toBe(true);
+    const restored = await TriggerResource.fetchById(adminAuth, trigger.sId);
+    expect(restored?.status).toBe("enabled");
+  });
+
+  it("lets a non-admin editor edit other fields of an admin-locked trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createAdminLockedTrigger(workspace, agent.sId);
+
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [
+        {
+          ...trigger,
+          sId: trigger.sId,
+          name: "renamed-trigger",
+          status: "disabled_by_admin",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.name).toBe("renamed-trigger");
+    expect(updated?.status).toBe("disabled_by_admin");
   });
 });

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -222,6 +222,34 @@ app.patch(
       }
 
       const validatedTrigger = triggerValidation.data;
+
+      const nextStatus = validatedTrigger.status ?? "enabled";
+      if (triggerToUpdate.isSystemStatusTransitionTo(nextStatus)) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "This trigger's status is managed by Dust and cannot be changed.",
+          },
+        });
+      }
+
+      const canUpdateStatus = triggerToUpdate.canUpdateStatusTo(
+        auth,
+        nextStatus
+      );
+      if (!canUpdateStatus) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "You don't have permission to change this trigger's status.",
+          },
+        });
+      }
+
       const webhookSourceViewId = isWebhookTriggerData(validatedTrigger)
         ? getResourceIdFromSId(validatedTrigger.webhookSourceViewId)
         : null;

--- a/front/components/agent_builder/triggers/TriggerStatusToggle.tsx
+++ b/front/components/agent_builder/triggers/TriggerStatusToggle.tsx
@@ -1,0 +1,58 @@
+import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
+import { TRIGGER_STATUS_LABELS } from "@app/components/triggers/TriggerStatusChip";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
+import { Label, SliderToggle, Tooltip } from "@dust-tt/sparkle";
+import { useController, useFormContext } from "react-hook-form";
+
+interface TriggerStatusToggleProps {
+  name: "schedule.status" | "webhook.status";
+  isEditor: boolean;
+}
+
+export function TriggerStatusToggle({
+  name,
+  isEditor,
+}: TriggerStatusToggleProps) {
+  const { control } = useFormContext<TriggerViewsSheetFormValues>();
+  const {
+    field: { value: status, onChange: setStatus },
+  } = useController({ control, name });
+  const { isAdmin } = useAuth();
+
+  const isEnabled = status === "enabled";
+  const statusOwner = getTriggerStatusOwner(status);
+  // Non-admins cannot flip an admin lock; nobody edits system-owned statuses.
+  const isStatusLocked =
+    statusOwner === "system" || (statusOwner === "admin" && !isAdmin);
+  const statusLabel = TRIGGER_STATUS_LABELS[status];
+
+  const toggle = (
+    <SliderToggle
+      disabled={!isEditor || isStatusLocked}
+      selected={isEnabled}
+      onClick={() => setStatus(isEnabled ? "disabled" : "enabled")}
+    />
+  );
+
+  return (
+    <div className="space-y-1">
+      <Label>Status</Label>
+      <div className="flex flex-row items-center gap-2">
+        <span className="min-w-16 whitespace-nowrap">{statusLabel}</span>
+        {isStatusLocked ? (
+          <Tooltip
+            label={
+              statusOwner === "system"
+                ? "This trigger's status is managed by Dust."
+                : "Only an admin can re-enable this trigger."
+            }
+            trigger={<div>{toggle}</div>}
+          />
+        ) : (
+          toggle
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
@@ -1,6 +1,7 @@
 import type { AgentBuilderScheduleTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ScheduleEditionScheduler } from "@app/components/agent_builder/triggers/schedule/ScheduleEditionScheduler";
 import { TriggerPodSelector } from "@app/components/agent_builder/triggers/TriggerPodSelector";
+import { TriggerStatusToggle } from "@app/components/agent_builder/triggers/TriggerStatusToggle";
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -8,7 +9,6 @@ import {
   Input,
   Label,
   Separator,
-  SliderToggle,
   TextArea,
 } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
@@ -38,35 +38,6 @@ function ScheduleEditionNameInput({ isEditor }: ScheduleEditionNameInputProps) {
         message={error?.message}
         messageStatus="error"
       />
-    </div>
-  );
-}
-
-interface ScheduleEditionStatusToggleProps {
-  isEditor: boolean;
-}
-
-function ScheduleEditionStatusToggle({
-  isEditor,
-}: ScheduleEditionStatusToggleProps) {
-  const { control } = useFormContext<TriggerViewsSheetFormValues>();
-  const {
-    field: { value: status, onChange: setStatus },
-  } = useController({ control, name: "schedule.status" });
-
-  const isEnabled = status === "enabled";
-
-  return (
-    <div className="space-y-1">
-      <Label>Status</Label>
-      <div className="flex flex-row items-center gap-2">
-        <span className="w-16">{isEnabled ? "Enabled" : "Disabled"}</span>
-        <SliderToggle
-          disabled={!isEditor}
-          selected={isEnabled}
-          onClick={() => setStatus(isEnabled ? "disabled" : "enabled")}
-        />
-      </div>
     </div>
   );
 }
@@ -151,7 +122,7 @@ export function ScheduleEditionSheetContent({
         {" "}
         <div className="flex flex-row items-center justify-between gap-4">
           <ScheduleEditionNameInput isEditor={isEditor} />
-          <ScheduleEditionStatusToggle isEditor={isEditor} />
+          <TriggerStatusToggle name="schedule.status" isEditor={isEditor} />
         </div>
         <ScheduleEditionScheduler isEditor={isEditor} owner={owner} />
         <Separator />

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -1,6 +1,7 @@
 import type { AgentBuilderWebhookTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { RecentWebhookRequests } from "@app/components/agent_builder/triggers/RecentWebhookRequests";
 import { TriggerPodSelector } from "@app/components/agent_builder/triggers/TriggerPodSelector";
+import { TriggerStatusToggle } from "@app/components/agent_builder/triggers/TriggerStatusToggle";
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import { WebhookEditionFilters } from "@app/components/agent_builder/triggers/webhook/WebhookEditionFilters";
 import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
@@ -25,7 +26,6 @@ import {
   Label,
   LinkWrapper,
   Separator,
-  SliderToggle,
   TextArea,
 } from "@dust-tt/sparkle";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
@@ -55,35 +55,6 @@ function WebhookEditionNameInput({ isEditor }: WebhookEditionNameInputProps) {
         message={error?.message}
         messageStatus="error"
       />
-    </div>
-  );
-}
-
-interface WebhookEditionStatusToggleProps {
-  isEditor: boolean;
-}
-
-function WebhookEditionStatusToggle({
-  isEditor,
-}: WebhookEditionStatusToggleProps) {
-  const { control } = useFormContext<TriggerViewsSheetFormValues>();
-  const {
-    field: { value: status, onChange: setStatus },
-  } = useController({ control, name: "webhook.status" });
-
-  const isEnabled = status === "enabled";
-
-  return (
-    <div className="space-y-1">
-      <Label>Status</Label>
-      <div className="flex flex-row items-center gap-2">
-        <span className="w-16">{isEnabled ? "Enabled" : "Disabled"}</span>
-        <SliderToggle
-          disabled={!isEditor}
-          selected={isEnabled}
-          onClick={() => setStatus(isEnabled ? "disabled" : "enabled")}
-        />
-      </div>
     </div>
   );
 }
@@ -315,7 +286,7 @@ export function WebhookEditionSheetContent({
       <div className="space-y-8">
         <div className="flex flex-row items-center justify-between gap-4">
           <WebhookEditionNameInput isEditor={isEditor} />
-          <WebhookEditionStatusToggle isEditor={isEditor} />
+          <TriggerStatusToggle name="webhook.status" isEditor={isEditor} />
         </div>
 
         <WebhookEditionEventSelector

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -1,3 +1,4 @@
+import { TriggerStatusChip } from "@app/components/triggers/TriggerStatusChip";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
   useAgentTriggers,
@@ -126,7 +127,20 @@ export function AgentTriggersTab({
               key={trigger.sId}
               icon={getTriggerIcon(trigger)}
               label={trigger.name}
-              description={getTriggerDescription(trigger)}
+              description={
+                trigger.status === "enabled" ? (
+                  getTriggerDescription(trigger)
+                ) : (
+                  <div className="flex flex-col items-start gap-1">
+                    <span>{getTriggerDescription(trigger)}</span>
+                    <TriggerStatusChip status={trigger.status} />
+                  </div>
+                )
+              }
+              // The chip counts as a clamped line: leave room for it.
+              descriptionLineClamp={
+                trigger.status === "enabled" ? undefined : 3
+              }
               canAdd={false}
               disabled={trigger.status !== "enabled"}
               onClick={() => onEditTrigger(trigger)}

--- a/front/components/me/UserTriggersTable.tsx
+++ b/front/components/me/UserTriggersTable.tsx
@@ -1,15 +1,14 @@
+import { TriggerStatusChip } from "@app/components/triggers/TriggerStatusChip";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useDeleteTrigger, useUserTriggers } from "@app/lib/swr/agent_triggers";
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import { getTriggerDescription } from "@app/lib/utils/trigger_description";
 import type { GetUserTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
-import type { TriggerStatus } from "@app/types/assistant/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
   Button,
-  Chip,
   DataTable,
   Dialog,
   DialogContainer,
@@ -28,15 +27,6 @@ import { useCallback, useMemo, useState } from "react";
 // `onClick` satisfies DataTable's row shape, which is otherwise a weak type.
 type UserTriggerRow = GetUserTriggersResponseBody["triggers"][number] & {
   onClick?: () => void;
-};
-
-type ChipColor = React.ComponentProps<typeof Chip>["color"];
-
-const STATUS_CHIP_COLORS: Record<TriggerStatus, ChipColor> = {
-  enabled: "success",
-  disabled: "primary",
-  relocating: "info",
-  downgraded: "warning",
 };
 
 interface UserTriggersTableProps {
@@ -150,14 +140,11 @@ export function UserTriggersTable({ owner }: UserTriggersTableProps) {
         header: "Status",
         cell: ({ row }) => (
           <DataTable.CellContent>
-            <Chip size="xs" color={STATUS_CHIP_COLORS[row.original.status]}>
-              {row.original.status.charAt(0).toUpperCase() +
-                row.original.status.slice(1)}
-            </Chip>
+            <TriggerStatusChip status={row.original.status} />
           </DataTable.CellContent>
         ),
         meta: {
-          className: "w-28",
+          className: "w-36",
         },
       },
       {

--- a/front/components/triggers/TriggerStatusChip.tsx
+++ b/front/components/triggers/TriggerStatusChip.tsx
@@ -1,0 +1,33 @@
+import type { TriggerStatus } from "@app/types/assistant/triggers";
+import { Chip } from "@dust-tt/sparkle";
+import type React from "react";
+
+type ChipColor = React.ComponentProps<typeof Chip>["color"];
+
+const STATUS_CHIP_COLORS: Record<TriggerStatus, ChipColor> = {
+  enabled: "success",
+  disabled: "primary",
+  disabled_by_admin: "warning",
+  relocating: "info",
+  downgraded: "warning",
+};
+
+export const TRIGGER_STATUS_LABELS: Record<TriggerStatus, string> = {
+  enabled: "Enabled",
+  disabled: "Disabled",
+  disabled_by_admin: "Disabled by admin",
+  relocating: "Relocating",
+  downgraded: "Downgraded",
+};
+
+interface TriggerStatusChipProps {
+  status: TriggerStatus;
+}
+
+export function TriggerStatusChip({ status }: TriggerStatusChipProps) {
+  return (
+    <Chip size="xs" color={STATUS_CHIP_COLORS[status]}>
+      {TRIGGER_STATUS_LABELS[status]}
+    </Chip>
+  );
+}

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -28,6 +28,7 @@ import type {
   TriggerType,
   WebhookConfig,
 } from "@app/types/assistant/triggers";
+import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -120,6 +121,27 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       id: this.id,
       workspaceId: this.workspaceId,
     });
+  }
+
+  canUpdateStatusTo(auth: Authenticator, to: TriggerStatus): boolean {
+    if (this.status === to) {
+      return true;
+    }
+    // Editor-owned statuses are open to the editor; anything else needs an
+    // admin (system transitions additionally never go through update(), see
+    // isSystemStatusTransitionTo).
+    return [this.status, to].every(
+      (s) => getTriggerStatusOwner(s) === "editor" || auth.isAdmin()
+    );
+  }
+
+  // The editing path never crosses system-owned statuses; only restore jobs
+  // do, via enable()/disable().
+  isSystemStatusTransitionTo(to: TriggerStatus): boolean {
+    return (
+      this.status !== to &&
+      [this.status, to].some((s) => getTriggerStatusOwner(s) === "system")
+    );
   }
 
   private static async baseFetch(
@@ -366,6 +388,26 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     ) {
       return new Err(
         new Error("Only the editor of the trigger can update the trigger")
+      );
+    }
+
+    if (
+      blob.status !== undefined &&
+      trigger.isSystemStatusTransitionTo(blob.status)
+    ) {
+      return new Err(
+        new Error(
+          "This trigger's status is managed by Dust and cannot be changed"
+        )
+      );
+    }
+
+    if (
+      blob.status !== undefined &&
+      !trigger.canUpdateStatusTo(auth, blob.status)
+    ) {
+      return new Err(
+        new Error("You don't have permission to change this trigger's status")
       );
     }
 
@@ -804,6 +846,12 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       return new Ok(undefined);
     }
 
+    if (!this.canUpdateStatusTo(auth, "enabled")) {
+      return new Err(
+        new Error("You don't have permission to change this trigger's status")
+      );
+    }
+
     const previousStatus = this.status;
 
     try {
@@ -864,6 +912,12 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     targetStatus: Exclude<TriggerStatus, "enabled"> = "disabled"
   ): Promise<Result<undefined, Error>> {
+    if (!this.canUpdateStatusTo(auth, targetStatus)) {
+      return new Err(
+        new Error("You don't have permission to change this trigger's status")
+      );
+    }
+
     // Even when the status is already the target, we still reconcile the
     // Temporal workflow below: a previous disable may have flipped the status
     // but failed (or been interrupted) before removing the schedule, leaving an

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -1,3 +1,4 @@
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { z } from "zod";
 
 export type CronScheduleConfig = {
@@ -71,6 +72,7 @@ export type TriggerExecutionMode = "fair_use" | "programmatic";
 export const TRIGGER_STATUSES = [
   "enabled",
   "disabled",
+  "disabled_by_admin",
   "relocating",
   "downgraded",
 ] as const;
@@ -78,6 +80,30 @@ export type TriggerStatus = (typeof TRIGGER_STATUSES)[number];
 
 export function isValidTriggerStatus(status: string): status is TriggerStatus {
   return (TRIGGER_STATUSES as readonly string[]).includes(status);
+}
+
+// Who may set or clear a status: the trigger's editor, only an admin, or only
+// Dust's bulk jobs (workspace relocation, plan downgrade).
+export type TriggerStatusOwner = "editor" | "admin" | "system";
+
+export function getTriggerStatusOwner(
+  status: TriggerStatus
+): TriggerStatusOwner {
+  switch (status) {
+    case "enabled":
+    case "disabled":
+      return "editor";
+    case "disabled_by_admin":
+      return "admin";
+    case "relocating":
+    case "downgraded":
+      return "system";
+    default:
+      // Called from client components: a status shipped server-first must not
+      // crash old clients. Unknown statuses are treated as locked.
+      assertNeverAndIgnore(status);
+      return "system";
+  }
 }
 
 export const WEBHOOK_REQUEST_TRIGGER_STATUSES = [


### PR DESCRIPTION
## Description

Shows trigger status where editors look: a status chip on the agent-detail trigger cards when not enabled, and locked status toggles in the schedule/webhook edition sheets — non-admins cannot flip an admin-locked trigger, nobody can flip system-owned statuses, each with an explanatory tooltip. Without this, users could flip the form toggle and only fail at save time.

Part 4/4, stacked on #30661. Independent of the analytics toggle PR.

## Tests

UI-only; manually tested the locked sheet toggle (admin lock and system statuses) and the card chips on the dev workspace.

## Risk

Presentation only; enforcement ships in #30661.
