### PR TITLE
chore: apply feedback on automations wording

### DIFF
--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -384,7 +384,7 @@ export const subNavigationAdmin = ({
 
   nav.push({
     id: "api",
-    label: "API & Programmatic",
+    label: "Programmatic Usage",
     menus: [
       {
         id: "api_keys",
@@ -399,7 +399,7 @@ export const subNavigationAdmin = ({
         : [
             {
               id: "credits_usage" as const,
-              label: "Programmatic Usage",
+              label: "Credits Usage",
               icon: Zap,
               href: `/w/${owner.sId}/developers/credits-usage`,
               current: isCurrent("credits_usage"),

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -43,8 +43,8 @@ export function AnalyticsAutomationsPage() {
             <div className="flex max-w-[700px] flex-col gap-1">
               <Page.H variant="h3">Automations</Page.H>
               <Page.P variant="secondary">
-                Everything that runs on its own: what it costs, how often, and
-                who set it up.
+                Everything that runs on its own: who set it up, how often it
+                runs, what it costs.
               </Page.P>
             </div>
             <ConsumptionPeriodSelector

--- a/front/components/workspace/analytics/automations/AutomationsOverview.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsOverview.tsx
@@ -31,16 +31,16 @@ export function AutomationsOverview({
   return (
     <div className="flex items-stretch gap-6">
       <SummaryCard
-        label="Credits spent"
+        label="Credits"
         value={formatCredits(automationCredits)}
         hint={
           workspaceTotalCredits > 0
-            ? `${Math.round((automationCredits / workspaceTotalCredits) * 100)}% of workspace usage`
+            ? `${Math.round((automationCredits / workspaceTotalCredits) * 100)}% of workspace consumption`
             : null
         }
       />
       <SummaryCard
-        label="Active triggers"
+        label="Triggers enabled"
         value={`${triggers.enabled.toLocaleString()} / ${triggers.total.toLocaleString()}`}
         hint={disabledCount > 0 ? `${disabledCount} disabled` : null}
       />

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
@@ -106,7 +106,7 @@ function CreditDestinationBlock({
 
   return (
     <StatBlock
-      label="Where the credits go"
+      label="What model is used"
       primaryText={
         <span className="font-semibold text-foreground">
           {creditDestination.name}

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -261,18 +261,6 @@ function buildColumns({
       ),
     },
     {
-      id: "runCount",
-      accessorKey: "runCount",
-      header: "Runs",
-      meta: { className: "w-20", headerAlign: "right" },
-      cell: (info) => (
-        <DataTable.BasicCellContent
-          className="justify-end text-right tabular-nums"
-          label={info.row.original.runCount.toLocaleString()}
-        />
-      ),
-    },
-    {
       id: "credits",
       accessorKey: "credits",
       header: "Credits",
@@ -285,7 +273,7 @@ function buildColumns({
     },
     {
       id: "status",
-      header: "",
+      header: "Enabled",
       enableSorting: false,
       meta: { className: "w-24" },
       cell: (info) => (


### PR DESCRIPTION
## Description

Following the Product review, this PR renames the section in Programmatic usage, twist some wording over the page, and removes the Cost column which is doubled in the details.

Closes https://github.com/dust-tt/tasks/issues/10128
Closes https://github.com/dust-tt/tasks/issues/10125

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Rendered live on a workspace with automations usage.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front spa