### PR TITLE
Admin governance: add method findRegularAutoGroupsForGrants in group_permission_resource

### DIFF
--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -6,6 +6,7 @@ import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { grantKey } from "@app/types/group_permissions";
 import { isString } from "@app/types/shared/utils/general";
 import type { QueryOptions } from "sequelize";
 import type { AbstractQuery } from "sequelize/types/dialects/abstract/query";
@@ -743,6 +744,119 @@ describe("GroupPermissionResource", () => {
       ]);
       expect(await group.isMember(user1)).toBe(false);
       expect(await group.isMember(user2)).toBe(true);
+    });
+  });
+
+  describe("findRegularAutoGroupForGrant / findRegularAutoGroupsForGrants", () => {
+    async function grantToNewUser(spec: {
+      grantType: "reader" | "member";
+      resourceType: "space";
+      resourceId: number;
+    }) {
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "user" });
+      const result = await GroupPermissionResource.grantToUser(auth, {
+        user: user.toJSON(),
+        ...spec,
+      });
+      expect(result.isOk()).toBe(true);
+    }
+
+    const readerOnSpace = (resourceId: number) => ({
+      grantType: "reader" as const,
+      resourceType: "space" as const,
+      resourceId,
+    });
+
+    it("finds the backing group of a tuple, and null when there is none", async () => {
+      await grantToNewUser(readerOnSpace(42));
+
+      const found = await GroupPermissionResource.findRegularAutoGroupForGrant(
+        auth,
+        readerOnSpace(42)
+      );
+      expect(found?.kind).toBe("regular_auto");
+
+      // Same resource, a grant type nobody was granted.
+      expect(
+        await GroupPermissionResource.findRegularAutoGroupForGrant(auth, {
+          ...readerOnSpace(42),
+          grantType: "member",
+        })
+      ).toBeNull();
+
+      // Same grant type, a resource nobody was granted.
+      expect(
+        await GroupPermissionResource.findRegularAutoGroupForGrant(
+          auth,
+          readerOnSpace(43)
+        )
+      ).toBeNull();
+    });
+
+    it("ignores grants held by groups that are not regular_auto", async () => {
+      // groupA is regular_auto but holds this tuple through grant(), not grantToUser: still the
+      // backing group. groupB is manual, so it must never be returned.
+      await GroupPermissionResource.grant(auth, {
+        group: groupB,
+        ...readerOnSpace(50),
+      });
+
+      expect(
+        await GroupPermissionResource.findRegularAutoGroupForGrant(
+          auth,
+          readerOnSpace(50)
+        )
+      ).toBeNull();
+    });
+
+    it("batches lookups, keyed by grant", async () => {
+      await grantToNewUser(readerOnSpace(60));
+      await grantToNewUser({ ...readerOnSpace(61), grantType: "member" });
+
+      const found =
+        await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
+          grants: [
+            readerOnSpace(60),
+            { ...readerOnSpace(61), grantType: "member" },
+            // Not granted: absent from the result rather than mapped to null.
+            readerOnSpace(62),
+          ],
+        });
+
+      expect(found.size).toBe(2);
+      expect(found.get(grantKey(readerOnSpace(60)))?.kind).toBe("regular_auto");
+      expect(
+        found.get(grantKey({ ...readerOnSpace(61), grantType: "member" }))?.kind
+      ).toBe("regular_auto");
+      expect(found.get(grantKey(readerOnSpace(62)))).toBeUndefined();
+    });
+
+    it("keeps two grant types on the same resource apart", async () => {
+      await grantToNewUser(readerOnSpace(70));
+      await grantToNewUser({ ...readerOnSpace(70), grantType: "member" });
+
+      const found =
+        await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
+          grants: [
+            readerOnSpace(70),
+            { ...readerOnSpace(70), grantType: "member" },
+          ],
+        });
+
+      // One entry per grant, and each tuple has its own backing group.
+      expect(found.size).toBe(2);
+      expect(found.get(grantKey(readerOnSpace(70)))?.id).not.toBe(
+        found.get(grantKey({ ...readerOnSpace(70), grantType: "member" }))?.id
+      );
+    });
+
+    it("returns an empty map for no grants", async () => {
+      const found =
+        await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
+          grants: [],
+        });
+      expect(found.size).toBe(0);
     });
   });
 

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -9,11 +9,14 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   CapabilitySpec,
+  GrantKey,
+  GrantSpec,
   GrantType,
   GroupPermissionResourceType,
 } from "@app/types/group_permissions";
 import {
   capabilityKey,
+  grantKey,
   WHOLE_TYPE_RESOURCE_ID,
 } from "@app/types/group_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -212,6 +215,65 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     });
 
     return groups.find((group) => group.kind === "regular_auto") ?? null;
