### PR TITLE
[front] Gate the Pod App UI and APIs behind a pod_applications flag

### DIFF
--- a/extension/ui/pages/PodMainPage.tsx
+++ b/extension/ui/pages/PodMainPage.tsx
@@ -122,6 +122,8 @@ export const PodMainPage = () => {
               setPodUiPreferences={setPodUiPreferences}
               mutatePodInfo={mutatePodInfo}
               clientSideMCPServerIds={clientSideMCPServerIds}
+              // The extension exposes no Apps tab trigger.
+              hasApps={false}
             />
           </GenerationContextProvider>
         </BlockedActionsProvider>

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/clone.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/clone.test.ts
@@ -5,6 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -69,6 +70,9 @@ async function setupPod() {
     role: "admin",
   });
   const pod = await SpaceFactory.project(workspace, user.id);
+
+  await FeatureFlagFactory.basic(auth, "sandbox_functions");
+  await FeatureFlagFactory.basic(auth, "pod_applications");
   const sandbox = await SandboxResource.makeNew(auth, {
     providerId: "test-provider-id",
     status: "running",

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/delete.test.ts
@@ -3,6 +3,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -51,6 +52,9 @@ async function setupPod() {
     role: "admin",
   });
   const pod = await SpaceFactory.project(workspace, user.id);
+
+  await FeatureFlagFactory.basic(auth, "sandbox_functions");
+  await FeatureFlagFactory.basic(auth, "pod_applications");
   const sandbox = await SandboxResource.makeNew(auth, {
     providerId: "test-provider-id",
     status: "running",

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/export.test.ts
@@ -5,6 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -27,6 +28,9 @@ async function setupPod() {
     role: "admin",
   });
   const pod = await SpaceFactory.project(workspace, user.id);
+
+  await FeatureFlagFactory.basic(auth, "sandbox_functions");
+  await FeatureFlagFactory.basic(auth, "pod_applications");
 
   return { workspace, user, auth, pod };
 }

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/import.test.ts
@@ -14,6 +14,7 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SandboxResource } from "@app/lib/resources/sandbox_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -100,6 +101,9 @@ async function setupPod() {
     role: "admin",
   });
   const pod = await SpaceFactory.project(workspace, user.id);
+
+  await FeatureFlagFactory.basic(auth, "sandbox_functions");
+  await FeatureFlagFactory.basic(auth, "pod_applications");
   const sandbox = await SandboxResource.makeNew(auth, {
     providerId: "test-provider-id",
     status: "running",

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.test.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
@@ -20,6 +21,9 @@ async function setupPod() {
     role: "admin",
   });
   const pod = await SpaceFactory.project(workspace, user.id);
+
+  await FeatureFlagFactory.basic(auth, "sandbox_functions");
+  await FeatureFlagFactory.basic(auth, "pod_applications");
 
   return { workspace, user, auth, pod };
 }
