### PR TITLE
perf: fetch consumption export slices concurrently instead of sequentially

### DIFF
--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -10,6 +10,7 @@ import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { microCreditsToCredits } from "@app/lib/credits/units";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -18,6 +19,9 @@ import type { estypes } from "@elastic/elasticsearch";
 import AdmZip from "adm-zip";
 
 const EXPORT_PAGE_SIZE = 10_000;
+// Fetches slices concurrently instead of paginating one page at a time.
+// Trades higher peak memory (one in-flight page per slice) for lower wall-clock time.
+const EXPORT_SLICE_COUNT = 4;
 
 type ConsumptionLineExportRow = {
   completedAt: string;
@@ -107,11 +111,19 @@ const CONSUMPTION_LINE_EXPORT_HEADERS: (keyof ConsumptionLineExportRow)[] = [
   "executionTimeMs",
 ];
 
-// One document per unit of billed credit consumption
-async function fetchAllConsumptionDocuments(
-  query: estypes.QueryDslQueryContainer
+const CONSUMPTION_EXPORT_SORT: estypes.Sort = [
+  { completed_at: "asc" },
+  { agent_message_id: "asc" },
+  { consumption_key: "asc" },
+];
+
+// Fetches one slice of the sliced-search partition to completion, paginating
+// within the slice with search_after.
+async function fetchConsumptionSliceDocuments(
+  query: estypes.QueryDslQueryContainer,
+  slice: estypes.SlicedScroll
 ): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
-  const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
+  const sliceDocs: AgentMessageConsumptionAnalyticsData[] = [];
   let searchAfter: estypes.SortResults | undefined;
   let hitCount: number;
 
@@ -121,12 +133,9 @@ async function fetchAllConsumptionDocuments(
         query,
         {
           size: EXPORT_PAGE_SIZE,
-          sort: [
-            { completed_at: "asc" },
-            { agent_message_id: "asc" },
-            { consumption_key: "asc" },
-          ],
+          sort: CONSUMPTION_EXPORT_SORT,
           search_after: searchAfter,
+          slice,
         }
       );
 
@@ -137,13 +146,41 @@ async function fetchAllConsumptionDocuments(
     const { hits } = result.value.hits;
     for (const hit of hits) {
       if (hit._source) {
-        allDocs.push(hit._source);
+        sliceDocs.push(hit._source);
       }
     }
 
     hitCount = hits.length;
     searchAfter = hits[hits.length - 1]?.sort;
   } while (hitCount === EXPORT_PAGE_SIZE);
+
+  return new Ok(sliceDocs);
+}
+
+// One document per unit of billed credit consumption. Slices are fetched
+// concurrently, each paginating its own partition of the result set.
+async function fetchAllConsumptionDocuments(
+  query: estypes.QueryDslQueryContainer
+): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
+  const sliceIds = Array.from({ length: EXPORT_SLICE_COUNT }, (_, id) => id);
+
+  const results = await concurrentExecutor(
+    sliceIds,
+    (id) =>
+      fetchConsumptionSliceDocuments(query, {
+        id: String(id),
+        max: EXPORT_SLICE_COUNT,
+      }),
+    { concurrency: EXPORT_SLICE_COUNT }
+  );
+
+  const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
+  for (const result of results) {
+    if (result.isErr()) {
+      return result;
+    }
+    allDocs.push(...result.value);
+  }
 
   return new Ok(allDocs);
 }

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -28,7 +28,7 @@ import AdmZip from "adm-zip";
 export const EXPORT_PAGE_SIZE = 10_000;
 // Fetches slices concurrently instead of paginating one page at a time.
 // Trades higher peak memory (one in-flight page per slice) for lower wall-clock time.
-export const EXPORT_SLICE_COUNT = 4;
+export const EXPORT_SLICE_COUNT = 3;
 // Long enough to cover a full export (all slices, fully paginated); refreshed on every
 // request so it only needs to outlive the gap between two consecutive page fetches.
 const EXPORT_PIT_KEEP_ALIVE = "5m";

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -138,51 +138,6 @@ function compareConsumptionExportRows(
   );
 }
 
