### PR TITLE
Ship the Dust filesystem in sandboxes

### DIFF
--- a/cli/dust-sandbox/Cargo.lock
+++ b/cli/dust-sandbox/Cargo.lock
@@ -313,7 +313,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dust-sandbox"
-version = "0.1.50"
+version = "0.1.51"
 dependencies = [
  "anyhow",
  "base64",

--- a/cli/dust-sandbox/Cargo.toml
+++ b/cli/dust-sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dust-sandbox"
-version = "0.1.50"
+version = "0.1.51"
 edition = "2021"
 
 [[bin]]

--- a/front/lib/api/sandbox/image/registry.test.ts
+++ b/front/lib/api/sandbox/image/registry.test.ts
@@ -94,12 +94,13 @@ describe("sandbox image registry", () => {
   test("pins the current dust-base and sbx bedrock image tags", () => {
     expect(getDustBaseImage().imageId).toEqual({
       imageName: "dust-base",
-      tag: "0.8.84",
+      tag: "0.8.85",
     });
     expect(getDustBaseImage().baseImage).toEqual({
       type: "docker",
       imageRef: "dust-sbx-bedrock:1.11.0",
     });
+    expect(getDustBaseImage().hasCapability("dust_filesystem")).toBe(true);
   });
 
   test("loads Fluent Bit credentials from a root-only runtime file", () => {
@@ -483,7 +484,7 @@ describe("sandbox image registry", () => {
     expect(runCommands).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.50/dsbx-linux-x86_64"
+          "https://github.com/dust-tt/dust/releases/download/dsbx-v0.1.51/dsbx-linux-x86_64"
         ),
         expect.stringContaining(
           "chown root:root /opt/bin/dsbx && chmod 755 /opt/bin/dsbx"

--- a/front/lib/api/sandbox/image/registry.ts
+++ b/front/lib/api/sandbox/image/registry.ts
@@ -26,8 +26,8 @@ import fs from "fs";
 import path from "path";
 
 const DUST_BEDROCK_IMAGE_VERSION = "1.11.0";
-const DUST_BASE_IMAGE_VERSION = "0.8.84";
-const DSBX_CLI_VERSION = "0.1.50";
+const DUST_BASE_IMAGE_VERSION = "0.8.85";
+const DSBX_CLI_VERSION = "0.1.51";
 // Identity, not coverage list: agent-proxied is a specific Linux user. The
 // nftables ruleset covers SANDBOX_EGRESS_CONTROLLED_UIDS; this constant is
 // the stable identity used when creating the workload account.
@@ -863,6 +863,7 @@ const DUST_BASE_IMAGE = SandboxImage.fromDocker(
     isDustTool: true,
   })
   .withCapability("gcsfuse")
+  .withCapability("dust_filesystem")
   .withResources({ vcpu: 2, memoryMb: 2048 })
   .withNetwork(PROXY_ONLY_NETWORK_POLICY)
   .setWorkdir("/home/agent")


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR ships the Rust filesystem daemon built in the previous PRs.

It bumps dsbx to 0.1.51 and dust-base to 0.8.85. The new image declares the `dust_filesystem` capability, which Front checks before starting the daemon. Sandboxes using the existing GCS filesystem remain unchanged.

Once merged, we will publish `dsbx-v0.1.51`. The sandbox image workflow can then build `dust-base:0.8.85` with that binary.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
