### PR TITLE
[front] enh: collapse multi-agent credit details

### DIFF
--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
@@ -3,7 +3,7 @@ import type {
   ConversationConsumptionDetails,
   ConversationConsumptionToolDetails,
 } from "@app/types/assistant/conversation_consumption";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/components/sparkle/ThemeContext", () => ({
@@ -76,7 +76,7 @@ describe("ConversationCreditUsageBreakdown", () => {
     expect(screen.queryByText("Research agent")).not.toBeInTheDocument();
   });
 
-  it("shows agent breakdowns for multi-agent conversations", () => {
+  it("collapses agent breakdowns by default in multi-agent conversations", () => {
     const agent = {
       pictureUrl: null,
       billedCredits: 10,
@@ -89,8 +89,18 @@ describe("ConversationCreditUsageBreakdown", () => {
       tools: [],
       models: [],
       agents: [
-        { ...agent, agentId: "agent_1", name: "Research agent" },
-        { ...agent, agentId: "agent_2", name: "Writing agent" },
+        {
+          ...agent,
+          agentId: "agent_1",
+          name: "Research agent",
+          tools: [makeTool("search", "Search tool", 4)],
+        },
+        {
+          ...agent,
+          agentId: "agent_2",
+          name: "Writing agent",
+          tools: [makeTool("write", "Writing tool", 6)],
+        },
       ],
     };
 
@@ -100,5 +110,21 @@ describe("ConversationCreditUsageBreakdown", () => {
 
     expect(screen.getByText("Research agent")).toBeInTheDocument();
     expect(screen.getByText("Writing agent")).toBeInTheDocument();
+    expect(screen.queryByText("Search tool")).not.toBeInTheDocument();
+    expect(screen.queryByText("Writing tool")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand credit details for Research agent",
+      })
+    );
+
+    expect(screen.getByText("Search tool")).toBeInTheDocument();
+    expect(screen.queryByText("Writing tool")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Collapse credit details for Research agent",
+      })
+    ).toHaveAttribute("aria-expanded", "true");
   });
 });

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -187,7 +187,11 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
     <section className="space-y-4">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <div className="flex min-w-0 items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-2">
+          <div className="flex min-w-0 items-center gap-1">
+            <CollapsibleTrigger
+              aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
+              className="size-11 shrink-0 justify-center rounded-lg focus-visible:ring-2 focus-visible:ring-ring"
+            />
             <Avatar
               name={agent.name}
               visual={agent.pictureUrl ?? undefined}
@@ -197,15 +201,9 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
               {agent.name}
             </h3>
           </div>
-          <div className="flex shrink-0 items-center gap-1">
-            <span className="text-base text-muted-foreground">
-              {formatCreditValue(agent.billedCredits)}
-            </span>
-            <CollapsibleTrigger
-              aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
-              className="size-11 shrink-0 justify-center rounded-lg focus-visible:ring-2 focus-visible:ring-ring"
-            />
-          </div>
+          <span className="shrink-0 text-base text-muted-foreground">
+            {formatCreditValue(agent.billedCredits)}
+          </span>
         </div>
         <CollapsibleContent className="pt-4">
           <ToolBreakdownCards

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -14,8 +14,17 @@ import type {
   ConversationConsumptionToolDetails,
 } from "@app/types/assistant/conversation_consumption";
 import { pluralize } from "@app/types/shared/utils/string_utils";
-import { Avatar, Chip, DustLogoSquare, Icon } from "@dust-tt/sparkle";
+import {
+  Avatar,
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  DustLogoSquare,
+  Icon,
+} from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
+import { useState } from "react";
 
 const MAX_VISIBLE_TOOLS = 3;
 
@@ -172,27 +181,39 @@ interface AgentBreakdownProps {
 }
 
 function AgentBreakdown({ agent }: AgentBreakdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <section className="space-y-4">
-      <div className="flex min-w-0 items-center justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2">
-          <Avatar
-            name={agent.name}
-            visual={agent.pictureUrl ?? undefined}
-            size="xs"
-          />
-          <h3 className="truncate text-base font-medium text-foreground">
-            {agent.name}
-          </h3>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <div className="flex min-w-0 items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Avatar
+              name={agent.name}
+              visual={agent.pictureUrl ?? undefined}
+              size="xs"
+            />
+            <h3 className="truncate text-base font-medium text-foreground">
+              {agent.name}
+            </h3>
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <span className="text-base text-muted-foreground">
+              {formatCreditValue(agent.billedCredits)}
+            </span>
+            <CollapsibleTrigger
+              aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
+              className="size-11 shrink-0 justify-center rounded-lg focus-visible:ring-2 focus-visible:ring-ring"
+            />
+          </div>
         </div>
-        <span className="shrink-0 text-base text-muted-foreground">
-          {formatCreditValue(agent.billedCredits)}
-        </span>
-      </div>
-      <ToolBreakdownCards
-        agentWorkCredits={agent.agentWorkCredits}
-        tools={agent.tools}
-      />
+        <CollapsibleContent className="pt-4">
+          <ToolBreakdownCards
+            agentWorkCredits={agent.agentWorkCredits}
+            tools={agent.tools}
+          />
+        </CollapsibleContent>
+      </Collapsible>
     </section>
   );
 }

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -187,7 +187,7 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
     <section className="space-y-4">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
         <div className="flex min-w-0 items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-1">
+          <div className="flex min-w-0 items-center gap-2">
             <CollapsibleTrigger
               aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
               className="size-11 shrink-0 justify-center rounded-lg focus-visible:ring-2 focus-visible:ring-ring"


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10118

In conversations that use multiple agents, the conversation credit panel currently expands every agent's full breakdown.

This PR keeps each agent's name, avatar, and credit total visible while collapsing its detailed usage by default. Each agent can be expanded if useful.

<img width="879" height="559" alt="image" src="https://github.com/user-attachments/assets/251c7c60-8814-4fa5-b3b5-5c81f35f7e36" />

## Tests

- Updated the existing tests.
- Tested locally + preview

## Risk

- Low.

## Deploy Plan

- Deploy front.
