### PR TITLE
[front] Update Legacy ACLs kill switch description for skills + spaces

### DIFF
--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -79,7 +79,7 @@ const KILL_SWITCH_DEFINITIONS: Record<KillSwitchType, KillSwitchDefinition> = {
   use_legacy_acls: {
     title: "Legacy ACLs",
     description:
-      "Serve skill permission checks from the legacy editor-group ACLs instead of the group_permissions table.",
+      "Serve skill and space permission checks from the legacy inline-group ACLs instead of the group_permissions table.",
     note: "Revert path for the governance migration. Takes up to 60s to apply on each pod, as permission checks read the switch from an in-process cache.",
     icon: RefreshCw02,
   },


### PR DESCRIPTION


## Description

The use_legacy_acls kill switch now reverts both skill and space permission checks to the
pre-migration inline-group ACLs (spaces were flipped in #30708). Update the Poke description to
say so.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
