### PR TITLE
[front] Seed default space group_permissions in the dust-hive seed

### DIFF
--- a/front/lib/dev/dust_hive_seed.sql
+++ b/front/lib/dev/dust_hive_seed.sql
@@ -161,6 +161,30 @@ inserted_group_permissions AS (
   RETURNING id
 ),
 
+-- Step 5e: Seed instance-level space group_permissions for the default spaces. Mirrors
+-- SpaceResource.writeGroupPermissions / spaceGroupRoles (front/lib/resources/space_resource.ts),
+-- which real space provisioning runs but this raw-SQL seed bypasses. Without these rows, space
+-- access resolves to nothing once use_legacy_acls is off (the default post-migration). Keep in sync
+-- with spaceGroupRoles: system space => system group 'member'; global and conversations spaces =>
+-- global group 'reader'.
+inserted_space_group_permissions AS (
+  INSERT INTO group_permissions (
+    "workspaceId", "groupId", "grantType", "resourceType", "resourceId", "createdAt", "updatedAt"
+  )
+  SELECT sg."workspaceId", sg.id, 'member', 'space', ss.id, NOW(), NOW()
+  FROM inserted_system_group sg
+  CROSS JOIN inserted_system_space ss
+  UNION ALL
+  SELECT gg."workspaceId", gg.id, 'reader', 'space', gs.id, NOW(), NOW()
+  FROM inserted_global_group gg
+  CROSS JOIN inserted_global_space gs
+  UNION ALL
+  SELECT gg."workspaceId", gg.id, 'reader', 'space', cs.id, NOW(), NOW()
+  FROM inserted_global_group gg
+  CROSS JOIN inserted_conversations_space cs
+  RETURNING id
+),
+
 -- Step 6: Create membership
 inserted_membership AS (
   INSERT INTO memberships ("workspaceId", "userId", role, origin, "startAt", "endAt", "firstUsedAt", "createdAt", "updatedAt")


### PR DESCRIPTION
## What

The raw-SQL dust-hive seed (`front/lib/dev/dust_hive_seed.sql`) creates the three default spaces (System, Company Data, Conversations) and their `group_vaults` links, and seeds the workspace-level (`resourceId = -1`) governance capabilities — but it never inserts the **instance-level** `group_permissions` rows for those spaces.

Real provisioning writes those rows via `SpaceResource.makeNew()` → `writeGroupPermissions()`, which this raw-SQL seed bypasses. With `use_legacy_acls` off (the default after the ACL→group_permissions flip), space access is resolved from `group_permissions` and finds nothing → access effectively denied on freshly-seeded hive workspaces.

## Fix

Add a `group_permissions` CTE seeding the three default space grants, mirroring `spaceGroupRoles`:
- System space → system group, `member`
- Company Data (global) → global group, `reader`
- Conversations → global group, `reader`

Only spaces are affected: the seed creates no default skill/agent/dust_app *instances*, and the type-wide capability grants were already correct.

## Note for existing hive DBs

This only fixes newly-seeded workspaces. To repair an already-seeded hive DB, run the idempotent backfill (it re-derives grants from the `group_vaults` links the seed already created):

```
npx tsx front/migrations/20260728_backfill_space_group_permissions.ts --execute
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)