### PR TITLE
[front] Make publishing a Frame adopt the path it publishes from

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -416,6 +416,7 @@ export async function createInteractiveContentTools(
         reader: createMountFrameSourceReader(fsResult.value, root),
         entryRelPath,
         rootScopedPath: root,
+        entryMountFilePath: fsResult.value.toMountFilePath(path),
         publishedByAgentConfigurationId: agentConfiguration?.sId,
       });
       if (result.isErr()) {

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -345,6 +345,41 @@ export async function moveCanonicalFile(
   return moveResult;
 }
 
+/**
+ * Point a FileResource at `scopedPath`, the location its bytes are actually at, when its record
+ * still describes another one. Returns whether the record was updated.
+ *
+ * Only the operations in this module keep the two in sync. Bytes moved any other way — a `mv` on the
+ * mount from the Computer, for instance — leave the record behind: it keeps the old `mountFilePath`,
+ * `useCase` and metadata, so the file is still treated as owned by the old scope. A Frame moved into
+ * a Pod that way lists as an app with no file id, because `listPodApps` joins the Pod's Frame entries
+ * to their FileResource on `mountFilePath`. Callers that learn a file's real path can heal the record
+ * here, applying exactly what {@link moveCanonicalFile} would have applied.
+ */
+export async function syncCanonicalFileLocation(
+  file: FileResource,
+  scopedPath: string,
+  mountFilePath: string
+): Promise<boolean> {
+  if (file.mountFilePath === mountFilePath) {
+    return false;
+  }
+
+  const destInfo = inferDestMountInfo(scopedPath);
+  if (!destInfo) {
+    return false;
+  }
+
+  await file.updateMount({
+    destFileName: path.posix.basename(scopedPath),
+    destMountFilePath: mountFilePath,
+    destUseCase: destInfo.useCase,
+    destUseCaseMetadata: destInfo.useCaseMetadata,
+  });
+
+  return true;
+}
+
 // ---------------------------------------------------------------------------
 // Content write
 // ---------------------------------------------------------------------------

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -619,6 +619,9 @@ export async function importPodApp(
       reader: createMountFrameSourceReader(dustFs, destFolderPath),
       entryRelPath: created.fileName,
       rootScopedPath: destFolderPath,
+      entryMountFilePath: dustFs.toMountFilePath(
+        `${destFolderPath}/${created.fileName}`
+      ),
     });
     if (publishResult.isErr()) {
       warnings.push(

--- a/front/lib/api/viz/edit_frame_text.test.ts
+++ b/front/lib/api/viz/edit_frame_text.test.ts
@@ -63,6 +63,9 @@ function mockMount(files: Map<string, string>) {
           .filter((p) => p.startsWith(`${root}/`))
           .map((p) => ({ path: p, isDirectory: false }))
       ),
+    // This stand-in has no GCS paths, so the rebuild has no entry mount path to compare the
+    // Frame's record against and leaves it alone.
+    toMountFilePath: () => null,
   };
   vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
     new Ok(fakeFs as unknown as DustFileSystem)

--- a/front/lib/api/viz/edit_frame_text.ts
+++ b/front/lib/api/viz/edit_frame_text.ts
@@ -153,6 +153,9 @@ export async function editFrameTextAtSource(
       reader: createMountFrameSourceReader(dustFs, rootScopedPath),
       entryRelPath,
       rootScopedPath,
+      entryMountFilePath: dustFs.toMountFilePath(
+        `${rootScopedPath}/${entryRelPath}`
+      ),
       publishedByAgentConfigurationId: editedByAgentConfigurationId,
     });
     if (publishResult.isErr()) {

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -15,8 +15,12 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { SCOPED_PREFIX_POD } from "@app/types/file_system";
 import { frameContentType, sandboxFunctionContentType } from "@app/types/files";
-import { splitFrameEntryScopedPath } from "@app/types/mount_path";
+import {
+  getPodFilesBasePath,
+  splitFrameEntryScopedPath,
+} from "@app/types/mount_path";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
@@ -207,6 +211,7 @@ describe("publishFrame", () => {
       reader: inMemoryReader(VALID_SOURCES),
       entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isOk()).toBe(true);
@@ -252,6 +257,7 @@ describe("publishFrame", () => {
       }),
       entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isErr()).toBe(true);
@@ -300,6 +306,7 @@ export default function Dashboard() {
       }),
       entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isOk(), result.isErr() ? result.error.message : "").toBe(
@@ -338,6 +345,7 @@ export default function Dashboard() {
       }),
       entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isErr()).toBe(true);
@@ -366,6 +374,7 @@ export default function Dashboard() {
       }),
       entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isErr()).toBe(true);
