### PR TITLE
fix: decouple free-plan provisioning from rate-limited seat-sync reads

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -22,6 +22,7 @@ import type { UserResource } from "@app/lib/resources/user_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
+import { launchMetronomeSeatCountSyncWorkflow } from "@app/temporal/usage_queue/client";
 import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import { removeNulls } from "@app/types/shared/utils/general";
 
@@ -109,6 +110,11 @@ async function provisionCreditPricedFreePlan(
     enableStripeBilling: false,
     planCode: CREDIT_PRICED_FREE_PLAN_CODE,
     displayedName: `Free Business ${currency.toUpperCase()}`,
+    // Skip the inline seat sync: it reads rate-limited Metronome seat endpoints
+    // (`getSubscriptionSeatsHistory`, `seatBalances/list`) and a transient 429
+    // there would abort signup after the contract was already created. Seats are
+    // reconciled out-of-band via the immediate seat-sync workflow launched below.
+    enableSeatSync: false,
     // We create the subscription row ourselves right below via
     // `createSubscriptionFromCheckout`. Stamp the contract so the
     // contract.start webhook skips its own subscription swap instead of
@@ -138,6 +144,24 @@ async function provisionCreditPricedFreePlan(
   }
 
   await invalidateContractCache(owner.sId);
+
+  // Seat sync was skipped inline (see `enableSeatSync: false` above). Now that
+  // the contract and subscription row exist, reconcile the seat out-of-band —
+  // `immediate` skips the debounce so the free seat is assigned promptly, and
+  // the workflow's Temporal retries ride out any transient seat-endpoint 429s
+  // without blocking signup. Best-effort: a launch failure is backstopped by the
+  // debounced sync from the earlier membership seat change.
+  const seatSyncResult = await launchMetronomeSeatCountSyncWorkflow({
+    workspaceId: owner.sId,
+    immediate: true,
+  });
+  if (seatSyncResult.isErr()) {
+    logger.warn(
+      { workspaceId: owner.sId, err: seatSyncResult.error },
+      "[Metronome] Failed to launch immediate seat-count sync after free-plan provisioning"
+    );
+  }
+
   await restoreWorkspaceAfterSubscription(auth);
 }
 

