### PR TITLE
[sparkle] fix: keep keyboard navigation in searchable submenus

### DIFF
--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -306,20 +306,9 @@ const nativeInputValueSetter =
 
 const SEARCHABLE_MENU_ITEM_SELECTOR =
   '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]';
-const OPEN_SEARCHABLE_MENU_ITEM_SELECTOR = [
-  '[data-radix-menu-content][data-state=open] [role="menuitem"]',
-  '[data-radix-menu-content][data-state=open] [role="menuitemcheckbox"]',
-  '[data-radix-menu-content][data-state=open] [role="menuitemradio"]',
-].join(", ");
 
 function getFirstDropdownMenuItem(container: ParentNode): HTMLElement | null {
   return container.querySelector<HTMLElement>(SEARCHABLE_MENU_ITEM_SELECTOR);
-}
-
-function getFirstOpenDropdownMenuItem(): HTMLElement | null {
-  return document.querySelector<HTMLElement>(
-    OPEN_SEARCHABLE_MENU_ITEM_SELECTOR
-  );
 }
 
 function getDropdownSearchInput(
@@ -904,16 +893,21 @@ const DropdownMenuSearchbar = React.forwardRef<
       e.stopPropagation();
       onKeyDown?.(e);
       if (!e.defaultPrevented) {
+        const menuContent = e.currentTarget.closest(
+          "[data-radix-menu-content]"
+        );
+        const firstItem = menuContent
+          ? getFirstDropdownMenuItem(menuContent)
+          : null;
+
         if (e.key === "Enter") {
           e.preventDefault();
-          const firstItem = getFirstOpenDropdownMenuItem();
           if (firstItem instanceof HTMLElement) {
             firstItem.click();
           }
         }
         if (e.key === "Tab" || e.key === "ArrowDown") {
           e.preventDefault();
-          const firstItem = getFirstOpenDropdownMenuItem();
           if (firstItem instanceof HTMLElement) {
             firstItem.focus();
           }

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -894,7 +894,7 @@ const DropdownMenuSearchbar = React.forwardRef<
       onKeyDown?.(e);
       if (!e.defaultPrevented) {
         const menuContent = e.currentTarget.closest(
-          "[data-radix-menu-content]"
+          '[data-radix-menu-content][data-state="open"]'
         );
         const firstItem = menuContent
           ? getFirstDropdownMenuItem(menuContent)

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -1,6 +1,7 @@
 import { DropdownMenuCheckboxItemProps } from "@radix-ui/react-dropdown-menu";
 import type { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
+import { expect, waitFor, within } from "storybook/test";
 
 import { Spinner } from "@sparkle/components";
 import {
@@ -198,6 +199,68 @@ export const ComplexDropdown: Story = {
         </DropdownMenuContent>
       </DropdownMenu>
     );
+  },
+};
+
+export const SearchableSubmenuKeyboardNavigation: Story = {
+  render: () => {
+    const [search, setSearch] = useState("");
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger>Open menu</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger label="Capabilities" />
+            <DropdownMenuSubContent
+              dropdownHeaders={
+                <DropdownMenuSearchbar
+                  autoFocus
+                  name="search-capabilities"
+                  placeholder="Search capabilities"
+                  value={search}
+                  onChange={setSearch}
+                />
+              }
+            >
+              <DropdownMenuItem label="First capability" />
+              <DropdownMenuItem label="Second capability" />
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+          <DropdownMenuItem label="Root action" />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  },
+  play: async ({ canvas, canvasElement, userEvent }) => {
+    const trigger = canvas.getByRole("button", { name: "Open menu" });
+    trigger.focus();
+    await userEvent.keyboard("{Enter}");
+
+    const page = within(canvasElement.ownerDocument.body);
+    const submenuTrigger = page.getByRole("menuitem", {
+      name: "Capabilities",
+    });
+    await waitFor(() => expect(submenuTrigger).toHaveFocus());
+
+    await userEvent.keyboard("{ArrowRight}");
+    const searchInput = page.getByPlaceholderText("Search capabilities");
+    await waitFor(() => expect(searchInput).toHaveFocus());
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect(
+      page.getByRole("menuitem", { name: "First capability" })
+    ).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowDown}");
+    await expect(
+      page.getByRole("menuitem", { name: "Second capability" })
+    ).toHaveFocus();
+
+    await userEvent.keyboard("{ArrowUp}");
+    await expect(
+      page.getByRole("menuitem", { name: "First capability" })
+    ).toHaveFocus();
   },
 };
 


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#10078.

Keyboard navigation in the input bar's searchable Capabilities, Knowledge, and Spaces submenus jumped back to the parent menu when pressing ArrowDown.

The search field now scopes its focus handoff to its closest open menu. This keeps arrow navigation within the active submenu while preserving existing top-level dropdown behavior.

Not super convinced but don't have anything better to suggest.

## Tests

- Added a Storybook story to documnt this.

## Risk

- Low.

## Deploy Plan

- Deploy front.
