### PR TITLE
Enable the Dust filesystem behind a feature flag

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8718,7 +8718,13 @@
                   },
                   "metadata": {
                     "type": "object",
-                    "nullable": true
+                    "nullable": true,
+                    "properties": {
+                      "useDatabaseFileSystem": {
+                        "type": "boolean",
+                        "description": "Use the database-backed filesystem for a fresh standalone conversation."
+                      }
+                    }
                   },
                   "selectedSpaceIds": {
                     "type": "array",

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -360,6 +360,14 @@ app.patch(
               message: r.error.message,
             },
           });
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: r.error.message,
+            },
+          });
         default:
           assertNever(r.error.code);
       }
@@ -407,6 +415,14 @@ app.patch(
             api_error: {
               type: "internal_server_error",
               message: "Internal server error",
+            },
+          });
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: r.error.message,
             },
           });
         default:

--- a/front-api/routes/w/[wId]/assistant/conversations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.test.ts
@@ -19,6 +19,7 @@ import { getContentFragmentBlob } from "@app/lib/api/assistant/conversation/cont
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -131,5 +132,86 @@ describe("POST /api/w/:wId/assistant/conversations", () => {
         (item: { type: string }) => item.type === "agent_message"
       )
     ).toBe(true);
+  });
+
+  it("requires the database filesystem flag for a standalone conversation", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: null,
+          visibility: "unlisted",
+          spaceId: null,
+          message: null,
+          contentFragments: [],
+          metadata: { useDatabaseFileSystem: true },
+        }),
+      }
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("creates an opted-in standalone conversation when the flag is enabled", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "dust_filesystem");
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Database filesystem",
+          visibility: "unlisted",
+          spaceId: null,
+          message: null,
+          contentFragments: [],
+          metadata: { useDatabaseFileSystem: true },
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.conversation.metadata).toMatchObject({
+      useDatabaseFileSystem: true,
+    });
+  });
+
+  it("does not let a Pod conversation select its filesystem", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(auth, "dust_filesystem");
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: null,
+          visibility: "unlisted",
+          spaceId: "vlt_testPod",
+          message: null,
+          contentFragments: [],
+          metadata: { useDatabaseFileSystem: true },
+        }),
+      }
+    );
+
+    expect(response.status).toBe(400);
   });
 });

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -11,6 +11,7 @@ import {
 } from "@app/lib/api/assistant/conversation/selected_spaces";
 import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import { getPaginationParams } from "@app/lib/api/pagination";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -171,6 +172,10 @@ const app = workspaceApp();
  *               metadata:
  *                 type: object
  *                 nullable: true
+ *                 properties:
+ *                   useDatabaseFileSystem:
+ *                     type: boolean
+ *                     description: Use the database-backed filesystem for a fresh standalone conversation.
  *               selectedSpaceIds:
  *                 type: array
  *                 items:
@@ -257,6 +262,29 @@ app.post(
       ...(selectedSpaceIds ?? []),
       ...(message?.context.selectedSpaceIds ?? []),
     ]);
+
+    if (metadata?.useDatabaseFileSystem === true) {
+      if (spaceId) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "Pod conversations inherit their Pod filesystem and cannot select one directly.",
+          },
+        });
+      }
+      if (!(await hasFeatureFlag(auth, "dust_filesystem"))) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "The database-backed filesystem is not enabled for this workspace.",
+          },
+        });
+      }
+    }
 
     if (allSelectedSpaceIds.length > 0) {
       const validationResult = await validateSelectableSpaces(auth, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -409,7 +409,16 @@ app.patch(
     }
 
     if (name) {
-      await space.updateName(auth, name);
+      const nameRes = await space.updateName(auth, name);
+      if (nameRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: nameRes.error.message,
+          },
+        });
+      }
     }
     return ctx.json({ space: space.toJSON() });
   }

--- a/front-api/routes/w/[wId]/spaces/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/index.test.ts
@@ -1,8 +1,10 @@
+import { DustError } from "@app/lib/error";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { GetSpacesResponseBody } from "@app/types/api/spaces";
+import { Err } from "@app/types/shared/result";
 import type { SpaceKind } from "@app/types/space";
 import { describe, expect, it, vi } from "vitest";
 
@@ -156,5 +158,34 @@ describe("POST /api/w/:wId/spaces", () => {
         isRestricted: false,
       })
     );
+  });
+
+  it("returns the database filesystem opt-in error from project creation", async () => {
+    mockCreateSpaceAndGroup.mockResolvedValue(
+      new Err(
+        new DustError(
+          "invalid_request_error",
+          "The database-backed filesystem is not enabled for this workspace."
+        )
+      )
+    );
+    const { workspace } = await createPrivateApiMockRequest({ role: "admin" });
+
+    const response = await postSpace(workspace, {
+      name: "[Dust FS] Test project",
+      isRestricted: true,
+      spaceKind: "project",
+      managementMode: "manual",
+      memberIds: [],
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message:
+          "The database-backed filesystem is not enabled for this workspace.",
+      },
+    });
   });
 });

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -246,6 +246,14 @@ app.post(
               message: spaceRes.error.message,
             },
           });
