### PR TITLE
[front] perf: cache skill facet metadata

### DIFF
--- a/front-api/lib/api/poke/cache_catalog.test.ts
+++ b/front-api/lib/api/poke/cache_catalog.test.ts
@@ -7,8 +7,8 @@ import { describe, expect, it } from "vitest";
 describe("Poke cache catalog", () => {
   it("uses owner-defined operations for migrated caches", () => {
     const workspace = getPokeCacheOperations("workspace_by_sid");
-    const skillMetadata = getPokeCacheOperations(
-      "skill_display_metadata_by_workspace"
+    const activeSkills = getPokeCacheOperations(
+      "skill_list_active_by_workspace"
     );
     const activeSeats = getPokeCacheOperations("workspace_active_seats");
 
@@ -18,8 +18,8 @@ describe("Poke cache catalog", () => {
     expect(workspace?.keyPattern).toBe(
       "cacheWithRedis-_fetchByIdUncached-workspace:v2:*"
     );
-    expect(skillMetadata?.buildKey({ workspaceId: "workspace-1" })).toBe(
-      "cacheWithRedis-skill_display_metadata_by_workspace-v1:workspace-1"
+    expect(activeSkills?.buildKey({ workspaceId: "workspace-1" })).toBe(
+      "cacheWithRedis-skill_list_active_by_workspace-v1:workspace-1"
     );
     expect(activeSeats?.buildKey({ workspaceId: "workspace-1" })).toBe(
       "cacheWithRedis-_countActiveSeatsInWorkspaceUncached-count-active-seats-in-workspace:workspace-1"
@@ -40,7 +40,7 @@ describe("Poke cache catalog", () => {
 
     expect(ids.filter((id) => id === "workspace_by_sid")).toHaveLength(1);
     expect(
-      ids.filter((id) => id === "skill_display_metadata_by_workspace")
+      ids.filter((id) => id === "skill_list_active_by_workspace")
     ).toHaveLength(1);
     expect(ids.filter((id) => id === "workspace_active_seats")).toHaveLength(1);
   });

--- a/front-api/lib/api/poke/cache_catalog.test.ts
+++ b/front-api/lib/api/poke/cache_catalog.test.ts
@@ -7,6 +7,9 @@ import { describe, expect, it } from "vitest";
 describe("Poke cache catalog", () => {
   it("uses owner-defined operations for migrated caches", () => {
     const workspace = getPokeCacheOperations("workspace_by_sid");
+    const skillMetadata = getPokeCacheOperations(
+      "skill_display_metadata_by_workspace"
+    );
     const activeSeats = getPokeCacheOperations("workspace_active_seats");
 
     expect(workspace?.buildKey({ wId: "workspace-1" })).toBe(
@@ -14,6 +17,9 @@ describe("Poke cache catalog", () => {
     );
     expect(workspace?.keyPattern).toBe(
       "cacheWithRedis-_fetchByIdUncached-workspace:v2:*"
+    );
+    expect(skillMetadata?.buildKey({ workspaceId: "workspace-1" })).toBe(
+      "cacheWithRedis-skill_display_metadata_by_workspace-v1:workspace-1"
     );
     expect(activeSeats?.buildKey({ workspaceId: "workspace-1" })).toBe(
       "cacheWithRedis-_countActiveSeatsInWorkspaceUncached-count-active-seats-in-workspace:workspace-1"
@@ -33,6 +39,9 @@ describe("Poke cache catalog", () => {
     const ids = catalog.map((entry) => entry.id);
 
     expect(ids.filter((id) => id === "workspace_by_sid")).toHaveLength(1);
+    expect(
+      ids.filter((id) => id === "skill_display_metadata_by_workspace")
+    ).toHaveLength(1);
     expect(ids.filter((id) => id === "workspace_active_seats")).toHaveLength(1);
   });
 

--- a/front-api/lib/api/poke/cache_catalog.test.ts
+++ b/front-api/lib/api/poke/cache_catalog.test.ts
@@ -19,7 +19,7 @@ describe("Poke cache catalog", () => {
       "cacheWithRedis-_fetchByIdUncached-workspace:v2:*"
     );
     expect(activeSkills?.buildKey({ workspaceId: "workspace-1" })).toBe(
-      "cacheWithRedis-skill_list_active_by_workspace-v1:workspace-1"
+      "cacheWithRedis-skill_list_active_by_workspace-workspace-1:v1"
     );
     expect(activeSeats?.buildKey({ workspaceId: "workspace-1" })).toBe(
       "cacheWithRedis-_countActiveSeatsInWorkspaceUncached-count-active-seats-in-workspace:workspace-1"

--- a/front-api/lib/api/poke/cache_catalog.ts
+++ b/front-api/lib/api/poke/cache_catalog.ts
@@ -1,4 +1,5 @@
 import { workspaceActiveSeatsCacheOperations } from "@app/lib/api/workspace_seats/cache";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { CacheOperations } from "@app/lib/utils/cache_operations";
 import type { PokeCacheResourceDescriptor } from "@app/types/api/poke/cache";
@@ -10,6 +11,7 @@ import {
 
 const migratedCacheOperations = [
   WorkspaceResource.byIdCacheOperations,
+  SkillResource.displayMetadataCacheOperations,
   workspaceActiveSeatsCacheOperations,
 ];
 

--- a/front-api/lib/api/poke/cache_catalog.ts
+++ b/front-api/lib/api/poke/cache_catalog.ts
@@ -11,7 +11,7 @@ import {
 
 const migratedCacheOperations = [
   WorkspaceResource.byIdCacheOperations,
-  SkillResource.displayMetadataCacheOperations,
+  SkillResource.listActiveCacheOperations,
   workspaceActiveSeatsCacheOperations,
 ];
 

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -180,7 +180,13 @@ async function listConsumptionFacetCatalogWithoutTracing(
     "skills",
     "skill",
     requestedDimension,
-    () => SkillResource.listDisplayMetadataByWorkspace(auth)
+    () =>
+      SkillResource.listByWorkspace(auth, {
+        status: "active",
+        withInstructions: false,
+        withTools: false,
+        withFileAttachments: false,
+      })
   );
 
   return {

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -180,7 +180,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
     "skills",
     "skill",
     requestedDimension,
-    () => SkillResource.listDisplayMetadata(auth, { status: "active" })
+    () => SkillResource.listDisplayMetadataByWorkspace(auth)
   );
 
   return {

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -180,13 +180,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
     "skills",
     "skill",
     requestedDimension,
-    () =>
-      SkillResource.listByWorkspace(auth, {
-        status: "active",
-        withInstructions: false,
-        withTools: false,
-        withFileAttachments: false,
-      })
+    () => SkillResource.listDisplayMetadata(auth, { status: "active" })
   );
 
   return {

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -180,13 +180,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
     "skills",
     "skill",
     requestedDimension,
-    () =>
-      SkillResource.listByWorkspace(auth, {
-        status: "active",
-        withInstructions: false,
-        withTools: false,
-        withFileAttachments: false,
-      })
+    () => SkillResource.listActiveMetadataByWorkspace(auth)
   );
 
   return {

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -141,10 +141,9 @@ export async function resolveDimensionLabels(
     }
 
     case "skill": {
-      const skills = await SkillResource.fetchByIds(auth, keys, {
-        withInstructions: false,
-        withTools: false,
-        withFileAttachments: false,
+      const skills = await SkillResource.listDisplayMetadata(auth, {
+        sIds: keys,
+        status: ["active", "archived", "suggested"],
       });
       const skillsById = new Map(skills.map((skill) => [skill.sId, skill]));
       return new Map(

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -141,9 +141,10 @@ export async function resolveDimensionLabels(
     }
 
     case "skill": {
-      const skills = await SkillResource.listDisplayMetadata(auth, {
-        sIds: keys,
-        status: ["active", "archived", "suggested"],
+      const skills = await SkillResource.fetchByIds(auth, keys, {
+        withInstructions: false,
+        withTools: false,
+        withFileAttachments: false,
       });
       const skillsById = new Map(skills.map((skill) => [skill.sId, skill]));
       return new Map(

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -157,20 +157,22 @@ describe("SkillResource", () => {
       expect(skill.instructions).toBe("");
       expect(skill.instructionsHtml).toBeNull();
     });
-  });
 
-  describe("listDisplayMetadataByWorkspace", () => {
-    it("refreshes cached metadata after a skill update and archive", async () => {
+    it("refreshes the cached active list after a skill update and archive", async () => {
       const skill = await SkillFactory.create(testContext.authenticator, {
         name: "Cached skill name",
         userFacingDescription: "Cached skill description",
       });
+      const listActiveSkills = () =>
+        SkillResource.listByWorkspace(testContext.authenticator, {
+          onlyCustom: true,
+          withInstructions: false,
+          withTools: false,
+          withFileAttachments: false,
+        });
 
-      const initialMetadata =
-        await SkillResource.listDisplayMetadataByWorkspace(
-          testContext.authenticator
-        );
-      expect(initialMetadata).toContainEqual(
+      const initialSkills = await listActiveSkills();
+      expect(initialSkills).toContainEqual(
         expect.objectContaining({
           sId: skill.sId,
           name: "Cached skill name",
@@ -189,11 +191,8 @@ describe("SkillResource", () => {
         requestedSpaceIds: [],
       });
 
-      const updatedMetadata =
-        await SkillResource.listDisplayMetadataByWorkspace(
-          testContext.authenticator
-        );
-      expect(updatedMetadata).toContainEqual(
+      const updatedSkills = await listActiveSkills();
+      expect(updatedSkills).toContainEqual(
         expect.objectContaining({
           sId: skill.sId,
           name: "Updated skill name",
@@ -203,10 +202,8 @@ describe("SkillResource", () => {
 
       await skill.archive(testContext.authenticator);
 
-      const activeMetadata = await SkillResource.listDisplayMetadataByWorkspace(
-        testContext.authenticator
-      );
-      expect(activeMetadata).not.toContainEqual(
+      const activeSkills = await listActiveSkills();
+      expect(activeSkills).not.toContainEqual(
         expect.objectContaining({ sId: skill.sId })
       );
     });

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -159,6 +159,68 @@ describe("SkillResource", () => {
     });
   });
 
+  describe("listDisplayMetadata", () => {
+    it("refreshes cached metadata after a skill update and archive", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Cached skill name",
+        userFacingDescription: "Cached skill description",
+      });
+
+      const initialMetadata = await SkillResource.listDisplayMetadata(
+        testContext.authenticator,
+        { status: "active" }
+      );
+      expect(initialMetadata).toContainEqual(
+        expect.objectContaining({
+          sId: skill.sId,
+          name: "Cached skill name",
+          userFacingDescription: "Cached skill description",
+        })
+      );
+
+      await skill.updateSkill(testContext.authenticator, {
+        name: "Updated skill name",
+        agentFacingDescription: skill.agentFacingDescription,
+        userFacingDescription: "Updated skill description",
+        instructions: skill.instructions,
+        icon: skill.icon,
+        mcpServerViews: [],
+        attachedKnowledge: [],
+        requestedSpaceIds: [],
+      });
+
+      const updatedMetadata = await SkillResource.listDisplayMetadata(
+        testContext.authenticator,
+        { sIds: [skill.sId] }
+      );
+      expect(updatedMetadata).toEqual([
+        expect.objectContaining({
+          sId: skill.sId,
+          name: "Updated skill name",
+          userFacingDescription: "Updated skill description",
+        }),
+      ]);
+
+      await skill.archive(testContext.authenticator);
+
+      const activeMetadata = await SkillResource.listDisplayMetadata(
+        testContext.authenticator,
+        { sIds: [skill.sId], status: "active" }
+      );
+      const archivedMetadata = await SkillResource.listDisplayMetadata(
+        testContext.authenticator,
+        { sIds: [skill.sId], status: "archived" }
+      );
+      expect(activeMetadata).toEqual([]);
+      expect(archivedMetadata).toEqual([
+        expect.objectContaining({
+          sId: skill.sId,
+          status: "archived",
+        }),
+      ]);
+    });
+  });
+
   describe("favorites", () => {
     it("stores one row per user and updates custom skill favorite counts", async () => {
       const skillA = await SkillFactory.create(testContext.authenticator, {

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -159,17 +159,17 @@ describe("SkillResource", () => {
     });
   });
 
-  describe("listDisplayMetadata", () => {
+  describe("listDisplayMetadataByWorkspace", () => {
     it("refreshes cached metadata after a skill update and archive", async () => {
       const skill = await SkillFactory.create(testContext.authenticator, {
         name: "Cached skill name",
         userFacingDescription: "Cached skill description",
       });
 
-      const initialMetadata = await SkillResource.listDisplayMetadata(
-        testContext.authenticator,
-        { status: "active" }
-      );
+      const initialMetadata =
+        await SkillResource.listDisplayMetadataByWorkspace(
+          testContext.authenticator
+        );
       expect(initialMetadata).toContainEqual(
         expect.objectContaining({
           sId: skill.sId,
@@ -189,35 +189,26 @@ describe("SkillResource", () => {
         requestedSpaceIds: [],
       });
 
-      const updatedMetadata = await SkillResource.listDisplayMetadata(
-        testContext.authenticator,
-        { sIds: [skill.sId] }
-      );
-      expect(updatedMetadata).toEqual([
+      const updatedMetadata =
+        await SkillResource.listDisplayMetadataByWorkspace(
+          testContext.authenticator
+        );
+      expect(updatedMetadata).toContainEqual(
         expect.objectContaining({
           sId: skill.sId,
           name: "Updated skill name",
           userFacingDescription: "Updated skill description",
-        }),
-      ]);
+        })
+      );
 
       await skill.archive(testContext.authenticator);
 
-      const activeMetadata = await SkillResource.listDisplayMetadata(
-        testContext.authenticator,
-        { sIds: [skill.sId], status: "active" }
+      const activeMetadata = await SkillResource.listDisplayMetadataByWorkspace(
+        testContext.authenticator
       );
-      const archivedMetadata = await SkillResource.listDisplayMetadata(
-        testContext.authenticator,
-        { sIds: [skill.sId], status: "archived" }
+      expect(activeMetadata).not.toContainEqual(
+        expect.objectContaining({ sId: skill.sId })
       );
-      expect(activeMetadata).toEqual([]);
-      expect(archivedMetadata).toEqual([
-        expect.objectContaining({
-          sId: skill.sId,
-          status: "archived",
-        }),
-      ]);
     });
   });
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -157,19 +157,16 @@ describe("SkillResource", () => {
       expect(skill.instructions).toBe("");
       expect(skill.instructionsHtml).toBeNull();
     });
+  });
 
+  describe("listActiveMetadataByWorkspace", () => {
     it("refreshes the cached active list after a skill update and archive", async () => {
       const skill = await SkillFactory.create(testContext.authenticator, {
         name: "Cached skill name",
         userFacingDescription: "Cached skill description",
       });
       const listActiveSkills = () =>
-        SkillResource.listByWorkspace(testContext.authenticator, {
-          onlyCustom: true,
-          withInstructions: false,
-          withTools: false,
-          withFileAttachments: false,
-        });
+        SkillResource.listActiveMetadataByWorkspace(testContext.authenticator);
 
       const initialSkills = await listActiveSkills();
       expect(initialSkills).toContainEqual(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -148,11 +148,10 @@ type SkillDisplayMetadataCacheEntry = {
   icon: string | null;
   name: string;
   requestedSpaceIds: ModelId[];
-  status: SkillStatus;
   userFacingDescription: string | null;
 };
 
-export type SkillDisplayMetadata = Omit<
+type SkillDisplayMetadata = Omit<
   SkillDisplayMetadataCacheEntry,
   "id" | "requestedSpaceIds"
 > & {
@@ -321,10 +320,9 @@ const skillDisplayMetadataCache = defineCache<
         "icon",
         "name",
         "requestedSpaceIds",
-        "status",
         "userFacingDescription",
       ],
-      where: { workspaceId: workspaceModelId },
+      where: { status: "active", workspaceId: workspaceModelId },
     });
 
     return skills.map((skill) => ({
@@ -332,7 +330,6 @@ const skillDisplayMetadataCache = defineCache<
       icon: skill.icon,
       name: skill.name,
       requestedSpaceIds: skill.requestedSpaceIds,
-      status: skill.status,
       userFacingDescription: skill.userFacingDescription,
     }));
   },
@@ -558,7 +555,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  private static invalidateDisplayMetadataCache(
+  private invalidateDisplayMetadataCache(
     workspace: LightWorkspaceType,
     transaction?: Transaction
   ): Promise<void> {
@@ -571,84 +568,36 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  static async listDisplayMetadata(
-    auth: Authenticator,
-    {
-      sIds,
-      status,
-    }: {
-      sIds?: string[];
-      status?: SkillStatus | SkillStatus[];
-    } = {}
+  static async listDisplayMetadataByWorkspace(
+    auth: Authenticator
   ): Promise<SkillDisplayMetadata[]> {
-    if (sIds?.length === 0) {
-      return [];
-    }
-
     const workspace = auth.getNonNullableWorkspace();
-    const customSkillModelIds = sIds
-      ? new Set(
-          removeNulls(
-            sIds.map((skillId) =>
-              isResourceSId("skill", skillId)
-                ? getResourceIdFromSId(skillId)
-                : null
-            )
-          )
-        )
-      : null;
-    const globalSkillIds = sIds
-      ? sIds.filter((skillId) => !isResourceSId("skill", skillId))
-      : undefined;
-    const statuses = status
-      ? new Set(Array.isArray(status) ? status : [status])
-      : null;
-
-    const customSkills =
-      customSkillModelIds?.size === 0
-        ? []
-        : await this.filterBySpacePermissions(
-            auth,
-            (
-              await skillDisplayMetadataCache.get({
-                workspaceId: workspace.sId,
-                workspaceModelId: workspace.id,
-              })
-            ).filter(
-              (skill) =>
-                (!customSkillModelIds || customSkillModelIds.has(skill.id)) &&
-                (!statuses || statuses.has(skill.status))
-            )
-          );
-
-    const codeDefinedWhere = {
-      ...(globalSkillIds ? { sId: globalSkillIds } : {}),
-      ...(status ? { status } : {}),
-    };
-    const codeDefinedSkills =
-      globalSkillIds?.length === 0
-        ? []
-        : [
-            ...(await GlobalSkillsRegistry.findAll(auth, codeDefinedWhere)),
-            ...(await SystemSkillsRegistry.findAll(auth, codeDefinedWhere)),
-          ];
+    const customSkills = await this.filterBySpacePermissions(
+      auth,
+      await skillDisplayMetadataCache.get({
+        workspaceId: workspace.sId,
+        workspaceModelId: workspace.id,
+      })
+    );
+    const codeDefinedSkills = [
+      ...(await GlobalSkillsRegistry.findAll(auth, { status: "active" })),
+      ...(await SystemSkillsRegistry.findAll(auth, { status: "active" })),
+    ];
 
     return [
       ...customSkills.map((skill) => ({
-        sId: SkillResource.modelIdToSId({
+        sId: this.modelIdToSId({
           id: skill.id,
           workspaceId: workspace.id,
         }),
         icon: skill.icon,
         name: skill.name,
-        status: skill.status,
         userFacingDescription: skill.userFacingDescription,
       })),
       ...codeDefinedSkills.map((skill) => ({
         sId: skill.sId,
         icon: skill.icon,
         name: skill.name,
-        status: "active" as const,
         userFacingDescription: skill.userFacingDescription,
       })),
     ];
@@ -750,7 +699,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       // association itself.
       await skillResource.writeGroupPermissions(auth, { transaction });
 
-      await this.invalidateDisplayMetadataCache(owner, transaction);
+      await skillResource.invalidateDisplayMetadataCache(owner, transaction);
 
       return skillResource;
     });
@@ -3314,10 +3263,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
-      await SkillResource.invalidateDisplayMetadataCache(
-        workspace,
-        transaction
-      );
+      await this.invalidateDisplayMetadataCache(workspace, transaction);
 
       return count;
     });
@@ -3365,10 +3311,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
-      await SkillResource.invalidateDisplayMetadataCache(
-        workspace,
-        transaction
-      );
+      await this.invalidateDisplayMetadataCache(workspace, transaction);
 
       return count;
     });
@@ -3517,10 +3460,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         { transaction }
       );
 
-      await SkillResource.invalidateDisplayMetadataCache(
-        workspace,
-        transaction
-      );
+      await this.invalidateDisplayMetadataCache(workspace, transaction);
     });
 
     if (fileAttachments) {
@@ -4201,10 +4141,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-        await SkillResource.invalidateDisplayMetadataCache(
-          workspace,
-          transaction
-        );
+        await this.invalidateDisplayMetadataCache(workspace, transaction);
 
         return deletedCount;
       });
@@ -4512,7 +4449,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where: { workspaceId },
     });
 
-    await this.invalidateDisplayMetadataCache(workspace);
+    await skillDisplayMetadataCache.invalidate({
+      workspaceId: workspace.sId,
+      workspaceModelId: workspace.id,
+    });
   }
 
   private static replaceSkillReferenceTags(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -143,19 +143,17 @@ type SkillReferenceTarget = {
   status: SkillStatus;
 };
 
-type SkillDisplayMetadataCacheEntry = {
-  id: ModelId;
-  icon: string | null;
-  name: string;
-  requestedSpaceIds: ModelId[];
-  userFacingDescription: string | null;
-};
-
-type SkillDisplayMetadata = Omit<
-  SkillDisplayMetadataCacheEntry,
-  "id" | "requestedSpaceIds"
+type SkillListActiveCacheEntry = Omit<
+  Attributes<SkillConfigurationModel>,
+  | "createdAt"
+  | "instructions"
+  | "instructionsHtml"
+  | "lastReinforcementAnalysisAt"
+  | "updatedAt"
 > & {
-  sId: string;
+  createdAt: string;
+  lastReinforcementAnalysisAt: string | null;
+  updatedAt: string;
 };
 
 type ReplaceSkillReferenceTagsOptions = {
@@ -300,49 +298,51 @@ const GLOBAL_SKILL_ROLE_GRANTS: RoleGrant[] = [
   { role: "builder", permissions: ["read"] },
 ];
 
-const SKILL_DISPLAY_METADATA_CACHE_ID = "skill_display_metadata_by_workspace";
-const SKILL_DISPLAY_METADATA_CACHE_KEY_VERSION = 1;
-const SKILL_DISPLAY_METADATA_CACHE_TTL_MS = 15 * 60 * 1000;
-const skillDisplayMetadataCacheKey = (workspaceId: string) =>
-  `v${SKILL_DISPLAY_METADATA_CACHE_KEY_VERSION}:${workspaceId}`;
+const SKILL_LIST_ACTIVE_CACHE_ID = "skill_list_active_by_workspace";
+const SKILL_LIST_ACTIVE_CACHE_KEY_VERSION = 1;
+const SKILL_LIST_ACTIVE_CACHE_TTL_MS = 15 * 60 * 1000;
+const skillListActiveCacheKey = (workspaceId: string) =>
+  `v${SKILL_LIST_ACTIVE_CACHE_KEY_VERSION}:${workspaceId}`;
 
-// Cache only database metadata. Space permissions and code-defined skill restrictions stay live.
-const skillDisplayMetadataCache = defineCache<
+const skillListActiveCache = defineCache<
   { workspaceId: string; workspaceModelId: ModelId },
-  SkillDisplayMetadataCacheEntry[]
+  SkillListActiveCacheEntry[]
 >({
-  id: SKILL_DISPLAY_METADATA_CACHE_ID,
-  key: ({ workspaceId }) => skillDisplayMetadataCacheKey(workspaceId),
+  id: SKILL_LIST_ACTIVE_CACHE_ID,
+  key: ({ workspaceId }) => skillListActiveCacheKey(workspaceId),
   load: async ({ workspaceModelId }) => {
     const skills = await SkillConfigurationModel.findAll({
-      attributes: [
-        "id",
-        "icon",
-        "name",
-        "requestedSpaceIds",
-        "userFacingDescription",
-      ],
+      attributes: { exclude: ["instructions", "instructionsHtml"] },
       where: { status: "active", workspaceId: workspaceModelId },
     });
 
-    return skills.map((skill) => ({
-      id: skill.id,
-      icon: skill.icon,
-      name: skill.name,
-      requestedSpaceIds: skill.requestedSpaceIds,
-      userFacingDescription: skill.userFacingDescription,
-    }));
+    return skills.map((skill) => {
+      const attributes = skill.get();
+      return {
+        ...omit(attributes, [
+          "createdAt",
+          "instructions",
+          "instructionsHtml",
+          "lastReinforcementAnalysisAt",
+          "updatedAt",
+        ]),
+        createdAt: attributes.createdAt.toISOString(),
+        lastReinforcementAnalysisAt:
+          attributes.lastReinforcementAnalysisAt?.toISOString() ?? null,
+        updatedAt: attributes.updatedAt.toISOString(),
+      };
+    });
   },
-  ttlMs: SKILL_DISPLAY_METADATA_CACHE_TTL_MS,
+  ttlMs: SKILL_LIST_ACTIVE_CACHE_TTL_MS,
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static model: ModelStatic<SkillConfigurationModel> = SkillConfigurationModel;
 
-  static readonly displayMetadataCacheOperations = defineCacheOperations({
-    id: SKILL_DISPLAY_METADATA_CACHE_ID,
-    label: "Skill display metadata (by workspace)",
+  static readonly listActiveCacheOperations = defineCacheOperations({
+    id: SKILL_LIST_ACTIVE_CACHE_ID,
+    label: "Active skills (by workspace)",
     inputSchema: z.object({ workspaceId: z.string().min(1) }),
     params: [
       {
@@ -354,12 +354,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     ],
     buildKey: ({ workspaceId }) =>
       buildCacheWithRedisKey(
-        SKILL_DISPLAY_METADATA_CACHE_ID,
-        skillDisplayMetadataCacheKey(workspaceId)
+        SKILL_LIST_ACTIVE_CACHE_ID,
+        skillListActiveCacheKey(workspaceId)
       ),
     keyPattern: buildCacheWithRedisKey(
-      SKILL_DISPLAY_METADATA_CACHE_ID,
-      skillDisplayMetadataCacheKey("*")
+      SKILL_LIST_ACTIVE_CACHE_ID,
+      skillListActiveCacheKey("*")
     ),
   });
 
@@ -526,41 +526,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  private static async filterBySpacePermissions<
-    T extends { requestedSpaceIds: ModelId[] },
-  >(auth: Authenticator, skills: T[], transaction?: Transaction): Promise<T[]> {
-    const uniqueRequestedSpaceIds = uniq(
-      skills.flatMap((skill) => skill.requestedSpaceIds)
-    );
-    const spaces =
-      uniqueRequestedSpaceIds.length > 0
-        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds, {
-            transaction,
-          })
-        : [];
-    const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
-    const foundSpaceIds = new Set(spaces.map((space) => space.id));
-
-    return skills.filter(
-      (skill) =>
-        skill.requestedSpaceIds.every((id) => foundSpaceIds.has(id)) &&
-        auth.hasPermissionForAcls(
-          "read",
-          createAccessControlListFromSpacesWithMap(
-            spaceIdToGroupsMap,
-            skill.requestedSpaceIds,
-            auth.getNonNullableWorkspace().id
-          )
-        )
-    );
-  }
-
-  private invalidateDisplayMetadataCache(
+  private invalidateListActiveCache(
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
-    return skillDisplayMetadataCache.invalidate(
+    return skillListActiveCache.invalidate(
       {
         workspaceId: workspace.sId,
         workspaceModelId: workspace.id,
@@ -569,39 +540,31 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  static async listDisplayMetadataByWorkspace(
+  private static async listActiveModelsByWorkspace(
     auth: Authenticator
-  ): Promise<SkillDisplayMetadata[]> {
+  ): Promise<SkillConfigurationModel[]> {
     const workspace = auth.getNonNullableWorkspace();
-    const customSkills = await this.filterBySpacePermissions(
-      auth,
-      await skillDisplayMetadataCache.get({
-        workspaceId: workspace.sId,
-        workspaceModelId: workspace.id,
-      })
-    );
-    const codeDefinedSkills = [
-      ...(await GlobalSkillsRegistry.findAll(auth, { status: "active" })),
-      ...(await SystemSkillsRegistry.findAll(auth, { status: "active" })),
-    ];
+    const cachedSkills = await skillListActiveCache.get({
+      workspaceId: workspace.sId,
+      workspaceModelId: workspace.id,
+    });
 
-    return [
-      ...customSkills.map((skill) => ({
-        sId: this.modelIdToSId({
-          id: skill.id,
-          workspaceId: workspace.id,
-        }),
-        icon: skill.icon,
-        name: skill.name,
-        userFacingDescription: skill.userFacingDescription,
-      })),
-      ...codeDefinedSkills.map((skill) => ({
-        sId: skill.sId,
-        icon: skill.icon,
-        name: skill.name,
-        userFacingDescription: skill.userFacingDescription,
-      })),
-    ];
+    return cachedSkills.map(
+      ({ createdAt, lastReinforcementAnalysisAt, updatedAt, ...attributes }) =>
+        this.model.build(
+          {
+            ...attributes,
+            createdAt: new Date(createdAt),
+            instructions: "",
+            instructionsHtml: null,
+            lastReinforcementAnalysisAt: lastReinforcementAnalysisAt
+              ? new Date(lastReinforcementAnalysisAt)
+              : null,
+            updatedAt: new Date(updatedAt),
+          },
+          { isNewRecord: false, raw: true }
+        )
+    );
   }
 
   static async makeNew(
@@ -700,7 +663,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       // association itself.
       await skillResource.writeGroupPermissions(auth, { transaction });
 
-      await skillResource.invalidateDisplayMetadataCache(auth, transaction);
+      await skillResource.invalidateListActiveCache(auth, transaction);
 
       return skillResource;
     });
@@ -805,6 +768,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     context: {
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds?: string[];
+      preloadedCustomSkills?: SkillConfigurationModel[];
       transaction?: Transaction;
     } = {}
   ): Promise<SkillResource[]> {
@@ -812,6 +776,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const {
       agentLoopData,
       effectiveSpaceIds: providedEffectiveSpaceIds,
+      preloadedCustomSkills,
       transaction,
     } = context;
 
@@ -826,25 +791,49 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...otherOptions
     } = options;
 
-    const customSkills = await this.model.findAll({
-      ...otherOptions,
-      ...(withInstructions
-        ? {}
-        : { attributes: { exclude: ["instructions", "instructionsHtml"] } }),
-      where: {
-        // Fetch active by default, unless explicitly overridden by the caller.
-        status: "active",
-        ...omit(where, "sId"),
-        workspaceId: workspace.id,
-      },
-      include: includes,
-      transaction,
-    });
+    const customSkills =
+      preloadedCustomSkills ??
+      (await this.model.findAll({
+        ...otherOptions,
+        ...(withInstructions
+          ? {}
+          : { attributes: { exclude: ["instructions", "instructionsHtml"] } }),
+        where: {
+          // Fetch active by default, unless explicitly overridden by the caller.
+          status: "active",
+          ...omit(where, "sId"),
+          workspaceId: workspace.id,
+        },
+        include: includes,
+        transaction,
+      }));
 
-    const allowedCustomSkills = await this.filterBySpacePermissions(
-      auth,
-      customSkills,
-      transaction
+    // Check if the user has access to skill requested spaces.
+    const uniqueRequestedSpaceIds = uniq(
+      customSkills.flatMap((c) => c.requestedSpaceIds)
+    );
+    const spaces =
+      uniqueRequestedSpaceIds.length > 0
+        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds, {
+            transaction,
+          })
+        : [];
+    const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
+    const foundSpaceIds = new Set(spaces.map((s) => s.id));
+
+    const validCustomSkills = customSkills.filter((skill) =>
+      skill.requestedSpaceIds.every((id) => foundSpaceIds.has(id))
+    );
+
+    const allowedCustomSkills = validCustomSkills.filter((skill) =>
+      auth.hasPermissionForAcls(
+        "read",
+        createAccessControlListFromSpacesWithMap(
+          spaceIdToGroupsMap,
+          skill.requestedSpaceIds,
+          auth.getNonNullableWorkspace().id
+        )
+      )
     );
     const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);
 
@@ -1683,19 +1672,32 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withFileAttachments?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
-    const skills = await this.baseFetch(auth, {
-      where: {
-        status,
-        ...(availability !== undefined ? { availability } : {}),
-        ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
-        ...(reinforcementNotOff ? { reinforcement: { [Op.ne]: "off" } } : {}),
+    const preloadedCustomSkills =
+      status === "active" &&
+      limit === undefined &&
+      availability === undefined &&
+      updatedAfter === undefined &&
+      !reinforcementNotOff &&
+      !withInstructions
+        ? await this.listActiveModelsByWorkspace(auth)
+        : undefined;
+    const skills = await this.baseFetch(
+      auth,
+      {
+        where: {
+          status,
+          ...(availability !== undefined ? { availability } : {}),
+          ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
+          ...(reinforcementNotOff ? { reinforcement: { [Op.ne]: "off" } } : {}),
+        },
+        ...(limit ? { limit } : {}),
+        onlyCustom,
+        withInstructions,
+        withTools,
+        withFileAttachments,
       },
-      ...(limit ? { limit } : {}),
-      onlyCustom,
-      withInstructions,
-      withTools,
-      withFileAttachments,
-    });
+      { preloadedCustomSkills }
+    );
 
     if (globalSpaceOnly) {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
@@ -3264,7 +3266,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
-      await this.invalidateDisplayMetadataCache(auth, transaction);
+      await this.invalidateListActiveCache(auth, transaction);
 
       return count;
     });
@@ -3310,7 +3312,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
-      await this.invalidateDisplayMetadataCache(auth, transaction);
+      await this.invalidateListActiveCache(auth, transaction);
 
       return count;
     });
@@ -3457,7 +3459,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         { transaction }
       );
 
-      await this.invalidateDisplayMetadataCache(auth, transaction);
+      await this.invalidateListActiveCache(auth, transaction);
     });
 
     if (fileAttachments) {
@@ -4138,7 +4140,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-        await this.invalidateDisplayMetadataCache(auth, transaction);
+        await this.invalidateListActiveCache(auth, transaction);
 
         return deletedCount;
       });
@@ -4446,7 +4448,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where: { workspaceId },
     });
 
-    await skillDisplayMetadataCache.invalidate({
+    await skillListActiveCache.invalidate({
       workspaceId: workspace.sId,
       workspaceModelId: workspace.id,
     });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -143,17 +143,15 @@ type SkillReferenceTarget = {
   status: SkillStatus;
 };
 
-type SkillListActiveCacheEntry = Omit<
-  Attributes<SkillConfigurationModel>,
-  | "createdAt"
-  | "instructions"
-  | "instructionsHtml"
-  | "lastReinforcementAnalysisAt"
-  | "updatedAt"
-> & {
-  createdAt: string;
-  lastReinforcementAnalysisAt: string | null;
-  updatedAt: string;
+type SkillListActiveCacheEntry = {
+  id: ModelId;
+  icon: string | null;
+  name: string;
+  userFacingDescription: string | null;
+};
+
+type SkillListActiveEntry = Omit<SkillListActiveCacheEntry, "id"> & {
+  sId: string;
 };
 
 type ReplaceSkillReferenceTagsOptions = {
@@ -304,6 +302,7 @@ const SKILL_LIST_ACTIVE_CACHE_TTL_MS = 15 * 60 * 1000;
 const skillListActiveCacheKey = (workspaceId: string) =>
   `${workspaceId}:v${SKILL_LIST_ACTIVE_CACHE_KEY_VERSION}`;
 
+// Keep the cached database snapshot small. Code-defined skills are read from their registries.
 const skillListActiveCache = defineCache<
   { workspaceId: string; workspaceModelId: ModelId },
   SkillListActiveCacheEntry[]
@@ -312,26 +311,16 @@ const skillListActiveCache = defineCache<
   key: ({ workspaceId }) => skillListActiveCacheKey(workspaceId),
   load: async ({ workspaceModelId }) => {
     const skills = await SkillConfigurationModel.findAll({
-      attributes: { exclude: ["instructions", "instructionsHtml"] },
+      attributes: ["id", "icon", "name", "userFacingDescription"],
       where: { status: "active", workspaceId: workspaceModelId },
     });
 
-    return skills.map((skill) => {
-      const attributes = skill.get();
-      return {
-        ...omit(attributes, [
-          "createdAt",
-          "instructions",
-          "instructionsHtml",
-          "lastReinforcementAnalysisAt",
-          "updatedAt",
-        ]),
-        createdAt: attributes.createdAt.toISOString(),
-        lastReinforcementAnalysisAt:
-          attributes.lastReinforcementAnalysisAt?.toISOString() ?? null,
-        updatedAt: attributes.updatedAt.toISOString(),
-      };
-    });
+    return skills.map((skill) => ({
+      id: skill.id,
+      icon: skill.icon,
+      name: skill.name,
+      userFacingDescription: skill.userFacingDescription,
+    }));
   },
   ttlMs: SKILL_LIST_ACTIVE_CACHE_TTL_MS,
 });
@@ -540,31 +529,36 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
-  private static async listActiveModelsByWorkspace(
+  static async listActiveMetadataByWorkspace(
     auth: Authenticator
-  ): Promise<SkillConfigurationModel[]> {
+  ): Promise<SkillListActiveEntry[]> {
     const workspace = auth.getNonNullableWorkspace();
-    const cachedSkills = await skillListActiveCache.get({
+    const customSkills = await skillListActiveCache.get({
       workspaceId: workspace.sId,
       workspaceModelId: workspace.id,
     });
+    const codeDefinedSkills = [
+      ...(await GlobalSkillsRegistry.findAll(auth, { status: "active" })),
+      ...(await SystemSkillsRegistry.findAll(auth, { status: "active" })),
+    ];
 
-    return cachedSkills.map(
-      ({ createdAt, lastReinforcementAnalysisAt, updatedAt, ...attributes }) =>
-        this.model.build(
-          {
-            ...attributes,
-            createdAt: new Date(createdAt),
-            instructions: "",
-            instructionsHtml: null,
-            lastReinforcementAnalysisAt: lastReinforcementAnalysisAt
-              ? new Date(lastReinforcementAnalysisAt)
-              : null,
-            updatedAt: new Date(updatedAt),
-          },
-          { isNewRecord: false, raw: true }
-        )
-    );
+    return [
+      ...customSkills.map((skill) => ({
+        sId: this.modelIdToSId({
+          id: skill.id,
+          workspaceId: workspace.id,
+        }),
+        icon: skill.icon,
+        name: skill.name,
+        userFacingDescription: skill.userFacingDescription,
+      })),
+      ...codeDefinedSkills.map((skill) => ({
+        sId: skill.sId,
+        icon: skill.icon,
+        name: skill.name,
+        userFacingDescription: skill.userFacingDescription,
+      })),
+    ];
   }
 
   static async makeNew(
@@ -768,7 +762,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     context: {
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds?: string[];
-      preloadedCustomSkills?: SkillConfigurationModel[];
       transaction?: Transaction;
     } = {}
   ): Promise<SkillResource[]> {
@@ -776,7 +769,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const {
       agentLoopData,
       effectiveSpaceIds: providedEffectiveSpaceIds,
-      preloadedCustomSkills,
       transaction,
     } = context;
 
@@ -791,22 +783,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       ...otherOptions
     } = options;
 
-    const customSkills =
-      preloadedCustomSkills ??
-      (await this.model.findAll({
-        ...otherOptions,
-        ...(withInstructions
-          ? {}
-          : { attributes: { exclude: ["instructions", "instructionsHtml"] } }),
-        where: {
-          // Fetch active by default, unless explicitly overridden by the caller.
-          status: "active",
-          ...omit(where, "sId"),
-          workspaceId: workspace.id,
-        },
-        include: includes,
-        transaction,
-      }));
+    const customSkills = await this.model.findAll({
+      ...otherOptions,
+      ...(withInstructions
+        ? {}
+        : { attributes: { exclude: ["instructions", "instructionsHtml"] } }),
+      where: {
+        // Fetch active by default, unless explicitly overridden by the caller.
+        status: "active",
+        ...omit(where, "sId"),
+        workspaceId: workspace.id,
+      },
+      include: includes,
+      transaction,
+    });
 
     // Check if the user has access to skill requested spaces.
     const uniqueRequestedSpaceIds = uniq(
@@ -1672,32 +1662,19 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       withFileAttachments?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
-    const preloadedCustomSkills =
-      status === "active" &&
-      limit === undefined &&
-      availability === undefined &&
-      updatedAfter === undefined &&
-      !reinforcementNotOff &&
-      !withInstructions
-        ? await this.listActiveModelsByWorkspace(auth)
-        : undefined;
-    const skills = await this.baseFetch(
-      auth,
-      {
-        where: {
-          status,
-          ...(availability !== undefined ? { availability } : {}),
-          ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
-          ...(reinforcementNotOff ? { reinforcement: { [Op.ne]: "off" } } : {}),
-        },
-        ...(limit ? { limit } : {}),
-        onlyCustom,
-        withInstructions,
-        withTools,
-        withFileAttachments,
+    const skills = await this.baseFetch(auth, {
+      where: {
+        status,
+        ...(availability !== undefined ? { availability } : {}),
+        ...(updatedAfter ? { updatedAt: { [Op.gte]: updatedAfter } } : {}),
+        ...(reinforcementNotOff ? { reinforcement: { [Op.ne]: "off" } } : {}),
       },
-      { preloadedCustomSkills }
-    );
+      ...(limit ? { limit } : {}),
+      onlyCustom,
+      withInstructions,
+      withTools,
+      withFileAttachments,
+    });
 
     if (globalSpaceOnly) {
       const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -556,9 +556,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   private invalidateDisplayMetadataCache(
-    workspace: LightWorkspaceType,
+    auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
     return skillDisplayMetadataCache.invalidate(
       {
         workspaceId: workspace.sId,
@@ -699,7 +700,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       // association itself.
       await skillResource.writeGroupPermissions(auth, { transaction });
 
-      await skillResource.invalidateDisplayMetadataCache(owner, transaction);
+      await skillResource.invalidateDisplayMetadataCache(auth, transaction);
 
       return skillResource;
     });
@@ -3263,7 +3264,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
-      await this.invalidateDisplayMetadataCache(workspace, transaction);
+      await this.invalidateDisplayMetadataCache(auth, transaction);
 
       return count;
     });
@@ -3276,8 +3277,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       this.canAdministrate(auth),
       "User is not authorized to restore this skill"
     );
-
-    const workspace = auth.getNonNullableWorkspace();
 
     const affectedCount = await withTransaction(async (transaction) => {
       const [count] = await this.update({ status: "active" }, transaction);
@@ -3311,7 +3310,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
-      await this.invalidateDisplayMetadataCache(workspace, transaction);
+      await this.invalidateDisplayMetadataCache(auth, transaction);
 
       return count;
     });
@@ -3356,8 +3355,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
   ): Promise<void> {
     assert(this.canWrite(auth), "User is not authorized to update this skill");
-
-    const workspace = auth.getNonNullableWorkspace();
 
     const availabilityChanged =
       availability !== undefined && availability !== this.availability;
@@ -3460,7 +3457,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         { transaction }
       );
 
-      await this.invalidateDisplayMetadataCache(workspace, transaction);
+      await this.invalidateDisplayMetadataCache(auth, transaction);
     });
 
     if (fileAttachments) {
@@ -4141,7 +4138,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-        await this.invalidateDisplayMetadataCache(workspace, transaction);
+        await this.invalidateDisplayMetadataCache(auth, transaction);
 
         return deletedCount;
       });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -71,6 +71,9 @@ import {
 } from "@app/lib/skills/format";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { buildCacheWithRedisKey } from "@app/lib/utils/cache";
+import { defineCache } from "@app/lib/utils/cache_handle";
+import { defineCacheOperations } from "@app/lib/utils/cache_operations";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   AgentConfigurationWithoutModelType,
@@ -124,6 +127,7 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
+import { z } from "zod";
 
 export type SkillMCPServerConfiguration = {
   view: MCPServerViewResource;
@@ -137,6 +141,22 @@ type SkillReferenceTarget = {
   name: string;
   requestedSpaceIds: readonly ModelId[];
   status: SkillStatus;
+};
+
+type SkillDisplayMetadataCacheEntry = {
+  id: ModelId;
+  icon: string | null;
+  name: string;
+  requestedSpaceIds: ModelId[];
+  status: SkillStatus;
+  userFacingDescription: string | null;
+};
+
+export type SkillDisplayMetadata = Omit<
+  SkillDisplayMetadataCacheEntry,
+  "id" | "requestedSpaceIds"
+> & {
+  sId: string;
 };
 
 type ReplaceSkillReferenceTagsOptions = {
@@ -281,9 +301,70 @@ const GLOBAL_SKILL_ROLE_GRANTS: RoleGrant[] = [
   { role: "builder", permissions: ["read"] },
 ];
 
+const SKILL_DISPLAY_METADATA_CACHE_ID = "skill_display_metadata_by_workspace";
+const SKILL_DISPLAY_METADATA_CACHE_KEY_VERSION = 1;
+const SKILL_DISPLAY_METADATA_CACHE_TTL_MS = 15 * 60 * 1000;
+const skillDisplayMetadataCacheKey = (workspaceId: string) =>
+  `v${SKILL_DISPLAY_METADATA_CACHE_KEY_VERSION}:${workspaceId}`;
+
+// Cache only database metadata. Space permissions and code-defined skill restrictions stay live.
+const skillDisplayMetadataCache = defineCache<
+  { workspaceId: string; workspaceModelId: ModelId },
+  SkillDisplayMetadataCacheEntry[]
+>({
+  id: SKILL_DISPLAY_METADATA_CACHE_ID,
+  key: ({ workspaceId }) => skillDisplayMetadataCacheKey(workspaceId),
+  load: async ({ workspaceModelId }) => {
+    const skills = await SkillConfigurationModel.findAll({
+      attributes: [
+        "id",
+        "icon",
+        "name",
+        "requestedSpaceIds",
+        "status",
+        "userFacingDescription",
+      ],
+      where: { workspaceId: workspaceModelId },
+    });
+
+    return skills.map((skill) => ({
+      id: skill.id,
+      icon: skill.icon,
+      name: skill.name,
+      requestedSpaceIds: skill.requestedSpaceIds,
+      status: skill.status,
+      userFacingDescription: skill.userFacingDescription,
+    }));
+  },
+  ttlMs: SKILL_DISPLAY_METADATA_CACHE_TTL_MS,
+});
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static model: ModelStatic<SkillConfigurationModel> = SkillConfigurationModel;
+
+  static readonly displayMetadataCacheOperations = defineCacheOperations({
+    id: SKILL_DISPLAY_METADATA_CACHE_ID,
+    label: "Skill display metadata (by workspace)",
+    inputSchema: z.object({ workspaceId: z.string().min(1) }),
+    params: [
+      {
+        key: "workspaceId",
+        label: "Workspace sId",
+        type: "string",
+        placeholder: "e.g. DevWkSpace",
+      },
+    ],
+    buildKey: ({ workspaceId }) =>
+      buildCacheWithRedisKey(
+        SKILL_DISPLAY_METADATA_CACHE_ID,
+        skillDisplayMetadataCacheKey(workspaceId)
+      ),
+    keyPattern: buildCacheWithRedisKey(
+      SKILL_DISPLAY_METADATA_CACHE_ID,
+      skillDisplayMetadataCacheKey("*")
+    ),
+  });
 
   readonly dataSourceConfigurations: SkillDataSourceConfigurationModel[];
   private fileAttachments: FileResource[];
@@ -448,6 +529,131 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
+  private static async filterBySpacePermissions<
+    T extends { requestedSpaceIds: ModelId[] },
+  >(auth: Authenticator, skills: T[], transaction?: Transaction): Promise<T[]> {
+    const uniqueRequestedSpaceIds = uniq(
+      skills.flatMap((skill) => skill.requestedSpaceIds)
+    );
+    const spaces =
+      uniqueRequestedSpaceIds.length > 0
+        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds, {
+            transaction,
+          })
+        : [];
+    const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
+    const foundSpaceIds = new Set(spaces.map((space) => space.id));
+
+    return skills.filter(
+      (skill) =>
+        skill.requestedSpaceIds.every((id) => foundSpaceIds.has(id)) &&
+        auth.hasPermissionForAcls(
+          "read",
+          createAccessControlListFromSpacesWithMap(
+            spaceIdToGroupsMap,
+            skill.requestedSpaceIds,
+            auth.getNonNullableWorkspace().id
+          )
+        )
+    );
+  }
+
+  private static invalidateDisplayMetadataCache(
+    workspace: LightWorkspaceType,
+    transaction?: Transaction
+  ): Promise<void> {
+    return skillDisplayMetadataCache.invalidate(
+      {
+        workspaceId: workspace.sId,
+        workspaceModelId: workspace.id,
+      },
+      transaction
+    );
+  }
+
+  static async listDisplayMetadata(
+    auth: Authenticator,
+    {
+      sIds,
+      status,
+    }: {
+      sIds?: string[];
+      status?: SkillStatus | SkillStatus[];
+    } = {}
+  ): Promise<SkillDisplayMetadata[]> {
+    if (sIds?.length === 0) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const customSkillModelIds = sIds
+      ? new Set(
+          removeNulls(
+            sIds.map((skillId) =>
+              isResourceSId("skill", skillId)
+                ? getResourceIdFromSId(skillId)
+                : null
+            )
+          )
+        )
+      : null;
+    const globalSkillIds = sIds
+      ? sIds.filter((skillId) => !isResourceSId("skill", skillId))
+      : undefined;
+    const statuses = status
+      ? new Set(Array.isArray(status) ? status : [status])
+      : null;
+
+    const customSkills =
+      customSkillModelIds?.size === 0
+        ? []
+        : await this.filterBySpacePermissions(
+            auth,
+            (
+              await skillDisplayMetadataCache.get({
+                workspaceId: workspace.sId,
+                workspaceModelId: workspace.id,
+              })
+            ).filter(
+              (skill) =>
+                (!customSkillModelIds || customSkillModelIds.has(skill.id)) &&
+                (!statuses || statuses.has(skill.status))
+            )
+          );
+
+    const codeDefinedWhere = {
+      ...(globalSkillIds ? { sId: globalSkillIds } : {}),
+      ...(status ? { status } : {}),
+    };
+    const codeDefinedSkills =
+      globalSkillIds?.length === 0
+        ? []
+        : [
+            ...(await GlobalSkillsRegistry.findAll(auth, codeDefinedWhere)),
+            ...(await SystemSkillsRegistry.findAll(auth, codeDefinedWhere)),
+          ];
+
+    return [
+      ...customSkills.map((skill) => ({
+        sId: SkillResource.modelIdToSId({
+          id: skill.id,
+          workspaceId: workspace.id,
+        }),
+        icon: skill.icon,
+        name: skill.name,
+        status: skill.status,
+        userFacingDescription: skill.userFacingDescription,
+      })),
+      ...codeDefinedSkills.map((skill) => ({
+        sId: skill.sId,
+        icon: skill.icon,
+        name: skill.name,
+        status: "active" as const,
+        userFacingDescription: skill.userFacingDescription,
+      })),
+    ];
+  }
+
   static async makeNew(
     auth: Authenticator,
     blob: Omit<CreationAttributes<SkillConfigurationModel>, "workspaceId">,
@@ -543,6 +749,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       // Mirror the editor-group association into group_permissions, in the same transaction as the
       // association itself.
       await skillResource.writeGroupPermissions(auth, { transaction });
+
+      await this.invalidateDisplayMetadataCache(owner, transaction);
 
       return skillResource;
     });
@@ -683,32 +891,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
     });
 
-    // Check if the user has access to skill requested spaces.
-    const uniqueRequestedSpaceIds = uniq(
-      customSkills.flatMap((c) => c.requestedSpaceIds)
-    );
-    const spaces =
-      uniqueRequestedSpaceIds.length > 0
-        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds, {
-            transaction,
-          })
-        : [];
-    const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
-    const foundSpaceIds = new Set(spaces.map((s) => s.id));
-
-    const validCustomSkills = customSkills.filter((skill) =>
-      skill.requestedSpaceIds.every((id) => foundSpaceIds.has(id))
-    );
-
-    const allowedCustomSkills = validCustomSkills.filter((skill) =>
-      auth.hasPermissionForAcls(
-        "read",
-        createAccessControlListFromSpacesWithMap(
-          spaceIdToGroupsMap,
-          skill.requestedSpaceIds,
-          auth.getNonNullableWorkspace().id
-        )
-      )
+    const allowedCustomSkills = await this.filterBySpacePermissions(
+      auth,
+      customSkills,
+      transaction
     );
     const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);
 
@@ -3128,6 +3314,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         }
       }
 
+      await SkillResource.invalidateDisplayMetadataCache(
+        workspace,
+        transaction
+      );
+
       return count;
     });
 
@@ -3139,6 +3330,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       this.canAdministrate(auth),
       "User is not authorized to restore this skill"
     );
+
+    const workspace = auth.getNonNullableWorkspace();
 
     const affectedCount = await withTransaction(async (transaction) => {
       const [count] = await this.update({ status: "active" }, transaction);
@@ -3171,6 +3364,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           await this.editorGroup.restoreMembers(auth, { transaction });
         }
       }
+
+      await SkillResource.invalidateDisplayMetadataCache(
+        workspace,
+        transaction
+      );
 
       return count;
     });
@@ -3215,6 +3413,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
   ): Promise<void> {
     assert(this.canWrite(auth), "User is not authorized to update this skill");
+
+    const workspace = auth.getNonNullableWorkspace();
 
     const availabilityChanged =
       availability !== undefined && availability !== this.availability;
@@ -3315,6 +3515,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         auth,
         { previousRequestedSpaceIds },
         { transaction }
+      );
+
+      await SkillResource.invalidateDisplayMetadataCache(
+        workspace,
+        transaction
       );
     });
 
@@ -3988,13 +4193,20 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           transaction,
         });
 
-        return this.model.destroy({
+        const deletedCount = await this.model.destroy({
           where: {
             id: this.id,
             workspaceId: workspace.id,
           },
           transaction,
         });
+
+        await SkillResource.invalidateDisplayMetadataCache(
+          workspace,
+          transaction
+        );
+
+        return deletedCount;
       });
 
       // Delete files from cloud storage outside the transaction (I/O with GCS).
@@ -4224,7 +4436,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
-    const workspaceId = auth.getNonNullableWorkspace().id;
+    const workspace = auth.getNonNullableWorkspace();
+    const workspaceId = workspace.id;
 
     await AgentSkillModel.destroy({
       where: { workspaceId },
@@ -4298,6 +4511,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     await this.model.destroy({
       where: { workspaceId },
     });
+
+    await this.invalidateDisplayMetadataCache(workspace);
   }
 
   private static replaceSkillReferenceTags(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -61,6 +61,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
   extractUniqueSkillReferenceIds,
   parseSkillReferenceTag,
@@ -303,16 +304,16 @@ const skillListActiveCacheKey = (workspaceId: string) =>
   `${workspaceId}:v${SKILL_LIST_ACTIVE_CACHE_KEY_VERSION}`;
 
 // Keep the cached database snapshot small. Code-defined skills are read from their registries.
-const skillListActiveCache = defineCache<
-  { workspaceId: string; workspaceModelId: ModelId },
-  SkillListActiveCacheEntry[]
->({
+const skillListActiveCache = defineCache<string, SkillListActiveCacheEntry[]>({
   id: SKILL_LIST_ACTIVE_CACHE_ID,
-  key: ({ workspaceId }) => skillListActiveCacheKey(workspaceId),
-  load: async ({ workspaceModelId }) => {
+  key: skillListActiveCacheKey,
+  load: async (workspaceId) => {
+    const workspace = await WorkspaceResource.fetchById(workspaceId);
+    assert(workspace, `Workspace not found: ${workspaceId}`);
+
     const skills = await SkillConfigurationModel.findAll({
       attributes: ["id", "icon", "name", "userFacingDescription"],
-      where: { status: "active", workspaceId: workspaceModelId },
+      where: { status: "active", workspaceId: workspace.id },
     });
 
     return skills.map((skill) => ({
@@ -520,23 +521,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     transaction?: Transaction
   ): Promise<void> {
     const workspace = auth.getNonNullableWorkspace();
-    return skillListActiveCache.invalidate(
-      {
-        workspaceId: workspace.sId,
-        workspaceModelId: workspace.id,
-      },
-      transaction
-    );
+    return skillListActiveCache.invalidate(workspace.sId, transaction);
   }
 
   static async listActiveMetadataByWorkspace(
     auth: Authenticator
   ): Promise<SkillListActiveEntry[]> {
     const workspace = auth.getNonNullableWorkspace();
-    const customSkills = await skillListActiveCache.get({
-      workspaceId: workspace.sId,
-      workspaceModelId: workspace.id,
-    });
+    const customSkills = await skillListActiveCache.get(workspace.sId);
     const codeDefinedSkills = [
       ...(await GlobalSkillsRegistry.findAll(auth, { status: "active" })),
       ...(await SystemSkillsRegistry.findAll(auth, { status: "active" })),
@@ -4425,10 +4417,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where: { workspaceId },
     });
 
-    await skillListActiveCache.invalidate({
-      workspaceId: workspace.sId,
-      workspaceModelId: workspace.id,
-    });
+    await skillListActiveCache.invalidate(workspace.sId);
   }
 
   private static replaceSkillReferenceTags(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -302,7 +302,7 @@ const SKILL_LIST_ACTIVE_CACHE_ID = "skill_list_active_by_workspace";
 const SKILL_LIST_ACTIVE_CACHE_KEY_VERSION = 1;
 const SKILL_LIST_ACTIVE_CACHE_TTL_MS = 15 * 60 * 1000;
 const skillListActiveCacheKey = (workspaceId: string) =>
-  `v${SKILL_LIST_ACTIVE_CACHE_KEY_VERSION}:${workspaceId}`;
+  `${workspaceId}:v${SKILL_LIST_ACTIVE_CACHE_KEY_VERSION}`;
 
 const skillListActiveCache = defineCache<
   { workspaceId: string; workspaceModelId: ModelId },


### PR DESCRIPTION
## Description

Loading analytics filters currently hydrates every active workspace skill, which makes skill facets slow on large workspaces.

Cache the small workspace-level skill metadata needed by facets and reuse it for both the active facet catalog and historical label resolution. Space permissions and code-defined skill restrictions are still evaluated after each cache read, and skill mutations invalidate the cache after commit.

This follows the Resource-owned query cache contract introduced in #30270. The cache stores display metadata instead of partial SkillResource instances.

## Tests

- Added coverage for cache refresh after skill updates and archives.
- Covered both analytics facet paths and Poke cache registration.

## Risk

- Low. The change is scoped to display metadata used by analytics skill facets.

## Deploy Plan

- Deploy front and front-api.