### PR TITLE
[Activation] Rename Activation email notification subject

### DIFF
--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -49,12 +49,12 @@ describe("getActivationNewConversationEmailSubject", () => {
       getActivationNewConversationEmailSubject(
         "  Prepare the weekly\ncustomer review  "
       )
-    ).toBe("[Dust] Recommendation For You: Prepare the weekly customer review");
+    ).toBe("[Dust] Try this next: Prepare the weekly customer review");
   });
 
   test("falls back when no recommendation name is available", () => {
     expect(getActivationNewConversationEmailSubject(null)).toBe(
-      "[Dust] Recommendation For You: A recommendation for you"
+      "[Dust] Try this next: A recommendation for you"
     );
   });
 });

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -32,7 +32,7 @@ export function getActivationNewConversationEmailSubject(
   recommendationName: string | null
 ): string {
   const normalizedName = recommendationName?.replace(/\s+/g, " ").trim();
-  return `[Dust] Recommendation For You: ${
+  return `[Dust] Try this next: ${
     normalizedName || ACTIVATION_NEW_CONVERSATION_EMAIL_SUBJECT_FALLBACK
   }`;
 }


### PR DESCRIPTION
## Description
Renames the activation email notification subject from
[Dust] Recommendation For You: (LLM generated description) --> [Dust] Try this next: (LLM generated description)

## Tests
Updated the subject name in `project-new-conversation.test.ts`.

## Risk
Low risk

## Deploy Plan
Deploy front
