### PR TITLE
feat: update mcp scopes when deactivating and reactivating

### DIFF
--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.test.ts
@@ -1,5 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
+import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerConnectionFactory } from "@app/tests/utils/MCPServerConnectionFactory";
@@ -258,6 +260,32 @@ describe("MCP connections handler", () => {
       { connectionType: "personal" }
     );
     expect(remainingPersonal).toHaveLength(0);
+  });
+
+  it("DELETE workspace connection clears the pinned OAuth scope when the server has no admin-defined scopes", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "DELETE",
+      role: "admin",
+    });
+
+    const server = await InternalMCPServerInMemoryResource.makeNew(auth, {
+      name: "gmail",
+      useCase: "personal_actions",
+      oauthScope: "https://www.googleapis.com/auth/gmail.readonly",
+    });
+    const workspaceConnection = await MCPServerConnectionFactory.internal(
+      auth,
+      server.id,
+      "workspace"
+    );
+
+    const response = await del(workspace, "workspace", workspaceConnection.sId);
+
+    expect(response.status).toBe(200);
+
+    const views = await MCPServerViewResource.listByMCPServer(auth, server.id);
+    expect(views.length).toBeGreaterThan(0);
+    expect(views.map((view) => view.oauthScope)).toEqual(views.map(() => null));
   });
 
   it("GET a non-existing connection should return 404", async () => {

--- a/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/connections/[connectionType]/[cId]/index.ts
@@ -1,3 +1,4 @@
+import { clearPinnedOAuthScopeForMCPServerViews } from "@app/lib/api/mcp/views";
 import type {
   MCPServerConnectionConnectionType,
   MCPServerConnectionType,
@@ -109,6 +110,12 @@ app.delete(
           type: "internal_server_error",
           message: "Failed to delete connection",
         },
+      });
+    }
+
+    if (connectionType === "workspace") {
+      await clearPinnedOAuthScopeForMCPServerViews(auth, {
+        mcpServerId: connectionRes.value.mcpServerId,
       });
     }
 

--- a/front-api/routes/w/[wId]/mcp/views/[viewId]/index.test.ts
+++ b/front-api/routes/w/[wId]/mcp/views/[viewId]/index.test.ts
@@ -71,6 +71,54 @@ describe("PATCH /api/w/:wId/mcp/views/:viewId", () => {
     );
   });
 
