### PR TITLE
feat: search automations by name in the analytics table

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
@@ -156,6 +156,21 @@ describe("POST /api/w/:wId/analytics/automations/triggers", () => {
     );
   });
 
+  it("forwards a trimmed search", async () => {
+    vi.mocked(fetchAutomationTriggers).mockResolvedValue(new Ok(TRIGGERS));
+    const { workspace } = await setupTest();
+
+    const response = await postTriggersRequest(workspace.sId, {
+      search: "  competitor  ",
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchAutomationTriggers)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ search: "competitor" })
+    );
+  });
+
   it("returns 400 on a negative offset", async () => {
     const { workspace } = await setupTest();
 

--- a/front-api/routes/w/[wId]/analytics/automations/triggers.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.ts
@@ -21,7 +21,8 @@ app.post(
   validate("json", AutomationTriggersBodySchema),
   async (ctx): HandlerResult<GetAutomationTriggersResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, filter, ...periodQuery } = ctx.req.valid("json");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -32,6 +33,7 @@ app.post(
       period,
       limit,
       offset,
+      search,
       filter,
     });
     if (result.isErr()) {

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -341,20 +341,20 @@ export function AutomationsTriggersTable({
     [filter]
   );
 
-  const { inputValue, debouncedValue, setValue } = useDebounce("", {
-    delay: SEARCH_DEBOUNCE_DELAY_MS,
-  });
-
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: TRIGGERS_PAGE_SIZE,
   });
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
 
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: SEARCH_DEBOUNCE_DELAY_MS,
+  });
+
   // A filter or search change invalidates the current page and any expanded
   // row. Reset during render
-  // (https://react.dev/learn/you-might-not-need-an-effect) instead of an effect
-  // keyed on them.
+  // (https://react.dev/learn/you-might-not-need-an-effect) instead of an
+  // effect keyed on the query.
   const [prevQuery, setPrevQuery] = useState({
     filter,
     search: debouncedValue,

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -12,6 +12,7 @@ import {
   EntityTooltipCard,
 } from "@app/components/workspace/analytics/creditsTableCells";
 import { useAutomationsTriggers } from "@app/hooks/useAutomationsTriggers";
+import { useDebounce } from "@app/hooks/useDebounce";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { useUpdateTriggerStatus } from "@app/lib/swr/agent_triggers";
@@ -30,6 +31,7 @@ import {
   DataTableLoadingSkeleton,
   Icon,
   Pagination,
+  SearchInput,
   SliderToggle,
   Tooltip,
 } from "@dust-tt/sparkle";
@@ -37,6 +39,7 @@ import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import type { ComponentProps, Dispatch, SetStateAction } from "react";
 import { useCallback, useContext, useMemo, useState } from "react";
 
+const SEARCH_DEBOUNCE_DELAY_MS = 300;
 const TRIGGERS_PAGE_SIZE = 25;
 
 interface TriggerRowData extends BaseTriggerRowData {
@@ -338,18 +341,26 @@ export function AutomationsTriggersTable({
     [filter]
   );
 
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: SEARCH_DEBOUNCE_DELAY_MS,
+  });
+
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: TRIGGERS_PAGE_SIZE,
   });
   const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
 
