### PR TITLE
[front] enh: use sentence case for tool display names

### DIFF
--- a/front/lib/actions/tool_approval_labels.test.ts
+++ b/front/lib/actions/tool_approval_labels.test.ts
@@ -28,7 +28,7 @@ describe("getApprovalArgsLabel", () => {
         argumentsRequiringApproval: ["dustPod"],
       })
     ).resolves.toBe(
-      'Always allow @assistant to Create Conversation in "pod://dust/w/ws123/pods/prj456".'
+      'Always allow @assistant to Create conversation in "pod://dust/w/ws123/pods/prj456".'
     );
 
     expect(fetchByIdSpy).toHaveBeenCalledWith(auth, "prj456");
@@ -58,7 +58,7 @@ describe("getApprovalArgsLabel", () => {
         argumentsRequiringApproval: ["dustPod"],
       })
     ).resolves.toBe(
-      'Always allow @assistant to Create Conversation in "Revenue Ops".'
+      'Always allow @assistant to Create conversation in "Revenue Ops".'
     );
 
     expect(fetchByIdSpy).toHaveBeenCalledWith(auth, "prj456");

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -313,6 +313,6 @@ describe("getToolAggregateDisplayLabel", () => {
         functionCallName: "custom_server__prepare_report",
         toolName: "prepare_report",
       })
-    ).toBe("Prepare Report");
+    ).toBe("Prepare peport");
   });
 });

--- a/front/lib/actions/tool_display_labels.test.ts
+++ b/front/lib/actions/tool_display_labels.test.ts
@@ -313,6 +313,6 @@ describe("getToolAggregateDisplayLabel", () => {
         functionCallName: "custom_server__prepare_report",
         toolName: "prepare_report",
       })
-    ).toBe("Prepare peport");
+    ).toBe("Prepare report");
   });
 });

--- a/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/conversation_read.test.ts
@@ -135,7 +135,7 @@ describe("getConversationConsumption", () => {
         agentWorkCredits: 5,
         tools: [
           {
-            label: "Test Tool",
+            label: "Test tool",
             callCount: 1,
             attributedCredits: 5,
             directCredits: 3,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
@@ -151,7 +151,7 @@ describe("getAgentMessageConsumption", () => {
         agentWorkCredits: 3,
         tools: [
           expect.objectContaining({
-            label: "Test Tool",
+            label: "Test tool",
             callCount: 2,
             attributedCredits: 7,
             directCredits: 4,

--- a/front/lib/api/assistant/observability/tool_usage.test.ts
+++ b/front/lib/api/assistant/observability/tool_usage.test.ts
@@ -25,7 +25,7 @@ describe("resolveServerDisplayNames", () => {
     ]);
 
     expect(names.get("image_generation")).toBe("Create Images");
-    expect(names.get(server.cachedName)).toBe("Customer Records");
+    expect(names.get(server.cachedName)).toBe("Customer records");
     expect(names.get(server.sId)).toBe("Customer records");
     expect(error).not.toHaveBeenCalled();
   });

--- a/front/lib/resources/skill/code_defined/system/discover_tools.test.ts
+++ b/front/lib/resources/skill/code_defined/system/discover_tools.test.ts
@@ -43,9 +43,9 @@ describe("buildDiscoverToolsInstructions", () => {
 
       const result = buildDiscoverToolsInstructions(toolsets);
 
-      const alphaIndex = result.indexOf("Alpha Tool");
-      const middleIndex = result.indexOf("Middle Tool");
-      const zebraIndex = result.indexOf("Zebra Tool");
+      const alphaIndex = result.indexOf("Alpha tool");
+      const middleIndex = result.indexOf("Middle tool");
+      const zebraIndex = result.indexOf("Zebra tool");
 
       expect(alphaIndex).toBeLessThan(middleIndex);
       expect(middleIndex).toBeLessThan(zebraIndex);
@@ -135,7 +135,7 @@ describe("buildDiscoverToolsInstructions", () => {
 
       const result = buildDiscoverToolsInstructions([toolset]);
 
-      expect(result).toContain("**Test Tool**");
+      expect(result).toContain("**Test tool**");
       expect(result).toContain(`(toolsetId: \`${toolset.sId}\`)`);
       expect(result).toContain("A test description");
     });

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -130,7 +130,7 @@ export function formatAsDisplayName(name: string): string {
       SPECIAL_CASES_PATTERN,
       (match) => SPECIAL_CASES[match as keyof typeof SPECIAL_CASES]
     )
-    .replace(/\b\w/g, (char) => char.toUpperCase());
+    .replace(/\b\w/, (char) => char.toUpperCase());
 }
 
 export function asDisplayToolName(name?: string | null) {


### PR DESCRIPTION
## Description

Tool names are currently fully capitalized, for instance "Hubspot Get Current User Id".

This PR replaces this to use sentence case (first letter is capitalized here).

Does not affect the main conversation UI (inline activity) for the internal tools as we have display labels, only affects remote MCP servers there.
Affects the agent builder details sheet for a tool, the spaces view.

## Tests

- Tested locally.

## Risk

- Low. Safe to rollback.

## Deploy Plan

- Deploy front.
