### PR TITLE
[front] fix: show pod app clone/delete/import progress on the grid

### DIFF
--- a/front/components/pod/apps/ClonePodAppDialog.tsx
+++ b/front/components/pod/apps/ClonePodAppDialog.tsx
@@ -1,8 +1,6 @@
-import { useClonePodApp } from "@app/lib/swr/pods";
 import type { PodApp } from "@app/types/api/pod_apps";
 import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
 import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   ContentMessage,
   Dialog,
@@ -12,32 +10,28 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
-  Spinner,
 } from "@dust-tt/sparkle";
 import type { ChangeEvent } from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 interface ClonePodAppDialogProps {
-  owner: LightWorkspaceType;
-  podId: string;
   app: PodApp;
   existingPrefixes: string[];
   isOpen: boolean;
   onClose: () => void;
+  /** The clone itself runs in the Apps tab, which outlives this dialog. */
+  onSubmit: (name: string) => void;
 }
 
 export function ClonePodAppDialog({
-  owner,
-  podId,
   app,
   existingPrefixes,
   isOpen,
   onClose,
+  onSubmit,
 }: ClonePodAppDialogProps) {
   const sourceName = app.name ?? app.prefix;
   const [name, setName] = useState(`${sourceName} Copy`);
-  const [isCloning, setIsCloning] = useState(false);
-  const doClone = useClonePodApp({ owner, podId });
 
   // The prefix is what actually has to be unique: two names that normalize alike would share
   // published slugs and databases.
@@ -55,15 +49,6 @@ export function ClonePodAppDialog({
     return null;
   }, [existingPrefixes, name, prefix]);
 
-  const onClone = useCallback(async () => {
-    setIsCloning(true);
-    const result = await doClone(app, name.trim());
-    setIsCloning(false);
-    if (result.isOk()) {
-      onClose();
-    }
-  }, [app, doClone, name, onClose]);
-
   return (
     <Dialog
       open={isOpen}
@@ -77,64 +62,49 @@ export function ClonePodAppDialog({
         <DialogHeader>
           <DialogTitle>{`Clone ${sourceName}`}</DialogTitle>
         </DialogHeader>
-        {isCloning ? (
-          <DialogContainer className="flex flex-col items-center gap-3 py-8">
-            <Spinner variant="dark" size="md" />
-            {/* Each function is a real build on the Pod's Computer, so this is not instant. */}
-            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-              Cloning {sourceName}. Each function is rebuilt on the Pod's
-              Computer, so this can take a while.
-            </p>
-          </DialogContainer>
-        ) : (
-          <>
-            <DialogContainer className="flex flex-col gap-4">
-              <div className="flex flex-col gap-1">
-                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
-                  New app name
-                </span>
-                <Input
-                  name="clone-app-name"
-                  value={name}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                    setName(e.target.value)
-                  }
-                  maxLength={MAX_POD_APP_NAME_LENGTH}
-                  message={nameError ?? undefined}
-                  messageStatus={nameError ? "error" : undefined}
-                  containerClassName="w-full"
-                />
-                {!nameError && (
-                  <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
-                    Functions will be published as{" "}
-                    <span className="font-mono">{prefix}__&lt;name&gt;</span>.
-                  </span>
-                )}
-              </div>
-
-              <ContentMessage variant="info" title="The copy starts empty">
-                Its {app.databases.length === 1 ? "database" : "databases"} are
-                created from the same schema but hold no data, and its Frame is
-                left unpublished so you can review it first.
-              </ContentMessage>
-            </DialogContainer>
-            <DialogFooter
-              leftButtonProps={{
-                label: "Cancel",
-                variant: "outline",
-                onClick: onClose,
-              }}
-              rightButtonProps={{
-                label: "Clone app",
-                variant: "primary",
-                disabled: nameError !== null,
-                onClick: () => {
-                  void onClone();
-                },
-              }}
+        <DialogContainer className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+              New app name
+            </span>
+            <Input
+              name="clone-app-name"
+              value={name}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setName(e.target.value)
+              }
+              maxLength={MAX_POD_APP_NAME_LENGTH}
+              message={nameError ?? undefined}
+              messageStatus={nameError ? "error" : undefined}
+              containerClassName="w-full"
             />
-          </>
-        )}
+            {!nameError && (
+              <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+                Functions will be published as{" "}
+                <span className="font-mono">{prefix}__&lt;name&gt;</span>.
+              </span>
+            )}
+          </div>
+
+          <ContentMessage variant="info" title="The copy starts empty">
+            Its {app.databases.length === 1 ? "database" : "databases"} are
+            created from the same schema but hold no data, and its Frame is left
+            unpublished so you can review it first.
+          </ContentMessage>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Clone app",
+            variant: "primary",
+            disabled: nameError !== null,
+            onClick: () => onSubmit(name.trim()),
+          }}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/front/components/pod/apps/DeletePodAppDialog.tsx
+++ b/front/components/pod/apps/DeletePodAppDialog.tsx
@@ -1,6 +1,4 @@
-import { useDeletePodApp } from "@app/lib/swr/pods";
 import type { PodApp } from "@app/types/api/pod_apps";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   ContentMessage,
   Dialog,
