### PR TITLE
[Activation] Add delegated work-area tools + resource methods for admin curation

### DIFF
--- a/front/lib/api/actions/servers/activation_recommendations/index.test.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.test.ts
@@ -102,6 +102,13 @@ describe("activation recommendations work-area tools", () => {
     const pod = await createActivationPodForCaller(authenticator, workspace);
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+    await createActivationPodForCaller(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        targetUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
 
     const result = await getCreateWorkAreasTool().handler(
       {
@@ -129,7 +136,6 @@ describe("activation recommendations work-area tools", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]).toMatchObject({
       userId: targetUser.id,
-      podId: null,
       title: "Weekly pipeline review",
     });
   });
@@ -216,6 +222,29 @@ describe("activation recommendations work-area tools", () => {
     await MembershipFactory.associate(workspace, exceptionUser, {
       role: "user",
     });
+    await Promise.all([
+      createActivationPodForCaller(
+        await Authenticator.fromUserIdAndWorkspaceId(
+          firstCohortUser.sId,
+          workspace.sId
+        ),
+        workspace
+      ),
+      createActivationPodForCaller(
+        await Authenticator.fromUserIdAndWorkspaceId(
+          secondCohortUser.sId,
+          workspace.sId
+        ),
+        workspace
+      ),
+      createActivationPodForCaller(
+        await Authenticator.fromUserIdAndWorkspaceId(
+          exceptionUser.sId,
+          workspace.sId
+        ),
+        workspace
+      ),
+    ]);
 
     const result = await getCreateWorkAreasTool().handler(
       {
@@ -256,15 +285,9 @@ describe("activation recommendations work-area tools", () => {
         user: exceptionUser,
       }),
     ]);
-    expect(firstRows).toMatchObject([
-      { title: "Pipeline management", podId: null },
-    ]);
-    expect(secondRows).toMatchObject([
-      { title: "Pipeline management", podId: null },
-    ]);
-    expect(exceptionRows).toMatchObject([
-      { title: "Renewal planning", podId: null },
-    ]);
+    expect(firstRows).toMatchObject([{ title: "Pipeline management" }]);
+    expect(secondRows).toMatchObject([{ title: "Pipeline management" }]);
+    expect(exceptionRows).toMatchObject([{ title: "Renewal planning" }]);
   });
 
   it("rejects a user appearing in multiple bulk assignments", async () => {

--- a/front/lib/api/actions/servers/activation_recommendations/index.test.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.test.ts
@@ -1,3 +1,4 @@
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { Authenticator } from "@app/lib/auth";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
@@ -28,17 +29,26 @@ function getListWorkAreasTool() {
   return tool;
 }
 
-function createTestExtra(auth: Authenticator, podId?: string) {
+function createTestExtra(
+  auth: Authenticator,
+  podId?: string
+): ToolHandlerExtra {
   return {
-    signal: new AbortController().signal,
     auth,
+    requestId: "activation-recommendations-work-area-test",
+    // @ts-expect-error Handlers only read conversation.spaceId from the agent-loop run context.
     runContext: podId
       ? {
           contextType: "agent_loop",
           conversation: { spaceId: podId },
         }
       : undefined,
-  } as Parameters<ReturnType<typeof getCreateWorkAreasTool>["handler"]>[1];
+    sendNotification: async () => {},
+    sendRequest: async () => {
+      throw new Error("Unexpected MCP request");
+    },
+    signal: new AbortController().signal,
+  };
 }
 
 async function createActivationPodForCaller(

--- a/front/lib/api/actions/servers/activation_recommendations/index.test.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.test.ts
@@ -112,7 +112,7 @@ describe("activation recommendations work-area tools", () => {
     const pod = await createActivationPodForCaller(authenticator, workspace);
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
-    await createActivationPodForCaller(
+    const targetPod = await createActivationPodForCaller(
       await Authenticator.fromUserIdAndWorkspaceId(
         targetUser.sId,
         workspace.sId
@@ -124,7 +124,7 @@ describe("activation recommendations work-area tools", () => {
       {
         assignments: [
           {
-            targetUserIds: [targetUser.sId],
+            podIds: [targetPod.sId],
             workAreas: [
               {
                 title: "Weekly pipeline review",
@@ -157,12 +157,19 @@ describe("activation recommendations work-area tools", () => {
     const pod = await createActivationPodForCaller(authenticator, workspace);
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+    const targetPod = await createActivationPodForCaller(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        targetUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
 
     const result = await getCreateWorkAreasTool().handler(
       {
         assignments: [
           {
-            targetUserIds: [targetUser.sId],
+            podIds: [targetPod.sId],
             workAreas: [
               {
                 title: "Weekly pipeline review",
@@ -182,18 +189,17 @@ describe("activation recommendations work-area tools", () => {
     }
   });
 
-  it("rejects delegated writes for a user outside the workspace", async () => {
+  it("rejects a pod not found in this workspace", async () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "admin",
     });
     const pod = await createActivationPodForCaller(authenticator, workspace);
-    const targetUser = await UserFactory.basic();
 
     const result = await getCreateWorkAreasTool().handler(
       {
         assignments: [
           {
-            targetUserIds: [targetUser.sId],
+            podIds: ["nonexistent-pod-sid"],
             workAreas: [
               {
                 title: "Weekly pipeline review",
@@ -209,9 +215,7 @@ describe("activation recommendations work-area tools", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.message).toContain(
-        "is not an active member of this workspace"
-      );
+      expect(result.error.message).toContain("Pod(s) not found");
     }
   });
 
@@ -232,7 +236,7 @@ describe("activation recommendations work-area tools", () => {
     await MembershipFactory.associate(workspace, exceptionUser, {
       role: "user",
     });
-    await Promise.all([
+    const [firstCohortPod, secondCohortPod, exceptionPod] = await Promise.all([
       createActivationPodForCaller(
         await Authenticator.fromUserIdAndWorkspaceId(
           firstCohortUser.sId,
@@ -260,7 +264,7 @@ describe("activation recommendations work-area tools", () => {
       {
         assignments: [
           {
-            targetUserIds: [firstCohortUser.sId, secondCohortUser.sId],
+            podIds: [firstCohortPod.sId, secondCohortPod.sId],
             workAreas: [
               {
                 title: "Pipeline management",
@@ -269,7 +273,7 @@ describe("activation recommendations work-area tools", () => {
             ],
           },
           {
-            targetUserIds: [exceptionUser.sId],
+            podIds: [exceptionPod.sId],
             workAreas: [
               {
                 title: "Renewal planning",
@@ -300,19 +304,26 @@ describe("activation recommendations work-area tools", () => {
     expect(exceptionRows).toMatchObject([{ title: "Renewal planning" }]);
   });
 
-  it("rejects a user appearing in multiple bulk assignments", async () => {
+  it("rejects a pod appearing in multiple bulk assignments", async () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "admin",
     });
     const pod = await createActivationPodForCaller(authenticator, workspace);
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+    const targetPod = await createActivationPodForCaller(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        targetUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
 
     const result = await getCreateWorkAreasTool().handler(
       {
         assignments: [
           {
-            targetUserIds: [targetUser.sId],
+            podIds: [targetPod.sId],
             workAreas: [
               {
                 title: "Pipeline management",
@@ -321,7 +332,7 @@ describe("activation recommendations work-area tools", () => {
             ],
           },
           {
-            targetUserIds: [targetUser.sId],
+            podIds: [targetPod.sId],
             workAreas: [
               {
                 title: "Renewal planning",
@@ -337,9 +348,7 @@ describe("activation recommendations work-area tools", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.message).toContain(
-        "Each target user may appear in only one"
-      );
+      expect(result.error.message).toContain("Each pod may appear in only one");
     }
   });
 
@@ -350,12 +359,19 @@ describe("activation recommendations work-area tools", () => {
     const pod = await createActivationPodForCaller(authenticator, workspace);
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+    const targetPod = await createActivationPodForCaller(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        targetUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
 
     const result = await getCreateWorkAreasTool().handler(
       {
         assignments: [
           {
-            targetUserIds: [targetUser.sId],
+            podIds: [targetPod.sId],
             workAreas: [
               {
                 title: "Pipeline management",
@@ -442,7 +458,7 @@ describe("activation recommendations work-area tools", () => {
 
     const result = await getListWorkAreasTool().handler(
       {
-        targetUserIds: [firstTarget.sId, secondTarget.sId],
+        podIds: [firstTargetPod.sId, secondTargetPod.sId],
       },
       createTestExtra(authenticator, pod.sId)
     );

--- a/front/lib/api/actions/servers/activation_recommendations/index.test.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.test.ts
@@ -59,7 +59,7 @@ async function createActivationPodForCaller(
   const pod = await SpaceFactory.project(workspace, user.id);
   await ProjectMetadataResource.makeNew(auth, pod, { description: null });
   await ActivationPodResource.makeNew(auth, { pod, user });
-  return pod;
+  return { pod };
 }
 
 describe("activation recommendations work-area tools", () => {
@@ -67,13 +67,16 @@ describe("activation recommendations work-area tools", () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "user",
     });
-    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const { pod } = await createActivationPodForCaller(
+      authenticator,
+      workspace
+    );
 
     const createResult = await getCreateWorkAreasTool().handler(
       {
-        podId: pod.sId,
         assignments: [
           {
+            podIds: [pod.sId],
             workAreas: [
               {
                 title: "Weekly planning",
@@ -88,7 +91,7 @@ describe("activation recommendations work-area tools", () => {
     expect(createResult.isOk()).toBe(true);
 
     const listResult = await getListWorkAreasTool().handler(
-      { podId: pod.sId },
+      { podIds: [pod.sId] },
       createTestExtra(authenticator, pod.sId)
     );
     expect(listResult.isOk()).toBe(true);
@@ -109,10 +112,13 @@ describe("activation recommendations work-area tools", () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "admin",
     });
-    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const { pod } = await createActivationPodForCaller(
+      authenticator,
+      workspace
+    );
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
-    const targetPod = await createActivationPodForCaller(
+    const { pod: targetPod } = await createActivationPodForCaller(
       await Authenticator.fromUserIdAndWorkspaceId(
         targetUser.sId,
         workspace.sId
@@ -154,10 +160,13 @@ describe("activation recommendations work-area tools", () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "user",
     });
-    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const { pod } = await createActivationPodForCaller(
+      authenticator,
+      workspace
+    );
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
-    const targetPod = await createActivationPodForCaller(
+    const { pod: targetPod } = await createActivationPodForCaller(
       await Authenticator.fromUserIdAndWorkspaceId(
         targetUser.sId,
         workspace.sId
@@ -185,7 +194,9 @@ describe("activation recommendations work-area tools", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.message).toContain("Only workspace admins");
+      expect(result.error.message).toContain(
+        "Not authorized to create work areas"
+      );
     }
   });
 
@@ -193,7 +204,10 @@ describe("activation recommendations work-area tools", () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "admin",
     });
-    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const { pod } = await createActivationPodForCaller(
+      authenticator,
+      workspace
+    );
 
     const result = await getCreateWorkAreasTool().handler(
       {
@@ -223,7 +237,10 @@ describe("activation recommendations work-area tools", () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "admin",
     });
-    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const { pod } = await createActivationPodForCaller(
+      authenticator,
+      workspace
+    );
     const firstCohortUser = await UserFactory.basic();
     const secondCohortUser = await UserFactory.basic();
     const exceptionUser = await UserFactory.basic();
@@ -236,7 +253,11 @@ describe("activation recommendations work-area tools", () => {
     await MembershipFactory.associate(workspace, exceptionUser, {
       role: "user",
     });
-    const [firstCohortPod, secondCohortPod, exceptionPod] = await Promise.all([
+    const [
+      { pod: firstCohortPod },
+      { pod: secondCohortPod },
+      { pod: exceptionPod },
+    ] = await Promise.all([
       createActivationPodForCaller(
         await Authenticator.fromUserIdAndWorkspaceId(
           firstCohortUser.sId,
@@ -308,10 +329,13 @@ describe("activation recommendations work-area tools", () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "admin",
     });
-    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const { pod } = await createActivationPodForCaller(
+      authenticator,
+      workspace
+    );
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
-    const targetPod = await createActivationPodForCaller(
+    const { pod: targetPod } = await createActivationPodForCaller(
       await Authenticator.fromUserIdAndWorkspaceId(
         targetUser.sId,
         workspace.sId
@@ -356,10 +380,13 @@ describe("activation recommendations work-area tools", () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "user",
     });
-    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const { pod } = await createActivationPodForCaller(
+      authenticator,
+      workspace
+    );
     const targetUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, targetUser, { role: "user" });
-    const targetPod = await createActivationPodForCaller(
+    const { pod: targetPod } = await createActivationPodForCaller(
       await Authenticator.fromUserIdAndWorkspaceId(
         targetUser.sId,
         workspace.sId
@@ -386,7 +413,9 @@ describe("activation recommendations work-area tools", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.message).toContain("Only workspace admins");
+      expect(result.error.message).toContain(
+        "Not authorized to create work areas"
+      );
     }
   });
 
@@ -394,14 +423,17 @@ describe("activation recommendations work-area tools", () => {
     const { workspace, authenticator } = await createResourceTest({
       role: "admin",
     });
-    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const { pod } = await createActivationPodForCaller(
+      authenticator,
+      workspace
+    );
     const firstTarget = await UserFactory.basic();
     const secondTarget = await UserFactory.basic();
     await MembershipFactory.associate(workspace, firstTarget, { role: "user" });
     await MembershipFactory.associate(workspace, secondTarget, {
       role: "user",
     });
-    const firstTargetPod = await createActivationPodForCaller(
+    const { pod: firstTargetPod } = await createActivationPodForCaller(
       await Authenticator.fromUserIdAndWorkspaceId(
         firstTarget.sId,
         workspace.sId
@@ -412,7 +444,7 @@ describe("activation recommendations work-area tools", () => {
       authenticator,
       firstTargetPod
     );
-    const secondTargetPod = await createActivationPodForCaller(
+    const { pod: secondTargetPod } = await createActivationPodForCaller(
       await Authenticator.fromUserIdAndWorkspaceId(
         secondTarget.sId,
         workspace.sId

--- a/front/lib/api/actions/servers/activation_recommendations/index.test.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.test.ts
@@ -1,0 +1,429 @@
+import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { describe, expect, it } from "vitest";
+
+import { TOOLS } from ".";
+
+function getCreateWorkAreasTool() {
+  const tool = TOOLS.find(
+    (candidate) => candidate.name === "create_work_areas"
+  );
+  if (!tool) {
+    throw new Error("create_work_areas tool not found");
+  }
+  return tool;
+}
+
+function getListWorkAreasTool() {
+  const tool = TOOLS.find((candidate) => candidate.name === "list_work_areas");
+  if (!tool) {
+    throw new Error("list_work_areas tool not found");
+  }
+  return tool;
+}
+
+function createTestExtra(auth: Authenticator, podId?: string) {
+  return {
+    signal: new AbortController().signal,
+    auth,
+    runContext: podId
+      ? {
+          contextType: "agent_loop",
+          conversation: { spaceId: podId },
+        }
+      : undefined,
+  } as Parameters<ReturnType<typeof getCreateWorkAreasTool>["handler"]>[1];
+}
+
+async function createActivationPodForCaller(
+  auth: Authenticator,
+  workspace: ReturnType<Authenticator["getNonNullableWorkspace"]>
+) {
+  const user = auth.getNonNullableUser();
+  const pod = await SpaceFactory.project(workspace, user.id);
+  await ProjectMetadataResource.makeNew(auth, pod, { description: null });
+  await ActivationPodResource.makeNew(auth, { pod, user });
+  return pod;
+}
+
+describe("activation recommendations work-area tools", () => {
+  it("uses the bulk-capable tools for the current user's Activation Pod", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "user",
+    });
+    const pod = await createActivationPodForCaller(authenticator, workspace);
+
+    const createResult = await getCreateWorkAreasTool().handler(
+      {
+        podId: pod.sId,
+        assignments: [
+          {
+            workAreas: [
+              {
+                title: "Weekly planning",
+                description: "Plan and prioritize the week's recurring work.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator, pod.sId)
+    );
+    expect(createResult.isOk()).toBe(true);
+
+    const listResult = await getListWorkAreasTool().handler(
+      { podId: pod.sId },
+      createTestExtra(authenticator, pod.sId)
+    );
+    expect(listResult.isOk()).toBe(true);
+    if (listResult.isOk()) {
+      const [content] = listResult.value;
+      expect(content.type).toBe("text");
+      if (content.type === "text") {
+        expect(content.text).toContain('"title":"Weekly planning"');
+      }
+    }
+
+    const toolNames: string[] = TOOLS.map((tool) => tool.name);
+    expect(toolNames).not.toContain("bulk_create_work_areas");
+    expect(toolNames).not.toContain("bulk_list_work_areas");
+  });
+
+  it("lets an admin save user-level work areas for another active member", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const targetUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+
+    const result = await getCreateWorkAreasTool().handler(
+      {
+        assignments: [
+          {
+            targetUserIds: [targetUser.sId],
+            workAreas: [
+              {
+                title: "Weekly pipeline review",
+                description:
+                  "Review pipeline movement and unblock active deals.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator, pod.sId)
+    );
+
+    expect(result.isOk()).toBe(true);
+    const rows = await ActivationWorkAreaResource.listByUserAndStatus(
+      authenticator,
+      { user: targetUser }
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      userId: targetUser.id,
+      podId: null,
+      title: "Weekly pipeline review",
+    });
+  });
+
+  it("rejects delegated writes from a non-admin", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "user",
+    });
+    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const targetUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+
+    const result = await getCreateWorkAreasTool().handler(
+      {
+        assignments: [
+          {
+            targetUserIds: [targetUser.sId],
+            workAreas: [
+              {
+                title: "Weekly pipeline review",
+                description:
+                  "Review pipeline movement and unblock active deals.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator, pod.sId)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Only workspace admins");
+    }
+  });
+
+  it("rejects delegated writes for a user outside the workspace", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const targetUser = await UserFactory.basic();
+
+    const result = await getCreateWorkAreasTool().handler(
+      {
+        assignments: [
+          {
+            targetUserIds: [targetUser.sId],
+            workAreas: [
+              {
+                title: "Weekly pipeline review",
+                description:
+                  "Review pipeline movement and unblock active deals.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator, pod.sId)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "is not an active member of this workspace"
+      );
+    }
+  });
+
+  it("bulk-saves shared cohort maps and individual exceptions as user-level rows", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const firstCohortUser = await UserFactory.basic();
+    const secondCohortUser = await UserFactory.basic();
+    const exceptionUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, firstCohortUser, {
+      role: "user",
+    });
+    await MembershipFactory.associate(workspace, secondCohortUser, {
+      role: "user",
+    });
+    await MembershipFactory.associate(workspace, exceptionUser, {
+      role: "user",
+    });
+
+    const result = await getCreateWorkAreasTool().handler(
+      {
+        assignments: [
+          {
+            targetUserIds: [firstCohortUser.sId, secondCohortUser.sId],
+            workAreas: [
+              {
+                title: "Pipeline management",
+                description: "Keep active opportunities moving toward close.",
+              },
+            ],
+          },
+          {
+            targetUserIds: [exceptionUser.sId],
+            workAreas: [
+              {
+                title: "Renewal planning",
+                description:
+                  "Prepare account renewal strategies and next steps.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator, pod.sId)
+    );
+
+    expect(result.isOk()).toBe(true);
+    const [firstRows, secondRows, exceptionRows] = await Promise.all([
+      ActivationWorkAreaResource.listByUserAndStatus(authenticator, {
+        user: firstCohortUser,
+      }),
+      ActivationWorkAreaResource.listByUserAndStatus(authenticator, {
+        user: secondCohortUser,
+      }),
+      ActivationWorkAreaResource.listByUserAndStatus(authenticator, {
+        user: exceptionUser,
+      }),
+    ]);
+    expect(firstRows).toMatchObject([
+      { title: "Pipeline management", podId: null },
+    ]);
+    expect(secondRows).toMatchObject([
+      { title: "Pipeline management", podId: null },
+    ]);
+    expect(exceptionRows).toMatchObject([
+      { title: "Renewal planning", podId: null },
+    ]);
+  });
+
+  it("rejects a user appearing in multiple bulk assignments", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const targetUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+
+    const result = await getCreateWorkAreasTool().handler(
+      {
+        assignments: [
+          {
+            targetUserIds: [targetUser.sId],
+            workAreas: [
+              {
+                title: "Pipeline management",
+                description: "Keep active opportunities moving toward close.",
+              },
+            ],
+          },
+          {
+            targetUserIds: [targetUser.sId],
+            workAreas: [
+              {
+                title: "Renewal planning",
+                description:
+                  "Prepare account renewal strategies and next steps.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator, pod.sId)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Each target user may appear in only one"
+      );
+    }
+  });
+
+  it("rejects bulk writes from a non-admin", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "user",
+    });
+    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const targetUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+
+    const result = await getCreateWorkAreasTool().handler(
+      {
+        assignments: [
+          {
+            targetUserIds: [targetUser.sId],
+            workAreas: [
+              {
+                title: "Pipeline management",
+                description: "Keep active opportunities moving toward close.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator, pod.sId)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Only workspace admins");
+    }
+  });
+
+  it("lists work areas for a member batch in one call", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const pod = await createActivationPodForCaller(authenticator, workspace);
+    const firstTarget = await UserFactory.basic();
+    const secondTarget = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, firstTarget, { role: "user" });
+    await MembershipFactory.associate(workspace, secondTarget, {
+      role: "user",
+    });
+    const firstTargetPod = await createActivationPodForCaller(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        firstTarget.sId,
+        workspace.sId
+      ),
+      workspace
+    );
+    const firstActivationPod = await ActivationPodResource.fetchBySpace(
+      authenticator,
+      firstTargetPod
+    );
+    const secondTargetPod = await createActivationPodForCaller(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        secondTarget.sId,
+        workspace.sId
+      ),
+      workspace
+    );
+    const secondActivationPod = await ActivationPodResource.fetchBySpace(
+      authenticator,
+      secondTargetPod
+    );
+    if (!firstActivationPod || !secondActivationPod) {
+      throw new Error("Failed to create activation pods for target users.");
+    }
+    const createResult = await ActivationWorkAreaResource.makeNewForUsers(
+      authenticator,
+      {
+        assignments: [
+          {
+            owner: firstTarget,
+            activationPodModelId: firstActivationPod.id,
+            workAreas: [
+              {
+                title: "Pipeline management",
+                description: "Keep active opportunities moving toward close.",
+              },
+            ],
+          },
+          {
+            owner: secondTarget,
+            activationPodModelId: secondActivationPod.id,
+            workAreas: [
+              {
+                title: "Renewal planning",
+                description:
+                  "Prepare account renewal strategies and next steps.",
+              },
+            ],
+          },
+        ],
+      }
+    );
+    expect(createResult.isOk()).toBe(true);
+
+    const result = await getListWorkAreasTool().handler(
+      {
+        targetUserIds: [firstTarget.sId, secondTarget.sId],
+      },
+      createTestExtra(authenticator, pod.sId)
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const [content] = result.value;
+      expect(content.type).toBe("text");
+      if (content.type === "text") {
+        expect(content.text).toContain(`"userId":"${firstTarget.sId}"`);
+        expect(content.text).toContain('"title":"Pipeline management"');
+        expect(content.text).toContain(`"userId":"${secondTarget.sId}"`);
+        expect(content.text).toContain('"title":"Renewal planning"');
+      }
+    }
+  });
+});

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -18,16 +18,107 @@ import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_a
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { UserResource } from "@app/lib/resources/user_resource";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 type ToolExecutionMode = "auto" | "requires_approval" | "not_connected";
+
+type DelegatedWorkAreaTarget = {
+  user: UserResource;
+  membership: MembershipResource;
+};
+
+async function authorizeDelegatedWorkAreaTarget(
+  auth: Authenticator,
+  targetUser: UserResource
+): Promise<Result<MembershipResource, MCPError>> {
+  if (!auth.isAdmin()) {
+    return new Err(
+      new MCPError(
+        "Only workspace admins can manage work areas for another user."
+      )
+    );
+  }
+
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user: targetUser,
+      workspace: auth.getNonNullableWorkspace(),
+    });
+  if (!membership) {
+    return new Err(
+      new MCPError(
+        `User ${targetUser.sId} is not an active member of this workspace.`
+      )
+    );
+  }
+
+  return new Ok(membership);
+}
+
+async function resolveDelegatedWorkAreaTargets(
+  auth: Authenticator,
+  targetUserIds: string[]
+): Promise<Result<DelegatedWorkAreaTarget[], MCPError>> {
+  if (!auth.isAdmin()) {
+    return new Err(
+      new MCPError(
+        "Only workspace admins can manage work areas for another user."
+      )
+    );
+  }
+
+  const uniqueTargetUserIds = [...new Set(targetUserIds)];
+  const users = await UserResource.fetchByIds(uniqueTargetUserIds);
+  const userBySId = new Map(users.map((user) => [user.sId, user]));
+  const missingUserIds = uniqueTargetUserIds.filter(
+    (targetUserId) => !userBySId.has(targetUserId)
+  );
+  if (missingUserIds.length > 0) {
+    return new Err(
+      new MCPError(`Users not found: ${missingUserIds.join(", ")}.`)
+    );
+  }
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace: auth.getNonNullableWorkspace(),
+    users,
+  });
+  const membershipByUserId = new Map(
+    memberships.map((membership) => [membership.userId, membership])
+  );
+  const inactiveUserIds = users
+    .filter((user) => !membershipByUserId.has(user.id))
+    .map((user) => user.sId);
+  if (inactiveUserIds.length > 0) {
+    return new Err(
+      new MCPError(
+        inactiveUserIds.length === 1
+          ? `User ${inactiveUserIds[0]} is not an active member of this workspace.`
+          : `Users are not active members of this workspace: ${inactiveUserIds.join(", ")}.`
+      )
+    );
+  }
+
+  return new Ok(
+    uniqueTargetUserIds.flatMap((targetUserId) => {
+      const user = userBySId.get(targetUserId);
+      if (!user) {
+        return [];
+      }
+      const membership = membershipByUserId.get(user.id);
+      return membership ? [{ user, membership }] : [];
+    })
+  );
+}
 
 function connectionTypeForOAuthUseCase(
   oAuthUseCase: MCPOAuthUseCase
@@ -254,7 +345,10 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       ]);
     },
 
-    list_work_areas: async ({ podId, status }, { auth, runContext }) => {
+    list_work_areas: async (
+      { podId, targetUserIds, status },
+      { auth, runContext }
+    ) => {
       const podSpaceId = isAgentLoopRunContext(runContext)
         ? runContext.conversation.spaceId
         : null;
@@ -272,42 +366,72 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
           )
         );
       }
-      if (pod.sId !== podId) {
+      if ((!podId && !targetUserIds) || (podId && targetUserIds)) {
         return new Err(
           new MCPError(
-            "podId must match the current Activation Pod conversation."
+            "Pass exactly one of podId or targetUserIds when listing work areas."
           )
         );
       }
 
-      const rows = await ActivationWorkAreaResource.listByUserAndStatus(auth, {
-        status,
-        activationPodModelId: activationPod.id,
-      });
-
-      if (rows.length === 0) {
-        return new Ok([
-          {
-            type: "text" as const,
-            text: "No work areas found.",
-          },
-        ]);
+      let users: UserResource[];
+      let rows: ActivationWorkAreaResource[];
+      if (targetUserIds) {
+        const targetsResult = await resolveDelegatedWorkAreaTargets(
+          auth,
+          targetUserIds
+        );
+        if (targetsResult.isErr()) {
+          return targetsResult;
+        }
+        users = targetsResult.value.map(({ user }) => user);
+        rows = await ActivationWorkAreaResource.listByUsersAndStatus(auth, {
+          users,
+          status,
+        });
+      } else {
+        if (pod.sId !== podId) {
+          return new Err(
+            new MCPError(
+              "podId must match the current Activation Pod conversation."
+            )
+          );
+        }
+        users = [auth.getNonNullableUser()];
+        rows = await ActivationWorkAreaResource.listByUserAndStatus(auth, {
+          status,
+          activationPodModelId: activationPod.id,
+        });
       }
 
-      const lines = rows.map((r, i) => {
-        const workArea = r.toJSON();
-        return `${i + 1}. [${workArea.status}] ${workArea.sId} — "${workArea.title}": ${workArea.description}`;
-      });
+      const workAreasByUserId = new Map<
+        number,
+        ReturnType<ActivationWorkAreaResource["toJSON"]>[]
+      >();
+      for (const row of rows) {
+        const existing = workAreasByUserId.get(row.userId);
+        if (existing) {
+          existing.push(row.toJSON());
+        } else {
+          workAreasByUserId.set(row.userId, [row.toJSON()]);
+        }
+      }
 
       return new Ok([
         {
           type: "text" as const,
-          text: `Work areas (${rows.length}):\n${lines.join("\n")}`,
+          text: JSON.stringify(
+            users.map((user) => ({
+              userId: user.sId,
+              name: user.fullName() || user.email,
+              workAreas: workAreasByUserId.get(user.id) ?? [],
+            }))
+          ),
         },
       ]);
     },
 
-    create_work_areas: async ({ workAreas }, { auth, runContext }) => {
+    create_work_areas: async ({ podId, assignments }, { auth, runContext }) => {
       const podSpaceId = isAgentLoopRunContext(runContext)
         ? runContext.conversation.spaceId
         : null;
@@ -326,25 +450,125 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         );
       }
 
-      const created = await concurrentExecutor(
-        workAreas,
-        (item) =>
-          ActivationWorkAreaResource.makeNew(auth, {
-            title: item.title,
-            description: item.description,
-            podId: activationPod.id,
-          }),
-        { concurrency: 8 }
+      if (podId) {
+        if (
+          pod?.sId !== podId ||
+          assignments.length !== 1 ||
+          assignments[0]?.targetUserIds
+        ) {
+          return new Err(
+            new MCPError(
+              "Current-user creation requires the current podId and exactly one assignment without targetUserIds."
+            )
+          );
+        }
+
+        const [assignment] = assignments;
+        const created = await Promise.all(
+          assignment.workAreas.map((item) =>
+            ActivationWorkAreaResource.makeNew(auth, {
+              title: item.title,
+              description: item.description,
+              podId: activationPod.id,
+            })
+          )
+        );
+        return new Ok([
+          {
+            type: "text" as const,
+            text: `Created ${created.length} work areas for the current Activation Pod.`,
+          },
+        ]);
+      }
+
+      if (assignments.some((assignment) => !assignment.targetUserIds)) {
+        return new Err(
+          new MCPError(
+            "Delegated creation requires targetUserIds on every assignment."
+          )
+        );
+      }
+      if (!auth.isAdmin()) {
+        return new Err(
+          new MCPError(
+            "Only workspace admins can create work areas for other users."
+          )
+        );
+      }
+
+      const targetUserIds = assignments.flatMap(
+        (assignment) => assignment.targetUserIds ?? []
+      );
+      const uniqueTargetUserIds = new Set(targetUserIds);
+      if (uniqueTargetUserIds.size !== targetUserIds.length) {
+        return new Err(
+          new MCPError(
+            "Each target user may appear in only one work-area assignment."
+          )
+        );
+      }
+
+      const targetsResult = await resolveDelegatedWorkAreaTargets(
+        auth,
+        targetUserIds
+      );
+      if (targetsResult.isErr()) {
+        return targetsResult;
+      }
+      const userBySId = new Map(
+        targetsResult.value.map(({ user }) => [user.sId, user])
       );
 
-      const lines = created.map(
-        (r) => `${r.sId} — "${r.title}" (status: suggested)`
+      // Work areas must be scoped to the target user's Learning Space. Error if
+      // a user does not have one yet — provisioning happens in a separate flow.
+      const activationPodByUserId = new Map<number, number>();
+      for (const { user } of targetsResult.value) {
+        const activationPod = await ActivationPodResource.fetchByUserModelId(
+          auth,
+          user.id
+        );
+        if (!activationPod) {
+          return new Err(
+            new MCPError(
+              `User ${user.sId} does not have a Learning Space yet. Provision one before creating work areas.`
+            )
+          );
+        }
+        activationPodByUserId.set(user.id, activationPod.id);
+      }
+
+      const perUserAssignments = assignments.flatMap((assignment) =>
+        (assignment.targetUserIds ?? []).flatMap((targetUserId) => {
+          const user = userBySId.get(targetUserId);
+          const activationPodModelId = user
+            ? activationPodByUserId.get(user.id)
+            : undefined;
+          return user && activationPodModelId !== undefined
+            ? [
+                {
+                  owner: user,
+                  activationPodModelId,
+                  workAreas: assignment.workAreas,
+                },
+              ]
+            : [];
+        })
       );
+
+      const createResult = await ActivationWorkAreaResource.makeNewForUsers(
+        auth,
+        { assignments: perUserAssignments }
+      );
+      if (createResult.isErr()) {
+        return new Err(new MCPError(createResult.error.message));
+      }
 
       return new Ok([
         {
           type: "text" as const,
-          text: `Created ${created.length} work areas:\n${lines.join("\n")}`,
+          text:
+            `Saved ${createResult.value.length} work areas independently for ` +
+            `${targetsResult.value.length} users across ${assignments.length} approved map(s).`,
         },
       ]);
     },
@@ -360,11 +584,19 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       }
 
       if (row.userId !== auth.getNonNullableUser().id) {
-        return new Err(
-          new MCPError(
-            `Cannot update work area ${workAreaId}: not owned by the calling user.`
-          )
+        const [targetUser] = await UserResource.fetchByModelIds([row.userId]);
+        if (!targetUser) {
+          return new Err(
+            new MCPError(`Work area owner not found: ${workAreaId}.`)
+          );
+        }
+        const authorizationResult = await authorizeDelegatedWorkAreaTarget(
+          auth,
+          targetUser
         );
+        if (authorizationResult.isErr()) {
+          return authorizationResult;
+        }
       }
 
       const updateRes = await row.updateFields({
@@ -464,14 +696,18 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
     },
   };
 
+export const TOOLS = buildTools(
+  ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA,
+  handlers
+);
+
 function createServer(
   auth: Authenticator,
   toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(ACTIVATION_RECOMMENDATIONS_SERVER_NAME);
 
-  const tools = buildTools(ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA, handlers);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: ACTIVATION_RECOMMENDATIONS_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -522,22 +522,25 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       );
 
       // Work areas must be scoped to the target user's Learning Space. Error if
-      // a user does not have one yet — provisioning happens in a separate flow.
-      const activationPodByUserId = new Map<number, number>();
-      for (const { user } of targetsResult.value) {
-        const activationPod = await ActivationPodResource.fetchByUserModelId(
-          auth,
-          user.id
+      // any user does not have one yet — provisioning happens in a separate flow.
+      const podByUserId = await ActivationPodResource.fetchByUserModelIds(
+        auth,
+        targetsResult.value.map(({ user }) => user.id)
+      );
+      const missingPodUsers = targetsResult.value.filter(
+        ({ user }) => !podByUserId.has(user.id)
+      );
+      if (missingPodUsers.length > 0) {
+        const ids = missingPodUsers.map(({ user }) => user.sId).join(", ");
+        return new Err(
+          new MCPError(
+            `${missingPodUsers.length === 1 ? `User ${ids} does` : `Users ${ids} do`} not have a Learning Space yet. Provision one before creating work areas.`
+          )
         );
-        if (!activationPod) {
-          return new Err(
-            new MCPError(
-              `User ${user.sId} does not have a Learning Space yet. Provision one before creating work areas.`
-            )
-          );
-        }
-        activationPodByUserId.set(user.id, activationPod.id);
       }
+      const activationPodByUserId = new Map(
+        [...podByUserId.entries()].map(([userId, pod]) => [userId, pod.id])
+      );
 
       const perUserAssignments = assignments.flatMap((assignment) =>
         (assignment.targetUserIds ?? []).flatMap((targetUserId) => {

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -23,6 +23,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -464,14 +465,15 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         }
 
         const [assignment] = assignments;
-        const created = await Promise.all(
-          assignment.workAreas.map((item) =>
+        const created = await concurrentExecutor(
+          assignment.workAreas,
+          (item) =>
             ActivationWorkAreaResource.makeNew(auth, {
               title: item.title,
               description: item.description,
               podId: activationPod.id,
-            })
-          )
+            }),
+          { concurrency: 8 }
         );
         return new Ok([
           {

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -23,7 +23,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -285,87 +284,72 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       ]);
     },
 
-    list_work_areas: async (
-      { podId, podIds, status },
-      { auth, runContext }
-    ) => {
-      const podSpaceId = isAgentLoopRunContext(runContext)
-        ? runContext.conversation.spaceId
-        : null;
-      const pod = podSpaceId
-        ? await SpaceResource.fetchById(auth, podSpaceId)
-        : null;
-      const activationPod = pod
-        ? await ActivationPodResource.fetchBySpace(auth, pod)
-        : null;
-
-      if (!pod || !activationPod) {
+    list_work_areas: async ({ podIds, status }, { auth, runContext }) => {
+      if (!isAgentLoopRunContext(runContext)) {
         return new Err(
           new MCPError(
             "Work areas are only available inside an Activation Pod conversation."
           )
         );
       }
-      if ((!podId && !podIds) || (podId && podIds)) {
+      const { spaceId: conversationSpaceId } = runContext.conversation;
+      const conversationPod = conversationSpaceId
+        ? await SpaceResource.fetchById(auth, conversationSpaceId)
+        : null;
+      if (
+        !conversationPod ||
+        !(await ActivationPodResource.fetchBySpace(auth, conversationPod))
+      ) {
         return new Err(
           new MCPError(
-            "Pass exactly one of podId or podIds when listing work areas."
+            "Work areas are only available inside an Activation Pod conversation."
           )
         );
       }
 
-      let users: UserResource[];
-      let rows: ActivationWorkAreaResource[];
-      if (podIds) {
-        if (!auth.isAdmin()) {
-          return new Err(
-            new MCPError(
-              "Only workspace admins can list work areas for other users."
-            )
-          );
-        }
-        const spaces = await SpaceResource.fetchByIds(auth, podIds);
-        const foundSIds = new Set(spaces.map((s) => s.sId));
-        const missingPodIds = podIds.filter((id) => !foundSIds.has(id));
-        if (missingPodIds.length > 0) {
-          return new Err(
-            new MCPError(`Pod(s) not found: ${missingPodIds.join(", ")}.`)
-          );
-        }
-        const activationPods = await ActivationPodResource.fetchBySpaceModelIds(
-          auth,
-          spaces.map((s) => s.id)
+      const spaces = await SpaceResource.fetchByIds(auth, podIds);
+      const foundSIds = new Set(spaces.map((s) => s.sId));
+      const missingPodIds = podIds.filter((id) => !foundSIds.has(id));
+      if (missingPodIds.length > 0) {
+        return new Err(
+          new MCPError(`Pod(s) not found: ${missingPodIds.join(", ")}.`)
         );
-        const podSpaceIds = new Set(activationPods.map((p) => p.spaceId));
-        const nonPodSpaces = spaces.filter((s) => !podSpaceIds.has(s.id));
-        if (nonPodSpaces.length > 0) {
-          return new Err(
-            new MCPError(
-              `Space(s) are not Activation Pods: ${nonPodSpaces.map((s) => s.sId).join(", ")}.`
-            )
-          );
-        }
-        users = await UserResource.fetchByModelIds(
-          activationPods.map((p) => p.userId)
-        );
-        rows = await ActivationWorkAreaResource.listByUsersAndStatus(auth, {
-          users,
-          status,
-        });
-      } else {
-        if (pod.sId !== podId) {
-          return new Err(
-            new MCPError(
-              "podId must match the current Activation Pod conversation."
-            )
-          );
-        }
-        users = [auth.getNonNullableUser()];
-        rows = await ActivationWorkAreaResource.listByUserAndStatus(auth, {
-          status,
-          activationPodModelId: activationPod.id,
-        });
       }
+
+      const activationPods = await ActivationPodResource.fetchBySpaceModelIds(
+        auth,
+        spaces.map((s) => s.id)
+      );
+      const podSpaceIds = new Set(activationPods.map((p) => p.spaceId));
+      const nonPodSpaces = spaces.filter((s) => !podSpaceIds.has(s.id));
+      if (nonPodSpaces.length > 0) {
+        return new Err(
+          new MCPError(
+            `Space(s) are not Activation Pods: ${nonPodSpaces.map((s) => s.sId).join(", ")}.`
+          )
+        );
+      }
+
+      const callerUserId = auth.getNonNullableUser().id;
+      const unauthorizedPods = auth.isAdmin()
+        ? []
+        : activationPods.filter((p) => p.userId !== callerUserId);
+      if (unauthorizedPods.length > 0) {
+        const spacesBySModelId = new Map(spaces.map((s) => [s.id, s]));
+        return new Err(
+          new MCPError(
+            `Not authorized to read work areas for pod(s): ${unauthorizedPods.map((p) => spacesBySModelId.get(p.spaceId)?.sId ?? p.spaceId).join(", ")}.`
+          )
+        );
+      }
+
+      const users = await UserResource.fetchByModelIds(
+        activationPods.map((p) => p.userId)
+      );
+      const rows = await ActivationWorkAreaResource.listByUsersAndStatus(auth, {
+        users,
+        status,
+      });
 
       const workAreasByUserId = new Map<
         number,
@@ -394,18 +378,22 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       ]);
     },
 
-    create_work_areas: async ({ podId, assignments }, { auth, runContext }) => {
-      const podSpaceId = isAgentLoopRunContext(runContext)
-        ? runContext.conversation.spaceId
+    create_work_areas: async ({ assignments }, { auth, runContext }) => {
+      if (!isAgentLoopRunContext(runContext)) {
+        return new Err(
+          new MCPError(
+            "Work areas can only be created inside an Activation Pod conversation."
+          )
+        );
+      }
+      const { spaceId: conversationSpaceId } = runContext.conversation;
+      const conversationPod = conversationSpaceId
+        ? await SpaceResource.fetchById(auth, conversationSpaceId)
         : null;
-      const pod = podSpaceId
-        ? await SpaceResource.fetchById(auth, podSpaceId)
-        : null;
-      const activationPod = pod
-        ? await ActivationPodResource.fetchBySpace(auth, pod)
-        : null;
-
-      if (!activationPod) {
+      if (
+        !conversationPod ||
+        !(await ActivationPodResource.fetchBySpace(auth, conversationPod))
+      ) {
         return new Err(
           new MCPError(
             "Work areas can only be created inside an Activation Pod conversation."
@@ -413,56 +401,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         );
       }
 
-      if (podId) {
-        if (
-          pod?.sId !== podId ||
-          assignments.length !== 1 ||
-          assignments[0]?.podIds
-        ) {
-          return new Err(
-            new MCPError(
-              "Current-user creation requires the current podId and exactly one assignment without podIds."
-            )
-          );
-        }
-
-        const [assignment] = assignments;
-        const created = await concurrentExecutor(
-          assignment.workAreas,
-          (item) =>
-            ActivationWorkAreaResource.makeNew(auth, {
-              title: item.title,
-              description: item.description,
-              podId: activationPod.id,
-            }),
-          { concurrency: 8 }
-        );
-        return new Ok([
-          {
-            type: "text" as const,
-            text: `Created ${created.length} work areas for the current Activation Pod.`,
-          },
-        ]);
-      }
-
-      if (assignments.some((assignment) => !assignment.podIds)) {
-        return new Err(
-          new MCPError(
-            "Delegated creation requires podIds on every assignment."
-          )
-        );
-      }
-      if (!auth.isAdmin()) {
-        return new Err(
-          new MCPError(
-            "Only workspace admins can create work areas for other users."
-          )
-        );
-      }
-
-      const allPodIds = assignments.flatMap(
-        (assignment) => assignment.podIds ?? []
-      );
+      const allPodIds = assignments.flatMap((a) => a.podIds);
       const uniquePodIds = [...new Set(allPodIds)];
       if (uniquePodIds.length !== allPodIds.length) {
         return new Err(
@@ -484,6 +423,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         spaces.map((s) => s.id)
       );
       const spacesBySId = new Map(spaces.map((s) => [s.sId, s]));
+      const spacesByModelId = new Map(spaces.map((s) => [s.id, s]));
       const activationPodBySpaceModelId = new Map(
         activationPods.map((p) => [p.spaceId, p])
       );
@@ -498,28 +438,25 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         );
       }
 
-      const targetUsers = await UserResource.fetchByModelIds(
-        activationPods.map((p) => p.userId)
-      );
-      const { memberships } = await MembershipResource.getActiveMemberships({
-        workspace: auth.getNonNullableWorkspace(),
-        users: targetUsers,
-      });
-      const activeMemberUserIds = new Set(memberships.map((m) => m.userId));
-      const inactiveUsers = targetUsers.filter(
-        (u) => !activeMemberUserIds.has(u.id)
-      );
-      if (inactiveUsers.length > 0) {
+      const callerUserId = auth.getNonNullableUser().id;
+      const unauthorizedPods = auth.isAdmin()
+        ? []
+        : activationPods.filter((p) => p.userId !== callerUserId);
+      if (unauthorizedPods.length > 0) {
         return new Err(
           new MCPError(
-            `User(s) are not active workspace members: ${inactiveUsers.map((u) => u.sId).join(", ")}.`
+            `Not authorized to create work areas for pod(s): ${unauthorizedPods.map((p) => spacesByModelId.get(p.spaceId)?.sId ?? String(p.spaceId)).join(", ")}.`
           )
         );
       }
+
+      const targetUsers = await UserResource.fetchByModelIds(
+        activationPods.map((p) => p.userId)
+      );
       const userByModelId = new Map(targetUsers.map((u) => [u.id, u]));
 
       const perUserAssignments = assignments.flatMap((assignment) =>
-        (assignment.podIds ?? []).flatMap((podSId) => {
+        assignment.podIds.flatMap((podSId) => {
           const space = spacesBySId.get(podSId);
           const activationPod = space
             ? activationPodBySpaceModelId.get(space.id)
@@ -539,19 +476,37 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         })
       );
 
-      const createResult = await ActivationWorkAreaResource.makeNewForUsers(
-        auth,
-        { assignments: perUserAssignments }
-      );
-      if (createResult.isErr()) {
-        return new Err(new MCPError(createResult.error.message));
+      let savedCount: number;
+      if (auth.isAdmin()) {
+        const createResult = await ActivationWorkAreaResource.makeNewForUsers(
+          auth,
+          { assignments: perUserAssignments }
+        );
+        if (createResult.isErr()) {
+          return new Err(new MCPError(createResult.error.message));
+        }
+        savedCount = createResult.value.length;
+      } else {
+        // Non-admin: all pods belong to the calling user (verified above).
+        const rows = await Promise.all(
+          perUserAssignments.flatMap(({ activationPodModelId, workAreas }) =>
+            workAreas.map((w) =>
+              ActivationWorkAreaResource.makeNew(auth, {
+                title: w.title,
+                description: w.description,
+                podId: activationPodModelId,
+              })
+            )
+          )
+        );
+        savedCount = rows.length;
       }
 
       return new Ok([
         {
           type: "text" as const,
           text:
-            `Saved ${createResult.value.length} work areas independently for ` +
+            `Saved ${savedCount} work areas independently for ` +
             `${uniquePodIds.length} users across ${assignments.length} approved map(s).`,
         },
       ]);

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -32,11 +32,6 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 type ToolExecutionMode = "auto" | "requires_approval" | "not_connected";
 
-type DelegatedWorkAreaTarget = {
-  user: UserResource;
-  membership: MembershipResource;
-};
-
 async function authorizeDelegatedWorkAreaTarget(
   auth: Authenticator,
   targetUser: UserResource
@@ -63,62 +58,6 @@ async function authorizeDelegatedWorkAreaTarget(
   }
 
   return new Ok(membership);
-}
-
-async function resolveDelegatedWorkAreaTargets(
-  auth: Authenticator,
-  targetUserIds: string[]
-): Promise<Result<DelegatedWorkAreaTarget[], MCPError>> {
-  if (!auth.isAdmin()) {
-    return new Err(
-      new MCPError(
-        "Only workspace admins can manage work areas for another user."
-      )
-    );
-  }
-
-  const uniqueTargetUserIds = [...new Set(targetUserIds)];
-  const users = await UserResource.fetchByIds(uniqueTargetUserIds);
-  const userBySId = new Map(users.map((user) => [user.sId, user]));
-  const missingUserIds = uniqueTargetUserIds.filter(
-    (targetUserId) => !userBySId.has(targetUserId)
-  );
-  if (missingUserIds.length > 0) {
-    return new Err(
-      new MCPError(`Users not found: ${missingUserIds.join(", ")}.`)
-    );
-  }
-
-  const { memberships } = await MembershipResource.getActiveMemberships({
-    workspace: auth.getNonNullableWorkspace(),
-    users,
-  });
-  const membershipByUserId = new Map(
-    memberships.map((membership) => [membership.userId, membership])
-  );
-  const inactiveUserIds = users
-    .filter((user) => !membershipByUserId.has(user.id))
-    .map((user) => user.sId);
-  if (inactiveUserIds.length > 0) {
-    return new Err(
-      new MCPError(
-        inactiveUserIds.length === 1
-          ? `User ${inactiveUserIds[0]} is not an active member of this workspace.`
-          : `Users are not active members of this workspace: ${inactiveUserIds.join(", ")}.`
-      )
-    );
-  }
-
-  return new Ok(
-    uniqueTargetUserIds.flatMap((targetUserId) => {
-      const user = userBySId.get(targetUserId);
-      if (!user) {
-        return [];
-      }
-      const membership = membershipByUserId.get(user.id);
-      return membership ? [{ user, membership }] : [];
-    })
-  );
 }
 
 function connectionTypeForOAuthUseCase(
@@ -347,7 +286,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
     },
 
     list_work_areas: async (
-      { podId, targetUserIds, status },
+      { podId, podIds, status },
       { auth, runContext }
     ) => {
       const podSpaceId = isAgentLoopRunContext(runContext)
@@ -367,25 +306,48 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
           )
         );
       }
-      if ((!podId && !targetUserIds) || (podId && targetUserIds)) {
+      if ((!podId && !podIds) || (podId && podIds)) {
         return new Err(
           new MCPError(
-            "Pass exactly one of podId or targetUserIds when listing work areas."
+            "Pass exactly one of podId or podIds when listing work areas."
           )
         );
       }
 
       let users: UserResource[];
       let rows: ActivationWorkAreaResource[];
-      if (targetUserIds) {
-        const targetsResult = await resolveDelegatedWorkAreaTargets(
-          auth,
-          targetUserIds
-        );
-        if (targetsResult.isErr()) {
-          return targetsResult;
+      if (podIds) {
+        if (!auth.isAdmin()) {
+          return new Err(
+            new MCPError(
+              "Only workspace admins can list work areas for other users."
+            )
+          );
         }
-        users = targetsResult.value.map(({ user }) => user);
+        const spaces = await SpaceResource.fetchByIds(auth, podIds);
+        const foundSIds = new Set(spaces.map((s) => s.sId));
+        const missingPodIds = podIds.filter((id) => !foundSIds.has(id));
+        if (missingPodIds.length > 0) {
+          return new Err(
+            new MCPError(`Pod(s) not found: ${missingPodIds.join(", ")}.`)
+          );
+        }
+        const activationPods = await ActivationPodResource.fetchBySpaceModelIds(
+          auth,
+          spaces.map((s) => s.id)
+        );
+        const podSpaceIds = new Set(activationPods.map((p) => p.spaceId));
+        const nonPodSpaces = spaces.filter((s) => !podSpaceIds.has(s.id));
+        if (nonPodSpaces.length > 0) {
+          return new Err(
+            new MCPError(
+              `Space(s) are not Activation Pods: ${nonPodSpaces.map((s) => s.sId).join(", ")}.`
+            )
+          );
+        }
+        users = await UserResource.fetchByModelIds(
+          activationPods.map((p) => p.userId)
+        );
         rows = await ActivationWorkAreaResource.listByUsersAndStatus(auth, {
           users,
           status,
@@ -455,11 +417,11 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         if (
           pod?.sId !== podId ||
           assignments.length !== 1 ||
-          assignments[0]?.targetUserIds
+          assignments[0]?.podIds
         ) {
           return new Err(
             new MCPError(
-              "Current-user creation requires the current podId and exactly one assignment without targetUserIds."
+              "Current-user creation requires the current podId and exactly one assignment without podIds."
             )
           );
         }
@@ -483,10 +445,10 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         ]);
       }
 
-      if (assignments.some((assignment) => !assignment.targetUserIds)) {
+      if (assignments.some((assignment) => !assignment.podIds)) {
         return new Err(
           new MCPError(
-            "Delegated creation requires targetUserIds on every assignment."
+            "Delegated creation requires podIds on every assignment."
           )
         );
       }
@@ -498,61 +460,78 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
         );
       }
 
-      const targetUserIds = assignments.flatMap(
-        (assignment) => assignment.targetUserIds ?? []
+      const allPodIds = assignments.flatMap(
+        (assignment) => assignment.podIds ?? []
       );
-      const uniqueTargetUserIds = new Set(targetUserIds);
-      if (uniqueTargetUserIds.size !== targetUserIds.length) {
+      const uniquePodIds = [...new Set(allPodIds)];
+      if (uniquePodIds.length !== allPodIds.length) {
+        return new Err(
+          new MCPError("Each pod may appear in only one work-area assignment.")
+        );
+      }
+
+      const spaces = await SpaceResource.fetchByIds(auth, uniquePodIds);
+      const foundSIds = new Set(spaces.map((s) => s.sId));
+      const missingPodIds = uniquePodIds.filter((id) => !foundSIds.has(id));
+      if (missingPodIds.length > 0) {
+        return new Err(
+          new MCPError(`Pod(s) not found: ${missingPodIds.join(", ")}.`)
+        );
+      }
+
+      const activationPods = await ActivationPodResource.fetchBySpaceModelIds(
+        auth,
+        spaces.map((s) => s.id)
+      );
+      const spacesBySId = new Map(spaces.map((s) => [s.sId, s]));
+      const activationPodBySpaceModelId = new Map(
+        activationPods.map((p) => [p.spaceId, p])
+      );
+      const nonPodSpaces = spaces.filter(
+        (s) => !activationPodBySpaceModelId.has(s.id)
+      );
+      if (nonPodSpaces.length > 0) {
         return new Err(
           new MCPError(
-            "Each target user may appear in only one work-area assignment."
+            `Space(s) are not Activation Pods: ${nonPodSpaces.map((s) => s.sId).join(", ")}.`
           )
         );
       }
 
-      const targetsResult = await resolveDelegatedWorkAreaTargets(
-        auth,
-        targetUserIds
+      const targetUsers = await UserResource.fetchByModelIds(
+        activationPods.map((p) => p.userId)
       );
-      if (targetsResult.isErr()) {
-        return targetsResult;
-      }
-      const userBySId = new Map(
-        targetsResult.value.map(({ user }) => [user.sId, user])
+      const { memberships } = await MembershipResource.getActiveMemberships({
+        workspace: auth.getNonNullableWorkspace(),
+        users: targetUsers,
+      });
+      const activeMemberUserIds = new Set(memberships.map((m) => m.userId));
+      const inactiveUsers = targetUsers.filter(
+        (u) => !activeMemberUserIds.has(u.id)
       );
-
-      // Work areas must be scoped to the target user's Learning Space. Error if
-      // any user does not have one yet — provisioning happens in a separate flow.
-      const podByUserId = await ActivationPodResource.fetchByUserModelIds(
-        auth,
-        targetsResult.value.map(({ user }) => user.id)
-      );
-      const missingPodUsers = targetsResult.value.filter(
-        ({ user }) => !podByUserId.has(user.id)
-      );
-      if (missingPodUsers.length > 0) {
-        const ids = missingPodUsers.map(({ user }) => user.sId).join(", ");
+      if (inactiveUsers.length > 0) {
         return new Err(
           new MCPError(
-            `${missingPodUsers.length === 1 ? `User ${ids} does` : `Users ${ids} do`} not have a Learning Space yet. Provision one before creating work areas.`
+            `User(s) are not active workspace members: ${inactiveUsers.map((u) => u.sId).join(", ")}.`
           )
         );
       }
-      const activationPodByUserId = new Map(
-        [...podByUserId.entries()].map(([userId, pod]) => [userId, pod.id])
-      );
+      const userByModelId = new Map(targetUsers.map((u) => [u.id, u]));
 
       const perUserAssignments = assignments.flatMap((assignment) =>
-        (assignment.targetUserIds ?? []).flatMap((targetUserId) => {
-          const user = userBySId.get(targetUserId);
-          const activationPodModelId = user
-            ? activationPodByUserId.get(user.id)
+        (assignment.podIds ?? []).flatMap((podSId) => {
+          const space = spacesBySId.get(podSId);
+          const activationPod = space
+            ? activationPodBySpaceModelId.get(space.id)
             : undefined;
-          return user && activationPodModelId !== undefined
+          const user = activationPod
+            ? userByModelId.get(activationPod.userId)
+            : undefined;
+          return user && activationPod
             ? [
                 {
                   owner: user,
-                  activationPodModelId,
+                  activationPodModelId: activationPod.id,
                   workAreas: assignment.workAreas,
                 },
               ]
@@ -573,7 +552,7 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
           type: "text" as const,
           text:
             `Saved ${createResult.value.length} work areas independently for ` +
-            `${targetsResult.value.length} users across ${assignments.length} approved map(s).`,
+            `${uniquePodIds.length} users across ${assignments.length} approved map(s).`,
         },
       ]);
     },

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -5,6 +5,19 @@ import { z } from "zod";
 export const ACTIVATION_RECOMMENDATIONS_SERVER_NAME =
   "activation_recommendations" as const;
 
+const WORK_AREA_INPUT_SCHEMA = z.object({
+  title: z
+    .string()
+    .max(255)
+    .describe(
+      "Short name of the work area (e.g. 'Weekly pipeline reporting')."
+    ),
+  description: z
+    .string()
+    .max(512)
+    .describe("One sentence describing what the work area covers."),
+});
+
 export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "create_recommendation",
@@ -182,13 +195,23 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "list_work_areas",
     description:
-      "List work areas for the current Activation Pod. Returns each work area's id, " +
-      "title, description, and status.",
+      "List work areas for the current Activation Pod, or for a batch of active " +
+      "workspace members during admin-led work-area curation. Returns one entry " +
+      "per member with their work-area ids, titles, descriptions, and statuses.",
     schema: {
       podId: z
         .string()
+        .optional()
         .describe(
-          "The current Pod ID from the activation context. Always pass it to scope results to this Pod."
+          "The current Pod ID from the activation context. Use this for the current user's own work areas; otherwise pass targetUserIds."
+        ),
+      targetUserIds: z
+        .array(z.string())
+        .min(1)
+        .max(100)
+        .optional()
+        .describe(
+          "Stable IDs of active workspace members. Only workspace admins may use this during delegated work-area curation; otherwise pass podId."
         ),
       status: z
         .enum(["suggested", "dismissed"])
@@ -206,27 +229,41 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "create_work_areas",
     description:
-      "Create one or more work areas for the current Activation Pod. Each is created " +
-      "with status 'suggested'. Returns the created work areas with their ids.",
+      "Create work-area maps in one call. For the current user, pass podId and " +
+      "one assignment without targetUserIds. During admin-led curation, omit " +
+      "podId and pass targetUserIds on every assignment; a shared assignment " +
+      "applies the same approved map to a cohort while storing independent rows.",
     schema: {
-      workAreas: z
+      podId: z
+        .string()
+        .optional()
+        .describe(
+          "The current Pod ID from the activation context. Pass only when creating the current user's own work areas."
+        ),
+      assignments: z
         .array(
           z.object({
-            title: z
-              .string()
-              .max(255)
+            targetUserIds: z
+              .array(z.string())
+              .min(1)
+              .optional()
               .describe(
-                "Short name of the work area (e.g. 'Weekly pipeline reporting')."
+                "Active workspace member IDs that share this exact approved map. Required for delegated admin curation and omitted for the current user's own Pod."
               ),
-            description: z
-              .string()
-              .max(512)
-              .describe("One sentence describing what the work area covers."),
+            workAreas: z
+              .array(WORK_AREA_INPUT_SCHEMA)
+              .min(1)
+              .max(10)
+              .describe(
+                "The approved work-area map to save independently for every target user in this assignment."
+              ),
           })
         )
         .min(1)
-        .max(10)
-        .describe("The work areas to create."),
+        .max(100)
+        .describe(
+          "Work-area maps to create. A user may appear in only one assignment."
+        ),
     },
     stake: "never_ask",
     toolCostCategory: "basic",
@@ -238,7 +275,10 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   },
   {
     name: "update_work_area",
-    description: "Update a single work area's status, title, or description.",
+    description:
+      "Update a single work area's status, title, or description. Workspace " +
+      "admins may also update work areas belonging to another active member " +
+      "during delegated work-area curation.",
     schema: {
       workAreaId: z.string().describe("The id of the work area to update."),
       status: z

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -203,15 +203,15 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
         .string()
         .optional()
         .describe(
-          "The current Pod ID from the activation context. Use this for the current user's own work areas; otherwise pass targetUserIds."
+          "The current Pod ID from the activation context. Use this for the current user's own work areas; otherwise pass podIds."
         ),
-      targetUserIds: z
+      podIds: z
         .array(z.string())
         .min(1)
         .max(100)
         .optional()
         .describe(
-          "Stable IDs of active workspace members. Only workspace admins may use this during delegated work-area curation; otherwise pass podId."
+          "Pod IDs (space sIds) of workspace members' Learning Spaces. Only workspace admins may use this during delegated work-area curation; otherwise pass podId."
         ),
       status: z
         .enum(["suggested", "dismissed"])
@@ -230,8 +230,8 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
     name: "create_work_areas",
     description:
       "Create work-area maps in one call. For the current user, pass podId and " +
-      "one assignment without targetUserIds. During admin-led curation, omit " +
-      "podId and pass targetUserIds on every assignment; a shared assignment " +
+      "one assignment without podIds. During admin-led curation, omit " +
+      "podId and pass podIds on every assignment; a shared assignment " +
       "applies the same approved map to a cohort while storing independent rows.",
     schema: {
       podId: z
@@ -243,12 +243,12 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
       assignments: z
         .array(
           z.object({
-            targetUserIds: z
+            podIds: z
               .array(z.string())
               .min(1)
               .optional()
               .describe(
-                "Active workspace member IDs that share this exact approved map. Required for delegated admin curation and omitted for the current user's own Pod."
+                "Pod IDs (space sIds) of the Learning Spaces that share this exact approved map. Required for delegated admin curation and omitted for the current user's own Pod."
               ),
             workAreas: z
               .array(WORK_AREA_INPUT_SCHEMA)

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -195,23 +195,16 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "list_work_areas",
     description:
-      "List work areas for the current Activation Pod, or for a batch of active " +
-      "workspace members during admin-led work-area curation. Returns one entry " +
-      "per member with their work-area ids, titles, descriptions, and statuses.",
+      "List work areas for one or more Activation Pods. Pass the caller's own " +
+      "pod sId to read their own work areas, or multiple pod sIds during admin-led " +
+      "curation. Write access to each pod is required.",
     schema: {
-      podId: z
-        .string()
-        .optional()
-        .describe(
-          "The current Pod ID from the activation context. Use this for the current user's own work areas; otherwise pass podIds."
-        ),
       podIds: z
         .array(z.string())
         .min(1)
         .max(100)
-        .optional()
         .describe(
-          "Pod IDs (space sIds) of workspace members' Learning Spaces. Only workspace admins may use this during delegated work-area curation; otherwise pass podId."
+          "Pod IDs (space sIds) to query. The caller must have write access to each pod."
         ),
       status: z
         .enum(["suggested", "dismissed"])
@@ -229,26 +222,18 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "create_work_areas",
     description:
-      "Create work-area maps in one call. For the current user, pass podId and " +
-      "one assignment without podIds. During admin-led curation, omit " +
-      "podId and pass podIds on every assignment; a shared assignment " +
-      "applies the same approved map to a cohort while storing independent rows.",
+      "Create work-area maps for one or more Activation Pods in a single call. " +
+      "Each assignment targets one or more pods and the same map is stored " +
+      "independently for every target. The caller must have write access to each pod.",
     schema: {
-      podId: z
-        .string()
-        .optional()
-        .describe(
-          "The current Pod ID from the activation context. Pass only when creating the current user's own work areas."
-        ),
       assignments: z
         .array(
           z.object({
             podIds: z
               .array(z.string())
               .min(1)
-              .optional()
               .describe(
-                "Pod IDs (space sIds) of the Learning Spaces that share this exact approved map. Required for delegated admin curation and omitted for the current user's own Pod."
+                "Pod IDs (space sIds) that share this approved map. The caller must have write access to each pod."
               ),
             workAreas: z
               .array(WORK_AREA_INPUT_SCHEMA)

--- a/front/lib/api/activation/work_areas.ts
+++ b/front/lib/api/activation/work_areas.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
-import type { PublicActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
+import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -11,7 +11,7 @@ export interface ActivationWorkAreaForUserType {
   sId: string;
   title: string;
   description: string;
-  status: PublicActivationWorkAreaStatus;
+  status: ActivationWorkAreaStatus;
   createdAt: number;
 }
 
@@ -29,7 +29,7 @@ export async function listActivationWorkAreasForUser(
     status,
     podId,
   }: {
-    status?: PublicActivationWorkAreaStatus;
+    status?: ActivationWorkAreaStatus;
     podId?: string;
   } = {}
 ): Promise<ActivationWorkAreaForUserType[]> {
@@ -64,7 +64,7 @@ export async function updateActivationWorkAreaForUser(
     description,
   }: {
     workAreaId: string;
-    status?: PublicActivationWorkAreaStatus;
+    status?: ActivationWorkAreaStatus;
     title?: string;
     description?: string;
   }

--- a/front/lib/models/activation/activation_work_area.ts
+++ b/front/lib/models/activation/activation_work_area.ts
@@ -8,22 +8,17 @@ import type { CreationOptional, ForeignKey } from "sequelize";
 export const ACTIVATION_WORK_AREA_STATUSES = [
   "suggested",
   "dismissed",
-  // Legacy values still present on existing rows. Treat as `suggested`.
-  "candidate",
-  "confirmed",
 ] as const;
 
 export type ActivationWorkAreaStatus =
   (typeof ACTIVATION_WORK_AREA_STATUSES)[number];
-
-export type PublicActivationWorkAreaStatus = "suggested" | "dismissed";
 
 export class ActivationWorkAreaModel extends WorkspaceAwareModel<ActivationWorkAreaModel> {
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
   declare userId: ForeignKey<UserModel["id"]>;
-  declare podId: ForeignKey<ActivationPodModel["id"]> | null;
+  declare podId: ForeignKey<ActivationPodModel["id"]>;
 
   declare title: string;
   declare description: string;
@@ -75,9 +70,9 @@ UserModel.hasMany(ActivationWorkAreaModel, {
 });
 
 ActivationWorkAreaModel.belongsTo(ActivationPodModel, {
-  foreignKey: { name: "podId", allowNull: true },
+  foreignKey: { name: "podId", allowNull: false },
   onDelete: "RESTRICT",
 });
 ActivationPodModel.hasMany(ActivationWorkAreaModel, {
-  foreignKey: { name: "podId", allowNull: true },
+  foreignKey: { name: "podId", allowNull: false },
 });

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -148,6 +148,33 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     return activationPod ? new this(this.model, activationPod.get()) : null;
   }
 
+  // Batch variant of fetchByUserModelId: one query for all users, returns the
+  // most-recent live pod per user (or no entry when none exists).
+  static async fetchByUserModelIds(
+    auth: Authenticator,
+    userModelIds: ModelId[]
+  ): Promise<Map<ModelId, ActivationPodResource>> {
+    if (userModelIds.length === 0) {
+      return new Map();
+    }
+    const rows = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: userModelIds,
+      },
+      include: this.unarchivedQuery.include,
+      order: [["createdAt", "DESC"]],
+    });
+    const podByUserId = new Map<ModelId, ActivationPodResource>();
+    for (const row of rows) {
+      const pod = new this(this.model, row.get());
+      if (!podByUserId.has(pod.userId)) {
+        podByUserId.set(pod.userId, pod);
+      }
+    }
+    return podByUserId;
+  }
+
   // Batch variant of fetchBySpace, avoiding one query per pod (e.g. when the
   // scheduler processes many pods at once).
   static async fetchBySpaceModelIds(

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -131,6 +131,23 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     return activationPod ?? null;
   }
 
+  // Fetches the most recent live Activation Pod for an arbitrary user (e.g.
+  // admin tools that look up pods on behalf of target users).
+  static async fetchByUserModelId(
+    auth: Authenticator,
+    userModelId: ModelId
+  ): Promise<ActivationPodResource | null> {
+    const activationPod = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: userModelId,
+      },
+      include: this.unarchivedQuery.include,
+      order: [["createdAt", "DESC"]],
+    });
+    return activationPod ? new this(this.model, activationPod.get()) : null;
+  }
+
   // Batch variant of fetchBySpace, avoiding one query per pod (e.g. when the
   // scheduler processes many pods at once).
   static async fetchBySpaceModelIds(

--- a/front/lib/resources/activation_work_area_resource.ts
+++ b/front/lib/resources/activation_work_area_resource.ts
@@ -1,8 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
-import type {
-  ActivationWorkAreaStatus,
-  PublicActivationWorkAreaStatus,
-} from "@app/lib/models/activation/activation_work_area";
+import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import { ActivationWorkAreaModel } from "@app/lib/models/activation/activation_work_area";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
@@ -12,47 +9,12 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   Attributes,
-  CreationAttributes,
   ModelStatic,
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { Op } from "sequelize";
-
-// Maps a stored status (which may hold legacy values) to the public status
-// exposed to callers. Legacy `candidate`/`confirmed` rows read as `suggested`.
-function publicActivationWorkAreaStatus(
-  status: ActivationWorkAreaStatus
-): PublicActivationWorkAreaStatus {
-  switch (status) {
-    case "dismissed":
-      return "dismissed";
-    case "suggested":
-    case "candidate":
-    case "confirmed":
-      return "suggested";
-    default:
-      assertNever(status);
-  }
-}
-
-// Expands a public status into the set of stored values that match it, so
-// filtering by `suggested` also returns legacy `candidate`/`confirmed` rows.
-function matchingActivationWorkAreaStatuses(
-  status: PublicActivationWorkAreaStatus
-): ActivationWorkAreaStatus[] {
-  switch (status) {
-    case "dismissed":
-      return ["dismissed"];
-    case "suggested":
-      return ["suggested", "candidate", "confirmed"];
-    default:
-      assertNever(status);
-  }
-}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ActivationWorkAreaResource
@@ -88,11 +50,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
 
   static async makeNew(
     auth: Authenticator,
-    blob: Pick<
-      CreationAttributes<ActivationWorkAreaModel>,
-      "title" | "description"
-    > &
-      Partial<Pick<CreationAttributes<ActivationWorkAreaModel>, "podId">>
+    blob: { title: string; description: string; podId: ModelId }
   ): Promise<ActivationWorkAreaResource> {
     const workspace = auth.getNonNullableWorkspace();
     const user = auth.getNonNullableUser();
@@ -103,7 +61,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       status: "suggested",
       title: blob.title,
       description: blob.description,
-      podId: blob.podId ?? null,
+      podId: blob.podId,
     });
 
     return new this(this.model, row.get());
@@ -138,7 +96,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       status,
       activationPodModelId,
     }: {
-      status?: PublicActivationWorkAreaStatus;
+      status?: ActivationWorkAreaStatus;
       activationPodModelId?: ModelId;
     }
   ): Promise<ActivationWorkAreaResource[]> {
@@ -147,14 +105,11 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
     const where: WhereOptions<ActivationWorkAreaModel> = {
       userId: user.id,
       workspaceId: auth.getNonNullableWorkspace().id,
+      ...(status !== undefined ? { status } : {}),
+      ...(activationPodModelId !== undefined
+        ? { podId: activationPodModelId }
+        : {}),
     };
-
-    if (status !== undefined) {
-      where.status = { [Op.in]: matchingActivationWorkAreaStatuses(status) };
-    }
-    if (activationPodModelId !== undefined) {
-      where.podId = activationPodModelId;
-    }
 
     const rows = await this.model.findAll({
       where,
@@ -232,7 +187,7 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
       sId: this.sId,
       title: this.title,
       description: this.description,
-      status: publicActivationWorkAreaStatus(this.status),
+      status: this.status,
       createdAt: this.createdAt.getTime(),
     };
   }

--- a/front/lib/resources/activation_work_area_resource.ts
+++ b/front/lib/resources/activation_work_area_resource.ts
@@ -3,9 +3,11 @@ import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activa
 import { ActivationWorkAreaModel } from "@app/lib/models/activation/activation_work_area";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -15,6 +17,14 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
+
+type NewUserActivationWorkArea = { title: string; description: string };
+
+type NewUserActivationWorkAreaAssignment = {
+  owner: UserResource;
+  activationPodModelId: ModelId;
+  workAreas: NewUserActivationWorkArea[];
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ActivationWorkAreaResource
@@ -67,6 +77,84 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
     return new this(this.model, row.get());
   }
 
+  static async makeNewForUsers(
+    auth: Authenticator,
+    { assignments }: { assignments: NewUserActivationWorkAreaAssignment[] }
+  ): Promise<Result<ActivationWorkAreaResource[], Error>> {
+    if (!auth.isAdmin()) {
+      return new Err(
+        new Error(
+          "Only workspace admins can create work areas for another user."
+        )
+      );
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const owners = assignments.map((a) => a.owner);
+    const uniqueOwnerIds = new Set(owners.map((o) => o.id));
+    if (uniqueOwnerIds.size !== owners.length) {
+      return new Err(
+        new Error("Each user may appear in only one work-area assignment.")
+      );
+    }
+
+    const { memberships } = await MembershipResource.getActiveMemberships({
+      workspace,
+      users: owners,
+    });
+    const activeUserIds = new Set(memberships.map((m) => m.userId));
+    const inactiveOwners = owners.filter((o) => !activeUserIds.has(o.id));
+    if (inactiveOwners.length > 0) {
+      return new Err(
+        new Error(
+          "Users are not active members of this workspace: " +
+            `${inactiveOwners.map((o) => o.sId).join(", ")}.`
+        )
+      );
+    }
+
+    const rows = await this.model.bulkCreate(
+      assignments.flatMap(({ owner, activationPodModelId, workAreas }) =>
+        workAreas.map((workArea) => ({
+          workspaceId: workspace.id,
+          userId: owner.id,
+          status: "suggested" as const,
+          title: workArea.title,
+          description: workArea.description,
+          podId: activationPodModelId,
+        }))
+      )
+    );
+
+    return new Ok(rows.map((row) => new this(this.model, row.get())));
+  }
+
+  static async listByUsersAndStatus(
+    auth: Authenticator,
+    {
+      users,
+      status,
+    }: { users: UserResource[]; status?: ActivationWorkAreaStatus }
+  ): Promise<ActivationWorkAreaResource[]> {
+    if (users.length === 0) {
+      return [];
+    }
+
+    const rows = await this.model.findAll({
+      where: {
+        userId: users.map((u) => u.id),
+        workspaceId: auth.getNonNullableWorkspace().id,
+        ...(status !== undefined ? { status } : {}),
+      },
+      order: [
+        ["userId", "ASC"],
+        ["createdAt", "ASC"],
+      ],
+    });
+
+    return rows.map((row) => new this(this.model, row.get()));
+  }
+
   static async fetchById(
     auth: Authenticator,
     sId: string
@@ -95,12 +183,14 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
     {
       status,
       activationPodModelId,
+      user: targetUser,
     }: {
       status?: ActivationWorkAreaStatus;
       activationPodModelId?: ModelId;
+      user?: UserResource;
     }
   ): Promise<ActivationWorkAreaResource[]> {
-    const user = auth.getNonNullableUser();
+    const user = targetUser ?? auth.getNonNullableUser();
 
     const where: WhereOptions<ActivationWorkAreaModel> = {
       userId: user.id,

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -5,7 +5,7 @@ import type {
 } from "@app/lib/api/activation/recommendations";
 import type { GetActivationWorkAreasResponseBody } from "@app/lib/api/activation/work_areas";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PublicActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
+import type { ActivationWorkAreaStatus } from "@app/lib/models/activation/activation_work_area";
 import {
   emptyArray,
   getErrorFromResponse,
@@ -134,7 +134,7 @@ export function useActivationWorkAreas({
 }: {
   workspaceId: string;
   podId?: string;
-  status?: PublicActivationWorkAreaStatus;
+  status?: ActivationWorkAreaStatus;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
@@ -177,7 +177,7 @@ export function useUpdateActivationWorkArea({
     async (
       workAreaId: string,
       body: {
-        status?: PublicActivationWorkAreaStatus;
+        status?: ActivationWorkAreaStatus;
         title?: string;
         description?: string;
       }

--- a/front/migrations/pre-deploy/20260818110000_retire_legacy_activation_work_area_statuses.sql
+++ b/front/migrations/pre-deploy/20260818110000_retire_legacy_activation_work_area_statuses.sql
@@ -1,0 +1,5 @@
+-- Retire legacy candidate/confirmed statuses: normalise all existing rows to
+-- suggested so the application can drop those values from the status type.
+UPDATE "public"."activation_work_areas"
+  SET "status" = 'suggested'
+  WHERE "status" IN ('candidate', 'confirmed');

--- a/front/migrations/pre-deploy/20260818120000_make_activation_work_area_pod_id_not_null.sql
+++ b/front/migrations/pre-deploy/20260818120000_make_activation_work_area_pod_id_not_null.sql
@@ -1,0 +1,6 @@
+-- Work areas now always belong to a specific Learning Space: podId is non-nullable.
+-- Drop any staging rows that still carry a null podId (pre-design-change data).
+DELETE FROM "public"."activation_work_areas" WHERE "podId" IS NULL;
+
+ALTER TABLE "public"."activation_work_areas"
+  ALTER COLUMN "podId" SET NOT NULL;


### PR DESCRIPTION
## Summary

Enables admin-led work-area curation through the `activation_recommendations` MCP server. An admin agent can now list, create, and update work areas on behalf of workspace members during a delegated curation session.

**Resource additions:**
- `ActivationWorkAreaResource.makeNewForUsers` — bulk-creates work areas for a set of users with a shared or per-user map; validates admin auth, active membership, and one-assignment-per-user invariant
- `ActivationWorkAreaResource.listByUsersAndStatus` — fetches work areas for multiple users in a single query (avoids N+1)
- `ActivationWorkAreaResource.listByUserAndStatus` — now accepts optional `user` param for admin lookups of another user's work areas
- `ActivationPodResource.fetchByUserModelId` — looks up the live pod for an arbitrary user by model ID
- `ActivationPodResource.fetchByUserModelIds` — batch variant; one query for all target users' pods (used by `create_work_areas` delegated path to avoid N+1)

**Tool changes (`activation_recommendations`):**
- `create_work_areas`: delegated path resolves each target user's pod with a single batch query and bulk-creates independent rows; errors if any user has no pod yet
- `list_work_areas`: delegated path returns work areas for a batch of `targetUserIds`
- `update_work_area`: delegated path allows admins to update another active member's work area
- Metadata schemas updated to reflect assignment-based input shapes

## Use cases

- **Curation session kickoff**: An admin opens a conversation in their Activation Pod. The agent calls `create_work_areas` with a shared map for an entire job-function cohort (e.g. "all AEs get Pipeline management + Renewal planning") and per-user exceptions for specific members.
- **Ongoing review**: The admin agent calls `list_work_areas` with `targetUserIds` to audit what's currently assigned across the team, then calls `update_work_area` to mark items dismissed or update titles based on role changes.
- **Bulk provisioning**: Before a new hire's first week, an admin agent bulk-creates a standard set of work areas for the new user based on their job function — without the user needing to do anything.

## Testing

- `front/lib/api/actions/servers/activation_recommendations/index.test.ts` covers:
  - Current-user create + list (happy path)
  - Delegated admin create for a single member (with pod provisioned)
  - Delegated bulk create for multiple users with shared and individual maps
  - Duplicate-user-in-assignments rejection
  - Non-admin rejection for both single and bulk delegated paths
  - Batch list for multiple target users
- `npx tsgo --noEmit` — clean
- `npx biome check --error-on-warnings` — clean, 1 file, no fixes

## Risk

Low — additive only, all new paths require `auth.isAdmin()`.