### PR TITLE
[front] Teach the agent how to change an existing Pod app

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -162,11 +162,11 @@ ${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
 
 From then on, edit the source at its Pod path and publish it again. Anything the Frame imports relatively must live under its folder, which is the bundling root.
 
-#### Changing An Existing Pod App
+#### Changing An Existing Pod Frame
 
-A Pod app you are asked to change was usually built in an earlier conversation, so you know neither its source path nor its file id, and publishing needs both. Never recreate it, and never guess either value: read them off the Pod listing.
+A Pod frame you are asked to change was usually built in an earlier conversation, so you know neither its source path nor its file id, and publishing needs both. Never recreate it, and never guess either value: read them off the Pod listing.
 
-1. List the Pod file system with \`${FILES_LIST_TOOL}\` (\`scope: { type: "pod" }\`). Every Frame is listed as its Pod path followed by \`[id: fil_...]\`, which is its \`file_id\`. Pick the entry whose folder matches the app the user named.
+1. List the Pod file system with \`${FILES_LIST_TOOL}\` (\`scope: { type: "pod" }\`). Every Frame is listed as its Pod path followed by \`[id: fil_...]\`, which is its \`file_id\`. Find the frame you're after.
 2. Edit that source in place as described under "Updating Existing Files" below.
 3. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`, passing the \`path\` and \`file_id\` exactly as listed in step 1.
 `;

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -94,7 +94,7 @@ Create a Frame only when the content does not exist yet. When the user asks for 
 const UPDATING_SECTION_COMPUTER_FIRST = `\
 ### Updating Existing Files (edit the source, then publish):
 
-After a Frame is created, its source file is already mounted in the Computer at \`/files/conversation-<conversationId>/<FrameName>.tsx\`. A Frame whose source was moved elsewhere, for example into a Pod app folder, is mounted at its current path instead; resolve it with \`${FILES_RESOLVE_TOOL}\` when unsure. To update the Frame:
+After a Frame is created, its source file is already mounted in the Computer at \`/files/conversation-<conversationId>/<FrameName>.tsx\`. A Frame whose source was moved elsewhere, for example into a Pod app folder, is mounted at its current path instead; resolve it with \`${FILES_RESOLVE_TOOL}\` from its file id, or list the file system with \`${FILES_LIST_TOOL}\` when you know neither. To update the Frame:
 1. Edit that file in place with your file tools, changing only the parts that need to change. Do not rewrite the whole file for partial changes. When the Computer is not available, edit it with \`${FILES_EDIT_TOOL}\` using its scoped path, e.g. \`conversation-<conversationId>/<FrameName>.tsx\`.
 2. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`, passing \`path\` set to the source file's own scoped path (the entry file itself, not the directory holding it), e.g. \`conversation-<conversationId>/<FrameName>.tsx\`.
 
@@ -161,6 +161,14 @@ ${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
 \`\`\`
 
 From then on, edit the source at its Pod path and publish it again. Anything the Frame imports relatively must live under its folder, which is the bundling root.
+
+#### Changing An Existing Pod App
+
+A Pod app you are asked to change was usually built in an earlier conversation, so you know neither its source path nor its file id, and publishing needs both. Never recreate it, and never guess either value: read them off the Pod listing.
+
+1. List the Pod file system with \`${FILES_LIST_TOOL}\` (\`scope: { type: "pod" }\`). Every Frame is listed as its Pod path followed by \`[id: fil_...]\`, which is its \`file_id\`. Pick the entry whose folder matches the app the user named.
+2. Edit that source in place as described under "Updating Existing Files" below.
+3. Publish with \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`, passing the \`path\` and \`file_id\` exactly as listed in step 1.
 `;
 
 // Pod conversations where pod functions are available. Without this, a Frame asked to hold data

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -147,7 +147,7 @@ Give each Frame its own folder on the Pod file system, named after the Frame, an
     MyApp.tsx
 \`\`\`
 
-\`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` creates the Frame's source in the current conversation, so move it into its folder before publishing. Use \`${FILES_MOVE_TOOL}\` (copying does not work on Frame files), then publish it from its Pod path:
+\`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` creates the Frame's source in the current conversation, so move it into its folder before publishing. Use \`${FILES_MOVE_TOOL}\` — never \`mv\` or \`cp\` in the Computer, and never a copy: only \`${FILES_MOVE_TOOL}\` carries the Frame's file record along with its bytes — then publish it from its Pod path:
 
 \`\`\`
 ${FILES_MOVE_TOOL}({

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -24,7 +24,7 @@ const FILES_FIRST_MARKER =
 
 // Markers unique to each Pod-only section.
 const POD_APP_MARKER = "### Frames In A Pod";
-const POD_APP_UPDATE_MARKER = "#### Changing An Existing Pod App";
+const POD_APP_UPDATE_MARKER = "#### Changing An Existing Pod Frame";
 const POD_STORAGE_MARKER = "### Where The Frame's Data Lives";
 
 const FILES_EDIT_TOOL = getPrefixedToolName(

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -1,6 +1,7 @@
 import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
 import {
   FILES_EDIT_ACTION_NAME,
+  FILES_LIST_ACTION_NAME,
   FILES_SERVER_NAME,
 } from "@app/lib/api/actions/servers/files/metadata";
 import {
@@ -23,11 +24,16 @@ const FILES_FIRST_MARKER =
 
 // Markers unique to each Pod-only section.
 const POD_APP_MARKER = "### Frames In A Pod";
+const POD_APP_UPDATE_MARKER = "#### Changing An Existing Pod App";
 const POD_STORAGE_MARKER = "### Where The Frame's Data Lives";
 
 const FILES_EDIT_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
   FILES_EDIT_ACTION_NAME
+);
+const FILES_LIST_TOOL = getPrefixedToolName(
+  FILES_SERVER_NAME,
+  FILES_LIST_ACTION_NAME
 );
 
 function agentLoopDataWithUseFileSystem(
@@ -130,6 +136,19 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).toContain("pod-<podId>/MyApp/MyApp.tsx");
     expect(instructions).toContain(POD_STORAGE_MARKER);
     expect(instructions).toContain(`\`${POD_FUNCTIONS_SKILL_NAME}\` skill`);
+  });
+
+  it("teaches how to find an existing Pod app's path and file id", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+
+    const instructions = await framesSkill.fetchInstructions(auth, {
+      spaceIds: [],
+      agentLoopData: agentLoopDataInPod("vlt_abc123"),
+    });
+
+    expect(instructions).toContain(POD_APP_UPDATE_MARKER);
+    expect(instructions).toContain(FILES_LIST_TOOL);
+    expect(instructions).toContain("[id: fil_...]");
   });
 
   it("omits the storage decision when pod functions are unavailable", async () => {


### PR DESCRIPTION
Instructions-only fixes.

**Finding an existing Pod app.** Editing a Pod app's Frame requires both the Frame's Pod source path and its `file_id` to publish. Teach agent how to get that correctly.

**Moving a Frame.** Observed in practice: the agent moved a new Frame into its Pod folder with `mv` in the Computer instead of `files__move`. Only `files__move` carries the Frame's file record along with its bytes, so the Frame stopped belonging to the Pod its source now lived in. The Pod section now says to use `files__move` and never `mv` or `cp` in the Computer.

One test asserting the new subsection is rendered in a Pod conversation.