### PR TITLE
[front] perf: Resolve system key permissions without reading grants

### DIFF
--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -1481,7 +1481,9 @@ describe("POST /api/w/:wId/skills", () => {
     const { auth, workspace, user } = await setupTest("admin");
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = await GroupFactory.regularAuto(
+    // A manual group: `SpaceFactory.regular` already attaches a `regular_auto` member group, and
+    // only one `regular_auto` group may hold a given grant tuple.
+    const memberGroup = await GroupFactory.regularManual(
       workspace,
       "Tool Space Members"
     );
@@ -1582,7 +1584,9 @@ describe("POST /api/w/:wId/skills", () => {
     const { auth, workspace, user } = await setupTest("admin");
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const memberGroup = await GroupFactory.regularAuto(
+    // A manual group: `SpaceFactory.regular` already attaches a `regular_auto` member group, and
+    // only one `regular_auto` group may hold a given grant tuple.
+    const memberGroup = await GroupFactory.regularManual(
       workspace,
       "Knowledge Space Members"
     );

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -974,6 +974,11 @@ export class Authenticator {
       : [];
     const keyGroupModelIds = allGroups.map((g) => g.id);
 
+    // `resolvePermissions` reads the key's grants from the key itself, so it only holds for the
+    // key's own workspace and its own groups: `requestedGroupIds` replaces those groups (the Slack
+    // bot acting as a user), and the target workspace below may not be the key's.
+    const permissionsKey = requestedGroupIds ? undefined : key;
+
     let permissions: GroupPermissions;
     let keyPermissions: GroupPermissions;
     if (isKeyWorkspace) {
@@ -982,6 +987,7 @@ export class Authenticator {
       permissions = await this.resolvePermissions({
         workspace,
         groupModelIds: workspaceGroupModelIds,
+        key: permissionsKey,
       });
       keyPermissions = permissions;
     } else {
@@ -993,6 +999,7 @@ export class Authenticator {
         this.resolvePermissions({
           workspace: keyWorkspace,
           groupModelIds: keyGroupModelIds,
+          key: permissionsKey,
         }),
       ]);
     }
@@ -1297,12 +1304,24 @@ export class Authenticator {
   static async resolvePermissions({
     workspace,
     groupModelIds,
+    key,
   }: {
     workspace?: WorkspaceResource | null;
     groupModelIds: ModelId[];
+    key?: Pick<KeyAuthType, "isSystem"> | null;
   }): Promise<GroupPermissions> {
     if (!workspace) {
       return GroupPermissions.empty();
+    }
+
+    if (key?.isSystem) {
+      return GroupPermissions.fromGrants([
+        {
+          grantType: "*",
+          resourceType: "*",
+          resourceId: WHOLE_TYPE_RESOURCE_ID,
+        },
+      ]);
     }
 
     const lightWorkspace = renderLightWorkspaceType({ workspace });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -19,7 +19,10 @@ import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
-import type { GroupPermissionsJSON } from "@app/lib/resources/group_permission_registry";
+import type {
+  GroupPermissionsJSON,
+  ResourcesWithVerb,
+} from "@app/lib/resources/group_permission_registry";
 import {
   allWorkspacePermissions,
   GroupPermissions,
@@ -1519,15 +1522,16 @@ export class Authenticator {
   }
 
   /**
-   * The instance ids of `resourceType` the caller may `verb`, resolved from their governance grants.
+   * The instances of `resourceType` the caller may `verb`, resolved from their governance grants.
    * The enumeration counterpart of `getGrantedVerbs` — "which resources may I act on" rather than
-   * "what may I do on this one" — for reverse lookups such as the projects a caller belongs to. See
-   * `GroupPermissions.resourceIdsWithVerb`; the type-wide (-1) grant is excluded there.
+   * "what may I do on this one" — for reverse lookups such as the projects a caller belongs to.
+   * Returns `{ kind: "all" }` when a type-wide grant confers the verb on every instance, which a
+   * system key holds on every type (see `resolvePermissions`).
    */
   getResourceIdsWithVerb(
     resourceType: ConcreteResourceType,
     verb: GrantVerb
-  ): ModelId[] {
+  ): ResourcesWithVerb {
     return this._permissions.resourceIdsWithVerb(resourceType, verb);
   }
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -27,9 +27,10 @@ import {
 } from "@app/lib/resources/group_permission_registry";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import type { KeyAuthType } from "@app/lib/resources/key_resource";
+import type { KeyAuthType, SystemKey } from "@app/lib/resources/key_resource";
 import {
   DEFAULT_SYSTEM_KEY_NAME,
+  isSystemKey,
   KeyResource,
   SECRET_KEY_PREFIX,
 } from "@app/lib/resources/key_resource";
@@ -974,33 +975,33 @@ export class Authenticator {
       : [];
     const keyGroupModelIds = allGroups.map((g) => g.id);
 
-    // `resolvePermissions` reads the key's grants from the key itself, so it only holds for the
-    // key's own workspace and its own groups: `requestedGroupIds` replaces those groups (the Slack
-    // bot acting as a user), and the target workspace below may not be the key's.
-    const permissionsKey = requestedGroupIds ? undefined : key;
+    // `requestedGroupIds` replaces the key's own groups (the Slack bot acting as a user), so the
+    // resolution goes through those groups instead of the key.
+    const systemKey = !requestedGroupIds && isSystemKey(key) ? key : null;
 
     let permissions: GroupPermissions;
     let keyPermissions: GroupPermissions;
     if (isKeyWorkspace) {
       // Same workspace and same groups: both Authenticators share one resolution rather than
       // running the same query twice. Safe to share the instance, GroupPermissions is immutable.
-      permissions = await this.resolvePermissions({
-        workspace,
-        groupModelIds: workspaceGroupModelIds,
-        key: permissionsKey,
-      });
+      permissions = await this.resolvePermissions(
+        systemKey
+          ? { workspace, systemKey }
+          : { workspace, groupModelIds: workspaceGroupModelIds }
+      );
       keyPermissions = permissions;
     } else {
       [permissions, keyPermissions] = await Promise.all([
+        // The target workspace is not the key's, so the key says nothing about it.
         this.resolvePermissions({
           workspace,
           groupModelIds: workspaceGroupModelIds,
         }),
-        this.resolvePermissions({
-          workspace: keyWorkspace,
-          groupModelIds: keyGroupModelIds,
-          key: permissionsKey,
-        }),
+        this.resolvePermissions(
+          systemKey
+            ? { workspace: keyWorkspace, systemKey }
+            : { workspace: keyWorkspace, groupModelIds: keyGroupModelIds }
+        ),
       ]);
     }
 
@@ -1301,20 +1302,22 @@ export class Authenticator {
    * NOT confer access to a specific instance unless a grant grants it. Cheap for callers with no
    * groups (no query).
    */
-  static async resolvePermissions({
-    workspace,
-    groupModelIds,
-    key,
-  }: {
-    workspace?: WorkspaceResource | null;
-    groupModelIds: ModelId[];
-    key?: Pick<KeyAuthType, "isSystem"> | null;
-  }): Promise<GroupPermissions> {
+  static async resolvePermissions(
+    // Groups or a system key, never both: a system key is attached to every group of its
+    // workspace, so its grants are the wildcard and reading them back would scan the workspace's
+    // whole `group_permissions` slice. A system key narrowed to a group subset must resolve from
+    // those groups, so the two inputs are mutually exclusive rather than a rule to remember.
+    params: { workspace?: WorkspaceResource | null } & (
+      | { groupModelIds: ModelId[]; systemKey?: never }
+      | { systemKey: SystemKey; groupModelIds?: never }
+    )
+  ): Promise<GroupPermissions> {
+    const { workspace } = params;
     if (!workspace) {
       return GroupPermissions.empty();
     }
 
-    if (key?.isSystem) {
+    if (params.systemKey) {
       return GroupPermissions.fromGrants([
         {
           grantType: "*",
@@ -1326,7 +1329,7 @@ export class Authenticator {
 
     const lightWorkspace = renderLightWorkspaceType({ workspace });
     const grants = await GroupPermissionResource.listForGroups(lightWorkspace, {
-      groupModelIds,
+      groupModelIds: params.groupModelIds,
     });
 
     return GroupPermissions.fromGrants(grants);

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -230,43 +230,90 @@ describe("Authenticator.fromKey permission resolution", () => {
     vi.restoreAllMocks();
   });
 
-  it("resolves permissions for unscoped system keys", async () => {
+  it("gives unscoped system keys every verb without reading grants", async () => {
     const workspace = await WorkspaceFactory.basic();
     const { systemGroup } = await GroupFactory.defaults(workspace);
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const includedGroup = await GroupFactory.regularManual(
-      workspace,
-      "included"
-    );
-    const excludedGroup = await GroupResource.makeNew({
-      name: "excluded",
-      kind: "agent_editors",
-      workspaceId: workspace.id,
-    });
+    const group = await GroupFactory.regularManual(workspace, "eng");
     await GroupPermissionResource.grant(adminAuth, {
-      group: includedGroup,
+      group,
       grantType: "editor",
       resourceType: "agent",
       resourceId: 42,
     });
-    await GroupPermissionResource.grant(adminAuth, {
-      group: excludedGroup,
-      grantType: "editor",
-      resourceType: "agent",
-      // A different agent, so the excluded group's grant is observable by its absence below.
-      resourceId: 99,
-    });
+
+    const listForGroups = vi.spyOn(GroupPermissionResource, "listForGroups");
 
     const key = await KeyFactory.system(systemGroup);
+    const { workspaceAuth, keyAuth } = await Authenticator.fromKey(
+      key,
+      workspace.sId
+    );
+
+    // A system key holds every group of its workspace, so its grants are stated, not read.
+    expect(listForGroups).not.toHaveBeenCalled();
+
+    // Every verb the registry defines holds, on the granted agent and on one that carries no
+    // grant at all (instance verbs and type-level capabilities alike).
+    expect([...workspaceAuth.getGrantedVerbs("agent", 42)].sort()).toEqual([
+      "create",
+      "publish",
+      "read",
+      "write",
+    ]);
+    expect([...workspaceAuth.getGrantedVerbs("agent", 99)].sort()).toEqual([
+      "create",
+      "publish",
+      "read",
+      "write",
+    ]);
+    expect(workspaceAuth.getGrantedVerbs("space", 1234)).toContain("admin");
+    expect(keyAuth.getGrantedVerbs("space", 1234)).toContain("admin");
+
+    // It survives the Temporal round trip the agent loop puts the auth through.
+    const restored = await Authenticator.fromJSON(workspaceAuth.toJSON());
+    expect(restored.getGrantedVerbs("space", 1234)).toContain("admin");
+  });
+
+  it("gives a system key nothing on a workspace that is not its own", async () => {
+    const keyWorkspace = await WorkspaceFactory.basic();
+    const { systemGroup } = await GroupFactory.defaults(keyWorkspace);
+    const otherWorkspace = await WorkspaceFactory.basic();
+    await GroupFactory.defaults(otherWorkspace);
+
+    const key = await KeyFactory.system(systemGroup);
+    const { workspaceAuth, keyAuth } = await Authenticator.fromKey(
+      key,
+      otherWorkspace.sId
+    );
+
+    expect(workspaceAuth.getGrantedVerbs("space", 1234)).toEqual([]);
+    // The key's own workspace still gets the full set.
+    expect(keyAuth.getGrantedVerbs("space", 1234)).toContain("admin");
+  });
+
+  it("resolves grants for non-system keys", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const { globalGroup } = await GroupFactory.defaults(workspace);
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await GroupPermissionResource.grant(adminAuth, {
+      group: globalGroup,
+      grantType: "editor",
+      resourceType: "agent",
+      resourceId: 42,
+    });
+
+    const key = await KeyFactory.regular(globalGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
 
-    // The in-scope group's grant on agent 42 is loaded; the out-of-scope group's grant on agent 99
-    // is not — resolved verbs are caller-scoped and carry no group ids.
-    expect(workspaceAuth.getGrantedVerbs("agent", 42).length).toBeGreaterThan(
-      0
-    );
+    expect([...workspaceAuth.getGrantedVerbs("agent", 42)].sort()).toEqual([
+      "read",
+      "write",
+    ]);
     expect(workspaceAuth.getGrantedVerbs("agent", 99)).toEqual([]);
   });
 
@@ -298,13 +345,16 @@ describe("Authenticator.fromKey permission resolution", () => {
       resourceId: 99,
     });
 
+    const listForGroups = vi.spyOn(GroupPermissionResource, "listForGroups");
+
     const key = await KeyFactory.system(systemGroup);
     const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId, [
       includedGroup.sId,
     ]);
 
-    // The in-scope group's grant on agent 42 is loaded; the out-of-scope group's grant on agent 99
-    // is not — resolved verbs are caller-scoped and carry no group ids.
+    // Downscoped by `requestedGroupIds`, so the grants are resolved for real: the in-scope group's
+    // grant on agent 42 is loaded; the out-of-scope group's grant on agent 99 is not.
+    expect(listForGroups).toHaveBeenCalled();
     expect(workspaceAuth.getGrantedVerbs("agent", 42).length).toBeGreaterThan(
       0
     );
@@ -313,7 +363,11 @@ describe("Authenticator.fromKey permission resolution", () => {
 });
 
 describe("Authenticator.refresh permission resolution", () => {
-  it("re-resolves grants for a user-less (system key) auth", async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("re-resolves grants for a user-less, downscoped key auth", async () => {
     const workspace = await WorkspaceFactory.basic();
     const { systemGroup } = await GroupFactory.defaults(workspace);
     const adminAuth = await Authenticator.internalAdminForWorkspace(
@@ -321,10 +375,12 @@ describe("Authenticator.refresh permission resolution", () => {
     );
     const group = await GroupFactory.regularManual(workspace, "eng");
 
-    // A system-key auth has no user; its grant snapshot is resolved once at build time. The agent
-    // loop freezes it at workflow start and refreshes it on every step.
+    // A key auth has no user; its grant snapshot is resolved once at build time. The agent loop
+    // freezes it at workflow start and refreshes it on every step.
     const key = await KeyFactory.system(systemGroup);
-    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
+    const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId, [
+      group.sId,
+    ]);
     expect(workspaceAuth.getGrantedVerbs("agent", 42)).toEqual([]);
 
     // A grant lands on one of the key's groups AFTER the auth was built (mirrors a backfill or an
@@ -344,5 +400,8 @@ describe("Authenticator.refresh permission resolution", () => {
       "read",
       "write",
     ]);
+    // It stays scoped to the requested groups: refreshing must not widen it back to everything the
+    // system key itself holds.
+    expect(workspaceAuth.getGrantedVerbs("space", 1234)).toEqual([]);
   });
 });

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -271,6 +271,71 @@ describe("GroupPermissions.fromJSON", () => {
   });
 });
 
+describe("GroupPermissions wildcard grant", () => {
+  const WILDCARD = [
+    {
+      grantType: "*",
+      resourceType: "*",
+      resourceId: WHOLE_TYPE_RESOURCE_ID,
+    },
+  ] as const;
+
+  it("confers every verb the registry defines, at every level", () => {
+    const perms = GroupPermissions.fromGrants([...WILDCARD]);
+
+    // Instance-level roles: `space` declares no type-level role at all, so a wildcard would confer
+    // nothing there if it only expanded type-level verbs.
+    expect(perms.resolvedVerbsForResource("space", 12).sort()).toEqual([
+      "admin",
+      "read",
+      "write",
+    ]);
+    // Type-level capabilities alongside the instance ones.
+    expect(perms.resolvedVerbsForResource("agent", 42).sort()).toEqual([
+      "create",
+      "publish",
+      "read",
+      "write",
+    ]);
+    expect(perms.resolvedVerbsForResource("billing", 1)).toEqual(["admin"]);
+  });
+
+  it("confers them on instances it has never seen", () => {
+    const perms = GroupPermissions.fromGrants([...WILDCARD]);
+    expect(perms.resolvedVerbsForResource("space", 999999)).toContain("write");
+  });
+
+  it("confers only the instance-level roles on a concrete id", () => {
+    // `assertValidGrant` pins a wildcard to WHOLE_TYPE_RESOURCE_ID, so this row is not one the
+    // product writes; a stale one must not confer the type-level capabilities on that instance.
+    const perms = GroupPermissions.fromGrants([
+      { grantType: "*", resourceType: "agent", resourceId: 42 },
+    ]);
+    expect(perms.resolvedVerbsForResource("agent", 42).sort()).toEqual([
+      "read",
+      "write",
+    ]);
+  });
+
+  it("round-trips through toJSON / fromJSON", () => {
+    const perms = GroupPermissions.fromGrants([...WILDCARD]);
+    const restored = GroupPermissions.fromJSON(perms.toJSON());
+    expect(restored.toJSON()).toEqual(perms.toJSON());
+    expect(restored.resolvedVerbsForResource("space", 12)).toContain("admin");
+  });
+
+  it("names no concrete instance", () => {
+    // Documented behaviour of the type-wide (-1) entry: it confers the verb on every id and so
+    // enumerating instances returns nothing.
+    expect(
+      GroupPermissions.fromGrants([...WILDCARD]).resourceIdsWithVerb(
+        "space",
+        "read"
+      )
+    ).toEqual([]);
+  });
+});
+
 describe("GroupPermissions.resourceIdsWithVerb", () => {
   // read = 1 << 0, write = 1 << 1, admin = 1 << 2 (see VERB_BIT / GRANT_VERBS order).
   it("returns the instance ids holding the verb", () => {

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -324,15 +324,15 @@ describe("GroupPermissions wildcard grant", () => {
     expect(restored.resolvedVerbsForResource("space", 12)).toContain("admin");
   });
 
-  it("names no concrete instance", () => {
-    // Documented behaviour of the type-wide (-1) entry: it confers the verb on every id and so
-    // enumerating instances returns nothing.
+  it("enumerates as every instance, not as none", () => {
+    // A type-wide entry names no id, so it cannot come back as a list. Reporting "all" is what
+    // keeps the enumeration consistent with `resolvedVerbsForResource`, which folds -1 in.
     expect(
       GroupPermissions.fromGrants([...WILDCARD]).resourceIdsWithVerb(
         "space",
         "read"
       )
-    ).toEqual([]);
+    ).toEqual({ kind: "all" });
   });
 });
 
@@ -342,30 +342,50 @@ describe("GroupPermissions.resourceIdsWithVerb", () => {
     const perms = GroupPermissions.fromJSON({
       grants: { space: { 12: 0b011, 34: 0b001 } },
     });
-    expect(perms.resourceIdsWithVerb("space", "read").sort()).toEqual([12, 34]);
-    expect(perms.resourceIdsWithVerb("space", "write")).toEqual([12]);
+    expect(perms.resourceIdsWithVerb("space", "read")).toEqual({
+      kind: "ids",
+      resourceIds: [12, 34],
+    });
+    expect(perms.resourceIdsWithVerb("space", "write")).toEqual({
+      kind: "ids",
+      resourceIds: [12],
+    });
   });
 
   it("filters out ids that lack the verb", () => {
     const perms = GroupPermissions.fromJSON({
       grants: { space: { 12: 0b001, 34: 0b011 } },
     });
-    expect(perms.resourceIdsWithVerb("space", "write")).toEqual([34]);
-    expect(perms.resourceIdsWithVerb("space", "admin")).toEqual([]);
+    expect(perms.resourceIdsWithVerb("space", "write")).toEqual({
+      kind: "ids",
+      resourceIds: [34],
+    });
+    expect(perms.resourceIdsWithVerb("space", "admin")).toEqual({
+      kind: "ids",
+      resourceIds: [],
+    });
   });
 
-  it("excludes the type-wide (-1) entry", () => {
-    // A type-wide grant confers the verb on every id but names no concrete instance.
+  it("reports the type-wide (-1) entry as every instance", () => {
     const perms = GroupPermissions.fromJSON({
       grants: { agent: { [WHOLE_TYPE_RESOURCE_ID]: 0b1000, 42: 0b011 } },
     });
-    expect(perms.resourceIdsWithVerb("agent", "read")).toEqual([42]);
-    expect(perms.resourceIdsWithVerb("agent", "create")).toEqual([]);
+    // `read` is held on 42 only; `create` comes from the type-wide entry, so it covers every agent.
+    expect(perms.resourceIdsWithVerb("agent", "read")).toEqual({
+      kind: "ids",
+      resourceIds: [42],
+    });
+    expect(perms.resourceIdsWithVerb("agent", "create")).toEqual({
+      kind: "all",
+    });
   });
 
-  it("returns an empty array when the resource type has no grants", () => {
+  it("returns an empty list when the resource type has no grants", () => {
     const perms = GroupPermissions.fromJSON({ grants: {} });
-    expect(perms.resourceIdsWithVerb("space", "read")).toEqual([]);
+    expect(perms.resourceIdsWithVerb("space", "read")).toEqual({
+      kind: "ids",
+      resourceIds: [],
+    });
   });
 });
 

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -178,6 +178,22 @@ function allVerbsForResourceAtLevel(
   return [...verbs];
 }
 
+// The verbs a "*" grant confers on `resourceType`. At WHOLE_TYPE_RESOURCE_ID the wildcard stands
+// for the type and for every instance of it, so the instance-level roles count alongside the
+// type-level ones; on a concrete id only the instance-level roles apply.
+function allVerbsForWildcard(
+  resourceType: ConcreteResourceType,
+  level: GrantLevel
+): GrantVerb[] {
+  const verbs = new Set(allVerbsForResourceAtLevel(resourceType, "instance"));
+  if (level === "type") {
+    for (const verb of allVerbsForResourceAtLevel(resourceType, "type")) {
+      verbs.add(verb);
+    }
+  }
+  return [...verbs];
+}
+
 // Every type-level verb on every resource type — an admin's implicit full access.
 export function allWorkspacePermissions(): WorkspacePermissions {
   const permissions = emptyWorkspacePermissions();
@@ -216,7 +232,7 @@ function maskToVerbs(mask: number): GrantVerb[] {
 // full resource and to keep the reference type-only.
 type GrantRow = Pick<
   GroupPermissionResource,
-  "groupId" | "grantType" | "resourceType" | "resourceId"
+  "grantType" | "resourceType" | "resourceId"
 >;
 
 // JSON-serializable form of GroupPermissions, embedded in a serialized Authenticator so it can be
@@ -313,7 +329,7 @@ export class GroupPermissions {
         }
         const verbs =
           grantType === "*"
-            ? allVerbsForResourceAtLevel(rt, level)
+            ? allVerbsForWildcard(rt, level)
             : verbsForGrantAtLevel(grantType, rt, level);
         add(rt, resourceId, verbsToMask(verbs));
       }

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -254,6 +254,13 @@ interface SerializedGroupPermissions {
   >;
 }
 
+// What the caller may act on for a given verb: a concrete instance list, or every instance of the
+// type when a type-wide (-1) grant confers it. Callers must handle "all" — that is the point of the
+// union (see `GroupPermissions.resourceIdsWithVerb`).
+export type ResourcesWithVerb =
+  | { kind: "all" }
+  | { kind: "ids"; resourceIds: number[] };
+
 /**
  * The governance grants the *caller* holds, resolved once at auth construction. Keyed by
  * (resourceType, resourceId) -> verb bitmask: resourceId is WHOLE_TYPE_RESOURCE_ID (-1) for type-
@@ -384,23 +391,28 @@ export class GroupPermissions {
     return maskToVerbs(mask);
   }
 
-  // The concrete instance ids of `resourceType` on which the caller holds `verb` — the reverse of
+  // The instances of `resourceType` on which the caller holds `verb` — the reverse of
   // resolvedVerbsForResource, for callers that enumerate what they may act on ("which spaces am I a
-  // member of") rather than checking one id. Excludes the type-wide (-1) entry: a type-wide grant
-  // confers the verb on every id of the type and names no concrete instance, so callers that must
-  // also account for type-wide access should consult toWorkspacePermissions separately.
+  // member of") rather than checking one id.
+  //
+  // A type-wide (-1) grant confers the verb on every instance and names none, so it cannot be
+  // returned as a list. It is reported as "all" rather than folded away: `resolvedVerbsForResource`
+  // does fold -1 in, so dropping it here would answer yes for a single id and no for the
+  // enumeration of the same verb.
   resourceIdsWithVerb(
     resourceType: ConcreteResourceType,
     verb: GrantVerb
-  ): number[] {
-    const byId = this.grants.get(resourceType);
-    if (!byId) {
-      return [];
-    }
+  ): ResourcesWithVerb {
     const bit = VERB_BIT.get(verb) ?? 0;
-    if (bit === 0) {
-      return [];
+    const byId = this.grants.get(resourceType);
+    if (!byId || bit === 0) {
+      return { kind: "ids", resourceIds: [] };
     }
+
+    if (((byId.get(WHOLE_TYPE_RESOURCE_ID) ?? 0) & bit) !== 0) {
+      return { kind: "all" };
+    }
+
     const resourceIds: number[] = [];
     for (const [resourceId, mask] of byId) {
       if (resourceId === WHOLE_TYPE_RESOURCE_ID) {
@@ -410,7 +422,7 @@ export class GroupPermissions {
         resourceIds.push(resourceId);
       }
     }
-    return resourceIds;
+    return { kind: "ids", resourceIds };
   }
 
   // The type-wide (-1) verbs the caller's grants confer per resource type — the flat record for the

--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -50,6 +50,16 @@ export interface KeyAuthType {
   monthlyCapMicroUsd: number | null;
 }
 
+// A key proven to be a system key. Callers that only make sense for a system key take this rather
+// than a key plus a boolean, so a regular key cannot reach them (see `Authenticator.resolvePermissions`).
+export type SystemKey = { isSystem: true };
+
+export function isSystemKey<T extends { isSystem: boolean }>(
+  key: T
+): key is T & SystemKey {
+  return key.isSystem;
+}
+
 export const DEFAULT_SYSTEM_KEY_NAME = "DustSystemKey";
 export const SECRET_KEY_PREFIX = "sk-";
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -2225,6 +2225,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   canWrite(auth: Authenticator): boolean {
     // TODO(governance): cleanup we we'll be able to assign API key to editor groups.
+    // TODO(@jd): Revisit this shortcircuit with our current ACLs stack.
     // API keys cannot be added to a skill's editor group (no such assignment mechanism exists),
     // so any key is allowed to write to any skill. Skill *creation* is separately gated by
     // `auth.hasWorkspacePermission("create", "skill")`; this only governs already-existing skills.

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -22,6 +22,7 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SandboxEnvVarFactory } from "@app/tests/utils/SandboxEnvVarFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -2255,6 +2256,23 @@ describe("SpaceResource", () => {
       const pods = await SpaceResource.listWorkspacePodsAsMember(adminAuth);
 
       expect(pods).toEqual([]);
+    });
+
+    it("returns every project for a system key", async () => {
+      const first = await SpaceFactory.project(workspace);
+      const second = await SpaceFactory.project(workspace);
+
+      const key = await KeyFactory.system(systemGroup);
+      const { workspaceAuth } = await Authenticator.fromKey(key, workspace.sId);
+
+      // A system key holds the type-wide space grant, so `isMember` is true on every project. The
+      // enumeration has to agree rather than come back empty.
+      const pods = await SpaceResource.listWorkspacePodsAsMember(workspaceAuth);
+
+      expect(pods.map((p) => p.sId).sort()).toEqual(
+        [first.sId, second.sId].sort()
+      );
+      expect(pods.every((p) => p.isMember(workspaceAuth))).toBe(true);
     });
   });
 });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -428,17 +428,21 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // Project (pod) spaces the caller belongs to are those on which they hold the pod membership
     // verb (see `POD_SPACE_MEMBERSHIP_VERB`): selecting by it and `kind: "project"` reproduces the
     // former `group_vaults` member/editor lookup, so the previous safety re-filter is redundant.
-    const podSpaceModelIds = auth.getResourceIdsWithVerb(
+    // A type-wide grant makes the caller a member of every pod (`isMember` says so too), so it
+    // drops the id filter rather than the whole result.
+    const podSpaces = auth.getResourceIdsWithVerb(
       "space",
       POD_SPACE_MEMBERSHIP_VERB
     );
-    if (podSpaceModelIds.length === 0) {
+    if (podSpaces.kind === "ids" && podSpaces.resourceIds.length === 0) {
       return [];
     }
 
     return this.baseFetch(auth, {
       where: {
-        id: { [Op.in]: podSpaceModelIds },
+        ...(podSpaces.kind === "ids"
+          ? { id: { [Op.in]: podSpaces.resourceIds } }
+          : {}),
         kind: "project",
       },
     });

--- a/front/tests/utils/GroupSpaceFactory.ts
+++ b/front/tests/utils/GroupSpaceFactory.ts
@@ -1,6 +1,9 @@
+import { Authenticator } from "@app/lib/auth";
 import type { GroupResource } from "@app/lib/resources/group_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import assert from "assert";
 
 export class GroupSpaceFactory {
   static async associate(
@@ -8,12 +11,25 @@ export class GroupSpaceFactory {
     group: GroupResource,
     kind: "member" | "project_editor" | "project_viewer" = "member"
   ): Promise<GroupSpaceModel> {
-    return GroupSpaceModel.create({
+    const groupSpace = await GroupSpaceModel.create({
       groupId: group.id,
       groupKind: group.kind,
       vaultId: space.id,
       workspaceId: space.workspaceId,
       kind,
     });
+
+    // Production rewrites the space's `group_permissions` on every association change, and space
+    // membership is now read from those grants, so writing only the `group_vaults` row would leave
+    // the association invisible to `isMember`.
+    const workspace = await WorkspaceResource.fetchByModelId(space.workspaceId);
+    assert(workspace, `Workspace ${space.workspaceId} not found.`);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    await space.writeGroupPermissions(
+      auth,
+      await space.fetchAssociatedGroups()
+    );
+
+    return groupSpace;
   }
 }


### PR DESCRIPTION
## Context

This PR aims at reducing the DB load induced by looking up group permission on every api request + agent_loop step.

There are 3 axis:
1. Optimize the query : ✅ this query is very simple, we've exhausted this topic
2. Cache everything everywhere : In progress not the subject of this PR. 
3. Reduce the hits on this query: This PR, still make sense because of how we resolve permission for a system key today, which means retrieving all group permission, thousands of lines x thousands of requests per second => 💣 

Why system key focus ? 

Mostly in connectors traffic, mostly data-source oriented, we use a system key without any requested groups.
In that case, and only in that case, it is equivalent to a wildcard grant scoped to the workspace this system key belongs to.

To optimize this very hot path, we introduce a synthetic wildcard grant.

##  Tests

Added unit tests
Actually very hard to front-edge since it's mostly connector related, can be tested in front-edge with sub-agent runs.

## Risk

Low
Blast radius: Mostly security breach if I'm wrong and it's not equivalent to a wildcard or if this code can grant access to cross workspace reads/writes.

## Plan

Deploy front