### PR TITLE
[front] Fix lazy-seed race in the spend-cap counters

### DIFF
--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -18,7 +18,7 @@ import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
   addFixedWindowCount,
   getFixedWindowCount,
-  setFixedWindowCount,
+  seedFixedWindowCountIfAbsent,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -168,13 +168,13 @@ async function readProgrammaticSpendLimitCountWithLazySeed(
   if (consumed === null || consumed <= 0) {
     return 0;
   }
-  await setFixedWindowCount({
+  const seedResult = await seedFixedWindowCountIfAbsent({
     key: redisKey,
     bounds,
     value: consumed,
     logger,
   });
-  return consumed;
+  return seedResult.isOk() ? seedResult.value : consumed;
 }
 
 /**

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -17,8 +17,7 @@ import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
 import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
   addFixedWindowCount,
-  getFixedWindowCount,
-  seedFixedWindowCountIfAbsent,
+  readFixedWindowCountWithLazySeed,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -154,27 +153,12 @@ async function readProgrammaticSpendLimitCountWithLazySeed(
   auth: Authenticator,
   { redisKey, bounds }: { redisKey: string; bounds: FixedWindowBounds }
 ): Promise<number | null> {
-  const countResult = await getFixedWindowCount({ key: redisKey, bounds });
-  if (countResult.isErr()) {
-    return null;
-  }
-  if (countResult.value > 0) {
-    return countResult.value;
-  }
-
-  const consumed = await getEsConsumedProgrammaticAwuCredits(auth, {});
-  // `null` means the ES read failed (or no cycle) — treat as unknown and skip
-  // the seed rather than writing 0 (fail-open read).
-  if (consumed === null || consumed <= 0) {
-    return 0;
-  }
-  const seedResult = await seedFixedWindowCountIfAbsent({
+  return readFixedWindowCountWithLazySeed({
     key: redisKey,
     bounds,
-    value: consumed,
     logger,
+    fetchSeedValue: () => getEsConsumedProgrammaticAwuCredits(auth, {}),
   });
-  return seedResult.isOk() ? seedResult.value : consumed;
 }
 
 /**

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -17,7 +17,7 @@ import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
   addFixedWindowCount,
   getFixedWindowCount,
-  setFixedWindowCount,
+  seedFixedWindowCountIfAbsent,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
@@ -362,15 +362,16 @@ async function readApiKeySpendLimitCountWithLazySeed(
     0,
     Math.round(await getEsConsumedAwuCreditsForApiKey(auth, { apiKeyName }))
   );
-  if (consumed > 0) {
-    await setFixedWindowCount({
-      key: redisKey,
-      bounds,
-      value: consumed,
-      logger,
-    });
+  if (consumed <= 0) {
+    return 0;
   }
-  return consumed;
+  const seedResult = await seedFixedWindowCountIfAbsent({
+    key: redisKey,
+    bounds,
+    value: consumed,
+    logger,
+  });
+  return seedResult.isOk() ? seedResult.value : consumed;
 }
 
 /**

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -16,8 +16,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
   addFixedWindowCount,
-  getFixedWindowCount,
-  seedFixedWindowCountIfAbsent,
+  readFixedWindowCountWithLazySeed,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
@@ -350,28 +349,13 @@ async function readApiKeySpendLimitCountWithLazySeed(
     bounds,
   }: { apiKeyName: string; redisKey: string; bounds: FixedWindowBounds }
 ): Promise<number | null> {
-  const countResult = await getFixedWindowCount({ key: redisKey, bounds });
-  if (countResult.isErr()) {
-    return null;
-  }
-  if (countResult.value > 0) {
-    return countResult.value;
-  }
-
-  const consumed = Math.max(
-    0,
-    Math.round(await getEsConsumedAwuCreditsForApiKey(auth, { apiKeyName }))
-  );
-  if (consumed <= 0) {
-    return 0;
-  }
-  const seedResult = await seedFixedWindowCountIfAbsent({
+  return readFixedWindowCountWithLazySeed({
     key: redisKey,
     bounds,
-    value: consumed,
     logger,
+    fetchSeedValue: () =>
+      getEsConsumedAwuCreditsForApiKey(auth, { apiKeyName }),
   });
-  return seedResult.isOk() ? seedResult.value : consumed;
 }
 
 /**

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -35,8 +35,7 @@ import { revertOnSyncFailure } from "@app/lib/spend_limits/revert_on_sync_failur
 import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
   addFixedWindowCount,
-  getFixedWindowCount,
-  seedFixedWindowCountIfAbsent,
+  readFixedWindowCountWithLazySeed,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
@@ -528,28 +527,12 @@ async function readSpendLimitCountWithLazySeed(
     cycle?: BillingCycle;
   }
 ): Promise<number | null> {
-  const countResult = await getFixedWindowCount({ key, bounds });
-  if (countResult.isErr()) {
-    return null;
-  }
-  if (countResult.value > 0) {
-    return countResult.value;
-  }
-
-  const consumed = Math.max(
-    0,
-    Math.round(await getEsConsumedAwuCreditsForUser(auth, { user, cycle }))
-  );
-  if (consumed <= 0) {
-    return 0;
-  }
-  const seedResult = await seedFixedWindowCountIfAbsent({
+  return readFixedWindowCountWithLazySeed({
     key,
     bounds,
-    value: consumed,
     logger,
+    fetchSeedValue: () => getEsConsumedAwuCreditsForUser(auth, { user, cycle }),
   });
-  return seedResult.isOk() ? seedResult.value : consumed;
 }
 
 /**

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -36,7 +36,7 @@ import type { FixedWindowBounds } from "@app/lib/utils/rate_limiter";
 import {
   addFixedWindowCount,
   getFixedWindowCount,
-  setFixedWindowCount,
+  seedFixedWindowCountIfAbsent,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type {
@@ -503,10 +503,12 @@ export async function expireUserSpendLimitOverride(
  * live (the first recorded delta bumps it above 0), so it's used as-is with no
  * ES read.
  *
- * Re-seeding on a 0 count is idempotent and cheap; `SET` (not `INCRBY`) makes
- * concurrent first-message seeds converge on the same value instead of doubling.
- * Recording (`recordUserSpendLimitUsage`) runs post-finalize, after this
- * send-time seed, so it accrues on top of the seeded value.
+ * The seed is applied with `seedFixedWindowCountIfAbsent` (atomic SET-if-absent,
+ * not a plain SET): if a concurrent `recordUserSpendLimitUsage` INCRBY lands
+ * while the ES value is being computed, the seed leaves that live value untouched
+ * rather than clobbering it, and returns the effective count. Recording runs
+ * post-finalize, after this send-time seed, so it accrues on top of the seeded
+ * value.
  *
  * Returns the effective count, or `null` on a Redis read error (caller fails
  * open). A seed write failure degrades to the ES value rather than throwing.
@@ -538,10 +540,16 @@ async function readSpendLimitCountWithLazySeed(
     0,
     Math.round(await getEsConsumedAwuCreditsForUser(auth, { user, cycle }))
   );
-  if (consumed > 0) {
-    await setFixedWindowCount({ key, bounds, value: consumed, logger });
+  if (consumed <= 0) {
+    return 0;
   }
-  return consumed;
+  const seedResult = await seedFixedWindowCountIfAbsent({
+    key,
+    bounds,
+    value: consumed,
+    logger,
+  });
+  return seedResult.isOk() ? seedResult.value : consumed;
 }
 
 /**

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -374,6 +374,77 @@ export async function setFixedWindowCount({
 }
 
 /**
+ * Atomically seeds the fixed-window counter for `key` in the window identified
+ * by `bounds` to `value`, but only if it does not already exist, and returns the
+ * effective count afterwards (the seeded `value`, or the current value when a
+ * concurrent `addFixedWindowCount` already created it).
+ *
+ * Unlike `setFixedWindowCount`, this never overwrites a live counter: use it for
+ * lazy backfill on a read miss, where an `addFixedWindowCount` (INCRBY) landing
+ * while the seed value is being computed must not be clobbered (which would
+ * undercount usage). Returns a Result so callers can fall back on failure.
+ */
+export async function seedFixedWindowCountIfAbsent({
+  key,
+  bounds,
+  value,
+  logger,
+}: {
+  key: string;
+  bounds: FixedWindowBounds;
+  value: number;
+  logger: LoggerInterface;
+}): Promise<Result<number, Error>> {
+  if (!Number.isInteger(value) || value < 0) {
+    return new Err(new Error("value must be a non-negative integer."));
+  }
+
+  const redisKey = makeRateLimiterKey(`${key}:${bounds.label}`);
+  const expireAtMs = bounds.windowEndMs + FIXED_WINDOW_EXPIRE_GRACE_MS;
+
+  // Seed-if-absent + read-back in one atomic step: only SET (and set the expiry)
+  // when the key is missing, otherwise leave the concurrently-written value
+  // untouched. Returns the effective count either way.
+  const luaScript = `
+    local key = KEYS[1]
+    local value = tonumber(ARGV[1])
+    local expire_at_ms = tonumber(ARGV[2])
+
+    local existing = redis.call('GET', key)
+    if existing == false then
+      redis.call('SET', key, value)
+      redis.call('PEXPIREAT', key, expire_at_ms)
+      return value
+    end
+    return tonumber(existing)
+  `;
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    const effective = await redis.eval(luaScript, {
+      keys: [redisKey],
+      arguments: [value.toString(), expireAtMs.toString()],
+    });
+    const count = Number(effective);
+    if (!Number.isFinite(count)) {
+      return new Err(
+        new Error(`Non-numeric fixed-window count: ${String(effective)}`)
+      );
+    }
+    return new Ok(count);
+  } catch (e) {
+    getStatsDClient().increment("ratelimiter.error.count", 1, [
+      "operation:seed_fixed_window",
+    ]);
+    logger.error(
+      { key, label: bounds.label, value, error: e },
+      "seedFixedWindowCountIfAbsent error"
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+/**
  * Reads the current fixed-window count for `key` in the window identified by
  * `bounds`. Returns 0 when the window has no entries yet. Mirrors
  * `getRateLimiterCount` but for the boundary-bucketed counter written by

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -402,21 +402,21 @@ export async function seedFixedWindowCountIfAbsent({
   const redisKey = makeRateLimiterKey(`${key}:${bounds.label}`);
   const expireAtMs = bounds.windowEndMs + FIXED_WINDOW_EXPIRE_GRACE_MS;
 
-  // Seed-if-absent + read-back in one atomic step: only SET (and set the expiry)
-  // when the key is missing, otherwise leave the concurrently-written value
-  // untouched. Returns the effective count either way.
+  // Seed-if-absent + read-back in one atomic step: SET NX only writes (and sets
+  // the expiry) when the key is missing, otherwise the concurrently-written
+  // value is read back untouched. Returns the effective count either way.
   const luaScript = `
     local key = KEYS[1]
     local value = tonumber(ARGV[1])
     local expire_at_ms = tonumber(ARGV[2])
 
-    local existing = redis.call('GET', key)
-    if existing == false then
-      redis.call('SET', key, value)
+    local seeded = redis.call('SET', key, value, 'NX')
+    if seeded then
       redis.call('PEXPIREAT', key, expire_at_ms)
       return value
     end
-    return tonumber(existing)
+
+    return redis.call('GET', key)
   `;
 
   try {
@@ -425,10 +425,16 @@ export async function seedFixedWindowCountIfAbsent({
       keys: [redisKey],
       arguments: [value.toString(), expireAtMs.toString()],
     });
+    // A well-formed counter is always a non-negative integer. Guard against a
+    // nil/malformed reply rather than letting `Number(null)` collapse to a
+    // silent 0.
+    if (effective === null || effective === undefined) {
+      return new Err(new Error("Empty fixed-window count reply."));
+    }
     const count = Number(effective);
-    if (!Number.isFinite(count)) {
+    if (!Number.isSafeInteger(count) || count < 0) {
       return new Err(
-        new Error(`Non-numeric fixed-window count: ${String(effective)}`)
+        new Error(`Non-integer fixed-window count: ${String(effective)}`)
       );
     }
     return new Ok(count);
@@ -442,6 +448,49 @@ export async function seedFixedWindowCountIfAbsent({
     );
     return new Err(normalizeError(e));
   }
+}
+
+/**
+ * Reads a fixed-window counter, lazily seeding it from `fetchSeedValue` on a
+ * read miss (count 0). Shared by the spend-cap backups so their read/seed flow
+ * stays in one place (`getFixedWindowCount` → return if positive → fetch seed →
+ * `seedFixedWindowCountIfAbsent` → effective count).
+ *
+ * Returns the effective count, or `null` when the Redis read errored (callers
+ * fail open). A `null` from `fetchSeedValue` (the seed source couldn't be
+ * determined — e.g. an Elasticsearch outage) is treated as "nothing to seed"
+ * and yields 0, so the counter is never overwritten from a failed read.
+ */
+export async function readFixedWindowCountWithLazySeed({
+  key,
+  bounds,
+  fetchSeedValue,
+  logger,
+}: {
+  key: string;
+  bounds: FixedWindowBounds;
+  fetchSeedValue: () => Promise<number | null>;
+  logger: LoggerInterface;
+}): Promise<number | null> {
+  const countResult = await getFixedWindowCount({ key, bounds });
+  if (countResult.isErr()) {
+    return null;
+  }
+  if (countResult.value > 0) {
+    return countResult.value;
+  }
+
+  const seedValue = await fetchSeedValue();
+  if (seedValue === null || seedValue <= 0) {
+    return 0;
+  }
+  const seedResult = await seedFixedWindowCountIfAbsent({
+    key,
+    bounds,
+    value: seedValue,
+    logger,
+  });
+  return seedResult.isOk() ? seedResult.value : seedValue;
 }
 
 /**


### PR DESCRIPTION
## Description

Addresses @avervaet's review note on #30641: the spend-cap lazy seed used an unconditional `SET`, which could clobber a concurrent `addFixedWindowCount` (INCRBY) landing while the Elasticsearch seed value was being computed — undercounting usage.

Applies across **all four** spend-cap counters (per-user, per-API-key, programmatic, workspace usage cap). Stacked on #30655.

- Adds `seedFixedWindowCountIfAbsent` to the rate limiter: an atomic SET-if-absent (via Lua) that seeds the counter only when the key is missing and returns the *effective* count (the seeded value, or the concurrently-written value if an INCRBY won the race).
- Each lazy seed now uses it instead of the unconditional `setFixedWindowCount`, and returns the effective count so enforcement reads the authoritative value rather than the (possibly stale) ES value.
- The unconditional `setFixedWindowCount` stays on the poke resync path, where overwriting from the source of truth is intentional.

## Tests

- `npx tsgo --noEmit` passes; `biome check` clean.
- No new automated tests (internal rate-limiter primitive + message-send path). The race is a narrow interleaving (an INCRBY during the ES-await on a fresh key); the atomic Lua makes seed-vs-increment ordering well-defined.

## Risk

- **Low.** Behavior is unchanged in the common (non-race) case: absent key → seed to ES value → return it. Off by default behind the same `enforce_user_spend_limit_rate_cap` flag.
- Strictly safer than before: the seed can no longer overwrite a live INCRBY. Any residual race (an INCRBY winning before the seed) leaves the live value in place and skips the ES baseline for that read — an under-count (fails toward under-blocking), corrected by the next poke resync.
- Safe to roll back via revert.

## Deploy Plan

1. Merge after #30655; deploy `front` normally. No migration.
2. No runtime effect until the `enforce_user_spend_limit_rate_cap` flag is enabled (unchanged rollout).
