### PR TITLE
[front] fix: align DeepSeek V4 Pro Fireworks metadata

### DIFF
--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -375,11 +375,12 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     output: 0.28,
     cache_read_input_tokens: 0.028,
   },
-  // https://fireworks.ai/models/fireworks/deepseek-v4-pro
+  // Verified 2026-08-19:
+  // https://docs.fireworks.ai/serverless/pricing
   "accounts/fireworks/models/deepseek-v4-pro": {
     input: 1.74,
     output: 3.48,
-    cache_read_input_tokens: 0.14,
+    cache_read_input_tokens: 0.145,
   },
   // https://fireworks.ai/models/fireworks/kimi-k2-instruct-0905
   "accounts/fireworks/models/kimi-k2-instruct-0905": {

--- a/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
@@ -10,6 +10,10 @@ export function WithDustDeepSeekDeepSeekV4ProConfig<
     static readonly displayName = "DeepSeek V4 Pro (Fireworks)";
     static readonly description =
       "DeepSeek's V4 Pro Mixture-of-Experts model with frontier reasoning, advanced coding, and 1M context (served via Fireworks).";
+    // Preserve the existing Dust product caps while the constructor exposes
+    // Fireworks' native 1040k context and DeepSeek's native 384k output.
+    static readonly contextSize = 1_000_000;
+    static readonly maxOutputTokens = 64_000;
     static readonly byok = false;
 
     // Nest the legacy model config under a single `modelConfig` static (see

--- a/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/llms/providers/fireworks/models/deepseek_v4_pro.ts
@@ -11,7 +11,7 @@ export function WithDustDeepSeekDeepSeekV4ProConfig<
     static readonly description =
       "DeepSeek's V4 Pro Mixture-of-Experts model with frontier reasoning, advanced coding, and 1M context (served via Fireworks).";
     // Preserve the existing Dust product caps while the constructor exposes
-    // Fireworks' native 1040k context and DeepSeek's native 384k output.
+    // Fireworks' native 1,048,576 context and DeepSeek's native 384k output.
     static readonly contextSize = 1_000_000;
     static readonly maxOutputTokens = 64_000;
     static readonly byok = false;

--- a/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.test.ts
+++ b/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment node
+
+import { DustDeepSeekDeepSeekV4ProGlobalFireworksStream } from "@app/lib/llms/stream/endpoints/deepseek_deepseek_v4_pro_global_fireworks";
+import { DeepSeekDeepSeekV4ProGlobalFireworksStream } from "@app/lib/model_constructors/stream/endpoints/deepseek_deepseek_v4_pro_global_fireworks";
+import { FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG } from "@app/types/assistant/models/fireworks";
+import { describe, expect, it } from "vitest";
+
+const NATIVE_CONTEXT_SIZE = 1_048_576;
+const NATIVE_MAX_OUTPUT_TOKENS = 384_000;
+
+const EXPECTED_CONTEXT_SIZE = 1_000_000;
+const EXPECTED_MAX_OUTPUT_TOKENS = 64_000;
+const EXPECTED_MAX_INPUT_TOKENS = 936_000;
+
+describe("DeepSeek V4 Pro model configuration", () => {
+  it("keeps the native spec on the model_constructors endpoint", () => {
+    expect(DeepSeekDeepSeekV4ProGlobalFireworksStream.contextSize).toBe(
+      NATIVE_CONTEXT_SIZE
+    );
+    expect(DeepSeekDeepSeekV4ProGlobalFireworksStream.maxOutputTokens).toBe(
+      NATIVE_MAX_OUTPUT_TOKENS
+    );
+  });
+
+  it("preserves the existing Dust context and rendering budget", () => {
+    expect(DustDeepSeekDeepSeekV4ProGlobalFireworksStream.contextSize).toBe(
+      EXPECTED_CONTEXT_SIZE
+    );
+    expect(DustDeepSeekDeepSeekV4ProGlobalFireworksStream.maxOutputTokens).toBe(
+      EXPECTED_MAX_OUTPUT_TOKENS
+    );
+    expect(FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG.contextSize).toBe(
+      EXPECTED_CONTEXT_SIZE
+    );
+    expect(FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG.generationTokensCount).toBe(
+      EXPECTED_MAX_OUTPUT_TOKENS
+    );
+    expect(
+      FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG.contextSize -
+        FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG.generationTokensCount
+    ).toBe(EXPECTED_MAX_INPUT_TOKENS);
+  });
+});

--- a/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.ts
@@ -2,10 +2,11 @@ import { fireworksConfigSchema } from "@app/lib/model_constructors/providers/fir
 import { DEEPSEEK_V4_PRO } from "@app/lib/model_constructors/types/models";
 import { z } from "zod";
 
-// Verified 2026-08-19: https://fireworks.ai/models/fireworks/deepseek-v4-pro
-// (1040k context) and https://api-docs.deepseek.com/quick_start/pricing
-// (384k maximum output).
-const CONTEXT_SIZE = 1_040_000;
+// Verified through Fireworks' Get Model API on 2026-08-19:
+// https://docs.fireworks.ai/api-reference/get-model
+// `contextLength` is exactly 1,048,576. DeepSeek documents a 384k maximum
+// output: https://api-docs.deepseek.com/quick_start/pricing
+const CONTEXT_SIZE = 1_048_576;
 const MAX_OUTPUT_TOKENS = 384_000;
 
 // DeepSeek documents exactly three states: thinking disabled

--- a/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.ts
+++ b/front/lib/model_constructors/providers/fireworks/models/deepseek_v4_pro.ts
@@ -2,8 +2,11 @@ import { fireworksConfigSchema } from "@app/lib/model_constructors/providers/fir
 import { DEEPSEEK_V4_PRO } from "@app/lib/model_constructors/types/models";
 import { z } from "zod";
 
-const CONTEXT_SIZE = 1_000_000;
-const MAX_OUTPUT_TOKENS = 64_000;
+// Verified 2026-08-19: https://fireworks.ai/models/fireworks/deepseek-v4-pro
+// (1040k context) and https://api-docs.deepseek.com/quick_start/pricing
+// (384k maximum output).
+const CONTEXT_SIZE = 1_040_000;
+const MAX_OUTPUT_TOKENS = 384_000;
 
 // DeepSeek documents exactly three states: thinking disabled
 // (`thinking: {type: "disabled"}`), effort `high` (the default) and effort
@@ -13,7 +16,7 @@ const MAX_OUTPUT_TOKENS = 64_000;
 // silently rewrite the caller's choice. We expose the three real states only;
 // our `maximal` is DeepSeek's `max`.
 //
-// Confirmed live through Fireworks on 2026-07-27 with the widest
+// Confirmed live through Fireworks on 2026-08-19 with the widest
 // `inputConfigSchema`: `none` returns no reasoning content at all, high and max
 // both reason, and the gateway rejects only `minimal`.
 //
@@ -38,8 +41,9 @@ export function WithDeepSeekDeepSeekV4ProConfig<
 
     static readonly configSchema = configSchema;
 
-    static readonly contextSize = CONTEXT_SIZE;
-    static readonly maxOutputTokens = MAX_OUTPUT_TOKENS;
+    // `number`, not the literal, so the Dust layer can cap them.
+    static readonly contextSize: number = CONTEXT_SIZE;
+    static readonly maxOutputTokens: number = MAX_OUTPUT_TOKENS;
   }
 
   return DeepSeekDeepSeekV4Pro;

