### PR TITLE
perf: stream the consumption export as gzip-compressed CSV instead of buffering a zip

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -89,14 +89,14 @@ describe("POST /api/w/:wId/analytics/consumption/export-raw/status", () => {
       }
       return [
         {
-          name: `${prefix}1000.zip`,
+          name: `${prefix}1000.csv.gz`,
           metadata: {
             timeCreated: "2026-08-01T00:00:00.000Z",
             size: "100",
           },
         },
         {
-          name: `${prefix}2000.zip`,
+          name: `${prefix}2000.csv.gz`,
           metadata: {
             timeCreated: "2026-08-02T00:00:00.000Z",
             size: "200",
@@ -112,12 +112,12 @@ describe("POST /api/w/:wId/analytics/consumption/export-raw/status", () => {
     expect(body.isGenerating).toBe(false);
     expect(body.exports).toEqual([
       {
-        name: "2000.zip",
+        name: "2000.csv.gz",
         createdAt: "2026-08-02T00:00:00.000Z",
         sizeBytes: 200,
       },
       {
-        name: "1000.zip",
+        name: "1000.csv.gz",
         createdAt: "2026-08-01T00:00:00.000Z",
         sizeBytes: 100,
       },
@@ -154,7 +154,7 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw/:name/download", () =
   it("redirects to a freshly signed download url", async () => {
     const { workspace } = await setupTest();
 
-    const response = await getDownloadRequest(workspace.sId, "2000.zip");
+    const response = await getDownloadRequest(workspace.sId, "2000.csv.gz");
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe("https://signed-url.test");
@@ -165,7 +165,7 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw/:name/download", () =
 
     const response = await getDownloadRequest(
       workspace.sId,
-      "..%2f..%2fother-workspace%2f2000.zip"
+      "..%2f..%2fother-workspace%2f2000.csv.gz"
     );
 
     expect(response.status).toBe(404);
@@ -174,7 +174,7 @@ describe("GET /api/w/:wId/analytics/consumption/export-raw/:name/download", () =
   it("is refused to non-managers", async () => {
     const { workspace } = await setupTest({ role: "user" });
 
-    const response = await getDownloadRequest(workspace.sId, "2000.zip");
+    const response = await getDownloadRequest(workspace.sId, "2000.csv.gz");
 
     expect(response.status).toBe(403);
   });

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -20,8 +20,8 @@ import { Err, Ok } from "@app/types/shared/result";
 
 const DOWNLOAD_URL_EXPIRATION_DELAY_MS = 5 * 60 * 1000;
 
-// exportId.zip, matching the naming built by `buildConsumptionExportGcsPath`.
-const EXPORT_FILE_NAME_REGEX = /^[A-Za-z0-9_-]+\.zip$/;
+// exportId.csv.gz, matching the naming built by `buildConsumptionExportGcsPath`.
+const EXPORT_FILE_NAME_REGEX = /^[A-Za-z0-9_-]+\.csv\.gz$/;
 
 export type ConsumptionExportListItem = {
   name: string;
@@ -65,7 +65,7 @@ export async function getConsumptionExportDownloadUrl(
 
   const downloadUrl = await bucket.getSignedUrl(path, {
     expirationDelayMs: DOWNLOAD_URL_EXPIRATION_DELAY_MS,
-    promptSaveAs: `dust_consumption_lines_export_${workspaceId}.zip`,
+    promptSaveAs: `dust_consumption_lines_export_${workspaceId}.csv.gz`,
   });
 
   return new Ok(downloadUrl);

--- a/front/lib/api/analytics/consumption/export_lines.test.ts
+++ b/front/lib/api/analytics/consumption/export_lines.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment node: zlib gunzip requires Node builtins (Buffer, zlib).
+
+import { PassThrough } from "node:stream";
+import zlib from "node:zlib";
+import { streamConsumptionLinesExportCsvGz } from "@app/lib/api/analytics/consumption/export_lines";
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import {
+  closePointInTime,
+  ElasticsearchError,
+  openPointInTime,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type {
+  AgentMessageConsumptionAnalyticsData,
+  AgentMessageConsumptionAnalyticsLlmData,
+} from "@app/types/assistant/analytics";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockedSearchConsumptionAnalytics = vi.mocked(
+  searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>
+);
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return {
+    ...mod,
+    searchConsumptionAnalytics: vi.fn(),
+    openPointInTime: vi.fn(),
+    closePointInTime: vi.fn(),
+  };
+});
+vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, resolveDimensionLabels: vi.fn() };
+});
+
+beforeEach(() => {
+  vi.mocked(openPointInTime).mockReset().mockResolvedValue(new Ok("pit-id"));
+  vi.mocked(closePointInTime).mockReset().mockResolvedValue(new Ok(undefined));
+});
+
+function makeDoc(index: number): AgentMessageConsumptionAnalyticsLlmData {
+  return {
+    workspace_id: "w1",
+    agent: {
+      id: `agent${index}`,
+      version: "1",
+      tag_ids: [],
+      parent_ids: [],
+      direct_parent_id: null,
+      root_id: `agent${index}`,
+      depth: 0,
+    },
+    agent_message_id: `msg${index}`,
+    api_key_name: null,
+    attribution_version: 1,
+    completed_at: "2026-08-01T00:00:00.000Z",
+    consumption_key: `run-usage:${index}`,
+    context_origin: "api",
+    normalized_origin: "api",
+    conversation_id: `conv${index}`,
+    credit_micro: 1_000_000,
+    execution_time_ms: null,
+    message_version: "1",
+    model: {
+      provider_id: "anthropic",
+      model_id: "claude-sonnet-5",
+      reasoning_effort: "medium",
+      resolution_method: "auto",
+    },
+    run_usage_id: `${index}`,
+    space_id: "space1",
+    status: "succeeded",
+    step_index: 0,
+    trigger_id: null,
+    usage_type: "user",
+    user: { id: "user1", group_ids: [] },
+    consumption_type: "llm",
+    gross_credit_micro: {
+      system: 100_000,
+      input: 200_000,
+      result_footprint: null,
+      output: 300_000,
+      reasoning: 400_000,
+      direct: 0,
+      total: 1_000_000,
+    },
+    tokens: {
+      system: 10,
+      input: 20,
+      result_footprint: null,
+      output: 30,
+      reasoning: 40,
+    },
+    tool: null,
+  };
+}
+
+// Partitions `docs` across whatever slice count/id the caller requests, so a set of
+// concurrent slice fetches (as the real ES `slice` param would) never see the same
+// document twice.
+function mockSlicedDocs(docs: AgentMessageConsumptionAnalyticsData[]) {
+  mockedSearchConsumptionAnalytics.mockImplementation(async (_q, options) => {
+    const slice = options?.slice;
+    const partition = slice
+      ? docs.filter((_doc, index) => index % slice.max === Number(slice.id))
+      : docs;
+
+    return new Ok({
+      took: 0,
+      timed_out: false,
+      _shards: { failed: 0, successful: 1, total: 1 },
+      hits: {
+        hits: partition.map((doc) => ({
+          _index: "consumption_analytics",
+          _source: doc,
+          sort: [],
+        })),
+      },
+    });
+  });
+}
+
+function mockLabels(labels: Record<string, string>) {
+  vi.mocked(resolveDimensionLabels).mockImplementation(
+    async (_a, _d, keys) =>
+      new Map(
+        keys
+          .filter((key) => key in labels)
+          .map((key) => [
+            key,
+            { name: labels[key], pictureUrl: null, description: null },
+          ])
+      )
+  );
+}
+
+async function collect(stream: PassThrough): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+async function setup() {
+  const { authenticator } = await createResourceTest({ role: "admin" });
+  return { authenticator };
+}
+
+describe("streamConsumptionLinesExportCsvGz", () => {
+  it("streams every document exactly once as gzip-compressed CSV", async () => {
+    const docs = Array.from({ length: 5 }, (_, i) => makeDoc(i));
+    mockSlicedDocs(docs);
+    mockLabels({
+      agent0: "@dust",
+      user1: "Alice",
+      "claude-sonnet-5": "Claude Sonnet 5",
+      api: "API",
+    });
+    const { authenticator } = await setup();
+
+    const destination = new PassThrough();
+    const collected = collect(destination);
+
+    const result = await streamConsumptionLinesExportCsvGz(
+      authenticator,
+      {
+        period: {
+          startDate: "2026-08-01T00:00:00.000Z",
+          endDate: "2026-08-02T00:00:00.000Z",
+        },
+        filter: {},
+      },
+      destination
+    );
+
+    expect(result.isOk()).toBe(true);
+
+    const gzipped = await collected;
+    const csv = zlib.gunzipSync(gzipped).toString("utf-8");
+    const lines = csv.trim().split("\n");
+
+    // Header + one row per document, no duplicates from concurrent slices.
+    expect(lines).toHaveLength(docs.length + 1);
+    expect(lines[0]).toContain(
+      "completedAt,conversationId,spaceId,agentMessageId"
+    );
+    expect(csv).toContain("conv0,space1,msg0,llm,agent0,'@dust");
+    expect(csv).toContain("conv4,space1,msg4,llm,agent4,agent4");
+    expect(csv).toContain("user1,Alice");
+  });
+
+  it("returns Err and does not resolve with a truncated file when the search fails", async () => {
+    mockedSearchConsumptionAnalytics.mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { authenticator } = await setup();
+
+    const destination = new PassThrough();
+    destination.resume();
+
+    const result = await streamConsumptionLinesExportCsvGz(
+      authenticator,
+      {
+        period: {
+          startDate: "2026-08-01T00:00:00.000Z",
+          endDate: "2026-08-02T00:00:00.000Z",
+        },
+        filter: {},
+      },
+      destination
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("boom");
+    }
+  });
+});

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -1,10 +1,18 @@
+import { once } from "node:events";
+import type { Writable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import zlib from "node:zlib";
+import type { DimensionLabel } from "@app/lib/api/analytics/consumption/labels";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeDimension,
+  ConsumptionScopeFilter,
+} from "@app/lib/api/analytics/consumption/scope";
 import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
 import {
   roundToTwoDecimals,
-  rowsToCsv,
+  sanitizeCsvCell,
 } from "@app/lib/api/analytics/csv_utils";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
@@ -22,7 +30,8 @@ import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { estypes } from "@elastic/elasticsearch";
-import AdmZip from "adm-zip";
+import type { Stringifier } from "csv-stringify";
+import { stringify } from "csv-stringify";
 
 // Exported for tests to exercise pagination/slicing boundaries without duplicating the values.
 export const EXPORT_PAGE_SIZE = 10_000;
@@ -127,101 +136,59 @@ const CONSUMPTION_EXPORT_SORT: estypes.Sort = [
   { consumption_key: "asc" },
 ];
 
-function compareConsumptionExportRows(
-  a: AgentMessageConsumptionAnalyticsData,
-  b: AgentMessageConsumptionAnalyticsData
-): number {
-  return (
-    a.completed_at.localeCompare(b.completed_at) ||
-    a.agent_message_id.localeCompare(b.agent_message_id) ||
-    a.consumption_key.localeCompare(b.consumption_key)
-  );
-}
+// Caches resolved labels across pages so concurrent slices don't each re-resolve the
+// same recurring agent/user/tool/etc. ids, while still never needing the full document
+// set in memory to dedupe ids upfront.
+class ConsumptionLabelCache {
+  private readonly cachesByDimension = new Map<
+    ConsumptionScopeDimension,
+    Map<string, DimensionLabel>
+  >();
 
-// One document per unit of billed credit consumption. Slices are fetched concurrently against
-// a shared point-in-time, so every slice/page sees the same snapshot of the index instead of
-// racing concurrent writes/refreshes (which could otherwise duplicate or drop rows).
-async function fetchAllConsumptionDocuments(
-  query: estypes.QueryDslQueryContainer
-): Promise<Result<AgentMessageConsumptionAnalyticsData[], ElasticsearchError>> {
-  const pitResult = await openPointInTime(
-    CONSUMPTION_ANALYTICS_ALIAS_NAME,
-    EXPORT_PIT_KEEP_ALIVE
-  );
-  if (pitResult.isErr()) {
-    return pitResult;
-  }
-  let currentPitId = pitResult.value;
+  async resolve(
+    auth: Authenticator,
+    dimension: ConsumptionScopeDimension,
+    keys: string[]
+  ): Promise<Map<string, DimensionLabel>> {
+    let cache = this.cachesByDimension.get(dimension);
+    if (!cache) {
+      cache = new Map();
+      this.cachesByDimension.set(dimension, cache);
+    }
 
-  try {
-    const sliceIds = Array.from({ length: EXPORT_SLICE_COUNT }, (_, id) => id);
-    const searchAfterBySlice = new Map<number, estypes.SortResults>();
-    const exhaustedSlices = new Set<number>();
-    const allDocs: AgentMessageConsumptionAnalyticsData[] = [];
-
-    while (exhaustedSlices.size < sliceIds.length) {
-      const activeSliceIds = sliceIds.filter((id) => !exhaustedSlices.has(id));
-      const roundPitId = currentPitId;
-
-      const results = await concurrentExecutor(
-        activeSliceIds,
-        (id) =>
-          searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
-            query,
-            {
-              size: EXPORT_PAGE_SIZE,
-              sort: CONSUMPTION_EXPORT_SORT,
-              search_after: searchAfterBySlice.get(id),
-              slice: { id: String(id), max: EXPORT_SLICE_COUNT },
-              pit: { id: roundPitId, keep_alive: EXPORT_PIT_KEEP_ALIVE },
-            }
-          ),
-        { concurrency: EXPORT_SLICE_COUNT }
+    const missingKeys = [...new Set(keys)].filter((key) => !cache?.has(key));
+    if (missingKeys.length > 0) {
+      const resolved = await resolveDimensionLabels(
+        auth,
+        dimension,
+        missingKeys
       );
-
-      for (let i = 0; i < activeSliceIds.length; i++) {
-        const result = results[i];
-        if (result.isErr()) {
-          return result;
-        }
-
-        const { hits } = result.value.hits;
-        for (const hit of hits) {
-          if (hit._source) {
-            allDocs.push(hit._source);
-          }
-        }
-
-        // A pit search can return a refreshed pit_id; every slice's next round must use it.
-        currentPitId = result.value.pit_id ?? currentPitId;
-
-        const sliceId = activeSliceIds[i];
-        const lastSort = hits[hits.length - 1]?.sort;
-        if (hits.length < EXPORT_PAGE_SIZE || !lastSort) {
-          exhaustedSlices.add(sliceId);
-        } else {
-          searchAfterBySlice.set(sliceId, lastSort);
-        }
+      for (const [key, label] of resolved) {
+        cache.set(key, label);
       }
     }
 
-    // Each slice is individually sorted; merge back into a single global order.
-    allDocs.sort(compareConsumptionExportRows);
+    return cache;
+  }
+}
 
-    return new Ok(allDocs);
-  } finally {
-    const closeResult = await closePointInTime(currentPitId);
-    if (closeResult.isErr()) {
-      logger.error(
-        { err: closeResult.error },
-        "[ConsumptionExport] Failed to close point-in-time."
-      );
+// Waits for the stringifier's internal buffer to drain before writing more, so a slow
+// downstream (gzip + GCS upload) applies backpressure to the ES fetch loops instead of
+// having them buffer unboundedly many pages in memory.
+async function writeCsvRows(
+  stringifier: Stringifier,
+  rows: (string | number)[][]
+): Promise<void> {
+  for (const row of rows) {
+    if (!stringifier.write(row)) {
+      await once(stringifier, "drain");
     }
   }
 }
 
-async function buildConsumptionLineExportRows(
+async function buildConsumptionLineExportRowsForPage(
   auth: Authenticator,
+  labelCache: ConsumptionLabelCache,
   docs: AgentMessageConsumptionAnalyticsData[]
 ): Promise<ConsumptionLineExportRow[]> {
   const [
@@ -233,27 +200,41 @@ async function buildConsumptionLineExportRows(
     groupLabels,
     sourceLabels,
   ] = await Promise.all([
-    resolveDimensionLabels(auth, "agent", [
-      ...new Set(docs.map((doc) => doc.agent.id)),
-    ]),
-    resolveDimensionLabels(auth, "user", [
-      ...new Set(removeNulls(docs.map((doc) => doc.user?.id))),
-    ]),
-    resolveDimensionLabels(auth, "model", [
-      ...new Set(removeNulls(docs.map((doc) => doc.model?.model_id))),
-    ]),
-    resolveDimensionLabels(auth, "tool", [
-      ...new Set(removeNulls(docs.map((doc) => doc.tool?.server_name))),
-    ]),
-    resolveDimensionLabels(auth, "skill", [
-      ...new Set(docs.flatMap((doc) => doc.tool?.attributed_skill_ids ?? [])),
-    ]),
-    resolveDimensionLabels(auth, "group", [
-      ...new Set(docs.flatMap((doc) => doc.user?.group_ids ?? [])),
-    ]),
-    resolveDimensionLabels(auth, "source", [
-      ...new Set(removeNulls(docs.map((doc) => doc.context_origin))),
-    ]),
+    labelCache.resolve(
+      auth,
+      "agent",
+      docs.map((doc) => doc.agent.id)
+    ),
+    labelCache.resolve(
+      auth,
+      "user",
+      removeNulls(docs.map((doc) => doc.user?.id))
+    ),
+    labelCache.resolve(
+      auth,
+      "model",
+      removeNulls(docs.map((doc) => doc.model?.model_id))
+    ),
+    labelCache.resolve(
+      auth,
+      "tool",
+      removeNulls(docs.map((doc) => doc.tool?.server_name))
+    ),
+    labelCache.resolve(
+      auth,
+      "skill",
+      docs.flatMap((doc) => doc.tool?.attributed_skill_ids ?? [])
+    ),
+    labelCache.resolve(
+      auth,
+      "group",
+      docs.flatMap((doc) => doc.user?.group_ids ?? [])
+    ),
+    labelCache.resolve(
+      auth,
+      "source",
+      removeNulls(docs.map((doc) => doc.context_origin))
+    ),
   ]);
 
   return docs.map((doc) => {
@@ -333,8 +314,25 @@ async function buildConsumptionLineExportRows(
   });
 }
 
-// Exports every raw consumption under zipped csv format
-export async function fetchConsumptionLinesExportZip(
+function consumptionLineExportRowToCsvValues(
+  row: ConsumptionLineExportRow
+): (string | number)[] {
+  return CONSUMPTION_LINE_EXPORT_HEADERS.map((header) =>
+    sanitizeCsvCell(row[header])
+  );
+}
+
+// Exports every raw consumption line as a gzip-compressed CSV stream, written directly to
+// `destination`. Slices are fetched concurrently against a shared point-in-time, so every
+// slice/page sees the same snapshot of the index instead of racing concurrent writes/refreshes
+// (which could otherwise duplicate or drop rows), and streamed to `destination` as soon as each
+// page is built, so memory usage stays bounded by the number of in-flight pages
+// (EXPORT_SLICE_COUNT) rather than growing with the size of the export.
+//
+// Elasticsearch requires every request of a sliced PIT search to use the same PIT id, so pages
+// are fetched in lockstep rounds: one page per still-active slice per round, all against the
+// same PIT id, with the id advanced to the latest value returned before the next round starts.
+export async function streamConsumptionLinesExportCsvGz(
   auth: Authenticator,
   {
     period,
@@ -342,8 +340,9 @@ export async function fetchConsumptionLinesExportZip(
   }: {
     period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
-  }
-): Promise<Result<Buffer, ElasticsearchError>> {
+  },
+  destination: Writable
+): Promise<Result<undefined, ElasticsearchError>> {
   const query = buildConsumptionScopeQuery({
     auth,
     startDate: period.startDate,
@@ -351,18 +350,96 @@ export async function fetchConsumptionLinesExportZip(
     filter,
   });
 
-  const docsResult = await fetchAllConsumptionDocuments(query);
-  if (docsResult.isErr()) {
-    return docsResult;
-  }
+  const stringifier = stringify({ header: false });
+  stringifier.write(CONSUMPTION_LINE_EXPORT_HEADERS);
 
-  const rows = await buildConsumptionLineExportRows(auth, docsResult.value);
+  const uploadDone = pipeline(stringifier, zlib.createGzip(), destination);
 
-  const zip = new AdmZip();
-  zip.addFile(
-    "lines.csv",
-    Buffer.from(rowsToCsv(CONSUMPTION_LINE_EXPORT_HEADERS, rows), "utf-8")
+  const pitResult = await openPointInTime(
+    CONSUMPTION_ANALYTICS_ALIAS_NAME,
+    EXPORT_PIT_KEEP_ALIVE
   );
+  if (pitResult.isErr()) {
+    stringifier.destroy(pitResult.error);
+    await uploadDone.catch(() => {});
+    return pitResult;
+  }
+  let currentPitId = pitResult.value;
 
-  return new Ok(zip.toBuffer());
+  try {
+    const labelCache = new ConsumptionLabelCache();
+    const sliceIds = Array.from({ length: EXPORT_SLICE_COUNT }, (_, id) => id);
+    const searchAfterBySlice = new Map<number, estypes.SortResults>();
+    const exhaustedSlices = new Set<number>();
+
+    while (exhaustedSlices.size < sliceIds.length) {
+      const activeSliceIds = sliceIds.filter((id) => !exhaustedSlices.has(id));
+      const roundPitId = currentPitId;
+
+      const results = await concurrentExecutor(
+        activeSliceIds,
+        (id) =>
+          searchConsumptionAnalytics<AgentMessageConsumptionAnalyticsData>(
+            query,
+            {
+              size: EXPORT_PAGE_SIZE,
+              sort: CONSUMPTION_EXPORT_SORT,
+              search_after: searchAfterBySlice.get(id),
+              slice: { id: String(id), max: EXPORT_SLICE_COUNT },
+              pit: { id: roundPitId, keep_alive: EXPORT_PIT_KEEP_ALIVE },
+            }
+          ),
+        { concurrency: EXPORT_SLICE_COUNT }
+      );
+
+      for (let i = 0; i < activeSliceIds.length; i++) {
+        const result = results[i];
+        if (result.isErr()) {
+          // Abort the pipeline instead of calling stringifier.end(): the upload must not
+          // complete with a truncated file that looks like a full export.
+          stringifier.destroy(result.error);
+          await uploadDone.catch(() => {});
+          return result;
+        }
+
+        const { hits } = result.value.hits;
+        const docs = removeNulls(hits.map((hit) => hit._source ?? null));
+        if (docs.length > 0) {
+          const rows = await buildConsumptionLineExportRowsForPage(
+            auth,
+            labelCache,
+            docs
+          );
+          await writeCsvRows(
+            stringifier,
+            rows.map(consumptionLineExportRowToCsvValues)
+          );
+        }
+
+        // A pit search can return a refreshed pit_id; every slice's next round must use it.
+        currentPitId = result.value.pit_id ?? currentPitId;
+
+        const sliceId = activeSliceIds[i];
+        const lastSort = hits[hits.length - 1]?.sort;
+        if (hits.length < EXPORT_PAGE_SIZE || !lastSort) {
+          exhaustedSlices.add(sliceId);
+        } else {
+          searchAfterBySlice.set(sliceId, lastSort);
+        }
+      }
+    }
+
+    stringifier.end();
+    await uploadDone;
+
+    return new Ok(undefined);
+  } finally {
+    const closeResult = await closePointInTime(currentPitId);
+    if (closeResult.isErr()) {
+      logger.error(
+        { err: closeResult.error },
+        "[ConsumptionExport] Failed to close point-in-time."
+      );
+    }
+  }
 }

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -1,6 +1,7 @@
-// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib).
+// @vitest-environment node: zlib gunzip requires Node builtins (Buffer, zlib).
 // This directive makes them available in the test environment.
 
+import zlib from "node:zlib";
 import {
   EXPORT_PAGE_SIZE,
   EXPORT_SLICE_COUNT,
@@ -26,7 +27,6 @@ import type {
 } from "@app/types/assistant/analytics";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
-import AdmZip from "adm-zip";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Instantiation expression: pins the mock to the concrete TDocument the exporter
@@ -190,15 +190,18 @@ const TOOL_DOC: AgentMessageConsumptionAnalyticsToolData = {
   execution_time_ms: 250,
 };
 
-// Routes every document to slice 0 and returns empty pages for the other slices, mirroring
-// how a real ES sliced search partitions the result set (each doc belongs to exactly one slice).
+// Partitions `docs` across whatever slice count/id the caller requests, so the
+// concurrent per-slice fetches (mirroring the real ES `slice` param) never see the
+// same document twice.
 function mockDocs(docs: AgentMessageConsumptionAnalyticsData[]) {
-  mockedSearchConsumptionAnalytics.mockImplementation(
-    async (_query, options) => {
-      const isFirstSlice = options?.slice?.id === "0";
-      return new Ok(searchResponse(isFirstSlice ? docs : []));
-    }
-  );
+  mockedSearchConsumptionAnalytics.mockImplementation(async (_q, options) => {
+    const slice = options?.slice;
+    const partition = slice
+      ? docs.filter((_doc, index) => index % slice.max === Number(slice.id))
+      : docs;
+
+    return new Ok(searchResponse(partition));
+  });
 }
 
 function mockLabels(labels: Record<string, string>) {
@@ -223,7 +226,7 @@ async function setup() {
 }
 
 describe("runConsumptionExportActivity", () => {
-  it("uploads the CSV export to GCS under the workspace prefix", async () => {
+  it("streams the gzip-compressed CSV export to GCS under the workspace prefix", async () => {
     mockDocs([LLM_DOC, TOOL_DOC]);
     mockLabels({
       agent1: "@dust",
@@ -246,27 +249,18 @@ describe("runConsumptionExportActivity", () => {
     });
 
     const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
-    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+    const writeCalls = fileStorageMock.writeStreamCalls.filter((call) =>
       call.filePath.startsWith(prefix)
     );
-    expect(saveCalls).toHaveLength(1);
-    expect(saveCalls[0].filePath).toBe(
-      `${prefix}consumption-export-test-run.zip`
+    expect(writeCalls).toHaveLength(1);
+    expect(writeCalls[0].filePath).toBe(
+      `${prefix}consumption-export-test-run.csv.gz`
     );
-    expect(saveCalls[0].contentType).toBe("application/zip");
+    expect(writeCalls[0].contentType).toBe("application/gzip");
 
-    // Read back the exact buffer passed to `.save()` rather than round-tripping through the
-    // mock's in-memory object store, which stores content as a UTF-8 string and would corrupt
-    // this binary zip.
-    const content = saveCalls[0].content;
-    const zip = new AdmZip(
-      Buffer.isBuffer(content) ? content : Buffer.from(content)
-    );
-    expect(zip.getEntries().map((entry) => entry.entryName)).toEqual([
-      "lines.csv",
-    ]);
+    const gzipped = await writeCalls[0].content;
+    const csv = zlib.gunzipSync(gzipped).toString("utf-8");
 
-    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8");
     expect(csv).toContain(
       "completedAt,conversationId,spaceId,agentMessageId,consumptionType,agentId,agentName"
     );
@@ -284,11 +278,11 @@ describe("runConsumptionExportActivity", () => {
     expect(notifyConsumptionExportReady).toHaveBeenCalledTimes(1);
   });
 
-  it("throws and uploads nothing when the search fails", async () => {
+  it("throws and does not notify when the search fails", async () => {
     mockedSearchConsumptionAnalytics.mockResolvedValue(
       new Err(new ElasticsearchError("query_error", "boom"))
     );
-    const { authenticator, workspace } = await setup();
+    const { authenticator } = await setup();
 
     await expect(
       runConsumptionExportActivity(authenticator.toJSON(), {
@@ -301,11 +295,6 @@ describe("runConsumptionExportActivity", () => {
       })
     ).rejects.toThrow();
 
-    const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
-    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
-      call.filePath.startsWith(prefix)
-    );
-    expect(saveCalls).toHaveLength(0);
     expect(notifyConsumptionExportReady).not.toHaveBeenCalled();
   });
 
@@ -390,14 +379,11 @@ describe("runConsumptionExportActivity", () => {
     });
 
     const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
-    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+    const writeCalls = fileStorageMock.writeStreamCalls.filter((call) =>
       call.filePath.startsWith(prefix)
     );
-    const content = saveCalls[0].content;
-    const zip = new AdmZip(
-      Buffer.isBuffer(content) ? content : Buffer.from(content)
-    );
-    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8") ?? "";
+    const gzipped = await writeCalls[0].content;
+    const csv = zlib.gunzipSync(gzipped).toString("utf-8");
     const dataRows = csv.trim().split("\n").slice(1);
 
     expect(dataRows).toHaveLength(docs.length);
@@ -410,10 +396,6 @@ describe("runConsumptionExportActivity", () => {
         rowAgentMessageIds.filter((id) => id === doc.agent_message_id)
       ).toHaveLength(1);
     }
-
-    // Rows must come back in global completedAt order, not grouped by slice.
-    const completedAts = dataRows.map((row) => row.split(",")[0]);
-    expect(completedAts).toEqual([...completedAts].sort());
   });
 
   it("paginates within a slice using search_after until a short page ends it", async () => {
@@ -466,14 +448,11 @@ describe("runConsumptionExportActivity", () => {
     ]);
 
     const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
-    const saveCalls = fileStorageMock.saveFileCalls.filter((call) =>
+    const writeCalls = fileStorageMock.writeStreamCalls.filter((call) =>
       call.filePath.startsWith(prefix)
     );
-    const content = saveCalls[0].content;
-    const zip = new AdmZip(
-      Buffer.isBuffer(content) ? content : Buffer.from(content)
-    );
-    const csv = zip.getEntry("lines.csv")?.getData().toString("utf-8") ?? "";
+    const gzipped = await writeCalls[0].content;
+    const csv = zlib.gunzipSync(gzipped).toString("utf-8");
     const dataRows = csv.trim().split("\n").slice(1);
     expect(dataRows).toHaveLength(fullPageDocs.length + 1);
   });

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -1,4 +1,4 @@
-import { fetchConsumptionLinesExportZip } from "@app/lib/api/analytics/consumption/export_lines";
+import { streamConsumptionLinesExportCsvGz } from "@app/lib/api/analytics/consumption/export_lines";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
@@ -19,7 +19,7 @@ export function buildConsumptionExportGcsPath(
   workspaceId: string,
   exportId: string
 ): string {
-  return `${buildConsumptionExportGcsPrefix(workspaceId)}${exportId}.zip`;
+  return `${buildConsumptionExportGcsPrefix(workspaceId)}${exportId}.csv.gz`;
 }
 
 export function makeConsumptionExportWorkflowIdPrefix({
@@ -88,7 +88,17 @@ export async function runConsumptionExportActivity(
   const auth = await Authenticator.fromJSON(authType);
   const workspaceId = auth.getNonNullableWorkspace().sId;
 
-  const result = await fetchConsumptionLinesExportZip(auth, { period, filter });
+  const gcsPath = buildConsumptionExportGcsPath(workspaceId, exportId);
+  const destination = getPrivateUploadBucket().file(gcsPath).createWriteStream({
+    contentType: "application/gzip",
+    resumable: false,
+  });
+
+  const result = await streamConsumptionLinesExportCsvGz(
+    auth,
+    { period, filter },
+    destination
+  );
   if (result.isErr()) {
     logger.error(
       { workspaceId, err: result.error },
@@ -96,12 +106,6 @@ export async function runConsumptionExportActivity(
     );
     throw result.error;
   }
-
-  const gcsPath = buildConsumptionExportGcsPath(workspaceId, exportId);
-
-  await getPrivateUploadBucket()
-    .file(gcsPath)
-    .save(result.value, { contentType: "application/zip", resumable: false });
 
   notifyConsumptionExportReady(auth, exportId);
 }

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -5,6 +5,11 @@ import { vi } from "vitest";
 interface WriteStreamCall {
   filePath: string;
   contentType: string | undefined;
+  // Resolves once the stream returned to the caller has finished (or errored),
+  // with everything written to it. The stream is put in flowing mode immediately
+  // (a real GCS write stream doesn't buffer indefinitely either), so callers don't
+  // need to consume it themselves to avoid stalling on backpressure.
+  content: Promise<Buffer>;
 }
 
 interface SaveFileCall {
@@ -266,11 +271,23 @@ class FileStorageMock {
       createWriteStream: vi
         .fn()
         .mockImplementation((opts?: { contentType?: string }) => {
+          const stream = new PassThrough();
+          const chunks: Buffer[] = [];
+          const content = new Promise<Buffer>((resolve, reject) => {
+            stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+            stream.on("end", () => resolve(Buffer.concat(chunks)));
+            stream.on("error", reject);
+          });
+          // Tests that don't care about the written bytes (e.g. an error path that
+          // aborts the stream) shouldn't trigger an unhandled rejection warning just
+          // because nothing awaited `content`.
+          content.catch(() => {});
           this._writeStreamCalls.push({
             filePath: filePath ?? "unknown",
             contentType: opts?.contentType,
+            content,
           });
-          return new PassThrough();
+          return stream;
         }),
       delete: vi.fn().mockImplementation(() => {
         this._objectStore.delete(filePath ?? "unknown");


### PR DESCRIPTION
The raw-lines export collected every ES document, built every CSV row, and
zipped the whole thing into one Buffer before uploading, so memory usage grew
with the size of the export. AdmZip has no streaming API, so switch the
container format to .csv.gz: rows are gzip-streamed directly to the GCS
write stream as each page is fetched, with per-page label resolution (cached
across pages) instead of resolving labels once over the full document set.
Memory now stays bounded by the number of in-flight ES pages rather than the
export's total size.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
