### PR TITLE
DO NOT MERGE: Add blind Frames evaluation toolkit

### DIFF
--- a/x/henry/king-of-the-frames/.gitignore
+++ b/x/henry/king-of-the-frames/.gitignore
@@ -1,0 +1,7 @@
+.env
+.auth*
+/work/
+/results/
+/packs/
+*.private.json
+*.log

--- a/x/henry/king-of-the-frames/ANALYSIS.md
+++ b/x/henry/king-of-the-frames/ANALYSIS.md
@@ -1,0 +1,112 @@
+# Analysis methodology
+
+The quantitative tally and qualitative review answer different questions. Keep them separate until
+the final synthesis.
+
+## Quantitative results
+
+For every matchup, count human slot reactions after excluding the bot's pre-seeded reaction.
+
+- `matchesPlayed`: matchups in which the candidate produced a reviewable Frame.
+- `decided`: played matchups with at least one human slot vote.
+- `rawVotes`: all human votes assigned to the candidate's slot.
+- `outrightWins`: the candidate has the unique highest vote count.
+- `tieShare`: `1 / numberOfTiedLeaders` when candidates tie for the highest non-zero count.
+- `winRate`: `(outrightWins + tieShare) / decided`.
+- `noneVotes`: votes that all Frames are unsuitable. Report separately and never assign to a
+  candidate.
+
+Always show `matchesPlayed`, `decided`, and the count of unvoted matchups next to win rate. Using all
+posted matchups as the denominator makes lightly reviewed candidates look artificially weak.
+
+## Reliability
+
+Review every Frame, including matchups with no votes. Use a small severity taxonomy:
+
+- `clean`: no material issue.
+- `minor-polish`: cosmetic or small usability issue.
+- `major-ux`: renders, but has a serious interaction, layout, accessibility, or prompt-adherence issue.
+- `broken`: blank, runtime error, missing core data, or unusable.
+
+Track failure tags separately, for example `data-fetch`, `blank-on-load`, `runtime-error`,
+`incomplete`, `mobile`, `overflow`, `accessibility`, and `brand-fidelity`. Define tags before the final
+rollup and deduplicate synonyms.
+
+## Blind qualitative pass
+
+Analyze by slot before reading `mapping.private.json`:
+
+1. Open every Frame in the same authenticated browser context used by reviewers.
+2. Exercise meaningful interactions and responsive layouts.
+3. Read the Frame source when available.
+4. Review votes, raw comments, and screenshots. A comment can refer to several slots, so do not assign
+   comments to candidates with a regex or keyword heuristic.
+5. Write one slot assessment per matchup using
+   [templates/matchup-analysis-prompt.md](./templates/matchup-analysis-prompt.md).
+6. Record severity, failure tags, strengths, evidence, and specific source patterns. If there is no
+   useful finding, say so.
+
+Only after the slot documents are complete should an operator join them to candidate IDs using the
+private mapping.
+
+## Cost and latency
+
+Export one normalized record per generated conversation to `usage.jsonl`:
+
+```json
+{
+  "packId": "pack-id",
+  "agentId": "agent-candidate-a",
+  "conversationId": "conversation-id",
+  "modelId": "model-a",
+  "frameProduced": true,
+  "startedAt": "2026-01-01T10:00:00Z",
+  "completedAt": "2026-01-01T10:02:00Z",
+  "freshInputTokens": 1000,
+  "cacheReadTokens": 4000,
+  "cacheWriteTokens": 0,
+  "outputTokens": 2000,
+  "recordedCostMicroUsd": 12345
+}
+```
+
+Gather it through an approved read-only path. The usual ownership chain is generated conversation to
+agent messages, run IDs, runs, and run-usage rows. Join run IDs by unnesting them and using equality on
+the indexed run identifier. Do not issue a broad production scan.
+
+Normalize provider counters before using the script. Some provider payloads report total prompt tokens
+with cache tokens already included. Convert that representation into disjoint
+`freshInputTokens`, `cacheReadTokens`, and `cacheWriteTokens`; never add cache counters on top of an
+inclusive prompt total.
+
+The calculator applies:
+
+```text
+fresh input * input rate
++ cache read * cache-read rate
++ cache write * cache-write rate
++ output * output rate
+```
+
+Use the exact model and price effective at evaluation time. Experimental models can have placeholder
+recorded costs, so validate the normalized formula against a production-priced control model before
+trusting derived costs. Count only conversations that produced the Frames used in review. Report N,
+total, mean, median, and p90 because retries and missing Frames otherwise distort comparisons.
+
+Latency is end-to-end generation time: final run completion minus conversation creation. Use the same
+boundary for every candidate.
+
+## Final report
+
+For each candidate include:
+
+- Raw votes, decided win rate, ties, participation, and no-Frame rate.
+- Clean/minor/major/broken distribution.
+- Latency median and p90.
+- Cost mean, median, p90, and total, with the pricing source and effective date.
+- Repeated strengths and failure modes, each grounded in matchup IDs, reviewer evidence, and source
+  examples.
+- Important confounders, including missing Frames, unequal N, auth failures, and viewer-access issues.
+
+Do not identify a winner from aesthetics alone. Reliability, cost, latency, and prompt adherence are
+part of the result.

--- a/x/henry/king-of-the-frames/PACKS.md
+++ b/x/henry/king-of-the-frames/PACKS.md
@@ -1,0 +1,108 @@
+# Building frame packs
+
+A frame pack is a self-contained version of one real Frame request. It isolates Frame design and
+implementation from research quality: candidates receive the same brief and the same supporting data,
+and should not browse, query a data source, or inspect the source conversation.
+
+## Candidate selection
+
+Start with more conversations than the target pack count, then filter aggressively:
+
+- Keep professional requests that ask for a new Frame.
+- Exclude personal, confidential, customer-specific, or private-space material unless the owner has
+  explicitly approved its use.
+- Exclude requests whose main task is editing an existing Frame.
+- Exclude tasks that cannot be made self-contained without disclosing restricted data.
+- Prefer a varied mix of dashboards, reports, presentations, explainers, operational tools, and
+  interactive experiences.
+- Record the selection query and filter criteria outside the committed repository.
+
+Use read-only, approved access for discovery and transcript export. Never put API keys, OAuth tokens,
+Slack tokens, signed URLs, raw private conversation URLs, workspace IDs, or database credentials in a
+pack.
+
+## Directory contract
+
+```text
+packs/<pack-id>/
+├── brief.md
+├── manifest.json
+├── context/
+│   ├── INDEX.md
+│   ├── data/
+│   └── notes/
+└── attachments/
+```
+
+`brief.md` is sent as the message. Every file under `context/data`, `context/notes`, and `attachments`,
+plus `context/INDEX.md`, is attached to the conversation. `manifest.json` is tooling metadata and is
+not attached.
+
+All attached basenames must be unique within a pack because the runner flattens attachment paths.
+
+## Construction procedure
+
+1. Export the complete source conversation through an approved read-only interface. Include user
+   messages, follow-ups, tool calls, tool results, generated/downloaded files, and the final Frame.
+2. Separate user intent from research output:
+   - User intent and constraints belong in `brief.md`.
+   - Query results, reports, and structured facts belong in `context/data`.
+   - Qualitative research belongs in `context/notes`.
+   - Original user-provided files belong in `attachments`.
+   - The generated Frame and its layout are evidence for pack completeness only. Do not describe or
+     imitate that layout in the brief.
+3. Download source files programmatically when possible. Do not hand-copy large tool outputs or
+   retype tabular data.
+4. Preserve fidelity. Store tables as CSV/TSV/JSON, binary documents in their original format, and
+   narrative research as concise Markdown. Do not silently round, summarize, or drop rows.
+5. Write `context/INDEX.md`. For every file, state what it contains, where it came from, the query or
+   extraction method, important columns/units, and any caveats.
+6. Write `brief.md` from the user's request and follow-ups. Remove research instructions that are now
+   satisfied by the attached files. Add a short instruction to read the supplied material and build the
+   Frame directly without additional research.
+7. Write `manifest.json` and list every attached file with a description and non-secret provenance.
+8. Review the pack without the source conversation. A reviewer should be able to explain the task,
+   locate every required fact, and identify the meaning of each file.
+9. Run `validate-packs.mjs`, then run one pack against one inexpensive candidate before scaling out.
+
+## Brief rules
+
+The brief must:
+
+- Preserve the requested outcome, audience, copy, interactions, and visual constraints.
+- Mention attached files by basename, not by local directory path.
+- Tell the candidate not to perform additional research.
+- Avoid suggesting a layout derived from a previous generated Frame.
+- Avoid mentioning candidate identities, the tournament, expected winners, or prior feedback.
+
+The brief must not contain answers copied from research when the attached source already communicates
+them. That creates prompt noise and can bias layout choices.
+
+## Manifest format
+
+```json
+{
+  "version": 1,
+  "packId": "stable-pack-id",
+  "source": {
+    "kind": "approved-conversation-export",
+    "reference": "private operator reference, omitted from committed examples"
+  },
+  "files": [
+    {
+      "path": "context/data/metrics.csv",
+      "description": "Monthly metrics used by the requested dashboard",
+      "provenance": "Read-only export of the query documented in INDEX.md"
+    }
+  ]
+}
+```
+
+The source reference may be useful in a private working copy. Remove it before sharing a pack outside
+the authorized evaluation group.
+
+## Pack-builder prompt template
+
+Use [templates/pack-builder-prompt.md](./templates/pack-builder-prompt.md) when delegating pack
+construction. Give each builder only one source conversation and its downloaded files. A second person
+should review each pack before it enters the run.

