### PR TITLE
fix: throttle metronome-events worker to ease contract-endpoint 429s

### DIFF
--- a/front/temporal/metronome_events_queue/worker.ts
+++ b/front/temporal/metronome_events_queue/worker.ts
@@ -23,7 +23,11 @@ export async function runMetronomeEventsWorker() {
     }),
     activities,
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 16,
+    // Each activity fans out into many Metronome contract-endpoint calls (seat
+    // sync, credit reconcile). Keep concurrency low so a burst of webhooks
+    // (e.g. a migration cohort activating on the hour) spreads over time
+    // instead of saturating Metronome's rate limit.
+    maxConcurrentActivityTaskExecutions: 4,
     connection,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     namespace,


### PR DESCRIPTION
## Problem

Trial signups started failing with `Error: Failed to provision Metronome contract: 429 Rate limit exceeded` (`provisionCreditPricedFreePlan`, `front/lib/api/subscription.ts`).

Root cause: Metronome rate-limits are per-endpoint-family and account-wide. The **contract-endpoint bucket** (`v1/contracts/*`, `v2.contracts.*`, incl. `getSubscriptionSeatsHistory`) — which `v1.contracts.create` shares with our seat-sync/reconcile reads — was saturated. Usage ingestion (`v1/ingest`) is a separate bucket and is not involved.

Trigger: the legacy Pro→Business migration activates contracts on the hour. A cohort activating on the same hour fires a burst of `contract.start`/`credit.create` webhooks; each migrated workspace fans out into several background workflows (seat sync, credit reconcile, ApiKeyCap reconcile), each making multiple contract-endpoint calls. With `maxConcurrentActivityTaskExecutions: 16` all slots ran that fan-out at once, saturating the endpoint; SDK retries (`maxRetries: 5`) plus Temporal activity retries kept it pinned, starving interactive contract creation.

## Change

Lower `maxConcurrentActivityTaskExecutions` from **16 → 4** on the `metronome_events_queue` worker. Billing reconciliation is not latency-sensitive, so capping concurrency spreads a webhook burst over time instead of hammering Metronome's contract endpoint. `4` matches the sibling `credit_alerts` billing worker.

## Notes / follow-ups

- This is **per-worker**; effective concurrency is `4 × replicas`. If the Aug 23 final migration batch still 429s, the stronger lever is the queue-global `maxTaskQueueActivitiesPerSecond`.
- Caching the `members-seats` billed-seats reads (another per-page-load contract-endpoint caller) and moving `members-usage` per-member consumption onto the ES consumption index are separate follow-ups being handled elsewhere.
- A temporary contract-endpoint rate-limit bump has been requested from Metronome to cover the migration tail.

## Test plan

- `npx tsgo --noEmit -p front` — clean
- Biome — clean
- Config-only change; behavior verified by reasoning about Temporal activity scheduling (excess webhook activities queue and drain rather than running concurrently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)