### PR TITLE
fix: prevent the triggers tool from clearing system-owned statuses

### DIFF
--- a/front/lib/api/actions/servers/triggers_management/tools/index.ts
+++ b/front/lib/api/actions/servers/triggers_management/tools/index.ts
@@ -399,6 +399,16 @@ export function createTriggersManagementTools(
         return new Err(new MCPError("Trigger not found"));
       }
 
+      // An admin editor could otherwise clear a system-owned status
+      // (relocating/downgraded), losing the marker the restore jobs key on.
+      if (trigger.isSystemStatusTransitionTo("disabled")) {
+        return new Err(
+          new MCPError(
+            "This trigger's status is managed by Dust and cannot be changed."
+          )
+        );
+      }
+
       const triggerName = trigger.name;
       const result = await trigger.disable(auth);
 


### PR DESCRIPTION
## Description

Follow-up to #30661. The triggers-management MCP tool calls `trigger.disable(auth)` under the calling user's auth; when that user is an admin editor, `canUpdateStatusTo` lets the call move a `relocating`/`downgraded` trigger to plain `disabled` — permanently losing the marker the restore bulk jobs key on (`enableAllForWorkspace` filters `status === fromStatus`). The tool now pre-checks `isSystemStatusTransitionTo("disabled")` and returns a clear MCPError instead, matching the guard the HTTP surfaces already have.

## Tests

Guard delegates to `TriggerResource.isSystemStatusTransitionTo`, covered by the #30661 suite; the MCP tool handlers have no test harness today. tsgo + biome clean.

## Risk

Agent-invokable path only; strictly narrows what the tool can do. Non-admin editors were already blocked by the resource policy.