+  }
+
+  // The regular_auto groups backing user-level grants, keyed by grant (see `grantKey`) — the
+  // batched counterpart of `findRegularAutoGroupForGrant`.
+  static async findRegularAutoGroupsForGrants(
+    auth: Authenticator,
+    {
+      grants,
+      transaction,
+    }: {
+      grants: GrantSpec[];
+      transaction?: Transaction;
+    }
+  ): Promise<Map<GrantKey, GroupResource>> {
+    const result = new Map<GrantKey, GroupResource>();
+    if (grants.length === 0) {
+      return result;
+    }
+
+    const rows = await GroupPermissionModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        [Op.or]: grants.map(({ grantType, resourceType, resourceId }) => ({
+          grantType,
+          resourceType,
+          resourceId,
+        })),
+      },
+      transaction,
+    });
+    if (rows.length === 0) {
+      return result;
+    }
+
+    const groupIds = [...new Set(rows.map((row) => row.groupId))];
+    const groups = await GroupResource.fetchByModelIds(auth, groupIds, {
+      transaction,
+    });
+    const autoGroupById = new Map(
+      groups
+        .filter((group) => group.kind === "regular_auto")
+        .map((group) => [group.id, group])
+    );
+
+    for (const row of rows) {
+      const group = autoGroupById.get(row.groupId);
+      if (group) {
+        result.set(
+          grantKey({
+            grantType: row.grantType,
+            resourceType: row.resourceType,
+            resourceId: row.resourceId,
+          }),
+          group
+        );
+      }
+    }
+
+    return result;
   }
 
   // Grant a user access to a resource by adding them to the regular_auto group that holds the

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -210,11 +210,12 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }
 
     const groupIds = [...new Set(grants.map((grant) => grant.groupId))];
-    const groups = await GroupResource.fetchByModelIds(auth, groupIds, {
+    const autoGroups = await GroupResource.fetchByModelIds(auth, groupIds, {
+      groupKinds: ["regular_auto"],
       transaction,
     });
 
-    return groups.find((group) => group.kind === "regular_auto") ?? null;
+    return autoGroups[0] ?? null;
   }
 
   // The regular_auto groups backing user-level grants, keyed by grant (see `grantKey`) — the
@@ -250,14 +251,11 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     }
 
     const groupIds = [...new Set(rows.map((row) => row.groupId))];
-    const groups = await GroupResource.fetchByModelIds(auth, groupIds, {
+    const autoGroups = await GroupResource.fetchByModelIds(auth, groupIds, {
+      groupKinds: ["regular_auto"],
       transaction,
     });
-    const autoGroupById = new Map(
-      groups
-        .filter((group) => group.kind === "regular_auto")
-        .map((group) => [group.id, group])
-    );
+    const autoGroupById = new Map(autoGroups.map((group) => [group.id, group]));
 
     for (const row of rows) {
       const group = autoGroupById.get(row.groupId);

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -117,6 +117,25 @@ describe("GroupResource", () => {
     inMemoryCache.clear();
   });
 
+  describe("fetchByModelIds", () => {
+    it("filters on group kind when asked", async () => {
+      const autoGroup = await GroupResource.makeNew({
+        name: "Auto Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      const ids = [autoGroup.id, globalGroup.id, systemGroup.id];
+
+      const all = await GroupResource.fetchByModelIds(authenticator, ids);
+      expect(all.map((g) => g.id).sort()).toEqual([...ids].sort());
+
+      const autoOnly = await GroupResource.fetchByModelIds(authenticator, ids, {
+        groupKinds: ["regular_auto"],
+      });
+      expect(autoOnly.map((g) => g.id)).toEqual([autoGroup.id]);
+    });
+  });
+
   describe("dangerouslyListUserGroupsForAuth", () => {
     it("returns global group and explicit groups for a workspace member", async () => {
       const regularGroup = await GroupResource.makeNew({

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -841,7 +841,10 @@ export class GroupResource extends BaseResource<GroupModel> {
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { transaction }: { transaction?: Transaction } = {}
+    {
+      groupKinds,
+      transaction,
+    }: { groupKinds?: GroupKind[]; transaction?: Transaction } = {}
   ) {
     return this.baseFetch(
       auth,
@@ -850,6 +853,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           id: {
             [Op.in]: ids,
           },
+          ...(groupKinds ? { kind: { [Op.in]: groupKinds } } : {}),
         },
       },
       transaction

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -153,6 +153,22 @@ export function capabilityKey({
   return `${grantType}:${resourceType}`;
 }
 
+// A grant tuple: a capability plus the resource instance it applies to.
+export type GrantSpec = CapabilitySpec & { resourceId: number };
+
+// Stable string key for a grant tuple — `capabilityKey` plus the resource instance.
+export type GrantKey = `${CapabilityKey}:${number}`;
+
+// The single source of truth for the grant-key format; used to key grant-indexed maps, where a
+// capability alone would collide across resources (and a resource id alone across capabilities).
+export function grantKey({
+  grantType,
+  resourceType,
+  resourceId,
+}: GrantSpec): GrantKey {
+  return `${capabilityKey({ grantType, resourceType })}:${resourceId}`;
+}
+
 /**
  * Catalog of the governance capabilities the Settings & Governance page manages, grouped by the
  * section they belong to.


### PR DESCRIPTION
## Description

Utility methods to batch fetch regular auto group
Will be used to batch fetch editors of skills

## Tests

added unit tests

## Risk

low, no prod code change

## Deploy Plan

deploy front
