### PR TITLE
[Activation] Make activation_work_areas.podId non-nullable, retire legacy statuses

### DIFF
--- a/front/lib/api/activation/work_areas.ts
+++ b/front/lib/api/activation/work_areas.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import type { PublicActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
+import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -11,7 +11,7 @@ export interface ActivationWorkAreaForUserType {
   sId: string;
   title: string;
   description: string;
-  status: PublicActivationWorkAreaStatus;
+  status: ActivationWorkAreaStatus;
   createdAt: number;
 }
 
@@ -29,7 +29,7 @@ export async function listActivationWorkAreasForUser(
     status,
     podId,
   }: {
-    status?: PublicActivationWorkAreaStatus;
+    status?: ActivationWorkAreaStatus;
     podId?: string;
   } = {}
 ): Promise<ActivationWorkAreaForUserType[]> {
@@ -64,7 +64,7 @@ export async function updateActivationWorkAreaForUser(
     description,
   }: {
     workAreaId: string;
-    status?: PublicActivationWorkAreaStatus;
+    status?: ActivationWorkAreaStatus;
     title?: string;
     description?: string;
   }

--- a/front/lib/models/activation/activation_work_area.ts
+++ b/front/lib/models/activation/activation_work_area.ts
@@ -8,22 +8,17 @@ import type { CreationOptional, ForeignKey } from "sequelize";
 export const ACTIVATION_WORK_AREA_STATUSES = [
   "suggested",
   "dismissed",
-  // Legacy values still present on existing rows. Treat as `suggested`.
-  "candidate",
-  "confirmed",
 ] as const;
 
 export type ActivationWorkAreaStatus =
   (typeof ACTIVATION_WORK_AREA_STATUSES)[number];
-
-export type PublicActivationWorkAreaStatus = "suggested" | "dismissed";
 
 export class ActivationWorkAreaModel extends WorkspaceAwareModel<ActivationWorkAreaModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare userId: ForeignKey<UserModel["id"]>;
-  declare podId: ForeignKey<ActivationPodModel["id"]> | null;
+  declare podId: ForeignKey<ActivationPodModel["id"]>;
 
   declare title: string;
   declare description: string;
@@ -75,9 +70,9 @@ UserModel.hasMany(ActivationWorkAreaModel, {
 });
 
 ActivationWorkAreaModel.belongsTo(ActivationPodModel, {
-  foreignKey: { name: "podId", allowNull: true },
+  foreignKey: { name: "podId", allowNull: false },
   onDelete: "RESTRICT",
 });
 ActivationPodModel.hasMany(ActivationWorkAreaModel, {
-  foreignKey: { name: "podId", allowNull: true },
+  foreignKey: { name: "podId", allowNull: false },
 });

--- a/front/lib/resources/activation_work_area_resource.ts
+++ b/front/lib/resources/activation_work_area_resource.ts
@@ -1,8 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  ActivationWorkAreaStatus,
-  PublicActivationWorkAreaStatus,
-} from "@app/lib/models/activation/activation_work_area";
+import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import { ActivationWorkAreaModel } from "@app/lib/models/activation/activation_work_area";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -12,47 +9,12 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   Attributes,
-  CreationAttributes,
   ModelStatic,
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op } from "sequelize";
-
-// Maps a stored status (which may hold legacy values) to the public status
-// exposed to callers. Legacy `candidate`/`confirmed` rows read as `suggested`.
-function publicActivationWorkAreaStatus(
-  status: ActivationWorkAreaStatus
-): PublicActivationWorkAreaStatus {
-  switch (status) {
-    case "dismissed":
-      return "dismissed";
-    case "suggested":
-    case "candidate":
-    case "confirmed":
-      return "suggested";
-    default:
-      assertNever(status);
-  }
-}
-
-// Expands a public status into the set of stored values that match it, so
-// filtering by `suggested` also returns legacy `candidate`/`confirmed` rows.
-function matchingActivationWorkAreaStatuses(
-  status: PublicActivationWorkAreaStatus
-): ActivationWorkAreaStatus[] {
-  switch (status) {
-    case "dismissed":
-      return ["dismissed"];
-    case "suggested":
-      return ["suggested", "candidate", "confirmed"];
-    default:
-      assertNever(status);
-  }
-}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ActivationWorkAreaResource
@@ -88,11 +50,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
 
   static async makeNew(
     auth: Authenticator,
-    blob: Pick<
-      CreationAttributes<ActivationWorkAreaModel>,
-      "title" | "description"
-    > &
-      Partial<Pick<CreationAttributes<ActivationWorkAreaModel>, "podId">>
+    blob: { title: string; description: string; podId: ModelId }
   ): Promise<ActivationWorkAreaResource> {
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
@@ -103,7 +61,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       status: "suggested",
       title: blob.title,
       description: blob.description,
-      podId: blob.podId ?? null,
+      podId: blob.podId,
     });
 
     return new this(this.model, row.get());
