### PR TITLE
[front] fix: polish conversation consumption agent breakdown

### DIFF
--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -180,13 +180,12 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
             name={agent.name}
             visual={agent.pictureUrl ?? undefined}
             size="xs"
-            isRounded
           />
           <h3 className="truncate text-base font-medium text-foreground">
             {agent.name}
           </h3>
         </div>
-        <span className="shrink-0 text-xs text-muted-foreground">
+        <span className="shrink-0 text-base text-muted-foreground">
           {formatCreditValue(agent.billedCredits)}
         </span>
       </div>


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10117

Per-agent totals in the conversation consumption breakdown were visually understated, and agent avatars appeared rounded instead of square (round -> human users, square -> agents).

This increases the per-agent credit total to the base text size and makes the avatar square.

Current live version

<img width="860" height="158" alt="image" src="https://github.com/user-attachments/assets/9f6a8d4e-7d3f-4a82-8a14-3393dcf9d022" />

Proposal

<img width="866" height="168" alt="image" src="https://github.com/user-attachments/assets/c23fd6c6-0ee1-48f7-a9a5-6b4dfbd56b96" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