@@ -392,6 +401,7 @@ export default function Dashboard() {
       }),
       entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isErr()).toBe(true);
@@ -428,6 +438,7 @@ export default function Dashboard() {
       reader,
       entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isOk()).toBe(true);
@@ -452,6 +463,7 @@ export default function Dashboard() {
       reader: inMemoryReader({ "Chart.tsx": VALID_SOURCES["Chart.tsx"] }),
       entryRelPath: "Dashboard.tsx",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isErr()).toBe(true);
@@ -481,6 +493,7 @@ export default function Dashboard() {
       reader: inMemoryReader({ "notes.txt": "hello" }),
       entryRelPath: "notes.txt",
       rootScopedPath: ROOT,
+      entryMountFilePath: null,
     });
 
     expect(result.isErr()).toBe(true);
@@ -544,6 +557,7 @@ export default function Dashboard() {
       reader: inMemoryReader({ [firstSplit.value.entryRelPath]: firstSource }),
       entryRelPath: firstSplit.value.entryRelPath,
       rootScopedPath: firstSplit.value.root,
+      entryMountFilePath: null,
     });
     const secondResult = await publishFrame(auth, {
       file: second,
@@ -552,6 +566,7 @@ export default function Dashboard() {
       }),
       entryRelPath: secondSplit.value.entryRelPath,
       rootScopedPath: secondSplit.value.root,
+      entryMountFilePath: null,
     });
 
     expect(firstResult.isOk()).toBe(true);
@@ -564,5 +579,39 @@ export default function Dashboard() {
     expect(second.useCaseMetadata?.frameEntryRelPath).toBe(
       secondSplit.value.entryRelPath
     );
+  });
+
+  it("re-parents a Frame published from a path its record does not point at", async () => {
+    const { auth, space } = await setupPodTestContext();
+    const file = await createFrameFile(auth);
+    expect(file.useCase).toBe("conversation");
+
+    vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+      Readable.from([Buffer.from("self contained", "utf-8")])
+    );
+
+    // What a `mv` in the Computer leaves behind: the sources sit in a Pod app folder while the
+    // Frame's record still describes the conversation path it was created at.
+    const podRoot = `${SCOPED_PREFIX_POD}${space.sId}/Dashboard`;
+    const podMountFilePath = `${getPodFilesBasePath({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      podId: space.sId,
+    })}Dashboard/Dashboard.tsx`;
+    expect(file.mountFilePath).not.toBe(podMountFilePath);
+
+    const result = await publishFrame(auth, {
+      file,
+      reader: inMemoryReader(VALID_SOURCES),
+      entryRelPath: "Dashboard.tsx",
+      rootScopedPath: podRoot,
+      entryMountFilePath: podMountFilePath,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(file.mountFilePath).toBe(podMountFilePath);
+    expect(file.useCase).toBe("project_context");
+    expect(file.useCaseMetadata?.spaceId).toBe(space.sId);
+    expect(file.useCaseMetadata?.frameBundleRootPath).toBe(podRoot);
+    expect(file.toScopedPath(auth)).toBe(`${podRoot}/Dashboard.tsx`);
   });
 });

--- a/front/lib/api/viz/publish_frame.ts
+++ b/front/lib/api/viz/publish_frame.ts
@@ -3,6 +3,7 @@ import {
   validateTailwindCode,
   validateTypeScriptSyntax,
 } from "@app/lib/api/files/content_validation";
