### PR TITLE
[front] Read space membership from governance grants, not the group list

### DIFF
--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -126,7 +126,7 @@ describe("selected conversation Spaces", () => {
       workspaceId: workspace.id,
       kind: "regular_auto",
     });
-    return SpaceResource.makeNew(
+    const space = await SpaceResource.makeNew(
       await Authenticator.internalAdminForWorkspace(workspace.sId),
       {
         name: "Open Space",
@@ -135,6 +135,11 @@ describe("selected conversation Spaces", () => {
       },
       { members: [memberGroup, globalGroup] }
     );
+    // Membership on the open space comes from the global group's `reader` grant, which lands in the
+    // caller's grant snapshot only after a refresh (the caller is already in the global group, but
+    // the space's grants did not exist when their auth was built).
+    await auth.refresh();
+    return space;
   }
 
   async function conversation() {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1497,6 +1497,19 @@ export class Authenticator {
   }
 
   /**
+   * The instance ids of `resourceType` the caller may `verb`, resolved from their governance grants.
+   * The enumeration counterpart of `getGrantedVerbs` — "which resources may I act on" rather than
+   * "what may I do on this one" — for reverse lookups such as the projects a caller belongs to. See
+   * `GroupPermissions.resourceIdsWithVerb`; the type-wide (-1) grant is excluded there.
+   */
+  getResourceIdsWithVerb(
+    resourceType: ConcreteResourceType,
+    verb: GrantVerb
+  ): ModelId[] {
+    return this._permissions.resourceIdsWithVerb(resourceType, verb);
+  }
+
+  /**
    * Shadow-compare (#9479) for the group_permissions rollout: while the `group_permissions_shadow`
    * flag is on for the workspace, compare two composed decisions for the same check — the served
    * `legacyAcls` and the `candidateAcls` (the same roles routed through the group_permissions

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1825,7 +1825,15 @@ describe("SpaceResource", () => {
         { members: [regularGroup, globalGroup] }
       );
 
-      const spaces = await SpaceResource.listWorkspaceSpacesAsMember(userAuth);
+      // Membership reads from the caller's grants, resolved once at auth construction, so rebuild
+      // the auth after the space (and its grants) exist — same as space authorization (`canRead`).
+      const refreshedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        userAuth.getNonNullableUser().sId,
+        workspace.sId
+      );
+
+      const spaces =
+        await SpaceResource.listWorkspaceSpacesAsMember(refreshedUserAuth);
       expect(spaces.some((s) => s.id === openSpace.id)).toBe(true);
     });
 

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -2018,9 +2018,26 @@ describe("SpaceResource", () => {
           { members: [regularGroup, globalGroup] }
         );
 
-        expect(openSpace.isMember(adminAuth)).toBe(true);
-        expect(openSpace.isMember(userAuth)).toBe(true);
-        expect(openSpace.isMember(nonMemberAuth)).toBe(true);
+        // Membership reads from the caller's grants, which are resolved once at auth construction,
+        // so the auths must be rebuilt after the space (and its grants) exist — same as the
+        // restricted case below. This matches how space authorization (`canRead`) already resolves.
+        const openAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          adminAuth.getNonNullableUser().sId,
+          workspace.sId
+        );
+        const openUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          userAuth.getNonNullableUser().sId,
+          workspace.sId
+        );
+        const openNonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          nonMemberAuth.getNonNullableUser().sId,
+          workspace.sId
+        );
+
+        // Open regular spaces grant every workspace member `reader`, so all are members.
+        expect(openSpace.isMember(openAdminAuth)).toBe(true);
+        expect(openSpace.isMember(openUserAuth)).toBe(true);
+        expect(openSpace.isMember(openNonMemberAuth)).toBe(true);
       });
     });
 
@@ -2133,6 +2150,103 @@ describe("SpaceResource", () => {
         expect(updatedSpace?.isMember(user1Auth)).toBe(true);
         expect(updatedSpace?.isMember(nonMemberAuth)).toBe(false);
       });
+    });
+  });
+
+  describe("listWorkspacePodsAsMember", () => {
+    let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+    let adminAuth: Authenticator;
+    let globalGroup: GroupResource;
+    let systemGroup: GroupResource;
+    let member: UserResource;
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      const adminUser = await UserFactory.basic();
+      member = await UserFactory.basic();
+
+      const { globalGroup: gGroup, systemGroup: sGroup } =
+        await GroupFactory.defaults(workspace);
+      globalGroup = gGroup;
+      systemGroup = sGroup;
+
+      await MembershipFactory.associate(workspace, adminUser, {
+        role: "admin",
+      });
+      await MembershipFactory.associate(workspace, member, { role: "user" });
+
+      const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceResource.makeDefaultsForWorkspace(internalAdminAuth, {
+        globalGroup,
+        systemGroup,
+      });
+
+      adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        adminUser.sId,
+        workspace.sId
+      );
+    });
+
+    it("returns only the projects the caller is a member or editor of", async () => {
+      // A project the caller is a plain member of.
+      const memberGroup = await GroupResource.makeNew({
+        name: "Pod Members",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      const projectAsMember = await SpaceResource.makeNew(
+        adminAuth,
+        { name: "Member Pod", kind: "project", workspaceId: workspace.id },
+        { members: [memberGroup] }
+      );
+      await memberGroup.dangerouslyAddMembers(adminAuth, {
+        users: [member.toJSON()],
+      });
+
+      // A project the caller is an editor of (SpaceFactory puts the creator in the editor group).
+      const projectAsEditor = await SpaceFactory.project(workspace, member.id);
+
+      // A project the caller has nothing to do with — must not be returned.
+      const otherProject = await SpaceFactory.project(workspace);
+
+      // A regular space the caller is a member of: they hold `write` on it, but it is not a
+      // project, so it must be filtered out by kind.
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Members",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await SpaceResource.makeNew(
+        adminAuth,
+        { name: "Regular Space", kind: "regular", workspaceId: workspace.id },
+        { members: [regularGroup] }
+      );
+      await regularGroup.dangerouslyAddMembers(adminAuth, {
+        users: [member.toJSON()],
+      });
+
+      // Build the caller's auth after all grants exist (grants are snapshotted at construction).
+      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        member.sId,
+        workspace.sId
+      );
+
+      const pods = await SpaceResource.listWorkspacePodsAsMember(memberAuth);
+
+      expect(pods.map((p) => p.sId).sort()).toEqual(
+        [projectAsMember.sId, projectAsEditor.sId].sort()
+      );
+      expect(pods.map((p) => p.sId)).not.toContain(otherProject.sId);
+    });
+
+    it("returns an empty list when the caller belongs to no project", async () => {
+      await SpaceFactory.project(workspace);
+
+      const pods = await SpaceResource.listWorkspacePodsAsMember(adminAuth);
+
+      expect(pods).toEqual([]);
     });
   });
 });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -24,7 +24,6 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
-import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import type { GrantVerb } from "@app/types/group_permissions";
 import type { GroupKind, GroupType } from "@app/types/groups";
@@ -46,7 +45,6 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { GroupSpaceKind, SpaceKind, SpaceType } from "@app/types/space";
 import assert from "assert";
-import uniq from "lodash/uniq";
 import type {
   Attributes,
   CreationAttributes,
@@ -417,40 +415,22 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async listWorkspacePodsAsMember(auth: Authenticator) {
-    // Fast path, lookup to pods spaces, we lookup the vault ids of the pods spaces and fetch the spaces by model ids.
-    const raw = await GroupSpaceModel.findAll({
-      attributes: ["vaultId"],
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        kind: { [Op.in]: ["member", "project_editor"] },
-        groupId: { [Op.in]: auth.groupModelIds() },
-      },
-    });
+    // Project (pod) spaces the caller belongs to are those on which they hold `write`: the workspace
+    // global group is attached to unrestricted projects as a `reader` viewer, so a `write` grant
+    // marks an actual member (an editor or member group), not every workspace member. Selecting by
+    // `write` and `kind: "project"` reproduces the former `group_vaults` member/editor lookup, so
+    // the previous safety re-filter is redundant.
+    const podSpaceModelIds = auth.getResourceIdsWithVerb("space", "write");
+    if (podSpaceModelIds.length === 0) {
+      return [];
+    }
 
-    const podVaultIds = uniq(raw.map((v) => v.vaultId));
-
-    // Then we fetch the spaces by model ids.
-    const allSpaces = await this.baseFetch(auth, {
+    return this.baseFetch(auth, {
       where: {
-        id: { [Op.in]: podVaultIds },
+        id: { [Op.in]: podSpaceModelIds },
         kind: "project",
       },
     });
-
-    // To be on the safe side.
-    const filteredSpaces = allSpaces.filter((s) => s.isMember(auth));
-    if (filteredSpaces.length !== allSpaces.length) {
-      logger.error(
-        {
-          spaceNotMember: allSpaces
-            .filter((s) => !s.isMember(auth))
-            .map((s) => s.sId),
-        },
-        "The user is not a member of some pod spaces. Action: check how we get the podVaultIds"
-      );
-    }
-
-    return filteredSpaces;
   }
 
   static async listProjectSpaces(
@@ -1735,9 +1715,29 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    */
 
   isMember(auth: Authenticator): boolean {
-    return this.isMemberByGroupPredicate((groupModelId) =>
-      auth.hasGroupByModelId(groupModelId)
-    );
+    // Read membership from the caller's resolved space grants rather than raw group membership. The
+    // grants written by `spaceGroupRoles` mirror `isMemberByGroupPredicate` exactly, per kind:
+    switch (this.kind) {
+      // The workspace-wide space: every member belongs to it.
+      case "global":
+        return true;
+      // System groups manage connections and the conversations space is not a membership space; the
+      // group predicate returns false for both regardless of grants.
+      case "system":
+      case "conversations":
+        return false;
+      // Regular spaces: open spaces grant every member `reader`, restricted spaces grant their
+      // groups `member` — either way membership means holding `read`.
+      case "regular":
+        return auth.getGrantedVerbs("space", this.id).includes("read");
+      // Projects: the workspace global group is attached to unrestricted projects as a `reader`
+      // viewer, so membership is `write` — held by editors (`admin`) and members (`member`) but not
+      // by the global viewer grant.
+      case "project":
+        return auth.getGrantedVerbs("space", this.id).includes("write");
+      default:
+        assertNever(this.kind);
+    }
   }
 
   /**

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -102,6 +102,16 @@ class SpaceGroupReference {
   }
 }
 
+// Space membership resolved from the caller's governance grants (see `SpaceResource.isMember`). The
+// membership verb differs by space kind because the grants `spaceGroupRoles` writes differ:
+// - Regular spaces grant `read` to every member — open spaces via the global group's `reader`,
+//   restricted spaces via their own groups' `member` — so holding `read` marks membership.
+// - Project (pod) spaces attach the workspace global group as a `reader` viewer on unrestricted
+//   projects, so `read` would count every workspace member as a member. `write` is held only by a
+//   project's editor (`admin`) and member (`member`) groups, so it is what marks an actual member.
+const REGULAR_SPACE_MEMBERSHIP_VERB: GrantVerb = "read";
+const POD_SPACE_MEMBERSHIP_VERB: GrantVerb = "write";
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SpaceResource extends BaseResource<SpaceModel> {
   static model: ModelStaticSoftDeletable<SpaceModel> = SpaceModel;
@@ -415,12 +425,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async listWorkspacePodsAsMember(auth: Authenticator) {
-    // Project (pod) spaces the caller belongs to are those on which they hold `write`: the workspace
-    // global group is attached to unrestricted projects as a `reader` viewer, so a `write` grant
-    // marks an actual member (an editor or member group), not every workspace member. Selecting by
-    // `write` and `kind: "project"` reproduces the former `group_vaults` member/editor lookup, so
-    // the previous safety re-filter is redundant.
-    const podSpaceModelIds = auth.getResourceIdsWithVerb("space", "write");
+    // Project (pod) spaces the caller belongs to are those on which they hold the pod membership
+    // verb (see `POD_SPACE_MEMBERSHIP_VERB`): selecting by it and `kind: "project"` reproduces the
+    // former `group_vaults` member/editor lookup, so the previous safety re-filter is redundant.
+    const podSpaceModelIds = auth.getResourceIdsWithVerb(
+      "space",
+      POD_SPACE_MEMBERSHIP_VERB
+    );
     if (podSpaceModelIds.length === 0) {
       return [];
     }
@@ -1715,8 +1726,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    */
 
   isMember(auth: Authenticator): boolean {
-    // Read membership from the caller's resolved space grants rather than raw group membership. The
-    // grants written by `spaceGroupRoles` mirror `isMemberByGroupPredicate` exactly, per kind:
+    // Read membership from the caller's resolved space grants rather than raw group membership; the
+    // grants `spaceGroupRoles` writes mirror `isMemberByGroupPredicate` per kind (see the
+    // `*_SPACE_MEMBERSHIP_VERB` constants for why the verb differs between regular and project).
     switch (this.kind) {
       // The workspace-wide space: every member belongs to it.
       case "global":
@@ -1726,15 +1738,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       case "system":
       case "conversations":
         return false;
-      // Regular spaces: open spaces grant every member `reader`, restricted spaces grant their
-      // groups `member` — either way membership means holding `read`.
       case "regular":
-        return auth.getGrantedVerbs("space", this.id).includes("read");
-      // Projects: the workspace global group is attached to unrestricted projects as a `reader`
-      // viewer, so membership is `write` — held by editors (`admin`) and members (`member`) but not
-      // by the global viewer grant.
+        return auth
+          .getGrantedVerbs("space", this.id)
+          .includes(REGULAR_SPACE_MEMBERSHIP_VERB);
       case "project":
-        return auth.getGrantedVerbs("space", this.id).includes("write");
+        return auth
+          .getGrantedVerbs("space", this.id)
+          .includes(POD_SPACE_MEMBERSHIP_VERB);
       default:
         assertNever(this.kind);
     }


### PR DESCRIPTION
Stacked on #30707.

## What

Rewrites `SpaceResource.isMember(auth)` and `SpaceResource.listWorkspacePodsAsMember(auth)` to read from the caller's resolved space grants — via `auth.getGrantedVerbs("space", id)` and the new `auth.getResourceIdsWithVerb("space", verb)` (backed by `GroupPermissions.resourceIdsWithVerb` from #30707) — instead of raw group membership (`auth.hasGroupByModelId` / `auth.groupModelIds`). This removes two consumers of the `Authenticator`'s group list.

## Membership verb per space kind

The grants `spaceGroupRoles` writes mirror the legacy `isMemberByGroupPredicate`, so the check is per-kind:

| kind | membership |
|------|------------|
| `global` | always a member |
| `system`, `conversations` | never a member |
| `regular` | holds `read` — open spaces grant every member `reader`, restricted grant members `member` |
| `project` | holds `write` — the workspace global group is only a `reader` viewer on unrestricted projects, so `write` marks an actual member (editor `admin` / member `member`) |

Using `read` for projects would be wrong: it would treat every workspace member as a project member via the global viewer grant. That's the one subtlety here.

## Notes

- `listWorkspacePodsAsMember` now selects projects the caller holds `write` on and filters `kind: "project"`, dropping the `GroupSpaceModel` member/editor lookup and its redundant safety re-filter + logging.
- `isMemberByGroupModelIds` (bulk other-user checks against an explicit group-id set) is intentionally left unchanged — it isn't part of the Authenticator group-list removal.
- Safe in prod: `space` grants have been backfilled and dual-written live since the group_permissions flip (2026-07-30).

## Test

- `npx tsgo --noEmit` clean. Relying on CI for the functional space/project suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)