### PR TITLE
[front] enh: increase contrast on consumption chart (new analytics)

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -93,11 +93,11 @@ const PARTIAL_BAR_OPACITY = "opacity-40";
 
 const CONSUMPTION_CHART_COLORS = [
   "text-blue-900",
-  "text-blue-800",
   "text-blue-700",
-  "text-blue-600",
   "text-blue-500",
-  "text-blue-400",
+  "text-blue-300",
+  "text-blue-100",
+  "text-blue-50",
 ] as const;
 
 // Request the top five categories, leaving the sixth shade available when the


### PR DESCRIPTION
## Description

This PR increases the contrast on the colors used in the bar chart of the new analytics.
Goes from steps 100 by 100 to 200 by 200.

Before
<img width="1093" height="339" alt="image" src="https://github.com/user-attachments/assets/855a5ffb-aa55-4e61-90ec-24655eb1d26a" />

After
<img width="1093" height="354" alt="image" src="https://github.com/user-attachments/assets/61c5e0b9-99dc-4e9c-a06e-17b5418dd284" />

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
