### PR TITLE
Admin governance: Dual write skill editor permissions in regular auto group

### DIFF
--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -178,7 +178,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
   // Find the regular_auto group backing user-level grants for the given tuple. At most one exists
   // per (grantType, resourceType, resourceId): grantToUser and revokeFromUser serialize on the
   // grant-tuple advisory lock (getGrantLock), and grant() rejects a second regular_auto group.
-  private static async findRegularAutoGroupForGrant(
+  static async findRegularAutoGroupForGrant(
     auth: Authenticator,
     {
       grantType,

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2874,10 +2874,11 @@ describe("SkillResource", () => {
         resourceId: skill.id,
       };
       const grantGroupMembers = async () => {
-        const group = await GroupPermissionResource.findRegularAutoGroupForGrant(
-          testContext.authenticator,
-          grantSpec
-        );
+        const group =
+          await GroupPermissionResource.findRegularAutoGroupForGrant(
+            testContext.authenticator,
+            grantSpec
+          );
         if (!group) {
           return null;
         }

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2865,6 +2865,44 @@ describe("SkillResource", () => {
       expect(skill.canAdministrate(editorAuth)).toBe(false);
     });
 
+    it("dual-writes editor changes to the per-user grant group", async () => {
+      const { skill, editor } = await setupSkillWithEditor("Dual Write Skill");
+
+      const grantSpec = {
+        grantType: "editor" as const,
+        resourceType: "skill" as const,
+        resourceId: skill.id,
+      };
+      const grantGroupMembers = async () => {
+        const group = await GroupPermissionResource.findRegularAutoGroupForGrant(
+          testContext.authenticator,
+          grantSpec
+        );
+        if (!group) {
+          return null;
+        }
+        const members = await group.getActiveMembers(testContext.authenticator);
+        return members.map((m) => m.sId);
+      };
+
+      // upsertEditors granted the editor, and makeNew granted the creator.
+      expect(await grantGroupMembers()).toContain(editor.sId);
+      expect(await grantGroupMembers()).toContain(testContext.user.sId);
+
+      const removeResult = await skill.removeEditors(
+        testContext.authenticator,
+        [editor]
+      );
+      expect(removeResult.isOk()).toBe(true);
+
+      // Both sides drop the editor.
+      expect(await grantGroupMembers()).not.toContain(editor.sId);
+      const legacyMembers = await skill.editorGroup!.getActiveMembers(
+        testContext.authenticator
+      );
+      expect(legacyMembers.map((m) => m.sId)).not.toContain(editor.sId);
+    });
+
     it("falls back to the editor group when the use_legacy_acls kill switch is on", async () => {
       const { skill, buildEditorAuth } = await setupSkillWithEditor(
         "Legacy Switch Skill"

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -35,7 +35,6 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
-import { verbsForGrantAtLevel } from "@app/lib/resources/group_permission_registry";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -72,6 +71,7 @@ import {
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
+import logger from "@app/logger/logger";
 import type {
   AgentConfigurationWithoutModelType,
   LightAgentConfigurationType,
@@ -98,7 +98,6 @@ import type { GrantVerb } from "@app/types/group_permissions";
 import { SKILL_GROUP_PREFIX } from "@app/types/groups";
 import type {
   AccessControlList,
-  GroupGrant,
   RoleGrant,
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -637,6 +636,30 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
       { transaction }
     );
+
+    // Dual write (see `writeEditorUserGrants`): the creator is also an editor through a per-user
+    // grant, not only through the skill_editors group. Best-effort — unlike the group above, the
+    // grant path requires a workspace membership row, and skill creation must not start failing for
+    // callers that lack one. Logged so the divergence is visible.
+    if (addCurrentUserAsEditor) {
+      const grantResult = await GroupPermissionResource.grantToUser(auth, {
+        user: auth.getNonNullableUser().toJSON(),
+        grantType: SKILL_EDITOR_GRANT_TYPE,
+        resourceType: "skill",
+        resourceId: skill.id,
+        transaction,
+      });
+      if (grantResult.isErr()) {
+        logger.error(
+          {
+            error: grantResult.error.message,
+            skillId: skill.id,
+            workspaceId: workspace.sId,
+          },
+          "Failed to grant the skill creator their editor user grant"
+        );
+      }
+    }
 
     return defaultGroup;
   }
@@ -2205,60 +2228,26 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     ];
   }
 
-  // The group grants a skill confers, derived from its `group_skills` association: the editor
-  // group holds the `editor` role. The verbs come from the registry rather than being restated
-  // here, so this cannot drift from `ROLE_REGISTRY.skill.editor`.
-  private skillGroupGrants(): GroupGrant[] {
-    if (!this.editorGroup) {
-      return [];
-    }
-
-    return [
-      {
-        id: this.editorGroup.id,
-        permissions: verbsForGrantAtLevel(
-          SKILL_EDITOR_GRANT_TYPE,
-          "skill",
-          "instance"
-        ),
-      },
-    ];
-  }
-
-  // Writes this skill's `group_permissions` rows directly from its `group_skills` association
-  // (see `skillGroupGrants`). The skill mutation paths call this to keep the table in sync as it
-  // becomes the source of truth. Idempotent — it clears the skill's instance grants then
-  // re-inserts the desired set, so it is safe to re-run.
+  // Writes this skill's `group_permissions` row from its `group_skills` association: the editor
+  // group holds the `editor` role on the skill. The skill mutation paths call this to keep the
+  // table in sync as it becomes the source of truth.
+  //
+  // Inserts find-or-create, so it is idempotent without clearing the skill's grants first — which
+  // matters now that per-user grants (the regular_auto group from `grantToUser`) live on the same
+  // resource: wiping them all would revoke those and orphan their group.
   async writeGroupPermissions(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<void> {
-    // Clear this skill's instance grants, then re-insert the desired set. `resourceId` is the
-    // skill id (> 0), so the type-wide governance rows (-1) are never touched.
-    await GroupPermissionResource.deleteAllForResource(auth, {
-      resourceType: "skill",
-      resourceId: this.id,
-      transaction,
-    });
-
-    const desiredGrants = this.skillGroupGrants();
-    if (desiredGrants.length === 0) {
+    if (!this.editorGroup) {
       return;
     }
 
-    const groups = await GroupResource.fetchByModelIds(
-      auth,
-      desiredGrants.map((grant) => grant.id),
-      { transaction }
-    );
-
-    await GroupPermissionResource.grantMany(auth, {
-      grants: groups.map((group) => ({
-        group,
-        grantType: SKILL_EDITOR_GRANT_TYPE,
-        resourceType: "skill" as const,
-        resourceId: this.id,
-      })),
+    await GroupPermissionResource.grant(auth, {
+      group: this.editorGroup,
+      grantType: SKILL_EDITOR_GRANT_TYPE,
+      resourceType: "skill",
+      resourceId: this.id,
       transaction,
     });
   }
@@ -2645,6 +2634,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return addResult;
     }
 
+    const grantResult = await this.writeEditorUserGrants(auth, users, "grant");
+    if (grantResult.isErr()) {
+      return new Err(new DustError("unauthorized", grantResult.error.message));
+    }
+
     return new Ok(undefined);
   }
 
@@ -2695,7 +2689,71 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return removeResult;
     }
 
+    const revokeResult = await this.writeEditorUserGrants(
+      auth,
+      users,
+      "revoke"
+    );
+    if (revokeResult.isErr()) {
+      return new Err(new DustError("unauthorized", revokeResult.error.message));
+    }
+
     return new Ok(undefined);
+  }
+
+  // Dual write for the editor-group migration: editors are becoming per-user grants
+  // (`grantToUser`, backed by one regular_auto group per skill) instead of members of the skill's
+  // `skill_editors` group. Both are written until the read side moves over; the legacy membership
+  // is still what `listEditors` — and therefore the served ACL — is derived from.
+  private async writeEditorUserGrants(
+    auth: Authenticator,
+    users: UserResource[],
+    operation: "grant" | "revoke"
+  ): Promise<Result<void, Error>> {
+    for (const user of users) {
+      const spec = {
+        user: user.toJSON(),
+        grantType: SKILL_EDITOR_GRANT_TYPE,
+        resourceType: "skill" as const,
+        resourceId: this.id,
+      };
+
+      const result =
+        operation === "grant"
+          ? await GroupPermissionResource.grantToUser(auth, spec)
+          : await GroupPermissionResource.revokeFromUser(auth, spec);
+
+      if (result.isErr()) {
+        return new Err(result.error);
+      }
+    }
+
+    return new Ok(undefined);
+  }
+
+  // Archive/restore suspend and restore the editor memberships; the per-user grant group holds the
+  // same people, so it has to follow (see `writeEditorUserGrants`).
+  private async suspendOrRestoreEditorGrantGroup(
+    auth: Authenticator,
+    operation: "suspend" | "restore",
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    const grantGroup =
+      await GroupPermissionResource.findRegularAutoGroupForGrant(auth, {
+        grantType: SKILL_EDITOR_GRANT_TYPE,
+        resourceType: "skill",
+        resourceId: this.id,
+        transaction,
+      });
+    if (!grantGroup) {
+      return;
+    }
+
+    if (operation === "suspend") {
+      await grantGroup.suspendMembers(auth, { transaction });
+    } else {
+      await grantGroup.restoreMembers(auth, { transaction });
+    }
   }
 
   private async upsertCurrentUserAsEditor(auth: Authenticator): Promise<void> {
@@ -3123,9 +3181,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
 
         // Suspend all editor group memberships for this skill.
+        // Editors los permissions on the skill and only admin can keep their "admin" permission to unarchive it.
         if (this.editorGroup) {
           await this.editorGroup.suspendMembers(auth, { transaction });
         }
+        // Dual write: same for the per-user grant group, or its members would keep access to an
+        // archived skill.
+        await this.suspendOrRestoreEditorGrantGroup(auth, "suspend", {
+          transaction,
+        });
       }
 
       return count;
@@ -3170,6 +3234,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         if (this.editorGroup) {
           await this.editorGroup.restoreMembers(auth, { transaction });
         }
+        await this.suspendOrRestoreEditorGrantGroup(auth, "restore", {
+          transaction,
+        });
       }
 
       return count;
@@ -3935,13 +4002,28 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-        // Drop the skill's instance grants before the editor group goes away: group_permissions
-        // rows are keyed by both, and this also covers grants held by any other group.
+        // The per-user grant group (see `writeEditorUserGrants`) exists only to hold this skill's
+        // grant, so it goes with the skill. Fetched before the grants are dropped, since that is
+        // what identifies it.
+        const editorGrantGroup =
+          await GroupPermissionResource.findRegularAutoGroupForGrant(auth, {
+            grantType: SKILL_EDITOR_GRANT_TYPE,
+            resourceType: "skill",
+            resourceId: this.id,
+            transaction,
+          });
+
+        // Drop the skill's instance grants before the groups go away: group_permissions rows are
+        // keyed by both, and this also covers grants held by any other group.
         await GroupPermissionResource.deleteAllForResource(auth, {
           resourceType: "skill",
           resourceId: this.id,
           transaction,
         });
+
+        if (editorGrantGroup) {
+          await editorGrantGroup.delete(auth, { transaction });
+        }
 
         if (this.editorGroup) {
           await this.editorGroup.delete(auth, { transaction });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -3181,7 +3181,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         );
 
         // Suspend all editor group memberships for this skill.
-        // Editors los permissions on the skill and only admin can keep their "admin" permission to unarchive it.
+        // Editors lose permissions on the skill and only admin keep their "admin" permission to unarchive it.
         if (this.editorGroup) {
           await this.editorGroup.suspendMembers(auth, { transaction });
         }

--- a/front/migrations/20260817_backfill_skill_editor_user_grants.ts
+++ b/front/migrations/20260817_backfill_skill_editor_user_grants.ts
@@ -1,0 +1,150 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { SKILL_STATUSES } from "@app/types/assistant/skill_configuration";
+import type { LightWorkspaceType } from "@app/types/user";
+
+// Backfill: give every current member of a skill's `skill_editors` group the equivalent per-user
+// grant (`editor` on `skill:<id>`), which `grantToUser` holds in one regular_auto group per skill.
+// The skill mutation paths dual-write both sides from now on; this catches the existing editors.
+// Idempotent: grantToUser is find-or-create on both the group and the membership.
+async function backfillWorkspaceSkillEditorUserGrants(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  // All groups: `listByWorkspace` filters on read access to the spaces a skill references, and
+  // restricted spaces grant read through group membership only. The default single-group auth
+  // silently skips those skills.
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+    dangerouslyRequestAllGroups: true,
+  });
+
+  // Every status: archived and suggested skills keep their editors, so their grants must be
+  // written too (an archived skill can be restored).
+  const skills = await SkillResource.listByWorkspace(auth, {
+    status: [...SKILL_STATUSES],
+    onlyCustom: true,
+    withInstructions: false,
+    withTools: false,
+    withFileAttachments: false,
+  });
+
+  // Sequential: a one-off with several queries per editor, so keep the load predictable. (The
+  // per-tuple advisory lock `grantToUser` takes is per skill, so parallel skills would not contend
+  // on it — it is not the reason.)
+  for (const skill of skills) {
+    const editors = await skill.listEditors(auth);
+    if (!editors || editors.length === 0) {
+      continue;
+    }
+
+    if (!execute) {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          skillId: skill.sId,
+          skillStatus: skill.status,
+          editorCount: editors.length,
+        },
+        "Dry-run: would grant skill editors their per-user grant"
+      );
+      continue;
+    }
+
+    for (const editor of editors) {
+      const result = await GroupPermissionResource.grantToUser(auth, {
+        user: editor.toJSON(),
+        grantType: "editor",
+        resourceType: "skill",
+        resourceId: skill.id,
+      });
+      if (result.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            skillId: skill.sId,
+            userId: editor.sId,
+            error: result.error.message,
+          },
+          "Failed to grant a skill editor their per-user grant"
+        );
+      }
+    }
+
+    // The editor list was read before the writes, so an edit in between would leave the grants
+    // stale (a removed editor keeps a grant nobody revokes). Re-read and report: the reconcile
+    // query is the source of truth, this just points at the skills to look at.
+    const editorsAfter = (await skill.listEditors(auth)) ?? [];
+    const grantedIds = new Set(editors.map((editor) => editor.sId));
+    const currentIds = new Set(editorsAfter.map((editor) => editor.sId));
+    const addedWhileRunning = editorsAfter
+      .filter((editor) => !grantedIds.has(editor.sId))
+      .map((editor) => editor.sId);
+    const removedWhileRunning = editors
+      .filter((editor) => !currentIds.has(editor.sId))
+      .map((editor) => editor.sId);
+
+    if (addedWhileRunning.length > 0 || removedWhileRunning.length > 0) {
+      logger.warn(
+        {
+          workspaceId: workspace.sId,
+          skillId: skill.sId,
+          skillModelId: skill.id,
+          addedWhileRunning,
+          removedWhileRunning,
+        },
+        "Skill editors changed while backfilling: grants may be stale, reconcile this skill"
+      );
+    }
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        skillId: skill.sId,
+        skillStatus: skill.status,
+        editorCount: editors.length,
+      },
+      "Granted skill editors their per-user grant"
+    );
+  }
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting skill editor user-grant backfill");
+
+    if (wId) {
+      const ws = await WorkspaceResource.fetchById(wId);
+      if (!ws) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      await backfillWorkspaceSkillEditorUserGrants(
+        execute,
+        logger,
+        renderLightWorkspaceType({ workspace: ws })
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await backfillWorkspaceSkillEditorUserGrants(
+            execute,
+            logger,
+            workspace
+          );
+        },
+        { concurrency: 4 }
+      );
+    }
+
+    logger.info("Skill editor user-grant backfill completed");
+  }
+);


### PR DESCRIPTION
## Description

 - Dual write permissions for editor directly instead of using the editor's group
 - Backfill script 

## Tests

updated unit tests + tested locally

## Risk

Can have slight discrepancie if a skill editor is remove in the middle of the script writing the new permission
Very unlikely, will check the logs after the migration and reconcile if needed

## Deploy Plan

merge and deploy front 
run migration script
```
  cd front && npx tsx migrations/20260817_backfill_skill_editor_user_grants.ts --execute \
    2>&1 | tee ~/skill_editor_grants_backfill.log
```
Check if any skill may have stale permissions due to change during write