### PR TITLE
[front] add CSV export to the automations triggers table

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_AUTOMATION_TRIGGERS_LIMIT } from "@app/lib/api/analytics/automations/schema";
 import type { GetAutomationTriggersResponse } from "@app/lib/api/analytics/automations/triggers";
 import { fetchAutomationTriggers } from "@app/lib/api/analytics/automations/triggers";
+import { CARDINALITY_PRECISION_THRESHOLD } from "@app/lib/api/analytics/consumption/scope";
 import { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import type { MembershipRoleType } from "@app/types/memberships";
@@ -181,6 +182,52 @@ describe("POST /api/w/:wId/analytics/automations/triggers", () => {
       error: { type: "invalid_request_error" },
     });
     expect(vi.mocked(fetchAutomationTriggers)).not.toHaveBeenCalled();
+  });
+
+  it("returns every trigger as CSV, ignoring the requested page", async () => {
+    vi.mocked(fetchAutomationTriggers).mockResolvedValue(new Ok(TRIGGERS));
+    const { workspace } = await setupTest();
+
+    const response = await postTriggersRequest(workspace.sId, {
+      limit: 10,
+      offset: 20,
+      format: "csv",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/csv");
+    expect(vi.mocked(fetchAutomationTriggers)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        limit: CARDINALITY_PRECISION_THRESHOLD,
+        offset: 0,
+      })
+    );
+    const csv = await response.text();
+    expect(csv).toContain("Competitor watch");
+    expect(csv).toContain("Inbound triage");
+  });
+
+  it("forwards the period, search and filter to the CSV export", async () => {
+    vi.mocked(fetchAutomationTriggers).mockResolvedValue(new Ok(TRIGGERS));
+    const { workspace } = await setupTest();
+
+    const response = await postTriggersRequest(workspace.sId, {
+      period: "days",
+      days: 7,
+      search: "  competitor  ",
+      filter: { agentIds: ["agent1"], kinds: ["schedule"] },
+      format: "csv",
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchAutomationTriggers)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        search: "competitor",
+        filter: { agentIds: ["agent1"], kinds: ["schedule"] },
+      })
+    );
   });
 
   it("returns 500 when the search fails", async () => {

--- a/front-api/routes/w/[wId]/analytics/automations/triggers.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.ts
@@ -9,6 +9,7 @@ import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/sch
 import { CARDINALITY_PRECISION_THRESHOLD } from "@app/lib/api/analytics/consumption/scope";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import logger from "@app/logger/logger";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
@@ -30,10 +31,21 @@ const CSV_HEADERS = [
   "credits",
 ] as const;
 
+function kindToLabel(kind: AutomationTriggerRow["kind"]): string {
+  switch (kind) {
+    case "schedule":
+      return "Schedule";
+    case "webhook":
+      return "Webhook";
+    default:
+      return assertNever(kind);
+  }
+}
+
 function toCsvRow(trigger: AutomationTriggerRow) {
   return {
     name: trigger.name,
-    type: trigger.kind === "schedule" ? "Schedule" : "Webhook",
+    type: kindToLabel(trigger.kind),
     status: trigger.status,
     agent: trigger.agent.name,
     editor: trigger.editor.name,
@@ -85,19 +97,23 @@ app.post(
       });
     }
 
-    if (format === "json") {
-      return ctx.json(result.value);
+    switch (format) {
+      case "json":
+        return ctx.json(result.value);
+      case "csv": {
+        const exportDate = new Date().toISOString().slice(0, 10);
+        ctx.header("Content-Type", "text/csv");
+        ctx.header(
+          "Content-Disposition",
+          `attachment; filename="dust_automations_${exportDate}.csv"`
+        );
+        return ctx.body(
+          rowsToCsv(CSV_HEADERS, result.value.triggers.map(toCsvRow))
+        );
+      }
+      default:
+        return assertNever(format);
     }
-
-    const exportDate = new Date().toISOString().slice(0, 10);
-    ctx.header("Content-Type", "text/csv");
-    ctx.header(
-      "Content-Disposition",
-      `attachment; filename="dust_automations_${exportDate}.csv"`
-    );
-    return ctx.body(
-      rowsToCsv(CSV_HEADERS, result.value.triggers.map(toCsvRow))
-    );
   }
 );
 

--- a/front-api/routes/w/[wId]/analytics/automations/triggers.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.ts
@@ -1,12 +1,17 @@
 import { AutomationTriggersBodySchema } from "@app/lib/api/analytics/automations/schema";
-import type { GetAutomationTriggersResponse } from "@app/lib/api/analytics/automations/triggers";
+import type {
+  AutomationTriggerRow,
+  GetAutomationTriggersResponse,
+} from "@app/lib/api/analytics/automations/triggers";
 import { fetchAutomationTriggers } from "@app/lib/api/analytics/automations/triggers";
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
+import { CARDINALITY_PRECISION_THRESHOLD } from "@app/lib/api/analytics/consumption/scope";
+import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
-import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
 export type { GetAutomationTriggersResponse };
@@ -14,14 +19,38 @@ export type { GetAutomationTriggersResponse };
 // Mounted at /api/w/:wId/analytics/automations/triggers.
 const app = workspaceApp();
 
+const CSV_HEADERS = [
+  "name",
+  "type",
+  "status",
+  "agent",
+  "editor",
+  "editorEmail",
+  "runs",
+  "credits",
+] as const;
+
+function toCsvRow(trigger: AutomationTriggerRow) {
+  return {
+    name: trigger.name,
+    type: trigger.kind === "schedule" ? "Schedule" : "Webhook",
+    status: trigger.status,
+    agent: trigger.agent.name,
+    editor: trigger.editor.name,
+    editorEmail: trigger.editor.email ?? "",
+    runs: trigger.runCount,
+    credits: trigger.credits,
+  };
+}
+
 /** @ignoreswagger */
 app.post(
   "/",
   ensureIsManager(),
   validate("json", AutomationTriggersBodySchema),
-  async (ctx): HandlerResult<GetAutomationTriggersResponse> => {
+  async (ctx) => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, format, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -29,10 +58,13 @@ app.post(
       toConsumptionPeriodInput(periodQuery)
     );
 
+    // The ranking behind this query is already capped at
+    // CARDINALITY_PRECISION_THRESHOLD buckets, so requesting that many rows
+    // in one page returns every trigger the paginated view could ever show.
     const result = await fetchAutomationTriggers(auth, {
       period,
-      limit,
-      offset,
+      limit: format === "csv" ? CARDINALITY_PRECISION_THRESHOLD : limit,
+      offset: format === "csv" ? 0 : offset,
       search,
       filter,
     });
@@ -53,7 +85,19 @@ app.post(
       });
     }
 
-    return ctx.json(result.value);
+    if (format === "json") {
+      return ctx.json(result.value);
+    }
+
+    const exportDate = new Date().toISOString().slice(0, 10);
+    ctx.header("Content-Type", "text/csv");
+    ctx.header(
+      "Content-Disposition",
+      `attachment; filename="dust_automations_${exportDate}.csv"`
+    );
+    return ctx.body(
+      rowsToCsv(CSV_HEADERS, result.value.triggers.map(toCsvRow))
+    );
   }
 );
 

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -6,6 +6,7 @@ import type { TriggerRowData as BaseTriggerRowData } from "@app/components/works
 import { AutomationsTriggersRowsTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
 import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
 import { toAutomationsTriggersFilter } from "@app/components/workspace/analytics/automationsFilter";
+import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {
   AvatarNameCell,
   CreditsCell,
@@ -13,7 +14,10 @@ import {
 } from "@app/components/workspace/analytics/creditsTableCells";
 import { useAutomationsTriggers } from "@app/hooks/useAutomationsTriggers";
 import { useDebounce } from "@app/hooks/useDebounce";
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
+import type { AutomationTriggersBody } from "@app/lib/api/analytics/automations/schema";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { useUpdateTriggerStatus } from "@app/lib/swr/agent_triggers";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
@@ -384,6 +388,24 @@ export function AutomationsTriggersTable({
   const confirm = useContext(ConfirmContext);
   const updateTriggerStatus = useUpdateTriggerStatus({ workspaceId });
 
+  const exportBody: AutomationTriggersBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    limit: TRIGGERS_PAGE_SIZE,
+    offset: 0,
+    search: debouncedValue.trim() || undefined,
+    filter: triggersFilter,
+    format: "csv",
+  };
+  const exportDate = new Date().toISOString().slice(0, 10);
+  const csvDownload = useDownloadCsv({
+    url: `/api/w/${workspaceId}/analytics/automations/triggers`,
+    filename: `dust_automations_${exportDate}.csv`,
+    body: exportBody,
+    disabled: isTriggersLoading || !!isTriggersError || totalCount === 0,
+  });
+
   // The table data comes from an expensive Elasticsearch query, so instead of
   // revalidating after a toggle we track the new statuses locally.
   const [statusOverrides, setStatusOverrides] = useState<
@@ -481,6 +503,7 @@ export function AutomationsTriggersTable({
             filter={filter}
             onFilterChange={onFilterChange}
           />
+          <CsvDownloadButton {...csvDownload} />
         </div>
         <AutomationsFilterSummary
           filter={filter}

--- a/front/hooks/useAutomationsTriggers.ts
+++ b/front/hooks/useAutomationsTriggers.ts
@@ -37,6 +37,7 @@ export function useAutomationsTriggers({
     offset,
     search: search?.trim(),
     filter,
+    format: "json",
   };
 
   const { data, error, isLoading, isValidating } = useConsumptionQuery<

--- a/front/lib/api/analytics/automations/schema.ts
+++ b/front/lib/api/analytics/automations/schema.ts
@@ -29,6 +29,9 @@ export const AutomationTriggersBodySchema = ConsumptionPeriodSchema.extend({
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().optional(),
   filter: AutomationTriggersFilterSchema.optional(),
+  // csv ignores limit/offset and returns every trigger matching the period,
+  // search and filter, up to the same ranking cap used for the page view.
+  format: z.enum(["json", "csv"]).optional().default("json"),
 });
 
 export type AutomationTriggersBody = z.infer<


### PR DESCRIPTION
## Description

Adds CSV export to the workspace automations triggers analytics table. 

**Visual:**
<img width="1139" height="472" alt="Capture d’écran 2026-08-19 à 12 00 58" src="https://github.com/user-attachments/assets/cd2ee4d5-8970-4e9c-a14b-000c61e9eb93" />
<img width="781" height="265" alt="Capture d’écran 2026-08-19 à 12 01 26" src="https://github.com/user-attachments/assets/ce153e54-7dc0-40de-ae56-54b1f22ab765" />

## Tests

Added route coverage for CSV responses, pagination being ignored for exports, and forwarding the period, search, and filter values. 

## Risk

Low - The existing JSON behavior remains unchanged: the schema defaults to JSON and the frontend JSON hook now sends `format: "json"` explicitly. CSV exports can run a larger query than the paginated table and return up to the existing cardinality cap, so export requests may use more query and response bandwidth. The endpoint remains manager-protected and the export is bounded by the same ranking limit.

## Deploy Plan

- Deploy front 