### PR TITLE
feat(agent_inactivity): add inactive agent archival business rules

### DIFF
--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
@@ -1,0 +1,234 @@
+import {
+  archiveAgentConfiguration,
+  getAgentConfigurations,
+} from "@app/lib/api/assistant/configuration/agent";
+import type {
+  AgentArchivalExclusionReason,
+  AgentInactivityPolicyError,
+  AgentInactivitySnapshot,
+  AgentTriggerSnapshot,
+} from "@app/lib/api/assistant/inactivity/policy";
+import {
+  computeInactivityCutoffAt,
+  evaluateAgentArchivalEligibility,
+} from "@app/lib/api/assistant/inactivity/policy";
+import type { Authenticator } from "@app/lib/auth";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import logger from "@app/logger/logger";
+import type { AgentConfigurationStatus } from "@app/types/assistant/agent";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * Archives a workspace's inactive agents: resolve the threshold into a cutoff, load the agents,
+ * judge each one against the rules in `policy.ts`, and archive those that are eligible.
+ *
+ * The manual endpoints and the nightly Temporal activity both enter here, so the rules cannot drift
+ * between them. The population can: every read is permission-filtered, so a manual run only ever
+ * considers the agents its caller can see, where the nightly run sees the whole workspace.
+ *
+ * The rules are applied against state re-read for the page rather than against what the fetch
+ * loaded, because the two do not answer the same question: the fetch finds candidates, the re-read
+ * goes through `getAgentConfigurations` and is therefore permission-filtered. That is also what
+ * makes a Temporal retry safe — replaying the same input re-reads an agent the first attempt
+ * archived, sees `archived`, and skips it instead of emitting a second `agent.archived` audit event.
+ *
+ * Archiving itself stays the existing `archiveAgentConfiguration` primitive, which owns the side
+ * effects (trigger disabling, wake-up cancellation, editor group suspension, audit event).
+ */
+
+/**
+ * Why an agent this operation looked at was not archived: the rules' own exclusions, plus the two
+ * outcomes only the mutation path can produce and that the rules therefore never see.
+ */
+export type AgentArchivalSkipReason =
+  | AgentArchivalExclusionReason
+  // The configuration disappeared, or is not visible to this actor, between the fetch and the
+  // re-read.
+  | "agent_not_found"
+  // The archival update matched no row: someone else archived the agent in the meantime.
+  | "archive_raced";
+
+export interface AgentArchivalSkip {
+  agentId: string;
+  reason: AgentArchivalSkipReason;
+}
+
+export interface InactiveAgentsArchivalInput {
+  thresholdDays: number;
+  evaluatedAt: Date;
+}
+
+export interface InactiveAgentsArchival {
+  evaluatedAt: Date;
+  cutoffAt: Date;
+  archivedAgentIds: string[];
+  skipped: AgentArchivalSkip[];
+}
+
+export type InactiveAgentsArchivalResult = Result<
+  InactiveAgentsArchival,
+  AgentInactivityPolicyError
+>;
+
+/** The facts the rules read about an agent, as they stand at the moment the page is judged. */
+interface AgentArchivalFacts {
+  status: AgentConfigurationStatus;
+  triggers: AgentTriggerSnapshot[];
+}
+
+type SkipCountsByReason = Partial<Record<AgentArchivalSkipReason, number>>;
+
+function countSkipsByReason(skipped: AgentArchivalSkip[]): SkipCountsByReason {
+  const counts: SkipCountsByReason = {};
+  for (const { reason } of skipped) {
+    counts[reason] = (counts[reason] ?? 0) + 1;
+  }
+
+  return counts;
+}
+
+/**
+ * Re-reads the whole page's facts in two batched queries, before any agent of it is judged. An
+ * agent missing from the returned map is one this actor cannot currently read.
+ */
+async function fetchArchivalFacts(
+  auth: Authenticator,
+  agentIds: string[]
+): Promise<Map<string, AgentArchivalFacts>> {
+  if (agentIds.length === 0) {
+    return new Map();
+  }
+
+  const configurations = await getAgentConfigurations(auth, {
+    agentIds,
+    variant: "light",
+  });
+
+  const triggers = await TriggerResource.listByAgentConfigurationIds(
+    auth,
+    agentIds
+  );
+
+  const triggersByAgentId = new Map<string, AgentTriggerSnapshot[]>();
+  for (const { agentConfigurationId, kind, status } of triggers) {
+    const agentTriggers = triggersByAgentId.get(agentConfigurationId) ?? [];
+    agentTriggers.push({ kind, status });
+    triggersByAgentId.set(agentConfigurationId, agentTriggers);
+  }
+
+  return new Map(
+    configurations.map(({ sId, status }) => [
+      sId,
+      { status, triggers: triggersByAgentId.get(sId) ?? [] },
+    ])
+  );
+}
+
+/**
+ * Safe to call twice: an agent archived by a first attempt re-reads as `archived` in a second and is
+ * skipped, so a Temporal activity retry cannot double-archive or emit a second `agent.archived`
+ * audit event.
+ */
+export async function archiveInactiveWorkspaceAgents(
+  auth: Authenticator,
+  { thresholdDays, evaluatedAt }: InactiveAgentsArchivalInput
+): Promise<InactiveAgentsArchivalResult> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const cutoffRes = computeInactivityCutoffAt({ thresholdDays, evaluatedAt });
+  if (cutoffRes.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        thresholdDays,
+        err: cutoffRes.error,
+      },
+      "Cannot archive inactive agents: unusable workspace inactivity policy"
+    );
+    return new Err(cutoffRes.error);
+  }
+  const cutoffAt = cutoffRes.value;
+
+  // TODO(2026-08-19 INACTIVE_AGENT_ARCHIVAL): load the workspace's candidate agents and, for each,
+  // when it was last mentioned. Deferred until the mentions query exists; the page bound (cursor,
+  // limit) becomes an input of this use case then, and `nextCursor` part of its result, so the
+  // caller keeps owning the loop. Status and triggers do not need to come back with it —
+  // `fetchArchivalFacts` is the authority on those, since it is the permission-filtered read.
+  //
+  // Read from the `mentions` table, not from `agentMentionsCount` in `agent_usage.ts`: its Redis
+  // cache only goes back 30 days, which is shorter than the thresholds this feature exists for, and
+  // the Elasticsearch index behind it is best-effort. Neither is a basis for a destructive decision.
+  // const { agents, nextCursor } = await fetchInactiveAgents(auth, { cutoffAt, cursor, limit });
+  const agents: AgentInactivitySnapshot[] = [];
+
+  const factsByAgentId = await fetchArchivalFacts(
+    auth,
+    agents.map(({ agentId }) => agentId)
+  );
+
+  const archivedAgentIds: string[] = [];
+  // Skips are not logged per agent: they are the common case, and one line per agent per night
+  // would drown the archivals. The run summary below carries the counts by reason.
+  const skipped: AgentArchivalSkip[] = [];
+
+  for (const agent of agents) {
+    const { agentId } = agent;
+
+    const facts = factsByAgentId.get(agentId);
+    if (!facts) {
+      skipped.push({ agentId, reason: "agent_not_found" });
+      continue;
+    }
+
+    const eligibility = evaluateAgentArchivalEligibility({
+      agent: { ...agent, ...facts },
+      cutoffAt,
+    });
+
+    if (!eligibility.eligible) {
+      skipped.push({ agentId, reason: eligibility.reason });
+      continue;
+    }
+
+    // The decision comes from the page's re-read, so the window before this mutation is the page's
+    // processing time: an agent mentioned or restored during it is archived anyway, and has to be
+    // restored by hand. Closing that window properly means a compare-and-set in
+    // `archiveAgentConfiguration` — an `expectedStatus` narrowing its `where` clause, which would
+    // make the mutation itself refuse an agent that stopped being active. Deliberately not done:
+    // it moves a business rule out of `policy.ts` and into a SQL predicate, and the exposure is one
+    // reversible archival on a page that takes seconds. Revisit if pages get long.
+    const archived = await archiveAgentConfiguration(auth, agentId);
+    if (!archived) {
+      skipped.push({ agentId, reason: "archive_raced" });
+      continue;
+    }
+
+    archivedAgentIds.push(agentId);
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        agentId,
+        lastMentionedAt: agent.lastMentionedAt,
+        cutoffAt,
+        thresholdDays,
+      },
+      "Archived inactive agent"
+    );
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      thresholdDays,
+      evaluatedAt,
+      cutoffAt,
+      archivedCount: archivedAgentIds.length,
+      skippedCount: skipped.length,
+      skippedCountByReason: countSkipsByReason(skipped),
+    },
+    "Finished archiving inactive agents"
+  );
+
+  return new Ok({ evaluatedAt, cutoffAt, archivedAgentIds, skipped });
+}

