### PR TITLE
fix(spaces): let the public spaces list return pods on request

### DIFF
--- a/cli/dust-cli/src/ui/commands/chat/nonInteractive.ts
+++ b/cli/dust-cli/src/ui/commands/chat/nonInteractive.ts
@@ -47,7 +47,10 @@ export async function resolveSpaceId(
     return undefined;
   }
 
-  const spacesRes = await dustClient.getSpaces();
+  // Projects are not listed by default by the public API, they have to be asked for explicitly.
+  const spacesRes = await dustClient.getSpaces({
+    kinds: ["system", "global", "regular", "project"],
+  });
   if (spacesRes.isErr()) {
     throw new Error(`Failed to fetch spaces: ${spacesRes.error.message}`);
   }

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6042,7 +6042,7 @@
             "in": "query",
             "name": "kinds",
             "required": false,
-            "description": "Comma-separated list of space kinds to filter on (e.g. `regular,global`).",
+            "description": "Comma-separated list of space kinds to filter on, among `system`, `global`, `regular` and `project`. Defaults to `system,global,regular` — projects must be requested explicitly.",
             "schema": {
               "type": "string"
             }

--- a/front-api/routes/v1/w/[wId]/spaces/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/index.test.ts
@@ -1,5 +1,6 @@
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { expectArrayOfObjectsWithSpecificLength } from "@app/tests/utils/utils";
 import { honoApp } from "@front-api/app";
@@ -70,6 +71,46 @@ describe("GET /api/v1/w/:wId/spaces", () => {
     expectArrayOfObjectsWithSpecificLength(spaces, 1);
     expect(spaces).toEqual([
       expect.objectContaining({ name: regularSpace.name, kind: "regular" }),
+    ]);
+  });
+
+  it("omits projects unless they are explicitly requested", async () => {
+    const { workspace, globalGroup } = await createPublicApiMockRequest();
+
+    await SpaceFactory.global(workspace);
+    const project = await SpaceFactory.project(workspace);
+
+    // A key is a workspace member, and the global group only ever reads a project, so the key has
+    // to hold the project's own member group to be a member of it.
+    const { members } = await project.fetchAssociatedGroups();
+    const key = await KeyFactory.regular([globalGroup, ...members]);
+
+    const defaultResponse = await honoApp.request(
+      `/api/v1/w/${workspace.sId}/spaces`,
+      {
+        headers: { authorization: `Bearer ${key.secret}` },
+      }
+    );
+
+    expect(defaultResponse.status).toBe(200);
+    const { spaces: defaultSpaces } = await defaultResponse.json();
+    expectArrayOfObjectsWithSpecificLength(defaultSpaces, 1);
+    expect(defaultSpaces).toEqual([
+      expect.objectContaining({ kind: "global" }),
+    ]);
+
+    const projectResponse = await honoApp.request(
+      `/api/v1/w/${workspace.sId}/spaces?kinds=project`,
+      {
+        headers: { authorization: `Bearer ${key.secret}` },
+      }
+    );
+
+    expect(projectResponse.status).toBe(200);
+    const { spaces: projectSpaces } = await projectResponse.json();
+    expectArrayOfObjectsWithSpecificLength(projectSpaces, 1);
+    expect(projectSpaces).toEqual([
+      expect.objectContaining({ name: project.name, kind: "project" }),
     ]);
   });
 

--- a/front-api/routes/v1/w/[wId]/spaces/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/index.ts
@@ -11,16 +11,19 @@ export type GetPublicSpacesResponseBody = {
   spaces: SpaceType[];
 };
 
-// The kinds this endpoint exposes. `kinds` narrows that list, it never widens
-// it.
-const LISTED_SPACE_KINDS = ["system", "global", "regular"] as const;
+// The kinds this endpoint returns when `kinds` is omitted.
+const DEFAULT_SPACE_KINDS = ["system", "global", "regular"] as const;
+
+// The kinds `kinds` can select. Projects are opt-in: they are noisy enough that
+// listing them by default would change what every existing caller sees.
+const SELECTABLE_SPACE_KINDS = [...DEFAULT_SPACE_KINDS, "project"] as const;
 
 const GetSpacesQuerySchema = z.object({
   kinds: z
     .string()
     .optional()
     .transform((value) => value?.split(","))
-    .pipe(z.array(z.enum(LISTED_SPACE_KINDS)).optional()),
+    .pipe(z.array(z.enum(SELECTABLE_SPACE_KINDS)).optional()),
 });
 
 // Mounted at /api/v1/w/:wId/spaces. publicApiAuth is applied by the parent
@@ -49,7 +52,7 @@ app.route("/:spaceId", spaceId);
  *       - in: query
  *         name: kinds
  *         required: false
- *         description: Comma-separated list of space kinds to filter on (e.g. `regular,global`).
+ *         description: Comma-separated list of space kinds to filter on, among `system`, `global`, `regular` and `project`. Defaults to `system,global,regular` — projects must be requested explicitly.
  *         schema:
  *           type: string
  *     responses:
@@ -82,7 +85,7 @@ app.get(
     const { kinds } = ctx.req.valid("query");
 
     const spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth, {
-      kinds: kinds ?? [...LISTED_SPACE_KINDS],
+      kinds: kinds ?? [...DEFAULT_SPACE_KINDS],
     });
 
     return ctx.json({


### PR DESCRIPTION
## Description

Fixes dust-tt/tasks#10056.

#29711 narrowed `GET /api/v1/w/{wId}/spaces` to `system`/`global`/`regular`, which was intentional: pods are numerous and nobody wanted them in the default listing. But `dust-cli` resolves `--projectId` / `--projectName` against that listing, so targeting a pod has been broken since July 29 while `POST /assistant/conversations` kept accepting a pod `spaceId`.

The default response is unchanged. `kinds` can now select `project` on top of the three existing kinds, and the CLI passes all four when resolving a project flag.

Note that a pod only shows up for a caller who is a member of it: the workspace global group is only ever a reader on a pod, so an API key that holds nothing but the global group still sees no pods. That matches the endpoint's existing "spaces you belong to" semantics.

## Tests

Added a case to `front-api/routes/v1/w/[wId]/spaces/index.test.ts` covering both halves: a pod is absent from the default response and present under `kinds=project`. Existing cases in that file still pass.

## Risk

Low. Purely additive on the API side, and callers that do not pass `kinds` see exactly what they saw before.

## Deploy Plan

Deploy front-api, then release the CLI.