### PR TITLE
feat: download instead of (re)triggering when a consumption export is cached

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -191,6 +191,19 @@ describe("POST /api/w/:wId/analytics/consumption/export-raw", () => {
     expect(startWorkflowMock).toHaveBeenCalledTimes(1);
   });
 
+  it("returns the cached export's name instead of starting a new workflow when one already exists", async () => {
+    fileStorageMock.setFileExists(() => true);
+    const { workspace } = await setupTest({ role: "admin" });
+
+    const response = await postExportRawRequest(workspace.sId, {});
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.isGenerating).toBe(false);
+    expect(body.name).toMatch(/^[A-Za-z0-9_-]+\.csv$/);
+    expect(startWorkflowMock).not.toHaveBeenCalled();
+  });
+
   it("is refused to non-managers", async () => {
     const { workspace } = await setupTest({ role: "user" });
 

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.ts
@@ -70,6 +70,16 @@ app.post(
       });
     }
 
+    // Already generated for this exact period+filter: nothing was (re)triggered, so the
+    // caller can go straight to downloading it instead of switching into a "generating" state.
+    if (result.value.status === "cached") {
+      const { gcsPath } = result.value;
+      return ctx.json({
+        isGenerating: false,
+        name: gcsPath.split("/").pop() ?? gcsPath,
+      });
+    }
+
     return ctx.json({ isGenerating: true }, 202);
   }
 );

--- a/front/hooks/useConsumptionExports.ts
+++ b/front/hooks/useConsumptionExports.ts
@@ -1,5 +1,8 @@
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { ConsumptionExportListItem } from "@app/lib/api/analytics/consumption/export_jobs";
+import type {
+  ConsumptionExportListItem,
+  StartConsumptionExportResponse,
+} from "@app/lib/api/analytics/consumption/export_jobs";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
@@ -77,6 +80,14 @@ export function useStartConsumptionExport({
           });
           return;
         }
+
+        const data: StartConsumptionExportResponse = await response.json();
+        if (!data.isGenerating) {
+          // Already generated for this exact period+filter: nothing was (re)triggered, so go
+          // straight to the download instead of showing a "generating" state for nothing.
+          window.location.href = `${url}/${data.name}/download`;
+        }
+
         await mutate([statusUrl, body, "POST"]);
       } finally {
         setIsStarting(false);

--- a/front/hooks/useConsumptionExports.ts
+++ b/front/hooks/useConsumptionExports.ts
@@ -4,6 +4,7 @@ import type {
   StartConsumptionExportResponse,
 } from "@app/lib/api/analytics/consumption/export_jobs";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
+import { getBaseUrl } from "@app/lib/api/config";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { useCallback, useState } from "react";
@@ -85,7 +86,7 @@ export function useStartConsumptionExport({
         if (!data.isGenerating) {
           // Already generated for this exact period+filter: nothing was (re)triggered, so go
           // straight to the download instead of showing a "generating" state for nothing.
-          window.location.href = `${url}/${data.name}/download`;
+          window.location.href = `${getBaseUrl()}${url}/${data.name}/download`;
         }
 
         await mutate([statusUrl, body, "POST"]);

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -29,6 +29,12 @@ export type ConsumptionExportListItem = {
   sizeBytes: number;
 };
 
+// Response shape of `POST .../export-raw`: either a new generation was (re)triggered, or one
+// already existed for this exact period+filter and the caller can download it directly.
+export type StartConsumptionExportResponse =
+  | { isGenerating: true }
+  | { isGenerating: false; name: string };
+
 export async function listConsumptionExports(
   auth: Authenticator
 ): Promise<ConsumptionExportListItem[]> {

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -29,8 +29,8 @@ export type ConsumptionExportListItem = {
   sizeBytes: number;
 };
 
-// Response shape of `POST .../export-raw`: either a new generation was (re)triggered, or one
-// already existed for this exact period+filter and the caller can download it directly.
+// Either a new generation was (re)triggered, or one already existed for
+// this exact period+filter and the caller can download it directly.
 export type StartConsumptionExportResponse =
   | { isGenerating: true }
   | { isGenerating: false; name: string };

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -29,8 +29,6 @@ export type ConsumptionExportListItem = {
   sizeBytes: number;
 };
 
-// Either a new generation was (re)triggered, or one already existed for
-// this exact period+filter and the caller can download it directly.
 export type StartConsumptionExportResponse =
   | { isGenerating: true }
   | { isGenerating: false; name: string };


### PR DESCRIPTION
## Description

Stacked on top of #30716.

Clicking "New export" (or the auto-start flow) for a period+filter that already had a completed export hit the same `"cached"` branch `launchConsumptionExportWorkflow` already used for the status check, but the start endpoint ignored it and always told the caller a workflow was generating (`{ isGenerating: true }`), even though nothing was actually (re)triggered.

Now the endpoint reports the cached export's file name instead, and the client goes straight to downloading it rather than switching into a misleading "generating" state.

## Tests

- `front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts`: covers the new cached-name response and that no workflow gets started.

## Risk

Low

## Deploy Plan

- Deploy front