### PR TITLE
[marketing] chore: remove unused sharp dependency

### DIFF
--- a/marketing/package.json
+++ b/marketing/package.json
@@ -45,7 +45,6 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "7.61.1",
     "react-intersection-observer": "^9.13.1",
-    "sharp": "^0.34.5",
     "swr": "^2.2.4",
     "tailwind-merge": "^2.2.1",
     "tailwind-scrollbar-hide": "^1.1.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,7 +1218,6 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "7.61.1",
         "react-intersection-observer": "^9.13.1",
-        "sharp": "^0.34.5",
         "swr": "^2.2.4",
         "tailwind-merge": "^2.2.1",
         "tailwind-scrollbar-hide": "^1.1.7",


### PR DESCRIPTION
## Description

Remove the unused `sharp` dependency from `marketing/package.json` and `package-lock.json`.

`sharp` has been declared in `marketing/package.json` since the workspace was introduced (#26962, 2026-06-09) but has never actually been imported anywhere in `marketing/` — it looks like it was copied over from another workspace's dependency list rather than added for an actual use. `front/lib/api/files/processing/images.ts` is the only real consumer of `sharp` in the monorepo, and `front` keeps its own dependency.

## Tests

Verified with `knip --dependencies` and a repo-wide grep that `sharp` is not imported anywhere under `marketing/`. Ran `npm install --package-lock-only -w marketing` to regenerate the lockfile.

## Risk

Low: dependency-only change with no runtime code changes.

## Deploy Plan

None — no runtime behavior change.
