### PR TITLE
[front] fix: pod app tile action buttons overlapping the name

### DIFF
--- a/front/components/pod/apps/PodAppTile.tsx
+++ b/front/components/pod/apps/PodAppTile.tsx
@@ -70,7 +70,7 @@ export function PodAppTile({
 
   return (
     <Card
-      size="sm"
+      size="md"
       onClick={openableFrame ? () => onOpenFrame(openableFrame) : undefined}
       action={
         <div className="flex gap-1">
@@ -100,18 +100,30 @@ export function PodAppTile({
         </div>
       }
     >
-      <div className="flex min-w-0 grow items-center gap-3">
+      {/*
+        The icon row shares its band with the actions `Card` pins to the top-right corner, so the
+        name goes on the row below and gets the tile's full width rather than running under (or
+        truncating ahead of) the buttons.
+      */}
+      <div className="flex min-w-0 grow flex-col items-start gap-3">
         <ResourceAvatar
           icon={getIcon(appIcon(app, iconByFramePath, defaultIcon))}
           size="md"
           backgroundColor="bg-background dark:bg-background-night"
         />
-        <span className="truncate heading-base text-foreground dark:text-foreground-night">
-          {app.name}
-        </span>
-        {isDraft && (
-          <Chip size="xs" color="primary" label="Draft" className="shrink-0" />
-        )}
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate heading-base text-foreground dark:text-foreground-night">
+            {app.name}
+          </span>
+          {isDraft && (
+            <Chip
+              size="xs"
+              color="primary"
+              label="Draft"
+              className="shrink-0"
+            />
+          )}
+        </div>
       </div>
     </Card>
   );


### PR DESCRIPTION
### Problem

On the Pod Apps tab, the hover action buttons (download / clone / delete) overlapped the app name. Sparkle's `Card` renders its `action` node as an absolute overlay pinned to the top-right, outside the content flow, and the tile laid out the icon and the name as a single row spanning the full card width — so any name long enough ran straight under the buttons.

### Fix

Split the tile into two rows: the app icon keeps the top band it already shared with the action overlay (the icon is narrow and sits on the left, so they never collide), and the name plus the Draft chip move to the row below, where they get the tile's full inner width. Card padding goes from `sm` to `md` so the taller tile reads as deliberate rather than cramped.

Reserving horizontal room for the overlay instead was the other option, but it truncated names with an ellipsis well before the tile's edge.