### PR TITLE
[front-api] chore: remove unused openai dependency

### DIFF
--- a/front-api/package.json
+++ b/front-api/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
     "@novu/framework": "^2.11.1",
-    "openai": "^6.46.0",
     "umzug": "3.8.3",
     "@hono/mcp": "^0.3.0",
     "@hono/node-server": "^1.19.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -571,7 +571,6 @@
         "@novu/framework": "^2.11.1",
         "hono": "^4.12.15",
         "jsonwebtoken": "^9.0.0",
-        "openai": "^6.46.0",
         "swagger-jsdoc": "^6.2.8",
         "umzug": "3.8.3",
         "zod": "^3.25.76",
@@ -751,36 +750,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "front-api/node_modules/openai": {
-      "version": "6.48.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
-      "integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
-        "@smithy/hash-node": ">=4.3.0 <5",
-        "@smithy/signature-v4": ">=5.4.0 <6",
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-provider-node": {
-          "optional": true
-        },
-        "@smithy/hash-node": {
-          "optional": true
-        },
-        "@smithy/signature-v4": {
-          "optional": true
-        },
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "front-api/node_modules/remark-gfm": {


### PR DESCRIPTION
## Description

Remove the unused `openai` dependency from `front-api/package.json` and `package-lock.json`.

`front-api` never imports the `openai` package directly — it talks to OpenAI's API via raw `fetch()` calls where needed (e.g. `routes/w/[wId]/providers/[pId]/check.ts`). The dependency was carried over from `front/package.json`'s dependency list when `front-api` split off as the Hono strangler router (#25136, merged 2026-05-11); it looks like copy-paste from `front` rather than an actual need. `front` itself still uses the `openai` SDK directly (see `front/lib/model_constructors/**`) and keeps its own dependency.

## Tests

Verified with `knip --dependencies` and a repo-wide grep that `openai` is not imported anywhere under `front-api/`. Ran `npm install --package-lock-only -w front-api` to regenerate the lockfile.

## Risk

Low: dependency-only change with no runtime code changes.

## Deploy Plan

None — no runtime behavior change.
