### PR TITLE
Fix attribution of late sandbox child actions

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -73,15 +73,42 @@ function selectRunUsagesNeedingEvidence({
   return usages.filter((usage) => {
     const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
+    const runActionById = new Map(
+      runActions.map((action) => [action.sId, action])
+    );
     const modelItemTypes = modelItemTypesByRunUsageModelId.get(
       usage.runUsageModelId
     );
-    const hasMissingActionItem = runActions.some(
-      (action) => !toolItemByActionModelId.has(action.id)
-    );
+    const hasUnexpectedMissingActionItem = runActions.some((action) => {
+      if (toolItemByActionModelId.has(action.id)) {
+        return false;
+      }
+
+      const childInfo = action.stepContext.sandboxChildActionInfo;
+      if (!isSandboxChildActionInfo(childInfo)) {
+        return true;
+      }
+
+      const parentAction = runActionById.get(childInfo.parentActionId);
+      if (!parentAction) {
+        return true;
+      }
+      const parentItem = toolItemByActionModelId.get(parentAction.id);
+
+      // A sandbox bash can create another child after an earlier attribution pass while its own
+      // tool item is still pending. The child is direct-charge-only, so adding its zero-footprint
+      // pending row cannot change the run's already-stored model-token partition. Require the
+      // durable parent relationship and the exact same producing run before accepting this gap.
+      return !(
+        parentItem?.completedAt === null &&
+        parentItem.runUsageId === usage.runUsageModelId &&
+        parentAction.stepContent.id === action.stepContent.id &&
+        parentAction.stepContent.dustRunId === dustRunId
+      );
+    });
     assert(
       !runUsageModelIdsWithEvidence.has(usage.runUsageModelId) ||
-        !hasMissingActionItem,
+        !hasUnexpectedMissingActionItem,
       "An attributed run usage is missing tool evidence"
     );
 

--- a/front/lib/api/sandbox/create_child_action.test.ts
+++ b/front/lib/api/sandbox/create_child_action.test.ts
@@ -21,20 +21,36 @@ vi.mock(
   }
 );
 
+vi.mock(import("@app/lib/api/provider_credentials"), () => ({
+  getLlmCredentials: vi.fn(),
+}));
+
+vi.mock(import("@app/lib/tokenization"), () => ({
+  tokenCountForTexts: vi.fn(),
+}));
+
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import { createSandboxChildAction } from "@app/lib/api/sandbox/create_child_action";
 import { Authenticator } from "@app/lib/auth";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { tokenCountForTexts } from "@app/lib/tokenization";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import { launchSandboxChildToolWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -43,16 +59,19 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { RunFactory } from "@app/tests/utils/RunFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
   ConversationType,
 } from "@app/types/assistant/conversation";
+import { Ok } from "@app/types/shared/result";
 import { slugify } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 
-const TOOL_NAME = "tool";
+const TOOL_NAME = "get-available-tables";
+const SECOND_TOOL_NAME = "get-audience-fields";
 
 describe("createSandboxChildAction", () => {
   let workspace: WorkspaceType;
@@ -66,6 +85,10 @@ describe("createSandboxChildAction", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.mocked(getLlmCredentials).mockResolvedValue({} as never);
+    vi.mocked(tokenCountForTexts).mockImplementation(
+      async (texts) => new Ok(texts.map(() => 2))
+    );
 
     const setup = await createResourceTest({ role: "admin" });
     workspace = setup.workspace;
@@ -76,6 +99,11 @@ describe("createSandboxChildAction", () => {
         {
           name: TOOL_NAME,
           description: "Tool description",
+          inputSchema: undefined,
+        },
+        {
+          name: SECOND_TOOL_NAME,
+          description: "Second tool description",
           inputSchema: undefined,
         },
       ],
@@ -174,7 +202,10 @@ describe("createSandboxChildAction", () => {
 
   async function callChildTool(
     rawInputs: Record<string, unknown> = { objectName: "Contact" },
-    { serverViewId = view.sId }: { serverViewId?: string } = {}
+    {
+      serverViewId = view.sId,
+      toolName = TOOL_NAME,
+    }: { serverViewId?: string; toolName?: string } = {}
   ) {
     return createSandboxChildAction(auth, {
       parentActionId,
@@ -183,18 +214,21 @@ describe("createSandboxChildAction", () => {
       conversationId: conversation.sId,
       agentMessageId: agentMessage.sId,
       serverViewId,
-      toolName: TOOL_NAME,
+      toolName,
       rawInputs,
     });
   }
 
   async function setToolPermission(
     permission: "medium" | "never_ask",
-    { enabled = true }: { enabled?: boolean } = {}
+    {
+      enabled = true,
+      toolName = TOOL_NAME,
+    }: { enabled?: boolean; toolName?: string } = {}
   ) {
     await RemoteMCPServerToolMetadataResource.updateOrCreateSettings(auth, {
       serverSId: serverId,
-      toolName: TOOL_NAME,
+      toolName,
       permission,
       enabled,
     });
@@ -247,6 +281,113 @@ describe("createSandboxChildAction", () => {
         }),
       })
     );
+  });
+
+  it("attributes a second sandbox child created after an earlier distinct child was attributed and errored", async () => {
+    await setToolPermission("never_ask");
+    await setToolPermission("medium", { toolName: SECOND_TOOL_NAME });
+
+    const parentAction = await AgentMCPActionResource.fetchById(
+      auth,
+      parentActionId
+    );
+    if (!parentAction) {
+      throw new Error("Expected the parent action to exist.");
+    }
+
+    const { run } = await RunFactory.createWithUsage(auth);
+    await Promise.all([
+      AgentMessageModel.update(
+        { runIds: [run.dustRunId] },
+        {
+          where: {
+            id: agentMessage.agentMessageId,
+            workspaceId: workspace.id,
+          },
+        }
+      ),
+      AgentStepContentModel.update(
+        { dustRunId: run.dustRunId },
+        {
+          where: {
+            id: parentAction.stepContent.id,
+            workspaceId: workspace.id,
+          },
+        }
+      ),
+      ConversationResource.updateAgentMessageCostCredits(auth, {
+        agentMessageModelId: agentMessage.agentMessageId,
+        costCredits: 10,
+      }),
+    ]);
+
+    const firstCall = await callChildTool({ source: "table" });
+    if (firstCall.isErr()) {
+      throw firstCall.error;
+    }
+    const firstChild = await AgentMCPActionResource.fetchById(
+      auth,
+      firstCall.value.actionId
+    );
+    if (!firstChild) {
+      throw new Error("Expected the first child action to exist.");
+    }
+    expect(firstChild.toolConfiguration.originalName).toBe(TOOL_NAME);
+
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId: agentMessage.sId,
+      conversationId: conversation.sId,
+    });
+
+    await firstChild.updateStatus("errored");
+
+    const secondCall = await callChildTool(
+      { audience: "contacts" },
+      { toolName: SECOND_TOOL_NAME }
+    );
+    if (secondCall.isErr()) {
+      throw secondCall.error;
+    }
+    const secondChild = await AgentMCPActionResource.fetchById(
+      auth,
+      secondCall.value.actionId
+    );
+    if (!secondChild) {
+      throw new Error("Expected the second child action to exist.");
+    }
+    expect(secondChild.toolConfiguration.originalName).toBe(SECOND_TOOL_NAME);
+
+    await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+      agentMessageId: agentMessage.sId,
+      conversationId: conversation.sId,
+    });
+
+    const toolItems = (
+      await AgentMessageConsumptionItemResource.listByAgentMessageModelIds(
+        auth,
+        {
+          agentMessageModelIds: [agentMessage.agentMessageId],
+          maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+        }
+      )
+    ).filter((item) => item.itemType === "tool");
+    const toolItemByActionId = new Map(
+      toolItems.map((item) => [item.agentMCPActionId, item])
+    );
+
+    expect(toolItems).toHaveLength(3);
+    expect(toolItemByActionId.get(parentAction.id)?.completedAt).toBeNull();
+    expect(toolItemByActionId.get(firstChild.id)).toMatchObject({
+      completedAt: expect.any(Date),
+      inputTokensCount: 0,
+      outputTokensCount: 0,
+    });
+    expect(toolItemByActionId.get(secondChild.id)).toMatchObject({
+      completedAt: null,
+      directCreditAmountMicro: null,
+      inputTokensCount: null,
+      outputTokensCount: 0,
+    });
   });
 
   it("auto-approves medium-stake tools when a direct-call approval exists", async () => {

--- a/front/scripts/verify_agent_message_consumption_attribution.ts
+++ b/front/scripts/verify_agent_message_consumption_attribution.ts
@@ -107,7 +107,7 @@ async function getCoverageSnapshot(
       return [];
     }
 
-    const dustRunId = action.stepContent.dustRunId;
+    const { dustRunId } = action.stepContent;
     if (!dustRunId) {
       return [];
     }

--- a/front/scripts/verify_agent_message_consumption_attribution.ts
+++ b/front/scripts/verify_agent_message_consumption_attribution.ts
@@ -113,7 +113,7 @@ async function getCoverageSnapshot(
     }
     const childInfo = action.stepContext.sandboxChildActionInfo;
     const parentAction = isSandboxChildActionInfo(childInfo)
-      ? actionBySId.get(childInfo.parentActionId)
+      ? actionById.get(childInfo.parentActionId)
       : undefined;
     const parentItem = parentAction
       ? toolItemByActionModelId.get(parentAction.id)

--- a/front/scripts/verify_agent_message_consumption_attribution.ts
+++ b/front/scripts/verify_agent_message_consumption_attribution.ts
@@ -83,7 +83,7 @@ async function getCoverageSnapshot(
       .filter((item) => item.itemType === "tool")
       .map((item) => [item.agentMCPActionId, item])
   );
-  const actionBySId = new Map(actions.map((action) => [action.sId, action]));
+  const actionById = new Map(actions.map((action) => [action.sId, action]));
   const dustRunIdByRunModelId = new Map(
     runs.map((run) => [run.id, run.dustRunId])
   );

--- a/front/scripts/verify_agent_message_consumption_attribution.ts
+++ b/front/scripts/verify_agent_message_consumption_attribution.ts
@@ -1,0 +1,251 @@
+/**
+ * Verifies action coverage for one agent message and, with --execute, invokes the exact
+ * attribution materializer used by the Temporal activity before reporting coverage again.
+ *
+ * Read-only inspection:
+ *   npx tsx scripts/verify_agent_message_consumption_attribution.ts \
+ *     --workspaceId <workspace-sId> \
+ *     --agentMessageId <agent-message-sId>
+ *
+ * Recompute and verify:
+ *   npx tsx scripts/verify_agent_message_consumption_attribution.ts \
+ *     --workspaceId <workspace-sId> \
+ *     --agentMessageId <agent-message-sId> \
+ *     --execute
+ */
+import { isSandboxChildActionInfo } from "@app/lib/actions/types";
+import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
+import { computeAndStoreAgentMessageConsumptionAttribution } from "@app/lib/api/assistant/agent_message_consumption_attribution/store";
+import { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { RunResource } from "@app/lib/resources/run_resource";
+import { makeScript } from "@app/scripts/helpers";
+import type { ModelId } from "@app/types/shared/model_id";
+
+type MissingActionCoverage = {
+  action: string;
+  actionModelId: ModelId;
+  tool: string;
+  status: string;
+  dustRunId: string;
+  runUsageIds: string;
+  parentAction: string;
+  parentItem: "completed" | "missing" | "pending" | "n/a";
+};
+
+type CoverageSnapshot = {
+  attributableActions: number;
+  actionItems: Array<{
+    actionModelId: ModelId;
+    itemModelId: ModelId;
+    inputTokens: number | null;
+    outputTokens: number | null;
+    directCredits: number | null;
+    completedAt: string;
+  }>;
+  currentToolItems: number;
+  missingActions: MissingActionCoverage[];
+};
+
+async function getCoverageSnapshot(
+  auth: Authenticator,
+  { agentMessageId }: { agentMessageId: string }
+): Promise<CoverageSnapshot> {
+  const creditContext =
+    await ConversationResource.fetchAgentMessageCreditContext(auth, {
+      agentMessageId,
+    });
+  if (!creditContext) {
+    throw new Error(`Agent message ${agentMessageId} was not found.`);
+  }
+
+  const dustRunIds = [...new Set(creditContext.runIds ?? [])];
+  const runs = await RunResource.listByDustRunIds(auth, { dustRunIds });
+  const usages = await RunResource.listRunUsagesForRuns(auth, { runs });
+  const [actions, items] = await Promise.all([
+    AgentMCPActionResource.listByAgentMessageIds(auth, [
+      creditContext.agentMessageModelId,
+    ]),
+    AgentMessageConsumptionItemResource.listByAgentMessageModelIds(auth, {
+      agentMessageModelIds: [creditContext.agentMessageModelId],
+      maxAttributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
+    }),
+  ]);
+
+  const currentItems = items.filter(
+    (item) =>
+      item.attributionVersion === AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION
+  );
+  const toolItemByActionModelId = new Map(
+    currentItems
+      .filter((item) => item.itemType === "tool")
+      .map((item) => [item.agentMCPActionId, item])
+  );
+  const actionBySId = new Map(actions.map((action) => [action.sId, action]));
+  const dustRunIdByRunModelId = new Map(
+    runs.map((run) => [run.id, run.dustRunId])
+  );
+  const runUsageIdsByDustRunId = new Map<string, ModelId[]>();
+  for (const usage of usages) {
+    const dustRunId = dustRunIdByRunModelId.get(usage.runModelId);
+    if (!dustRunId) {
+      continue;
+    }
+    const runUsageIds = runUsageIdsByDustRunId.get(dustRunId) ?? [];
+    runUsageIds.push(usage.runUsageModelId);
+    runUsageIdsByDustRunId.set(dustRunId, runUsageIds);
+  }
+
+  const attributableActions = actions.filter((action) => {
+    const dustRunId = action.stepContent.dustRunId;
+    return dustRunId && runUsageIdsByDustRunId.has(dustRunId);
+  });
+  const missingActions = attributableActions.flatMap((action) => {
+    if (toolItemByActionModelId.has(action.id)) {
+      return [];
+    }
+
+    const dustRunId = action.stepContent.dustRunId;
+    if (!dustRunId) {
+      return [];
+    }
+    const childInfo = action.stepContext.sandboxChildActionInfo;
+    const parentAction = isSandboxChildActionInfo(childInfo)
+      ? actionBySId.get(childInfo.parentActionId)
+      : undefined;
+    const parentItem = parentAction
+      ? toolItemByActionModelId.get(parentAction.id)
+      : undefined;
+
+    return [
+      {
+        action: action.sId,
+        actionModelId: action.id,
+        tool: action.toolConfiguration.originalName,
+        status: action.status,
+        dustRunId,
+        runUsageIds: (runUsageIdsByDustRunId.get(dustRunId) ?? []).join(","),
+        parentAction: parentAction?.sId ?? "n/a",
+        parentItem: parentAction
+          ? parentItem?.completedAt === null
+            ? "pending"
+            : parentItem
+              ? "completed"
+              : "missing"
+          : "n/a",
+      } satisfies MissingActionCoverage,
+    ];
+  });
+
+  return {
+    attributableActions: attributableActions.length,
+    actionItems: attributableActions.flatMap((action) => {
+      const item = toolItemByActionModelId.get(action.id);
+      return item
+        ? [
+            {
+              actionModelId: action.id,
+              itemModelId: item.id,
+              inputTokens: item.inputTokensCount,
+              outputTokens: item.outputTokensCount,
+              directCredits:
+                item.directCreditAmountMicro === null
+                  ? null
+                  : item.directCreditAmountMicro / 1_000_000,
+              completedAt: item.completedAt?.toISOString() ?? "pending",
+            },
+          ]
+        : [];
+    }),
+    currentToolItems: toolItemByActionModelId.size,
+    missingActions,
+  };
+}
+
+function printCoverage(label: string, snapshot: CoverageSnapshot): void {
+  console.log(`\n${label}`);
+  console.table([
+    {
+      attributableActions: snapshot.attributableActions,
+      currentToolItems: snapshot.currentToolItems,
+      missingActions: snapshot.missingActions.length,
+    },
+  ]);
+  if (snapshot.missingActions.length > 0) {
+    console.log("\nMissing action items");
+    console.table(snapshot.missingActions);
+  }
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      demandOption: true,
+      description: "Workspace sId.",
+    },
+    agentMessageId: {
+      type: "string",
+      demandOption: true,
+      description: "Agent message sId.",
+    },
+  },
+  async ({ agentMessageId, execute, workspaceId }) => {
+    const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+    const analyticsContext =
+      await ConversationResource.fetchAgentMessageConsumptionAnalyticsContext(
+        auth,
+        { agentMessageId }
+      );
+    if (!analyticsContext) {
+      throw new Error(
+        `Consumption context for agent message ${agentMessageId} was not found.`
+      );
+    }
+
+    const before = await getCoverageSnapshot(auth, { agentMessageId });
+    printCoverage("Before attribution", before);
+
+    if (!execute) {
+      return;
+    }
+
+    const consumptionUpdate =
+      await computeAndStoreAgentMessageConsumptionAttribution(auth, {
+        agentMessageId,
+        conversationId: analyticsContext.conversation.conversationId,
+      });
+    console.log("\nAttribution result", consumptionUpdate ?? "incomplete");
+
+    const after = await getCoverageSnapshot(auth, { agentMessageId });
+    printCoverage("After attribution", after);
+
+    const remainingMissingActionIds = new Set(
+      after.missingActions.map((action) => action.actionModelId)
+    );
+    const afterItemByActionModelId = new Map(
+      after.actionItems.map((item) => [item.actionModelId, item])
+    );
+    const createdActionItems = before.missingActions.flatMap((action) => {
+      if (remainingMissingActionIds.has(action.actionModelId)) {
+        return [];
+      }
+      const item = afterItemByActionModelId.get(action.actionModelId);
+      return item
+        ? [{ action: action.action, tool: action.tool, ...item }]
+        : [];
+    });
+    if (createdActionItems.length > 0) {
+      console.log("\nCreated action items");
+      console.table(createdActionItems);
+    }
+
+    if (after.missingActions.length > 0) {
+      throw new Error(
+        `${after.missingActions.length} attributable action(s) still lack current-version tool items.`
+      );
+    }
+  }
+);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We observed a few churning attribution workflows repeatedly failing with:

```
AssertionError: An attributed run usage is missing tool evidence
```

One LLM run produced a `sandbox__bash` parent. During that same bash execution, two distinct `dsbx` calls occurred sequentially:
1. `get-available-tables`
2. `get-audience-fields`

They shared the same parent action, step content, and dustRunId, but had different tool names and input hashes.

The first attribution pass ran while the parent was still pending and persisted:
- The model usage items.
- The pending parent bash item.
- The first sandbox-child item.

Five minutes later, the first child errored and the same bash process created the second child, which blocked for approval.

### Failure

On the next attribution pass, the workflow correctly fetched fresh database state. It found the second action but no corresponding consumption item.

The coverage assertion rejected any new action belonging to an already-attributed run before the existing `hasActionNeedingEvidence` path could process it. Temporal retries therefore encountered the same
deterministic failure.

This PR fixes by allowing a missing action item only when all of the following prove it is a legitimate continuation:
- It is a sandbox child.
- Its referenced parent exists.
- The parent consumption item is still pending.
- Parent and child share the same step and producing run usage.

The existing attribution workflow then:

- Completes previously pending children that have finished.
- Creates the new child’s zero-footprint pending item.
- Leaves the parent pending until its actual bash result becomes available.
- Preserves the already-stored model-token partition.

Missing ordinary/model-visible actions, missing parents, completed parents, or mismatched runs still trigger the assertion.

No consumption items are created outside the attribution workflow.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
