### PR TITLE
[front] enh: replace "Always approve" checkbox with separate button

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -226,7 +226,7 @@ export function ToolValidationCard({
       </div>
 
       <div className="flex flex-col gap-4 px-5 py-4">
-        <div className="text-base">{displayLabel}</div>
+        <div className="text-base text-faint">{displayLabel}</div>
         {canCurrentUserRespond ? (
           <>
             {errorMessage && (

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -256,6 +256,17 @@ export function ToolValidationCard({
             isLoading={submittingDecision === "rejected"}
             onClick={() => void handleValidation("rejected")}
           />
+          {canAlwaysAllow && (
+            <Button
+              label="Always allow"
+              variant="outline"
+              icon={CheckDouble}
+              tooltip={alwaysAllowScopeLabel ?? undefined}
+              disabled={isSubmitting}
+              isLoading={submittingDecision === "always_approved"}
+              onClick={() => void handleValidation("always_approved")}
+            />
+          )}
           <Button
             label={approveOnceLabel}
             variant="highlight"
@@ -264,17 +275,6 @@ export function ToolValidationCard({
             isLoading={submittingDecision === "approved"}
             onClick={() => void handleValidation("approved")}
           />
-          {canAlwaysAllow && (
-            <Button
-              label="Always allow"
-              variant="highlight"
-              icon={CheckDouble}
-              tooltip={alwaysAllowScopeLabel ?? undefined}
-              disabled={isSubmitting}
-              isLoading={submittingDecision === "always_approved"}
-              onClick={() => void handleValidation("always_approved")}
-            />
-          )}
         </div>
       )}
     </Card>

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Card,
   Check,
+  CheckDouble,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -21,7 +22,6 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-  Infinity,
   PieChart01,
   XClose,
 } from "@dust-tt/sparkle";
@@ -262,16 +262,6 @@ export function ToolValidationCard({
               isLoading={submittingDecision === "rejected"}
               onClick={() => void handleValidation("rejected")}
             />
-            {canAlwaysAllow && (
-              <Button
-                label="Always allow"
-                variant="highlight-ghost"
-                icon={Infinity}
-                disabled={isSubmitting}
-                isLoading={submittingDecision === "always_approved"}
-                onClick={() => void handleValidation("always_approved")}
-              />
-            )}
             <Button
               label={approveOnceLabel}
               variant="highlight"
@@ -280,6 +270,16 @@ export function ToolValidationCard({
               isLoading={submittingDecision === "approved"}
               onClick={() => void handleValidation("approved")}
             />
+            {canAlwaysAllow && (
+              <Button
+                label="Always allow"
+                variant="highlight-ghost"
+                icon={CheckDouble}
+                disabled={isSubmitting}
+                isLoading={submittingDecision === "always_approved"}
+                onClick={() => void handleValidation("always_approved")}
+              />
+            )}
           </div>
         </div>
       )}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -22,6 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  InfoCircle,
   PieChart01,
   XClose,
 } from "@dust-tt/sparkle";
@@ -247,10 +248,11 @@ export function ToolValidationCard({
       </div>
 
       {canCurrentUserRespond && (
-        <div className="flex flex-col gap-3 px-4 pb-3 pt-2">
+        <div className="flex flex-col gap-4 px-4 pb-3 pt-2">
           {alwaysAllowScopeLabel && (
-            <div className="text-sm text-muted-foreground">
-              {alwaysAllowScopeLabel}
+            <div className="flex items-start gap-2 text-sm text-muted-foreground">
+              <InfoCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span>{alwaysAllowScopeLabel}</span>
             </div>
           )}
           <div className="flex flex-wrap justify-end gap-2">

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -254,11 +254,7 @@ export function ToolValidationCard({
               label="Always allow"
               variant="outline"
               icon={CheckDouble}
-              tooltip={
-                validationRequest.stake === "medium"
-                  ? getToolValidationAlwaysAllowLabel(validationRequest)
-                  : undefined
-              }
+              tooltip={getToolValidationAlwaysAllowLabel(validationRequest)}
               disabled={isSubmitting}
               isLoading={submittingDecision === "always_approved"}
               onClick={() => void handleValidation("always_approved")}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -273,7 +273,7 @@ export function ToolValidationCard({
             {canAlwaysAllow && (
               <Button
                 label="Always allow"
-                variant="highlight-ghost"
+                variant="primary"
                 icon={CheckDouble}
                 disabled={isSubmitting}
                 isLoading={submittingDecision === "always_approved"}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -21,6 +21,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+  Infinity,
   PieChart01,
   XClose,
 } from "@dust-tt/sparkle";
@@ -264,7 +265,8 @@ export function ToolValidationCard({
             {canAlwaysAllow && (
               <Button
                 label="Always allow"
-                variant="outline"
+                variant="highlight-ghost"
+                icon={Infinity}
                 disabled={isSubmitting}
                 isLoading={submittingDecision === "always_approved"}
                 onClick={() => void handleValidation("always_approved")}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -14,7 +14,6 @@ import {
   Button,
   Card,
   Check,
-  Checkbox,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -22,7 +21,6 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-  Label,
   PieChart01,
   XClose,
 } from "@dust-tt/sparkle";
@@ -151,11 +149,9 @@ export function ToolValidationCard({
   isPulsing = false,
   onValidate,
 }: ToolValidationCardProps) {
-  const [neverAskAgain, setNeverAskAgain] = useState(false);
   const toolOverride = getToolOverride(validationRequest.metadata);
-  const [submittingDecision, setSubmittingDecision] = useState<
-    "approved" | "rejected" | null
-  >(null);
+  const [submittingDecision, setSubmittingDecision] =
+    useState<MCPValidationOutputType | null>(null);
   const isSubmitting = isValidating || submittingDecision !== null;
 
   const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
@@ -167,15 +163,10 @@ export function ToolValidationCard({
     ? getIcon(validationRequest.metadata.icon)
     : undefined;
 
-  const handleValidation = async (approved: "approved" | "rejected") => {
-    setSubmittingDecision(approved);
+  const handleValidation = async (approvalState: MCPValidationOutputType) => {
+    setSubmittingDecision(approvalState);
     try {
-      const success = await onValidate(
-        approved === "approved" && neverAskAgain ? "always_approved" : approved
-      );
-      if (success) {
-        setNeverAskAgain(false);
-      }
+      await onValidate(approvalState);
     } finally {
       setSubmittingDecision(null);
     }
@@ -190,6 +181,17 @@ export function ToolValidationCard({
     asDisplayName(validationRequest.metadata.toolName);
   const hasDetails =
     canCurrentUserRespond && Object.keys(validationRequest.inputs).length > 0;
+  const canAlwaysAllow = ["low", "medium"].includes(
+    validationRequest.stake ?? ""
+  );
+  const approveLabel = toolOverride?.approveLabel ?? "Allow";
+  const approveOnceLabel = canAlwaysAllow
+    ? `${approveLabel} once`
+    : approveLabel;
+  const alwaysAllowScopeLabel =
+    validationRequest.stake === "medium"
+      ? getToolValidationAlwaysAllowLabel(validationRequest)
+      : null;
 
   return (
     <Card
@@ -244,26 +246,13 @@ export function ToolValidationCard({
       </div>
 
       {canCurrentUserRespond && (
-        <div className="flex flex-col gap-3 px-4 pb-3 pt-2 sm:flex-row sm:items-center">
-          {["low", "medium"].includes(validationRequest.stake ?? "") && (
-            <Label
-              htmlFor={`never-ask-again-${validationRequest.actionId}`}
-              className="flex min-h-11 cursor-pointer items-center gap-2 px-1 sm:min-h-0"
-            >
-              <Checkbox
-                id={`never-ask-again-${validationRequest.actionId}`}
-                checked={neverAskAgain}
-                disabled={isSubmitting}
-                onCheckedChange={(check) => {
-                  setNeverAskAgain(!!check);
-                }}
-              />
-              <span className="font-normal">
-                {getToolValidationAlwaysAllowLabel(validationRequest)}
-              </span>
-            </Label>
+        <div className="flex flex-col gap-3 px-4 pb-3 pt-2">
+          {alwaysAllowScopeLabel && (
+            <div className="text-sm text-muted-foreground">
+              {alwaysAllowScopeLabel}
+            </div>
           )}
-          <div className="flex gap-2 sm:ml-auto">
+          <div className="flex flex-wrap justify-end gap-2">
             <Button
               label="Decline"
               variant="outline"
@@ -272,8 +261,17 @@ export function ToolValidationCard({
               isLoading={submittingDecision === "rejected"}
               onClick={() => void handleValidation("rejected")}
             />
+            {canAlwaysAllow && (
+              <Button
+                label="Always allow"
+                variant="outline"
+                disabled={isSubmitting}
+                isLoading={submittingDecision === "always_approved"}
+                onClick={() => void handleValidation("always_approved")}
+              />
+            )}
             <Button
-              label={toolOverride?.approveLabel ?? "Allow"}
+              label={approveOnceLabel}
               variant="highlight"
               icon={Check}
               disabled={isSubmitting}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -226,7 +226,7 @@ export function ToolValidationCard({
       </div>
 
       <div className="flex flex-col gap-4 px-5 py-4">
-        <div className="text-base text-faint">{displayLabel}</div>
+        <div className="text-base text-muted-foreground">{displayLabel}</div>
         {canCurrentUserRespond ? (
           <>
             {errorMessage && (

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -22,7 +22,6 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-  InfoCircle,
   PieChart01,
   XClose,
 } from "@dust-tt/sparkle";
@@ -248,41 +247,34 @@ export function ToolValidationCard({
       </div>
 
       {canCurrentUserRespond && (
-        <div className="flex flex-col gap-4 px-4 pb-3 pt-2">
-          {alwaysAllowScopeLabel && (
-            <div className="flex items-start gap-2 text-sm text-muted-foreground">
-              <InfoCircle className="mt-0.5 h-4 w-4 shrink-0" />
-              <span>{alwaysAllowScopeLabel}</span>
-            </div>
-          )}
-          <div className="flex flex-wrap justify-end gap-2">
+        <div className="flex flex-wrap justify-end gap-2 px-4 pb-3 pt-2">
+          <Button
+            label="Decline"
+            variant="outline"
+            icon={XClose}
+            disabled={isSubmitting}
+            isLoading={submittingDecision === "rejected"}
+            onClick={() => void handleValidation("rejected")}
+          />
+          <Button
+            label={approveOnceLabel}
+            variant="highlight"
+            icon={Check}
+            disabled={isSubmitting}
+            isLoading={submittingDecision === "approved"}
+            onClick={() => void handleValidation("approved")}
+          />
+          {canAlwaysAllow && (
             <Button
-              label="Decline"
-              variant="outline"
-              icon={XClose}
-              disabled={isSubmitting}
-              isLoading={submittingDecision === "rejected"}
-              onClick={() => void handleValidation("rejected")}
-            />
-            <Button
-              label={approveOnceLabel}
+              label="Always allow"
               variant="highlight"
-              icon={Check}
+              icon={CheckDouble}
+              tooltip={alwaysAllowScopeLabel ?? undefined}
               disabled={isSubmitting}
-              isLoading={submittingDecision === "approved"}
-              onClick={() => void handleValidation("approved")}
+              isLoading={submittingDecision === "always_approved"}
+              onClick={() => void handleValidation("always_approved")}
             />
-            {canAlwaysAllow && (
-              <Button
-                label="Always allow"
-                variant="highlight"
-                icon={CheckDouble}
-                disabled={isSubmitting}
-                isLoading={submittingDecision === "always_approved"}
-                onClick={() => void handleValidation("always_approved")}
-              />
-            )}
-          </div>
+          )}
         </div>
       )}
     </Card>

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -186,13 +186,6 @@ export function ToolValidationCard({
     validationRequest.stake ?? ""
   );
   const approveLabel = toolOverride?.approveLabel ?? "Allow";
-  const approveOnceLabel = canAlwaysAllow
-    ? `${approveLabel} once`
-    : approveLabel;
-  const alwaysAllowScopeLabel =
-    validationRequest.stake === "medium"
-      ? getToolValidationAlwaysAllowLabel(validationRequest)
-      : null;
 
   return (
     <Card
@@ -261,14 +254,18 @@ export function ToolValidationCard({
               label="Always allow"
               variant="outline"
               icon={CheckDouble}
-              tooltip={alwaysAllowScopeLabel ?? undefined}
+              tooltip={
+                validationRequest.stake === "medium"
+                  ? getToolValidationAlwaysAllowLabel(validationRequest)
+                  : undefined
+              }
               disabled={isSubmitting}
               isLoading={submittingDecision === "always_approved"}
               onClick={() => void handleValidation("always_approved")}
             />
           )}
           <Button
-            label={approveOnceLabel}
+            label={canAlwaysAllow ? `${approveLabel} once` : approveLabel}
             variant="highlight"
             icon={Check}
             disabled={isSubmitting}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -264,7 +264,7 @@ export function ToolValidationCard({
             />
             <Button
               label={approveOnceLabel}
-              variant="highlight"
+              variant={canAlwaysAllow ? "highlight-ghost" : "highlight"}
               icon={Check}
               disabled={isSubmitting}
               isLoading={submittingDecision === "approved"}
@@ -273,7 +273,7 @@ export function ToolValidationCard({
             {canAlwaysAllow && (
               <Button
                 label="Always allow"
-                variant="primary"
+                variant="highlight"
                 icon={CheckDouble}
                 disabled={isSubmitting}
                 isLoading={submittingDecision === "always_approved"}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -264,7 +264,7 @@ export function ToolValidationCard({
             />
             <Button
               label={approveOnceLabel}
-              variant={canAlwaysAllow ? "highlight-ghost" : "highlight"}
+              variant="highlight"
               icon={Check}
               disabled={isSubmitting}
               isLoading={submittingDecision === "approved"}

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -214,18 +214,23 @@ export function getToolValidationAlwaysAllowLabel(
     return data.approvalArgsLabel;
   }
   const args = data.argumentsRequiringApproval ?? [];
-  const argValues = args
+  const approvalScopes = args
     .filter((arg) => data.inputs[arg] != null)
     .map((arg) => {
       const value = data.inputs[arg];
-      if (Array.isArray(value)) {
-        return value.map(String).join(", ");
-      }
-      return JSON.stringify(value);
+      const displayValue = Array.isArray(value)
+        ? value.map(String).join(", ")
+        : typeof value === "string" ||
+            typeof value === "number" ||
+            typeof value === "boolean"
+          ? String(value)
+          : JSON.stringify(value);
+
+      return `${asDisplayName(arg)} is ${displayValue}`;
     });
-  return `Always allow agent to ${asDisplayName(data.metadata.toolName)} ${
-    argValues.length > 0
-      ? ` for the following parameters: ${argValues.join(", ")}`
+  return `Always allow ${data.metadata.agentName} to ${asDisplayName(data.metadata.toolName)}${
+    approvalScopes.length > 0
+      ? ` only when ${approvalScopes.join(" and ")}`
       : ""
   }`;
 }

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -227,7 +227,7 @@ export function getToolValidationAlwaysAllowLabel(
           : JSON.stringify(value);
 
       return {
-        label: `${asDisplayName(arg)} is ${displayValue}`,
+        label: `“${asDisplayName(arg).toLowerCase()}” is ${displayValue}`,
         value: displayValue,
       };
     });

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -226,11 +226,19 @@ export function getToolValidationAlwaysAllowLabel(
           ? String(value)
           : JSON.stringify(value);
 
-      return `${asDisplayName(arg)} is ${displayValue}`;
+      return {
+        label: `${asDisplayName(arg)} is ${displayValue}`,
+        value: displayValue,
+      };
     });
-  return `Always allow ${data.metadata.agentName} to ${asDisplayName(data.metadata.toolName)}${
-    approvalScopes.length > 0
-      ? ` only when ${approvalScopes.join(" and ")}`
-      : ""
-  }`;
+
+  const [approvalScope] = approvalScopes;
+  let scopeLabel = "";
+  if (approvalScopes.length === 1 && approvalScope) {
+    scopeLabel = ` only for ${approvalScope.value}`;
+  } else if (approvalScopes.length > 1) {
+    scopeLabel = ` only when ${approvalScopes.map(({ label }) => label).join(" and ")}`;
+  }
+
+  return `Always allow ${data.metadata.agentName} to ${asDisplayName(data.metadata.toolName)}${scopeLabel}`;
 }

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -203,7 +203,7 @@ export function getToolValidationAlwaysAllowLabel(
   data: ToolValidationLabelData
 ): string {
   if (data.stake !== "medium") {
-    return `Allow every time any agent uses the “${asDisplayName(data.metadata.toolName)}” tool`;
+    return `Allow every time an agent uses the “${asDisplayName(data.metadata.toolName)}” tool`;
   }
   const toolOverride = getToolOverride(data.metadata);
   if (toolOverride?.alwaysAllowLabel) {

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -203,7 +203,7 @@ export function getToolValidationAlwaysAllowLabel(
   data: ToolValidationLabelData
 ): string {
   if (data.stake !== "medium") {
-    return "Always allow";
+    return `Allow every time any agent uses the “${asDisplayName(data.metadata.toolName)}” tool`;
   }
   const toolOverride = getToolOverride(data.metadata);
   if (toolOverride?.alwaysAllowLabel) {

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -6,6 +6,7 @@ import {
   AttachmentChip,
   Button,
   Check,
+  Infinity,
   Paperclip,
   XClose,
 } from "@dust-tt/sparkle";
@@ -208,8 +209,9 @@ export function GmailSendMailValidation({
           {alwaysAllowLabel && (
             <Button
               label="Always allow"
-              variant="outline"
+              variant="highlight-ghost"
               size="sm"
+              icon={Infinity}
               isRounded
               disabled={isSubmitting}
               onClick={() => void onApprove("always_approved")}

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   Check,
   CheckDouble,
-  InfoCircle,
   Paperclip,
   XClose,
 } from "@dust-tt/sparkle";
@@ -190,46 +189,41 @@ export function GmailSendMailValidation({
         </div>
       )}
 
-      <div className="flex flex-col gap-4 border-t border-border px-4 py-2.5">
-        {blockedAction.stake === "medium" && alwaysAllowLabel && (
-          <div className="flex items-start gap-2 text-xs text-muted-foreground">
-            <InfoCircle className="h-4 w-4 shrink-0" />
-            <span>{alwaysAllowLabel}</span>
-          </div>
-        )}
-        <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 border-t border-border px-4 py-2.5">
+        <Button
+          label="Decline"
+          variant="outline"
+          size="sm"
+          icon={XClose}
+          isRounded
+          disabled={isSubmitting}
+          onClick={() => void handleReject()}
+        />
+        <div className="flex-1" />
+        <Button
+          label={alwaysAllowLabel ? "Allow once" : "Allow"}
+          variant="highlight"
+          size="sm"
+          icon={Check}
+          isRounded
+          disabled={isSubmitting}
+          isPulsing={isPulsing}
+          onClick={() => void onApprove("approved")}
+        />
+        {alwaysAllowLabel && (
           <Button
-            label="Decline"
-            variant="outline"
-            size="sm"
-            icon={XClose}
-            isRounded
-            disabled={isSubmitting}
-            onClick={() => void handleReject()}
-          />
-          <div className="flex-1" />
-          <Button
-            label={alwaysAllowLabel ? "Allow once" : "Allow"}
+            label="Always allow"
             variant="highlight"
             size="sm"
-            icon={Check}
+            icon={CheckDouble}
+            tooltip={
+              blockedAction.stake === "medium" ? alwaysAllowLabel : undefined
+            }
             isRounded
             disabled={isSubmitting}
-            isPulsing={isPulsing}
-            onClick={() => void onApprove("approved")}
+            onClick={() => void onApprove("always_approved")}
           />
-          {alwaysAllowLabel && (
-            <Button
-              label="Always allow"
-              variant="highlight"
-              size="sm"
-              icon={CheckDouble}
-              isRounded
-              disabled={isSubmitting}
-              onClick={() => void onApprove("always_approved")}
-            />
-          )}
-        </div>
+        )}
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -219,7 +219,7 @@ export function GmailSendMailValidation({
           {alwaysAllowLabel && (
             <Button
               label="Always allow"
-              variant="highlight-ghost"
+              variant="primary"
               size="sm"
               icon={CheckDouble}
               isRounded

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -206,9 +206,7 @@ export function GmailSendMailValidation({
             variant="outline"
             size="sm"
             icon={CheckDouble}
-            tooltip={
-              blockedAction.stake === "medium" ? alwaysAllowLabel : undefined
-            }
+            tooltip={alwaysAllowLabel}
             isRounded
             disabled={isSubmitting}
             onClick={() => void onApprove("always_approved")}

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -200,20 +200,10 @@ export function GmailSendMailValidation({
           onClick={() => void handleReject()}
         />
         <div className="flex-1" />
-        <Button
-          label={alwaysAllowLabel ? "Allow once" : "Allow"}
-          variant="highlight"
-          size="sm"
-          icon={Check}
-          isRounded
-          disabled={isSubmitting}
-          isPulsing={isPulsing}
-          onClick={() => void onApprove("approved")}
-        />
         {alwaysAllowLabel && (
           <Button
             label="Always allow"
-            variant="highlight"
+            variant="outline"
             size="sm"
             icon={CheckDouble}
             tooltip={
@@ -224,6 +214,16 @@ export function GmailSendMailValidation({
             onClick={() => void onApprove("always_approved")}
           />
         )}
+        <Button
+          label={alwaysAllowLabel ? "Allow once" : "Allow"}
+          variant="highlight"
+          size="sm"
+          icon={Check}
+          isRounded
+          disabled={isSubmitting}
+          isPulsing={isPulsing}
+          onClick={() => void onApprove("approved")}
+        />
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -2,7 +2,13 @@ import type { EditableToolValidationComponentProps } from "@app/components/assis
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { GmailSendMailInput } from "@app/lib/api/actions/servers/gmail/types";
 import { isGmailSendMailInput } from "@app/lib/api/actions/servers/gmail/types";
-import { AttachmentChip, Button, Paperclip, Trash01 } from "@dust-tt/sparkle";
+import {
+  AttachmentChip,
+  Button,
+  Check,
+  Paperclip,
+  XClose,
+} from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMemo } from "react";
 import { useForm } from "react-hook-form";
@@ -190,12 +196,12 @@ export function GmailSendMailValidation({
         )}
         <div className="flex items-center gap-3 px-4 py-2.5">
           <Button
-            tooltip="Discard"
-            variant="ghost"
-            size="icon"
-            icon={Trash01}
+            label="Decline"
+            variant="outline"
+            size="sm"
+            icon={XClose}
+            isRounded
             disabled={isSubmitting}
-            isPulsing={isPulsing}
             onClick={() => void handleReject()}
           />
           <div className="flex-1" />
@@ -210,9 +216,10 @@ export function GmailSendMailValidation({
             />
           )}
           <Button
-            label={alwaysAllowLabel ? "Send once" : "Send"}
+            label={alwaysAllowLabel ? "Allow once" : "Allow"}
             variant="highlight"
             size="sm"
+            icon={Check}
             isRounded
             disabled={isSubmitting}
             isPulsing={isPulsing}

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -1,16 +1,10 @@
 import type { EditableToolValidationComponentProps } from "@app/components/assistant/conversation/editable_tool_validation/types";
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { GmailSendMailInput } from "@app/lib/api/actions/servers/gmail/types";
 import { isGmailSendMailInput } from "@app/lib/api/actions/servers/gmail/types";
-import {
-  AttachmentChip,
-  Button,
-  Checkbox,
-  Label,
-  Paperclip,
-  Trash01,
-} from "@dust-tt/sparkle";
+import { AttachmentChip, Button, Paperclip, Trash01 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -79,8 +73,6 @@ export function GmailSendMailValidation({
   isPulsing,
   onApproveWithEditedArguments,
 }: EditableToolValidationComponentProps) {
-  const [neverAskAgain, setNeverAskAgain] = useState(false);
-
   const inputs = useMemo(
     () =>
       isGmailSendMailInput(blockedAction.inputs) ? blockedAction.inputs : null,
@@ -114,15 +106,16 @@ export function GmailSendMailValidation({
   const attachmentName = inputs?.attachmentFilePath?.split("/").pop() ?? null;
   const recipientRows = inputs ? getRecipientRows(inputs) : [];
 
-  const onApprove = handleSubmit(async ({ subject, body }) => {
-    await onApproveWithEditedArguments({
-      editedArguments: {
-        ...(isSubjectEditable && { subject }),
-        ...(isBodyEditable && { body }),
-      },
-      approved: neverAskAgain ? "always_approved" : "approved",
-    });
-  });
+  const onApprove = (approved: MCPValidationOutputType) =>
+    handleSubmit(async ({ subject, body }) => {
+      await onApproveWithEditedArguments({
+        editedArguments: {
+          ...(isSubjectEditable && { subject }),
+          ...(isBodyEditable && { body }),
+        },
+        approved,
+      });
+    })();
 
   const handleReject = async () => {
     await onApproveWithEditedArguments({
@@ -189,40 +182,43 @@ export function GmailSendMailValidation({
         </div>
       )}
 
-      <div className="flex items-center gap-3 border-t border-border px-4 py-2.5">
-        <Button
-          label="Send"
-          variant="highlight"
-          size="sm"
-          isRounded
-          disabled={isSubmitting}
-          isPulsing={isPulsing}
-          onClick={() => void onApprove()}
-        />
-        {alwaysAllowLabel && (
-          <Label
-            htmlFor={`gmail-always-allow-${blockedAction.actionId}`}
-            className="flex cursor-pointer flex-row items-center gap-2 text-xs"
-          >
-            <Checkbox
-              id={`gmail-always-allow-${blockedAction.actionId}`}
-              checked={neverAskAgain}
-              disabled={isSubmitting}
-              onCheckedChange={(check) => setNeverAskAgain(!!check)}
-            />
-            <span className="font-normal">{alwaysAllowLabel}</span>
-          </Label>
+      <div className="border-t border-border">
+        {blockedAction.stake === "medium" && alwaysAllowLabel && (
+          <div className="px-4 pt-2.5 text-xs text-muted-foreground">
+            {alwaysAllowLabel}
+          </div>
         )}
-        <div className="flex-1" />
-        <Button
-          tooltip="Discard"
-          variant="ghost"
-          size="icon"
-          icon={Trash01}
-          disabled={isSubmitting}
-          isPulsing={isPulsing}
-          onClick={() => void handleReject()}
-        />
+        <div className="flex items-center gap-3 px-4 py-2.5">
+          <Button
+            tooltip="Discard"
+            variant="ghost"
+            size="icon"
+            icon={Trash01}
+            disabled={isSubmitting}
+            isPulsing={isPulsing}
+            onClick={() => void handleReject()}
+          />
+          <div className="flex-1" />
+          {alwaysAllowLabel && (
+            <Button
+              label="Always allow"
+              variant="outline"
+              size="sm"
+              isRounded
+              disabled={isSubmitting}
+              onClick={() => void onApprove("always_approved")}
+            />
+          )}
+          <Button
+            label={alwaysAllowLabel ? "Send once" : "Send"}
+            variant="highlight"
+            size="sm"
+            isRounded
+            disabled={isSubmitting}
+            isPulsing={isPulsing}
+            onClick={() => void onApprove("approved")}
+          />
+        </div>
       </div>
     </div>
   );

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -208,7 +208,7 @@ export function GmailSendMailValidation({
           <div className="flex-1" />
           <Button
             label={alwaysAllowLabel ? "Allow once" : "Allow"}
-            variant="highlight"
+            variant={alwaysAllowLabel ? "highlight-ghost" : "highlight"}
             size="sm"
             icon={Check}
             isRounded
@@ -219,7 +219,7 @@ export function GmailSendMailValidation({
           {alwaysAllowLabel && (
             <Button
               label="Always allow"
-              variant="primary"
+              variant="highlight"
               size="sm"
               icon={CheckDouble}
               isRounded

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -6,7 +6,7 @@ import {
   AttachmentChip,
   Button,
   Check,
-  Infinity,
+  CheckDouble,
   Paperclip,
   XClose,
 } from "@dust-tt/sparkle";
@@ -206,17 +206,6 @@ export function GmailSendMailValidation({
             onClick={() => void handleReject()}
           />
           <div className="flex-1" />
-          {alwaysAllowLabel && (
-            <Button
-              label="Always allow"
-              variant="highlight-ghost"
-              size="sm"
-              icon={Infinity}
-              isRounded
-              disabled={isSubmitting}
-              onClick={() => void onApprove("always_approved")}
-            />
-          )}
           <Button
             label={alwaysAllowLabel ? "Allow once" : "Allow"}
             variant="highlight"
@@ -227,6 +216,17 @@ export function GmailSendMailValidation({
             isPulsing={isPulsing}
             onClick={() => void onApprove("approved")}
           />
+          {alwaysAllowLabel && (
+            <Button
+              label="Always allow"
+              variant="highlight-ghost"
+              size="sm"
+              icon={CheckDouble}
+              isRounded
+              disabled={isSubmitting}
+              onClick={() => void onApprove("always_approved")}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -208,7 +208,7 @@ export function GmailSendMailValidation({
           <div className="flex-1" />
           <Button
             label={alwaysAllowLabel ? "Allow once" : "Allow"}
-            variant={alwaysAllowLabel ? "highlight-ghost" : "highlight"}
+            variant="highlight"
             size="sm"
             icon={Check}
             isRounded

--- a/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
+++ b/front/components/assistant/conversation/editable_tool_validation/gmail/tools/GmailSendMailValidation.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Check,
   CheckDouble,
+  InfoCircle,
   Paperclip,
   XClose,
 } from "@dust-tt/sparkle";
@@ -189,13 +190,14 @@ export function GmailSendMailValidation({
         </div>
       )}
 
-      <div className="border-t border-border">
+      <div className="flex flex-col gap-4 border-t border-border px-4 py-2.5">
         {blockedAction.stake === "medium" && alwaysAllowLabel && (
-          <div className="px-4 pt-2.5 text-xs text-muted-foreground">
-            {alwaysAllowLabel}
+          <div className="flex items-start gap-2 text-xs text-muted-foreground">
+            <InfoCircle className="h-4 w-4 shrink-0" />
+            <span>{alwaysAllowLabel}</span>
           </div>
         )}
-        <div className="flex items-center gap-3 px-4 py-2.5">
+        <div className="flex items-center gap-3">
           <Button
             label="Decline"
             variant="outline"

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -34,7 +34,7 @@ interface ToolExecutionBase<
 
   // For medium-stake tools: which arguments will be saved for future auto-approval.
   argumentsRequiringApproval?: string[];
-  // Human-readable label for the "always allow" approval checkbox.
+  // Human-readable label describing the scope of an "always allow" approval.
   approvalArgsLabel?: string;
 }
 


### PR DESCRIPTION
## Description

This PR follows up on https://github.com/dust-tt/dust/pull/30606

Replaces the "Always allow" checkbox with a third button, mimicking the "Deny", "Allow once", "Always allow" pattern that exists for systems like geolocalisation in browsers.

The decision is really a 3-state selection rather than a 4-state one; checking the checkbox while denying doesn't do anything.

For medium stakes, the Always approve button has a tooltip that explains what the scope of the "always" is.
I did not find a perfect way to explicit this scope in the card content itself, but this tooltip is right in the path of a user that would need explaining, whether it is on the first try, or on a second try where they try to understand why they'd have to click again.

> [!NOTE]
> Interesting learning from IRL chat with Clément: the Always allow button is secondary and in the middle. In the middle because it's not the default "Accept" action a user would expect on the bottom right and is a deliberate choice. Not primary to avoid 2 primary buttons and because the Allow once button is the 0-commitment default choice that is part of the golden path a user can follow by following only primary buttons.

Current
<img width="607" height="281" alt="image" src="https://github.com/user-attachments/assets/4899369a-ca48-4b36-a9e7-7755310dbda2" />

Proposal
<img width="608" height="268" alt="image" src="https://github.com/user-attachments/assets/c2a5bc3e-c72d-43e0-8e34-b53423c6bbb4" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
