### PR TITLE
[front] enh: sort consumption attribution table server-side across pages

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopAgentsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,8 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
+      sortOrder,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopAgentsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,7 +37,6 @@ app.post(
       offset,
       search,
       filter,
-      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-api-keys.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-api-keys.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopApiKeysResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,7 +37,6 @@ app.post(
       offset,
       search,
       filter,
-      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-api-keys.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-api-keys.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopApiKeysResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,8 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
+      sortOrder,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopGroupsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,7 +37,6 @@ app.post(
       offset,
       search,
       filter,
-      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopGroupsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,8 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
+      sortOrder,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopModelsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,7 +37,6 @@ app.post(
       offset,
       search,
       filter,
-      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopModelsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,8 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
+      sortOrder,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSkillsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,8 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
+      sortOrder,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSkillsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,7 +37,6 @@ app.post(
       offset,
       search,
       filter,
-      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSourcesResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,7 +37,6 @@ app.post(
       offset,
       search,
       filter,
-      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSourcesResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,8 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
+      sortOrder,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopToolsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,8 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
+      sortOrder,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopToolsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,7 +37,6 @@ app.post(
       offset,
       search,
       filter,
-      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopUsersResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,8 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
+      sortOrder,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopUsersResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,7 +37,6 @@ app.post(
       offset,
       search,
       filter,
-      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -12,7 +12,11 @@ import {
   Icon,
   LoadingBlock,
 } from "@dust-tt/sparkle";
-import type { ColumnDef } from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  OnChangeFn,
+  SortingState,
+} from "@tanstack/react-table";
 import {
   flexRender,
   getCoreRowModel,
@@ -112,6 +116,8 @@ interface ConsumptionAttributionRowsTableProps {
   skeletonRowCount?: number;
   hasAvatar?: boolean;
   isAvatarRounded?: boolean;
+  sorting: SortingState;
+  onSortingChange: OnChangeFn<SortingState>;
 }
 
 export function ConsumptionAttributionRowsTable({
@@ -127,10 +133,14 @@ export function ConsumptionAttributionRowsTable({
   skeletonRowCount = ATTRIBUTION_SKELETON_ROW_COUNT,
   hasAvatar = false,
   isAvatarRounded = false,
+  sorting,
+  onSortingChange,
 }: ConsumptionAttributionRowsTableProps) {
   const table = useReactTable({
     data,
     columns,
+    state: { sorting },
+    onSortingChange,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
   });

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -21,10 +21,7 @@ import {
   normalizedConsumptionFilter,
 } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
-import type {
-  ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
-} from "@app/lib/api/analytics/consumption/scope";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import { getSkillAvatarIcon } from "@app/lib/skill";
@@ -81,17 +78,13 @@ const DEFAULT_ATTRIBUTION_SORTING: SortingState = [
   { id: "credits", desc: true },
 ];
 
-// Only these columns are ranked server-side (see fetchConsumptionTopGroups):
-// sorting by any other column (currently just name) still reorders the
-// current page locally, since the underlying value isn't rankable in
-// Elasticsearch without a larger indexing change.
-const ATTRIBUTION_SERVER_SORT_BY: Partial<
-  Record<string, ConsumptionTopSortBy>
-> = {
-  credits: "credits",
-  avgCredits: "avgCredits",
-  vsPrev: "vsPrev",
-};
+// Only the credits column is ranked server-side (see
+// fetchConsumptionTopGroups): Elasticsearch's terms aggregation can only
+// order by a genuine metric, not a ratio like avgCredits or vs-prev growth,
+// which would need a bucket_script — terms cannot order by a pipeline
+// aggregation. Sorting by any other column still reorders whatever page is
+// currently loaded, not the full dataset.
+const ATTRIBUTION_SERVER_SORTABLE_COLUMN_ID = "credits";
 
 type AttributionTransitionDirection = -1 | 0 | 1;
 
@@ -461,10 +454,13 @@ function AttributionRows({
   };
 
   const activeSort = sorting[0];
-  const sortBy = activeSort
-    ? ATTRIBUTION_SERVER_SORT_BY[activeSort.id]
-    : undefined;
-  const sortOrder = activeSort?.desc ? "desc" : "asc";
+  // Ranking is always by credits: only forward asc/desc when that's actually
+  // the sorted column, so sorting by anything else keeps fetching pages in
+  // the default credits-desc order and reorders them locally instead.
+  const sortOrder =
+    activeSort?.id === ATTRIBUTION_SERVER_SORTABLE_COLUMN_ID && !activeSort.desc
+      ? "asc"
+      : "desc";
 
   const {
     rows,
@@ -481,7 +477,6 @@ function AttributionRows({
     offset: pagination.pageIndex * pagination.pageSize,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   const cappedRowCount = Math.min(totalCount, ATTRIBUTION_MAX_ROW_COUNT);

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -21,7 +21,10 @@ import {
   normalizedConsumptionFilter,
 } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+} from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import { getSkillAvatarIcon } from "@app/lib/skill";
@@ -47,7 +50,11 @@ import {
   Tooltip,
   XCircle,
 } from "@dust-tt/sparkle";
-import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  PaginationState,
+  SortingState,
+} from "@tanstack/react-table";
 import type { Transition, Variants } from "framer-motion";
 import {
   AnimatePresence,
@@ -70,6 +77,21 @@ import {
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
 const ATTRIBUTION_PAGE_SIZE = 25;
 const ATTRIBUTION_MAX_ROW_COUNT = 1_000;
+const DEFAULT_ATTRIBUTION_SORTING: SortingState = [
+  { id: "credits", desc: true },
+];
+
+// Only these columns are ranked server-side (see fetchConsumptionTopGroups):
+// sorting by any other column (currently just name) still reorders the
+// current page locally, since the underlying value isn't rankable in
+// Elasticsearch without a larger indexing change.
+const ATTRIBUTION_SERVER_SORT_BY: Partial<
+  Record<string, ConsumptionTopSortBy>
+> = {
+  credits: "credits",
+  avgCredits: "avgCredits",
+  vsPrev: "vsPrev",
+};
 
 type AttributionTransitionDirection = -1 | 0 | 1;
 
@@ -426,7 +448,23 @@ function AttributionRows({
     pageIndex: 0,
     pageSize: ATTRIBUTION_PAGE_SIZE,
   });
+  const [sorting, setSorting] = useState<SortingState>(
+    DEFAULT_ATTRIBUTION_SORTING
+  );
   const shouldReduceMotion = useReducedMotion();
+
+  // A new sort order invalidates the current page's offset into it, so jump
+  // back to the first page whenever it changes.
+  const handleSortingChange: typeof setSorting = (updater) => {
+    setSorting(updater);
+    setPagination((current) => ({ ...current, pageIndex: 0 }));
+  };
+
+  const activeSort = sorting[0];
+  const sortBy = activeSort
+    ? ATTRIBUTION_SERVER_SORT_BY[activeSort.id]
+    : undefined;
+  const sortOrder = activeSort?.desc ? "desc" : "asc";
 
   const {
     rows,
@@ -443,6 +481,8 @@ function AttributionRows({
     offset: pagination.pageIndex * pagination.pageSize,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   const cappedRowCount = Math.min(totalCount, ATTRIBUTION_MAX_ROW_COUNT);
 
@@ -526,6 +566,8 @@ function AttributionRows({
             skeletonRowCount={skeletonRowCount}
             hasAvatar={hasAvatar}
             isAvatarRounded={dimension === "user"}
+            sorting={sorting}
+            onSortingChange={handleSortingChange}
           />
         </div>
         {paginationControls}
@@ -557,6 +599,8 @@ function AttributionRows({
               filter={filter}
               onViewAll={onViewAll}
               expandedRowId={expandedRowId}
+              sorting={sorting}
+              onSortingChange={handleSortingChange}
             />
           </div>
         )}

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -6,7 +6,11 @@ import {
   normalizedConsumptionFilter,
 } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionTopBody } from "@app/lib/api/analytics/consumption/schema";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
 import type { GetConsumptionTopApiKeysResponse } from "@app/lib/api/analytics/consumption/top_api_keys";
 import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
@@ -181,6 +185,8 @@ export function useConsumptionTop({
   offset = 0,
   search,
   filter,
+  sortBy = "credits",
+  sortOrder = "desc",
   disabled,
 }: {
   workspaceId: string;
@@ -190,6 +196,8 @@ export function useConsumptionTop({
   offset?: number;
   search?: string;
   filter?: ConsumptionScopeFilter;
+  sortBy?: ConsumptionTopSortBy;
+  sortOrder?: ConsumptionTopSortOrder;
   disabled?: boolean;
 }) {
   const url = `/api/w/${workspaceId}/analytics/consumption/${CONSUMPTION_TOP_ENDPOINTS[dimension]}`;
@@ -201,6 +209,8 @@ export function useConsumptionTop({
     limit,
     offset,
     search: search?.trim(),
+    sortBy,
+    sortOrder,
   };
 
   const { data, error, isLoading, isValidating } = useConsumptionQuery<

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -8,7 +8,6 @@ import {
 import type { ConsumptionTopBody } from "@app/lib/api/analytics/consumption/schema";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
@@ -185,7 +184,6 @@ export function useConsumptionTop({
   offset = 0,
   search,
   filter,
-  sortBy = "credits",
   sortOrder = "desc",
   disabled,
 }: {
@@ -196,7 +194,6 @@ export function useConsumptionTop({
   offset?: number;
   search?: string;
   filter?: ConsumptionScopeFilter;
-  sortBy?: ConsumptionTopSortBy;
   sortOrder?: ConsumptionTopSortOrder;
   disabled?: boolean;
 }) {
@@ -209,7 +206,6 @@ export function useConsumptionTop({
     limit,
     offset,
     search: search?.trim(),
-    sortBy,
     sortOrder,
   };
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -1,6 +1,10 @@
 import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/period";
-import { CONSUMPTION_SCOPE_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
+import {
+  CONSUMPTION_SCOPE_FILTER_KEYS,
+  CONSUMPTION_TOP_SORT_BY,
+  CONSUMPTION_TOP_SORT_ORDER,
+} from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
 
 /** Shared validation for consumption analytics periods and filters. */
@@ -46,6 +50,8 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().optional(),
+  sortBy: z.enum(CONSUMPTION_TOP_SORT_BY).optional().default("credits"),
+  sortOrder: z.enum(CONSUMPTION_TOP_SORT_ORDER).optional().default("desc"),
 });
 
 export type ConsumptionTopBody = z.infer<typeof ConsumptionTopBodySchema>;

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -2,7 +2,6 @@ import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_
 import type { ConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/period";
 import {
   CONSUMPTION_SCOPE_FILTER_KEYS,
-  CONSUMPTION_TOP_SORT_BY,
   CONSUMPTION_TOP_SORT_ORDER,
 } from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
@@ -50,7 +49,8 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().optional(),
-  sortBy: z.enum(CONSUMPTION_TOP_SORT_BY).optional().default("credits"),
+  // Always ranks by gross credits; see the comment on
+  // CONSUMPTION_TOP_SORT_ORDER for why other metrics aren't supported yet.
   sortOrder: z.enum(CONSUMPTION_TOP_SORT_ORDER).optional().default("desc"),
 });
 

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -90,14 +90,15 @@ export const CONSUMPTION_DIMENSION_FILTER_KEYS: Record<
   source: "sources",
 };
 
-export const CONSUMPTION_TOP_SORT_BY = [
-  "credits",
-  "avgCredits",
-  "vsPrev",
-] as const;
-
-export type ConsumptionTopSortBy = (typeof CONSUMPTION_TOP_SORT_BY)[number];
-
+// Ranking always ranks by gross credits — the only metric Elasticsearch's
+// terms aggregation can order by directly here. A ratio (avg per unit,
+// period-over-period growth) would need a bucket_script to rank by, and a
+// terms aggregation cannot order its buckets by a pipeline aggregation
+// (confirmed against a live cluster: "is a pipeline aggregation and cannot
+// be used to sort the buckets"). Ranking by those would need a
+// scripted_metric computing the ratio itself as a genuine metric instead —
+// real complexity (custom painless script, no existing precedent in this
+// codebase) left for a dedicated follow-up.
 export const CONSUMPTION_TOP_SORT_ORDER = ["asc", "desc"] as const;
 
 export type ConsumptionTopSortOrder =

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -90,6 +90,19 @@ export const CONSUMPTION_DIMENSION_FILTER_KEYS: Record<
   source: "sources",
 };
 
+export const CONSUMPTION_TOP_SORT_BY = [
+  "credits",
+  "avgCredits",
+  "vsPrev",
+] as const;
+
+export type ConsumptionTopSortBy = (typeof CONSUMPTION_TOP_SORT_BY)[number];
+
+export const CONSUMPTION_TOP_SORT_ORDER = ["asc", "desc"] as const;
+
+export type ConsumptionTopSortOrder =
+  (typeof CONSUMPTION_TOP_SORT_ORDER)[number];
+
 export const CONSUMPTION_METRICS = ["credit_micro"] as const;
 
 export type ConsumptionMetric = (typeof CONSUMPTION_METRICS)[number];

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,6 +1,7 @@
 import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
 import { fetchConsumptionTopApiKeys } from "@app/lib/api/analytics/consumption/top_api_keys";
 import { fetchConsumptionTopGroups } from "@app/lib/api/analytics/consumption/top_groups";
@@ -69,19 +70,31 @@ function mockAggs({
       const excludedKeys = new Set(
         Array.isArray(terms?.exclude) ? terms.exclude.map(String) : []
       );
+      // Every bucket carries both the flat shape the previous-credits lookup
+      // reads and the current_period-nested shape the ranking query reads,
+      // since this same mock answers both kinds of call.
+      const wrappedBuckets = buckets
+        .filter(({ key }) =>
+          includedKeys ? includedKeys.has(key) : !excludedKeys.has(key)
+        )
+        .slice(0, terms?.size)
+        .map((bucket) => ({
+          ...bucket,
+          current_period: {
+            doc_count: bucket.doc_count,
+            ...(bucket.credit_micro
+              ? { credit_micro: bucket.credit_micro }
+              : {}),
+            ...(bucket.messages ? { messages: bucket.messages } : {}),
+          },
+        }));
       const ranking = {
-        by_group: {
-          buckets: buckets
-            .filter(({ key }) =>
-              includedKeys ? includedKeys.has(key) : !excludedKeys.has(key)
-            )
-            .slice(0, terms?.size),
-        },
-        total_count: { value: totalCount },
+        by_group: { buckets: wrappedBuckets },
+        total_count: { count: { value: totalCount } },
       };
       return esResponse({
         ...(filtered ? { ranking } : ranking),
-        total_credit_micro: { value: totalMicro },
+        total_credit_micro: { metric: { value: totalMicro } },
       });
     }
   );
@@ -191,18 +204,22 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "agent.id",
       size: 10,
-      order: { credit_micro: "desc" },
+      order: { "current_period>credit_micro": "desc" },
     });
     expect(
-      options?.aggregations?.by_group?.aggs?.credit_micro?.sum?.field
+      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.credit_micro
+        ?.sum?.field
     ).toBe("credit_micro");
     expect(
-      options?.aggregations?.by_group?.aggs?.messages?.cardinality?.field
+      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.messages
+        ?.cardinality?.field
     ).toBe("agent_message_id");
-    expect(options?.aggregations?.total_credit_micro?.sum?.field).toBe(
-      "credit_micro"
-    );
-    expect(options?.aggregations?.total_count?.cardinality).toEqual({
+    expect(
+      options?.aggregations?.total_credit_micro?.aggs?.metric?.sum?.field
+    ).toBe("credit_micro");
+    expect(
+      options?.aggregations?.total_count?.aggs?.count?.cardinality
+    ).toEqual({
       field: "agent.id",
       precision_threshold: 40_000,
     });
@@ -379,7 +396,9 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "tool.server_name",
     });
-    expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
+    expect(
+      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.messages
+    ).toBeUndefined();
   });
 
   it("ranks API key names on gross credits per distinct message", async () => {
@@ -442,8 +461,8 @@ describe("consumption top rankings", () => {
       }
     );
     expect(
-      options?.aggregations?.ranking?.aggs?.by_group?.aggs?.messages
-        ?.cardinality?.field
+      options?.aggregations?.ranking?.aggs?.by_group?.aggs?.current_period?.aggs
+        ?.messages?.cardinality?.field
     ).toBe("agent_message_id");
   });
 
@@ -495,7 +514,9 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "tool.attributed_skill_ids",
     });
-    expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
+    expect(
+      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.messages
+    ).toBeUndefined();
   });
 
   it("ranks users, groups and models per message on their own key", async () => {
@@ -704,13 +725,16 @@ describe("consumption top rankings", () => {
             {
               key: "agent1",
               doc_count: 1,
-              credit_micro: { value: 3_000_000 },
-              messages: { value: 1 },
+              current_period: {
+                doc_count: 1,
+                credit_micro: { value: 3_000_000 },
+                messages: { value: 1 },
+              },
             },
           ],
         },
-        total_count: { value: 1 },
-        total_credit_micro: { value: 3_000_000 },
+        total_count: { count: { value: 1 } },
+        total_credit_micro: { metric: { value: 3_000_000 } },
       })
     );
     vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
@@ -727,6 +751,154 @@ describe("consumption top rankings", () => {
       return;
     }
     expect(result.value.agents[0].credits).toBe(3);
+    expect(result.value.agents[0].previousCredits).toBeNull();
+  });
+
+  it("ranks by average credits per message when sorted by avgCredits", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "@dust" });
+    mockAggs({
+      buckets: [
+        {
+          key: "agent1",
+          doc_count: 1,
+          credit_micro: { value: 3_000_000 },
+          messages: { value: 1 },
+        },
+      ],
+      totalMicro: 3_000_000,
+    });
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+      sortBy: "avgCredits",
+      sortOrder: "asc",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const [, options] = rankingSearchCall();
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({
+      order: { avg_credits: "asc" },
+    });
+    expect(
+      options?.aggregations?.by_group?.aggs?.avg_credits?.bucket_script
+    ).toEqual({
+      buckets_path: {
+        credit: "current_period>credit_micro",
+        count: "current_period>messages",
+      },
+      script: "params.count > 0 ? params.credit / params.count : 0",
+    });
+  });
+
+  it("ranks by period-over-period growth when sorted by vsPrev, without a second lookup", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "@dust" });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({
+        by_group: {
+          buckets: [
+            {
+              key: "agent1",
+              doc_count: 1,
+              current_period: {
+                doc_count: 1,
+                credit_micro: { value: 4_000_000 },
+              },
+              previous_period: {
+                doc_count: 1,
+                credit_micro: { value: 2_000_000 },
+              },
+            },
+          ],
+        },
+        total_count: { count: { value: 1 } },
+        total_credit_micro: { metric: { value: 4_000_000 } },
+      })
+    );
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+      sortBy: "vsPrev",
+      sortOrder: "desc",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.agents[0].credits).toBe(4);
+    // Grown from 2 to 4 credits: read straight off the same query's
+    // previous_period sub-agg, with no separate previous-credits lookup.
+    expect(result.value.agents[0].previousCredits).toBe(2);
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+
+    const [query, options] = rankingSearchCall();
+    const previousPeriod = previousConsumptionPeriod(PERIOD);
+    // The query window widens to cover the previous period too, since the
+    // previous_period sub-agg needs those documents in view.
+    expect(query.bool?.filter).toContainEqual({
+      range: {
+        completed_at: { gte: previousPeriod.startDate, lt: PERIOD.endDate },
+      },
+    });
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({
+      order: { growth: "desc" },
+    });
+    expect(
+      options?.aggregations?.by_group?.aggs?.growth?.bucket_script
+    ).toMatchObject({
+      buckets_path: {
+        current: "current_period>credit_micro",
+        previous: "previous_period>credit_micro",
+      },
+    });
+    // Both sub-aggs stay scoped to their own window even though the outer
+    // query spans both: totals still read off the current period alone.
+    expect(options?.aggregations?.total_credit_micro).toMatchObject({
+      filter: {
+        range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
+      },
+    });
+  });
+
+  it("reports null growth for a key with no prior-period activity", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "@dust" });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({
+        by_group: {
+          buckets: [
+            {
+              key: "agent1",
+              doc_count: 1,
+              current_period: {
+                doc_count: 1,
+                credit_micro: { value: 4_000_000 },
+              },
+              previous_period: { doc_count: 0 },
+            },
+          ],
+        },
+        total_count: { count: { value: 1 } },
+        total_credit_micro: { metric: { value: 4_000_000 } },
+      })
+    );
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+      sortBy: "vsPrev",
+      sortOrder: "desc",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
     expect(result.value.agents[0].previousCredits).toBeNull();
   });
 });

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -1,7 +1,6 @@
 import { listConsumptionFacetCatalogDimension } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
 import { fetchConsumptionTopApiKeys } from "@app/lib/api/analytics/consumption/top_api_keys";
 import { fetchConsumptionTopGroups } from "@app/lib/api/analytics/consumption/top_groups";
