### PR TITLE
[Agent Loop] Don't let deploy interruptions exhaust the model activity's retry budget

### DIFF
--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -88,7 +88,8 @@ export function getQueueForUserMessageOrigin(
   }
 }
 
-// Max retry attempts for the runModelAndCreateActions activity.
+// Attempt after which run_model surfaces a retryable model error to the user instead of throwing
+// for a Temporal retry (see shouldSurfaceModelError).
 export const RUN_MODEL_MAX_RETRIES = 5;
 
 // Leave room for our code to surface a retryable agent error before Temporal enforces StartToClose.

--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -1,10 +1,13 @@
+import { RETRY_ON_INTERRUPT_MAX_ATTEMPTS } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp_schemas";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
 import {
   buildBaseSpecifications,
   buildSpecificationsWithReplayPlaceholders,
   buildToolDefinitionsForTokenCount,
+  shouldSurfaceModelError,
 } from "@app/temporal/agent_loop/lib/run_model";
 import type {
   ModelConversationTypeMultiActions,
@@ -617,5 +620,37 @@ describe("buildSpecificationsWithReplayPlaceholders", () => {
 
     expect(missingReplayedToolNames).toEqual(["removed_tool"]);
     expect(specifications).toHaveLength(1);
+  });
+});
+
+describe("shouldSurfaceModelError", () => {
+  it("retries a retryable model error below the error budget", () => {
+    expect(
+      shouldSurfaceModelError({
+        isRetryable: true,
+        attempt: RUN_MODEL_MAX_RETRIES - 1,
+      })
+    ).toBe(false);
+  });
+
+  it("surfaces a retryable model error once the budget is exhausted, even though the policy cap allows more attempts", () => {
+    expect(
+      shouldSurfaceModelError({
+        isRetryable: true,
+        attempt: RUN_MODEL_MAX_RETRIES,
+      })
+    ).toBe(true);
+    expect(
+      shouldSurfaceModelError({
+        isRetryable: true,
+        attempt: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
+      })
+    ).toBe(true);
+  });
+
+  it("surfaces a non-retryable model error immediately", () => {
+    expect(shouldSurfaceModelError({ isRetryable: false, attempt: 1 })).toBe(
+      true
+    );
   });
 });

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -132,6 +132,19 @@ const ASK_USER_QUESTION_BLOCKED_ORIGINS: readonly UserMessageOrigin[] = [
   "reinforcement",
 ];
 
+// Retryable model errors stop retrying at RUN_MODEL_MAX_RETRIES even though the activity retry
+// policy allows more attempts: the extra attempts only serve non-model failures (worker-shutdown
+// interruptions, timeouts, internal errors). Exported for tests.
+export function shouldSurfaceModelError({
+  isRetryable,
+  attempt,
+}: {
+  isRetryable: boolean;
+  attempt: number;
+}): boolean {
+  return !isRetryable || attempt >= RUN_MODEL_MAX_RETRIES;
+}
+
 // Builds the JSON blob whose token count estimates how many tokens the tool
 // definitions actually cost in context, for the model's token budget. When
 // tool search is active, deferred (non-eager) tool schemas are excluded from
@@ -918,7 +931,6 @@ export async function runModel(
         const { type, isRetryable } = error.content;
         const errorDustRunId = llm?.getTraceId();
         const currentAttempt = Context.current().info.attempt;
-        const isLastAttempt = currentAttempt >= RUN_MODEL_MAX_RETRIES;
         const plan = auth.getNonNullablePlan();
 
         if (
@@ -964,8 +976,7 @@ export async function runModel(
             ? getByokUserFacingLLMErrorMessage(type, metadata)
             : getUserFacingLLMErrorMessage(type, metadata);
 
-        if (!isRetryable || isLastAttempt) {
-          // Non-retryable errors or last retry attempt: surface error to user.
+        if (shouldSurfaceModelError({ isRetryable, attempt: currentAttempt })) {
           await publishAgentError(
             {
               code: "multi_actions_error",

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -15,7 +15,6 @@ import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_lo
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
 import {
   MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
-  RUN_MODEL_MAX_RETRIES,
   TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
 } from "@app/temporal/agent_loop/config";
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
@@ -80,8 +79,10 @@ const { runModelAndCreateActionsActivity } = proxyActivities<
   heartbeatTimeout: MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
   cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
   retry: {
-    maximumAttempts: RUN_MODEL_MAX_RETRIES,
-    backoffCoefficient: 1,
+    // Attempts past RUN_MODEL_MAX_RETRIES only serve non-model failures (worker-shutdown
+    // interruptions, timeouts, internal errors): real model errors self-limit in run_model
+    // (see shouldSurfaceModelError).
+    maximumAttempts: RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
   },
 });
 


### PR DESCRIPTION
## Description

Follow up of #30742.

Goal: deploys must stop putting agent workflows in FAILED status. On 2026-08-19, 4 workflows failed with `ModelInterruption` after exhausting the model activity's 5 attempts ([Datadog](https://app.datadoghq.eu/logs?query=service%3Afront-agent-loop-worker%20%22Model%20activity%20interrupted%22%20%40attempt%3A5&from_ts=1787270400000&to_ts=1787356800000)): model steps are multi-minute LLM streams, so a single deploy train (3 deploys in 19 minutes) kills 5 attempts in a row.

Fix: bump the activity's `maximumAttempts` from 5 to `RETRY_ON_INTERRUPT_MAX_ATTEMPTS` (15), the same trade tools made, and drop the `backoffCoefficient: 1` pin so retries spread out (SDK-default exponential backoff) instead of re-entering the same drain window. Surviving a deploy-train now requires ~1h of continuous churn on one step.

Why this does not mean "retry everything 15 times": model errors (rate limits, provider 5xx, stream timeouts) never reach the policy cap. `run_model` surfaces them to the user at attempt >= `RUN_MODEL_MAX_RETRIES` (5) and returns instead of throwing, unchanged behavior. That gate is extracted as `shouldSurfaceModelError` and tested, since the bump relies on it. Attempts 6-15 are only reachable by interruptions, timeouts and internal errors.

Workflows still go FAILED when all 15 attempts exhaust (persistent internal errors, non-LLM hangs): those are bugs or infra incidents and should stay visible in Temporal, unlike deploy noise.

No workflow command change (retry policy is an activity option): replay-safe, no patch marker.

## Tests

Unit tests for `shouldSurfaceModelError`. `tsgo --noEmit` clean.

## Risk

Worst case, a step failing for non-transient, non-model reasons burns 15 attempts instead of 5 before erroring. Safe to rollback.

## Deploy Plan

- [ ] Deploy front.
- [ ] Watch `service:front-agent-loop-worker "Model activity interrupted" @attempt:>=5`: no longer implies failure, only retries past the old cap.
- [ ] Watch `@workflowType:agentLoopWorkflow status:error "Model activity interrupted"`: terminal failures should drop to zero across deploy trains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
