### PR TITLE
Prevent sandbox parent action rewinds

### DIFF
--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -103,10 +103,8 @@ export async function getExitOrPauseEvents(
       const { blockingEvents, state } = exitOutputItem;
 
       if (isAgentLoopRunContext(runContext)) {
-        // Update the action status to blocked_child_action_input_required to break the agent loop.
-        await runContext.action.updateStatus(
-          "blocked_child_action_input_required"
-        );
+        // Break the agent loop without allowing a stale pause event to rewind a final action.
+        await runContext.action.blockForSandboxChild(auth);
 
         // Update the step context to save the resume state.
         await runContext.action.updateStepContext({

--- a/front/lib/api/sandbox/sandbox_child_block.test.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.test.ts
@@ -8,13 +8,17 @@ vi.mock("@app/temporal/agent_loop/client", () => ({
 
 import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import { resolveSandboxChildBlock } from "@app/lib/api/sandbox/sandbox_child_block";
+import {
+  pauseSandboxBashForBlockedChild,
+  resolveSandboxChildBlock,
+} from "@app/lib/api/sandbox/sandbox_child_block";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -34,7 +38,7 @@ const AGENT_LOOP_ARGS = {
   userMessageOrigin: "api",
 } as const;
 
-describe("resolveSandboxChildBlock", () => {
+describe("sandbox child blocking", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;
   let conversation: ConversationType;
@@ -166,6 +170,82 @@ describe("resolveSandboxChildBlock", () => {
       agentLoopArgs: AGENT_LOOP_ARGS,
     });
   }
+
+  it("atomically blocks a running parent before pausing its sandbox", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "running",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_authentication_required",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(child).not.toBeNull();
+    const pauseSandbox = vi
+      .spyOn(ConversationSandboxAdapter, "pauseSandboxForApproval")
+      .mockResolvedValue(new Ok(undefined));
+
+    await pauseSandboxBashForBlockedChild(auth, child!, conversation);
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(parent?.status).toBe("blocked_child_action_input_required");
+    expect(pauseSandbox).toHaveBeenCalledTimes(1);
+    pauseSandbox.mockRestore();
+  });
+
+  it("keeps an already-blocked parent blocked for a concurrent sibling", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "blocked_child_action_input_required",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(child).not.toBeNull();
+    const pauseSandbox = vi
+      .spyOn(ConversationSandboxAdapter, "pauseSandboxForApproval")
+      .mockResolvedValue(new Ok(undefined));
+
+    await pauseSandboxBashForBlockedChild(auth, child!, conversation);
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(parent?.status).toBe("blocked_child_action_input_required");
+    expect(pauseSandbox).toHaveBeenCalledTimes(1);
+    pauseSandbox.mockRestore();
+  });
+
+  it("does not rewind a completed parent when a stale child blocks", async () => {
+    const { sId: parentId } = await createAction({
+      name: "bash",
+      status: "succeeded",
+    });
+    const { sId: childId } = await createAction({
+      name: "child_tool",
+      status: "blocked_validation_required",
+      sandboxChildActionInfo: { parentActionId: parentId },
+    });
+    const child = await AgentMCPActionResource.fetchById(auth, childId);
+    expect(child).not.toBeNull();
+    const pauseSandbox = vi
+      .spyOn(ConversationSandboxAdapter, "pauseSandboxForApproval")
+      .mockResolvedValue(new Ok(undefined));
+
+    await expect(
+      pauseSandboxBashForBlockedChild(auth, child!, conversation)
+    ).rejects.toThrow(
+      "cannot transition from succeeded to blocked_child_action_input_required"
+    );
+
+    const parent = await AgentMCPActionResource.fetchById(auth, parentId);
+    expect(parent?.status).toBe("succeeded");
+    expect(pauseSandbox).not.toHaveBeenCalled();
+    pauseSandbox.mockRestore();
+  });
 
   it("relaunches the parent loop when it is blocked, has an execId, and no sibling is still blocked", async () => {
     const { sId: parentId } = await createAction({

--- a/front/lib/api/sandbox/sandbox_child_block.ts
+++ b/front/lib/api/sandbox/sandbox_child_block.ts
@@ -50,13 +50,10 @@ export async function pauseSandboxBashForBlockedChild(
     return;
   }
 
-  // Flip the action status BEFORE pausing the sandbox provider. If the
-  // provider pause then fails, the bash exec inside the sandbox is still
-  // synchronously blocked on the dust-call awaiting the child response —
-  // so when the child resolves, resolveSandboxChildBlock observes the
-  // parent as blocked, relaunches in resume mode, and the running bash
-  // reconnects via execId. DB-first is the self-converging shape.
-  await parentAction.updateStatus("blocked_child_action_input_required");
+  // DB-first keeps the pause self-converging if the provider call fails. The resource owns the
+  // atomic lifecycle check: running parents become blocked, concurrent siblings are idempotent,
+  // and a stale child attempting to rewind a final parent fails loudly.
+  await parentAction.blockForSandboxChild(auth);
 
   const pauseResult = await ConversationSandboxAdapter.pauseSandboxForApproval(
     auth,
@@ -194,7 +191,22 @@ export async function resolveSandboxChildBlock(
   // we log loudly below — the inverse order would risk launching against a
   // parent still marked `blocked_child_action_input_required`, which the
   // resume path treats as "still paused" and would no-op.
-  await parentAction.updateStatus("ready_allowed_explicitly");
+  const [updatedCount] = await parentAction.updateStatusFromExpected(auth, {
+    status: "ready_allowed_explicitly",
+    expectedStatus: "blocked_child_action_input_required",
+  });
+  if (updatedCount !== 1) {
+    logger.info(
+      {
+        actionId: action.sId,
+        parentActionId,
+        conversationId: agentLoopArgs.conversationId,
+        workspaceId,
+      },
+      "Sandbox parent advanced while resolving child — skipping relaunch"
+    );
+    return;
+  }
 
   const launchResult = await launchAgentLoopWorkflow({
     auth,

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -398,6 +398,45 @@ describe("listBlockedActionsForConversation", () => {
     );
     expect(reloadedAction?.status).toBe("blocked_validation_required");
   });
+
+  it("does not rewind a final action through a stale sandbox parent resource", async () => {
+    const agentMessage = await AgentMessageModel.create({
+      conversationId: conversation.id,
+      workspaceId: workspace.id,
+      agentConfigurationId: "test-agent",
+      agentConfigurationVersion: 0,
+      status: "created",
+      skipToolsValidation: false,
+    });
+    const { action } = await createBlockedAction({
+      agentMessageModelId: agentMessage.id,
+    });
+    await action.updateStatus("running");
+
+    const staleParent = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId
+    );
+    const currentParent = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId
+    );
+    if (!staleParent || !currentParent) {
+      throw new Error("Expected both sandbox parent resources to exist.");
+    }
+    expect(staleParent.status).toBe("running");
+    expect(currentParent.status).toBe("running");
+    await currentParent.updateStatus("succeeded");
+
+    await expect(staleParent.blockForSandboxChild(auth)).rejects.toThrow(
+      "cannot transition from succeeded to blocked_child_action_input_required"
+    );
+    const reloadedParent = await AgentMCPActionResource.fetchById(
+      auth,
+      action.sId
+    );
+    expect(reloadedParent?.status).toBe("succeeded");
+  });
 });
 
 describe("Output items with GCS storage", () => {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -1544,6 +1544,41 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   }
 
   /**
+   * Atomically blocks a running sandbox parent. Multiple children may block concurrently, so the
+   * target status is idempotent. Every other source status is an invariant violation: in
+   * particular, a late sandbox child must never rewind a final parent into a resumable state.
+   */
+  async blockForSandboxChild(auth: Authenticator): Promise<void> {
+    await withTransaction(async (transaction) => {
+      const action = await AgentMCPActionModel.findOne({
+        attributes: ["id", "status"],
+        where: {
+          id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+        lock: transaction.LOCK.UPDATE,
+      });
+      assert(action, `Sandbox parent action ${this.sId} no longer exists.`);
+
+      if (action.status === "blocked_child_action_input_required") {
+        return;
+      }
+      assert(
+        action.status === "running",
+        `Sandbox parent action ${this.sId} cannot transition from ${action.status} to blocked_child_action_input_required.`
+      );
+
+      await action.update(
+        { status: "blocked_child_action_input_required" },
+        { transaction }
+      );
+    });
+
+    Object.assign(this, { status: "blocked_child_action_input_required" });
+  }
+
+  /**
    * Updates only if the action still has the expected status. Combined with the invariant that
    * blocked actions are denied in the same transaction as their message's terminal status update
    * (see updateAgentMessageWithFinalStatus), a blocked-status transition implies resumability.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While debugging stuck analytics workflows, I've discovered that somehow a sandbox parent action whose consumption
item was completed, while the action had moved back to `blocked_child_action_input_required`.

This proved that a late sandbox-child pause could rewind a final parent action. The transition was written unconditionally from two paths.

This PR adds some guards around preventing this (yes, it fails hard but for good reasons, and TBH there is not good way to handle this at an application level)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
