### PR TITLE
feat: accept pool-based trigger execution modes on read

### DIFF
--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -5,7 +5,10 @@ import {
 } from "@app/components/shared/tools_picker/types";
 import type { ProjectConfiguration } from "@app/lib/api/assistant/configuration/types";
 import { SKILL_AVAILABILITIES } from "@app/types/assistant/skill_configuration";
-import { TRIGGER_STATUSES } from "@app/types/assistant/triggers";
+import {
+  STORED_TRIGGER_EXECUTION_MODES,
+  TRIGGER_STATUSES,
+} from "@app/types/assistant/triggers";
 import { editorUserSchema } from "@app/types/editors";
 import { WEBHOOK_PROVIDERS } from "@app/types/triggers/webhooks";
 import { createContext } from "react";
@@ -82,7 +85,7 @@ const webhookTriggerSchema = z.object({
   webhookSourceViewId: z.string().nullable().optional(),
   editorName: z.string().optional(),
   executionPerDayLimitOverride: z.number().nullable(),
-  executionMode: z.enum(["fair_use", "programmatic"]).nullable(),
+  executionMode: z.enum(STORED_TRIGGER_EXECUTION_MODES).nullable(),
   spaceId: z.string().nullable().optional(),
 });
 

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -5,6 +5,7 @@ import { TriggerStatusToggle } from "@app/components/agent_builder/triggers/Trig
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import { WebhookEditionFilters } from "@app/components/agent_builder/triggers/webhook/WebhookEditionFilters";
 import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
