### PR TITLE
fix: render a toggle in case of unknown status in automations

### DIFF
--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -126,7 +126,13 @@ function RunningCell({ row }: { row: TriggerRowData }) {
       );
     default:
       assertNeverAndIgnore(row.displayStatus);
-      return null;
+      return (
+        <SliderToggle
+          selected={row.displayStatus === "enabled"}
+          disabled={row.isStatusPending}
+          onClick={row.onToggleStatus}
+        />
+      );
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

In the automations administration page, an unknown status renders an empty cell in the table. We instead render an unselected toggle so that it's actionnable.

This happened during the migration of disabled_by_admin to disabled_by_manager, where we didn't backfill the previous status. The lines holding an old status rendered an empty cell, unactionable.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy SPA