### PR TITLE
fix: restore cache mock in programmatic credit state machine test

### DIFF
--- a/front/lib/metronome/programmatic_credit_state_machine.test.ts
+++ b/front/lib/metronome/programmatic_credit_state_machine.test.ts
@@ -28,9 +28,13 @@ vi.mock("@app/lib/metronome/user_block", () => ({
     mockSetWorkspaceProgrammaticCreditStatus,
 }));
 
-vi.mock("@app/lib/utils/cache", () => ({
-  invalidateCacheAfterCommit: mockInvalidateCacheAfterCommit,
-}));
+vi.mock("@app/lib/utils/cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/utils/cache")>();
+  return {
+    ...actual,
+    invalidateCacheAfterCommit: mockInvalidateCacheAfterCommit,
+  };
+});
 
 vi.mock("@app/logger/logger", () => ({
   default: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },


### PR DESCRIPTION
## Description

Shard 3 of front tests has failed on every main push since #30753: `client.ts` now calls `cacheWithRedis` at module scope, and this test's `vi.mock` factory only exported `invalidateCacheAfterCommit`, so switch it to the `importOriginal` partial mock used elsewhere.

## Tests

`NODE_ENV=test npm test -- lib/metronome` — 21 files, 357 tests pass.

## Risk

None, test-only.

## Deploy Plan

Deploy front.