### PR TITLE
Keep the filesystem harness in step with the daemon contract

### DIFF
--- a/x/flav/dust-filesystem-harness/README.md
+++ b/x/flav/dust-filesystem-harness/README.md
@@ -52,9 +52,7 @@ file keeping its identity across a move between roots.
 
 `staging_checks.sh` mounts several times over to check what startup does with the
 local staging directory: a fresh one, one it already claimed, one left mid-claim
-by a crash, and one belonging to something else that must be left untouched. The
-mid-claim case reports a failure until the staging recovery change lands, since
-that is the bug it describes.
+by a crash, and one belonging to something else that must be left untouched.
 
 `time_probe.sh` prints the time a file reports after each step of a write, then
 checks that it stops moving once the file is saved. A time that settles late is

--- a/x/flav/dust-filesystem-harness/fake_front.py
+++ b/x/flav/dust-filesystem-harness/fake_front.py
@@ -142,7 +142,9 @@ class Handler(BaseHTTPRequestHandler):
             return ok(self, {"node": node})
 
         if operation == "setExecutableBits":
-            node = NODES[request["nodeId"]]
+            node = NODES.get(request["nodeId"])
+            if node is None:
+                return error(self, "not_found")
             node["mode"] = (node["mode"] & ~0o111) | request["executableBits"]
             return ok(self, {"node": node})
 
@@ -153,7 +155,7 @@ class Handler(BaseHTTPRequestHandler):
             if any(other["parentId"] == node["id"] for other in NODES.values()):
                 return error(self, "not_empty")
             del NODES[node["id"]]
-            return ok(self, {})
+            return ok(self, {"removedNodeId": node["id"]})
 
         if operation == "rename":
             node = child_by_name(request["sourceParentId"], request["sourceName"])
@@ -162,14 +164,19 @@ class Handler(BaseHTTPRequestHandler):
             existing = child_by_name(
                 request["destinationParentId"], request["destinationName"]
             )
+            replaced_node_id = None
             if existing is not None:
+                replaced_node_id = existing["id"]
                 del NODES[existing["id"]]
             node["parentId"] = request["destinationParentId"]
             node["name"] = request["destinationName"]
-            return ok(self, {"node": node})
+            # Null rather than a missing field: the daemon tells the two apart.
+            return ok(self, {"node": node, "replacedNodeId": replaced_node_id})
 
         if operation == "getContent":
-            node = NODES[request["nodeId"]]
+            node = NODES.get(request["nodeId"])
+            if node is None:
+                return error(self, "not_found")
             url = None
             if node["blobId"] is not None:
                 url = f"{base}/blob/{node['blobId']}"
@@ -185,7 +192,9 @@ class Handler(BaseHTTPRequestHandler):
             )
 
         if operation == "prepareContentUpload":
-            node = NODES[request["nodeId"]]
+            node = NODES.get(request["nodeId"])
+            if node is None:
+                return error(self, "not_found")
             if node["blobId"] != request.get("expectedBlobId"):
                 return error(self, "stale")
             blob_id = f"blob-{NEXT_BLOB[0]}"
@@ -207,7 +216,9 @@ class Handler(BaseHTTPRequestHandler):
             )
 
         if operation == "commitContentUpload":
-            node = NODES[request["nodeId"]]
+            node = NODES.get(request["nodeId"])
+            if node is None:
+                return error(self, "not_found")
             if node["blobId"] != request.get("expectedBlobId"):
                 return error(self, "stale")
             stored = BLOBS.get(request["blobId"])

--- a/x/flav/dust-filesystem-harness/staging_checks.sh
+++ b/x/flav/dust-filesystem-harness/staging_checks.sh
@@ -2,10 +2,6 @@
 # Mounts the daemon several times over to check what startup does with the local
 # staging directory: a fresh one, one it already claimed, one left mid-claim by a
 # crash, and one that belongs to something else and must be left alone.
-#
-# The mid-claim case fails until the staging recovery change lands, because
-# startup refuses a directory holding the file a half-written marker leaves. That
-# failure is the bug, not a broken check.
 set -uo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/lib.sh"


### PR DESCRIPTION
## Description

The local mount harness stopped working once removes and renames started relying on the node IDs Front reports. Its stand-in Front never learned to send them, so the daemon rejected every answer it gave for those two operations. Deleting or renaming a file through the harness failed with an I/O error, which took the acceptance script down with it. Nothing in the sandbox itself was affected, because the real Front has been sending both fields since they were added.

The stand-in now sends the node it removed, and the node a rename replaced. It sends an explicit empty value when the destination name was free, rather than leaving the field out, because the daemon deliberately treats those as different answers. It also reports a node as gone instead of failing outright when asked about one that no longer exists, which is what the real thing does and what made this confusing to track down in the first place.

Two notes in the harness went stale when the staging directory recovery landed. Both said that one case was expected to fail, and it now passes, so they are gone.

## Tests

All five harness scripts were run against the current daemon, not only the one that was broken. The acceptance script that ships with the sandbox passes end to end, and the mount, staging, time and space checks all report clean. The staging checks are the interesting ones: they went from three failures to passing, which is the recovery fix showing up in the tool for the first time.

## Risk

None to the product. Nothing here ships to a sandbox, and no code outside this directory changes.

The wider point is that this directory pins a copy of Front's contract, so a change on the Front side can leave it quietly wrong while everything else looks healthy, and nothing runs it automatically. Running it in CI would need a runner with FUSE available.

## Deploy Plan

Nothing to deploy.