--- a/x/henry/king-of-the-frames/README.md
+++ b/x/henry/king-of-the-frames/README.md
@@ -1,0 +1,109 @@
+# King of the Frames
+
+Human-judged, blind comparison of Frames generated from the same self-contained tasks. Research is
+prepared once in a frame pack, each candidate receives identical inputs, and reviewers vote on the
+rendered Frames without seeing which agent produced them.
+
+This is separate from `x/henry/dust-evals`: there is no model judge and no automatic quality score.
+
+## Quick start
+
+1. Create a private working directory. Never put credentials or real evaluation data in this repo.
+
+   ```bash
+   cd x/henry/king-of-the-frames
+   mkdir -p work/packs work/run work/review
+   cp config.example.json work/config.json
+   cp pricing.example.json work/pricing.json
+   ```
+
+2. Select professional, shareable source conversations and turn each into a self-contained pack.
+   Follow [PACKS.md](./PACKS.md). Keep the original request in `brief.md`, move research outputs into
+   attached files, and remove personal or workspace-specific material that reviewers should not see.
+
+3. Validate the packs before spending model budget.
+
+   ```bash
+   node src/validate-packs.mjs --packs work/packs
+   ```
+
+4. Smoke-test one pack against every candidate. Supply a supported user OAuth token and workspace ID
+   through the shell only.
+
+   ```bash
+   export DUST_WORKSPACE_ID='<workspace-sId>'
+   read -rs DUST_ACCESS_TOKEN && export DUST_ACCESS_TOKEN
+   node src/run-eval.mjs \
+     --config work/config.json \
+     --packs work/packs \
+     --out work/run \
+     --only-pack '<pack-id>' \
+     --concurrency 1
+   ```
+
+5. Inspect the resulting conversations and Frames. If the smoke test is sound, run the full matrix.
+   The runner is resumable, so running the same command again retries only unfinished cells.
+
+   ```bash
+   node src/run-eval.mjs \
+     --config work/config.json \
+     --packs work/packs \
+     --out work/run
+   ```
+
+6. Resolve each generated file URL to a reviewer-accessible Frame share URL using the current,
+   approved application or internal tooling. Save the normalized map as `work/frame-index.json`:
+
+   ```json
+   {
+     "pack-id": {
+       "agent-candidate-a": "https://example.invalid/share/frame/redacted-a",
+       "agent-candidate-b": "https://example.invalid/share/frame/redacted-b"
+     }
+   }
+   ```
+
+7. Build randomized, blind review payloads and the private slot mapping.
+
+   ```bash
+   node src/build-blind-eval.mjs \
+     --config work/config.json \
+     --packs work/packs \
+     --frame-index work/frame-index.json \
+     --out work/review
+   ```
+
+8. Preview one matchup, then post the full set to a dedicated Slack channel. The bot token and channel
+   ID remain in environment variables. Posting is resumable.
+
+   ```bash
+   export SLACK_CHANNEL_ID='<channel-id>'
+   read -rs SLACK_BOT_TOKEN && export SLACK_BOT_TOKEN
+   node src/post-slack.mjs --review work/review --dry-run --max 1
+   node src/post-slack.mjs --review work/review --max 1
+   # Inspect the real post, then:
+   node src/post-slack.mjs --review work/review
+   ```
+
+9. At the end of the voting window, collect reactions and comments, tally the blind results, and
+   compute cost and latency from a normalized usage export.
+
+   ```bash
+   export SLACK_BOT_USER_ID='<bot-user-id>'
+   node src/collect-feedback.mjs --review work/review --out work/feedback.private.json
+   node src/tally.mjs \
+     --feedback work/feedback.private.json \
+     --mapping work/review/mapping.private.json \
+     --out work/tally
+   node src/cost-latency.mjs \
+     --usage work/usage.jsonl \
+     --pricing work/pricing.json \
+     --out work/cost-latency
+   ```
+
+10. Read [ANALYSIS.md](./ANALYSIS.md) before de-blinding qualitative findings. Combine voting,
+    reliability, cost, latency, comments, screenshots, and code-grounded failure modes in the final
+    report.
+
+Read [RUNBOOK.md](./RUNBOOK.md) before a full run. It contains selection rules, data contracts,
+retry behavior, cost accounting, Slack pitfalls, and the final quality checklist.

--- a/x/henry/king-of-the-frames/RUNBOOK.md
+++ b/x/henry/king-of-the-frames/RUNBOOK.md
@@ -1,0 +1,349 @@
+# Frame evaluation runbook
+
+Use this runbook for a blind, human-judged comparison of candidate agents' ability to build Frames.
+The method controls research inputs so the comparison measures design, implementation, reliability,
+cost, and latency rather than differences in browsing or data retrieval.
+
+## 1. Define the run
+
+Write down the following before collecting data:
+
+- The question being tested, for example whether a new Frame skill improves quality.
+- Candidate agent IDs and neutral display labels.
+- Model IDs, reasoning levels, feature flags, and deployment versions.
+- Target number and mix of packs.
+- Workspace whose members and data are authorized for the run.
+- Review channel, voting window, and intended reviewer group.
+- Pricing source and effective date.
+- Exclusion rules, retry policy, and tie policy.
+
+Change one experimental variable at a time when possible. If candidates differ in both model and skill
+prompt, the result cannot isolate either factor.
+
+Create `work/config.json` from `config.example.json`. Keep real candidate and workspace identifiers in
+the ignored working directory.
+
+## 2. Preflight access and privacy
+
+Confirm:
+
+- The operator can use a supported user OAuth session in the target workspace.
+- Every candidate agent is active and available to the operator.
+- The operator has approved read-only access for conversation discovery, transcript export, and usage
+  export.
+- Reviewers can open the intended Frame share scope.
+- A Slack bot is installed in a dedicated channel.
+- Real packs and results are stored only in the ignored working directory.
+
+Recommended Slack scopes are `chat:write`, `channels:read`, `channels:history`, `reactions:read`,
+`reactions:write`, and `files:read` if screenshots will be downloaded. Invite the bot to the channel.
+Use channel IDs, not names, in scripts.
+
+Read [SECURITY.md](./SECURITY.md). Do not continue if source conversations include unapproved personal,
+customer, or private-space data.
+
+## 3. Discover candidate source conversations
+
+Use an approved read-only query or export to find recent conversations that generated a Frame. Start
+with more candidates than the desired pack count because filtering is intentionally strict.
+
+The discovery record should contain only what is needed to review eligibility:
+
+- Conversation identifier and timestamp.
+- Space visibility and professional/private classification.
+- Request type: create, edit, or unrelated.
+- Whether a Frame was produced.
+- Whether source files and tool outputs remain retrievable.
+
+Constrain the query by workspace, time range, Frame content type/use case, and ready state so it uses
+existing indexes. Never perform a broad production scan. Store the query and raw output privately.
+
+Apply the selection rules in [PACKS.md](./PACKS.md). Have a human approve the final list.
+
+## 4. Build self-contained packs
+
+For every selected conversation:
+
+1. Export the complete transcript and download source/tool-output files through approved read-only
+   paths.
+2. Run one pack-builder task using [templates/pack-builder-prompt.md](./templates/pack-builder-prompt.md).
+3. Put user intent in `brief.md`, research evidence in `context`, and original user files in
+   `attachments`.
+4. Document every attached file in `context/INDEX.md` and `manifest.json`.
+5. Review the pack without opening the source conversation.
+6. Scan for secrets, identifiers, private URLs, personal data, and irrelevant transcript noise.
+
+Do not use the previous generated Frame as a style target. It is useful only to check that the pack has
+enough information to satisfy the original request.
+
+Validate the complete set:
+
+```bash
+node src/validate-packs.mjs --packs work/packs
+```
+
+Fix all validation errors. The validator checks required files, unique attachment basenames, manifest
+coverage, the no-research instruction, symlinks, and common credential patterns. It is not a substitute
+for privacy review.
+
+## 5. Smoke-test generation
+
+The runner uses the Dust v1 conversation and file-upload APIs with a user OAuth bearer. It intentionally
+does not implement a login flow or persist credentials. Obtain a token through the currently supported
+auth path and export it only in the shell.
+
+```bash
+export DUST_WORKSPACE_ID='<workspace-sId>'
+read -rs DUST_ACCESS_TOKEN && export DUST_ACCESS_TOKEN
+node src/run-eval.mjs \
+  --config work/config.json \
+  --packs work/packs \
+  --out work/run \
+  --only-pack '<pack-id>' \
+  --concurrency 1
+```
+
+Inspect every smoke-test candidate:
+
+- The conversation received the same brief and attachment basenames.
+- The candidate did not redo research.
+- A Frame file was generated.
+- The Frame renders in the intended reviewer context.
+- Attached data loads in a shared Frame.
+- Candidate identity is not visible in the artifact or review copy.
+
+The public API can evolve. Treat the smoke test as a compatibility check before every run.
+
+## 6. Generate the full matrix
+
+Run every pack against every candidate:
+
+```bash
+node src/run-eval.mjs \
+  --config work/config.json \
+  --packs work/packs \
+  --out work/run
+```
+
+The runner:
+
+- Uploads each pack file and attaches it to a new unlisted conversation.
+- Mentions exactly one candidate in the message.
+- Polls until it sees a generated file with the Frame content type, hits a terminal error, or times out.
+- Writes one cell file under `work/run/cells/<pack>/<agent>.json`.
+- Appends an audit record to `work/run/results.jsonl`.
+- Skips cells that already contain a non-empty Frame file URL.
+
+Keep concurrency moderate. Start at four and increase only after watching rate limits and model latency.
+High reasoning agents can be the long tail.
+
+An OAuth access token may expire during a long run. The runner stops retrying a 401 and tells the
+operator to refresh the token. Export the new token and run the same command again. Completed cells are
+preserved. Never run two refresh-token consumers concurrently when the identity provider rotates refresh
+tokens.
+
+`status=created` is not automatically a failure. The Frame file can appear while the conversation is
+still streaming. The file artifact is the completion criterion.
+
+## 7. Retry and completeness
+
+Classify unfinished cells:
+
+- Authentication or authorization failure: fix credentials, then rerun.
+- Rate limit or transient platform failure: wait, then rerun.
+- Poll timeout with server-side completion: recover the finished Frame through an approved lookup rather
+  than generating a duplicate.
+- Candidate finished without a Frame: retry once.
+- Repeated candidate refusal or failure: record it as a no-Frame outcome.
+
+Do not retry indefinitely. Retries change cost and can introduce selection bias. Keep the retry policy
+identical across candidates and retain every attempt in the audit data.
+
+Before review, generate a completeness table with one row per pack and candidate. A fair N-way matchup
+requires a reviewable Frame from every candidate. The included blind-payload builder skips incomplete
+packs and writes `skipped.json`.
+
+## 8. Resolve reviewer links
+
+`run-eval.mjs` captures authenticated file API URLs. Reviewers need Frame share URLs with an appropriate
+scope. Resolve each file through the current approved application or internal read-only tooling and
+write `work/frame-index.json`:
+
+```json
+{
+  "pack-id": {
+    "agent-candidate-a": "https://host/share/frame/token-a",
+    "agent-candidate-b": "https://host/share/frame/token-b"
+  }
+}
+```
+
+Do not commit this file. Share URLs can be sensitive even when they require a signed-in workspace user.
+Prefer workspace-restricted sharing unless public access is an explicit requirement.
+
+Open a sample of every candidate's links in the same browser state reviewers will use. A Frame that works
+inside its source conversation can still fail in a share context if it hardcodes conversation-scoped
+file paths.
+
+## 9. Build the blind review set
+
+```bash
+node src/build-blind-eval.mjs \
+  --config work/config.json \
+  --packs work/packs \
+  --frame-index work/frame-index.json \
+  --out work/review
+```
+
+Outputs:
+
+- `payloads.json`: randomized slot URLs and briefs. Candidate identities are absent.
+- `mapping.private.json`: slot to candidate mapping. Keep private until blind analysis is complete.
+- `skipped.json`: incomplete packs and missing candidates.
+
+The builder uses a cryptographic Fisher-Yates shuffle for every matchup. Do not reuse a fixed slot order.
+
+## 10. Post to Slack
+
+Always preview locally, post one real matchup, inspect it, then post the rest.
+
+```bash
+export SLACK_CHANNEL_ID='<channel-id>'
+read -rs SLACK_BOT_TOKEN && export SLACK_BOT_TOKEN
+node src/post-slack.mjs --review work/review --dry-run --max 1
+node src/post-slack.mjs --review work/review --max 1
+# After human approval:
+node src/post-slack.mjs --review work/review
+```
+
+Each matchup has:
+
+- A root message with numbered Frame links.
+- Numbered vote reactions plus a `none suitable` reaction.
+- The full brief in a thread reply.
+
+The tool adds reactions sequentially with a default 1100 ms gap. Slack clients order reactions using
+their first-add timestamps, whose coarse precision can reorder reactions added in parallel or within the
+same second. Tallying uses reaction names, but stable display order prevents reviewer mistakes.
+
+Posting is resumable through `posted.private.json`. There is intentionally no automated cleanup command.
+Deleting channel content must be a separate, explicit human decision.
+
+## 11. Run the voting window
+
+Tell reviewers:
+
+- Open every Frame before voting.
+- Vote for the best implementation, not the slot number they usually prefer.
+- Use `none suitable` if all candidates fail materially.
+- Add comments for concrete strengths or failures.
+- Attach screenshots for rendering or interaction problems.
+
+Keep the candidate mapping closed. Do not publish interim candidate standings because they can influence
+later voters. Track participation and extend the window if too many matchups have no votes.
+
+## 12. Collect feedback
+
+```bash
+export SLACK_BOT_USER_ID='<bot-user-id>' # optional; auth.test is used otherwise
+node src/collect-feedback.mjs \
+  --review work/review \
+  --out work/feedback.private.json
+```
+
+The collector excludes the bot's seeded reactions and captures slot votes, none votes, reviewer IDs,
+thread comments, and file metadata. It does not download screenshots. If screenshots are required for
+qualitative analysis, download them with `files:read` and a bearer token, then verify file magic bytes.
+A redirect or HTML login page saved as `.png` is not a valid screenshot.
+
+Do not assign comments to candidates programmatically. Reviewers write free-form references such as
+"2 is blank" and can discuss several slots in one comment. Preserve raw context for the blind review.
+
+## 13. Tally votes
+
+```bash
+node src/tally.mjs \
+  --feedback work/feedback.private.json \
+  --mapping work/review/mapping.private.json \
+  --out work/tally
+```
+
+The output includes matches played, decided matchups, outright wins, tie share, raw votes, win rate,
+none votes, no-vote matchups, and unique reviewers. Read [ANALYSIS.md](./ANALYSIS.md) for definitions.
+
+Freeze the feedback and tally at the announced close time. Record late votes separately rather than
+silently changing the published denominator.
+
+## 14. Export usage and compute cost/latency
+
+Use a production read replica or approved analytics export. Start from the generated conversation IDs in
+`work/run/results.jsonl`, then join narrowly to messages, agent messages, run IDs, runs, and run usage.
+Export only the fields in the normalized contract documented in [ANALYSIS.md](./ANALYSIS.md).
+
+Before calculating:
+
+1. Confirm whether provider prompt tokens include cache-read and cache-write tokens.
+2. Normalize into disjoint fresh-input, cache-read, cache-write, and output counters.
+3. Confirm the exact model ID used by each candidate.
+4. Record per-million-token prices and their effective date in `work/pricing.json`.
+5. Reproduce the recorded cost of at least one production-priced control conversation.
+6. Mark only reviewed, Frame-producing conversations with `frameProduced: true`.
+
+Then run:
+
+```bash
+node src/cost-latency.mjs \
+  --usage work/usage.jsonl \
+  --pricing work/pricing.json \
+  --out work/cost-latency
+```
+
+Do not add cache counters to an inclusive prompt-token total. That error can multiply input cost.
+Experimental models may have placeholder recorded costs; the verified price table is authoritative for
+those models.
+
+## 15. Perform blind qualitative analysis
+
+Follow [ANALYSIS.md](./ANALYSIS.md) and
+[templates/matchup-analysis-prompt.md](./templates/matchup-analysis-prompt.md).
+
+Keep analysis slot-blind. Read code, exercise interactions, inspect responsive behavior, and ground every
+claim in the brief, reviewer evidence, screenshots, or a specific source pattern. Analyze every Frame,
+not only winners. Reliability failures are often underrepresented in raw votes when reviewers abandon a
+broken page without reacting.
+
+After all slot documents are frozen, join them to candidates with `mapping.private.json` and build a
+per-candidate synthesis.
+
+## 16. Publish and archive
+
+The final report must state:
+
+- Candidate configuration and evaluation dates.
+- Pack count, selection filters, and skipped/incomplete counts.
+- Reviewer count, total votes, decided matchups, and no-vote matchups.
+- Retry policy and operational incidents.
+- Voting, reliability, cost, latency, and qualitative results.
+- Pricing assumptions and token-normalization method.
+- Limitations and known confounders.
+
+Archive the private working directory in an approved restricted location. Keep the committed toolkit
+generic. Never commit a real run to this package.
+
+## Final checklist
+
+- [ ] Candidate matrix and experimental variable are documented.
+- [ ] Packs passed privacy review and `validate-packs`.
+- [ ] Every candidate passed a one-pack smoke test.
+- [ ] Full run is complete or missing cells are explicitly recorded.
+- [ ] Share links work in reviewer context.
+- [ ] Blind payloads contain no candidate identity.
+- [ ] Private mapping is access-restricted.
+- [ ] One Slack post was approved before bulk posting.
+- [ ] Seed reactions appear in stable numeric order.
+- [ ] Bot votes are excluded.
+- [ ] Vote denominator is decided matchups, not all posted matchups.
+- [ ] Usage counters are disjoint and pricing is dated and verified.
+- [ ] Blind qualitative documents were frozen before de-blinding.
+- [ ] Final claims have matchup and source evidence.
+- [ ] Real data and credentials remain outside git.