+import { getTriggerExecutionMode } from "@app/types/assistant/triggers";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
 import type {
@@ -87,7 +88,7 @@ function WebhookEditionExecutionLimit({
         This trigger can send a limited number of messages per day. This
         prevents a single trigger from using up your workspace's message fair
         use quota. This trigger is currently running on your workspace's{" "}
-        {executionMode === "fair_use" ? "fair use" : "programmatic usage"}{" "}
+        {executionMode === "user_pool" ? "fair use" : "programmatic usage"}{" "}
         quota.
         <br /> (
         <LinkWrapper
@@ -313,7 +314,9 @@ export function WebhookEditionSheetContent({
         <Separator />
 
         <WebhookEditionExecutionLimit
-          executionMode={trigger?.executionMode ?? "fair_use"}
+          executionMode={getTriggerExecutionMode(
+            trigger?.executionMode ?? null
+          )}
         />
 
         <Separator />

--- a/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
@@ -3,7 +3,10 @@ import type {
   AgentBuilderWebhookTriggerType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { triggerStatusSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT } from "@app/types/assistant/triggers";
+import {
+  DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT,
+  STORED_TRIGGER_EXECUTION_MODES,
+} from "@app/types/assistant/triggers";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type { UserType } from "@app/types/user";
@@ -22,7 +25,7 @@ export const WebhookFormSchema = z.object({
   includePayload: z.boolean().default(false),
   naturalDescription: z.string().optional(),
   executionPerDayLimitOverride: z.number(),
-  executionMode: z.enum(["fair_use", "programmatic"]).default("fair_use"),
+  executionMode: z.enum(STORED_TRIGGER_EXECUTION_MODES).default("fair_use"),
   spaceId: z.string().nullable(),
 });
 

--- a/front/lib/api/poke/plugins/triggers/webhook_settings.ts
+++ b/front/lib/api/poke/plugins/triggers/webhook_settings.ts
@@ -1,5 +1,6 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
+import type { LegacyTriggerExecutionMode } from "@app/types/assistant/triggers";
+import { getTriggerExecutionMode } from "@app/types/assistant/triggers";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const webhookSettingsPlugin = createPlugin({
@@ -41,12 +42,14 @@ export const webhookSettingsPlugin = createPlugin({
       {
         label: "Fair Use",
         value: "fair_use",
-        checked: resource.executionMode === "fair_use",
+        checked:
+          getTriggerExecutionMode(resource.executionMode) === "user_pool",
       },
       {
         label: "Programmatic",
         value: "programmatic",
-        checked: resource.executionMode === "programmatic",
+        checked:
+          getTriggerExecutionMode(resource.executionMode) === "workspace_pool",
       },
     ];
 
@@ -62,7 +65,7 @@ export const webhookSettingsPlugin = createPlugin({
 
     const executionPerDayLimitOverride = args.executionPerDayLimitOverride;
     const executionMode = args.executionMode[0] as
-      | TriggerExecutionMode
+      | LegacyTriggerExecutionMode
       | undefined;
 
     if (executionPerDayLimitOverride < 1) {

--- a/front/lib/models/agent/triggers/triggers.ts
+++ b/front/lib/models/agent/triggers/triggers.ts
@@ -9,8 +9,8 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
+  StoredTriggerExecutionMode,
   TriggerConfigurationType,
-  TriggerExecutionMode,
   TriggerKind,
   TriggerOrigin,
   TriggerStatus,
@@ -39,7 +39,7 @@ export class TriggerModel extends WorkspaceAwareModel<TriggerModel> {
    */
   declare webhookSourceViewId: ForeignKey<WebhookSourcesViewModel["id"]> | null;
   declare executionPerDayLimitOverride: number | null;
-  declare executionMode: TriggerExecutionMode | null;
+  declare executionMode: StoredTriggerExecutionMode | null;
 
   /**
    * We use the sId, because it's static between an agent versions,

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -23,7 +23,7 @@ import {
 } from "@app/temporal/triggers/schedule_client";
 import type {
   ScheduleConfig,
-  TriggerExecutionMode,
+  StoredTriggerExecutionMode,
   TriggerKind,
   TriggerStatus,
   TriggerType,
@@ -1053,7 +1053,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
    */
   async updateWebhookSettings(
     executionPerDayLimitOverride: number | null,
-    executionMode: TriggerExecutionMode | null
+    executionMode: StoredTriggerExecutionMode | null
   ): Promise<Result<undefined, Error>> {
     if (this.kind !== "webhook") {
       return new Err(

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -27,7 +27,10 @@ import type {
   WebhookRequestTriggerStatus,
   WebhookTriggerType,
 } from "@app/types/assistant/triggers";
-import { isWebhookTrigger } from "@app/types/assistant/triggers";
+import {
+  getTriggerExecutionMode,
+  isWebhookTrigger,
+} from "@app/types/assistant/triggers";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -288,6 +291,7 @@ async function checkWorkspaceRateLimit({
 
   const plan = auth.subscription()?.plan;
   const owner = auth.getNonNullableWorkspace();
+  const executionMode = getTriggerExecutionMode(trigger.executionMode);
 
   // Credit-priced pool gate: applies to any execution mode. If the pool is
   // depleted, no downstream message can be posted, so reject early instead of
@@ -301,12 +305,12 @@ async function checkWorkspaceRateLimit({
       };
     }
 
-    // Programmatic monthly cap gate: if the programmatic cap is reached, reject
-    // early for programmatic triggers.
+    // Programmatic monthly cap gate: if the cap is reached, reject early for
+    // triggers charged to the workspace pool.
     if (
       !block &&
       owner.metronomeCustomerId &&
-      trigger.executionMode === "programmatic" &&
+      executionMode === "workspace_pool" &&
       (await isProgrammaticApiBlocked(owner.sId))
     ) {
       block = {
@@ -319,29 +323,35 @@ async function checkWorkspaceRateLimit({
 
   /**
    * Check for workspace-level rate limits
-   * - for fair use execution mode, check global rate limits
-   * - for programmatic usage mode, check public API limits
+   * - user pool: check global rate limits
+   * - workspace pool: check public API limits
    */
   if (!block) {
-    if (!trigger.executionMode || trigger.executionMode === "fair_use") {
-      const { rateLimited, message } =
-        await checkWebhookRequestForRateLimit(auth);
-      if (rateLimited) {
-        block = { status: "rate_limited", message };
-      }
-    } else {
-      // Programmatic execution mode: legacy programmatic-credit gate applies
-      // to legacy plans only. Credit-priced plans are already gated above by
-      // the workspace pool check.
-      if (!plan || !isCreditPricedPlan(plan)) {
-        const limitsResult = await checkProgrammaticUsageLimits(auth);
-        if (limitsResult.isErr()) {
-          block = {
-            status: "rate_limited",
-            message: limitsResult.error.message,
-          };
+    switch (executionMode) {
+      case "user_pool": {
+        const { rateLimited, message } =
+          await checkWebhookRequestForRateLimit(auth);
+        if (rateLimited) {
+          block = { status: "rate_limited", message };
         }
+        break;
       }
+      case "workspace_pool": {
+        // The legacy programmatic-credit gate applies to legacy plans only.
+        // Credit-priced plans are already gated above by the pool check.
+        if (!plan || !isCreditPricedPlan(plan)) {
+          const limitsResult = await checkProgrammaticUsageLimits(auth);
+          if (limitsResult.isErr()) {
+            block = {
+              status: "rate_limited",
+              message: limitsResult.error.message,
+            };
+          }
+        }
+        break;
+      }
+      default:
+        assertNever(executionMode);
     }
   }
 

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -26,6 +26,7 @@ import type {
   UserMessageContext,
 } from "@app/types/assistant/conversation";
 import type { TriggerType } from "@app/types/assistant/triggers";
+import { getTriggerExecutionMode } from "@app/types/assistant/triggers";
 import type { WakeUpType } from "@app/types/assistant/wakeups";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -78,7 +79,8 @@ async function createConversationForAgentConfiguration({
     email: auth.getNonNullableUser().email,
     profilePictureUrl: null,
     origin:
-      trigger.kind === "webhook" && trigger.executionMode === "programmatic"
+      trigger.kind === "webhook" &&
+      getTriggerExecutionMode(trigger.executionMode) === "workspace_pool"
         ? "triggered_programmatic"
         : "triggered",
     lastTriggerRunAt: lastRunAt?.getTime() ?? null,

--- a/front/types/assistant/triggers.test.ts
+++ b/front/types/assistant/triggers.test.ts
@@ -1,0 +1,18 @@
+import { getTriggerExecutionMode } from "@app/types/assistant/triggers";
+import { describe, expect, it } from "vitest";
+
+describe("getTriggerExecutionMode", () => {
+  it("maps legacy modes onto their pool", () => {
+    expect(getTriggerExecutionMode("fair_use")).toBe("user_pool");
+    expect(getTriggerExecutionMode("programmatic")).toBe("workspace_pool");
+  });
+
+  it("treats an unset mode as the user pool", () => {
+    expect(getTriggerExecutionMode(null)).toBe("user_pool");
+  });
+
+  it("passes pool modes through", () => {
+    expect(getTriggerExecutionMode("user_pool")).toBe("user_pool");
+    expect(getTriggerExecutionMode("workspace_pool")).toBe("workspace_pool");
+  });
+});

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -67,7 +67,43 @@ export type TriggerConfigurationType = ScheduleConfig | WebhookConfig;
 
 export const DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT = 42;
 
-export type TriggerExecutionMode = "fair_use" | "programmatic";
+export const TRIGGER_EXECUTION_MODES = ["user_pool", "workspace_pool"] as const;
+export type TriggerExecutionMode = (typeof TRIGGER_EXECUTION_MODES)[number];
+
+// Still stored in the database and returned by the API until the pool rename
+// has rolled out. Read through `getTriggerExecutionMode`, never by comparison.
+export const LEGACY_TRIGGER_EXECUTION_MODES = [
+  "fair_use",
+  "programmatic",
+] as const;
+export type LegacyTriggerExecutionMode =
+  (typeof LEGACY_TRIGGER_EXECUTION_MODES)[number];
+
+export type StoredTriggerExecutionMode =
+  | TriggerExecutionMode
+  | LegacyTriggerExecutionMode;
+
+export const STORED_TRIGGER_EXECUTION_MODES = [
+  ...TRIGGER_EXECUTION_MODES,
+  ...LEGACY_TRIGGER_EXECUTION_MODES,
+] as const;
+
+export function getTriggerExecutionMode(
+  mode: StoredTriggerExecutionMode | null
+): TriggerExecutionMode {
+  switch (mode) {
+    case "workspace_pool":
+    case "programmatic":
+      return "workspace_pool";
+    case "user_pool":
+    case "fair_use":
+    case null:
+      return "user_pool";
+    default:
+      assertNeverAndIgnore(mode);
+      return "user_pool";
+  }
+}
 
 export const TRIGGER_STATUSES = [
   "enabled",
@@ -172,7 +208,7 @@ export const FullTriggerSchema = z.discriminatedUnion("kind", [
     configuration: WebhookConfigSchema,
     executionPerDayLimitOverride: z.number().nullable(),
     webhookSourceViewId: z.string().nullable(),
-    executionMode: z.enum(["fair_use", "programmatic"]).nullable(),
+    executionMode: z.enum(STORED_TRIGGER_EXECUTION_MODES).nullable(),
   }),
 ]);
 
@@ -187,7 +223,7 @@ export function isValidTriggerKind(kind: string): kind is TriggerKind {
 export type WebhookTriggerType = TriggerType & {
   kind: "webhook";
   webhookSourceViewId: string;
-  executionMode: TriggerExecutionMode | null;
+  executionMode: StoredTriggerExecutionMode | null;
   executionPerDayLimitOverride: number | null;
 };
 


### PR DESCRIPTION
## Description

Stack, renaming trigger `executionMode` from `fair_use`/`programmatic`/`NULL` to `user_pool`/`workspace_pool`: this PR adds the new vocabulary while keeping the old one supported, #30783 flips the writers and migrates the data, #30784 deletes the legacy vocabulary and adds `NOT NULL`.
Three deploys on purpose. Merging the write flip together with the read narrowing would break browser tabs holding an older bundle. Following those 3 PRs, the front rendering will be unchanged. Only stored data will be harmonized. Product PRs will come later on.

`TriggerExecutionMode` becomes the destination union, with `LEGACY_TRIGGER_EXECUTION_MODES` and `getTriggerExecutionMode` carrying the transition. Every schema that parses the field accepts all four values, and the webhook gates, trigger activity, edition sheet and poke plugin read through the normalizer. Writes are untouched, so this ships as a pure no-op and gives old clients a deploy cycle to age out before the server starts emitting the new values.

## Tests

Unit test for `getTriggerExecutionMode` covering both legacy values, both pool values and `NULL`.
Existing `trigger_resource` and `lib/triggers` suites pass.

## Risk

Low, nothing changes behaviour. The widened enums are strictly more permissive than what the database holds, and every read path normalizes to the same two outcomes it produced before.

## Deploy Plan

Deploy front, wait for rollout, then move on to second PR.