### PR TITLE
Test: Depot runner for Lint & Build & Test (front) workflow

### DIFF
--- a/.github/workflows/build-and-test-front.yml
+++ b/.github/workflows/build-and-test-front.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         shardIndex: [ 1, 2, 3 ]
         shardTotal: [ 3 ]
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     services:
       redis:
         image: redis:7.2.5
@@ -69,7 +69,7 @@ jobs:
           group_suite: true
           check_name: Tests Report (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
   tsgo:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies
@@ -85,7 +85,7 @@ jobs:
           FRONT_DATABASE_URI: "postgres://fake:fake@localhost:5432/fake"
         run: npm run build:temporal-bundles
   lint:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   format-check:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   format-check:
-    runs-on: depot-ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node Dependencies


### PR DESCRIPTION
## Summary
- Switch all three jobs in `build-and-test-front.yml` (`tests` matrix shards, `tsgo`, `lint`) from `runs-on: ubuntu-latest` to `runs-on: depot-ubuntu-24.04`, as a test of Depot's GitHub Actions runner integration.
- Purpose: get a clean comparison against `ubuntu-latest` (runtime, reliability) for this workflow before rolling Depot runners out elsewhere.

## Test plan
- [ ] Watch the Actions run for this PR and confirm all jobs (test shards 1-3, tsgo, lint) complete successfully on `depot-ubuntu-24.04`
- [ ] Compare run time against recent `ubuntu-latest` runs of the same workflow
- [ ] If clean, roll out to additional workflows in follow-up PRs