### PR TITLE
fix: use correct header for get transcript content teams

### DIFF
--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -731,6 +731,10 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       );
     }
 
+    // The /content endpoint supports the following formats. Select text/vtt with either the
+    // $format query parameter or the Accept request header. The
+    // application/vnd.microsoft.graph.transcript+text format must be selected with the Accept
+    // request header.
     // See: https://learn.microsoft.com/en-us/graph/api/calltranscript-get?view=graph-rest-1.0&tabs=http#transcript-content-formats
     const formats = [
       "text/vtt", // With speaker-attributed content - Requires extra permission on the tenant.
@@ -742,9 +746,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
           .api(
             `/me/onlineMeetings/${meetingId}/transcripts/${transcriptId}/content`
           )
-          .query({ $format: format })
+          .header("Accept", format)
           // The SDK infers the response type from Content-Type, preserving messages
-          // in JSON error bodies and returning successful text/vtt bodies as
+          // in JSON error bodies and returning successful transcript bodies as
           // ReadableStreams handled below.
           .get();
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10105

This PR updates the get_transcript_content tool to call the teams API correctly when getting a transcript content.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low.

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
Standard deployment.

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
