### PR TITLE
Give the sandbox filesystem mount the public API URL

### DIFF
--- a/front/lib/api/config.test.ts
+++ b/front/lib/api/config.test.ts
@@ -1,0 +1,47 @@
+import config from "@app/lib/api/config";
+import { afterEach, describe, expect, it } from "vitest";
+
+const PUBLIC_URL = "https://eu.dust.tt";
+const INTERNAL_URL = "http://front-internal-service";
+
+describe("getSandboxApiBaseUrl", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns the public URL where the internal one would be used", () => {
+    // Sandboxes run outside the cluster, so the internal service address that
+    // the rest of Front prefers is unreachable for them.
+    process.env.NEXT_PUBLIC_DUST_API_URL = PUBLIC_URL;
+    process.env.DUST_INTERNAL_API_URL = INTERNAL_URL;
+
+    expect(config.getApiBaseUrl()).toBe(INTERNAL_URL);
+    expect(config.getSandboxApiBaseUrl()).toBe(PUBLIC_URL);
+  });
+
+  it("follows the public URL of the region it runs in", () => {
+    process.env.NEXT_PUBLIC_DUST_API_URL = PUBLIC_URL;
+    delete process.env.DUST_INTERNAL_API_URL;
+
+    expect(config.getSandboxApiBaseUrl()).toBe(PUBLIC_URL);
+  });
+
+  it("uses the development host when one is set", () => {
+    process.env.NEXT_PUBLIC_DUST_API_URL = PUBLIC_URL;
+    process.env.IS_DEVELOPMENT = "true";
+    process.env.SBX_DEV_FRONT_URL = "https://tunnel.example.com";
+
+    expect(config.getSandboxApiBaseUrl()).toBe("https://tunnel.example.com");
+  });
+
+  it("ignores the development host outside development", () => {
+    process.env.NEXT_PUBLIC_DUST_API_URL = PUBLIC_URL;
+    delete process.env.IS_DEVELOPMENT;
+    process.env.NODE_ENV = "production";
+    process.env.SBX_DEV_FRONT_URL = "https://tunnel.example.com";
+
+    expect(config.getSandboxApiBaseUrl()).toBe(PUBLIC_URL);
+  });
+});

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -11,6 +11,14 @@ export function setBaseUrlResolver(fn: (() => string) | null): void {
   baseUrlResolver = fn;
 }
 
+function publicApiBaseUrl(): string {
+  // Using process.env here to make sure the function is usable on the client side.
+  if (!process.env.NEXT_PUBLIC_DUST_API_URL) {
+    throw new Error("NEXT_PUBLIC_DUST_API_URL is not set");
+  }
+  return process.env.NEXT_PUBLIC_DUST_API_URL;
+}
+
 // Returns the resolver's URL if set, or empty string.
 // Used by clientFetch to decide whether to rewrite relative URLs (SPA cross-origin only).
 export function getBaseUrl(): string {
@@ -61,18 +69,27 @@ const config = {
     // We override the NEXT_PUBLIC_DUST_API_URL in `front-internal` to ensure that the
     // uploadUrl returned by the file API points to the `http://front-internal-service` and not our
     // public API URL.
-    let override = EnvironmentConfig.getOptionalEnvVariable(
+    const override = EnvironmentConfig.getOptionalEnvVariable(
       "DUST_INTERNAL_API_URL"
     );
     if (override) {
       return override;
     }
 
-    // Using process.env here to make sure the function is usable on the client side.
-    if (!process.env.NEXT_PUBLIC_DUST_API_URL) {
-      throw new Error("NEXT_PUBLIC_DUST_API_URL is not set");
+    return publicApiBaseUrl();
+  },
+
+  // The URL a sandbox uses to reach us. Sandboxes run outside our cluster, so
+  // this stays the public URL: getApiBaseUrl prefers the internal service
+  // address wherever DUST_INTERNAL_API_URL is set, and nothing in a sandbox can
+  // reach that. Every sandbox-facing caller must use this one.
+  getSandboxApiBaseUrl: (): string => {
+    const developmentHostName = config.getSandboxDevFrontHostName();
+    if (isDevelopment() && developmentHostName) {
+      return `https://${developmentHostName}`;
     }
-    return process.env.NEXT_PUBLIC_DUST_API_URL;
+
+    return publicApiBaseUrl();
   },
 
   getStaticWebsiteUrl: (): string => {

--- a/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
+++ b/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.test.ts
@@ -23,10 +23,7 @@ vi.mock(
 
 vi.mock("@app/lib/api/config", () => ({
   default: {
-    getDustAPIConfig: vi.fn(() => ({
-      url: "https://api.example.test",
-      nodeEnv: "test",
-    })),
+    getSandboxApiBaseUrl: vi.fn(() => "https://api.example.test"),
   },
 }));
 

--- a/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.ts
+++ b/front/lib/api/file_system/sandbox/database_sandbox_mount_adapter.ts
@@ -145,7 +145,7 @@ export class DatabaseSandboxMountAdapter implements SandboxMountAdapter {
       }
     }
 
-    const apiUrl = config.getDustAPIConfig().url;
+    const apiUrl = config.getSandboxApiBaseUrl();
     const workspaceId = auth.getNonNullableWorkspace().sId;
     // systemd restarts the supervisor itself. The Rust supervisor separately
     // restarts a crashed FUSE child and detaches its stale mount before retrying.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
A sandbox runs outside our infrastructure, so the only address it can use to reach Front is the public one. Today four call sites work that address out for themselves. Three go through the general base URL helper, which prefers the internal service address wherever that override is set, so they can hand a sandbox an address nothing there can reach. The fourth, the filesystem mount, used a hardcoded production address instead, which is wrong in every region that is not production US and offers no way to point a local sandbox at a development tunnel.

This adds one helper in the config module that resolves the sandbox-facing URL in a single place: the development host when configured, otherwise the public URL of the region it runs in, never the internal override.

It moves only the database filesystem mount onto it, to limit blast radius. The other three keep their own resolution for now, and can follow once we know which processes actually set the internal override.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Four tests on the new helper: the public URL wins over the internal override, it follows the region it runs in, it uses the development host when configured, and it ignores that host outside development. The existing mount tests still pass.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Production US should resolve to the same address as before. Other regions change on purpose, from the production address to their own. Worth confirming that no environment sets the production API variable to something other than its public URL, since that is the value this stops using. Rollback is a single revert and only affects sandboxes mounted afterwards.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Nothing to sequence. Existing mounts keep the address they started with until recreated.
