### PR TITLE
Consumption attribution table sort vs prev growth server side

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -87,6 +87,7 @@ const ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID: Partial<
   credits: "credits",
   costShare: "credits",
   avgCredits: "avgCredits",
+  vsPrev: "vsPrev",
 };
 
 type AttributionTransitionDirection = -1 | 0 | 1;
@@ -344,6 +345,13 @@ function buildColumns({
     },
     {
       id: "vsPrev",
+      // Rows already arrive from the server in vs-prev order when that's the
+      // active sort (see ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID); this accessor
+      // just keeps the table's own client-side sort consistent with it,
+      // including sinking "no prior data" rows the same way the server does.
+      accessorFn: (row) =>
+        growthPercent(row.credits, row.previousCredits) ??
+        Number.NEGATIVE_INFINITY,
       header: "vs prev",
       enableSorting: false,
       meta: { sizeRatio: 18, headerAlign: "right" },

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -345,10 +345,9 @@ function buildColumns({
     },
     {
       id: "vsPrev",
-      // Rows already arrive from the server in vs-prev order when that's the
-      // active sort (see ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID); this accessor
-      // just keeps the table's own client-side sort consistent with it,
-      // including sinking "no prior data" rows the same way the server does.
+      // Sinks "no prior data" rows the same way the server's vs-prev sort
+      // does, so client-side sort stays consistent when the server has
+      // already sorted this way.
       accessorFn: (row) =>
         growthPercent(row.credits, row.previousCredits) ??
         Number.NEGATIVE_INFINITY,

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -95,23 +95,32 @@ export const CONSUMPTION_TOP_SORT_ORDER = ["asc", "desc"] as const;
 export type ConsumptionTopSortOrder =
   (typeof CONSUMPTION_TOP_SORT_ORDER)[number];
 
-// A terms aggregation cannot order its buckets by a pipeline aggregation
-// so a ratio like avg credits per unit can't be
-// ranked with a bucket_script the way gross credits is. Two metrics avoid
-// that:
+// A terms aggregation can only order its buckets by a genuine metric
+// (avg, sum, cardinality, ...), never by a ratio of two metrics — a
+// scripted_metric or bucket_script pipeline aggregation both fail with an
+// invalid order path. That rules out an Elasticsearch-native order for two
+// of these three:
 // - "credits" orders by the sum(credit_micro) metric directly. Cost share is
 //   credits divided by the same totalCredits for every row, so it rides this
 //   same ranking (see ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS in
 //   ConsumptionAttributionTable.tsx).
 // - "avgCredits" orders by average credits per unit. For "invocation"
 //   dimensions (tool, skill) that unit is the document itself, so a plain
-//   avg(credit_micro) metric already equals credits-per-invocation. For
-//   "message" dimensions it isn't: several documents (one per LLM run, one
-//   per tool action) can share a message, so the average needs a
-//   scripted_metric to divide the summed credits by the count of *distinct*
-//   message ids in the bucket — the "real complexity" previously left for a
-//   follow-up. See AVG_CREDIT_PER_MESSAGE_AGG in top.ts.
-export const CONSUMPTION_TOP_SORT_BY = ["credits", "avgCredits"] as const;
+//   avg(credit_micro) metric already equals credits-per-invocation and
+//   Elasticsearch can order by it directly. For "message" dimensions it
+//   isn't: several documents (one per LLM run, one per tool action) can
+//   share a message, so the average is a ratio (summed credits over
+//   distinct message count) and top.ts fetches every bucket to rank it in
+//   memory instead.
+// - "vsPrev" orders by growth — current credits over previous-period
+//   credits, a ratio across two separate queries — so it always ranks in
+//   memory: top.ts fetches every bucket's current credits, looks up every
+//   key's previous-period credits, and sorts by growth from there.
+export const CONSUMPTION_TOP_SORT_BY = [
+  "credits",
+  "avgCredits",
+  "vsPrev",
+] as const;
 
 export type ConsumptionTopSortBy = (typeof CONSUMPTION_TOP_SORT_BY)[number];
 

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -855,4 +855,128 @@ describe("consumption top rankings", () => {
       avg: { field: "credit_micro" },
     });
   });
+
+  it("ranks by growth in memory when sortBy is vsPrev, looking up every group's previous credits once", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "Agent 1", agent2: "Agent 2" });
+    // Both agents have the same current credits, so a credits-based sort
+    // would tie them, but agent2 grew far more from its previous period —
+    // Elasticsearch cannot order by that ratio, so it must be ranked in
+    // memory from a full previous-period lookup.
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValueOnce(
+      esResponse({
+        by_group: {
+          buckets: [
+            {
+              key: "agent1",
+              doc_count: 1,
+              credit_micro: { value: 6_000_000 },
+              messages: { value: 1 },
+            },
+            {
+              key: "agent2",
+              doc_count: 1,
+              credit_micro: { value: 6_000_000 },
+              messages: { value: 1 },
+            },
+          ],
+        },
+        total_count: { value: 2 },
+        total_credit_micro: { value: 12_000_000 },
+      })
+    );
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValueOnce(
+      esResponse({
+        by_group: {
+          buckets: [
+            { key: "agent1", doc_count: 1, credit_micro: { value: 3_000_000 } },
+            { key: "agent2", doc_count: 1, credit_micro: { value: 1_000_000 } },
+          ],
+        },
+      })
+    );
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+      sortBy: "vsPrev",
+      sortOrder: "desc",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    // agent1 grew 6/3 - 1 = 100%, agent2 grew 6/1 - 1 = 500%.
+    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
+      "agent2",
+      "agent1",
+    ]);
+    expect(result.value.agents.map((agent) => agent.previousCredits)).toEqual([
+      1, 3,
+    ]);
+    // The full-key previous-credits lookup done to rank by growth is reused
+    // for the page's display values, so no third query follows it.
+    expect(vi.mocked(searchConsumptionAnalytics).mock.calls).toHaveLength(2);
+
+    const [, rankingOptions] = rankingSearchCall();
+    expect(rankingOptions?.aggregations?.by_group?.terms).toMatchObject({
+      order: { credit_micro: "desc" },
+    });
+  });
+
+  it("sinks a vsPrev-sorted group with no previous credits to the bottom", async () => {
+    const { auth } = await setup();
+    mockLabels({ agent1: "Agent 1", agent2: "Agent 2" });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValueOnce(
+      esResponse({
+        by_group: {
+          buckets: [
+            {
+              key: "agent1",
+              doc_count: 1,
+              credit_micro: { value: 1_000_000 },
+              messages: { value: 1 },
+            },
+            {
+              key: "agent2",
+              doc_count: 1,
+              credit_micro: { value: 5_000_000 },
+              messages: { value: 1 },
+            },
+          ],
+        },
+        total_count: { value: 2 },
+        total_credit_micro: { value: 6_000_000 },
+      })
+    );
+    // agent1 has prior credits to compute real (negative) growth from,
+    // agent2 has none at all.
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValueOnce(
+      esResponse({
+        by_group: {
+          buckets: [
+            { key: "agent1", doc_count: 1, credit_micro: { value: 5_000_000 } },
+          ],
+        },
+      })
+    );
+
+    const result = await fetchConsumptionTopAgents(auth, {
+      period: PERIOD,
+      limit: 10,
+      sortBy: "vsPrev",
+      sortOrder: "desc",
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.agents.map((agent) => agent.agentId)).toEqual([
+      "agent1",
+      "agent2",
+    ]);
+    expect(result.value.agents[1].previousCredits).toBeNull();
+  });
 });

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -353,13 +353,15 @@ export async function fetchConsumptionTopGroups(
     filter,
   });
 
