### PR TITLE
fix: scope consumption export status to the requested period+filter

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -4,24 +4,12 @@ import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { describeWorkflowMock, startWorkflowMock, listWorkflowMock } =
-  vi.hoisted(() => ({
-    describeWorkflowMock: vi.fn().mockResolvedValue({
-      status: { name: "COMPLETED" },
-    }),
-    startWorkflowMock: vi.fn().mockResolvedValue(undefined),
-    listWorkflowMock: vi.fn(),
-  }));
-
-function asyncIterableOf<T>(items: T[]) {
-  return {
-    [Symbol.asyncIterator]: async function* () {
-      for (const item of items) {
-        yield item;
-      }
-    },
-  };
-}
+const { describeWorkflowMock, startWorkflowMock } = vi.hoisted(() => ({
+  describeWorkflowMock: vi.fn().mockResolvedValue({
+    status: { name: "COMPLETED" },
+  }),
+  startWorkflowMock: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("@app/lib/temporal", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@app/lib/temporal")>();
@@ -31,7 +19,6 @@ vi.mock("@app/lib/temporal", async (importOriginal) => {
       workflow: {
         start: startWorkflowMock,
         getHandle: vi.fn().mockReturnValue({ describe: describeWorkflowMock }),
-        list: listWorkflowMock,
       },
     }),
   };
@@ -40,7 +27,6 @@ vi.mock("@app/lib/temporal", async (importOriginal) => {
 beforeEach(() => {
   describeWorkflowMock.mockResolvedValue({ status: { name: "COMPLETED" } });
   startWorkflowMock.mockResolvedValue(undefined);
-  listWorkflowMock.mockReturnValue(asyncIterableOf([]));
   // No cached export by default, so POST tests exercise the actual workflow start.
   fileStorageMock.setFileExists(() => false);
 });
@@ -53,8 +39,15 @@ async function setupTest({
   return createPrivateApiMockRequest({ role });
 }
 
-function getExportRawRequest(wId: string) {
-  return honoApp.request(`/api/w/${wId}/analytics/consumption/export-raw`);
+function postExportStatusRequest(wId: string, body: Record<string, unknown>) {
+  return honoApp.request(
+    `/api/w/${wId}/analytics/consumption/export-raw/status`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
 }
 
 function postExportRawRequest(wId: string, body: Record<string, unknown>) {
@@ -72,15 +65,19 @@ function getDownloadRequest(wId: string, name: string) {
   );
 }
 
-describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
-  it("returns an empty list and not-generating when nothing exists", async () => {
+describe("POST /api/w/:wId/analytics/consumption/export-raw/status", () => {
+  it("returns an empty list and not-generating/not-ready when nothing exists", async () => {
     fileStorageMock.setFilesByPrefix(() => []);
     const { workspace } = await setupTest();
 
-    const response = await getExportRawRequest(workspace.sId);
+    const response = await postExportStatusRequest(workspace.sId, {});
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ exports: [], isGenerating: false });
+    const body = await response.json();
+    expect(body.exports).toEqual([]);
+    expect(body.isGenerating).toBe(false);
+    expect(body.isReady).toBe(false);
+    expect(typeof body.exportId).toBe("string");
   });
 
   it("lists past exports for the workspace, newest first", async () => {
@@ -108,7 +105,7 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
       ];
     });
 
-    const response = await getExportRawRequest(workspace.sId);
+    const response = await postExportStatusRequest(workspace.sId, {});
 
     expect(response.status).toBe(200);
     const body = await response.json();
@@ -127,15 +124,29 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw", () => {
     ]);
   });
 
-  it("reports isGenerating when the workspace's export workflow is running", async () => {
-    listWorkflowMock.mockReturnValue(asyncIterableOf([{}]));
+  it("reports isGenerating when the workflow for this exact period+filter is running", async () => {
+    describeWorkflowMock.mockResolvedValue({ status: { name: "RUNNING" } });
     fileStorageMock.setFilesByPrefix(() => []);
     const { workspace } = await setupTest();
 
-    const response = await getExportRawRequest(workspace.sId);
+    const response = await postExportStatusRequest(workspace.sId, {});
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ exports: [], isGenerating: true });
+    const body = await response.json();
+    expect(body.exports).toEqual([]);
+    expect(body.isGenerating).toBe(true);
+  });
+
+  it("reports isReady when a cached export exists for this exact period+filter", async () => {
+    fileStorageMock.setFileExists(() => true);
+    fileStorageMock.setFilesByPrefix(() => []);
+    const { workspace } = await setupTest();
+
+    const response = await postExportStatusRequest(workspace.sId, {});
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.isReady).toBe(true);
   });
 });
 

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
@@ -1,6 +1,6 @@
 import {
   getConsumptionExportDownloadUrl,
-  isConsumptionExportGenerating,
+  getConsumptionExportStatus,
   listConsumptionExports,
   startConsumptionExport,
 } from "@app/lib/api/analytics/consumption/export_jobs";
@@ -22,17 +22,29 @@ const DownloadParamsSchema = z.object({
   name: z.string(),
 });
 
+// POST (not GET) so the filter travels in the JSON body, consistent with every other
+// consumption endpoint: it scopes isGenerating/isReady to this exact period+filter
+// combination instead of any export running for the workspace.
 /** @ignoreswagger */
-app.get("/", ensureIsManager(), async (ctx) => {
-  const auth = ctx.get("auth");
+app.post(
+  "/status",
+  ensureIsManager(),
+  validate("json", ConsumptionExportBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { filter, ...periodQuery } = ctx.req.valid("json");
+    const periodInput = toConsumptionPeriodInput(periodQuery);
 
-  const [exports, isGenerating] = await Promise.all([
-    listConsumptionExports(auth),
-    isConsumptionExportGenerating(auth),
-  ]);
+    const period = await resolveConsumptionPeriod(auth, periodInput);
 
-  return ctx.json({ exports, isGenerating });
-});
+    const [exports, status] = await Promise.all([
+      listConsumptionExports(auth),
+      getConsumptionExportStatus(auth, { period, filter }),
+    ]);
+
+    return ctx.json({ exports, ...status });
+  }
+);
 
 /** @ignoreswagger */
 app.post(

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.test.tsx
@@ -27,6 +27,7 @@ describe("ConsumptionExportPanel", () => {
     mockUseConsumptionExports.mockReturnValue({
       exports: [],
       isGenerating: false,
+      isReady: false,
       isConsumptionExportsLoading: false,
       isConsumptionExportsError: undefined,
     });
@@ -62,6 +63,7 @@ describe("ConsumptionExportPanel", () => {
     mockUseConsumptionExports.mockReturnValue({
       exports: [],
       isGenerating: false,
+      isReady: false,
       isConsumptionExportsLoading: false,
       isConsumptionExportsError: new Error("boom"),
     });

--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
@@ -54,9 +54,10 @@ export function ConsumptionExportPanel({
   const {
     exports,
     isGenerating,
+    isReady,
     isConsumptionExportsLoading,
     isConsumptionExportsError,
-  } = useConsumptionExports({ workspaceId, disabled: !isOpen });
+  } = useConsumptionExports({ workspaceId, exportBody, disabled: !isOpen });
   const { isStarting, startConsumptionExport } = useStartConsumptionExport({
     workspaceId,
   });
@@ -69,11 +70,12 @@ export function ConsumptionExportPanel({
     }
   };
 
-  // Opening the panel with no past export and nothing already generating starts one
-  // automatically, so the user doesn't have to find a separate "generate" action. This
-  // only fires once per time the panel is opened: a workflow that failed or timed out
-  // also leaves exports empty with isGenerating false, so without this guard the effect
-  // would relaunch an expensive export indefinitely instead of surfacing the failure.
+  // Opening the panel with no export ready for the current period+filter and nothing
+  // already generating for it starts one automatically, so the user doesn't have to find
+  // a separate "generate" action. This only fires once per time the panel is opened: a
+  // workflow that failed or timed out also leaves isReady/isGenerating both false, so
+  // without this guard the effect would relaunch an expensive export indefinitely instead
+  // of surfacing the failure.
   useEffect(() => {
     if (
       isOpen &&
@@ -82,7 +84,7 @@ export function ConsumptionExportPanel({
       !isGenerating &&
       !isStarting &&
       !hasAttemptedAutoStart &&
-      exports.length === 0
+      !isReady
     ) {
       setHasAttemptedAutoStart(true);
       void startConsumptionExport(exportBody);
@@ -94,16 +96,13 @@ export function ConsumptionExportPanel({
     isGenerating,
     isStarting,
     hasAttemptedAutoStart,
-    exports.length,
+    isReady,
     exportBody,
     startConsumptionExport,
   ]);
 
   const hasAutoStartFailed =
-    hasAttemptedAutoStart &&
-    !isGenerating &&
-    !isStarting &&
-    exports.length === 0;
+    hasAttemptedAutoStart && !isGenerating && !isStarting && !isReady;
 
   return (
     <PopoverRoot open={isOpen} onOpenChange={handleOpenChange}>

--- a/front/hooks/useConsumptionExports.ts
+++ b/front/hooks/useConsumptionExports.ts
@@ -4,28 +4,36 @@ import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/s
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { useCallback, useState } from "react";
-import type { Fetcher } from "swr";
 import { useSWRConfig } from "swr";
 
 const GENERATING_POLL_INTERVAL_MS = 3_000;
 
-type GetConsumptionExportsResponse = {
+type GetConsumptionExportStatusResponse = {
   exports: ConsumptionExportListItem[];
+  exportId: string;
   isGenerating: boolean;
+  isReady: boolean;
 };
 
+// Status is scoped to `exportBody` (period+filter), matching the cache key the export
+// workflow itself uses: a workflow running for a different filter must not read as
+// "generating" here, and a stale export from a different filter must not read as "ready".
 export function useConsumptionExports({
   workspaceId,
+  exportBody,
   disabled,
 }: {
   workspaceId: string;
+  exportBody: ConsumptionExportBody;
   disabled?: boolean;
 }) {
-  const { fetcher } = useFetcher();
-  const url = `/api/w/${workspaceId}/analytics/consumption/export-raw`;
-  const exportsFetcher: Fetcher<GetConsumptionExportsResponse> = fetcher;
+  const { fetcherWithBody } = useFetcher();
+  const url = `/api/w/${workspaceId}/analytics/consumption/export-raw/status`;
 
-  const { data, error, mutate } = useSWRWithDefaults(url, exportsFetcher, {
+  const { data, error, mutate } = useSWRWithDefaults<
+    [string, ConsumptionExportBody, string],
+    GetConsumptionExportStatusResponse
+  >([url, exportBody, "POST"], fetcherWithBody, {
     disabled,
     refreshInterval: (latest) =>
       latest?.isGenerating ? GENERATING_POLL_INTERVAL_MS : 0,
@@ -34,6 +42,7 @@ export function useConsumptionExports({
   return {
     exports: data?.exports ?? [],
     isGenerating: data?.isGenerating ?? false,
+    isReady: data?.isReady ?? false,
     mutateConsumptionExports: mutate,
     isConsumptionExportsLoading: !error && !data && !disabled,
     isConsumptionExportsError: error,
@@ -49,6 +58,7 @@ export function useStartConsumptionExport({
   const sendNotification = useSendNotification();
   const { mutate } = useSWRConfig();
   const url = `/api/w/${workspaceId}/analytics/consumption/export-raw`;
+  const statusUrl = `${url}/status`;
 
   const startConsumptionExport = useCallback(
     async (body: ConsumptionExportBody) => {
@@ -67,12 +77,12 @@ export function useStartConsumptionExport({
           });
           return;
         }
-        await mutate(url);
+        await mutate([statusUrl, body, "POST"]);
       } finally {
         setIsStarting(false);
       }
     },
-    [url, sendNotification, mutate]
+    [url, statusUrl, sendNotification, mutate]
   );
 
   return { isStarting, startConsumptionExport };

--- a/front/lib/api/analytics/consumption/export_jobs.test.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.test.ts
@@ -1,0 +1,109 @@
+import {
+  getConsumptionExportStatus,
+  startConsumptionExport,
+} from "@app/lib/api/analytics/consumption/export_jobs";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getHandleMock, describeWorkflowMock, startWorkflowMock } = vi.hoisted(
+  () => ({
+    getHandleMock: vi.fn(),
+    describeWorkflowMock: vi.fn().mockResolvedValue({
+      status: { name: "COMPLETED" },
+    }),
+    startWorkflowMock: vi.fn().mockResolvedValue(undefined),
+  })
+);
+
+vi.mock(import("@app/lib/temporal"), async (importOriginal) => {
+  const actual = await importOriginal();
+  getHandleMock.mockReturnValue({ describe: describeWorkflowMock });
+  return {
+    ...actual,
+    getTemporalClientForFrontNamespace: vi.fn().mockResolvedValue({
+      workflow: {
+        start: startWorkflowMock,
+        getHandle: getHandleMock,
+      },
+    }),
+  };
+});
+
+beforeEach(() => {
+  getHandleMock.mockClear();
+  describeWorkflowMock
+    .mockClear()
+    .mockResolvedValue({ status: { name: "COMPLETED" } });
+  startWorkflowMock.mockClear().mockResolvedValue(undefined);
+  fileStorageMock.setFileExists(() => false);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Regression test for a bug where `resolveConsumptionPeriod` resolves a "days" period's
+// endDate to `now.toISOString()`, which is different on every call. The status check, the
+// start request, and every later poll each computed a different exportId/workflowId for
+// what should be the same logical export, so a poll could report the export as not-running
+// while it was still generating.
+describe("consumption export cache key stability for 'days' periods", () => {
+  it("resolves the same exportId (and Temporal workflow ID) across status -> start -> status", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-18T10:00:00.000Z"));
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const periodAtFirstStatusCheck = await resolveConsumptionPeriod(
+      authenticator,
+      { kind: "days", days: 7 }
+    );
+    const status1 = await getConsumptionExportStatus(authenticator, {
+      period: periodAtFirstStatusCheck,
+      filter: {},
+    });
+
+    // Time passes before the user clicks "export".
+    vi.setSystemTime(new Date("2026-08-18T10:00:05.500Z"));
+
+    const periodAtStart = await resolveConsumptionPeriod(authenticator, {
+      kind: "days",
+      days: 7,
+    });
+    const startResult = await startConsumptionExport(authenticator, {
+      period: periodAtStart,
+      filter: {},
+    });
+    expect(startResult.isOk()).toBe(true);
+
+    // More time passes before the panel polls status again.
+    vi.setSystemTime(new Date("2026-08-18T10:00:12.900Z"));
+
+    const periodAtSecondStatusCheck = await resolveConsumptionPeriod(
+      authenticator,
+      { kind: "days", days: 7 }
+    );
+    const status2 = await getConsumptionExportStatus(authenticator, {
+      period: periodAtSecondStatusCheck,
+      filter: {},
+    });
+
+    expect(status1.exportId).toBe(status2.exportId);
+
+    // The workflow ID used to check status before starting, the one actually started, and
+    // the one used to poll status afterwards must all be the same. `getHandle` is called
+    // three times: by the first status check, by `launchConsumptionExportWorkflow`'s own
+    // already-running guard, and by the second status check.
+    expect(startWorkflowMock).toHaveBeenCalledTimes(1);
+    const startedWorkflowId = startWorkflowMock.mock.calls[0][1].workflowId;
+    const polledWorkflowIds = getHandleMock.mock.calls.map((call) => call[0]);
+
+    expect(polledWorkflowIds).toEqual([
+      startedWorkflowId,
+      startedWorkflowId,
+      startedWorkflowId,
+    ]);
+  });
+});

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -4,11 +4,17 @@ import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import {
+  buildConsumptionExportCacheKey,
+  buildConsumptionExportGcsPath,
   buildConsumptionExportGcsPrefix,
-  makeConsumptionExportWorkflowIdPrefix,
+  makeConsumptionExportWorkflowId,
 } from "@app/temporal/analytics_queue/activities/consumption_export";
 import type { LaunchConsumptionExportOutcome } from "@app/temporal/analytics_queue/client";
-import { launchConsumptionExportWorkflow } from "@app/temporal/analytics_queue/client";
+import {
+  isConsumptionExportRunning,
+  launchConsumptionExportWorkflow,
+  resolveExportPeriod,
+} from "@app/temporal/analytics_queue/client";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -65,19 +71,43 @@ export async function getConsumptionExportDownloadUrl(
   return new Ok(downloadUrl);
 }
 
-export async function isConsumptionExportGenerating(
-  auth: Authenticator
-): Promise<boolean> {
-  const workspaceId = auth.getNonNullableWorkspace().sId;
-  const client = await getTemporalClientForFrontNamespace();
+export type ConsumptionExportStatus = {
+  exportId: string;
+  isGenerating: boolean;
+  isReady: boolean;
+};
 
-  // Export for this workspace is matched by prefix.
-  const query = `WorkflowId STARTS_WITH "${makeConsumptionExportWorkflowIdPrefix({ workspaceId })}" AND ExecutionStatus="Running"`;
-  for await (const _workflow of client.workflow.list({ query })) {
-    return true;
+// Scoped to the exact period+filter combination (same cache key the export workflow
+// itself uses), unlike a workspace-wide check: a workflow running for one filter must
+// not be mistaken for one running for another.
+export async function getConsumptionExportStatus(
+  auth: Authenticator,
+  {
+    period,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    filter?: ConsumptionScopeFilter;
   }
+): Promise<ConsumptionExportStatus> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const exportPeriod = resolveExportPeriod(period);
+  const exportId = buildConsumptionExportCacheKey({
+    period: exportPeriod,
+    filter: filter ?? {},
+  });
 
-  return false;
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeConsumptionExportWorkflowId({ workspaceId, exportId });
+
+  const [isGenerating, [isReady]] = await Promise.all([
+    isConsumptionExportRunning(client.workflow.getHandle(workflowId)),
+    getPrivateUploadBucket()
+      .file(buildConsumptionExportGcsPath(workspaceId, exportId))
+      .exists(),
+  ]);
+
+  return { exportId, isGenerating, isReady };
 }
 
 export async function startConsumptionExport(

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -197,12 +197,7 @@ function endOfUtcToday(): Date {
 
 // Normalizes any period whose end falls on or after today to a fixed end-of-day
 // boundary, so exports stay cacheable within a day but refresh once new data can
-// have accrued. This covers two distinct sources of instability: an open-ended
-// period (e.g. "this cycle") whose endDate is a future cycle boundary, and a
-// relative period (e.g. "last N days") whose endDate is `now.toISOString()`,
-// which is different on every call. Without this, the cache key (and the
-// Temporal workflow ID derived from it) would differ between the status check,
-// the start request, and every subsequent poll for the same logical export.
+// have accrued.
 export function resolveExportPeriod(
   period: ConsumptionPeriod
 ): ConsumptionPeriod {

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -190,7 +190,9 @@ function endOfUtcToday(): Date {
 
 // Caps an open-ended period (e.g. "this cycle") to today, so exports stay
 // cacheable within a day but refresh once new data can have accrued.
-function resolveExportPeriod(period: ConsumptionPeriod): ConsumptionPeriod {
+export function resolveExportPeriod(
+  period: ConsumptionPeriod
+): ConsumptionPeriod {
   const endOfTodayMs = endOfUtcToday().getTime();
   const endMs = Math.min(new Date(period.endDate).getTime(), endOfTodayMs);
   return {
@@ -199,7 +201,7 @@ function resolveExportPeriod(period: ConsumptionPeriod): ConsumptionPeriod {
   };
 }
 
-async function isConsumptionExportRunning(
+export async function isConsumptionExportRunning(
   handle: WorkflowHandle
 ): Promise<boolean> {
   try {

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -181,6 +181,13 @@ export type LaunchConsumptionExportOutcome =
       filter: ConsumptionScopeFilter;
     };
 
+function startOfUtcToday(): Date {
+  const now = new Date();
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
+}
+
 function endOfUtcToday(): Date {
   const now = new Date();
   return new Date(
@@ -188,16 +195,24 @@ function endOfUtcToday(): Date {
   );
 }
 
-// Caps an open-ended period (e.g. "this cycle") to today, so exports stay
-// cacheable within a day but refresh once new data can have accrued.
+// Normalizes any period whose end falls on or after today to a fixed end-of-day
+// boundary, so exports stay cacheable within a day but refresh once new data can
+// have accrued. This covers two distinct sources of instability: an open-ended
+// period (e.g. "this cycle") whose endDate is a future cycle boundary, and a
+// relative period (e.g. "last N days") whose endDate is `now.toISOString()`,
+// which is different on every call. Without this, the cache key (and the
+// Temporal workflow ID derived from it) would differ between the status check,
+// the start request, and every subsequent poll for the same logical export.
 export function resolveExportPeriod(
   period: ConsumptionPeriod
 ): ConsumptionPeriod {
+  const endMs = new Date(period.endDate).getTime();
   const endOfTodayMs = endOfUtcToday().getTime();
-  const endMs = Math.min(new Date(period.endDate).getTime(), endOfTodayMs);
+  const normalizedEndMs =
+    endMs >= startOfUtcToday().getTime() ? endOfTodayMs : endMs;
   return {
     startDate: period.startDate,
-    endDate: new Date(endMs).toISOString(),
+    endDate: new Date(normalizedEndMs).toISOString(),
   };
 }
 


### PR DESCRIPTION
## Description

The consumption export panel previously determined `isGenerating` by scanning any running export workflow for the workspace, and treated any historical export as available. As a result, an export generated for one period or filter could suppress or mask the export needed for a different selection.

This change scopes export status to the exact period+filter cache key used by the export workflow. 
The endpoint contract changes from the previous workspace-wide `GET /export-raw` status check to the scoped `POST /export-raw/status` check; the callers in this PR are updated together.

## Tests


## Risk

Low

## Deploy Plan

- Deploy front