-  // A filter change invalidates the current page and any expanded row.
-  // Reset during render (https://react.dev/learn/you-might-not-need-an-effect)
-  // instead of an effect keyed on `filter`.
-  const [prevFilter, setPrevFilter] = useState(filter);
-  if (prevFilter !== filter) {
-    setPrevFilter(filter);
+  // A filter or search change invalidates the current page and any expanded
+  // row. Reset during render
+  // (https://react.dev/learn/you-might-not-need-an-effect) instead of an effect
+  // keyed on them.
+  const [prevQuery, setPrevQuery] = useState({
+    filter,
+    search: debouncedValue,
+  });
+  if (prevQuery.filter !== filter || prevQuery.search !== debouncedValue) {
+    setPrevQuery({ filter, search: debouncedValue });
     setPagination((current) => ({ ...current, pageIndex: 0 }));
     setExpandedRowId(null);
   }
@@ -364,6 +375,7 @@ export function AutomationsTriggersTable({
   } = useAutomationsTriggers({
     workspaceId,
     period,
+    search: debouncedValue,
     filter: triggersFilter,
     limit: pagination.pageSize,
     offset: pagination.pageIndex * pagination.pageSize,
@@ -456,7 +468,14 @@ export function AutomationsTriggersTable({
   return (
     <div className="rounded-lg border border-border bg-panel-background p-4">
       <div className="mb-4 flex flex-col gap-2">
-        <div className="flex items-center justify-end">
+        <div className="flex items-center gap-2">
+          <SearchInput
+            name="automations-triggers-search"
+            placeholder="Search…"
+            value={inputValue}
+            onChange={setValue}
+            className="flex-1"
+          />
           <AutomationsFilterPanel
             owner={owner}
             filter={filter}
@@ -471,6 +490,7 @@ export function AutomationsTriggersTable({
       <TriggersTableBody
         isLoading={isTriggersLoading}
         isError={!!isTriggersError}
+        search={debouncedValue}
         rows={rows}
         totalCount={totalCount}
         medianRunCount={medianRunCount}
@@ -488,6 +508,7 @@ export function AutomationsTriggersTable({
 interface TriggersTableBodyProps {
   isLoading: boolean;
   isError: boolean;
+  search: string;
   rows: TriggerRowData[];
   totalCount: number;
   medianRunCount: number;
@@ -502,6 +523,7 @@ interface TriggersTableBodyProps {
 function TriggersTableBody({
   isLoading,
   isError,
+  search,
   rows,
   totalCount,
   medianRunCount,
@@ -534,7 +556,9 @@ function TriggersTableBody({
   if (rows.length === 0) {
     return (
       <div className="text-sm text-muted-foreground">
-        No automation ran over this period.
+        {search.trim()
+          ? `No match for "${search.trim()}".`
+          : "No automation ran over this period."}
       </div>
     );
   }

--- a/front/hooks/useAutomationsTriggers.ts
+++ b/front/hooks/useAutomationsTriggers.ts
@@ -16,6 +16,7 @@ export function useAutomationsTriggers({
   period,
   limit,
   offset = 0,
+  search,
   filter,
   disabled,
 }: {
@@ -23,6 +24,7 @@ export function useAutomationsTriggers({
   period: ConsumptionPeriodSelection;
   limit: number;
   offset?: number;
+  search?: string;
   filter?: AutomationTriggersFilter;
   disabled?: boolean;
 }) {
@@ -33,6 +35,7 @@ export function useAutomationsTriggers({
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
     limit,
     offset,
+    search: search?.trim(),
     filter,
   };
 

--- a/front/lib/api/analytics/automations/schema.ts
+++ b/front/lib/api/analytics/automations/schema.ts
@@ -27,6 +27,7 @@ export const AutomationTriggersBodySchema = ConsumptionPeriodSchema.extend({
     .max(100)
     .default(DEFAULT_AUTOMATION_TRIGGERS_LIMIT),
   offset: z.number().int().nonnegative().default(0),
+  search: z.string().trim().optional(),
   filter: AutomationTriggersFilterSchema.optional(),
 });
 

--- a/front/lib/api/analytics/automations/triggers.test.ts
+++ b/front/lib/api/analytics/automations/triggers.test.ts
@@ -1,5 +1,6 @@
 import { fetchAutomationTriggers } from "@app/lib/api/analytics/automations/triggers";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { TRIGGER_ID_FIELD } from "@app/lib/api/analytics/consumption/scope";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -96,6 +97,116 @@ describe("fetchAutomationTriggers", () => {
     expect(page1.value.triggers[0].triggerId).toBe(highCreditTrigger.sId);
     expect(page2.value.triggers).toHaveLength(1);
     expect(page2.value.triggers[0].triggerId).toBe(lowCreditTrigger.sId);
+  });
+
+  it("narrows the page to the search matches without moving the median baseline", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const matchingTrigger = await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Competitor watch",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+    const otherTrigger = await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Inbound triage",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const buckets = [
+      bucket(matchingTrigger.sId, 100, 100_000_000),
+      bucket(otherTrigger.sId, 10, 100_000),
+    ];
+    mockRanking(buckets);
+    const unsearched = await fetchAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 10,
+      offset: 0,
+    });
+    mockRanking(buckets);
+    const searched = await fetchAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 10,
+      offset: 0,
+      search: "competitor",
+    });
+
+    expect(unsearched.isOk()).toBe(true);
+    expect(searched.isOk()).toBe(true);
+    if (!unsearched.isOk() || !searched.isOk()) {
+      return;
+    }
+
+    expect(searched.value.triggers.map((t) => t.triggerId)).toEqual([
+      matchingTrigger.sId,
+    ]);
+    expect(searched.value.totalCount).toBe(1);
+
+    // A search narrows the rows, not the population a row's stats compare
+    // against: the breakdown captions say "median across all triggers".
+    expect(searched.value.medianRunCount).toBe(unsearched.value.medianRunCount);
+    expect(searched.value.medianCostPerRun).toBe(
+      unsearched.value.medianCostPerRun
+    );
+    expect(searched.value.medianRunCount).toBe(55);
+  });
+
+  it("restricts the query to the filtered kinds", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const scheduleTrigger = await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Competitor watch",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    mockRanking([bucket(scheduleTrigger.sId, 100, 100_000_000)]);
+    const result = await fetchAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 10,
+      offset: 0,
+      filter: { kinds: ["schedule"] },
+    });
+
+    expect(result.isOk()).toBe(true);
+    // Kind is not indexed in the consumption documents, so it reaches
+    // Elasticsearch as the resolved set of trigger ids.
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toMatchObject({
+      bool: {
+        filter: expect.arrayContaining([
+          { terms: { [TRIGGER_ID_FIELD]: [scheduleTrigger.sId] } },
+        ]),
+      },
+    });
+  });
+
+  it("returns no rows when the search matches no trigger name", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const trigger = await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Competitor watch",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    mockRanking([bucket(trigger.sId, 100, 100_000_000)]);
+    const result = await fetchAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 10,
+      offset: 0,
+      search: "nothing matches this",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.triggers).toEqual([]);
+    expect(result.value.totalCount).toBe(0);
   });
 
   it("keeps a zero run-count trigger out of the median without dividing by zero", async () => {

--- a/front/lib/api/analytics/automations/triggers.test.ts
+++ b/front/lib/api/analytics/automations/triggers.test.ts
@@ -1,6 +1,5 @@
 import { fetchAutomationTriggers } from "@app/lib/api/analytics/automations/triggers";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import { TRIGGER_ID_FIELD } from "@app/lib/api/analytics/consumption/scope";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -141,6 +140,7 @@ describe("fetchAutomationTriggers", () => {
     expect(searched.value.triggers.map((t) => t.triggerId)).toEqual([
       matchingTrigger.sId,
     ]);
+    // The cardinality aggregation would have reported 2 here.
     expect(searched.value.totalCount).toBe(1);
 
     // A search narrows the rows, not the population a row's stats compare
@@ -150,37 +150,6 @@ describe("fetchAutomationTriggers", () => {
       unsearched.value.medianCostPerRun
     );
     expect(searched.value.medianRunCount).toBe(55);
-  });
-
-  it("restricts the query to the filtered kinds", async () => {
-    const { authenticator } = await createResourceTest({ role: "admin" });
-    const agent =
-      await AgentConfigurationFactory.createTestAgent(authenticator);
-    const scheduleTrigger = await TriggerFactory.schedule(authenticator, {
-      agentConfigurationId: agent.sId,
-      name: "Competitor watch",
-      configuration: { cron: "0 9 * * *", timezone: "UTC" },
-    });
-
-    mockRanking([bucket(scheduleTrigger.sId, 100, 100_000_000)]);
-    const result = await fetchAutomationTriggers(authenticator, {
-      period: PERIOD,
-      limit: 10,
-      offset: 0,
-      filter: { kinds: ["schedule"] },
-    });
-
-    expect(result.isOk()).toBe(true);
-    // Kind is not indexed in the consumption documents, so it reaches
-    // Elasticsearch as the resolved set of trigger ids.
-    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
-    expect(query).toMatchObject({
-      bool: {
-        filter: expect.arrayContaining([
-          { terms: { [TRIGGER_ID_FIELD]: [scheduleTrigger.sId] } },
-        ]),
-      },
-    });
   });
 
   it("returns no rows when the search matches no trigger name", async () => {

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -107,56 +107,41 @@ function median(values: number[]): number {
     : sorted[mid];
 }
 
-type TriggerRestrictions = {
-  // Applied as a terms filter on the query, so it scopes the ranking and the
-  // median baseline alike. Null means no restriction.
-  kindIds: string[] | null;
-  // Applied to the ranked buckets instead, so a search narrows the rows
-  // without moving the median baseline. Null means no restriction.
-  searchIds: Set<string> | null;
-};
+/**
+ * Trigger kind isn't indexed in the consumption Elasticsearch documents, so
+ * a kind filter is resolved to a concrete set of trigger ids up front and
+ * applied as a terms filter on TRIGGER_ID_FIELD. Returns null when no kind
+ * filter is requested (no restriction).
+ */
+async function resolveTriggerIdsForKindFilter(
+  auth: Authenticator,
+  kinds: TriggerKind[] | undefined
+): Promise<string[] | null> {
+  if (!kinds || kinds.length === 0) {
+    return null;
+  }
+  const triggers = await TriggerResource.listByWorkspaceAndKinds(auth, kinds);
+  return triggers.map((trigger) => trigger.sId);
+}
 
 /**
- * Neither trigger kind nor trigger name is indexed in the consumption
- * Elasticsearch documents, so both restrictions are resolved to concrete sets
- * of trigger ids up front, from one read of the workspace's triggers. Matching
- * names in memory mirrors how the consumption ranking resolves its own search
- * against the facet catalog (resolveConsumptionTopSearchFilter).
+ * Trigger name isn't indexed in the consumption documents either, so a search
+ * resolves to trigger ids the same way a kind filter does. Unlike the kind
+ * filter it stays out of the query: the median baseline has to keep comparing a
+ * row against every trigger that ran, not just the ones that matched.
  */
-async function resolveTriggerRestrictions(
+async function resolveTriggerIdsForSearch(
   auth: Authenticator,
-  {
-    kinds,
-    search,
-  }: {
-    kinds: TriggerKind[] | undefined;
-    search: string | undefined;
+  search: string | undefined
+): Promise<Set<string> | null> {
+  if (!search) {
+    return null;
   }
-): Promise<TriggerRestrictions> {
-  const kindSet = kinds?.length ? new Set(kinds) : null;
-  const normalizedSearch = search?.trim().toLowerCase();
-  if (!kindSet && !normalizedSearch) {
-    return { kindIds: null, searchIds: null };
-  }
-
-  const triggers = await TriggerResource.listByWorkspace(auth);
-
-  return {
-    kindIds: kindSet
-      ? triggers
-          .filter((trigger) => kindSet.has(trigger.kind))
-          .map((trigger) => trigger.sId)
-      : null,
-    searchIds: normalizedSearch
-      ? new Set(
-          triggers
-            .filter((trigger) =>
-              trigger.name.toLowerCase().includes(normalizedSearch)
-            )
-            .map((trigger) => trigger.sId)
-        )
-      : null,
-  };
+  const triggers = await TriggerResource.listByWorkspaceAndNameSearch(
+    auth,
+    search
+  );
+  return new Set(triggers.map((trigger) => trigger.sId));
 }
 
 /**
@@ -166,7 +151,7 @@ async function resolveTriggerRestrictions(
  * count below), so both the requested page and the median baseline are
  * sliced/derived from that same, page-independent set — a trigger's stats
  * always compare against the full active set, never just the triggers
- * ranked ahead of it, nor just the ones a search matched.
+ * ranked ahead of it.
  */
 async function fetchTriggersRanking(
   auth: Authenticator,
@@ -202,10 +187,11 @@ async function fetchTriggersRanking(
     scopeFilter.users = filter.editorIds;
   }
 
-  const { kindIds, searchIds } = await resolveTriggerRestrictions(auth, {
-    kinds: filter?.kinds,
-    search,
-  });
+  const triggerIdsForKindFilter = await resolveTriggerIdsForKindFilter(
+    auth,
+    filter?.kinds
+  );
+  const triggerIdsForSearch = await resolveTriggerIdsForSearch(auth, search);
 
   const query = buildConsumptionScopeQuery({
     auth,
@@ -213,7 +199,9 @@ async function fetchTriggersRanking(
     endDate: period.endDate,
     filter: scopeFilter,
     extraFilters:
-      kindIds !== null ? [{ terms: { [TRIGGER_ID_FIELD]: kindIds } }] : [],
+      triggerIdsForKindFilter !== null
+        ? [{ terms: { [TRIGGER_ID_FIELD]: triggerIdsForKindFilter } }]
+        : [],
   });
 
   const result = await searchConsumptionAnalytics<never, TriggerAggs>(query, {
@@ -254,20 +242,18 @@ async function fetchTriggersRanking(
   // Triggers that never ran have nothing to compare a "how often" or "per
   // run cost" stat against, so the baseline only looks at the ones that did.
   const activeRanked = ranked.filter((r) => r.runCount > 0);
-
-  const searched =
-    searchIds !== null
-      ? ranked.filter((r) => searchIds.has(r.triggerId))
-      : ranked;
+  const matched = triggerIdsForSearch
+    ? ranked.filter((r) => triggerIdsForSearch.has(r.triggerId))
+    : ranked;
 
   return new Ok({
-    ranking: searched.slice(offset, offset + limit),
-    // The searched set is already fully materialized, so its length is exact
-    // where the unsearched count is the aggregation's approximation.
-    totalCount:
-      searchIds !== null
-        ? searched.length
-        : Math.round(result.value.aggregations?.[TOTAL_COUNT_AGG]?.value ?? 0),
+    ranking: matched.slice(offset, offset + limit),
+    // The cardinality aggregation counts the unsearched set, so a search takes
+    // its count from the matched ranking instead. That count is exact, since
+    // the ranking itself is unpaginated.
+    totalCount: triggerIdsForSearch
+      ? matched.length
+      : Math.round(result.value.aggregations?.[TOTAL_COUNT_AGG]?.value ?? 0),
     medianRunCount: median(activeRanked.map((r) => r.runCount)),
     medianCostPerRun: median(activeRanked.map((r) => r.credits / r.runCount)),
   });

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -107,21 +107,56 @@ function median(values: number[]): number {
     : sorted[mid];
 }
 
+type TriggerRestrictions = {
+  // Applied as a terms filter on the query, so it scopes the ranking and the
+  // median baseline alike. Null means no restriction.
+  kindIds: string[] | null;
+  // Applied to the ranked buckets instead, so a search narrows the rows
+  // without moving the median baseline. Null means no restriction.
+  searchIds: Set<string> | null;
+};
+
 /**
- * Trigger kind isn't indexed in the consumption Elasticsearch documents, so
- * a kind filter is resolved to a concrete set of trigger ids up front and
- * applied as a terms filter on TRIGGER_ID_FIELD. Returns null when no kind
- * filter is requested (no restriction).
+ * Neither trigger kind nor trigger name is indexed in the consumption
+ * Elasticsearch documents, so both restrictions are resolved to concrete sets
+ * of trigger ids up front, from one read of the workspace's triggers. Matching
+ * names in memory mirrors how the consumption ranking resolves its own search
+ * against the facet catalog (resolveConsumptionTopSearchFilter).
  */
-async function resolveTriggerIdsForKindFilter(
+async function resolveTriggerRestrictions(
   auth: Authenticator,
-  kinds: TriggerKind[] | undefined
-): Promise<string[] | null> {
-  if (!kinds || kinds.length === 0) {
-    return null;
+  {
+    kinds,
+    search,
+  }: {
+    kinds: TriggerKind[] | undefined;
+    search: string | undefined;
   }
-  const triggers = await TriggerResource.listByWorkspaceAndKinds(auth, kinds);
-  return triggers.map((trigger) => trigger.sId);
+): Promise<TriggerRestrictions> {
+  const kindSet = kinds?.length ? new Set(kinds) : null;
+  const normalizedSearch = search?.trim().toLowerCase();
+  if (!kindSet && !normalizedSearch) {
+    return { kindIds: null, searchIds: null };
+  }
+
+  const triggers = await TriggerResource.listByWorkspace(auth);
+
+  return {
+    kindIds: kindSet
+      ? triggers
+          .filter((trigger) => kindSet.has(trigger.kind))
+          .map((trigger) => trigger.sId)
+      : null,
+    searchIds: normalizedSearch
+      ? new Set(
+          triggers
+            .filter((trigger) =>
+              trigger.name.toLowerCase().includes(normalizedSearch)
+            )
+            .map((trigger) => trigger.sId)
+        )
+      : null,
+  };
 }
 
 /**
@@ -131,7 +166,7 @@ async function resolveTriggerIdsForKindFilter(
  * count below), so both the requested page and the median baseline are
  * sliced/derived from that same, page-independent set — a trigger's stats
  * always compare against the full active set, never just the triggers
- * ranked ahead of it.
+ * ranked ahead of it, nor just the ones a search matched.
  */
 async function fetchTriggersRanking(
   auth: Authenticator,
@@ -139,11 +174,13 @@ async function fetchTriggersRanking(
     period,
     limit,
     offset,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset: number;
+    search?: string;
     filter?: AutomationTriggersFilter;
   }
 ): Promise<
@@ -165,10 +202,10 @@ async function fetchTriggersRanking(
     scopeFilter.users = filter.editorIds;
   }
 
-  const triggerIdsForKindFilter = await resolveTriggerIdsForKindFilter(
-    auth,
-    filter?.kinds
-  );
+  const { kindIds, searchIds } = await resolveTriggerRestrictions(auth, {
+    kinds: filter?.kinds,
+    search,
+  });
 
   const query = buildConsumptionScopeQuery({
     auth,
@@ -176,9 +213,7 @@ async function fetchTriggersRanking(
     endDate: period.endDate,
     filter: scopeFilter,
     extraFilters:
-      triggerIdsForKindFilter !== null
-        ? [{ terms: { [TRIGGER_ID_FIELD]: triggerIdsForKindFilter } }]
-        : [],
+      kindIds !== null ? [{ terms: { [TRIGGER_ID_FIELD]: kindIds } }] : [],
   });
 
   const result = await searchConsumptionAnalytics<never, TriggerAggs>(query, {
@@ -220,11 +255,19 @@ async function fetchTriggersRanking(
   // run cost" stat against, so the baseline only looks at the ones that did.
   const activeRanked = ranked.filter((r) => r.runCount > 0);
 
+  const searched =
+    searchIds !== null
+      ? ranked.filter((r) => searchIds.has(r.triggerId))
+      : ranked;
+
   return new Ok({
-    ranking: ranked.slice(offset, offset + limit),
-    totalCount: Math.round(
-      result.value.aggregations?.[TOTAL_COUNT_AGG]?.value ?? 0
-    ),
+    ranking: searched.slice(offset, offset + limit),
+    // The searched set is already fully materialized, so its length is exact
+    // where the unsearched count is the aggregation's approximation.
+    totalCount:
+      searchIds !== null
+        ? searched.length
+        : Math.round(result.value.aggregations?.[TOTAL_COUNT_AGG]?.value ?? 0),
     medianRunCount: median(activeRanked.map((r) => r.runCount)),
     medianCostPerRun: median(activeRanked.map((r) => r.credits / r.runCount)),
   });
@@ -278,11 +321,13 @@ export async function fetchAutomationTriggers(
     period,
     limit,
     offset,
+    search,
     filter,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset: number;
+    search?: string;
     filter?: AutomationTriggersFilter;
   }
 ): Promise<Result<AutomationTriggers, ElasticsearchError>> {
@@ -290,6 +335,7 @@ export async function fetchAutomationTriggers(
     period,
     limit,
     offset,
+    search,
     filter,
   });
   if (rankingResult.isErr()) {

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -24,7 +24,6 @@ import {
 import type {
   ScheduleConfig,
   TriggerExecutionMode,
-  TriggerKind,
   TriggerStatus,
   TriggerType,
   WebhookConfig,
@@ -274,15 +273,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     ]);
 
     return { enabled, total };
-  }
-
-  static listByWorkspaceAndKinds(
-    auth: Authenticator,
-    kinds: TriggerKind[]
-  ): Promise<TriggerResource[]> {
-    return this.baseFetch(auth, {
-      where: { kind: { [Op.in]: kinds } },
-    });
   }
 
   static async listBySpace(

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -24,6 +24,7 @@ import {
 import type {
   ScheduleConfig,
   TriggerExecutionMode,
+  TriggerKind,
   TriggerStatus,
   TriggerType,
   WebhookConfig,
@@ -273,6 +274,24 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     ]);
 
     return { enabled, total };
+  }
+
+  static listByWorkspaceAndKinds(
+    auth: Authenticator,
+    kinds: TriggerKind[]
+  ): Promise<TriggerResource[]> {
+    return this.baseFetch(auth, {
+      where: { kind: { [Op.in]: kinds } },
+    });
+  }
+
+  static listByWorkspaceAndNameSearch(
+    auth: Authenticator,
+    search: string
+  ): Promise<TriggerResource[]> {
+    return this.baseFetch(auth, {
+      where: { name: { [Op.iLike]: `%${search}%` } },
+    });
   }
 
   static async listBySpace(


### PR DESCRIPTION
## Description

This adds a search input on the automations page, on the same line as the filters.

Ranking, ordering and the total count stay in Elasticsearch. The search resolves to a set of trigger ids with an ILIKE (`listByWorkspaceAndNameSearch`), the way the kind filter already resolves its own through `listByWorkspaceAndKinds`, and applies to the ranked buckets rather than to the query.

Keeping the filtering out of the query allows to keep the whole data from the filter for the line details. Without it, we would have line details (How often it runs, etc...) compared to the triggers matching the query, which is not what we want.

<img width="1245" height="634" alt="Capture d’écran 2026-08-18 à 16 44 25" src="https://github.com/user-attachments/assets/c5e51686-1ffd-4c83-8d4e-db112fdf8873" />

## Tests

`front/lib/api/analytics/automations/triggers.test.ts`: a search narrows the rows while stats stay equal to the unsearched call.

## Risk

Low. The unsearched path is unchanged.

## Deploy Plan

Deploy front.
