### PR TITLE
sparkle: add icon prop to SliderToggle

### DIFF
--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -7,6 +7,9 @@ type SliderToggleProps = {
   disabled?: boolean;
   selected?: boolean;
   icon?: ComponentType<{ className?: string }>;
+  // Mutes the active track color, e.g. to signal a setting that is on but
+  // restricted (paired with `icon`) rather than a plain active toggle.
+  faded?: boolean;
 };
 
 const baseClasses = cn(
@@ -29,6 +32,7 @@ const hoverDarkenClasses = cn(
 const stateClasses = {
   idle: cn("bg-slider-toggle-bg-idle", hoverDarkenClasses),
   selected: cn("bg-highlight-400", hoverDarkenClasses),
+  selectedFaded: cn("bg-highlight-400/50", hoverDarkenClasses),
   disabled: cn(
     "bg-primary-200",
     "hover:bg-primary-200",
@@ -43,9 +47,14 @@ export function SliderToggle({
   className = "",
   selected = false,
   icon: Icon,
+  faded = false,
 }: SliderToggleProps) {
   const combinedStateClasses = cn(
-    selected ? stateClasses.selected : stateClasses.idle,
+    selected
+      ? faded
+        ? stateClasses.selectedFaded
+        : stateClasses.selected
+      : stateClasses.idle,
     disabled ? stateClasses.disabled : ""
   );
 

--- a/sparkle/src/components/SliderToggle.tsx
+++ b/sparkle/src/components/SliderToggle.tsx
@@ -1,11 +1,12 @@
 import { cn } from "@sparkle/lib/utils";
-import React, { type MouseEventHandler } from "react";
+import React, { type ComponentType, type MouseEventHandler } from "react";
 
 type SliderToggleProps = {
   onClick?: MouseEventHandler<HTMLElement>;
   className?: string;
   disabled?: boolean;
   selected?: boolean;
+  icon?: ComponentType<{ className?: string }>;
 };
 
 const baseClasses = cn(
@@ -41,6 +42,7 @@ export function SliderToggle({
   disabled = false,
   className = "",
   selected = false,
+  icon: Icon,
 }: SliderToggleProps) {
   const combinedStateClasses = cn(
     selected ? stateClasses.selected : stateClasses.idle,
@@ -65,6 +67,7 @@ export function SliderToggle({
         id="cursor"
         className={cn(
           "h-4 w-4 transform rounded-full bg-white drop-shadow",
+          "flex items-center justify-center",
           // Width shares the translate's timing: the hover stretch and the
           // slide must animate together so the knob stays edge-anchored.
           // (v4 translate-x-* sets the standalone `translate` property, so it
@@ -83,7 +86,11 @@ export function SliderToggle({
               ? "group-hover/slider:w-[18px] group-hover/slider:translate-x-[12px] group-active/slider:w-4 group-active/slider:translate-x-[14px]"
               : "group-hover/slider:w-[18px] group-active/slider:w-4")
         )}
-      />
+      >
+        {Icon && (
+          <Icon className="h-2.5 w-2.5 shrink-0 text-muted-foreground" />
+        )}
+      </div>
     </div>
   );
 

--- a/sparkle/src/stories/SliderToggle.stories.tsx
+++ b/sparkle/src/stories/SliderToggle.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 import { useArgs } from "storybook/preview-api";
 
-import { Button, SliderToggle } from "../index_with_tw_base";
+import { Button, Lock01, SliderToggle } from "../index_with_tw_base";
 
 const meta = {
   title: "Forms & Inputs/SliderToggle",
@@ -18,7 +18,8 @@ const meta = {
 **Guidelines**
 - Use **selected** as the source of truth and update it from the toggle handler.
 - For an option that is part of a form submitted later, or that needs an inline label and description, prefer **Checkbox**.
-- Pair with **SettingsList.Row** to align toggles with their title and description.`,
+- Pair with **SettingsList.Row** to align toggles with their title and description.
+- Pass **icon** to show a small icon inside the knob, e.g. a lock icon to signal the setting is restricted.`,
       },
     },
   },
@@ -69,5 +70,12 @@ export const SliderExample = () => (
     <InteractiveSliderToggle selected />
     <InteractiveSliderToggle disabled />
     <InteractiveSliderToggle selected disabled />
+  </div>
+);
+
+export const SliderWithIcon = () => (
+  <div className="flex items-center gap-2">
+    <SliderToggle icon={Lock01} selected={false} disabled />
+    <SliderToggle icon={Lock01} selected disabled />
   </div>
 );

--- a/sparkle/src/stories/SliderToggle.stories.tsx
+++ b/sparkle/src/stories/SliderToggle.stories.tsx
@@ -19,7 +19,8 @@ const meta = {
 - Use **selected** as the source of truth and update it from the toggle handler.
 - For an option that is part of a form submitted later, or that needs an inline label and description, prefer **Checkbox**.
 - Pair with **SettingsList.Row** to align toggles with their title and description.
-- Pass **icon** to show a small icon inside the knob, e.g. a lock icon to signal the setting is restricted.`,
+- Pass **icon** to show a small icon inside the knob, e.g. a lock icon to signal the setting is restricted.
+- Pass **faded** with **selected** to mute the active track color, e.g. for a setting that is on but restricted.`,
       },
     },
   },
@@ -77,5 +78,6 @@ export const SliderWithIcon = () => (
   <div className="flex items-center gap-2">
     <SliderToggle icon={Lock01} selected={false} disabled />
     <SliderToggle icon={Lock01} selected disabled />
+    <SliderToggle icon={Lock01} selected faded />
   </div>
 );


### PR DESCRIPTION
## Description

Extends the Sparkle `SliderToggle` component with two optional presentation props for restricted or managed settings:

- `icon` accepts a React component and renders it inside the toggle knob. The Storybook example uses `Lock01` to make the restricted state visible without relying only on a surrounding tooltip.
- `faded` mutes the active track color when `selected` is true, using a translucent highlight. It has no effect on unselected toggles, and the existing disabled styling still takes precedence.

The change also updates the component documentation and adds a `SliderWithIcon` Storybook story covering unselected disabled, selected disabled, and selected faded states. Existing callers remain compatible because both props are optional.

**In Sparkle:** 
<img width="1068" height="219" alt="Capture d’écran 2026-08-19 à 10 48 18" src="https://github.com/user-attachments/assets/1ad86bf6-1ed5-4190-8bff-bd293ad8913b" />


## Tests


## Risk

Low and limited to the Sparkle `SliderToggle` component. The API change is additive, with no changes required for existing callers and no data or backend behavior involved.

## Deploy Plan

- Deploy Sparkle