+        case "invalid_request_error":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: spaceRes.error.message,
+            },
+          });
         case "unauthorized":
           return apiError(ctx, {
             status_code: 403,

--- a/front/lib/api/actions/servers/run_agent/conversation.ts
+++ b/front/lib/api/actions/servers/run_agent/conversation.ts
@@ -348,6 +348,24 @@ export async function getOrCreateConversation(
 
   const { conversation } = convRes.value;
 
+  if (
+    !mainConversation.spaceId &&
+    mainConversation.metadata?.useDatabaseFileSystem === true
+  ) {
+    const inheritRes = await ConversationResource.inheritDatabaseFileSystem(
+      auth,
+      conversation.sId
+    );
+    if (inheritRes.isErr()) {
+      await cleanupSubConversationAfterSetupFailure(auth, conversation.sId);
+      return new Err(
+        new MCPError("Failed to inherit the parent filesystem", {
+          cause: inheritRes.error,
+        })
+      );
+    }
+  }
+
   const selectedSpacesResult = await copySelectedConversationSpacesToChild(
     auth,
     {

--- a/front/lib/api/assistant/conversation/forks.ts
+++ b/front/lib/api/assistant/conversation/forks.ts
@@ -542,6 +542,8 @@ export async function createConversationFork(
         requestedSpaceIds: [...parentConversation.requestedSpaceIds],
         metadata: {
           useFileSystem: parentConversation.metadata?.useFileSystem ?? false,
+          useDatabaseFileSystem:
+            parentConversation.metadata?.useDatabaseFileSystem === true,
         },
       },
       parentConversation.space,

--- a/front/lib/api/file_system/backends/database_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/database_file_system_backend.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { text } from "node:stream/consumers";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
 import { DATABASE_FILE_SYSTEM_POD_PREFIX } from "@app/lib/api/file_system/storage_mode";
@@ -8,6 +9,7 @@ import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_reso
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import assert from "assert";
 import { describe, expect, it } from "vitest";
@@ -63,6 +65,34 @@ async function databaseFileSystem() {
 }
 
 describe("DatabaseFileSystemBackend", () => {
+  it("writes and reads immutable GCS content through a database node", async () => {
+    const { conversation, dustFileSystem } = await databaseFileSystem();
+    const path = `conversation-${conversation.sId}/report.txt`;
+    fileStorageMock.setFileMetadata(() => ({
+      size: "5",
+      contentType: "text/plain",
+      contentEncoding: "identity",
+    }));
+
+    const written = await dustFileSystem.write(path, "hello", "text/plain");
+
+    expect(written.isOk()).toBe(true);
+    expect(fileStorageMock.saveFileCalls).toHaveLength(1);
+    const [saved] = fileStorageMock.saveFileCalls;
+    assert(saved);
+    fileStorageMock.setFileContent((filePath) =>
+      filePath === saved.filePath ? "hello" : null
+    );
+    const read = await dustFileSystem.read(path);
+    assert(read.isOk() && read.value);
+    expect(await text(read.value)).toBe("hello");
+    expect(await dustFileSystem.stat(path)).toEqual(
+      expect.objectContaining({
+        value: { contentType: "text/plain", sizeBytes: 5 },
+      })
+    );
+  });
+
   it("preserves the inode while moving a file from a conversation to its Pod", async () => {
     const { auth, conversation, dustFileSystem, pod, scope, conversationRoot } =
       await databaseFileSystem();

--- a/front/lib/api/file_system/backends/database_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/database_file_system_backend.test.ts
@@ -1,0 +1,124 @@
+import { randomUUID } from "node:crypto";
+import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
+import { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
+import { DATABASE_FILE_SYSTEM_POD_PREFIX } from "@app/lib/api/file_system/storage_mode";
+import { Authenticator } from "@app/lib/auth";
+import { FileSystemMutationResource } from "@app/lib/resources/file_system_mutation_resource";
+import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+async function databaseFileSystem() {
+  const { user, workspace } = await createResourceTest({
+    role: "admin",
+  });
+  const pod = await SpaceFactory.project(workspace, user.id, {
+    name: `${DATABASE_FILE_SYSTEM_POD_PREFIX}Backend test`,
+  });
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  const agent = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agent.sId,
+    messagesCreatedAt: [],
+    spaceId: pod.id,
+  });
+  const result = await DustFileSystem.forConversation(auth, conversation);
+  assert(result.isOk());
+  const scope = new FileSystemScope(
+    result.value.getMounts().flatMap((mount) =>
+      mount.kind === "user"
+        ? []
+        : [
+            {
+              kind: mount.kind,
+              id: mount.id,
+              name: mount.scopedPrefix,
+              permissions: mount.permissions,
+            },
+          ]
+    )
+  );
+  const roots = await FileSystemNodeResource.ensureRoots(auth, scope);
+  const conversationRoot = roots.find(
+    (root) => root.rootKind === "conversation"
+  );
+  const podRoot = roots.find((root) => root.rootKind === "pod");
+  assert(conversationRoot && podRoot);
+  return {
+    auth,
+    conversation,
+    dustFileSystem: result.value,
+    pod,
+    scope,
+    conversationRoot,
+    podRoot,
+  };
+}
+
+describe("DatabaseFileSystemBackend", () => {
+  it("preserves the inode while moving a file from a conversation to its Pod", async () => {
+    const { auth, conversation, dustFileSystem, pod, scope, conversationRoot } =
+      await databaseFileSystem();
+    const created = await FileSystemMutationResource.createNode(auth, scope, {
+      operation: "create",
+      requestId: randomUUID(),
+      parentId: conversationRoot.id,
+      name: "report.txt",
+      kind: "file",
+      mode: 0o644,
+    });
+    assert(created.isOk());
+
+    const moved = await dustFileSystem.move({
+      src: `conversation-${conversation.sId}/report.txt`,
+      dest: `pod-${pod.sId}/report.txt`,
+    });
+
+    expect(moved).toEqual(
+      expect.objectContaining({
+        value: { sourceDeletionFailed: false },
+      })
+    );
+    const node = await FileSystemNodeResource.fetchById(
+      auth,
+      scope,
+      created.value.id
+    );
+    expect(node).toMatchObject({
+      id: created.value.id,
+      rootKind: "pod",
+      rootId: pod.sId,
+      name: "report.txt",
+    });
+    const entries = await dustFileSystem.list(`pod-${pod.sId}`);
+    expect(entries.isOk() && entries.value).toEqual([
+      expect.objectContaining({
+        fileName: "report.txt",
+        path: `pod-${pod.sId}/report.txt`,
+      }),
+    ]);
+  });
+
+  it("removes a directory tree from the inode namespace", async () => {
+    const { conversation, dustFileSystem } = await databaseFileSystem();
+    const root = `conversation-${conversation.sId}`;
+    expect((await dustFileSystem.mkdir(`${root}/folder`)).isOk()).toBe(true);
+    expect((await dustFileSystem.mkdir(`${root}/folder/nested`)).isOk()).toBe(
+      true
+    );
+
+    const removed = await dustFileSystem.delete(`${root}/folder`);
+
+    expect(removed.isOk()).toBe(true);
+    expect(await dustFileSystem.exists(`${root}/folder`)).toEqual(
+      expect.objectContaining({ value: false })
+    );
+  });
+});

--- a/front/lib/api/file_system/backends/database_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/database_file_system_backend.ts
@@ -1,0 +1,622 @@
+import { randomUUID } from "node:crypto";
+import type { Readable } from "node:stream";
+
+import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
+import {
+  getFileSystemDownloadUrl,
+  getFileSystemReadStream,
+  writeFileSystemContent,
+} from "@app/lib/api/file_system/file_system_content";
+import { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
+import { FileSystemOperationError } from "@app/lib/api/file_system/namespace_types";
+import { DatabaseSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/database_sandbox_mount_adapter";
+import type { SandboxMountAdapter } from "@app/lib/api/file_system/sandbox/sandbox_mount_adapter";
+import type { Authenticator } from "@app/lib/auth";
+import { FILE_SYSTEM_CONTENT_URL_EXPIRATION_MS } from "@app/lib/file_storage/file_system_blobs";
+import { FileSystemMutationResource } from "@app/lib/resources/file_system_mutation_resource";
+import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
+import type {
+  FileSystemDirectoryEntry,
+  FileSystemEntry,
+} from "@app/types/api/file_system/types";
+import type { FileSystemMount, SandboxOnlyMount } from "@app/types/file_system";
+import { DustFileSystemError } from "@app/types/file_system";
+import { stripMimeParameters } from "@app/types/files";
+import { TOOL_OUTPUTS_FOLDER_NAME } from "@app/types/mount_path";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+type ParsedPath = {
+  mount: FileSystemMount;
+  segments: string[];
+};
+
+type ResolvedPath = ParsedPath & {
+  node: FileSystemNodeResource;
+};
+
+const DIRECTORY_CONTENT_TYPE = "application/x-directory";
+const DEFAULT_CONTENT_TYPE = "application/octet-stream";
+const DIRECTORY_PAGE_SIZE = 256;
+
+/** PostgreSQL owns names and inodes; GCS stores only immutable file bytes. */
+export class DatabaseFileSystemBackend implements FileSystemBackend {
+  private readonly scope: FileSystemScope;
+  private rootsPromise: Promise<FileSystemNodeResource[]> | null = null;
+
+  constructor(
+    private readonly auth: Authenticator,
+    private readonly mounts: ReadonlyArray<FileSystemMount>,
+    private readonly sandboxOnlyMounts: ReadonlyArray<SandboxOnlyMount> = []
+  ) {
+    this.scope = new FileSystemScope(
+      mounts.flatMap((mount) =>
+        mount.kind === "user"
+          ? []
+          : [
+              {
+                kind: mount.kind,
+                id: mount.id,
+                name: mount.scopedPrefix,
+                permissions: mount.permissions,
+              },
+            ]
+      )
+    );
+  }
+
+  private parse(scopedPath: string): ParsedPath | null {
+    const mount = this.mounts.find(
+      (candidate) =>
+        scopedPath === candidate.scopedPrefix ||
+        scopedPath.startsWith(`${candidate.scopedPrefix}/`)
+    );
+    if (!mount || mount.kind === "user") {
+      return null;
+    }
+    const relativePath = scopedPath.slice(mount.scopedPrefix.length + 1);
+    return {
+      mount,
+      segments: relativePath ? relativePath.split("/").filter(Boolean) : [],
+    };
+  }
+
+  private async roots(): Promise<FileSystemNodeResource[]> {
+    this.rootsPromise ??= FileSystemNodeResource.ensureRoots(
+      this.auth,
+      this.scope
+    );
+    return this.rootsPromise;
+  }
+
+  private async rootFor(
+    mount: FileSystemMount
+  ): Promise<FileSystemNodeResource> {
+    const root = (await this.roots()).find(
+      (candidate) =>
+        candidate.rootKind === mount.kind && candidate.rootId === mount.id
+    );
+    if (!root) {
+      throw new Error(`Filesystem root was not created: ${mount.scopedPrefix}`);
+    }
+    return root;
+  }
+
+  private async resolve(scopedPath: string): Promise<ResolvedPath | null> {
+    const parsed = this.parse(scopedPath);
+    if (!parsed) {
+      throw new DustFileSystemError(
+        "invalid_path",
+        `Unknown database filesystem path: ${scopedPath}`
+      );
+    }
+    let node = await this.rootFor(parsed.mount);
+    for (const segment of parsed.segments) {
+      if (node.kind !== "directory") {
+        return null;
+      }
+      const child = await node.lookupChild(this.auth, this.scope, segment);
+      if (child.isErr()) {
+        throw child.error;
+      }
+      if (!child.value) {
+        return null;
+      }
+      node = child.value;
+    }
+    return { ...parsed, node };
+  }
+
+  private async resolveParent(scopedPath: string): Promise<{
+    parsed: ParsedPath;
+    parent: FileSystemNodeResource;
+    name: string;
+    existing: FileSystemNodeResource | null;
+  }> {
+    const parsed = this.parse(scopedPath);
+    if (!parsed || parsed.segments.length === 0) {
+      throw new DustFileSystemError(
+        "invalid_path",
+        `A filesystem root cannot be modified: ${scopedPath}`
+      );
+    }
+    const name = parsed.segments.at(-1);
+    if (!name) {
+      throw new DustFileSystemError("invalid_path", "A file name is required.");
+    }
+    const parentPath = [
+      parsed.mount.scopedPrefix,
+      ...parsed.segments.slice(0, -1),
+    ].join("/");
+    const parent = await this.resolve(parentPath);
+    if (!parent || parent.node.kind !== "directory") {
+      throw new FileSystemOperationError(
+        "not_found",
+        "The parent directory was not found."
+      );
+    }
+    const existing = await parent.node.lookupChild(this.auth, this.scope, name);
+    if (existing.isErr()) {
+      throw existing.error;
+    }
+    return { parsed, parent: parent.node, name, existing: existing.value };
+  }
+
+  private error(error: unknown): DustFileSystemError {
+    if (error instanceof DustFileSystemError) {
+      return error;
+    }
+    if (error instanceof FileSystemOperationError) {
+      switch (error.code) {
+        case "already_exists":
+          return new DustFileSystemError("already_exists", error.message);
+        case "not_found":
+          return new DustFileSystemError("not_found", error.message);
+        case "unauthorized":
+          return new DustFileSystemError("unauthorized", error.message);
+        case "is_directory":
+        case "not_directory":
+        case "invalid_operation":
+        case "not_empty":
+        case "stale":
+          return new DustFileSystemError("internal", error.message);
+      }
+    }
+    return new DustFileSystemError("internal", normalizeError(error).message);
+  }
+
+  private entry(
+    node: FileSystemNodeResource,
+    scopedPath: string
+  ): FileSystemEntry {
+    if (node.kind === "directory") {
+      return {
+        isDirectory: true,
+        fileName: node.name,
+        path: scopedPath,
+        sizeBytes: 0,
+        lastModifiedMs: node.updatedAt.getTime(),
+      };
+    }
+    return {
+      isDirectory: false,
+      fileName: node.name,
+      path: scopedPath,
+      sizeBytes: node.size,
+      contentType: stripMimeParameters(
+        node.contentType ?? DEFAULT_CONTENT_TYPE
+      ),
+      lastModifiedMs: node.updatedAt.getTime(),
+      fileId: null,
+      thumbnailUrl: null,
+    };
+  }
+
+  private async children(
+    node: FileSystemNodeResource
+  ): Promise<FileSystemNodeResource[]> {
+    const children: FileSystemNodeResource[] = [];
+    let afterName: string | null = null;
+    do {
+      const page = await node.readDir(this.auth, this.scope, {
+        afterName,
+        limit: DIRECTORY_PAGE_SIZE,
+      });
+      if (page.isErr()) {
+        throw page.error;
+      }
+      children.push(...page.value.nodes);
+      afterName = page.value.nextAfterName;
+    } while (afterName !== null);
+    return children;
+  }
+
+  async list(
+    scopedPath: string,
+    {
+      maxFiles,
+      includeProcessed = false,
+    }: { maxFiles?: number; includeProcessed?: boolean } = {}
+  ): Promise<Result<FileSystemEntry[], DustFileSystemError>> {
+    try {
+      const resolved = await this.resolve(scopedPath.replace(/\/$/, ""));
+      if (!resolved || resolved.node.kind !== "directory") {
+        return new Ok([]);
+      }
+      const entries: FileSystemEntry[] = [];
+      const pending: Array<{ node: FileSystemNodeResource; path: string }> = [
+        { node: resolved.node, path: scopedPath.replace(/\/$/, "") },
+      ];
+      while (
+        pending.length > 0 &&
+        (maxFiles === undefined || entries.length < maxFiles)
+      ) {
+        const current = pending.pop();
+        if (!current) {
+          break;
+        }
+        for (const child of await this.children(current.node)) {
+          const childPath = `${current.path}/${child.name}`;
+          const hidden =
+            child.name.startsWith(".") &&
+            child.name !== TOOL_OUTPUTS_FOLDER_NAME;
+          const processed =
+            child.kind === "file" && child.name.includes(".processed.");
+          if (!hidden && (includeProcessed || !processed)) {
+            entries.push(this.entry(child, childPath));
+          }
+          if (child.kind === "directory" && !hidden) {
+            pending.push({ node: child, path: childPath });
+          }
+          if (maxFiles !== undefined && entries.length >= maxFiles) {
+            break;
+          }
+        }
+      }
+      return new Ok(entries);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async read(
+    scopedPath: string
+  ): Promise<Result<Readable | null, DustFileSystemError>> {
+    try {
+      const resolved = await this.resolve(scopedPath);
+      if (!resolved) {
+        return new Ok(null);
+      }
+      const stream = await getFileSystemReadStream(
+        this.auth,
+        this.scope,
+        resolved.node.id
+      );
+      return stream.isErr()
+        ? new Err(this.error(stream.error))
+        : new Ok(stream.value);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async stat(
+    scopedPath: string
+  ): Promise<
+    Result<
+      { contentType: string; sizeBytes: number } | null,
+      DustFileSystemError
+    >
+  > {
+    try {
+      const resolved = await this.resolve(scopedPath);
+      if (!resolved) {
+        return new Ok(null);
+      }
+      return new Ok({
+        contentType:
+          resolved.node.kind === "directory"
+            ? DIRECTORY_CONTENT_TYPE
+            : stripMimeParameters(
+                resolved.node.contentType ?? DEFAULT_CONTENT_TYPE
+              ),
+        sizeBytes: resolved.node.size,
+      });
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async exists(
+    scopedPath: string
+  ): Promise<Result<boolean, DustFileSystemError>> {
+    try {
+      return new Ok((await this.resolve(scopedPath)) !== null);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async write(
+    scopedPath: string,
+    content: Buffer | string | Readable,
+    contentType: string
+  ): Promise<Result<void, DustFileSystemError>> {
+    try {
+      const destination = await this.resolveParent(scopedPath);
+      let node = destination.existing;
+      if (!node) {
+        const created = await FileSystemMutationResource.createNode(
+          this.auth,
+          this.scope,
+          {
+            operation: "create",
+            requestId: randomUUID(),
+            parentId: destination.parent.id,
+            name: destination.name,
+            kind: "file",
+            mode: 0o644,
+          }
+        );
+        if (created.isErr()) {
+          throw created.error;
+        }
+        node = created.value;
+      }
+      if (node.kind !== "file") {
+        throw new FileSystemOperationError(
+          "invalid_operation",
+          "A directory cannot be overwritten with file content."
+        );
+      }
+      const written = await writeFileSystemContent(this.auth, this.scope, {
+        nodeId: node.id,
+        expectedBlobId: node.blobId,
+        content,
+        contentType,
+      });
+      if (written.isErr()) {
+        throw written.error;
+      }
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async mkdir(
+    scopedPath: string
+  ): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>> {
+    try {
+      const destination = await this.resolveParent(scopedPath);
+      if (destination.existing) {
+        return new Err(
+          new DustFileSystemError(
+            "already_exists",
+            "A file or directory already exists at this path."
+          )
+        );
+      }
+      const created = await FileSystemMutationResource.createNode(
+        this.auth,
+        this.scope,
+        {
+          operation: "create",
+          requestId: randomUUID(),
+          parentId: destination.parent.id,
+          name: destination.name,
+          kind: "directory",
+          mode: 0o755,
+        }
+      );
+      if (created.isErr()) {
+        throw created.error;
+      }
+      const entry = this.entry(created.value, scopedPath);
+      if (!entry.isDirectory) {
+        throw new Error("Created directory rendered as a file.");
+      }
+      return new Ok(entry);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  private async removeNode(
+    parentId: number,
+    node: FileSystemNodeResource
+  ): Promise<void> {
+    if (node.kind === "directory") {
+      for (const child of await this.children(node)) {
+        await this.removeNode(node.id, child);
+      }
+    }
+    const removed = await FileSystemMutationResource.removeNode(
+      this.auth,
+      this.scope,
+      {
+        operation: "remove",
+        requestId: randomUUID(),
+        parentId,
+        name: node.name,
+        kind: node.kind,
+      }
+    );
+    if (removed.isErr()) {
+      throw removed.error;
+    }
+  }
+
+  async delete(
+    scopedPath: string,
+    { ignoreNotFound = false }: { ignoreNotFound?: boolean } = {}
+  ): Promise<Result<void, DustFileSystemError>> {
+    try {
+      const destination = await this.resolveParent(scopedPath);
+      if (!destination.existing) {
+        return ignoreNotFound
+          ? new Ok(undefined)
+          : new Err(
+              new DustFileSystemError(
+                "not_found",
+                `Path not found: ${scopedPath}`
+              )
+            );
+      }
+      await this.removeNode(destination.parent.id, destination.existing);
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  private async copyNode(
+    source: FileSystemNodeResource,
+    destinationParent: FileSystemNodeResource,
+    destinationName: string
+  ): Promise<void> {
+    const created = await FileSystemMutationResource.createNode(
+      this.auth,
+      this.scope,
+      {
+        operation: "create",
+        requestId: randomUUID(),
+        parentId: destinationParent.id,
+        name: destinationName,
+        kind: source.kind,
+        mode: source.mode,
+      }
+    );
+    if (created.isErr()) {
+      throw created.error;
+    }
+    if (source.kind === "file") {
+      const stream = await getFileSystemReadStream(
+        this.auth,
+        this.scope,
+        source.id
+      );
+      if (stream.isErr()) {
+        throw stream.error;
+      }
+      const written = await writeFileSystemContent(this.auth, this.scope, {
+        nodeId: created.value.id,
+        expectedBlobId: null,
+        content: stream.value,
+        contentType: source.contentType ?? DEFAULT_CONTENT_TYPE,
+      });
+      if (written.isErr()) {
+        throw written.error;
+      }
+      return;
+    }
+    for (const child of await this.children(source)) {
+      await this.copyNode(child, created.value, child.name);
+    }
+  }
+
+  async copy({
+    src,
+    dest,
+  }: {
+    src: string;
+    dest: string;
+  }): Promise<Result<void, DustFileSystemError>> {
+    try {
+      const source = await this.resolve(src);
+      if (!source) {
+        return new Err(
+          new DustFileSystemError("not_found", `Path not found: ${src}`)
+        );
+      }
+      const destination = await this.resolveParent(dest);
+      if (destination.existing) {
+        return new Err(
+          new DustFileSystemError(
+            "already_exists",
+            "A file or directory already exists at the destination."
+          )
+        );
+      }
+      await this.copyNode(source.node, destination.parent, destination.name);
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async move({
+    src,
+    dest,
+  }: {
+    src: string;
+    dest: string;
+  }): Promise<Result<{ sourceDeletionFailed: boolean }, DustFileSystemError>> {
+    try {
+      const source = await this.resolveParent(src);
+      if (!source.existing) {
+        return new Err(
+          new DustFileSystemError("not_found", `Path not found: ${src}`)
+        );
+      }
+      const destination = await this.resolveParent(dest);
+      if (destination.existing) {
+        return new Err(
+          new DustFileSystemError(
+            "already_exists",
+            "A file or directory already exists at the destination."
+          )
+        );
+      }
+      const moved = await FileSystemMutationResource.renameNode(
+        this.auth,
+        this.scope,
+        {
+          operation: "rename",
+          requestId: randomUUID(),
+          sourceParentId: source.parent.id,
+          sourceName: source.name,
+          destinationParentId: destination.parent.id,
+          destinationName: destination.name,
+        }
+      );
+      if (moved.isErr()) {
+        throw moved.error;
+      }
+      return new Ok({ sourceDeletionFailed: false });
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async getDownloadUrl(
+    scopedPath: string,
+    opts?: { expiresInMs?: number; fileName?: string }
+  ): Promise<Result<string, DustFileSystemError>> {
+    try {
+      const resolved = await this.resolve(scopedPath);
+      if (!resolved) {
+        return new Err(
+          new DustFileSystemError("not_found", `Path not found: ${scopedPath}`)
+        );
+      }
+      const result = await getFileSystemDownloadUrl(
+        this.auth,
+        this.scope,
+        resolved.node.id,
+        opts?.expiresInMs ?? FILE_SYSTEM_CONTENT_URL_EXPIRATION_MS,
+        opts?.fileName
+      );
+      return result.isErr()
+        ? new Err(this.error(result.error))
+        : new Ok(result.value);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  createSandboxAdapter(): SandboxMountAdapter {
+    return new DatabaseSandboxMountAdapter(this.mounts, this.sandboxOnlyMounts);
+  }
+}

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -100,6 +100,15 @@ export interface FileSystemBackend {
     dest: string;
   }): Promise<Result<void, DustFileSystemError>>;
 
+  /** Move one entry while preserving the backend's native identity rules. */
+  move({
+    src,
+    dest,
+  }: {
+    src: string;
+    dest: string;
+  }): Promise<Result<{ sourceDeletionFailed: boolean }, DustFileSystemError>>;
+
   /**
    * Returns a short-lived signed URL for unauthenticated download.
    * `fileName` overrides the Content-Disposition filename hint.

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -593,6 +593,43 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
   }
 
+  async move({
+    src,
+    dest,
+  }: {
+    src: string;
+    dest: string;
+  }): Promise<Result<{ sourceDeletionFailed: boolean }, DustFileSystemError>> {
+    const destExists = await this.exists(dest);
+    if (destExists.isErr()) {
+      return destExists;
+    }
+    if (destExists.value) {
+      return new Err(
+        new DustFileSystemError(
+          "already_exists",
+          "File name already exists in the destination directory."
+        )
+      );
+    }
+
+    const copyResult = await this.copy({ src, dest });
+    if (copyResult.isErr()) {
+      return copyResult;
+    }
+
+    const deleteResult = await this.delete(src);
+    if (deleteResult.isErr()) {
+      logger.error(
+        { err: deleteResult.error, src, dest },
+        "GCS move left the source after copying the destination"
+      );
+      return new Ok({ sourceDeletionFailed: true });
+    }
+
+    return new Ok({ sourceDeletionFailed: false });
+  }
+
   async getDownloadUrl(
     scopedPath: string,
     opts?: { expiresInMs?: number; fileName?: string }

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -399,13 +399,16 @@ export class DustFileSystem {
 
     const mount = createPodMount(auth, space, { includeLegacy: false });
 
-    const backend = new GCSFileSystemBackend(
-      owner.sId,
-      fileStorageConfig.getGcsPrivateUploadsBucket()
+    const storageMode = fileSystemStorageModeForPod(space);
+    const backend = DustFileSystem.createBackend(
+      auth,
+      [mount],
+      storageMode,
+      sandboxOnlyMounts
     );
 
     return new Ok(
-      new DustFileSystem(auth, [mount], backend, sandboxOnlyMounts)
+      new DustFileSystem(auth, [mount], backend, storageMode, sandboxOnlyMounts)
     );
   }
 

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -17,8 +17,14 @@
  */
 
 import config from "@app/lib/api/config";
+import { DatabaseFileSystemBackend } from "@app/lib/api/file_system/backends/database_file_system_backend";
 import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
+import type { FileSystemStorageMode } from "@app/lib/api/file_system/storage_mode";
+import {
+  fileSystemStorageModeForPod,
+  fileSystemStorageModeForStandaloneConversation,
+} from "@app/lib/api/file_system/storage_mode";
 import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { Authenticator } from "@app/lib/auth";
 import fileStorageConfig from "@app/lib/file_storage/config";
@@ -221,8 +227,25 @@ export class DustFileSystem {
     private readonly auth: Authenticator,
     private readonly mounts: ReadonlyArray<FileSystemMount>,
     private readonly backend: FileSystemBackend,
+    private readonly storageMode: FileSystemStorageMode,
     private readonly sandboxOnlyMounts: ReadonlyArray<SandboxOnlyMount> = []
   ) {}
+
+  private static createBackend(
+    auth: Authenticator,
+    mounts: ReadonlyArray<FileSystemMount>,
+    storageMode: FileSystemStorageMode,
+    sandboxOnlyMounts: ReadonlyArray<SandboxOnlyMount> = []
+  ): FileSystemBackend {
+    if (storageMode === "database") {
+      return new DatabaseFileSystemBackend(auth, mounts, sandboxOnlyMounts);
+    }
+
+    return new GCSFileSystemBackend(
+      auth.getNonNullableWorkspace().sId,
+      fileStorageConfig.getGcsPrivateUploadsBucket()
+    );
+  }
 
   // --------------------------------------------------------------------------
   // Factories
@@ -243,7 +266,6 @@ export class DustFileSystem {
     // TODO(FILE SYSTEM MIGRATION): Ideally, we accept ConversationResource directly.
     conversations: ConversationWithoutContentType[]
   ): Promise<Result<DustFileSystem, DustFileSystemError>> {
-    const owner = auth.getNonNullableWorkspace();
     const mounts: FileSystemMount[] = [];
 
     // Legacy mount points are only meaningful for sandbox use, which is always single-conversation.
@@ -256,11 +278,13 @@ export class DustFileSystem {
     // Collect unique pod space IDs, then batch-fetch to avoid N+1 queries.
     const podConversations = conversations.filter(isPodConversation);
     const uniqueSpaceIds = [...new Set(podConversations.map((c) => c.spaceId))];
+    const spaces =
+      uniqueSpaceIds.length > 0
+        ? await SpaceResource.fetchByIds(auth, uniqueSpaceIds)
+        : [];
+    const spaceById = new Map(spaces.map((space) => [space.sId, space]));
 
     if (uniqueSpaceIds.length > 0) {
-      const spaces = await SpaceResource.fetchByIds(auth, uniqueSpaceIds);
-      const spaceById = new Map(spaces.map((s) => [s.sId, s]));
-
       for (const spaceId of uniqueSpaceIds) {
         const space = spaceById.get(spaceId);
         if (space) {
@@ -269,12 +293,37 @@ export class DustFileSystem {
       }
     }
 
-    const backend = new GCSFileSystemBackend(
-      owner.sId,
-      fileStorageConfig.getGcsPrivateUploadsBucket()
-    );
+    const storageModes = new Set<FileSystemStorageMode>();
+    for (const conversation of conversations) {
+      const pod = isPodConversation(conversation)
+        ? spaceById.get(conversation.spaceId)
+        : null;
+      if (isPodConversation(conversation) && !pod) {
+        return new Err(
+          new DustFileSystemError(
+            "not_found",
+            `Pod not found: ${conversation.spaceId}`
+          )
+        );
+      }
+      storageModes.add(
+        pod
+          ? fileSystemStorageModeForPod(pod)
+          : fileSystemStorageModeForStandaloneConversation(conversation)
+      );
+    }
+    if (storageModes.size > 1) {
+      return new Err(
+        new DustFileSystemError(
+          "internal",
+          "One filesystem cannot mix GCS roots and database-backed roots."
+        )
+      );
+    }
+    const storageMode = storageModes.values().next().value ?? "gcs";
+    const backend = DustFileSystem.createBackend(auth, mounts, storageMode);
 
-    return new Ok(new DustFileSystem(auth, mounts, backend));
+    return new Ok(new DustFileSystem(auth, mounts, backend, storageMode));
   }
 
   /**
@@ -309,16 +358,17 @@ export class DustFileSystem {
       );
     }
 
-    const owner = auth.getNonNullableWorkspace();
     const mount = createPodMount(auth, space, { includeLegacy: false });
-
-    const backend = new GCSFileSystemBackend(
-      owner.sId,
-      fileStorageConfig.getGcsPrivateUploadsBucket()
+    const storageMode = fileSystemStorageModeForPod(space);
+    const backend = DustFileSystem.createBackend(
+      auth,
+      [mount],
+      storageMode,
+      sandboxOnlyMounts
     );
 
     return new Ok(
-      new DustFileSystem(auth, [mount], backend, sandboxOnlyMounts)
+      new DustFileSystem(auth, [mount], backend, storageMode, sandboxOnlyMounts)
     );
   }
 
@@ -386,7 +436,7 @@ export class DustFileSystem {
     );
 
     return new Ok(
-      new DustFileSystem(auth, [createUserMount(user.sId)], backend)
+      new DustFileSystem(auth, [createUserMount(user.sId)], backend, "gcs")
     );
   }
 
@@ -462,8 +512,12 @@ export class DustFileSystem {
       (podId) => !hasMount(mounts, `${SCOPED_PREFIX_POD}${podId}`)
     );
 
+    const additionalSpaces =
+      podIdsToFetch.length > 0
+        ? await SpaceResource.fetchByIds(auth, podIdsToFetch)
+        : [];
     if (podIdsToFetch.length > 0) {
-      const spaces = await SpaceResource.fetchByIds(auth, podIdsToFetch);
+      const spaces = additionalSpaces;
       const spaceById = new Map(spaces.map((s) => [s.sId, s]));
 
       for (const podId of podIdsToFetch) {
@@ -487,13 +541,23 @@ export class DustFileSystem {
       return fsResult;
     }
 
-    const owner = auth.getNonNullableWorkspace();
-    const backend = new GCSFileSystemBackend(
-      owner.sId,
-      fileStorageConfig.getGcsPrivateUploadsBucket()
+    const addedModes = new Set(
+      additionalSpaces.map((space) => fileSystemStorageModeForPod(space))
     );
+    addedModes.add(fsResult.value.storageMode);
+    if (addedModes.size > 1) {
+      return new Err(
+        new DustFileSystemError(
+          "invalid_path",
+          "One agent loop cannot mount GCS roots and database-backed roots together."
+        )
+      );
+    }
 
-    return new Ok(new DustFileSystem(auth, mounts, backend));
+    const storageMode = fsResult.value.storageMode;
+    const backend = DustFileSystem.createBackend(auth, mounts, storageMode);
+
+    return new Ok(new DustFileSystem(auth, mounts, backend, storageMode));
   }
 
   /**
@@ -980,13 +1044,7 @@ export class DustFileSystem {
     return new Ok({ dest, ...moveResult.value });
   }
 
-  /**
-   * Move `src` to `dest` (copy then delete source).
-   *
-   * GCS has no atomic rename so this is copy-then-delete. When the source deletion fails
-   * after a successful copy, returns `Ok({ sourceDeletionFailed: true })` rather than
-   * `Err` because the destination is already the authoritative copy.
-   */
+  /** Move `src` to `dest` using the selected backend. */
   async move({
     src,
     dest,
@@ -1003,41 +1061,10 @@ export class DustFileSystem {
       return resolvedDest;
     }
 
-    const destExists = await this.backend.exists(resolvedDest.value.path);
-    if (destExists.isErr()) {
-      return destExists;
-    }
-    if (destExists.value) {
-      return new Err(
-        new DustFileSystemError(
-          "already_exists",
-          "File name already exists in the destination directory."
-        )
-      );
-    }
-
-    const copyResult = await this.backend.copy({
+    return this.backend.move({
       src: resolvedSrc.value.path,
       dest: resolvedDest.value.path,
     });
-    if (copyResult.isErr()) {
-      return copyResult;
-    }
-
-    const deleteResult = await this.backend.delete(resolvedSrc.value.path);
-    if (deleteResult.isErr()) {
-      logger.error(
-        {
-          err: deleteResult.error,
-          src: resolvedSrc.value.path,
-          dest: resolvedDest.value.path,
-        },
-        "DustFileSystem.move: source delete failed after successful copy"
-      );
-      return new Ok({ sourceDeletionFailed: true });
-    }
-
-    return new Ok({ sourceDeletionFailed: false });
   }
 
   async getDownloadUrl(

--- a/front/lib/api/file_system/file_system_content.ts
+++ b/front/lib/api/file_system/file_system_content.ts
@@ -1,0 +1,211 @@
+import { createReadStream, createWriteStream } from "node:fs";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+
+import type { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
+import {
+  FILE_SYSTEM_CONTENT_MAX_BYTES,
+  FileSystemOperationError,
+} from "@app/lib/api/file_system/namespace_types";
+import type { Authenticator } from "@app/lib/auth";
+import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { fileSystemBlobPath } from "@app/lib/file_storage/file_system_blobs";
+import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { isString } from "@app/types/shared/utils/general";
+import { fileSync } from "tmp";
+
+async function fetchFile(
+  auth: Authenticator,
+  scope: FileSystemScope,
+  nodeId: number
+): Promise<Result<FileSystemNodeResource, FileSystemOperationError>> {
+  const node = await FileSystemNodeResource.fetchById(auth, scope, nodeId);
+  if (!node) {
+    return new Err(
+      new FileSystemOperationError("not_found", "The file was not found.")
+    );
+  }
+  if (node.kind !== "file") {
+    return new Err(
+      new FileSystemOperationError(
+        "invalid_operation",
+        "A directory has no file content."
+      )
+    );
+  }
+  return new Ok(node);
+}
+
+type StagedContent =
+  | { kind: "buffer"; bytes: Buffer; size: number; cleanup: () => void }
+  | { kind: "file"; path: string; size: number; cleanup: () => void };
+
+async function stageContent(
+  content: Buffer | string | Readable
+): Promise<Result<StagedContent, FileSystemOperationError>> {
+  if (isString(content)) {
+    const bytes = Buffer.from(content);
+    return new Ok({ kind: "buffer", bytes, size: bytes.length, cleanup() {} });
+  }
+  if (Buffer.isBuffer(content)) {
+    return new Ok({
+      kind: "buffer",
+      bytes: content,
+      size: content.length,
+      cleanup() {},
+    });
+  }
+
+  // Front needs the size before it signs the immutable upload. Streams first
+  // go to a local file so large writes do not stay in the Node.js heap.
+  const temporaryFile = fileSync({ discardDescriptor: true });
+  let size = 0;
+  try {
+    await pipeline(
+      content,
+      async function* enforceSize(source) {
+        for await (const chunk of source) {
+          const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+          size += bytes.length;
+          if (size > FILE_SYSTEM_CONTENT_MAX_BYTES) {
+            throw new FileSystemOperationError(
+              "invalid_operation",
+              `Content cannot exceed ${FILE_SYSTEM_CONTENT_MAX_BYTES} bytes.`
+            );
+          }
+          yield bytes;
+        }
+      },
+      createWriteStream(temporaryFile.name, { flags: "w" })
+    );
+  } catch (error) {
+    temporaryFile.removeCallback();
+    if (error instanceof FileSystemOperationError) {
+      return new Err(error);
+    }
+    throw error;
+  }
+  return new Ok({
+    kind: "file",
+    path: temporaryFile.name,
+    size,
+    cleanup: temporaryFile.removeCallback,
+  });
+}
+
+/** Reads one node directly from its immutable GCS blob. */
+export async function getFileSystemReadStream(
+  auth: Authenticator,
+  scope: FileSystemScope,
+  nodeId: number
+): Promise<Result<Readable, FileSystemOperationError>> {
+  const nodeRes = await fetchFile(auth, scope, nodeId);
+  if (nodeRes.isErr()) {
+    return nodeRes;
+  }
+  const node = nodeRes.value;
+  if (node.blobId === null) {
+    return new Ok(Readable.from([]));
+  }
+  return new Ok(
+    getPrivateUploadBucket()
+      .file(fileSystemBlobPath(auth, node.id, node.blobId))
+      .createReadStream()
+  );
+}
+
+/** Writes application bytes through the same content checks used by FUSE. */
+export async function writeFileSystemContent(
+  auth: Authenticator,
+  scope: FileSystemScope,
+  request: {
+    nodeId: number;
+    expectedBlobId: string | null;
+    content: Buffer | string | Readable;
+    contentType: string;
+  }
+): Promise<Result<number, FileSystemOperationError>> {
+  const nodeRes = await fetchFile(auth, scope, request.nodeId);
+  if (nodeRes.isErr()) {
+    return nodeRes;
+  }
+  const stagedRes = await stageContent(request.content);
+  if (stagedRes.isErr()) {
+    return stagedRes;
+  }
+  const staged = stagedRes.value;
+  try {
+    const preparedRes = await nodeRes.value.prepareContentUpload(auth, scope, {
+      expectedBlobId: request.expectedBlobId,
+      expectedSizeBytes: staged.size,
+      contentType: request.contentType,
+    });
+    if (preparedRes.isErr()) {
+      return preparedRes;
+    }
+    const upload = preparedRes.value;
+    const file = getPrivateUploadBucket().file(
+      fileSystemBlobPath(auth, request.nodeId, upload.blobId)
+    );
+
+    if (staged.kind === "buffer") {
+      await file.save(staged.bytes, {
+        contentType: upload.contentType,
+        metadata: { contentEncoding: "identity" },
+        preconditionOpts: { ifGenerationMatch: 0 },
+      });
+    } else {
+      await pipeline(
+        createReadStream(staged.path),
+        file.createWriteStream({
+          resumable: true,
+          metadata: {
+            contentType: upload.contentType,
+            contentEncoding: "identity",
+          },
+          preconditionOpts: { ifGenerationMatch: 0 },
+        })
+      );
+    }
+
+    const committedRes = await nodeRes.value.commitContentUpload(auth, scope, {
+      expectedBlobId: request.expectedBlobId,
+      blobId: upload.blobId,
+      expectedSizeBytes: staged.size,
+      contentType: upload.contentType,
+    });
+    return committedRes.isErr() ? committedRes : new Ok(committedRes.value.id);
+  } finally {
+    staged.cleanup();
+  }
+}
+
+export async function getFileSystemDownloadUrl(
+  auth: Authenticator,
+  scope: FileSystemScope,
+  nodeId: number,
+  expirationDelayMs: number,
+  fileName?: string
+): Promise<Result<string, FileSystemOperationError>> {
+  const nodeRes = await fetchFile(auth, scope, nodeId);
+  if (nodeRes.isErr()) {
+    return nodeRes;
+  }
+  const node = nodeRes.value;
+  if (node.blobId === null) {
+    return new Err(
+      new FileSystemOperationError(
+        "not_found",
+        "The file does not have content yet."
+      )
+    );
+  }
+  return new Ok(
+    await getPrivateUploadBucket().getSignedUrl(
+      fileSystemBlobPath(auth, node.id, node.blobId),
+      { expirationDelayMs, promptSaveAs: fileName }
+    )
+  );
+}

--- a/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
@@ -1,10 +1,11 @@
+import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import { DatabaseSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/database_sandbox_mount_adapter";
 import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
 import type { RootCommand } from "@app/lib/api/sandbox/root_command";
 import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
 import { setupPlainConversation } from "@app/tests/utils/conversation_test_factories";
 import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
-import type { FileSystemMount } from "@app/types/file_system";
+import type { FileSystemMount, SandboxOnlyMount } from "@app/types/file_system";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -47,6 +48,15 @@ const mounts: FileSystemMount[] = [
     legacyPrefix: "project",
     legacySandboxMountPoint: "/files/pod",
     permissions: { canRead: true, canWrite: true },
+  },
+];
+
+const sandboxOnlyMounts: SandboxOnlyMount[] = [
+  {
+    kind: "pod_state",
+    id: "pod1",
+    sandboxMountPoint: "/pod-state/replica",
+    readOnly: false,
   },
 ];
 
@@ -142,6 +152,48 @@ describe("DatabaseSandboxMountAdapter", () => {
     expect(result.isErr()).toBe(true);
     expect(requestKill).toHaveBeenCalledOnce();
     expect(execRoot).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when a Pod image cannot mount its GCS-only directories", async () => {
+    const { auth, sandbox, execRoot, requestKill } = await setup();
+    const adapter = new DatabaseSandboxMountAdapter(mounts, sandboxOnlyMounts);
+
+    const result = await adapter.setup(
+      auth,
+      sandbox,
+      SandboxImage.fromDocker("incomplete-image").withCapability(
+        "dust_filesystem"
+      )
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(requestKill).toHaveBeenCalledOnce();
+    expect(execRoot).not.toHaveBeenCalled();
+  });
+
+  it("mounts the Pod's GCS-only directories before starting the daemon", async () => {
+    const { auth, sandbox, execRoot } = await setup();
+    const auxiliarySetup = vi.fn().mockResolvedValue(new Ok(undefined));
+    const createAdapter = vi
+      .spyOn(GCSFileSystemBackend.prototype, "createSandboxAdapter")
+      .mockReturnValue({
+        setup: auxiliarySetup,
+        refreshCredential: vi.fn(),
+      });
+    const adapter = new DatabaseSandboxMountAdapter(mounts, sandboxOnlyMounts);
+    const image = SandboxImage.fromDocker("complete-image")
+      .withCapability("dust_filesystem")
+      .withCapability("gcsfuse");
+
+    const result = await adapter.setup(auth, sandbox, image);
+
+    expect(result.isOk()).toBe(true);
+    expect(createAdapter).toHaveBeenCalledWith([], sandboxOnlyMounts);
+    expect(auxiliarySetup).toHaveBeenCalledWith(auth, sandbox, image);
+    expect(auxiliarySetup.mock.invocationCallOrder[0]).toBeLessThan(
+      execRoot.mock.invocationCallOrder[1]
+    );
+    createAdapter.mockRestore();
   });
 
   it("rotates the token without restarting the mounted daemon", async () => {

--- a/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
@@ -1,0 +1,159 @@
+import { DatabaseSandboxMountAdapter } from "@app/lib/api/file_system/sandbox/database_sandbox_mount_adapter";
+import { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import type { RootCommand } from "@app/lib/api/sandbox/root_command";
+import { renderRootCommand } from "@app/lib/api/sandbox/root_command";
+import { setupPlainConversation } from "@app/tests/utils/conversation_test_factories";
+import { SandboxFactory } from "@app/tests/utils/SandboxFactory";
+import type { FileSystemMount } from "@app/types/file_system";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { generateToken } = vi.hoisted(() => ({
+  generateToken: vi.fn(async () => "scoped-filesystem-token"),
+}));
+
+vi.mock(
+  import("@app/lib/api/sandbox/access_tokens"),
+  async (importOriginal) => {
+    const original = await importOriginal();
+    return { ...original, generateSandboxFileSystemToken: generateToken };
+  }
+);
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getDustAPIConfig: vi.fn(() => ({
+      url: "https://api.example.test",
+      nodeEnv: "test",
+    })),
+  },
+}));
+
+const mounts: FileSystemMount[] = [
+  {
+    kind: "conversation",
+    id: "conv1",
+    scopedPrefix: "conversation-conv1",
+    sandboxMountPoint: "/files/conversation-conv1",
+    legacyPrefix: "conversation",
+    legacySandboxMountPoint: "/files/conversation",
+    permissions: { canRead: true, canWrite: true },
+  },
+  {
+    kind: "pod",
+    id: "pod1",
+    scopedPrefix: "pod-pod1",
+    sandboxMountPoint: "/files/pod-pod1",
+    legacyPrefix: "project",
+    legacySandboxMountPoint: "/files/pod",
+    permissions: { canRead: true, canWrite: true },
+  },
+];
+
+async function setup() {
+  const { auth, conversation } = await setupPlainConversation();
+  const sandbox = await SandboxFactory.create(auth, conversation.toJSON());
+  const execRoot = vi
+    .spyOn(sandbox, "execRoot")
+    .mockResolvedValue(new Ok({ exitCode: 0, stdout: "", stderr: "" }));
+  const requestKill = vi
+    .spyOn(sandbox, "requestKill")
+    .mockResolvedValue(undefined);
+  return { auth, sandbox, execRoot, requestKill };
+}
+
+function commandAt(
+  execRoot: { mock: { calls: unknown[][] } },
+  index: number
+): string {
+  return renderRootCommand(execRoot.mock.calls[index][1] as RootCommand);
+}
+
+describe("DatabaseSandboxMountAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("writes a scoped token through stdin and mounts one filesystem at /files", async () => {
+    const { auth, sandbox, execRoot } = await setup();
+    const adapter = new DatabaseSandboxMountAdapter(mounts, []);
+    const image =
+      SandboxImage.fromDocker("test").withCapability("dust_filesystem");
+
+    const result = await adapter.setup(auth, sandbox, image);
+
+    expect(result.isOk()).toBe(true);
+    expect(generateToken).toHaveBeenCalledWith(auth, {
+      sandbox,
+      roots: [
+        {
+          kind: "conversation",
+          id: "conv1",
+          permissions: { canRead: true, canWrite: true },
+        },
+        {
+          kind: "pod",
+          id: "pod1",
+          permissions: { canRead: true, canWrite: true },
+        },
+      ],
+    });
+    expect(execRoot).toHaveBeenCalledTimes(2);
+    expect(execRoot.mock.calls[0][2]).toMatchObject({
+      stdin: "scoped-filesystem-token",
+    });
+    const tokenCommand = commandAt(execRoot, 0);
+    expect(tokenCommand).not.toContain("scoped-filesystem-token");
+    expect(tokenCommand).toContain("/run/dust-filesystem/token");
+    expect(tokenCommand).toContain("-m 700 /run/dust-filesystem");
+
+    const mountCommand = commandAt(execRoot, 1);
+    expect(mountCommand).toContain(
+      "/usr/bin/systemd-run --unit=dust-filesystem.service --collect"
+    );
+    expect(mountCommand).toContain("--property=Restart=always");
+    expect(mountCommand).toContain("--property=KillMode=control-group");
+    expect(mountCommand).toContain("/opt/bin/dsbx filesystem supervise");
+    expect(mountCommand).toContain("--mountpoint /files");
+    expect(mountCommand).toContain("--api-url 'https://api.example.test'");
+    expect(mountCommand).toContain("/usr/bin/mountpoint -q /files");
+    expect(mountCommand).toContain("/usr/bin/stat -f /files");
+    expect(mountCommand).toContain(
+      "/usr/bin/systemctl is-active --quiet dust-filesystem.service"
+    );
+    expect(mountCommand).toContain(
+      "/usr/bin/journalctl --unit=dust-filesystem.service"
+    );
+    expect(mountCommand).toContain(
+      "/usr/bin/chmod 700 /run/dust-filesystem/staging"
+    );
+  });
+
+  it("fails closed when the image does not contain the daemon", async () => {
+    const { auth, sandbox, execRoot, requestKill } = await setup();
+    const adapter = new DatabaseSandboxMountAdapter(mounts, []);
+
+    const result = await adapter.setup(
+      auth,
+      sandbox,
+      SandboxImage.fromDocker("old-image")
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(requestKill).toHaveBeenCalledOnce();
+    expect(execRoot).not.toHaveBeenCalled();
+  });
+
+  it("rotates the token without restarting the mounted daemon", async () => {
+    const { auth, sandbox, execRoot } = await setup();
+    const adapter = new DatabaseSandboxMountAdapter(mounts, []);
+    const image =
+      SandboxImage.fromDocker("test").withCapability("dust_filesystem");
+
+    const result = await adapter.refreshCredential(auth, sandbox, image);
+
+    expect(result.isOk()).toBe(true);
+    expect(execRoot).toHaveBeenCalledOnce();
+    expect(commandAt(execRoot, 0)).not.toContain("filesystem mount");
+  });
+});

--- a/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.ts
@@ -100,8 +100,7 @@ export class DatabaseSandboxMountAdapter implements SandboxMountAdapter {
     ).createSandboxAdapter([], this.sandboxOnlyMounts);
   }
 
-  async setup(
-    auth: Authenticator,
+  private async checkImage(
     sandbox: SandboxResource,
     image: SandboxImage
   ): Promise<Result<void, Error>> {
@@ -110,6 +109,24 @@ export class DatabaseSandboxMountAdapter implements SandboxMountAdapter {
       return new Err(
         new Error("Sandbox image does not contain the Dust filesystem daemon.")
       );
+    }
+    if (this.sandboxOnlyMounts.length > 0 && !image.hasCapability("gcsfuse")) {
+      await sandbox.requestKill();
+      return new Err(
+        new Error("Sandbox image cannot mount the Pod's GCS-only directories.")
+      );
+    }
+    return new Ok(undefined);
+  }
+
+  async setup(
+    auth: Authenticator,
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>> {
+    const imageRes = await this.checkImage(sandbox, image);
+    if (imageRes.isErr()) {
+      return imageRes;
     }
 
     const tokenResult = await this.writeToken(auth, sandbox);
@@ -196,11 +213,9 @@ export class DatabaseSandboxMountAdapter implements SandboxMountAdapter {
     sandbox: SandboxResource,
     image: SandboxImage
   ): Promise<Result<void, Error>> {
-    if (!image.hasCapability("dust_filesystem")) {
-      await sandbox.requestKill();
-      return new Err(
-        new Error("Sandbox image does not contain the Dust filesystem daemon.")
-      );
+    const imageRes = await this.checkImage(sandbox, image);
+    if (imageRes.isErr()) {
+      return imageRes;
     }
     const tokenResult = await this.writeToken(auth, sandbox);
     if (tokenResult.isErr()) {

--- a/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.ts
@@ -1,0 +1,214 @@
+import { randomBytes } from "node:crypto";
+
+import config from "@app/lib/api/config";
+import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
+import type { SandboxFileSystemRoot } from "@app/lib/api/sandbox/access_tokens";
+import { generateSandboxFileSystemToken } from "@app/lib/api/sandbox/access_tokens";
+import type { SandboxImage } from "@app/lib/api/sandbox/image/sandbox_image";
+import { traceSandboxStartupPhase } from "@app/lib/api/sandbox/instrumentation";
+import { rootCommand } from "@app/lib/api/sandbox/root_command";
+import type { Authenticator } from "@app/lib/auth";
+import fileStorageConfig from "@app/lib/file_storage/config";
+import type { SandboxResource } from "@app/lib/resources/sandbox_resource";
+import logger from "@app/logger/logger";
+import type { FileSystemMount, SandboxOnlyMount } from "@app/types/file_system";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+import type { SandboxMountAdapter } from "./sandbox_mount_adapter";
+
+const FILE_SYSTEM_DIRECTORY = "/run/dust-filesystem";
+const TOKEN_PATH = `${FILE_SYSTEM_DIRECTORY}/token`;
+const STAGING_DIRECTORY = `${FILE_SYSTEM_DIRECTORY}/staging`;
+const SYSTEMD_UNIT = "dust-filesystem.service";
+const MOUNT_POINT = "/files";
+const MOUNT_TIMEOUT_MS = 30_000;
+
+function isTokenRootMount(
+  mount: FileSystemMount
+): mount is FileSystemMount & { kind: SandboxFileSystemRoot["kind"] } {
+  return mount.kind === "conversation" || mount.kind === "pod";
+}
+
+/** Starts one Dust FUSE mount at /files and refreshes its short-lived token. */
+export class DatabaseSandboxMountAdapter implements SandboxMountAdapter {
+  constructor(
+    private readonly mounts: ReadonlyArray<FileSystemMount>,
+    private readonly sandboxOnlyMounts: ReadonlyArray<SandboxOnlyMount>
+  ) {}
+
+  private tokenRoots(): SandboxFileSystemRoot[] {
+    return this.mounts.filter(isTokenRootMount).map((mount) => ({
+      kind: mount.kind,
+      id: mount.id,
+      permissions: mount.permissions,
+    }));
+  }
+
+  private async writeToken(
+    auth: Authenticator,
+    sandbox: SandboxResource
+  ): Promise<Result<void, Error>> {
+    const token = await generateSandboxFileSystemToken(auth, {
+      sandbox,
+      roots: this.tokenRoots(),
+    });
+    const temporaryPath = `${FILE_SYSTEM_DIRECTORY}/.token-${randomBytes(8).toString("hex")}`;
+    const result = await sandbox.execRoot(
+      auth,
+      rootCommand.and([
+        rootCommand.exec("/usr/bin/install", [
+          "-d",
+          "-o",
+          "root",
+          "-g",
+          "root",
+          "-m",
+          "700",
+          FILE_SYSTEM_DIRECTORY,
+        ]),
+        rootCommand.exec("/usr/bin/install", [
+          "-o",
+          "root",
+          "-g",
+          "root",
+          "-m",
+          "600",
+          "/dev/stdin",
+          temporaryPath,
+        ]),
+        rootCommand.exec("/usr/bin/mv", [temporaryPath, TOKEN_PATH]),
+      ]),
+      { stdin: token }
+    );
+    if (result.isErr()) {
+      return result;
+    }
+    return result.value.exitCode === 0
+      ? new Ok(undefined)
+      : new Err(
+          new Error(
+            `Failed to write filesystem token: ${result.value.stderr || result.value.stdout}`
+          )
+        );
+  }
+
+  private auxiliaryAdapter(auth: Authenticator): SandboxMountAdapter {
+    return new GCSFileSystemBackend(
+      auth.getNonNullableWorkspace().sId,
+      fileStorageConfig.getGcsPrivateUploadsBucket()
+    ).createSandboxAdapter([], this.sandboxOnlyMounts);
+  }
+
+  async setup(
+    auth: Authenticator,
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>> {
+    if (!image.hasCapability("dust_filesystem")) {
+      await sandbox.requestKill();
+      return new Err(
+        new Error("Sandbox image does not contain the Dust filesystem daemon.")
+      );
+    }
+
+    const tokenResult = await this.writeToken(auth, sandbox);
+    if (tokenResult.isErr()) {
+      return tokenResult;
+    }
+
+    if (this.sandboxOnlyMounts.length > 0) {
+      const auxiliaryResult = await this.auxiliaryAdapter(auth).setup(
+        auth,
+        sandbox,
+        image
+      );
+      if (auxiliaryResult.isErr()) {
+        return auxiliaryResult;
+      }
+    }
+
+    const apiUrl = config.getDustAPIConfig().url;
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    // systemd restarts the supervisor itself. The Rust supervisor separately
+    // restarts a crashed FUSE child and detaches its stale mount before retrying.
+    const startResult = await traceSandboxStartupPhase(
+      "filesystem.database_mount",
+      () =>
+        sandbox.execRoot(
+          auth,
+          rootCommand.unsafeShell(
+            `/usr/bin/mkdir -p ${STAGING_DIRECTORY} ${MOUNT_POINT}; ` +
+              `/usr/bin/chmod 700 ${STAGING_DIRECTORY}; ` +
+              `if /usr/bin/mountpoint -q ${MOUNT_POINT} && /usr/bin/stat -f ${MOUNT_POINT} >/dev/null 2>&1; then exit 0; fi; ` +
+              `if ! /usr/bin/systemctl is-active --quiet ${SYSTEMD_UNIT}; then ` +
+              `/usr/bin/systemctl reset-failed ${SYSTEMD_UNIT} >/dev/null 2>&1 || true; ` +
+              `/usr/bin/systemd-run --unit=${SYSTEMD_UNIT} --collect ` +
+              `--property=Type=simple --property=Restart=always --property=RestartSec=1s ` +
+              `--property=KillMode=control-group --property=TimeoutStopSec=10s ` +
+              `/opt/bin/dsbx filesystem supervise ` +
+              `--mountpoint ${MOUNT_POINT} ` +
+              `--staging-dir ${STAGING_DIRECTORY} ` +
+              `--api-url '${apiUrl}' ` +
+              `--workspace-id '${workspaceId}' ` +
+              `--token-file ${TOKEN_PATH}; fi; ` +
+              `i=0; while [ $i -lt 200 ]; do ` +
+              `if /usr/bin/mountpoint -q ${MOUNT_POINT} && /usr/bin/stat -f ${MOUNT_POINT} >/dev/null 2>&1; then exit 0; fi; ` +
+              `/usr/bin/sleep 0.05; i=$((i+1)); done; ` +
+              `/usr/bin/printf 'Dust filesystem mount timed out\n' >&2; ` +
+              `/usr/bin/systemctl status ${SYSTEMD_UNIT} --no-pager >&2; ` +
+              `/usr/bin/journalctl --unit=${SYSTEMD_UNIT} --no-pager -n 100 >&2; exit 1`,
+            "Start the Dust filesystem daemon and wait for /files to mount"
+          ),
+          { timeoutMs: MOUNT_TIMEOUT_MS }
+        ),
+      { sandbox_id: sandbox.sId }
+    );
+    if (startResult.isErr()) {
+      return startResult;
+    }
+    if (startResult.value.exitCode !== 0) {
+      logger.error(
+        {
+          sandboxId: sandbox.sId,
+          workspaceId,
+          stderr: startResult.value.stderr,
+          stdout: startResult.value.stdout,
+        },
+        "Dust filesystem daemon failed to mount"
+      );
+      return new Err(
+        new Error(
+          `Dust filesystem daemon failed: ${startResult.value.stderr || startResult.value.stdout}`
+        )
+      );
+    }
+
+    logger.info(
+      { sandboxId: sandbox.sId, workspaceId },
+      "Dust filesystem mounted"
+    );
+    return new Ok(undefined);
+  }
+
+  async refreshCredential(
+    auth: Authenticator,
+    sandbox: SandboxResource,
+    image: SandboxImage
+  ): Promise<Result<void, Error>> {
+    if (!image.hasCapability("dust_filesystem")) {
+      await sandbox.requestKill();
+      return new Err(
+        new Error("Sandbox image does not contain the Dust filesystem daemon.")
+      );
+    }
+    const tokenResult = await this.writeToken(auth, sandbox);
+    if (tokenResult.isErr()) {
+      return tokenResult;
+    }
+    if (this.sandboxOnlyMounts.length === 0) {
+      return new Ok(undefined);
+    }
+    return this.auxiliaryAdapter(auth).refreshCredential(auth, sandbox, image);
+  }
+}

--- a/front/lib/api/file_system/sandbox/sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/sandbox_mount_adapter.ts
@@ -14,7 +14,8 @@ export interface SandboxMountAdapter {
    * server, create mount directories, run the mount tool for each target, and create
    * backward-compat symlinks.
    *
-   * Returns `Ok(undefined)` when the image does not support the required capability.
+   * Each adapter decides how to handle an older sandbox image. The database adapter
+   * returns an error because an opted-in root must never fall back to GCS.
    */
   setup(
     auth: Authenticator,

--- a/front/lib/api/file_system/storage_mode.test.ts
+++ b/front/lib/api/file_system/storage_mode.test.ts
@@ -1,0 +1,34 @@
+import {
+  DATABASE_FILE_SYSTEM_POD_PREFIX,
+  fileSystemStorageModeForPod,
+  fileSystemStorageModeForStandaloneConversation,
+  isDatabaseFileSystemPodName,
+} from "@app/lib/api/file_system/storage_mode";
+import { describe, expect, it } from "vitest";
+
+describe("filesystem storage mode", () => {
+  it("selects the database backend from the Pod name prefix", () => {
+    expect(
+      isDatabaseFileSystemPodName(
+        `${DATABASE_FILE_SYSTEM_POD_PREFIX}Playground`
+      )
+    ).toBe(true);
+    expect(fileSystemStorageModeForPod({ name: "Regular Pod" })).toBe("gcs");
+    expect(
+      fileSystemStorageModeForPod({
+        name: `${DATABASE_FILE_SYSTEM_POD_PREFIX}Playground`,
+      })
+    ).toBe("database");
+  });
+
+  it("selects the database backend from standalone conversation metadata", () => {
+    expect(
+      fileSystemStorageModeForStandaloneConversation({ metadata: {} })
+    ).toBe("gcs");
+    expect(
+      fileSystemStorageModeForStandaloneConversation({
+        metadata: { useDatabaseFileSystem: true },
+      })
+    ).toBe("database");
+  });
+});

--- a/front/lib/api/file_system/storage_mode.ts
+++ b/front/lib/api/file_system/storage_mode.ts
@@ -1,0 +1,25 @@
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+
+export type FileSystemStorageMode = "database" | "gcs";
+
+/** Prefix used to opt a fresh Pod into the database-backed filesystem. */
+export const DATABASE_FILE_SYSTEM_POD_PREFIX = "[Dust FS] ";
+
+export function isDatabaseFileSystemPodName(name: string): boolean {
+  return name.startsWith(DATABASE_FILE_SYSTEM_POD_PREFIX);
+}
+
+export function fileSystemStorageModeForPod(
+  pod: Pick<SpaceResource, "name">
+): FileSystemStorageMode {
+  return isDatabaseFileSystemPodName(pod.name) ? "database" : "gcs";
+}
+
+export function fileSystemStorageModeForStandaloneConversation(
+  conversation: Pick<ConversationWithoutContentType, "metadata">
+): FileSystemStorageMode {
+  return conversation.metadata?.useDatabaseFileSystem === true
+    ? "database"
+    : "gcs";
+}

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -1,3 +1,4 @@
+import { DATABASE_FILE_SYSTEM_POD_PREFIX } from "@app/lib/api/file_system/storage_mode";
 import {
   moveConversationOutOfProject,
   moveConversationToProject,
@@ -76,6 +77,33 @@ describe("moveConversationToProject", () => {
     const setup = await createResourceTest({});
     auth = setup.authenticator;
     workspace = setup.workspace;
+  });
+
+  it("does not move an existing conversation into a database filesystem Pod", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const pod = await SpaceFactory.project(workspace, undefined, {
+      name: `${DATABASE_FILE_SYSTEM_POD_PREFIX}Move test`,
+    });
+    const internalAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const memberGroup = await fetchRegularAutoGroup(pod, internalAuth);
+    expect(memberGroup).not.toBeNull();
+    await memberGroup?.dangerouslyAddMember(internalAuth, {
+      user: auth.getNonNullableUser().toJSON(),
+    });
+    await auth.refresh();
+
+    const result = await moveConversationToProject(auth, {
+      conversation,
+      spaceId: pod.sId,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_request_error");
   });
 
   it("moves a non-project conversation to a project and updates its space", async () => {
@@ -860,6 +888,24 @@ describe("moveConversationOutOfProject", () => {
     const setup = await createResourceTest({});
     auth = setup.authenticator;
     workspace = setup.workspace;
+  });
+
+  it("does not move a conversation out of a database filesystem Pod", async () => {
+    const user = auth.getNonNullableUser();
+    const pod = await SpaceFactory.project(workspace, user.id, {
+      name: `${DATABASE_FILE_SYSTEM_POD_PREFIX}Move out test`,
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+      spaceId: pod.id,
+    });
+    await auth.refresh();
+
+    const result = await moveConversationOutOfProject(auth, { conversation });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_request_error");
   });
 
   it("moves a project conversation out and clears its spaceId", async () => {

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -106,6 +106,31 @@ describe("moveConversationToProject", () => {
     expect(result.isErr() && result.error.code).toBe("invalid_request_error");
   });
 
+  it("does not move an opted-in standalone conversation into a Pod", async () => {
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const optInRes = await ConversationResource.inheritDatabaseFileSystem(
+      auth,
+      conversation.sId
+    );
+    expect(optInRes.isOk()).toBe(true);
+    const pod = await SpaceFactory.project(
+      workspace,
+      auth.getNonNullableUser().id
+    );
+    await auth.refresh();
+
+    const result = await moveConversationToProject(auth, {
+      conversation,
+      spaceId: pod.sId,
+    });
+
+    expect(result.isErr() && result.error.code).toBe("invalid_request_error");
+  });
+
   it("moves a non-project conversation to a project and updates its space", async () => {
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
       name: "Test Agent",

--- a/front/lib/api/projects/conversations.ts
+++ b/front/lib/api/projects/conversations.ts
@@ -2,6 +2,10 @@ import {
   canUserAccessConversation,
   rebuildConversationRequirements,
 } from "@app/lib/api/assistant/conversation/permissions";
+import {
+  fileSystemStorageModeForPod,
+  fileSystemStorageModeForStandaloneConversation,
+} from "@app/lib/api/file_system/storage_mode";
 import { Authenticator } from "@app/lib/auth";
 import type { DustErrorCode } from "@app/lib/error";
 import { DustError } from "@app/lib/error";
@@ -76,6 +80,7 @@ export async function moveConversationToProject(
       | "conversation_not_found"
       | "space_not_found"
       | "conversation_agent_running"
+      | "invalid_request_error"
     >
   >
 > {
@@ -107,6 +112,14 @@ export async function moveConversationToProject(
       )
     );
   }
+  if (fileSystemStorageModeForPod(project) === "database") {
+    return new Err(
+      new DustError(
+        "invalid_request_error",
+        "Conversations cannot be moved into or out of a Pod that uses the database-backed filesystem yet."
+      )
+    );
+  }
 
   // One lifecycle-lock hold covers source validation, the strict sandbox
   // destroy, and the database move — validated against the conversation as
@@ -123,10 +136,27 @@ export async function moveConversationToProject(
       ): Promise<
         Result<
           undefined,
-          DustError<"internal_error" | "space_not_found" | "unauthorized">
+          DustError<
+            | "internal_error"
+            | "invalid_request_error"
+            | "space_not_found"
+            | "unauthorized"
+          >
         >
       > => {
         const sourceSpaceId = freshConversation.spaceSId;
+        if (
+          !sourceSpaceId &&
+          fileSystemStorageModeForStandaloneConversation(freshConversation) ===
+            "database"
+        ) {
+          return new Err(
+            new DustError(
+              "invalid_request_error",
+              "A standalone conversation using the database-backed filesystem cannot be moved into a Pod yet."
+            )
+          );
+        }
         if (sourceSpaceId === project.sId) {
           return new Err(
             new DustError(
@@ -143,6 +173,14 @@ export async function moveConversationToProject(
           if (!previousProject) {
             return new Err(
               new DustError("space_not_found", "Previous project not found")
+            );
+          }
+          if (fileSystemStorageModeForPod(previousProject) === "database") {
+            return new Err(
+              new DustError(
+                "invalid_request_error",
+                "Conversations cannot be moved into or out of a Pod that uses the database-backed filesystem yet."
+              )
             );
           }
           if (!previousProject.canAdministrate(auth)) {
@@ -235,6 +273,7 @@ export async function moveConversationOutOfProject(
       | "unauthorized"
       | "conversation_not_found"
       | "space_not_found"
+      | "invalid_request_error"
     >
   >
 > {
@@ -258,7 +297,12 @@ export async function moveConversationOutOfProject(
             oldUpdatedAt: Date;
             participants: (UserType & { lastReadAt: Date | null })[];
           },
-          DustError<"internal_error" | "space_not_found" | "unauthorized">
+          DustError<
+            | "internal_error"
+            | "invalid_request_error"
+            | "space_not_found"
+            | "unauthorized"
+          >
         >
       > => {
         const sourceSpaceId = freshConversation.spaceSId;
@@ -270,6 +314,14 @@ export async function moveConversationOutOfProject(
         const project = await SpaceResource.fetchById(auth, sourceSpaceId);
         if (!project) {
           return new Err(new DustError("space_not_found", "Project not found"));
+        }
+        if (fileSystemStorageModeForPod(project) === "database") {
+          return new Err(
+            new DustError(
+              "invalid_request_error",
+              "Conversations cannot be moved into or out of a Pod that uses the database-backed filesystem yet."
+            )
+          );
         }
         if (!project.canAdministrate(auth)) {
           return new Err(

--- a/front/lib/api/sandbox/egress_policy.test.ts
+++ b/front/lib/api/sandbox/egress_policy.test.ts
@@ -34,9 +34,15 @@ vi.mock("@app/lib/api/sandbox/egress", () => ({
   mintEgressInvalidationJwt: mockMintEgressInvalidationJwt,
 }));
 
-vi.mock("@app/lib/file_storage", () => ({
-  getBucketInstance: mockGetBucketInstance,
-}));
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
+
+  return {
+    ...original,
+    getBucketInstance: mockGetBucketInstance,
+  };
+});
 
 import {
   addOwnerPolicyDomain,

--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -178,7 +178,7 @@ export interface ToolManifest {
  * The Docker image must actually have the corresponding tooling installed. The capability tag tells
  * orchestration it is safe to attempt the feature.
  */
-export type SandboxCapability = "gcsfuse";
+export type SandboxCapability = "dust_filesystem" | "gcsfuse";
 
 // ---------------------------------------------------------------------------
 // Base Image

--- a/front/lib/api/sandbox/instrumentation.ts
+++ b/front/lib/api/sandbox/instrumentation.ts
@@ -28,6 +28,7 @@ type SandboxStartupPhase =
   | "egress_prep"
   | "gcs_mount"
   | "gcs_refresh"
+  | "filesystem.database_mount"
   | "egress_on_exec"
   | "telemetry_start"
   // provider.create split.

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1,4 +1,5 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
+import { DATABASE_FILE_SYSTEM_POD_PREFIX } from "@app/lib/api/file_system/storage_mode";
 import { getProjectConversationsDatasourceName } from "@app/lib/api/projects/data_sources";
 import {
   createSpaceAndGroup,
@@ -17,6 +18,7 @@ import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces"
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
@@ -84,6 +86,40 @@ describe("createSpaceAndGroup", () => {
   });
 
   describe("successful creation", () => {
+    it("only allows fresh database filesystem Pods when the flag is enabled", async () => {
+      const params = {
+        name: `${DATABASE_FILE_SYSTEM_POD_PREFIX}Playground`,
+        isRestricted: true,
+        spaceKind: "project" as const,
+        managementMode: "manual" as const,
+        memberIds: [],
+      };
+
+      const disabledRes = await createSpaceAndGroup(adminAuth, params);
+      expect(disabledRes.isErr() && disabledRes.error.code).toBe(
+        "invalid_request_error"
+      );
+
+      await FeatureFlagFactory.basic(adminAuth, "dust_filesystem");
+      const enabledRes = await createSpaceAndGroup(adminAuth, params);
+      expect(enabledRes.isOk()).toBe(true);
+      if (enabledRes.isErr()) {
+        return;
+      }
+
+      const sameModeRenameRes = await enabledRes.value.updateName(
+        adminAuth,
+        `${DATABASE_FILE_SYSTEM_POD_PREFIX}Renamed`
+      );
+      expect(sameModeRenameRes.isOk()).toBe(true);
+
+      const removePrefixRes = await enabledRes.value.updateName(
+        adminAuth,
+        "Regular Pod"
+      );
+      expect(removePrefixRes.isErr()).toBe(true);
+    });
+
     it("should create a regular space with manual management mode and members", async () => {
       const result = await createSpaceAndGroup(adminAuth, {
         name: "Test Regular Space",

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -8,10 +8,12 @@ import {
 import { getWebhookSourcesUsage } from "@app/lib/api/agent_triggers";
 import { hardDeleteApp } from "@app/lib/api/apps";
 import { updateAgentRequirements } from "@app/lib/api/assistant/configuration/agent_requirements";
+import { isDatabaseFileSystemPodName } from "@app/lib/api/file_system/storage_mode";
 import { createDataSourceAndConnectorForProject } from "@app/lib/api/projects/connector";
 import { deleteOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
 import { getWorkspaceAdministrationVersionLock } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
+import { hasFeatureFlag } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -625,6 +627,7 @@ export async function createSpaceAndGroup(
       | "limit_reached"
       | "space_already_exists"
       | "internal_error"
+      | "invalid_request_error"
       | "unauthorized"
     >
   >
@@ -643,6 +646,20 @@ export async function createSpaceAndGroup(
   const owner = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();
   const { name: rawName, isRestricted, spaceKind, managementMode } = params;
+  const name = rawName.trim();
+
+  if (
+    spaceKind === "project" &&
+    isDatabaseFileSystemPodName(name) &&
+    !(await hasFeatureFlag(auth, "dust_filesystem"))
+  ) {
+    return new Err(
+      new DustError(
+        "invalid_request_error",
+        "The database-backed filesystem is not enabled for this workspace."
+      )
+    );
+  }
 
   const result = await withTransaction(async (t) => {
     await getWorkspaceAdministrationVersionLock(owner, t);
@@ -663,8 +680,6 @@ export async function createSpaceAndGroup(
     }
 
     // Trim the name to prevent issues with leading/trailing whitespace
-    const name = rawName.trim();
-
     if (spaceKind === "regular" && !isRestricted) {
       assert(
         managementMode === "manual",

--- a/front/lib/file_storage/file_system_blobs.ts
+++ b/front/lib/file_storage/file_system_blobs.ts
@@ -13,7 +13,7 @@ const IDENTITY_CONTENT_ENCODING = "identity";
 export const FILE_SYSTEM_CONTENT_URL_EXPIRATION_MS =
   2 * DEFAULT_SIGNED_URL_EXPIRATION_DELAY_MS;
 
-function objectPath(
+export function fileSystemBlobPath(
   auth: Authenticator,
   nodeId: number,
   blobId: string
@@ -28,7 +28,7 @@ export async function getFileSystemBlobDownloadUrl(
   blobId: string
 ): Promise<string> {
   return getPrivateUploadBucket().getSignedUrl(
-    objectPath(auth, nodeId, blobId),
+    fileSystemBlobPath(auth, nodeId, blobId),
     { expirationDelayMs: FILE_SYSTEM_CONTENT_URL_EXPIRATION_MS }
   );
 }
@@ -52,7 +52,7 @@ export async function prepareFileSystemBlobUpload(
     [GCS_CREATE_ONLY_HEADER]: GCS_CREATE_ONLY_VALUE,
   };
   const uploadUrl = await getPrivateUploadBucket().getSignedUploadUrl(
-    objectPath(auth, nodeId, blobId),
+    fileSystemBlobPath(auth, nodeId, blobId),
     {
       contentType,
       expirationDelayMs: FILE_SYSTEM_CONTENT_URL_EXPIRATION_MS,
@@ -79,7 +79,7 @@ export async function getFileSystemBlobMetadata(
   contentDisposition: string | undefined;
 }> {
   const [metadata] = await getPrivateUploadBucket()
-    .file(objectPath(auth, nodeId, blobId))
+    .file(fileSystemBlobPath(auth, nodeId, blobId))
     .getMetadata();
 
   return {

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -39,42 +39,50 @@ import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 const gcsStore = new Map<string, Buffer>();
 let gcsSaveFailureMarker: string | null = null;
 
-vi.mock("@app/lib/file_storage", () => ({
-  getPrivateUploadBucket: vi.fn(() => ({
-    file: vi.fn((path: string) => ({
-      copy: vi.fn().mockResolvedValue(undefined),
-      save: vi.fn(async (data: Buffer) => {
-        if (
-          gcsSaveFailureMarker &&
-          data.toString("utf-8").includes(gcsSaveFailureMarker)
-        ) {
-          throw new Error("Simulated GCS write failure");
-        }
-        gcsStore.set(path, data);
-      }),
-      download: vi.fn(async () => {
-        const buf = gcsStore.get(path);
-        if (!buf) {
-          throw new Error(`GCS file not found: ${path}`);
-        }
-        return [buf];
-      }),
-    })),
-    delete: vi.fn(async (path: string, opts?: { ignoreNotFound?: boolean }) => {
-      if (!gcsStore.has(path) && !opts?.ignoreNotFound) {
-        throw new Error(`GCS file not found: ${path}`);
-      }
-      gcsStore.delete(path);
-    }),
-    deleteByPrefix: vi.fn(async (prefix: string) => {
-      for (const path of [...gcsStore.keys()]) {
-        if (path.startsWith(prefix)) {
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
+
+  return {
+    ...original,
+    getPrivateUploadBucket: vi.fn(() => ({
+      file: vi.fn((path: string) => ({
+        copy: vi.fn().mockResolvedValue(undefined),
+        save: vi.fn(async (data: Buffer) => {
+          if (
+            gcsSaveFailureMarker &&
+            data.toString("utf-8").includes(gcsSaveFailureMarker)
+          ) {
+            throw new Error("Simulated GCS write failure");
+          }
+          gcsStore.set(path, data);
+        }),
+        download: vi.fn(async () => {
+          const buf = gcsStore.get(path);
+          if (!buf) {
+            throw new Error(`GCS file not found: ${path}`);
+          }
+          return [buf];
+        }),
+      })),
+      delete: vi.fn(
+        async (path: string, opts?: { ignoreNotFound?: boolean }) => {
+          if (!gcsStore.has(path) && !opts?.ignoreNotFound) {
+            throw new Error(`GCS file not found: ${path}`);
+          }
           gcsStore.delete(path);
         }
-      }
-    }),
-  })),
-}));
+      ),
+      deleteByPrefix: vi.fn(async (prefix: string) => {
+        for (const path of [...gcsStore.keys()]) {
+          if (path.startsWith(prefix)) {
+            gcsStore.delete(path);
+          }
+        }
+      }),
+    })),
+  };
+});
 
 // Bypass Redis caching, pass through to the underlying function.
 vi.mock("@app/lib/utils/cache", async (importOriginal) => {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -4592,6 +4592,30 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok(undefined);
   }
 
+  /** Copies the filesystem choice to a fresh standalone child conversation. */
+  static async inheritDatabaseFileSystem(
+    auth: Authenticator,
+    sId: string
+  ): Promise<Result<undefined, Error>> {
+    const conversation = await this.fetchById(auth, sId);
+    if (!conversation) {
+      return new Err(new ConversationError("conversation_not_found"));
+    }
+    if (conversation.spaceId !== null) {
+      return new Err(
+        new Error("Pod conversations inherit their Pod filesystem.")
+      );
+    }
+
+    await conversation.update({
+      metadata: {
+        ...conversation.metadata,
+        useDatabaseFileSystem: true,
+      },
+    });
+    return new Ok(undefined);
+  }
+
   static async fetchMCPServerViews(
     auth: Authenticator,
     conversation: ConversationWithoutContentType | ConversationResource,

--- a/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
+++ b/front/lib/resources/sandbox_function_mcp_action_resource.test.ts
@@ -15,33 +15,41 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // In-memory GCS mock: writes persist content that reads can return.
 const gcsStore = new Map<string, Buffer>();
 
-vi.mock("@app/lib/file_storage", () => ({
-  getPrivateUploadBucket: vi.fn(() => ({
-    file: vi.fn((path: string) => ({
-      save: vi.fn(async (data: Buffer) => {
-        gcsStore.set(path, data);
-      }),
-      download: vi.fn(async () => {
-        const buf = gcsStore.get(path);
-        if (!buf) {
-          throw new Error(`GCS file not found: ${path}`);
+vi.mock("@app/lib/file_storage", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@app/lib/file_storage")>();
+
+  return {
+    ...original,
+    getPrivateUploadBucket: vi.fn(() => ({
+      file: vi.fn((path: string) => ({
+        save: vi.fn(async (data: Buffer) => {
+          gcsStore.set(path, data);
+        }),
+        download: vi.fn(async () => {
+          const buf = gcsStore.get(path);
+          if (!buf) {
+            throw new Error(`GCS file not found: ${path}`);
+          }
+          return [buf];
+        }),
+      })),
+      delete: vi.fn(
+        async (path: string, opts?: { ignoreNotFound?: boolean }) => {
+          if (!gcsStore.has(path) && !opts?.ignoreNotFound) {
+            throw new Error(`GCS file not found: ${path}`);
+          }
+          gcsStore.delete(path);
         }
-        return [buf];
-      }),
+      ),
+      uploadBufferToBucket: vi.fn(
+        async ({ buffer, filePath }: { buffer: Buffer; filePath: string }) => {
+          gcsStore.set(filePath, buffer);
+        }
+      ),
     })),
-    delete: vi.fn(async (path: string, opts?: { ignoreNotFound?: boolean }) => {
-      if (!gcsStore.has(path) && !opts?.ignoreNotFound) {
-        throw new Error(`GCS file not found: ${path}`);
-      }
-      gcsStore.delete(path);
-    }),
-    uploadBufferToBucket: vi.fn(
-      async ({ buffer, filePath }: { buffer: Buffer; filePath: string }) => {
-        gcsStore.set(filePath, buffer);
-      }
-    ),
-  })),
-}));
+  };
+});
 
 const inputSchema: JSONSchema = {
   type: "object",

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1,3 +1,4 @@
+import { isDatabaseFileSystemPodName } from "@app/lib/api/file_system/storage_mode";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentProjectConfigurationModel } from "@app/lib/models/agent/actions/projects";
@@ -891,6 +892,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     const trimmedName = newName.trim();
+    if (
+      this.isProject() &&
+      isDatabaseFileSystemPodName(this.name) !==
+        isDatabaseFileSystemPodName(trimmedName)
+    ) {
+      return new Err(
+        new Error(
+          "A Pod cannot add or remove the database filesystem prefix after creation."
+        )
+      );
+    }
     const existingSpace = await SpaceResource.fetchByName(auth, trimmedName);
     if (existingSpace && existingSpace.id !== this.id) {
       return new Err(new Error("This space name is already used."));

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -94,8 +94,11 @@ export class SpaceFactory {
     );
   }
 
-  static async project(workspace: WorkspaceType, creatorId?: number) {
-    const name = "project " + faker.string.alphanumeric(8);
+  static async project(
+    workspace: WorkspaceType,
+    creatorId?: number,
+    { name = "project " + faker.string.alphanumeric(8) }: { name?: string } = {}
+  ) {
     const group = await GroupResource.makeNew({
       name: `${PROJECT_GROUP_PREFIX} ${name}`,
       workspaceId: workspace.id,

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -528,6 +528,8 @@ export type ConversationMetadata = Record<string, unknown> & {
   urlAccessMode?: ConversationUrlAccessMode;
   projectTaskId?: string;
   useFileSystem?: boolean;
+  /** Selects the database-backed filesystem for a fresh standalone conversation. */
+  useDatabaseFileSystem?: boolean;
 };
 
 function isConversationUrlAccessMode(

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -1,4 +1,9 @@
 export const WHITELISTABLE_FEATURES_CONFIG = {
+  dust_filesystem: {
+    description:
+      "Allow fresh Pods and standalone conversations to use the database-backed filesystem",
+    stage: "dust_only",
+  },
   allow_sso: {
     description:
       "Allow this workspace to configure SSO, independently of the plan's isSSOAllowed flag. Enable on demand for Business plan workspaces.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -756,6 +756,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dummy_feature_for_flag_testing"
   | "dust_agent_gpt_5_6_luna_default"
   | "dust_agent_sonnet_5_default"
+  | "dust_filesystem"
   | "dust_internal_dangerous_in_cluster_mcp_servers"
   | "dust_internal_global_agents"
   | "fireworks_new_model_feature"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR connects the new database-backed filesystem to Front and sandbox startup while keeping the current GCS filesystem as the default.

Nothing changes unless the `dust_filesystem` feature flag is enabled and a fresh Pod or standalone conversation explicitly selects the new filesystem. Existing Pods and conversations continue using GCS. There is no data migration and no new
database field.

For this first rollout, a Pod opts in through the `[Dust FS]`  name prefix ]. The prefix can only be selected when the workspace has the feature flag, and it cannot be added or removed after creation (yeah not ideal, but it saves us from altering the data model of project metadata).

A fresh standalone conversation can opt in with `metadata.useDatabaseFileSystem`. Pod conversations cannot choose independently because they inherit their Pod’s filesystem. Forks and `run_agent` child conversations keep the choice made by their standalone parent.

Front now selects one of two complete backends behind the existing `DustFileSystem` interface. The GCS backend keeps today’s behavior. The database backend uses filesystem nodes for names and identity, while immutable file bytes remain in GCS. Reads, writes, directory creation, deletion, copy, move and download URLs therefore continue using the same application-facing API.

A database-backed move updates the node’s parent and name instead of copying bytes and deleting the source. This preserves the inode when a file moves between the conversation and Pod roots.

A filesystem instance cannot mix GCS and database-backed roots. We also prevent moving conversations into or out of a database-backed Pod for now, since that would require migrating their existing files between the two stores.

For sandbox use, the new adapter writes a short-lived scoped token and starts the Rust daemon under systemd at `/files`. Token refresh does not restart the mount. Startup fails clearly if the sandbox image does not contain the `dust_filesystem` capability. Pod directories that still require GCS remain mounted through the existing adapter.

A final sandbox image change will ship the matching `dsbx` daemon before we enable the flag.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
