### PR TITLE
feat: write pool-based trigger execution modes and backfill

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -380,7 +380,7 @@ app.post(
         editor: auth.getNonNullableUser().id,
         webhookSourceViewId,
         executionPerDayLimitOverride: executionPerDay,
-        executionMode: validatedTrigger.kind === "webhook" ? "fair_use" : null,
+        executionMode: "user_pool",
         origin: "user",
         spaceId: spaceIdRes.value,
       });

--- a/front/lib/api/actions/servers/triggers_management/tools/index.ts
+++ b/front/lib/api/actions/servers/triggers_management/tools/index.ts
@@ -221,7 +221,7 @@ export function createTriggersManagementTools(
           editor: user.id,
           webhookSourceViewId: null,
           executionPerDayLimitOverride: null,
-          executionMode: "fair_use",
+          executionMode: "user_pool",
           origin: "agent",
           spaceId,
         });
@@ -604,7 +604,7 @@ export function createTriggersManagementTools(
           webhookSourceViewId: view.id,
           executionPerDayLimitOverride:
             DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT,
-          executionMode: "fair_use",
+          executionMode: "user_pool",
           origin: "agent",
           spaceId,
         });

--- a/front/lib/api/poke/plugins/triggers/webhook_settings.ts
+++ b/front/lib/api/poke/plugins/triggers/webhook_settings.ts
@@ -1,6 +1,9 @@
 import { createPlugin } from "@app/lib/api/poke/types";
-import type { LegacyTriggerExecutionMode } from "@app/types/assistant/triggers";
-import { getTriggerExecutionMode } from "@app/types/assistant/triggers";
+import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
+import {
+  getTriggerExecutionMode,
+  TRIGGER_EXECUTION_MODES,
+} from "@app/types/assistant/triggers";
 import { Err, Ok } from "@app/types/shared/result";
 
 export const webhookSettingsPlugin = createPlugin({
@@ -40,14 +43,14 @@ export const webhookSettingsPlugin = createPlugin({
       checked?: boolean;
     }[] = [
       {
-        label: "Fair Use",
-        value: "fair_use",
+        label: "User pool",
+        value: "user_pool",
         checked:
           getTriggerExecutionMode(resource.executionMode) === "user_pool",
       },
       {
-        label: "Programmatic",
-        value: "programmatic",
+        label: "Workspace pool",
+        value: "workspace_pool",
         checked:
           getTriggerExecutionMode(resource.executionMode) === "workspace_pool",
       },
@@ -65,7 +68,7 @@ export const webhookSettingsPlugin = createPlugin({
 
     const executionPerDayLimitOverride = args.executionPerDayLimitOverride;
     const executionMode = args.executionMode[0] as
-      | LegacyTriggerExecutionMode
+      | TriggerExecutionMode
       | undefined;
 
     if (executionPerDayLimitOverride < 1) {
@@ -74,13 +77,11 @@ export const webhookSettingsPlugin = createPlugin({
       );
     }
 
-    if (
-      executionMode &&
-      executionMode !== "fair_use" &&
-      executionMode !== "programmatic"
-    ) {
+    if (executionMode && !TRIGGER_EXECUTION_MODES.includes(executionMode)) {
       return new Err(
-        new Error('Execution mode must be "fair_use" or "programmatic"')
+        new Error(
+          `Execution mode must be one of ${TRIGGER_EXECUTION_MODES.join(", ")}`
+        )
       );
     }
 

--- a/front/migrations/post-deploy/20260819150100_sweep_trigger_execution_modes_to_pools.sql
+++ b/front/migrations/post-deploy/20260819150100_sweep_trigger_execution_modes_to_pools.sql
@@ -1,0 +1,21 @@
+/*
+Post-deploy: sweep any triggers still holding a legacy "executionMode".
+
+Identical to the pre-deploy rename. Rows can only reach here if an old pod
+created or updated a trigger between the pre-deploy migration and the end of the
+rollout, so they are all fair_use or NULL, both of which map to user_pool.
+
+The NOT NULL constraint lands in a follow-up PR, once this has run and
+`SELECT "executionMode", count(*) FROM triggers GROUP BY 1` returns nothing but
+the two pool values.
+ */
+SET SESSION statement_timeout = 60000;
+SET SESSION lock_timeout = 3000;
+
+UPDATE "public"."triggers"
+SET "executionMode" = CASE
+                          WHEN "executionMode" = 'programmatic' THEN 'workspace_pool'
+                          ELSE 'user_pool'
+                          END
+WHERE "executionMode" IS NULL
+   OR "executionMode" IN ('fair_use', 'programmatic');

--- a/front/migrations/pre-deploy/20260819150000_rename_trigger_execution_modes_to_pools.sql
+++ b/front/migrations/pre-deploy/20260819150000_rename_trigger_execution_modes_to_pools.sql
@@ -1,0 +1,26 @@
+/*
+Pre-deploy: rename triggers."executionMode" from fair_use/programmatic to the
+pool-based user_pool/workspace_pool.
+
+Runs before the code that writes the new values is live, on purpose. The
+currently deployed code already reads both vocabularies through
+getTriggerExecutionMode, so converting early is a no-op behaviourally, and it
+means the programmatic rows are already correct when the new code takes over.
+Leaving them for the post-deploy sweep would gate them against the user pool
+instead of the workspace pool for the length of the deploy.
+
+NULL means "never set", which the code has always treated as fair use.
+
+A post-deploy sweep re-runs this to catch rows written by old pods during the
+rollout.
+ */
+SET SESSION statement_timeout = 60000;
+SET SESSION lock_timeout = 3000;
+
+UPDATE "public"."triggers"
+SET "executionMode" = CASE
+                          WHEN "executionMode" = 'programmatic' THEN 'workspace_pool'
+                          ELSE 'user_pool'
+                          END
+WHERE "executionMode" IS NULL
+   OR "executionMode" IN ('fair_use', 'programmatic');


### PR DESCRIPTION
Stacked on #30782.

## Description

Every writer now sets `user_pool`, schedule triggers included: the API route used to leave them `NULL` and the trigger management tool used to set `fair_use`, so the column was already inconsistent across kinds. Poke becomes the only way to move a trigger onto the workspace pool.
The pre-deploy migration renames existing rows, the post-deploy one sweeps whatever old pods wrote during the rollout, and both are idempotent.

## Tests

`trigger_resource` and `lib/triggers` suites pass.

## Risk

Low. Rolling back means reverting the code, and the renamed rows stay readable because the reverted code can read both vocabularies.

## Deploy Plan

Pre-deploy migration, deploy front, post-deploy migration. Then check `SELECT "executionMode", count(*) FROM triggers GROUP BY 1` before merging the next PR.