### PR TITLE
[Agent Loop] Heartbeat the whole model activity and retry steps on worker shutdown

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -5,6 +5,11 @@ import type {
 
 export const DEFAULT_MCP_REQUEST_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes.
 
+// Timeout for agent-loop tools/list requests. The MCP SDK default (60s) equals the model
+// activity heartbeat timeout, and a hung server should not stall every step for a minute:
+// a failed listing degrades gracefully (the server's tools are skipped for the step).
+export const MCP_LIST_TOOLS_TIMEOUT_MS = 30 * 1000;
+
 export const RUN_AGENT_CALL_TOOL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes.
 
 export const RETRY_ON_INTERRUPT_MAX_ATTEMPTS = 15;

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_MCP_REQUEST_TIMEOUT_MS,
   FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
+  MCP_LIST_TOOLS_TIMEOUT_MS,
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/constants";
 import type {
@@ -1322,7 +1323,9 @@ async function listToolsForClientSideMCPServer(
 
   // Fetch all tools, handling pagination if supported by the MCP server.
   do {
-    const { tools, nextCursor } = await mcpClient.listTools();
+    const { tools, nextCursor } = await mcpClient.listTools(undefined, {
+      timeout: MCP_LIST_TOOLS_TIMEOUT_MS,
+    });
 
     nextPageCursor = nextCursor;
     const dustMetaByTool = new Map(
@@ -1364,7 +1367,9 @@ export async function listToolsForServerSideMCPServer(
 
   // Fetch all tools, handling pagination if supported by the MCP server.
   do {
-    const { tools, nextCursor } = await mcpClient.listTools();
+    const { tools, nextCursor } = await mcpClient.listTools(undefined, {
+      timeout: MCP_LIST_TOOLS_TIMEOUT_MS,
+    });
     nextPageCursor = nextCursor;
     allToolsRaw = [
       ...allToolsRaw,

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -133,6 +133,9 @@ const MCP_NOTIFICATION_EVENT_NAME = "mcp-notification";
 const MCP_TOOL_DONE_EVENT_NAME = "TOOL_DONE" as const;
 const MCP_TOOL_ERROR_EVENT_NAME = "TOOL_ERROR" as const;
 const MCP_TOOL_HEARTBEAT_EVENT_NAME = "TOOL_HEARTBEAT" as const;
+// Threshold above which a tools/list duration is logged, to build the latency
+// distribution behind the MCP_LIST_TOOLS_TIMEOUT_MS cap.
+const SLOW_MCP_TOOLS_LIST_THRESHOLD_MS = 5_000;
 const TOOL_EXECUTION_CANCELLED_MESSAGE = "The tool execution was cancelled.";
 const TOOL_EXECUTION_INTERRUPTED_MESSAGE =
   "A tool was interrupted before Dust could confirm the result. Please check whether it completed, then retry.";
@@ -1541,6 +1544,7 @@ async function listMCPServerToolsAndServerInstructions(
 
     const serverInstructions = mcpClient.getInstructions();
 
+    const listStartMs = Date.now();
     let toolsRes: Result<MCPToolConfigurationType[], Error>;
     if (isConnectViaClientSideMCPServer(connectionParams)) {
       assert(
@@ -1558,6 +1562,23 @@ async function listMCPServerToolsAndServerInstructions(
         connectionParams,
         mcpClient,
         config
+      );
+    }
+
+    // Listing normally completes in well under a second: log the slow tail so the
+    // MCP_LIST_TOOLS_TIMEOUT_MS cap can be tuned on real latency data.
+    const listDurationMs = Date.now() - listStartMs;
+    if (listDurationMs > SLOW_MCP_TOOLS_LIST_THRESHOLD_MS) {
+      logger.info(
+        {
+          workspaceId: owner.sId,
+          conversationId: agentLoopListToolsContext.conversation.sId,
+          messageId: agentLoopListToolsContext.agentMessage.sId,
+          mcpServerName: config.name,
+          durationMs: listDurationMs,
+          success: toolsRes.isOk(),
+        },
+        "Slow MCP tools listing"
       );
     }
 

--- a/front/lib/temporal/cancellation.test.ts
+++ b/front/lib/temporal/cancellation.test.ts
@@ -1,0 +1,21 @@
+import { classifyTemporalAbortReason } from "@app/lib/temporal/cancellation";
+import { CancelledFailure } from "@temporalio/common";
+import { describe, expect, it } from "vitest";
+
+describe("classifyTemporalAbortReason", () => {
+  it("classifies the SDK worker shutdown cancellation as worker_shutdown", () => {
+    expect(
+      classifyTemporalAbortReason(new CancelledFailure("WORKER_SHUTDOWN"))
+    ).toBe("worker_shutdown");
+  });
+
+  it("classifies the SDK user cancellation as user_cancellation", () => {
+    expect(classifyTemporalAbortReason(new CancelledFailure("CANCELLED"))).toBe(
+      "user_cancellation"
+    );
+  });
+
+  it("returns none for unrelated errors", () => {
+    expect(classifyTemporalAbortReason(new Error("random"))).toBe("none");
+  });
+});

--- a/front/lib/utils/async_utils.test.ts
+++ b/front/lib/utils/async_utils.test.ts
@@ -1,0 +1,58 @@
+import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("withPeriodicHeartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires heartbeatFn periodically while fn is pending", async () => {
+    const heartbeatFn = vi.fn();
+    let resolveFn: (value: string) => void = () => {};
+
+    const promise = withPeriodicHeartbeat(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFn = resolve;
+        }),
+      { intervalMs: 10_000, heartbeatFn }
+    );
+
+    // A stall longer than the 60s Temporal heartbeat timeout keeps heartbeating.
+    await vi.advanceTimersByTimeAsync(65_000);
+    expect(heartbeatFn).toHaveBeenCalledTimes(6);
+
+    resolveFn("done");
+    await expect(promise).resolves.toBe("done");
+  });
+
+  it("stops heartbeating once fn resolves", async () => {
+    const heartbeatFn = vi.fn();
+
+    const promise = withPeriodicHeartbeat(() => Promise.resolve(42), {
+      intervalMs: 10_000,
+      heartbeatFn,
+    });
+
+    await expect(promise).resolves.toBe(42);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(heartbeatFn).not.toHaveBeenCalled();
+  });
+
+  it("stops heartbeating when fn rejects", async () => {
+    const heartbeatFn = vi.fn();
+
+    const promise = withPeriodicHeartbeat(
+      () => Promise.reject(new Error("boom")),
+      { intervalMs: 10_000, heartbeatFn }
+    );
+
+    await expect(promise).rejects.toThrow("boom");
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(heartbeatFn).not.toHaveBeenCalled();
+  });
+});

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -15,7 +15,11 @@ import {
   AGENT_LOOP_SUBAGENT_HARD_CAP,
   checkCostAndSubagentsThresholds,
 } from "@app/temporal/agent_loop/activities/cost_threshold_warnings";
-import { RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS } from "@app/temporal/agent_loop/config";
+import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
+import {
+  MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
+  RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS,
+} from "@app/temporal/agent_loop/config";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { handlePromptCommand } from "@app/temporal/agent_loop/lib/prompt_commands";
@@ -31,7 +35,7 @@ import {
 } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
 import { startActiveObservation } from "@langfuse/tracing";
-import { Context } from "@temporalio/activity";
+import { Context, heartbeat } from "@temporalio/activity";
 
 export type RunModelAndCreateActionsResult = {
   actionBlobs: ActionBlob[];
@@ -79,15 +83,27 @@ export async function runModelAndCreateActionsActivity({
   step: number;
   forceDisableToolUse?: boolean;
 }): Promise<RunModelAndCreateActionsResult | null> {
-  return tracer.trace("runModelAndCreateActionsActivity", async () =>
-    _runModelAndCreateActionsActivity({
-      authType,
-      checkForResume,
-      runAgentArgs,
-      runIds,
-      step,
-      forceDisableToolUse,
-    })
+  // The pre-stream setup (agent data loading, MCP tools listing, conversation rendering) can
+  // stall past the heartbeat timeout, e.g. on a hung MCP server's tools/list call: heartbeat
+  // immediately and periodically for the whole activity. The LLM stream adds its own heartbeats.
+  heartbeat();
+
+  return withPeriodicHeartbeat(
+    () =>
+      tracer.trace("runModelAndCreateActionsActivity", async () =>
+        _runModelAndCreateActionsActivity({
+          authType,
+          checkForResume,
+          runAgentArgs,
+          runIds,
+          step,
+          forceDisableToolUse,
+        })
+      ),
+    {
+      intervalMs: MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
+      heartbeatFn: () => heartbeat(),
+    }
   );
 }
 

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -7,6 +7,7 @@ import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/action
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { notifyManualActionRequired } from "@app/lib/notifications/workflows/manual-action-required";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
@@ -15,7 +16,6 @@ import {
   AGENT_LOOP_SUBAGENT_HARD_CAP,
   checkCostAndSubagentsThresholds,
 } from "@app/temporal/agent_loop/activities/cost_threshold_warnings";
-import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import {
   MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
   RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS,

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -97,6 +97,12 @@ export const RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS = 1 * 60 * 1000;
 export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 export const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 
+// Heartbeat cadence for the whole model activity. Its setup phase (agent data loading, MCP
+// tools listing, conversation rendering) can stall past the heartbeat timeout, e.g. a hung MCP
+// server's tools/list call times out after 60s, exactly the heartbeat timeout. Aligned with the
+// worker's maxHeartbeatThrottleInterval.
+export const MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS = 20 * 1000;
+
 // Heartbeat cadence while tool result processing runs (file handling can take minutes): fire
 // comfortably within the heartbeat timeout.
 const TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS = 5 * 1000;

--- a/front/temporal/agent_loop/lib/get_output_from_llm.test.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.test.ts
@@ -4,14 +4,7 @@ import {
   resolveStableToolCallName,
   withPeriodicHeartbeat,
 } from "@app/temporal/agent_loop/lib/get_output_from_llm";
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-} from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const shutdownMock = vi.hoisted(() => ({ controller: new AbortController() }));
 

--- a/front/temporal/agent_loop/lib/get_output_from_llm.test.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.test.ts
@@ -2,8 +2,30 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import {
   getToolCallStartDeduplicationKeys,
   resolveStableToolCallName,
+  withPeriodicHeartbeat,
 } from "@app/temporal/agent_loop/lib/get_output_from_llm";
-import { describe, expect, it } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const shutdownMock = vi.hoisted(() => ({ controller: new AbortController() }));
+
+vi.mock("@app/lib/shutdown_signal", () => ({
+  DUST_WORKER_SHUTDOWN_ABORT_REASON: "DUST_WORKER_SHUTDOWN_ABORT",
+  getShutdownSignal: () => shutdownMock.controller.signal,
+  markShuttingDownWithDelayedAbort: vi.fn(),
+}));
+
+vi.mock("@temporalio/activity", () => ({
+  CancelledFailure: class CancelledFailure extends Error {},
+  heartbeat: vi.fn(),
+  sleep: vi.fn().mockResolvedValue(undefined),
+}));
 
 const specifications: AgentActionSpecification[] = [
   {
@@ -58,5 +80,66 @@ describe("getToolCallStartDeduplicationKeys", () => {
         stableToolName: "create_interactive_content_file",
       })
     ).toEqual(["name:create_interactive_content_file"]);
+  });
+});
+
+describe("withPeriodicHeartbeat", () => {
+  beforeEach(() => {
+    shutdownMock.controller = new AbortController();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("passes stream values through and closes the stream when done", async () => {
+    const returnFn = vi.fn().mockResolvedValue({ done: true });
+    const values = ["a", "b"][Symbol.iterator]();
+    const stream: AsyncIterator<string> = {
+      next: async () => {
+        const { value, done } = values.next();
+        return done ? { value: undefined, done: true } : { value, done: false };
+      },
+      return: returnFn,
+    };
+
+    const collected: string[] = [];
+    for await (const value of withPeriodicHeartbeat(
+      stream,
+      Date.now() + 600_000
+    )) {
+      collected.push(value);
+    }
+
+    expect(collected).toEqual(["a", "b"]);
+    expect(returnFn).toHaveBeenCalled();
+  });
+
+  it("fails fast on worker shutdown even when the provider stream is stalled", async () => {
+    // next() never resolves (stalled provider read) and return() never settles either: the
+    // async generator method queue would block cleanup behind the in-flight next().
+    const returnFn = vi.fn(() => new Promise<IteratorResult<string>>(() => {}));
+    const stalledStream: AsyncIterator<string> = {
+      next: () => new Promise(() => {}),
+      return: returnFn,
+    };
+
+    const generator = withPeriodicHeartbeat(
+      stalledStream,
+      Date.now() + 600_000
+    );
+    const pending = generator.next();
+    const assertion = expect(pending).rejects.toThrow(
+      "Model activity interrupted by worker shutdown"
+    );
+
+    shutdownMock.controller.abort("DUST_WORKER_SHUTDOWN_ABORT");
+
+    // The bounded cleanup (2s) is the only wait: well within the 10s shutdown buffer.
+    await vi.advanceTimersByTimeAsync(3_000);
+
+    await assertion;
+    expect(returnFn).toHaveBeenCalled();
   });
 });

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -8,8 +8,10 @@ import type { LLM } from "@app/lib/api/llm/llm";
 import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
+import { classifyTemporalAbortReason } from "@app/lib/temporal/cancellation";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
+import { makeModelInterruptionError } from "@app/temporal/agent_loop/lib/run_model_errors";
 import type {
   GetOutputRequestParams,
   GetOutputResponse,
@@ -332,6 +334,12 @@ export async function getOutputFromLLMStream(
         await sleep(1);
       } catch (err) {
         if (err instanceof CancelledFailure) {
+          // Worker shutdown also cancels in-flight activities. Surface a retryable failure so
+          // Temporal reruns the step on another worker, instead of finalizing the message as
+          // successful mid-answer like a user stop would.
+          if (classifyTemporalAbortReason(err) === "worker_shutdown") {
+            throw makeModelInterruptionError();
+          }
           logger.info("Activity cancelled, stopping");
           return new Err({ type: "shouldReturnNull" });
         }

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -9,10 +9,7 @@ import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getShutdownSignal } from "@app/lib/shutdown_signal";
-import {
-  classifyTemporalAbortReason,
-  classifyTemporalAbortSignal,
-} from "@app/lib/temporal/cancellation";
+import { classifyTemporalAbortReason } from "@app/lib/temporal/cancellation";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { makeModelInterruptionError } from "@app/temporal/agent_loop/lib/run_model_errors";
@@ -32,6 +29,9 @@ const HEARTBEAT_LOG_INTERVAL = 6; // Every minute (6 * 10s)
 // Timeout for waiting on a single LLM event (first or subsequent).
 const LLM_EVENT_TIMEOUT_MINUTES = 2;
 const LLM_EVENT_TIMEOUT_MS = LLM_EVENT_TIMEOUT_MINUTES * 60 * 1000;
+// Bound on waiting for the stream to close on early exit: exit paths that must report quickly
+// (worker shutdown has ~10s before SIGKILL) cannot wait on a stalled provider read.
+const STREAM_CLEANUP_TIMEOUT_MS = 2_000;
 type LLMStreamTimeoutKind = "activity" | "event";
 
 export function resolveStableToolCallName(
@@ -100,7 +100,8 @@ function makeLLMTimeoutResponse(kind: LLMStreamTimeoutKind): GetOutputResponse {
 
 // Wraps an async iterator and ensures heartbeat() is called at regular intervals
 // even when the source is slow to yield values.
-async function* withPeriodicHeartbeat<T>(
+// Exported for tests.
+export async function* withPeriodicHeartbeat<T>(
   stream: AsyncIterator<T>,
   activityTimeoutDeadlineMs: number,
   logContext?: {
@@ -118,15 +119,23 @@ async function* withPeriodicHeartbeat<T>(
 
   let heartbeatTimer: NodeJS.Timeout | undefined;
 
+  // The pod shutdown signal aborts 10s before the termination grace period ends, while
+  // Temporal's own WORKER_SHUTDOWN cancellation only fires at grace expiry, together with
+  // SIGKILL, too late to report anything. Raced against the stream below so a shutdown is
+  // detected immediately, not at the next event or heartbeat tick, and the retryable failure
+  // can be reported while the pod can still talk to Temporal.
+  const shutdownSignal = getShutdownSignal();
+  let onShutdownAbort: (() => void) | undefined;
+  const shutdownPromise = new Promise<{ type: "shutdown" }>((resolve) => {
+    onShutdownAbort = () => resolve({ type: "shutdown" as const });
+    shutdownSignal.addEventListener("abort", onShutdownAbort, { once: true });
+  });
+
   try {
     while (!streamExhausted) {
-      // The pod shutdown signal aborts 10s before the termination grace period ends, while
-      // Temporal's own WORKER_SHUTDOWN cancellation only fires at grace expiry, together with
-      // SIGKILL, too late to report anything. Checked here (every event or 10s heartbeat tick)
-      // so the retryable failure is reported while the pod can still talk to Temporal.
-      if (
-        classifyTemporalAbortSignal(getShutdownSignal()) === "worker_shutdown"
-      ) {
+      // The abort listener above never fires for a signal that aborted before this generator
+      // started: cover it here.
+      if (shutdownSignal.aborted) {
         throw makeModelInterruptionError();
       }
 
@@ -161,10 +170,15 @@ async function* withPeriodicHeartbeat<T>(
             Math.min(LLM_HEARTBEAT_INTERVAL_MS, remainingActivityTimeMs)
           );
         }),
+        shutdownPromise,
       ]);
 
       // Clear the heartbeat timer if the stream event won the race.
       clearTimeout(heartbeatTimer);
+
+      if (result.type === "shutdown") {
+        throw makeModelInterruptionError();
+      }
 
       heartbeat();
 
@@ -237,16 +251,30 @@ async function* withPeriodicHeartbeat<T>(
     // Clear any pending heartbeat timer to prevent leaked closures.
     clearTimeout(heartbeatTimer);
 
-    // Ensure the underlying stream is closed on early exit (timeout, error, or break).
-    // This aborts the HTTP connection to the LLM provider.
-    // Wrapped in try/catch to avoid masking the original error if cleanup fails.
-    try {
-      await stream.return?.();
-    } catch (cleanupError) {
+    if (onShutdownAbort) {
+      shutdownSignal.removeEventListener("abort", onShutdownAbort);
+    }
+
+    // Ensure the underlying stream is closed on early exit (timeout, error, worker shutdown, or
+    // break). This aborts the HTTP connection to the LLM provider. An async generator's return()
+    // queues behind an in-flight next(), so a stalled provider read would block this await
+    // indefinitely: bound it and abandon the stream if it does not settle. The pending read
+    // keeps the connection until it settles or the process exits.
+    const cleanupPromise = stream.return?.()?.catch((cleanupError) => {
       logger.warn(
         { err: cleanupError, ...logContext },
         "[LLM stream] cleanup error"
       );
+    });
+    if (cleanupPromise) {
+      let cleanupTimer: NodeJS.Timeout | undefined;
+      await Promise.race([
+        cleanupPromise,
+        new Promise<void>((resolve) => {
+          cleanupTimer = setTimeout(resolve, STREAM_CLEANUP_TIMEOUT_MS);
+        }),
+      ]);
+      clearTimeout(cleanupTimer);
     }
   }
 }

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -8,7 +8,11 @@ import type { LLM } from "@app/lib/api/llm/llm";
 import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
-import { classifyTemporalAbortReason } from "@app/lib/temporal/cancellation";
+import { getShutdownSignal } from "@app/lib/shutdown_signal";
+import {
+  classifyTemporalAbortReason,
+  classifyTemporalAbortSignal,
+} from "@app/lib/temporal/cancellation";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import logger from "@app/logger/logger";
 import { makeModelInterruptionError } from "@app/temporal/agent_loop/lib/run_model_errors";
@@ -116,6 +120,16 @@ async function* withPeriodicHeartbeat<T>(
 
   try {
     while (!streamExhausted) {
+      // The pod shutdown signal aborts 10s before the termination grace period ends, while
+      // Temporal's own WORKER_SHUTDOWN cancellation only fires at grace expiry, together with
+      // SIGKILL, too late to report anything. Checked here (every event or 10s heartbeat tick)
+      // so the retryable failure is reported while the pod can still talk to Temporal.
+      if (
+        classifyTemporalAbortSignal(getShutdownSignal()) === "worker_shutdown"
+      ) {
+        throw makeModelInterruptionError();
+      }
+
       const remainingActivityTimeMs = activityTimeoutDeadlineMs - Date.now();
 
       if (remainingActivityTimeMs <= 0) {

--- a/front/temporal/agent_loop/lib/run_model_errors.ts
+++ b/front/temporal/agent_loop/lib/run_model_errors.ts
@@ -10,6 +10,17 @@ const RUN_MODEL_LLM_UNRESPONSIVE_ERROR_TYPES = new Set<LLMErrorType>([
   "timeout_error",
 ]);
 
+export const MODEL_INTERRUPTION_ERROR_TYPE = "ModelInterruption";
+
+// Same pattern as makeToolInterruptionError: a retryable failure so Temporal reruns the step on
+// another worker when the current one is shutting down.
+export function makeModelInterruptionError(): ApplicationFailure {
+  return ApplicationFailure.retryable(
+    "Model activity interrupted by worker shutdown",
+    MODEL_INTERRUPTION_ERROR_TYPE
+  );
+}
+
 export function makeRunModelLLMError({
   type,
   message,

--- a/front/temporal/agent_loop/lib/run_model_errors.ts
+++ b/front/temporal/agent_loop/lib/run_model_errors.ts
@@ -10,7 +10,7 @@ const RUN_MODEL_LLM_UNRESPONSIVE_ERROR_TYPES = new Set<LLMErrorType>([
   "timeout_error",
 ]);
 
-export const MODEL_INTERRUPTION_ERROR_TYPE = "ModelInterruption";
+const MODEL_INTERRUPTION_ERROR_TYPE = "ModelInterruption";
 
 // Same pattern as makeToolInterruptionError: a retryable failure so Temporal reruns the step on
 // another worker when the current one is shutting down.


### PR DESCRIPTION
## Description

Fixes for the 2026-08-18 `agent-loop-interactive-queue-v2` incident ([Datadog](https://app.datadoghq.eu/logs?from_ts=1787050500000&live=false&query=service%3Afront-agent-loop-worker+task_queue%3Aagent-loop-interactive-queue-v2+%22Activity+task+timed+out%3A+activity+Heartbeat+timeout%22&stream_sort=asc&to_ts=1787051400000)): 70 EU + 56 US workflow failures, with `runModelAndCreateActionsActivity` failing all 5 attempts with `TIMEOUT_TYPE_HEARTBEAT`.

- **Heartbeat the whole model activity.** The pre-stream setup had no heartbeat, and a hung MCP server's tools/list call times out after 60s, exactly the heartbeat timeout, so every retry died before reaching the LLM stream (each failed attempt shows "Starting multi-action loop iteration", 60s of silence, then "Error listing tools from MCP server: MCP error -32001"). The activity now heartbeats on entry and every 20s for its whole duration (same pattern as tool setup, #28780). This is not incident-specific: the fleet-wide max of `agent_loop_step.time_to_provider_call` exceeds 60s many times per day, every day (spikes up to 562s over the past week), and each of those is a silently heartbeat-timed-out attempt today.
- **Retry on worker shutdown instead of finalizing as success.** The LLM stream loop treated any `CancelledFailure` as a user "Stop agent", so a deploy mid-stream silently finalized the message as successful with a truncated answer. Worker shutdown is now surfaced as a retryable failure so the step reruns on another worker. The stream loop watches the pod shutdown signal (aborts 10s before the grace period ends, like tools do), because Temporal's own WORKER_SHUTDOWN cancellation only fires at grace expiry, together with SIGKILL, too late to report anything.

- **Cap agent-loop tools/list requests at 30s** (review feedback): they inherited the MCP SDK default of exactly 60s, the same value as the heartbeat timeout, which made the collision deterministic. A failed listing already degrades gracefully (the server's tools are skipped for the step), so the lower cap only makes that existing degraded mode kick in sooner. No latency data exists for tools/list today, so 30s is deliberately conservative; listings slower than 5s are now logged ("Slow MCP tools listing") to tune the cap on real data.

> [!NOTE]
> Behavior change on every deploy: all in-flight model streams on a draining pod abort at 110s into the grace period and retry the step on another worker, redoing the full LLM call. This includes streams that would have completed in the 110-120s window before SIGKILL. Tools already made this exact trade (`SHUTDOWN_TOOL_ABORT_DELAY_MS`); the alternative is dying at 120s and being discovered by heartbeat timeout 60s later, or worse, being finalized as a truncated "success".

Follow-ups (separate PRs): heartbeat the tool activity's MCP connect phase (the un-heartbeated gap that killed 69 sandbox child tool workflows in the EU burst), exponential backoff on the model activity retry policy, thread an AbortSignal into `llm.stream()` so early exits (timeouts, shutdown) abort the provider read eagerly instead of abandoning it after the bounded cleanup wait.

## Tests

- New unit tests for `withPeriodicHeartbeat` and `classifyTemporalAbortReason` (neither had any).
- `tsgo --noEmit` clean, existing agent-loop tests pass.

## Risk

Low. Heartbeats are throttled by the SDK; no happy-path change. The deploy-time behavior change is described in the note above: interrupted model steps retry (at the cost of redoing the LLM call) instead of being silently truncated. No schema/API change, safe to rollback.

## Deploy Plan

- [ ] Deploy `front` (front-agent-loop-worker picks it up on rollout).
- [ ] Watch `service:front-agent-loop-worker "Activity task timed out: activity Heartbeat timeout"` in Datadog: model-activity heartbeat timeouts should disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