--- a/x/henry/king-of-the-frames/SECURITY.md
+++ b/x/henry/king-of-the-frames/SECURITY.md
@@ -1,0 +1,24 @@
+# Security and privacy
+
+The repository contains tooling and synthetic examples only. Real packs, mappings, responses, Frame
+URLs, conversation IDs, workspace IDs, usage exports, and reviewer identities stay in an ignored
+working directory.
+
+## Never commit
+
+- API keys, OAuth access or refresh tokens, Slack tokens, cookies, database credentials, or signed URLs.
+- Workspace, user, customer, private-space, conversation, file, or channel identifiers from a real run.
+- `mapping.private.json`, `posted.private.json`, or `feedback.private.json`.
+- Raw transcripts, generated Frame source, screenshots, or usage exports.
+- Private share links, even if they only work for signed-in workspace members.
+
+Supply credentials through environment variables or an approved secret manager. OAuth token files must
+be outside the repository and mode `0600`. Use one token-refreshing process at a time if the identity
+provider rotates refresh tokens.
+
+Before sharing a run directory, remove the private mapping and scan every text file for credentials,
+identifiers, email addresses, and signed URLs. Treat the de-blinding mapping as confidential until the
+voting window and blind qualitative review have closed.
+
+Use a dedicated Slack channel. Preview one real post before bulk posting. The included tool has no
+channel-cleanup or deletion command; cleanup remains an explicit human action.

--- a/x/henry/king-of-the-frames/config.example.json
+++ b/x/henry/king-of-the-frames/config.example.json
@@ -1,0 +1,21 @@
+{
+  "apiBaseUrl": "https://dust.tt/api/v1",
+  "agents": [
+    {
+      "id": "agent-candidate-a",
+      "label": "Candidate A"
+    },
+    {
+      "id": "agent-candidate-b",
+      "label": "Candidate B"
+    },
+    {
+      "id": "agent-candidate-c",
+      "label": "Candidate C"
+    }
+  ],
+  "concurrency": 4,
+  "timeoutMs": 900000,
+  "pollIntervalMs": 4000,
+  "timezone": "UTC"
+}

--- a/x/henry/king-of-the-frames/examples/feedback.example.json
+++ b/x/henry/king-of-the-frames/examples/feedback.example.json
@@ -1,0 +1,16 @@
+{
+  "collectedAt": "2026-01-02T12:00:00Z",
+  "uniqueReviewerCount": 3,
+  "matchups": [
+    {
+      "packId": "example-pack",
+      "votesBySlot": {
+        "1": 2,
+        "2": 1,
+        "3": 0
+      },
+      "noneVotes": 0,
+      "comments": []
+    }
+  ]
+}

--- a/x/henry/king-of-the-frames/examples/frame-index.example.json
+++ b/x/henry/king-of-the-frames/examples/frame-index.example.json
@@ -1,0 +1,7 @@
+{
+  "example-pack": {
+    "agent-candidate-a": "https://example.invalid/share/frame/candidate-a",
+    "agent-candidate-b": "https://example.invalid/share/frame/candidate-b",
+    "agent-candidate-c": "https://example.invalid/share/frame/candidate-c"
+  }
+}

--- a/x/henry/king-of-the-frames/examples/mapping.example.json
+++ b/x/henry/king-of-the-frames/examples/mapping.example.json
@@ -1,0 +1,18 @@
+{
+  "example-pack": {
+    "slots": {
+      "1": {
+        "agentId": "agent-candidate-b",
+        "label": "Candidate B"
+      },
+      "2": {
+        "agentId": "agent-candidate-a",
+        "label": "Candidate A"
+      },
+      "3": {
+        "agentId": "agent-candidate-c",
+        "label": "Candidate C"
+      }
+    }
+  }
+}

--- a/x/henry/king-of-the-frames/examples/packs/example-pack/brief.md
+++ b/x/henry/king-of-the-frames/examples/packs/example-pack/brief.md
@@ -1,0 +1,7 @@
+# Regional operations overview
+
+Build an interactive Frame that helps an operations lead compare monthly throughput and quality across
+regions. Use `regional_metrics.csv` as the source of truth. Make trends and exceptions easy to scan,
+and include a useful region filter.
+
+Read the supplied files and build the Frame directly. Do not perform additional research.

--- a/x/henry/king-of-the-frames/examples/packs/example-pack/context/INDEX.md
+++ b/x/henry/king-of-the-frames/examples/packs/example-pack/context/INDEX.md
@@ -1,0 +1,6 @@
+# Attached data
+
+## `regional_metrics.csv`
+
+Synthetic monthly regional metrics. `throughput` is a count of completed items. `quality_pct` is a
+percentage from 0 to 100. The file is complete and requires no additional query.