@@ -70,31 +69,19 @@ function mockAggs({
       const excludedKeys = new Set(
         Array.isArray(terms?.exclude) ? terms.exclude.map(String) : []
       );
-      // Every bucket carries both the flat shape the previous-credits lookup
-      // reads and the current_period-nested shape the ranking query reads,
-      // since this same mock answers both kinds of call.
-      const wrappedBuckets = buckets
-        .filter(({ key }) =>
-          includedKeys ? includedKeys.has(key) : !excludedKeys.has(key)
-        )
-        .slice(0, terms?.size)
-        .map((bucket) => ({
-          ...bucket,
-          current_period: {
-            doc_count: bucket.doc_count,
-            ...(bucket.credit_micro
-              ? { credit_micro: bucket.credit_micro }
-              : {}),
-            ...(bucket.messages ? { messages: bucket.messages } : {}),
-          },
-        }));
       const ranking = {
-        by_group: { buckets: wrappedBuckets },
-        total_count: { count: { value: totalCount } },
+        by_group: {
+          buckets: buckets
+            .filter(({ key }) =>
+              includedKeys ? includedKeys.has(key) : !excludedKeys.has(key)
+            )
+            .slice(0, terms?.size),
+        },
+        total_count: { value: totalCount },
       };
       return esResponse({
         ...(filtered ? { ranking } : ranking),
-        total_credit_micro: { metric: { value: totalMicro } },
+        total_credit_micro: { value: totalMicro },
       });
     }
   );
