### PR TITLE
[front] Support both regular_auto and space_editors for space editor groups

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -267,7 +267,7 @@ app.get(
     const shouldIncludeAllMembers =
       ctx.req.query("includeAllMembers") === "true";
 
-    const { groupsToProcess, allGroupMemberships } =
+    const { groupsToProcess, allGroupMemberships, editorGroupModelId } =
       await space.fetchManualGroupsMemberships(auth, {
         shouldIncludeAllMembers,
       });
@@ -293,7 +293,7 @@ app.get(
             const groupMemberships = membershipMap.get(group.id);
             return groupMembers.map((member) => ({
               ...member.toJSON(),
-              isEditor: group.kind === "space_editors",
+              isEditor: group.id === editorGroupModelId,
               joinedAt: groupMemberships?.get(member.id),
             }));
           },

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -46,9 +46,7 @@ app.post(
     const groupsToLeave = await space.fetchGroupResources(auth, {
       groupReferences: groupReferencesToLeave,
     });
-    const editorGroup = groupsToLeave.find(
-      (group) => group.kind === "space_editors"
-    );
+    const editorGroup = await space.fetchManualEditorGroup(auth);
 
     if (editorGroup) {
       const activeEditors = await editorGroup.getActiveMembers(auth);

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -249,7 +249,7 @@ export async function resolvePodUserRolesBySId(
   auth: Authenticator,
   pod: SpaceResource
 ): Promise<Map<string, "editor" | "member">> {
-  const { groupsToProcess, allGroupMemberships } =
+  const { groupsToProcess, allGroupMemberships, editorGroupModelId } =
     await pod.fetchManualGroupsMemberships(auth, {
       shouldIncludeAllMembers: false,
     });
@@ -267,7 +267,7 @@ export async function resolvePodUserRolesBySId(
 
     const previous = membershipByUserId.get(membership.userId);
     membershipByUserId.set(membership.userId, {
-      isEditor: Boolean(previous?.isEditor) || group.kind === "space_editors",
+      isEditor: Boolean(previous?.isEditor) || group.id === editorGroupModelId,
     });
   }
 

--- a/front/lib/api/actions/servers/pod_manager/tools/index.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.ts
@@ -748,7 +748,7 @@ export function createProjectManagerTools(
           );
         }
 
-        const { groupsToProcess, allGroupMemberships } =
+        const { groupsToProcess, allGroupMemberships, editorGroupModelId } =
           await pod.fetchManualGroupsMemberships(auth, {
             shouldIncludeAllMembers: true,
           });
@@ -774,7 +774,7 @@ export function createProjectManagerTools(
           const previous = membershipByUserId.get(membership.userId);
           membershipByUserId.set(membership.userId, {
             isEditor:
-              Boolean(previous?.isEditor) || group.kind === "space_editors",
+              Boolean(previous?.isEditor) || group.id === editorGroupModelId,
             isActive:
               Boolean(previous?.isActive) || membership.status === "active",
             joinedAtMs: Math.min(

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -302,10 +302,10 @@ describe("createSpaceAndGroup", () => {
       if (result.isOk()) {
         const pod = result.value;
         const creator = userAuth.getNonNullableUser();
-        const { groupsToProcess, allGroupMemberships } =
+        const { groupsToProcess, allGroupMemberships, editorGroupModelId } =
           await pod.fetchManualGroupsMemberships(userAuth);
         const editorGroup = groupsToProcess.find(
-          (group) => group.kind === "space_editors"
+          (group) => group.id === editorGroupModelId
         );
 
         expect(editorGroup).toBeDefined();
@@ -355,10 +355,10 @@ describe("createSpaceAndGroup", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         const pod = result.value;
-        const { groupsToProcess } =
+        const { groupsToProcess, editorGroupModelId } =
           await pod.fetchManualGroupsMemberships(userAuth);
         const editorGroup = groupsToProcess.find(
-          (group) => group.kind === "space_editors"
+          (group) => group.id === editorGroupModelId
         );
         expect(editorGroup).toBeDefined();
 

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -739,7 +739,7 @@ export async function createSpaceAndGroup(
         {
           name: `${PROJECT_EDITOR_GROUP_PREFIX} ${name}`,
           workspaceId: owner.id,
-          kind: "space_editors",
+          kind: "regular_auto",
         },
         { transaction: t, memberIds: [creator.id] }
       );

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -27,6 +27,7 @@ import {
   isGroupPermissionResourceType,
   WHOLE_TYPE_RESOURCE_ID,
 } from "@app/types/group_permissions";
+import type { GroupKind } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -283,11 +284,16 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       grantType,
       resourceType,
       resourceId,
+      // Transitional: while space editor groups are being migrated off the "space_editors" kind
+      // onto "regular_auto", callers pass ["regular_auto", "space_editors"] so the lookup also
+      // finds not-yet-backfilled editor groups. Drop the override once "space_editors" is removed.
+      groupKinds = ["regular_auto"],
       transaction,
     }: {
       grantType: GrantType;
       resourceType: GroupPermissionResourceType;
       resourceId: number;
+      groupKinds?: GroupKind[];
       transaction?: Transaction;
     }
   ): Promise<GroupResource | null> {
@@ -307,7 +313,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
     const groupIds = [...new Set(grants.map((grant) => grant.groupId))];
     const autoGroups = await GroupResource.fetchByModelIds(auth, groupIds, {
-      groupKinds: ["regular_auto"],
+      groupKinds,
       transaction,
     });
 

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -42,8 +42,8 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
   ): Promise<GroupSpaceEditorResource> {
     assert(space.isProject(), "Editor groups only apply to project spaces");
     assert(
-      group.isSpaceEditor() || group.isProvisioned(),
-      "Only space editor or provisioned groups can be an editor group"
+      group.isRegularAuto() || group.isSpaceEditor() || group.isProvisioned(),
+      "Only regular_auto, space_editors or provisioned groups can be an editor group"
     );
     const groupSpace = await GroupSpaceModel.create(
       {
@@ -104,24 +104,29 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
         "One and only one group must exist for editor group space"
       );
       assert(
-        groupModel.kind === "space_editors" ||
+        groupModel.kind === "regular_auto" ||
+          groupModel.kind === "space_editors" ||
           groupModel.kind === "provisioned",
-        "Only space_editors or provisioned groups can be editor groups"
+        "Only regular_auto, space_editors or provisioned groups can be editor groups"
       );
 
       if (filterOnManagementMode) {
-        // Keep only space_editors groups in manual mode, provisioned groups in provisioned mode
-        const filterOnKind =
-          space.managementMode === "manual" ? "space_editors" : "provisioned";
-        if (groupModel.kind !== filterOnKind) {
+        // Manual mode uses the auto editor group (regular_auto, or space_editors pre-migration);
+        // provisioned mode uses the provisioned group.
+        const isProvisionedGroup = groupModel.kind === "provisioned";
+        const keep =
+          space.managementMode === "manual"
+            ? !isProvisionedGroup
+            : isProvisionedGroup;
+        if (!keep) {
           return null;
         }
       }
 
       const group = new GroupResource(GroupModel, groupModel.get());
       assert(
-        group.isSpaceEditor() || group.isProvisioned(),
-        "Only space editors or provisioned groups can be an editor group"
+        group.isRegularAuto() || group.isSpaceEditor() || group.isProvisioned(),
+        "Only regular_auto, space editors or provisioned groups can be an editor group"
       );
 
       return new this(GroupSpaceModel, groupSpace.get(), space, group);
@@ -147,8 +152,9 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       // Editor group stays empty while admin-controlled.
       return false;
     }
-    const acls = await this.getAccessControlLists(auth);
-    return auth.hasPermissionForAcls("write", acls);
+    // Editing the editor group is gated on administrating the space; never rely on the editor
+    // group's own ACL / canWrite (the "space_editors" kind is being removed).
+    return this.space.canAdministrate(auth);
   }
 
   async canRemoveMember(
@@ -160,8 +166,9 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     if (!skipCheckLastMember && editorsCount <= 1) {
       return false;
     }
-    const acls = await this.getAccessControlLists(auth);
-    return auth.hasPermissionForAcls("write", acls);
+    // Editing the editor group is gated on administrating the space; never rely on the editor
+    // group's own ACL / canWrite (the "space_editors" kind is being removed).
+    return this.space.canAdministrate(auth);
   }
 
   async getAccessControlLists(

--- a/front/lib/resources/group_space_resource.test.ts
+++ b/front/lib/resources/group_space_resource.test.ts
@@ -142,20 +142,20 @@ describe("GroupSpaceEditorResource", () => {
       ).rejects.toThrow("Editor groups only apply to project spaces");
     });
 
-    it("should throw an assertion error when group is not a space editor or provisioned group", async () => {
-      const regularGroup = await GroupResource.makeNew({
-        name: "Regular Group",
+    it("should throw an assertion error when group is not a valid editor group kind", async () => {
+      const manualGroup = await GroupResource.makeNew({
+        name: "Manual Group",
         workspaceId: workspace.id,
-        kind: "regular_auto",
+        kind: "regular_manual",
       });
 
       await expect(
         GroupSpaceEditorResource.makeNew(auth, {
-          group: regularGroup,
+          group: manualGroup,
           space: projectSpace,
         })
       ).rejects.toThrow(
-        "Only space editor or provisioned groups can be an editor group"
+        "Only regular_auto, space_editors or provisioned groups can be an editor group"
       );
     });
 
@@ -219,11 +219,11 @@ describe("GroupSpaceEditorResource", () => {
     // creating orphaned GroupSpace records. The assertion is still valid in production
     // if data integrity issues occur.
 
-    it("should throw an assertion error when group is not matching the management mode", async () => {
-      const regularGroup = await GroupResource.makeNew({
-        name: "Regular Group",
+    it("should throw an assertion error when the group kind is not a valid editor kind", async () => {
+      const manualGroup = await GroupResource.makeNew({
+        name: "Manual Group",
         workspaceId: workspace.id,
-        kind: "regular_auto",
+        kind: "regular_manual",
       });
 
       // Delete existing editor groups
@@ -235,22 +235,21 @@ describe("GroupSpaceEditorResource", () => {
         },
       });
 
-      // Create a GroupSpaceModel with a non-editor group
+      // Create a GroupSpaceModel linking a group whose kind is not a valid editor kind.
       await GroupSpaceModel.create({
-        groupId: regularGroup.id,
-        groupKind: regularGroup.kind,
+        groupId: manualGroup.id,
+        groupKind: manualGroup.kind,
         vaultId: projectSpace.id,
         workspaceId: workspace.id,
         kind: "project_editor",
       });
 
-      // When filtering on management mode, the group won't be found because it doesn't match the expected kind
       await expect(
         GroupSpaceEditorResource.fetchBySpace({
           space: projectSpace,
         })
       ).rejects.toThrow(
-        "Only space_editors or provisioned groups can be editor groups"
+        "Only regular_auto, space_editors or provisioned groups can be editor groups"
       );
     });
   });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -27,9 +27,11 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import tracer from "@app/logger/tracer";
 import type { GrantVerb } from "@app/types/group_permissions";
+import { SPACE_EDITOR_GRANT_TYPE } from "@app/types/group_permissions";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
+  MIGRATING_SPACE_EDITOR_GROUP_KINDS,
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
   SPACE_GROUP_PREFIX,
@@ -116,6 +118,11 @@ const POD_SPACE_MEMBERSHIP_VERB: GrantVerb = "write";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SpaceResource extends BaseResource<SpaceModel> {
   static model: ModelStaticSoftDeletable<SpaceModel> = SpaceModel;
+
+  // Memoized manual editor group. A space's editor group identity is immutable, so it is resolved
+  // from `group_permissions` at most once per instance. `undefined` = not yet resolved; `null` =
+  // resolved to "no manual editor group" (non-project space, or provisioned mode).
+  private cachedManualEditorGroup?: GroupResource | null;
 
   constructor(
     model: ModelStaticSoftDeletable<SpaceModel>,
@@ -908,30 +915,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     if (this.isRegular() || this.isProject()) {
       // For regular spaces that only have a single group, update
       // the group's name too (see https://github.com/dust-tt/tasks/issues/1738)
-      const regularGroupReference = this.getSpaceManualMemberGroupReference();
-      const spaceEditorGroupReference =
-        this.getSpaceManualEditorGroupReference();
-      const [regularGroup, spaceEditorGroup] = await this.fetchGroupResources(
-        auth,
-        {
-          groupReferences: [
-            regularGroupReference,
-            ...(spaceEditorGroupReference && this.isProject()
-              ? [spaceEditorGroupReference]
-              : []),
-          ],
-        }
-      );
+      const regularGroup = await this.fetchManualMemberGroup(auth);
       await regularGroup.updateName(
         auth,
         `${this.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${this.name}`
       );
 
-      if (spaceEditorGroup && this.isProject()) {
-        await spaceEditorGroup.updateName(
-          auth,
-          `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`
-        );
+      if (this.isProject()) {
+        const spaceEditorGroup = await this.fetchManualEditorGroup(auth);
+        if (spaceEditorGroup) {
+          await spaceEditorGroup.updateName(
+            auth,
+            `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`
+          );
+        }
       }
     }
 
@@ -1118,7 +1115,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             const editorGroup = await GroupResource.makeNew(
               {
                 name: `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`,
-                kind: "space_editors",
+                kind: "regular_auto",
                 workspaceId: this.workspaceId,
               },
               { transaction: t }
@@ -1713,27 +1710,51 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return new Ok(users);
   }
 
-  private getSpaceManualMemberGroupReference(): SpaceGroupReference {
-    const regularGroups = this.groups.filter((group) => group.isRegularAuto());
-    assert(
-      regularGroups.length === 1,
-      `Expected exactly one regular group for the space, but found ${regularGroups.length}.`
-    );
-    return regularGroups[0];
-  }
-
-  private getSpaceManualEditorGroupReference(): SpaceGroupReference | null {
-    const editorGroups = this.groups.filter(
-      (group) => group.groupKind === "space_editors"
-    );
-    if (editorGroups.length === 0) {
+  // The space's manual editor group (project spaces only): the regular_auto group holding the
+  // `admin` grant on this space in `group_permissions`. Read from `group_permissions` rather than
+  // `group_vaults` (being removed). Returns null for non-project spaces and for provisioned mode,
+  // where the editor grant is held by a provisioned group rather than the manual editor group.
+  // Memoized on the instance (see `cachedManualEditorGroup`).
+  async fetchManualEditorGroup(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<GroupResource | null> {
+    if (!this.isProject()) {
       return null;
     }
-    assert(
-      editorGroups.length === 1,
-      `Expected at most one space editors group for the space, but found ${editorGroups.length}.`
+    if (this.cachedManualEditorGroup === undefined) {
+      this.cachedManualEditorGroup =
+        await GroupPermissionResource.findRegularAutoGroupForGrant(auth, {
+          grantType: SPACE_EDITOR_GRANT_TYPE,
+          resourceType: "space",
+          resourceId: this.id,
+          groupKinds: MIGRATING_SPACE_EDITOR_GROUP_KINDS,
+          transaction,
+        });
+    }
+    return this.cachedManualEditorGroup;
+  }
+
+  // The space's manual member group: the regular_auto group holding this space's membership. A
+  // project space has two regular_auto groups (member + editor), so the editor group (identified
+  // by its `admin` grant in `group_permissions`) is excluded; a regular space has exactly one.
+  private async fetchManualMemberGroup(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<GroupResource> {
+    const editorGroup = await this.fetchManualEditorGroup(auth, transaction);
+    const memberReferences = this.groups.filter(
+      (group) => group.isRegularAuto() && group.groupId !== editorGroup?.id
     );
-    return editorGroups[0];
+    assert(
+      memberReferences.length === 1,
+      `Expected exactly one member group for the space, but found ${memberReferences.length}.`
+    );
+    const [memberGroup] = await this.fetchGroupResources(auth, {
+      groupReferences: memberReferences,
+      transaction,
+    });
+    return memberGroup;
   }
 
   /**
@@ -1961,7 +1982,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return groups.map((group) => {
         // Editors manage the project.
         if (editorGroupIdSet.has(group.id)) {
-          return { groupId: group.id, grantType: "admin" };
+          return { groupId: group.id, grantType: SPACE_EDITOR_GRANT_TYPE };
         }
         // The workspace global group is attached to unrestricted projects as a viewer, so it must
         // only read: conferring write would hand write on every unrestricted project to every
@@ -2267,15 +2288,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const memberGroupReference = this.getSpaceManualMemberGroupReference();
-    const editorGroupReference = this.getSpaceManualEditorGroupReference();
-    const groups = await this.fetchGroupResources(auth, {
-      groupReferences: [
-        memberGroupReference,
-        ...(editorGroupReference ? [editorGroupReference] : []),
-      ],
-      transaction,
-    });
+    const memberGroup = await this.fetchManualMemberGroup(auth, transaction);
+    const editorGroup = await this.fetchManualEditorGroup(auth, transaction);
+    const groups = [memberGroup, ...(editorGroup ? [editorGroup] : [])];
 
     for (const group of groups) {
       await group.suspendMembers(auth, { transaction });
@@ -2289,15 +2304,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const memberGroupReference = this.getSpaceManualMemberGroupReference();
-    const editorGroupReference = this.getSpaceManualEditorGroupReference();
-    const groups = await this.fetchGroupResources(auth, {
-      groupReferences: [
-        memberGroupReference,
-        ...(editorGroupReference ? [editorGroupReference] : []),
-      ],
-      transaction,
-    });
+    const memberGroup = await this.fetchManualMemberGroup(auth, transaction);
+    const editorGroup = await this.fetchManualEditorGroup(auth, transaction);
+    const groups = [memberGroup, ...(editorGroup ? [editorGroup] : [])];
 
     for (const group of groups) {
       await group.restoreMembers(auth, { transaction });
@@ -2320,6 +2329,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   ): Promise<{
     groupsToProcess: GroupResource[];
     allGroupMemberships: GroupMembershipModel[];
+    editorGroupModelId: ModelId | null;
   }> {
     const groupReferences = this.groups.filter(
       (group) => group.isRegularAuto() || group.groupKind === "space_editors"
@@ -2327,6 +2337,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const groupsToProcess = await this.fetchGroupResources(auth, {
       groupReferences,
     });
+    const editorGroup = await this.fetchManualEditorGroup(auth);
+    const editorGroupModelId = editorGroup?.id ?? null;
 
     // Fetch all group memberships to get the startAt date (will be the joinedAt date returned for each member)
     const allGroupMemberships = await GroupMembershipModel.findAll({
@@ -2351,6 +2363,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return {
       groupsToProcess,
       allGroupMemberships,
+      editorGroupModelId,
     };
   }
 

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -46,6 +46,11 @@ export const GRANT_TYPES = [
 ] as const;
 export type GrantType = (typeof GRANT_TYPES)[number];
 
+// A space's editors are the group holding the space-level `admin` role (see the `space` entry in
+// the role registry). Single source of truth for that mapping, shared by the code that writes the
+// grant (SpaceResource.spaceGroupRoles) and the code that reads it back (fetchManualEditorGroup).
+export const SPACE_EDITOR_GRANT_TYPE = "admin" satisfies GrantType;
+
 // Resource domains. "*" means "all resource types".
 export const GROUP_PERMISSION_RESOURCE_TYPES = [
   "space",

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -90,6 +90,15 @@ export function isSkillEditorGroupKind(value: GroupKind): boolean {
   return value === "skill_editors";
 }
 
+// Transitional: space editor groups are being migrated from the "space_editors" kind to
+// "regular_auto". Until the backfill has run and the kind is removed, editor-group lookups must
+// accept both kinds. Remove this constant (and the "space_editors" entry) once the migration
+// completes.
+export const MIGRATING_SPACE_EDITOR_GROUP_KINDS: GroupKind[] = [
+  "regular_auto",
+  "space_editors",
+];
+
 export type GroupType = {
   id: ModelId;
   name: string;


### PR DESCRIPTION
## Description

First step of removing the `space_editors` group kind in favor of `regular_auto`.

- Space **editor groups are now created as `regular_auto`** (both creation sites).
- **Editor/member identity is resolved from `group_permissions`**, not the group kind or `group_vaults`: the editor group is the one holding the space `admin` grant, the member group the one holding the `member` grant. Resolved via `GroupPermissionResource.findRegularAutoGroupForGrant` (`SpaceResource.fetchManualEditorGroup` / `fetchManualMemberGroup`, memoized per instance), and `fetchManualGroupsMemberships` now returns `editorGroupModelId` so `isEditor` no longer depends on kind.
- `findRegularAutoGroupForGrant` gains an optional `groupKinds` arg; during the migration editor lookups pass `["regular_auto", "space_editors"]` (`MIGRATING_SPACE_EDITOR_GROUP_KINDS`) so not-yet-backfilled editor groups are still found.
- Editor-group membership edits are gated on `space.canAdministrate`, never the editor group's own ACL/`canWrite`.

Bottom of a 3-PR stack: **this → #30822 (backfill) → #30823 (remove kind)**.

## Tests

Existing functional tests updated (editor identity via `editorGroupModelId` / `fetchManual*Group`) and passing:
- front: `space_resource` (69), `spaces` (39), `group_space_resource` (16), `pod_manager` helpers (7) + tools (4), `auth.fromjson`, `workspace_user`, `permissions` (27).
- front-api: `spaces/[spaceId]/leave` (5), `spaces/[spaceId]` (2), `members` (2).
- `tsgo --noEmit` clean on front and front-api.

## Risk

Low / behavior-preserving. Both kinds are accepted throughout, so old (`space_editors`) and new (`regular_auto`) editor groups work simultaneously. Editor identity now comes from the space `admin` grant in `group_permissions`, which is already populated for existing spaces (backfilled by `20260728_backfill_space_group_permissions`). No schema or data changes — safe to roll back by reverting the code.

## Deploy Plan

Standard deploy, no migration. Once deployed, proceed to the backfill (#30822).