--- a/front/lib/model_constructors/stream/endpoints/deepseek_deepseek_v4_pro_global_fireworks.ts
+++ b/front/lib/model_constructors/stream/endpoints/deepseek_deepseek_v4_pro_global_fireworks.ts
@@ -7,9 +7,10 @@ import { GLOBAL } from "@app/lib/model_constructors/types/regions";
 export class DeepSeekDeepSeekV4ProGlobalFireworksStream extends WithDeepSeekDeepSeekV4ProConfig(
   FireworksStream
 ) {
-  // https://fireworks.ai/models/fireworks/deepseek-v4-pro
+  // Verified 2026-08-19:
+  // https://docs.fireworks.ai/serverless/pricing
   static readonly tokenPricing = {
-    cacheHit: 0.14,
+    cacheHit: 0.145,
     standardInput: 1.74,
     standardOutput: 3.48,
   };

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -93,12 +93,15 @@ export const FIREWORKS_DEEPSEEK_V4_FLASH_0731_MODEL_CONFIG: ModelConfigurationTy
       "europe-west1": false,
     },
   };
+// Verified 2026-08-19: https://fireworks.ai/models/fireworks/deepseek-v4-pro
+// (1040k context) and https://api-docs.deepseek.com/quick_start/pricing
+// (384k maximum output).
 export const FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
   modelMaker: "deepseek",
   modelId: FIREWORKS_DEEPSEEK_V4_PRO_MODEL_ID,
   displayName: "DeepSeek V4 Pro (Fireworks)",