--- a/front/lib/api/assistant/inactivity/policy.test.ts
+++ b/front/lib/api/assistant/inactivity/policy.test.ts
@@ -1,0 +1,396 @@
+import type {
+  AgentInactivitySnapshot,
+  AgentTriggerSnapshot,
+} from "@app/lib/api/assistant/inactivity/policy";
+import {
+  computeInactivityCutoffAt,
+  evaluateAgentArchivalEligibility,
+  MAX_INACTIVITY_THRESHOLD_DAYS,
+  MIN_INACTIVITY_THRESHOLD_DAYS,
+} from "@app/lib/api/assistant/inactivity/policy";
+import type { AgentConfigurationStatus } from "@app/types/assistant/agent";
+import type { TriggerStatus } from "@app/types/assistant/triggers";
+import { describe, expect, it } from "vitest";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const EVALUATED_AT = new Date("2026-08-18T09:00:00.000Z");
+
+const THRESHOLD_30_DAYS = 30;
+
+function agent(
+  overrides: Partial<AgentInactivitySnapshot> = {}
+): AgentInactivitySnapshot {
+  return {
+    agentId: "agent_12345",
+    // Old enough that tests which say nothing about creation are testing what they mean to.
+    createdAt: new Date("2020-01-01T00:00:00.000Z"),
+    lastMentionedAt: null,
+    status: "active",
+    triggers: [],
+    ...overrides,
+  };
+}
+
+function scheduleTrigger(status: TriggerStatus): AgentTriggerSnapshot {
+  return { kind: "schedule", status };
+}
+
+function daysBeforeEvaluation(days: number): Date {
+  return new Date(EVALUATED_AT.getTime() - days * ONE_DAY_MS);
+}
+
+/** The cutoff for the 30-day threshold, which every eligibility test below evaluates against. */
+function cutoffFor(thresholdDays: number): Date {
+  const cutoffRes = computeInactivityCutoffAt({
+    thresholdDays,
+    evaluatedAt: EVALUATED_AT,
+  });
+  if (cutoffRes.isErr()) {
+    throw cutoffRes.error;
+  }
+  return cutoffRes.value;
+}
+
+const CUTOFF_30_DAYS = cutoffFor(THRESHOLD_30_DAYS);
+
+describe("computeInactivityCutoffAt", () => {
+  it("subtracts the threshold and truncates to the start of the UTC day", () => {
+    const cutoffRes = computeInactivityCutoffAt({
+      thresholdDays: THRESHOLD_30_DAYS,
+      evaluatedAt: EVALUATED_AT,
+    });
+
+    expect(cutoffRes.isOk()).toBe(true);
+    expect(cutoffRes.isOk() && cutoffRes.value).toEqual(
+      new Date("2026-07-19T00:00:00.000Z")
+    );
+  });
+
+  it("resolves the minimum threshold", () => {
+    const cutoffRes = computeInactivityCutoffAt({
+      thresholdDays: MIN_INACTIVITY_THRESHOLD_DAYS,
+      evaluatedAt: EVALUATED_AT,
+    });
+
+    expect(cutoffRes.isOk()).toBe(true);
+    expect(cutoffRes.isOk() && cutoffRes.value).toEqual(
+      new Date("2026-08-16T00:00:00.000Z")
+    );
+  });
+
+  it("ignores the time of day, so every run on one date shares a cutoff", () => {
+    // A nightly job at 02:00 and an admin previewing at 17:00 must judge every agent identically.
+    const nightly = computeInactivityCutoffAt({
+      thresholdDays: THRESHOLD_30_DAYS,
+      evaluatedAt: new Date("2026-08-18T02:00:00.000Z"),
+    });
+    const afternoon = computeInactivityCutoffAt({
+      thresholdDays: THRESHOLD_30_DAYS,
+      evaluatedAt: new Date("2026-08-18T17:45:12.345Z"),
+    });
+
+    expect(nightly.isOk() && nightly.value).toEqual(
+      new Date("2026-07-19T00:00:00.000Z")
+    );
+    expect(afternoon.isOk() && afternoon.value).toEqual(
+      new Date("2026-07-19T00:00:00.000Z")
+    );
+  });
+
+  it("resolves the maximum threshold", () => {
+    expect(MAX_INACTIVITY_THRESHOLD_DAYS).toBe(366);
+
+    const cutoffRes = computeInactivityCutoffAt({
+      thresholdDays: MAX_INACTIVITY_THRESHOLD_DAYS,
+      evaluatedAt: EVALUATED_AT,
+    });
+
+    expect(cutoffRes.isOk()).toBe(true);
+    expect(cutoffRes.isOk() && cutoffRes.value).toEqual(
+      new Date("2025-08-17T00:00:00.000Z")
+    );
+  });
+
+  it("fails on every invalid threshold, so nothing can be archived", () => {
+    const invalidThresholds = [
+      1,
+      0,
+      -1,
+      -5,
+      2.5,
+      NaN,
+      Infinity,
+      // A year is fine; a decade is a typo that would silently archive nothing forever.
+      MAX_INACTIVITY_THRESHOLD_DAYS + 1,
+      3650,
+      // Large enough that the cutoff arithmetic overflows to an Invalid Date, which
+      // `Number.isInteger` alone would have let through and bound straight into SQL.
+      Number.MAX_SAFE_INTEGER,
+    ];
+
+    for (const thresholdDays of invalidThresholds) {
+      const cutoffRes = computeInactivityCutoffAt({
+        thresholdDays,
+        evaluatedAt: EVALUATED_AT,
+      });
+
+      expect(cutoffRes.isErr()).toBe(true);
+      expect(cutoffRes.isErr() && cutoffRes.error.type).toBe(
+        "invalid_threshold"
+      );
+    }
+  });
+
+  it("reports the offending threshold in the error message", () => {
+    const cutoffRes = computeInactivityCutoffAt({
+      thresholdDays: 1,
+      evaluatedAt: EVALUATED_AT,
+    });
+
+    expect(cutoffRes.isErr() && cutoffRes.error.message).toContain("got 1");
+  });
+});
+
+describe("evaluateAgentArchivalEligibility", () => {
+  it("keeps an agent created after the cutoff, however unused", () => {
+    // A young agent has not existed long enough to have fallen out of use. Without this rule the
+    // first nightly run after somebody builds an agent archives it.
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({
+          createdAt: daysBeforeEvaluation(5),
+          lastMentionedAt: null,
+        }),
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: false, reason: "recent_creation" });
+  });
+
+  it("puts the creation boundary where the mention boundary is", () => {
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({ createdAt: new Date(CUTOFF_30_DAYS.getTime() - 1) }),
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: true });
+
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({ createdAt: CUTOFF_30_DAYS }),
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: false, reason: "recent_creation" });
+  });
+
+  it("archives an agent that was never mentioned", () => {
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({ lastMentionedAt: null }),
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: true });
+  });
+
+  it("archives an agent whose last mention predates the cutoff", () => {
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({ lastMentionedAt: daysBeforeEvaluation(31) }),
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: true });
+  });
+
+  it("keeps an agent whose last mention is more recent than the cutoff", () => {
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({ lastMentionedAt: daysBeforeEvaluation(29) }),
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: false, reason: "recent_mention" });
+  });
+
+  describe("cutoff boundary", () => {
+    it("keeps an agent whose mention lands exactly on the cutoff", () => {
+      expect(
+        evaluateAgentArchivalEligibility({
+          agent: agent({ lastMentionedAt: CUTOFF_30_DAYS }),
+          cutoffAt: CUTOFF_30_DAYS,
+        })
+      ).toEqual({ eligible: false, reason: "recent_mention" });
+    });
+
+    it("archives an agent one millisecond before the cutoff", () => {
+      expect(
+        evaluateAgentArchivalEligibility({
+          agent: agent({
+            lastMentionedAt: new Date(CUTOFF_30_DAYS.getTime() - 1),
+          }),
+          cutoffAt: CUTOFF_30_DAYS,
+        })
+      ).toEqual({ eligible: true });
+    });
+  });
+
+  describe("schedule exemption", () => {
+    it("exempts an agent with an enabled schedule trigger, however inactive", () => {
+      expect(
+        evaluateAgentArchivalEligibility({
+          agent: agent({
+            lastMentionedAt: null,
+            triggers: [scheduleTrigger("enabled")],
+          }),
+          cutoffAt: CUTOFF_30_DAYS,
+        })
+      ).toEqual({ eligible: false, reason: "active_schedule" });
+    });
+
+    it("exempts an agent whose schedule Dust paused, not the workspace", () => {
+      // Workspace relocation and plan downgrade flip every enabled trigger of a workspace in bulk.
+      // Reading those as "no schedule" would archive every scheduled agent of a workspace that
+      // happens to be mid-relocation.
+      const dustPausedStatuses: TriggerStatus[] = ["relocating", "downgraded"];
+
+      for (const status of dustPausedStatuses) {
+        expect(
+          evaluateAgentArchivalEligibility({
+            agent: agent({
+              lastMentionedAt: null,
+              triggers: [scheduleTrigger(status)],
+            }),
+            cutoffAt: CUTOFF_30_DAYS,
+          })
+        ).toEqual({ eligible: false, reason: "active_schedule" });
+      }
+    });
+
+    it("does not exempt an agent whose schedule the workspace turned off", () => {
+      const workspaceDisabledStatuses: TriggerStatus[] = [
+        "disabled",
+        "disabled_by_manager",
+      ];
+
+      for (const status of workspaceDisabledStatuses) {
+        expect(
+          evaluateAgentArchivalEligibility({
+            agent: agent({
+              lastMentionedAt: null,
+              triggers: [scheduleTrigger(status)],
+            }),
+            cutoffAt: CUTOFF_30_DAYS,
+          })
+        ).toEqual({ eligible: true });
+      }
+    });
+
+    it("does not exempt an agent that only has a webhook trigger", () => {
+      expect(
+        evaluateAgentArchivalEligibility({
+          agent: agent({
+            lastMentionedAt: null,
+            triggers: [{ kind: "webhook", status: "enabled" }],
+          }),
+          cutoffAt: CUTOFF_30_DAYS,
+        })
+      ).toEqual({ eligible: true });
+    });
+
+    it("exempts on any one protecting trigger among several", () => {
+      expect(
+        evaluateAgentArchivalEligibility({
+          agent: agent({
+            lastMentionedAt: null,
+            triggers: [
+              scheduleTrigger("disabled"),
+              { kind: "webhook", status: "enabled" },
+              scheduleTrigger("relocating"),
+            ],
+          }),
+          cutoffAt: CUTOFF_30_DAYS,
+        })
+      ).toEqual({ eligible: false, reason: "active_schedule" });
+    });
+  });
+
+  it("does not exempt an agent that only has pending wake-ups", () => {
+    // Wake-ups are a delayed continuation of one conversation, not a durable automation, so they are
+    // not represented in the snapshot at all: an inactive agent stays eligible.
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({
+          lastMentionedAt: daysBeforeEvaluation(31),
+          triggers: [],
+        }),
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: true });
+  });
+
+  it("excludes agents that are not active", () => {
+    // `disabled_by_admin`, `disabled_missing_datasource` and `disabled_free_workspace` only ever
+    // belong to global agents: a workspace policy has no business retiring an agent it does not own.
+    const nonActiveStatuses: AgentConfigurationStatus[] = [
+      "archived",
+      "draft",
+      "pending",
+      "disabled_by_admin",
+      "disabled_missing_datasource",
+      "disabled_free_workspace",
+    ];
+
+    for (const status of nonActiveStatuses) {
+      expect(
+        evaluateAgentArchivalEligibility({
+          agent: agent({ status, lastMentionedAt: null }),
+          cutoffAt: CUTOFF_30_DAYS,
+        })
+      ).toEqual({ eligible: false, reason: "agent_not_active" });
+    }
+  });
+
+  it("reports the status exclusion before any activity-based reason", () => {
+    // An already-archived agent must never read as "recently used": a repeated run has to be a
+    // no-op for the same machine-readable reason every time.
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({
+          status: "archived",
+          triggers: [scheduleTrigger("enabled")],
+          lastMentionedAt: EVALUATED_AT,
+        }),
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: false, reason: "agent_not_active" });
+  });
+
+  it("archives at the minimum threshold", () => {
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: agent({ lastMentionedAt: daysBeforeEvaluation(3) }),
+        cutoffAt: cutoffFor(MIN_INACTIVITY_THRESHOLD_DAYS),
+      })
+    ).toEqual({ eligible: true });
+  });
+
+  it("is deterministic for a given cutoff", () => {
+    const snapshot = agent({
+      lastMentionedAt: daysBeforeEvaluation(30),
+    });
+
+    // Same agent, same cutoff: same decision. Evaluated a day later — i.e. against a cutoff that has
+    // moved past its last mention — the very same snapshot becomes eligible.
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: snapshot,
+        cutoffAt: CUTOFF_30_DAYS,
+      })
+    ).toEqual({ eligible: false, reason: "recent_mention" });
+
+    expect(
+      evaluateAgentArchivalEligibility({
+        agent: snapshot,
+        cutoffAt: new Date(CUTOFF_30_DAYS.getTime() + ONE_DAY_MS),
+      })
+    ).toEqual({ eligible: true });
+  });
+});

