### PR TITLE
[sparkle] refactor: move blocked action cards to Sparkle

### DIFF
--- a/front/components/actions/blocked/PersonalAuthenticationCard.tsx
+++ b/front/components/actions/blocked/PersonalAuthenticationCard.tsx
@@ -1,134 +1,40 @@
-import {
-  areCredentialOverridesValid,
-  PersonalAuthCredentialOverrides,
-} from "@app/components/oauth/PersonalAuthCredentialOverrides";
-import { getIcon } from "@app/components/resources/resources_icons";
-import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
-import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
-import type { MCPServerType } from "@app/lib/api/mcp";
-import {
-  useCreatePersonalConnection,
-  useMCPServer,
-} from "@app/lib/swr/mcp_servers";
-import type { OAuthProvider } from "@app/types/oauth/lib";
-import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
-import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { Avatar, Button, Card, Check, Key01, XClose } from "@dust-tt/sparkle";
-import { useMemo, useRef, useState } from "react";
+import type React from "react";
 
-export type PersonalAuthResolutionOutcome = "completed" | "denied";
-
-interface PersonalAuthenticationCardProps {
-  triggeringUser: UserType | null;
-  // The viewer looking at the card. Passed in rather than read from `AuthContext` because shared
-  // frames render this card outside of any AuthProvider.
-  currentUser: UserType;
-  mcpServerId: string;
-  owner: LightWorkspaceType;
-  provider: OAuthProvider;
-  scope?: string;
-  isResolving: boolean;
-  // Submits the resolution outcome; returns whether the submission succeeded.
-  onResolve: (outcome: PersonalAuthResolutionOutcome) => Promise<boolean>;
+export interface PersonalAuthenticationCardProps {
+  icon?: React.ComponentProps<typeof Avatar>["icon"];
+  serviceName?: string;
+  canRespond: boolean;
+  triggeringUserName?: string;
+  credentialInputs?: React.ReactNode;
+  errorMessage?: string | null;
+  isConnecting?: boolean;
+  isResolving?: boolean;
+  connectDisabled?: boolean;
+  onDecline?: () => void;
+  onConnect?: () => void;
 }
 
 export function PersonalAuthenticationCard({
-  triggeringUser,
-  currentUser,
-  mcpServerId,
-  owner,
-  provider,
-  scope,
-  isResolving,
-  onResolve,
+  icon = Key01,
+  serviceName,
+  canRespond,
+  triggeringUserName,
+  credentialInputs,
+  errorMessage,
+  isConnecting = false,
+  isResolving = false,
+  connectDisabled = false,
+  onDecline,
+  onConnect,
 }: PersonalAuthenticationCardProps) {
-  const { server: mcpServer } = useMCPServer({
-    owner,
-    serverId: mcpServerId,
-  });
-
-  const { createPersonalConnection } = useCreatePersonalConnection(owner);
-
-  const [isConnecting, setIsConnecting] = useState<boolean>(false);
-  const [connectionError, setConnectionError] = useState<string | null>(null);
-  const [overriddenCredentials, setCredentialOverrides] = useState<
-    Record<string, string>
-  >({});
-
-  // Tracks whether the user declined this action while a connection
-  // attempt is still in flight, so the post-await "completed" branch does not
-  // resolve an action that has already been denied.
-  const cancelledRef = useRef<boolean>(false);
-
-  const overridableInputs = getOverridablePersonalAuthInputs({ provider });
-
-  const icon = mcpServer?.icon ? getIcon(mcpServer.icon) : Key01;
-
-  const serverDisplayName =
-    mcpServer && mcpServer.name
-      ? getMcpServerDisplayName(mcpServer)
-      : undefined;
-
-  const canCurrentUserRespond = useMemo(
-    () =>
-      canCurrentUserRespondToParentUserMessage({
-        parentUserId: triggeringUser?.sId,
-        currentUserId: currentUser.sId,
-      }),
-    [triggeringUser, currentUser.sId]
-  );
-
-  const onConnectClick = async (mcpServer: MCPServerType) => {
-    cancelledRef.current = false;
-    setIsConnecting(true);
-    setConnectionError(null);
-
-    const result = await createPersonalConnection({
-      mcpServerId: mcpServer.sId,
-      mcpServerDisplayName: getMcpServerDisplayName(mcpServer),
-      authorization: mcpServer.authorization,
-      provider,
-      useCase: "personal_actions",
-      scope,
-      overriddenCredentials:
-        Object.keys(overriddenCredentials).length > 0
-          ? overriddenCredentials
-          : undefined,
-    });
-
-    if (!result.success) {
-      if (result.error) {
-        setConnectionError(result.error);
-      }
-      return;
-    }
-
-    // The user declined while the connection attempt was still in flight: the
-    // action was already denied, so do not resolve it as completed.
-    if (cancelledRef.current) {
-      return;
-    }
-
-    const completed = await onResolve("completed");
-
-    if (!completed) {
-      return;
-    }
-  };
-
-  const onDeclineClick = async () => {
-    // Signal any in-flight connection attempt to abandon its completed branch.
-    cancelledRef.current = true;
-    setConnectionError(null);
-
-    await onResolve("denied");
-  };
+  const displayName = serviceName ?? "this service";
 
   return (
     <Card
       variant="secondary"
       containerClassName="w-full max-w-xl"
-      className="flex flex-col shadow gap-4"
+      className="flex flex-col gap-4 shadow"
     >
       <div className="flex items-center gap-2">
         <Avatar icon={icon} size="sm" />
@@ -136,29 +42,18 @@ export function PersonalAuthenticationCard({
       </div>
 
       <div className="text-base text-muted-foreground">
-        {`Dust needs access to ${serverDisplayName ?? "this service"} to complete this action.`}
+        {`Dust needs access to ${displayName} to complete this action.`}
       </div>
       <div className="text-base text-muted-foreground">
-        {`Once connected, ${serverDisplayName ?? "this service"} will remain connected for future requests.`}
+        {`Once connected, ${displayName} will remain connected for future requests.`}
       </div>
-      {canCurrentUserRespond ? (
+
+      {canRespond ? (
         <>
-          {overridableInputs && mcpServer && (
-            <PersonalAuthCredentialOverrides
-              inputs={overridableInputs}
-              values={overriddenCredentials}
-              idPrefix={mcpServerId}
-              onChange={(key, value) =>
-                setCredentialOverrides((prev) => ({
-                  ...prev,
-                  [key]: value,
-                }))
-              }
-            />
-          )}
-          {connectionError && (
+          {credentialInputs}
+          {errorMessage && (
             <div className="text-sm font-medium text-warning-800">
-              {connectionError}
+              {errorMessage}
             </div>
           )}
         </>
@@ -166,37 +61,30 @@ export function PersonalAuthenticationCard({
         <div className="text-sm text-muted-foreground">
           Waiting for{" "}
           <span className="font-semibold text-foreground">
-            {triggeringUser?.fullName}
+            {triggeringUserName}
           </span>{" "}
           to connect their account.
         </div>
       )}
 
-      {canCurrentUserRespond && mcpServer && (
+      {canRespond && onDecline && onConnect && (
         <div className="flex justify-end gap-3">
           <Button
             variant="outline"
             label="Decline"
             icon={XClose}
-            // Not gated on `isConnecting`: the user must always be able to abandon
-            // a connection attempt, even if it is (or appears) stuck.
+            // A connection can get stuck, so users must be able to abandon it
+            // while the connection request is still in flight.
             disabled={isResolving}
-            onClick={() => void onDeclineClick()}
+            onClick={onDecline}
           />
           <Button
             variant="highlight"
-            label={`Connect ${serverDisplayName ?? "account"}`}
+            label={`Connect ${serviceName ?? "account"}`}
             icon={Check}
-            disabled={
-              isConnecting ||
-              isResolving ||
-              !areCredentialOverridesValid(
-                overridableInputs,
-                overriddenCredentials
-              )
-            }
+            disabled={isConnecting || isResolving || connectDisabled}
             isLoading={isConnecting}
-            onClick={() => void onConnectClick(mcpServer)}
+            onClick={onConnect}
           />
         </div>
       )}

--- a/front/components/actions/blocked/PersonalAuthenticationCardContainer.tsx
+++ b/front/components/actions/blocked/PersonalAuthenticationCardContainer.tsx
@@ -1,4 +1,3 @@
-import { PersonalAuthenticationCard as PersonalAuthenticationCardView } from "@app/components/actions/blocked/PersonalAuthenticationCard";
 import {
   areCredentialOverridesValid,
   PersonalAuthCredentialOverrides,
@@ -14,7 +13,10 @@ import {
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
-import { Key01 } from "@dust-tt/sparkle";
+import {
+  Key01,
+  PersonalAuthenticationCard as PersonalAuthenticationCardView,
+} from "@dust-tt/sparkle";
 import { useRef, useState } from "react";
 
 export type PersonalAuthResolutionOutcome = "completed" | "denied";

--- a/front/components/actions/blocked/PersonalAuthenticationCardContainer.tsx
+++ b/front/components/actions/blocked/PersonalAuthenticationCardContainer.tsx
@@ -1,0 +1,164 @@
+import { PersonalAuthenticationCard as PersonalAuthenticationCardView } from "@app/components/actions/blocked/PersonalAuthenticationCard";
+import {
+  areCredentialOverridesValid,
+  PersonalAuthCredentialOverrides,
+} from "@app/components/oauth/PersonalAuthCredentialOverrides";
+import { getIcon } from "@app/components/resources/resources_icons";
+import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import type { MCPServerType } from "@app/lib/api/mcp";
+import {
+  useCreatePersonalConnection,
+  useMCPServer,
+} from "@app/lib/swr/mcp_servers";
+import type { OAuthProvider } from "@app/types/oauth/lib";
+import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+import { Key01 } from "@dust-tt/sparkle";
+import { useRef, useState } from "react";
+
+export type PersonalAuthResolutionOutcome = "completed" | "denied";
+
+interface PersonalAuthenticationCardContainerProps {
+  triggeringUser: UserType | null;
+  // The viewer looking at the card. Passed in rather than read from `AuthContext` because shared
+  // frames render this card outside of any AuthProvider.
+  currentUser: UserType;
+  mcpServerId: string;
+  owner: LightWorkspaceType;
+  provider: OAuthProvider;
+  scope?: string;
+  isResolving: boolean;
+  // Submits the resolution outcome; returns whether the submission succeeded.
+  onResolve: (outcome: PersonalAuthResolutionOutcome) => Promise<boolean>;
+}
+
+export function PersonalAuthenticationCardContainer({
+  triggeringUser,
+  currentUser,
+  mcpServerId,
+  owner,
+  provider,
+  scope,
+  isResolving,
+  onResolve,
+}: PersonalAuthenticationCardContainerProps) {
+  const { server: mcpServer } = useMCPServer({
+    owner,
+    serverId: mcpServerId,
+  });
+
+  const { createPersonalConnection } = useCreatePersonalConnection(owner);
+
+  const [isConnecting, setIsConnecting] = useState<boolean>(false);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+  const [overriddenCredentials, setCredentialOverrides] = useState<
+    Record<string, string>
+  >({});
+
+  // Tracks whether the user declined this action while a connection
+  // attempt is still in flight, so the post-await "completed" branch does not
+  // resolve an action that has already been denied.
+  const cancelledRef = useRef<boolean>(false);
+
+  const overridableInputs = getOverridablePersonalAuthInputs({ provider });
+
+  const icon = mcpServer?.icon ? getIcon(mcpServer.icon) : Key01;
+
+  const serverDisplayName =
+    mcpServer && mcpServer.name
+      ? getMcpServerDisplayName(mcpServer)
+      : undefined;
+
+  const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
+    parentUserId: triggeringUser?.sId,
+    currentUserId: currentUser.sId,
+  });
+
+  const onConnectClick = async (mcpServer: MCPServerType) => {
+    cancelledRef.current = false;
+    setIsConnecting(true);
+    setConnectionError(null);
+
+    const result = await createPersonalConnection({
+      mcpServerId: mcpServer.sId,
+      mcpServerDisplayName: getMcpServerDisplayName(mcpServer),
+      authorization: mcpServer.authorization,
+      provider,
+      useCase: "personal_actions",
+      scope,
+      overriddenCredentials:
+        Object.keys(overriddenCredentials).length > 0
+          ? overriddenCredentials
+          : undefined,
+    });
+
+    if (!result.success) {
+      if (result.error) {
+        setConnectionError(result.error);
+      }
+      return;
+    }
+
+    // The user declined while the connection attempt was still in flight: the
+    // action was already denied, so do not resolve it as completed.
+    if (cancelledRef.current) {
+      return;
+    }
+
+    const completed = await onResolve("completed");
+
+    if (!completed) {
+      return;
+    }
+  };
+
+  const onDeclineClick = async () => {
+    // Signal any in-flight connection attempt to abandon its completed branch.
+    cancelledRef.current = true;
+    setConnectionError(null);
+
+    await onResolve("denied");
+  };
+
+  const credentialInputs =
+    canCurrentUserRespond && overridableInputs && mcpServer ? (
+      <PersonalAuthCredentialOverrides
+        inputs={overridableInputs}
+        values={overriddenCredentials}
+        idPrefix={mcpServerId}
+        onChange={(key, value) =>
+          setCredentialOverrides((prev) => ({
+            ...prev,
+            [key]: value,
+          }))
+        }
+      />
+    ) : undefined;
+
+  return (
+    <PersonalAuthenticationCardView
+      icon={icon}
+      serviceName={serverDisplayName}
+      canRespond={canCurrentUserRespond}
+      triggeringUserName={triggeringUser?.fullName}
+      credentialInputs={credentialInputs}
+      errorMessage={connectionError}
+      isConnecting={isConnecting}
+      isResolving={isResolving}
+      connectDisabled={
+        !areCredentialOverridesValid(overridableInputs, overriddenCredentials)
+      }
+      onDecline={
+        canCurrentUserRespond && mcpServer
+          ? () => void onDeclineClick()
+          : undefined
+      }
+      onConnect={
+        canCurrentUserRespond && mcpServer
+          ? () => void onConnectClick(mcpServer)
+          : undefined
+      }
+    />
+  );
+}

--- a/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.test.tsx
+++ b/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.test.tsx
@@ -2,7 +2,6 @@ import type { SandboxFunctionToolPersonalAuthRequiredEvent } from "@app/lib/acti
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SandboxFunctionPersonalAuthCard } from "./SandboxFunctionPersonalAuthCard";
@@ -52,17 +51,6 @@ vi.mock("@app/components/oauth/PersonalAuthCredentialOverrides", () => ({
 
 vi.mock("@app/types/oauth/lib", () => ({
   getOverridablePersonalAuthInputs: () => null,
-}));
-
-vi.mock("@dust-tt/sparkle", () => ({
-  Avatar: () => null,
-  Card: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  Button: ({ label, onClick }: { label: string; onClick?: () => void }) => (
-    <button onClick={onClick}>{label}</button>
-  ),
-  Check: () => null,
-  Key01: () => null,
-  XClose: () => null,
 }));
 
 const viewer = {

--- a/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.tsx
+++ b/front/components/actions/blocked/SandboxFunctionPersonalAuthCard.tsx
@@ -1,5 +1,5 @@
-import type { PersonalAuthResolutionOutcome } from "@app/components/actions/blocked/PersonalAuthenticationCard";
-import { PersonalAuthenticationCard } from "@app/components/actions/blocked/PersonalAuthenticationCard";
+import type { PersonalAuthResolutionOutcome } from "@app/components/actions/blocked/PersonalAuthenticationCardContainer";
+import { PersonalAuthenticationCardContainer } from "@app/components/actions/blocked/PersonalAuthenticationCardContainer";
 import type { FrameViewer } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { SandboxFunctionToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { useResolveAuthentication } from "@app/lib/swr/tool_actions";
@@ -47,7 +47,7 @@ export function SandboxFunctionPersonalAuthCard({
   };
 
   return (
-    <PersonalAuthenticationCard
+    <PersonalAuthenticationCardContainer
       triggeringUser={viewer.user}
       currentUser={viewer.user}
       mcpServerId={authError.mcpServerId}

--- a/front/components/actions/blocked/SandboxFunctionToolApprovalCard.tsx
+++ b/front/components/actions/blocked/SandboxFunctionToolApprovalCard.tsx
@@ -1,4 +1,4 @@
-import { ToolValidationCard } from "@app/components/actions/blocked/ToolValidationCard";
+import { ToolValidationCardContainer } from "@app/components/actions/blocked/ToolValidationCardContainer";
 import type { FrameViewer } from "@app/components/assistant/conversation/actions/VisualizationActionIframe";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { SandboxFunctionMCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
@@ -47,7 +47,7 @@ export function SandboxFunctionToolApprovalCard({
   };
 
   return (
-    <ToolValidationCard
+    <ToolValidationCardContainer
       validationRequest={event}
       triggeringUser={viewer.user}
       currentUser={viewer.user}

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -1,15 +1,4 @@
 import {
-  getToolOverride,
-  getToolValidationAlwaysAllowLabel,
-} from "@app/components/actions/blocked/toolValidationLabels";
-import { ToolValidationDetails } from "@app/components/assistant/conversation/ToolValidationDetails";
-import { getIcon } from "@app/components/resources/resources_icons";
-import type { MCPValidationOutputType } from "@app/lib/actions/constants";
-import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
-import { asDisplayName } from "@app/types/shared/utils/string_utils";
-import type { LightWorkspaceType, UserType } from "@app/types/user";
-import {
   Avatar,
   Button,
   Card,
@@ -25,29 +14,38 @@ import {
   PieChart01,
   XClose,
 } from "@dust-tt/sparkle";
+import type React from "react";
 import { useState } from "react";
 
-const DEFAULT_ICON = PieChart01;
+export type ToolValidationDecision =
+  | "approved"
+  | "rejected"
+  | "always_approved";
 
-// Display data needed to render a tool validation card, for both agent-loop and sandbox-function
-// blocked tool executions.
-type ToolValidationRequest = Pick<
-  BlockedToolExecution,
-  | "actionId"
-  | "userId"
-  | "stake"
-  | "inputs"
-  | "metadata"
-  | "approvalArgsLabel"
-  | "argumentsRequiringApproval"
->;
-
-type ApprovalProgressProps = {
+export interface ToolValidationProgress {
   current: number;
   total: number;
-};
+}
 
-function ApprovalProgress({ current, total }: ApprovalProgressProps) {
+export interface ToolValidationCardProps {
+  title: string;
+  description: React.ReactNode;
+  icon?: React.ComponentProps<typeof Avatar>["icon"];
+  approvalProgress?: ToolValidationProgress;
+  canRespond: boolean;
+  triggeringUserName?: string;
+  details?: React.ReactNode;
+  detailsDefaultOpen?: boolean;
+  errorMessage?: string | null;
+  isValidating?: boolean;
+  isPulsing?: boolean;
+  canAlwaysAllow?: boolean;
+  alwaysAllowTooltip?: string;
+  approveLabel?: string;
+  onValidate: (decision: ToolValidationDecision) => Promise<unknown>;
+}
+
+function ApprovalProgress({ current, total }: ToolValidationProgress) {
   if (total <= 1) {
     return null;
   }
@@ -64,47 +62,25 @@ function ApprovalProgress({ current, total }: ApprovalProgressProps) {
   );
 }
 
-interface ToolValidationCardProps {
-  validationRequest: ToolValidationRequest;
-  approvalProgress?: ApprovalProgressProps;
-  triggeringUser: UserType | null;
-  // The viewer looking at the card. Passed in rather than read from `AuthContext` because shared
-  // frames render this card outside of any AuthProvider.
-  currentUser: UserType;
-  owner: LightWorkspaceType;
-  conversationId?: string | null;
-  errorMessage: string | null;
-  isValidating: boolean;
-  isPulsing?: boolean;
-  // Submits the user's decision; returns whether the submission succeeded.
-  onValidate: (approved: MCPValidationOutputType) => Promise<boolean>;
-}
-
 interface ToolValidationDetailsDialogProps {
-  validationRequest: ToolValidationRequest;
-  approvalTitle: string;
-  displayLabel: string;
-  icon: React.ComponentProps<typeof Avatar>["icon"];
-  currentUser: UserType;
-  owner: LightWorkspaceType;
-  conversationId?: string | null;
+  title: string;
+  description: React.ReactNode;
+  icon: NonNullable<ToolValidationCardProps["icon"]>;
+  details: React.ReactNode;
+  defaultOpen: boolean;
   isSubmitting: boolean;
 }
 
 function ToolValidationDetailsDialog({
-  validationRequest,
-  approvalTitle,
-  displayLabel,
+  title,
+  description,
   icon,
-  currentUser,
-  owner,
-  conversationId,
+  details,
+  defaultOpen,
   isSubmitting,
 }: ToolValidationDetailsDialogProps) {
-  const toolOverride = getToolOverride(validationRequest.metadata);
-
   return (
-    <Dialog defaultOpen={toolOverride?.detailsOpen ?? false}>
+    <Dialog defaultOpen={defaultOpen}>
       <DialogTrigger asChild>
         <Button
           label="Review details"
@@ -121,107 +97,76 @@ function ToolValidationDetailsDialog({
       >
         <DialogHeader className="gap-1 p-0">
           <DialogTitle visual={<Avatar icon={icon} size="sm" />}>
-            {approvalTitle}
+            {title}
           </DialogTitle>
-          <DialogDescription className="pl-11">
-            {displayLabel}
-          </DialogDescription>
+          <DialogDescription className="pl-11">{description}</DialogDescription>
         </DialogHeader>
-        <DialogContainer className="p-0">
-          <ToolValidationDetails
-            blockedAction={validationRequest}
-            user={currentUser}
-            owner={owner}
-            conversationId={conversationId}
-          />
-        </DialogContainer>
+        <DialogContainer className="p-0">{details}</DialogContainer>
       </DialogContent>
     </Dialog>
   );
 }
 
 export function ToolValidationCard({
-  validationRequest,
+  title,
+  description,
+  icon = PieChart01,
   approvalProgress,
-  triggeringUser,
-  currentUser,
-  owner,
-  conversationId,
+  canRespond,
+  triggeringUserName,
+  details,
+  detailsDefaultOpen = false,
   errorMessage,
-  isValidating,
+  isValidating = false,
   isPulsing = false,
+  canAlwaysAllow = false,
+  alwaysAllowTooltip,
+  approveLabel = "Allow",
   onValidate,
 }: ToolValidationCardProps) {
-  const toolOverride = getToolOverride(validationRequest.metadata);
   const [submittingDecision, setSubmittingDecision] =
-    useState<MCPValidationOutputType | null>(null);
+    useState<ToolValidationDecision | null>(null);
   const isSubmitting = isValidating || submittingDecision !== null;
 
-  const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
-    parentUserId: validationRequest.userId,
-    currentUserId: currentUser.sId,
-  });
-
-  const icon = validationRequest.metadata.icon
-    ? getIcon(validationRequest.metadata.icon)
-    : undefined;
-
-  const handleValidation = async (approvalState: MCPValidationOutputType) => {
-    setSubmittingDecision(approvalState);
+  const handleValidation = async (decision: ToolValidationDecision) => {
+    setSubmittingDecision(decision);
     try {
-      await onValidate(approvalState);
+      await onValidate(decision);
     } finally {
       setSubmittingDecision(null);
     }
   };
 
-  const {
-    metadata: { agentName, mcpServerName },
-  } = validationRequest;
-
-  const approvalTitle = `Allow ${agentName} to use ${asDisplayName(mcpServerName)}?`;
-  const displayLabel =
-    validationRequest.metadata.displayLabel ??
-    asDisplayName(validationRequest.metadata.toolName);
-
-  const canAlwaysAllow = ["low", "medium"].includes(
-    validationRequest.stake ?? ""
-  );
-  const approveLabel = toolOverride?.approveLabel ?? "Allow";
-
   return (
     <Card
       variant="secondary"
       containerClassName="w-full max-w-xl"
-      className="flex flex-col shadow gap-4"
+      className="flex flex-col gap-4 shadow"
       isPulsing={isPulsing}
     >
       <div className="flex items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
-          <Avatar icon={icon ?? DEFAULT_ICON} size="sm" />
-          <div className="heading-base min-w-0">{approvalTitle}</div>
+          <Avatar icon={icon} size="sm" />
+          <div className="heading-base min-w-0">{title}</div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {approvalProgress && <ApprovalProgress {...approvalProgress} />}
-          {canCurrentUserRespond &&
-            Object.keys(validationRequest.inputs).length > 0 && (
-              <ToolValidationDetailsDialog
-                validationRequest={validationRequest}
-                approvalTitle={approvalTitle}
-                displayLabel={displayLabel}
-                icon={icon ?? DEFAULT_ICON}
-                currentUser={currentUser}
-                owner={owner}
-                conversationId={conversationId}
-                isSubmitting={isSubmitting}
-              />
-            )}
+          {canRespond && details && (
+            <ToolValidationDetailsDialog
+              title={title}
+              description={description}
+              icon={icon}
+              details={details}
+              defaultOpen={detailsDefaultOpen}
+              isSubmitting={isSubmitting}
+            />
+          )}
         </div>
       </div>
 
-      <div className="text-base text-muted-foreground">{displayLabel}</div>
+      <div className="text-base text-muted-foreground">{description}</div>
 
-      {canCurrentUserRespond ? (
+      {canRespond ? (
         <>
           {errorMessage && (
             <div className="text-sm font-medium text-warning-800">
@@ -233,13 +178,13 @@ export function ToolValidationCard({
         <div className="text-sm text-muted-foreground">
           Waiting for{" "}
           <span className="font-semibold text-foreground">
-            {triggeringUser?.fullName}
+            {triggeringUserName}
           </span>{" "}
           to confirm.
         </div>
       )}
 
-      {canCurrentUserRespond && (
+      {canRespond && (
         <div className="flex flex-wrap justify-end gap-3">
           <Button
             label="Decline"
@@ -254,7 +199,7 @@ export function ToolValidationCard({
               label="Always allow"
               variant="outline"
               icon={CheckDouble}
-              tooltip={getToolValidationAlwaysAllowLabel(validationRequest)}
+              tooltip={alwaysAllowTooltip}
               disabled={isSubmitting}
               isLoading={submittingDecision === "always_approved"}
               onClick={() => void handleValidation("always_approved")}

--- a/front/components/actions/blocked/ToolValidationCardContainer.tsx
+++ b/front/components/actions/blocked/ToolValidationCardContainer.tsx
@@ -1,0 +1,115 @@
+import type { ToolValidationProgress } from "@app/components/actions/blocked/ToolValidationCard";
+import { ToolValidationCard as ToolValidationCardView } from "@app/components/actions/blocked/ToolValidationCard";
+import {
+  getToolOverride,
+  getToolValidationAlwaysAllowLabel,
+} from "@app/components/actions/blocked/toolValidationLabels";
+import { ToolValidationDetails } from "@app/components/assistant/conversation/ToolValidationDetails";
+import { getIcon } from "@app/components/resources/resources_icons";
+import type { MCPValidationOutputType } from "@app/lib/actions/constants";
+import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
+import { asDisplayName } from "@app/types/shared/utils/string_utils";
+import type { LightWorkspaceType, UserType } from "@app/types/user";
+
+// Display data needed to render a tool validation card, for both agent-loop and sandbox-function
+// blocked tool executions.
+type ToolValidationRequest = Pick<
+  BlockedToolExecution,
+  | "actionId"
+  | "userId"
+  | "stake"
+  | "inputs"
+  | "metadata"
+  | "approvalArgsLabel"
+  | "argumentsRequiringApproval"
+>;
+
+interface ToolValidationCardContainerProps {
+  validationRequest: ToolValidationRequest;
+  approvalProgress?: ToolValidationProgress;
+  triggeringUser: UserType | null;
+  // The viewer looking at the card. Passed in rather than read from `AuthContext` because shared
+  // frames render this card outside of any AuthProvider.
+  currentUser: UserType;
+  owner: LightWorkspaceType;
+  conversationId?: string | null;
+  errorMessage: string | null;
+  isValidating: boolean;
+  isPulsing?: boolean;
+  // Submits the user's decision; returns whether the submission succeeded.
+  onValidate: (approved: MCPValidationOutputType) => Promise<boolean>;
+}
+
+export function ToolValidationCardContainer({
+  validationRequest,
+  approvalProgress,
+  triggeringUser,
+  currentUser,
+  owner,
+  conversationId,
+  errorMessage,
+  isValidating,
+  isPulsing = false,
+  onValidate,
+}: ToolValidationCardContainerProps) {
+  const toolOverride = getToolOverride(validationRequest.metadata);
+
+  const canCurrentUserRespond = canCurrentUserRespondToParentUserMessage({
+    parentUserId: validationRequest.userId,
+    currentUserId: currentUser.sId,
+  });
+
+  const icon = validationRequest.metadata.icon
+    ? getIcon(validationRequest.metadata.icon)
+    : undefined;
+
+  const {
+    metadata: { agentName, mcpServerName },
+  } = validationRequest;
+
+  const approvalTitle = `Allow ${agentName} to use ${asDisplayName(mcpServerName)}?`;
+  const displayLabel =
+    validationRequest.metadata.displayLabel ??
+    asDisplayName(validationRequest.metadata.toolName);
+
+  const canAlwaysAllow = ["low", "medium"].includes(
+    validationRequest.stake ?? ""
+  );
+  const approveLabel = toolOverride?.approveLabel ?? "Allow";
+
+  const details =
+    canCurrentUserRespond &&
+    Object.keys(validationRequest.inputs).length > 0 ? (
+      <ToolValidationDetails
+        blockedAction={validationRequest}
+        user={currentUser}
+        owner={owner}
+        conversationId={conversationId}
+      />
+    ) : undefined;
+
+  return (
+    <ToolValidationCardView
+      title={approvalTitle}
+      description={displayLabel}
+      icon={icon}
+      approvalProgress={approvalProgress}
+      canRespond={canCurrentUserRespond}
+      triggeringUserName={triggeringUser?.fullName}
+      details={details}
+      detailsDefaultOpen={toolOverride?.detailsOpen}
+      errorMessage={errorMessage}
+      isValidating={isValidating}
+      isPulsing={isPulsing}
+      canAlwaysAllow={canAlwaysAllow}
+      alwaysAllowTooltip={
+        canAlwaysAllow
+          ? getToolValidationAlwaysAllowLabel(validationRequest)
+          : undefined
+      }
+      approveLabel={approveLabel}
+      onValidate={onValidate}
+    />
+  );
+}

--- a/front/components/actions/blocked/ToolValidationCardContainer.tsx
+++ b/front/components/actions/blocked/ToolValidationCardContainer.tsx
@@ -1,5 +1,3 @@
-import type { ToolValidationProgress } from "@app/components/actions/blocked/ToolValidationCard";
-import { ToolValidationCard as ToolValidationCardView } from "@app/components/actions/blocked/ToolValidationCard";
 import {
   getToolOverride,
   getToolValidationAlwaysAllowLabel,
@@ -11,6 +9,8 @@ import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
+import type { ToolValidationProgress } from "@dust-tt/sparkle";
+import { ToolValidationCard as ToolValidationCardView } from "@dust-tt/sparkle";
 
 // Display data needed to render a tool validation card, for both agent-loop and sandbox-function
 // blocked tool executions.

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.test.tsx
@@ -2,7 +2,6 @@ import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
 import type { LightWorkspaceType } from "@app/types/user";
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MCPServerPersonalAuthenticationRequired } from "./MCPServerPersonalAuthenticationRequired";
@@ -69,27 +68,6 @@ vi.mock("@app/components/oauth/PersonalAuthCredentialOverrides", () => ({
 
 vi.mock("@app/types/oauth/lib", () => ({
   getOverridablePersonalAuthInputs: () => null,
-}));
-
-vi.mock("@dust-tt/sparkle", () => ({
-  Avatar: () => null,
-  Card: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
-  Button: ({
-    label,
-    onClick,
-    disabled,
-  }: {
-    label: string;
-    onClick?: () => void;
-    disabled?: boolean;
-  }) => (
-    <button type="button" onClick={onClick} disabled={disabled}>
-      {label}
-    </button>
-  ),
-  Check: () => null,
-  Key01: () => null,
-  XClose: () => null,
 }));
 
 const owner: LightWorkspaceType = {

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -1,5 +1,5 @@
-import type { PersonalAuthResolutionOutcome } from "@app/components/actions/blocked/PersonalAuthenticationCard";
-import { PersonalAuthenticationCard } from "@app/components/actions/blocked/PersonalAuthenticationCard";
+import type { PersonalAuthResolutionOutcome } from "@app/components/actions/blocked/PersonalAuthenticationCardContainer";
+import { PersonalAuthenticationCardContainer } from "@app/components/actions/blocked/PersonalAuthenticationCardContainer";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import type { AgentLoopBlockedToolExecution } from "@app/lib/actions/mcp";
 import { useAuth } from "@app/lib/auth/AuthContext";
@@ -54,7 +54,7 @@ export function MCPServerPersonalAuthenticationRequired({
   };
 
   return (
-    <PersonalAuthenticationCard
+    <PersonalAuthenticationCardContainer
       triggeringUser={triggeringUser}
       currentUser={user}
       mcpServerId={mcpServerId}

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -1,4 +1,4 @@
-import { ToolValidationCard } from "@app/components/actions/blocked/ToolValidationCard";
+import { ToolValidationCardContainer } from "@app/components/actions/blocked/ToolValidationCardContainer";
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import {
   EditableToolValidation,
@@ -141,7 +141,7 @@ export function MCPToolValidationRequired({
   }
 
   return (
-    <ToolValidationCard
+    <ToolValidationCardContainer
       validationRequest={blockedAction}
       approvalProgress={approvalProgress}
       triggeringUser={triggeringUser}

--- a/sparkle/src/components/PersonalAuthenticationCard.tsx
+++ b/sparkle/src/components/PersonalAuthenticationCard.tsx
@@ -1,5 +1,8 @@
-import { Avatar, Button, Card, Check, Key01, XClose } from "@dust-tt/sparkle";
-import type React from "react";
+import { Avatar } from "@sparkle/components/Avatar";
+import { Button } from "@sparkle/components/Button";
+import { Card } from "@sparkle/components/Card";
+import { Check, Key01, XClose } from "@sparkle/icons/v2-stroke";
+import React from "react";
 
 export interface PersonalAuthenticationCardProps {
   icon?: React.ComponentProps<typeof Avatar>["icon"];

--- a/sparkle/src/components/ToolValidationCard.tsx
+++ b/sparkle/src/components/ToolValidationCard.tsx
@@ -1,9 +1,7 @@
+import { Avatar } from "@sparkle/components/Avatar";
+import { Button } from "@sparkle/components/Button";
+import { Card } from "@sparkle/components/Card";
 import {
-  Avatar,
-  Button,
-  Card,
-  Check,
-  CheckDouble,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -11,11 +9,14 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
+} from "@sparkle/components/Dialog";
+import {
+  Check,
+  CheckDouble,
   PieChart01,
   XClose,
-} from "@dust-tt/sparkle";
-import type React from "react";
-import { useState } from "react";
+} from "@sparkle/icons/v2-stroke";
+import React, { useState } from "react";
 
 export type ToolValidationDecision =
   | "approved"

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -232,6 +232,10 @@ export { OptionCard } from "./OptionCard";
 export { Page } from "./Page";
 export { PaginatedCitationsGrid } from "./PaginatedCitationsGrid";
 export { Pagination } from "./Pagination";
+export {
+  PersonalAuthenticationCard,
+  type PersonalAuthenticationCardProps,
+} from "./PersonalAuthenticationCard";
 export { ColorPicker, IconPicker } from "./Picker";
 export {
   AnchoredPopover,
@@ -303,6 +307,12 @@ export {
   TooltipRoot,
   TooltipTrigger,
 } from "./Tooltip";
+export {
+  ToolValidationCard,
+  type ToolValidationCardProps,
+  type ToolValidationDecision,
+  type ToolValidationProgress,
+} from "./ToolValidationCard";
 export { Tree } from "./Tree";
 export {
   TruncatedContent,

--- a/sparkle/src/stories/PersonalAuthenticationCard.stories.tsx
+++ b/sparkle/src/stories/PersonalAuthenticationCard.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import {
+  GithubLogo,
+  Input,
+  PersonalAuthenticationCard,
+} from "../index_with_tw_base";
+
+const meta = {
+  title: "Product/Conversation/PersonalAuthenticationCard",
+  component: PersonalAuthenticationCard,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Prompts a user to connect a personal account before a blocked action can continue. The product layer supplies the service metadata, optional credential inputs, and connection handlers.",
+      },
+    },
+  },
+  args: {
+    icon: GithubLogo,
+    serviceName: "GitHub",
+    canRespond: true,
+    isConnecting: false,
+    isResolving: false,
+    connectDisabled: false,
+    onDecline: () => undefined,
+    onConnect: () => undefined,
+  },
+} satisfies Meta<typeof PersonalAuthenticationCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithCredentialInputs: Story = {
+  args: {
+    credentialInputs: (
+      <Input
+        id="workspace-domain"
+        name="workspace-domain"
+        label="Workspace domain"
+        placeholder="example.com"
+      />
+    ),
+  },
+};
+
+export const Connecting: Story = {
+  args: {
+    isConnecting: true,
+  },
+};
+
+export const WaitingForAnotherUser: Story = {
+  args: {
+    canRespond: false,
+    triggeringUserName: "Alex Smith",
+    onDecline: undefined,
+    onConnect: undefined,
+  },
+};

--- a/sparkle/src/stories/ToolValidationCard.stories.tsx
+++ b/sparkle/src/stories/ToolValidationCard.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { GithubLogo, ToolValidationCard } from "../index_with_tw_base";
+
+const meta = {
+  title: "Product/Conversation/ToolValidationCard",
+  component: ToolValidationCard,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Asks a user to approve or decline a blocked tool action. Product code supplies the action copy, optional details, persistence scope, and validation handler.",
+      },
+    },
+  },
+  args: {
+    title: "Allow Research assistant to use GitHub?",
+    description: "Create an issue",
+    icon: GithubLogo,
+    canRespond: true,
+    isValidating: false,
+    isPulsing: false,
+    canAlwaysAllow: true,
+    alwaysAllowTooltip: "Always allow this agent to create GitHub issues",
+    approveLabel: "Allow",
+    onValidate: async () => true,
+  },
+} satisfies Meta<typeof ToolValidationCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithDetails: Story = {
+  args: {
+    details: (
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm text-foreground">
+        <dt className="text-muted-foreground">Repository</dt>
+        <dd>dust-tt/dust</dd>
+        <dt className="text-muted-foreground">Title</dt>
+        <dd>Add reusable blocked action cards</dd>
+      </dl>
+    ),
+  },
+};
+
+export const ApprovalQueue: Story = {
+  args: {
+    approvalProgress: {
+      current: 2,
+      total: 4,
+    },
+  },
+};
+
+export const WaitingForAnotherUser: Story = {
+  args: {
+    canRespond: false,
+    triggeringUserName: "Alex Smith",
+    canAlwaysAllow: false,
+  },
+};


### PR DESCRIPTION
## Description

The same blocked tool approval and account connection UI is used across conversations and sandbox functions, but its presentation is not available in Sparkle.

This moves `ToolValidationCard` and `PersonalAuthenticationCard` into Sparkle. The `front` wrappers continue to own permissions, MCP and authentication metadata, credential inputs, tool details, labels, and mutations, so rendering and interaction behavior stay unchanged. Storybook now documents the main responder, waiting, loading, details, and approval queue states.

## Tests

- Added Storybook coverage and updated existing tests.

## Risk

- Low. Refactors blocked action rendering without changing behavior.

## Deploy Plan

- Deploy front.
