### PR TITLE
[admin governance] remove group's members access from non editor type groups

### DIFF
--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -45,6 +45,10 @@ app.get(
         : [kind]
       : ["global", "regular_auto", "space_editors"];
 
+    // Both list helpers filter by `canRead`. For role-only group kinds
+    // (regular_manual, provisioned, regular_auto, global, system) only
+    // admins/managers can read, so a plain member gets an empty list rather
+    // than the groups they belong to.
     const groups: GroupResource[] = spaceId
       ? await GroupResource.listForSpaceById(auth, spaceId, { groupKinds })
       : await GroupResource.listAllWorkspaceGroups(auth, { groupKinds });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -2554,25 +2554,23 @@ export class GroupResource extends BaseResource<GroupModel> {
   // Permissions
 
   /**
-   * Returns the requested permissions for this resource.
+   * We are migrating away from a group storing permissions for itself (the
+   * self-referential `groups: [{ id: this.id }]` entry): editor groups should
+   * derive access from their parent resource via `group_permissions`. Until that
+   * lands the branches below are mixed:
+   * - regular_manual / provisioned / regular_auto / global / system: role-only,
+   *   membership grants nothing. Admins get read/write/admin everywhere;
+   *   managers get read/write/admin on regular_manual and read on provisioned.
+   * - agent_editors / skill_editors / space_editors: still self-referential
+   *   (legacy) — members get full access through this ACL.
    *
-   * Configures two types of access:
-   * 1. Group-based: The group's members get read access
-   * 2. Role-based: Workspace admins get read and write access
+   * NOTE: as a result, group info for the role-only kinds (regular_manual,
+   * provisioned, regular_auto, global, system) is only exposed to admins and
+   * managers — a member cannot read a group they belong to. Exposing it to
+   * non-admin/manager users would require updating the logic.
    *
-   * For agent_editors and skill_editors groups, the permissions are:
-   * 1. Group-based: The group's members get full access
-   * 2. Role-based: Workspace admins get read and admin access. All users can
-   *    read "agent_editors" and "skill_editors" groups.
-   *    Admin do not have write access, they can however add themselves to
-   *    groups to gain it.
-   *
-   * CAUTION: if / when editing, note that for role permissions, permissions are
-   * NOT inherited, i.e., if you set a permission for role "user", an "admin"
-   * will NOT have it
-   *
-   * @returns Array of AccessControlList objects defining the default access
-   * configuration
+   * CAUTION: role permissions are NOT inherited — a permission set for "user" is
+   * not implied for "admin".
    */
   getAccessControlLists(auth: Authenticator): AccessControlList[] {
     if (this.kind === "agent_editors" || this.kind === "skill_editors") {
@@ -2622,12 +2620,6 @@ export class GroupResource extends BaseResource<GroupModel> {
     if (this.isRegularManual()) {
       return [
         {
-          groups: [
-            {
-              id: this.id,
-              permissions: ["read"],
-            },
-          ],
           roles: [
             { role: "admin", permissions: ["read", "write", "admin"] },
             { role: "manager", permissions: ["read", "write", "admin"] },
@@ -2642,12 +2634,6 @@ export class GroupResource extends BaseResource<GroupModel> {
     if (this.isProvisioned()) {
       return [
         {
-          groups: [
-            {
-              id: this.id,
-              permissions: ["read"],
-            },
-          ],
           roles: [
             { role: "admin", permissions: ["read", "write", "admin"] },
             { role: "manager", permissions: ["read"] },
@@ -2659,12 +2645,6 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     return [
       {
-        groups: [
-          {
-            id: this.id,
-            permissions: ["read"],
-          },
-        ],
         roles: [{ role: "admin", permissions: ["read", "write", "admin"] }],
         workspaceId: this.workspaceId,
       },


### PR DESCRIPTION
## Description
We decided to not store permission for group itself for editors kind (= agent editors, skill editors, space editors) and its permission will be the same as resource itself (e.g. can you edit a skill? then you can edit its skill editor group too).

Now remaining groups are: regular_manual, global, system (and regular_auto for model tiers? I haven't digged that one much yet). From what I understood, we don't expose these groups data to non-admin/non-managers. It's probably simple to not store permission for each group and let only admin/managers read it.

In group resource, sometimes we filter by canRead and sometimes we don't. I have no idea if this is intentional 🤔 (I even wonder if we really need canRead check, don't feel like confidential?) 

In group_resource:
- `listUserGroupsInWorkspace`: no canRead check (used in auth/group resolution, user.ts, workspace.ts, groups/members.ts). 
-  `listAllWorkspaceGroups`, `listForSpaceById`, `fetchByIds`: have canRead check, but all consumers are gated by role check (= available only to managers & admins) 


Here are the consumers of `api/w/wId/groups` (useGroups) according to Claude code:
```

┌────────────────────────┬─────────────────────────┬───────────────────────────────┬──────────────────────────────┐
│        Consumer        │     kinds requested     │         Route gating          │   Affected by your change?   │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│                        │ default → global,       │ admin-only (RequireRoleLayout │ Requests the affected kinds  │
│ APIKeysPage            │ regular_auto,           │  requiredRole="admin")        │ — but admin reads all → no   │
│                        │ space_editors           │                               │ effect                       │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ GovernancePage         │ provisioned,            │ manager+                      │ No — managers read both      │
│                        │ regular_manual          │                               │                              │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ WorkspaceGroupsList    │ provisioned,            │ manager+                      │ No                           │
│                        │ regular_manual          │                               │                              │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ UsageFilterPanel       │ provisioned,            │ manager+                      │ No                           │
│                        │ regular_manual          │                               │                              │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ GroupsUsageTable       │ provisioned,            │ manager+                      │ No                           │
│                        │ regular_manual          │                               │                              │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ UsagePage              │ provisioned,            │ manager+                      │ No                           │
│                        │ regular_manual          │                               │                              │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ MemberGroupsSection    │ regular_manual          │ manager+                      │ No                           │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ DirectorySync          │ provisioned             │ admin/manager                 │ No                           │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ CreateOrEditSpaceModal │ provisioned             │ (space edit)                  │ No — managers/admins read    │
│                        │                         │                               │ provisioned                  │
├────────────────────────┼─────────────────────────┼───────────────────────────────┼──────────────────────────────┤
│ GroupSelectionTable    │ provisioned             │ (space edit)                  │ No                           │
└────────────────────────┴─────────────────────────┴───────────────────────────────┴──────────────────────────────┘

```

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
