### PR TITLE
[front] Gate UserSettingsPopover usage fetches on popover visibility

### DIFF
--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -231,16 +231,16 @@ function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
 
   const { myUsage, nextCreditResetAt, isMyUsageLoading } = useMyUsage({
     workspaceId: owner.sId,
-    disabled: !isCreditBased,
+    disabled: !isCreditBased || !visible,
   });
   const { seatPlans } = useSeatPlan({
     workspaceId: owner.sId,
-    disabled: !isCreditBased,
+    disabled: !isCreditBased || !visible,
   });
 
   const { hasPendingUpgradeRequest } = useWorkspaceUsageStatus({
     owner,
-    disabled: isManager || !isCreditBased,
+    disabled: isManager || !isCreditBased || !visible,
   });
 
   const seatName =


### PR DESCRIPTION
## Description

Found while investigating the Metronome 429 rate-limit incident (workspace provisioning failures on `/trial/start`): the user settings dialog stays mounted while closed (animated exit), and the `UsageSection` hooks were only gated on the plan, not on visibility. As a result, every credit-based user fetched `/credits/my-usage`, `/credits/seat-plan` and (non-managers) the workspace usage status on **every page load**, popover closed.

The sibling `useMyTopConversations` in the same file already gates on `visible` — this aligns the remaining three hooks:

- `useMyUsage`: mostly absorbed by SWR key-dedup with the sidebar's intentional call, but no reason to subscribe from a hidden dialog.
- `useSeatPlan`: no other always-mounted caller, so this was pure wasted traffic to a Metronome-backed endpoint.
- `useWorkspaceUsageStatus`: same.

The existing loading spinner in `UsageSection` covers the fetch when the popover opens.

This trims steady-state read pressure feeding the Metronome-backed caches; the amplification fix itself ships separately (follow-up to the `metronome-429` branch work).

## Risk

Worst case, the usage section briefly shows a spinner on popover open instead of pre-fetched data. Safe to rollback.

## Tests

Type-check and biome clean. Behavior gated by the same `disabled` mechanism already covered by the SWR helpers.
