### PR TITLE
[connectors] fix: github - Never automatically skip repository

### DIFF
--- a/connectors/migrations/20260818_clear_github_persistent_download_failure_skips.ts
+++ b/connectors/migrations/20260818_clear_github_persistent_download_failure_skips.ts
@@ -1,0 +1,27 @@
+import { GithubCodeRepositoryModel } from "@connectors/lib/models/github";
+import { makeScript } from "scripts/helpers";
+
+makeScript({}, async ({ execute }, logger) => {
+  const where = { skipReason: "persistent_download_failure" };
+
+  const repositoriesCount = await GithubCodeRepositoryModel.count({ where });
+  logger.info(
+    { repositoriesCount },
+    "Found GitHub repositories skipped on persistent download failure"
+  );
+
+  if (!execute) {
+    logger.info("Dry run mode. Pass -e to clear their skipReason.");
+    return;
+  }
+
+  const [updatedCount] = await GithubCodeRepositoryModel.update(
+    { skipReason: null },
+    { where }
+  );
+
+  logger.info(
+    { updatedCount },
+    "Cleared skipReason on GitHub repositories, code sync will be retried"
+  );
+});

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -7,6 +7,7 @@ import {
   isSupportedFile,
 } from "@connectors/connectors/github/lib/code/supported_files";
 import {
+  describeGithubError,
   isGithubRequestErrorNotFound,
   isGithubRequestErrorRepositoryAccessBlocked,
   RepositoryAccessBlockedError,
@@ -217,6 +218,8 @@ export async function extractGitHubTarballToGCS(
   for (let attempt = 0; attempt < MAX_TARBALL_EXTRACTION_RETRIES; attempt++) {
     let filesUploaded = 0;
     let filesSkipped = 0;
+    let contentLength: number | null = null;
+    const downloadStartedAtMs = Date.now();
     const seenDirs = new Set<string>();
 
     // Create upload queue to limit concurrent GCS uploads.
@@ -364,7 +367,8 @@ export async function extractGitHubTarballToGCS(
         return new Err(streamResult.error);
       }
 
-      const { stream: tarballStream, contentLength } = streamResult.value;
+      const { stream: tarballStream } = streamResult.value;
+      contentLength = streamResult.value.contentLength;
 
       // Track bytes received for content-length validation.
       // Use Buffer.byteLength for strings to handle multi-byte characters correctly.
@@ -436,6 +440,19 @@ export async function extractGitHubTarballToGCS(
     } catch (error) {
       lastError = error;
 
+      const downloadContext = {
+        ...describeGithubError(error),
+        error,
+        bytesReceived,
+        contentLength,
+        downloadDurationMs: Date.now() - downloadStartedAtMs,
+        extractionAttempt: attempt,
+        filesUploaded,
+        maxExtractionAttempts: MAX_TARBALL_EXTRACTION_RETRIES,
+        missingBytes:
+          contentLength !== null ? contentLength - bytesReceived : null,
+      };
+
       // Check if this is a retryable error.
       if (
         isRetryableStreamError(error) &&
@@ -443,13 +460,7 @@ export async function extractGitHubTarballToGCS(
       ) {
         const delay = TARBALL_RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
         childLogger.warn(
-          {
-            error,
-            attempt,
-            maxAttempts: MAX_TARBALL_EXTRACTION_RETRIES,
-            bytesReceived,
-            delay,
-          },
+          { ...downloadContext, delay },
           "Retryable stream error during tarball extraction, will retry"
         );
         await setTimeoutAsync(delay);
@@ -458,12 +469,7 @@ export async function extractGitHubTarballToGCS(
 
       // Non-retryable error or max retries reached.
       childLogger.error(
-        {
-          error,
-          attempt,
-          maxAttempts: MAX_TARBALL_EXTRACTION_RETRIES,
-          bytesReceived,
-        },
+        downloadContext,
         "Non-retryable error or max retries reached during tarball extraction"
       );
       throw error;

--- a/connectors/src/connectors/github/lib/errors.ts
+++ b/connectors/src/connectors/github/lib/errors.ts
@@ -120,3 +120,50 @@ export function isTransientNetworkError(error: unknown): boolean {
     error.message.toLowerCase().includes(msg.toLowerCase())
   );
 }
+
+const MAX_ERROR_CAUSE_DEPTH = 5;
+
+interface GithubErrorDetails {
+  errorCauses: string[];
+  errorCode: string | null;
+  errorMessage: string;
+  errorName: string;
+  githubRateLimitRemaining: string | number | null;
+  githubRequestId: string | number | null;
+  githubRetryAfter: string | number | null;
+  githubStatus: number | null;
+  isTransient: boolean;
+}
+
+function getErrorCode(error: Error): string | null {
+  return "code" in error && typeof error.code === "string" ? error.code : null;
+}
+
+export function describeGithubError(error: unknown): GithubErrorDetails {
+  const normalizedError = normalizeError(error);
+
+  const errorCauses: string[] = [];
+  let cause: unknown = normalizedError.cause;
+  while (cause instanceof Error && errorCauses.length < MAX_ERROR_CAUSE_DEPTH) {
+    const causeCode = getErrorCode(cause);
+    errorCauses.push(
+      `${cause.name}: ${cause.message}${causeCode ? ` (${causeCode})` : ""}`
+    );
+    cause = cause.cause;
+  }
+
+  const headers =
+    error instanceof RequestError ? error.response?.headers : undefined;
+
+  return {
+    errorCauses,
+    errorCode: getErrorCode(normalizedError),
+    errorMessage: normalizedError.message,
+    errorName: normalizedError.name,
+    githubRateLimitRemaining: headers?.["x-ratelimit-remaining"] ?? null,
+    githubRequestId: headers?.["x-github-request-id"] ?? null,
+    githubRetryAfter: headers?.["retry-after"] ?? null,
+    githubStatus: error instanceof RequestError ? error.status : null,
+    isTransient: isTransientNetworkError(error),
+  };
+}

--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -8,9 +8,9 @@ import {
   TarballNotFoundError,
 } from "@connectors/connectors/github/lib/code/tar_extraction";
 import {
+  describeGithubError,
   isBadCredentials,
   isGithubRequestErrorNotFound,
-  isTransientNetworkError,
   RepositoryAccessBlockedError,
 } from "@connectors/connectors/github/lib/errors";
 import { getOctokit } from "@connectors/connectors/github/lib/github_api";
@@ -34,6 +34,7 @@ import {
   GithubCodeRepositoryModel,
   GithubConnectorStateModel,
 } from "@connectors/lib/models/github";
+import { syncFailed } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -48,6 +49,8 @@ const PARALLEL_FILE_UPLOADS = 128;
 const PARALLEL_DIRECTORY_UPLOADS = 64;
 
 const GITHUB_TARBALL_DOWNLOAD_TIMEOUT_MS = 20 * 60 * 1000; // 20 minutes.
+
+const ATTEMPTS_BEFORE_REPORTING_SYNC_FAILURE = 20;
 
 export async function githubExtractToGcsActivity({
   connectorId,
@@ -70,10 +73,13 @@ export async function githubExtractToGcsActivity({
     throw new Error(`Connector ${connectorId} not found`);
   }
 
+  const activityAttempt = Context.current().info.attempt;
+
   const logger = getActivityLogger(connector, {
     repoName,
     repoLogin,
     repoId,
+    activityAttempt,
     activityType: "githubExtractToGcsActivity",
   });
 
@@ -121,13 +127,26 @@ export async function githubExtractToGcsActivity({
     return null;
   }
 
-  logger.info("Setting up tarball stream provider for extraction");
+  const repoSizeKb = repoInfo.size;
+
+  logger.info(
+    { repoSizeKb },
+    "Setting up tarball stream provider for extraction"
+  );
+
+  let tarballFetchCount = 0;
+  let tarballContentLengthBytes: number | null = null;
 
   // Create a stream provider that can fetch a fresh tarball stream on each attempt.
   // This is necessary because streams can only be consumed once, so retries need fresh streams.
   const tarballStreamProvider: TarballStreamProvider = {
     getStream: async () => {
-      logger.info("Fetching GitHub repository tarball");
+      tarballFetchCount += 1;
+
+      logger.info(
+        { repoSizeKb, tarballFetchCount },
+        "Fetching GitHub repository tarball"
+      );
 
       const octokit = await getOctokit(connector);
 
@@ -148,9 +167,10 @@ export async function githubExtractToGcsActivity({
         // Extract content-length from headers if available.
         const headers = response.headers;
         const contentLength = headers["content-length"] ?? null;
+        tarballContentLengthBytes = contentLength;
 
         logger.info(
-          { contentLength },
+          { contentLength, repoSizeKb, tarballFetchCount },
           "Tarball stream obtained from GitHub API"
         );
 
@@ -184,12 +204,15 @@ export async function githubExtractToGcsActivity({
           });
         }
 
-        if (isTransientNetworkError(error)) {
-          logger.warn(
-            { err: error, repoLogin, repoName, repoId },
-            "Transient network error fetching tarball, will be retried."
-          );
-        }
+        logger.error(
+          {
+            ...describeGithubError(error),
+            err: error,
+            repoSizeKb,
+            tarballFetchCount,
+          },
+          "Failed to fetch GitHub repository tarball, will be retried."
+        );
 
         throw error;
       }
@@ -198,7 +221,7 @@ export async function githubExtractToGcsActivity({
 
   logger.info("Extracting GitHub repository tarball to GCS");
 
-  const MAX_ATTEMPTS_BEFORE_SKIP = 20;
+  const extractionStartedAtMs = Date.now();
 
   let extractResult;
   try {
@@ -211,25 +234,25 @@ export async function githubExtractToGcsActivity({
       logger
     );
   } catch (error) {
-    const attempt = Context.current().info.attempt;
+    const isPersistentFailure =
+      activityAttempt >= ATTEMPTS_BEFORE_REPORTING_SYNC_FAILURE;
 
-    if (isTransientNetworkError(error) && attempt >= MAX_ATTEMPTS_BEFORE_SKIP) {
-      logger.error(
-        { err: error, attempt },
-        "Persistent transient error after max attempts: marking repository as skipped."
-      );
+    logger.error(
+      {
+        ...describeGithubError(error),
+        err: error,
+        defaultBranch: repoInfo.default_branch,
+        extractionDurationMs: Date.now() - extractionStartedAtMs,
+        isPersistentFailure,
+        repoSizeKb,
+        tarballContentLengthBytes,
+        tarballFetchCount,
+      },
+      "Failed to extract GitHub repository tarball to GCS"
+    );
 
-      await GithubCodeRepositoryModel.update(
-        { skipReason: "persistent_download_failure" },
-        {
-          where: {
-            connectorId: connector.id,
-            repoId: repoId.toString(),
-          },
-        }
-      );
-
-      return null;
+    if (isPersistentFailure) {
+      await syncFailed(connectorId, "transient_upstream_error");
     }
 
     throw error;

--- a/connectors/src/types/api.ts
+++ b/connectors/src/types/api.ts
@@ -62,6 +62,7 @@ const CONNECTORS_ERROR_TYPES = [
   "oauth_token_revoked",
   "workspace_quota_exceeded",
   "third_party_internal_error",
+  "transient_upstream_error",
   "webcrawling_error",
   "webcrawling_error_empty_content",
   "webcrawling_error_content_too_large",

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -44,6 +44,17 @@ export default function ConnectorSyncingChip({
             trigger={<Chip color="warning">Synchronization failed</Chip>}
           />
         );
+      case "transient_upstream_error":
+        return (
+          <Tooltip
+            label={
+              `We are having trouble retrieving your data from ${CONNECTOR_CONFIGURATIONS[connector.type].name}. ` +
+              "Synchronization will resume automatically once the issue is resolved."
+            }
+            className="max-w-md"
+            trigger={<Chip color="warning">Synchronization delayed</Chip>}
+          />
+        );
       case "webcrawling_error_content_too_large":
         return (
           <Tooltip

--- a/front/lib/api/poke/plugins/data_sources/index.ts
+++ b/front/lib/api/poke/plugins/data_sources/index.ts
@@ -14,6 +14,7 @@ export * from "./notion_update_orphaned_resources_parents";
 export * from "./notion_url_sync";
 export * from "./operations";
 export * from "./remove_old_documents";
+export * from "./skip_github_repository";
 export * from "./skip_slack_channel";
 export * from "./slack_whitelist_bot";
 export * from "./toggle_restricted_space_agent_slack_access";

--- a/front/lib/api/poke/plugins/data_sources/skip_github_repository.ts
+++ b/front/lib/api/poke/plugins/data_sources/skip_github_repository.ts
@@ -1,0 +1,102 @@
+import config from "@app/lib/api/config";
+import { createPlugin } from "@app/lib/api/poke/types";
+import logger, { auditLog } from "@app/logger/logger";
+import type { AdminCommandType } from "@app/types/connectors/admin/cli";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const skipGithubRepositoryPlugin = createPlugin({
+  manifest: {
+    id: "skip-github-repository",
+    name: "Skip GitHub repository",
+    description: "Stop syncing the code of a GitHub repository",
+    resourceTypes: ["data_sources"],
+    warning:
+      "Code already synced for this repository stays in the data source but is not refreshed " +
+      "anymore. Running code sync workflows are not interrupted: terminate them in Temporal if " +
+      "one is stuck.",
+    args: {
+      repoId: {
+        type: "string",
+        label: "Repository ID",
+        description:
+          "Numeric GitHub repository ID, e.g. 12345678 for the node github-repository-12345678",
+      },
+      skipReason: {
+        type: "string",
+        label: "Skip reason",
+        description: "Why this repository is skipped, stored on the repository",
+      },
+    },
+    requiredRoles: ["support"],
+  },
+  isApplicableTo: (auth, dataSource) => {
+    if (!dataSource) {
+      return false;
+    }
+
+    return dataSource.connectorProvider === "github";
+  },
+  execute: async (auth, dataSource, args) => {
+    if (!dataSource) {
+      return new Err(new Error("Data source not found."));
+    }
+
+    if (dataSource.connectorProvider !== "github") {
+      return new Err(new Error("Data source is not a GitHub connector."));
+    }
+
+    const repoId = args.repoId.trim();
+    const skipReason = args.skipReason.trim();
+
+    if (!repoId || !skipReason) {
+      return new Err(new Error("Repository ID and skip reason are required."));
+    }
+
+    if (!/^\d+$/.test(repoId)) {
+      return new Err(
+        new Error("Repository ID must be the numeric GitHub repository ID.")
+      );
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+
+    const connectorsAPI = new ConnectorsAPI(
+      config.getConnectorsAPIConfig(),
+      logger
+    );
+
+    const skipRepoCommand: AdminCommandType = {
+      majorCommand: "github",
+      command: "skip-repo",
+      args: {
+        wId: owner.sId,
+        dsId: dataSource.sId,
+        repoId,
+        skipReason,
+      },
+    };
+
+    const res = await connectorsAPI.admin(skipRepoCommand);
+    if (res.isErr()) {
+      return new Err(
+        new Error(`Failed to skip repository: ${res.error.message}`)
+      );
+    }
+
+    auditLog(
+      {
+        author: auth.user()?.toJSON() ?? "no-author",
+        dataSourceId: dataSource.sId,
+        repoId,
+        skipReason,
+      },
+      "Skipping GitHub repository"
+    );
+
+    return new Ok({
+      display: "text",
+      value: `Repository ${repoId} is now skipped. Reason: ${skipReason}`,
+    });
+  },
+});

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -57,6 +57,7 @@ export const CONNECTORS_ERROR_TYPES = [
   "oauth_token_revoked",
   "workspace_quota_exceeded",
   "third_party_internal_error",
+  "transient_upstream_error",
   "webcrawling_error",
   "webcrawling_error_empty_content",
   "webcrawling_error_content_too_large",


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10074

https://dust4ai.slack.com/archives/C050SM8NSPK/p1787039614497129

Currently, we skip permanently repositories for which we have tried 20 times to download a tarball.
While there are genuine cases stretching the limit of our implementation, it should bubble up, and I suspect most cases are simply github API hiccups (happen a lot these days). 
To make things worse, this skip never bubbles up to the user, we mark everything as OK despite having essentially a stuck connector.

This PR:

- Remove the auto skip, instead logs more information and if > 20 tries mark the sync as failed
- Adds user facing error new sync failed message for this failure mode
- Adds a poke plugging to mark a repository as skipped, so that we still can for genuine repository that we know will never succeed.
- Add a small script to remove this skip reason for repository that have it, which will unstuck these connections.


## Tests

N/A

## Risk

Low

## Deploy Plan

Deploy connector
Run the script