-  // Elasticsearch cannot order terms buckets by a ratio of two metrics
-  // (summed credits over distinct message count), so ranking "message"
-  // dimensions by avg credits requires fetching every bucket and sorting by
-  // average in memory, rather than relying on the requested page's size.
+  // Elasticsearch cannot order terms buckets by a ratio of two metrics —
+  // summed credits over distinct message count for a "message" dimension's
+  // avg credits, or current credits over previous-period credits for a
+  // vs-prev sort. Both require fetching every bucket and ranking in memory,
+  // rather than relying on the requested page's size.
   const sortInMemory =
-    sortBy === "avgCredits" &&
-    CONSUMPTION_DIMENSION_UNIT[dimension] === "message";
+    sortBy === "vsPrev" ||
+    (sortBy === "avgCredits" &&
+      CONSUMPTION_DIMENSION_UNIT[dimension] === "message");
   const requestedBucketCount = sortInMemory
     ? Number.MAX_SAFE_INTEGER
     : offset + limit;
@@ -415,39 +417,48 @@ export async function fetchConsumptionTopGroups(
     buckets.length === batchSize
   );
 
-  const sortedGroups = sortInMemory
-    ? [...rankedGroups].sort((a, b) => {
-        const diff =
-          avgCreditsPerUnit(a.credits, a.count) -
-          avgCreditsPerUnit(b.credits, b.count);
-        return sortOrder === "asc" ? diff : -diff;
-      })
-    : rankedGroups;
+  // A vs-prev sort ranks every group by growth, which needs each one's
+  // previous-period credits up front — not just the page's, since a group
+  // outside the requested page can still outrank one inside it.
+  let previousCreditsByKey = new Map<string, number>();
+  if (sortBy === "vsPrev") {
+    previousCreditsByKey = await fetchPreviousCreditsWithFallback(auth, {
+      dimension,
+      previousPeriod: previousConsumptionPeriod(period),
+      filter,
+      keys: rankedGroups.map((group) => group.key),
+    });
+  }
+
+  const sortedGroups =
+    sortBy === "vsPrev"
+      ? [...rankedGroups].sort((a, b) => {
+          const diff =
+            growthForSort(a.credits, previousCreditsByKey.get(a.key) ?? null) -
+            growthForSort(b.credits, previousCreditsByKey.get(b.key) ?? null);
+          return sortOrder === "asc" ? diff : -diff;
+        })
+      : sortInMemory
+        ? [...rankedGroups].sort((a, b) => {
+            const diff =
+              avgCreditsPerUnit(a.credits, a.count) -
+              avgCreditsPerUnit(b.credits, b.count);
+            return sortOrder === "asc" ? diff : -diff;
+          })
+        : rankedGroups;
   const pagedGroups = sortedGroups.slice(offset, offset + limit);
 
