### PR TITLE
front fix: skill mount failure check & fallback

### DIFF
--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -10,7 +10,7 @@ const {
   mockFetchByIds,
   mockHasFiles,
   mockListForAgentLoop,
-  mockLoadSkillFilesToConversation,
+  mockUpsertSkillFilesToConversation,
 } = vi.hoisted(() => ({
   mockEnableForAgent: vi.fn(),
   mockBatchFetchUsedBySkills: vi.fn(),
@@ -18,11 +18,11 @@ const {
   mockFetchByIds: vi.fn(),
   mockHasFiles: vi.fn(),
   mockListForAgentLoop: vi.fn(),
-  mockLoadSkillFilesToConversation: vi.fn(),
+  mockUpsertSkillFilesToConversation: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/skills/conversation_files", () => ({
-  loadSkillFilesToConversation: mockLoadSkillFilesToConversation,
+  upsertSkillFilesToConversation: mockUpsertSkillFilesToConversation,
 }));
 
 vi.mock("@app/lib/resources/skill/skill_resource", () => ({
@@ -93,7 +93,7 @@ describe("skill_management enable_skill tool", () => {
     mockFetchByIds.mockResolvedValue([]);
     mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: false });
     mockHasFiles.mockReturnValue(true);
-    mockLoadSkillFilesToConversation.mockResolvedValue(
+    mockUpsertSkillFilesToConversation.mockResolvedValue(
       new Ok({
         loadedPaths: ["conversation-conversation-id/skills/commit/SKILL.md"],
       })
@@ -141,7 +141,7 @@ describe("skill_management enable_skill tool", () => {
       conversation,
       userMessage,
     });
-    expect(mockLoadSkillFilesToConversation).toHaveBeenCalledWith(auth, {
+    expect(mockUpsertSkillFilesToConversation).toHaveBeenCalledWith(auth, {
       skill,
       conversation,
     });
@@ -165,7 +165,7 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
+    expect(mockUpsertSkillFilesToConversation).not.toHaveBeenCalled();
   });
 
   it("enables a favorite-only skill", async () => {
@@ -186,7 +186,7 @@ describe("skill_management enable_skill tool", () => {
   });
 
   it("returns a distinct mount-failure error when a newly enabled skill's file copy fails, without leaving it reported as ready", async () => {
-    mockLoadSkillFilesToConversation.mockResolvedValue(
+    mockUpsertSkillFilesToConversation.mockResolvedValue(
       new Err(
         new Error(
           "Failed to write skill file(s): conversation-conversation-id/skills/commit/sf_query.py (socket hang up)"
@@ -227,7 +227,7 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockLoadSkillFilesToConversation).toHaveBeenCalledWith(auth, {
+    expect(mockUpsertSkillFilesToConversation).toHaveBeenCalledWith(auth, {
       skill,
       conversation,
     });
@@ -251,7 +251,7 @@ describe("skill_management enable_skill tool", () => {
       favoriteSkills: [],
       systemSkills: [],
     });
-    mockLoadSkillFilesToConversation.mockResolvedValue(
+    mockUpsertSkillFilesToConversation.mockResolvedValue(
       new Err(
         new Error(
           "Failed to write skill file(s): conversation-conversation-id/skills/commit/config/queries.json (ENOENT)"
@@ -289,7 +289,7 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
+    expect(mockUpsertSkillFilesToConversation).not.toHaveBeenCalled();
   });
 
   it("does not enable skills outside the agent loop allow-list and reports a distinct not-equipped error", async () => {
@@ -310,7 +310,7 @@ describe("skill_management enable_skill tool", () => {
       expect(result.error.message).toContain("not equipped");
     }
     expect(mockEnableForAgent).not.toHaveBeenCalled();
-    expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
+    expect(mockUpsertSkillFilesToConversation).not.toHaveBeenCalled();
   });
 
   it("enables skills referenced by current root skills", async () => {

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -292,7 +292,7 @@ describe("skill_management enable_skill tool", () => {
     expect(mockUpsertSkillFilesToConversation).not.toHaveBeenCalled();
   });
 
-  it("does not enable skills outside the agent loop allow-list and reports a distinct not-equipped error", async () => {
+  it("does not enable skills outside the agent loop allow-list and reports a not-found error", async () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
@@ -307,7 +307,7 @@ describe("skill_management enable_skill tool", () => {
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
-      expect(result.error.message).toContain("not equipped");
+      expect(result.error.message).toContain("not found");
     }
     expect(mockEnableForAgent).not.toHaveBeenCalled();
     expect(mockUpsertSkillFilesToConversation).not.toHaveBeenCalled();

--- a/front/lib/api/actions/servers/skill_management/tools/index.test.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.test.ts
@@ -185,9 +185,13 @@ describe("skill_management enable_skill tool", () => {
     expect(mockEnableForAgent).toHaveBeenCalled();
   });
 
-  it("reports file load failures without failing the tool", async () => {
+  it("returns a distinct mount-failure error when a newly enabled skill's file copy fails, without leaving it reported as ready", async () => {
     mockLoadSkillFilesToConversation.mockResolvedValue(
-      new Err(new Error("GCS copy failed"))
+      new Err(
+        new Error(
+          "Failed to write skill file(s): conversation-conversation-id/skills/commit/sf_query.py (socket hang up)"
+        )
+      )
     );
 
     const result = await getTool().handler(
@@ -195,18 +199,83 @@ describe("skill_management enable_skill tool", () => {
       makeExtra()
     );
 
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        'Failed to mount files for skill "commit"'
+      );
+      expect(result.error.message).toContain(
+        "conversation-conversation-id/skills/commit/sf_query.py"
+      );
+    }
+    // The skill must not be persisted as enabled until the mount is confirmed.
+    expect(mockEnableForAgent).not.toHaveBeenCalled();
+  });
+
+  it("retries the file mount when the skill was already enabled but still has files to load", async () => {
+    mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: true });
+    mockListForAgentLoop.mockResolvedValue({
+      enabledSkills: [skill],
+      equippedSkills: [],
+      favoriteSkills: [],
+      systemSkills: [],
+    });
+
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra()
+    );
+
     expect(result.isOk()).toBe(true);
+    expect(mockLoadSkillFilesToConversation).toHaveBeenCalledWith(auth, {
+      skill,
+      conversation,
+    });
     if (result.isOk()) {
       const [output] = result.value;
       if (!isEnableSkillResultOutput(output)) {
         throw new Error("Expected an enable_skill resource output");
       }
-      expect(output.resource.text).toContain("Failed to load skill files");
+      expect(output.resource.text).toContain("was already enabled");
+      expect(output.resource.text).toContain(
+        "conversation-conversation-id/skills/commit/SKILL.md"
+      );
     }
   });
 
-  it("does not load files when the skill was already enabled", async () => {
+  it("returns a mount-failure error on retry when an already-enabled skill's files are still missing", async () => {
     mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: true });
+    mockListForAgentLoop.mockResolvedValue({
+      enabledSkills: [skill],
+      equippedSkills: [],
+      favoriteSkills: [],
+      systemSkills: [],
+    });
+    mockLoadSkillFilesToConversation.mockResolvedValue(
+      new Err(
+        new Error(
+          "Failed to write skill file(s): conversation-conversation-id/skills/commit/config/queries.json (ENOENT)"
+        )
+      )
+    );
+
+    const result = await getTool().handler(
+      { skillName: "commit" },
+      makeExtra()
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        'Failed to mount files for skill "commit"'
+      );
+      expect(result.error.message).toContain("config/queries.json");
+    }
+  });
+
+  it("does not retry the file mount when the already-enabled skill has no files", async () => {
+    mockEnableForAgent.mockResolvedValue({ wasAlreadyEnabled: true });
+    mockHasFiles.mockReturnValue(false);
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [skill],
       equippedSkills: [],
@@ -223,7 +292,7 @@ describe("skill_management enable_skill tool", () => {
     expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
   });
 
-  it("does not enable skills outside the agent loop allow-list", async () => {
+  it("does not enable skills outside the agent loop allow-list and reports a distinct not-equipped error", async () => {
     mockListForAgentLoop.mockResolvedValue({
       enabledSkills: [],
       equippedSkills: [],
@@ -237,6 +306,9 @@ describe("skill_management enable_skill tool", () => {
     );
 
     expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("not equipped");
+    }
     expect(mockEnableForAgent).not.toHaveBeenCalled();
     expect(mockLoadSkillFilesToConversation).not.toHaveBeenCalled();
   });

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -10,7 +10,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isUserMessageType } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 
@@ -37,6 +39,21 @@ function extractSkillIdsFromConversationMessages(
   }
 
   return [...userMessageSkillIds];
+}
+
+async function ensureSkillFilesMounted(
+  auth: Authenticator,
+  skill: SkillResource,
+  conversation: ConversationWithoutContentType
+): Promise<Result<{ loadedPaths: string[] }, Error>> {
+  if (!skill.hasFiles()) {
+    return new Ok({ loadedPaths: [] });
+  }
+
+  return loadSkillFilesToConversation(auth, {
+    skill,
+    conversation,
+  });
 }
 
 async function findAvailableSkillForAgentLoop({
@@ -133,9 +150,28 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
 
     if (!skill) {
       return new Err(
-        new MCPError(`Skill "${skillName}" not found`, {
+        new MCPError(`Skill "${skillName}" is not equipped for this agent.`, {
           tracked: false,
         })
+      );
+    }
+
+    // Mount the skill's files before persisting the enablement, since persistingit before the
+    // mount is confirmed would let those consumers see the skill as enabled eventhough its
+    // files never landed.
+    const mountResult = await ensureSkillFilesMounted(
+      auth,
+      skill,
+      conversation
+    );
+
+    if (mountResult.isErr()) {
+      // Returns a failure, not a successful enablement with a warning. A retried enable_skill call
+      // will attempt the mount again since it is idempotent.
+      return new Err(
+        new MCPError(
+          `Failed to mount files for skill "${skill.name}": ${mountResult.error.message}`
+        )
       );
     }
 
@@ -144,36 +180,16 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       conversation,
     });
 
-    if (wasAlreadyEnabled) {
-      return new Ok([
-        {
-          type: "text" as const,
-          text: `Skill "${skill.name}" was already enabled. No action taken.`,
-        },
-      ]);
-    }
-
-    // Copy the skill's files into the conversation file system so they are visible to both the
-    // files tools and the sandbox (when one exists). Covers both custom-skill attachments and
-    // code-defined skill files.
-    let fileMessage: string | null = null;
-    if (skill.hasFiles()) {
-      const fileLoadResult = await loadSkillFilesToConversation(auth, {
-        skill,
-        conversation,
-      });
-
-      if (fileLoadResult.isOk()) {
-        fileMessage =
-          "Skill files successfully loaded:\n" +
-          fileLoadResult.value.loadedPaths.map((p) => `  - ${p}`).join("\n");
-      } else {
-        fileMessage = `Failed to load skill files: ${fileLoadResult.error.message}`;
-      }
-    }
+    const fileMessage =
+      mountResult.value.loadedPaths.length > 0
+        ? "Skill files successfully loaded:\n" +
+          mountResult.value.loadedPaths.map((p) => `  - ${p}`).join("\n")
+        : null;
 
     const text =
-      `Skill "${skill.name}" has been enabled.` +
+      (wasAlreadyEnabled
+        ? `Skill "${skill.name}" was already enabled.`
+        : `Skill "${skill.name}" has been enabled.`) +
       (fileMessage ? `\n\n${fileMessage}` : "");
 
     return new Ok([makeEnableSkillResultOutput({ skillId: skill.sId, text })]);

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -156,9 +156,8 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       );
     }
 
-    // Mount the skill's files before persisting the enablement, since persistingit before the
-    // mount is confirmed would let those consumers see the skill as enabled eventhough its
-    // files never landed.
+    // Mount the skill's files before persisting the enablement: persisting it first would let a
+    // failed mount still leave the skill looking "enabled".
     const mountResult = await ensureSkillFilesMounted(
       auth,
       skill,

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -179,19 +179,22 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       conversation,
     });
 
-    const loadedFilesList = mountResult.value.loadedPaths
-      .map((p) => `  - ${p}`)
-      .join("\n");
+    const { loadedPaths } = mountResult.value;
+    const loadedFilesList = loadedPaths.map((p) => `  - ${p}`).join("\n");
 
-    const text = wasAlreadyEnabled
-      ? mountResult.value.loadedPaths.length > 0
-        ? `Skill "${skill.name}" was already enabled, but some files were missing and have ` +
-          `been additionally loaded:\n\n${loadedFilesList}`
-        : `Skill "${skill.name}" was already enabled.`
-      : `Skill "${skill.name}" has been enabled.` +
-        (mountResult.value.loadedPaths.length > 0
-          ? `\n\nSkill files successfully loaded:\n${loadedFilesList}`
-          : "");
+    let text: string;
+    if (!wasAlreadyEnabled) {
+      text = `Skill "${skill.name}" has been enabled.`;
+      if (loadedPaths.length > 0) {
+        text += `\n\nSkill files successfully loaded:\n${loadedFilesList}`;
+      }
+    } else if (loadedPaths.length > 0) {
+      text =
+        `Skill "${skill.name}" was already enabled, but some files were missing and ` +
+        `have been additionally loaded:\n\n${loadedFilesList}`;
+    } else {
+      text = `Skill "${skill.name}" was already enabled.`;
+    }
 
     return new Ok([makeEnableSkillResultOutput({ skillId: skill.sId, text })]);
   },

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -150,7 +150,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
 
     if (!skill) {
       return new Err(
-        new MCPError(`Skill "${skillName}" is not equipped for this agent.`, {
+        new MCPError(`Skill "${skillName}" not found`, {
           tracked: false,
         })
       );
@@ -179,17 +179,19 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       conversation,
     });
 
-    const fileMessage =
-      mountResult.value.loadedPaths.length > 0
-        ? "Skill files successfully loaded:\n" +
-          mountResult.value.loadedPaths.map((p) => `  - ${p}`).join("\n")
-        : null;
+    const loadedFilesList = mountResult.value.loadedPaths
+      .map((p) => `  - ${p}`)
+      .join("\n");
 
-    const text =
-      (wasAlreadyEnabled
-        ? `Skill "${skill.name}" was already enabled.`
-        : `Skill "${skill.name}" has been enabled.`) +
-      (fileMessage ? `\n\n${fileMessage}` : "");
+    const text = wasAlreadyEnabled
+      ? mountResult.value.loadedPaths.length > 0
+        ? `Skill "${skill.name}" was already enabled, but some files were missing and have ` +
+          `been additionally loaded:\n\n${loadedFilesList}`
+        : `Skill "${skill.name}" was already enabled.`
+      : `Skill "${skill.name}" has been enabled.` +
+        (mountResult.value.loadedPaths.length > 0
+          ? `\n\nSkill files successfully loaded:\n${loadedFilesList}`
+          : "");
 
     return new Ok([makeEnableSkillResultOutput({ skillId: skill.sId, text })]);
   },

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -5,7 +5,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { isAgentLoopRunContext } from "@app/lib/actions/types";
 import { SKILL_MANAGEMENT_TOOLS_METADATA } from "@app/lib/api/actions/servers/skill_management/metadata";
 import { makeEnableSkillResultOutput } from "@app/lib/api/actions/servers/skill_management/rendering";
-import { loadSkillFilesToConversation } from "@app/lib/api/skills/conversation_files";
+import { upsertSkillFilesToConversation } from "@app/lib/api/skills/conversation_files";
 import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { extractUniqueSkillIds } from "@app/lib/skills/format";
@@ -41,7 +41,7 @@ function extractSkillIdsFromConversationMessages(
   return [...userMessageSkillIds];
 }
 
-async function ensureSkillFilesMounted(
+async function mountSkillFilesToConversation(
   auth: Authenticator,
   skill: SkillResource,
   conversation: ConversationWithoutContentType
@@ -50,7 +50,7 @@ async function ensureSkillFilesMounted(
     return new Ok({ loadedPaths: [] });
   }
 
-  return loadSkillFilesToConversation(auth, {
+  return upsertSkillFilesToConversation(auth, {
     skill,
     conversation,
   });
@@ -158,7 +158,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
 
     // Mount the skill's files before persisting the enablement: persisting it first would let a
     // failed mount still leave the skill looking "enabled".
-    const mountResult = await ensureSkillFilesMounted(
+    const mountResult = await mountSkillFilesToConversation(
       auth,
       skill,
       conversation

--- a/front/lib/api/skills/conversation_files.test.ts
+++ b/front/lib/api/skills/conversation_files.test.ts
@@ -1,0 +1,273 @@
+import { upsertSkillFilesToConversation } from "@app/lib/api/skills/conversation_files";
+import type { Authenticator } from "@app/lib/auth";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SKILL_ICON } from "@app/lib/skill";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { grantWorkspacePermission } from "@app/tests/utils/permissions";
+import { conversationScopedPath } from "@app/types/file_system";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+// Mirrors `GCSFileSystemBackend.toGCSPath` for a conversation-scoped path (front/lib/api/file_system/backends/gcs_file_system_backend.ts).
+function gcsPathForSkillFile({
+  workspaceId,
+  conversationId,
+  skillName,
+  fileName,
+}: {
+  workspaceId: string;
+  conversationId: string;
+  skillName: string;
+  fileName: string;
+}): string {
+  return `w/${workspaceId}/conversations/${conversationId}/files/skills/${skillName}/${fileName}`;
+}
+
+async function setupConversationAndSkillPermissions() {
+  const {
+    authenticator: auth,
+    user,
+    workspace,
+  } = await createResourceTest({ role: "builder" });
+
+  if (!(await auth.hasWorkspacePermission("create", "skill"))) {
+    await grantWorkspacePermission(workspace, user, {
+      grantType: "create",
+      resourceType: "skill",
+    });
+    await auth.refresh();
+  }
+
+  const agent = await AgentConfigurationFactory.createTestAgent(auth);
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId: agent.sId,
+    messagesCreatedAt: [],
+  });
+
+  return { auth, user, workspace, conversation };
+}
+
+async function createSkillFileAttachment(
+  auth: Authenticator,
+  user: Parameters<typeof FileFactory.create>[1],
+  { fileName, content }: { fileName: string; content: string }
+) {
+  const file = await FileFactory.create(auth, user, {
+    contentType: "text/plain",
+    fileName,
+    fileSize: content.length,
+    status: "ready",
+    useCase: "skill_attachment",
+  });
+
+  return { file, content };
+}
+
+describe("upsertSkillFilesToConversation", () => {
+  it("writes every missing skill file and returns their scoped paths", async () => {
+    const { auth, user, workspace, conversation } =
+      await setupConversationAndSkillPermissions();
+
+    const attachments = await Promise.all(
+      [
+        { fileName: "a.txt", content: "content-a" },
+        { fileName: "b.txt", content: "content-b" },
+      ].map((spec) => createSkillFileAttachment(auth, user, spec))
+    );
+
+    const contentBySourcePath = new Map(
+      attachments.map(({ file, content }) => [
+        file.getCloudStoragePath(auth, "original"),
+        content,
+      ])
+    );
+    fileStorageMock.setFileExists(() => false);
+    fileStorageMock.setFileContent(
+      (filePath) => contentBySourcePath.get(filePath) ?? null
+    );
+
+    const skill = await SkillResource.makeNew(
+      auth,
+      {
+        editedBy: user.id,
+        agentFacingDescription: "desc",
+        userFacingDescription: "desc",
+        instructions: "instructions",
+        instructionsHtml: null,
+        name: "Test Skill",
+        requestedSpaceIds: [],
+        status: "active",
+        icon: SKILL_ICON.name,
+        availability: "editors",
+      },
+      {
+        mcpServerViews: [],
+        fileAttachments: attachments.map(({ file }) => file),
+      }
+    );
+
+    const result = await upsertSkillFilesToConversation(auth, {
+      skill,
+      conversation,
+    });
+
+    assert(result.isOk());
+    expect(result.value.loadedPaths.sort()).toEqual(
+      [
+        conversationScopedPath({
+          conversationId: conversation.sId,
+          rel: `skills/${skill.name}/a.txt`,
+        }),
+        conversationScopedPath({
+          conversationId: conversation.sId,
+          rel: `skills/${skill.name}/b.txt`,
+        }),
+      ].sort()
+    );
+
+    for (const { file } of attachments) {
+      const gcsPath = gcsPathForSkillFile({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        skillName: skill.name,
+        fileName: file.fileName,
+      });
+      expect(
+        fileStorageMock.writeStreamCalls.some(
+          (call) => call.filePath === gcsPath
+        )
+      ).toBe(true);
+    }
+  });
+
+  it("skips files already present and never re-reads their content", async () => {
+    const { auth, user, conversation } =
+      await setupConversationAndSkillPermissions();
+
+    const { file } = await createSkillFileAttachment(auth, user, {
+      fileName: "already-there.txt",
+      content: "irrelevant",
+    });
+    fileStorageMock.setFileExists(() => true);
+
+    const skill = await SkillResource.makeNew(
+      auth,
+      {
+        editedBy: user.id,
+        agentFacingDescription: "desc",
+        userFacingDescription: "desc",
+        instructions: "instructions",
+        instructionsHtml: null,
+        name: "Test Skill",
+        requestedSpaceIds: [],
+        status: "active",
+        icon: SKILL_ICON.name,
+        availability: "editors",
+      },
+      { mcpServerViews: [], fileAttachments: [file] }
+    );
+
+    const result = await upsertSkillFilesToConversation(auth, {
+      skill,
+      conversation,
+    });
+
+    assert(result.isOk());
+    expect(result.value.loadedPaths).toEqual([
+      conversationScopedPath({
+        conversationId: conversation.sId,
+        rel: `skills/${skill.name}/already-there.txt`,
+      }),
+    ]);
+    expect(fileStorageMock.writeStreamCalls).toHaveLength(0);
+    expect(fileStorageMock.readStreamCalls).toHaveLength(0);
+  });
+
+  it("cleans up files written by this call when a later write fails, leaving pre-existing files untouched", async () => {
+    const { auth, user, workspace, conversation } =
+      await setupConversationAndSkillPermissions();
+
+    const specs = [
+      { fileName: "pre-existing.txt", content: "already-mounted" },
+      { fileName: "will-succeed.txt", content: "content-b" },
+      { fileName: "will-fail.txt", content: "content-c" },
+    ];
+    const attachments = await Promise.all(
+      specs.map((spec) => createSkillFileAttachment(auth, user, spec))
+    );
+    const [preExisting, willSucceed, willFail] = attachments;
+
+    const contentBySourcePath = new Map(
+      attachments.map(({ file, content }) => [
+        file.getCloudStoragePath(auth, "original"),
+        content,
+      ])
+    );
+    fileStorageMock.setFileContent(
+      (filePath) => contentBySourcePath.get(filePath) ?? null
+    );
+
+    const skill = await SkillResource.makeNew(
+      auth,
+      {
+        editedBy: user.id,
+        agentFacingDescription: "desc",
+        userFacingDescription: "desc",
+        instructions: "instructions",
+        instructionsHtml: null,
+        name: "Test Skill",
+        requestedSpaceIds: [],
+        status: "active",
+        icon: SKILL_ICON.name,
+        availability: "editors",
+      },
+      {
+        mcpServerViews: [],
+        fileAttachments: attachments.map(({ file }) => file),
+      }
+    );
+
+    const gcsPathFor = (fileName: string) =>
+      gcsPathForSkillFile({
+        workspaceId: workspace.sId,
+        conversationId: conversation.sId,
+        skillName: skill.name,
+        fileName,
+      });
+    const preExistingPath = gcsPathFor(preExisting.file.fileName);
+    const willSucceedPath = gcsPathFor(willSucceed.file.fileName);
+    const willFailPath = gcsPathFor(willFail.file.fileName);
+
+    const existsCallCounts = new Map<string, number>();
+    fileStorageMock.setFileExists((filePath) => {
+      existsCallCounts.set(filePath, (existsCallCounts.get(filePath) ?? 0) + 1);
+      return filePath === preExistingPath;
+    });
+    fileStorageMock.setFileSaveFails((filePath) => filePath === willFailPath);
+
+    const result = await upsertSkillFilesToConversation(auth, {
+      skill,
+      conversation,
+    });
+
+    assert(result.isErr());
+    expect(result.error.message).toContain(willFail.file.fileName);
+
+    // Pre-existing file: only the pass-1 existence check, never written or cleaned up.
+    expect(existsCallCounts.get(preExistingPath)).toBe(1);
+    // Written-then-failed sibling: pass-1 check plus the cleanup delete's own existence check.
+    expect(existsCallCounts.get(willSucceedPath)).toBe(2);
+    // The file whose own write failed is never a cleanup target for itself.
+    expect(existsCallCounts.get(willFailPath)).toBe(1);
+
+    expect(
+      fileStorageMock.writeStreamCalls.some(
+        (call) => call.filePath === preExistingPath
+      )
+    ).toBe(false);
+  });
+});

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -87,7 +87,7 @@ export async function upsertSkillFilesToConversation(
     if (existsResult.isErr()) {
       return new Err(
         new Error(
-          `Failed to check skill file(s): ${expectedPaths.slice(index).join(", ")} (${existsResult.error.message})`
+          `Failed to check skill file: ${scopedPath} (${existsResult.error.message})`
         )
       );
     }
@@ -123,7 +123,7 @@ export async function upsertSkillFilesToConversation(
 
       return new Err(
         new Error(
-          `Failed to write skill file(s): ${scopedPath} (${writeResult.error.message})`
+          `Failed to write skill file: ${scopedPath} (${writeResult.error.message})`
         )
       );
     }

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -9,10 +9,13 @@ import type { Readable } from "stream";
 // A skill file ready to be written into a conversation, regardless of whether it
 // came from a database-backed `FileResource` (custom skills) or was declared
 // inline by a code-defined skill.
+//
+// `getContent` is only invoked when the file is confirmed missing from the conversation mount, so
+// a file already present is never re-read: no wasted GCS read stream for `FileResource` attachments.
 type WritableSkillFile = {
   fileName: string;
   contentType: string;
-  content: Readable | string;
+  getContent: () => Readable | string;
 };
 
 /**
@@ -27,7 +30,8 @@ type WritableSkillFile = {
  * Writing through DustFileSystem (rather than the sandbox filesystem) makes the files visible
  * everywhere the conversation files are: the `files__*` tools, the sandbox gcsfuse mount
  * (`/files/conversation-{cId}/skills/...`), the conversation files panel, and conversation
- * branching copies. The write is idempotent: re-enabling a skill overwrites the same paths.
+ * branching copies. Idempotent: files already present at their deterministic path are left
+ * untouched, and re-enabling a skill only writes whatever is still missing.
  *
  * Returns the canonical scoped paths (`conversation-{cId}/skills/...`) of the loaded files, as
  * surfaced by the `files__list` tool.
@@ -46,12 +50,12 @@ export async function loadSkillFilesToConversation(
     ...skill.getFileAttachments().map((file) => ({
       fileName: file.fileName,
       contentType: file.contentType,
-      content: file.getReadStream({ auth, version: "original" }),
+      getContent: () => file.getReadStream({ auth, version: "original" }),
     })),
     ...skill.getCodeDefinedFiles().map((file) => ({
       fileName: file.fileName,
       contentType: file.contentType,
-      content: file.content,
+      getContent: () => file.content,
     })),
   ];
 
@@ -83,18 +87,28 @@ export async function loadSkillFilesToConversation(
   for (const [index, file] of files.entries()) {
     const scopedPath = expectedPaths[index];
 
-    const writeResult = await fileSystem.write(
-      scopedPath,
-      file.content,
-      file.contentType
-    );
-    if (writeResult.isErr()) {
-      const missingPaths = expectedPaths.slice(index);
+    const existsResult = await fileSystem.exists(scopedPath);
+    if (existsResult.isErr()) {
       return new Err(
         new Error(
-          `Failed to write skill file(s): ${missingPaths.join(", ")} (${writeResult.error.message})`
+          `Failed to check skill file(s): ${expectedPaths.slice(index).join(", ")} (${existsResult.error.message})`
         )
       );
+    }
+
+    if (!existsResult.value) {
+      const writeResult = await fileSystem.write(
+        scopedPath,
+        file.getContent(),
+        file.contentType
+      );
+      if (writeResult.isErr()) {
+        return new Err(
+          new Error(
+            `Failed to write skill file(s): ${expectedPaths.slice(index).join(", ")} (${writeResult.error.message})`
+          )
+        );
+      }
     }
 
     loadedPaths.push(scopedPath);

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -1,7 +1,9 @@
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import type { Authenticator } from "@app/lib/auth";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { conversationScopedPath } from "@app/types/file_system";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { Readable } from "stream";
@@ -31,12 +33,14 @@ type WritableSkillFile = {
  * everywhere the conversation files are: the `files__*` tools, the sandbox gcsfuse mount
  * (`/files/conversation-{cId}/skills/...`), the conversation files panel, and conversation
  * branching copies. Idempotent: files already present at their deterministic path are left
- * untouched, and re-enabling a skill only writes whatever is still missing.
+ * untouched, and re-enabling a skill only writes whatever is still missing. All-or-nothing per
+ * call: if a write fails partway, the files written by this call are deleted so the agent never
+ * sees a half-mounted skill; files that were already present before this call are left alone.
  *
  * Returns the canonical scoped paths (`conversation-{cId}/skills/...`) of the loaded files, as
  * surfaced by the `files__list` tool.
  */
-export async function loadSkillFilesToConversation(
+export async function upsertSkillFilesToConversation(
   auth: Authenticator,
   {
     skill,
@@ -69,24 +73,16 @@ export async function loadSkillFilesToConversation(
   }
   const fileSystem = fsResult.value;
 
-  const conversationMount = fileSystem
-    .getMounts()
-    .find((m) => m.kind === "conversation" && m.id === conversation.sId);
-  // `forConversation` always creates the conversation mount.
-  if (!conversationMount) {
-    throw new Error("Conversation mount not found.");
-  }
-
-  const expectedPaths = files.map(
-    (file) =>
-      `${conversationMount.scopedPrefix}/skills/${skill.name}/${file.fileName}`
+  const expectedPaths = files.map((file) =>
+    conversationScopedPath({
+      conversationId: conversation.sId,
+      rel: `skills/${skill.name}/${file.fileName}`,
+    })
   );
 
-  const loadedPaths: string[] = [];
+  const missingIndexes: number[] = [];
 
-  for (const [index, file] of files.entries()) {
-    const scopedPath = expectedPaths[index];
-
+  for (const [index, scopedPath] of expectedPaths.entries()) {
     const existsResult = await fileSystem.exists(scopedPath);
     if (existsResult.isErr()) {
       return new Err(
@@ -97,22 +93,46 @@ export async function loadSkillFilesToConversation(
     }
 
     if (!existsResult.value) {
-      const writeResult = await fileSystem.write(
-        scopedPath,
-        file.getContent(),
-        file.contentType
-      );
-      if (writeResult.isErr()) {
-        return new Err(
-          new Error(
-            `Failed to write skill file(s): ${expectedPaths.slice(index).join(", ")} (${writeResult.error.message})`
-          )
-        );
-      }
+      missingIndexes.push(index);
     }
-
-    loadedPaths.push(scopedPath);
   }
 
-  return new Ok({ loadedPaths });
+  const writtenPaths: string[] = [];
+
+  for (const index of missingIndexes) {
+    const scopedPath = expectedPaths[index];
+    const file = files[index];
+
+    const writeResult = await fileSystem.write(
+      scopedPath,
+      file.getContent(),
+      file.contentType
+    );
+    if (writeResult.isErr()) {
+      for (const writtenPath of writtenPaths) {
+        const cleanupResult = await fileSystem.delete(writtenPath, {
+          ignoreNotFound: true,
+        });
+        if (cleanupResult.isErr()) {
+          logger.warn(
+            {
+              scopedPath: writtenPath,
+              error: cleanupResult.error.message,
+            },
+            "Failed to clean up skill file after mount failure."
+          );
+        }
+      }
+
+      return new Err(
+        new Error(
+          `Failed to write skill file(s): ${scopedPath} (${writeResult.error.message})`
+        )
+      );
+    }
+
+    writtenPaths.push(scopedPath);
+  }
+
+  return new Ok({ loadedPaths: expectedPaths });
 }

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -80,7 +80,7 @@ export async function upsertSkillFilesToConversation(
     })
   );
 
-  const missingIndexes: number[] = [];
+  const missing: { file: WritableSkillFile; scopedPath: string }[] = [];
 
   for (const [index, scopedPath] of expectedPaths.entries()) {
     const existsResult = await fileSystem.exists(scopedPath);
@@ -93,16 +93,13 @@ export async function upsertSkillFilesToConversation(
     }
 
     if (!existsResult.value) {
-      missingIndexes.push(index);
+      missing.push({ file: files[index], scopedPath });
     }
   }
 
   const writtenPaths: string[] = [];
 
-  for (const index of missingIndexes) {
-    const scopedPath = expectedPaths[index];
-    const file = files[index];
-
+  for (const { file, scopedPath } of missing) {
     const writeResult = await fileSystem.write(
       scopedPath,
       file.getContent(),

--- a/front/lib/api/skills/conversation_files.ts
+++ b/front/lib/api/skills/conversation_files.ts
@@ -3,7 +3,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 import type { Readable } from "stream";
 
 // A skill file ready to be written into a conversation, regardless of whether it
@@ -73,10 +73,15 @@ export async function loadSkillFilesToConversation(
     throw new Error("Conversation mount not found.");
   }
 
+  const expectedPaths = files.map(
+    (file) =>
+      `${conversationMount.scopedPrefix}/skills/${skill.name}/${file.fileName}`
+  );
+
   const loadedPaths: string[] = [];
 
-  for (const file of files) {
-    const scopedPath = `${conversationMount.scopedPrefix}/skills/${skill.name}/${file.fileName}`;
+  for (const [index, file] of files.entries()) {
+    const scopedPath = expectedPaths[index];
 
     const writeResult = await fileSystem.write(
       scopedPath,
@@ -84,7 +89,12 @@ export async function loadSkillFilesToConversation(
       file.contentType
     );
     if (writeResult.isErr()) {
-      return writeResult;
+      const missingPaths = expectedPaths.slice(index);
+      return new Err(
+        new Error(
+          `Failed to write skill file(s): ${missingPaths.join(", ")} (${writeResult.error.message})`
+        )
+      );
     }
 
     loadedPaths.push(scopedPath);

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -103,8 +103,9 @@ class FileStorageMock {
   }
 
   /**
-   * Makes `file(path).save(...)` reject for paths matching the predicate.
-   * Defaults to never failing. Reset between tests via `reset()`.
+   * Makes `file(path).save(...)` reject, and `file(path).createWriteStream(...)` emit an error,
+   * for paths matching the predicate. Defaults to never failing. Reset between tests via
+   * `reset()`.
    */
   setFileSaveFails(predicate: (filePath: string) => boolean): void {
     this._saveShouldFail = predicate;
@@ -266,11 +267,19 @@ class FileStorageMock {
       createWriteStream: vi
         .fn()
         .mockImplementation((opts?: { contentType?: string }) => {
+          const path = filePath ?? "unknown";
           this._writeStreamCalls.push({
-            filePath: filePath ?? "unknown",
+            filePath: path,
             contentType: opts?.contentType,
           });
-          return new PassThrough();
+          const stream = new PassThrough();
+          if (this._saveShouldFail(path)) {
+            // Deferred so `pipeline()` has already attached its error listeners
+            queueMicrotask(() =>
+              stream.destroy(new Error(`Simulated GCS write failure: ${path}`))
+            );
+          }
+          return stream;
         }),
       delete: vi.fn().mockImplementation(() => {
         this._objectStore.delete(filePath ?? "unknown");


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10111.

When `enable_skill` mounted a Skill’s attached files, it persisted the Skill as enabled before confirming that the mount succeeded. If a file download or write failed, the conversation could contain a partial Skill mount while the Skill was still marked as enabled.

A subsequent `enable_skill` call then returned `already enabled` and skipped the file mount, leaving the conversation without a recovery path.

Change:

1. Check: look up every expected file path; if a file already exists, leave it alone.
2. Write: write only the files that are missing.
3. Fail clean: if any write fails, delete whatever this call just wrote (pre-existing files stay untouched) and return an error, so the skill never ends up half-mounted.

This covers the customer case where the FPSH Skill encountered a GCS socket hang-up and only part of its file set was copied. On retry, the existing files are kept and the missing files are mounted.

## Tests

Added and updated unit tests covering:

- Initial file-mount failures.
- Retry of an already-enabled Skill with missing files.
- Successful loading of missing files while preserving existing files.
- Failed retries.
- Skills without files.
- Skills that are not equipped for the Agent.

## Risk

Low. The change is limited to Skill activation and conversation file mounting.

## Deploy Plan

Deploy `front`.