### PR TITLE
[viz] chore: remove unused dd-trace dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58816,7 +58816,6 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
-        "dd-trace": "^5.87.0",
         "embla-carousel-react": "^8.6.0",
         "html-to-image": "^1.11.11",
         "input-otp": "^1.4.2",

--- a/viz/package.json
+++ b/viz/package.json
@@ -46,7 +46,6 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
-    "dd-trace": "^5.87.0",
     "embla-carousel-react": "^8.6.0",
     "html-to-image": "^1.11.11",
     "input-otp": "^1.4.2",


### PR DESCRIPTION
## Description

Remove the unused `dd-trace` dependency from `viz/package.json` and `package-lock.json`.

`dd-trace` was added to `viz/package.json` the day the workspace was created (#6469, then #6473, both 2024-07-24) but there has never been a require/import of `dd-trace` anywhere in `viz/` — it looks like it was declared defensively at the time (matching root/front/connectors, which do instrument with `dd-trace`) but never actually wired up in this service. It's one of the heavier deps in the monorepo (APM tracer with dozens of auto-instrumentation plugins), so dropping it here trims a meaningful chunk of `viz`'s install size.

## Tests

Verified with `knip --dependencies` and a repo-wide grep that `dd-trace` is not required/imported anywhere under `viz/`. Ran `npm install --package-lock-only -w viz` to regenerate the lockfile.

## Risk

Low: dependency-only change with no runtime code changes.

## Deploy Plan

None — no runtime behavior change.
