### PR TITLE
[front] Cache & gate Metronome per-user credit reads

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -263,6 +263,9 @@ export function UsagePage() {
   const [membersTab, setMembersTab] = useState<"members" | "requests">(
     "members"
   );
+  const [usageTab, setUsageTab] = useState<
+    "members" | "groups" | "top-ups" | "settings"
+  >("members");
   const { upgradeRequests, isUpgradeRequestsLoading } = useUpgradeRequests({
     workspaceId: owner.sId,
   });
@@ -476,11 +479,17 @@ export function UsagePage() {
     orderDirection: membersOrderDirection,
     seatType: seatTypeFilter ?? undefined,
     groupId: groupFilter ?? undefined,
+    // Only the Members tab renders this data — skip the fetch (and its Metronome
+    // per-user credit read) while another tab is active.
+    disabled: usageTab !== "members",
   });
 
   const { groups } = useGroups({
     owner,
     kinds: [...CAP_ELIGIBLE_GROUP_KINDS],
+    // Only feeds the Members tab (group filter + Groups column); the Groups tab
+    // self-fetches via GroupsUsageTable.
+    disabled: usageTab !== "members",
   });
   const selectedGroupName =
     groups.find((g) => g.sId === groupFilter)?.name ?? null;
@@ -1078,7 +1087,16 @@ export function UsagePage() {
           </Page.Vertical>
         )}
 
-        <Tabs defaultValue="members">
+        <Tabs
+          value={usageTab}
+          onValueChange={(v) =>
+            setUsageTab(
+              v === "groups" || v === "top-ups" || v === "settings"
+                ? v
+                : "members"
+            )
+          }
+        >
           <TabsList className="mb-4">
             <TabsTrigger value="members" label="Members" />
             <TabsTrigger value="groups" label="Groups" />

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -18,7 +18,7 @@ import {
 } from "@app/lib/metronome/alerts/spend_limits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import {