-// Fetches one slice of the sliced-search partition to completion, paginating
-// within the slice with search_after against the shared point-in-time.
-async function fetchConsumptionSliceDocuments(
-  query: estypes.QueryDslQueryContainer,
-  slice: estypes.SlicedScroll,
-  pitId: string
-): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
-  const sliceDocs: AgentMessageConsumptionAnalyticsData[] = [];
-  let searchAfter: estypes.SortResults | undefined;
-  let currentPitId = pitId;
-  let hitCount: number;
-
-  do {
-    const result =
-      await searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
-        query,
-        {
-          size: EXPORT_PAGE_SIZE,
-          sort: CONSUMPTION_EXPORT_SORT,
-          search_after: searchAfter,
-          slice,
-          pit: { id: currentPitId, keep_alive: EXPORT_PIT_KEEP_ALIVE },
-        }
-      );
-
-    if (result.isErr()) {
-      return result;
-    }
-
-    const { hits } = result.value.hits;
-    for (const hit of hits) {
-      if (hit._source) {
-        sliceDocs.push(hit._source);
-      }
-    }
-
-    // A pit search can return a refreshed pit_id; subsequent pages must use it.
-    currentPitId = result.value.pit_id ?? currentPitId;
-    hitCount = hits.length;
-    searchAfter = hits[hits.length - 1]?.sort;
-  } while (hitCount === EXPORT_PAGE_SIZE);
-
-  return new Ok(sliceDocs);
-}
-
 // One document per unit of billed credit consumption. Slices are fetched concurrently against
 // a shared point-in-time, so every slice/page sees the same snapshot of the index instead of
 // racing concurrent writes/refreshes (which could otherwise duplicate or drop rows).
