### PR TITLE
[front] perf: add (workspaceId, groupId) index on group_permissions

### DIFF
--- a/front/lib/resources/storage/models/group_permissions.ts
+++ b/front/lib/resources/storage/models/group_permissions.ts
@@ -75,6 +75,14 @@ GroupPermissionModel.init(
         name: "group_permissions_ws_rtype_rid",
         fields: ["workspaceId", "resourceType", "resourceId"],
       },
+      // Auth direction: resolvePermissions loads all grants for the caller's groups
+      // (workspaceId + groupId = ANY). Without this index the planner falls back to a BitmapAnd
+      // that scans every grant row of the workspace on each call.
+      {
+        name: "group_permissions_ws_group",
+        fields: ["workspaceId", "groupId"],
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/pre-deploy/20260818171006_add_ws_group_index_to_group_permissions.sql
+++ b/front/migrations/pre-deploy/20260818171006_add_ws_group_index_to_group_permissions.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY group_permissions_ws_group ON public.group_permissions USING btree ("workspaceId", "groupId");


### PR DESCRIPTION
## Problem

`SELECT ... FROM group_permissions WHERE "workspaceId" = $2 AND "groupId" = ANY($1::bigint[])` is one of the top CPU consumers in Cloud SQL Query Insights. It backs `Authenticator.resolvePermissions`, which runs on every Authenticator construction — including every agent-loop Temporal activity via `fromJsonWithRefrehedGroups`.

## Root cause

No index covers both predicates. The unique index leads on `groupId` (it also serves as the FK index for group deletion per BACK13, so it cannot be reordered) and `group_permissions_ws_rtype_rid` leads on `workspaceId` but not `groupId`. At moderate array sizes (~500-2000 group ids) the planner picks a `BitmapAnd` that scans **every grant row of the workspace** on each call and intersects it with the groupId probes.

## Fix

A `(workspaceId, groupId)` index satisfies both predicates in one path, so the BitmapAnd is never built.

## Benchmarks

PG 14 (matching prod), synthetic 363k-row table with a 60k-grant-row workspace, prepared statements matching Sequelize binds:

| array size | before | after | notes |
|---|---|---|---|
| 100 | 0.15 ms | 0.13 ms | already fine |
| 500 | 2.4 ms | **0.53 ms** | BitmapAnd removed |
| 1000 | 1.8 ms | **0.83 ms** | BitmapAnd removed |
| 5000 | 5.5 ms | 6.0 ms | planner falls back to workspace-prefix scan either way; inherent cost, no regression |

## Alternatives tested and rejected

- **unnest-CTE hash join behind a size threshold**: loses at every array size on PG >= 14 (14-18 ms at 1k+). Hashed `ScalarArrayOpExpr` (PG 14) already gives the `ANY` filter hash semantics, and the explicit join has to hash/probe all workspace rows anyway.
- **`CREATE STATISTICS (dependencies)` on (groupId, workspaceId)**: learns the 1:1 dependency (degree 1.0) and fixes row estimates, but bitmap-AND path costing does not consult extended statistics, so the plan and latency do not change. Complementary, not a fix.
- **Dropping the redundant `workspaceId` predicate**: degrades to whole-table seq scans from ~1k elements, and removes tenant scoping from an auth-path query.

## Deploy

Pre-deploy phase, `CREATE INDEX CONCURRENTLY` — no lock on the auth hot path. Write overhead is negligible: grant mutations are rare relative to reads.

Follow-up if Query Insights still shows this query hot after a week: cache the resolution — the huge-array regime is the one the index cannot fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)