### PR TITLE
[front] enh: sort consumption attribution table server-side by avg credits

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopAgentsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,7 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-api-keys.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-api-keys.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopApiKeysResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,7 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-groups.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopGroupsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,7 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopModelsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,7 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSkillsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,7 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSourcesResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,7 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopToolsResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,7 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-users.ts
@@ -23,7 +23,7 @@ app.post(
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopUsersResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+    const { limit, offset, search, filter, sortBy, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
     const period = await resolveConsumptionPeriod(
@@ -37,6 +37,7 @@ app.post(
       offset,
       search,
       filter,
+      sortBy,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -360,6 +360,7 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
       period: { startDate: expect.any(String), endDate: expect.any(String) },
       search: undefined,
       filter: undefined,
+      sortBy: "credits",
       sortOrder: "desc",
     });
   });

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -78,7 +78,10 @@ const DEFAULT_ATTRIBUTION_SORTING: SortingState = [
   { id: "credits", desc: true },
 ];
 
-const ATTRIBUTION_SERVER_SORTABLE_COLUMN_ID = "credits";
+const ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS = new Set([
+  "credits",
+  "costShare",
+]);
 
 type AttributionTransitionDirection = -1 | 0 | 1;
 
@@ -291,6 +294,10 @@ function buildColumns({
     },
     {
       id: "costShare",
+      // Same denominator (totalCredits) for every row, so ranking by cost
+      // share is the same order as ranking by credits — reuse that accessor
+      // instead of introducing a separate ranking.
+      accessorFn: (row) => (totalCredits > 0 ? row.credits / totalCredits : 0),
       header: "Consumption share",
       meta: { sizeRatio: 20, headerAlign: "left" },
       cell: (info) => (
@@ -444,11 +451,14 @@ function AttributionRows({
   };
 
   const activeSort = sorting[0];
-  // Ranking is always by credits: only forward asc/desc when that's actually
-  // the sorted column, so sorting by anything else keeps fetching pages in
-  // the default credits-desc order and reorders them locally instead.
+  // Ranking is always by credits: only forward asc/desc when the sorted
+  // column actually rides that ranking, so sorting by anything else keeps
+  // fetching pages in the default credits-desc order and reorders them
+  // locally instead.
   const sortOrder =
-    activeSort?.id === ATTRIBUTION_SERVER_SORTABLE_COLUMN_ID && !activeSort.desc
+    activeSort?.id &&
+    ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS.has(activeSort.id) &&
+    !activeSort.desc
       ? "asc"
       : "desc";
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -229,6 +229,7 @@ function buildColumns({
       id: "name",
       accessorKey: "name",
       header: "Name",
+      enableSorting: false,
       meta: { sizeRatio: 32, headerAlign: "left" },
       cell: (info) => {
         const row = info.row.original;
@@ -298,6 +299,7 @@ function buildColumns({
       // share is the same order as ranking by credits
       accessorFn: (row) => (totalCredits > 0 ? row.credits / totalCredits : 0),
       header: "Consumption share",
+      enableSorting: true,
       meta: { sizeRatio: 20, headerAlign: "left" },
       cell: (info) => (
         <DataTable.CellContent className="w-full justify-start">
@@ -325,6 +327,7 @@ function buildColumns({
       id: "avgCredits",
       accessorKey: "avgCredits",
       header: avgLabel,
+      enableSorting: false,
       meta: { sizeRatio: 22, headerAlign: "right" },
       cell: (info) => (
         <DataTable.BasicCellContent
@@ -336,6 +339,7 @@ function buildColumns({
     {
       id: "vsPrev",
       header: "vs prev",
+      enableSorting: false,
       meta: { sizeRatio: 18, headerAlign: "right" },
       cell: (info) => (
         <VsPrevCell

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -21,7 +21,10 @@ import {
   normalizedConsumptionFilter,
 } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
+} from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import { getSkillAvatarIcon } from "@app/lib/skill";
@@ -78,10 +81,13 @@ const DEFAULT_ATTRIBUTION_SORTING: SortingState = [
   { id: "credits", desc: true },
 ];
 
-const ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS = new Set([
-  "credits",
-  "costShare",
-]);
+const ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID: Partial<
+  Record<string, ConsumptionTopSortBy>
+> = {
+  credits: "credits",
+  costShare: "credits",
+  avgCredits: "avgCredits",
+};
 
 type AttributionTransitionDirection = -1 | 0 | 1;
 
@@ -454,16 +460,15 @@ function AttributionRows({
   };
 
   const activeSort = sorting[0];
-  // Ranking is always by credits: only forward asc/desc when the sorted
-  // column actually rides that ranking, so sorting by anything else keeps
-  // fetching pages in the default credits-desc order and reorders them
-  // locally instead.
-  const sortOrder =
-    activeSort?.id &&
-    ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS.has(activeSort.id) &&
-    !activeSort.desc
-      ? "asc"
-      : "desc";
+  // Only forward the sort to the server when the sorted column actually
+  // rides a server-side ranking; sorting by anything else keeps fetching
+  // pages in the default credits-desc order and reorders them locally
+  // instead.
+  const serverSortBy: ConsumptionTopSortBy | undefined = activeSort?.id
+    ? ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID[activeSort.id]
+    : undefined;
+  const sortBy = serverSortBy ?? "credits";
+  const sortOrder = serverSortBy && !activeSort.desc ? "asc" : "desc";
 
   const {
     rows,
@@ -480,6 +485,7 @@ function AttributionRows({
     offset: pagination.pageIndex * pagination.pageSize,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   const cappedRowCount = Math.min(totalCount, ATTRIBUTION_MAX_ROW_COUNT);

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -295,8 +295,7 @@ function buildColumns({
     {
       id: "costShare",
       // Same denominator (totalCredits) for every row, so ranking by cost
-      // share is the same order as ranking by credits — reuse that accessor
-      // instead of introducing a separate ranking.
+      // share is the same order as ranking by credits
       accessorFn: (row) => (totalCredits > 0 ? row.credits / totalCredits : 0),
       header: "Consumption share",
       meta: { sizeRatio: 20, headerAlign: "left" },

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -8,6 +8,7 @@ import {
 import type { ConsumptionTopBody } from "@app/lib/api/analytics/consumption/schema";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
@@ -184,6 +185,7 @@ export function useConsumptionTop({
   offset = 0,
   search,
   filter,
+  sortBy = "credits",
   sortOrder = "desc",
   disabled,
 }: {
@@ -194,6 +196,7 @@ export function useConsumptionTop({
   offset?: number;
   search?: string;
   filter?: ConsumptionScopeFilter;
+  sortBy?: ConsumptionTopSortBy;
   sortOrder?: ConsumptionTopSortOrder;
   disabled?: boolean;
 }) {
@@ -206,6 +209,7 @@ export function useConsumptionTop({
     limit,
     offset,
     search: search?.trim(),
+    sortBy,
     sortOrder,
   };
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -2,6 +2,7 @@ import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_
 import type { ConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/period";
 import {
   CONSUMPTION_SCOPE_FILTER_KEYS,
+  CONSUMPTION_TOP_SORT_BY,
   CONSUMPTION_TOP_SORT_ORDER,
 } from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
@@ -49,8 +50,9 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().optional(),
-  // Always ranks by gross credits; see the comment on
-  // CONSUMPTION_TOP_SORT_ORDER for why other metrics aren't supported yet.
+  // Which metric to rank by; see the comment on CONSUMPTION_TOP_SORT_BY for
+  // why only these two are supported.
+  sortBy: z.enum(CONSUMPTION_TOP_SORT_BY).optional().default("credits"),
   sortOrder: z.enum(CONSUMPTION_TOP_SORT_ORDER).optional().default("desc"),
 });
 

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -96,8 +96,7 @@ export type ConsumptionTopSortOrder =
   (typeof CONSUMPTION_TOP_SORT_ORDER)[number];
 
 // A terms aggregation cannot order its buckets by a pipeline aggregation
-// (confirmed against a live cluster: "is a pipeline aggregation and cannot
-// be used to sort the buckets"), so a ratio like avg credits per unit can't be
+// so a ratio like avg credits per unit can't be
 // ranked with a bucket_script the way gross credits is. Two metrics avoid
 // that:
 // - "credits" orders by the sum(credit_micro) metric directly. Cost share is

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -95,6 +95,27 @@ export const CONSUMPTION_TOP_SORT_ORDER = ["asc", "desc"] as const;
 export type ConsumptionTopSortOrder =
   (typeof CONSUMPTION_TOP_SORT_ORDER)[number];
 
+// A terms aggregation cannot order its buckets by a pipeline aggregation
+// (confirmed against a live cluster: "is a pipeline aggregation and cannot
+// be used to sort the buckets"), so a ratio like avg credits per unit can't be
+// ranked with a bucket_script the way gross credits is. Two metrics avoid
+// that:
+// - "credits" orders by the sum(credit_micro) metric directly. Cost share is
+//   credits divided by the same totalCredits for every row, so it rides this
+//   same ranking (see ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS in
+//   ConsumptionAttributionTable.tsx).
+// - "avgCredits" orders by average credits per unit. For "invocation"
+//   dimensions (tool, skill) that unit is the document itself, so a plain
+//   avg(credit_micro) metric already equals credits-per-invocation. For
+//   "message" dimensions it isn't: several documents (one per LLM run, one
+//   per tool action) can share a message, so the average needs a
+//   scripted_metric to divide the summed credits by the count of *distinct*
+//   message ids in the bucket — the "real complexity" previously left for a
+//   follow-up. See AVG_CREDIT_PER_MESSAGE_AGG in top.ts.
+export const CONSUMPTION_TOP_SORT_BY = ["credits", "avgCredits"] as const;
+
+export type ConsumptionTopSortBy = (typeof CONSUMPTION_TOP_SORT_BY)[number];
+
 export const CONSUMPTION_METRICS = ["credit_micro"] as const;
 
 export type ConsumptionMetric = (typeof CONSUMPTION_METRICS)[number];

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -758,4 +758,90 @@ describe("consumption top rankings", () => {
       order: { credit_micro: "asc" },
     });
   });
+
+  it("ranks message-unit dimensions by a scripted avg-per-message metric when sortBy is avgCredits", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "@dust" });
+    mockAggs({
+      buckets: [
+        {
+          key: "agent1",
+          doc_count: 2,
+          credit_micro: { value: 3_000_000 },
+          messages: { value: 2 },
+          avg_credit_per_message: { value: 1.5 },
+        },
+      ],
+      totalMicro: 3_000_000,
+    });
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+      sortBy: "avgCredits",
+      sortOrder: "asc",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const [, options] = rankingSearchCall();
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({
+      order: { avg_credit_per_message: "asc" },
+    });
+    expect(
+      options?.aggregations?.by_group?.aggs?.avg_credit_per_message
+    ).toMatchObject({
+      scripted_metric: expect.objectContaining({
+        map_script: expect.any(String),
+        reduce_script: expect.any(String),
+      }),
+    });
+  });
+
+  it("ranks invocation-unit dimensions by a plain avg metric when sortBy is avgCredits", async () => {
+    const { auth } = await setup();
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(
+      new Map([
+        [
+          "web_search_browse",
+          {
+            name: "Web Search & Browse",
+            pictureUrl: null,
+            description: null,
+            icon: "Globe01Icon",
+          },
+        ],
+      ])
+    );
+    mockAggs({
+      buckets: [
+        {
+          key: "web_search_browse",
+          doc_count: 4,
+          credit_micro: { value: 2_000_000 },
+          avg_credit_per_invocation: { value: 500_000 },
+        },
+      ],
+      totalMicro: 2_000_000,
+    });
+
+    const result = await fetchConsumptionTopTools(auth, {
+      period: PERIOD,
+      limit: 10,
+      sortBy: "avgCredits",
+      sortOrder: "desc",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const [, options] = rankingSearchCall();
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({
+      order: { avg_credit_per_invocation: "desc" },
+    });
+    expect(
+      options?.aggregations?.by_group?.aggs?.avg_credit_per_invocation
+    ).toMatchObject({
+      avg: { field: "credit_micro" },
+    });
+  });
 });

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -759,43 +759,54 @@ describe("consumption top rankings", () => {
     });
   });
 
-  it("ranks message-unit dimensions by a scripted avg-per-message metric when sortBy is avgCredits", async () => {
+  it("ranks message-unit dimensions by average credits in memory when sortBy is avgCredits", async () => {
     const { auth } = await setup();
-    mockLabels({ agent1: "@dust" });
+    mockLabels({ agent1: "Agent 1", agent2: "Agent 2" });
     mockAggs({
+      // agent1 has more gross credits but a lower per-message average than
+      // agent2 — Elasticsearch cannot order by that ratio, so the query
+      // below orders by gross credits and the response must be re-ranked
+      // by average in memory to put agent2 first.
       buckets: [
         {
           key: "agent1",
-          doc_count: 2,
+          doc_count: 4,
+          credit_micro: { value: 4_000_000 },
+          messages: { value: 4 },
+        },
+        {
+          key: "agent2",
+          doc_count: 1,
           credit_micro: { value: 3_000_000 },
-          messages: { value: 2 },
-          avg_credit_per_message: { value: 1.5 },
+          messages: { value: 1 },
         },
       ],
-      totalMicro: 3_000_000,
+      totalMicro: 7_000_000,
     });
 
     const result = await fetchConsumptionTopAgents(auth, {
       period: PERIOD,
       limit: 10,
       sortBy: "avgCredits",
-      sortOrder: "asc",
+      sortOrder: "desc",
     });
 
     expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
+      "agent2",
+      "agent1",
+    ]);
 
     const [, options] = rankingSearchCall();
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
-      order: { avg_credit_per_message: "asc" },
+      order: { credit_micro: "desc" },
     });
     expect(
       options?.aggregations?.by_group?.aggs?.avg_credit_per_message
-    ).toMatchObject({
-      scripted_metric: expect.objectContaining({
-        map_script: expect.any(String),
-        reduce_script: expect.any(String),
-      }),
-    });
+    ).toBeUndefined();
   });
 
   it("ranks invocation-unit dimensions by a plain avg metric when sortBy is avgCredits", async () => {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -74,10 +74,7 @@ type GroupBucket = {
   [AVG_CREDIT_PER_INVOCATION_AGG]?: estypes.AggregationsAvgAggregate;
 };
 
-// The avg-credit-per-unit sub-aggregation is only worth computing when the
-// ranking actually orders by it. "message" dimensions rank by average in
-// memory (see `fetchConsumptionTopGroups`) from the credits/messages sums
-// already computed here, so no extra sub-aggregation is needed for them.
+// Only worth computing when the ranking actually orders by it.
 function subAggs(unit: ConsumptionTopUnit, sortBy: ConsumptionTopSortBy) {
   return {
     [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -59,32 +59,12 @@ const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
 const TOTAL_COUNT_AGG = "total_count";
 // Ranks "invocation" dimensions by avg credits: one document is one
-// invocation there, so a plain avg metric already equals credits per unit.
+// invocation there, so a plain avg metric already equals credits per unit,
+// and terms aggregations can order buckets by it directly.
 const AVG_CREDIT_PER_INVOCATION_AGG = "avg_credit_per_invocation";
-// Ranks "message" dimensions by avg credits. Several documents (one per LLM
-// run, one per tool action) can share a message, so a plain avg(credit_micro)
-// would average per-document slices instead of per-message totals. A
-// scripted_metric divides the bucket's summed credits by its count of
-// *distinct* message ids instead, giving a genuine single-value metric a
-// terms aggregation can order by (a bucket_script, the alternative, is a
-// pipeline aggregation and terms cannot order by those).
-const AVG_CREDIT_PER_MESSAGE_AGG = "avg_credit_per_message";
 const RANKING_TERMS_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
-
-const AVG_CREDIT_PER_MESSAGE_SCRIPT: estypes.AggregationsScriptedMetricAggregation =
-  {
-    init_script: "state.creditMicro = 0L; state.messageIds = new HashSet();",
-    map_script:
-      "state.creditMicro += doc['credit_micro'].value; " +
-      "state.messageIds.add(doc['agent_message_id'].value);",
-    combine_script: "return [state.creditMicro, state.messageIds];",
-    reduce_script:
-      "long creditMicro = 0L; Set messageIds = new HashSet(); " +
-      "for (s in states) { creditMicro += s[0]; messageIds.addAll(s[1]); } " +
-      "return messageIds.isEmpty() ? 0.0 : (double) creditMicro / messageIds.size();",
-  };
 
 type GroupBucket = {
   key: string;
@@ -92,46 +72,42 @@ type GroupBucket = {
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
   [AVG_CREDIT_PER_INVOCATION_AGG]?: estypes.AggregationsAvgAggregate;
-  [AVG_CREDIT_PER_MESSAGE_AGG]?: estypes.AggregationsScriptedMetricAggregate;
 };
 
 // The avg-credit-per-unit sub-aggregation is only worth computing when the
-// ranking actually orders by it — a scripted_metric in particular runs a
-// painless script over every document in every bucket.
+// ranking actually orders by it. "message" dimensions rank by average in
+// memory (see `fetchConsumptionTopGroups`) from the credits/messages sums
+// already computed here, so no extra sub-aggregation is needed for them.
 function subAggs(unit: ConsumptionTopUnit, sortBy: ConsumptionTopSortBy) {
   return {
     [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
     ...(unit === "message"
       ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
       : {}),
-    ...(sortBy === "avgCredits"
-      ? unit === "message"
-        ? {
-            [AVG_CREDIT_PER_MESSAGE_AGG]: {
-              scripted_metric: AVG_CREDIT_PER_MESSAGE_SCRIPT,
-            },
-          }
-        : {
-            [AVG_CREDIT_PER_INVOCATION_AGG]: {
-              avg: { field: CREDIT_MICRO_FIELD },
-            },
-          }
+    ...(sortBy === "avgCredits" && unit === "invocation"
+      ? {
+          [AVG_CREDIT_PER_INVOCATION_AGG]: {
+            avg: { field: CREDIT_MICRO_FIELD },
+          },
+        }
       : {}),
   };
 }
 
 // The sub-aggregation a terms aggregation orders its buckets by for a given
-// ranking metric and unit.
+// ranking metric and unit. "message" dimensions ranked by avg credits are a
+// ratio of two metrics (summed credits over distinct message count):
+// Elasticsearch terms aggregations can only order by a genuine metric
+// aggregation (avg, sum, cardinality, ...), not a ratio, so that case orders
+// by credits here and is re-ranked by average in memory afterwards.
 function orderAggName(
   sortBy: ConsumptionTopSortBy,
   unit: ConsumptionTopUnit
 ): string {
-  if (sortBy === "credits") {
-    return CREDIT_AGG;
+  if (sortBy === "avgCredits" && unit === "invocation") {
+    return AVG_CREDIT_PER_INVOCATION_AGG;
   }
-  return unit === "message"
-    ? AVG_CREDIT_PER_MESSAGE_AGG
-    : AVG_CREDIT_PER_INVOCATION_AGG;
+  return CREDIT_AGG;
 }
 
 type RankingAggs = {
@@ -380,7 +356,16 @@ export async function fetchConsumptionTopGroups(
     filter,
   });
 
-  const requestedBucketCount = offset + limit;
+  // Elasticsearch cannot order terms buckets by a ratio of two metrics
+  // (summed credits over distinct message count), so ranking "message"
+  // dimensions by avg credits requires fetching every bucket and sorting by
+  // average in memory, rather than relying on the requested page's size.
+  const sortInMemory =
+    sortBy === "avgCredits" &&
+    CONSUMPTION_DIMENSION_UNIT[dimension] === "message";
+  const requestedBucketCount = sortInMemory
+    ? Number.MAX_SAFE_INTEGER
+    : offset + limit;
   const rankedGroups: Omit<ConsumptionTopGroup, "previousCredits">[] = [];
   let buckets: GroupBucket[];
   let batchSize = 0;
@@ -389,7 +374,8 @@ export async function fetchConsumptionTopGroups(
 
   // Terms aggregations do not expose an after_key when ordered by a metric.
   // Continue the ranked result in bounded batches by excluding the keys
-  // already returned, and stop as soon as the requested page is available.
+  // already returned, and stop as soon as the requested page is available
+  // (or, when sorting in memory, once every bucket has been fetched).
   do {
     batchSize = Math.min(
       requestedBucketCount - rankedGroups.length,
@@ -432,7 +418,15 @@ export async function fetchConsumptionTopGroups(
     buckets.length === batchSize
   );
 
-  const pagedGroups = rankedGroups.slice(offset, offset + limit);
+  const sortedGroups = sortInMemory
+    ? [...rankedGroups].sort((a, b) => {
+        const diff =
+          avgCreditsPerUnit(a.credits, a.count) -
+          avgCreditsPerUnit(b.credits, b.count);
+        return sortOrder === "asc" ? diff : -diff;
+      })
+    : rankedGroups;
+  const pagedGroups = sortedGroups.slice(offset, offset + limit);
 
   const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
     dimension,

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -5,6 +5,7 @@ import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/pe
 import type {
   ConsumptionScopeDimension,
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
   ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
@@ -57,24 +58,80 @@ export type ConsumptionTopGroups = {
 const CREDIT_AGG = "credit_micro";
 const MESSAGES_AGG = "messages";
 const TOTAL_COUNT_AGG = "total_count";
+// Ranks "invocation" dimensions by avg credits: one document is one
+// invocation there, so a plain avg metric already equals credits per unit.
+const AVG_CREDIT_PER_INVOCATION_AGG = "avg_credit_per_invocation";
+// Ranks "message" dimensions by avg credits. Several documents (one per LLM
+// run, one per tool action) can share a message, so a plain avg(credit_micro)
+// would average per-document slices instead of per-message totals. A
+// scripted_metric divides the bucket's summed credits by its count of
+// *distinct* message ids instead, giving a genuine single-value metric a
+// terms aggregation can order by (a bucket_script, the alternative, is a
+// pipeline aggregation and terms cannot order by those).
+const AVG_CREDIT_PER_MESSAGE_AGG = "avg_credit_per_message";
 const RANKING_TERMS_PAGE_SIZE = 1_000;
 const MAX_ES_QUERY_CLAUSES = 1_024;
 const MAX_ES_TERMS_QUERY_VALUES = 65_536;
+
+const AVG_CREDIT_PER_MESSAGE_SCRIPT: estypes.AggregationsScriptedMetricAggregation =
+  {
+    init_script: "state.creditMicro = 0L; state.messageIds = new HashSet();",
+    map_script:
+      "state.creditMicro += doc['credit_micro'].value; " +
+      "state.messageIds.add(doc['agent_message_id'].value);",
+    combine_script: "return [state.creditMicro, state.messageIds];",
+    reduce_script:
+      "long creditMicro = 0L; Set messageIds = new HashSet(); " +
+      "for (s in states) { creditMicro += s[0]; messageIds.addAll(s[1]); } " +
+      "return messageIds.isEmpty() ? 0.0 : (double) creditMicro / messageIds.size();",
+  };
 
 type GroupBucket = {
   key: string;
   doc_count: number;
   [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
   [MESSAGES_AGG]?: estypes.AggregationsCardinalityAggregate;
+  [AVG_CREDIT_PER_INVOCATION_AGG]?: estypes.AggregationsAvgAggregate;
+  [AVG_CREDIT_PER_MESSAGE_AGG]?: estypes.AggregationsScriptedMetricAggregate;
 };
 
-function subAggs(unit: ConsumptionTopUnit) {
+// The avg-credit-per-unit sub-aggregation is only worth computing when the
+// ranking actually orders by it — a scripted_metric in particular runs a
+// painless script over every document in every bucket.
+function subAggs(unit: ConsumptionTopUnit, sortBy: ConsumptionTopSortBy) {
   return {
     [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
     ...(unit === "message"
       ? { [MESSAGES_AGG]: { cardinality: { field: AGENT_MESSAGE_ID_FIELD } } }
       : {}),
+    ...(sortBy === "avgCredits"
+      ? unit === "message"
+        ? {
+            [AVG_CREDIT_PER_MESSAGE_AGG]: {
+              scripted_metric: AVG_CREDIT_PER_MESSAGE_SCRIPT,
+            },
+          }
+        : {
+            [AVG_CREDIT_PER_INVOCATION_AGG]: {
+              avg: { field: CREDIT_MICRO_FIELD },
+            },
+          }
+      : {}),
   };
+}
+
+// The sub-aggregation a terms aggregation orders its buckets by for a given
+// ranking metric and unit.
+function orderAggName(
+  sortBy: ConsumptionTopSortBy,
+  unit: ConsumptionTopUnit
+): string {
+  if (sortBy === "credits") {
+    return CREDIT_AGG;
+  }
+  return unit === "message"
+    ? AVG_CREDIT_PER_MESSAGE_AGG
+    : AVG_CREDIT_PER_INVOCATION_AGG;
 }
 
 type RankingAggs = {
@@ -172,12 +229,14 @@ function buildConsumptionTopAggregations({
   bucketCount,
   excludedKeys,
   searchFilter,
+  sortBy,
   sortOrder,
 }: {
   dimension: ConsumptionScopeDimension;
   bucketCount: number;
   excludedKeys: string[];
   searchFilter: estypes.QueryDslQueryContainer | null;
+  sortBy: ConsumptionTopSortBy;
   sortOrder: ConsumptionTopSortOrder;
 }): Record<string, estypes.AggregationsAggregationContainer> {
   const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
@@ -188,10 +247,10 @@ function buildConsumptionTopAggregations({
       terms: {
         field: dimensionField,
         size: bucketCount,
-        order: { [CREDIT_AGG]: sortOrder },
+        order: { [orderAggName(sortBy, unit)]: sortOrder },
         ...(excludedKeys.length > 0 ? { exclude: excludedKeys } : {}),
       },
-      aggs: subAggs(unit),
+      aggs: subAggs(unit, sortBy),
     },
     [TOTAL_COUNT_AGG]: {
       cardinality: {
@@ -296,6 +355,7 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
+    sortBy = "credits",
     sortOrder = "desc",
   }: {
     dimension: ConsumptionScopeDimension;
@@ -304,6 +364,7 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
@@ -339,6 +400,7 @@ export async function fetchConsumptionTopGroups(
       bucketCount: batchSize,
       excludedKeys: rankedGroups.map((group) => group.key),
       searchFilter,
+      sortBy,
       sortOrder,
     });
     const result = await searchConsumptionAnalytics<never, TopAggs>(query, {

--- a/front/lib/api/analytics/consumption/top_agents.ts
+++ b/front/lib/api/analytics/consumption/top_agents.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -50,6 +51,7 @@ export async function fetchConsumptionTopAgents(
     offset = 0,
     search,
     filter,
+    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -57,6 +59,7 @@ export async function fetchConsumptionTopAgents(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopAgents, ElasticsearchError>> {
@@ -67,6 +70,7 @@ export async function fetchConsumptionTopAgents(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_api_keys.ts
+++ b/front/lib/api/analytics/consumption/top_api_keys.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -46,6 +47,7 @@ export async function fetchConsumptionTopApiKeys(
     offset = 0,
     search,
     filter,
+    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -53,6 +55,7 @@ export async function fetchConsumptionTopApiKeys(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopApiKeys, ElasticsearchError>> {
@@ -63,6 +66,7 @@ export async function fetchConsumptionTopApiKeys(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_groups.ts
+++ b/front/lib/api/analytics/consumption/top_groups.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -47,6 +48,7 @@ export async function fetchConsumptionTopGroups(
     offset = 0,
     search,
     filter,
+    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -54,6 +56,7 @@ export async function fetchConsumptionTopGroups(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopGroups, ElasticsearchError>> {
@@ -64,6 +67,7 @@ export async function fetchConsumptionTopGroups(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_models.ts
+++ b/front/lib/api/analytics/consumption/top_models.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -47,6 +48,7 @@ export async function fetchConsumptionTopModels(
     offset = 0,
     search,
     filter,
+    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -54,6 +56,7 @@ export async function fetchConsumptionTopModels(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopModels, ElasticsearchError>> {
@@ -64,6 +67,7 @@ export async function fetchConsumptionTopModels(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_skills.ts
+++ b/front/lib/api/analytics/consumption/top_skills.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -55,6 +56,7 @@ export async function fetchConsumptionTopSkills(
     offset = 0,
     search,
     filter,
+    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -62,6 +64,7 @@ export async function fetchConsumptionTopSkills(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopSkills, ElasticsearchError>> {
@@ -72,6 +75,7 @@ export async function fetchConsumptionTopSkills(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_sources.ts
+++ b/front/lib/api/analytics/consumption/top_sources.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -48,6 +49,7 @@ export async function fetchConsumptionTopSources(
     offset = 0,
     search,
     filter,
+    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -55,6 +57,7 @@ export async function fetchConsumptionTopSources(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopSources, ElasticsearchError>> {
@@ -65,6 +68,7 @@ export async function fetchConsumptionTopSources(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_tools.ts
+++ b/front/lib/api/analytics/consumption/top_tools.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -53,6 +54,7 @@ export async function fetchConsumptionTopTools(
     offset = 0,
     search,
     filter,
+    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -60,6 +62,7 @@ export async function fetchConsumptionTopTools(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopTools, ElasticsearchError>> {
@@ -70,6 +73,7 @@ export async function fetchConsumptionTopTools(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {

--- a/front/lib/api/analytics/consumption/top_users.ts
+++ b/front/lib/api/analytics/consumption/top_users.ts
@@ -1,6 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
   ConsumptionScopeFilter,
+  ConsumptionTopSortBy,
   ConsumptionTopSortOrder,
 } from "@app/lib/api/analytics/consumption/scope";
 import {
@@ -51,6 +52,7 @@ export async function fetchConsumptionTopUsers(
     offset = 0,
     search,
     filter,
+    sortBy,
     sortOrder,
   }: {
     period: ConsumptionPeriod;
@@ -58,6 +60,7 @@ export async function fetchConsumptionTopUsers(
     offset?: number;
     search?: string;
     filter?: ConsumptionScopeFilter;
+    sortBy?: ConsumptionTopSortBy;
     sortOrder?: ConsumptionTopSortOrder;
   }
 ): Promise<Result<ConsumptionTopUsers, ElasticsearchError>> {
@@ -68,6 +71,7 @@ export async function fetchConsumptionTopUsers(
     offset,
     search,
     filter,
+    sortBy,
     sortOrder,
   });
   if (result.isErr()) {


### PR DESCRIPTION
## Description

This is the third PR in the stack [#30794](https://github.com/dust-tt/dust/pull/30794) → [#30795](https://github.com/dust-tt/dust/pull/30795) → **#30796**. It adds support for ranking the Consumption Attribution table by average credits per unit.

The optional `sortBy` parameter now flows from the table through the shared consumption hook, schema, all top-* API routes, and dimension fetchers. It supports `credits` (the default) and `avgCredits`, while the existing server-side credits ranking remains unchanged for callers that do not provide `sortBy`.

For invocation-based dimensions such as tools and skills, the ranking uses an Elasticsearch `avg(credit_micro)` sub-aggregation and orders buckets directly by that metric. For message-based dimensions, average credits are computed as the bucket's credits divided by its distinct message count. Elasticsearch terms aggregations cannot order by that ratio, so this path fetches all matching buckets in batches, re-ranks them in memory, and applies pagination after sorting. The extra average aggregation is only requested when it is needed for invocation-based average sorting.

The UI maps the `avgCredits` column to this server-side ranking and keeps local sorting for columns that do not have a corresponding server ranking. No persisted data or migration changes are included; `sortBy` is optional and remains backwards compatible through its `credits` default.

## Tests

Added Vitest coverage in `front/lib/api/analytics/consumption/top.test.ts` for average-credit ranking on message-unit and invocation-unit dimensions. 

## Risk

The default credits ranking is preserved, but average-credit sorting for message-based dimensions can be substantially more expensive than the normal paginated path because it fetches every matching bucket and sorts the complete result set in memory. **High-cardinality dimensions may therefore have increased query time and memory usage.**

## Deploy Plan

Deploy `front` in stack order: [#30794](https://github.com/dust-tt/dust/pull/30794), then [#30795](https://github.com/dust-tt/dust/pull/30795), then this PR. No migration or additional rollout step is identified.