-  listCustomerPerUserCreditBalances,
+  getCachedCustomerPerUserCreditBalances,
   listMetronomeSeatBalances,
 } from "@app/lib/metronome/client";
 import {
@@ -634,7 +634,7 @@ async function fetchFreeSeatCreditsForMembersTable({
   if (!metronomeCustomerId) {
     return { freeBalanceByUserId, freeStartingByUserId };
   }
-  const perUserCreditBalances = await listCustomerPerUserCreditBalances({
+  const perUserCreditBalances = await getCachedCustomerPerUserCreditBalances({
     metronomeCustomerId,
     contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
   });
@@ -1192,7 +1192,7 @@ export async function getMemberUsage({
   let freeSeatBalanceAwu: number | null = null;
   let freeSeatAllowanceAwu: number | null = null;
   if (membership.seatType === "free" && metronomeCustomerId) {
-    const balances = await listCustomerPerUserCreditBalances({
+    const balances = await getCachedCustomerPerUserCreditBalances({
       metronomeCustomerId,
       contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
     });

--- a/front/lib/api/metronome/process_webhook.ts
+++ b/front/lib/api/metronome/process_webhook.ts
@@ -47,6 +47,7 @@ import {
   getMetronomeCommit,
   getMetronomeContractById,
   getMetronomeCredit,
+  invalidateCachedCustomerPerUserCreditBalances,
   listMetronomeContracts,
   setMetronomeCommitCustomFields,
   setMetronomeContractCreditCustomFields,
@@ -54,6 +55,7 @@ import {
 import {
   CONTRACT_CREDIT_TYPE_CUSTOM_FIELD_KEY,
   CONTRACT_CREDIT_TYPE_EXCESS,
+  CONTRACT_CREDIT_TYPE_FREE_SEAT,
   CONTRACT_CREDIT_TYPE_POOL,
   fromFreeMetronomeUserId,
   getCreditTypeAwuId,
@@ -1336,6 +1338,13 @@ export async function processMetronomeWebhook({
         break;
       }
 
+      // A new AWU credit changes free-seat per-user balances — drop the cached
+      // read so the members/usage views reflect the grant on their next load.
+      await invalidateCachedCustomerPerUserCreditBalances({
+        metronomeCustomerId,
+        contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+      });
+
       // A credit granted at contract-switch time (see `stepContractEdits`) is
       // added to the already-active contract *after* `contract.start` fired, so
       // that handler's reconcile ran before the credit existed. Metronome only
@@ -1536,6 +1545,13 @@ export async function processMetronomeWebhook({
       ) {
         break;
       }
+
+      // A segment start / amount edit changes free-seat per-user balances — drop
+      // the cached read so the members/usage views reflect it on their next load.
+      await invalidateCachedCustomerPerUserCreditBalances({
+        metronomeCustomerId,
+        contractCreditType: CONTRACT_CREDIT_TYPE_FREE_SEAT,
+      });
 
       if (isSeatAwuCredit(credit)) {
         // Per-seat (INDIVIDUAL) AWU credit: a seat segment starting (a seat

--- a/front/lib/metronome/client.ts
+++ b/front/lib/metronome/client.ts
@@ -9,6 +9,10 @@ import {
   SEAT_TYPE_CUSTOM_FIELD_KEY,
 } from "@app/lib/metronome/constants";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import {
+  bestEffortInvalidateCacheWithRedis,
+  cacheWithRedis,
+} from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { SupportedCurrency } from "@app/types/currency";
 import type { MembershipSeatType } from "@app/types/memberships";
@@ -2801,6 +2805,116 @@ export async function listCustomerPerUserCreditBalances({
     metronomeCustomerId,
     contractCreditType,
     includeBalances: true,
+  });
+}
+
+// Long TTL: the cache is invalidated from the Metronome webhook whenever a
+// credit is created / a segment starts / an amount is edited, so the TTL is only
+// a fallback for missed events rather than the primary freshness bound.
+const PER_USER_CREDIT_BALANCES_CACHE_TTL_MS = 60 * 60 * 1000;
+
+const perUserCreditBalancesCacheResolver = ({
+  metronomeCustomerId,
+  contractCreditType,
+}: {
+  metronomeCustomerId: string;
+  contractCreditType: ContractCreditType;
+}) => `${metronomeCustomerId}-${contractCreditType}`;
+
+async function fetchPerUserCreditBalancesRecord(args: {
+  metronomeCustomerId: string;
+  contractCreditType: ContractCreditType;
+}): Promise<
+  Record<
+    string,
+    { creditIds: string[]; balanceAwu: number; startingBalanceAwu: number }
+  >
+> {
+  const result = await listCustomerPerUserCreditBalances(args);
+  // Throw at the cache boundary so a transient fetch failure is not cached.
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return Object.fromEntries(result.value);
+}
+
+// At most one `credits.list` fan-out in flight per (customer, credit type)
+// fleet-wide: concurrent misses on other processes get null (callers degrade)
+// instead of each firing their own read. Mirrors `getCachedSeatDataByUserId`.
+const getCachedPerUserCreditBalancesRecord = cacheWithRedis(
+  fetchPerUserCreditBalancesRecord,
+  perUserCreditBalancesCacheResolver,
+  {
+    ttlMs: PER_USER_CREDIT_BALANCES_CACHE_TTL_MS,
+    useDistributedLock: true,
+    skipIfLocked: true,
+  }
+);
+
+const invalidatePerUserCreditBalancesRecord =
+  bestEffortInvalidateCacheWithRedis(
+    fetchPerUserCreditBalancesRecord,
+    perUserCreditBalancesCacheResolver,
+    "per-user credit balances"
+  );
+
+/**
+ * Cached variant of `listCustomerPerUserCreditBalances`. Same shape, backed by a
+ * Redis cache keyed by (customer, credit type). Use this on read-heavy
+ * surfaces (members usage table, per-member usage) so repeated views don't each
+ * hit Metronome's `credits.list` endpoint. The cache is invalidated from the
+ * Metronome webhook when a credit is created or a segment starts (see
+ * `invalidateCachedCustomerPerUserCreditBalances`). Degrades to an empty map
+ * when another process holds the fetch lock, so callers must tolerate a
+ * transiently-missing balance (they already fall back to the seat-type
+ * constant).
+ */
+export async function getCachedCustomerPerUserCreditBalances({
+  metronomeCustomerId,
+  contractCreditType,
+}: {
+  metronomeCustomerId: string;
+  contractCreditType: ContractCreditType;
+}): Promise<
+  Result<
+    Map<
+      string,
+      { creditIds: string[]; balanceAwu: number; startingBalanceAwu: number }
+    >,
+    Error
+  >
+> {
+  try {
+    const record = await getCachedPerUserCreditBalancesRecord({
+      metronomeCustomerId,
+      contractCreditType,
+    });
+    // null: another process holds the fetch lock (skipIfLocked). Degrade rather
+    // than piling a duplicate Metronome fan-out on top.
+    if (record === null) {
+      return new Ok(new Map());
+    }
+    return new Ok(new Map(Object.entries(record)));
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Invalidate the cached per-user credit balances for a customer. Best-effort:
+ * logs and swallows on failure. Called from the Metronome webhook when a credit
+ * is added or a segment starts so the next read reflects the new balance.
+ */
+export async function invalidateCachedCustomerPerUserCreditBalances({
+  metronomeCustomerId,
+  contractCreditType,
+}: {
+  metronomeCustomerId: string;
+  contractCreditType: ContractCreditType;
+}): Promise<void> {
+  await invalidatePerUserCreditBalancesRecord({
+    metronomeCustomerId,
+    contractCreditType,
   });
 }
 

--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -412,7 +412,12 @@ export function useMyUsage({
   const { data, error } = useSWRWithDefaults(
     `/api/w/${workspaceId}/credits/my-usage`,
     myUsageFetcher,
-    { disabled }
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      dedupingInterval: 60_000,
+      disabled,
+    }
   );
 
   return {


### PR DESCRIPTION
## Problem

We were hitting rate limits on Metronome's `/v1/contracts/customerCredits/list` endpoint. Tracing the callers, the SWR-reachable path is the per-user free-seat credit balance read (`listCustomerPerUserCreditBalances`), which was **uncached** and fetched from two read-heavy surfaces (members usage table, per-member usage), plus a couple of ungated SWR hooks that fetched even when their data wasn't displayed.

## Changes

**Cache the per-user credit balances read** (`front/lib/metronome/client.ts`)
- New `getCachedCustomerPerUserCreditBalances` wrapping `listCustomerPerUserCreditBalances`, backed by a Redis cache keyed by `(customer, credit type)`. Mirrors the existing `getCachedSeatDataByUserId` pattern (`useDistributedLock` + `skipIfLocked`, degrades to empty on lock contention).
- TTL is **1 hour** — a fallback behind webhook invalidation, not the primary freshness bound.
- Both hot read paths in `lib/api/credits/members_usage.ts` (`fetchFreeSeatCreditsForMembersTable`, `getMemberUsage`) now use the cached variant. Same `Result<Map>` shape, no caller logic change.

**Invalidate on webhook** (`front/lib/api/metronome/process_webhook.ts`)
- Drop the cache in the `credit.create` and `credit.segment.start` / `credit.edit` handlers so a new grant / segment / amount edit is reflected on the next read rather than waiting out the TTL.

**Gate ungated SWR fetches in `UsagePage`** (`front/components/pages/workspace/UsagePage.tsx`)
- Made the outer `<Tabs>` controlled and gate `useMembersUsage` (the `credits.list` path) and `useGroups` on `usageTab === "members"` — both only feed the Members tab.

**Align `useMyUsage` revalidation** (`front/lib/swr/credits.ts`)
- Added `revalidateOnFocus: false`, `revalidateOnReconnect: false`, `dedupingInterval: 60_000` to match `useMembersUsage`. This hook renders in the sidebar on every page for credit-based plans and was revalidating on every window focus / navigation.

## Testing

- `npx tsgo --noEmit` passes.
- `npm run format:changed` (biome) clean.
- Functional tests (`process_webhook.test.ts`) not run in this env — the shared test DB was occupied by another suite and its concurrent schema-sync deadlocked global setup (unrelated to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)