+  it("should pin the authorized OAuth scope on all views of the same MCP server", async () => {
+    const { workspace, auth, globalSpace } = await setup("admin");
+
+    const server = await RemoteMCPServerFactory.create(workspace);
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        server.sId
+      );
+    expect(systemView).toBeDefined();
+
+    await MCPServerViewFactory.create(workspace, server.sId, globalSpace);
+
+    const oauthScope = "scope.read scope.write";
+    const response = await patchView(workspace.sId, systemView!.sId, {
+      oAuthUseCase: "personal_actions",
+      oauthScope,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updatedViews = await MCPServerViewResource.listByMCPServer(
+      auth,
+      server.sId
+    );
+    expect(updatedViews.length).toBeGreaterThan(1);
+    for (const view of updatedViews) {
+      expect(view.oauthScope).toBe(oauthScope);
+    }
+
+    // A later update that carries no scope must leave the pin alone.
+    const useCaseOnlyResponse = await patchView(
+      workspace.sId,
+      systemView!.sId,
+      { oAuthUseCase: "platform_actions" }
+    );
+
+    expect(useCaseOnlyResponse.status).toBe(200);
+
+    const viewsAfterUseCaseOnly = await MCPServerViewResource.listByMCPServer(
+      auth,
+      server.sId
+    );
+    for (const view of viewsAfterUseCaseOnly) {
+      expect(view.oauthScope).toBe(oauthScope);
+    }
+  });
+
   it("should update settings for all views of the same MCP server when admin", async () => {
     const { workspace, auth, globalSpace } = await setup("admin");
 

--- a/front-api/routes/w/[wId]/mcp/views/[viewId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/views/[viewId]/index.ts
@@ -62,6 +62,7 @@ app.patch(
       const updateResult = await updateOAuthUseCaseForMCPServerViews(auth, {
         mcpServerId,
         oAuthUseCase: body.oAuthUseCase,
+        oauthScope: body.oauthScope,
       });
 
       if (updateResult.isErr()) {

--- a/front/components/actions/mcp/forms/submitConnectMCPServerDialogForm.ts
+++ b/front/components/actions/mcp/forms/submitConnectMCPServerDialogForm.ts
@@ -23,6 +23,7 @@ type CreateMCPServerConnectionFn = (
 
 interface UpdateMCPServerViewParams {
   oAuthUseCase: NonNullable<MCPServerOAuthFormValues["useCase"]>;
+  oauthScope?: string;
 }
 
 // Returns true on success, false on error (error handling is done internally via notifications).
@@ -85,10 +86,13 @@ export async function submitConnectMCPServerDialogForm({
     provider: authorization.provider,
   });
 
-  // Step 3: Update the oAuthUseCase for the MCP server view.
+  // Step 3: Update the oAuthUseCase for the MCP server view, pinning the scope this connection was
+  // authorized for. Personal connections read their scope from the view, so this bounds members to
+  // what the admin just consented to instead of letting them follow the server metadata as it grows.
   // Error handling for this step is done internally by the hook via notifications.
   await updateServerView({
     oAuthUseCase: values.useCase,
+    ...(scope ? { oauthScope: scope } : {}),
   });
 
   return new Ok(null);

--- a/front/lib/api/mcp/views.ts
+++ b/front/lib/api/mcp/views.ts
@@ -2,6 +2,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -10,6 +11,9 @@ import { z } from "zod";
 export const PatchMCPServerViewBodySchema = z
   .object({
     oAuthUseCase: z.enum(["platform_actions", "personal_actions"]),
+    // Sent on activation with the scope the connection was authorized for, so personal connections
+    // stay bounded by what the admin consented to. Omitted leaves the stored scope untouched.
+    oauthScope: z.string().optional(),
   })
   .or(
     z.object({
@@ -54,9 +58,11 @@ export async function updateOAuthUseCaseForMCPServerViews(
   {
     mcpServerId,
     oAuthUseCase,
+    oauthScope,
   }: {
     mcpServerId: string;
     oAuthUseCase: MCPOAuthUseCase;
+    oauthScope?: string;
   }
 ): Promise<
   Result<undefined, DustError<"mcp_server_view_not_found" | "unauthorized">>
@@ -68,13 +74,67 @@ export async function updateOAuthUseCaseForMCPServerViews(
   const views = r.value;
 
   for (const view of views) {
-    const result = await view.updateOAuthUseCase(auth, oAuthUseCase);
+    const result = await view.updateOAuthUseCase(
+      auth,
+      oAuthUseCase,
+      oauthScope
+    );
     if (result.isErr()) {
       return result;
     }
   }
 
   return new Ok(undefined);
+}
+
+/**
+ * Drops the scope pinned on a server's views, called when its workspace connection is deactivated.
+ *
+ * Paired with the write on activation (`updateOAuthUseCaseForMCPServerViews`, called with the scope
+ * the admin just authorized), this keeps `oauthScope` meaning "what the admin last consented to"
+ * instead of "the metadata default the day the tool was installed". Deactivating frees the pin so
+ * the next activation asks for what the server declares today; activating pins it again so members,
+ * whose personal connections read their scope from the view, can never request more than the admin
+ * approved. Clearing without that write would leave the view tracking metadata forever, and every
+ * scope we later add would reach members with no admin involved.
+ *
+ * Servers that declare `availableScopes` are left untouched — there the pin is the admin's own scope
+ * selection, which reactivation currently preserves since the connect dialog offers no scope picker.
+ */
+export async function clearPinnedOAuthScopeForMCPServerViews(
+  auth: Authenticator,
+  { mcpServerId }: { mcpServerId: string }
+): Promise<void> {
+  const views = await MCPServerViewResource.listByMCPServer(auth, mcpServerId, {
+    includeHeavyAttributes: ["authorization"],
+  });
+
+  // Every view of a server shares its authorization, so one check covers the whole set.
+  if (
+    views.length === 0 ||
+    views.some((v) => v.getAuthorization()?.availableScopes)
+  ) {
+    return;
+  }
+
+  for (const view of views) {
+    if (view.oauthScope === null) {
+      continue;
+    }
+
+    const result = await view.clearOAuthScope(auth);
+    if (result.isErr()) {
+      logger.warn(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          mcpServerId,
+          mcpServerViewId: view.sId,
+          error: result.error,
+        },
+        "Failed to clear pinned OAuth scope after connection deactivation"
+      );
+    }
+  }
 }
 
 export async function updateNameAndDescriptionForMCPServerViews(

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -1273,7 +1273,10 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
   public async updateOAuthUseCase(
     auth: Authenticator,
-    oAuthUseCase: MCPOAuthUseCase
+    oAuthUseCase: MCPOAuthUseCase,
+    // Set on activation with the scope the admin just authorized. Personal connections read their
+    // scope from the view, so this is what bounds members to the admin's consent.
+    oauthScope?: string
   ): Promise<Result<number, DustError<"unauthorized">>> {
     if (!this.canAdministrate(auth)) {
       return new Err(
@@ -1283,9 +1286,23 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
 
     const [affectedCount] = await this.update({
       oAuthUseCase,
+      ...(oauthScope !== undefined ? { oauthScope } : {}),
       editedAt: new Date(),
       editedByUserId: auth.getNonNullableUser().id,
     });
+    return new Ok(affectedCount);
+  }
+
+  public async clearOAuthScope(
+    auth: Authenticator
+  ): Promise<Result<number, DustError<"unauthorized">>> {
+    if (!this.canAdministrate(auth)) {
+      return new Err(
+        new DustError("unauthorized", "Not allowed to clear OAuth scope.")
+      );
+    }
+
+    const [affectedCount] = await this.update({ oauthScope: null });
     return new Ok(affectedCount);
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10107

When we add a new scope to an MCP server, there is no way to update existing connections to use the scope and tool calls fail with missing scopes errors. The current workaround is deleting and recreating the MCP server, but this means having to reconnect all the agents and skills to it.

This PR updates MCP OAuth scope handling so scopes are cleared when a workspace connection is deactivated and pinned to the administrator’s latest authorization when it is reactivated again.


## Tests
Manually and added tests covering OAuth scope pinning and clearing.

## Risks

Low risk. The changes affect MCP OAuth scope persistence during workspace connection lifecycle events. Easy to revert.

## Deploy Plan

Standard deployment.