### PR TITLE
Branched conversation opens in a new tab

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -115,9 +115,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
   GitBranch01,
+  Icon,
   InfoCircle,
   InteractiveImageGrid,
   Link01,
+  LinkExternal01,
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
@@ -826,7 +828,15 @@ export function AgentMessage({
 
     dropdownItems.push({
       label: "Branch from here",
+      description: "Opens in a new tab",
       icon: GitBranch01,
+      endComponent: (
+        <Icon
+          visual={LinkExternal01}
+          size="xs"
+          className="text-muted-foreground"
+        />
+      ),
       onSelect: () => {
         void branchConversation(agentMessage.sId);
       },

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -58,6 +58,7 @@ import {
   Eye,
   EyeOff,
   GitBranch01,
+  Icon,
   Link01,
   LinkExternal01,
   MessageCircle01,
@@ -452,10 +453,18 @@ export function ConversationMenu({
           />
           <DropdownMenuItem
             label="Branch conversation"
+            description="Opens in a new tab"
             onClick={() => {
               void branchConversation();
             }}
             icon={GitBranch01}
+            endComponent={
+              <Icon
+                visual={LinkExternal01}
+                size="xs"
+                className="text-muted-foreground"
+              />
+            }
             disabled={isBranching}
           />
           <DropdownMenuSeparator />

--- a/front/hooks/conversations/useBranchConversation.ts
+++ b/front/hooks/conversations/useBranchConversation.ts
@@ -1,7 +1,7 @@
 import { useConversations } from "@app/hooks/conversations/useConversations";
 import { useSendNotification } from "@app/hooks/useNotification";
+import config from "@app/lib/api/config";
 import { clientFetch } from "@app/lib/egress/client";
-import { useAppRouter } from "@app/lib/platform";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { PostConversationForkResponseBody } from "@app/types/api/assistant/conversation/forks";
@@ -34,7 +34,6 @@ export function useBranchConversation({
   onConversationBranched?: () => Promise<void> | void;
 }) {
   const sendNotification = useSendNotification();
-  const router = useAppRouter();
   const { mutateConversations } = useConversations({
     workspaceId: owner.sId,
     options: { disabled: true },
@@ -127,9 +126,21 @@ export function useBranchConversation({
         }
 
         void onConversationBranched?.();
-        await router.push(
-          getConversationRoute(owner.sId, responseBody.conversationId)
+        window.open(
+          getConversationRoute(
+            owner.sId,
+            responseBody.conversationId,
+            undefined,
+            config.getAppUrl()
+          ),
+          "_blank"
         );
+
+        sendNotification({
+          type: "success",
+          title: "Branch created",
+          description: "Opened in a new tab.",
+        });
 
         return true;
       } catch {
@@ -149,7 +160,6 @@ export function useBranchConversation({
       mutateConversations,
       onConversationBranched,
       owner.sId,
-      router,
       sendNotification,
     ]
   );


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#10104

Branching a conversation now keeps the source conversation open in the current tab and opens the newly created branch in a new tab.

Changes:
- Replace in-app router navigation with `window.open(..., "_blank")`.
- Add an “Opens in a new tab” description to both branching actions.
- Add external-link icons to make the new-tab behavior visible.
- Show a success notification after the branch is created.

UI Edit:
<img width="867" height="464" alt="Screenshot 2026-08-18 at 14 26 25" src="https://github.com/user-attachments/assets/9a9665a7-3f22-4eec-8f96-2720ff9c8609" />


## Tests
Local tests

## Risk

Low. The change is limited to the conversation branching flow. The main behavior change is the navigation target. Browser popup-blocking or browser-specific behavior could affect opening the new tab, while the existing error handling remains unchanged.

## Deploy Plan

N/A. Standard frontend deployment.