### PR TITLE
[front] Match automations download button size to filter button

### DIFF
--- a/front/components/workspace/analytics/CsvDownloadButton.tsx
+++ b/front/components/workspace/analytics/CsvDownloadButton.tsx
@@ -1,3 +1,4 @@
+import type { ButtonProps } from "@dust-tt/sparkle";
 import { Button, Download01 } from "@dust-tt/sparkle";
 
 interface CsvDownloadButtonProps {
@@ -5,6 +6,7 @@ interface CsvDownloadButtonProps {
   disabled: boolean;
   handleDownload: () => void;
   label?: string;
+  size?: ButtonProps["size"];
 }
 
 export function CsvDownloadButton({
@@ -12,6 +14,7 @@ export function CsvDownloadButton({
   disabled,
   handleDownload,
   label,
+  size,
 }: CsvDownloadButtonProps) {
   return (
     <Button
@@ -19,7 +22,7 @@ export function CsvDownloadButton({
       iconRight={label ? Download01 : undefined}
       label={label}
       variant="outline"
-      size={label ? "sm" : "xs"}
+      size={size ?? (label ? "sm" : "xs")}
       tooltip={label ? undefined : "Download CSV"}
       onClick={handleDownload}
       disabled={disabled}

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -491,7 +491,7 @@ export function AutomationsTriggersTable({
             filter={filter}
             onFilterChange={onFilterChange}
           />
-          <CsvDownloadButton {...csvDownload} />
+          <CsvDownloadButton {...csvDownload} size="sm" />
         </div>
         <AutomationsFilterSummary
           filter={filter}


### PR DESCRIPTION
## Description

BIG BOÏ BUTTON !

The CSV download button on the Automations page was rendered at `xs`, while the adjacent Filters button uses `sm`. This change adds an optional `size` override to `CsvDownloadButton` and sets it to `sm` in `AutomationsTriggersTable`, aligning the two controls. Callers that do not provide an override retain the existing behavior: labeled buttons use `sm`, and icon-only buttons use `xs`.

![Automations download and filter buttons](https://github.com/user-attachments/assets/0e6d8914-f207-4cb8-8c9e-3561691be3ff)

## Tests

Manual verification:

- Confirm the download and filter buttons are the same size on the Automations page.
- Confirm other pages using `CsvDownloadButton`, including the Workspace usage/credits charts, are unchanged.

## Risk

Low 

## Deploy Plan

- Deploy front