### PR TITLE
Make run usage classification immutable

### DIFF
--- a/front/lib/analytics/agent_message_consumption/documents.test.ts
+++ b/front/lib/analytics/agent_message_consumption/documents.test.ts
@@ -117,10 +117,6 @@ async function setupSettledMessage({
       },
     }
   );
-  await RunResource.setUsageTypeForRuns(auth, {
-    runs: [run],
-    usageType: USAGE_TYPE_USER,
-  });
 
   return {
     agent,

--- a/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
+++ b/front/lib/analytics/agent_message_consumption/llm_documents.test.ts
@@ -2,11 +2,9 @@ import { buildLlmConsumptionDocuments } from "@app/lib/analytics/agent_message_c
 import { loadAgentMessageConsumptionAnalyticsInput } from "@app/lib/analytics/agent_message_consumption/load";
 import { buildLatestMessageConsumptionAllocation } from "@app/lib/api/assistant/agent_message_consumption_attribution/allocation";
 import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
-import { USAGE_TYPE_USER } from "@app/lib/metronome/constants";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { AgentMessageConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { RunResource } from "@app/lib/resources/run_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -74,10 +72,6 @@ describe("buildLlmConsumptionDocuments", () => {
       },
       { where: { id: agentMessageModelId, workspaceId: workspace.id } }
     );
