### PR TITLE
Return node identity from file system writes and directory creations

### DIFF
--- a/front/lib/api/config.test.ts
+++ b/front/lib/api/config.test.ts
@@ -1,5 +1,5 @@
 import config from "@app/lib/api/config";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const PUBLIC_URL = "https://eu.dust.tt";
 const INTERNAL_URL = "http://front-internal-service";
@@ -8,6 +8,7 @@ describe("getSandboxApiBaseUrl", () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     process.env = { ...originalEnv };
   });
 
@@ -39,7 +40,8 @@ describe("getSandboxApiBaseUrl", () => {
   it("ignores the development host outside development", () => {
     process.env.NEXT_PUBLIC_DUST_API_URL = PUBLIC_URL;
     delete process.env.IS_DEVELOPMENT;
-    process.env.NODE_ENV = "production";
+    // Node's types mark NODE_ENV read-only, so stub it instead of assigning.
+    vi.stubEnv("NODE_ENV", "production");
     process.env.SBX_DEV_FRONT_URL = "https://tunnel.example.com";
 
     expect(config.getSandboxApiBaseUrl()).toBe(PUBLIC_URL);

--- a/front/lib/api/file_system/backends/database_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/database_file_system_backend.test.ts
@@ -93,6 +93,59 @@ describe("DatabaseFileSystemBackend", () => {
     );
   });
 
+  it("returns the id of the node a write or mkdir touched", async () => {
+    const { auth, conversation, dustFileSystem, pod, scope } =
+      await databaseFileSystem();
+    fileStorageMock.setFileMetadata(() => ({
+      size: "5",
+      contentType: "text/plain",
+      contentEncoding: "identity",
+    }));
+
+    const directory = await dustFileSystem.mkdir(
+      `conversation-${conversation.sId}/reports`
+    );
+    assert(directory.isOk());
+    expect(directory.value.entry).toMatchObject({
+      isDirectory: true,
+      fileName: "reports",
+    });
+    expect(directory.value.nodeId).not.toBeNull();
+
+    const written = await dustFileSystem.write(
+      `conversation-${conversation.sId}/reports/report.txt`,
+      "hello",
+      "text/plain"
+    );
+    assert(written.isOk());
+    const { nodeId } = written.value;
+    assert(nodeId !== null);
+
+    // Overwriting reports the node that already carries the name, not a new one.
+    const overwritten = await dustFileSystem.write(
+      `conversation-${conversation.sId}/reports/report.txt`,
+      "world",
+      "text/plain"
+    );
+    assert(overwritten.isOk());
+    expect(overwritten.value.nodeId).toBe(nodeId);
+
+    // The id is what a caller may hold onto: it still names the same file
+    // after a move, which a path would not.
+    const moved = await dustFileSystem.move({
+      src: `conversation-${conversation.sId}/reports/report.txt`,
+      dest: `pod-${pod.sId}/report.txt`,
+    });
+    assert(moved.isOk());
+    const node = await FileSystemNodeResource.fetchById(auth, scope, nodeId);
+    expect(node).toMatchObject({
+      id: nodeId,
+      rootKind: "pod",
+      rootId: pod.sId,
+      name: "report.txt",
+    });
+  });
+
   it("preserves the inode while moving a file from a conversation to its Pod", async () => {
     const { auth, conversation, dustFileSystem, pod, scope, conversationRoot } =
       await databaseFileSystem();

--- a/front/lib/api/file_system/backends/database_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/database_file_system_backend.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from "node:crypto";
 import type { Readable } from "node:stream";
 
-import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
+import type {
+  FileSystemBackend,
+  FileSystemNodeIdentity,
+} from "@app/lib/api/file_system/backends/file_system_backend";
 import {
   getFileSystemDownloadUrl,
   getFileSystemReadStream,
@@ -342,7 +345,7 @@ export class DatabaseFileSystemBackend implements FileSystemBackend {
     scopedPath: string,
     content: Buffer | string | Readable,
     contentType: string
-  ): Promise<Result<void, DustFileSystemError>> {
+  ): Promise<Result<FileSystemNodeIdentity, DustFileSystemError>> {
     try {
       const destination = await this.resolveParent(scopedPath);
       let node = destination.existing;
@@ -379,7 +382,7 @@ export class DatabaseFileSystemBackend implements FileSystemBackend {
       if (written.isErr()) {
         throw written.error;
       }
-      return new Ok(undefined);
+      return new Ok({ nodeId: node.id });
     } catch (error) {
       return new Err(this.error(error));
     }
@@ -387,7 +390,12 @@ export class DatabaseFileSystemBackend implements FileSystemBackend {
 
   async mkdir(
     scopedPath: string
-  ): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>> {
+  ): Promise<
+    Result<
+      { entry: FileSystemDirectoryEntry } & FileSystemNodeIdentity,
+      DustFileSystemError
+    >
+  > {
     try {
       const destination = await this.resolveParent(scopedPath);
       if (destination.existing) {
@@ -417,7 +425,7 @@ export class DatabaseFileSystemBackend implements FileSystemBackend {
       if (!entry.isDirectory) {
         throw new Error("Created directory rendered as a file.");
       }
-      return new Ok(entry);
+      return new Ok({ entry, nodeId: created.value.id });
     } catch (error) {
       return new Err(this.error(error));
     }

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -14,6 +14,17 @@ import type { Readable } from "stream";
 export type { FileSystemEntry } from "@app/types/api/file_system/types";
 
 /**
+ * Identity of the node a write or mkdir touched. `nodeId` is the stable id that
+ * survives every move and rename, so it is what a feature stores when it must
+ * find the same file or directory again later. The GCS backend stores plain
+ * objects with no node table and reports null.
+ *
+ * Server-side only: numeric ids never go to a client (SEC2), so this stays out
+ * of the wire entry types on purpose.
+ */
+export type FileSystemNodeIdentity = { nodeId: number | null };
+
+/**
  * Backend-agnostic file system interface.
  *
  * All paths are scoped paths (`{scopedPrefix}/{relPath}`, e.g. `conversation-{cId}/report.pdf`).
@@ -72,7 +83,7 @@ export interface FileSystemBackend {
     scopedPath: string,
     content: Buffer | string | Readable,
     contentType: string
-  ): Promise<Result<void, DustFileSystemError>>;
+  ): Promise<Result<FileSystemNodeIdentity, DustFileSystemError>>;
 
   /**
    * Create a directory placeholder at `scopedPath`.
@@ -80,7 +91,12 @@ export interface FileSystemBackend {
    */
   mkdir(
     scopedPath: string
-  ): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>>;
+  ): Promise<
+    Result<
+      { entry: FileSystemDirectoryEntry } & FileSystemNodeIdentity,
+      DustFileSystemError
+    >
+  >;
 
   /**
    * Returns `Err("not_found")` when the path does not exist and `ignoreNotFound` is false.

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -14,13 +14,9 @@ import type { Readable } from "stream";
 export type { FileSystemEntry } from "@app/types/api/file_system/types";
 
 /**
- * Identity of the node a write or mkdir touched. `nodeId` is the stable id that
- * survives every move and rename, so it is what a feature stores when it must
- * find the same file or directory again later. The GCS backend stores plain
- * objects with no node table and reports null.
- *
- * Server-side only: numeric ids never go to a client (SEC2), so this stays out
- * of the wire entry types on purpose.
+ * Identity of the node a write or mkdir touched. `nodeId` is the stable id that survives every move
+ * and rename, so it is what a feature stores when it must find the same file or directory again
+ * later. The GCS backend stores plain objects with no node table and reports null.
  */
 export type FileSystemNodeIdentity = { nodeId: number | null };
 

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.test.ts
@@ -486,6 +486,15 @@ describe("GCSFileSystemBackend.write", () => {
       expect(result.error.code).toBe("invalid_path");
     }
   });
+
+  it("reports no node identity, since GCS objects have no node", async () => {
+    const result = await makeBackend().write(
+      `conversation-${CONV_ID}/report.txt`,
+      Buffer.from("hello"),
+      "text/plain"
+    );
+    expect(result.isOk() && result.value).toEqual({ nodeId: null });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -26,7 +26,10 @@ import { isString } from "@app/types/shared/utils/general";
 import type { Readable } from "stream";
 import { pipeline } from "stream/promises";
 
-import type { FileSystemBackend } from "./file_system_backend";
+import type {
+  FileSystemBackend,
+  FileSystemNodeIdentity,
+} from "./file_system_backend";
 
 // ---------------------------------------------------------------------------
 // Scoped-path helpers
@@ -387,7 +390,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     scopedPath: string,
     content: Buffer | string | Readable,
     contentType: string
-  ): Promise<Result<void, DustFileSystemError>> {
+  ): Promise<Result<FileSystemNodeIdentity, DustFileSystemError>> {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
       return new Err(
@@ -411,7 +414,7 @@ export class GCSFileSystemBackend implements FileSystemBackend {
         );
       }
 
-      return new Ok(undefined);
+      return new Ok({ nodeId: null });
     } catch (err) {
       return new Err(
         new DustFileSystemError("internal", normalizeError(err).message)
@@ -421,7 +424,12 @@ export class GCSFileSystemBackend implements FileSystemBackend {
 
   async mkdir(
     scopedPath: string
-  ): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>> {
+  ): Promise<
+    Result<
+      { entry: FileSystemDirectoryEntry } & FileSystemNodeIdentity,
+      DustFileSystemError
+    >
+  > {
     const gcsPath = this.toGCSPath(scopedPath);
     if (!gcsPath) {
       return new Err(
@@ -451,11 +459,14 @@ export class GCSFileSystemBackend implements FileSystemBackend {
 
       const fileName = gcsPath.split("/").pop() ?? "";
       return new Ok({
-        isDirectory: true as const,
-        fileName,
-        path: scopedPath,
-        sizeBytes: 0,
-        lastModifiedMs: Date.now(),
+        entry: {
+          isDirectory: true as const,
+          fileName,
+          path: scopedPath,
+          sizeBytes: 0,
+          lastModifiedMs: Date.now(),
+        },
+        nodeId: null,
       });
     } catch (err) {
       return new Err(

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -18,7 +18,10 @@
 
 import config from "@app/lib/api/config";
 import { DatabaseFileSystemBackend } from "@app/lib/api/file_system/backends/database_file_system_backend";
-import type { FileSystemBackend } from "@app/lib/api/file_system/backends/file_system_backend";
+import type {
+  FileSystemBackend,
+  FileSystemNodeIdentity,
+} from "@app/lib/api/file_system/backends/file_system_backend";
 import { GCSFileSystemBackend } from "@app/lib/api/file_system/backends/gcs_file_system_backend";
 import type { FileSystemStorageMode } from "@app/lib/api/file_system/storage_mode";
 import {
@@ -948,7 +951,7 @@ export class DustFileSystem {
     scopedPath: string,
     content: Buffer | string | Readable,
     contentType: string
-  ): Promise<Result<void, DustFileSystemError>> {
+  ): Promise<Result<FileSystemNodeIdentity, DustFileSystemError>> {
     const resolved = this.requireWriteMount(scopedPath);
     if (resolved.isErr()) {
       return resolved;
@@ -970,7 +973,12 @@ export class DustFileSystem {
 
   async mkdir(
     scopedPath: string
-  ): Promise<Result<FileSystemDirectoryEntry, DustFileSystemError>> {
+  ): Promise<
+    Result<
+      { entry: FileSystemDirectoryEntry } & FileSystemNodeIdentity,
+      DustFileSystemError
+    >
+  > {
     const resolved = this.requireWriteMount(scopedPath);
     if (resolved.isErr()) {
       return resolved;

--- a/front/lib/api/projects/context.ts
+++ b/front/lib/api/projects/context.ts
@@ -626,7 +626,14 @@ export async function createProjectFolder(
     return fsResult;
   }
 
-  return fsResult.value.mkdir(podScopedPath(space.sId, relativeDirPath));
+  const created = await fsResult.value.mkdir(
+    podScopedPath(space.sId, relativeDirPath)
+  );
+  if (created.isErr()) {
+    return created;
+  }
+  // The handler serializes this entry to the client, so the node id stays here.
+  return new Ok(created.value.entry);
 }
 
 /**


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
The server-side file system never tells its callers which node a write or a directory creation touched. Nodes have a stable id that survives every move and rename, and it is the only safe thing for a feature to hold onto when it must find the same file again later; a path goes stale the moment anything moves. Frames are the first consumer: they need to reference their source tree by identity rather than by the path stored today, which breaks live edits when a published frame's directory moves.

Writes now return the id of the node they created or overwrote, and directory creation returns it alongside the entry it already returned. The database backend already holds the node in both paths, so this surfaces information rather than fetching more. The GCS backend has no nodes and reports null, which is also what makes the degradation explicit for conversations not yet on the database file system.

The id rides next to the wire entry rather than on it, on purpose: the folder creation endpoint serializes that entry verbatim to the client, and numeric ids stay inside the server. The one caller that fed an entry to the wire unwraps it and sends exactly the same JSON as before. Every other caller only ever checked for errors and is unchanged.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
A database backend test pins the property this exists for rather than the plumbing: a directory and a file both report ids, overwriting the file reports the same node rather than a new one, and after moving the file from a conversation to its Pod, fetching by the stored id still finds it. A GCS backend test pins the null. The existing file system, projects and file tool suites all pass.

Also fixes a test of mine from an earlier PR that assigned NODE_ENV directly, which current Node types reject; it stubs the variable through vitest instead.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
None observable: no endpoint changes its response, no schema changes, and no caller behaves differently. The change widens an internal return type that callers were ignoring. Rollback is a revert.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Nothing to sequence.