@@ -72,6 +76,22 @@ describe("GET /api/w/:wId/pods/:podId/apps", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fileStorageMock.reset();
+  });
+
+  it("returns 403 when the pod_applications flag is off", async () => {
+    const { workspace, user, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    // Pod Functions alone are not enough to reach the Apps routes.
+    await FeatureFlagFactory.basic(auth, "sandbox_functions");
+
+    const res = await honoApp.request(
+      `/api/w/${workspace.sId}/pods/${pod.sId}/apps`
+    );
+
+    expect(res.status).toBe(403);
   });
 
   it("returns an empty list for a Pod with no app", async () => {

--- a/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/apps/index.ts
@@ -18,12 +18,24 @@ import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 import { withSpace } from "@front-api/middlewares/with_space";
 
 import importRoute from "./import";
 
 // Mounted under /api/w/:wId/pods/:podId/apps.
 const app = workspaceApp();
+
+// Pod Apps sit on top of Pod Functions, so both flags are required — same gate as the Apps tab.
+app.use(
+  "*",
+  withFeatureFlag("sandbox_functions", {
+    message: "Sandbox Functions are not enabled for this workspace.",
+  }),
+  withFeatureFlag("pod_applications", {
+    message: "Pod Apps are not enabled for this workspace.",
+  })
+);
 
 app.route("/import", importRoute);
 

--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -69,7 +69,9 @@ export function PodPage() {
   const { hasFeature } = useFeatureFlags();
   const podId = useActivePodId();
   const hasFrameTabs = hasFeature("pod_frame_tabs");
-  const hasApps = hasFeature("sandbox_functions");
+  // Pod Apps sit on top of Pod Functions, so both flags are required.
+  const hasApps =
+    hasFeature("sandbox_functions") && hasFeature("pod_applications");
   const [editingFrameTab, setEditingFrameTab] = useState<PodFrameTab | null>(
     null
   );
@@ -129,6 +131,13 @@ export function PodPage() {
     () => buildPodNavItemsBeforeSettings(frameTabs, tabsOrder, navVisibility),
     [frameTabs, tabsOrder, navVisibility]
   );
+
+  // Drop an Apps selection (persisted preference or deep link) when the flag is off.
+  useEffect(() => {
+    if (currentTab === "apps" && !hasApps) {
+      handleTabChange("conversations");
+    }
+  }, [currentTab, handleTabChange, hasApps]);
 
   // Drop frame-tab selection when the flag is off or the tab was removed
   // (including restored preference pointing at a deleted tab).
@@ -247,6 +256,7 @@ export function PodPage() {
           setPodUiPreferences={setPodUiPreferences}
           mutatePodInfo={mutatePodInfo}
           frameTabs={frameTabs}
+          hasApps={hasApps}
         />
       </NavTabPill>
 

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -39,6 +39,7 @@ interface PodPageContentProps {
   mutatePodInfo: () => Promise<unknown>;
   clientSideMCPServerIds?: string[];
   frameTabs?: PodFrameTab[];
+  hasApps: boolean;
 }
 
 export function PodPageContent({
@@ -49,6 +50,7 @@ export function PodPageContent({
   mutatePodInfo,
   clientSideMCPServerIds,
   frameTabs = [],
+  hasApps,
 }: PodPageContentProps) {
   const owner = useWorkspace();
   const { user } = useAuth();
@@ -220,13 +222,15 @@ export function PodPageContent({
       <NavTabPillContent value="files">
         <PodFilesTab owner={owner} pod={podInfo} />
       </NavTabPillContent>
-      <NavTabPillContent value="apps">
-        <PodAppsTab
-          owner={owner}
-          pod={podInfo}
-          onNavigateToConversations={() => onTabChange("conversations")}
-        />
-      </NavTabPillContent>
+      {hasApps && (
+        <NavTabPillContent value="apps">
+          <PodAppsTab
+            owner={owner}
+            pod={podInfo}
+            onNavigateToConversations={() => onTabChange("conversations")}
+          />
+        </NavTabPillContent>
+      )}
       {podInfo.isAdminControlled && (
         <NavTabPillContent value="connected_data">
           <PodConnectedDataTab owner={owner} pod={podInfo} />

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -332,6 +332,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Allow adding frames from the pod file system as custom tabs (title, icon, order) on the pod.",
     stage: "dust_only",
   },
+  pod_applications: {
+    description:
+      "Enable the Pod Apps UI: browse, import, clone, export and delete the apps published on a Pod.",
+    stage: "dust_only",
+  },
   group_permissions_shadow: {
     description:
       "Admin Governance: evaluate the new group_permissions checks alongside the legacy ones and log mismatches (shadow mode). Serves the legacy result; safe to toggle.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -781,6 +781,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "legacy_billing"
   | "plan_mode"
   | "pod_frame_tabs"
+  | "pod_applications"
   | "skill_favorites"
   | "poke_mcp"
   | "restricted_spaces_in_input_bar"


### PR DESCRIPTION
## Description

Pod Apps were reachable by anyone with `sandbox_functions`, which is the flag for the broader Pod Functions surface. This adds a dedicated `pod_applications` flag so the Apps surface can be rolled out independently, and applies the same gate on the client and the server.

## Risk

Low.

## Deploy Plan

Enable `pod_applications` on the Dust workspaces that currently use Pod Apps, then deploy front + front-api.