+import { syncCanonicalFileLocation } from "@app/lib/api/files/file_system_ops";
 import { ensureAuthorizedFileAccessForShare } from "@app/lib/api/viz/authorized_file_access";
 import type { FrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
 import { buildFrameBundle } from "@app/lib/api/viz/build_frame_bundle";
@@ -54,15 +55,18 @@ function shouldValidate(relPath: string): boolean {
  *    each file as it loads: TS/JSX syntax errors are blocking, Tailwind warnings are not and are
  *    returned to the caller. Files in the mount that the frame does not import are never touched.
  * 2. Validate Pod function references and inputs before writing.
- * 3. Refresh the canonical source from the entry so MCP retrieve and the render fallback match.
- * 4. Store the bundle as the processed (rendered) version and record the root and entry in
+ * 3. Adopt the entry as the Frame's own location, so the writes below land where the Frame is
+ *    published from.
+ * 4. Refresh the canonical source from the entry so MCP retrieve and the render fallback match.
+ * 5. Store the bundle as the processed (rendered) version and record the root and entry in
  *    metadata, which flips {@link FileResource.getRenderableVersion} to "processed".
- * 5. Recompute the authorized-file allowlist against the rendered bundle.
+ * 6. Recompute the authorized-file allowlist against the rendered bundle.
  *
  * `reader` is injected (rather than a `DustFileSystem`) so this stays unit-testable with an
  * in-memory tree. The handler wires `createMountFrameSourceReader`. `entryRelPath` is resolved by
  * the caller, not derived here from `file.fileName` (see `frameEntryRelPath` on
- * `FileUseCaseMetadata` for why).
+ * `FileUseCaseMetadata` for why), and `entryMountFilePath` is the mount path of that entry on the
+ * file system the reader reads (`null` when the sources do not come from a mount).
  */
 export async function publishFrame(
   auth: Authenticator,
@@ -71,12 +75,14 @@ export async function publishFrame(
     reader,
     entryRelPath,
     rootScopedPath,
+    entryMountFilePath,
     publishedByAgentConfigurationId,
   }: {
     file: FileResource;
     reader: FrameSourceReader;
     entryRelPath: string;
     rootScopedPath: string;
+    entryMountFilePath: string | null;
     publishedByAgentConfigurationId?: string;
   }
 ): Promise<Result<{ warnings: ValidationWarning[] }, PublishFrameError>> {
@@ -177,14 +183,27 @@ export async function publishFrame(
         );
       }
 
-      // 3. Refresh the canonical source from the entry so MCP retrieve and the render fallback
+      // 3. Adopt the entry as the Frame's own location. Publishing from a path is the statement
+      //    that the Frame lives there, and a Frame whose source was moved through the mount without
+      //    `moveCanonicalFile` (a `mv` in the Computer) still points at its old path: the canonical
+      //    write below would recreate it in the old scope, and a Frame moved into a Pod that way
+      //    would keep listing as an app with no file id.
+      if (entryMountFilePath) {
+        await syncCanonicalFileLocation(
+          file,
+          `${rootScopedPath}/${entryRelPath}`,
+          entryMountFilePath
+        );
+      }
+
+      // 4. Refresh the canonical source from the entry so MCP retrieve and the render fallback
       //    stay in sync with what was published (the entry is always read during the build).
       const entrySource = cache.get(entryRelPath);
       if (entrySource !== undefined) {
         await file.uploadContent(auth, entrySource);
       }
 
-      // 4. Store the bundle as the rendered version and mark the frame published.
+      // 5. Store the bundle as the rendered version and mark the frame published.
       await file.uploadProcessed(auth, buildResult.value.code);
       // frameBundleRootPath and frameEntryRelPath flip rendering to the bundle and let live
       // edits rebuild later without a model in the loop.
@@ -199,7 +218,7 @@ export async function publishFrame(
           : {}),
       });
 
-      // 5. Recompute the allowlist against the rendered bundle.
+      // 6. Recompute the allowlist against the rendered bundle.
       const allowlist = await ensureAuthorizedFileAccessForShare(auth, file);
       if (allowlist.isErr()) {
         return new Err(


### PR DESCRIPTION
Observed in practice: an agent creating a Pod app moved its new Frame into the Pod folder with `mv` in the Computer instead of `files__move`, then published successfully — and the app showed up in the Pod with no file id.

Only `moveCanonicalFile` (behind `files__move`) re-parents the `FileResource`. A move through the mount by any other route leaves the record behind: `mountFilePath`, `useCase` and `useCaseMetadata` still describe the old location. `publishFrame` never compared the entry path it was given against the Frame's own `mountFilePath`, so it read the source from the Pod path while its canonical dual-write went back to the conversation path, and `listPodApps` — which joins a Pod folder's Frame entries to their `FileResource` on `mountFilePath` — found nothing to join.

Publishing from a path is the statement that the Frame lives there, so `publishFrame` now adopts the entry as the Frame's location when the record points elsewhere, applying exactly what `moveCanonicalFile` would have. The new `syncCanonicalFileLocation` sits next to `moveCanonicalFile` and reuses its `inferDestMountInfo`.

Ordering matters and is deliberate: the adopt step runs after the bundle builds, so the adopted path is always an entry that was read successfully, and before the canonical write, so that write lands where the Frame now lives rather than recreating it in the old scope.

Callers pass the entry's mount path (`null` when the sources do not come from a mount), which keeps `publishFrame` unit-testable against an in-memory tree instead of taking a `DustFileSystem`.

Tests: one asserting the re-parent, verified failing without the fix (`expected 'w/…/conversations/…' to be 'w/…/pods/…'`). `lib/api/viz`, `lib/api/projects` and `lib/api/files/file_system_ops` pass (169 tests).

The prompt-side half of this — telling the agent to move a Frame with `files__move` and never with `mv`/`cp` — is in #30733.