--- a/front/lib/api/assistant/inactivity/policy.ts
+++ b/front/lib/api/assistant/inactivity/policy.ts
@@ -1,0 +1,240 @@
+import type { AgentConfigurationStatus } from "@app/types/assistant/agent";
+import type { TriggerKind, TriggerStatus } from "@app/types/assistant/triggers";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+/**
+ * Business rules for the "automatically archive inactive agents" feature.
+ *
+ * This module is deliberately pure: no database, no Temporal, no HTTP, no Authenticator. It only
+ * answers one question — "given what we know about a logical agent, is it eligible for automatic
+ * archival?" — so that the manual (synchronous API) path and the nightly (Temporal) path share the
+ * exact same decision and can both be tested without infrastructure.
+ *
+ * The rules:
+ *
+ * - Opt-in per workspace : no threshold configured, nothing archived. There is no default.
+ * - Threshold between 2 and 366 days : a whole number of days; anything else archives nothing.
+ * - Mentions are the only activity : any mention resets it, whatever became of the run it started.
+ * - Creating or editing an agent is not activity : only being reached for counts. Editing in
+ *   particular must not push archival back, so what counts is when the agent first appeared, not
+ *   when its current version was written.
+ * - An agent must predate the cutoff : one created inside the window has not existed long enough to
+ *   have fallen out of use, whatever its mentions say.
+ * - Inactive means last mentioned before the cutoff : never mentioned counts as inactive.
+ * - Only active agents are archivable : archived, draft and pending ones are left alone.
+ * - Schedules are exempt : never archive an agent a schedule still drives, whatever its frequency —
+ *   including one Dust itself paused (relocation, plan downgrade), which the workspace never chose
+ *   to stop.
+ * - Wake-ups are not exempt : a pending wake-up does not protect an agent, and archiving cancels it.
+ *
+ * Archival itself goes through the existing `archiveAgentConfiguration` primitive, which owns every
+ * side effect (trigger disabling, wake-up cancellation, editor group suspension, audit event).
+ */
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+// Archiving after a single day of inactivity is never a legitimate policy: it would archive agents
+// used weekly, or an agent created over a weekend. Two days is the product-agreed floor.
+export const MIN_INACTIVITY_THRESHOLD_DAYS = 2;
+
+// A year and a leap day. Guards a typo (3650 for 365), which would silently archive nothing forever,
+// and a value large enough to overflow the cutoff arithmetic into an Invalid Date.
+export const MAX_INACTIVITY_THRESHOLD_DAYS = 366;
+
+type AgentInactivityPolicyErrorType = "invalid_threshold";
+
+export class AgentInactivityPolicyError extends Error {
+  constructor(
+    readonly type: AgentInactivityPolicyErrorType,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export interface AgentInactivityCutoffInput {
+  // The workspace-level threshold, owned by the workspace and configured in Governance. Always
+  // explicit — there is no fallback value in this module.
+  thresholdDays: number;
+  evaluatedAt: Date;
+}
+
+export type AgentInactivityCutoffResult = Result<
+  Date,
+  AgentInactivityPolicyError
+>;
+
+/** One logical agent — the stable `sId`, not a configuration version. */
+export interface AgentInactivitySnapshot {
+  agentId: string;
+  // The earliest version's creation, not the active row's: upgrading inserts a new row, so the
+  // active row's date is the last edit, and editing must not postpone archival.
+  createdAt: Date;
+  // Null means never mentioned.
+  lastMentionedAt: Date | null;
+  status: AgentConfigurationStatus;
+  // All of them. Which ones protect the agent is `doesTriggerPreventArchival`'s call.
+  triggers: AgentTriggerSnapshot[];
+}
+
+/** Not a `TriggerResource`: the rules only ask what kind of automation it is and whether it runs. */
+export interface AgentTriggerSnapshot {
+  kind: TriggerKind;
+  status: TriggerStatus;
+}
+
+export type AgentArchivalExclusionReason =
+  | "agent_not_active"
+  | "active_schedule"
+  | "recent_creation"
+  | "recent_mention";
+
+export type AgentArchivalEligibility =
+  | { eligible: true }
+  | { eligible: false; reason: AgentArchivalExclusionReason };
+
+export interface AgentArchivalEvaluationInput {
+  agent: AgentInactivitySnapshot;
+  // Resolved once per operation by `computeInactivityCutoffAt` and shared by every agent of that
+  // operation, so the cutoff cannot drift mid-batch.
+  cutoffAt: Date;
+}
+
+// Module-private: callers validate a threshold by resolving a cutoff from it, so there is one way to
+// be told a policy is unusable.
+function isValidInactivityThresholdDays(thresholdDays: number): boolean {
+  return (
+    Number.isInteger(thresholdDays) &&
+    thresholdDays >= MIN_INACTIVITY_THRESHOLD_DAYS &&
+    thresholdDays <= MAX_INACTIVITY_THRESHOLD_DAYS
+  );
+}
+
+/**
+ * The day an agent must have been inactive since to be archivable.
+ *
+ * A day boundary rather than an instant, because the threshold is in whole days: a nightly run at
+ * 02:00 and an admin previewing at 17:00 then judge every agent identically, and truncating downwards
+ * only ever grants more grace than asked for.
+ */
+export function computeInactivityCutoffAt({
+  thresholdDays,
+  evaluatedAt,
+}: AgentInactivityCutoffInput): AgentInactivityCutoffResult {
+  if (!isValidInactivityThresholdDays(thresholdDays)) {
+    return new Err(
+      new AgentInactivityPolicyError(
+        "invalid_threshold",
+        `Inactivity threshold must be a whole number of days between ` +
+          `${MIN_INACTIVITY_THRESHOLD_DAYS} and ${MAX_INACTIVITY_THRESHOLD_DAYS} ` +
+          `(got ${thresholdDays}).`
+      )
+    );
+  }
+
+  const cutoffAt = new Date(evaluatedAt.getTime() - thresholdDays * ONE_DAY_MS);
+  cutoffAt.setUTCHours(0, 0, 0, 0);
+
+  return new Ok(cutoffAt);
+}
+
+/** Only `active` agents are candidates. Drafts, pending and already-archived agents are not. */
+function isArchivableStatus(status: AgentConfigurationStatus): boolean {
+  switch (status) {
+    case "active":
+      return true;
+    case "archived":
+    case "draft":
+    case "pending":
+    case "disabled_by_admin":
+    case "disabled_missing_datasource":
+    case "disabled_free_workspace":
+      return false;
+    default:
+      return assertNever(status);
+  }
+}
+
+/**
+ * Only schedules protect an agent: they drive it on their own, so one nobody mentions can still run
+ * every night.
+ *
+ * Protection drops only on a status the workspace itself chose. `relocating` and `downgraded` are set
+ * in bulk by Dust on triggers meant to be enabled again, so reading them as "no schedule" would
+ * archive every scheduled agent of a workspace mid-relocation.
+ */
+export function doesTriggerPreventArchival({
+  kind,
+  status,
+}: AgentTriggerSnapshot): boolean {
+  if (kind !== "schedule") {
+    return false;
+  }
+
+  switch (status) {
+    case "enabled":
+    // Paused by Dust and not by the workspace: the schedule is expected to resume.
+    case "relocating":
+    case "downgraded":
+      return true;
+    case "disabled":
+    case "disabled_by_manager":
+      return false;
+    default:
+      return assertNever(status);
+  }
+}
+
+/**
+ * Decides whether one logical agent is eligible for automatic archival, against a cutoff already
+ * resolved by `computeInactivityCutoffAt`.
+ *
+ * Both branches are legitimate business outcomes, so this returns a decision rather than a
+ * `Result`: "not eligible" is an answer, not a failure. Exclusions are ordered from the cheapest and
+ * most decisive check to the activity comparison.
+ */
+export function evaluateAgentArchivalEligibility({
+  agent,
+  cutoffAt,
+}: AgentArchivalEvaluationInput): AgentArchivalEligibility {
+  if (!isArchivableStatus(agent.status)) {
+    return {
+      eligible: false,
+      reason: "agent_not_active",
+    };
+  }
+
+  if (agent.triggers.some(doesTriggerPreventArchival)) {
+    return {
+      eligible: false,
+      reason: "active_schedule",
+    };
+  }
+
+  // Checked before the mentions, because a young agent is protected whatever they say: one created
+  // inside the window has not existed long enough to have fallen out of use.
+  if (agent.createdAt.getTime() >= cutoffAt.getTime()) {
+    return {
+      eligible: false,
+      reason: "recent_creation",
+    };
+  }
+
+  // Never mentioned: nothing has ever reset inactivity, so the agent is inactive.
+  if (!agent.lastMentionedAt) {
+    return { eligible: true };
+  }
+
+  // Strictly before the cutoff. A mention landing exactly on the cutoff counts as recent, so a
+  // threshold of N days always leaves a full N days of grace.
+  if (agent.lastMentionedAt.getTime() < cutoffAt.getTime()) {
+    return { eligible: true };
+  }
+
+  return {
+    eligible: false,
+    reason: "recent_mention",
+  };
+}


### PR DESCRIPTION
## Description

First brick of the opt-in "automatically archive inactive agents" feature: the business rules and the application layer that drives them. No PostgreSQL, Temporal, HTTP or adapters yet — this only encodes and tests the agreed rules.

- inactivity/policy.ts: domain rules. Threshold validation (integer, 2 days minimum, no implicit default), cutoff resolution and per-agent eligibility, with machine-readable exclusion reasons.
- inactivity/evaluate_inactive_agents.ts: application layer. Splits a batch of agents into eligible ids and reasoned exclusions, against a cutoff resolved once per operation so it cannot drift mid-batch.

An invalid threshold is returned as an Err for the whole operation rather than as a per-agent exclusion, so a misconfigured workspace can never be mistaken for "no agent to archive".

Activity is read from mentions rather than agent messages: mention rows carry the stable agent sId with no configuration version, their createdAt is never null, and (workspaceId, agentConfigurationId, createdAt) is already indexed. Any mention counts, whatever became of the run it started.

## Tests

Business logic, unit tests only. 

## Risk

Not called yet. 

## Deploy Plan

None