@@ -138,7 +96,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       status,
       activationPodModelId,
     }: {
-      status?: PublicActivationWorkAreaStatus;
+      status?: ActivationWorkAreaStatus;
       activationPodModelId?: ModelId;
     }
   ): Promise<ActivationWorkAreaResource[]> {
@@ -147,14 +105,11 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
     const where: WhereOptions<ActivationWorkAreaModel> = {
       userId: user.id,
       workspaceId: auth.getNonNullableWorkspace().id,
+      ...(status !== undefined ? { status } : {}),
+      ...(activationPodModelId !== undefined
+        ? { podId: activationPodModelId }
+        : {}),
     };
-
-    if (status !== undefined) {
-      where.status = { [Op.in]: matchingActivationWorkAreaStatuses(status) };
-    }
-    if (activationPodModelId !== undefined) {
-      where.podId = activationPodModelId;
-    }
 
     const rows = await this.model.findAll({
       where,
@@ -232,7 +187,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       sId: this.sId,
       title: this.title,
       description: this.description,
-      status: publicActivationWorkAreaStatus(this.status),
+      status: this.status,
       createdAt: this.createdAt.getTime(),
     };
   }

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -5,7 +5,7 @@ import type {
 } from "@app/lib/api/activation/recommendations";
 import type { GetActivationWorkAreasResponseBody } from "@app/lib/api/activation/work_areas";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PublicActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
+import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -134,7 +134,7 @@ export function useActivationWorkAreas({
 }: {
   workspaceId: string;
   podId?: string;
-  status?: PublicActivationWorkAreaStatus;
+  status?: ActivationWorkAreaStatus;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -177,7 +177,7 @@ export function useUpdateActivationWorkArea({
     async (
       workAreaId: string,
       body: {
-        status?: PublicActivationWorkAreaStatus;
+        status?: ActivationWorkAreaStatus;
         title?: string;
         description?: string;
       }

--- a/front/migrations/pre-deploy/20260818110000_retire_legacy_activation_work_area_statuses.sql
+++ b/front/migrations/pre-deploy/20260818110000_retire_legacy_activation_work_area_statuses.sql
@@ -1,0 +1,5 @@
+-- Retire legacy candidate/confirmed statuses: normalise all existing rows to
+-- suggested so the application can drop those values from the status type.
+UPDATE "public"."activation_work_areas"
+  SET "status" = 'suggested'
+  WHERE "status" IN ('candidate', 'confirmed');

--- a/front/migrations/pre-deploy/20260818120000_make_activation_work_area_pod_id_not_null.sql
+++ b/front/migrations/pre-deploy/20260818120000_make_activation_work_area_pod_id_not_null.sql
@@ -1,0 +1,6 @@
+-- Work areas now always belong to a specific Learning Space: podId is non-nullable.
+-- Drop any staging rows that still carry a null podId (pre-design-change data).
+DELETE FROM "public"."activation_work_areas" WHERE "podId" IS NULL;
+
+ALTER TABLE "public"."activation_work_areas"
+  ALTER COLUMN "podId" SET NOT NULL;


### PR DESCRIPTION
## Summary
- Kill unused `candidate`/`confirmed` statuses.
- Make invariant that work areas are associated with a pod. Ok to drop columns.
- Why? Logical clean up before we had more complexity around this.
- Clean to deploy before as it should not effect any customer facing logic

## Testing
migrations ran

## Risk
Low

## Deploy
1. Run both migration
2. 