### PR TITLE
Use the node IDs Front reports for removes and renames

### DIFF
--- a/cli/dust-sandbox/src/commands/filesystem/client.rs
+++ b/cli/dust-sandbox/src/commands/filesystem/client.rs
@@ -94,7 +94,29 @@ struct UploadResponse {
 }
 
 #[derive(Debug, Deserialize)]
-struct EmptyResponse {}
+#[serde(rename_all = "camelCase")]
+struct RemoveResponse {
+    // Nothing else tells the daemon which node lost its name, so a response
+    // without this is invalid.
+    removed_node_id: u64,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RenameResponse {
+    #[serde(deserialize_with = "deserialize_required_option")]
+    node: Option<RemoteNode>,
+    // Front must send null when the destination name was free. A missing field is
+    // an invalid response, not a rename that replaced nothing.
+    #[serde(deserialize_with = "deserialize_required_option")]
+    replaced_node_id: Option<u64>,
+}
+
+#[derive(Debug)]
+pub struct RenamedNode {
+    pub node: RemoteNode,
+    pub replaced_node_id: Option<u64>,
+}
 
 fn deserialize_required_option<'de, D, T>(deserializer: D) -> Result<Option<T>, D::Error>
 where

--- a/cli/dust-sandbox/src/commands/filesystem/client/namespace.rs
+++ b/cli/dust-sandbox/src/commands/filesystem/client/namespace.rs
@@ -1,8 +1,8 @@
 use std::io;
 
 use super::{
-    errno, invalid_response, EmptyResponse, FileSystemClient, InitializeResponse, NodeKind,
-    NodeResponse, Operation, ReadDirResponse, RemoteNode,
+    errno, invalid_response, FileSystemClient, InitializeResponse, NodeKind, NodeResponse,
+    Operation, ReadDirResponse, RemoteNode, RemoveResponse, RenameResponse, RenamedNode,
 };
 
 impl FileSystemClient {
@@ -73,20 +73,23 @@ impl FileSystemClient {
         .ok_or_else(invalid_response)
     }
 
+    // Returns the node Front removed, which is what tells the caller whether the
+    // name still pointed at the node it had looked up.
     pub fn remove(
         &self,
         request_id: &str,
         parent_id: u64,
         name: &str,
         kind: NodeKind,
-    ) -> io::Result<()> {
-        self.operation::<EmptyResponse>(&Operation::Remove {
-            request_id,
-            parent_id,
-            name,
-            kind,
-        })?;
-        Ok(())
+    ) -> io::Result<u64> {
+        Ok(self
+            .operation::<RemoveResponse>(&Operation::Remove {
+                request_id,
+                parent_id,
+                name,
+                kind,
+            })?
+            .removed_node_id)
     }
 
     pub fn rename(
@@ -96,16 +99,18 @@ impl FileSystemClient {
         source_name: &str,
         destination_parent_id: u64,
         destination_name: &str,
-    ) -> io::Result<RemoteNode> {
-        self.operation::<NodeResponse>(&Operation::Rename {
+    ) -> io::Result<RenamedNode> {
+        let renamed = self.operation::<RenameResponse>(&Operation::Rename {
             request_id,
             source_parent_id,
             source_name,
             destination_parent_id,
             destination_name,
-        })?
-        .node
-        .ok_or_else(invalid_response)
+        })?;
+        Ok(RenamedNode {
+            node: renamed.node.ok_or_else(invalid_response)?,
+            replaced_node_id: renamed.replaced_node_id,
+        })
     }
 }
 
@@ -120,6 +125,115 @@ mod tests {
 
     use super::*;
     use crate::commands::filesystem::client::test_support::read_request;
+
+    // Answers one request with this body, then stops.
+    fn front_answering(body: String) -> (String, std::thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listen");
+        let address = listener.local_addr().expect("local address");
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            read_request(&mut stream);
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            )
+            .expect("write response");
+        });
+        (format!("http://{address}"), server)
+    }
+
+    fn client_calling(api_url: &str, directory: &std::path::Path) -> FileSystemClient {
+        let token_file = directory.join("token");
+        fs::write(&token_file, "token").expect("write token");
+        fs::set_permissions(&token_file, fs::Permissions::from_mode(0o600))
+            .expect("restrict token");
+        FileSystemClient::new(api_url, "w_test", "token".to_owned(), token_file).expect("client")
+    }
+
+    fn renamed_node_body(replaced: &str) -> String {
+        format!(
+            r#"{{"node":{{"id":42,"parentId":10,"name":"new.txt","kind":"file","mode":420,"size":0,"contentType":null,"blobId":null,"createdAtMs":1,"modifiedAtMs":1}},"replacedNodeId":{replaced}}}"#
+        )
+    }
+
+    #[test]
+    fn a_remove_reports_the_node_front_removed() {
+        let directory = tempdir().expect("temporary directory");
+        let (api_url, server) = front_answering(r#"{"removedNodeId":9}"#.to_owned());
+        let client = client_calling(&api_url, directory.path());
+
+        let removed = client
+            .remove("request", 10, "old.txt", NodeKind::File)
+            .expect("remove the file");
+
+        assert_eq!(removed, 9);
+        server.join().expect("server thread");
+    }
+
+    #[test]
+    fn a_remove_answered_without_the_removed_node_is_rejected() {
+        let directory = tempdir().expect("temporary directory");
+        let (api_url, server) = front_answering("{}".to_owned());
+        let client = client_calling(&api_url, directory.path());
+
+        let error = client
+            .remove("request", 10, "old.txt", NodeKind::File)
+            .expect_err("reject an answer that names no node");
+
+        assert_eq!(error.raw_os_error(), Some(libc::EIO));
+        server.join().expect("server thread");
+    }
+
+    #[test]
+    fn a_rename_reports_the_node_it_replaced() {
+        let directory = tempdir().expect("temporary directory");
+        let (api_url, server) = front_answering(renamed_node_body("7"));
+        let client = client_calling(&api_url, directory.path());
+
+        let renamed = client
+            .rename("request", 10, "old.txt", 10, "new.txt")
+            .expect("rename the file");
+
+        assert_eq!(renamed.node.id, 42);
+        assert_eq!(renamed.replaced_node_id, Some(7));
+        server.join().expect("server thread");
+    }
+
+    #[test]
+    fn a_rename_answered_without_the_replaced_node_is_rejected() {
+        let directory = tempdir().expect("temporary directory");
+        // Front sends null when the destination name was free. Leaving the field
+        // out means something else, and guessing between the two is what the
+        // daemon must not do.
+        let (api_url, server) = front_answering(
+            r#"{"node":{"id":42,"parentId":10,"name":"new.txt","kind":"file","mode":420,"size":0,"contentType":null,"blobId":null,"createdAtMs":1,"modifiedAtMs":1}}"#
+                .to_owned(),
+        );
+        let client = client_calling(&api_url, directory.path());
+
+        let error = client
+            .rename("request", 10, "old.txt", 10, "new.txt")
+            .expect_err("reject an answer that omits the replaced node");
+
+        assert_eq!(error.raw_os_error(), Some(libc::EIO));
+        server.join().expect("server thread");
+    }
+
+    #[test]
+    fn a_rename_onto_a_free_name_reports_that_nothing_was_replaced() {
+        let directory = tempdir().expect("temporary directory");
+        let (api_url, server) = front_answering(renamed_node_body("null"));
+        let client = client_calling(&api_url, directory.path());
+
+        let renamed = client
+            .rename("request", 10, "old.txt", 10, "new.txt")
+            .expect("rename the file");
+
+        assert_eq!(renamed.replaced_node_id, None);
+        server.join().expect("server thread");
+    }
 
     #[test]
     fn retries_create_with_the_same_request_id() {

--- a/cli/dust-sandbox/src/commands/filesystem/fuse.rs
+++ b/cli/dust-sandbox/src/commands/filesystem/fuse.rs
@@ -221,18 +221,19 @@ impl DustFuse {
         let _namespace = self.namespace_write()?;
         let node = self.lookup_node(parent, name)?;
         let _inode = self.inode_locks.lock(node.inode)?;
-        self.store.remove_file(parent, name)?;
+        // The lookup above only chooses which lock to take. Which node stops
+        // publishing is decided by the removal itself.
+        let removed_inode = self.store.remove_file(parent, name)?;
         // Do this only after Front confirms the removal. A failed removal must
         // leave a dirty open handle able to publish its bytes later.
-        self.mark_unlinked(node.inode)?;
-        self.clear_staged_attributes(node.inode)
+        self.mark_unlinked(removed_inode)?;
+        self.clear_staged_attributes(removed_inode)
     }
 
     fn remove_directory_node(&self, parent: INodeNo, name: &str) -> io::Result<()> {
         let _namespace = self.namespace_write()?;
-        let node = self.lookup_node(parent, name)?;
-        self.store.remove_directory(parent, name)?;
-        self.clear_staged_attributes(node.inode)
+        let removed_inode = self.store.remove_directory(parent, name)?;
+        self.clear_staged_attributes(removed_inode)
     }
 
     fn rename_node(
@@ -254,14 +255,15 @@ impl DustFuse {
         let _destination = destination_inode
             .map(|inode| self.inode_locks.lock(inode))
             .transpose()?;
-        let node = self.store.rename(parent, name, new_parent, new_name)?;
-        if let Some(destination_inode) = destination_inode {
-            // The old destination stays readable through existing descriptors,
+        let renamed = self.store.rename(parent, name, new_parent, new_name)?;
+        // As with a removal, the lookup above only chooses the lock.
+        if let Some(replaced_inode) = renamed.replaced_inode {
+            // The replaced node stays readable through existing descriptors,
             // but those descriptors must never replace the new path later.
-            self.mark_unlinked(destination_inode)?;
-            self.clear_staged_attributes(destination_inode)?;
+            self.mark_unlinked(replaced_inode)?;
+            self.clear_staged_attributes(replaced_inode)?;
         }
-        debug!(inode = node.inode.0, "renamed filesystem inode");
+        debug!(inode = renamed.node.inode.0, "renamed filesystem inode");
         Ok(())
     }
 

--- a/cli/dust-sandbox/src/commands/filesystem/store.rs
+++ b/cli/dust-sandbox/src/commands/filesystem/store.rs
@@ -111,6 +111,12 @@ impl RootLink {
     }
 }
 
+// The node that now carries the new name, and the one the rename replaced.
+pub struct RenameOutcome {
+    pub node: Node,
+    pub replaced_inode: Option<INodeNo>,
+}
+
 pub struct FileStore {
     client: FileSystemClient,
     staging_dir: PathBuf,
@@ -258,7 +264,7 @@ impl FileStore {
         Ok(node)
     }
 
-    pub fn remove_file(&self, parent_inode: INodeNo, name: &str) -> io::Result<()> {
+    pub fn remove_file(&self, parent_inode: INodeNo, name: &str) -> io::Result<INodeNo> {
         let node = self.lookup(parent_inode, name)?;
         match node.kind {
             NodeKind::File => {}
@@ -270,7 +276,7 @@ impl FileStore {
         self.remove(parent_inode, name, node.inode, RemoteNodeKind::File)
     }
 
-    pub fn remove_directory(&self, parent_inode: INodeNo, name: &str) -> io::Result<()> {
+    pub fn remove_directory(&self, parent_inode: INodeNo, name: &str) -> io::Result<INodeNo> {
         let node = self.lookup(parent_inode, name)?;
         if node.kind != NodeKind::Directory {
             return Err(errno(libc::ENOTDIR));
@@ -278,26 +284,40 @@ impl FileStore {
         self.remove(parent_inode, name, node.inode, RemoteNodeKind::Directory)
     }
 
+    // Returns the node that lost this name. Another sandbox can move a different
+    // node onto the name between the caller's lookup and this removal, so Front's
+    // answer decides, not the inode the caller resolved.
     fn remove(
         &self,
         parent_inode: INodeNo,
         name: &str,
         inode: INodeNo,
         kind: RemoteNodeKind,
-    ) -> io::Result<()> {
+    ) -> io::Result<INodeNo> {
         if parent_inode == FUSE_ROOT_INODE {
             return Err(errno(libc::EPERM));
         }
-        self.client.remove(
+        let removed_node_id = self.client.remove(
             &Uuid::new_v4().to_string(),
             node_id_for_inode(parent_inode)?,
             name,
             kind,
         )?;
-        self.invalidate_node(inode)?;
+        let removed_inode = inode_for_node_id(removed_node_id)?;
+        if removed_inode != inode {
+            warn!(
+                expected_inode = inode.0,
+                removed_inode = removed_inode.0,
+                "another sandbox changed this name before it was removed"
+            );
+            // The node the caller resolved still exists under another name, so
+            // only its stale details go and its local content stays usable.
+            self.invalidate_node(inode)?;
+        }
+        self.invalidate_node(removed_inode)?;
         self.invalidate_directory(parent_inode)?;
-        self.forget_content_after_namespace_change(inode);
-        Ok(())
+        self.forget_content_after_namespace_change(removed_inode);
+        Ok(removed_inode)
     }
 
     fn forget_content_after_namespace_change(&self, inode: INodeNo) {
@@ -314,33 +334,39 @@ impl FileStore {
         name: &str,
         new_parent_inode: INodeNo,
         new_name: &str,
-    ) -> io::Result<Node> {
+    ) -> io::Result<RenameOutcome> {
         validate_name(name)?;
         validate_name(new_name)?;
         if parent_inode == FUSE_ROOT_INODE || new_parent_inode == FUSE_ROOT_INODE {
             return Err(errno(libc::EPERM));
         }
-        let replaced_inode = match self.lookup(new_parent_inode, new_name) {
-            Ok(destination) => Some(destination.inode),
-            Err(error) if error.raw_os_error() == Some(libc::ENOENT) => None,
-            Err(error) => return Err(error),
-        };
-        let node = Node::from_remote(self.client.rename(
+        let renamed = self.client.rename(
             &Uuid::new_v4().to_string(),
             node_id_for_inode(parent_inode)?,
             name,
             node_id_for_inode(new_parent_inode)?,
             new_name,
-        )?)?;
+        )?;
+        // Front names the node the rename replaced, so the destination needs no
+        // lookup of its own.
+        let replaced_inode = renamed
+            .replaced_node_id
+            .map(inode_for_node_id)
+            .transpose()?;
+        let node = Node::from_remote(renamed.node)?;
         self.invalidate_directory(parent_inode)?;
         self.invalidate_directory(new_parent_inode)?;
         self.cache_node(node.clone())?;
         if let Some(replaced_inode) = replaced_inode {
             if replaced_inode != node.inode {
+                self.invalidate_node(replaced_inode)?;
                 self.forget_content_after_namespace_change(replaced_inode);
             }
         }
-        Ok(node)
+        Ok(RenameOutcome {
+            node,
+            replaced_inode,
+        })
     }
 
     pub fn set_mode(&self, inode: INodeNo, mode: u16) -> io::Result<Node> {
@@ -951,6 +977,48 @@ mod tests {
             .expect_err("report the conflict to the caller");
 
         assert_eq!(error.raw_os_error(), Some(libc::ESTALE));
+        server.join().expect("server thread");
+    }
+
+    #[test]
+    fn the_node_front_reports_removing_wins_over_the_one_looked_up() {
+        // Front answers the lookup with node 7 and then reports removing node 9.
+        // That is what another sandbox moving a different node onto this name
+        // looks like from here, and the caller has to hear about node 9.
+        let listener = TcpListener::bind("127.0.0.1:0").expect("listen");
+        let address = listener.local_addr().expect("local address");
+        let server = std::thread::spawn(move || {
+            let bodies = [
+                r#"{"node":{"id":7,"parentId":2,"name":"file.txt","kind":"file","mode":420,"size":0,"contentType":null,"blobId":null,"createdAtMs":1,"modifiedAtMs":1}}"#,
+                r#"{"removedNodeId":9}"#,
+            ];
+            for body in bodies {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                read_request(&mut stream);
+                write!(
+                    stream,
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+                .expect("write response");
+            }
+        });
+
+        let directory = tempdir().expect("temporary directory");
+        let store = store(
+            directory.path(),
+            1024,
+            &format!("http://{address}"),
+            Vec::new(),
+        );
+
+        let removed = store
+            .remove_file(super::INodeNo(2), "file.txt")
+            .expect("remove the file");
+
+        assert_eq!(removed, inode_for_node_id(9).expect("removed inode"));
+        assert_ne!(removed, inode_for_node_id(7).expect("looked up inode"));
         server.join().expect("server thread");
     }
 }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When the daemon deletes a file it first asks Front which node the name points at, then asks Front to remove that name. Another sandbox sharing the same Pod can move a different node onto that name between those two steps, and the daemon's own one-second cache of file details widens the gap. Until now the daemon assumed the name still pointed at the node it had looked up, and it marked that node as gone. Renaming over an existing file made the same assumption about the file being replaced.

Marking the wrong node has a quiet consequence. A file that is still there gets treated as deleted, so if a program had it open with unsaved changes, those changes are dropped rather than sent to Front, and nothing reports an error. The file that really did lose its name is treated as still alive, so a program writing to it gets a confusing failure later when its save reaches a node that no longer exists. This needs two sandboxes acting on the same name at almost the same moment, so it is a narrow race, but sharing a Pod is a supported arrangement rather than an accident.

Front now answers both operations with the node it actually affected, so the daemon uses that answer instead of its own guess. A rename no longer looks the destination up beforehand either, which removes both a request and one more thing that could be out of date. When Front's answer and the daemon's own lookup disagree, the daemon records it and keeps Front's answer.

Both fields are required rather than optional. A rename sends an empty value when the destination name was free, and a response that omits the field entirely is refused instead of guessed at, which is how the directory listing cursor is already treated in the same code. Guessing was the alternative and it was worse: an earlier version of this change tried to fall back to the daemon's own lookup when the field was missing, which quietly reintroduced the same race on that path.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
