### PR TITLE
[front] fix: show -- instead of N.A for missing vs-prev data

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -171,7 +171,7 @@ function VsPrevCell({
         <Tooltip
           label="Not enough data to compute"
           tooltipTriggerAsChild
-          trigger={<span className="text-sm text-muted-foreground">N.A</span>}
+          trigger={<span className="text-sm text-muted-foreground">--</span>}
         />
       </DataTable.CellContent>
     );


### PR DESCRIPTION
## Description

In the consumption attribution table, the `vs prev` cell displayed `N.A` when there was not enough prior-period data to compute the comparison. This changes the displayed placeholder to `--` while keeping the existing `Not enough data to compute` tooltip. No calculation or data-handling behavior is changed; this is a presentation-only adjustment.

<img width="1241" height="170" alt="Capture d’écran 2026-08-19 à 15 28 50" src="https://github.com/user-attachments/assets/531d1405-aadf-4efd-8fba-91556cd48b38"/>

## Tests


## Risk

## Deploy Plan

- Deploy front 