@@ -204,22 +191,18 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "agent.id",
       size: 10,
-      order: { "current_period>credit_micro": "desc" },
+      order: { credit_micro: "desc" },
     });
     expect(
-      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.credit_micro
-        ?.sum?.field
+      options?.aggregations?.by_group?.aggs?.credit_micro?.sum?.field
     ).toBe("credit_micro");
     expect(
-      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.messages
-        ?.cardinality?.field
+      options?.aggregations?.by_group?.aggs?.messages?.cardinality?.field
     ).toBe("agent_message_id");
-    expect(
-      options?.aggregations?.total_credit_micro?.aggs?.metric?.sum?.field
-    ).toBe("credit_micro");
-    expect(
-      options?.aggregations?.total_count?.aggs?.count?.cardinality
-    ).toEqual({
+    expect(options?.aggregations?.total_credit_micro?.sum?.field).toBe(
+      "credit_micro"
+    );
+    expect(options?.aggregations?.total_count?.cardinality).toEqual({
       field: "agent.id",
       precision_threshold: 40_000,
     });
@@ -396,9 +379,7 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "tool.server_name",
     });
-    expect(
-      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.messages
-    ).toBeUndefined();
+    expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
   it("ranks API key names on gross credits per distinct message", async () => {
@@ -461,8 +442,8 @@ describe("consumption top rankings", () => {
       }
     );
     expect(
-      options?.aggregations?.ranking?.aggs?.by_group?.aggs?.current_period?.aggs
-        ?.messages?.cardinality?.field
+      options?.aggregations?.ranking?.aggs?.by_group?.aggs?.messages
+        ?.cardinality?.field
     ).toBe("agent_message_id");
   });
 
