### PR TITLE
[front] fix: Switch scroll sentinel in knowledge side panel

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceList.tsx
@@ -12,17 +12,11 @@ import {
   pathToString,
   removeNodeFromTree,
 } from "@app/components/data_source_view/context/utils";
+import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { isRemoteDatabase } from "@app/lib/data_sources";
 import { Checkbox, cn, Icon, Separator, Spinner } from "@dust-tt/sparkle";
 import type { ComponentType, ReactNode } from "react";
-import {
-  Fragment,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from "react";
+import { Fragment, useCallback, useContext, useMemo } from "react";
 
 export interface DataSourceListItem {
   id: string;
@@ -96,32 +90,11 @@ export function DataSourceList({
   const { field } = useSourcesFormController();
   const confirm = useContext(ConfirmContext);
 
-  const containerRef = useRef<HTMLDivElement>(null);
-
   const handleLoadMore = useCallback(async () => {
     if (hasMore && !isLoading && onLoadMore) {
       await onLoadMore();
     }
   }, [hasMore, isLoading, onLoadMore]);
-
-  // Infinite scroll implementation
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container || !hasMore || isLoading || !onLoadMore) {
-      return;
-    }
-
-    const handleScroll = () => {
-      const { scrollTop, scrollHeight, clientHeight } = container;
-      // Trigger loading when we're within 100px of the bottom
-      if (scrollHeight - scrollTop - clientHeight < 100) {
-        void handleLoadMore();
-      }
-    };
-
-    container.addEventListener("scroll", handleScroll);
-    return () => container.removeEventListener("scroll", handleScroll);
-  }, [hasMore, isLoading, onLoadMore, handleLoadMore]);
 
   const shouldHideCheckbox = useCallback(
     (item: DataSourceListItem): boolean => {
@@ -344,7 +317,6 @@ export function DataSourceList({
 
   return (
     <div
-      ref={containerRef}
       className={cn("flex max-h-full flex-col overflow-auto pr-1", className)}
     >
       {showSelectAllHeader && selectableItems.length > 0 && (
@@ -382,7 +354,13 @@ export function DataSourceList({
           <Fragment key={item.id}>
             <div
               className="flex cursor-pointer items-center justify-between rounded-md p-3 hover:bg-muted/60"
-              onClick={() => item.onClick?.()}
+              onClick={() => {
+                if (item.onClick) {
+                  item.onClick();
+                } else if (shouldShowCheckbox) {
+                  void handleSelectionChange(item, selectionState !== true);
+                }
+              }}
             >
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 {shouldShowCheckbox ? (
@@ -422,12 +400,17 @@ export function DataSourceList({
         );
       })}
 
-      {/* Loading indicator at the bottom */}
-      {isLoading && hasMore && (
-        <div className="flex justify-center py-4">
-          <Spinner size="sm" />
-        </div>
-      )}
+      <InfiniteScroll
+        nextPage={handleLoadMore}
+        hasMore={hasMore}
+        showLoader={isLoading && hasMore}
+        loader={
+          <div className="flex justify-center py-4">
+            <Spinner size="sm" />
+          </div>
+        }
+        options={{ rootMargin: "200px" }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description

The knowledge picker in the agent builder stops loading after the first 50 nodes, so anyone with a lot of nodes only sees the beginning of the alphabet. Fixes dust-tt/tasks#10086.

The infinite scroll in DataSourceList was listening for scroll on its own container, and that container never scrolls. It is replaced it with our InfiniteScroll component.

## Tests

Tested locally

## Risk

Low

Blast radius: DataSourceList only, 5 call sites, all inside the knowledge sheet. Only the node table passes onLoadMore, the other four keep hasMore false so the sentinel and the loader never render. Clicked through spaces, categories, data source views, nodes, nested nodes and search, plus selection and select all.

## Deploy Plan

Deploy front.