### PR TITLE
[front] fix: preserve legacy usage without analytics flag

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -119,7 +119,6 @@ import {
   LoadingBlock,
   Page,
   SearchInput,
-  Spinner,
   Tabs,
   TabsContent,
   TabsList,
@@ -1270,7 +1269,7 @@ export function UsagePage() {
 
         {!isAnalyticsConsumptionEnabled &&
         !isAwuPoolSummaryLoading &&
-        (!!isAwuPoolSummaryError || hasPool || isReadOnly) ? (
+        (isAwuPoolSummaryError || hasPool || isReadOnly) ? (
           <Page.Vertical gap="xs" align="stretch">
             <Page.H variant="h4">Workspace credit pool</Page.H>
 
@@ -1286,13 +1285,7 @@ export function UsagePage() {
               </ContentMessage>
             )}
 
-            {isAwuPoolSummaryLoading && (
-              <div className="flex justify-center py-8">
-                <Spinner />
-              </div>
-            )}
-
-            {!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && (
+            {!isAwuPoolSummaryError && (
               <>
                 <div className="flex items-baseline gap-1">
                   <span className="heading-mono-4xl text-foreground">

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -1269,11 +1269,12 @@ export function UsagePage() {
         ) : null}
 
         {!isAnalyticsConsumptionEnabled &&
-        (isAwuPoolSummaryLoading || !!isAwuPoolSummaryError || hasPool) ? (
+        !isAwuPoolSummaryLoading &&
+        (!!isAwuPoolSummaryError || hasPool || isReadOnly) ? (
           <Page.Vertical gap="xs" align="stretch">
             <Page.H variant="h4">Workspace credit pool</Page.H>
 
-            {isAwuPoolSummaryError ? (
+            {isAwuPoolSummaryError && (
               <ContentMessage
                 title="Failed to load Workspace Credits Pool"
                 icon={AlertCircle}
@@ -1283,11 +1284,15 @@ export function UsagePage() {
                 data. Please refresh the page or contact support if the issue
                 persists.
               </ContentMessage>
-            ) : isAwuPoolSummaryLoading ? (
+            )}
+
+            {isAwuPoolSummaryLoading && (
               <div className="flex justify-center py-8">
                 <Spinner />
               </div>
-            ) : (
+            )}
+
+            {!isAwuPoolSummaryLoading && !isAwuPoolSummaryError && (
               <>
                 <div className="flex items-baseline gap-1">
                   <span className="heading-mono-4xl text-foreground">

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -896,9 +896,10 @@ export function UsagePage() {
     creditUsage &&
     (creditUsage.status.target === "on_target" ? "on_target" : "off_target");
 
-  const totalConsumedCredits =
-    consumptionOverview?.totalCredits ??
-    (isReadOnly ? periodSpendCredits : poolConsumedCredits);
+  const totalConsumedCredits = isAnalyticsConsumptionEnabled
+    ? (consumptionOverview?.totalCredits ??
+      (isReadOnly ? periodSpendCredits : poolConsumedCredits))
+    : poolConsumedCredits;
 
   const initialTotalCredits = creditUsage?.capCredits ?? totalActiveCredits;
   const hasPool = totalActiveCredits > 0;

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -119,6 +119,7 @@ import {
   LoadingBlock,
   Page,
   SearchInput,
+  Spinner,
   Tabs,
   TabsContent,
   TabsList,
@@ -1274,7 +1275,7 @@ export function UsagePage() {
           <Page.Vertical gap="xs" align="stretch">
             <Page.H variant="h4">Workspace credit pool</Page.H>
 
-            {isAwuPoolSummaryError && (
+            {isAwuPoolSummaryError ? (
               <ContentMessage
                 title="Failed to load Workspace Credits Pool"
                 icon={AlertCircle}
@@ -1284,9 +1285,11 @@ export function UsagePage() {
                 data. Please refresh the page or contact support if the issue
                 persists.
               </ContentMessage>
-            )}
-
-            {!isAwuPoolSummaryError && (
+            ) : isAwuPoolSummaryLoading ? (
+              <div className="flex justify-center py-8">
+                <Spinner />
+              </div>
+            ) : (
               <>
                 <div className="flex items-baseline gap-1">
                   <span className="heading-mono-4xl text-foreground">


### PR DESCRIPTION
## Description

The Usage page redesign of https://github.com/dust-tt/dust/pull/30721 may have changed the pool value for non-credit workspaces and usage value visibility for workspaces without the `enable_analytics_consumption` FF.

This PR restores the previous legacy behavior for those workspaces.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
