### PR TITLE
fix: fail fast on members-seats seat-state reads to spare Metronome budget

### DIFF
--- a/front/lib/api/credits/members_seats.ts
+++ b/front/lib/api/credits/members_seats.ts
@@ -84,6 +84,9 @@ async function getMetronomeBilledSeatsByType(
           metronomeCustomerId,
           contractId,
           subscriptionId: sub.id,
+          // Display-only overview: fail fast instead of burning the shared
+          // Metronome rate-limit budget on retries (see buildSeatDataByUserId).
+          maxRetries: 1,
         });
         if (state.isErr()) {
           logger.warn(

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -4,10 +4,10 @@ import {
   grantTypesForVerb,
   ROLE_REGISTRY,
 } from "@app/lib/resources/group_permission_registry";
+import type { GrantVerb } from "@app/types/group_permissions";
 import {
   GRANT_TYPES,
   GRANT_VERBS,
-  type GrantVerb,
   WHOLE_TYPE_RESOURCE_ID,
 } from "@app/types/group_permissions";
 import { describe, expect, it } from "vitest";


### PR DESCRIPTION
## Context

Follow-up to the Metronome 429 incident (#30682, #30683, #30684). Those PRs fixed the dominant read path — `buildSeatDataByUserId` / `/credits/my-usage` (fetched for every user on every page load) — with fleet-wide dedup, no uncached refetch, and `maxRetries: 1`.

`getMetronomeBilledSeatsByType` (`members_seats.ts`) is the remaining unmitigated caller of the same contract endpoint (`getSubscriptionSeatsHistory`). It's lower traffic — only the admin billing seats overview (`BillingSeatsOverview`, mounted on the dedicated billing page) — but it still ran at the **default 5 SDK retries**, so during a rate-limit brownout it burns 5× the shared contract-endpoint budget that contract provisioning needs.

## Change

Pass `maxRetries: 1` to the display-only `getMetronomeSubscriptionSeatState` call (the per-request override added in #30684), matching `buildSeatDataByUserId`. Seat fields are already nullable and the overview degrades to empty on failure.

Deliberately **not** adding a Redis cache here: with the firehose fixed, this admin-only surface doesn't justify the invalidation surface. `maxRetries: 1` is the cheap, consistent hardening.

## Test plan

- `npx tsgo --noEmit -p front` — clean
- Biome — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)