### PR TITLE
[front] Add GroupPermissions.resourceIdsWithVerb accessor

### DIFF
--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -271,6 +271,39 @@ describe("GroupPermissions.fromJSON", () => {
   });
 });
 
+describe("GroupPermissions.resourceIdsWithVerb", () => {
+  // read = 1 << 0, write = 1 << 1, admin = 1 << 2 (see VERB_BIT / GRANT_VERBS order).
+  it("returns the instance ids holding the verb", () => {
+    const perms = GroupPermissions.fromJSON({
+      grants: { space: { 12: 0b011, 34: 0b001 } },
+    });
+    expect(perms.resourceIdsWithVerb("space", "read").sort()).toEqual([12, 34]);
+    expect(perms.resourceIdsWithVerb("space", "write")).toEqual([12]);
+  });
+
+  it("filters out ids that lack the verb", () => {
+    const perms = GroupPermissions.fromJSON({
+      grants: { space: { 12: 0b001, 34: 0b011 } },
+    });
+    expect(perms.resourceIdsWithVerb("space", "write")).toEqual([34]);
+    expect(perms.resourceIdsWithVerb("space", "admin")).toEqual([]);
+  });
+
+  it("excludes the type-wide (-1) entry", () => {
+    // A type-wide grant confers the verb on every id but names no concrete instance.
+    const perms = GroupPermissions.fromJSON({
+      grants: { agent: { [WHOLE_TYPE_RESOURCE_ID]: 0b1000, 42: 0b011 } },
+    });
+    expect(perms.resourceIdsWithVerb("agent", "read")).toEqual([42]);
+    expect(perms.resourceIdsWithVerb("agent", "create")).toEqual([]);
+  });
+
+  it("returns an empty array when the resource type has no grants", () => {
+    const perms = GroupPermissions.fromJSON({ grants: {} });
+    expect(perms.resourceIdsWithVerb("space", "read")).toEqual([]);
+  });
+});
+
 describe("GRANT_VERBS bit-position stability", () => {
   // Each verb is stored as bit `1 << its index in GRANT_VERBS` (see VERB_BIT), and those masks are
   // serialized into in-flight Temporal payloads. So the positions must stay stable: only append new

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -368,6 +368,35 @@ export class GroupPermissions {
     return maskToVerbs(mask);
   }
 
+  // The concrete instance ids of `resourceType` on which the caller holds `verb` — the reverse of
+  // resolvedVerbsForResource, for callers that enumerate what they may act on ("which spaces am I a
+  // member of") rather than checking one id. Excludes the type-wide (-1) entry: a type-wide grant
+  // confers the verb on every id of the type and names no concrete instance, so callers that must
+  // also account for type-wide access should consult toWorkspacePermissions separately.
+  resourceIdsWithVerb(
+    resourceType: ConcreteResourceType,
+    verb: GrantVerb
+  ): number[] {
+    const byId = this.grants.get(resourceType);
+    if (!byId) {
+      return [];
+    }
+    const bit = VERB_BIT.get(verb) ?? 0;
+    if (bit === 0) {
+      return [];
+    }
+    const resourceIds: number[] = [];
+    for (const [resourceId, mask] of byId) {
+      if (resourceId === WHOLE_TYPE_RESOURCE_ID) {
+        continue;
+      }
+      if ((mask & bit) !== 0) {
+        resourceIds.push(resourceId);
+      }
+    }
+    return resourceIds;
+  }
+
   // The type-wide (-1) verbs the caller's grants confer per resource type — the flat record for the
   // auth context / Workspace & Governance page. Grants only; admin-by-default is layered on by the
   // Authenticator (see `getWorkspacePermissions`).


### PR DESCRIPTION
## What

Adds `GroupPermissions.resourceIdsWithVerb(resourceType, verb)`: the reverse of `resolvedVerbsForResource`. Instead of "what verbs does the caller hold on this id", it answers "which instance ids may the caller `<verb>`".

## Why

This is the primitive the reverse-lookup consumers of the `Authenticator`'s raw group list need in order to move off `auth.groupModelIds()` and read from the already-resolved governance grants (`_permissions`) instead. First step toward removing the group list as an `Authenticator` member and making `groupIds()` async.

Next in the stack: rewrite `SpaceResource.isMember` / `listWorkspacePodsAsMember` against grants.

## Notes

- Excludes the type-wide (`-1`) entry — a type-wide grant confers the verb on every id and names no concrete instance; callers needing type-wide access consult `toWorkspacePermissions` separately.
- Unit tests added alongside the existing `GroupPermissions` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)