### PR TITLE
[front] enh: remove name sort from consumption attribution table

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -467,10 +467,9 @@ function AttributionRows({
   };
 
   const activeSort = sorting[0];
-  // Only forward the sort to the server when the sorted column actually
-  // rides a server-side ranking; sorting by anything else keeps fetching
-  // pages in the default credits-desc order and reorders them locally
-  // instead.
+  // Every sortable column rides a server-side ranking (see
+  // ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID); the lookup is only there to
+  // narrow the column id's plain string type.
   const serverSortBy: ConsumptionTopSortBy | undefined = activeSort?.id
     ? ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID[activeSort.id]
     : undefined;

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -467,9 +467,6 @@ function AttributionRows({
   };
 
   const activeSort = sorting[0];
-  // Every sortable column rides a server-side ranking (see
-  // ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID); the lookup is only there to
-  // narrow the column id's plain string type.
   const serverSortBy: ConsumptionTopSortBy | undefined = activeSort?.id
     ? ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID[activeSort.id]
     : undefined;

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -51,7 +51,7 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().optional(),
   // Which metric to rank by; see the comment on CONSUMPTION_TOP_SORT_BY for
-  // why only these two are supported.
+  // how each one is ranked.
   sortBy: z.enum(CONSUMPTION_TOP_SORT_BY).optional().default("credits"),
   sortOrder: z.enum(CONSUMPTION_TOP_SORT_ORDER).optional().default("desc"),
 });

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -50,8 +50,6 @@ export const ConsumptionTopBodySchema = ConsumptionBodySchema.extend({
     .transform((limit) => limit ?? DEFAULT_CONSUMPTION_TOP_LIMIT),
   offset: z.number().int().nonnegative().default(0),
   search: z.string().trim().optional(),
-  // Which metric to rank by; see the comment on CONSUMPTION_TOP_SORT_BY for
-  // how each one is ranked.
   sortBy: z.enum(CONSUMPTION_TOP_SORT_BY).optional().default("credits"),
   sortOrder: z.enum(CONSUMPTION_TOP_SORT_ORDER).optional().default("desc"),
 });

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -102,7 +102,7 @@ export type ConsumptionTopSortOrder =
 // of these three:
 // - "credits" orders by the sum(credit_micro) metric directly. Cost share is
 //   credits divided by the same totalCredits for every row, so it rides this
-//   same ranking (see ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS in
+//   same ranking (see ATTRIBUTION_SERVER_SORT_BY_COLUMN_ID in
 //   ConsumptionAttributionTable.tsx).
 // - "avgCredits" orders by average credits per unit. For "invocation"
 //   dimensions (tool, skill) that unit is the document itself, so a plain


### PR DESCRIPTION
## Description

This is the final PR in the stack [#30794](https://github.com/dust-tt/dust/pull/30794) → [#30795](https://github.com/dust-tt/dust/pull/30795) → [#30796](https://github.com/dust-tt/dust/pull/30796) → [#30809](https://github.com/dust-tt/dust/pull/30809) → **#30810**.

It disables sorting on the Consumption Attribution table's **Name** column. Name never had a server-side ranking, so enabling it only reordered the currently loaded page and could give a misleading order across paginated results. All remaining sortable columns now map to a server-side ranking, so the stale fallback-to-local-sorting comment is removed as well. The change also updates the related sort-mapping reference and removes an outdated schema comment.

## Tests

No tests were added or modified for this UI-only cleanup. No local test command or result was supplied.

## Risk

Low. This prevents a misleading sort option without changing data, API behavior, ranking logic, or persisted state. Existing server-backed sorting for the other columns is unchanged.

## Deploy Plan

Deploy `front` in stack order: [#30794](https://github.com/dust-tt/dust/pull/30794), [#30795](https://github.com/dust-tt/dust/pull/30795), [#30796](https://github.com/dust-tt/dust/pull/30796), [#30809](https://github.com/dust-tt/dust/pull/30809), then this PR. No migration or additional rollout step is identified.

## Open Questions

Please add the test command and result if available.