### PR TITLE
Attribute hidden helper credits to parent agents

### DIFF
--- a/front/lib/analytics/agent_message_consumption/documents.ts
+++ b/front/lib/analytics/agent_message_consumption/documents.ts
@@ -10,8 +10,8 @@ import type { AgentMessageConsumptionAnalyticsData } from "@app/types/assistant/
  * Projects one complete message attribution into the document grain of the consumption index:
  * one LLM document per run usage and one tool document per action.
  *
- * Documents stay with the agent message that incurred the cost. Agent ancestry supports rollups,
- * but sub-agent costs are not reassigned to their parent.
+ * Documents stay with the agent message and execution agent that incurred the cost. The separate
+ * attributed agent identity rolls hidden helpers up to their user-facing parent for analytics.
  *
  * A regular tool document includes the cost of emitting its call, carrying its result into model
  * context, and its direct charge. Current attribution records a tool called through Computer with

--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -13,8 +13,10 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { RunFactory } from "@app/tests/utils/RunFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { WorkspaceType } from "@app/types/user";
+import assert from "assert";
 import { describe, expect, it } from "vitest";
 
 async function createAgenticMessage({
@@ -205,6 +207,7 @@ describe("loadAgentMessageConsumptionAnalyticsInput", () => {
 
     expect(input).toMatchObject({
       agent: {
+        attributed_id: context.agent.sId,
         id: context.agent.sId,
         version: context.agent.version.toString(),
         parent_ids: [],
@@ -343,6 +346,53 @@ describe("loadAgentMessageConsumptionAnalyticsInput", () => {
     });
 
     expect(input?.agent).toMatchObject({
+      parent_ids: [parent.agent.sId],
+      direct_parent_id: parent.agent.sId,
+      root_id: parent.agent.sId,
+      depth: 1,
+    });
+  });
+
+  it("attributes a hidden helper to its direct parent agent", async () => {
+    const testContext = await createResourceTest({ role: "admin" });
+    const parent = await createAgenticMessage({
+      auth: testContext.authenticator,
+      workspace: testContext.workspace,
+      depth: 0,
+      agentName: "Visible parent agent",
+    });
+    const child = await setupSettledMessage({
+      testContext,
+      depth: 1,
+      agenticOriginMessageId: parent.agentMessage.sId,
+      agentName: "Temporary child agent",
+    });
+    assert(
+      child.agentMessage.agentMessageId,
+      "Hidden helper agent message was not created"
+    );
+    await AgentMessageModel.update(
+      {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST_TASK,
+        agentConfigurationVersion: 0,
+      },
+      {
+        where: {
+          id: child.agentMessage.agentMessageId,
+          workspaceId: child.workspace.id,
+        },
+      }
+    );
+
+    const input = await loadAgentMessageConsumptionAnalyticsInput(child.auth, {
+      agentMessageId: child.agentMessage.sId,
+    });
+
+    expect(input?.agent).toEqual({
+      attributed_id: parent.agent.sId,
+      id: GLOBAL_AGENTS_SID.DUST_TASK,
+      version: "0",
+      tag_ids: [],
       parent_ids: [parent.agent.sId],
       direct_parent_id: parent.agent.sId,
       root_id: parent.agent.sId,

--- a/front/lib/analytics/agent_message_consumption/load.ts
+++ b/front/lib/analytics/agent_message_consumption/load.ts
@@ -26,7 +26,10 @@ import type {
   AgentMessageConsumptionAnalyticsUsageType,
   AgentMessageConsumptionAnalyticsUser,
 } from "@app/types/assistant/analytics";
-import { isGlobalAgentId } from "@app/types/assistant/assistant";
+import {
+  getAgentUsageAttributedId,
+  isGlobalAgentId,
+} from "@app/types/assistant/assistant";
 import type {
   AgentMessageStatus,
   UserMessageOrigin,
@@ -261,6 +264,10 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
   )
     .map((ancestor) => ancestor.agentConfigurationId)
     .reverse();
+  const attributedAgentId = getAgentUsageAttributedId({
+    agentId: agentMessage.agentConfigurationId,
+    parentAgentId: ancestorAgentIds.at(-1),
+  });
   const agentTagIds = await loadAgentTagIds(auth, agentMessage);
   const user = await loadAnalyticsUser({
     completedAt: agentMessage.completedAt,
@@ -277,6 +284,7 @@ export async function loadAgentMessageConsumptionAnalyticsInput(
   return {
     actions,
     agent: {
+      attributed_id: attributedAgentId,
       id: agentMessage.agentConfigurationId,
       version: agentMessage.agentConfigurationVersion.toString(),
       tag_ids: agentTagIds,

--- a/front/lib/analytics/agent_message_consumption/store.test.ts
+++ b/front/lib/analytics/agent_message_consumption/store.test.ts
@@ -23,6 +23,7 @@ const bulkMock = vi.spyOn(client, "bulk");
 function makeDocument(): AgentMessageConsumptionAnalyticsData {
   return {
     agent: {
+      attributed_id: "agent_1",
       id: "agent_1",
       version: "1",
       tag_ids: [],

--- a/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
+++ b/front/lib/analytics/indices/agent_message_consumption_analytics_1.mappings.json
@@ -33,6 +33,9 @@
     "agent": {
       "type": "object",
       "properties": {
+        "attributed_id": {
+          "type": "keyword"
+        },
         "id": {
           "type": "keyword"
         },

--- a/front/lib/analytics/migrations/20260819_add_attributed_agent_id_to_agent_message_consumption_analytics_1.http
+++ b/front/lib/analytics/migrations/20260819_add_attributed_agent_id_to_agent_message_consumption_analytics_1.http
@@ -1,0 +1,13 @@
+PUT /front.agent_message_consumption_analytics_1/_mapping
+{
+  "properties": {
+    "agent": {
+      "type": "object",
+      "properties": {
+        "attributed_id": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}

--- a/front/lib/analytics/migrations/20260819_backfill_attributed_agent_id_to_agent_message_consumption_analytics_1.http
+++ b/front/lib/analytics/migrations/20260819_backfill_attributed_agent_id_to_agent_message_consumption_analytics_1.http
@@ -24,20 +24,3 @@ POST /front.agent_message_consumption_analytics_1/_update_by_query?wait_for_comp
     }
   }
 }
-
-### Run after the update task completes. The reader rollout is safe only when
-### this count is zero.
-GET /front.agent_message_consumption_analytics_1/_count
-{
-  "query": {
-    "bool": {
-      "must_not": [
-        {
-          "exists": {
-            "field": "agent.attributed_id"
-          }
-        }
-      ]
-    }
-  }
-}

--- a/front/lib/analytics/migrations/20260819_backfill_attributed_agent_id_to_agent_message_consumption_analytics_1.http
+++ b/front/lib/analytics/migrations/20260819_backfill_attributed_agent_id_to_agent_message_consumption_analytics_1.http
@@ -1,0 +1,43 @@
+POST /front.agent_message_consumption_analytics_1/_update_by_query?wait_for_completion=false&slices=auto&scroll_size=5000&requests_per_second=10000
+{
+  "conflicts": "proceed",
+  "script": {
+    "lang": "painless",
+    "source": "def agent = ctx._source.agent; agent.attributed_id = params.hidden_agent_ids.contains(agent.id) && agent.direct_parent_id != null ? agent.direct_parent_id : agent.id;",
+    "params": {
+      "hidden_agent_ids": [
+        "dust-task",
+        "dust-planning",
+        "dust-browser-summary"
+      ]
+    }
+  },
+  "query": {
+    "bool": {
+      "must_not": [
+        {
+          "exists": {
+            "field": "agent.attributed_id"
+          }
+        }
+      ]
+    }
+  }
+}
+
+### Run after the update task completes. The reader rollout is safe only when
+### this count is zero.
+GET /front.agent_message_consumption_analytics_1/_count
+{
+  "query": {
+    "bool": {
+      "must_not": [
+        {
+          "exists": {
+            "field": "agent.attributed_id"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/front/scripts/seed/factories/seedConsumptionAnalytics.ts
+++ b/front/scripts/seed/factories/seedConsumptionAnalytics.ts
@@ -216,6 +216,7 @@ function makeAgent(
   parentAgentId?: string
 ): AgentMessageConsumptionAnalyticsAgent {
   return {
+    attributed_id: agentId,
     id: agentId,
     version: "0",
     tag_ids: [],

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -52,6 +52,7 @@ beforeEach(() => {
 const LLM_DOC: AgentMessageConsumptionAnalyticsLlmData = {
   workspace_id: "w1",
   agent: {
+    attributed_id: "agent1",
     id: "agent1",
     version: "1",
     tag_ids: ["tag1"],

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -115,7 +115,7 @@ export type AgentMessageConsumptionAnalyticsUsageType =
 
 export interface AgentMessageConsumptionAnalyticsAgent {
   // Agent used for analytics grouping. Hidden helpers are attributed to their
-  // immediate parent; every other agent is attributed to itself.
+  // immediate parent. Every other agent is attributed to itself.
   attributed_id: string;
   // Agent that executed the message. Kept distinct from `attributed_id` so the
   // underlying execution remains inspectable.

--- a/front/types/assistant/analytics.ts
+++ b/front/types/assistant/analytics.ts
@@ -114,6 +114,11 @@ export type AgentMessageConsumptionAnalyticsUsageType =
   | typeof USAGE_TYPE_PROGRAMMATIC;
 
 export interface AgentMessageConsumptionAnalyticsAgent {
+  // Agent used for analytics grouping. Hidden helpers are attributed to their
+  // immediate parent; every other agent is attributed to itself.
+  attributed_id: string;
+  // Agent that executed the message. Kept distinct from `attributed_id` so the
+  // underlying execution remains inspectable.
   id: string;
   version: string;
   tag_ids: string[];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR keeps moving towards removing the `dust-task` sub agent from all analytics places (previous PR https://github.com/dust-tt/dust/pull/30829). This one PR focuses around adding the new field in the ES mapping so we can backfill before switching read queries.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

This will require to update the existing mapping before running the backfill. Another PR will them switch the read to this field.