--- a/x/henry/king-of-the-frames/examples/packs/example-pack/context/data/regional_metrics.csv
+++ b/x/henry/king-of-the-frames/examples/packs/example-pack/context/data/regional_metrics.csv
@@ -1,0 +1,5 @@
+month,region,throughput,quality_pct
+2026-01,North,120,96.0
+2026-01,South,105,91.5
+2026-02,North,132,95.2
+2026-02,South,118,93.1

--- a/x/henry/king-of-the-frames/examples/packs/example-pack/manifest.json
+++ b/x/henry/king-of-the-frames/examples/packs/example-pack/manifest.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "packId": "example-pack",
+  "source": {
+    "kind": "synthetic-example"
+  },
+  "files": [
+    {
+      "path": "context/data/regional_metrics.csv",
+      "description": "Synthetic monthly throughput and quality metrics",
+      "provenance": "Generated for the committed example"
+    },
+    {
+      "path": "context/INDEX.md",
+      "description": "File inventory and column definitions",
+      "provenance": "Generated for the committed example"
+    }
+  ]
+}

--- a/x/henry/king-of-the-frames/examples/usage.example.jsonl
+++ b/x/henry/king-of-the-frames/examples/usage.example.jsonl
@@ -1,0 +1,2 @@
+{"packId":"example-pack","agentId":"agent-candidate-a","conversationId":"conversation-a","modelId":"model-a","frameProduced":true,"startedAt":"2026-01-01T10:00:00Z","completedAt":"2026-01-01T10:02:00Z","freshInputTokens":1000,"cacheReadTokens":4000,"cacheWriteTokens":0,"outputTokens":2000}
+{"packId":"example-pack","agentId":"agent-candidate-b","conversationId":"conversation-b","modelId":"model-b","frameProduced":true,"startedAt":"2026-01-01T10:00:00Z","completedAt":"2026-01-01T10:01:30Z","freshInputTokens":1200,"cacheReadTokens":3800,"cacheWriteTokens":0,"outputTokens":1800}

--- a/x/henry/king-of-the-frames/package.json
+++ b/x/henry/king-of-the-frames/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "king-of-the-frames",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "validate-packs": "node src/validate-packs.mjs",
+    "run": "node src/run-eval.mjs",
+    "build-blind": "node src/build-blind-eval.mjs",
+    "post-slack": "node src/post-slack.mjs",
+    "collect-feedback": "node src/collect-feedback.mjs",
+    "tally": "node src/tally.mjs",
+    "cost-latency": "node src/cost-latency.mjs",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/x/henry/king-of-the-frames/pricing.example.json
+++ b/x/henry/king-of-the-frames/pricing.example.json
@@ -1,0 +1,16 @@
+{
+  "models": {
+    "model-a": {
+      "inputUsdPerMillion": 1,
+      "cacheReadUsdPerMillion": 0.1,
+      "cacheWriteUsdPerMillion": 1.25,
+      "outputUsdPerMillion": 5
+    },
+    "model-b": {
+      "inputUsdPerMillion": 2,
+      "cacheReadUsdPerMillion": 0.2,
+      "cacheWriteUsdPerMillion": 2,
+      "outputUsdPerMillion": 8
+    }
+  }
+}

