### PR TITLE
[front] Fix refresh() after the resolvePermissions/getGrantedVerbs refactor

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -392,12 +392,10 @@ export class Authenticator {
     // for every auth — including auths that have no user (API/system keys, internal auths), which
     // the `_user` gate above skips. The agent loop freezes a serialized (user-less) key auth at
     // workflow start and refreshes it per step (see `fromJsonWithRefrehedGroups`); without this it
-    // would keep a stale grant snapshot and deny access to resources granted mid-run. System keys
-    // scan the workspace grant set to avoid sending their whole group list to Postgres.
+    // would keep a stale grant snapshot and deny access to resources granted mid-run.
     this._permissions = await Authenticator.resolvePermissions({
       workspace: this._workspace,
       groupModelIds: this._groupModelIds,
-      scanWorkspacePermissions: this.isSystemKey(),
     });
   }
 

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -325,10 +325,10 @@ describe("Authenticator.refresh permission resolution", () => {
     // loop freezes it at workflow start and refreshes it on every step.
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
-    expect(workspaceAuth.getGroupPermissions("agent", 42)).toEqual([]);
+    expect(workspaceAuth.getGrantedVerbs("agent", 42)).toEqual([]);
 
     // A grant lands on one of the key's groups AFTER the auth was built (mirrors a backfill or an
-    // updatePermissions write arriving mid-run).
+    // updatePermissions write arriving mid-run). `editor` on `agent` confers read + write.
     await GroupPermissionResource.grant(adminAuth, {
       group,
       grantType: "editor",
@@ -340,8 +340,9 @@ describe("Authenticator.refresh permission resolution", () => {
     // `_user`-gated body skipped user-less auths entirely, leaving the stale (empty) snapshot.
     await workspaceAuth.refresh();
 
-    expect(
-      workspaceAuth.getGroupPermissions("agent", 42).map((grant) => grant.id)
-    ).toEqual([group.id]);
+    expect([...workspaceAuth.getGrantedVerbs("agent", 42)].sort()).toEqual([
+      "read",
+      "write",
+    ]);
   });
 });

--- a/front/types/resource_permissions.ts
+++ b/front/types/resource_permissions.ts
@@ -59,7 +59,7 @@ export type AccessControlList = {
  * A resource whose access is governed by one or more access-control lists. The caller passes when
  * they satisfy every ACL returned by `getAccessControlLists(auth)` (see
  * `Authenticator.hasPermission`). `auth` is passed so a resource can build its ACL from the caller's
- * governance grants (`auth.getGroupPermissions`) — e.g. the per-workspace flip.
+ * governance grants (`auth.getGrantedVerbs`) — e.g. the per-workspace flip.
  */
 export interface WithAccessControl {
   getAccessControlLists(auth: Authenticator): AccessControlList[];


### PR DESCRIPTION
## Description

Follow-up to #30656, which merged concurrently with a refactor of the grant-resolution API. The merge was textually clean but left two stale references that broke `main`:

1. `resolvePermissions` lost its `scanWorkspacePermissions` param (and `listForGroupsFromWorkspaceScan` was removed), but `Authenticator.refresh()` — added in #30656 — still passed `scanWorkspacePermissions: this.isSystemKey()`.
2. `getGroupPermissions(rt, id): GroupGrant[]` was renamed to `getGrantedVerbs(rt, id): GrantVerb[]` (ACLs now carry `grantedVerbs`), but the test added in #30656 still called `getGroupPermissions`.

### Fix
- `refresh()`: drop the removed `scanWorkspacePermissions` argument — `resolvePermissions({ workspace, groupModelIds })` now.
- Test: use `getGrantedVerbs` and assert the resolved verbs (`editor` on `agent` → `[read, write]`) instead of per-group ids.
- Fix a stale doc reference to `auth.getGroupPermissions` in `resource_permissions.ts`.

No behavior change — this only realigns the #30656 code with the refactored API so `main` type-checks and the test passes.

## Tests
`auth.workspace_permission` (14) passes; `tsgo` clean on `auth.ts` / `resource_permissions.ts` / the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