--- a/front/temporal/usage_queue/client.ts
+++ b/front/temporal/usage_queue/client.ts
@@ -191,19 +191,26 @@ export async function launchEmitMetronomeUsageEventsWorkflow({
 
 export async function launchMetronomeSeatCountSyncWorkflow({
   workspaceId,
+  immediate = false,
 }: {
   workspaceId: string;
+  // Skip the debounce window and sync now. Used when a caller needs the seat
+  // reflected immediately (e.g. right after provisioning a new contract) rather
+  // than after the coalescing delay.
+  immediate?: boolean;
 }): Promise<Result<undefined, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = makeMetronomeSeatCountSyncWorkflowId({ workspaceId });
 
   try {
+    // `args` seeds a fresh workflow; `signalArgs` carries `immediate` to an
+    // already-running (debouncing) instance so it wakes early.
     await client.workflow.signalWithStart(syncMetronomeSeatCountWorkflow, {
-      args: [workspaceId],
+      args: [workspaceId, { immediate }],
       taskQueue: QUEUE_NAME,
       workflowId,
       signal: syncMetronomeSeatCountSignal,
-      signalArgs: undefined,
+      signalArgs: [{ immediate }],
       memo: {
         workspaceId,
       },

--- a/front/temporal/usage_queue/signals.ts
+++ b/front/temporal/usage_queue/signals.ts
@@ -1,8 +1,8 @@
 import { defineSignal } from "@temporalio/workflow";
 
-export const syncMetronomeSeatCountSignal = defineSignal<[void]>(
-  "sync_metronome_seat_count_signal"
-);
+export const syncMetronomeSeatCountSignal = defineSignal<
+  [{ immediate?: boolean }?]
+>("sync_metronome_seat_count_signal");
 
 export const reconcileApiKeyCreditStateSignal = defineSignal<[void]>(
   "reconcile_api_key_credit_state_signal"

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -5,7 +5,12 @@ import {
   syncMetronomeSeatCountSignal,
 } from "@app/temporal/usage_queue/signals";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
-import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
+import {
+  condition,
+  proxyActivities,
+  setHandler,
+  sleep,
+} from "@temporalio/workflow";
 
 const METRONOME_SEAT_COUNT_DEBOUNCE_MS = 15 * 1000;
 
@@ -50,17 +55,30 @@ export async function updateWorkspaceUsageWorkflow(workspaceId: string) {
 }
 
 export async function syncMetronomeSeatCountWorkflow(
-  workspaceId: string
+  workspaceId: string,
+  { immediate = false }: { immediate?: boolean } = {}
 ): Promise<void> {
   let pendingSync = true;
+  // Skips the debounce for the next run. Set at start (fresh workflow) or by an
+  // immediate signal — e.g. a just-provisioned workspace that needs its seat
+  // assigned now rather than after the debounce window.
+  let runImmediately = immediate;
 
-  setHandler(syncMetronomeSeatCountSignal, () => {
+  setHandler(syncMetronomeSeatCountSignal, (signalArgs) => {
     pendingSync = true;
+    if (signalArgs?.immediate) {
+      runImmediately = true;
+    }
   });
 
   while (pendingSync) {
-    await sleep(METRONOME_SEAT_COUNT_DEBOUNCE_MS);
     pendingSync = false;
+    if (!runImmediately) {
+      // Debounce, but wake early if an immediate sync is requested mid-wait
+      // (coalesces bursts; an immediate trigger interrupts the window).
+      await condition(() => runImmediately, METRONOME_SEAT_COUNT_DEBOUNCE_MS);
+    }
+    runImmediately = false;
     await syncMetronomeSeatCountActivity(workspaceId);
   }
 }

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -7,6 +7,7 @@ import {
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import {
   condition,
+  patched,
   proxyActivities,
   setHandler,
   sleep,
@@ -73,12 +74,21 @@ export async function syncMetronomeSeatCountWorkflow(
 
   while (pendingSync) {
     pendingSync = false;
-    if (!runImmediately) {
-      // Debounce, but wake early if an immediate sync is requested mid-wait
-      // (coalesces bursts; an immediate trigger interrupts the window).
-      await condition(() => runImmediately, METRONOME_SEAT_COUNT_DEBOUNCE_MS);
+    // patched: workflows started before this change replay the plain `sleep` so
+    // they stay deterministic; new ones use an interruptible `condition` so an
+    // `immediate` signal can skip the debounce window. Safe to remove the patch
+    // (→ `deprecatePatch` → delete) a few days after deploy — these workflows
+    // are short-lived, so no pre-change instance survives that long.
+    if (patched("seat-count-immediate-debounce")) {
+      if (!runImmediately) {
+        // Debounce, but wake early if an immediate sync is requested mid-wait
+        // (coalesces bursts; an immediate trigger interrupts the window).
+        await condition(() => runImmediately, METRONOME_SEAT_COUNT_DEBOUNCE_MS);
+      }
+      runImmediately = false;
+    } else {
+      await sleep(METRONOME_SEAT_COUNT_DEBOUNCE_MS);
     }
-    runImmediately = false;
     await syncMetronomeSeatCountActivity(workspaceId);
   }
 }


### PR DESCRIPTION
## Problem

Trial signup (`provisionCreditPricedFreePlan`) failed with `Failed to provision Metronome contract: 429 Rate limit exceeded` during the migration storm — and per Metronome, **`contracts.create` was never rate-limited**. The 429 came from the **inline seat sync** that `provisionMetronomeContract` runs *after* creating the contract:

1. `createMetronomeContract` ✅
2. `remapMembershipSeatTypesForContract` → reads `getSubscriptionSeatsHistory`
3. `syncSeatCount` → reads `getSubscriptionSeatsHistory` + `seatBalances/list`

Those two read endpoints (each with its own limit) were saturated by the migration's seat-sync/reconcile storm, so the inline sync 429'd, `provisionMetronomeContract` returned `Err`, and signup threw **after the contract was already created** — stranding the workspace on FREE_NO_PLAN with a contract but no subscription row.

## Change

- **Provision with `enableSeatSync: false`** in `provisionCreditPricedFreePlan`, then reconcile the seat **out-of-band** via `launchMetronomeSeatCountSyncWorkflow` once the contract + subscription row exist. The Temporal workflow's retries absorb transient seat-endpoint 429s without blocking (or failing) signup.
- **Add an `immediate` option to the seat-count sync workflow** so it skips the 15s debounce — the free seat must be assigned promptly. The flag travels via:
  - the workflow **args** (seeds a fresh workflow), and
  - the **signal payload** (wakes an already-debouncing instance — the membership seat-change earlier in the same flow usually started one — by racing a `condition()` instead of a fixed `sleep`).

## Impact / trade-off

- Signups become immune to seat/credit read-endpoint brownouts.
- The `contract.start` webhook does **not** assign seats (it only reconciles credit states assuming seats exist), so the async workflow is the real backstop — hence launching it explicitly rather than relying on the webhook.
- Worst case on a brand-new workspace: the free seat's credits provision a moment late (workflow run instead of inline). Acceptable — the workspace can't hit limits in that window.

## Test plan

- `npx tsgo --noEmit -p front` — clean
- Biome — clean
- `signup.test.ts` (2), `membership.test.ts` (6), `metronome/process_webhook.test.ts` (31) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)