### PR TITLE
[sparkle] enh: support segmented progress bars

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -188,19 +188,19 @@ function CreditPoolProgressBar({
       aria-label="Workspace credit usage"
       aria-valuenow={clampedUsedPercentage}
       className="h-2 w-full bg-background"
-      segments={[
+      values={[
         {
-          percentage: clampedUsedPercentage,
+          value: clampedUsedPercentage,
           className:
             target === "off_target" ? "bg-warning-500" : "bg-highlight-500",
         },
         {
-          percentage: projectedRemainderPercentage,
+          value: projectedRemainderPercentage,
           className:
             target === "off_target" ? "bg-warning-100" : "bg-highlight-100",
         },
         {
-          percentage: unusedPercentage,
+          value: unusedPercentage,
           className: "bg-muted-background",
         },
       ]}

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -193,7 +193,7 @@ function CreditPoolProgressBar({
         target === "off_target" ? "bg-warning-100" : "bg-highlight-100",
         "bg-gray-50",
       ]}
-      percentage={[
+      percentages={[
         clampedUsedPercentage,
         projectedRemainderPercentage,
         unusedPercentage,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -118,6 +118,7 @@ import {
   LinkExternal01,
   LoadingBlock,
   Page,
+  ProgressBar,
   SearchInput,
   Spinner,
   Tabs,
@@ -183,37 +184,22 @@ function CreditPoolProgressBar({
   const unusedPercentage = 100 - clampedProjectedPercentage;
 
   return (
-    <div
-      className="flex h-2 w-full gap-0.5 bg-background"
-      role="progressbar"
+    <ProgressBar
       aria-label="Workspace credit usage"
-      aria-valuemin={0}
-      aria-valuemax={100}
       aria-valuenow={clampedUsedPercentage}
-    >
-      {clampedUsedPercentage > 0 && (
-        <div
-          className={`h-full rounded-xs ${
-            target === "off_target" ? "bg-warning-500" : "bg-highlight-500"
-          }`}
-          style={{ flexBasis: 0, flexGrow: clampedUsedPercentage }}
-        />
-      )}
-      {projectedRemainderPercentage > 0 && (
-        <div
-          className={`h-full rounded-xs ${
-            target === "off_target" ? "bg-warning-100" : "bg-highlight-100"
-          }`}
-          style={{ flexBasis: 0, flexGrow: projectedRemainderPercentage }}
-        />
-      )}
-      {unusedPercentage > 0 && (
-        <div
-          className="h-full rounded-xs bg-gray-50"
-          style={{ flexBasis: 0, flexGrow: unusedPercentage }}
-        />
-      )}
-    </div>
+      className="h-2 w-full bg-background"
+      fillClassName={[
+        target === "off_target" ? "bg-warning-500" : "bg-highlight-500",
+        target === "off_target" ? "bg-warning-100" : "bg-highlight-100",
+        "bg-gray-50",
+      ]}
+      percentage={[
+        clampedUsedPercentage,
+        projectedRemainderPercentage,
+        unusedPercentage,
+      ]}
+      radius="xs"
+    />
   );
 }
 

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -188,15 +188,21 @@ function CreditPoolProgressBar({
       aria-label="Workspace credit usage"
       aria-valuenow={clampedUsedPercentage}
       className="h-2 w-full bg-background"
-      fillClassName={[
-        target === "off_target" ? "bg-warning-500" : "bg-highlight-500",
-        target === "off_target" ? "bg-warning-100" : "bg-highlight-100",
-        "bg-muted-background",
-      ]}
-      percentages={[
-        clampedUsedPercentage,
-        projectedRemainderPercentage,
-        unusedPercentage,
+      segments={[
+        {
+          percentage: clampedUsedPercentage,
+          className:
+            target === "off_target" ? "bg-warning-500" : "bg-highlight-500",
+        },
+        {
+          percentage: projectedRemainderPercentage,
+          className:
+            target === "off_target" ? "bg-warning-100" : "bg-highlight-100",
+        },
+        {
+          percentage: unusedPercentage,
+          className: "bg-muted-background",
+        },
       ]}
       radius="xs"
     />

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -191,7 +191,7 @@ function CreditPoolProgressBar({
       fillClassName={[
         target === "off_target" ? "bg-warning-500" : "bg-highlight-500",
         target === "off_target" ? "bg-warning-100" : "bg-highlight-100",
-        "bg-gray-50",
+        "bg-muted-background",
       ]}
       percentages={[
         clampedUsedPercentage,

--- a/sparkle/src/components/ProgressBar.tsx
+++ b/sparkle/src/components/ProgressBar.tsx
@@ -2,24 +2,36 @@ import { cn } from "@sparkle/lib/utils";
 import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
-const progressBarVariants = cva("h-1.5 overflow-hidden rounded-full", {
+const progressBarVariants = cva("h-1.5 overflow-hidden", {
   variants: {
+    radius: {
+      none: "rounded-none",
+      xs: "rounded-xs",
+      full: "rounded-full",
+    },
     variant: {
       default: "bg-muted-background",
     },
   },
   defaultVariants: {
+    radius: "full",
     variant: "default",
   },
 });
 
-const progressBarFillVariants = cva("h-full rounded-full", {
+const progressBarFillVariants = cva("h-full", {
   variants: {
+    radius: {
+      none: "rounded-none",
+      xs: "rounded-xs",
+      full: "rounded-full",
+    },
     variant: {
       default: "bg-primary-light",
     },
   },
   defaultVariants: {
+    radius: "full",
     variant: "default",
   },
 });
@@ -27,27 +39,65 @@ const progressBarFillVariants = cva("h-full rounded-full", {
 export interface ProgressBarProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
     VariantProps<typeof progressBarVariants> {
-  percentage: number;
+  fillClassName?: string | string[];
+  percentage: number | number[];
 }
 
 export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
-  ({ percentage, variant = "default", className, ...props }, ref) => {
-    const clampedPercentage = Math.min(100, Math.max(0, percentage));
+  (
+    {
+      percentage,
+      radius = "full",
+      variant = "default",
+      className,
+      fillClassName,
+      ...props
+    },
+    ref
+  ) => {
+    const isSegmented = Array.isArray(percentage);
+    const clampedPercentages = (isSegmented ? percentage : [percentage]).map(
+      (value) => Math.min(100, Math.max(0, value))
+    );
+    const valueNow = isSegmented
+      ? Math.min(
+          100,
+          clampedPercentages.reduce((total, value) => total + value, 0)
+        )
+      : clampedPercentages[0];
 
     return (
       <div
         ref={ref}
         role="progressbar"
-        aria-valuenow={clampedPercentage}
+        aria-valuenow={valueNow}
         aria-valuemin={0}
         aria-valuemax={100}
-        className={cn(progressBarVariants({ variant }), className)}
+        className={cn(
+          progressBarVariants({ radius, variant }),
+          isSegmented && "flex gap-0.5",
+          className
+        )}
         {...props}
       >
-        <div
-          className={progressBarFillVariants({ variant })}
-          style={{ width: `${clampedPercentage}%` }}
-        />
+        {clampedPercentages.map((value, index) =>
+          !isSegmented || value > 0 ? (
+            <div
+              key={index}
+              className={cn(
+                progressBarFillVariants({ radius, variant }),
+                Array.isArray(fillClassName)
+                  ? fillClassName[index]
+                  : fillClassName
+              )}
+              style={
+                isSegmented
+                  ? { flexBasis: 0, flexGrow: value }
+                  : { width: `${value}%` }
+              }
+            />
+          ) : null
+        )}
       </div>
     );
   }

--- a/sparkle/src/components/ProgressBar.tsx
+++ b/sparkle/src/components/ProgressBar.tsx
@@ -42,18 +42,11 @@ interface ProgressBarBaseProps
   fillClassName?: string | string[];
 }
 
-interface SingleProgressBarProps {
-  percentage: number;
-  percentages?: never;
-}
-
-interface SegmentedProgressBarProps {
-  percentage?: never;
-  percentages: number[];
-}
-
 export type ProgressBarProps = ProgressBarBaseProps &
-  (SingleProgressBarProps | SegmentedProgressBarProps);
+  (
+    | { percentage: number; percentages?: never }
+    | { percentage?: never; percentages: number[] }
+  );
 
 export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   (

--- a/sparkle/src/components/ProgressBar.tsx
+++ b/sparkle/src/components/ProgressBar.tsx
@@ -36,26 +36,24 @@ const progressBarFillVariants = cva("h-full", {
   },
 });
 
-interface ProgressBarSegment {
-  percentage: number;
-  className?: string;
-}
-
 export type ProgressBarProps = Omit<
   React.HTMLAttributes<HTMLDivElement>,
   "children"
 > &
   VariantProps<typeof progressBarVariants> &
   (
-    | { percentage: number; segments?: never }
-    | { percentage?: never; segments: ProgressBarSegment[] }
+    | { percentage: number; values?: never }
+    | {
+        percentage?: never;
+        values: Array<{ value: number; className?: string }>;
+      }
   );
 
 export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   (
     {
       percentage,
-      segments,
+      values,
       radius = "full",
       variant = "default",
       className,
@@ -63,22 +61,32 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
     },
     ref
   ) => {
-    const isSegmented = segments !== undefined;
-    const values: ProgressBarSegment[] =
-      segments ?? (percentage === undefined ? [] : [{ percentage }]);
-    const clampedSegments = values.map((segment) => ({
-      ...segment,
-      percentage: Math.min(100, Math.max(0, segment.percentage)),
-    }));
+    const isSegmented = values !== undefined;
+    const nonNegativeValues =
+      values?.map((item) => ({
+        ...item,
+        value: Math.max(0, item.value),
+      })) ?? [];
+    const totalValue = nonNegativeValues.reduce(
+      (total, item) => total + item.value,
+      0
+    );
+    const normalizedValues = isSegmented
+      ? nonNegativeValues.map((item) => ({
+          percentage: totalValue > 0 ? (item.value / totalValue) * 100 : 0,
+          className: item.className,
+        }))
+      : [
+          {
+            percentage: Math.min(100, Math.max(0, percentage ?? 0)),
+            className: undefined,
+          },
+        ];
     const valueNow = isSegmented
-      ? Math.min(
-          100,
-          clampedSegments.reduce(
-            (total, segment) => total + segment.percentage,
-            0
-          )
-        )
-      : clampedSegments[0]?.percentage;
+      ? totalValue > 0
+        ? 100
+        : 0
+      : normalizedValues[0]?.percentage;
 
     return (
       <div
@@ -94,7 +102,7 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
         )}
         {...props}
       >
-        {clampedSegments.map((segment, index) =>
+        {normalizedValues.map((segment, index) =>
           !isSegmented || segment.percentage > 0 ? (
             <div
               key={index}

--- a/sparkle/src/components/ProgressBar.tsx
+++ b/sparkle/src/components/ProgressBar.tsx
@@ -82,17 +82,11 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
             className: undefined,
           },
         ];
-    const valueNow = isSegmented
-      ? totalValue > 0
-        ? 100
-        : 0
-      : normalizedValues[0]?.percentage;
-
     return (
       <div
         ref={ref}
         role="progressbar"
-        aria-valuenow={valueNow}
+        aria-valuenow={normalizedValues[0]?.percentage}
         aria-valuemin={0}
         aria-valuemax={100}
         className={cn(

--- a/sparkle/src/components/ProgressBar.tsx
+++ b/sparkle/src/components/ProgressBar.tsx
@@ -36,43 +36,49 @@ const progressBarFillVariants = cva("h-full", {
   },
 });
 
-interface ProgressBarBaseProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
-    VariantProps<typeof progressBarVariants> {
-  fillClassName?: string | string[];
+interface ProgressBarSegment {
+  percentage: number;
+  className?: string;
 }
 
-export type ProgressBarProps = ProgressBarBaseProps &
+export type ProgressBarProps = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "children"
+> &
+  VariantProps<typeof progressBarVariants> &
   (
-    | { percentage: number; percentages?: never }
-    | { percentage?: never; percentages: number[] }
+    | { percentage: number; segments?: never }
+    | { percentage?: never; segments: ProgressBarSegment[] }
   );
 
 export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   (
     {
       percentage,
-      percentages,
+      segments,
       radius = "full",
       variant = "default",
       className,
-      fillClassName,
       ...props
     },
     ref
   ) => {
-    const isSegmented = percentages !== undefined;
-    const values =
-      percentages ?? (percentage === undefined ? [] : [percentage]);
-    const clampedPercentages = values.map((value) =>
-      Math.min(100, Math.max(0, value))
-    );
+    const isSegmented = segments !== undefined;
+    const values: ProgressBarSegment[] =
+      segments ?? (percentage === undefined ? [] : [{ percentage }]);
+    const clampedSegments = values.map((segment) => ({
+      ...segment,
+      percentage: Math.min(100, Math.max(0, segment.percentage)),
+    }));
     const valueNow = isSegmented
       ? Math.min(
           100,
-          clampedPercentages.reduce((total, value) => total + value, 0)
+          clampedSegments.reduce(
+            (total, segment) => total + segment.percentage,
+            0
+          )
         )
-      : clampedPercentages[0];
+      : clampedSegments[0]?.percentage;
 
     return (
       <div
@@ -88,20 +94,18 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
         )}
         {...props}
       >
-        {clampedPercentages.map((value, index) =>
-          !isSegmented || value > 0 ? (
+        {clampedSegments.map((segment, index) =>
+          !isSegmented || segment.percentage > 0 ? (
             <div
               key={index}
               className={cn(
                 progressBarFillVariants({ radius, variant }),
-                Array.isArray(fillClassName)
-                  ? fillClassName[index]
-                  : fillClassName
+                segment.className
               )}
               style={
                 isSegmented
-                  ? { flexBasis: 0, flexGrow: value }
-                  : { width: `${value}%` }
+                  ? { flexBasis: 0, flexGrow: segment.percentage }
+                  : { width: `${segment.percentage}%` }
               }
             />
           ) : null

--- a/sparkle/src/components/ProgressBar.tsx
+++ b/sparkle/src/components/ProgressBar.tsx
@@ -36,17 +36,30 @@ const progressBarFillVariants = cva("h-full", {
   },
 });
 
-export interface ProgressBarProps
+interface ProgressBarBaseProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
     VariantProps<typeof progressBarVariants> {
   fillClassName?: string | string[];
-  percentage: number | number[];
 }
+
+interface SingleProgressBarProps {
+  percentage: number;
+  percentages?: never;
+}
+
+interface SegmentedProgressBarProps {
+  percentage?: never;
+  percentages: number[];
+}
+
+export type ProgressBarProps = ProgressBarBaseProps &
+  (SingleProgressBarProps | SegmentedProgressBarProps);
 
 export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
   (
     {
       percentage,
+      percentages,
       radius = "full",
       variant = "default",
       className,
@@ -55,9 +68,11 @@ export const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
     },
     ref
   ) => {
-    const isSegmented = Array.isArray(percentage);
-    const clampedPercentages = (isSegmented ? percentage : [percentage]).map(
-      (value) => Math.min(100, Math.max(0, value))
+    const isSegmented = percentages !== undefined;
+    const values =
+      percentages ?? (percentage === undefined ? [] : [percentage]);
+    const clampedPercentages = values.map((value) =>
+      Math.min(100, Math.max(0, value))
     );
     const valueNow = isSegmented
       ? Math.min(

--- a/sparkle/src/stories/ProgressBar.stories.tsx
+++ b/sparkle/src/stories/ProgressBar.stories.tsx
@@ -16,6 +16,8 @@ const meta = {
 
 **Guidelines**
 - Pass a \`percentage\` between 0 and 100; out-of-range values are clamped.
+- Pass an array of percentages to render adjacent segments separated by a 2px gap. Use \`fillClassName\` to style each segment.
+- Use \`radius\` to switch between square, extra-small, and fully rounded corners.
 - Control the bar's width via \`className\` (e.g. \`w-24\`, \`w-full\`).`,
       },
     },
@@ -45,5 +47,16 @@ export const Percentages: Story = {
         <ProgressBar key={percentage} percentage={percentage} />
       ))}
     </div>
+  ),
+};
+
+export const Segmented: Story = {
+  render: () => (
+    <ProgressBar
+      className="h-2 w-48 bg-background"
+      fillClassName={["bg-highlight-500", "bg-highlight-100", "bg-gray-50"]}
+      percentage={[35, 20, 45]}
+      radius="xs"
+    />
   ),
 };

--- a/sparkle/src/stories/ProgressBar.stories.tsx
+++ b/sparkle/src/stories/ProgressBar.stories.tsx
@@ -54,7 +54,11 @@ export const Segmented: Story = {
   render: () => (
     <ProgressBar
       className="h-2 w-48 bg-background"
-      fillClassName={["bg-highlight-500", "bg-highlight-100", "bg-gray-50"]}
+      fillClassName={[
+        "bg-highlight-500",
+        "bg-highlight-100",
+        "bg-muted-background",
+      ]}
       percentages={[35, 20, 45]}
       radius="xs"
     />

--- a/sparkle/src/stories/ProgressBar.stories.tsx
+++ b/sparkle/src/stories/ProgressBar.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
 
 **Guidelines**
 - Pass a \`percentage\` between 0 and 100; out-of-range values are clamped.
-- Pass an array of percentages to render adjacent segments separated by a 2px gap. Use \`fillClassName\` to style each segment.
+- Pass an array to \`percentages\` to render adjacent segments separated by a 2px gap. Use \`fillClassName\` to style each segment.
 - Use \`radius\` to switch between square, extra-small, and fully rounded corners.
 - Control the bar's width via \`className\` (e.g. \`w-24\`, \`w-full\`).`,
       },
@@ -55,7 +55,7 @@ export const Segmented: Story = {
     <ProgressBar
       className="h-2 w-48 bg-background"
       fillClassName={["bg-highlight-500", "bg-highlight-100", "bg-gray-50"]}
-      percentage={[35, 20, 45]}
+      percentages={[35, 20, 45]}
       radius="xs"
     />
   ),

--- a/sparkle/src/stories/ProgressBar.stories.tsx
+++ b/sparkle/src/stories/ProgressBar.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
 
 **Guidelines**
 - Pass a \`percentage\` between 0 and 100; out-of-range values are clamped.
-- Pass an array to \`percentages\` to render adjacent segments separated by a 2px gap. Use \`fillClassName\` to style each segment.
+- Pass an array to \`segments\` to render adjacent segments separated by a 2px gap. Each segment pairs its \`percentage\` with an optional \`className\`.
 - Use \`radius\` to switch between square, extra-small, and fully rounded corners.
 - Control the bar's width via \`className\` (e.g. \`w-24\`, \`w-full\`).`,
       },
@@ -54,12 +54,11 @@ export const Segmented: Story = {
   render: () => (
     <ProgressBar
       className="h-2 w-48 bg-background"
-      fillClassName={[
-        "bg-highlight-500",
-        "bg-highlight-100",
-        "bg-muted-background",
+      segments={[
+        { percentage: 35, className: "bg-highlight-500" },
+        { percentage: 20, className: "bg-highlight-100" },
+        { percentage: 45, className: "bg-muted-background" },
       ]}
-      percentages={[35, 20, 45]}
       radius="xs"
     />
   ),

--- a/sparkle/src/stories/ProgressBar.stories.tsx
+++ b/sparkle/src/stories/ProgressBar.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
 
 **Guidelines**
 - Pass a \`percentage\` between 0 and 100; out-of-range values are clamped.
-- Pass an array to \`segments\` to render adjacent segments separated by a 2px gap. Each segment pairs its \`percentage\` with an optional \`className\`.
+- Pass an array to \`values\` to render adjacent segments separated by a 2px gap. Each entry pairs its \`value\` with an optional \`className\`; values are normalized to total 100.
 - Use \`radius\` to switch between square, extra-small, and fully rounded corners.
 - Control the bar's width via \`className\` (e.g. \`w-24\`, \`w-full\`).`,
       },
@@ -54,10 +54,10 @@ export const Segmented: Story = {
   render: () => (
     <ProgressBar
       className="h-2 w-48 bg-background"
-      segments={[
-        { percentage: 35, className: "bg-highlight-500" },
-        { percentage: 20, className: "bg-highlight-100" },
-        { percentage: 45, className: "bg-muted-background" },
+      values={[
+        { value: 7, className: "bg-highlight-500" },
+        { value: 4, className: "bg-highlight-100" },
+        { value: 9, className: "bg-muted-background" },
       ]}
       radius="xs"
     />


### PR DESCRIPTION
## Description

The workspace credit usage bar shows the used, projected, and remaining credits as a progress bar (actually a succession of 3 little segments with a tiny gap).

This PR extends the `ProgressBar` component to support this behavior. It now accepts either one percentage or an array of values. Segmented bars keep a 2px gap, support per-segment colors and configurable radius.

Also added a customizable border radius.

## Tests

- Added a segmented Storybook story.
- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
