### PR TITLE
[front] show lock icon on trigger status toggle when locked

### DIFF
--- a/front/components/agent_builder/triggers/TriggerStatusToggle.tsx
+++ b/front/components/agent_builder/triggers/TriggerStatusToggle.tsx
@@ -2,7 +2,7 @@ import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/
 import { TRIGGER_STATUS_LABELS } from "@app/components/triggers/TriggerStatusChip";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
-import { Label, SliderToggle, Tooltip } from "@dust-tt/sparkle";
+import { Label, Lock01, SliderToggle, Tooltip } from "@dust-tt/sparkle";
 import { useController, useFormContext } from "react-hook-form";
 
 interface TriggerStatusToggleProps {
@@ -31,6 +31,7 @@ export function TriggerStatusToggle({
     <SliderToggle
       disabled={!isEditor || isStatusLocked}
       selected={isEnabled}
+      icon={isStatusLocked ? Lock01 : undefined}
       onClick={() => setStatus(isEnabled ? "disabled" : "enabled")}
     />
   );


### PR DESCRIPTION
## Description

Updates `TriggerStatusToggle` to pass the Sparkle `Lock01` icon to `SliderToggle` whenever the trigger status is locked.

Non-locked statuses continue to render without an icon. This PR is stacked on [#30750](https://github.com/dust-tt/dust/pull/30750), which adds the `SliderToggle` `icon` prop.

**Visual:**
<img width="1502" height="304" alt="Capture d’écran 2026-08-19 à 11 08 33" src="https://github.com/user-attachments/assets/662a9623-cbd1-4e4d-bc4c-a376140b8bb2" />

## Tests

- Tested localy

## Risk

Low and limited to the front-end trigger status toggle. Existing enabled, disabled, and non-locked behavior is unchanged.

## Deploy Plan

- Deploy front