### PR TITLE
feat(front): raise model picker tier row contrast and rename section header

### DIFF
--- a/front/components/model_picker/ModelPickerContent.tsx
+++ b/front/components/model_picker/ModelPickerContent.tsx
@@ -94,7 +94,7 @@ export function ModelPickerContent({
       align="start"
       side={side}
     >
-      <DropdownMenuLabel label="Model" />
+      <DropdownMenuLabel label="Recommendations" className="text-sm" />
 
       {MODEL_TIERS.map((tier) => {
         const isSelected = isTierDisplayed(tier.id, shown.display);
@@ -126,20 +126,18 @@ export function ModelPickerContent({
             key={tier.id}
             icon={TIER_ICON[tier.id]}
             label={tier.name}
+            className="text-foreground"
             endComponent={
-              <div className="flex items-center gap-1.5">
-                <span className="whitespace-nowrap text-xs text-faint">
+              <div className="flex items-center gap-3">
+                <span className="whitespace-nowrap text-xs text-muted-foreground">
                   {getTierResolvedModelLabel(tier.id, streams)}
                 </span>
-                {isSelected ? (
+                {isSelected && (
                   <ModelPickerSelectionIndicator
                     canRevert={canRevert}
                     onRevert={onRevert}
                     size="xs"
                   />
-                ) : (
-                  // Reserved slot, so the resolved model labels stay aligned
-                  <span aria-hidden className="h-4 w-4 shrink-0" />
                 )}
               </div>
             }

--- a/front/components/model_picker/ModelPickerSelectionIndicator.tsx
+++ b/front/components/model_picker/ModelPickerSelectionIndicator.tsx
@@ -17,16 +17,14 @@ export function ModelPickerSelectionIndicator({
   size = "sm",
 }: ModelPickerSelectionIndicatorProps) {
   if (!canRevert) {
-    return (
-      <Icon visual={Check} size={size} className="text-muted-foreground" />
-    );
+    return <Icon visual={Check} size={size} className="text-foreground" />;
   }
 
   return (
     <button
       type="button"
       aria-label="Revert to default"
-      className="group/indicator flex items-center justify-center text-muted-foreground hover:text-foreground"
+      className="group/indicator flex items-center justify-center text-foreground"
       onClick={(e) => {
         e.stopPropagation();
         onRevert();


### PR DESCRIPTION
## Description
<img width="411" height="245" alt="Screenshot 2026-08-19 at 11 43 08" src="https://github.com/user-attachments/assets/21f5c53a-6007-4d50-9232-f62108a131a0" />

Visual polish on the model picker dropdown's tier section (Fast / Standard / Complex rows):

- Section header renamed from **"Model"** to **"Recommendations"**, at `text-sm`.
- Tier rows and their resolved-model labels get more contrast: rows are `text-foreground`, the resolved model name moves from `text-faint` to `text-xs text-muted-foreground`, and the selection check / revert control drops the muted resting state for `text-foreground`.
- Spacing between the resolved model name and the trailing check goes from `gap-1.5` to `gap-3`.
- The reserved `h-4 w-4` placeholder on unselected rows is removed, so the check only occupies space on the selected row.

CSS-only change — no behavior, props, or API surface touched.

Note on the last point: that placeholder existed to keep the resolved model labels right-aligned across rows, so the selected row's label now sits slightly further right than the others. Intentional given the wider `gap-3`, but worth a look in review.

## Tests

Manual, in the conversation input bar model picker:

- Header reads "Recommendations".
- All three tier rows show their resolved model name; only the selected row shows the trailing check.
- Hovering the check on the selected row still swaps it for the X and reverting restores the agent default.
- Locked tiers still render the padlock and tooltip.
- Both light and dark theme.
