### PR TITLE
feat: move automations page to /automations and tidy its table

### DIFF
--- a/front-spa/src/app/routes/adminRoutes.tsx
+++ b/front-spa/src/app/routes/adminRoutes.tsx
@@ -133,7 +133,7 @@ export const adminRoutes: RouteObject[] = [
     element: <RequireRoleLayout requiredRole="admin" />,
     children: [
       {
-        path: "analytics/automations",
+        path: "automations",
         element: <AnalyticsAutomationsPage />,
       },
       { path: "model-providers", element: <ModelProvidersPage /> },

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -98,7 +98,7 @@ type SubNavigationAdminId =
   | "sandbox"
   | "analytics"
   | "analytics_consumption"
-  | "analytics_automations"
+  | "automations"
   | "credits_usage"
   | "usage"
   | "self_improving_skills";
@@ -111,7 +111,7 @@ const ADMIN_ROUTE_PATTERNS: Record<SubNavigationAdminId, string[]> = {
   model_providers: ["/w/[wId]/model-providers"],
   analytics: ["/w/[wId]/analytics"],
   analytics_consumption: ["/w/[wId]/analytics/consumption"],
-  analytics_automations: ["/w/[wId]/analytics/automations"],
+  automations: ["/w/[wId]/automations"],
   subscription: ["/w/[wId]/subscription"],
   billing: ["/w/[wId]/billing"],
   api_keys: ["/w/[wId]/developers/api-keys"],
@@ -231,7 +231,7 @@ export const getTopNavigationTabs = (
           "/w/[wId]/billing",
           "/w/[wId]/analytics",
           "/w/[wId]/analytics/consumption",
-          "/w/[wId]/analytics/automations",
+          "/w/[wId]/automations",
           "/w/[wId]/actions",
           "/w/[wId]/developers/credits-usage",
           "/w/[wId]/developers/providers",
@@ -409,11 +409,11 @@ export const subNavigationAdmin = ({
       ...(featureFlags.includes("enable_analytics_automations")
         ? [
             {
-              id: "analytics_automations" as const,
-              label: "Automation",
+              id: "automations" as const,
+              label: "Automations",
               icon: Clock,
-              href: `/w/${owner.sId}/analytics/automations`,
-              current: isCurrent("analytics_automations"),
+              href: `/w/${owner.sId}/automations`,
+              current: isCurrent("automations"),
               disabled: !hasAdminRole,
             },
           ]

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -20,7 +20,7 @@ export function AnalyticsAutomationsPage() {
   if (!isEnabled) {
     return (
       <Page.Vertical align="stretch" gap="xl">
-        <Page.Header title={<Page.H variant="h3">Automation</Page.H>} />
+        <Page.Header title={<Page.H variant="h3">Automations</Page.H>} />
         <div
           className={cn(
             "flex flex-col gap-2 rounded-xl border p-6",
@@ -41,7 +41,7 @@ export function AnalyticsAutomationsPage() {
         title={
           <div className="flex w-full flex-row justify-between gap-4">
             <div className="flex max-w-[700px] flex-col gap-1">
-              <Page.H variant="h3">Automation</Page.H>
+              <Page.H variant="h3">Automations</Page.H>
               <Page.P variant="secondary">
                 Everything that runs on its own: what it costs, how often, and
                 who set it up.

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -116,17 +116,27 @@ function TypeLabel({
   label: string;
 }) {
   return (
-    <div className="flex items-center gap-2">
-      <Icon visual={visual} size="xs" className="text-muted-foreground" />
-      <span className="truncate text-sm">{label}</span>
-    </div>
+    <Tooltip
+      label={label}
+      tooltipTriggerAsChild
+      trigger={
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon visual={visual} size="xs" className="text-muted-foreground" />
+          <span className="truncate text-sm">{label}</span>
+        </div>
+      }
+    />
   );
 }
 
 function AgentCell({ agent }: { agent: AutomationTriggerRow["agent"] }) {
   const content = (
     <div className="min-w-0">
-      <AvatarNameCell name={agent.name} imageUrl={agent.pictureUrl} />
+      <AvatarNameCell
+        name={agent.name}
+        imageUrl={agent.pictureUrl}
+        size="xxs"
+      />
     </div>
   );
 
@@ -192,7 +202,7 @@ function buildColumns({
       id: "name",
       accessorKey: "name",
       header: "Name",
-      meta: { className: "w-56", headerAlign: "left" },
+      meta: { className: "w-48", headerAlign: "left" },
       cell: (info) => (
         <DataTable.CellContent className="w-full justify-start text-left">
           <span className="truncate text-sm">{info.row.original.name}</span>
@@ -257,11 +267,11 @@ function buildColumns({
     },
     {
       id: "status",
-      header: "Enabled",
+      header: "",
       enableSorting: false,
-      meta: { className: "w-24", headerAlign: "left" },
+      meta: { className: "w-24" },
       cell: (info) => (
-        <DataTable.CellContent className="w-full justify-start">
+        <DataTable.CellContent className="w-full justify-center">
           <RunningCell row={info.row.original} />
         </DataTable.CellContent>
       ),
@@ -270,7 +280,7 @@ function buildColumns({
       id: "details",
       header: "",
       enableSorting: false,
-      meta: { className: "w-12", headerAlign: "right" },
+      meta: { className: "w-12" },
       cell: (info) => {
         const row = info.row.original;
         const isExpanded = expandedRowId === row.triggerId;

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -8,7 +8,7 @@ import {
   ProgressBar,
   Tooltip,
 } from "@dust-tt/sparkle";
-import type { ReactNode } from "react";
+import type { ComponentProps, ReactNode } from "react";
 
 function EmptyCell() {
   return <span className="text-xs text-muted-foreground">—</span>;
@@ -18,19 +18,21 @@ interface AvatarNameCellProps {
   name: string;
   imageUrl: string | null;
   isRounded?: boolean;
+  size?: ComponentProps<typeof Avatar>["size"];
 }
 
 export function AvatarNameCell({
   name,
   imageUrl,
   isRounded,
+  size = "xs",
 }: AvatarNameCellProps) {
   return (
     <div className="flex items-center gap-2">
       <Avatar
         name={name}
         visual={imageUrl ?? undefined}
-        size="xs"
+        size={size}
         isRounded={isRounded}
       />
       <span className="truncate text-sm">{name}</span>


### PR DESCRIPTION
## Description

The automations page is a top-level admin destination, not an analytics sub-page, so its URL loses the `/analytics` prefix and its title goes plural. In the triggers table: smaller agent avatar, the full Type value on hover, and a narrower centered Enabled column.

Old `/analytics/automations` URLs now 404. Skipped a redirect since the page is behind `enable_analytics_automations`.

<img width="1257" height="834" alt="Capture d’écran 2026-08-18 à 13 37 07" src="https://github.com/user-attachments/assets/3176cb81-9ef4-4816-97e1-f891605fd209" />

## Tests

Existing analytics component tests pass (50).

## Risk

Low, UI only.

## Deploy Plan

Deploy front.