### PR TITLE
Return affected filesystem node IDs

### DIFF
--- a/front-api/routes/v1/w/[wId]/sandbox/filesystem.test.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/filesystem.test.ts
@@ -114,6 +114,88 @@ describe("POST /api/v1/w/[wId]/sandbox/filesystem", () => {
     );
   });
 
+  it("returns the node removed or replaced by a namespace mutation", async () => {
+    const context = await createSandboxTokenTestContext();
+    const token = await generateSandboxFileSystemToken(context.auth, {
+      sandbox: context.sandbox,
+      roots: [
+        {
+          kind: "conversation",
+          id: context.conversation.sId,
+          permissions: { canRead: true, canWrite: true },
+        },
+      ],
+    });
+    const initializeResponse = await requestFileSystem(
+      context.workspace.sId,
+      token,
+      { operation: "initialize" }
+    );
+    const initialized = FileSystemOperationResponseSchema.parse(
+      await initializeResponse.json()
+    );
+    const root = initialized.roots?.[0];
+    if (!root) {
+      throw new Error("Expected a conversation filesystem root.");
+    }
+
+    const createFile = async (name: string) => {
+      const response = await requestFileSystem(context.workspace.sId, token, {
+        operation: "create",
+        requestId: randomUUID(),
+        parentId: root.id,
+        name,
+        kind: "file",
+        mode: 0o644,
+      });
+      const created = FileSystemOperationResponseSchema.parse(
+        await response.json()
+      );
+      if (!created.node) {
+        throw new Error(`Expected ${name} to be created.`);
+      }
+      return created.node;
+    };
+    const source = await createFile("source.txt");
+    const destination = await createFile("destination.txt");
+
+    const renameResponse = await requestFileSystem(
+      context.workspace.sId,
+      token,
+      {
+        operation: "rename",
+        requestId: randomUUID(),
+        sourceParentId: root.id,
+        sourceName: source.name,
+        destinationParentId: root.id,
+        destinationName: destination.name,
+      }
+    );
+    expect(renameResponse.status).toBe(200);
+    const renamed = FileSystemOperationResponseSchema.parse(
+      await renameResponse.json()
+    );
+    expect(renamed.node?.id).toBe(source.id);
+    expect(renamed.replacedNodeId).toBe(destination.id);
+
+    const removeResponse = await requestFileSystem(
+      context.workspace.sId,
+      token,
+      {
+        operation: "remove",
+        requestId: randomUUID(),
+        parentId: root.id,
+        name: destination.name,
+        kind: "file",
+      }
+    );
+    expect(removeResponse.status).toBe(200);
+    const removed = FileSystemOperationResponseSchema.parse(
+      await removeResponse.json()
+    );
+    expect(removed.removedNodeId).toBe(source.id);
+  });
+
   it("rejects malformed filesystem operations before running them", async () => {
     const context = await createSandboxTokenTestContext();
     const token = await generateSandboxFileSystemToken(context.auth, {

--- a/front/lib/api/file_system/namespace.test.ts
+++ b/front/lib/api/file_system/namespace.test.ts
@@ -497,18 +497,24 @@ describe("filesystem namespace rename", () => {
       parentId: root.id,
       name: request.destinationName,
     });
+    expect(renamedRes.isOk() && renamedRes.value.replacedNodeId).toBeNull();
     expect(retriedRes.isOk() && retriedRes.value.node).toMatchObject({
       id: source.id,
       name: request.destinationName,
     });
+    expect(retriedRes.isOk() && retriedRes.value.replacedNodeId).toBeNull();
     expect(oldPathRes.isOk() && oldPathRes.value.node).toBeNull();
     expect(newPathRes.isOk() && newPathRes.value.node?.id).toBe(source.id);
     expect(noOpRes.isOk() && noOpRes.value.node?.id).toBe(source.id);
+    expect(noOpRes.isOk() && noOpRes.value.replacedNodeId).toBeNull();
     expect(reusedRequestIdRes.isErr() && reusedRequestIdRes.error.code).toBe(
       "invalid_operation"
     );
     expect(replacementRes.isOk() && replacementRes.value.node?.id).toBe(
       replacement.id
+    );
+    expect(replacementRes.isOk() && replacementRes.value.replacedNodeId).toBe(
+      source.id
     );
     expect(replacedSourceRes.isErr() && replacedSourceRes.error.code).toBe(
       "not_found"
@@ -517,6 +523,10 @@ describe("filesystem namespace rename", () => {
       replayedAfterReplacementRes.isOk() &&
         replayedAfterReplacementRes.value.node
     ).toEqual(renamedRes.isOk() ? renamedRes.value.node : undefined);
+    expect(
+      replayedAfterReplacementRes.isOk() &&
+        replayedAfterReplacementRes.value.replacedNodeId
+    ).toBeNull();
   });
 
   it("moves a directory tree between conversation and Pod roots", async () => {
@@ -682,6 +692,9 @@ describe("filesystem namespace rename", () => {
       name: destination.name,
       blobId: source.blobId,
     });
+    expect(renamedRes.isOk() && renamedRes.value.replacedNodeId).toBe(
+      destination.id
+    );
     expect(replacedNodeRes.isErr() && replacedNodeRes.error.code).toBe(
       "not_found"
     );
@@ -732,6 +745,9 @@ describe("filesystem namespace rename", () => {
       id: source.id,
       name: destination.name,
     });
+    expect(renamedRes.isOk() && renamedRes.value.replacedNodeId).toBe(
+      destination.id
+    );
     expect(replacedNodeRes.isErr() && replacedNodeRes.error.code).toBe(
       "not_found"
     );
@@ -996,6 +1012,11 @@ describe("filesystem namespace removal", () => {
       scope,
       request
     );
+    const replacement = await createNode(authenticator, scope, {
+      parentId: root.id,
+      name: file.name,
+      kind: "file",
+    });
     const retriedRes = await applyFileSystemOperation(
       authenticator,
       scope,
@@ -1021,12 +1042,12 @@ describe("filesystem namespace removal", () => {
       { blobId }
     );
 
-    expect(removedRes.isOk() && removedRes.value).toEqual({});
-    expect(retriedRes.isOk() && retriedRes.value).toEqual({});
+    expect(removedRes.isOk() && removedRes.value.removedNodeId).toBe(file.id);
+    expect(retriedRes.isOk() && retriedRes.value.removedNodeId).toBe(file.id);
     expect(reusedRequestIdRes.isErr() && reusedRequestIdRes.error.code).toBe(
       "invalid_operation"
     );
-    expect(lookupRes.isOk() && lookupRes.value.node).toBeNull();
+    expect(lookupRes.isOk() && lookupRes.value.node?.id).toBe(replacement.id);
     expect(getAttrRes.isErr() && getAttrRes.error.code).toBe("not_found");
     expect(cleanup).toMatchObject({ nodeId: file.id, blobId });
   });

--- a/front/lib/api/file_system/namespace.ts
+++ b/front/lib/api/file_system/namespace.ts
@@ -117,17 +117,24 @@ export async function applyFileSystemOperation(
         request
       );
 
-      return removedRes.isErr() ? removedRes : new Ok({});
+      return removedRes.isErr()
+        ? removedRes
+        : new Ok({ removedNodeId: removedRes.value });
     }
 
     case "rename": {
-      const nodeRes = await FileSystemMutationResource.renameNode(
+      const renamedRes = await FileSystemMutationResource.renameNode(
         auth,
         scope,
         request
       );
 
-      return nodeRes.isErr() ? nodeRes : new Ok({ node: nodeRes.value });
+      return renamedRes.isErr()
+        ? renamedRes
+        : new Ok({
+            node: renamedRes.value.node,
+            replacedNodeId: renamedRes.value.replacedNodeId,
+          });
     }
 
     case "getContent": {

--- a/front/lib/api/file_system/namespace_types.ts
+++ b/front/lib/api/file_system/namespace_types.ts
@@ -180,6 +180,8 @@ export type FileSystemOperation = z.infer<typeof FileSystemOperationSchema>;
 export const FileSystemOperationResponseSchema = z.object({
   roots: z.array(FileSystemNodeSchema).optional(),
   node: FileSystemNodeSchema.nullable().optional(),
+  removedNodeId: FileSystemNodeIdSchema.optional(),
+  replacedNodeId: FileSystemNodeIdSchema.nullable().optional(),
   nodes: z.array(FileSystemNodeSchema).optional(),
   nextAfterName: z.string().nullable().optional(),
   content: FileSystemContentSchema.optional(),

--- a/front/lib/resources/file_system_mutation_resource.ts
+++ b/front/lib/resources/file_system_mutation_resource.ts
@@ -30,6 +30,7 @@ const CreateMutationResponseSchema = z.object({
   nodeId: z.number().int().positive(),
 });
 const RemoveMutationResponseSchema = z.object({
+  nodeId: z.number().int().positive(),
   parentId: z.number().int().positive(),
   name: z.string(),
   nodeKind: FileSystemNodeSchema.shape.kind,
@@ -38,11 +39,17 @@ const RemoveMutationResponseSchema = z.object({
 });
 const RenameMutationResponseSchema = z.object({
   node: FileSystemNodeSchema,
+  replacedNodeId: z.number().int().positive().nullable(),
   sourceParentId: z.number().int().positive(),
   sourceName: z.string(),
   destinationParentId: z.number().int().positive(),
   destinationName: z.string(),
 });
+
+interface RenameNodeResult {
+  node: FileSystemNodeType;
+  replacedNodeId: number | null;
+}
 
 const FILE_SYSTEM_NAMESPACE_LOCK_PREFIX = "file_system_namespace";
 
@@ -168,7 +175,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
   private async renamedNode(
     scope: FileSystemScope,
     request: RenameRequest
-  ): Promise<Result<FileSystemNodeType, FileSystemOperationError>> {
+  ): Promise<Result<RenameNodeResult, FileSystemOperationError>> {
     if (this.kind !== "rename") {
       return new Err(
         new FileSystemOperationError(
@@ -212,13 +219,16 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
 
     // Return the result saved by the first request. Fetching the node again
     // could return a later move, or nothing if another rename replaced it.
-    return new Ok(parsed.data.node);
+    return new Ok({
+      node: parsed.data.node,
+      replacedNodeId: parsed.data.replacedNodeId,
+    });
   }
 
   private async removedNode(
     scope: FileSystemScope,
     request: RemoveRequest
-  ): Promise<Result<undefined, FileSystemOperationError>> {
+  ): Promise<Result<number, FileSystemOperationError>> {
     if (this.kind !== "remove") {
       return new Err(
         new FileSystemOperationError(
@@ -266,7 +276,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
       );
     }
 
-    return new Ok(undefined);
+    return new Ok(parsed.data.nodeId);
   }
 
   static async createNode(
@@ -371,7 +381,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
     auth: Authenticator,
     scope: FileSystemScope,
     request: RenameRequest
-  ): Promise<Result<FileSystemNodeType, FileSystemOperationError>> {
+  ): Promise<Result<RenameNodeResult, FileSystemOperationError>> {
     const requestIdRes = this.validateRequestId(request.requestId);
     if (requestIdRes.isErr()) {
       return requestIdRes;
@@ -434,7 +444,11 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
       if (movedRes.isErr()) {
         return movedRes;
       }
-      const node = movedRes.value.toJSON();
+      const node = movedRes.value.node.toJSON();
+      const result = {
+        node,
+        replacedNodeId: movedRes.value.replacedNodeId,
+      };
 
       await this.model.create(
         {
@@ -444,6 +458,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
           kind: "rename",
           response: {
             node,
+            replacedNodeId: result.replacedNodeId,
             sourceParentId: request.sourceParentId,
             sourceName: request.sourceName,
             destinationParentId: request.destinationParentId,
@@ -453,7 +468,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
         { transaction }
       );
 
-      return new Ok(node);
+      return new Ok(result);
     });
   }
 
@@ -461,7 +476,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
     auth: Authenticator,
     scope: FileSystemScope,
     request: RemoveRequest
-  ): Promise<Result<undefined, FileSystemOperationError>> {
+  ): Promise<Result<number, FileSystemOperationError>> {
     const requestIdRes = this.validateRequestId(request.requestId);
     if (requestIdRes.isErr()) {
       return requestIdRes;
@@ -521,6 +536,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
             requestId: request.requestId,
             kind: "remove",
             response: {
+              nodeId: removedRes.value,
               parentId: request.parentId,
               name: request.name,
               nodeKind: request.kind,
@@ -531,7 +547,7 @@ export class FileSystemMutationResource extends BaseResource<FileSystemMutationM
           { transaction }
         );
 
-        return new Ok(undefined);
+        return removedRes;
       });
     } catch (error) {
       if (error instanceof UniqueConstraintError) {

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -66,6 +66,10 @@ type MoveOptions = Pick<
 > & {
   destinationParent: FileSystemNodeResource;
 };
+interface RenameChildResult {
+  node: FileSystemNodeResource;
+  replacedNodeId: number | null;
+}
 type PrepareContentUploadRequest = Extract<
   FileSystemOperation,
   { operation: "prepareContentUpload" }
@@ -573,7 +577,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     auth: Authenticator,
     scope: FileSystemScope,
     options: RemoveChildOptions
-  ): Promise<Result<undefined, FileSystemOperationError>> {
+  ): Promise<Result<number, FileSystemOperationError>> {
     const accessRes = this.checkWritableDirectory(auth, scope, {
       description: "parent",
     });
@@ -621,7 +625,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     }
 
     await child.destroyAndRetireBlob(auth, options.transaction);
-    return new Ok(undefined);
+    return new Ok(child.id);
   }
 
   private async moveDescendantsToRoot(
@@ -671,7 +675,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     auth: Authenticator,
     scope: FileSystemScope,
     options: MoveOptions
-  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+  ): Promise<Result<RenameChildResult, FileSystemOperationError>> {
     const nameRes = FileSystemNodeResource.validateName(
       options.destinationName
     );
@@ -683,7 +687,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       this.parentId === options.destinationParent.id &&
       this.name === options.destinationName
     ) {
-      return new Ok(this);
+      return new Ok({ node: this, replacedNodeId: null });
     }
 
     if (
@@ -732,6 +736,7 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       );
     }
 
+    const replacedNodeId = destination?.id ?? null;
     if (destination) {
       await destination.destroyAndRetireBlob(auth, options.transaction);
     }
@@ -756,14 +761,14 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
       options.transaction
     );
 
-    return new Ok(this);
+    return new Ok({ node: this, replacedNodeId });
   }
 
   async renameChild(
     auth: Authenticator,
     scope: FileSystemScope,
     options: RenameChildOptions
-  ): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+  ): Promise<Result<RenameChildResult, FileSystemOperationError>> {
     const sourceAccessRes = this.checkWritableDirectory(auth, scope, {
       description: "source",
     });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The filesystem daemon must know which node Front actually removed or replaced. Looking up the path before the mutation
is not enough because another sandbox may change that path first.

This PR makes Front return that information directly:
- `remove` returns `removedNodeId`
- `rename` returns `replacedNodeId`, or `null` when nothing was replaced

These IDs come from the rows changed inside the mutation transaction. They are also stored in the mutation receipt, so
retrying a request returns the original result even if the path has since been reused.

There is no database migration. Nothing consumes this endpoint yet.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