@@ -196,29 +151,57 @@ async function fetchAllConsumptionDocuments(
   if (pitResult.isErr()) {
     return pitResult;
   }
-  const pitId = pitResult.value;
+  let currentPitId = pitResult.value;
 
   try {
     const sliceIds = Array.from({ length: EXPORT_SLICE_COUNT }, (_, id) => id);
-
-    const results = await concurrentExecutor(
-      sliceIds,
-      (id) =>
-        fetchConsumptionSliceDocuments(
-          query,
-          { id: String(id), max: EXPORT_SLICE_COUNT },
-          pitId
-        ),
-      { concurrency: EXPORT_SLICE_COUNT }
-    );
-
+    const searchAfterBySlice = new Map<number, estypes.SortResults>();
+    const exhaustedSlices = new Set<number>();
     const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
-    for (const result of results) {
-      if (result.isErr()) {
-        return result;
-      }
-      for (const doc of result.value) {
-        allDocs.push(doc);
+
+    while (exhaustedSlices.size < sliceIds.length) {
+      const activeSliceIds = sliceIds.filter((id) => !exhaustedSlices.has(id));
+      const roundPitId = currentPitId;
+
+      const results = await concurrentExecutor(
+        activeSliceIds,
+        (id) =>
+          searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
+            query,
+            {
+              size: EXPORT_PAGE_SIZE,
+              sort: CONSUMPTION_EXPORT_SORT,
+              search_after: searchAfterBySlice.get(id),
+              slice: { id: String(id), max: EXPORT_SLICE_COUNT },
+              pit: { id: roundPitId, keep_alive: EXPORT_PIT_KEEP_ALIVE },
+            }
+          ),
+        { concurrency: EXPORT_SLICE_COUNT }
+      );
+
+      for (let i = 0; i < activeSliceIds.length; i++) {
+        const result = results[i];
+        if (result.isErr()) {
+          return result;
+        }
+
+        const { hits } = result.value.hits;
+        for (const hit of hits) {
+          if (hit._source) {
+            allDocs.push(hit._source);
+          }
+        }
+
+        // A pit search can return a refreshed pit_id; every slice's next round must use it.
+        currentPitId = result.value.pit_id ?? currentPitId;
+
+        const sliceId = activeSliceIds[i];
+        const lastSort = hits[hits.length - 1]?.sort;
+        if (hits.length < EXPORT_PAGE_SIZE || !lastSort) {
+          exhaustedSlices.add(sliceId);
+        } else {
+          searchAfterBySlice.set(sliceId, lastSort);
+        }
       }
     }
 
@@ -227,7 +210,7 @@ async function fetchAllConsumptionDocuments(
 
     return new Ok(allDocs);
   } finally {
-    const closeResult = await closePointInTime(pitId);
+    const closeResult = await closePointInTime(currentPitId);
     if (closeResult.isErr()) {
       logger.error(
         { err: closeResult.error },

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -7,10 +7,16 @@ import {
   rowsToCsv,
 } from "@app/lib/api/analytics/csv_utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
-import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  CONSUMPTION_ANALYTICS_ALIAS_NAME,
+  closePointInTime,
+  openPointInTime,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { microCreditsToCredits } from "@app/lib/credits/units";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
 import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/analytics";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -18,10 +24,14 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import type { estypes } from "@elastic/elasticsearch";
 import AdmZip from "adm-zip";
 
-const EXPORT_PAGE_SIZE = 10_000;
+// Exported for tests to exercise pagination/slicing boundaries without duplicating the values.
+export const EXPORT_PAGE_SIZE = 10_000;
 // Fetches slices concurrently instead of paginating one page at a time.
 // Trades higher peak memory (one in-flight page per slice) for lower wall-clock time.
-const EXPORT_SLICE_COUNT = 4;
+export const EXPORT_SLICE_COUNT = 4;
+// Long enough to cover a full export (all slices, fully paginated); refreshed on every
+// request so it only needs to outlive the gap between two consecutive page fetches.
+const EXPORT_PIT_KEEP_ALIVE = "5m";
 
 type ConsumptionLineExportRow = {
   completedAt: string;
@@ -117,14 +127,27 @@ const CONSUMPTION_EXPORT_SORT: estypes.Sort = [
   { consumption_key: "asc" },
 ];
 
+function compareConsumptionExportRows(
+  a: AgentMessageConsumptionAnalyticsData,
+  b: AgentMessageConsumptionAnalyticsData
+): number {
+  return (
+    a.completed_at.localeCompare(b.completed_at) ||
+    a.agent_message_id.localeCompare(b.agent_message_id) ||
+    a.consumption_key.localeCompare(b.consumption_key)
+  );
+}
+
 // Fetches one slice of the sliced-search partition to completion, paginating
-// within the slice with search_after.
+// within the slice with search_after against the shared point-in-time.
 async function fetchConsumptionSliceDocuments(
   query: estypes.QueryDslQueryContainer,
-  slice: estypes.SlicedScroll
+  slice: estypes.SlicedScroll,
+  pitId: string
 ): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
   const sliceDocs: AgentMessageConsumptionAnalyticsData[] = [];
   let searchAfter: estypes.SortResults | undefined;
+  let currentPitId = pitId;
   let hitCount: number;
 
   do {
@@ -136,6 +159,7 @@ async function fetchConsumptionSliceDocuments(
           sort: CONSUMPTION_EXPORT_SORT,
           search_after: searchAfter,
           slice,
+          pit: { id: currentPitId, keep_alive: EXPORT_PIT_KEEP_ALIVE },
         }
       );
 
@@ -150,6 +174,8 @@ async function fetchConsumptionSliceDocuments(
       }
     }
 
+    // A pit search can return a refreshed pit_id; subsequent pages must use it.
+    currentPitId = result.value.pit_id ?? currentPitId;
     hitCount = hits.length;
     searchAfter = hits[hits.length - 1]?.sort;
   } while (hitCount === EXPORT_PAGE_SIZE);
@@ -157,32 +183,58 @@ async function fetchConsumptionSliceDocuments(
   return new Ok(sliceDocs);
 }
 
-// One document per unit of billed credit consumption. Slices are fetched
-// concurrently, each paginating its own partition of the result set.
+// One document per unit of billed credit consumption. Slices are fetched concurrently against
+// a shared point-in-time, so every slice/page sees the same snapshot of the index instead of
+// racing concurrent writes/refreshes (which could otherwise duplicate or drop rows).
 async function fetchAllConsumptionDocuments(
   query: estypes.QueryDslQueryContainer
 ): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
-  const sliceIds = Array.from({ length: EXPORT_SLICE_COUNT }, (_, id) => id);
-
-  const results = await concurrentExecutor(
-    sliceIds,
-    (id) =>
-      fetchConsumptionSliceDocuments(query, {
-        id: String(id),
-        max: EXPORT_SLICE_COUNT,
-      }),
-    { concurrency: EXPORT_SLICE_COUNT }
+  const pitResult = await openPointInTime(
+    CONSUMPTION_ANALYTICS_ALIAS_NAME,
+    EXPORT_PIT_KEEP_ALIVE
   );
-
-  const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
-  for (const result of results) {
-    if (result.isErr()) {
-      return result;
-    }
-    allDocs.push(...result.value);
+  if (pitResult.isErr()) {
+    return pitResult;
   }
+  const pitId = pitResult.value;
 
-  return new Ok(allDocs);
+  try {
+    const sliceIds = Array.from({ length: EXPORT_SLICE_COUNT }, (_, id) => id);
+
+    const results = await concurrentExecutor(
+      sliceIds,
+      (id) =>
+        fetchConsumptionSliceDocuments(
+          query,
+          { id: String(id), max: EXPORT_SLICE_COUNT },
+          pitId
+        ),
+      { concurrency: EXPORT_SLICE_COUNT }
+    );
+
+    const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
+    for (const result of results) {
+      if (result.isErr()) {
+        return result;
+      }
+      for (const doc of result.value) {
+        allDocs.push(doc);
+      }
+    }
+
+    // Each slice is individually sorted; merge back into a single global order.
+    allDocs.sort(compareConsumptionExportRows);
+
+    return new Ok(allDocs);
+  } finally {
+    const closeResult = await closePointInTime(pitId);
+    if (closeResult.isErr()) {
+      logger.error(
+        { err: closeResult.error },
+        "[ConsumptionExport] Failed to close point-in-time."
+      );
+    }
+  }
 }
 
 async function buildConsumptionLineExportRows(

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -272,6 +272,7 @@ export async function searchConsumptionAnalytics<
     from?: number;
     sort?: estypes.Sort;
     search_after?: estypes.SortResults;
+    slice?: estypes.SlicedScroll;
   }
 ): Promise<
   Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
@@ -284,6 +285,7 @@ export async function searchConsumptionAnalytics<
     from: options?.from,
     sort: options?.sort,
     search_after: options?.search_after,
+    slice: options?.slice,
     // Never needed for aggregation-only queries (size: 0); excluded unconditionally
     // to keep the raw-lines export from pulling the large tokens payload.
     _source: { excludes: ["tokens"] },

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -109,6 +109,29 @@ export async function withEs<T>(
   }
 }
 
+// Opens a point-in-time so a set of paginated/sliced searches (e.g. an export) all see the
+// same consistent snapshot of the index instead of racing concurrent writes/refreshes.
+export async function openPointInTime(
+  index: string,
+  keepAlive: string
+): Promise<Result<string, ElasticsearchError>> {
+  return withEs(async (client) => {
+    const response = await client.openPointInTime({
+      index,
+      keep_alive: keepAlive,
+    });
+    return response.id;
+  });
+}
+
+export async function closePointInTime(
+  id: string
+): Promise<Result<void, ElasticsearchError>> {
+  return withEs(async (client) => {
+    await client.closePointInTime({ id });
+  });
+}
+
 export async function getClient(): Promise<Client> {
   if (esClient) {
     return esClient;
@@ -273,12 +296,14 @@ export async function searchConsumptionAnalytics<
     sort?: estypes.Sort;
     search_after?: estypes.SortResults;
     slice?: estypes.SlicedScroll;
+    pit?: estypes.SearchPointInTimeReference;
   }
 ): Promise<
   Result<estypes.SearchResponse<TDocument, TAggregations>, ElasticsearchError>
 > {
   return esSearch<TDocument, TAggregations>({
-    index: CONSUMPTION_ANALYTICS_ALIAS_NAME,
+    // A pit target pins the shards/snapshot to search, so it replaces the index parameter.
+    index: options?.pit ? undefined : CONSUMPTION_ANALYTICS_ALIAS_NAME,
     query,
     aggs: options?.aggregations,
     size: options?.size,
@@ -286,6 +311,7 @@ export async function searchConsumptionAnalytics<
     sort: options?.sort,
     search_after: options?.search_after,
     slice: options?.slice,
+    pit: options?.pit,
     // Never needed for aggregation-only queries (size: 0); excluded unconditionally
     // to keep the raw-lines export from pulling the large tokens payload.
     _source: { excludes: ["tokens"] },

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -68,13 +68,14 @@ beforeEach(() => {
 });
 
 function searchResponse(
-  docs: AgentMessageConsumptionAnalyticsData[]
+  docs: AgentMessageConsumptionAnalyticsData[],
+  pitId: string = PIT_ID
 ): estypes.SearchResponse<AgentMessageConsumptionAnalyticsData> {
   return {
     took: 0,
     timed_out: false,
     _shards: { failed: 0, successful: 1, total: 1 },
-    pit_id: PIT_ID,
+    pit_id: pitId,
     hits: {
       hits: docs.map((doc, index) => ({
         _index: "consumption_analytics",
@@ -475,5 +476,73 @@ describe("runConsumptionExportActivity", () => {
     const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8") ?? "";
     const dataRows = csv.trim().split("\n").slice(1);
     expect(dataRows).toHaveLength(fullPageDocs.length + 1);
+  });
+
+  it("coordinates a single, latest PIT id across all slices and closes only that id", async () => {
+    const PIT_ID_V2 = "test-pit-id-v2";
+    const fullPageDocs = Array.from({ length: EXPORT_PAGE_SIZE }, (_, index) =>
+      docWithKeys(LLM_DOC, {
+        agentMessageId: `page1-${index}`,
+        consumptionKey: `run-usage:${index}`,
+        completedAt: "2026-08-01T00:00:00.000Z",
+      })
+    );
+    const lastPageDoc = docWithKeys(LLM_DOC, {
+      agentMessageId: "page2-0",
+      consumptionKey: "run-usage:last",
+      completedAt: "2026-08-01T00:00:01.000Z",
+    });
+
+    // Simulates ES refreshing the PIT id on the very first round: every slice's first
+    // request still targets the id from openPointInTime, but every response (including
+    // the empty ones from already-exhausted slices) carries the refreshed id forward.
+    mockedSearchConsumptionAnalytics.mockImplementation(
+      async (_query, options) => {
+        const isFirstSlice = options?.slice?.id === "0";
+        if (!isFirstSlice) {
+          return new Ok(searchResponse([], PIT_ID_V2));
+        }
+        return new Ok(
+          searchResponse(
+            options.search_after ? [lastPageDoc] : fullPageDocs,
+            PIT_ID_V2
+          )
+        );
+      }
+    );
+    mockLabels({});
+    const { authenticator } = await setup();
+
+    await runConsumptionExportActivity(authenticator.toJSON(), {
+      period: {
+        startDate: "2026-08-01T00:00:00.000Z",
+        endDate: "2026-08-02T00:00:00.000Z",
+      },
+      filter: {},
+      exportId: "consumption-export-test-run",
+    });
+
+    // Slice 0 needs a second round (search_after) since its first page was full; that
+    // round must use the refreshed PIT id rather than the original one.
+    const sliceZeroCalls = mockedSearchConsumptionAnalytics.mock.calls.filter(
+      ([, options]) => options?.slice?.id === "0"
+    );
+    expect(sliceZeroCalls).toHaveLength(2);
+    expect(sliceZeroCalls[0][1]?.pit?.id).toBe(PIT_ID);
+    expect(sliceZeroCalls[1][1]?.pit?.id).toBe(PIT_ID_V2);
+
+    // The other slices only need one round, and it must use the original PIT id since
+    // the refresh only surfaces once slice 0's first response comes back.
+    const otherSliceCalls = mockedSearchConsumptionAnalytics.mock.calls.filter(
+      ([, options]) => options?.slice?.id !== "0"
+    );
+    expect(otherSliceCalls.length).toBeGreaterThan(0);
+    for (const [, options] of otherSliceCalls) {
+      expect(options?.pit?.id).toBe(PIT_ID);
+    }
+
+    // The final close must target the latest coordinated id, not the one PIT was opened with.
+    expect(mockedClosePointInTime).toHaveBeenCalledTimes(1);
+    expect(mockedClosePointInTime).toHaveBeenCalledWith(PIT_ID_V2);
   });
 });

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -1,9 +1,15 @@
 // @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
 // This directive makes them available in the test environment.
 
+import {
+  EXPORT_PAGE_SIZE,
+  EXPORT_SLICE_COUNT,
+} from "@app/lib/api/analytics/consumption/export_lines";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import {
+  closePointInTime,
   ElasticsearchError,
+  openPointInTime,
   searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
 import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/consumption-export-ready";
@@ -19,6 +25,7 @@ import type {
   AgentMessageConsumptionAnalyticsToolData,
 } from "@app/types/assistant/analytics";
 import { Err, Ok } from "@app/types/shared/result";
+import type { estypes } from "@elastic/elasticsearch";
 import AdmZip from "adm-zip";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -28,10 +35,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockedSearchConsumptionAnalytics = vi.mocked(
   searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>
 );
+const mockedOpenPointInTime = vi.mocked(openPointInTime);
+const mockedClosePointInTime = vi.mocked(closePointInTime);
 
 vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
   const mod = await orig();
-  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+  return {
+    ...mod,
+    searchConsumptionAnalytics: vi.fn(),
+    openPointInTime: vi.fn(),
+    closePointInTime: vi.fn(),
+  };
 });
 vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
   const mod = await orig();
@@ -45,9 +59,48 @@ vi.mock(
   }
 );
 
+const PIT_ID = "test-pit-id";
+
 beforeEach(() => {
   vi.mocked(notifyConsumptionExportReady).mockClear();
+  mockedOpenPointInTime.mockReset().mockResolvedValue(new Ok(PIT_ID));
+  mockedClosePointInTime.mockReset().mockResolvedValue(new Ok(undefined));
 });
+
+function searchResponse(
+  docs: AgentMessageConsumptionAnalyticsData[]
+): estypes.SearchResponse<AgentMessageConsumptionAnalyticsData> {
+  return {
+    took: 0,
+    timed_out: false,
+    _shards: { failed: 0, successful: 1, total: 1 },
+    pit_id: PIT_ID,
+    hits: {
+      hits: docs.map((doc, index) => ({
+        _index: "consumption_analytics",
+        _source: doc,
+        sort: [doc.completed_at, doc.agent_message_id, doc.consumption_key],
+        _id: `${doc.agent_message_id}-${doc.consumption_key}-${index}`,
+      })),
+    },
+  } as estypes.SearchResponse<AgentMessageConsumptionAnalyticsData>;
+}
+
+function docWithKeys(
+  base: AgentMessageConsumptionAnalyticsLlmData,
+  overrides: {
+    agentMessageId: string;
+    consumptionKey: string;
+    completedAt: string;
+  }
+): AgentMessageConsumptionAnalyticsLlmData {
+  return {
+    ...base,
+    agent_message_id: overrides.agentMessageId,
+    consumption_key: overrides.consumptionKey,
+    completed_at: overrides.completedAt,
+  };
+}
 
 const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
   workspace_id: "w1",
@@ -136,20 +189,14 @@ const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
   execution_time_ms: 250,
 };
 
+// Routes every document to slice 0 and returns empty pages for the other slices, mirroring
+// how a real ES sliced search partitions the result set (each doc belongs to exactly one slice).
 function mockDocs(docs: AgentMessageConsumptionAnalyticsData[]) {
-  mockedSearchConsumptionAnalytics.mockResolvedValue(
-    new Ok({
-      took: 0,
-      timed_out: false,
-      _shards: { failed: 0, successful: 1, total: 1 },
-      hits: {
-        hits: docs.map((doc) => ({
-          _index: "consumption_analytics",
-          _source: doc,
-          sort: [],
-        })),
-      },
-    })
+  mockedSearchConsumptionAnalytics.mockImplementation(
+    async (_query, options) => {
+      const isFirstSlice = options?.slice?.id === "0";
+      return new Ok(searchResponse(isFirstSlice ? docs : []));
+    }
   );
 }
 
@@ -259,5 +306,174 @@ describe("runConsumptionExportActivity", () => {
     );
     expect(saveCalls).toHaveLength(0);
     expect(notifyConsumptionExportReady).not.toHaveBeenCalled();
+  });
+
+  it("opens a single point-in-time, reuses it across every slice, and closes it once", async () => {
+    mockDocs([LLM_DOC]);
+    mockLabels({});
+    const { authenticator } = await setup();
+
+    await runConsumptionExportActivity(authenticator.toJSON(), {
+      period: {
+        startDate: "2026-08-01T00:00:00.000Z",
+        endDate: "2026-08-02T00:00:00.000Z",
+      },
+      filter: {},
+      exportId: "consumption-export-test-run",
+    });
+
+    expect(mockedOpenPointInTime).toHaveBeenCalledTimes(1);
+    expect(mockedClosePointInTime).toHaveBeenCalledTimes(1);
+    expect(mockedClosePointInTime).toHaveBeenCalledWith(PIT_ID);
+
+    const sliceIdsQueried = mockedSearchConsumptionAnalytics.mock.calls.map(
+      ([, options]) => options?.slice?.id
+    );
+    expect(new Set(sliceIdsQueried)).toEqual(
+      new Set(Array.from({ length: EXPORT_SLICE_COUNT }, (_, id) => String(id)))
+    );
+    for (const [, options] of mockedSearchConsumptionAnalytics.mock.calls) {
+      expect(options?.pit?.id).toBe(PIT_ID);
+    }
+  });
+
+  it("closes the point-in-time even when a slice fails", async () => {
+    mockedSearchConsumptionAnalytics.mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { authenticator } = await setup();
+
+    await expect(
+      runConsumptionExportActivity(authenticator.toJSON(), {
+        period: {
+          startDate: "2026-08-01T00:00:00.000Z",
+          endDate: "2026-08-02T00:00:00.000Z",
+        },
+        filter: {},
+        exportId: "consumption-export-test-run",
+      })
+    ).rejects.toThrow();
+
+    expect(mockedClosePointInTime).toHaveBeenCalledTimes(1);
+    expect(mockedClosePointInTime).toHaveBeenCalledWith(PIT_ID);
+  });
+
+  it("partitions documents across slices without duplicating or dropping rows", async () => {
+    // Each slice owns a disjoint subset of documents, as a real ES sliced search would.
+    const docs = Array.from({ length: EXPORT_SLICE_COUNT * 3 }, (_, index) =>
+      docWithKeys(LLM_DOC, {
+        agentMessageId: `msg-${index}`,
+        consumptionKey: `run-usage:${index}`,
+        completedAt: `2026-08-01T00:00:${String(index).padStart(2, "0")}.000Z`,
+      })
+    );
+    mockedSearchConsumptionAnalytics.mockImplementation(
+      async (_query, options) => {
+        const sliceId = Number(options?.slice?.id ?? 0);
+        const sliceDocs = docs.filter(
+          (_doc, index) => index % EXPORT_SLICE_COUNT === sliceId
+        );
+        return new Ok(searchResponse(sliceDocs));
+      }
+    );
+    mockLabels({});
+    const { authenticator, workspace } = await setup();
+
+    await runConsumptionExportActivity(authenticator.toJSON(), {
+      period: {
+        startDate: "2026-08-01T00:00:00.000Z",
+        endDate: "2026-08-02T00:00:00.000Z",
+      },
+      filter: {},
+      exportId: "consumption-export-test-run",
+    });
+
+    const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
+    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+      call.filePath.startsWith(prefix)
+    );
+    const content = saveCalls[0].content;
+    const zip = new AdmZip(
+      Buffer.isBuffer(content) ? content : Buffer.from(content)
+    );
+    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8") ?? "";
+    const dataRows = csv.trim().split("\n").slice(1);
+
+    expect(dataRows).toHaveLength(docs.length);
+    const agentMessageIdColumn = 3;
+    const rowAgentMessageIds = dataRows.map(
+      (row) => row.split(",")[agentMessageIdColumn]
+    );
+    for (const doc of docs) {
+      expect(
+        rowAgentMessageIds.filter((id) => id === doc.agent_message_id)
+      ).toHaveLength(1);
+    }
+
+    // Rows must come back in global completedAt order, not grouped by slice.
+    const completedAts = dataRows.map((row) => row.split(",")[0]);
+    expect(completedAts).toEqual([...completedAts].sort());
+  });
+
+  it("paginates within a slice using search_after until a short page ends it", async () => {
+    const fullPageDocs = Array.from({ length: EXPORT_PAGE_SIZE }, (_, index) =>
+      docWithKeys(LLM_DOC, {
+        agentMessageId: `page1-${index}`,
+        consumptionKey: `run-usage:${index}`,
+        completedAt: "2026-08-01T00:00:00.000Z",
+      })
+    );
+    const lastPageDoc = docWithKeys(LLM_DOC, {
+      agentMessageId: "page2-0",
+      consumptionKey: "run-usage:last",
+      completedAt: "2026-08-01T00:00:01.000Z",
+    });
+
+    mockedSearchConsumptionAnalytics.mockImplementation(
+      async (_query, options) => {
+        if (options?.slice?.id !== "0") {
+          return new Ok(searchResponse([]));
+        }
+        // The exporter paginates with search_after: the first call has none, the
+        // second must carry the sort tuple of the last row of the first page.
+        return new Ok(
+          searchResponse(options.search_after ? [lastPageDoc] : fullPageDocs)
+        );
+      }
+    );
+    mockLabels({});
+    const { authenticator, workspace } = await setup();
+
+    await runConsumptionExportActivity(authenticator.toJSON(), {
+      period: {
+        startDate: "2026-08-01T00:00:00.000Z",
+        endDate: "2026-08-02T00:00:00.000Z",
+      },
+      filter: {},
+      exportId: "consumption-export-test-run",
+    });
+
+    const sliceZeroCalls = mockedSearchConsumptionAnalytics.mock.calls.filter(
+      ([, options]) => options?.slice?.id === "0"
+    );
+    const lastDocOfFirstPage = fullPageDocs[fullPageDocs.length - 1];
+    expect(sliceZeroCalls).toHaveLength(2);
+    expect(sliceZeroCalls[1][1]?.search_after).toEqual([
+      lastDocOfFirstPage.completed_at,
+      lastDocOfFirstPage.agent_message_id,
+      lastDocOfFirstPage.consumption_key,
+    ]);
+
+    const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
+    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+      call.filePath.startsWith(prefix)
+    );
+    const content = saveCalls[0].content;
+    const zip = new AdmZip(
+      Buffer.isBuffer(content) ? content : Buffer.from(content)
+    );
+    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8") ?? "";
+    const dataRows = csv.trim().split("\n").slice(1);
+    expect(dataRows).toHaveLength(fullPageDocs.length + 1);
   });
 });


### PR DESCRIPTION
## Description

The raw-lines CSV export previously paginated the full result set sequentially with `search_after`, so wall-clock time grew with the total row count. This change partitions the query into three Elasticsearch slices and fetches the slices concurrently, while each slice continues to paginate independently with `search_after`.

The export opens one shared point-in-time (PIT) so all slices and pages read from the same index snapshot, propagates refreshed PIT IDs between rounds, merges the individually sorted results back into the existing global order, and closes the PIT when the export finishes. The activity tests were extended to cover PIT lifecycle and cleanup, sliced pagination, row uniqueness/order, and PIT ID refresh behavior.

## Tests



## Risk

The main risk is higher peak memory usage: concurrent slices can keep one in-flight 10,000-row page per slice, in addition to the accumulated export rows. **Warning:** this is currently the only part of the codebase where PIT is used, so we lack production data about the potential memory pressure of this approach. The shared PIT provides a consistent snapshot across slices, and cleanup runs in `finally`; failures to close the PIT are logged.

## Deploy Plan

- Deploy front