### PR TITLE
[front] Refresh caller's auth grants after space permission mutations

### DIFF
--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -331,6 +331,49 @@ describe("createSpaceAndGroup", () => {
       createConnectorSpy.mockRestore();
     });
 
+    it("refreshes the live creator auth so it can administrate the new project in the same request", async () => {
+      const createConnectorSpy = vi
+        .spyOn(
+          await import("@app/lib/api/projects/connector"),
+          "createDataSourceAndConnectorForProject"
+        )
+        .mockResolvedValue(new Ok(undefined));
+
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user1.sId,
+        workspace.sId
+      );
+
+      const result = await createSpaceAndGroup(userAuth, {
+        name: "Test Project Live Auth Refresh",
+        isRestricted: true,
+        spaceKind: "project",
+        managementMode: "manual",
+        memberIds: [],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const pod = result.value;
+        const { groupsToProcess } =
+          await pod.fetchManualGroupsMemberships(userAuth);
+        const editorGroup = groupsToProcess.find(
+          (group) => group.kind === "space_editors"
+        );
+        expect(editorGroup).toBeDefined();
+
+        // createSpaceAndGroup added the creator to the new editor group, wrote its grants, and
+        // refreshed `userAuth` post-commit. The same live auth must now see the group and
+        // administrate the pod with no manual refresh (contrast the reconstructed stale-auth test
+        // above, which has to call refresh() itself).
+        expect(userAuth.hasGroupByModelId(editorGroup!.id)).toBe(true);
+        expect(userAuth.getGrantedVerbs("space", pod.id)).toContain("admin");
+        expect(pod.canAdministrate(userAuth)).toBe(true);
+      }
+
+      createConnectorSpy.mockRestore();
+    });
+
     it("should handle connector creation failure gracefully", async () => {
       // Mock createDataSourceAndConnectorForProject to fail
       const createConnectorError = new Error("Failed to create connector");

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -879,6 +879,13 @@ export async function createSpaceAndGroup(
   });
 
   if (result.isOk()) {
+    // Creating the space wrote `group_permissions` and, for projects, added the creator to the new
+    // editor group, so the group set and grants `auth` resolved at construction are now stale.
+    // Refresh the caller's snapshot now that the write has committed (no transaction, so the re-read
+    // sees the committed rows and the `afterCommit`-invalidated cache), so later permission checks in
+    // this request see the new access instead of a pre-creation view.
+    await auth.refresh();
+
     const space = result.value;
     if (space.kind === "project") {
       // If this is a project space, create the dust_project connector

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -2585,4 +2585,26 @@ describe("SpaceResource group_permissions enforcement", () => {
     expect(space.canRead(memberAuth)).toBe(true);
     expect(space.canWrite(memberAuth)).toBe(true);
   });
+
+  it("refreshes the caller's grant snapshot after opening a space", async () => {
+    // Restricted regular space: the global group is not attached, and the admin's "admin" role
+    // grants nothing on the table path, so the admin holds no read grant on it yet.
+    const space = await SpaceFactory.regular(workspace);
+    expect(adminAuth.getGrantedVerbs("space", space.id)).not.toContain("read");
+
+    const res = await space.updatePermissions(adminAuth, {
+      name: space.name,
+      isRestricted: false,
+      managementMode: "manual",
+      memberIds: [],
+      editorIds: [],
+    });
+    expect(res.isOk()).toBe(true);
+
+    // Opening attached the global group with a reader grant. updatePermissions refreshed adminAuth
+    // post-commit, so its snapshot now resolves that grant. Without the refresh this stays [] (the
+    // stale construction-time snapshot), which — now that the table is the served path — would deny
+    // read on a space the caller just opened, in the same request.
+    expect(adminAuth.getGrantedVerbs("space", space.id)).toContain("read");
+  });
 });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -997,7 +997,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     const globalGroup = groupRes.value;
 
-    return withTransaction(async (t) => {
+    const result = await withTransaction(async (t) => {
       // Update managementMode if provided
       const { managementMode } = params;
 
@@ -1221,6 +1221,16 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
       return new Ok(undefined);
     });
+
+    // Opening/closing the space or changing its groups rewrote `group_permissions` (and possibly the
+    // caller's own membership), so the group set and grants `auth` resolved at construction are now
+    // stale. Refresh the caller's snapshot now that the write has committed — no transaction, so the
+    // re-read sees the committed rows and the `afterCommit`-invalidated cache — so any later
+    // permission check in the same request (e.g. the post-update `canRead` in the members handler)
+    // sees the new state instead of a pre-mutation view.
+    await auth.refresh();
+
+    return result;
   }
 
   private async removeGroup(


### PR DESCRIPTION
## Description

`updatePermissions` and `createSpaceAndGroup` rewrite a space's `group_permissions` inside their transaction — and, for project creation, add the caller to the new editor group — but an `Authenticator` resolves its grant snapshot (`_groupModelIds` + `_permissions`) **once at construction** and never refreshes it for the life of the request.

Now that `group_permissions` is the served path (`#30708`, `use_legacy_acls` kill switch), a permission check made **later in the same request** reads the pre-mutation snapshot and returns the wrong answer. Concretely:

- an admin who just opened a restricted space is denied `read` on it (their snapshot predates the global-group reader grant), and
- a project creator can't `administrate` the pod they just created (their snapshot predates their membership in the new editor group).

This first surfaced as a `group_permissions_shadow_mismatch` on an open Pod: the served (legacy) decision granted read via the global group while the candidate (table) snapshot was stale. Two-request races of this shape are benign and self-heal on the next request; the single-request case fixed here does not.

The fix reuses the existing `Authenticator.refresh()` (which reloads live group membership and re-resolves grants) at each grant-mutation operation boundary, **after the transaction commits** — so the re-read sees committed rows past the `afterCommit` cache invalidation:

- `SpaceResource.updatePermissions` — after its `withTransaction` resolves.
- `createSpaceAndGroup` — after its `withTransaction` resolves.

Placed at the operation boundary rather than inside `GroupPermissionResource` (which writes grants row-by-row and is exercised by background/migration paths that never re-check), and post-commit rather than in-transaction (the `group_permissions` cache is only invalidated on `afterCommit`, so a pre-commit refresh would refill the snapshot from the old rows).

## Tests

Added a regression test for each path; both fail without the fix and pass with it:

- `space_resource.test.ts` → *"refreshes the caller's grant snapshot after opening a space"*: admin opens a restricted regular space; `getGrantedVerbs("space", id)` goes `[]` → `["read"]`. Without the fix: `expected [] to include 'read'`.
- `spaces.test.ts` → *"refreshes the live creator auth so it can administrate the new project in the same request"*: after `createSpaceAndGroup`, the live `userAuth` sees the new editor group and can `administrate` the pod with no manual refresh. Without the fix: `expected false to be true`. (Complements the existing test that reconstructs a stale auth and refreshes it manually.)

Verified: `tsgo --noEmit` clean; `group_permissions enforcement` describe 4 passed; `createSpaceAndGroup` describe 26 passed; both full files green.

## Risk

Low. `refresh()` is an existing, already-used method (the agent loop refreshes per step). The extra work is one membership query + one grants read per space create / permission update — cold-path operations, not hot paths. No behavior change to callers that don't reuse the auth after the mutation. Safe to roll back (revert the two `await auth.refresh()` calls).

## Deploy Plan

Standard `front` deploy. No migration, no config, no coordinated rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)