### PR TITLE
[front] enh: move API key analytics to automations

### DIFF
--- a/front/components/pages/workspace/AnalyticsAutomationsPage.test.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.test.tsx
@@ -1,0 +1,45 @@
+import { AnalyticsAutomationsPage } from "@app/components/pages/workspace/AnalyticsAutomationsPage";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useFeatureFlags: () => ({ hasFeature: () => true }),
+  useWorkspace: () => ({ sId: "workspace-id" }),
+}));
+
+vi.mock(
+  "@app/components/workspace/analytics/automations/AutomationsOverview",
+  () => ({ AutomationsOverview: () => <div>Automations overview</div> })
+);
+
+vi.mock(
+  "@app/components/workspace/analytics/automations/AutomationsTriggersTable",
+  () => ({ AutomationsTriggersTable: () => <div>Triggers table</div> })
+);
+
+vi.mock(
+  "@app/components/workspace/analytics/automations/AutomationsApiKeysTable",
+  () => ({ AutomationsApiKeysTable: () => <div>API keys table</div> })
+);
+
+vi.mock(
+  "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector",
+  () => ({ ConsumptionPeriodSelector: () => <div>Period selector</div> })
+);
+
+describe("AnalyticsAutomationsPage", () => {
+  it("switches from triggers to API keys", () => {
+    render(<AnalyticsAutomationsPage />);
+
+    expect(screen.getByText("Triggers table")).toBeInTheDocument();
+    expect(screen.queryByText("API keys table")).not.toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "API keys" }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    expect(screen.getByText("API keys table")).toBeInTheDocument();
+    expect(screen.queryByText("Triggers table")).not.toBeInTheDocument();
+  });
+});

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -1,3 +1,4 @@
+import { AutomationsApiKeysTable } from "@app/components/workspace/analytics/automations/AutomationsApiKeysTable";
 import { AutomationsOverview } from "@app/components/workspace/analytics/automations/AutomationsOverview";
 import { AutomationsTriggersTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersTable";
 import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
@@ -5,8 +6,14 @@ import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/c
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
-import { cn, Page } from "@dust-tt/sparkle";
+import { cn, Page, Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
 import { useState } from "react";
+
+type AutomationsView = "triggers" | "api_keys";
+
+function isAutomationsView(value: string): value is AutomationsView {
+  return value === "triggers" || value === "api_keys";
+}
 
 export function AnalyticsAutomationsPage() {
   const owner = useWorkspace();
@@ -16,6 +23,7 @@ export function AnalyticsAutomationsPage() {
     DEFAULT_CONSUMPTION_PERIOD
   );
   const [filter, setFilter] = useState<AutomationsFilter>({});
+  const [view, setView] = useState<AutomationsView>("triggers");
 
   if (!isEnabled) {
     return (
@@ -56,12 +64,31 @@ export function AnalyticsAutomationsPage() {
       />
       <div className="flex flex-col gap-8 pb-8 pt-4">
         <AutomationsOverview workspaceId={owner.sId} period={period} />
-        <AutomationsTriggersTable
-          owner={owner}
-          period={period}
-          filter={filter}
-          onFilterChange={setFilter}
-        />
+        <div className="flex flex-col gap-3">
+          <Tabs
+            value={view}
+            onValueChange={(value) => {
+              if (isAutomationsView(value)) {
+                setView(value);
+              }
+            }}
+          >
+            <TabsList border>
+              <TabsTrigger value="triggers" label="Triggers" />
+              <TabsTrigger value="api_keys" label="API keys" />
+            </TabsList>
+          </Tabs>
+          {view === "triggers" ? (
+            <AutomationsTriggersTable
+              owner={owner}
+              period={period}
+              filter={filter}
+              onFilterChange={setFilter}
+            />
+          ) : (
+            <AutomationsApiKeysTable workspaceId={owner.sId} period={period} />
+          )}
+        </div>
       </div>
     </Page.Vertical>
   );

--- a/front/components/workspace/analytics/automations/AutomationsApiKeysTable.test.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsApiKeysTable.test.tsx
@@ -1,0 +1,69 @@
+import { AutomationsApiKeysTable } from "@app/components/workspace/analytics/automations/AutomationsApiKeysTable";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseAutomationsApiKeys } = vi.hoisted(() => ({
+  mockUseAutomationsApiKeys: vi.fn(),
+}));
+
+vi.mock("@app/hooks/useAutomationsApiKeys", () => ({
+  useAutomationsApiKeys: mockUseAutomationsApiKeys,
+}));
+
+const period = { kind: "days", days: 30 } as const;
+
+describe("AutomationsApiKeysTable", () => {
+  beforeEach(() => {
+    mockUseAutomationsApiKeys.mockReturnValue({
+      apiKeys: [
+        {
+          apiKeyName: "Support sync",
+          name: "Support sync",
+          credits: 120,
+          previousCredits: 100,
+          messageCount: 24,
+          avgCreditsPerMessage: 5,
+        },
+      ],
+      totalCredits: 1_000,
+      totalCount: 1,
+      isApiKeysLoading: false,
+      isApiKeysError: undefined,
+      isApiKeysValidating: false,
+    });
+  });
+
+  it("shows API key usage on the Automations page", () => {
+    render(
+      <AutomationsApiKeysTable workspaceId="workspace-id" period={period} />
+    );
+
+    expect(screen.getByText("Support sync")).toBeInTheDocument();
+    expect(screen.getByText("Messages")).toBeInTheDocument();
+    expect(screen.getByText("24")).toBeInTheDocument();
+    expect(mockUseAutomationsApiKeys).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-id",
+        period,
+        limit: 25,
+        offset: 0,
+      })
+    );
+  });
+
+  it("sends search terms to the API key ranking", async () => {
+    render(
+      <AutomationsApiKeysTable workspaceId="workspace-id" period={period} />
+    );
+
+    fireEvent.change(screen.getByPlaceholderText("Search…"), {
+      target: { value: "support" },
+    });
+
+    await waitFor(() => {
+      expect(mockUseAutomationsApiKeys).toHaveBeenLastCalledWith(
+        expect.objectContaining({ search: "support", offset: 0 })
+      );
+    });
+  });
+});

--- a/front/components/workspace/analytics/automations/AutomationsApiKeysTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsApiKeysTable.tsx
@@ -1,0 +1,284 @@
+import {
+  CostShareCell,
+  CreditsGrowthCell,
+} from "@app/components/workspace/analytics/creditsTableCells";
+import { useAutomationsApiKeys } from "@app/hooks/useAutomationsApiKeys";
+import { useDebounce } from "@app/hooks/useDebounce";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionTopApiKeyRow } from "@app/lib/api/analytics/consumption/top_api_keys";
+import { formatCredits } from "@app/lib/client/credits";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronSelectorVertical,
+  cn,
+  DataTable,
+  DataTableLoadingSkeleton,
+  Icon,
+  Pagination,
+  SearchInput,
+} from "@dust-tt/sparkle";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import type { ReactNode } from "react";
+import { useMemo, useState } from "react";
+
+const SEARCH_DEBOUNCE_DELAY_MS = 300;
+const API_KEYS_PAGE_SIZE = 25;
+const API_KEYS_MAX_ROW_COUNT = 1_000;
+
+function buildColumns(
+  totalCredits: number
+): ColumnDef<ConsumptionTopApiKeyRow>[] {
+  return [
+    {
+      id: "name",
+      accessorKey: "name",
+      header: "Name",
+      meta: { sizeRatio: 28, headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-start text-left">
+          <span className="truncate text-sm">{info.row.original.name}</span>
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "costShare",
+      header: "Cost share",
+      meta: { sizeRatio: 20, headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-start">
+          <CostShareCell
+            share={
+              totalCredits > 0 ? info.row.original.credits / totalCredits : 0
+            }
+          />
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "messageCount",
+      accessorKey: "messageCount",
+      header: "Messages",
+      meta: { sizeRatio: 16, headerAlign: "right" },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          className="justify-end text-right tabular-nums"
+          label={info.row.original.messageCount.toLocaleString()}
+        />
+      ),
+    },
+    {
+      id: "credits",
+      accessorKey: "credits",
+      header: "Total credits",
+      meta: { sizeRatio: 18, headerAlign: "right" },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          className="justify-end text-right tabular-nums"
+          label={formatCredits(info.row.original.credits)}
+        />
+      ),
+    },
+    {
+      id: "avgCreditsPerMessage",
+      accessorKey: "avgCreditsPerMessage",
+      header: "Cost / message",
+      meta: { sizeRatio: 20, headerAlign: "right" },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          className="justify-end text-right tabular-nums"
+          label={formatCredits(info.row.original.avgCreditsPerMessage)}
+        />
+      ),
+    },
+    {
+      id: "vsPrev",
+      header: "vs prev",
+      meta: { sizeRatio: 16, headerAlign: "right" },
+      cell: (info) => (
+        <CreditsGrowthCell
+          credits={info.row.original.credits}
+          previousCredits={info.row.original.previousCredits}
+        />
+      ),
+    },
+  ];
+}
+
+interface ApiKeysRowsTableProps {
+  rows: ConsumptionTopApiKeyRow[];
+  totalCredits: number;
+}
+
+function ApiKeysRowsTable({ rows, totalCredits }: ApiKeysRowsTableProps) {
+  const columns = useMemo(() => buildColumns(totalCredits), [totalCredits]);
+  const table = useReactTable({
+    data: rows,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <DataTable.Root className="min-w-175">
+      <DataTable.Header>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <DataTable.Row key={headerGroup.id} widthClassName="w-full">
+            {headerGroup.headers.map((header) => (
+              <DataTable.Head
+                column={header.column}
+                key={header.id}
+                onClick={
+                  header.column.getCanSort()
+                    ? header.column.getToggleSortingHandler()
+                    : undefined
+                }
+                className={cn(header.column.getCanSort() && "cursor-pointer")}
+              >
+                <div
+                  className={cn(
+                    "flex items-center space-x-1 whitespace-nowrap",
+                    header.column.columnDef.meta?.headerAlign === "right" &&
+                      "justify-end"
+                  )}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext()
+                  )}
+                  {header.column.getCanSort() && (
+                    <Icon
+                      visual={
+                        header.column.getIsSorted() === "asc"
+                          ? ArrowUp
+                          : header.column.getIsSorted() === "desc"
+                            ? ArrowDown
+                            : ChevronSelectorVertical
+                      }
+                      size="xs"
+                      className="ml-1"
+                    />
+                  )}
+                </div>
+              </DataTable.Head>
+            ))}
+          </DataTable.Row>
+        ))}
+      </DataTable.Header>
+      <DataTable.Body>
+        {table.getRowModel().rows.map((row) => (
+          <DataTable.Row key={row.id} widthClassName="w-full">
+            {row.getVisibleCells().map((cell) => (
+              <DataTable.Cell column={cell.column} key={cell.id}>
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </DataTable.Cell>
+            ))}
+          </DataTable.Row>
+        ))}
+      </DataTable.Body>
+    </DataTable.Root>
+  );
+}
+
+interface AutomationsApiKeysTableProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+}
+
+export function AutomationsApiKeysTable({
+  workspaceId,
+  period,
+}: AutomationsApiKeysTableProps) {
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: API_KEYS_PAGE_SIZE,
+  });
+  const { inputValue, debouncedValue, setValue } = useDebounce("", {
+    delay: SEARCH_DEBOUNCE_DELAY_MS,
+  });
+
+  const [previousQuery, setPreviousQuery] = useState({
+    period,
+    search: debouncedValue,
+  });
+  if (
+    previousQuery.period !== period ||
+    previousQuery.search !== debouncedValue
+  ) {
+    setPreviousQuery({ period, search: debouncedValue });
+    setPagination((current) => ({ ...current, pageIndex: 0 }));
+  }
+
+  const {
+    apiKeys,
+    totalCredits,
+    totalCount,
+    isApiKeysLoading,
+    isApiKeysError,
+    isApiKeysValidating,
+  } = useAutomationsApiKeys({
+    workspaceId,
+    period,
+    limit: pagination.pageSize,
+    offset: pagination.pageIndex * pagination.pageSize,
+    search: debouncedValue,
+  });
+  const cappedRowCount = Math.min(totalCount, API_KEYS_MAX_ROW_COUNT);
+
+  let content: ReactNode;
+  if (isApiKeysLoading) {
+    content = (
+      <DataTableLoadingSkeleton showSelectionColumn={false} showTrailingCell />
+    );
+  } else if (isApiKeysError) {
+    content = (
+      <div className="text-sm text-muted-foreground">
+        Failed to load API keys.
+      </div>
+    );
+  } else if (apiKeys.length === 0) {
+    content = (
+      <div className="text-sm text-muted-foreground">
+        {debouncedValue.trim()
+          ? `No match for "${debouncedValue.trim()}".`
+          : "No API key usage over this period."}
+      </div>
+    );
+  } else {
+    content = (
+      <div className="overflow-x-auto">
+        <ApiKeysRowsTable rows={apiKeys} totalCredits={totalCredits} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-panel-background p-4">
+      <SearchInput
+        name="automations-api-keys-search"
+        placeholder="Search…"
+        value={inputValue}
+        onChange={setValue}
+        className="mb-4 w-full"
+      />
+      <div aria-busy={isApiKeysLoading || isApiKeysValidating}>{content}</div>
+      {cappedRowCount > pagination.pageSize && (
+        <div className="mt-2 p-1">
+          <Pagination
+            size="xs"
+            showDetails={false}
+            pagination={pagination}
+            setPagination={setPagination}
+            rowCount={cappedRowCount}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -9,7 +9,6 @@ import {
   within,
 } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
@@ -57,29 +56,6 @@ vi.mock(
 );
 
 const period = { kind: "days", days: 30 } as const;
-
-function ControlledAttributionTable({
-  onDimensionChange,
-}: {
-  onDimensionChange: (dimension: ConsumptionDimension) => void;
-}) {
-  const [dimension, setDimension] = useState<ConsumptionDimension>("source");
-
-  return (
-    <ConsumptionAttributionTable
-      workspaceId="workspace-id"
-      period={period}
-      dimension={dimension}
-      onDimensionChange={(nextDimension) => {
-        onDimensionChange(nextDimension);
-        setDimension(nextDimension);
-      }}
-      onAddFilter={vi.fn()}
-      onRemoveFilter={vi.fn()}
-      onViewAll={vi.fn()}
-    />
-  );
-}
 
 describe("ConsumptionAttributionTable", () => {
   beforeEach(() => {
@@ -247,54 +223,6 @@ describe("ConsumptionAttributionTable", () => {
         expect.objectContaining({ search: "Agent 080", offset: 0, limit: 25 })
       );
     });
-  });
-
-  it("selects the API key dimension with a pointer", () => {
-    const onDimensionChange = vi.fn();
-    mockUseConsumptionTop.mockReturnValue({
-      rows: [],
-      totalCredits: 0,
-      isTopLoading: false,
-      isTopError: undefined,
-    });
-
-    render(
-      <ControlledAttributionTable onDimensionChange={onDimensionChange} />
-    );
-
-    const apiKeysTab = screen.getByRole("tab", { name: "API keys" });
-    fireEvent.pointerDown(apiKeysTab);
-    fireEvent.mouseDown(apiKeysTab, { button: 0, ctrlKey: false });
-
-    expect(onDimensionChange).toHaveBeenCalledWith("api_key");
-    expect(apiKeysTab).toHaveAttribute("aria-selected", "true");
-    expect(mockUseConsumptionTop).toHaveBeenLastCalledWith(
-      expect.objectContaining({ dimension: "api_key" })
-    );
-  });
-
-  it("selects the API key dimension with the keyboard", () => {
-    const onDimensionChange = vi.fn();
-    mockUseConsumptionTop.mockReturnValue({
-      rows: [],
-      totalCredits: 0,
-      isTopLoading: false,
-      isTopError: undefined,
-    });
-
-    render(
-      <ControlledAttributionTable onDimensionChange={onDimensionChange} />
-    );
-
-    const apiKeysTab = screen.getByRole("tab", { name: "API keys" });
-    fireEvent.focus(apiKeysTab);
-    fireEvent.keyDown(apiKeysTab, { key: "Enter" });
-
-    expect(onDimensionChange).toHaveBeenCalledWith("api_key");
-    expect(apiKeysTab).toHaveAttribute("aria-selected", "true");
-    expect(mockUseConsumptionTop).toHaveBeenLastCalledWith(
-      expect.objectContaining({ dimension: "api_key" })
-    );
   });
 
   it("resets expanded rows when switching dimensions", async () => {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -9,6 +9,7 @@ import { ConsumptionExportPanel } from "@app/components/workspace/analytics/cons
 import {
   AvatarNameCell,
   CostShareCell,
+  CreditsGrowthCell,
   EntityTooltipCard,
 } from "@app/components/workspace/analytics/creditsTableCells";
 import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
@@ -26,13 +27,10 @@ import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consum
 import { formatCredits } from "@app/lib/client/credits";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
-  ArrowNarrowDownRight,
-  ArrowNarrowUpRight,
   Avatar,
   Button,
   ChevronDown,
   ChevronUp,
-  cn,
   DataTable,
   DustLogoSquare,
   FilterFunnel01,
@@ -142,54 +140,6 @@ function AttributionTooltipCard({
       modelId={dimension === "agent" ? row.modelId : null}
       modelDisplayName={dimension === "agent" ? row.modelDisplayName : null}
     />
-  );
-}
-
-// Growth is undefined (not just zero) with no prior credits to grow from, so
-// callers must distinguish that case from an actual percentage.
-function growthPercent(
-  currentCredits: number,
-  previousCredits: number | null
-): number | null {
-  return previousCredits && previousCredits > 0
-    ? ((currentCredits - previousCredits) / previousCredits) * 100
-    : null;
-}
-
-function VsPrevCell({
-  credits,
-  previousCredits,
-}: {
-  credits: number;
-  previousCredits: number | null;
-}) {
-  const growth = growthPercent(credits, previousCredits);
-
-  if (growth === null) {
-    return (
-      <DataTable.CellContent className="w-full justify-end text-right">
-        <Tooltip
-          label="Not enough data to compute"
-          tooltipTriggerAsChild
-          trigger={<span className="text-sm text-muted-foreground">--</span>}
-        />
-      </DataTable.CellContent>
-    );
-  }
-
-  return (
-    <div
-      className={cn(
-        "flex w-full items-center justify-end gap-1 text-right text-sm tabular-nums",
-        growth > 100 ? "text-highlight-600" : "text-muted-foreground"
-      )}
-    >
-      <Icon
-        visual={growth >= 0 ? ArrowNarrowUpRight : ArrowNarrowDownRight}
-        size="xs"
-      />
-      <span>{Math.round(Math.abs(growth))}%</span>
-    </div>
   );
 }
 
@@ -323,7 +273,7 @@ function buildColumns({
       header: "vs prev",
       meta: { sizeRatio: 18, headerAlign: "right" },
       cell: (info) => (
-        <VsPrevCell
+        <CreditsGrowthCell
           credits={info.row.original.credits}
           previousCredits={info.row.original.previousCredits}
         />

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
@@ -8,12 +8,12 @@ import { describe, expect, it } from "vitest";
 describe("consumption dimension URL state", () => {
   it("reads valid dimensions and falls back to agents", () => {
     expect(consumptionDimensionFromQueryParam("user")).toBe("user");
-    expect(consumptionDimensionFromQueryParam("api_key")).toBe("api_key");
+    expect(consumptionDimensionFromQueryParam("api_key")).toBe("agent");
     expect(consumptionDimensionFromQueryParam("invalid")).toBe("agent");
     expect(consumptionDimensionFromQueryParam(undefined)).toBe("agent");
   });
 
-  it("registers the API key attribution tab", () => {
+  it("registers the consumption attribution tabs", () => {
     expect(CONSUMPTION_DIMENSIONS).toEqual([
       "agent",
       "user",
@@ -22,8 +22,7 @@ describe("consumption dimension URL state", () => {
       "tool",
       "skill",
       "source",
-      "api_key",
     ]);
-    expect(CONSUMPTION_DIMENSION_CONFIG.api_key.label).toBe("API keys");
+    expect(CONSUMPTION_DIMENSION_CONFIG.agent.label).toBe("Agents");
   });
 });

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -1,11 +1,7 @@
 import type { ConsumptionBreakdownDimension } from "@app/lib/api/analytics/consumption/timeseries";
 
-export type ConsumptionDimension = ConsumptionBreakdownDimension;
-
-export const DEFAULT_CONSUMPTION_DIMENSION: ConsumptionDimension = "agent";
-
 // Tab order, left to right.
-export const CONSUMPTION_DIMENSIONS: ConsumptionDimension[] = [
+export const CONSUMPTION_DIMENSIONS = [
   "agent",
   "user",
   "group",
@@ -13,8 +9,11 @@ export const CONSUMPTION_DIMENSIONS: ConsumptionDimension[] = [
   "tool",
   "skill",
   "source",
-  "api_key",
-];
+] as const satisfies readonly ConsumptionBreakdownDimension[];
+
+export type ConsumptionDimension = (typeof CONSUMPTION_DIMENSIONS)[number];
+
+export const DEFAULT_CONSUMPTION_DIMENSION: ConsumptionDimension = "agent";
 
 interface ConsumptionDimensionConfig {
   label: string;
@@ -69,12 +68,6 @@ export const CONSUMPTION_DIMENSION_CONFIG: Record<
   source: {
     label: "Sources",
     breakdownLabel: "source",
-    hasAvatar: false,
-    avgLabel: MESSAGE_AVG_LABEL,
-  },
-  api_key: {
-    label: "API keys",
-    breakdownLabel: "API key",
     hasAvatar: false,
     avgLabel: MESSAGE_AVG_LABEL,
   },

--- a/front/components/workspace/analytics/creditsTableCells.tsx
+++ b/front/components/workspace/analytics/creditsTableCells.tsx
@@ -2,7 +2,11 @@ import { getModelLogoByModelId } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import {
+  ArrowNarrowDownRight,
+  ArrowNarrowUpRight,
   Avatar,
+  cn,
+  DataTable,
   DustLogoSquare,
   Icon,
   ProgressBar,
@@ -96,6 +100,48 @@ export function CostShareCell({ share }: { share: number }) {
       <span className="w-8 text-right text-xs text-muted-foreground tabular-nums">
         {percentage}%
       </span>
+    </div>
+  );
+}
+
+interface CreditsGrowthCellProps {
+  credits: number;
+  previousCredits: number | null;
+}
+
+export function CreditsGrowthCell({
+  credits,
+  previousCredits,
+}: CreditsGrowthCellProps) {
+  const growth =
+    previousCredits && previousCredits > 0
+      ? ((credits - previousCredits) / previousCredits) * 100
+      : null;
+
+  if (growth === null) {
+    return (
+      <DataTable.CellContent className="w-full justify-end text-right">
+        <Tooltip
+          label="Not enough data to compute"
+          tooltipTriggerAsChild
+          trigger={<span className="text-sm text-muted-foreground">--</span>}
+        />
+      </DataTable.CellContent>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex w-full items-center justify-end gap-1 text-right text-sm tabular-nums",
+        growth > 100 ? "text-highlight-600" : "text-muted-foreground"
+      )}
+    >
+      <Icon
+        visual={growth >= 0 ? ArrowNarrowUpRight : ArrowNarrowDownRight}
+        size="xs"
+      />
+      <span>{Math.round(Math.abs(growth))}%</span>
     </div>
   );
 }

--- a/front/hooks/useAutomationsApiKeys.ts
+++ b/front/hooks/useAutomationsApiKeys.ts
@@ -1,0 +1,49 @@
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionTopBody } from "@app/lib/api/analytics/consumption/schema";
+import type {
+  ConsumptionTopApiKeyRow,
+  GetConsumptionTopApiKeysResponse,
+} from "@app/lib/api/analytics/consumption/top_api_keys";
+import { emptyArray } from "@app/lib/swr/swr";
+
+export function useAutomationsApiKeys({
+  workspaceId,
+  period,
+  limit,
+  offset = 0,
+  search,
+  disabled,
+}: {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  limit: number;
+  offset?: number;
+  search?: string;
+  disabled?: boolean;
+}) {
+  const url = `/api/w/${workspaceId}/analytics/consumption/top-api-keys`;
+  const body: ConsumptionTopBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    limit,
+    offset,
+    search: search?.trim(),
+  };
+
+  const { data, error, isLoading, isValidating } = useConsumptionQuery<
+    ConsumptionTopBody,
+    GetConsumptionTopApiKeysResponse
+  >({ url, body, disabled });
+
+  return {
+    apiKeys: data?.apiKeys ?? emptyArray<ConsumptionTopApiKeyRow>(),
+    totalCredits: data?.totalCredits ?? 0,
+    totalCount: data?.totalCount ?? 0,
+    isApiKeysLoading: !error && isLoading,
+    isApiKeysError: error,
+    isApiKeysValidating: isValidating,
+  };
+}

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -8,7 +8,6 @@ import {
 import type { ConsumptionTopBody } from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
-import type { GetConsumptionTopApiKeysResponse } from "@app/lib/api/analytics/consumption/top_api_keys";
 import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
 import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";
@@ -27,7 +26,6 @@ const CONSUMPTION_TOP_ENDPOINTS = {
   tool: "top-tools",
   skill: "top-skills",
   source: "top-sources",
-  api_key: "top-api-keys",
 } as const satisfies Record<ConsumptionDimension, string>;
 
 export type ConsumptionTopRow = {
@@ -50,8 +48,7 @@ type ConsumptionTopResponse =
   | GetConsumptionTopModelsResponse
   | GetConsumptionTopToolsResponse
   | GetConsumptionTopSkillsResponse
-  | GetConsumptionTopSourcesResponse
-  | GetConsumptionTopApiKeysResponse;
+  | GetConsumptionTopSourcesResponse;
 
 // Narrowed on the collection each response carries rather than on the requested
 // dimension, so a row shape that drifts from its endpoint is a type error here
@@ -144,20 +141,6 @@ function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
   if ("sources" in data) {
     return data.sources.map((row) => ({
       id: row.source,
-      name: row.name,
-      pictureUrl: null,
-      description: null,
-      icon: null,
-      modelId: null,
-      modelDisplayName: null,
-      credits: row.credits,
-      avgCredits: row.avgCreditsPerMessage,
-      previousCredits: row.previousCredits,
-    }));
-  }
-  if ("apiKeys" in data) {
-    return data.apiKeys.map((row) => ({
-      id: row.apiKeyName,
       name: row.name,
       pictureUrl: null,
       description: null,


### PR DESCRIPTION
## Description

API key usage currently appears alongside people, agents, models, and other consumption attribution dimensions. It belongs with the programmatic work tracked on the Automations page instead.

This removes API keys from the Consumption attribution tabs and adds a dedicated API keys tab to Automations with searchable, paginated usage. The table shows message count, total and average credits, workspace cost share, and previous-period change while keeping the existing aggregation and consumption-filter contracts unchanged.

## Tests

- Added coverage for switching to API keys on Automations and rendering and searching API key usage.
- Updated Consumption dimension coverage.

## Risk

- Low. Limited to the feature-flagged Automations and Consumption analytics UI.

## Deploy Plan

- Deploy front.