### PR TITLE
[connectors] Slack: ignore channel_created for teams without a connector

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.test.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.test.ts
@@ -1,0 +1,61 @@
+import mainLogger from "@connectors/logger/logger";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@connectors/connectors/slack/temporal/client"), () => ({
+  launchJoinChannelWorkflow: vi.fn(),
+}));
+
+import { launchJoinChannelWorkflow } from "@connectors/connectors/slack/temporal/client";
+
+import { autoReadChannel } from "./auto_read_channel";
+
+const logger = mainLogger.child({});
+
+async function makeSlackConnector(slackTeamId: string) {
+  return ConnectorResource.makeNew(
+    "slack",
+    {
+      connectionId: "connection-id",
+      dataSourceId: "data-source-id",
+      workspaceAPIKey: "workspace-api-key",
+      workspaceId: "workspace-id",
+    },
+    {
+      autoReadChannelPatterns: [],
+      botEnabled: true,
+      feedbackVisibleToAuthorOnly: true,
+      restrictedSpaceAgentsEnabled: true,
+      slackTeamId,
+    }
+  );
+}
+
+describe("autoReadChannel", () => {
+  it("should ignore channels whose team has no connector", async () => {
+    const res = await autoReadChannel("T_NO_CONNECTOR", logger, "C123");
+
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      expect(res.value).toBe(false);
+    }
+    expect(launchJoinChannelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("should ignore channels whose team has no connector for the requested provider", async () => {
+    await makeSlackConnector("T_SLACK_ONLY");
+
+    const res = await autoReadChannel(
+      "T_SLACK_ONLY",
+      logger,
+      "C123",
+      "slack_bot"
+    );
+
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      expect(res.value).toBe(false);
+    }
+    expect(launchJoinChannelWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -34,11 +34,13 @@ export async function autoReadChannel(
   const connector = connectors.find((c) => c.type === provider);
 
   if (!connector) {
-    return new Err(
-      new Error(
-        `Connector not found for teamId ${teamId} and provider ${provider}`
-      )
+    // Expected on shared channels and Enterprise Grid orgs: the channel's
+    // context team may have no connector at all. Nothing to auto-read.
+    logger.info(
+      { teamId, slackChannelId, provider },
+      "Ignoring channel: no connector for team"
     );
+    return new Ok(false);
   }
 
   const slackConfiguration = slackConfigurations.find(


### PR DESCRIPTION
## Description

[Temporal failed workflows
](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=ExecutionStatus%3D%22Failed%22)
`slackWebhookEventWorkflow` fails (and the slack_bot webhook 500s, making Slack retry forever) on `channel_created` events whose `context_team_id` has no connector. On shared channels and Enterprise Grid orgs, the channel's context team differs from the webhook team id and may have no connector at all: an expected condition, not a failure.

Fix: `autoReadChannel` now logs and returns `Ok(false)` when no connector exists for the team, instead of `Err("Connector not found")`.

**Why `Ok(false)` rather than a typed error:** the function's contract already models "did an auto-read get launched" as a boolean, returning `Ok(false)` today when no auto-read patterns are configured. "No connector for the team" is just another flavor of nothing-to-launch, and no caller distinguishes the two (the webhook paths discard the value, the CLI only counts it). Modeling it as a typed `Err` would force every caller to remember an `instanceof` branch or regress to failing, duplicating the handling at each call site.

## Tests

Added `auto_read_channel.test.ts`: no connector for the team, and no connector for the requested provider, both return `Ok(false)` without launching the join workflow.

## Risk

Worst case, a legitimate auto-read is silently skipped instead of surfacing an error. Safe to rollback.

## Deploy Plan

- [ ] Deploy connectors
