### PR TITLE
[front] Clarify resource-wide permission levels

### DIFF
--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -1,3 +1,4 @@
+import type { GrantLevel } from "@app/lib/resources/group_permission_registry";
 import {
   assertValidGrant,
   GroupPermissions,
@@ -244,12 +245,15 @@ describe("ROLE_REGISTRY invariants", () => {
 
 describe("verbsForGrantAtLevels", () => {
   it("matches a role against any supplied level", () => {
-    expect(
-      verbsForGrantAtLevels("create", "agent", ["instance", "type"])
-    ).toEqual(["create"]);
-    expect(
-      verbsForGrantAtLevels("editor", "agent", ["type", "instance"])
-    ).toEqual(["read", "write"]);
+    const levels = new Set<GrantLevel>(["instance", "type"]);
+
+    expect(verbsForGrantAtLevels("create", "agent", levels)).toEqual([
+      "create",
+    ]);
+    expect(verbsForGrantAtLevels("editor", "agent", levels)).toEqual([
+      "read",
+      "write",
+    ]);
   });
 });
 

--- a/front/lib/resources/group_permission_registry.test.ts
+++ b/front/lib/resources/group_permission_registry.test.ts
@@ -3,6 +3,7 @@ import {
   GroupPermissions,
   grantTypesForVerb,
   ROLE_REGISTRY,
+  verbsForGrantAtLevels,
 } from "@app/lib/resources/group_permission_registry";
 import type { GrantVerb } from "@app/types/group_permissions";
 import {
@@ -238,6 +239,17 @@ describe("ROLE_REGISTRY invariants", () => {
         expect(roleNames.has(grantType)).toBe(true);
       }
     }
+  });
+});
+
+describe("verbsForGrantAtLevels", () => {
+  it("matches a role against any supplied level", () => {
+    expect(
+      verbsForGrantAtLevels("create", "agent", ["instance", "type"])
+    ).toEqual(["create"]);
+    expect(
+      verbsForGrantAtLevels("editor", "agent", ["type", "instance"])
+    ).toEqual(["read", "write"]);
   });
 });
 

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -153,14 +153,10 @@ export function grantTypesForVerb(
 export function verbsForGrantAtLevels(
   grantType: ConcreteGrantType,
   resourceType: ConcreteResourceType,
-  levels: GrantLevel[]
+  levels: ReadonlySet<GrantLevel>
 ): GrantVerb[] {
   const role = ROLE_REGISTRY[resourceType]?.[grantType];
-  if (!role) {
-    return [];
-  }
-  const levelSet = new Set(levels);
-  if (!role.levels.some((level) => levelSet.has(level))) {
+  if (!role || !role.levels.some((level) => levels.has(level))) {
     return [];
   }
   return [...role.verbs];
@@ -169,12 +165,11 @@ export function verbsForGrantAtLevels(
 // Every verb valid at any of `levels` on `resourceType` — used to expand a "*" grant.
 function allVerbsForResourceAtLevels(
   resourceType: ConcreteResourceType,
-  levels: GrantLevel[]
+  levels: ReadonlySet<GrantLevel>
 ): GrantVerb[] {
-  const levelSet = new Set(levels);
   const verbs = new Set<GrantVerb>();
   for (const role of Object.values(ROLE_REGISTRY[resourceType] ?? {})) {
-    if (role.levels.some((level) => levelSet.has(level))) {
+    if (role.levels.some((level) => levels.has(level))) {
       for (const verb of role.verbs) {
         verbs.add(verb);
       }
@@ -188,9 +183,10 @@ export function allWorkspacePermissions(): WorkspacePermissions {
   const permissions = emptyWorkspacePermissions();
   for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
     if (isConcreteResourceType(resourceType)) {
-      permissions[resourceType] = allVerbsForResourceAtLevels(resourceType, [
-        "type",
-      ]);
+      permissions[resourceType] = allVerbsForResourceAtLevels(
+        resourceType,
+        new Set<GrantLevel>(["type"])
+      );
     }
   }
   return permissions;
@@ -310,10 +306,11 @@ export class GroupPermissions {
 
     for (const { grantType, resourceType, resourceId } of grants) {
       // A whole-type grant applies both to the type itself and to all its instances.
-      const levels: GrantLevel[] =
+      const levels = new Set<GrantLevel>(
         resourceId === WHOLE_TYPE_RESOURCE_ID
           ? ["type", "instance"]
-          : ["instance"];
+          : ["instance"]
+      );
       const resourceTypes =
         resourceType === "*"
           ? GROUP_PERMISSION_RESOURCE_TYPES.filter(isConcreteResourceType)

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -148,47 +148,36 @@ export function grantTypesForVerb(
   });
 }
 
-// Verbs a grant type confers at `level`; empty when the role is not valid at that level, or the
-// resource type is unknown (e.g. a stale grant row for a removed type).
-export function verbsForGrantAtLevel(
+// Verbs a grant type confers at any of `levels`; empty when the role is not valid at those levels,
+// or the resource type is unknown (e.g. a stale grant row for a removed type).
+export function verbsForGrantAtLevels(
   grantType: ConcreteGrantType,
   resourceType: ConcreteResourceType,
-  level: GrantLevel
+  levels: GrantLevel[]
 ): GrantVerb[] {
   const role = ROLE_REGISTRY[resourceType]?.[grantType];
-  if (!role || !role.levels.includes(level)) {
+  if (!role) {
+    return [];
+  }
+  const levelSet = new Set(levels);
+  if (!role.levels.some((level) => levelSet.has(level))) {
     return [];
   }
   return [...role.verbs];
 }
 
-// Every verb valid at `level` on `resourceType` — used to expand a "*" grant.
-function allVerbsForResourceAtLevel(
+// Every verb valid at any of `levels` on `resourceType` — used to expand a "*" grant.
+function allVerbsForResourceAtLevels(
   resourceType: ConcreteResourceType,
-  level: GrantLevel
+  levels: GrantLevel[]
 ): GrantVerb[] {
+  const levelSet = new Set(levels);
   const verbs = new Set<GrantVerb>();
   for (const role of Object.values(ROLE_REGISTRY[resourceType] ?? {})) {
-    if (role.levels.includes(level)) {
+    if (role.levels.some((level) => levelSet.has(level))) {
       for (const verb of role.verbs) {
         verbs.add(verb);
       }
-    }
-  }
-  return [...verbs];
-}
-
-// The verbs a "*" grant confers on `resourceType`. At WHOLE_TYPE_RESOURCE_ID the wildcard stands
-// for the type and for every instance of it, so the instance-level roles count alongside the
-// type-level ones; on a concrete id only the instance-level roles apply.
-function allVerbsForWildcard(
-  resourceType: ConcreteResourceType,
-  level: GrantLevel
-): GrantVerb[] {
-  const verbs = new Set(allVerbsForResourceAtLevel(resourceType, "instance"));
-  if (level === "type") {
-    for (const verb of allVerbsForResourceAtLevel(resourceType, "type")) {
-      verbs.add(verb);
     }
   }
   return [...verbs];
@@ -199,10 +188,9 @@ export function allWorkspacePermissions(): WorkspacePermissions {
   const permissions = emptyWorkspacePermissions();
   for (const resourceType of GROUP_PERMISSION_RESOURCE_TYPES) {
     if (isConcreteResourceType(resourceType)) {
-      permissions[resourceType] = allVerbsForResourceAtLevel(
-        resourceType,
-        "type"
-      );
+      permissions[resourceType] = allVerbsForResourceAtLevels(resourceType, [
+        "type",
+      ]);
     }
   }
   return permissions;
@@ -321,9 +309,11 @@ export class GroupPermissions {
     };
 
     for (const { grantType, resourceType, resourceId } of grants) {
-      // A "*" grant / -1 resourceId are always type-wide; concrete ids are instance-level.
-      const level: GrantLevel =
-        resourceId === WHOLE_TYPE_RESOURCE_ID ? "type" : "instance";
+      // A whole-type grant applies both to the type itself and to all its instances.
+      const levels: GrantLevel[] =
+        resourceId === WHOLE_TYPE_RESOURCE_ID
+          ? ["type", "instance"]
+          : ["instance"];
       const resourceTypes =
         resourceType === "*"
           ? GROUP_PERMISSION_RESOURCE_TYPES.filter(isConcreteResourceType)
@@ -336,8 +326,8 @@ export class GroupPermissions {
         }
         const verbs =
           grantType === "*"
-            ? allVerbsForWildcard(rt, level)
-            : verbsForGrantAtLevel(grantType, rt, level);
+            ? allVerbsForResourceAtLevels(rt, levels)
+            : verbsForGrantAtLevels(grantType, rt, levels);
         add(rt, resourceId, verbsToMask(verbs));
       }
     }


### PR DESCRIPTION
## Description

Follow-up from https://github.com/dust-tt/dust/pull/30741/changes#r3811142849

Make resource-wide permissions explicitly expand across both type and instance grant levels in `GroupPermissions.fromGrants`.

Pluralize concrete and wildcard verb resolution so both paths evaluate every applicable level, and remove the special-case `allVerbsForWildcard` helper.

## Tests

- Covered by tests in particular [these ones](https://github.com/dust-tt/dust/blob/41dcc249cc8c617b7dada7f46d60e516c4ac6e8d/front/lib/resources/group_permission_registry.test.ts#L290)

## Risk

High. Permissions related

## Deploy Plan

- deploy `front`