### PR TITLE
[front] enh: Add fair-use limit on premium model for legacy plans

### DIFF
--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -18,7 +18,8 @@ function postMessage(
   workspace: { sId: string },
   conversationId: string,
   key: { secret: string },
-  body: unknown
+  body: unknown,
+  extraHeaders: Record<string, string> = {}
 ) {
   return honoApp.request(
     `/api/v1/w/${workspace.sId}/assistant/conversations/${conversationId}/messages`,
@@ -27,6 +28,7 @@ function postMessage(
       headers: {
         authorization: `Bearer ${key.secret}`,
         "Content-Type": "application/json",
+        ...extraHeaders,
       },
       body: JSON.stringify(body),
     }
@@ -204,5 +206,77 @@ describe("POST /api/v1/w/[wId]/assistant/conversations/[cId]/messages", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.message.requestedModel).toEqual(modelSelection);
+  });
+
+  it("rebuilds the posting user from x-api-user-email on a system key", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await postMessage(
+      workspace,
+      conversation.sId,
+      key,
+      {
+        content: "Hello",
+        mentions: [],
+        // No `context.email`: the only path to an attributed user is the header
+        // exchange, so this asserts the auth rebuild and not email attribution.
+        context: {
+          username: "sub-agent",
+          timezone: "Europe/Paris",
+          origin: "api",
+        },
+      },
+      { "x-api-user-email": user.email }
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.message.user?.sId).toBe(user.sId);
+  });
+
+  it("leaves the posting user unattributed without x-api-user-email", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      method: "POST",
+      systemKey: true,
+    });
+
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const conversation = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+
+    const response = await postMessage(workspace, conversation.sId, key, {
+      content: "Hello",
+      mentions: [],
+      context: {
+        username: "sub-agent",
+        timezone: "Europe/Paris",
+        origin: "api",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.message.user).toBeNull();
   });
 });

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -34,6 +34,7 @@ import {
   batchRenderUserMessagesWithoutMentions,
 } from "@app/lib/api/assistant/messages";
 import { isProviderWhitelistedForAuth } from "@app/lib/api/assistant/models";
+import { checkPremiumModelMessageLimit } from "@app/lib/api/assistant/premium_model_limit";
 import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
 import {
   MESSAGE_RATE_LIMIT_PER_ACTOR_PER_HOUR,
@@ -829,6 +830,17 @@ export async function postUserMessage(
       })
     : null;
 
