### PR TITLE
[front] perf: Fix slow conversation deletion on EU cluster

### DIFF
--- a/front/migrations/post-deploy/20260818200100_drop_legacy_conversation_participants_conversation_id_fk.sql
+++ b/front/migrations/post-deploy/20260818200100_drop_legacy_conversation_participants_conversation_id_fk.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY IF EXISTS "conversation_participants_conversationId_fk";

--- a/front/migrations/pre-deploy/20260818200000_add_conversation_participants_conversation_id_index.sql
+++ b/front/migrations/pre-deploy/20260818200000_add_conversation_participants_conversation_id_index.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS conversation_participants_conversation_id ON public.conversation_participants USING btree ("conversationId");


### PR DESCRIPTION

## Description


topped at 20% CPU for 1h today because of an index absent : conversation_participants FK

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
