### PR TITLE
[admin governance] Create group resource type

### DIFF
--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -84,6 +84,10 @@ export const ROLE_REGISTRY: Record<
   dust_app: {
     admin: { verbs: ["admin"], levels: ["type"] },
   },
+  group: {
+    reader: { verbs: ["read"], levels: ["instance"] },
+    editor: { verbs: ["read", "write", "admin"], levels: ["instance"] },
+  },
 };
 
 interface GrantSpec {

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -86,7 +86,7 @@ export const ROLE_REGISTRY: Record<
   },
   group: {
     reader: { verbs: ["read"], levels: ["instance"] },
-    editor: { verbs: ["read", "write", "admin"], levels: ["instance"] },
+    admin: { verbs: ["read", "write", "admin"], levels: ["instance"] },
   },
 };
 

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -56,6 +56,7 @@ export const GROUP_PERMISSION_RESOURCE_TYPES = [
   "security",
   "models_tier",
   "dust_app",
+  "group",
   "*",
 ] as const;
 export type GroupPermissionResourceType =
@@ -139,6 +140,7 @@ export function emptyWorkspacePermissions(): WorkspacePermissions {
     security: [],
     models_tier: [],
     dust_app: [],
+    group: [],
   };
 }
 


### PR DESCRIPTION
## Description
This PR is the first mini PR for us to manage groups in group permission table. 

### How does it work? 
For example, when you create a skill, you create two resources: Skill and Group (editors).
Let's say skill id is 123, and editor group id is 456. What we want to store in group permissions table is:
- Permission for the skill, so something like: `groupId: 456, resource type: "skill", resource id: 123, grant type: "editor"`, meaning that the member of groupId 456 can read/write/admin the skill id 123. Everyone in the workspace should be able to read the skill so we need to create `groupId: GLOBAL_ID, resource type: "skill", resource id: 123, grant type: "reader"`,
- Permission for group, because we need a separate permission for controlling permission for groups, something like  `groupId: 456, resource type: "group", resource id: 456, grant type: "admin"`. And same for global group to be able to read it `groupId: GLOBAL_ID, resource type: "group", resource id: 456, grant type: "reader"`. 

The next step is whenever we create a new group, we should store permission in tables. Once we cover all the different path for groups (we have lots of different groups), we can run backfill scripts, make sure it stays the same as before, and then remove the old path. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