-  const previousCreditsResult = await fetchConsumptionPreviousCredits(auth, {
-    dimension,
-    previousPeriod: previousConsumptionPeriod(period),
-    filter,
-    keys: pagedGroups.map((group) => group.key),
-  });
-  // The prior-period lookup only feeds the vs-prev display column: a failure
-  // there should not take down the current-period ranking, which already
-  // succeeded. Fall back to unknown growth for every group instead.
-  if (previousCreditsResult.isErr()) {
-    logger.warn(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        dimension,
-        err: previousCreditsResult.error,
-      },
-      "[ConsumptionAnalytics] Failed to fetch previous-period credits, " +
-        "falling back to null vs-prev values."
-    );
+  // vs-prev sort already looked up every group's previous-period credits
+  // above; every other sort still needs that lookup, scoped to just the
+  // page's keys.
+  if (sortBy !== "vsPrev") {
+    previousCreditsByKey = await fetchPreviousCreditsWithFallback(auth, {
+      dimension,
+      previousPeriod: previousConsumptionPeriod(period),
+      filter,
+      keys: pagedGroups.map((group) => group.key),
+    });
   }
-  const previousCreditsByKey = previousCreditsResult.isOk()
-    ? previousCreditsResult.value
-    : new Map<string, number>();
 
   return new Ok({
     groups: pagedGroups.map((group) => ({
@@ -458,6 +469,43 @@ export async function fetchConsumptionTopGroups(
     totalCount,
     totalCredits,
   });
+}
+
+// A key with no prior-period credits has no ratio to rank a vs-prev sort by.
+// Sink it to whichever end of the sort its magnitude puts it at, rather than
+// dropping it from the ranking or dividing by zero.
+const NO_PREVIOUS_DATA_GROWTH_SENTINEL = -1_000_000;
+
+function growthForSort(
+  credits: number,
+  previousCredits: number | null
+): number {
+  return previousCredits && previousCredits > 0
+    ? (credits - previousCredits) / previousCredits
+    : NO_PREVIOUS_DATA_GROWTH_SENTINEL;
+}
+
+// The prior-period lookup only feeds the vs-prev display column and sort: a
+// failure there should not take down the current-period ranking, which
+// already succeeded. Fall back to unknown/no-growth values instead.
+async function fetchPreviousCreditsWithFallback(
+  auth: Authenticator,
+  args: Parameters<typeof fetchConsumptionPreviousCredits>[1]
+): Promise<Map<string, number>> {
+  const result = await fetchConsumptionPreviousCredits(auth, args);
+  if (result.isErr()) {
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        dimension: args.dimension,
+        err: result.error,
+      },
+      "[ConsumptionAnalytics] Failed to fetch previous-period credits, " +
+        "falling back to null vs-prev values."
+    );
+    return new Map();
+  }
+  return result.value;
 }
 
 // A group can hold credits with nothing to divide them by — a message whose id


### PR DESCRIPTION
## Description

This is the fourth PR in the stack [#30794](https://github.com/dust-tt/dust/pull/30794) → [#30795](https://github.com/dust-tt/dust/pull/30795) → [#30796](https://github.com/dust-tt/dust/pull/30796) → **#30809**. It adds support for ranking the Consumption Attribution table by vs-prev growth.

Growth is computed as `(currentCredits - previousCredits) / previousCredits`. Because this ratio combines values from the current and previous periods and cannot be used as an Elasticsearch terms order path, the ranking fetches all current-period buckets in batches, retrieves previous-period credits for every bucket, sorts the complete set in memory, and only then applies pagination. The full previous-period lookup is reused to populate the page's vs-prev display values, avoiding a second lookup for the same data. Other sort modes continue to fetch previous-period credits only for the displayed page.

## Tests

Added Vitest coverage in `front/lib/api/analytics/consumption/top.test.ts` for growth ordering and for placing a group with no previous-period credits consistently. 

## Risk

The main risk is performance for high-cardinality dimensions: vs-prev sorting now enumerates every current bucket, performs a previous-period lookup for every key, and sorts the complete result set in memory instead of using the normal page-sized ranking path.

## Deploy Plan

Deploy `front` in stack order: [#30794](https://github.com/dust-tt/dust/pull/30794), [#30795](https://github.com/dust-tt/dust/pull/30795), [#30796](https://github.com/dust-tt/dust/pull/30796), then this PR. No migration or additional rollout step is identified.