### PR TITLE
chore(extension): remove unused moment dependency

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -79,7 +79,6 @@
     "https-browserify": "^1.0.0",
     "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
-    "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -267,7 +267,6 @@
         "https-browserify": "^1.0.0",
         "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
-        "moment": "^2.30.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.3.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -58589,7 +58589,6 @@
         "emoji-mart": "^5.5.2",
         "framer-motion": "^11.18.2",
         "lottie-react": "^2.4.0",
-        "lottie-web": "^5.12.2",
         "mermaid": "^11.4.1",
         "nstall": "^0.2.0",
         "react-confetti": "^6.1.0",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -129,7 +129,6 @@
     "emoji-mart": "^5.5.2",
     "framer-motion": "^11.18.2",
     "lottie-react": "^2.4.0",
-    "lottie-web": "^5.12.2",
     "mermaid": "^11.4.1",
     "nstall": "^0.2.0",
     "react-confetti": "^6.1.0",


### PR DESCRIPTION
## Description

Stacked on top of #30745.

`extension` declared `moment` as a dependency, but no source file in the
workspace imports it. Removing the legacy, unused date library.

The last real usage was removed in #22131 (merged 2026-02-24), which dropped
an `import moment from "moment"` in the conversation-switching sidebar when
it was replaced with the shared front sidebar — the `package.json` entry was
just never cleaned up afterwards.

## Tests

N/A — dependency removal only, no source changes.

## Risk

Low

## Deploy Plan

- Deploy extension