### PR TITLE
[front] fix: paginate consumption attribution ES query

### DIFF
--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -47,37 +47,39 @@ function esResponse(aggregations: unknown) {
   >;
 }
 
-type MockGroupBucket = {
-  key: string;
-  doc_count: number;
-  credit_micro?: { value: number };
-  messages?: { value: number };
-};
-
 function mockAggs({
   buckets,
+  totalCount = buckets.length,
   totalMicro,
   filtered = false,
 }: {
-  buckets: MockGroupBucket[];
+  buckets: Array<Record<string, unknown> & { key: string }>;
+  totalCount?: number;
   totalMicro: number;
   filtered?: boolean;
 }) {
-  const compositeRanking = {
-    by_group: {
-      buckets: buckets.map(({ key, ...metrics }) => ({
-        ...metrics,
-        key: { group: key },
-      })),
-    },
-  };
-  const termsRanking = { by_group: { buckets } };
+  const compositeBuckets = buckets.map(({ key, ...metrics }) => ({
+    ...metrics,
+    key: { group: key },
+  }));
 
   vi.mocked(searchConsumptionAnalytics).mockImplementation(
     async (_query, options) => {
-      const ranking = options?.aggregations?.by_group?.terms
-        ? termsRanking
-        : compositeRanking;
+      const composite =
+        options?.aggregations?.by_group?.composite ??
+        options?.aggregations?.ranking?.aggs?.by_group?.composite;
+      const firstPage = compositeBuckets.slice(0, 2);
+      const ranking = {
+        by_group: composite
+          ? {
+              buckets: composite.after ? compositeBuckets.slice(2) : firstPage,
+              ...(!composite.after && compositeBuckets.length > 2
+                ? { after_key: firstPage.at(-1)?.key }
+                : {}),
+            }
+          : { buckets },
+        total_count: { value: totalCount },
+      };
       return esResponse({
         ...(filtered ? { ranking } : ranking),
         total_credit_micro: { value: totalMicro },
@@ -113,21 +115,6 @@ function lastSearchCall() {
 // previous-period comparison follows it whenever the ranking has keys.
 function rankingSearchCall() {
   return vi.mocked(searchConsumptionAnalytics).mock.calls[0];
-}
-
-function lastRankingSearchCall() {
-  const call = vi
-    .mocked(searchConsumptionAnalytics)
-    .mock.calls.toReversed()
-    .find(
-      ([, options]) =>
-        options?.aggregations?.by_group?.composite !== undefined ||
-        options?.aggregations?.ranking?.aggs?.by_group?.composite !== undefined
-    );
-  if (!call) {
-    throw new Error("Missing consumption ranking search call.");
-  }
-  return call;
 }
 
 describe("consumption top rankings", () => {
@@ -215,36 +202,40 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.total_credit_micro?.sum?.field).toBe(
       "credit_micro"
     );
+    expect(options?.aggregations?.total_count?.cardinality).toEqual({
+      field: "agent.id",
+      precision_threshold: 40_000,
+    });
     expect(options?.aggregations?.ranking).toBeUndefined();
   });
 
-  it("returns one ranked page with the total number of groups", async () => {
+  it("paginates buckets before returning a ranked page", async () => {
     const { auth } = await setup();
-    mockLabels({ agent2: "Agent 2", agent3: "Agent 3" });
+    mockLabels({ agent3: "Agent 3", agent4: "Agent 4" });
     mockAggs({
       buckets: [
         {
           key: "agent1",
           doc_count: 1,
-          credit_micro: { value: 4_000_000 },
+          credit_micro: { value: 1_000_000 },
           messages: { value: 1 },
         },
         {
           key: "agent2",
           doc_count: 1,
-          credit_micro: { value: 3_000_000 },
+          credit_micro: { value: 4_000_000 },
           messages: { value: 1 },
         },
         {
           key: "agent3",
           doc_count: 1,
-          credit_micro: { value: 2_000_000 },
+          credit_micro: { value: 3_000_000 },
           messages: { value: 1 },
         },
         {
           key: "agent4",
           doc_count: 1,
-          credit_micro: { value: 1_000_000 },
+          credit_micro: { value: 2_000_000 },
           messages: { value: 1 },
         },
       ],
@@ -262,118 +253,18 @@ describe("consumption top rankings", () => {
       return;
     }
     expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
-      "agent2",
       "agent3",
+      "agent4",
     ]);
     expect(result.value.hasMore).toBe(true);
     expect(result.value.totalCount).toBe(4);
     expect(
       rankingSearchCall()[1]?.aggregations?.by_group?.composite
     ).toMatchObject({ size: 1_000 });
-  });
-
-  it("paginates composite buckets before ranking the requested page", async () => {
-    const { auth } = await setup();
-    mockLabels({ agent3: "Agent 3", agent4: "Agent 4" });
-    vi.mocked(searchConsumptionAnalytics).mockImplementation(
-      async (_query, options) => {
-        const composite = options?.aggregations?.by_group?.composite;
-        if (composite?.after) {
-          return esResponse({
-            by_group: {
-              buckets: [
-                {
-                  key: { group: "agent3" },
-                  doc_count: 1,
-                  credit_micro: { value: 3_000_000 },
-                  messages: { value: 1 },
-                },
-                {
-                  key: { group: "agent4" },
-                  doc_count: 1,
-                  credit_micro: { value: 2_000_000 },
-                  messages: { value: 1 },
-                },
-              ],
-            },
-            total_credit_micro: { value: 10_000_000 },
-          });
-        }
-        if (composite) {
-          return esResponse({
-            by_group: {
-              buckets: [
-                {
-                  key: { group: "agent1" },
-                  doc_count: 1,
-                  credit_micro: { value: 1_000_000 },
-                  messages: { value: 1 },
-                },
-                {
-                  key: { group: "agent2" },
-                  doc_count: 1,
-                  credit_micro: { value: 4_000_000 },
-                  messages: { value: 1 },
-                },
-              ],
-              after_key: { group: "agent2" },
-            },
-            total_credit_micro: { value: 10_000_000 },
-          });
-        }
-        return esResponse({
-          by_group: {
-            buckets: [
-              {
-                key: "agent3",
-                doc_count: 1,
-                credit_micro: { value: 300_000 },
-              },
-              {
-                key: "agent4",
-                doc_count: 1,
-                credit_micro: { value: 200_000 },
-              },
-            ],
-          },
-        });
-      }
-    );
-
-    const result = await fetchConsumptionTopAgents(auth, {
-      period: PERIOD,
-      limit: 2,
-      offset: 1,
+    const calls = vi.mocked(searchConsumptionAnalytics).mock.calls;
+    expect(calls[1]?.[1]?.aggregations?.by_group?.composite?.after).toEqual({
+      group: "agent2",
     });
-
-    expect(result.isOk()).toBe(true);
-    if (!result.isOk()) {
-      return;
-    }
-    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
-      "agent3",
-      "agent4",
-    ]);
-    expect(result.value.agents.map((agent) => agent.previousCredits)).toEqual([
-      0.3, 0.2,
-    ]);
-    expect(result.value.totalCount).toBe(4);
-    expect(result.value.hasMore).toBe(true);
-    expect(result.value.totalCredits).toBe(10);
-
-    const rankingCalls = vi
-      .mocked(searchConsumptionAnalytics)
-      .mock.calls.filter(
-        ([, options]) =>
-          options?.aggregations?.by_group?.composite !== undefined
-      );
-    expect(rankingCalls).toHaveLength(2);
-    expect(rankingCalls[0]?.[1]?.aggregations?.by_group?.composite?.after).toBe(
-      undefined
-    );
-    expect(
-      rankingCalls[1]?.[1]?.aggregations?.by_group?.composite?.after
-    ).toEqual({ group: "agent2" });
   });
 
   it.each([
@@ -387,6 +278,7 @@ describe("consumption top rankings", () => {
     mockLabels({});
     mockAggs({
       buckets: [],
+      totalCount: 0,
       totalMicro: 10_000_000,
       filtered: true,
     });
@@ -423,6 +315,7 @@ describe("consumption top rankings", () => {
     mockLabels({});
     mockAggs({
       buckets: [],
+      totalCount: 0,
       totalMicro: 0,
       filtered: true,
     });
@@ -497,11 +390,10 @@ describe("consumption top rankings", () => {
     // The tools are a slice of the period, not all of it.
     expect(result.value.totalCredits).toBe(10);
 
-    const [, options] = lastRankingSearchCall();
-    expect(
-      options?.aggregations?.by_group?.composite?.sources?.[0]?.group?.terms
-        ?.field
-    ).toBe("tool.server_name");
+    const [, options] = lastSearchCall();
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({
+      field: "tool.server_name",
+    });
     expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
@@ -613,11 +505,10 @@ describe("consumption top rankings", () => {
       },
     ]);
 
-    const [, options] = lastRankingSearchCall();
-    expect(
-      options?.aggregations?.by_group?.composite?.sources?.[0]?.group?.terms
-        ?.field
-    ).toBe("tool.attributed_skill_ids");
+    const [, options] = lastSearchCall();
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({
+      field: "tool.attributed_skill_ids",
+    });
     expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
@@ -653,10 +544,9 @@ describe("consumption top rankings", () => {
       messageCount: 4,
       avgCreditsPerMessage: 0.5,
     });
-    expect(
-      lastRankingSearchCall()[1]?.aggregations?.by_group?.composite
-        ?.sources?.[0]?.group?.terms?.field
-    ).toBe("user.id");
+    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
+      field: "user.id",
+    });
 
     mockLabels({ key1: "Engineering" });
     const groups = await fetchConsumptionTopGroups(auth, {
@@ -675,10 +565,9 @@ describe("consumption top rankings", () => {
       messageCount: 4,
       avgCreditsPerMessage: 0.5,
     });
-    expect(
-      lastRankingSearchCall()[1]?.aggregations?.by_group?.composite
-        ?.sources?.[0]?.group?.terms?.field
-    ).toBe("user.group_ids");
+    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
+      field: "user.group_ids",
+    });
 
     mockLabels({ key1: "Claude 4 Sonnet" });
     const models = await fetchConsumptionTopModels(auth, {
@@ -697,10 +586,9 @@ describe("consumption top rankings", () => {
       messageCount: 4,
       avgCreditsPerMessage: 0.5,
     });
-    expect(
-      lastRankingSearchCall()[1]?.aggregations?.by_group?.composite
-        ?.sources?.[0]?.group?.terms?.field
-    ).toBe("model.model_id");
+    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
+      field: "model.model_id",
+    });
   });
 
   it("keys sources on the raw context origin so the row can be filtered on", async () => {
@@ -735,10 +623,9 @@ describe("consumption top rankings", () => {
       messageCount: 4,
       avgCreditsPerMessage: 1,
     });
-    expect(
-      lastRankingSearchCall()[1]?.aggregations?.by_group?.composite
-        ?.sources?.[0]?.group?.terms?.field
-    ).toBe("normalized_origin");
+    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
+      field: "normalized_origin",
+    });
   });
 
   it("narrows the scope with the requested filter", async () => {
@@ -836,6 +723,7 @@ describe("consumption top rankings", () => {
             },
           ],
         },
+        total_count: { value: 1 },
         total_credit_micro: { value: 3_000_000 },
       })
     );

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -58,26 +58,25 @@ function mockAggs({
   totalMicro: number;
   filtered?: boolean;
 }) {
-  const compositeBuckets = buckets.map(({ key, ...metrics }) => ({
-    ...metrics,
-    key: { group: key },
-  }));
-
   vi.mocked(searchConsumptionAnalytics).mockImplementation(
     async (_query, options) => {
-      const composite =
-        options?.aggregations?.by_group?.composite ??
-        options?.aggregations?.ranking?.aggs?.by_group?.composite;
-      const firstPage = compositeBuckets.slice(0, 2);
+      const terms =
+        options?.aggregations?.by_group?.terms ??
+        options?.aggregations?.ranking?.aggs?.by_group?.terms;
+      const includedKeys = Array.isArray(terms?.include)
+        ? new Set(terms.include.map(String))
+        : null;
+      const excludedKeys = new Set(
+        Array.isArray(terms?.exclude) ? terms.exclude.map(String) : []
+      );
       const ranking = {
-        by_group: composite
-          ? {
-              buckets: composite.after ? compositeBuckets.slice(2) : firstPage,
-              ...(!composite.after && compositeBuckets.length > 2
-                ? { after_key: firstPage.at(-1)?.key }
-                : {}),
-            }
-          : { buckets },
+        by_group: {
+          buckets: buckets
+            .filter(({ key }) =>
+              includedKeys ? includedKeys.has(key) : !excludedKeys.has(key)
+            )
+            .slice(0, terms?.size),
+        },
         total_count: { value: totalCount },
       };
       return esResponse({
@@ -189,9 +188,10 @@ describe("consumption top rankings", () => {
     expect(query.bool?.filter).toContainEqual({
       range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
     });
-    expect(options?.aggregations?.by_group?.composite).toMatchObject({
-      size: 1_000,
-      sources: [{ group: { terms: { field: "agent.id" } } }],
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({
+      field: "agent.id",
+      size: 10,
+      order: { credit_micro: "desc" },
     });
     expect(
       options?.aggregations?.by_group?.aggs?.credit_micro?.sum?.field
@@ -209,43 +209,24 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.ranking).toBeUndefined();
   });
 
-  it("paginates buckets before returning a ranked page", async () => {
+  it("fetches only enough terms batches for the requested page", async () => {
     const { auth } = await setup();
-    mockLabels({ agent3: "Agent 3", agent4: "Agent 4" });
+    const buckets = Array.from({ length: 1_001 }, (_, index) => ({
+      key: `agent${index}`,
+      doc_count: 1,
+      credit_micro: { value: 1_001_000_000 - index * 1_000_000 },
+      messages: { value: 1 },
+    }));
+    mockLabels({ agent1000: "Agent 1000" });
     mockAggs({
-      buckets: [
-        {
-          key: "agent1",
-          doc_count: 1,
-          credit_micro: { value: 1_000_000 },
-          messages: { value: 1 },
-        },
-        {
-          key: "agent2",
-          doc_count: 1,
-          credit_micro: { value: 4_000_000 },
-          messages: { value: 1 },
-        },
-        {
-          key: "agent3",
-          doc_count: 1,
-          credit_micro: { value: 3_000_000 },
-          messages: { value: 1 },
-        },
-        {
-          key: "agent4",
-          doc_count: 1,
-          credit_micro: { value: 2_000_000 },
-          messages: { value: 1 },
-        },
-      ],
-      totalMicro: 10_000_000,
+      buckets,
+      totalMicro: 1_001_000_000,
     });
 
     const result = await fetchConsumptionTopAgents(auth, {
       period: PERIOD,
-      limit: 2,
-      offset: 1,
+      limit: 1,
+      offset: 1_000,
     });
 
     expect(result.isOk()).toBe(true);
@@ -253,18 +234,22 @@ describe("consumption top rankings", () => {
       return;
     }
     expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
-      "agent3",
-      "agent4",
+      "agent1000",
     ]);
-    expect(result.value.hasMore).toBe(true);
-    expect(result.value.totalCount).toBe(4);
-    expect(
-      rankingSearchCall()[1]?.aggregations?.by_group?.composite
-    ).toMatchObject({ size: 1_000 });
+    expect(result.value.hasMore).toBe(false);
+    expect(result.value.totalCount).toBe(1_001);
     const calls = vi.mocked(searchConsumptionAnalytics).mock.calls;
-    expect(calls[1]?.[1]?.aggregations?.by_group?.composite?.after).toEqual({
-      group: "agent2",
+    expect(calls).toHaveLength(3);
+    expect(calls[0]?.[1]?.aggregations?.by_group?.terms).toMatchObject({
+      size: 1_000,
     });
+    expect(
+      calls[0]?.[1]?.aggregations?.by_group?.terms?.exclude
+    ).toBeUndefined();
+    expect(calls[1]?.[1]?.aggregations?.by_group?.terms?.size).toBe(1);
+    expect(calls[1]?.[1]?.aggregations?.by_group?.terms?.exclude).toHaveLength(
+      1_000
+    );
   });
 
   it.each([
@@ -451,10 +436,11 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.ranking?.filter).toEqual({
       terms: { api_key_name: ["Production key"] },
     });
-    expect(
-      options?.aggregations?.ranking?.aggs?.by_group?.composite?.sources?.[0]
-        ?.group?.terms?.field
-    ).toBe("api_key_name");
+    expect(options?.aggregations?.ranking?.aggs?.by_group?.terms).toMatchObject(
+      {
+        field: "api_key_name",
+      }
+    );
     expect(
       options?.aggregations?.ranking?.aggs?.by_group?.aggs?.messages
         ?.cardinality?.field
@@ -716,7 +702,7 @@ describe("consumption top rankings", () => {
         by_group: {
           buckets: [
             {
-              key: { group: "agent1" },
+              key: "agent1",
               doc_count: 1,
               credit_micro: { value: 3_000_000 },
               messages: { value: 1 },

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -47,26 +47,42 @@ function esResponse(aggregations: unknown) {
   >;
 }
 
+type MockGroupBucket = {
+  key: string;
+  doc_count: number;
+  credit_micro?: { value: number };
+  messages?: { value: number };
+};
+
 function mockAggs({
   buckets,
-  totalCount = buckets.length,
   totalMicro,
   filtered = false,
 }: {
-  buckets: unknown[];
-  totalCount?: number;
+  buckets: MockGroupBucket[];
   totalMicro: number;
   filtered?: boolean;
 }) {
-  const ranking = {
-    by_group: { buckets },
-    total_count: { value: totalCount },
+  const compositeRanking = {
+    by_group: {
+      buckets: buckets.map(({ key, ...metrics }) => ({
+        ...metrics,
+        key: { group: key },
+      })),
+    },
   };
-  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
-    esResponse({
-      ...(filtered ? { ranking } : ranking),
-      total_credit_micro: { value: totalMicro },
-    })
+  const termsRanking = { by_group: { buckets } };
+
+  vi.mocked(searchConsumptionAnalytics).mockImplementation(
+    async (_query, options) => {
+      const ranking = options?.aggregations?.by_group?.terms
+        ? termsRanking
+        : compositeRanking;
+      return esResponse({
+        ...(filtered ? { ranking } : ranking),
+        total_credit_micro: { value: totalMicro },
+      });
+    }
   );
 }
 
@@ -97,6 +113,21 @@ function lastSearchCall() {
 // previous-period comparison follows it whenever the ranking has keys.
 function rankingSearchCall() {
   return vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+}
+
+function lastRankingSearchCall() {
+  const call = vi
+    .mocked(searchConsumptionAnalytics)
+    .mock.calls.toReversed()
+    .find(
+      ([, options]) =>
+        options?.aggregations?.by_group?.composite !== undefined ||
+        options?.aggregations?.ranking?.aggs?.by_group?.composite !== undefined
+    );
+  if (!call) {
+    throw new Error("Missing consumption ranking search call.");
+  }
+  return call;
 }
 
 describe("consumption top rankings", () => {
@@ -171,10 +202,9 @@ describe("consumption top rankings", () => {
     expect(query.bool?.filter).toContainEqual({
       range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
     });
-    expect(options?.aggregations?.by_group?.terms).toMatchObject({
-      field: "agent.id",
-      size: 10,
-      order: { credit_micro: "desc" },
+    expect(options?.aggregations?.by_group?.composite).toMatchObject({
+      size: 1_000,
+      sources: [{ group: { terms: { field: "agent.id" } } }],
     });
     expect(
       options?.aggregations?.by_group?.aggs?.credit_micro?.sum?.field
@@ -185,10 +215,6 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.total_credit_micro?.sum?.field).toBe(
       "credit_micro"
     );
-    expect(options?.aggregations?.total_count?.cardinality).toEqual({
-      field: "agent.id",
-      precision_threshold: 40_000,
-    });
     expect(options?.aggregations?.ranking).toBeUndefined();
   });
 
@@ -241,11 +267,113 @@ describe("consumption top rankings", () => {
     ]);
     expect(result.value.hasMore).toBe(true);
     expect(result.value.totalCount).toBe(4);
-    expect(rankingSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject(
-      {
-        size: 3,
+    expect(
+      rankingSearchCall()[1]?.aggregations?.by_group?.composite
+    ).toMatchObject({ size: 1_000 });
+  });
+
+  it("paginates composite buckets before ranking the requested page", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent3: "Agent 3", agent4: "Agent 4" });
+    vi.mocked(searchConsumptionAnalytics).mockImplementation(
+      async (_query, options) => {
+        const composite = options?.aggregations?.by_group?.composite;
+        if (composite?.after) {
+          return esResponse({
+            by_group: {
+              buckets: [
+                {
+                  key: { group: "agent3" },
+                  doc_count: 1,
+                  credit_micro: { value: 3_000_000 },
+                  messages: { value: 1 },
+                },
+                {
+                  key: { group: "agent4" },
+                  doc_count: 1,
+                  credit_micro: { value: 2_000_000 },
+                  messages: { value: 1 },
+                },
+              ],
+            },
+            total_credit_micro: { value: 10_000_000 },
+          });
+        }
+        if (composite) {
+          return esResponse({
+            by_group: {
+              buckets: [
+                {
+                  key: { group: "agent1" },
+                  doc_count: 1,
+                  credit_micro: { value: 1_000_000 },
+                  messages: { value: 1 },
+                },
+                {
+                  key: { group: "agent2" },
+                  doc_count: 1,
+                  credit_micro: { value: 4_000_000 },
+                  messages: { value: 1 },
+                },
+              ],
+              after_key: { group: "agent2" },
+            },
+            total_credit_micro: { value: 10_000_000 },
+          });
+        }
+        return esResponse({
+          by_group: {
+            buckets: [
+              {
+                key: "agent3",
+                doc_count: 1,
+                credit_micro: { value: 300_000 },
+              },
+              {
+                key: "agent4",
+                doc_count: 1,
+                credit_micro: { value: 200_000 },
+              },
+            ],
+          },
+        });
       }
     );
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 2,
+      offset: 1,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
+      "agent3",
+      "agent4",
+    ]);
+    expect(result.value.agents.map((agent) => agent.previousCredits)).toEqual([
+      0.3, 0.2,
+    ]);
+    expect(result.value.totalCount).toBe(4);
+    expect(result.value.hasMore).toBe(true);
+    expect(result.value.totalCredits).toBe(10);
+
+    const rankingCalls = vi
+      .mocked(searchConsumptionAnalytics)
+      .mock.calls.filter(
+        ([, options]) =>
+          options?.aggregations?.by_group?.composite !== undefined
+      );
+    expect(rankingCalls).toHaveLength(2);
+    expect(rankingCalls[0]?.[1]?.aggregations?.by_group?.composite?.after).toBe(
+      undefined
+    );
+    expect(
+      rankingCalls[1]?.[1]?.aggregations?.by_group?.composite?.after
+    ).toEqual({ group: "agent2" });
   });
 
   it.each([
@@ -259,7 +387,6 @@ describe("consumption top rankings", () => {
     mockLabels({});
     mockAggs({
       buckets: [],
-      totalCount: 0,
       totalMicro: 10_000_000,
       filtered: true,
     });
@@ -296,7 +423,6 @@ describe("consumption top rankings", () => {
     mockLabels({});
     mockAggs({
       buckets: [],
-      totalCount: 0,
       totalMicro: 0,
       filtered: true,
     });
@@ -371,10 +497,11 @@ describe("consumption top rankings", () => {
     // The tools are a slice of the period, not all of it.
     expect(result.value.totalCredits).toBe(10);
 
-    const [, options] = lastSearchCall();
-    expect(options?.aggregations?.by_group?.terms).toMatchObject({
-      field: "tool.server_name",
-    });
+    const [, options] = lastRankingSearchCall();
+    expect(
+      options?.aggregations?.by_group?.composite?.sources?.[0]?.group?.terms
+        ?.field
+    ).toBe("tool.server_name");
     expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
@@ -432,11 +559,10 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.ranking?.filter).toEqual({
       terms: { api_key_name: ["Production key"] },
     });
-    expect(options?.aggregations?.ranking?.aggs?.by_group?.terms).toMatchObject(
-      {
-        field: "api_key_name",
-      }
-    );
+    expect(
+      options?.aggregations?.ranking?.aggs?.by_group?.composite?.sources?.[0]
+        ?.group?.terms?.field
+    ).toBe("api_key_name");
     expect(
       options?.aggregations?.ranking?.aggs?.by_group?.aggs?.messages
         ?.cardinality?.field
@@ -487,10 +613,11 @@ describe("consumption top rankings", () => {
       },
     ]);
 
-    const [, options] = lastSearchCall();
-    expect(options?.aggregations?.by_group?.terms).toMatchObject({
-      field: "tool.attributed_skill_ids",
-    });
+    const [, options] = lastRankingSearchCall();
+    expect(
+      options?.aggregations?.by_group?.composite?.sources?.[0]?.group?.terms
+        ?.field
+    ).toBe("tool.attributed_skill_ids");
     expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
@@ -526,9 +653,10 @@ describe("consumption top rankings", () => {
       messageCount: 4,
       avgCreditsPerMessage: 0.5,
     });
-    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
-      field: "user.id",
-    });
+    expect(
+      lastRankingSearchCall()[1]?.aggregations?.by_group?.composite
+        ?.sources?.[0]?.group?.terms?.field
+    ).toBe("user.id");
 
     mockLabels({ key1: "Engineering" });
     const groups = await fetchConsumptionTopGroups(auth, {
@@ -547,9 +675,10 @@ describe("consumption top rankings", () => {
       messageCount: 4,
       avgCreditsPerMessage: 0.5,
     });
-    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
-      field: "user.group_ids",
-    });
+    expect(
+      lastRankingSearchCall()[1]?.aggregations?.by_group?.composite
+        ?.sources?.[0]?.group?.terms?.field
+    ).toBe("user.group_ids");
 
     mockLabels({ key1: "Claude 4 Sonnet" });
     const models = await fetchConsumptionTopModels(auth, {
@@ -568,9 +697,10 @@ describe("consumption top rankings", () => {
       messageCount: 4,
       avgCreditsPerMessage: 0.5,
     });
-    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
-      field: "model.model_id",
-    });
+    expect(
+      lastRankingSearchCall()[1]?.aggregations?.by_group?.composite
+        ?.sources?.[0]?.group?.terms?.field
+    ).toBe("model.model_id");
   });
 
   it("keys sources on the raw context origin so the row can be filtered on", async () => {
@@ -605,9 +735,10 @@ describe("consumption top rankings", () => {
       messageCount: 4,
       avgCreditsPerMessage: 1,
     });
-    expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
-      field: "normalized_origin",
-    });
+    expect(
+      lastRankingSearchCall()[1]?.aggregations?.by_group?.composite
+        ?.sources?.[0]?.group?.terms?.field
+    ).toBe("normalized_origin");
   });
 
   it("narrows the scope with the requested filter", async () => {
@@ -698,14 +829,13 @@ describe("consumption top rankings", () => {
         by_group: {
           buckets: [
             {
-              key: "agent1",
+              key: { group: "agent1" },
               doc_count: 1,
               credit_micro: { value: 3_000_000 },
               messages: { value: 1 },
             },
           ],
         },
-        total_count: { value: 1 },
         total_credit_micro: { value: 3_000_000 },
       })
     );

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -10,6 +10,7 @@ import type {
 import {
   AGENT_MESSAGE_ID_FIELD,
   buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
   CONSUMPTION_DIMENSION_FIELDS,
   CONSUMPTION_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
@@ -45,8 +46,8 @@ export type ConsumptionTopGroups = {
   // Distinct dimension values over the scoped period.
   totalCount: number;
   // Gross credits over the whole scoped period, every document included. Not the
-  // sum of the returned page. A dimension that only exists on some documents (a
-  // tool, a skill) accounts for part of the total.
+  // sum of `groups`. The ranking is capped at `limit`, and a dimension that only
+  // exists on some documents (a tool, a skill) accounts for part of the total.
   totalCredits: number;
 };
 
@@ -54,23 +55,19 @@ export type ConsumptionTopGroups = {
 // bucket reads below cannot drift apart.
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
+const TOTAL_COUNT_AGG = "total_count";
 const RANKING_COMPOSITE_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
 
-type GroupBucketMetrics = {
+type GroupBucket<Key = string> = {
+  key: Key;
   doc_count: number;
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
-type GroupBucket = GroupBucketMetrics & { key: string };
-
 type CompositeGroupKey = { group: string };
-
-type CompositeGroupBucket = GroupBucketMetrics & {
-  key: CompositeGroupKey;
-};
 
 function subAggs(unit: ConsumptionTopUnit) {
   return {
@@ -83,9 +80,10 @@ function subAggs(unit: ConsumptionTopUnit) {
 
 type RankingAggs = {
   by_group?: estypes.AggregationsCompositeAggregate & {
-    buckets: CompositeGroupBucket[];
+    buckets: GroupBucket<CompositeGroupKey>[];
     after_key?: CompositeGroupKey;
   };
+  [TOTAL_COUNT_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
 type TopAggs = RankingAggs & {
@@ -94,7 +92,7 @@ type TopAggs = RankingAggs & {
 };
 
 function countFromBucket(
-  bucket: GroupBucketMetrics,
+  bucket: GroupBucket<unknown>,
   unit: ConsumptionTopUnit
 ): number {
   switch (unit) {
@@ -193,6 +191,12 @@ function buildConsumptionTopAggregations({
         ...(afterKey ? { after: afterKey } : {}),
       },
       aggs: subAggs(unit),
+    },
+    [TOTAL_COUNT_AGG]: {
+      cardinality: {
+        field: dimensionField,
+        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+      },
     },
   } satisfies Record<string, estypes.AggregationsAggregationContainer>;
 
@@ -314,7 +318,8 @@ export async function fetchConsumptionTopGroups(
 
   const rankedGroups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
   let afterKey: CompositeGroupKey | undefined;
-  let buckets: CompositeGroupBucket[];
+  let buckets: GroupBucket<CompositeGroupKey>[];
+  let totalCount = 0;
   let totalCredits = 0;
 
   // Composite aggregations page by key rather than by a sub-aggregation. Read
@@ -338,7 +343,9 @@ export async function fetchConsumptionTopGroups(
     const ranking = searchFilter
       ? result.value.aggregations?.ranking
       : result.value.aggregations;
-    buckets = bucketsToArray<CompositeGroupBucket>(ranking?.by_group?.buckets);
+    buckets = bucketsToArray<GroupBucket<CompositeGroupKey>>(
+      ranking?.by_group?.buckets
+    );
     rankedGroups.push(
       ...buckets.map((bucket) => ({
         key: bucket.key.group,
@@ -349,6 +356,7 @@ export async function fetchConsumptionTopGroups(
     totalCredits = microCreditsToCredits(
       result.value.aggregations?.total_credit_micro?.value ?? 0
     );
+    totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
     afterKey = ranking?.by_group?.after_key;
   } while (afterKey !== undefined && buckets.length > 0);
 
@@ -386,8 +394,8 @@ export async function fetchConsumptionTopGroups(
       ...group,
       previousCredits: previousCreditsByKey.get(group.key) ?? null,
     })),
-    hasMore: sortedGroups.length > offset + limit,
-    totalCount: sortedGroups.length,
+    hasMore: totalCount > offset + limit,
+    totalCount,
     totalCredits,
   });
 }

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -10,7 +10,6 @@ import type {
 import {
   AGENT_MESSAGE_ID_FIELD,
   buildConsumptionScopeQuery,
-  CARDINALITY_PRECISION_THRESHOLD,
   CONSUMPTION_DIMENSION_FIELDS,
   CONSUMPTION_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
@@ -46,8 +45,8 @@ export type ConsumptionTopGroups = {
   // Distinct dimension values over the scoped period.
   totalCount: number;
   // Gross credits over the whole scoped period, every document included. Not the
-  // sum of `groups`. The ranking is capped at `limit`, and a dimension that only
-  // exists on some documents (a tool, a skill) accounts for part of the total.
+  // sum of the returned page. A dimension that only exists on some documents (a
+  // tool, a skill) accounts for part of the total.
   totalCredits: number;
 };
 
@@ -55,15 +54,22 @@ export type ConsumptionTopGroups = {
 // bucket reads below cannot drift apart.
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
-const TOTAL_COUNT_AGG = "total_count";
+const RANKING_COMPOSITE_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
 
-type GroupBucket = {
-  key: string;
+type GroupBucketMetrics = {
   doc_count: number;
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
+};
+
+type GroupBucket = GroupBucketMetrics & { key: string };
+
+type CompositeGroupKey = { group: string };
+
+type CompositeGroupBucket = GroupBucketMetrics & {
+  key: CompositeGroupKey;
 };
 
 function subAggs(unit: ConsumptionTopUnit) {
@@ -76,8 +82,10 @@ function subAggs(unit: ConsumptionTopUnit) {
 }
 
 type RankingAggs = {
-  by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
-  [TOTAL_COUNT_AGG]?: estypes.AggregationsCardinalityAggregate;
+  by_group?: estypes.AggregationsCompositeAggregate & {
+    buckets: CompositeGroupBucket[];
+    after_key?: CompositeGroupKey;
+  };
 };
 
 type TopAggs = RankingAggs & {
@@ -86,7 +94,7 @@ type TopAggs = RankingAggs & {
 };
 
 function countFromBucket(
-  bucket: GroupBucket,
+  bucket: GroupBucketMetrics,
   unit: ConsumptionTopUnit
 ): number {
   switch (unit) {
@@ -167,34 +175,24 @@ async function resolveConsumptionTopSearchFilter(
 
 function buildConsumptionTopAggregations({
   dimension,
-  limit,
-  offset,
+  afterKey,
   searchFilter,
 }: {
   dimension: ConsumptionScopeDimension;
-  limit: number;
-  offset: number;
+  afterKey?: CompositeGroupKey;
   searchFilter: estypes.QueryDslQueryContainer | null;
 }): Record<string, estypes.AggregationsAggregationContainer> {
   const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
   const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
 
-  // TODO(2026-08-14 aubin): Add pagination beyond the maximum bucket count.
-  const requestedBucketCount = offset + limit;
   const rankingAggregations = {
     by_group: {
-      terms: {
-        field: dimensionField,
-        size: requestedBucketCount,
-        order: { [CREDIT_AGG]: "desc" },
+      composite: {
+        size: RANKING_COMPOSITE_PAGE_SIZE,
+        sources: [{ group: { terms: { field: dimensionField } } }],
+        ...(afterKey ? { after: afterKey } : {}),
       },
       aggs: subAggs(unit),
-    },
-    [TOTAL_COUNT_AGG]: {
-      cardinality: {
-        field: dimensionField,
-        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
-      },
     },
   } satisfies Record<string, estypes.AggregationsAggregationContainer>;
 
@@ -314,34 +312,50 @@ export async function fetchConsumptionTopGroups(
     filter,
   });
 
-  const aggregations = buildConsumptionTopAggregations({
-    dimension,
-    limit,
-    offset,
-    searchFilter,
-  });
+  const rankedGroups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
+  let afterKey: CompositeGroupKey | undefined;
+  let buckets: CompositeGroupBucket[];
+  let totalCredits = 0;
 
-  const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
-    aggregations,
-    size: 0,
-  });
+  // Composite aggregations page by key rather than by a sub-aggregation. Read
+  // every fixed-size page to stay below search.max_buckets, then restore the
+  // credits ranking before applying the requested offset.
+  do {
+    const aggregations = buildConsumptionTopAggregations({
+      dimension,
+      afterKey,
+      searchFilter,
+    });
+    const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
+      aggregations,
+      size: 0,
+    });
 
-  if (result.isErr()) {
-    return result;
-  }
+    if (result.isErr()) {
+      return result;
+    }
 
-  const ranking = searchFilter
-    ? result.value.aggregations?.ranking
-    : result.value.aggregations;
-  const rankedGroups = bucketsToArray<GroupBucket>(
-    ranking?.by_group?.buckets
-  ).map((bucket) => ({
-    key: String(bucket.key),
-    credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-    count: countFromBucket(bucket, CONSUMPTION_DIMENSION_UNIT[dimension]),
-  }));
-  const totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
-  const pagedGroups = rankedGroups.slice(offset, offset + limit);
+    const ranking = searchFilter
+      ? result.value.aggregations?.ranking
+      : result.value.aggregations;
+    buckets = bucketsToArray<CompositeGroupBucket>(ranking?.by_group?.buckets);
+    rankedGroups.push(
+      ...buckets.map((bucket) => ({
+        key: bucket.key.group,
+        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
+        count: countFromBucket(bucket, CONSUMPTION_DIMENSION_UNIT[dimension]),
+      }))
+    );
+    totalCredits = microCreditsToCredits(
+      result.value.aggregations?.total_credit_micro?.value ?? 0
+    );
+    afterKey = ranking?.by_group?.after_key;
+  } while (afterKey !== undefined && buckets.length > 0);
+
+  const sortedGroups = rankedGroups.toSorted(
+    (left, right) => right.credits - left.credits
+  );
+  const pagedGroups = sortedGroups.slice(offset, offset + limit);
 
   const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
     dimension,
@@ -372,11 +386,9 @@ export async function fetchConsumptionTopGroups(
       ...group,
       previousCredits: previousCreditsByKey.get(group.key) ?? null,
     })),
-    hasMore: totalCount > offset + limit,
-    totalCount,
-    totalCredits: microCreditsToCredits(
-      result.value.aggregations?.total_credit_micro?.value ?? 0
-    ),
+    hasMore: sortedGroups.length > offset + limit,
+    totalCount: sortedGroups.length,
+    totalCredits,
   });
 }
 

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -56,18 +56,16 @@ export type ConsumptionTopGroups = {
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
 const TOTAL_COUNT_AGG = "total_count";
-const RANKING_COMPOSITE_PAGE_SIZE = 1_000;
+const RANKING_TERMS_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
 
-type GroupBucket<Key = string> = {
-  key: Key;
+type GroupBucket = {
+  key: string;
   doc_count: number;
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
-
-type CompositeGroupKey = { group: string };
 
 function subAggs(unit: ConsumptionTopUnit) {
   return {
@@ -79,10 +77,7 @@ function subAggs(unit: ConsumptionTopUnit) {
 }
 
 type RankingAggs = {
-  by_group?: estypes.AggregationsCompositeAggregate & {
-    buckets: GroupBucket<CompositeGroupKey>[];
-    after_key?: CompositeGroupKey;
-  };
+  by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
   [TOTAL_COUNT_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
@@ -92,7 +87,7 @@ type TopAggs = RankingAggs & {
 };
 
 function countFromBucket(
-  bucket: GroupBucket<unknown>,
+  bucket: GroupBucket,
   unit: ConsumptionTopUnit
 ): number {
   switch (unit) {
@@ -173,11 +168,13 @@ async function resolveConsumptionTopSearchFilter(
 
 function buildConsumptionTopAggregations({
   dimension,
-  afterKey,
+  bucketCount,
+  excludedKeys,
   searchFilter,
 }: {
   dimension: ConsumptionScopeDimension;
-  afterKey?: CompositeGroupKey;
+  bucketCount: number;
+  excludedKeys: string[];
   searchFilter: estypes.QueryDslQueryContainer | null;
 }): Record<string, estypes.AggregationsAggregationContainer> {
   const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
@@ -185,10 +182,11 @@ function buildConsumptionTopAggregations({
 
   const rankingAggregations = {
     by_group: {
-      composite: {
-        size: RANKING_COMPOSITE_PAGE_SIZE,
-        sources: [{ group: { terms: { field: dimensionField } } }],
-        ...(afterKey ? { after: afterKey } : {}),
+      terms: {
+        field: dimensionField,
+        size: bucketCount,
+        order: { [CREDIT_AGG]: "desc" },
+        ...(excludedKeys.length > 0 ? { exclude: excludedKeys } : {}),
       },
       aggs: subAggs(unit),
     },
@@ -316,19 +314,25 @@ export async function fetchConsumptionTopGroups(
     filter,
   });
 
+  const requestedBucketCount = offset + limit;
   const rankedGroups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
-  let afterKey: CompositeGroupKey | undefined;
-  let buckets: GroupBucket<CompositeGroupKey>[];
+  let buckets: GroupBucket[];
+  let batchSize = 0;
   let totalCount = 0;
   let totalCredits = 0;
 
-  // Composite aggregations page by key rather than by a sub-aggregation. Read
-  // every fixed-size page to stay below search.max_buckets, then restore the
-  // credits ranking before applying the requested offset.
+  // Terms aggregations do not expose an after_key when ordered by a metric.
+  // Continue the credit-ranked result in bounded batches by excluding the keys
+  // already returned, and stop as soon as the requested page is available.
   do {
+    batchSize = Math.min(
+      requestedBucketCount - rankedGroups.length,
+      RANKING_TERMS_PAGE_SIZE
+    );
     const aggregations = buildConsumptionTopAggregations({
       dimension,
-      afterKey,
+      bucketCount: batchSize,
+      excludedKeys: rankedGroups.map((group) => group.key),
       searchFilter,
     });
     const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
@@ -343,12 +347,10 @@ export async function fetchConsumptionTopGroups(
     const ranking = searchFilter
       ? result.value.aggregations?.ranking
       : result.value.aggregations;
-    buckets = bucketsToArray<GroupBucket<CompositeGroupKey>>(
-      ranking?.by_group?.buckets
-    );
+    buckets = bucketsToArray<GroupBucket>(ranking?.by_group?.buckets);
     rankedGroups.push(
       ...buckets.map((bucket) => ({
-        key: bucket.key.group,
+        key: String(bucket.key),
         credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
         count: countFromBucket(bucket, CONSUMPTION_DIMENSION_UNIT[dimension]),
       }))
@@ -357,13 +359,12 @@ export async function fetchConsumptionTopGroups(
       result.value.aggregations?.total_credit_micro?.value ?? 0
     );
     totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
-    afterKey = ranking?.by_group?.after_key;
-  } while (afterKey !== undefined && buckets.length > 0);
-
-  const sortedGroups = rankedGroups.toSorted(
-    (left, right) => right.credits - left.credits
+  } while (
+    rankedGroups.length < requestedBucketCount &&
+    buckets.length === batchSize
   );
-  const pagedGroups = sortedGroups.slice(offset, offset + limit);
+
+  const pagedGroups = rankedGroups.slice(offset, offset + limit);
 
   const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
     dimension,


### PR DESCRIPTION
## Description

If we have a large number of results to show in the attribution table, we currently grow one Elasticsearch terms aggregation with the requested offset, which can eventually exceed the maximum bucket count.

This PR paginates the queries in the backend (in most of the cases we'll only fetch one page).

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
