### PR TITLE
[Activation] Add explicit pod kind

### DIFF
--- a/front/lib/models/activation/activation_pod.ts
+++ b/front/lib/models/activation/activation_pod.ts
@@ -6,6 +6,9 @@ import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 
+export const ACTIVATION_POD_KINDS = ["learning", "goal"] as const;
+export type ActivationPodKind = (typeof ACTIVATION_POD_KINDS)[number];
+
 // One row = one Activation Pod: a Pod (project space) provisioned by the
 // activation flow. Canonical record for a pod's owner.
 export class ActivationPodModel extends WorkspaceAwareModel<ActivationPodModel> {
@@ -16,6 +19,7 @@ export class ActivationPodModel extends WorkspaceAwareModel<ActivationPodModel> 
   declare spaceId: ForeignKey<SpaceModel["id"]>;
   // The user for whom we created the activation pod.
   declare userId: ForeignKey<UserModel["id"]>;
+  declare kind: CreationOptional<ActivationPodKind>;
 
   declare projectMetadata?: NonAttribute<ProjectMetadataModel>;
 }
@@ -31,6 +35,14 @@ ActivationPodModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    kind: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "learning",
+      validate: {
+        isIn: [ACTIVATION_POD_KINDS],
+      },
     },
   },
   {

--- a/front/migrations/pre-deploy/20260817205010_add_activation_pod_kind.sql
+++ b/front/migrations/pre-deploy/20260817205010_add_activation_pod_kind.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."activation_pods"
+  ADD COLUMN IF NOT EXISTS "kind" character varying(255) DEFAULT 'learning' NOT NULL;


### PR DESCRIPTION
## Summary
- add an explicit `learning | goal` discriminator to `ActivationPodModel`
- This discriminator will only be used to switch the skill logic + perhaps some minor UX. The purpose is I want to experiment a bit with "group" activation pods. Not going to be customer facing yet

## Testing
tests pass

## Risk
Very low

## Deploy
1. migrate pre-deploy
2. Deploy front