### PR TITLE
fix: show the server view name in a space's Add Tools dropdown

### DIFF
--- a/front/components/spaces/SpaceActionsList.tsx
+++ b/front/components/spaces/SpaceActionsList.tsx
@@ -8,12 +8,12 @@ import {
   getMcpServerViewDisplayName,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { useAppRouter } from "@app/lib/platform";
 import {
   useAddMCPServerToSpace,
-  useAvailableMCPServers,
   useMCPServerViews,
+  useMCPServerViewsNotActivated,
   useRemoveMCPServerViewFromSpace,
 } from "@app/lib/swr/mcp_servers";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
@@ -65,10 +65,8 @@ export const SpaceActionsList = ({
     });
   const { addToSpace } = useAddMCPServerToSpace(owner);
   const { removeFromSpace } = useRemoveMCPServerViewFromSpace(owner);
-  const { mutateAvailableMCPServers } = useAvailableMCPServers({
-    owner,
-    space,
-  });
+  const { mutateMCPServerViews: mutateActivableMCPServerViews } =
+    useMCPServerViewsNotActivated({ owner, space, disabled: true });
 
   const [shouldOpenToolsMenu, setShouldOpenToolsMenu] = React.useState(false);
   React.useEffect(() => {
@@ -87,16 +85,16 @@ export const SpaceActionsList = ({
     urlPrefix: "table",
   });
 
-  const onAddServer = async (server: MCPServerType) => {
-    await addToSpace(server, space);
+  const onAddServerView = async (serverView: MCPServerViewType) => {
+    await addToSpace(serverView.server, space);
     await mutateMCPServerViews();
-    await mutateAvailableMCPServers();
+    await mutateActivableMCPServerViews();
   };
 
   const onRemoveServer = async (sId: string) => {
     await removeFromSpace(serverViews.find((view) => view.sId === sId)!, space);
     await mutateMCPServerViews();
-    await mutateAvailableMCPServers();
+    await mutateActivableMCPServerViews();
   };
 
   const getTableColumns = (): ColumnDef<RowData, string>[] => {
@@ -191,7 +189,7 @@ export const SpaceActionsList = ({
           <SpaceManagedActionsViewsModel
             space={space}
             owner={owner}
-            onAddServer={onAddServer}
+            onAddServerView={onAddServerView}
             shouldOpenMenu={shouldOpenToolsMenu}
             onOpenMenuHandled={() => setShouldOpenToolsMenu(false)}
           />

--- a/front/components/spaces/SpaceManagedActionsViewsModal.tsx
+++ b/front/components/spaces/SpaceManagedActionsViewsModal.tsx
@@ -1,8 +1,11 @@
-import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import type { MCPServerType } from "@app/lib/api/mcp";
-import { filterMCPServer } from "@app/lib/mcp";
-import { useAvailableMCPServers } from "@app/lib/swr/mcp_servers";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { filterMCPServerView } from "@app/lib/mcp";
+import { useMCPServerViewsNotActivated } from "@app/lib/swr/mcp_servers";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
@@ -17,25 +20,25 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
-type SpaceManagedActionsViewsModelProps = {
+interface SpaceManagedActionsViewsModelProps {
   owner: LightWorkspaceType;
   space: SpaceType;
-  onAddServer: (server: MCPServerType) => void;
+  onAddServerView: (serverView: MCPServerViewType) => void;
   shouldOpenMenu?: boolean;
   onOpenMenuHandled?: () => void;
-};
+}
 
 export default function SpaceManagedActionsViewsModel({
   owner,
   space,
-  onAddServer,
+  onAddServerView,
   shouldOpenMenu,
   onOpenMenuHandled,
 }: SpaceManagedActionsViewsModelProps) {
   const [searchText, setSearchText] = useState("");
   const [menuOpen, setMenuOpen] = useState(false);
-  const { availableMCPServers, isAvailableMCPServersLoading } =
-    useAvailableMCPServers({
+  const { serverViews, isMCPServerViewsLoading } =
+    useMCPServerViewsNotActivated({
       owner,
       space,
       disabled: !menuOpen,
@@ -75,31 +78,28 @@ export default function SpaceManagedActionsViewsModel({
             name="search"
             value={searchText}
             onChange={setSearchText}
-            disabled={isAvailableMCPServersLoading}
+            disabled={isMCPServerViewsLoading}
           />
         }
       >
-        {isAvailableMCPServersLoading && (
+        {isMCPServerViewsLoading && (
           <div className="flex justify-center py-4">
             <Spinner size="sm" />{" "}
           </div>
         )}
-        {!isAvailableMCPServersLoading && availableMCPServers.length <= 0 && (
+        {!isMCPServerViewsLoading && serverViews.length <= 0 && (
           <DropdownMenuItem label="No more tools to add" disabled />
         )}
-        {availableMCPServers
-          .filter((s) => filterMCPServer(s, searchText))
-          .sort((a, b) =>
-            getMcpServerDisplayName(a).localeCompare(getMcpServerDisplayName(b))
-          )
-          .map((server) => (
+        {serverViews
+          .filter((serverView) => filterMCPServerView(serverView, searchText))
+          .map((serverView) => (
             <DropdownMenuItem
-              key={server.sId}
-              label={getMcpServerDisplayName(server)}
-              icon={() => getAvatar(server, "xs")}
-              description={server.description}
+              key={serverView.sId}
+              label={getMcpServerViewDisplayName(serverView)}
+              icon={() => getAvatar(serverView.server, "xs")}
+              description={getMcpServerViewDescription(serverView)}
               onClick={() => {
-                onAddServer(server);
+                onAddServerView(serverView);
               }}
             />
           ))}

--- a/front/lib/actions/mcp_helper.ts
+++ b/front/lib/actions/mcp_helper.ts
@@ -147,7 +147,10 @@ export const mcpServerViewSortingFn = (
   a: MCPServerViewType,
   b: MCPServerViewType
 ) => {
-  return mcpServersSortingFn({ mcpServer: a.server }, { mcpServer: b.server });
+  return mcpServersSortingFn(
+    { mcpServer: a.server, mcpServerView: a },
+    { mcpServer: b.server, mcpServerView: b }
+  );
 };
 
 export const mcpServersSortingFn = (

--- a/front/lib/mcp.ts
+++ b/front/lib/mcp.ts
@@ -1,4 +1,8 @@
-import type { MCPServerType } from "@app/lib/api/mcp";
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
+import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 
 export const filterMCPServer = (
   mcpServer: MCPServerType,
@@ -13,4 +17,23 @@ export const filterMCPServer = (
       )
     );
   }
+};
+
+export const filterMCPServerView = (
+  mcpServerView: MCPServerViewType,
+  filterValue: string
+) => {
+  const filterLower = filterValue.toLowerCase();
+
+  return (
+    getMcpServerViewDisplayName(mcpServerView)
+      .toLowerCase()
+      .includes(filterLower) ||
+    getMcpServerViewDescription(mcpServerView)
+      .toLowerCase()
+      .includes(filterLower) ||
+    mcpServerView.server.tools.some((tool) =>
+      tool.name.toLowerCase().includes(filterLower)
+    )
+  );
 };


### PR DESCRIPTION
## Description

The Add Tools dropdown on a space's tools page listed each MCP server's raw name and description. But `MCPServerViewResource.create` copies `name` and `description` from the system space view, so the row that appeared after picking a tool was named whatever an admin had set in Admin > Tools, not what the dropdown said, and finding the right tool in the dropdown was hard.

## Tests

Manual on front-edge: on a restricted space with a renamed tool in Admin > Tools, the dropdown, the search box, and the resulting row all agree on the name.

The endpoint behind this is already covered by `mcp_views/index.test.ts`.

## Risk

Low, and UI-only.

## Deploy Plan

Deploy front.