### PR TITLE
Allow the sandbox filesystem daemon to reach the Dust API

### DIFF
--- a/front/lib/api/sandbox/image/types.ts
+++ b/front/lib/api/sandbox/image/types.ts
@@ -137,6 +137,8 @@ export interface NetworkPolicy {
 export const PROXY_ONLY_NETWORK_POLICY: NetworkPolicy = {
   mode: "deny_all",
   allowlist: [
+    // Dust API — the database filesystem daemon runs as root
+    "dust.tt",
     // GCS — gcsfuse mounts run as root
     "storage.googleapis.com",
     // Datadog EU — sandbox telemetry runs as root


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
A sandbox denies outbound traffic by default and permits a short list of destinations for the processes that run as root and therefore bypass the in-sandbox forwarder: cloud storage for the gcsfuse mounts, and telemetry. The database filesystem daemon is the newest of those, and it talks to the Dust API, which was never added to that list.

The result is that the daemon cannot reach us at all. It fails on its very first call, so the mount never appears, and the supervisor retries every five seconds forever. From inside a sandbox the failure looks odd rather than blocked: the name resolves, the connection is accepted, and then it is dropped while the handshake is in flight. Connecting to the same address with any other server name completes normally, which is what pointed at the allowlist rather than at DNS, at our own edge, or at anything in the daemon.

This adds the Dust API to that list. The list is read from code each time a sandbox is created and handed to the provider then, so no image rebuild is involved.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
The existing image tests pass, and the path was traced from the policy through to the provider call that sends it. The behaviour itself was confirmed in a live sandbox: through the forwarder the Dust API answers normally, while the direct path used by the daemon is dropped mid-handshake, and the same direct path reaches cloud storage without trouble.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
It widens what a sandbox may reach directly by one destination, our own API, which the daemon needs and which agent code already reaches through the forwarder. Nothing else changes, and rolling back is a single revert.

Note that sandboxes carry the policy they were created with, so existing ones keep denying it until they are recreated.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Deploy, then use a sandbox created afterwards. The filesystem cannot mount anywhere until this is in, so it gates the rollout.
