### PR TITLE
Admin governance: use permissions to list skill editors

### DIFF
--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -778,11 +778,8 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
 
     const coEditor = await UserFactory.basic();
     await MembershipFactory.associate(workspace, coEditor, { role: "builder" });
-    const addRes = await skill.editorGroup?.dangerouslyAddMembers(
-      requestUserAuth,
-      { users: [coEditor.toJSON()] }
-    );
-    if (!addRes || addRes.isErr()) {
+    const addRes = await skill.addEditors(requestUserAuth, [coEditor]);
+    if (addRes.isErr()) {
       throw new Error("Failed to add the co-editor");
     }
 
@@ -827,11 +824,8 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
       userIds: [requestUser.sId, coEditor.sId],
     });
 
-    const addRes = await skill.editorGroup?.dangerouslyAddMembers(
-      requestUserAuth,
-      { users: [coEditor.toJSON()] }
-    );
-    if (!addRes || addRes.isErr()) {
+    const addRes = await skill.addEditors(requestUserAuth, [coEditor]);
+    if (addRes.isErr()) {
       throw new Error("Failed to add the co-editor");
     }
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -2906,6 +2906,11 @@ describe("SkillResource", () => {
   });
 
   describe("group_permissions as the source of truth", () => {
+    // The kill switch is a module mock: reset it per test so one flipping it cannot leak.
+    beforeEach(() => {
+      vi.mocked(isLegacyAclsEnabled).mockReturnValue(false);
+    });
+
     // A skill's editor group grants [read, write, admin] through its group_permissions row; a
     // "user" role grants only read, so write and admin flow purely through the grant.
     //
@@ -3005,6 +3010,27 @@ describe("SkillResource", () => {
         testContext.authenticator
       );
       expect(legacyMembers.map((m) => m.sId)).not.toContain(editor.sId);
+    });
+
+    it("lists editors from the per-user grants, and from the group under the kill switch", async () => {
+      const { skill, editor } = await setupSkillWithEditor(
+        "Editor Source Skill"
+      );
+
+      // Served from the grant group.
+      const fromGrants = await skill.listEditors(testContext.authenticator);
+      expect(fromGrants?.map((e) => e.sId)).toContain(editor.sId);
+
+      // Drop the grants: the new source is empty, the kill switch restores the group's members.
+      await GroupPermissionResource.deleteAllForResource(
+        testContext.authenticator,
+        { resourceType: "skill", resourceId: skill.id }
+      );
+      expect(await skill.listEditors(testContext.authenticator)).toEqual([]);
+
+      vi.mocked(isLegacyAclsEnabled).mockReturnValue(true);
+      const fromGroup = await skill.listEditors(testContext.authenticator);
+      expect(fromGroup?.map((e) => e.sId)).toContain(editor.sId);
     });
 
     it("falls back to the editor group when the use_legacy_acls kill switch is on", async () => {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -92,6 +92,7 @@ import type {
 import { isDefaultFromAvailability } from "@app/types/assistant/skill_configuration";
 import type { AgentsUsageType } from "@app/types/data_source";
 import type { GrantVerb } from "@app/types/group_permissions";
+import { grantKey } from "@app/types/group_permissions";
 import { SKILL_GROUP_PREFIX } from "@app/types/groups";
 import type {
   AccessControlList,
@@ -2602,7 +2603,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    * Returns null when the skill has no editor group (global/system skills).
    */
   async listEditors(auth: Authenticator): Promise<UserResource[] | null> {
-    return this.editorGroup?.getActiveMembers(auth) ?? null;
+    // Code-defined global/system skills have no editors at all.
+    if (this.globalSId) {
+      return null;
+    }
+
+    if (isLegacyAclsEnabled()) {
+      return (await this.editorGroup?.getActiveMembers(auth)) ?? null;
+    }
+
+    const grantGroup =
+      await GroupPermissionResource.findRegularAutoGroupForGrant(auth, {
+        grantType: SKILL_EDITOR_GRANT_TYPE,
+        resourceType: "skill",
+        resourceId: this.id,
+      });
+
+    return grantGroup ? grantGroup.getActiveMembers(auth) : [];
   }
 
   async upsertEditors(
@@ -3088,18 +3105,51 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       skills.map((s) => [s.sId, null])
     );
 
-    const skillsWithEditorGroups = skills.filter((s) => s.editorGroup !== null);
+    // Code-defined global/system skills have no editors — see `listEditors`.
+    const customSkills = skills.filter((s) => !s.globalSId);
 
-    if (skillsWithEditorGroups.length === 0) {
+    if (customSkills.length === 0) {
       return result;
     }
 
-    const editorGroups = removeNulls(
-      skillsWithEditorGroups.map((s) => s.editorGroup)
-    );
+    // Editors come from the per-user grants (one regular_auto group per skill). Only the kill
+    // switch reads the skill_editors group — see `listEditors`.
+    let groupBySkillModelId: Map<ModelId, GroupResource>;
+    if (isLegacyAclsEnabled()) {
+      groupBySkillModelId = new Map(
+        removeNulls(
+          customSkills.map((skill) =>
+            skill.editorGroup ? ([skill.id, skill.editorGroup] as const) : null
+          )
+        )
+      );
+    } else {
+      const editorGrantSpec = (skill: SkillResource) => ({
+        grantType: SKILL_EDITOR_GRANT_TYPE,
+        resourceType: "skill" as const,
+        resourceId: skill.id,
+      });
+
+      const groupByGrant =
+        await GroupPermissionResource.findRegularAutoGroupsForGrants(auth, {
+          grants: customSkills.map(editorGrantSpec),
+        });
+
+      groupBySkillModelId = new Map(
+        removeNulls(
+          customSkills.map((skill) => {
+            const group = groupByGrant.get(grantKey(editorGrantSpec(skill)));
+
+            return group ? ([skill.id, group] as const) : null;
+          })
+        )
+      );
+    }
 
     const membershipsByGroupId =
-      await GroupResource.getActiveMembershipsForGroups(auth, editorGroups);
+      await GroupResource.getActiveMembershipsForGroups(auth, [
+        ...groupBySkillModelId.values(),
+      ]);
 
     const allUserIds = [...new Set(Object.values(membershipsByGroupId).flat())];
 
@@ -3127,9 +3177,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         .map((u) => [u.id, u])
     );
 
-    for (const skill of skillsWithEditorGroups) {
-      const groupId = skill.editorGroup!.id;
-      const userIds = membershipsByGroupId[groupId] ?? [];
+    for (const skill of customSkills) {
+      const group = groupBySkillModelId.get(skill.id);
+      const userIds = group ? (membershipsByGroupId[group.id] ?? []) : [];
       const users = removeNulls(userIds.map((id) => userById.get(id) ?? null));
       result.set(skill.sId, users);
     }


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/tasks/issues/9472

Update skill reosurce listEditors and batchListEditors to use the members from the regular_auto group backing the skills permissions.
With this PR, we will be switch to using the new permissions groups unless the kill switch is enabled.

To be merged when backfill has been run to backfill all the regular_auto group and we are sure we are consistent with skill editors group permissions. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

We keep writing the info in the old skill editors group system, so if anything goes wrong we can enable the kill switch and go back to previous behaviour.

## Deploy Plan

wait for backfill to be run before merging.
deploy front
