### PR TITLE
[front] perf: Add stats deps on groupId, workspaceId

### DIFF
--- a/front/migrations/pre-deploy/20260818165651_add_dependencies_statistics_on_group_permissions.sql
+++ b/front/migrations/pre-deploy/20260818165651_add_dependencies_statistics_on_group_permissions.sql
@@ -1,0 +1,9 @@
+-- Same rationale as messages (20260722195624): groupId functionally determines workspaceId (a group
+-- belongs to a single workspace), but the planner multiplies both selectivities and underestimates
+-- the caller's grant lookup by two orders of magnitude. Functional-dependency statistics clamp the
+-- pair to the narrower of the two selectivities instead of their product.
+SET SESSION statement_timeout = 60000;
+SET SESSION lock_timeout = 3000;
+CREATE STATISTICS IF NOT EXISTS group_permissions_group_id_workspace_id_dependencies (dependencies)
+  ON "groupId", "workspaceId" FROM group_permissions;
+ANALYZE group_permissions;


### PR DESCRIPTION
## Description

Add a dependency stat on groupId / workspaceId to hint pg planner on the fact a group only belongs to ONE group.

Leads to better estimates of rows, so always useful, but also I don't expect a huge win on this codepath because of how simple the query is.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
