### PR TITLE
[front] perf: add caching on `GroupResource` lookups by ID

### DIFF
--- a/front-api/lib/api/poke/cache_catalog.test.ts
+++ b/front-api/lib/api/poke/cache_catalog.test.ts
@@ -10,12 +10,10 @@ describe("Poke cache catalog", () => {
     const workspace = getPokeCacheOperations("workspace_by_sid");
     const activeSeats = getPokeCacheOperations("workspace_active_seats");
 
-    expect(
-      group?.buildKey({ workspaceModelId: "42", groupModelId: "7" })
-    ).toBe("cacheWithRedis-group_by_model_id-v1:workspace:42:group:7");
-    expect(group?.keyPattern).toBe(
-      "cacheWithRedis-group_by_model_id-v1:*"
+    expect(group?.buildKey({ workspaceModelId: "42", groupModelId: "7" })).toBe(
+      "cacheWithRedis-group_by_model_id-v1:workspace:42:group:7"
     );
+    expect(group?.keyPattern).toBe("cacheWithRedis-group_by_model_id-v1:*");
     expect(workspace?.buildKey({ wId: "workspace-1" })).toBe(
       "cacheWithRedis-_fetchByIdUncached-workspace:v2:workspace-1"
     );

--- a/front-api/lib/api/poke/cache_catalog.test.ts
+++ b/front-api/lib/api/poke/cache_catalog.test.ts
@@ -6,9 +6,16 @@ import { describe, expect, it } from "vitest";
 
 describe("Poke cache catalog", () => {
   it("uses owner-defined operations for migrated caches", () => {
+    const group = getPokeCacheOperations("group_by_model_id");
     const workspace = getPokeCacheOperations("workspace_by_sid");
     const activeSeats = getPokeCacheOperations("workspace_active_seats");
 
+    expect(
+      group?.buildKey({ workspaceModelId: "42", groupModelId: "7" })
+    ).toBe("cacheWithRedis-group_by_model_id-v1:workspace:42:group:7");
+    expect(group?.keyPattern).toBe(
+      "cacheWithRedis-group_by_model_id-v1:*"
+    );
     expect(workspace?.buildKey({ wId: "workspace-1" })).toBe(
       "cacheWithRedis-_fetchByIdUncached-workspace:v2:workspace-1"
     );
@@ -32,6 +39,7 @@ describe("Poke cache catalog", () => {
     const catalog = getPokeCacheCatalog();
     const ids = catalog.map((entry) => entry.id);
 
+    expect(ids.filter((id) => id === "group_by_model_id")).toHaveLength(1);
     expect(ids.filter((id) => id === "workspace_by_sid")).toHaveLength(1);
     expect(ids.filter((id) => id === "workspace_active_seats")).toHaveLength(1);
   });

--- a/front-api/lib/api/poke/cache_catalog.ts
+++ b/front-api/lib/api/poke/cache_catalog.ts
@@ -1,5 +1,6 @@
 import { workspaceActiveSeatsCacheOperations } from "@app/lib/api/workspace_seats/cache";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { CacheOperations } from "@app/lib/utils/cache_operations";
 import type { PokeCacheResourceDescriptor } from "@app/types/api/poke/cache";
@@ -11,6 +12,7 @@ import {
 
 const migratedCacheOperations = [
   GroupPermissionResource.cacheOperations,
+  GroupResource.byModelIdCacheOperations,
   WorkspaceResource.byIdCacheOperations,
   workspaceActiveSeatsCacheOperations,
 ];

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1446,6 +1446,12 @@ export async function batchHardDeletePendingAgentConfigurations(
         where: { id: groupIds, workspaceId },
         transaction: t,
       });
+
+      await GroupResource.invalidateByModelIdsCache({
+        workspaceModelId: workspaceId,
+        groupModelIds: groupIds,
+        transaction: t,
+      });
     }
 
     // Delete agent suggestions before agents (FK constraint)

--- a/front/lib/api/resources/cached_resource_lookup.ts
+++ b/front/lib/api/resources/cached_resource_lookup.ts
@@ -112,10 +112,6 @@ type OperableCachedResourceBatchLookup<Input, Resource> =
       inputs: Input[],
       transaction?: Transaction
     ) => Promise<Resource[]>;
-    invalidateMany: (
-      inputs: Input[],
-      transaction?: Transaction
-    ) => Promise<void>;
   };
 
 // Marks database errors so they are not mistaken for Redis failures and retried by the database
@@ -290,7 +286,6 @@ export function defineCachedResourceBatchLookup<Input, Snapshot, Resource>({
   Snapshot,
   Resource
 >): OperableCachedResourceBatchLookup<Input, Resource> {
-  const versionedKey = (input: Input) => `v${version}:${key(input)}`;
   const loadFromDatabase = async (
     input: Input,
     transaction?: Transaction
@@ -306,13 +301,8 @@ export function defineCachedResourceBatchLookup<Input, Snapshot, Resource>({
     toSnapshot,
     fromSnapshot,
   });
-  const invalidateManySnapshots = batchInvalidateCacheWithRedis(
-    loadFromDatabase,
-    versionedKey,
-    { cacheId: id }
-  );
   const cacheKey = (input: Input) =>
-    buildCacheWithRedisKey(id, versionedKey(input));
+    buildCacheWithRedisKey(id, `v${version}:${key(input)}`);
 
   return {
     ...lookup,
@@ -413,23 +403,6 @@ export function defineCachedResourceBatchLookup<Input, Snapshot, Resource>({
         );
         return loadManyFromDatabase(uniqueInputs);
       }
-    },
-    invalidateMany: async (inputs, transaction) => {
-      if (inputs.length === 0) {
-        return;
-      }
-
-      const uniqueInputs = [
-        ...new Map(inputs.map((input) => [cacheKey(input), input])).values(),
-      ];
-      const invalidate = () =>
-        invalidateManySnapshots(uniqueInputs.map((input) => [input]));
-
-      if (transaction) {
-        invalidateCacheAfterCommit(transaction, invalidate);
-        return;
-      }
-      await invalidate();
     },
   };
 }

--- a/front/lib/api/resources/cached_resource_lookup.ts
+++ b/front/lib/api/resources/cached_resource_lookup.ts
@@ -1,3 +1,4 @@
+import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { JsonSerializable } from "@app/lib/utils/cache";
 import {
   batchInvalidateCacheWithRedis,
@@ -39,6 +40,18 @@ type CachedResourceLookupDefinition<Input, Snapshot, Resource> = {
   fromSnapshot: (
     snapshot: JsonSerializable<Snapshot>
   ) => Promise<Resource> | Resource;
+};
+
+type CachedResourceBatchLookupDefinition<Input, Snapshot, Resource> = Omit<
+  CachedResourceLookupDefinition<Input, Snapshot, Resource>,
+  "loadFromDatabase" | "readFromKeyFirst"
+> & {
+  loadManyFromDatabase: (
+    inputs: Input[],
+    transaction?: Transaction
+  ) => Promise<Resource[]>;
+  inputFromResource: (resource: Resource) => Input;
+  parseSnapshot: (serializedSnapshot: string) => JsonSerializable<Snapshot>;
 };
 
 export type CachedResourceLookup<Input, Resource> = {
@@ -92,6 +105,14 @@ type OperableCachedResourceList<Input, Resource> = CachedResourceList<
     toLookupInput: (input: OperationsInput) => Input;
   }) => CacheOperations;
 };
+
+type OperableCachedResourceBatchLookup<Input, Resource> =
+  OperableCachedResourceLookup<Input, Resource> & {
+    fetchMany: (
+      inputs: Input[],
+      transaction?: Transaction
+    ) => Promise<Resource[]>;
+  };
 
 // Marks database errors so they are not mistaken for Redis failures and retried by the database
 // fallback below.
@@ -244,5 +265,140 @@ export function defineCachedResourceList<Input, Snapshot, Resource>(
     invalidate: lookup.invalidate,
     invalidateMany: lookup.invalidateMany,
     createCacheOperations: lookup.createCacheOperations,
+  };
+}
+
+/**
+ * Batched counterpart of `defineCachedResourceLookup`. Each Resource keeps its own cache key,
+ * while cache misses are loaded from the database in one query.
+ */
+export function defineCachedResourceBatchLookup<Input, Snapshot, Resource>({
+  id,
+  version,
+  key,
+  loadManyFromDatabase,
+  inputFromResource,
+  toSnapshot,
+  fromSnapshot,
+  parseSnapshot,
+}: CachedResourceBatchLookupDefinition<
+  Input,
+  Snapshot,
+  Resource
+>): OperableCachedResourceBatchLookup<Input, Resource> {
+  const lookup = defineCachedResourceLookup({
+    id,
+    version,
+    key,
+    loadFromDatabase: async (input: Input, transaction?: Transaction) => {
+      const [resource] = await loadManyFromDatabase([input], transaction);
+      return resource ?? null;
+    },
+    toSnapshot,
+    fromSnapshot,
+  });
+  const cacheKey = (input: Input) =>
+    buildCacheWithRedisKey(id, `v${version}:${key(input)}`);
+
+  return {
+    ...lookup,
+    fetchMany: async (inputs, transaction) => {
+      if (inputs.length === 0) {
+        return [];
+      }
+
+      const uniqueInputsByKey = new Map(
+        inputs.map((input) => [cacheKey(input), input])
+      );
+      const uniqueInputs = [...uniqueInputsByKey.values()];
+
+      if (transaction) {
+        return loadManyFromDatabase(uniqueInputs, transaction);
+      }
+
+      try {
+        const redis = await getRedisCacheClient({ origin: "cache_with_redis" });
+        const serializedSnapshots = await redis.mGet([
+          ...uniqueInputsByKey.keys(),
+        ]);
+        const resourcesByKey = new Map<string, Resource>();
+        const missingInputs: Input[] = [];
+
+        for (const [index, input] of uniqueInputs.entries()) {
+          const serializedSnapshot = serializedSnapshots[index];
+          if (serializedSnapshot === null) {
+            missingInputs.push(input);
+            continue;
+          }
+          if (serializedSnapshot === undefined) {
+            throw new Error("Missing Redis result for Resource cache key");
+          }
+
+          resourcesByKey.set(
+            cacheKey(input),
+            await fromSnapshot(parseSnapshot(serializedSnapshot))
+          );
+        }
+
+        if (missingInputs.length > 0) {
+          let loadedResources: Resource[];
+          try {
+            loadedResources = await loadManyFromDatabase(missingInputs);
+          } catch (err) {
+            throw new ResourceDatabaseLoadError(err);
+          }
+
+          const missingKeys = new Set(missingInputs.map(cacheKey));
+          const snapshotsToCache: {
+            key: string;
+            snapshot: JsonSerializable<Snapshot>;
+          }[] = [];
+          for (const resource of loadedResources) {
+            const resourceKey = cacheKey(inputFromResource(resource));
+            if (!missingKeys.has(resourceKey)) {
+              continue;
+            }
+            resourcesByKey.set(resourceKey, resource);
+            snapshotsToCache.push({
+              key: resourceKey,
+              snapshot: toSnapshot(resource),
+            });
+          }
+
+          if (snapshotsToCache.length > 0) {
+            try {
+              const multi = redis.multi();
+              for (const { key: snapshotKey, snapshot } of snapshotsToCache) {
+                multi.set(snapshotKey, JSON.stringify(snapshot));
+              }
+              await multi.exec();
+            } catch (err) {
+              logger.warn(
+                { cacheId: id, err: normalizeError(err) },
+                "Resource cache write failed; returning database results"
+              );
+            }
+          }
+        }
+
+        const resources: Resource[] = [];
+        for (const input of uniqueInputs) {
+          const resource = resourcesByKey.get(cacheKey(input));
+          if (resource !== undefined) {
+            resources.push(resource);
+          }
+        }
+        return resources;
+      } catch (err) {
+        if (err instanceof ResourceDatabaseLoadError) {
+          throw err.cause;
+        }
+        logger.warn(
+          { cacheId: id, err: normalizeError(err) },
+          "Resource cache read failed; falling back to the database"
+        );
+        return loadManyFromDatabase(uniqueInputs);
+      }
+    },
   };
 }

--- a/front/lib/api/resources/cached_resource_lookup.ts
+++ b/front/lib/api/resources/cached_resource_lookup.ts
@@ -112,6 +112,10 @@ type OperableCachedResourceBatchLookup<Input, Resource> =
       inputs: Input[],
       transaction?: Transaction
     ) => Promise<Resource[]>;
+    invalidateMany: (
+      inputs: Input[],
+      transaction?: Transaction
+    ) => Promise<void>;
   };
 
 // Marks database errors so they are not mistaken for Redis failures and retried by the database
@@ -286,19 +290,29 @@ export function defineCachedResourceBatchLookup<Input, Snapshot, Resource>({
   Snapshot,
   Resource
 >): OperableCachedResourceBatchLookup<Input, Resource> {
+  const versionedKey = (input: Input) => `v${version}:${key(input)}`;
+  const loadFromDatabase = async (
+    input: Input,
+    transaction?: Transaction
+  ): Promise<Resource | null> => {
+    const [resource] = await loadManyFromDatabase([input], transaction);
+    return resource ?? null;
+  };
   const lookup = defineCachedResourceLookup({
     id,
     version,
     key,
-    loadFromDatabase: async (input: Input, transaction?: Transaction) => {
-      const [resource] = await loadManyFromDatabase([input], transaction);
-      return resource ?? null;
-    },
+    loadFromDatabase,
     toSnapshot,
     fromSnapshot,
   });
+  const invalidateManySnapshots = batchInvalidateCacheWithRedis(
+    loadFromDatabase,
+    versionedKey,
+    { cacheId: id }
+  );
   const cacheKey = (input: Input) =>
-    buildCacheWithRedisKey(id, `v${version}:${key(input)}`);
+    buildCacheWithRedisKey(id, versionedKey(input));
 
   return {
     ...lookup,
@@ -399,6 +413,23 @@ export function defineCachedResourceBatchLookup<Input, Snapshot, Resource>({
         );
         return loadManyFromDatabase(uniqueInputs);
       }
+    },
+    invalidateMany: async (inputs, transaction) => {
+      if (inputs.length === 0) {
+        return;
+      }
+
+      const uniqueInputs = [
+        ...new Map(inputs.map((input) => [cacheKey(input), input])).values(),
+      ];
+      const invalidate = () =>
+        invalidateManySnapshots(uniqueInputs.map((input) => [input]));
+
+      if (transaction) {
+        invalidateCacheAfterCommit(transaction, invalidate);
+        return;
+      }
+      await invalidate();
     },
   };
 }

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -3,10 +3,33 @@ import { getNamespace } from "@app/tests/utils/test_cls";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const inMemoryCache = vi.hoisted(() => new Map<string, string>());
+const cacheReadFailure = vi.hoisted(() => ({ current: null as Error | null }));
 
 vi.mock("@app/lib/api/redis", () => ({
   getRedisCacheClient: vi.fn().mockImplementation(() =>
     Promise.resolve({
+      mGet: vi.fn().mockImplementation((keys: string[]) => {
+        if (cacheReadFailure.current) {
+          throw cacheReadFailure.current;
+        }
+        return Promise.resolve(keys.map((key) => inMemoryCache.get(key) ?? null));
+      }),
+      multi: vi.fn().mockImplementation(() => {
+        const values = new Map<string, string>();
+        const multi = {
+          set: vi.fn().mockImplementation((key: string, value: string) => {
+            values.set(key, value);
+            return multi;
+          }),
+          exec: vi.fn().mockImplementation(() => {
+            for (const [key, value] of values) {
+              inMemoryCache.set(key, value);
+            }
+            return Promise.resolve([]);
+          }),
+        };
+        return multi;
+      }),
       del: vi.fn().mockImplementation((keyOrKeys: string | string[]) => {
         const keys = Array.isArray(keyOrKeys) ? keyOrKeys : [keyOrKeys];
         keys.forEach((key) => inMemoryCache.delete(key));
@@ -44,10 +67,11 @@ vi.mock("@app/lib/utils/cache", async (importOriginal) => {
       .mockImplementation(
         <T, Args extends unknown[]>(
           fn: CacheableFunction<JsonSerializable<T>, Args>,
-          resolver: (...args: Args) => string
+          resolver: (...args: Args) => string,
+          options?: { cacheId?: string }
         ) => {
           return async (...args: Args): Promise<void> => {
-            const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+            const key = `cacheWithRedis-${options?.cacheId ?? fn.name}-${resolver(...args)}`;
             inMemoryCache.delete(key);
           };
         }
@@ -99,6 +123,16 @@ function getCacheKeyForWorkspaceGroupsFromSystemKey(
   return `cacheWithRedis-_listWorkspaceGroupsFromSystemKeyUncached-workspace-groups-from-system-key:${workspaceId}`;
 }
 
+function getCacheKeyForGroup(
+  workspaceModelId: number,
+  groupModelId: number
+): string {
+  return GroupResource.byModelIdCacheOperations.buildKey({
+    workspaceModelId: String(workspaceModelId),
+    groupModelId: String(groupModelId),
+  });
+}
+
 describe("GroupResource", () => {
   let workspace: LightWorkspaceType;
   let user: UserResource;
@@ -113,26 +147,100 @@ describe("GroupResource", () => {
     authenticator = testSetup.authenticator;
     globalGroup = testSetup.globalGroup;
     systemGroup = testSetup.systemGroup;
+    cacheReadFailure.current = null;
     // Clear cache after setup since Authenticator creation may populate it
     inMemoryCache.clear();
   });
 
   describe("fetchByModelIds", () => {
-    it("filters on group kind when asked", async () => {
+    it("caches each group while loading cache misses in one database query", async () => {
       const autoGroup = await GroupResource.makeNew({
         name: "Auto Group",
         workspaceId: workspace.id,
         kind: "regular_auto",
       });
       const ids = [autoGroup.id, globalGroup.id, systemGroup.id];
+      const findAllSpy = vi.spyOn(GroupModel, "findAll");
 
       const all = await GroupResource.fetchByModelIds(authenticator, ids);
       expect(all.map((g) => g.id).sort()).toEqual([...ids].sort());
+      expect(findAllSpy).toHaveBeenCalledTimes(1);
+      for (const groupModelId of ids) {
+        expect(
+          inMemoryCache.has(getCacheKeyForGroup(workspace.id, groupModelId))
+        ).toBe(true);
+      }
+
+      const cached = await GroupResource.fetchByModelIds(authenticator, ids);
+      expect(cached.map((g) => g.id).sort()).toEqual([...ids].sort());
+      expect(findAllSpy).toHaveBeenCalledTimes(1);
 
       const autoOnly = await GroupResource.fetchByModelIds(authenticator, ids, {
         groupKinds: ["regular_auto"],
       });
       expect(autoOnly.map((g) => g.id)).toEqual([autoGroup.id]);
+      expect(findAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("bypasses the cache in a transaction", async () => {
+      const transaction = getNamespace("test-namespace")?.get("transaction");
+      if (!transaction) {
+        throw new Error("Expected the test transaction to be available.");
+      }
+
+      const groups = await GroupResource.fetchByModelIds(
+        authenticator,
+        [globalGroup.id],
+        { transaction }
+      );
+
+      expect(groups.map((group) => group.id)).toEqual([globalGroup.id]);
+      expect(
+        inMemoryCache.has(getCacheKeyForGroup(workspace.id, globalGroup.id))
+      ).toBe(false);
+    });
+
+    it("falls back to the database when Redis is unavailable", async () => {
+      cacheReadFailure.current = new Error("Redis unavailable");
+
+      const groups = await GroupResource.fetchByModelIds(authenticator, [
+        globalGroup.id,
+      ]);
+
+      expect(groups.map((group) => group.id)).toEqual([globalGroup.id]);
+    });
+
+    it("invalidates cached groups after updates and deletion", async () => {
+      const group = await GroupResource.makeNew({
+        name: "Cached Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      const cacheKey = getCacheKeyForGroup(workspace.id, group.id);
+
+      await GroupResource.fetchByModelIds(authenticator, [group.id]);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const updateResult = await group.updateName(
+        authenticator,
+        "Updated Cached Group"
+      );
+      expect(updateResult.isOk()).toBe(true);
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+
+      const [updatedGroup] = await GroupResource.fetchByModelIds(
+        authenticator,
+        [group.id]
+      );
+      expect(updatedGroup?.name).toBe("Updated Cached Group");
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const deleteResult = await group.delete(authenticator);
+      expect(deleteResult.isOk()).toBe(true);
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+      await expect(
+        GroupResource.fetchByModelIds(authenticator, [group.id])
+      ).resolves.toEqual([]);
     });
   });
 

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -83,11 +83,12 @@ vi.mock("@app/lib/utils/cache", async (importOriginal) => {
       .mockImplementation(
         <T, Args extends unknown[]>(
           fn: CacheableFunction<JsonSerializable<T>, Args>,
-          resolver: (...args: Args) => string
+          resolver: (...args: Args) => string,
+          options?: { cacheId?: string }
         ) => {
           return async (argsList: Args[]): Promise<void> => {
             for (const args of argsList) {
-              const key = `cacheWithRedis-${fn.name}-${resolver(...args)}`;
+              const key = `cacheWithRedis-${options?.cacheId ?? fn.name}-${resolver(...args)}`;
               inMemoryCache.delete(key);
             }
           };
@@ -96,12 +97,19 @@ vi.mock("@app/lib/utils/cache", async (importOriginal) => {
   };
 });
 
+import {
+  batchHardDeletePendingAgentConfigurations,
+  createPendingAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
 import {
   BUILDER_GROUP_NAME,
   GroupResource,
   MANUAL_BUILDERS_GROUP_NAME,
 } from "@app/lib/resources/group_resource";
+import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
@@ -111,6 +119,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { LightWorkspaceType } from "@app/types/user";
 
@@ -243,6 +252,136 @@ describe("GroupResource", () => {
       await expect(
         GroupResource.fetchByModelIds(authenticator, [group.id])
       ).resolves.toEqual([]);
+    });
+
+    it("invalidates a cached group deleted through a group-space resource", async () => {
+      const space = await SpaceFactory.regular(workspace);
+      const group = await GroupResource.makeNew({
+        name: "Cached Space Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      const groupSpace = await GroupSpaceMemberResource.makeNew(authenticator, {
+        group,
+        space,
+      });
+      const cacheKey = getCacheKeyForGroup(workspace.id, group.id);
+
+      await GroupResource.fetchByModelIds(authenticator, [group.id]);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const deleteResult = await groupSpace.delete(authenticator);
+      expect(deleteResult.isOk()).toBe(true);
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+      await expect(
+        GroupResource.fetchByModelIds(authenticator, [group.id])
+      ).resolves.toEqual([]);
+    });
+
+    it("defers batched invalidation until the transaction commits", async () => {
+      const firstGroup = await GroupResource.makeNew({
+        name: "First Cached Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      const secondGroup = await GroupResource.makeNew({
+        name: "Second Cached Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      const groups = [firstGroup, secondGroup];
+      const groupIds = groups.map((group) => group.id);
+      const cacheKeys = groupIds.map((groupId) =>
+        getCacheKeyForGroup(workspace.id, groupId)
+      );
+      await GroupResource.fetchByModelIds(authenticator, groupIds);
+
+      const parentTransaction =
+        getNamespace("test-namespace")?.get("transaction");
+      if (!parentTransaction) {
+        throw new Error("Expected the test transaction to be available.");
+      }
+      const transaction = await frontSequelize.transaction({
+        transaction: parentTransaction,
+      });
+
+      try {
+        await GroupResource.invalidateByModelIdsCache({
+          workspaceModelId: workspace.id,
+          groupModelIds: groupIds,
+          transaction,
+        });
+        for (const cacheKey of cacheKeys) {
+          expect(inMemoryCache.has(cacheKey)).toBe(true);
+        }
+
+        await transaction.commit();
+
+        for (const cacheKey of cacheKeys) {
+          expect(inMemoryCache.has(cacheKey)).toBe(false);
+        }
+      } catch (err) {
+        await transaction.rollback();
+        throw err;
+      }
+    });
+
+    it("schedules batched invalidation for editor groups deleted with pending agents", async () => {
+      const pendingAgentIds: string[] = [];
+      for (let i = 0; i < 2; i++) {
+        const pendingAgentResult =
+          await createPendingAgentConfiguration(authenticator);
+        if (pendingAgentResult.isErr()) {
+          throw pendingAgentResult.error;
+        }
+        pendingAgentIds.push(pendingAgentResult.value.sId);
+      }
+
+      const pendingAgents = await AgentConfigurationModel.findAll({
+        where: { sId: pendingAgentIds, workspaceId: workspace.id },
+      });
+      const groupAgents = await GroupAgentModel.findAll({
+        where: {
+          agentConfigurationId: pendingAgents.map((agent) => agent.id),
+          workspaceId: workspace.id,
+        },
+      });
+      const groupIds = groupAgents.map((groupAgent) => groupAgent.groupId);
+
+      await GroupResource.fetchByModelIds(authenticator, groupIds);
+      for (const groupId of groupIds) {
+        expect(
+          inMemoryCache.has(getCacheKeyForGroup(workspace.id, groupId))
+        ).toBe(true);
+      }
+
+      const invalidateSpy = vi.spyOn(
+        GroupResource,
+        "invalidateByModelIdsCache"
+      );
+      try {
+        await batchHardDeletePendingAgentConfigurations(
+          pendingAgents,
+          workspace.id
+        );
+
+        expect(invalidateSpy).toHaveBeenCalledOnce();
+        const invalidation = invalidateSpy.mock.calls[0]?.[0];
+        expect(invalidation?.workspaceModelId).toBe(workspace.id);
+        expect(invalidation?.groupModelIds.toSorted((a, b) => a - b)).toEqual(
+          groupIds.toSorted((a, b) => a - b)
+        );
+        expect(invalidation?.transaction).toBe(
+          getNamespace("test-namespace")?.get("transaction")
+        );
+
+        const remainingGroups = await GroupModel.count({
+          where: { id: groupIds, workspaceId: workspace.id },
+        });
+        expect(remainingGroups).toBe(0);
+      } finally {
+        invalidateSpy.mockRestore();
+      }
     });
   });
 

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -12,7 +12,9 @@ vi.mock("@app/lib/api/redis", () => ({
         if (cacheReadFailure.current) {
           throw cacheReadFailure.current;
         }
-        return Promise.resolve(keys.map((key) => inMemoryCache.get(key) ?? null));
+        return Promise.resolve(
+          keys.map((key) => inMemoryCache.get(key) ?? null)
+        );
       }),
       multi: vi.fn().mockImplementation(() => {
         const values = new Map<string, string>();

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -205,7 +205,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   };
 
   private static fromCachedGroup(data: CachedGroup): GroupResource {
-    return new GroupResource(GroupModel, {
+    return new this(this.model, {
       id: data.id,
       name: data.name,
       kind: data.kind,
@@ -392,7 +392,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         workspaceModelId
       )
     );
-    await GroupResource.byModelIdCache.invalidate(
+    await this.byModelIdCache.invalidate(
       {
         workspaceModelId,
         groupModelId: group.id,
@@ -781,7 +781,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         throw new Error("Group for key not found.");
       }
 
-      return cached.map((g) => GroupResource.fromCachedGroup(g));
+      return cached.map((g) => this.fromCachedGroup(g));
     }
 
     const groups = await this.model.findAll({
@@ -891,7 +891,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     const requestedKeys = new Set(inputs.map(groupCacheKey));
-    const groupModels = await GroupModel.findAll({
+    const groupModels = await this.model.findAll({
       where: {
         workspaceId: workspaceModelId,
         id: {
@@ -910,14 +910,15 @@ export class GroupResource extends BaseResource<GroupModel> {
           })
         )
       )
-      .map((group) => new GroupResource(GroupModel, group.get()));
+      .map((group) => new this(this.model, group.get()));
   }
 
   private static readonly byModelIdCache = defineCachedResourceBatchLookup({
     id: "group_by_model_id",
     version: GROUP_BY_MODEL_ID_CACHE_KEY_VERSION,
     key: groupCacheKey,
-    loadManyFromDatabase: GroupResource.fetchByModelIdsFromDatabase,
+    loadManyFromDatabase: (inputs, transaction) =>
+      this.fetchByModelIdsFromDatabase(inputs, transaction),
     inputFromResource: (group: GroupResource) => ({
       workspaceModelId: group.workspaceId,
       groupModelId: group.id,
@@ -927,11 +928,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       const parsedSnapshot: unknown = JSON.parse(serializedSnapshot);
       return CachedGroupSchema.parse(parsedSnapshot);
     },
-    fromSnapshot: GroupResource.fromCachedGroup,
+    fromSnapshot: (snapshot) => this.fromCachedGroup(snapshot),
   });
 
   static readonly byModelIdCacheOperations =
-    GroupResource.byModelIdCache.createCacheOperations({
+    this.byModelIdCache.createCacheOperations({
       label: "Group (by ModelId)",
       inputSchema: GroupCacheInputSchema,
       params: [
@@ -960,7 +961,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     groupModelIds: ModelId[];
     transaction?: Transaction;
   }): Promise<void> {
-    await GroupResource.byModelIdCache.invalidateMany(
+    await this.byModelIdCache.invalidateMany(
       groupModelIds.map((groupModelId) => ({
         workspaceModelId,
         groupModelId,
@@ -978,7 +979,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     }: { groupKinds?: GroupKind[]; transaction?: Transaction } = {}
   ) {
     const workspaceModelId = auth.getNonNullableWorkspace().id;
-    const groups = await GroupResource.byModelIdCache.fetchMany(
+    const groups = await this.byModelIdCache.fetchMany(
       ids.map((groupModelId) => ({ workspaceModelId, groupModelId })),
       transaction
     );

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -951,6 +951,24 @@ export class GroupResource extends BaseResource<GroupModel> {
       toLookupInput: (input) => input,
     });
 
+  static async invalidateByModelIdsCache({
+    workspaceModelId,
+    groupModelIds,
+    transaction,
+  }: {
+    workspaceModelId: ModelId;
+    groupModelIds: ModelId[];
+    transaction?: Transaction;
+  }): Promise<void> {
+    await GroupResource.byModelIdCache.invalidateMany(
+      groupModelIds.map((groupModelId) => ({
+        workspaceModelId,
+        groupModelId,
+      })),
+      transaction
+    );
+  }
+
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1,7 +1,9 @@
+import { defineCachedResourceBatchLookup } from "@app/lib/api/resources/cached_resource_lookup";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
+import type { ResourceUpdateBlob } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -55,6 +57,7 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { col, fn, Op, QueryTypes, UniqueConstraintError } from "sequelize";
+import { z } from "zod";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";
@@ -63,6 +66,8 @@ export const MANAGER_GROUP_NAME = "dust-managers";
 // syncBuilderGroupMembership). Distinct from BUILDER_GROUP_NAME: workspaces provisioning
 // builders via SCIM keep their "dust-builders" IdP group alongside this one.
 export const MANUAL_BUILDERS_GROUP_NAME = "Builders";
+
+const GROUP_BY_MODEL_ID_CACHE_KEY_VERSION = 1;
 
 /**
  * ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -78,16 +83,30 @@ export const MANUAL_BUILDERS_GROUP_NAME = "Builders";
  * ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
  */
 
-type CachedGroup = {
-  id: ModelId;
-  name: string;
-  kind: GroupKind;
-  workspaceId: ModelId;
-  workOSGroupId: string | null;
-  poolCapAwuCredits: number | null;
-  createdAt: number;
-  updatedAt: number;
-};
+const CachedGroupSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  kind: z.enum(GROUP_KINDS),
+  workspaceId: z.number(),
+  workOSGroupId: z.string().nullable(),
+  poolCapAwuCredits: z.number().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+type CachedGroup = z.infer<typeof CachedGroupSchema>;
+
+const GroupCacheInputSchema = z.object({
+  workspaceModelId: z.coerce.number().int().positive(),
+  groupModelId: z.coerce.number().int().positive(),
+});
+type GroupCacheInput = z.infer<typeof GroupCacheInputSchema>;
+
+function groupCacheKey({
+  workspaceModelId,
+  groupModelId,
+}: GroupCacheInput): string {
+  return `workspace:${workspaceModelId}:group:${groupModelId}`;
+}
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -102,6 +121,19 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   constructor(model: ModelStatic<GroupModel>, blob: Attributes<GroupModel>) {
     super(GroupModel, blob);
+  }
+
+  private toCacheSnapshot(): CachedGroup {
+    return {
+      id: this.id,
+      name: this.name,
+      kind: this.kind,
+      workspaceId: this.workspaceId,
+      workOSGroupId: this.workOSGroupId,
+      poolCapAwuCredits: this.poolCapAwuCredits,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+    };
   }
 
   // Default group kinds for auth (excludes system groups).
@@ -359,6 +391,13 @@ export class GroupResource extends BaseResource<GroupModel> {
       GroupResource.invalidateWorkspaceGroupsFromSystemKeyCache(
         workspaceModelId
       )
+    );
+    await GroupResource.byModelIdCache.invalidate(
+      {
+        workspaceModelId,
+        groupModelId: group.id,
+      },
+      transaction
     );
 
     // If memberIds are provided, create memberships
@@ -838,6 +877,80 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groupModels.map((b) => new this(this.model, b.get()));
   }
 
+  private static async fetchByModelIdsFromDatabase(
+    inputs: GroupCacheInput[],
+    transaction?: Transaction
+  ): Promise<GroupResource[]> {
+    if (inputs.length === 0) {
+      return [];
+    }
+
+    const workspaceModelId = inputs[0].workspaceModelId;
+    if (inputs.some((input) => input.workspaceModelId !== workspaceModelId)) {
+      throw new Error("Cannot fetch groups from multiple workspaces");
+    }
+
+    const requestedKeys = new Set(inputs.map(groupCacheKey));
+    const groupModels = await GroupModel.findAll({
+      where: {
+        workspaceId: workspaceModelId,
+        id: {
+          [Op.in]: [...new Set(inputs.map((input) => input.groupModelId))],
+        },
+      },
+      transaction,
+    });
+
+    return groupModels
+      .filter((group) =>
+        requestedKeys.has(
+          groupCacheKey({
+            workspaceModelId: group.workspaceId,
+            groupModelId: group.id,
+          })
+        )
+      )
+      .map((group) => new GroupResource(GroupModel, group.get()));
+  }
+
+  private static readonly byModelIdCache = defineCachedResourceBatchLookup({
+    id: "group_by_model_id",
+    version: GROUP_BY_MODEL_ID_CACHE_KEY_VERSION,
+    key: groupCacheKey,
+    loadManyFromDatabase: GroupResource.fetchByModelIdsFromDatabase,
+    inputFromResource: (group: GroupResource) => ({
+      workspaceModelId: group.workspaceId,
+      groupModelId: group.id,
+    }),
+    toSnapshot: (group: GroupResource) => group.toCacheSnapshot(),
+    parseSnapshot: (serializedSnapshot: string) => {
+      const parsedSnapshot: unknown = JSON.parse(serializedSnapshot);
+      return CachedGroupSchema.parse(parsedSnapshot);
+    },
+    fromSnapshot: GroupResource.fromCachedGroup,
+  });
+
+  static readonly byModelIdCacheOperations =
+    GroupResource.byModelIdCache.createCacheOperations({
+      label: "Group (by ModelId)",
+      inputSchema: GroupCacheInputSchema,
+      params: [
+        {
+          key: "workspaceModelId",
+          label: "Workspace ModelId",
+          type: "number",
+          placeholder: "e.g. 42",
+        },
+        {
+          key: "groupModelId",
+          label: "Group ModelId",
+          type: "number",
+          placeholder: "e.g. 7",
+        },
+      ],
+      toLookupInput: (input) => input,
+    });
+
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
@@ -846,18 +959,15 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: { groupKinds?: GroupKind[]; transaction?: Transaction } = {}
   ) {
-    return this.baseFetch(
-      auth,
-      {
-        where: {
-          id: {
-            [Op.in]: ids,
-          },
-          ...(groupKinds ? { kind: { [Op.in]: groupKinds } } : {}),
-        },
-      },
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
+    const groups = await GroupResource.byModelIdCache.fetchMany(
+      ids.map((groupModelId) => ({ workspaceModelId, groupModelId })),
       transaction
     );
+
+    return groupKinds
+      ? groups.filter((group) => groupKinds.includes(group.kind))
+      : groups;
   }
 
   static async fetchById(
@@ -2251,6 +2361,21 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   // Updates
 
+  protected override async update(
+    blob: ResourceUpdateBlob<GroupModel>,
+    transaction?: Transaction
+  ): Promise<[affectedCount: number]> {
+    const result = await super.update(blob, transaction);
+    await GroupResource.byModelIdCache.invalidate(
+      {
+        workspaceModelId: this.workspaceId,
+        groupModelId: this.id,
+      },
+      transaction
+    );
+    return result;
+  }
+
   async updateName(
     auth: Authenticator,
     newName: string
@@ -2547,6 +2672,13 @@ export class GroupResource extends BaseResource<GroupModel> {
       const workspaceId = owner.id;
       invalidateCacheAfterCommit(transaction, () =>
         GroupResource.invalidateWorkspaceGroupsFromSystemKeyCache(workspaceId)
+      );
+      await GroupResource.byModelIdCache.invalidate(
+        {
+          workspaceModelId: workspaceId,
+          groupModelId: this.id,
+        },
+        transaction
       );
 
       return new Ok(undefined);

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -1,7 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
@@ -225,6 +225,12 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
           // Delete the corresponding group if it's regular_auto or space_editors (system, global, provisioned groups should not be deleted)
           kind: ["regular_auto", "space_editors"],
         },
+        transaction,
+      });
+
+      await GroupResource.invalidateByModelIdsCache({
+        workspaceModelId: auth.getNonNullableWorkspace().id,
+        groupModelIds: [this.groupId],
         transaction,
       });
 


### PR DESCRIPTION
## Description

When fetching skills, the query on groups can take a significant amount of time (in [this trace](https://app.datadoghq.eu/apm/traces?query=operation_name%3Ahono.request%20service%3Afront%20%40span.kind%3Aserver%20resource_name%3A%22POST%20%2Fapi%2Fw%2F%3AwId%2Fanalytics%2Fconsumption%2Ffacets%22&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&fromUser=false&graphType=waterfall&historicalData=true&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=desc&spanID=6693657449113243275&spanType=all&storage=hot&timeHint=1787057678789&trace=AwAAAaAU8CnFxkyleQAAABhBYUFVOEVEWUFBRGtFMGpwcW5ueFlNcHUAAAAkMTFhMDE0ZmItMTU5NC00Zjk0LWFlZTgtOTE2ZjU4N2Y4M2Q3AAPU0w&trace_group_by_from=a&trace_group_by_metrics=a&traceID=6a84560c000000006ecabb3852242598&traceQuery=&view=spans&start=1787123238852&end=1787126838852&paused=false) it's the slowest query of all). We fetch the groups in the `baseFetch` through `GroupResource.fetchByModelIds`.

This PR adds a per-group read-through caching using what was introduced in #30270.

The existing pattern did not support batch fetches. this PR extends it for this. We still cache each resource individually, and retrieve them with an `MGET` + fetch from the db the missing ones. In our case the sets of groups to fetch are often disjoint and actually only containing 1 value, which would encourage the use of a single value for an array of resources, but this made the invalidation path a bit complex and since the complexity of the mget grows linearly with the number of resources to retrieve I felt like it didn't have too much of a cost and I'd rather introduce this pattern than one customized on the exact access patterns of this specific resource (group). Also, we often batch fetch skills, and depending on your rights you might be pulling different lists of groups so it's better to cache each group in this case.

## Tests

- Added tests.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
