### PR TITLE
Stop Metronome 429 amplification from the members-usage read paths

### DIFF
--- a/front/lib/api/credits/members_usage.test.ts
+++ b/front/lib/api/credits/members_usage.test.ts
@@ -1,0 +1,73 @@
+import { fetchSeatDataForMembersTable } from "@app/lib/api/credits/members_usage";
+import {
+  buildSeatDataByUserId,
+  getCachedSeatDataByUserId,
+} from "@app/lib/metronome/seats";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/metronome/seats", async () => {
+  const actual = await vi.importActual<
+    typeof import("@app/lib/metronome/seats")
+  >("@app/lib/metronome/seats");
+  return {
+    ...actual,
+    getCachedSeatDataByUserId: vi.fn(),
+    buildSeatDataByUserId: vi.fn(),
+  };
+});
+
+// Regression tests for the Metronome 429 storm of 2026-08: a failing cached
+// seat-data read must degrade to an empty map, never trigger a second
+// (uncached) Metronome fan-out.
+describe("fetchSeatDataForMembersTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("degrades to an empty map when the cached read fails, without an uncached refetch", async () => {
+    vi.mocked(getCachedSeatDataByUserId).mockRejectedValue(
+      new Error("429 rate limit exceeded")
+    );
+
+    const result = await fetchSeatDataForMembersTable({
+      metronomeCustomerId: "cust_1",
+      metronomeContractId: "contract_1",
+    });
+
+    expect(result).toEqual(new Map());
+    expect(buildSeatDataByUserId).not.toHaveBeenCalled();
+  });
+
+  it("degrades to an empty map when another process holds the fetch lock", async () => {
+    vi.mocked(getCachedSeatDataByUserId).mockResolvedValue(null);
+
+    const result = await fetchSeatDataForMembersTable({
+      metronomeCustomerId: "cust_1",
+      metronomeContractId: "contract_1",
+    });
+
+    expect(result).toEqual(new Map());
+    expect(buildSeatDataByUserId).not.toHaveBeenCalled();
+  });
+
+  it("returns the cached seat data keyed by user id", async () => {
+    vi.mocked(getCachedSeatDataByUserId).mockResolvedValue({
+      user_1: {
+        awuAllocation: 5000,
+        billingFrequency: "MONTHLY",
+        nextCreditResetAt: "2026-09-01T00:00:00.000Z",
+      },
+    });
+
+    const result = await fetchSeatDataForMembersTable({
+      metronomeCustomerId: "cust_1",
+      metronomeContractId: "contract_1",
+    });
+
+    expect(result.get("user_1")).toEqual({
+      awuAllocation: 5000,
+      billingFrequency: "MONTHLY",
+      nextCreditResetAt: "2026-09-01T00:00:00.000Z",
+    });
+  });
+});

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -15,10 +15,6 @@ import type {
 import {
   getCachedDefaultCapThresholdsBySeatType,
   getCachedPerUserCapAlertIds,
-  getMetronomeDefaultUserCapAlertForSeatType,
-  getMetronomeDefaultUserWarningAlertForSeatType,
-  listMetronomePerUserCapsForWorkspace,
-  listMetronomePerUserWarningAlertsForWorkspace,
 } from "@app/lib/metronome/alerts/spend_limits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import {
@@ -31,17 +27,11 @@ import {
   toFreeMetronomeUserId,
 } from "@app/lib/metronome/constants";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
-import {
-  fetchPerUserAwuUsage,
-  getPerUserAwuUsage,
-} from "@app/lib/metronome/per_user_usage";
+import { getPerUserAwuUsage } from "@app/lib/metronome/per_user_usage";
 import { getActiveContract } from "@app/lib/metronome/plan_type";
 import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_types";
 import type { SeatData } from "@app/lib/metronome/seats";
-import {
-  buildSeatDataByUserId,
-  getCachedSeatDataByUserId,
-} from "@app/lib/metronome/seats";
+import { getCachedSeatDataByUserId } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
 import { isUserAwuWarned } from "@app/lib/metronome/user_block";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
@@ -518,30 +508,6 @@ export async function getEsConsumedAwuCreditsForApiKey(
   return consumedByApiKeyName.get(apiKeyName) ?? 0;
 }
 
-async function fetchPerUserUsageCreditsForMembersTableUncached({
-  workspaceId,
-  metronomeCustomerId,
-  userIds,
-}: {
-  workspaceId: string;
-  metronomeCustomerId: string;
-  userIds: string[];
-}): Promise<Map<string, number>> {
-  const result = await fetchPerUserAwuUsage({
-    workspaceId,
-    metronomeCustomerId,
-    userIds,
-  });
-  if (result.isErr()) {
-    logger.warn(
-      { err: result.error, metronomeCustomerId },
-      "[MembersUsage] Failed to fetch per-user usage"
-    );
-    return new Map();
-  }
-  return result.value;
-}
-
 async function fetchPerUserUsageCreditsForMembersTable({
   workspaceId,
   metronomeCustomerId,
@@ -564,40 +530,17 @@ async function fetchPerUserUsageCreditsForMembersTable({
       userIds,
     });
   } catch (err) {
+    // No uncached fallback (see fetchSeatDataForMembersTable).
     logger.warn(
       { err: normalizeError(err), metronomeCustomerId },
-      "[MembersUsage] Failed to read cached per-user usage, falling back to uncached fetch"
-    );
-    return fetchPerUserUsageCreditsForMembersTableUncached({
-      workspaceId,
-      metronomeCustomerId,
-      userIds,
-    });
-  }
-}
-
-async function fetchSeatDataForMembersTableUncached({
-  metronomeCustomerId,
-  metronomeContractId,
-}: {
-  metronomeCustomerId: string;
-  metronomeContractId: string;
-}): Promise<Map<string, SeatData>> {
-  const seatDataResult = await buildSeatDataByUserId({
-    metronomeCustomerId,
-    contractId: metronomeContractId,
-  });
-  if (seatDataResult.isErr()) {
-    logger.warn(
-      { err: seatDataResult.error, metronomeCustomerId },
-      "[MembersUsage] Failed to build seat data, degrading to empty map"
+      "[MembersUsage] Failed to read cached per-user usage, degrading to empty map"
     );
     return new Map();
   }
-  return seatDataResult.value;
 }
 
-async function fetchSeatDataForMembersTable({
+/** Exported for testing. */
+export async function fetchSeatDataForMembersTable({
   metronomeCustomerId,
   metronomeContractId,
 }: {
@@ -608,23 +551,24 @@ async function fetchSeatDataForMembersTable({
     return new Map();
   }
   try {
-    return new Map(
-      Object.entries(
-        await getCachedSeatDataByUserId({
-          metronomeCustomerId,
-          contractId: metronomeContractId,
-        })
-      )
-    );
+    const seatData = await getCachedSeatDataByUserId({
+      metronomeCustomerId,
+      contractId: metronomeContractId,
+    });
+    // null: another process holds the fetch lock (skipIfLocked). Degrade
+    // rather than piling a duplicate Metronome fan-out on top.
+    if (!seatData) {
+      return new Map();
+    }
+    return new Map(Object.entries(seatData));
   } catch (err) {
+    // No uncached fallback: a failing loader means Metronome is already under
+    // pressure, and refetching would amplify it (see the 429 storm of 2026-08).
     logger.warn(
       { err: normalizeError(err), metronomeCustomerId },
-      "[MembersUsage] Failed to read cached seat data, falling back to uncached fetch"
+      "[MembersUsage] Failed to read cached seat data, degrading to empty map"
     );
-    return fetchSeatDataForMembersTableUncached({
-      metronomeCustomerId,
-      metronomeContractId,
-    });
+    return new Map();
   }
 }
 
@@ -709,85 +653,6 @@ async function fetchFreeSeatCreditsForMembersTable({
     );
   }
   return { freeBalanceByUserId, freeStartingByUserId };
-}
-
-async function fetchPerUserCapAlertIdsUncached({
-  metronomeCustomerId,
-  workspaceId,
-}: {
-  metronomeCustomerId: string;
-  workspaceId: string;
-}): Promise<Map<string, MetronomeCapAlertIds>> {
-  const [capsResult, warningsResult] = await Promise.all([
-    listMetronomePerUserCapsForWorkspace({ metronomeCustomerId, workspaceId }),
-    listMetronomePerUserWarningAlertsForWorkspace({
-      metronomeCustomerId,
-      workspaceId,
-    }),
-  ]);
-  if (capsResult.isErr()) {
-    logger.warn(
-      { err: capsResult.error, workspaceId },
-      "[MembersUsage] Failed to fetch per-user spend cap alerts"
-    );
-    return new Map();
-  }
-  const warnings = warningsResult.isErr() ? new Map() : warningsResult.value;
-
-  const caps = new Map<string, MetronomeCapAlertIds>();
-  for (const [userId, entry] of capsResult.value) {
-    caps.set(userId, {
-      alertId: entry.alert.id,
-      warningAlertId: warnings.get(userId)?.alert.id ?? null,
-    });
-  }
-
-  return caps;
-}
-
-async function fetchDefaultCapsBySeatTypeUncached({
-  metronomeCustomerId,
-  workspaceId,
-}: {
-  metronomeCustomerId: string;
-  workspaceId: string;
-}): Promise<
-  Partial<Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>>
-> {
-  const caps: Partial<
-    Record<NormalizedPoolLimitSeatType, MetronomeCapAlertInfo>
-  > = {};
-  for (const seatType of NORMALIZED_POOL_LIMIT_SEAT_TYPES) {
-    const [capResult, warningResult] = await Promise.all([
-      getMetronomeDefaultUserCapAlertForSeatType({
-        metronomeCustomerId,
-        workspaceId,
-        seatType,
-      }),
-      getMetronomeDefaultUserWarningAlertForSeatType({
-        metronomeCustomerId,
-        workspaceId,
-        seatType,
-      }),
-    ]);
-    if (capResult.isErr()) {
-      logger.warn(
-        { err: capResult.error, workspaceId, seatType },
-        "[MembersUsage] Failed to fetch default spend cap for seat type"
-      );
-      continue;
-    }
-    if (capResult.value) {
-      caps[seatType] = {
-        threshold: capResult.value.alert.threshold,
-        alertId: capResult.value.alert.id,
-        warningAlertId: warningResult.isOk()
-          ? (warningResult.value?.alert.id ?? null)
-          : null,
-      };
-    }
-  }
-  return caps;
 }
 
 /**
@@ -889,14 +754,12 @@ async function fetchPerUserCapAlertIds({
       )
     );
   } catch (err) {
+    // No uncached fallback (see fetchSeatDataForMembersTable).
     logger.warn(
       { err: normalizeError(err), workspaceId },
-      "[MembersUsage] Failed to read cached per-user spend cap alert ids, falling back to uncached fetch"
+      "[MembersUsage] Failed to read cached per-user spend cap alert ids, degrading to empty map"
     );
-    return fetchPerUserCapAlertIdsUncached({
-      metronomeCustomerId,
-      workspaceId,
-    });
+    return new Map();
   }
 }
 
@@ -915,14 +778,12 @@ async function fetchDefaultCapsBySeatType({
       workspaceId,
     });
   } catch (err) {
+    // No uncached fallback (see fetchSeatDataForMembersTable).
     logger.warn(
       { err: normalizeError(err), workspaceId },
-      "[MembersUsage] Failed to read cached default spend caps by seat type, falling back to uncached fetch"
+      "[MembersUsage] Failed to read cached default spend caps by seat type, degrading to empty result"
     );
-    return fetchDefaultCapsBySeatTypeUncached({
-      metronomeCustomerId,
-      workspaceId,
-    });
+    return {};
   }
 }
 

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -1070,15 +1070,22 @@ export async function findMetronomeContractByUniquenessKey({
 export async function getMetronomeContractById({
   metronomeCustomerId,
   metronomeContractId,
+  maxRetries,
 }: {
   metronomeCustomerId: string;
   metronomeContractId: string;
+  // Overrides the client-level retry count (5). Degradable interactive reads
+  // should fail fast instead of amplifying rate-limit pressure.
+  maxRetries?: number;
 }): Promise<Result<ContractV2, Error>> {
   try {
-    const response = await getMetronomeClient().v2.contracts.retrieve({
-      customer_id: metronomeCustomerId,
-      contract_id: metronomeContractId,
-    });
+    const response = await getMetronomeClient().v2.contracts.retrieve(
+      {
+        customer_id: metronomeCustomerId,
+        contract_id: metronomeContractId,
+      },
+      maxRetries !== undefined ? { maxRetries } : undefined
+    );
 
     return new Ok(response.data);
   } catch (err) {
@@ -1389,6 +1396,7 @@ export async function getMetronomeSubscriptionSeatState({
   contractId,
   subscriptionId,
   coveringDate,
+  maxRetries,
 }: {
   metronomeCustomerId: string;
   contractId: string;
@@ -1396,6 +1404,9 @@ export async function getMetronomeSubscriptionSeatState({
   // Defaults to `now`. Pass a future date to read the assignments projected
   // at that point in time.
   coveringDate?: Date;
+  // Overrides the client-level retry count (5). Degradable interactive reads
+  // should fail fast instead of amplifying rate-limit pressure.
+  maxRetries?: number;
 }): Promise<Result<SubscriptionSeatState, Error>> {
   try {
     const response =
@@ -1408,6 +1419,7 @@ export async function getMetronomeSubscriptionSeatState({
             subscription_id: subscriptionId,
             covering_date: (coveringDate ?? new Date()).toISOString(),
           },
+          ...(maxRetries !== undefined ? { maxRetries } : {}),
         }
       );
     // History is returned ascending by starting_at; take the last entry to

--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -1,7 +1,9 @@
+import { getMetronomeContractById } from "@app/lib/metronome/client";
 import type { CachedContract } from "@app/lib/metronome/plan_type";
 import {
   classifySeatChange,
   computeSeatCreditTransfers,
+  getCachedSeatDataByUserId,
   getSeatCreditNameForSeatType,
   hasContractSeatSubscription,
   promoteNoneSeatTypesForContract,
@@ -14,11 +16,13 @@ import {
 } from "@app/lib/metronome/setup_common";
 import type { SeatLimit } from "@app/lib/resources/workspace_seat_limit_resource";
 import type { MembershipSeatType } from "@app/types/memberships";
+import { Err } from "@app/types/shared/result";
 import type { LightWorkspaceType } from "@app/types/user";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/metronome/client", () => ({
   getMetronomeContractById: vi.fn(),
+  getMetronomeSubscriptionSeatState: vi.fn(),
   updateSubscriptionQuantity: vi.fn(),
 }));
 
@@ -1101,5 +1105,49 @@ describe("computeSeatCreditTransfers", () => {
       remaining: 8000,
       consumed: 0,
     });
+  });
+});
+
+// Regression tests for the Metronome 429 storm of 2026-08: the seat-data cache
+// must dedupe fetches fleet-wide (distributed lock + skipIfLocked) and surface
+// loader failures instead of returning empty data. The lock/skip semantics of
+// cacheWithRedis itself are covered by lib/utils/cache.test.ts; vite.setup.ts
+// replaces cacheWithRedis with a passthrough here, so we pin the registration
+// options rather than the runtime behavior.
+describe("getCachedSeatDataByUserId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers the seat-data cache with fleet-wide fetch dedup", async () => {
+    // Re-import so the module-level cacheWithRedis registration call is
+    // recorded on a fresh mock (earlier clearAllMocks wiped the original).
+    vi.resetModules();
+    const cache = await import("@app/lib/utils/cache");
+    await import("@app/lib/metronome/seats");
+
+    const registration = vi
+      .mocked(cache.cacheWithRedis)
+      .mock.calls.find((call) => call[0]?.name === "fetchSeatDataRecord");
+    // Coupled to the loader's function name: if this is undefined after a
+    // rename in seats.ts, update the string above (the dedup is likely fine).
+    expect(registration).toBeDefined();
+    expect(registration?.[2]).toMatchObject({
+      useDistributedLock: true,
+      skipIfLocked: true,
+    });
+  });
+
+  it("surfaces a loader failure to the caller instead of returning empty data", async () => {
+    vi.mocked(getMetronomeContractById).mockResolvedValue(
+      new Err(new Error("429 rate limit exceeded"))
+    );
+
+    await expect(
+      getCachedSeatDataByUserId({
+        metronomeCustomerId: "cust_err",
+        contractId: "contract_1",
+      })
+    ).rejects.toThrow("429");
   });
 });

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -2302,6 +2302,10 @@ export type SeatData = {
   nextCreditResetAt: string | null;
 };
 
+// Seat data only feeds display surfaces that degrade gracefully, so failing
+// fast beats burning rate-limit budget on retries when Metronome is throttling.
+const SEAT_DATA_READ_MAX_RETRIES = 1;
+
 /**
  * Query Metronome for all SEAT_BASED subscriptions on the contract and return
  * a map of userId → { awuAllocation, billingFrequency }. Makes a single
@@ -2319,6 +2323,7 @@ export async function buildSeatDataByUserId({
   const contractResult = await getMetronomeContractById({
     metronomeCustomerId,
     metronomeContractId: contractId,
+    maxRetries: SEAT_DATA_READ_MAX_RETRIES,
   });
   if (contractResult.isErr()) {
     logger.warn(
@@ -2355,6 +2360,7 @@ export async function buildSeatDataByUserId({
         metronomeCustomerId,
         contractId,
         subscriptionId: sub.id,
+        maxRetries: SEAT_DATA_READ_MAX_RETRIES,
       });
       if (seatStateResult.isErr()) {
         logger.warn(
@@ -2426,10 +2432,19 @@ async function fetchSeatDataRecord(args: {
   return Object.fromEntries(seatDataResult.value);
 }
 
+// At most one Metronome fan-out in flight per contract fleet-wide: concurrent
+// misses on other processes get null (callers degrade) instead of each firing
+// their own contract + per-subscription seat reads. Best-effort past the
+// distributed lock's 5s TTL: a fan-out slower than that lets a second fetcher
+// start, so the bound is "a couple in flight", never a storm.
 export const getCachedSeatDataByUserId = cacheWithRedis(
   fetchSeatDataRecord,
   seatDataCacheResolver,
-  { ttlMs: SEAT_DATA_CACHE_TTL_MS }
+  {
+    ttlMs: SEAT_DATA_CACHE_TTL_MS,
+    useDistributedLock: true,
+    skipIfLocked: true,
+  }
 );
 
 const invalidateCachedSeatDataByUserId = bestEffortInvalidateCacheWithRedis(


### PR DESCRIPTION
## Context

`/api/w/:wId/trial/start` started failing with `Failed to provision Metronome contract: 429 Rate limit exceeded`, leaving new workspaces without a contract or subscription row. All Metronome calls share one API key, so its rate limit is a global budget: the provisioning writes were being starved by read traffic.

The dominant source (95 of the top 100 Metronome-429 log lines over 24h, plus ~5K "falling back to uncached fetch" warnings over 2 days) is the seat-data read path (`buildSeatDataByUserId`: 1 contract retrieve + one `getSubscriptionSeatsHistory` per SEAT_BASED subscription). It is hit by the admin members table and by `/credits/my-usage`, which the sidebar user menu fetches for every user of every credit-priced workspace.

Under a 429 brownout, one request amplified into up to `(1 + N subscriptions) x 6 SDK attempts x 2` Metronome calls:
- the cached loader throws on failure, so nothing is cached and every request retries;
- the cache used the in-process lock only, so every pod (and every queued in-process waiter after a failure) fired its own fan-out;
- on failure, `members_usage.ts` caught the error and immediately re-ran the same fan-out uncached;
- each HTTP call was retried up to 5 times by the SDK.

## Changes

- **Remove the four catch-and-refetch-uncached fallbacks** in `members_usage.ts` (seat data, per-user usage, per-user cap alert ids, default caps by seat type). On a cache-loader failure each path now logs and degrades to an empty result; all consumers already treat these fields as nullable.
- **Fleet-wide fetch dedup on the seat-data cache**: `getCachedSeatDataByUserId` now uses `useDistributedLock: true, skipIfLocked: true`, so at most one seat fan-out is in flight per contract across all pods. Concurrent misses get `null` and the caller degrades for that request.
- **Fail fast on degradable reads**: `getMetronomeContractById` and `getMetronomeSubscriptionSeatState` accept a per-request `maxRetries`; `buildSeatDataByUserId` (which only feeds display surfaces) passes `maxRetries: 1`. Writes and bulk jobs keep the client-level 5 retries.

Net effect during a brownout, per workspace per minute fleet-wide: a single `(1 + N) x 2` fan-out instead of the unbounded storm; everything else serves degraded seat metadata instead of burning the budget contract provisioning needs.

Trade-off: in healthy operation, when the 60s cache expires, requests racing the single refill briefly see seat fields as unavailable (previously each pod refetched). Seat fields are nullable everywhere and refresh on the next request.

## Tests

- `members_usage.test.ts` (new): loader failure and lock-skip both degrade to an empty map without an uncached refetch; happy path returns the cached data.
- `seats.test.ts`: pins the cache registration options (distributed lock + skipIfLocked) and that loader failures propagate instead of returning cacheable empty data. The lock/skip runtime semantics are covered by `lib/utils/cache.test.ts` (vite.setup.ts stubs `cacheWithRedis` in unit tests).

## Deploy Plan

Deploy front. 