-    await RunResource.setUsageTypeForRuns(auth, {
-      runs: [run],
-      usageType: USAGE_TYPE_USER,
-    });
     await AgentMessageConsumptionItemResource.recordItemsIdempotently(auth, {
       conversation,
       agentMessageModelId,

--- a/front/lib/analytics/agent_message_consumption/load.test.ts
+++ b/front/lib/analytics/agent_message_consumption/load.test.ts
@@ -8,7 +8,6 @@ import {
 import type { UsageType } from "@app/lib/metronome/types";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
-import { RunResource } from "@app/lib/resources/run_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
@@ -157,6 +156,7 @@ async function setupSettledMessage({
     inputTokens: 100,
     outputTokens: 20,
     modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
+    usageType,
   });
   await AgentMessageModel.update(
     {
@@ -172,13 +172,6 @@ async function setupSettledMessage({
       },
     }
   );
-  if (usageType !== null) {
-    await RunResource.setUsageTypeForRuns(auth, {
-      runs: [run],
-      usageType,
-    });
-  }
-
   return {
     agent,
     agentMessage,

--- a/front/lib/api/assistant/conversation/forks.test.ts
+++ b/front/lib/api/assistant/conversation/forks.test.ts
@@ -13,6 +13,7 @@ import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import * as fileUtilsModule from "@app/lib/api/files/utils";
 import * as uploadFrameContentModule from "@app/lib/api/viz/upload_frame_content";
 import { Authenticator } from "@app/lib/auth";
+import { USAGE_TYPE_USER } from "@app/lib/metronome/constants";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import {
   AgentMCPActionModel,
@@ -279,7 +280,8 @@ async function attachRunToAgentMessage(
       totalOutputTokens: 20,
       totalTokens: promptTokens + 20,
     },
-    model.modelId
+    model.modelId,
+    { usageType: USAGE_TYPE_USER }
   );
 
   const [updatedCount] = await AgentMessageModel.update(

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -259,11 +259,10 @@ export async function computeAndStoreAgentMessageCredits(
     dustRunIds: [...new Set(runIds ?? [])],
   });
 
-  // Persist the billing usage type on the run usages so free/user/programmatic
-  // consumption can be queried directly (e.g. free-usage monitoring). Reuses the
-  // same origin-based classification as the Metronome events.
+  // Repair legacy run usages that predate creation-time classification. New
+  // rows are already classified and this fallback never overwrites them.
   const messageOrigin = triggeringUserMessageOrigin ?? "web";
-  await RunResource.setUsageTypeForRuns(auth, {
+  await RunResource.setUsageTypeForRunsIfMissing(auth, {
     runs,
     usageType: getUsageType(
       isProgrammaticUsage(auth, { userMessageOrigin: messageOrigin }),

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -28,10 +28,13 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import { emitTokenUsageMetrics } from "@app/lib/api/llm/usage_metrics";
+import { isProgrammaticUsageFromContext } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import { USAGE_TYPE_FREE } from "@app/lib/metronome/constants";
+import { getUsageType } from "@app/lib/metronome/events";
+import type { UsageType } from "@app/lib/metronome/types";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -550,6 +553,7 @@ export abstract class LLM<
     results: BatchResult
   ): Promise<BatchResultWithRunIds> {
     const enrichedResults: BatchResultWithRunIds = new Map();
+    const usageType = this.getUsageType();
 
     for (const [customId, events] of results) {
       const traceId = createLLMTraceId(randomUUID());
@@ -569,7 +573,11 @@ export abstract class LLM<
             this.authenticator,
             event.content,
             this.modelId,
-            { isBatch: true, inferenceRegion: this.metadata.inferenceRegion }
+            {
+              isBatch: true,
+              inferenceRegion: this.metadata.inferenceRegion,
+              usageType,
+            }
           );
         }
       }
@@ -778,11 +786,25 @@ export abstract class LLM<
     }
   }
 
-  private getUsageType() {
-    // Calls without tracing context cannot be attributed to a billable agent conversation,
-    // so keep them free until the caller provides that context.
-    return !this.context || isFreeUsageContext(this.context)
-      ? USAGE_TYPE_FREE
-      : undefined;
+  private getUsageType(): UsageType {
+    // Calls without tracing context and non-agent utility calls are free.
+    if (!this.context || isFreeUsageContext(this.context)) {
+      return USAGE_TYPE_FREE;
+    }
+
+    const userMessageOrigin = this.context.userMessageOrigin;
+    if (!userMessageOrigin) {
+      throw new Error(
+        "Agent conversation LLM context is missing userMessageOrigin"
+      );
+    }
+
+    return getUsageType(
+      isProgrammaticUsageFromContext({
+        authMethod: this.authenticator.authMethod(),
+        userMessageOrigin,
+      }),
+      userMessageOrigin
+    );
   }
 }

--- a/front/lib/api/llm/run_lifecycle.test.ts
+++ b/front/lib/api/llm/run_lifecycle.test.ts
@@ -7,6 +7,11 @@ import { DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesBatch } from "@app/lib/llm
 import { DustNoopNoopGlobalNoopStream } from "@app/lib/llms/stream/endpoints/noop_noop_global_noop";
 import { DustOpenAIGptFiveDotFiveEuropeOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_five_eu_openai_responses";
 import { DustOpenAIGptFiveDotFiveGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_five_global_openai_responses";
+import {
+  USAGE_TYPE_FREE,
+  USAGE_TYPE_PROGRAMMATIC,
+  USAGE_TYPE_USER,
+} from "@app/lib/metronome/constants";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -85,7 +90,9 @@ function makeNoopLLM(
   return llm;
 }
 
-function makeLifecycleParameters() {
+function makeLifecycleParameters(): Parameters<
+  typeof LLMRunLifecycle.start
+>[1] {
   return {
     dustRunId: createLLMTraceId(generateRandomModelSId()),
     inferenceProvider: "openai-responses",
@@ -93,6 +100,7 @@ function makeLifecycleParameters() {
     modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
     providerId: GPT_5_MINI_MODEL_CONFIG.providerId,
     region: "us" as const,
+    usageType: USAGE_TYPE_USER,
   };
 }
 
@@ -118,6 +126,7 @@ describe("LLMRunLifecycle", () => {
         isBatch: false,
         region: "us",
         usageState: "pending",
+        usageType: USAGE_TYPE_USER,
       },
     ]);
 
@@ -150,6 +159,7 @@ describe("LLMRunLifecycle", () => {
         promptTokens: 120,
         completionTokens: 30,
         usageState: "reported",
+        usageType: USAGE_TYPE_USER,
       },
     ]);
     expect(await run.listRunUsages(auth)).toHaveLength(1);
@@ -251,6 +261,7 @@ describe("non-batch LLM run persistence", () => {
     const llm = makeNoopLLM(auth, DustNoopNoopGlobalNoopStream, {
       operationType: "agent_conversation",
       conversationId: generateRandomModelSId(),
+      userMessageOrigin: "web",
       workspaceId: auth.getNonNullableWorkspace().sId,
     });
 
@@ -270,6 +281,33 @@ describe("non-batch LLM run persistence", () => {
       1,
       expect.any(Array)
     );
+  });
+
+  it.each([
+    { origin: "web" as const, usageType: USAGE_TYPE_USER },
+    { origin: "api" as const, usageType: USAGE_TYPE_PROGRAMMATIC },
+  ])("classifies $origin agent usage as $usageType when creating the run", async ({
+    origin,
+    usageType,
+  }) => {
+    const { authenticator: auth } = await createResourceTest({});
+    const llm = makeNoopLLM(auth, DustNoopNoopGlobalNoopStream, {
+      operationType: "agent_conversation",
+      userMessageOrigin: origin,
+    });
+
+    for await (const _event of llm.stream(
+      makeStreamParameters("consume $1.25")
+    )) {
+      // Consume the stream fully so the noop request completes.
+    }
+
+    const run = await RunResource.fetchByDustRunId(auth, {
+      dustRunId: llm.getTraceId(),
+    });
+    expect(await run?.listRunUsageAttempts(auth)).toMatchObject([
+      { usageState: "reported", usageType },
+    ]);
   });
 
   it("finalizes usage from the provider stream", async () => {
@@ -319,7 +357,7 @@ describe("non-batch LLM run persistence", () => {
         costMicroUsd: 1_250_000,
         isBatch: false,
         usageState: "reported",
-        usageType: "free",
+        usageType: USAGE_TYPE_FREE,
       },
     ]);
   });

--- a/front/lib/api/llm/run_lifecycle.ts
+++ b/front/lib/api/llm/run_lifecycle.ts
@@ -18,7 +18,7 @@ interface LLMRunLifecycleParameters {
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
   region: Region | null;
-  usageType?: UsageType;
+  usageType: UsageType;
 }
 
 /**
@@ -67,7 +67,6 @@ export class LLMRunLifecycle {
       this.parameters.modelId,
       {
         inferenceRegion: this.parameters.inferenceRegion,
-        usageType: this.parameters.usageType,
       }
     );
   }
@@ -76,8 +75,7 @@ export class LLMRunLifecycle {
     await this.run.finalizePendingRunUsage(
       this.auth,
       this.runUsageModelId,
-      usages,
-      { usageType: this.parameters.usageType }
+      usages
     );
   }
 

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -46,7 +46,7 @@ interface LLMTraceContextBase {
   userId?: string;
   /**
    * Origin of the triggering user message, set for agent_conversation calls.
-   * Used to classify free (unbilled) usage at the LLM call site.
+   * Used to classify usage as free, user, or programmatic at the LLM call site.
    */
   userMessageOrigin?: UserMessageOrigin;
 }

--- a/front/lib/api/run.ts
+++ b/front/lib/api/run.ts
@@ -1,6 +1,7 @@
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { USAGE_TYPE_PROGRAMMATIC } from "@app/lib/metronome/constants";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import logger from "@app/logger/logger";
@@ -178,7 +179,10 @@ export async function consumeRunStream({
     useWorkspaceCredentials: !useDustCredentials,
   });
 
-  await run.recordRunUsage(auth, usages);
+  // App runs are invoked through the public API, so their usage is programmatic.
+  await run.recordRunUsage(auth, usages, {
+    usageType: USAGE_TYPE_PROGRAMMATIC,
+  });
   return { usages, traces, dustRunId };
 }
 

--- a/front/lib/resources/run_resource.test.ts
+++ b/front/lib/resources/run_resource.test.ts
@@ -1,6 +1,8 @@
+import { USAGE_TYPE_FREE, USAGE_TYPE_USER } from "@app/lib/metronome/constants";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { RunFactory } from "@app/tests/utils/RunFactory";
 import { GPT_5_MINI_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import { describe, expect, it } from "vitest";
 
@@ -23,7 +25,8 @@ describe("RunResource reasoning token usage", () => {
         reasoningTokens: 200,
         totalTokens: 1_300,
       },
-      GPT_5_MINI_MODEL_CONFIG.modelId
+      GPT_5_MINI_MODEL_CONFIG.modelId,
+      { usageType: USAGE_TYPE_USER }
     );
 
     const usages = await run.listRunUsages(auth);
@@ -52,7 +55,8 @@ describe("RunResource reasoning token usage", () => {
         totalOutputTokens: 100,
         totalTokens: 1_100,
       },
-      GPT_5_MINI_MODEL_CONFIG.modelId
+      GPT_5_MINI_MODEL_CONFIG.modelId,
+      { usageType: USAGE_TYPE_USER }
     );
 
     const usages = await run.listRunUsages(auth);
@@ -61,38 +65,72 @@ describe("RunResource reasoning token usage", () => {
   });
 });
 
-describe("RunResource.setUsageTypeForRuns", () => {
-  it("stamps the usage type on the run's usage rows", async () => {
-    const { authenticator: auth, workspace } = await createResourceTest({});
-    const run = await RunResource.makeNew({
-      appId: null,
-      dustRunId: generateRandomModelSId(),
-      runType: "deploy",
-      useWorkspaceCredentials: false,
-      workspaceId: workspace.id,
+describe("RunResource.setUsageTypeForRunsIfMissing", () => {
+  it("classifies legacy rows without overriding existing classifications", async () => {
+    const { authenticator: auth } = await createResourceTest({});
+    const { run: legacyRun } = await RunFactory.createWithUsage(auth, {
+      usageType: null,
+    });
+    const { run: classifiedRun } = await RunFactory.createWithUsage(auth, {
+      usageType: USAGE_TYPE_USER,
     });
 
-    await run.recordTokenUsage(
-      auth,
-      {
-        inputTokens: 1_000,
-        totalOutputTokens: 100,
-        totalTokens: 1_100,
-      },
-      GPT_5_MINI_MODEL_CONFIG.modelId
-    );
-
-    await RunResource.setUsageTypeForRuns(auth, {
-      runs: [run],
-      usageType: "free",
+    await RunResource.setUsageTypeForRunsIfMissing(auth, {
+      runs: [legacyRun, classifiedRun],
+      usageType: USAGE_TYPE_FREE,
     });
 
     const usages = await RunResource.listRunUsagesForRuns(auth, {
-      runs: [run],
+      runs: [legacyRun, classifiedRun],
     });
 
-    expect(usages).toHaveLength(1);
-    expect(usages[0]?.usageType).toBe("free");
+    expect(
+      new Map(usages.map((usage) => [usage.runModelId, usage.usageType]))
+    ).toEqual(
+      new Map([
+        [legacyRun.id, USAGE_TYPE_FREE],
+        [classifiedRun.id, USAGE_TYPE_USER],
+      ])
+    );
+  });
+});
+
+describe("RunResource usage type immutability", () => {
+  it("preserves the creation-time classification when finalizing", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const { run, runUsageModelId } = await RunResource.makeNewWithPendingUsage(
+      {
+        appId: null,
+        dustRunId: generateRandomModelSId(),
+        runType: "deploy",
+        useWorkspaceCredentials: false,
+        workspaceId: workspace.id,
+      },
+      {
+        inferenceProvider: "openai-responses",
+        modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
+        providerId: GPT_5_MINI_MODEL_CONFIG.providerId,
+        region: "global",
+        usageType: USAGE_TYPE_USER,
+      }
+    );
+
+    await run.finalizePendingRunUsage(auth, runUsageModelId, [
+      {
+        cachedTokens: null,
+        completionTokens: 30,
+        costMicroUsd: 10,
+        isBatch: false,
+        modelId: GPT_5_MINI_MODEL_CONFIG.modelId,
+        promptTokens: 120,
+        providerId: GPT_5_MINI_MODEL_CONFIG.providerId,
+        reasoningTokens: null,
+      },
+    ]);
+
+    expect(await run.listRunUsageAttempts(auth)).toMatchObject([
+      { usageState: "reported", usageType: USAGE_TYPE_USER },
+    ]);
   });
 });
 

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -75,7 +75,7 @@ interface PendingRunUsageParameters {
   modelId: ModelIdType;
   providerId: ModelProviderIdType;
   region: Region | null;
-  usageType?: UsageType;
+  usageType: UsageType;
 }
 
 type FetchRunOptions<T extends boolean> = {
@@ -123,7 +123,7 @@ export class RunResource extends BaseResource<RunModel> {
           cacheCreationTokens: null,
           costMicroUsd: 0,
           isBatch: false,
-          usageType: usage.usageType ?? null,
+          usageType: usage.usageType,
           usageState: "pending",
         },
         { transaction }
@@ -271,8 +271,8 @@ export class RunResource extends BaseResource<RunModel> {
     );
   }
 
-  // Stamp the billing usage type onto the usage rows of the given runs.
-  static async setUsageTypeForRuns(
+  // Classify legacy usage rows without ever changing an existing classification.
+  static async setUsageTypeForRunsIfMissing(
     auth: Authenticator,
     { runs, usageType }: { runs: RunResource[]; usageType: UsageType }
   ): Promise<void> {
@@ -285,6 +285,7 @@ export class RunResource extends BaseResource<RunModel> {
       {
         where: {
           runId: { [Op.in]: runModelIds },
+          usageType: null,
           workspaceId: auth.getNonNullableWorkspace().id,
         },
       }
@@ -449,14 +450,12 @@ export class RunResource extends BaseResource<RunModel> {
    * Run usage.
    */
 
-  // `usageType` tags the created rows with their billing usage type. Pass it for
-  // operations whose type is known at creation (e.g. internal/utility LLM calls
-  // are free); leave it undefined for agent-conversation runs, which the usage
-  // queue classifies from the triggering message origin.
+  // Billing classification is immutable event-time metadata. Every new usage
+  // row must be classified when it is created.
   async recordRunUsage(
     auth: Authenticator,
     usages: RunUsageType[],
-    { usageType }: { usageType?: UsageType } = {}
+    { usageType }: { usageType: UsageType }
   ) {
     await RunUsageModel.bulkCreate(
       usages.map(
@@ -484,7 +483,7 @@ export class RunResource extends BaseResource<RunModel> {
           cacheCreationTokens: cacheCreationTokens ?? null,
           costMicroUsd,
           isBatch,
-          usageType: usageType ?? null,
+          usageType,
           usageState: "reported",
         })
       )
@@ -551,8 +550,8 @@ export class RunResource extends BaseResource<RunModel> {
     }: {
       isBatch?: boolean;
       inferenceRegion?: InferenceRegionType;
-      usageType?: UsageType;
-    } = {}
+      usageType: UsageType;
+    }
   ) {
     const runUsage = this.tokenUsageToRunUsage(usage, modelId, {
       isBatch,
@@ -589,15 +588,14 @@ export class RunResource extends BaseResource<RunModel> {
   async finalizePendingRunUsage(
     auth: Authenticator,
     runUsageModelId: ModelId,
-    usages: RunUsageType[],
-    { usageType }: { usageType?: UsageType } = {}
+    usages: RunUsageType[]
   ): Promise<boolean> {
     const [firstUsage, ...additionalUsages] = usages;
     if (!firstUsage) {
       return false;
     }
 
-    const [updatedCount] = await RunUsageModel.update(
+    const [updatedCount, updatedUsages] = await RunUsageModel.update(
       {
         providerId: firstUsage.providerId,
         modelId: firstUsage.modelId,
@@ -608,10 +606,10 @@ export class RunResource extends BaseResource<RunModel> {
         cacheCreationTokens: firstUsage.cacheCreationTokens ?? null,
         costMicroUsd: firstUsage.costMicroUsd,
         isBatch: firstUsage.isBatch,
-        usageType: usageType ?? null,
         usageState: "reported",
       },
       {
+        returning: true,
         where: {
           id: runUsageModelId,
           runId: this.id,
@@ -628,6 +626,12 @@ export class RunResource extends BaseResource<RunModel> {
     }
 
     if (additionalUsages.length > 0) {
+      const usageType = updatedUsages[0]?.usageType;
+      if (!usageType) {
+        throw new Error(
+          "Cannot record additional usage for a run without a billing classification"
+        );
+      }
       await this.recordRunUsage(auth, additionalUsages, { usageType });
     }
     this.emitRunUsageMetrics([firstUsage]);
@@ -641,10 +645,8 @@ export class RunResource extends BaseResource<RunModel> {
     modelId: ModelIdType,
     {
       inferenceRegion = "global",
-      usageType,
     }: {
       inferenceRegion?: InferenceRegionType;
-      usageType?: UsageType;
     } = {}
   ): Promise<number | undefined> {
     const runUsage = this.tokenUsageToRunUsage(usage, modelId, {
@@ -658,8 +660,7 @@ export class RunResource extends BaseResource<RunModel> {
     const wasFinalized = await this.finalizePendingRunUsage(
       auth,
       runUsageModelId,
-      [runUsage],
-      { usageType }
+      [runUsage]
     );
     return wasFinalized ? runUsage.costMicroUsd : undefined;
   }

--- a/front/lib/resources/storage/models/runs.ts
+++ b/front/lib/resources/storage/models/runs.ts
@@ -97,12 +97,9 @@ export class RunUsageModel extends WorkspaceAwareModel<RunUsageModel> {
   declare costMicroUsd: number;
   declare isBatch: boolean;
 
-  // Billing usage type (free / user / programmatic). Internal/utility LLM
-  // operations are tagged free at creation (they are never billed); agent
-  // conversation runs are tagged by the usage queue from the triggering
-  // message's origin via getUsageType. Nullable: agent conversation rows are
-  // briefly null between creation and the usage queue, and legacy/app runs are
-  // never tagged.
+  // Immutable billing usage type (free / user / programmatic), set when the
+  // usage row is created. Nullable only for legacy rows written before every
+  // creation path supplied the classification.
   declare usageType: UsageType | null;
   // Pending and unavailable rows represent provider attempts for which usage has not been
   // reported. Null is accepted during the rolling deployment.

--- a/front/temporal/analytics_queue/activities/agent_analytics.test.ts
+++ b/front/temporal/analytics_queue/activities/agent_analytics.test.ts
@@ -1,6 +1,7 @@
 import { ANALYTICS_ALIAS_NAME, withEs } from "@app/lib/api/elasticsearch";
 
 import type { Authenticator } from "@app/lib/auth";
+import { USAGE_TYPE_USER } from "@app/lib/metronome/constants";
 import {
   AgentMessageModel,
   MessageModel,
@@ -421,7 +422,8 @@ describe("storeAgentAnalyticsActivity - reasoning tokens", () => {
         reasoningTokens: 200,
         totalTokens: 1_300,
       },
-      GPT_5_MINI_MODEL_CONFIG.modelId
+      GPT_5_MINI_MODEL_CONFIG.modelId,
+      { usageType: USAGE_TYPE_USER }
     );
     await AgentMessageModel.update(
       { runIds: [run.dustRunId] },

--- a/front/tests/utils/RunFactory.ts
+++ b/front/tests/utils/RunFactory.ts
@@ -1,4 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
+import { USAGE_TYPE_USER } from "@app/lib/metronome/constants";
+import type { UsageType } from "@app/lib/metronome/types";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { RunUsageModel } from "@app/lib/resources/storage/models/runs";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
@@ -13,11 +15,13 @@ export class RunFactory {
       outputTokens = 20,
       reasoningTokens,
       modelId = GPT_5_MINI_MODEL_CONFIG.modelId,
+      usageType = USAGE_TYPE_USER,
     }: {
       inputTokens?: number;
       outputTokens?: number;
       reasoningTokens?: number;
       modelId?: ModelIdType;
+      usageType?: UsageType | null;
     } = {}
   ) {
     const workspace = auth.getNonNullableWorkspace();
@@ -36,7 +40,8 @@ export class RunFactory {
         reasoningTokens,
         totalTokens: inputTokens + outputTokens,
       },
-      modelId
+      modelId,
+      { usageType: usageType ?? USAGE_TYPE_USER }
     );
 
     const runUsage = await RunUsageModel.findOne({
@@ -44,6 +49,12 @@ export class RunFactory {
     });
     if (!runUsage) {
       throw new Error("Run usage not found after recording token usage");
+    }
+    if (usageType === null) {
+      await RunUsageModel.update(
+        { usageType: null },
+        { where: { id: runUsage.id, workspaceId: workspace.id } }
+      );
     }
 
     return { run, runUsageModelId: runUsage.id };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
We have been observing lots of "Error: Run usage billing classification is incomplete" error in out attribution items, after digging the recently introduced `usageType` field is sometimes never set for a given run usage. We currently only set it for "free" run usage, but one could argue that if we know that a run is free we should also be able to get the `usageType` directly and make it a required property to create a usage and immutable. That is what this PR does.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

No SQL migration required.