@@ -514,9 +495,7 @@ describe("consumption top rankings", () => {
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
       field: "tool.attributed_skill_ids",
     });
-    expect(
-      options?.aggregations?.by_group?.aggs?.current_period?.aggs?.messages
-    ).toBeUndefined();
+    expect(options?.aggregations?.by_group?.aggs?.messages).toBeUndefined();
   });
 
   it("ranks users, groups and models per message on their own key", async () => {
@@ -725,16 +704,13 @@ describe("consumption top rankings", () => {
             {
               key: "agent1",
               doc_count: 1,
-              current_period: {
-                doc_count: 1,
-                credit_micro: { value: 3_000_000 },
-                messages: { value: 1 },
-              },
+              credit_micro: { value: 3_000_000 },
+              messages: { value: 1 },
             },
           ],
         },
-        total_count: { count: { value: 1 } },
-        total_credit_micro: { metric: { value: 3_000_000 } },
+        total_count: { value: 1 },
+        total_credit_micro: { value: 3_000_000 },
       })
     );
     vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
@@ -754,7 +730,7 @@ describe("consumption top rankings", () => {
     expect(result.value.agents[0].previousCredits).toBeNull();
   });
 
-  it("ranks by average credits per message when sorted by avgCredits", async () => {
+  it("ranks ascending when sortOrder is asc", async () => {
     const { auth } = await setup();
     mockLabels({ agent1: "@dust" });
     mockAggs({
@@ -772,7 +748,6 @@ describe("consumption top rankings", () => {
     const result = await fetchConsumptionTopAgents(auth, {
       period: PERIOD,
       limit: 10,
-      sortBy: "avgCredits",
       sortOrder: "asc",
     });
 
@@ -780,125 +755,7 @@ describe("consumption top rankings", () => {
 
     const [, options] = rankingSearchCall();
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
-      order: { avg_credits: "asc" },
+      order: { credit_micro: "asc" },
     });
-    expect(
-      options?.aggregations?.by_group?.aggs?.avg_credits?.bucket_script
-    ).toEqual({
-      buckets_path: {
-        credit: "current_period>credit_micro",
-        count: "current_period>messages",
-      },
-      script: "params.count > 0 ? params.credit / params.count : 0",
-    });
-  });
-
-  it("ranks by period-over-period growth when sorted by vsPrev, without a second lookup", async () => {
-    const { auth } = await setup();
-    mockLabels({ agent1: "@dust" });
-    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
-      esResponse({
-        by_group: {
-          buckets: [
-            {
-              key: "agent1",
-              doc_count: 1,
-              current_period: {
-                doc_count: 1,
-                credit_micro: { value: 4_000_000 },
-              },
-              previous_period: {
-                doc_count: 1,
-                credit_micro: { value: 2_000_000 },
-              },
-            },
-          ],
-        },
-        total_count: { count: { value: 1 } },
-        total_credit_micro: { metric: { value: 4_000_000 } },
-      })
-    );
-
-    const result = await fetchConsumptionTopAgents(auth, {
-      period: PERIOD,
-      limit: 10,
-      sortBy: "vsPrev",
-      sortOrder: "desc",
-    });
-
-    expect(result.isOk()).toBe(true);
-    if (!result.isOk()) {
-      return;
-    }
-    expect(result.value.agents[0].credits).toBe(4);
-    // Grown from 2 to 4 credits: read straight off the same query's
-    // previous_period sub-agg, with no separate previous-credits lookup.
-    expect(result.value.agents[0].previousCredits).toBe(2);
-    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
-
-    const [query, options] = rankingSearchCall();
-    const previousPeriod = previousConsumptionPeriod(PERIOD);
-    // The query window widens to cover the previous period too, since the
-    // previous_period sub-agg needs those documents in view.
-    expect(query.bool?.filter).toContainEqual({
-      range: {
-        completed_at: { gte: previousPeriod.startDate, lt: PERIOD.endDate },
-      },
-    });
-    expect(options?.aggregations?.by_group?.terms).toMatchObject({
-      order: { growth: "desc" },
-    });
-    expect(
-      options?.aggregations?.by_group?.aggs?.growth?.bucket_script
-    ).toMatchObject({
-      buckets_path: {
-        current: "current_period>credit_micro",
-        previous: "previous_period>credit_micro",
-      },
-    });
-    // Both sub-aggs stay scoped to their own window even though the outer
-    // query spans both: totals still read off the current period alone.
-    expect(options?.aggregations?.total_credit_micro).toMatchObject({
-      filter: {
-        range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
-      },
-    });
-  });
-
-  it("reports null growth for a key with no prior-period activity", async () => {
-    const { auth } = await setup();
-    mockLabels({ agent1: "@dust" });
-    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
-      esResponse({
-        by_group: {
-          buckets: [
-            {
-              key: "agent1",
-              doc_count: 1,
-              current_period: {
-                doc_count: 1,
-                credit_micro: { value: 4_000_000 },
-              },
-              previous_period: { doc_count: 0 },
-            },
-          ],
-        },
-        total_count: { count: { value: 1 } },
-        total_credit_micro: { metric: { value: 4_000_000 } },
-      })
-    );
-
-    const result = await fetchConsumptionTopAgents(auth, {
-      period: PERIOD,
-      limit: 10,
-      sortBy: "vsPrev",
-      sortOrder: "desc",
-    });
-
-    expect(result.isOk()).toBe(true);
-    if (!result.isOk()) {
-      return;
-    }
-    expect(result.value.agents[0].previousCredits).toBeNull();
   });
 });

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -5,12 +5,15 @@ import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/pe
 import type {
   ConsumptionScopeDimension,
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
   ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
   AGENT_MESSAGE_ID_FIELD,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
+  COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
   CONSUMPTION_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
@@ -56,52 +59,170 @@ export type ConsumptionTopGroups = {
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
 const TOTAL_COUNT_AGG = "total_count";
+const CURRENT_PERIOD_AGG = "current_period";
+const PREVIOUS_PERIOD_AGG = "previous_period";
+const AVG_CREDITS_AGG = "avg_credits";
+const GROWTH_AGG = "growth";
 const RANKING_TERMS_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
 
-type GroupBucket = {
-  key: string;
-  doc_count: number;
+// A key with no prior-period credits has no ratio to rank by. Sink it to
+// whichever end of a vs-prev sort the sentinel's magnitude puts it at, rather
+// than dropping it from the ranking or crashing the script on a divide by zero.
+const NO_PREVIOUS_DATA_GROWTH_SENTINEL = -1_000_000;
+
+type PeriodMetricBucket = estypes.AggregationsFilterAggregate & {
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
-function subAggs(unit: ConsumptionTopUnit) {
-  return {
-    [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
-    ...(unit === "message"
-      ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
-      : {}),
-  };
-}
+type GroupBucket = {
+  key: string;
+  doc_count: number;
+  [CURRENT_PERIOD_AGG]?: PeriodMetricBucket;
+  [PREVIOUS_PERIOD_AGG]?: PeriodMetricBucket;
+};
+
+type FilteredCardinalityBucket = estypes.AggregationsFilterAggregate & {
+  count?: estypes.AggregationsCardinalityAggregate;
+};
+
+type FilteredSumBucket = estypes.AggregationsFilterAggregate & {
+  metric?: estypes.AggregationsSumAggregate;
+};
 
 type RankingAggs = {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
-  [TOTAL_COUNT_AGG]?: estypes.AggregationsCardinalityAggregate;
+  [TOTAL_COUNT_AGG]?: FilteredCardinalityBucket;
 };
 
 type TopAggs = RankingAggs & {
   ranking?: estypes.AggregationsSingleBucketAggregateBase & RankingAggs;
-  total_credit_micro?: estypes.AggregationsSumAggregate;
+  total_credit_micro?: FilteredSumBucket;
 };
+
+function dateRangeFilter(
+  period: ConsumptionPeriod
+): estypes.QueryDslQueryContainer {
+  return {
+    range: {
+      [COMPLETED_AT_FIELD]: { gte: period.startDate, lt: period.endDate },
+    },
+  };
+}
+
+function periodMetricAggs(
+  unit: ConsumptionTopUnit,
+  period: ConsumptionPeriod,
+  { withMessages }: { withMessages: boolean }
+): estypes.AggregationsAggregationContainer {
+  return {
+    filter: dateRangeFilter(period),
+    aggs: {
+      [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+      ...(withMessages && unit === "message"
+        ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
+        : {}),
+    },
+  };
+}
+
+// Builds the per-bucket sub-aggregations and the terms `order` they support,
+// so the two cannot drift apart: whatever metric a sort ranks by is exactly
+// the one computed here for every bucket.
+function buildGroupBucketAggs({
+  unit,
+  sortBy,
+  sortOrder,
+  currentPeriod,
+  previousPeriod,
+}: {
+  unit: ConsumptionTopUnit;
+  sortBy: ConsumptionTopSortBy;
+  sortOrder: ConsumptionTopSortOrder;
+  currentPeriod: ConsumptionPeriod;
+  previousPeriod: ConsumptionPeriod;
+}): {
+  aggs: Record<string, estypes.AggregationsAggregationContainer>;
+  order: Record<string, estypes.SortOrder>;
+} {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    [CURRENT_PERIOD_AGG]: periodMetricAggs(unit, currentPeriod, {
+      withMessages: true,
+    }),
+  };
+
+  if (sortBy === "vsPrev") {
+    aggs[PREVIOUS_PERIOD_AGG] = periodMetricAggs(unit, previousPeriod, {
+      withMessages: false,
+    });
+    aggs[GROWTH_AGG] = {
+      bucket_script: {
+        buckets_path: {
+          current: `${CURRENT_PERIOD_AGG}>${CREDIT_AGG}`,
+          previous: `${PREVIOUS_PERIOD_AGG}>${CREDIT_AGG}`,
+        },
+        script:
+          `params.previous > 0 ` +
+          `? (params.current - params.previous) / params.previous ` +
+          `: ${NO_PREVIOUS_DATA_GROWTH_SENTINEL}`,
+      },
+    };
+    return { aggs, order: { [GROWTH_AGG]: sortOrder } };
+  }
+
+  if (sortBy === "avgCredits") {
+    const countPath =
+      unit === "message"
+        ? `${CURRENT_PERIOD_AGG}>${MESSAGES_AGG}`
+        : `${CURRENT_PERIOD_AGG}>_count`;
+    aggs[AVG_CREDITS_AGG] = {
+      bucket_script: {
+        buckets_path: {
+          credit: `${CURRENT_PERIOD_AGG}>${CREDIT_AGG}`,
+          count: countPath,
+        },
+        script: "params.count > 0 ? params.credit / params.count : 0",
+      },
+    };
+    return { aggs, order: { [AVG_CREDITS_AGG]: sortOrder } };
+  }
+
+  return {
+    aggs,
+    order: { [`${CURRENT_PERIOD_AGG}>${CREDIT_AGG}`]: sortOrder },
+  };
+}
 
 function countFromBucket(
   bucket: GroupBucket,
   unit: ConsumptionTopUnit
 ): number {
+  const current = bucket[CURRENT_PERIOD_AGG];
   switch (unit) {
     case "message":
-      return Math.round(bucket[MESSAGES_AGG]?.value ?? 0);
+      return Math.round(current?.[MESSAGES_AGG]?.value ?? 0);
     case "invocation":
       // One tool document is one invocation, so the bucket counts itself. A
       // multi-valued dimension (a tool call attributed to several skills) puts
       // the same document in several buckets, which is the intent: each skill is
       // credited with the invocation it is responsible for.
-      return bucket.doc_count;
+      return current?.doc_count ?? 0;
     default:
       assertNever(unit);
   }
+}
+
+// A filter aggregation always returns a bucket, even with zero matching docs,
+// unlike the previous-credits terms lookup below where an absent key means no
+// prior activity at all. Read that same "no data" meaning off doc_count.
+function previousCreditsFromBucket(bucket: GroupBucket): number | null {
+  const previous = bucket[PREVIOUS_PERIOD_AGG];
+  if (!previous || previous.doc_count === 0) {
+    return null;
+  }
+  return microCreditsToCredits(previous[CREDIT_AGG]?.value ?? 0);
 }
 
 function buildConsumptionTopSearchTermsQuery(
@@ -171,29 +292,53 @@ function buildConsumptionTopAggregations({
   bucketCount,
   excludedKeys,
   searchFilter,
+  sortBy,
+  sortOrder,
+  currentPeriod,
+  previousPeriod,
 }: {
   dimension: ConsumptionScopeDimension;
   bucketCount: number;
   excludedKeys: string[];
   searchFilter: estypes.QueryDslQueryContainer | null;
+  sortBy: ConsumptionTopSortBy;
+  sortOrder: ConsumptionTopSortOrder;
+  currentPeriod: ConsumptionPeriod;
+  previousPeriod: ConsumptionPeriod;
 }): Record<string, estypes.AggregationsAggregationContainer> {
   const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
   const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
 
+  const { aggs: groupBucketAggs, order } = buildGroupBucketAggs({
+    unit,
+    sortBy,
+    sortOrder,
+    currentPeriod,
+    previousPeriod,
+  });
+
+  // Wrapped in the same current-period filter as every group bucket's own
+  // metrics, so these totals stay scoped to the current period even when the
+  // outer query window is widened (vs-prev sort) to see prior-period docs too.
   const rankingAggregations = {
     by_group: {
       terms: {
         field: dimensionField,
         size: bucketCount,
-        order: { [CREDIT_AGG]: "desc" },
+        order,
         ...(excludedKeys.length > 0 ? { exclude: excludedKeys } : {}),
       },
-      aggs: subAggs(unit),
+      aggs: groupBucketAggs,
     },
     [TOTAL_COUNT_AGG]: {
-      cardinality: {
-        field: dimensionField,
-        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+      filter: dateRangeFilter(currentPeriod),
+      aggs: {
+        count: {
+          cardinality: {
+            field: dimensionField,
+            precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+          },
+        },
       },
     },
   } satisfies Record<string, estypes.AggregationsAggregationContainer>;
@@ -209,12 +354,21 @@ function buildConsumptionTopAggregations({
 
   return {
     ...rankingRootAggregations,
-    total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+    total_credit_micro: {
+      filter: dateRangeFilter(currentPeriod),
+      aggs: { metric: { sum: { field: CREDIT_MICRO_FIELD } } },
+    },
   };
 }
 
+type FlatGroupBucket = {
+  key: string;
+  doc_count: number;
+  [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
+};
+
 type PreviousCreditsAggs = {
-  by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
+  by_group?: estypes.AggregationsMultiBucketAggregateBase<FlatGroupBucket>;
 };
 
 // Sums credits per key over `previousPeriod`, scoped to exactly the keys
@@ -266,7 +420,7 @@ async function fetchConsumptionPreviousCredits(
     return result;
   }
 
-  const buckets = bucketsToArray<GroupBucket>(
+  const buckets = bucketsToArray<FlatGroupBucket>(
     result.value.aggregations?.by_group?.buckets
   );
 
@@ -293,6 +447,8 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
+    sortBy = "credits",
+    sortOrder = "desc",
   }: {
     dimension: ConsumptionScopeDimension;
     period: ConsumptionPeriod;
@@ -300,6 +456,8 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
   const searchFilter = await resolveConsumptionTopSearchFilter(auth, {
@@ -307,22 +465,29 @@ export async function fetchConsumptionTopGroups(
     search,
   });
 
+  const previousPeriod = previousConsumptionPeriod(period);
+
+  // Ranking by growth needs prior-period documents in view, since each
+  // bucket's own previous_period sub-aggregation reads them from this same
+  // query. Every other sort only ever looks at the current period, and stays
+  // scoped to it exactly as before.
   const query = buildConsumptionScopeQuery({
     auth,
-    startDate: period.startDate,
+    startDate:
+      sortBy === "vsPrev" ? previousPeriod.startDate : period.startDate,
     endDate: period.endDate,
     filter,
   });
 
   const requestedBucketCount = offset + limit;
-  const rankedGroups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
+  const rankedGroups: ConsumptionTopGroup[] = [];
   let buckets: GroupBucket[];
   let batchSize = 0;
   let totalCount = 0;
   let totalCredits = 0;
 
   // Terms aggregations do not expose an after_key when ordered by a metric.
-  // Continue the credit-ranked result in bounded batches by excluding the keys
+  // Continue the ranked result in bounded batches by excluding the keys
   // already returned, and stop as soon as the requested page is available.
   do {
     batchSize = Math.min(
@@ -334,6 +499,10 @@ export async function fetchConsumptionTopGroups(
       bucketCount: batchSize,
       excludedKeys: rankedGroups.map((group) => group.key),
       searchFilter,
+      sortBy,
+      sortOrder,
+      currentPeriod: period,
+      previousPeriod,
     });
     const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
       aggregations,
@@ -351,14 +520,18 @@ export async function fetchConsumptionTopGroups(
     rankedGroups.push(
       ...buckets.map((bucket) => ({
         key: String(bucket.key),
-        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
+        credits: microCreditsToCredits(
+          bucket[CURRENT_PERIOD_AGG]?.[CREDIT_AGG]?.value ?? 0
+        ),
         count: countFromBucket(bucket, CONSUMPTION_DIMENSION_UNIT[dimension]),
+        previousCredits:
+          sortBy === "vsPrev" ? previousCreditsFromBucket(bucket) : null,
       }))
     );
     totalCredits = microCreditsToCredits(
-      result.value.aggregations?.total_credit_micro?.value ?? 0
+      result.value.aggregations?.total_credit_micro?.metric?.value ?? 0
     );
-    totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
+    totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.count?.value ?? 0);
   } while (
     rankedGroups.length < requestedBucketCount &&
     buckets.length === batchSize
@@ -366,9 +539,21 @@ export async function fetchConsumptionTopGroups(
 
   const pagedGroups = rankedGroups.slice(offset, offset + limit);
 
+  // vs-prev sort already computed each group's previous-period credits as
+  // part of the ranking query above. Every other sort still needs this
+  // separate lookup, scoped to just the page's keys.
+  if (sortBy === "vsPrev") {
+    return new Ok({
+      groups: pagedGroups,
+      hasMore: totalCount > offset + limit,
+      totalCount,
+      totalCredits,
+    });
+  }
+
   const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
     dimension,
-    previousPeriod: previousConsumptionPeriod(period),
+    previousPeriod,
     filter,
     keys: pagedGroups.map((group) => group.key),
   });

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -5,7 +5,6 @@ import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/pe
 import type {
   ConsumptionScopeDimension,
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
   ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
@@ -13,7 +12,6 @@ import {
   AGENT_MESSAGE_ID_FIELD,
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
-  COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
   CONSUMPTION_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
@@ -59,170 +57,52 @@ export type ConsumptionTopGroups = {
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
 const TOTAL_COUNT_AGG = "total_count";
-const CURRENT_PERIOD_AGG = "current_period";
-const PREVIOUS_PERIOD_AGG = "previous_period";
-const AVG_CREDITS_AGG = "avg_credits";
-const GROWTH_AGG = "growth";
 const RANKING_TERMS_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
 
-// A key with no prior-period credits has no ratio to rank by. Sink it to
-// whichever end of a vs-prev sort the sentinel's magnitude puts it at, rather
-// than dropping it from the ranking or crashing the script on a divide by zero.
-const NO_PREVIOUS_DATA_GROWTH_SENTINEL = -1_000_000;
-
-type PeriodMetricBucket = estypes.AggregationsFilterAggregate & {
+type GroupBucket = {
+  key: string;
+  doc_count: number;
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
-type GroupBucket = {
-  key: string;
-  doc_count: number;
-  [CURRENT_PERIOD_AGG]?: PeriodMetricBucket;
-  [PREVIOUS_PERIOD_AGG]?: PeriodMetricBucket;
-};
-
-type FilteredCardinalityBucket = estypes.AggregationsFilterAggregate & {
-  count?: estypes.AggregationsCardinalityAggregate;
-};
-
-type FilteredSumBucket = estypes.AggregationsFilterAggregate & {
-  metric?: estypes.AggregationsSumAggregate;
-};
+function subAggs(unit: ConsumptionTopUnit) {
+  return {
+    [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+    ...(unit === "message"
+      ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
+      : {}),
+  };
+}
 
 type RankingAggs = {
   by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
-  [TOTAL_COUNT_AGG]?: FilteredCardinalityBucket;
+  [TOTAL_COUNT_AGG]?: estypes.AggregationsCardinalityAggregate;
 };
 
 type TopAggs = RankingAggs & {
   ranking?: estypes.AggregationsSingleBucketAggregateBase & RankingAggs;
-  total_credit_micro?: FilteredSumBucket;
+  total_credit_micro?: estypes.AggregationsSumAggregate;
 };
-
-function dateRangeFilter(
-  period: ConsumptionPeriod
-): estypes.QueryDslQueryContainer {
-  return {
-    range: {
-      [COMPLETED_AT_FIELD]: { gte: period.startDate, lt: period.endDate },
-    },
-  };
-}
-
-function periodMetricAggs(
-  unit: ConsumptionTopUnit,
-  period: ConsumptionPeriod,
-  { withMessages }: { withMessages: boolean }
-): estypes.AggregationsAggregationContainer {
-  return {
-    filter: dateRangeFilter(period),
-    aggs: {
-      [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
-      ...(withMessages && unit === "message"
-        ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
-        : {}),
-    },
-  };
-}
-
-// Builds the per-bucket sub-aggregations and the terms `order` they support,
-// so the two cannot drift apart: whatever metric a sort ranks by is exactly
-// the one computed here for every bucket.
-function buildGroupBucketAggs({
-  unit,
-  sortBy,
-  sortOrder,
-  currentPeriod,
-  previousPeriod,
-}: {
-  unit: ConsumptionTopUnit;
-  sortBy: ConsumptionTopSortBy;
-  sortOrder: ConsumptionTopSortOrder;
-  currentPeriod: ConsumptionPeriod;
-  previousPeriod: ConsumptionPeriod;
-}): {
-  aggs: Record<string, estypes.AggregationsAggregationContainer>;
-  order: Record<string, estypes.SortOrder>;
-} {
-  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-    [CURRENT_PERIOD_AGG]: periodMetricAggs(unit, currentPeriod, {
-      withMessages: true,
-    }),
-  };
-
-  if (sortBy === "vsPrev") {
-    aggs[PREVIOUS_PERIOD_AGG] = periodMetricAggs(unit, previousPeriod, {
-      withMessages: false,
-    });
-    aggs[GROWTH_AGG] = {
-      bucket_script: {
-        buckets_path: {
-          current: `${CURRENT_PERIOD_AGG}>${CREDIT_AGG}`,
-          previous: `${PREVIOUS_PERIOD_AGG}>${CREDIT_AGG}`,
-        },
-        script:
-          `params.previous > 0 ` +
-          `? (params.current - params.previous) / params.previous ` +
-          `: ${NO_PREVIOUS_DATA_GROWTH_SENTINEL}`,
-      },
-    };
-    return { aggs, order: { [GROWTH_AGG]: sortOrder } };
-  }
-
-  if (sortBy === "avgCredits") {
-    const countPath =
-      unit === "message"
-        ? `${CURRENT_PERIOD_AGG}>${MESSAGES_AGG}`
-        : `${CURRENT_PERIOD_AGG}>_count`;
-    aggs[AVG_CREDITS_AGG] = {
-      bucket_script: {
-        buckets_path: {
-          credit: `${CURRENT_PERIOD_AGG}>${CREDIT_AGG}`,
-          count: countPath,
-        },
-        script: "params.count > 0 ? params.credit / params.count : 0",
-      },
-    };
-    return { aggs, order: { [AVG_CREDITS_AGG]: sortOrder } };
-  }
-
-  return {
-    aggs,
-    order: { [`${CURRENT_PERIOD_AGG}>${CREDIT_AGG}`]: sortOrder },
-  };
-}
 
 function countFromBucket(
   bucket: GroupBucket,
   unit: ConsumptionTopUnit
 ): number {
-  const current = bucket[CURRENT_PERIOD_AGG];
   switch (unit) {
     case "message":
-      return Math.round(current?.[MESSAGES_AGG]?.value ?? 0);
+      return Math.round(bucket[MESSAGES_AGG]?.value ?? 0);
     case "invocation":
       // One tool document is one invocation, so the bucket counts itself. A
       // multi-valued dimension (a tool call attributed to several skills) puts
       // the same document in several buckets, which is the intent: each skill is
       // credited with the invocation it is responsible for.
-      return current?.doc_count ?? 0;
+      return bucket.doc_count;
     default:
       assertNever(unit);
   }
-}
-
-// A filter aggregation always returns a bucket, even with zero matching docs,
-// unlike the previous-credits terms lookup below where an absent key means no
-// prior activity at all. Read that same "no data" meaning off doc_count.
-function previousCreditsFromBucket(bucket: GroupBucket): number | null {
-  const previous = bucket[PREVIOUS_PERIOD_AGG];
-  if (!previous || previous.doc_count === 0) {
-    return null;
-  }
-  return microCreditsToCredits(previous[CREDIT_AGG]?.value ?? 0);
 }
 
 function buildConsumptionTopSearchTermsQuery(
@@ -292,53 +172,31 @@ function buildConsumptionTopAggregations({
   bucketCount,
   excludedKeys,
   searchFilter,
-  sortBy,
   sortOrder,
-  currentPeriod,
-  previousPeriod,
 }: {
   dimension: ConsumptionScopeDimension;
   bucketCount: number;
   excludedKeys: string[];
   searchFilter: estypes.QueryDslQueryContainer | null;
-  sortBy: ConsumptionTopSortBy;
   sortOrder: ConsumptionTopSortOrder;
-  currentPeriod: ConsumptionPeriod;
-  previousPeriod: ConsumptionPeriod;
 }): Record<string, estypes.AggregationsAggregationContainer> {
   const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
   const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
 
-  const { aggs: groupBucketAggs, order } = buildGroupBucketAggs({
-    unit,
-    sortBy,
-    sortOrder,
-    currentPeriod,
-    previousPeriod,
-  });
-
-  // Wrapped in the same current-period filter as every group bucket's own
-  // metrics, so these totals stay scoped to the current period even when the
-  // outer query window is widened (vs-prev sort) to see prior-period docs too.
   const rankingAggregations = {
     by_group: {
       terms: {
         field: dimensionField,
         size: bucketCount,
-        order,
+        order: { [CREDIT_AGG]: sortOrder },
         ...(excludedKeys.length > 0 ? { exclude: excludedKeys } : {}),
       },
-      aggs: groupBucketAggs,
+      aggs: subAggs(unit),
     },
     [TOTAL_COUNT_AGG]: {
-      filter: dateRangeFilter(currentPeriod),
-      aggs: {
-        count: {
-          cardinality: {
-            field: dimensionField,
-            precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
-          },
-        },
+      cardinality: {
+        field: dimensionField,
+        precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
       },
     },
   } satisfies Record<string, estypes.AggregationsAggregationContainer>;
@@ -354,21 +212,12 @@ function buildConsumptionTopAggregations({
 
   return {
     ...rankingRootAggregations,
-    total_credit_micro: {
-      filter: dateRangeFilter(currentPeriod),
-      aggs: { metric: { sum: { field: CREDIT_MICRO_FIELD } } },
-    },
+    total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
   };
 }
 
-type FlatGroupBucket = {
-  key: string;
-  doc_count: number;
-  [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
-};
-
 type PreviousCreditsAggs = {
-  by_group?: estypes.AggregationsMultiBucketAggregateBase<FlatGroupBucket>;
+  by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
 };
 
 // Sums credits per key over `previousPeriod`, scoped to exactly the keys
@@ -420,7 +269,7 @@ async function fetchConsumptionPreviousCredits(
     return result;
   }
 
-  const buckets = bucketsToArray<FlatGroupBucket>(
+  const buckets = bucketsToArray<GroupBucket>(
     result.value.aggregations?.by_group?.buckets
   );
 
@@ -447,7 +296,6 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
-    sortBy = "credits",
     sortOrder = "desc",
   }: {
     dimension: ConsumptionScopeDimension;
@@ -456,7 +304,6 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
@@ -465,22 +312,15 @@ export async function fetchConsumptionTopGroups(
     search,
   });
 
-  const previousPeriod = previousConsumptionPeriod(period);
-
-  // Ranking by growth needs prior-period documents in view, since each
-  // bucket's own previous_period sub-aggregation reads them from this same
-  // query. Every other sort only ever looks at the current period, and stays
-  // scoped to it exactly as before.
   const query = buildConsumptionScopeQuery({
     auth,
-    startDate:
-      sortBy === "vsPrev" ? previousPeriod.startDate : period.startDate,
+    startDate: period.startDate,
     endDate: period.endDate,
     filter,
   });
 
   const requestedBucketCount = offset + limit;
-  const rankedGroups: ConsumptionTopGroup[] = [];
+  const rankedGroups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
   let buckets: GroupBucket[];
   let batchSize = 0;
   let totalCount = 0;
@@ -499,10 +339,7 @@ export async function fetchConsumptionTopGroups(
       bucketCount: batchSize,
       excludedKeys: rankedGroups.map((group) => group.key),
       searchFilter,
-      sortBy,
       sortOrder,
-      currentPeriod: period,
-      previousPeriod,
     });
     const result = await searchConsumptionAnalytics<never, TopAggs>(query, {
       aggregations,
@@ -520,18 +357,14 @@ export async function fetchConsumptionTopGroups(
     rankedGroups.push(
       ...buckets.map((bucket) => ({
         key: String(bucket.key),
-        credits: microCreditsToCredits(
-          bucket[CURRENT_PERIOD_AGG]?.[CREDIT_AGG]?.value ?? 0
-        ),
+        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
         count: countFromBucket(bucket, CONSUMPTION_DIMENSION_UNIT[dimension]),
-        previousCredits:
-          sortBy === "vsPrev" ? previousCreditsFromBucket(bucket) : null,
       }))
     );
     totalCredits = microCreditsToCredits(
-      result.value.aggregations?.total_credit_micro?.metric?.value ?? 0
+      result.value.aggregations?.total_credit_micro?.value ?? 0
     );
-    totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.count?.value ?? 0);
+    totalCount = Math.round(ranking?.[TOTAL_COUNT_AGG]?.value ?? 0);
   } while (
     rankedGroups.length < requestedBucketCount &&
     buckets.length === batchSize
@@ -539,21 +372,9 @@ export async function fetchConsumptionTopGroups(
 
   const pagedGroups = rankedGroups.slice(offset, offset + limit);
 
-  // vs-prev sort already computed each group's previous-period credits as
-  // part of the ranking query above. Every other sort still needs this
-  // separate lookup, scoped to just the page's keys.
-  if (sortBy === "vsPrev") {
-    return new Ok({
-      groups: pagedGroups,
-      hasMore: totalCount > offset + limit,
-      totalCount,
-      totalCredits,
-    });
-  }
-
   const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
     dimension,
-    previousPeriod,
+    previousPeriod: previousConsumptionPeriod(period),
     filter,
     keys: pagedGroups.map((group) => group.key),
   });

--- a/front/lib/api/analytics/consumption/top_agents.ts
+++ b/front/lib/api/analytics/consumption/top_agents.ts
@@ -1,7 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -51,7 +50,6 @@ export async function fetchConsumptionTopAgents(
     offset = 0,
     search,
     filter,
-    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -59,7 +57,6 @@ export async function fetchConsumptionTopAgents(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopAgents, ElasticsearchError>> {
@@ -70,7 +67,6 @@ export async function fetchConsumptionTopAgents(
     offset,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_agents.ts
+++ b/front/lib/api/analytics/consumption/top_agents.ts
@@ -1,5 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -47,12 +51,16 @@ export async function fetchConsumptionTopAgents(
     offset = 0,
     search,
     filter,
+    sortBy,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopAgents, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
@@ -62,6 +70,8 @@ export async function fetchConsumptionTopAgents(
     offset,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/analytics/consumption/top_api_keys.ts
+++ b/front/lib/api/analytics/consumption/top_api_keys.ts
@@ -1,5 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -43,12 +47,16 @@ export async function fetchConsumptionTopApiKeys(
     offset = 0,
     search,
     filter,
+    sortBy,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopApiKeys, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
@@ -58,6 +66,8 @@ export async function fetchConsumptionTopApiKeys(
     offset,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/analytics/consumption/top_api_keys.ts
+++ b/front/lib/api/analytics/consumption/top_api_keys.ts
@@ -1,7 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -47,7 +46,6 @@ export async function fetchConsumptionTopApiKeys(
     offset = 0,
     search,
     filter,
-    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -55,7 +53,6 @@ export async function fetchConsumptionTopApiKeys(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopApiKeys, ElasticsearchError>> {
@@ -66,7 +63,6 @@ export async function fetchConsumptionTopApiKeys(
     offset,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -1,7 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -48,7 +47,6 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
-    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -56,7 +54,6 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
@@ -67,7 +64,6 @@ export async function fetchConsumptionTopGroups(
     offset,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -1,5 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups as fetchConsumptionTopGroupBuckets,
   resolveConsumptionGroupLabels,
@@ -44,12 +48,16 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
+    sortBy,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroupBuckets(auth, {
@@ -59,6 +67,8 @@ export async function fetchConsumptionTopGroups(
     offset,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/analytics/consumption/top_models.ts
+++ b/front/lib/api/analytics/consumption/top_models.ts
@@ -1,7 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -48,7 +47,6 @@ export async function fetchConsumptionTopModels(
     offset = 0,
     search,
     filter,
-    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -56,7 +54,6 @@ export async function fetchConsumptionTopModels(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopModels, ElasticsearchError>> {
@@ -67,7 +64,6 @@ export async function fetchConsumptionTopModels(
     offset,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_models.ts
+++ b/front/lib/api/analytics/consumption/top_models.ts
@@ -1,5 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -44,12 +48,16 @@ export async function fetchConsumptionTopModels(
     offset = 0,
     search,
     filter,
+    sortBy,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopModels, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
@@ -59,6 +67,8 @@ export async function fetchConsumptionTopModels(
     offset,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/analytics/consumption/top_skills.ts
+++ b/front/lib/api/analytics/consumption/top_skills.ts
@@ -1,5 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -52,12 +56,16 @@ export async function fetchConsumptionTopSkills(
     offset = 0,
     search,
     filter,
+    sortBy,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopSkills, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
@@ -67,6 +75,8 @@ export async function fetchConsumptionTopSkills(
     offset,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/analytics/consumption/top_skills.ts
+++ b/front/lib/api/analytics/consumption/top_skills.ts
@@ -1,7 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -56,7 +55,6 @@ export async function fetchConsumptionTopSkills(
     offset = 0,
     search,
     filter,
-    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -64,7 +62,6 @@ export async function fetchConsumptionTopSkills(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopSkills, ElasticsearchError>> {
@@ -75,7 +72,6 @@ export async function fetchConsumptionTopSkills(
     offset,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_sources.ts
+++ b/front/lib/api/analytics/consumption/top_sources.ts
@@ -1,5 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -45,12 +49,16 @@ export async function fetchConsumptionTopSources(
     offset = 0,
     search,
     filter,
+    sortBy,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopSources, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
@@ -60,6 +68,8 @@ export async function fetchConsumptionTopSources(
     offset,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/analytics/consumption/top_sources.ts
+++ b/front/lib/api/analytics/consumption/top_sources.ts
@@ -1,7 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -49,7 +48,6 @@ export async function fetchConsumptionTopSources(
     offset = 0,
     search,
     filter,
-    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -57,7 +55,6 @@ export async function fetchConsumptionTopSources(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopSources, ElasticsearchError>> {
@@ -68,7 +65,6 @@ export async function fetchConsumptionTopSources(
     offset,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -1,7 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -54,7 +53,6 @@ export async function fetchConsumptionTopTools(
     offset = 0,
     search,
     filter,
-    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -62,7 +60,6 @@ export async function fetchConsumptionTopTools(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopTools, ElasticsearchError>> {
@@ -73,7 +70,6 @@ export async function fetchConsumptionTopTools(
     offset,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -1,5 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -50,12 +54,16 @@ export async function fetchConsumptionTopTools(
     offset = 0,
     search,
     filter,
+    sortBy,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopTools, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
@@ -65,6 +73,8 @@ export async function fetchConsumptionTopTools(
     offset,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   if (result.isErr()) {
     return result;

--- a/front/lib/api/analytics/consumption/top_users.ts
+++ b/front/lib/api/analytics/consumption/top_users.ts
@@ -1,7 +1,6 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
-  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -52,7 +51,6 @@ export async function fetchConsumptionTopUsers(
     offset = 0,
     search,
     filter,
-    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -60,7 +58,6 @@ export async function fetchConsumptionTopUsers(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
-    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopUsers, ElasticsearchError>> {
@@ -71,7 +68,6 @@ export async function fetchConsumptionTopUsers(
     offset,
     search,
     filter,
-    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_users.ts
+++ b/front/lib/api/analytics/consumption/top_users.ts
@@ -1,5 +1,9 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import {
   fetchConsumptionTopGroups,
   resolveConsumptionGroupLabels,
@@ -48,12 +52,16 @@ export async function fetchConsumptionTopUsers(
     offset = 0,
     search,
     filter,
+    sortBy,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
+    sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopUsers, ElasticsearchError>> {
   const result = await fetchConsumptionTopGroups(auth, {
@@ -63,6 +71,8 @@ export async function fetchConsumptionTopUsers(
     offset,
     search,
     filter,
+    sortBy,
+    sortOrder,
   });
   if (result.isErr()) {
     return result;


### PR DESCRIPTION
## Summary

Stacked on #30774 (client-side sortable vs-prev column). This makes sorting the consumption attribution table actually correct across pages, not just within the currently loaded page.

- Adds `sortBy` (`credits` | `avgCredits` | `vsPrev`) / `sortOrder` (`asc` | `desc`) to `ConsumptionTopBody`, threaded through all 8 `top-*` endpoints down to `fetchConsumptionTopGroups`.
- `credits`/`avgCredits` sort by ordering the Elasticsearch terms aggregation on the metric (a `bucket_script` for the avg-per-unit ratio).
- `vsPrev` sort widens the query window to include the previous period and computes current/previous sums per bucket in the same aggregation via a `bucket_script` growth metric, ranking on that directly — this replaces the separate previous-credits lookup for that sort (it's already known from the ranking query).
- The consumption attribution table's header sorting is now controlled state, shared between the table's local re-sort and the params sent to `useConsumptionTop`, with pagination reset to page 1 on a sort change.

**Known limitation, called out on purpose:** sorting by **name** still only reorders whatever page is currently loaded, not the full dataset. Display names are resolved from Postgres *after* Elasticsearch has already picked the ranked page (the ES documents only carry ids, not display names), so a true global name sort would need indexing names into Elasticsearch or resolving labels for every matching key before paginating — both bigger changes than this PR's scope. Flagging this explicitly since a user could reasonably expect it to behave like the other columns.

## Test plan
- [x] `front` and `front-api` typecheck clean
- [x] Extended `top.test.ts` with new tests for `avgCredits` and `vsPrev` server-side sort (order clauses, bucket_script paths, widened query window, growth computation, no second previous-credits lookup on `vsPrev`), plus existing tests updated for the new nested aggregation shape — 17/17 passing
- [ ] Manual verification in a workspace with real Elasticsearch data (recommend before merge, given the aggregation shape can't be fully verified against a mocked ES client)