### PR TITLE
[front] enh: sort consumption attribution table server-side by cost share

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -78,7 +78,10 @@ const DEFAULT_ATTRIBUTION_SORTING: SortingState = [
   { id: "credits", desc: true },
 ];
 
-const ATTRIBUTION_SERVER_SORTABLE_COLUMN_ID = "credits";
+const ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS = new Set([
+  "credits",
+  "costShare",
+]);
 
 type AttributionTransitionDirection = -1 | 0 | 1;
 
@@ -291,6 +294,10 @@ function buildColumns({
     },
     {
       id: "costShare",
+      // Same denominator (totalCredits) for every row, so ranking by cost
+      // share is the same order as ranking by credits — reuse that accessor
+      // instead of introducing a separate ranking.
+      accessorFn: (row) => (totalCredits > 0 ? row.credits / totalCredits : 0),
       header: "Consumption share",
       meta: { sizeRatio: 20, headerAlign: "left" },
       cell: (info) => (
@@ -444,11 +451,14 @@ function AttributionRows({
   };
 
   const activeSort = sorting[0];
-  // Ranking is always by credits: only forward asc/desc when that's actually
-  // the sorted column, so sorting by anything else keeps fetching pages in
-  // the default credits-desc order and reorders them locally instead.
+  // Ranking is always by credits: only forward asc/desc when the sorted
+  // column actually rides that ranking, so sorting by anything else keeps
+  // fetching pages in the default credits-desc order and reorders them
+  // locally instead.
   const sortOrder =
-    activeSort?.id === ATTRIBUTION_SERVER_SORTABLE_COLUMN_ID && !activeSort.desc
+    activeSort?.id &&
+    ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS.has(activeSort.id) &&
+    !activeSort.desc
       ? "asc"
       : "desc";
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -229,6 +229,7 @@ function buildColumns({
       id: "name",
       accessorKey: "name",
       header: "Name",
+      enableSorting: false,
       meta: { sizeRatio: 32, headerAlign: "left" },
       cell: (info) => {
         const row = info.row.original;
@@ -298,6 +299,7 @@ function buildColumns({
       // share is the same order as ranking by credits
       accessorFn: (row) => (totalCredits > 0 ? row.credits / totalCredits : 0),
       header: "Consumption share",
+      enableSorting: true,
       meta: { sizeRatio: 20, headerAlign: "left" },
       cell: (info) => (
         <DataTable.CellContent className="w-full justify-start">
@@ -325,6 +327,7 @@ function buildColumns({
       id: "avgCredits",
       accessorKey: "avgCredits",
       header: avgLabel,
+      enableSorting: false,
       meta: { sizeRatio: 22, headerAlign: "right" },
       cell: (info) => (
         <DataTable.BasicCellContent
@@ -336,6 +339,7 @@ function buildColumns({
     {
       id: "vsPrev",
       header: "vs prev",
+      enableSorting: false,
       meta: { sizeRatio: 18, headerAlign: "right" },
       cell: (info) => (
         <VsPrevCell

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -295,8 +295,7 @@ function buildColumns({
     {
       id: "costShare",
       // Same denominator (totalCredits) for every row, so ranking by cost
-      // share is the same order as ranking by credits — reuse that accessor
-      // instead of introducing a separate ranking.
+      // share is the same order as ranking by credits
       accessorFn: (row) => (totalCredits > 0 ? row.credits / totalCredits : 0),
       header: "Consumption share",
       meta: { sizeRatio: 20, headerAlign: "left" },


### PR DESCRIPTION
## Description

This stacked follow-up to [#30794](https://github.com/dust-tt/dust/pull/30794) makes the **Consumption share** column in the Consumption Attribution table eligible for the same server-side ranking as **Credits**.

`costShare` is computed as `row.credits / totalCredits`, where `totalCredits` is the same denominator for every row. Therefore, sorting by cost share produces the same order as sorting by credits. The change adds a `costShare` accessor and includes it in the set of server-sortable columns, so ascending/descending pagination uses the existing credit-based server ranking. 

## Tests


## Risk

Low. This is a small analytics UI/read-path change with no migrations or writes.

## Deploy Plan

Deploy `front` after [#30794](https://github.com/dust-tt/dust/pull/30794), which is the base PR for this stack.