--- a/x/henry/king-of-the-frames/src/build-blind-eval.mjs
+++ b/x/henry/king-of-the-frames/src/build-blind-eval.mjs
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  listPackIds,
+  parseArgs,
+  randomShuffle,
+  readJson,
+  requireArg,
+  stderr,
+  stdout,
+  validateConfig,
+  writeJson,
+} from "./lib.mjs";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const config = validateConfig(
+    await readJson(path.resolve(requireArg(args, "config"))),
+  );
+  const packsRoot = path.resolve(requireArg(args, "packs"));
+  const frameIndex = await readJson(
+    path.resolve(requireArg(args, "frame-index")),
+  );
+  const outRoot = path.resolve(requireArg(args, "out"));
+  const packIds = await listPackIds(packsRoot);
+  const payloads = [];
+  const mappings = {};
+  const skipped = [];
+
+  for (const packId of packIds) {
+    const candidates = config.agents.map((agent) => ({
+      agentId: agent.id,
+      label: agent.label,
+      frameUrl: frameIndex[packId]?.[agent.id],
+    }));
+    const missing = candidates.filter(
+      ({ frameUrl }) => typeof frameUrl !== "string" || frameUrl.length === 0,
+    );
+    if (missing.length > 0) {
+      skipped.push({
+        packId,
+        missingAgents: missing.map(({ agentId }) => agentId),
+      });
+      continue;
+    }
+    for (const candidate of candidates) {
+      let parsed;
+      try {
+        parsed = new URL(candidate.frameUrl);
+      } catch {
+        throw new Error(
+          `${packId}/${candidate.agentId} has an invalid Frame URL`,
+        );
+      }
+      if (!["https:", "http:"].includes(parsed.protocol)) {
+        throw new Error(
+          `${packId}/${candidate.agentId} Frame URL must use HTTP or HTTPS`,
+        );
+      }
+    }
+
+    const shuffled = randomShuffle(candidates);
+    const slots = shuffled.map((candidate, index) => ({
+      slot: String(index + 1),
+      frameUrl: candidate.frameUrl,
+    }));
+    const mapping = Object.fromEntries(
+      shuffled.map((candidate, index) => [
+        String(index + 1),
+        { agentId: candidate.agentId, label: candidate.label },
+      ]),
+    );
+    payloads.push({
+      packId,
+      slots,
+      brief: (
+        await fs.readFile(path.join(packsRoot, packId, "brief.md"), "utf8")
+      ).trim(),
+    });
+    mappings[packId] = { slots: mapping };
+  }
+
+  await writeJson(path.join(outRoot, "payloads.json"), payloads);
+  await writeJson(path.join(outRoot, "mapping.private.json"), mappings);
+  await writeJson(path.join(outRoot, "skipped.json"), skipped);
+  stdout(
+    `Built ${payloads.length} blind matchup(s); skipped ${skipped.length} incomplete pack(s).`,
+  );
+  stdout(`Private mapping: ${path.join(outRoot, "mapping.private.json")}`);
+}
+
+main().catch((error) => {
+  stderr(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/x/henry/king-of-the-frames/src/collect-feedback.mjs
+++ b/x/henry/king-of-the-frames/src/collect-feedback.mjs
@@ -1,0 +1,127 @@
+import path from "node:path";
+
+import {
+  parseArgs,
+  readJson,
+  requireArg,
+  sleep,
+  stderr,
+  stdout,
+  writeJson,
+} from "./lib.mjs";
+
+const SLOT_BY_REACTION = new Map([
+  ["one", "1"],
+  ["two", "2"],
+  ["three", "3"],
+  ["four", "4"],
+  ["five", "5"],
+]);
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const reviewRoot = path.resolve(requireArg(args, "review"));
+  const outPath = path.resolve(requireArg(args, "out"));
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    throw new Error("SLACK_BOT_TOKEN must be set in the shell");
+  }
+
+  const slack = async (method, params = {}) => {
+    const query = new URLSearchParams(params);
+    const response = await fetch(`https://slack.com/api/${method}?${query}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const result = await response.json();
+    if (!response.ok || !result.ok) {
+      throw new Error(
+        `Slack ${method} failed: ${result.error ?? response.status}`,
+      );
+    }
+    return result;
+  };
+
+  const botUserId =
+    process.env.SLACK_BOT_USER_ID ?? (await slack("auth.test")).user_id;
+  const posted = await readJson(path.join(reviewRoot, "posted.private.json"));
+  const matchups = [];
+  const reviewerIds = new Set();
+  const gapMs = Number(process.env.SLACK_READ_GAP_MS ?? 350);
+
+  for (const post of posted) {
+    const reactionResponse = await slack("reactions.get", {
+      channel: post.channel,
+      timestamp: post.ts,
+      full: "true",
+    });
+    const message = reactionResponse.message;
+    const votesBySlot = {};
+    const voteUserIdsBySlot = {};
+    let noneVotes = 0;
+    for (const reaction of message.reactions ?? []) {
+      const humanUsers = (reaction.users ?? []).filter(
+        (userId) => userId !== botUserId,
+      );
+      for (const userId of humanUsers) {
+        reviewerIds.add(userId);
+      }
+      const slot = SLOT_BY_REACTION.get(reaction.name);
+      if (slot) {
+        votesBySlot[slot] = humanUsers.length;
+        voteUserIdsBySlot[slot] = humanUsers;
+      } else if (reaction.name === "no_entry_sign") {
+        noneVotes = humanUsers.length;
+      }
+    }
+
+    const replies = await slack("conversations.replies", {
+      channel: post.channel,
+      ts: post.ts,
+      limit: "200",
+    });
+    const comments = (replies.messages ?? [])
+      .slice(1)
+      .filter((reply) => reply.user !== botUserId)
+      .map((reply) => ({
+        userId: reply.user ?? null,
+        text: reply.text ?? "",
+        ts: reply.ts,
+        files: (reply.files ?? []).map((file) => ({
+          id: file.id,
+          name: file.name,
+          mimetype: file.mimetype,
+        })),
+      }));
+    for (const comment of comments) {
+      if (comment.userId) {
+        reviewerIds.add(comment.userId);
+      }
+    }
+
+    matchups.push({
+      packId: post.packId,
+      channel: post.channel,
+      ts: post.ts,
+      votesBySlot,
+      voteUserIdsBySlot,
+      noneVotes,
+      comments,
+    });
+    stdout(`Collected ${post.packId}.`);
+    await sleep(gapMs);
+  }
+
+  await writeJson(outPath, {
+    collectedAt: new Date().toISOString(),
+    uniqueReviewerCount: reviewerIds.size,
+    matchups,
+  });
+  stdout(
+    `Saved ${matchups.length} matchup(s), ${reviewerIds.size} unique reviewer(s).`,
+  );
+}
+
+main().catch((error) => {
+  stderr(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/x/henry/king-of-the-frames/src/cost-latency.mjs
+++ b/x/henry/king-of-the-frames/src/cost-latency.mjs
@@ -1,0 +1,175 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  loadJsonl,
+  mean,
+  parseArgs,
+  percentile,
+  readJson,
+  requireArg,
+  stderr,
+  stdout,
+  writeJson,
+} from "./lib.mjs";
+
+function tokenCount(record, key) {
+  const value = Number(record[key] ?? 0);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(
+      `${record.conversationId ?? "unknown conversation"}: ${key} must be non-negative`,
+    );
+  }
+  return value;
+}
+
+export function costMicroUsd(record, pricing) {
+  const freshInputTokens = tokenCount(record, "freshInputTokens");
+  const cacheReadTokens = tokenCount(record, "cacheReadTokens");
+  const cacheWriteTokens = tokenCount(record, "cacheWriteTokens");
+  const outputTokens = tokenCount(record, "outputTokens");
+  const requiredRates = [
+    "inputUsdPerMillion",
+    "cacheReadUsdPerMillion",
+    "cacheWriteUsdPerMillion",
+    "outputUsdPerMillion",
+  ];
+  for (const rate of requiredRates) {
+    if (
+      !Number.isFinite(Number(pricing?.[rate])) ||
+      Number(pricing[rate]) < 0
+    ) {
+      throw new Error(`Missing or invalid ${rate} for model ${record.modelId}`);
+    }
+  }
+  return (
+    freshInputTokens * Number(pricing.inputUsdPerMillion) +
+    cacheReadTokens * Number(pricing.cacheReadUsdPerMillion) +
+    cacheWriteTokens * Number(pricing.cacheWriteUsdPerMillion) +
+    outputTokens * Number(pricing.outputUsdPerMillion)
+  );
+}
+
+function latencyMs(record) {
+  const startMs = Date.parse(record.startedAt);
+  const endMs = Date.parse(record.completedAt);
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    throw new Error(
+      `${record.conversationId ?? "unknown conversation"}: invalid latency timestamps`,
+    );
+  }
+  return endMs - startMs;
+}
+
+export function summarizeUsage(records, pricingByModel) {
+  const grouped = new Map();
+  for (const record of records.filter(
+    ({ frameProduced }) => frameProduced === true,
+  )) {
+    const pricing = pricingByModel[record.modelId];
+    if (!pricing) {
+      throw new Error(`No pricing for model ${record.modelId}`);
+    }
+    if (!grouped.has(record.agentId)) {
+      grouped.set(record.agentId, []);
+    }
+    grouped.get(record.agentId).push({
+      ...record,
+      latencyMs: latencyMs(record),
+      computedCostMicroUsd: costMicroUsd(record, pricing),
+    });
+  }
+
+  return [...grouped.entries()]
+    .map(([agentId, rows]) => {
+      const latencies = rows.map(({ latencyMs: value }) => value);
+      const costs = rows.map(
+        ({ computedCostMicroUsd }) => computedCostMicroUsd,
+      );
+      const freshInputTokens = rows.reduce(
+        (sum, row) => sum + tokenCount(row, "freshInputTokens"),
+        0,
+      );
+      const cacheReadTokens = rows.reduce(
+        (sum, row) => sum + tokenCount(row, "cacheReadTokens"),
+        0,
+      );
+      const cacheWriteTokens = rows.reduce(
+        (sum, row) => sum + tokenCount(row, "cacheWriteTokens"),
+        0,
+      );
+      const outputTokens = rows.reduce(
+        (sum, row) => sum + tokenCount(row, "outputTokens"),
+        0,
+      );
+      const totalInputTokens =
+        freshInputTokens + cacheReadTokens + cacheWriteTokens;
+      return {
+        agentId,
+        frameCount: rows.length,
+        latencyMs: {
+          mean: mean(latencies),
+          median: percentile(latencies, 0.5),
+          p90: percentile(latencies, 0.9),
+        },
+        costMicroUsd: {
+          total: costs.reduce((sum, value) => sum + value, 0),
+          mean: mean(costs),
+          median: percentile(costs, 0.5),
+          p90: percentile(costs, 0.9),
+        },
+        averageTokens: {
+          freshInput: freshInputTokens / rows.length,
+          cacheRead: cacheReadTokens / rows.length,
+          cacheWrite: cacheWriteTokens / rows.length,
+          output: outputTokens / rows.length,
+        },
+        cacheHitRate:
+          totalInputTokens === 0 ? 0 : cacheReadTokens / totalInputTokens,
+      };
+    })
+    .sort((left, right) => left.agentId.localeCompare(right.agentId));
+}
+
+function cents(microUsd) {
+  return microUsd / 10_000;
+}
+
+function markdown(summary) {
+  const lines = [
+    "# Frame cost and latency",
+    "",
+    "Only conversations that produced reviewed Frames are included. Costs use disjoint fresh-input, cache-read, cache-write, and output counters.",
+    "",
+    "| Candidate | N | Latency median/p90 (s) | Cost mean/median/p90 (cents) | Total (USD) | Cache hit |",
+    "|---|---:|---:|---:|---:|---:|",
+  ];
+  for (const candidate of summary) {
+    lines.push(
+      `| ${candidate.agentId} | ${candidate.frameCount} | ${(candidate.latencyMs.median / 1000).toFixed(1)} / ${(candidate.latencyMs.p90 / 1000).toFixed(1)} | ${cents(candidate.costMicroUsd.mean).toFixed(2)} / ${cents(candidate.costMicroUsd.median).toFixed(2)} / ${cents(candidate.costMicroUsd.p90).toFixed(2)} | ${(candidate.costMicroUsd.total / 1_000_000).toFixed(2)} | ${(candidate.cacheHitRate * 100).toFixed(1)}% |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const usage = await loadJsonl(path.resolve(requireArg(args, "usage")));
+  const pricing = await readJson(path.resolve(requireArg(args, "pricing")));
+  const outRoot = path.resolve(requireArg(args, "out"));
+  const summary = summarizeUsage(usage, pricing.models ?? {});
+  await writeJson(path.join(outRoot, "summary.json"), summary);
+  await fs.mkdir(outRoot, { recursive: true });
+  await fs.writeFile(path.join(outRoot, "COST_LATENCY.md"), markdown(summary));
+  stdout(`Computed cost and latency for ${summary.length} candidate(s).`);
+}
+
+const isMain =
+  process.argv[1] &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+  main().catch((error) => {
+    stderr(error.stack ?? error.message);
+    process.exitCode = 1;
+  });
+}

--- a/x/henry/king-of-the-frames/src/lib.mjs
+++ b/x/henry/king-of-the-frames/src/lib.mjs
@@ -1,0 +1,323 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const TEXT_EXTENSIONS = new Set([
+  ".csv",
+  ".html",
+  ".json",
+  ".md",
+  ".sql",
+  ".tsv",
+  ".txt",
+  ".xml",
+  ".yaml",
+  ".yml",
+]);
+
+const SECRET_PATTERNS = [
+  { name: "Slack token", pattern: /xox[baprs]-[A-Za-z0-9-]{10,}/i },
+  { name: "API key", pattern: /\bsk-[A-Za-z0-9_-]{20,}\b/ },
+  { name: "private key", pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
+  { name: "AWS access key", pattern: /\bAKIA[0-9A-Z]{16}\b/ },
+  {
+    name: "serialized access or refresh token",
+    pattern:
+      /["'](?:access_token|refresh_token|client_secret)["']\s*:\s*["'][^"']{8,}["']/i,
+  },
+];
+
+export function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const part = argv[index];
+    if (!part.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${part}`);
+    }
+    const key = part.slice(2);
+    const next = argv[index + 1];
+    if (next && !next.startsWith("--")) {
+      parsed[key] = next;
+      index += 1;
+    } else {
+      parsed[key] = true;
+    }
+  }
+  return parsed;
+}
+
+export function requireArg(args, key) {
+  const value = args[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Missing --${key}`);
+  }
+  return value;
+}
+
+export async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, "utf8"));
+}
+
+export async function writeJson(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+export async function loadJsonl(filePath) {
+  const body = await fs.readFile(filePath, "utf8");
+  return body
+    .split("\n")
+    .filter((line) => line.trim().length > 0)
+    .map((line, index) => {
+      try {
+        return JSON.parse(line);
+      } catch (error) {
+        throw new Error(`${filePath}:${index + 1}: ${error.message}`);
+      }
+    });
+}
+
+export async function appendJsonl(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.appendFile(filePath, `${JSON.stringify(value)}\n`);
+}
+
+export async function pathExists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function walkFiles(rootPath) {
+  if (!(await pathExists(rootPath))) {
+    return [];
+  }
+  const entries = await fs.readdir(rootPath, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries.sort((left, right) =>
+    left.name.localeCompare(right.name),
+  )) {
+    const entryPath = path.join(rootPath, entry.name);
+    if (entry.isSymbolicLink()) {
+      throw new Error(`Symlinks are not allowed in packs: ${entryPath}`);
+    }
+    if (entry.isDirectory()) {
+      files.push(...(await walkFiles(entryPath)));
+    } else if (entry.isFile() && !entry.name.startsWith(".")) {
+      files.push(entryPath);
+    }
+  }
+  return files;
+}
+
+export async function listPackIds(packsRoot) {
+  const entries = await fs.readdir(packsRoot, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+export async function collectPackAttachments(packDir) {
+  const candidates = [
+    ...(await walkFiles(path.join(packDir, "context", "data"))),
+    ...(await walkFiles(path.join(packDir, "context", "notes"))),
+    ...(await walkFiles(path.join(packDir, "attachments"))),
+  ];
+  const indexPath = path.join(packDir, "context", "INDEX.md");
+  const files = (await pathExists(indexPath))
+    ? [...candidates, indexPath]
+    : candidates;
+  const basenames = new Set();
+  return files.sort().map((filePath) => {
+    const name = path.basename(filePath);
+    if (basenames.has(name)) {
+      throw new Error(`Duplicate attachment basename in ${packDir}: ${name}`);
+    }
+    basenames.add(name);
+    return { filePath, name };
+  });
+}
+
+function isNonEmptyString(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export async function validatePack(packsRoot, packId) {
+  const packDir = path.join(packsRoot, packId);
+  const errors = [];
+  const briefPath = path.join(packDir, "brief.md");
+  const manifestPath = path.join(packDir, "manifest.json");
+  const indexPath = path.join(packDir, "context", "INDEX.md");
+
+  for (const requiredPath of [briefPath, manifestPath, indexPath]) {
+    if (!(await pathExists(requiredPath))) {
+      errors.push(`Missing ${path.relative(packDir, requiredPath)}`);
+    }
+  }
+
+  let attachments = [];
+  try {
+    attachments = await collectPackAttachments(packDir);
+  } catch (error) {
+    errors.push(error.message);
+  }
+
+  if (await pathExists(briefPath)) {
+    const brief = await fs.readFile(briefPath, "utf8");
+    if (brief.trim().length < 40) {
+      errors.push("brief.md is too short to be a useful task");
+    }
+    if (
+      !/no (?:additional|further) research|do not (?:perform|do) (?:additional|further) research/i.test(
+        brief,
+      )
+    ) {
+      errors.push("brief.md must explicitly prohibit additional research");
+    }
+  }
+
+  if (await pathExists(manifestPath)) {
+    try {
+      const manifest = await readJson(manifestPath);
+      if (manifest.version !== 1) {
+        errors.push("manifest.json version must be 1");
+      }
+      if (manifest.packId !== packId) {
+        errors.push(`manifest.json packId must equal directory name ${packId}`);
+      }
+      if (!Array.isArray(manifest.files)) {
+        errors.push("manifest.json files must be an array");
+      } else {
+        const actualPaths = new Set(
+          attachments.map(({ filePath }) =>
+            path.relative(packDir, filePath).split(path.sep).join("/"),
+          ),
+        );
+        const declaredPaths = new Set();
+        for (const file of manifest.files) {
+          if (
+            !isNonEmptyString(file?.path) ||
+            !isNonEmptyString(file?.description)
+          ) {
+            errors.push("Every manifest file needs path and description");
+            continue;
+          }
+          declaredPaths.add(file.path);
+          if (!actualPaths.has(file.path)) {
+            errors.push(
+              `Manifest references missing attached file: ${file.path}`,
+            );
+          }
+        }
+        for (const actualPath of actualPaths) {
+          if (!declaredPaths.has(actualPath)) {
+            errors.push(`Attached file missing from manifest: ${actualPath}`);
+          }
+        }
+      }
+    } catch (error) {
+      errors.push(`Invalid manifest.json: ${error.message}`);
+    }
+  }
+
+  const textFiles = [
+    briefPath,
+    manifestPath,
+    indexPath,
+    ...attachments.map(({ filePath }) => filePath),
+  ];
+  for (const filePath of textFiles) {
+    if (
+      !(await pathExists(filePath)) ||
+      !TEXT_EXTENSIONS.has(path.extname(filePath).toLowerCase())
+    ) {
+      continue;
+    }
+    const stat = await fs.stat(filePath);
+    if (stat.size > 5_000_000) {
+      continue;
+    }
+    const body = await fs.readFile(filePath, "utf8");
+    for (const secretPattern of SECRET_PATTERNS) {
+      if (secretPattern.pattern.test(body)) {
+        errors.push(
+          `${path.relative(packDir, filePath)} looks like it contains a ${secretPattern.name}`,
+        );
+      }
+    }
+  }
+
+  return { packId, attachmentCount: attachments.length, errors };
+}
+
+export function validateConfig(config) {
+  if (!isNonEmptyString(config?.apiBaseUrl)) {
+    throw new Error("config.apiBaseUrl is required");
+  }
+  if (
+    !Array.isArray(config.agents) ||
+    config.agents.length < 2 ||
+    config.agents.length > 5
+  ) {
+    throw new Error("config.agents must contain two to five candidates");
+  }
+  const ids = new Set();
+  for (const agent of config.agents) {
+    if (!isNonEmptyString(agent?.id) || !/^[A-Za-z0-9_-]+$/.test(agent.id)) {
+      throw new Error(
+        "Every agent id must use only letters, digits, underscore, or hyphen",
+      );
+    }
+    if (!isNonEmptyString(agent.label)) {
+      throw new Error(`Agent ${agent.id} needs a label`);
+    }
+    if (ids.has(agent.id)) {
+      throw new Error(`Duplicate agent id: ${agent.id}`);
+    }
+    ids.add(agent.id);
+  }
+  return config;
+}
+
+export function randomShuffle(values) {
+  const shuffled = [...values];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const target = crypto.randomInt(index + 1);
+    [shuffled[index], shuffled[target]] = [shuffled[target], shuffled[index]];
+  }
+  return shuffled;
+}
+
+export function mean(values) {
+  return values.length === 0
+    ? 0
+    : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function percentile(values, fraction) {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(fraction * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+export function sleep(durationMs) {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+export function stdout(message) {
+  process.stdout.write(`${message}\n`);
+}
+
+export function stderr(message) {
+  process.stderr.write(`${message}\n`);
+}

--- a/x/henry/king-of-the-frames/src/metrics.test.mjs
+++ b/x/henry/king-of-the-frames/src/metrics.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { costMicroUsd, summarizeUsage } from "./cost-latency.mjs";
+import { validatePack } from "./lib.mjs";
+import { tally } from "./tally.mjs";
+
+const packageRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+test("the committed example pack satisfies the pack contract", async () => {
+  const result = await validatePack(
+    path.join(packageRoot, "examples", "packs"),
+    "example-pack",
+  );
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.attachmentCount, 2);
+});
+
+test("cost accounting treats token classes as disjoint", () => {
+  const cost = costMicroUsd(
+    {
+      conversationId: "conversation",
+      modelId: "model",
+      freshInputTokens: 1_000_000,
+      cacheReadTokens: 1_000_000,
+      cacheWriteTokens: 500_000,
+      outputTokens: 200_000,
+    },
+    {
+      inputUsdPerMillion: 1,
+      cacheReadUsdPerMillion: 0.1,
+      cacheWriteUsdPerMillion: 1.25,
+      outputUsdPerMillion: 5,
+    },
+  );
+  assert.equal(cost, 2_725_000);
+});
+
+test("usage summary excludes conversations without a Frame", () => {
+  const records = [
+    {
+      agentId: "agent-a",
+      conversationId: "used",
+      modelId: "model",
+      frameProduced: true,
+      startedAt: "2026-01-01T00:00:00Z",
+      completedAt: "2026-01-01T00:01:00Z",
+      freshInputTokens: 100,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      outputTokens: 100,
+    },
+    {
+      agentId: "agent-a",
+      conversationId: "unused",
+      modelId: "model",
+      frameProduced: false,
+      startedAt: "2026-01-01T00:00:00Z",
+      completedAt: "2026-01-01T01:00:00Z",
+      freshInputTokens: 100,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      outputTokens: 100,
+    },
+  ];
+  const summary = summarizeUsage(records, {
+    model: {
+      inputUsdPerMillion: 1,
+      cacheReadUsdPerMillion: 0.1,
+      cacheWriteUsdPerMillion: 1.25,
+      outputUsdPerMillion: 5,
+    },
+  });
+  assert.equal(summary[0].frameCount, 1);
+  assert.equal(summary[0].latencyMs.median, 60_000);
+});
+
+test("tally uses decided matchups and splits ties", () => {
+  const result = tally(
+    {
+      matchups: [
+        { packId: "one", votesBySlot: { 1: 2, 2: 1 }, noneVotes: 0 },
+        { packId: "two", votesBySlot: { 1: 1, 2: 1 }, noneVotes: 0 },
+        { packId: "three", votesBySlot: {}, noneVotes: 1 },
+      ],
+    },
+    {
+      one: {
+        slots: {
+          1: { agentId: "a", label: "A" },
+          2: { agentId: "b", label: "B" },
+        },
+      },
+      two: {
+        slots: {
+          1: { agentId: "a", label: "A" },
+          2: { agentId: "b", label: "B" },
+        },
+      },
+      three: {
+        slots: {
+          1: { agentId: "a", label: "A" },
+          2: { agentId: "b", label: "B" },
+        },
+      },
+    },
+  );
+  const agentA = result.candidates.find(({ agentId }) => agentId === "a");
+  assert.equal(result.decidedMatchups, 2);
+  assert.equal(result.noVoteMatchups, 1);
+  assert.equal(agentA.decided, 2);
+  assert.equal(agentA.outrightWins, 1);
+  assert.equal(agentA.tieShare, 0.5);
+  assert.equal(agentA.winRate, 0.75);
+});

--- a/x/henry/king-of-the-frames/src/post-slack.mjs
+++ b/x/henry/king-of-the-frames/src/post-slack.mjs
@@ -1,0 +1,139 @@
+import path from "node:path";
+
+import {
+  parseArgs,
+  pathExists,
+  readJson,
+  requireArg,
+  sleep,
+  stderr,
+  stdout,
+  writeJson,
+} from "./lib.mjs";
+
+const REACTION_NAMES = ["one", "two", "three", "four", "five"];
+const NONE_REACTION = "no_entry_sign";
+
+function mainMessage(payload) {
+  const lines = [
+    `*Blind Frame evaluation: ${payload.packId}*`,
+    "Same brief, independent candidates. Open every Frame before voting.",
+    "",
+  ];
+  for (const slot of payload.slots) {
+    lines.push(
+      `:${REACTION_NAMES[Number(slot.slot) - 1]}: <${slot.frameUrl}|Frame ${slot.slot}>`,
+    );
+  }
+  lines.push(
+    "",
+    `Vote with :one: to :${REACTION_NAMES[payload.slots.length - 1]}:, or :${NONE_REACTION}: if none is suitable.`,
+  );
+  return lines.join("\n");
+}
+
+function threadMessage(payload) {
+  return `*Brief*\n${payload.brief}`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const reviewRoot = path.resolve(requireArg(args, "review"));
+  const payloads = await readJson(path.join(reviewRoot, "payloads.json"));
+  const postedPath = path.join(reviewRoot, "posted.private.json");
+  const posted = (await pathExists(postedPath))
+    ? await readJson(postedPath)
+    : [];
+  const postedPackIds = new Set(posted.map(({ packId }) => packId));
+  const max =
+    typeof args.max === "string" ? Number(args.max) : Number.POSITIVE_INFINITY;
+  const dryRun = args["dry-run"] === true;
+  const postsPerMinute = Number(process.env.SLACK_POSTS_PER_MIN ?? 5);
+  const reactionGapMs = Number(process.env.SLACK_REACTION_GAP_MS ?? 1100);
+  const delayMs = Math.ceil(60_000 / postsPerMinute);
+
+  if (!Number.isFinite(max) || max < 1) {
+    throw new Error("--max must be a positive integer");
+  }
+
+  const token = process.env.SLACK_BOT_TOKEN;
+  const channel = process.env.SLACK_CHANNEL_ID;
+  if (!dryRun && (!token || !channel)) {
+    throw new Error(
+      "SLACK_BOT_TOKEN and SLACK_CHANNEL_ID must be set in the shell",
+    );
+  }
+
+  const slack = async (method, body) => {
+    const response = await fetch(`https://slack.com/api/${method}`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const result = await response.json();
+    if (!response.ok || !result.ok) {
+      throw new Error(
+        `Slack ${method} failed: ${result.error ?? response.status}`,
+      );
+    }
+    return result;
+  };
+
+  const remaining = payloads
+    .filter(({ packId }) => !postedPackIds.has(packId))
+    .slice(0, max);
+  if (dryRun) {
+    for (const payload of remaining) {
+      stdout(mainMessage(payload));
+      stdout("\n--- thread ---\n");
+      stdout(threadMessage(payload));
+    }
+    stdout(`Dry run: ${remaining.length} matchup(s).`);
+    return;
+  }
+
+  let postedThisRun = 0;
+  for (const payload of remaining) {
+    const root = await slack("chat.postMessage", {
+      channel,
+      text: mainMessage(payload),
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+    for (let index = 0; index < payload.slots.length; index += 1) {
+      await slack("reactions.add", {
+        channel,
+        name: REACTION_NAMES[index],
+        timestamp: root.ts,
+      });
+      await sleep(reactionGapMs);
+    }
+    await slack("reactions.add", {
+      channel,
+      name: NONE_REACTION,
+      timestamp: root.ts,
+    });
+    await slack("chat.postMessage", {
+      channel,
+      thread_ts: root.ts,
+      text: threadMessage(payload),
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+    posted.push({ packId: payload.packId, channel, ts: root.ts });
+    await writeJson(postedPath, posted);
+    postedThisRun += 1;
+    stdout(`Posted ${payload.packId} (${postedThisRun}/${remaining.length}).`);
+    if (postedThisRun < remaining.length) {
+      await sleep(delayMs);
+    }
+  }
+}
+
+main().catch((error) => {
+  stderr(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/x/henry/king-of-the-frames/src/run-eval.mjs
+++ b/x/henry/king-of-the-frames/src/run-eval.mjs
@@ -1,0 +1,354 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  appendJsonl,
+  collectPackAttachments,
+  listPackIds,
+  parseArgs,
+  pathExists,
+  readJson,
+  requireArg,
+  sleep,
+  stderr,
+  stdout,
+  validateConfig,
+  validatePack,
+  writeJson,
+} from "./lib.mjs";
+
+const CONTENT_TYPES = new Map([
+  [".csv", "text/csv"],
+  [
+    ".docx",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ],
+  [".gif", "image/gif"],
+  [".html", "text/html"],
+  [".jpeg", "image/jpeg"],
+  [".jpg", "image/jpeg"],
+  [".json", "application/json"],
+  [".md", "text/markdown"],
+  [".pdf", "application/pdf"],
+  [".png", "image/png"],
+  [".svg", "image/svg+xml"],
+  [".tsv", "text/tab-separated-values"],
+  [".txt", "text/plain"],
+  [".xls", "application/vnd.ms-excel"],
+  [
+    ".xlsx",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ],
+  [".xml", "application/xml"],
+]);
+
+function contentType(fileName) {
+  return (
+    CONTENT_TYPES.get(path.extname(fileName).toLowerCase()) ??
+    "application/octet-stream"
+  );
+}
+
+function frameFileUrl(apiRoot, conversation) {
+  for (const group of conversation.content ?? []) {
+    if (!Array.isArray(group)) {
+      continue;
+    }
+    for (const item of group) {
+      if (item.type !== "agent_message" || !Array.isArray(item.actions)) {
+        continue;
+      }
+      for (const action of item.actions) {
+        for (const generatedFile of action.generatedFiles ?? []) {
+          if (
+            typeof generatedFile.contentType === "string" &&
+            generatedFile.contentType.startsWith("application/vnd.dust.frame")
+          ) {
+            const fileId =
+              generatedFile.fileId ?? generatedFile.sId ?? generatedFile.id;
+            return `${apiRoot}/files/${fileId}`;
+          }
+        }
+      }
+    }
+  }
+  return null;
+}
+
+function finalStatus(conversation) {
+  for (const group of [...(conversation.content ?? [])].reverse()) {
+    if (!Array.isArray(group)) {
+      continue;
+    }
+    for (const item of [...group].reverse()) {
+      if (item.type === "agent_message") {
+        return item.status ?? "unknown";
+      }
+    }
+  }
+  return "no-agent-message";
+}
+
+async function withRetry(operation, callback, maxAttempts = 5) {
+  let lastError;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await callback();
+    } catch (error) {
+      lastError = error;
+      const message = String(error?.message ?? error);
+      const transient =
+        /fetch failed|ECONNRESET|ETIMEDOUT|EAI_AGAIN|socket hang up|network|\b5\d\d\b/i.test(
+          message,
+        );
+      if (!transient || attempt === maxAttempts) {
+        throw error;
+      }
+      stderr(
+        `${operation} failed, retrying (${attempt}/${maxAttempts}): ${message}`,
+      );
+      await sleep(3000 * attempt);
+    }
+  }
+  throw lastError;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const config = validateConfig(
+    await readJson(path.resolve(requireArg(args, "config"))),
+  );
+  const packsRoot = path.resolve(requireArg(args, "packs"));
+  const outRoot = path.resolve(requireArg(args, "out"));
+  const workspaceId = process.env.DUST_WORKSPACE_ID;
+  const accessToken = process.env.DUST_ACCESS_TOKEN;
+  if (!workspaceId || !accessToken) {
+    throw new Error(
+      "DUST_WORKSPACE_ID and DUST_ACCESS_TOKEN must be set in the shell",
+    );
+  }
+
+  const apiRoot = `${config.apiBaseUrl.replace(/\/$/, "")}/w/${workspaceId}`;
+  const headers = (extra = {}) => ({
+    Authorization: `Bearer ${accessToken}`,
+    ...extra,
+  });
+  const timeoutMs = Number(config.timeoutMs ?? 900_000);
+  const pollIntervalMs = Number(config.pollIntervalMs ?? 4000);
+  const concurrency = Number(args.concurrency ?? config.concurrency ?? 4);
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 32) {
+    throw new Error("concurrency must be an integer from 1 to 32");
+  }
+
+  const apiJson = async (method, endpoint, body) => {
+    const response = await fetch(`${apiRoot}/${endpoint}`, {
+      method,
+      headers: headers({ "Content-Type": "application/json" }),
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const responseBody = await response.text().catch(() => "");
+      if (response.status === 401) {
+        throw new Error(
+          "Dust API returned 401. Refresh DUST_ACCESS_TOKEN and rerun; completed cells are preserved.",
+        );
+      }
+      throw new Error(
+        `${method} ${endpoint} returned ${response.status}: ${responseBody.slice(0, 300)}`,
+      );
+    }
+    return response.json();
+  };
+
+  const uploadAttachment = async ({ filePath, name }) => {
+    const body = await fs.readFile(filePath);
+    const mimeType = contentType(name);
+    const registration = await withRetry(`register ${name}`, () =>
+      apiJson("POST", "files", {
+        contentType: mimeType,
+        fileName: name,
+        fileSize: body.length,
+        useCase: "conversation",
+      }),
+    );
+    const file = registration.file ?? registration;
+    const uploadUrl = file.uploadUrl;
+    const fileId = file.sId ?? file.id;
+    if (!uploadUrl || !fileId) {
+      throw new Error(
+        `File registration for ${name} omitted uploadUrl or file id`,
+      );
+    }
+    await withRetry(`upload ${name}`, async () => {
+      const form = new FormData();
+      form.append("file", new Blob([body], { type: mimeType }), name);
+      const response = await fetch(uploadUrl, {
+        method: "POST",
+        headers: headers(),
+        body: form,
+      });
+      if (!response.ok) {
+        throw new Error(`Signed upload returned ${response.status}`);
+      }
+    });
+    return fileId;
+  };
+
+  const runCell = async ({ packId, agent }) => {
+    const cellPath = path.join(outRoot, "cells", packId, `${agent.id}.json`);
+    if (!args.force && (await pathExists(cellPath))) {
+      const prior = await readJson(cellPath);
+      if (
+        typeof prior.frameFileUrl === "string" &&
+        prior.frameFileUrl.length > 0
+      ) {
+        return { ...prior, skipped: true };
+      }
+    }
+
+    const packDir = path.join(packsRoot, packId);
+    const brief = (
+      await fs.readFile(path.join(packDir, "brief.md"), "utf8")
+    ).trim();
+    const attachments = await collectPackAttachments(packDir);
+    const contentFragments = [];
+    for (const attachment of attachments) {
+      contentFragments.push({
+        title: attachment.name,
+        fileId: await uploadAttachment(attachment),
+      });
+    }
+
+    const mention = `:mention[${agent.id}]{sId=${agent.id}}`;
+    const response = await withRetry(`create ${packId}/${agent.id}`, () =>
+      apiJson("POST", "assistant/conversations", {
+        title: `frame-eval ${packId} ${agent.id}`,
+        visibility: "unlisted",
+        blocking: false,
+        skipToolsValidation: true,
+        message: {
+          content: `${mention} ${brief}`,
+          mentions: [{ configurationId: agent.id }],
+          context: {
+            username: "frame-eval-runner",
+            timezone: config.timezone ?? "UTC",
+            fullName: "Frame Eval Runner",
+            origin: "api",
+          },
+        },
+        ...(contentFragments.length > 0 ? { contentFragments } : {}),
+      }),
+    );
+
+    let conversation = response.conversation;
+    const generatedConversationId = conversation.sId;
+    let generatedFrameFileUrl = frameFileUrl(apiRoot, conversation);
+    let status = finalStatus(conversation);
+    const startedAt = new Date().toISOString();
+    const deadline = Date.now() + timeoutMs;
+    while (!generatedFrameFileUrl && Date.now() < deadline) {
+      if (["succeeded", "failed", "cancelled"].includes(status)) {
+        break;
+      }
+      await sleep(pollIntervalMs);
+      const poll = await apiJson(
+        "GET",
+        `assistant/conversations/${generatedConversationId}`,
+      );
+      conversation = poll.conversation;
+      generatedFrameFileUrl = frameFileUrl(apiRoot, conversation);
+      status = finalStatus(conversation);
+    }
+
+    const result = {
+      packId,
+      agentId: agent.id,
+      generatedConversationId,
+      frameFileUrl: generatedFrameFileUrl,
+      status,
+      startedAt,
+      completedAt: new Date().toISOString(),
+      attachments: contentFragments.map(({ title }) => title),
+    };
+    await writeJson(cellPath, result);
+    await appendJsonl(path.join(outRoot, "results.jsonl"), result);
+    return result;
+  };
+
+  const allPackIds = await listPackIds(packsRoot);
+  const packIds =
+    typeof args["only-pack"] === "string" ? [args["only-pack"]] : allPackIds;
+  for (const packId of packIds) {
+    if (!allPackIds.includes(packId)) {
+      throw new Error(`Unknown pack: ${packId}`);
+    }
+    const validation = await validatePack(packsRoot, packId);
+    if (validation.errors.length > 0) {
+      throw new Error(
+        `${packId} is invalid:\n${validation.errors.map((error) => `- ${error}`).join("\n")}`,
+      );
+    }
+  }
+
+  const jobs = packIds.flatMap((packId) =>
+    config.agents.map((agent) => ({ packId, agent })),
+  );
+  stdout(
+    `Running ${jobs.length} cell(s), ${packIds.length} pack(s), concurrency ${concurrency}.`,
+  );
+  let cursor = 0;
+  let completed = 0;
+  let produced = 0;
+  let stopRequested = false;
+  const worker = async () => {
+    while (cursor < jobs.length && !stopRequested) {
+      const jobIndex = cursor;
+      cursor += 1;
+      const job = jobs[jobIndex];
+      try {
+        const result = await runCell(job);
+        completed += 1;
+        if (result.frameFileUrl) {
+          produced += 1;
+        }
+        stdout(
+          `[${completed}/${jobs.length}] ${result.frameFileUrl ? "FRAME" : "NO FRAME"} ${job.packId}/${job.agent.id}${result.skipped ? " (skipped)" : ""}`,
+        );
+      } catch (error) {
+        completed += 1;
+        const failure = {
+          packId: job.packId,
+          agentId: job.agent.id,
+          error: String(error?.message ?? error),
+          completedAt: new Date().toISOString(),
+        };
+        await writeJson(
+          path.join(outRoot, "cells", job.packId, `${job.agent.id}.json`),
+          failure,
+        );
+        await appendJsonl(path.join(outRoot, "results.jsonl"), failure);
+        stderr(
+          `[${completed}/${jobs.length}] ERROR ${job.packId}/${job.agent.id}: ${failure.error}`,
+        );
+        if (failure.error.includes("Dust API returned 401")) {
+          stopRequested = true;
+        }
+      }
+    }
+  };
+
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, jobs.length) }, () => worker()),
+  );
+  stdout(`Done. ${produced}/${jobs.length} cells have a Frame file URL.`);
+  if (produced < jobs.length) {
+    stdout(
+      "Refresh credentials if needed and rerun the same command to retry unfinished cells once.",
+    );
+  }
+}
+
+main().catch((error) => {
+  stderr(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/x/henry/king-of-the-frames/src/tally.mjs
+++ b/x/henry/king-of-the-frames/src/tally.mjs
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  parseArgs,
+  readJson,
+  requireArg,
+  stderr,
+  stdout,
+  writeJson,
+} from "./lib.mjs";
+
+export function tally(feedback, mapping) {
+  const stats = new Map();
+  const getStats = (agentId, label) => {
+    if (!stats.has(agentId)) {
+      stats.set(agentId, {
+        agentId,
+        label,
+        matchesPlayed: 0,
+        decided: 0,
+        outrightWins: 0,
+        tieShare: 0,
+        rawVotes: 0,
+      });
+    }
+    return stats.get(agentId);
+  };
+
+  let decidedMatchups = 0;
+  let noVoteMatchups = 0;
+  let totalSlotVotes = 0;
+  let totalNoneVotes = 0;
+  for (const matchup of feedback.matchups ?? []) {
+    const slots = mapping[matchup.packId]?.slots;
+    if (!slots) {
+      throw new Error(`Missing private mapping for ${matchup.packId}`);
+    }
+    const slotEntries = Object.entries(slots);
+    for (const [, candidate] of slotEntries) {
+      getStats(candidate.agentId, candidate.label).matchesPlayed += 1;
+    }
+
+    const votes = slotEntries.map(([slot, candidate]) => ({
+      slot,
+      candidate,
+      votes: Number(matchup.votesBySlot?.[slot] ?? 0),
+    }));
+    const voteCount = votes.reduce((sum, vote) => sum + vote.votes, 0);
+    totalSlotVotes += voteCount;
+    totalNoneVotes += Number(matchup.noneVotes ?? 0);
+    for (const vote of votes) {
+      getStats(vote.candidate.agentId, vote.candidate.label).rawVotes +=
+        vote.votes;
+    }
+
+    if (voteCount === 0) {
+      noVoteMatchups += 1;
+      continue;
+    }
+    decidedMatchups += 1;
+    for (const [, candidate] of slotEntries) {
+      getStats(candidate.agentId, candidate.label).decided += 1;
+    }
+    const topVotes = Math.max(...votes.map(({ votes: count }) => count));
+    const leaders = votes.filter(({ votes: count }) => count === topVotes);
+    if (leaders.length === 1) {
+      getStats(
+        leaders[0].candidate.agentId,
+        leaders[0].candidate.label,
+      ).outrightWins += 1;
+    } else {
+      for (const leader of leaders) {
+        getStats(leader.candidate.agentId, leader.candidate.label).tieShare +=
+          1 / leaders.length;
+      }
+    }
+  }
+
+  const candidates = [...stats.values()]
+    .map((candidate) => ({
+      ...candidate,
+      winRate:
+        candidate.decided === 0
+          ? 0
+          : (candidate.outrightWins + candidate.tieShare) / candidate.decided,
+    }))
+    .sort(
+      (left, right) =>
+        right.winRate - left.winRate || right.rawVotes - left.rawVotes,
+    );
+  return {
+    collectedAt: feedback.collectedAt ?? null,
+    uniqueReviewerCount: feedback.uniqueReviewerCount ?? null,
+    matchupCount: (feedback.matchups ?? []).length,
+    decidedMatchups,
+    noVoteMatchups,
+    totalSlotVotes,
+    totalNoneVotes,
+    candidates,
+  };
+}
+
+function markdown(summary) {
+  const lines = [
+    "# Blind Frame evaluation tally",
+    "",
+    `- Matchups: ${summary.matchupCount}`,
+    `- Decided: ${summary.decidedMatchups}`,
+    `- No slot votes: ${summary.noVoteMatchups}`,
+    `- Slot votes: ${summary.totalSlotVotes}`,
+    `- None suitable votes: ${summary.totalNoneVotes}`,
+    `- Unique reviewers: ${summary.uniqueReviewerCount ?? "unknown"}`,
+    "",
+    "| Candidate | Played | Decided | Outright | Tie share | Raw votes | Win rate |",
+    "|---|---:|---:|---:|---:|---:|---:|",
+  ];
+  for (const candidate of summary.candidates) {
+    lines.push(
+      `| ${candidate.label} | ${candidate.matchesPlayed} | ${candidate.decided} | ${candidate.outrightWins} | ${candidate.tieShare.toFixed(2)} | ${candidate.rawVotes} | ${(candidate.winRate * 100).toFixed(1)}% |`,
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const feedback = await readJson(path.resolve(requireArg(args, "feedback")));
+  const mapping = await readJson(path.resolve(requireArg(args, "mapping")));
+  const outRoot = path.resolve(requireArg(args, "out"));
+  const summary = tally(feedback, mapping);
+  await writeJson(path.join(outRoot, "summary.json"), summary);
+  await fs.mkdir(outRoot, { recursive: true });
+  await fs.writeFile(path.join(outRoot, "SUMMARY.md"), markdown(summary));
+  stdout(`Tallied ${summary.matchupCount} matchup(s).`);
+}
+
+const isMain =
+  process.argv[1] &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+if (isMain) {
+  main().catch((error) => {
+    stderr(error.stack ?? error.message);
+    process.exitCode = 1;
+  });
+}

--- a/x/henry/king-of-the-frames/src/validate-packs.mjs
+++ b/x/henry/king-of-the-frames/src/validate-packs.mjs
@@ -1,0 +1,43 @@
+import path from "node:path";
+
+import {
+  listPackIds,
+  parseArgs,
+  requireArg,
+  stderr,
+  stdout,
+  validatePack,
+} from "./lib.mjs";
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const packsRoot = path.resolve(requireArg(args, "packs"));
+  const packIds = await listPackIds(packsRoot);
+  if (packIds.length === 0) {
+    throw new Error(`No packs found in ${packsRoot}`);
+  }
+
+  let errorCount = 0;
+  for (const packId of packIds) {
+    const result = await validatePack(packsRoot, packId);
+    if (result.errors.length === 0) {
+      stdout(`OK   ${packId} (${result.attachmentCount} attachments)`);
+      continue;
+    }
+    errorCount += result.errors.length;
+    stderr(`FAIL ${packId}`);
+    for (const error of result.errors) {
+      stderr(`  - ${error}`);
+    }
+  }
+
+  if (errorCount > 0) {
+    throw new Error(`${errorCount} pack validation error(s)`);
+  }
+  stdout(`Validated ${packIds.length} pack(s).`);
+}
+
+main().catch((error) => {
+  stderr(error.stack ?? error.message);
+  process.exitCode = 1;
+});

--- a/x/henry/king-of-the-frames/templates/matchup-analysis-prompt.md
+++ b/x/henry/king-of-the-frames/templates/matchup-analysis-prompt.md
@@ -1,0 +1,15 @@
+# Blind matchup analysis
+
+Analyze the supplied brief, slot Frames, source code, vote counts, reviewer comments, and screenshots.
+Do not inspect or infer candidate identities.
+
+For each slot provide:
+
+- Severity: `clean`, `minor-polish`, `major-ux`, or `broken`.
+- Concise strengths.
+- Concise failures with stable failure tags.
+- Evidence from reviewer feedback, behavior, screenshots, and exact source patterns.
+- What the strongest competing slot did better for the same brief.
+
+Comments may reference several slots. Attribute them by meaning and evidence, not by a simple keyword
+match. If there is no useful finding for a slot, say so.

--- a/x/henry/king-of-the-frames/templates/pack-builder-prompt.md
+++ b/x/henry/king-of-the-frames/templates/pack-builder-prompt.md
@@ -1,0 +1,21 @@
+# Frame pack builder
+
+Create one self-contained Frame task from the supplied conversation export and downloaded files.
+
+Deliver `brief.md`, `manifest.json`, `context/INDEX.md`, any structured research under
+`context/data/`, any concise narrative research under `context/notes/`, and original user files under
+`attachments/`.
+
+Requirements:
+
+- Preserve user intent, follow-ups, content, audience, interaction requirements, and constraints.
+- Remove research instructions that have already been completed.
+- Do not copy the previous Frame's layout or infer design instructions from it.
+- Download or transform data programmatically. Do not hand-copy large outputs.
+- Keep source fidelity and document units, columns, queries, and caveats in `context/INDEX.md`.
+- Give every attached file a unique basename.
+- Remove secrets, personal content, private identifiers, and signed URLs.
+- In `brief.md`, tell the candidate to use the supplied files and build the Frame without more research.
+- Keep the pack compact. Include every necessary fact, but no irrelevant transcript noise.
+
+Validate the finished pack without referring back to the source conversation.


### PR DESCRIPTION
## Description

**DO NOT MERGE. Handoff draft for review.**

- Adds a concise quick start and detailed runbook for self-contained Frame packs, generation, blind Slack review, tallying, and qualitative analysis.
- Adds reusable tools for pack validation, resumable generation, randomized payloads, Slack posting and collection, vote tallying, and normalized cost and latency reporting.
- Keeps real run data, identifiers, URLs, mappings, and credentials ignored. Committed fixtures are synthetic.

## Tests

Ran the full offline workflow with the synthetic fixture: pack validation, blind payload generation, Slack dry-run rendering, tallying, and cost and latency reporting. Added four focused Node tests.

## Risk

Draft only. Live Dust and Slack calls were not executed. The receiving engineer must smoke-test one pack and one real post against current endpoints and permissions before a full run.

## Deploy Plan

Do not deploy. Handoff PR only.