+  if (user && modelResolution) {
+    const premiumModelLimitResult = await checkPremiumModelMessageLimit(auth, {
+      user,
+      resolvedModel: modelResolution.resolvedModel,
+      context,
+    });
+    if (premiumModelLimitResult.isErr()) {
+      return premiumModelLimitResult;
+    }
+  }
+
   // In one big transaction create all Message, UserMessage, AgentMessage and Mention rows.
   const { userMessage, agentMessages } = await withTransaction(async (t) => {
     // Since we are getting a transaction level lock, we can't execute any other SQL query outside of
@@ -1237,6 +1249,17 @@ export async function editUserMessage(
         selection: message.requestedModel ?? undefined,
       })
     : null;
+
+  if (user && modelResolution) {
+    const premiumModelLimitResult = await checkPremiumModelMessageLimit(auth, {
+      user,
+      resolvedModel: modelResolution.resolvedModel,
+      context: message.context,
+    });
+    if (premiumModelLimitResult.isErr()) {
+      return premiumModelLimitResult;
+    }
+  }
 
   try {
     // In one big transaction create all Message, UserMessage, AgentMessage, and Mention rows.
@@ -1791,6 +1814,26 @@ export async function retryAgentMessage(
   });
   if (limitResult.isErr()) {
     return limitResult;
+  }
+
+  const user = auth.user();
+  if (user) {
+    const resolvedModel =
+      message.resolvedModel ??
+      (
+        await resolveModelForMentionedAgent(auth, {
+          configuration: message.configuration,
+        })
+      ).resolvedModel;
+
+    const premiumModelLimitResult = await checkPremiumModelMessageLimit(auth, {
+      user,
+      resolvedModel,
+      context: parentUserMessage.context,
+    });
+    if (premiumModelLimitResult.isErr()) {
+      return premiumModelLimitResult;
+    }
   }
 
   const retryAgentConfiguration = await getAgentConfiguration(auth, {

--- a/front/lib/api/assistant/conversation/validate_agent_mention.ts
+++ b/front/lib/api/assistant/conversation/validate_agent_mention.ts
@@ -12,6 +12,7 @@ import {
   createAgentMessages,
   resolveModelForMentionedAgent,
 } from "@app/lib/api/assistant/conversation/messages";
+import { checkPremiumModelMessageLimit } from "@app/lib/api/assistant/premium_model_limit";
 import { publishMessageEventsOnMessagePostOrEdit } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
 import { MentionModel } from "@app/lib/models/agent/conversation";
@@ -234,6 +235,15 @@ export async function validateAgentMention(
     configuration,
     selection: message.requestedModel ?? undefined,
   });
+
+  const premiumModelLimitResult = await checkPremiumModelMessageLimit(auth, {
+    user: auth.getNonNullableUser(),
+    resolvedModel: modelResolution.resolvedModel,
+    context: message.context,
+  });
+  if (premiumModelLimitResult.isErr()) {
+    return premiumModelLimitResult;
+  }
 
   let agentMessages: AgentMessageType[];
   let updatedRichMentions: RichMentionWithStatus[];

--- a/front/lib/api/assistant/premium_model_limit.test.ts
+++ b/front/lib/api/assistant/premium_model_limit.test.ts
@@ -1,0 +1,217 @@
+import { checkPremiumModelMessageLimit } from "@app/lib/api/assistant/premium_model_limit";
+import type { Authenticator, AuthMethodType } from "@app/lib/auth";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type {
+  UserMessageContext,
+  UserMessageOrigin,
+} from "@app/types/assistant/conversation";
+import type { ResolvedRequestedModel } from "@app/types/assistant/models/types";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockGetFeatureFlags,
+  mockGetRateLimiterCount,
+  mockAddRateLimiterCount,
+} = vi.hoisted(() => ({
+  mockGetFeatureFlags: vi.fn(),
+  mockGetRateLimiterCount: vi.fn(),
+  mockAddRateLimiterCount: vi.fn(),
+}));
+
+vi.mock("@app/lib/auth", () => ({
+  getFeatureFlags: mockGetFeatureFlags,
+}));
+
+vi.mock("@app/lib/utils/rate_limiter", () => ({
+  getRateLimiterCount: mockGetRateLimiterCount,
+  addRateLimiterCount: mockAddRateLimiterCount,
+}));
+
+const PREMIUM_MODEL: ResolvedRequestedModel = {
+  providerId: "anthropic",
+  modelId: "claude-opus-5",
+  reasoningEffort: "medium",
+};
+
+const BALANCED_MODEL: ResolvedRequestedModel = {
+  providerId: "anthropic",
+  modelId: "claude-sonnet-5",
+  reasoningEffort: "medium",
+};
+
+const EXPECTED_KEY = "workspace:42:user:7:premium_model_message_count";
+const EXPECTED_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+
+// Minimal stand-in for the Authenticator class exposing only the members the gate reads. A class
+// instance can't be constructed structurally, so a single `as unknown as` is the standard test-mock
+// escape here (see the same pattern across the suite); the cast surface is kept to this one spot.
+function makeAuth({
+  planCode = "PRO_PLAN_SEAT_29",
+  authMethod = "session",
+}: {
+  planCode?: string;
+  authMethod?: AuthMethodType;
+} = {}): Authenticator {
+  return {
+    getNonNullableWorkspace: () => ({ id: 42, sId: "ws_test" }),
+    getNonNullablePlan: () => ({ code: planCode }),
+    authMethod: () => authMethod,
+  } as unknown as Authenticator;
+}
+
+const USER = {
+  id: 7,
+  sId: "user_test",
+  toJSON: () => ({ id: 7, sId: "user_test" }),
+} as unknown as UserResource;
+
+function callGate(
+  auth: Authenticator,
+  {
+    resolvedModel = PREMIUM_MODEL,
+    origin = "web",
+  }: {
+    resolvedModel?: ResolvedRequestedModel;
+    origin?: UserMessageOrigin;
+  } = {}
+) {
+  return checkPremiumModelMessageLimit(auth, {
+    user: USER,
+    resolvedModel,
+    context: { origin } as UserMessageContext,
+  });
+}
+
+describe("checkPremiumModelMessageLimit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetFeatureFlags.mockResolvedValue([
+      "enforce_premium_model_message_limit",
+    ]);
+    mockGetRateLimiterCount.mockResolvedValue(new Ok(0));
+    mockAddRateLimiterCount.mockResolvedValue(undefined);
+  });
+
+  it("records a premium message under the weekly limit", async () => {
+    const result = await callGate(makeAuth());
+
+    expect(result.isOk()).toBe(true);
+    expect(mockGetRateLimiterCount).toHaveBeenCalledWith({
+      key: EXPECTED_KEY,
+      timeframeSeconds: EXPECTED_WINDOW_SECONDS,
+    });
+    expect(mockAddRateLimiterCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: EXPECTED_KEY,
+        timeframeSeconds: EXPECTED_WINDOW_SECONDS,
+        incrementBy: 1,
+      })
+    );
+  });
+
+  it("blocks and stops recording once the limit is reached and the flag is on", async () => {
+    mockGetRateLimiterCount.mockResolvedValue(new Ok(25));
+
+    const result = await callGate(makeAuth());
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.status_code).toBe(429);
+      expect(result.error.api_error.type).toBe("rate_limit_error");
+    }
+    expect(mockAddRateLimiterCount).not.toHaveBeenCalled();
+  });
+
+  it("keeps recording past the limit when the flag is off", async () => {
+    mockGetFeatureFlags.mockResolvedValue([]);
+    mockGetRateLimiterCount.mockResolvedValue(new Ok(60));
+
+    const result = await callGate(makeAuth());
+
+    expect(result.isOk()).toBe(true);
+    expect(mockAddRateLimiterCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows and records when the count cannot be read", async () => {
+    mockGetRateLimiterCount.mockResolvedValue(new Err(new Error("redis down")));
+
+    const result = await callGate(makeAuth());
+
+    expect(result.isOk()).toBe(true);
+    expect(mockAddRateLimiterCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not count non-premium models", async () => {
+    const result = await callGate(makeAuth(), {
+      resolvedModel: BALANCED_MODEL,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockGetRateLimiterCount).not.toHaveBeenCalled();
+    expect(mockAddRateLimiterCount).not.toHaveBeenCalled();
+  });
+
+  it("does not count credit-priced plans", async () => {
+    const result = await callGate(makeAuth({ planCode: "CP_PRO" }));
+
+    expect(result.isOk()).toBe(true);
+    expect(mockGetRateLimiterCount).not.toHaveBeenCalled();
+    expect(mockAddRateLimiterCount).not.toHaveBeenCalled();
+  });
+
+  it("counts trigger and wakeup runs as fair use", async () => {
+    for (const origin of ["triggered", "wakeup"] as const) {
+      vi.clearAllMocks();
+      mockGetRateLimiterCount.mockResolvedValue(new Ok(0));
+
+      const result = await callGate(makeAuth({ authMethod: "internal" }), {
+        origin,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(mockAddRateLimiterCount).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("does not count programmatic origins", async () => {
+    for (const origin of ["api", "triggered_programmatic", "zapier"] as const) {
+      vi.clearAllMocks();
+
+      const result = await callGate(makeAuth({ authMethod: "internal" }), {
+        origin,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(mockGetRateLimiterCount).not.toHaveBeenCalled();
+      expect(mockAddRateLimiterCount).not.toHaveBeenCalled();
+    }
+  });
+
+  it("does not count non-system API key auth", async () => {
+    const result = await callGate(makeAuth({ authMethod: "api_key" }), {
+      origin: "slack",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockGetRateLimiterCount).not.toHaveBeenCalled();
+    expect(mockAddRateLimiterCount).not.toHaveBeenCalled();
+  });
+
+  it("counts system-key sub-agent runs that inherit an interactive origin", async () => {
+    const result = await callGate(makeAuth({ authMethod: "system_api_key" }), {
+      origin: "web",
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockAddRateLimiterCount).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not count free origins", async () => {
+    const result = await callGate(makeAuth(), { origin: "agent_sidekick" });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockGetRateLimiterCount).not.toHaveBeenCalled();
+    expect(mockAddRateLimiterCount).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/assistant/premium_model_limit.ts
+++ b/front/lib/api/assistant/premium_model_limit.ts
@@ -1,0 +1,119 @@
+import {
+  makePremiumModelMessageRateLimitKeyForUser,
+  PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK,
+  PREMIUM_MODEL_MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
+} from "@app/lib/api/assistant/rate_limits";
+import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { isFreeOrigin } from "@app/lib/credits/agent_message_billing";
+import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import {
+  addRateLimiterCount,
+  getRateLimiterCount,
+} from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import type { UserMessageContext } from "@app/types/assistant/conversation";
+import type { ResolvedRequestedModel } from "@app/types/assistant/models/types";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { isCreditPricedPlan } from "@app/types/plan";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export async function checkPremiumModelMessageLimit(
+  auth: Authenticator,
+  {
+    user,
+    resolvedModel,
+    context,
+  }: {
+    user: UserResource;
+    resolvedModel: ResolvedRequestedModel;
+    context: UserMessageContext;
+  }
+): Promise<Result<void, APIErrorWithContentfulStatusCode>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const plan = auth.getNonNullablePlan();
+
+  if (
+    isCreditPricedPlan(plan) ||
+    isFreeOrigin(context.origin) ||
+    isProgrammaticUsage(auth, { userMessageOrigin: context.origin })
+  ) {
+    return new Ok(undefined);
+  }
+
+  const tierName = ModelsTierResource.getTierForModel(
+    resolvedModel.modelId,
+    resolvedModel.reasoningEffort
+  );
+  if (tierName !== "premium") {
+    return new Ok(undefined);
+  }
+
+  const key = makePremiumModelMessageRateLimitKeyForUser(
+    workspace,
+    user.toJSON()
+  );
+  const countResult = await getRateLimiterCount({
+    key,
+    timeframeSeconds: PREMIUM_MODEL_MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
+  });
+
+  if (countResult.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        error: countResult.error,
+      },
+      "[PremiumModelLimit] Failed to read the premium model count; allowing message."
+    );
+  }
+
+  if (
+    countResult.isOk() &&
+    countResult.value >= PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK
+  ) {
+    const featureFlags = await getFeatureFlags(auth);
+    const isBlocked = featureFlags.includes(
+      "enforce_premium_model_message_limit"
+    );
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        userId: user.sId,
+        count: countResult.value,
+        limit: PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK,
+        modelId: resolvedModel.modelId,
+        reasoningEffort: resolvedModel.reasoningEffort,
+        origin: context.origin,
+        isBlocked,
+      },
+      "[PremiumModelLimit] Premium model weekly limit reached."
+    );
+
+    if (isBlocked) {
+      return new Err({
+        status_code: 429,
+        api_error: {
+          type: "rate_limit_error",
+          message:
+            `You have reached the limit of ${PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK} messages ` +
+            `per week on premium models. Pick another model or try again later.`,
+        },
+      });
+    }
+  }
+
+  await addRateLimiterCount({
+    key,
+    timeframeSeconds: PREMIUM_MODEL_MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
+    incrementBy: 1,
+    logger,
+  });
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -85,6 +85,16 @@ export const makeFairUseAwuCreditsRateLimitKeyForUser = (
   return `workspace:${owner.id}:user:${user.id}:fair_use_awu_credit_count:${maxAwuCreditsTimeframe}`;
 };
 
+export const PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK = 25;
+export const PREMIUM_MODEL_MESSAGE_RATE_LIMIT_WINDOW_SECONDS = 7 * 24 * 60 * 60;
+
+export const makePremiumModelMessageRateLimitKeyForUser = (
+  workspace: LightWorkspaceType,
+  user: UserType
+) => {
+  return `workspace:${workspace.id}:user:${user.id}:premium_model_message_count`;
+};
+
 // Fixed-window counter backing the admin-configured per-user spend cap. Always
 // bucketed on the Metronome contract billing cycle (the fixed-window counter
 // appends the cycle-boundary label). Distinct from the rolling plan-level

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -342,6 +342,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Enable the per-user spend-cap backup: record per-user AWU usage into the Redis fixed-window counter and enforce it at message send (blocks with user_cap_reached). When off, usage is neither recorded nor enforced.",
     stage: "dust_only",
   },
+  enforce_premium_model_message_limit: {
+    description:
+      "Enforce the premium-model cap: block a message once the user has spent 25 premium-tier messages in the rolling week, on workspaces with a non-credit-priced (legacy) plan. Usage is counted regardless, so the flag only controls blocking.",
+    stage: "dust_only",
+  },
   editable_tool_inputs: {
     description:
       "Allow editing tool inputs before approving a tool call in the tool validation UI.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -812,6 +812,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "user_memory"
   | "similar_agents_check"
   | "enforce_user_spend_limit_rate_cap"
+  | "enforce_premium_model_message_limit"
   | "editable_tool_inputs"
   | "skip_free_usage_rate_limit"
 >();


### PR DESCRIPTION
## Description

Add rate limiting for legacy plans usage of premium models: 25/users/week.

The counting & flagging will be live at deploy, the blocking is behind a feature flag.

Caveats:

- for sub-agent runs, we rely on the fact that we pass an email header along with system key and reconstruct auth object with user(). so they will count toward the limit
- triggers / wake-ups do too (unless under programmatic)
- programmatic is bypassed

This code should be cleaned up once we have switched all legacy plans to CP

## Tests

Added tests (system key email matching, new fair limit, etc)

## Risk

Low
Blast radius: Whole agent loop

## Deploy Plan

Deploy front