### PR TITLE
[front] fix: hide burn-up target when consumption is filtered

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
@@ -105,12 +105,15 @@ export function ConsumptionBurnUpChart({
   filter,
 }: ConsumptionBurnUpChartProps) {
   const { overview } = useConsumptionOverview({ workspaceId, period, filter });
-  // A cap only exists on a billing cycle. Gating on the selection rather than on
-  // the response alone keeps a previous cycle's cap — kept around by
-  // `keepPreviousData` while the new request lands — from drawing a target over
-  // a period that has none.
+  const isFiltered = Object.values(filter ?? {}).some(
+    (values) => values.length > 0
+  );
+  // A cap only exists on a billing cycle, when there's no filter. Gating on the
+  // selection rather than on the response alone keeps a previous cycle's cap —
+  // kept around by `keepPreviousData` while the new request lands — from drawing
+  // a target over a period that has none.
   const capCredits =
-    period.kind === "cycle"
+    period.kind === "cycle" && !isFiltered
       ? (overview?.creditUsage?.capCredits ?? null)
       : null;
 


### PR DESCRIPTION
## Description

The credit cap covers the whole workspace, so drawing the target against a filtered part of the credits consumption made every filtered view look far under target. This PR drops the target line (and its legend entry) as soon as a scope filter is active.

## Tests

Manual: filtered by agent and by user on a cycle period, target line disappears. Cleared the filter, it comes back.

## Risk

Low, one chart.

## Deploy Plan

Deploy front.