@@ -10,19 +8,18 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
-  Spinner,
 } from "@dust-tt/sparkle";
 import type { ChangeEvent } from "react";
-import { useCallback, useState } from "react";
+import { useState } from "react";
 
 const CONFIRM_WORD = "delete";
 
 interface DeletePodAppDialogProps {
-  owner: LightWorkspaceType;
-  podId: string;
   app: PodApp;
   isOpen: boolean;
   onClose: () => void;
+  /** The deletion itself runs in the Apps tab, which outlives this dialog. */
+  onSubmit: () => void;
 }
 
 interface InventoryLineProps {
@@ -50,27 +47,15 @@ function InventoryLine({ label, items }: InventoryLineProps) {
 }
 
 export function DeletePodAppDialog({
-  owner,
-  podId,
   app,
   isOpen,
   onClose,
+  onSubmit,
 }: DeletePodAppDialogProps) {
-  const [isDeleting, setIsDeleting] = useState(false);
   const [confirmText, setConfirmText] = useState("");
-  const doDelete = useDeletePodApp({ owner, podId });
 
   const appName = app.name ?? app.prefix;
   const sharedFrames = app.frames.filter((frame) => frame.isPublished);
-
-  const onDelete = useCallback(async () => {
-    setIsDeleting(true);
-    const result = await doDelete(app);
-    setIsDeleting(false);
-    if (result.isOk()) {
-      onClose();
-    }
-  }, [app, doDelete, onClose]);
 
   return (
     <Dialog
@@ -86,106 +71,81 @@ export function DeletePodAppDialog({
         <DialogHeader>
           <DialogTitle>{`Delete ${appName}?`}</DialogTitle>
         </DialogHeader>
-        {isDeleting ? (
-          <DialogContainer className="flex flex-col items-center gap-3 py-8">
-            <Spinner variant="dark" size="md" />
-            {/* Removing the databases needs a live sandbox, so a sleeping Pod is woken first. */}
-            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-              Deleting {appName}. This waits for the Pod's Computer to be ready,
-              so it can take a moment.
-            </p>
-          </DialogContainer>
-        ) : (
-          <>
-            <DialogContainer className="flex flex-col gap-4">
-              <div className="flex flex-col gap-2">
-                <p className="copy-sm">This permanently removes:</p>
-                <ul className="flex flex-col gap-1 pl-4 copy-sm list-disc">
-                  <InventoryLine
-                    label={
-                      app.functions.length === 1 ? "function" : "functions"
-                    }
-                    items={app.functions.map((fn) => fn.name)}
-                  />
-                  <InventoryLine
-                    label={
-                      app.databases.length === 1 ? "database" : "databases"
-                    }
-                    items={app.databases.map((db) => db.name)}
-                  />
-                  <InventoryLine
-                    label={app.frames.length === 1 ? "Frame" : "Frames"}
-                    items={app.frames.map((frame) => frame.fileName)}
-                  />
-                  {app.fileCount > 0 && (
-                    <li>
-                      <span className="font-semibold">
-                        {app.fileCount} {app.fileCount === 1 ? "file" : "files"}
-                      </span>
-                      <span className="text-muted-foreground dark:text-muted-foreground-night">
-                        {" — "}
-                        {app.collidingFolderNames.length > 0
-                          ? app.collidingFolderNames.join(", ")
-                          : appName}
-                      </span>
-                    </li>
-                  )}
-                </ul>
-              </div>
-
-              {app.databases.length > 0 && (
-                <ContentMessage
-                  variant="warning"
-                  title="Data cannot be recovered"
-                >
-                  The {app.databases.length === 1 ? "database" : "databases"}{" "}
-                  above and everything stored in{" "}
-                  {app.databases.length === 1 ? "it" : "them"} are deleted for
-                  good, including the replicated copy.
-                </ContentMessage>
-              )}
-
-              {sharedFrames.length > 0 && (
-                <ContentMessage
-                  variant="warning"
-                  title="Shared links will break"
-                >
-                  {sharedFrames.length === 1
-                    ? "This app's Frame has been published, so anyone holding its link loses access."
-                    : "This app's Frames have been published, so anyone holding their links loses access."}
-                </ContentMessage>
-              )}
-
-              <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-                Type <strong>{CONFIRM_WORD}</strong> below to confirm.
-              </p>
-              <Input
-                name="delete-app-confirm"
-                value={confirmText}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  setConfirmText(e.target.value)
-                }
-                placeholder={`Type ${CONFIRM_WORD} to confirm`}
-                containerClassName="w-full"
+        <DialogContainer className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <p className="copy-sm">This permanently removes:</p>
+            <ul className="flex flex-col gap-1 pl-4 copy-sm list-disc">
+              <InventoryLine
+                label={app.functions.length === 1 ? "function" : "functions"}
+                items={app.functions.map((fn) => fn.name)}
               />
-            </DialogContainer>
-            <DialogFooter
-              leftButtonProps={{
-                label: "Cancel",
-                variant: "outline",
-                onClick: onClose,
-              }}
-              rightButtonProps={{
-                label: "Delete permanently",
-                variant: "warning",
-                disabled: confirmText.trim().toLowerCase() !== CONFIRM_WORD,
-                onClick: () => {
-                  void onDelete();
-                },
-              }}
-            />
-          </>
-        )}
+              <InventoryLine
+                label={app.databases.length === 1 ? "database" : "databases"}
+                items={app.databases.map((db) => db.name)}
+              />
+              <InventoryLine
+                label={app.frames.length === 1 ? "Frame" : "Frames"}
+                items={app.frames.map((frame) => frame.fileName)}
+              />
+              {app.fileCount > 0 && (
+                <li>
+                  <span className="font-semibold">
+                    {app.fileCount} {app.fileCount === 1 ? "file" : "files"}
+                  </span>
+                  <span className="text-muted-foreground dark:text-muted-foreground-night">
+                    {" — "}
+                    {app.collidingFolderNames.length > 0
+                      ? app.collidingFolderNames.join(", ")
+                      : appName}
+                  </span>
+                </li>
+              )}
+            </ul>
+          </div>
+
+          {app.databases.length > 0 && (
+            <ContentMessage variant="warning" title="Data cannot be recovered">
+              The {app.databases.length === 1 ? "database" : "databases"} above
+              and everything stored in{" "}
+              {app.databases.length === 1 ? "it" : "them"} are deleted for good,
+              including the replicated copy.
+            </ContentMessage>
+          )}
+
+          {sharedFrames.length > 0 && (
+            <ContentMessage variant="warning" title="Shared links will break">
+              {sharedFrames.length === 1
+                ? "This app's Frame has been published, so anyone holding its link loses access."
+                : "This app's Frames have been published, so anyone holding their links loses access."}
+            </ContentMessage>
+          )}
+
+          <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+            Type <strong>{CONFIRM_WORD}</strong> below to confirm.
+          </p>
+          <Input
+            name="delete-app-confirm"
+            value={confirmText}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setConfirmText(e.target.value)
+            }
+            placeholder={`Type ${CONFIRM_WORD} to confirm`}
+            containerClassName="w-full"
+          />
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Delete permanently",
+            variant: "warning",
+            disabled: confirmText.trim().toLowerCase() !== CONFIRM_WORD,
+            onClick: onSubmit,
+          }}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/front/components/pod/apps/ImportPodAppDialog.tsx
+++ b/front/components/pod/apps/ImportPodAppDialog.tsx
@@ -1,8 +1,5 @@
-import { useImportPodApp } from "@app/lib/swr/pods";
-import type { PodAppImportSummary } from "@app/types/api/pod_app_archive";
 import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
 import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   ContentMessage,
@@ -13,33 +10,28 @@ import {
   DialogHeader,
   DialogTitle,
   Input,
-  Spinner,
   Upload01,
 } from "@dust-tt/sparkle";
 import type { ChangeEvent } from "react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 
 interface ImportPodAppDialogProps {
-  owner: LightWorkspaceType;
-  podId: string;
   existingPrefixes: string[];
   isOpen: boolean;
   onClose: () => void;
+  /** The import itself runs in the Apps tab, which outlives this dialog. */
+  onSubmit: (file: File, name: string | undefined) => void;
 }
 
 export function ImportPodAppDialog({
-  owner,
-  podId,
   existingPrefixes,
   isOpen,
   onClose,
+  onSubmit,
 }: ImportPodAppDialogProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [name, setName] = useState("");
-  const [isImporting, setIsImporting] = useState(false);
-  const [report, setReport] = useState<PodAppImportSummary | null>(null);
-  const doImport = useImportPodApp({ owner, podId });
 
   const trimmedName = name.trim();
   const prefix = useMemo(
@@ -63,24 +55,6 @@ export function ImportPodAppDialog({
     return null;
   }, [existingPrefixes, trimmedName, prefix]);
 
-  const onImport = useCallback(async () => {
-    if (!file) {
-      return;
-    }
-    setIsImporting(true);
-    const result = await doImport(file, trimmedName || undefined);
-    setIsImporting(false);
-    if (result.isOk()) {
-      const summary = result.value;
-      if (summary.warnings.length > 0 || summary.skipped.length > 0) {
-        // Keep the dialog open so the issues are read before they scroll away.
-        setReport(summary);
-      } else {
-        onClose();
-      }
-    }
-  }, [doImport, file, trimmedName, onClose]);
-
   return (
     <Dialog
       open={isOpen}
@@ -94,102 +68,68 @@ export function ImportPodAppDialog({
         <DialogHeader>
           <DialogTitle>Import an app</DialogTitle>
         </DialogHeader>
-        {isImporting ? (
-          <DialogContainer className="flex flex-col items-center gap-3 py-8">
-            <Spinner variant="dark" size="md" />
-            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
-              Importing. Each function is rebuilt on the Pod's Computer, so this
-              can take a while.
-            </p>
-          </DialogContainer>
-        ) : report ? (
-          <>
-            <DialogContainer className="flex flex-col gap-4">
-              <ContentMessage
-                variant="warning"
-                title={`${report.name} imported with issues`}
-              >
-                <ul className="list-disc pl-4">
-                  {[...report.warnings, ...report.skipped].map(
-                    (issue, index) => (
-                      <li key={`${index}-${issue}`}>{issue}</li>
-                    )
-                  )}
-                </ul>
-              </ContentMessage>
-            </DialogContainer>
-            <DialogFooter
-              rightButtonProps={{
-                label: "Done",
-                variant: "primary",
-                onClick: onClose,
-              }}
+        <DialogContainer className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1">
+            <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+              App archive (.zip)
+            </span>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".zip"
+              className="hidden"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setFile(e.target.files?.[0] ?? null)
+              }
             />
-          </>
-        ) : (
-          <>
-            <DialogContainer className="flex flex-col gap-4">
-              <div className="flex flex-col gap-1">
-                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
-                  App archive (.zip)
-                </span>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".zip"
-                  className="hidden"
-                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                    setFile(e.target.files?.[0] ?? null)
-                  }
-                />
-                <Button
-                  label={file ? file.name : "Choose archive"}
-                  icon={Upload01}
-                  variant="outline"
-                  size="sm"
-                  onClick={() => fileInputRef.current?.click()}
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
-                  App name (optional)
-                </span>
-                <Input
-                  name="import-app-name"
-                  value={name}
-                  placeholder="Defaults to the archive's app name"
-                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                    setName(e.target.value)
-                  }
-                  maxLength={MAX_POD_APP_NAME_LENGTH}
-                  message={nameError ?? undefined}
-                  messageStatus={nameError ? "error" : undefined}
-                  containerClassName="w-full"
-                />
-              </div>
-              <ContentMessage variant="info" title="The import starts empty">
-                Databases are created from the archive's schemas but hold no
-                data. Missing secrets or configuration in this workspace will
-                surface when the app runs.
-              </ContentMessage>
-            </DialogContainer>
-            <DialogFooter
-              leftButtonProps={{
-                label: "Cancel",
-                variant: "outline",
-                onClick: onClose,
-              }}
-              rightButtonProps={{
-                label: "Import app",
-                variant: "primary",
-                disabled: file === null || nameError !== null,
-                onClick: () => {
-                  void onImport();
-                },
-              }}
+            <Button
+              label={file ? file.name : "Choose archive"}
+              icon={Upload01}
+              variant="outline"
+              size="sm"
+              onClick={() => fileInputRef.current?.click()}
             />
-          </>
-        )}
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="label-xs uppercase text-muted-foreground dark:text-muted-foreground-night">
+              App name (optional)
+            </span>
+            <Input
+              name="import-app-name"
+              value={name}
+              placeholder="Defaults to the archive's app name"
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                setName(e.target.value)
+              }
+              maxLength={MAX_POD_APP_NAME_LENGTH}
+              message={nameError ?? undefined}
+              messageStatus={nameError ? "error" : undefined}
+              containerClassName="w-full"
+            />
+          </div>
+          <ContentMessage variant="info" title="The import starts empty">
+            Databases are created from the archive's schemas but hold no data.
+            Missing secrets or configuration in this workspace will surface when
+            the app runs.
+          </ContentMessage>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: onClose,
+          }}
+          rightButtonProps={{
+            label: "Import app",
+            variant: "primary",
+            disabled: file === null || nameError !== null,
+            onClick: () => {
+              if (file) {
+                onSubmit(file, trimmedName || undefined);
+              }
+            },
+          }}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/front/components/pod/apps/PendingPodAppTile.tsx
+++ b/front/components/pod/apps/PendingPodAppTile.tsx
@@ -1,0 +1,31 @@
+import { Card, Spinner } from "@dust-tt/sparkle";
+
+interface PendingPodAppTileProps {
+  name: string;
+  kind: "clone" | "import";
+}
+
+/**
+ * Placeholder tile for an app being created. Cloning and importing both rebuild every function on
+ * the Pod's Computer, so they run long enough that the grid has to show the work in progress.
+ * Sized like `PodAppTile` (the spinner box matches the `md` avatar) so tiles stay aligned.
+ */
+export function PendingPodAppTile({ name, kind }: PendingPodAppTileProps) {
+  return (
+    <Card size="md" isPulsing>
+      <div className="flex min-w-0 grow flex-col items-start gap-3">
+        <div className="flex h-12 w-12 items-center justify-center">
+          <Spinner size="md" />
+        </div>
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="truncate heading-base text-foreground dark:text-foreground-night">
+            {name}
+          </span>
+          <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+            {kind === "clone" ? "Cloning…" : "Importing…"}
+          </span>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/front/components/pod/apps/PodAppImportReportDialog.tsx
+++ b/front/components/pod/apps/PodAppImportReportDialog.tsx
@@ -1,0 +1,58 @@
+import type { PodAppImportSummary } from "@app/types/api/pod_app_archive";
+import {
+  ContentMessage,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+
+interface PodAppImportReportDialogProps {
+  report: PodAppImportSummary;
+  onClose: () => void;
+}
+
+/**
+ * Shown once an import lands with warnings or skipped steps. The import form is long gone by then
+ * (the archive uploads and rebuilds in the background), so the issues get their own dialog rather
+ * than a toast that scrolls away.
+ */
+export function PodAppImportReportDialog({
+  report,
+  onClose,
+}: PodAppImportReportDialogProps) {
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>{`${report.name} imported with issues`}</DialogTitle>
+        </DialogHeader>
+        <DialogContainer className="flex flex-col gap-4">
+          <ContentMessage variant="warning" title="Review before using the app">
+            <ul className="list-disc pl-4">
+              {[...report.warnings, ...report.skipped].map((issue, index) => (
+                <li key={`${index}-${issue}`}>{issue}</li>
+              ))}
+            </ul>
+          </ContentMessage>
+        </DialogContainer>
+        <DialogFooter
+          rightButtonProps={{
+            label: "Done",
+            variant: "primary",
+            onClick: onClose,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/pod/apps/PodAppTile.tsx
+++ b/front/components/pod/apps/PodAppTile.tsx
@@ -10,6 +10,7 @@ import {
   Chip,
   Download01,
   GitBranch01,
+  Spinner,
   Trash01,
 } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
@@ -25,6 +26,8 @@ interface PodAppTileProps {
   onClone?: () => void;
   /** Absent when the viewer cannot edit (no write access). */
   onDelete?: () => void;
+  /** Deletion is in flight: the tile stays put, inert, until the app is actually gone. */
+  isDeleting: boolean;
 }
 
 /**
@@ -54,6 +57,7 @@ export function PodAppTile({
   onDownload,
   onClone,
   onDelete,
+  isDeleting,
 }: PodAppTileProps) {
   // The tile surfaces a single Frame — the app's first — as apps almost always have exactly one.
   const frame = app.frames[0] ?? null;
@@ -71,33 +75,42 @@ export function PodAppTile({
   return (
     <Card
       size="md"
-      onClick={openableFrame ? () => onOpenFrame(openableFrame) : undefined}
+      className={isDeleting ? "opacity-50" : undefined}
+      onClick={
+        openableFrame && !isDeleting
+          ? () => onOpenFrame(openableFrame)
+          : undefined
+      }
       action={
-        <div className="flex gap-1">
-          <CardActionButton
-            size="icon"
-            icon={Download01}
-            tooltip="Download this app as a portable archive"
-            onClick={() => void handleDownload()}
-            isLoading={isDownloading}
-          />
-          {onClone && (
+        isDeleting ? (
+          <Spinner size="xs" />
+        ) : (
+          <div className="flex gap-1">
             <CardActionButton
               size="icon"
-              icon={GitBranch01}
-              tooltip="Clone this app into a new folder, with empty databases"
-              onClick={onClone}
+              icon={Download01}
+              tooltip="Download this app as a portable archive"
+              onClick={() => void handleDownload()}
+              isLoading={isDownloading}
             />
-          )}
-          {onDelete && (
-            <CardActionButton
-              size="icon"
-              icon={Trash01}
-              tooltip="Delete this app and everything it owns"
-              onClick={onDelete}
-            />
-          )}
-        </div>
+            {onClone && (
+              <CardActionButton
+                size="icon"
+                icon={GitBranch01}
+                tooltip="Clone this app into a new folder, with empty databases"
+                onClick={onClone}
+              />
+            )}
+            {onDelete && (
+              <CardActionButton
+                size="icon"
+                icon={Trash01}
+                tooltip="Delete this app and everything it owns"
+                onClick={onDelete}
+              />
+            )}
+          </div>
+        )
       }
     >
       {/*
@@ -111,17 +124,24 @@ export function PodAppTile({
           size="md"
           backgroundColor="bg-background dark:bg-background-night"
         />
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="truncate heading-base text-foreground dark:text-foreground-night">
-            {app.name}
-          </span>
-          {isDraft && (
-            <Chip
-              size="xs"
-              color="primary"
-              label="Draft"
-              className="shrink-0"
-            />
+        <div className="flex min-w-0 flex-col gap-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate heading-base text-foreground dark:text-foreground-night">
+              {app.name}
+            </span>
+            {isDraft && !isDeleting && (
+              <Chip
+                size="xs"
+                color="primary"
+                label="Draft"
+                className="shrink-0"
+              />
+            )}
+          </div>
+          {isDeleting && (
+            <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
+              Deleting…
+            </span>
           )}
         </div>
       </div>

--- a/front/components/pod/apps/PodAppsTab.tsx
+++ b/front/components/pod/apps/PodAppsTab.tsx
@@ -1,11 +1,22 @@
 import { ClonePodAppDialog } from "@app/components/pod/apps/ClonePodAppDialog";
 import { DeletePodAppDialog } from "@app/components/pod/apps/DeletePodAppDialog";
 import { ImportPodAppDialog } from "@app/components/pod/apps/ImportPodAppDialog";
+import { PendingPodAppTile } from "@app/components/pod/apps/PendingPodAppTile";
+import { PodAppImportReportDialog } from "@app/components/pod/apps/PodAppImportReportDialog";
 import { PodAppTile } from "@app/components/pod/apps/PodAppTile";
 import { PodFrameSheet } from "@app/components/pod/files/PodFrameSheet";
 import type { CustomResourceIconType } from "@app/components/resources/resources_icon_names";
-import { useDownloadPodApp, usePodApps } from "@app/lib/swr/pods";
+import {
+  useClonePodApp,
+  useDeletePodApp,
+  useDownloadPodApp,
+  useImportPodApp,
+  usePodApps,
+} from "@app/lib/swr/pods";
+import type { PodAppImportSummary } from "@app/types/api/pod_app_archive";
 import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
+import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { PodType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import {
@@ -16,12 +27,34 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 
 interface PodAppsTabProps {
   owner: WorkspaceType;
   pod: PodType;
 }
+
+/**
+ * An app being created by a clone or an import. Both rebuild every function on the Pod's Computer,
+ * so they run long after their dialog is gone and need a tile of their own in the meantime.
+ */
+interface PendingPodAppCreation {
+  id: number;
+  kind: "clone" | "import";
+  name: string;
+  /** Null for an import that lets the archive name the app: the prefix is only known server-side. */
+  prefix: string | null;
+}
+
+/** A tile on the grid: an app that exists, or one still being created. */
+type PodAppGridEntry =
+  | { kind: "app"; key: string; name: string; app: PodApp }
+  | {
+      kind: "pending";
+      key: string;
+      name: string;
+      creation: PendingPodAppCreation;
+    };
 
 // Not DEFAULT_POD_FRAME_TAB_ICON (a gauge that reads as a clock at tile size): an app is a Frame,
 // so the fallback is the Frame glyph.
@@ -37,6 +70,9 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
 
   const canEdit = pod.isEditor && !pod.archivedAt;
   const downloadPodApp = useDownloadPodApp({ owner, podId: pod.sId });
+  const clonePodApp = useClonePodApp({ owner, podId: pod.sId });
+  const importPodApp = useImportPodApp({ owner, podId: pod.sId });
+  const deletePodApp = useDeletePodApp({ owner, podId: pod.sId });
 
   const [framePreview, setFramePreview] = useState<PodAppFrame | null>(null);
   const [appPendingDeletion, setAppPendingDeletion] = useState<PodApp | null>(
@@ -44,6 +80,16 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
   );
   const [appPendingClone, setAppPendingClone] = useState<PodApp | null>(null);
   const [isImportOpen, setIsImportOpen] = useState(false);
+  const [importReport, setImportReport] = useState<PodAppImportSummary | null>(
+    null
+  );
+
+  // Clones and imports are long enough to overlap, so each in-flight one gets its own tile.
+  const [pendingCreations, setPendingCreations] = useState<
+    PendingPodAppCreation[]
+  >([]);
+  const [deletingPrefixes, setDeletingPrefixes] = useState<string[]>([]);
+  const nextPendingCreationIdRef = useRef(0);
 
   const iconByFramePath = useMemo(
     () =>
@@ -51,6 +97,87 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
         (pod.frameTabs ?? []).map((tab) => [tab.path, tab.icon])
       ),
     [pod.frameTabs]
+  );
+
+  const deletingPrefixSet = useMemo(
+    () => new Set(deletingPrefixes),
+    [deletingPrefixes]
+  );
+
+  // Names taken by an existing app or by a creation still running, so two concurrent clones cannot
+  // both claim the same prefix.
+  const existingPrefixes = useMemo(
+    () => [
+      ...apps.map((app) => app.prefix),
+      ...pendingCreations.flatMap((creation) =>
+        creation.prefix ? [creation.prefix] : []
+      ),
+    ],
+    [apps, pendingCreations]
+  );
+
+  const runCreation = useCallback(
+    async (
+      creation: Omit<PendingPodAppCreation, "id">,
+      run: () => Promise<void>
+    ) => {
+      const id = nextPendingCreationIdRef.current++;
+      setPendingCreations((creations) => [...creations, { ...creation, id }]);
+      await run();
+      setPendingCreations((creations) =>
+        creations.filter((candidate) => candidate.id !== id)
+      );
+    },
+    []
+  );
+
+  const onClone = useCallback(
+    async (app: PodApp, name: string) => {
+      setAppPendingClone(null);
+      await runCreation(
+        { kind: "clone", name, prefix: normalizeAppPrefix(name) },
+        async () => {
+          await clonePodApp(app, name);
+        }
+      );
+    },
+    [clonePodApp, runCreation]
+  );
+
+  const onImport = useCallback(
+    async (file: File, name: string | undefined) => {
+      setIsImportOpen(false);
+      await runCreation(
+        {
+          kind: "import",
+          name: name ?? file.name,
+          prefix: name ? normalizeAppPrefix(name) : null,
+        },
+        async () => {
+          const result = await importPodApp(file, name);
+          if (
+            result.isOk() &&
+            (result.value.warnings.length > 0 ||
+              result.value.skipped.length > 0)
+          ) {
+            setImportReport(result.value);
+          }
+        }
+      );
+    },
+    [importPodApp, runCreation]
+  );
+
+  const onDelete = useCallback(
+    async (app: PodApp) => {
+      setAppPendingDeletion(null);
+      setDeletingPrefixes((prefixes) => [...prefixes, app.prefix]);
+      await deletePodApp(app);
+      setDeletingPrefixes((prefixes) =>
+        prefixes.filter((prefix) => prefix !== app.prefix)
+      );
+    },
+    [deletePodApp]
   );
 
   const importButton = canEdit && (
@@ -68,12 +195,28 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
     (app) => app.collidingFolderNames.length > 0
   );
 
-  // Computed as a variable (rather than returned from separate early-return branches) so
-  // `ImportPodAppDialog` below always sits at the same position in the returned tree. If it were
-  // rendered inside each branch instead, a mutation that flips `apps.length` between 0 and >0
-  // mid-import (the first-ever import into an empty pod) would swap which branch renders and React
-  // would unmount/remount the dialog, wiping its local state (the post-import warnings report)
-  // exactly on that path.
+  // Sorted by name like `listPodApps` does, so a pending tile already sits where its app will land
+  // and the grid does not reshuffle when the real tile replaces it. An import that lets the archive
+  // name the app is ordered on its file name, so that one can still move.
+  const gridEntries = useMemo(() => {
+    const entries: PodAppGridEntry[] = [
+      ...apps.map((app) => ({
+        kind: "app" as const,
+        key: app.prefix,
+        name: app.name,
+        app,
+      })),
+      ...pendingCreations.map((creation) => ({
+        kind: "pending" as const,
+        key: `pending-${creation.id}`,
+        name: creation.name,
+        creation,
+      })),
+    ];
+
+    return entries.sort((a, b) => a.name.localeCompare(b.name));
+  }, [apps, pendingCreations]);
+
   let body: ReactNode;
   if (isPodAppsLoading) {
     body = (
@@ -90,7 +233,7 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
         </ContentMessage>
       </div>
     );
-  } else if (apps.length === 0) {
+  } else if (apps.length === 0 && pendingCreations.length === 0) {
     body = (
       <div className="flex h-full w-full flex-col gap-4 px-6 py-8">
         {importButton}
@@ -123,46 +266,46 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
             ))}
 
             <CardGrid>
-              {apps.map((app) => (
-                <PodAppTile
-                  key={app.prefix}
-                  app={app}
-                  iconByFramePath={iconByFramePath}
-                  defaultIcon={DEFAULT_POD_APP_ICON}
-                  onOpenFrame={setFramePreview}
-                  onDownload={() => downloadPodApp(app)}
-                  onClone={canEdit ? () => setAppPendingClone(app) : undefined}
-                  onDelete={
-                    canEdit ? () => setAppPendingDeletion(app) : undefined
-                  }
-                />
-              ))}
+              {gridEntries.map((entry) => {
+                switch (entry.kind) {
+                  case "app":
+                    return (
+                      <PodAppTile
+                        key={entry.key}
+                        app={entry.app}
+                        iconByFramePath={iconByFramePath}
+                        defaultIcon={DEFAULT_POD_APP_ICON}
+                        onOpenFrame={setFramePreview}
+                        onDownload={() => downloadPodApp(entry.app)}
+                        onClone={
+                          canEdit
+                            ? () => setAppPendingClone(entry.app)
+                            : undefined
+                        }
+                        onDelete={
+                          canEdit
+                            ? () => setAppPendingDeletion(entry.app)
+                            : undefined
+                        }
+                        isDeleting={deletingPrefixSet.has(entry.app.prefix)}
+                      />
+                    );
+                  case "pending":
+                    return (
+                      <PendingPodAppTile
+                        key={entry.key}
+                        name={entry.name}
+                        kind={entry.creation.kind}
+                      />
+                    );
+                  default:
+                    assertNeverAndIgnore(entry);
+                    return null;
+                }
+              })}
             </CardGrid>
           </div>
         </ScrollArea>
-
-        {appPendingClone && (
-          <ClonePodAppDialog
-            key={`clone-${appPendingClone.prefix}`}
-            owner={owner}
-            podId={pod.sId}
-            app={appPendingClone}
-            existingPrefixes={apps.map((candidate) => candidate.prefix)}
-            isOpen
-            onClose={() => setAppPendingClone(null)}
-          />
-        )}
-
-        {appPendingDeletion && (
-          <DeletePodAppDialog
-            key={appPendingDeletion.prefix}
-            owner={owner}
-            podId={pod.sId}
-            app={appPendingDeletion}
-            isOpen
-            onClose={() => setAppPendingDeletion(null)}
-          />
-        )}
 
         <PodFrameSheet
           owner={owner}
@@ -183,16 +326,42 @@ export function PodAppsTab({ owner, pod }: PodAppsTabProps) {
     );
   }
 
+  // The dialogs sit outside `body` so a mutation that flips which branch renders (the first import
+  // into an empty Pod, the deletion of the last app) cannot unmount them mid-edit.
   return (
     <>
       {body}
+      {appPendingClone && (
+        <ClonePodAppDialog
+          key={`clone-${appPendingClone.prefix}`}
+          app={appPendingClone}
+          existingPrefixes={existingPrefixes}
+          isOpen
+          onClose={() => setAppPendingClone(null)}
+          onSubmit={(name) => void onClone(appPendingClone, name)}
+        />
+      )}
+      {appPendingDeletion && (
+        <DeletePodAppDialog
+          key={appPendingDeletion.prefix}
+          app={appPendingDeletion}
+          isOpen
+          onClose={() => setAppPendingDeletion(null)}
+          onSubmit={() => void onDelete(appPendingDeletion)}
+        />
+      )}
       {isImportOpen && (
         <ImportPodAppDialog
-          owner={owner}
-          podId={pod.sId}
-          existingPrefixes={apps.map((candidate) => candidate.prefix)}
+          existingPrefixes={existingPrefixes}
           isOpen
           onClose={() => setIsImportOpen(false)}
+          onSubmit={(file, name) => void onImport(file, name)}
+        />
+      )}
+      {importReport && (
+        <PodAppImportReportDialog
+          report={importReport}
+          onClose={() => setImportReport(null)}
         />
       )}
     </>


### PR DESCRIPTION
## Problem

Cloning, deleting or importing a Pod app gave no feedback at all until the toast fired at the end — the dialog just vanished on submit and the grid sat unchanged for however long the Computer took to rebuild the functions.

The cause: Sparkle's `DialogFooter` wraps every non-`disabled` `leftButtonProps`/`rightButtonProps` button in a Radix `DialogClose` (`sparkle/src/components/Dialog.tsx:255-266`). All three dialogs put their action in `rightButtonProps`, so the click closed the dialog, the parent dropped its state, and the component unmounted before `setIsCloning(true)` could render. The in-progress spinner branches those dialogs already carried were unreachable dead code. The `fetch` itself kept running inside the hook, which is why the operation still completed.

Note this trap is generic and `disabled: isLoading` does not avoid it: on the first click the button is not disabled yet, so it still closes.

## Fix

Rather than resurrect the blocking modal for an operation that can run for minutes, the progress now lives on the Apps grid and the rest of the page stays usable:

- **Clone / import** — a pulsing pending tile appears with the app's name and `Cloning…` / `Importing…`. It is inserted in the slot the app will occupy (the list endpoint sorts by name, `lib/api/projects/apps.ts:430`), so nothing reshuffles when the real tile replaces it.
- **Delete** — the target tile dims, its action buttons collapse to a spinner, it stops being clickable, and it shows `Deleting…` until the app is actually gone.

To make that possible the three dialogs became pure forms taking an `onSubmit`, and the mutation hooks moved up into `PodAppsTab`, which outlives them and owns the in-flight state. The import warnings/skipped report needed a new home once the import form closes at submit, so it got its own small dialog.

Also included: `existingPrefixes` now counts pending creations, so two overlapping clones cannot both claim the same prefix. That collision was unreachable before, when the modal serialized everything.

## Files

- `PodAppsTab.tsx` — owns `pendingCreations` / `deletingPrefixes`, holds the clone/import/delete hooks, merges real and pending tiles into one name-sorted grid
- `PendingPodAppTile.tsx` (new) — the placeholder tile, sized to match a real one
- `PodAppImportReportDialog.tsx` (new) — post-import warnings
- `PodAppTile.tsx` — `isDeleting` state
- `Clone` / `Delete` / `ImportPodAppDialog.tsx` — reduced to forms

## Testing

Type-check and Biome pass. Not yet exercised against a live Pod — clone, delete and import each want a click-through before merge.

## Follow-up (not in this PR)

The `DialogFooter` / `DialogClose` behaviour silently kills the loading state of any dialog that does async work from `rightButtonProps`; a coarse grep finds ~30 candidates. The real fix probably belongs in Sparkle — only wrap in `DialogClose` when the caller opts in — rather than in each call site.