### PR TITLE
[front] enh: update new analytics page layout

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -119,37 +119,35 @@ export function AnalyticsConsumptionPage() {
 
       <ConsumptionSummary workspaceId={owner.sId} period={period} />
 
-      <div className="flex flex-col gap-8">
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col bg-panel-background">
-            <div className="flex items-center justify-between gap-4">
-              <h2 className="text-lg font-semibold text-foreground">Explore</h2>
-              <UsageFilterPanel
-                owner={owner}
-                period={period}
-                filter={filter}
-                onFilterChange={setFilter}
-              />
-            </div>
-            <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col bg-panel-background">
+          <div className="flex items-center justify-between gap-4">
+            <h2 className="text-lg font-semibold text-foreground">Explore</h2>
+            <UsageFilterPanel
+              owner={owner}
+              period={period}
+              filter={filter}
+              onFilterChange={setFilter}
+            />
           </div>
-          <LazyMotion features={domMax}>
-            <m.div
-              layout={!shouldReduceMotion}
-              transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
-              className="flex flex-col"
-            >
-              <SafeSuspense fallback={<ChartFallback />}>
-                <ConsumptionChart
-                  workspaceId={owner.sId}
-                  period={period}
-                  dimension={dimension}
-                  filter={scopeFilter}
-                />
-              </SafeSuspense>
-            </m.div>
-          </LazyMotion>
+          <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
         </div>
+        <LazyMotion features={domMax}>
+          <m.div
+            layout={!shouldReduceMotion}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
+            className="flex flex-col"
+          >
+            <SafeSuspense fallback={<ChartFallback />}>
+              <ConsumptionChart
+                workspaceId={owner.sId}
+                period={period}
+                dimension={dimension}
+                filter={scopeFilter}
+              />
+            </SafeSuspense>
+          </m.div>
+        </LazyMotion>
       </div>
 
       <ConsumptionAttributionTable

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -101,7 +101,7 @@ export function AnalyticsConsumptionPage() {
   }
 
   return (
-    <Page.Vertical align="stretch" gap="none">
+    <Page.Vertical align="stretch" gap="xl">
       <Page.Header
         title={
           <>
@@ -148,43 +148,32 @@ export function AnalyticsConsumptionPage() {
               </SafeSuspense>
             </m.div>
           </LazyMotion>
-          <ConsumptionAttributionTable
-            workspaceId={owner.sId}
-            period={period}
-            filter={scopeFilter}
-            onAddFilter={(selectedRow) => {
-              setFilter((current) =>
-                addUsageFilterFromAttributionRow(
-                  current,
-                  dimension,
-                  selectedRow
-                )
-              );
-            }}
-            onRemoveFilter={(selectedRow) => {
-              setFilter((current) =>
-                removeUsageFilterFromAttributionRow(
-                  current,
-                  dimension,
-                  selectedRow
-                )
-              );
-            }}
-            dimension={dimension}
-            onDimensionChange={handleDimensionChange}
-            onViewAll={(nextDimension, selectedRow) => {
-              setFilter((current) =>
-                setUsageFilterFromAttributionRow(
-                  current,
-                  dimension,
-                  selectedRow
-                )
-              );
-              handleDimensionChange(nextDimension);
-            }}
-          />
         </div>
       </div>
+
+      <ConsumptionAttributionTable
+        workspaceId={owner.sId}
+        period={period}
+        filter={scopeFilter}
+        onAddFilter={(selectedRow) => {
+          setFilter((current) =>
+            addUsageFilterFromAttributionRow(current, dimension, selectedRow)
+          );
+        }}
+        onRemoveFilter={(selectedRow) => {
+          setFilter((current) =>
+            removeUsageFilterFromAttributionRow(current, dimension, selectedRow)
+          );
+        }}
+        dimension={dimension}
+        onDimensionChange={handleDimensionChange}
+        onViewAll={(nextDimension, selectedRow) => {
+          setFilter((current) =>
+            setUsageFilterFromAttributionRow(current, dimension, selectedRow)
+          );
+          handleDimensionChange(nextDimension);
+        }}
+      />
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -116,11 +116,12 @@ export function AnalyticsConsumptionPage() {
           </>
         }
       />
+
       <ConsumptionSummary workspaceId={owner.sId} period={period} />
 
       <div className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
-          <div className="sticky top-0 z-30 -mb-4 flex flex-col bg-panel-background pb-4 pt-4">
+          <div className="flex flex-col bg-panel-background">
             <div className="flex items-center justify-between gap-4">
               <h2 className="text-lg font-semibold text-foreground">Explore</h2>
               <UsageFilterPanel

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -2,6 +2,7 @@ import { CHART_HEIGHT } from "@app/components/charts/constants";
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { consumptionDimensionFromQueryParam } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
@@ -26,7 +27,6 @@ import {
   safeLazy,
 } from "@dust-tt/sparkle";
 import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
-
 import { useMemo, useState } from "react";
 
 const canReload = () => !isNavigationLocked();
@@ -104,17 +104,21 @@ export function AnalyticsConsumptionPage() {
     <Page.Vertical align="stretch" gap="none">
       <Page.Header
         title={
-          <div className="flex w-full flex-row justify-between">
-            <Page.H variant="h3">Analytics</Page.H>
-            <ConsumptionPeriodSelector
-              period={period}
-              onPeriodChange={setPeriod}
-            />
-          </div>
+          <>
+            <div className="flex w-full flex-row justify-between">
+              <Page.H variant="h3">Analytics</Page.H>
+              <ConsumptionPeriodSelector
+                period={period}
+                onPeriodChange={setPeriod}
+              />
+            </div>
+            <ConsumptionOverview workspaceId={owner.sId} period={period} />
+          </>
         }
       />
-      <div className="flex flex-col gap-8 pb-8 pt-4">
-        <ConsumptionOverview workspaceId={owner.sId} period={period} />
+      <ConsumptionSummary workspaceId={owner.sId} period={period} />
+
+      <div className="flex flex-col gap-8">
         <div className="flex flex-col gap-4">
           <div className="sticky top-0 z-30 -mb-4 flex flex-col bg-panel-background pb-4 pt-4">
             <div className="flex items-center justify-between gap-4">

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@dust-tt/sparkle";
+
 interface SummaryCardProps {
   label: string;
   value: string;
@@ -6,7 +8,12 @@ interface SummaryCardProps {
 
 export function SummaryCard({ label, value, hint }: SummaryCardProps) {
   return (
-    <div className="flex flex-1 flex-col justify-center gap-1 rounded-xl border border-border bg-panel-background p-4">
+    <div
+      className={cn(
+        "flex flex-1 flex-col justify-center h-20 gap-1 rounded-xl",
+        "border border-border bg-panel-background p-4"
+      )}
+    >
       <span className="text-xs font-semibold text-muted-foreground">
         {label}
       </span>

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -10,7 +10,7 @@ export function SummaryCard({ label, value, hint }: SummaryCardProps) {
   return (
     <div
       className={cn(
-        "flex flex-1 flex-col justify-center h-20 gap-1 rounded-xl",
+        "flex flex-1 flex-col justify-center h-24 gap-1 rounded-xl",
         "border border-border bg-panel-background p-4"
       )}
     >

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -19,7 +19,6 @@ export function ConsumptionOverview({
     return (
       <div className="flex flex-col gap-6">
         <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
-        <div className="h-32 w-full animate-pulse rounded-xl bg-muted-background" />
       </div>
     );
   }

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -17,9 +17,7 @@ export function ConsumptionOverview({
 
   if (isOverviewLoading) {
     return (
-      <div className="flex flex-col gap-6">
-        <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
-      </div>
+      <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
     );
   }
 
@@ -38,19 +36,17 @@ export function ConsumptionOverview({
   ];
 
   return (
-    <div className="flex flex-col gap-4">
-      <p className="text-sm text-muted-foreground">
-        {header.map((item, index) => (
-          <span key={item}>
-            {index > 0 && (
-              <span className="mx-2" aria-hidden="true">
-                |
-              </span>
-            )}
-            {item}
-          </span>
-        ))}
-      </p>
-    </div>
+    <p className="text-sm text-muted-foreground">
+      {header.map((item, index) => (
+        <span key={item}>
+          {index > 0 && (
+            <span className="mx-2" aria-hidden="true">
+              |
+            </span>
+          )}
+          {item}
+        </span>
+      ))}
+    </p>
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -1,92 +1,7 @@
-import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
-import type { ConsumptionOverview as ConsumptionOverviewType } from "@app/lib/api/analytics/consumption/overview";
-import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import { formatCredits } from "@app/lib/client/credits";
 import { timeAgoFrom } from "@app/lib/utils";
-import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
-import { ArrowUpRight, Button, Chip } from "@dust-tt/sparkle";
-
-const TARGET_CHIP: Record<
-  CreditUsageTarget,
-  { label: string; color: "highlight" | "info" | "warning" }
-> = {
-  on_target: { label: "On target", color: "highlight" },
-  elevated: { label: "Off target", color: "info" },
-  critical: { label: "Critical", color: "warning" },
-};
-
-// The counterpart the used share of the cap is read against.
-function cycleElapsedPercent({
-  startDate,
-  endDate,
-}: ConsumptionPeriod): number {
-  const startMs = new Date(startDate).getTime();
-  const endMs = new Date(endDate).getTime();
-  const elapsedRatio = (Date.now() - startMs) / (endMs - startMs);
-  return Math.round(Math.min(Math.max(elapsedRatio, 0), 1) * 100);
-}
-
-interface ConsumptionSummaryProps {
-  workspaceId: string;
-  overview: ConsumptionOverviewType;
-}
-
-function ConsumptionSummary({
-  workspaceId,
-  overview,
-}: ConsumptionSummaryProps) {
-  const { topAgent, totalCredits, creditUsage } = overview;
-
-  return (
-    <div className="flex flex-col gap-4">
-      {creditUsage && (
-        <div className="flex items-center justify-between gap-4 rounded-xl border border-border bg-panel-background p-2">
-          <div className="flex items-center gap-2">
-            <Chip
-              size="mini"
-              color={TARGET_CHIP[creditUsage.status.target].color}
-              label={TARGET_CHIP[creditUsage.status.target].label}
-            />
-            <span className="text-sm text-muted-foreground">
-              {creditUsage.status.usedPercentage}% of the cap used,{" "}
-              {cycleElapsedPercent(overview.period)}% of the cycle elapsed
-            </span>
-          </div>
-          <Button
-            label="Manage in Usage"
-            variant="highlight-ghost"
-            size="xs"
-            iconRight={ArrowUpRight}
-            href={`/w/${workspaceId}/usage`}
-          />
-        </div>
-      )}
-      <div className="flex items-stretch gap-6">
-        <SummaryCard
-          label="Used this period"
-          value={formatCredits(totalCredits)}
-          hint={
-            creditUsage
-              ? `${creditUsage.status.usedPercentage}% of ${formatCredits(creditUsage.capCredits)} cap`
-              : null
-          }
-        />
-        <SummaryCard
-          label="Top agent"
-          value={topAgent?.name ?? "—"}
-          hint={
-            topAgent && totalCredits > 0
-              ? `${Math.round((topAgent.credits / totalCredits) * 100)}% of total spend`
-              : null
-          }
-        />
-      </div>
-    </div>
-  );
-}
 
 interface ConsumptionOverviewProps {
   workspaceId: string;
@@ -137,7 +52,6 @@ export function ConsumptionOverview({
           </span>
         ))}
       </p>
-      <ConsumptionSummary workspaceId={workspaceId} overview={overview} />
     </div>
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -40,8 +40,9 @@ export function ConsumptionSummary({
 
   if (isOverviewLoading) {
     return (
-      <div className="flex flex-col gap-6">
-        <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
+      <div className="flex items-stretch gap-6">
+        <div className="h-20 flex-1 animate-pulse rounded-xl bg-muted-background" />
+        <div className="h-20 flex-1 animate-pulse rounded-xl bg-muted-background" />
       </div>
     );
   }

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -1,0 +1,101 @@
+import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
+import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { formatCredits } from "@app/lib/client/credits";
+import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
+import { ArrowUpRight, Button, Chip } from "@dust-tt/sparkle";
+
+const TARGET_CHIP: Record<
+  CreditUsageTarget,
+  { label: string; color: "highlight" | "info" | "warning" }
+> = {
+  on_target: { label: "On target", color: "highlight" },
+  elevated: { label: "Off target", color: "info" },
+  critical: { label: "Critical", color: "warning" },
+};
+
+// The counterpart the used share of the cap is read against.
+function cycleElapsedPercent({
+  startDate,
+  endDate,
+}: ConsumptionPeriod): number {
+  const startMs = new Date(startDate).getTime();
+  const endMs = new Date(endDate).getTime();
+  const elapsedRatio = (Date.now() - startMs) / (endMs - startMs);
+  return Math.round(Math.min(Math.max(elapsedRatio, 0), 1) * 100);
+}
+
+interface ConsumptionSummaryProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+}
+
+export function ConsumptionSummary({
+  workspaceId,
+  period: periodSelection,
+}: ConsumptionSummaryProps) {
+  const { overview, isOverviewLoading, isOverviewError } =
+    useConsumptionOverview({ workspaceId, period: periodSelection });
+
+  if (isOverviewLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
+      </div>
+    );
+  }
+
+  if (isOverviewError || !overview) {
+    return null;
+  }
+
+  const { topAgent, totalCredits, creditUsage } = overview;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {creditUsage && (
+        <div className="flex items-center justify-between gap-4 rounded-xl border border-border bg-panel-background p-2">
+          <div className="flex items-center gap-2">
+            <Chip
+              size="mini"
+              color={TARGET_CHIP[creditUsage.status.target].color}
+              label={TARGET_CHIP[creditUsage.status.target].label}
+            />
+            <span className="text-sm text-muted-foreground">
+              {creditUsage.status.usedPercentage}% of the cap used,{" "}
+              {cycleElapsedPercent(overview.period)}% of the cycle elapsed
+            </span>
+          </div>
+          <Button
+            label="Manage in Usage"
+            variant="highlight-ghost"
+            size="xs"
+            iconRight={ArrowUpRight}
+            href={`/w/${workspaceId}/usage`}
+          />
+        </div>
+      )}
+      <div className="flex items-stretch gap-6">
+        <SummaryCard
+          label="Used this period"
+          value={formatCredits(totalCredits)}
+          hint={
+            creditUsage
+              ? `${creditUsage.status.usedPercentage}% of ${formatCredits(creditUsage.capCredits)} cap`
+              : null
+          }
+        />
+        <SummaryCard
+          label="Top agent"
+          value={topAgent?.name ?? "—"}
+          hint={
+            topAgent && totalCredits > 0
+              ? `${Math.round((topAgent.credits / totalCredits) * 100)}% of total spend`
+              : null
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -41,8 +41,8 @@ export function ConsumptionSummary({
   if (isOverviewLoading) {
     return (
       <div className="flex items-stretch gap-6">
-        <div className="h-20 flex-1 animate-pulse rounded-xl bg-muted-background" />
-        <div className="h-20 flex-1 animate-pulse rounded-xl bg-muted-background" />
+        <div className="h-24 flex-1 animate-pulse rounded-xl bg-muted-background" />
+        <div className="h-24 flex-1 animate-pulse rounded-xl bg-muted-background" />
       </div>
     );
   }


### PR DESCRIPTION
## Description

Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=12828-71347&m=dev)

This PR updates the new analytics page to fit the layout of the initial design.
Restructures the page to rely on high-level gaps rather than per-element custom paddings.

Also updates the skeletons for the summary cards and overview header.

Current live version

<img width="1120" height="763" alt="image" src="https://github.com/user-attachments/assets/2828ad51-9d02-4696-94ee-2fb7bd637394" />

Mockup

<img width="604" height="558" alt="image" src="https://github.com/user-attachments/assets/7195a246-b1e5-422c-ac30-9fa6413652fb" />

Proposal

<img width="1113" height="776" alt="image" src="https://github.com/user-attachments/assets/951352f6-75b7-4ee2-be6c-a181f39be54d" />

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
