### PR TITLE
chore(sparkle): remove unused lottie-web dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58589,7 +58589,6 @@
         "emoji-mart": "^5.5.2",
         "framer-motion": "^11.18.2",
         "lottie-react": "^2.4.0",
-        "lottie-web": "^5.12.2",
         "mermaid": "^11.4.1",
         "nstall": "^0.2.0",
         "react-confetti": "^6.1.0",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -129,7 +129,6 @@
     "emoji-mart": "^5.5.2",
     "framer-motion": "^11.18.2",
     "lottie-react": "^2.4.0",
-    "lottie-web": "^5.12.2",
     "mermaid": "^11.4.1",
     "nstall": "^0.2.0",
     "react-confetti": "^6.1.0",


### PR DESCRIPTION
## Description

`sparkle` declared `lottie-web` directly, but the workspace only ever imports
Lottie animations through `lottie-react` (`CollapseButton.tsx`,
`DropzoneOverlay.tsx`, `SpinnerBrand.tsx`, `Spinner.tsx`). `lottie-react`
already lists `lottie-web` as its own dependency, so the direct entry in
`sparkle` was a redundant, unused top-level dependency — extra install size
and audit surface with no source using it directly.

`lottie-web` was added directly to `package.json` in #5212 (May 2024) at the
same time `lottie-react` and `CollapseButton` were introduced — it appears it
was never actually imported directly at any point since, only pulled in
transitively via `lottie-react`.

Removing it here since it's the largest of a batch of unused-dependency
cleanups; see the follow-up PRs stacked on top for the smaller ones.

## Tests

N/A — dependency removal only, no source changes.

## Risk

Low

## Deploy Plan

- Deploy sparkle