### PR TITLE
[ci] fix: correct self-referential path filter in build-spa.yaml

### DIFF
--- a/.github/workflows/build-spa.yaml
+++ b/.github/workflows/build-spa.yaml
@@ -8,7 +8,7 @@ on:
       - front-spa/**
       - sparkle/**
       - sdks/js/**
-      - .github/workflows/build-and-test-spa.yml
+      - .github/workflows/build-spa.yaml
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

`build-spa.yaml`'s push path filter referenced `.github/workflows/build-and-test-spa.yml`, a file that doesn't exist :) the workflow's actual filename is `build-spa.yaml`. As a result, edits to this workflow file itself never triggered a run of it (it would only run incidentally if the same push also touched `front/**`, `front-spa/**`, `sparkle/**`, or `sdks/js/**`).

Fixed the path entry to point at the correct filename.

## Tests

Manual: confirmed the corrected path (`.github/workflows/build-spa.yaml`) matches the actual file path. No functional code paths affected.

## Risk

Low. This only affects when the `Typecheck (spa)` workflow re-triggers; it does not change what the workflow does. Worst case if wrong, the workflow simply wouldn't fire on some pushes (same as today), so there's no regression risk beyond the status quo.

## Deploy Plan