-  contextSize: 1_000_000,
+  contextSize: 1_040_000,
   recommendedTopK: 32,
   recommendedExhaustiveTopK: 64,
   largeModel: true,
@@ -107,7 +110,7 @@ export const FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "DeepSeek's V4 Pro model.",
   isLegacy: false,
   isLatest: true,
-  generationTokensCount: 64_000,
+  generationTokensCount: 384_000,
   supportsVision: false,
   supportedReasoningEfforts: {
     none: true,

--- a/front/types/assistant/models/fireworks.ts
+++ b/front/types/assistant/models/fireworks.ts
@@ -93,15 +93,14 @@ export const FIREWORKS_DEEPSEEK_V4_FLASH_0731_MODEL_CONFIG: ModelConfigurationTy
       "europe-west1": false,
     },
   };
-// Verified 2026-08-19: https://fireworks.ai/models/fireworks/deepseek-v4-pro
-// (1040k context) and https://api-docs.deepseek.com/quick_start/pricing
-// (384k maximum output).
 export const FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "fireworks",
   modelMaker: "deepseek",
   modelId: FIREWORKS_DEEPSEEK_V4_PRO_MODEL_ID,
   displayName: "DeepSeek V4 Pro (Fireworks)",
-  contextSize: 1_040_000,
+  // Product caps: this legacy config still drives conversation rendering.
+  // Native 1,048,576/384k limits live on the model_constructors endpoint.
+  contextSize: 1_000_000,
   recommendedTopK: 32,
   recommendedExhaustiveTopK: 64,
   largeModel: true,
@@ -110,7 +109,7 @@ export const FIREWORKS_DEEPSEEK_V4_PRO_MODEL_CONFIG: ModelConfigurationType = {
   shortDescription: "DeepSeek's V4 Pro model.",
   isLegacy: false,
   isLatest: true,
-  generationTokensCount: 384_000,
+  generationTokensCount: 64_000,
   supportsVision: false,
   supportedReasoningEfforts: {
     none: true,


### PR DESCRIPTION
## Description

DeepSeek V4 Pro is already registered through Fireworks serverless, but the older integration stored Dust's 1M/64k caps as provider limits and undercounted cached input pricing.

This aligns the endpoint and model config with the current provider specs: 1040k context, 384k maximum output, and $1.74/$0.145/$3.48 input/cached-input/output pricing. The existing Dust-facing 1M context and 64k output caps stay in the Dust wrapper, so runtime limits remain unchanged.

## Tests

- Revalidated all 46 live Fireworks endpoint contract cases.

## Risk

- Low. Runtime caps remain unchanged; this updates native metadata and cached-token accounting.

## Deploy Plan

- Deploy front.
