### PR TITLE
[front] Remove the space_editors group kind

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -40,7 +40,7 @@ app.get(
 
     const groupReferences = space.groups.filter((group) =>
       space.managementMode === "manual"
-        ? group.isRegularAuto() || group.groupKind === "space_editors"
+        ? group.isRegularAuto()
         : group.isProvisioned()
     );
     const groups = await space.fetchGroupResources(auth, { groupReferences });

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -43,7 +43,7 @@ app.get(
       ? Array.isArray(kind)
         ? kind
         : [kind]
-      : ["global", "regular_auto", "space_editors"];
+      : ["global", "regular_auto"];
 
     const groups: GroupResource[] = spaceId
       ? await GroupResource.listForSpaceById(auth, spaceId, { groupKinds })

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -20,23 +20,18 @@ async function addUserToProject(
   user: UserResource,
   options: { asEditor?: boolean } = {}
 ) {
-  const groups = await project.fetchGroupResources(adminAuth, {
-    groupReferences: project.groups.filter(
-      (group) => group.isRegularAuto() || group.groupKind === "space_editors"
-    ),
+  const memberGroup = await project.fetchManualMemberGroup(adminAuth);
+  await memberGroup.dangerouslyAddMembers(adminAuth, {
+    users: [user.toJSON()],
   });
-  const memberGroup = groups.find((group) => group.kind === "regular_auto");
-  const editorGroup = groups.find((group) => group.kind === "space_editors");
 
-  if (memberGroup) {
-    await memberGroup.dangerouslyAddMembers(adminAuth, {
-      users: [user.toJSON()],
-    });
-  }
-  if (options.asEditor && editorGroup) {
-    await editorGroup.dangerouslyAddMembers(adminAuth, {
-      users: [user.toJSON()],
-    });
+  if (options.asEditor) {
+    const editorGroup = await project.fetchManualEditorGroup(adminAuth);
+    if (editorGroup) {
+      await editorGroup.dangerouslyAddMembers(adminAuth, {
+        users: [user.toJSON()],
+      });
+    }
   }
 }
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -40,8 +40,8 @@ app.post(
 
     const user = auth.getNonNullableUser();
 
-    const groupReferencesToLeave = space.groups.filter(
-      (group) => group.isRegularAuto() || group.groupKind === "space_editors"
+    const groupReferencesToLeave = space.groups.filter((group) =>
+      group.isRegularAuto()
     );
     const groupsToLeave = await space.fetchGroupResources(auth, {
       groupReferences: groupReferencesToLeave,

--- a/front/components/groups/GroupKinds.ts
+++ b/front/components/groups/GroupKinds.ts
@@ -25,7 +25,6 @@ export function getGroupKindChip(kind: GroupKind): {
     case "global":
     case "regular_auto":
     case "skill_editors":
-    case "space_editors":
     case "system":
       return { label: "Other", color: "primary" };
     default:

--- a/front/lib/api/sandbox_functions/workspace_user.test.ts
+++ b/front/lib/api/sandbox_functions/workspace_user.test.ts
@@ -28,16 +28,15 @@ async function makeWorkspaceMember(
 async function addToSpaceGroup(
   adminAuth: Authenticator,
   space: SpaceResource,
-  groupKind: "regular_auto" | "space_editors",
+  role: "member" | "editor",
   user: UserResource
 ): Promise<void> {
-  const [group] = await space.fetchGroupResources(adminAuth, {
-    groupReferences: space.groups.filter(
-      (reference) => reference.groupKind === groupKind
-    ),
-  });
+  const group =
+    role === "editor"
+      ? await space.fetchManualEditorGroup(adminAuth)
+      : await space.fetchManualMemberGroup(adminAuth);
   if (!group) {
-    throw new Error(`Expected the ${groupKind} group to exist.`);
+    throw new Error(`Expected the ${role} group to exist.`);
   }
   const addMemberResult = await group.dangerouslyAddMember(adminAuth, {
     user: user.toJSON(),
@@ -60,7 +59,7 @@ describe("authorizeSandboxFunctionInvocation with pod_member_required", () => {
   it("authorizes a member of the pod member group", async () => {
     const { workspace, adminAuth, space } = await setup();
     const member = await makeWorkspaceMember(workspace);
-    await addToSpaceGroup(adminAuth, space, "regular_auto", member);
+    await addToSpaceGroup(adminAuth, space, "member", member);
     const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
       member.sId,
       workspace.sId
@@ -77,7 +76,7 @@ describe("authorizeSandboxFunctionInvocation with pod_member_required", () => {
   it("authorizes a member of the pod editor group", async () => {
     const { workspace, adminAuth, space } = await setup();
     const editor = await makeWorkspaceMember(workspace);
-    await addToSpaceGroup(adminAuth, space, "space_editors", editor);
+    await addToSpaceGroup(adminAuth, space, "editor", editor);
     const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
       editor.sId,
       workspace.sId

--- a/front/lib/auth.fromjson.test.ts
+++ b/front/lib/auth.fromjson.test.ts
@@ -146,16 +146,14 @@ describe("Authenticator.fromJSON", () => {
     const staleAuthJson = auth.toJSON();
 
     const pod = await SpaceFactory.project(workspace, user.id);
-    const editorGroup = pod.groups.find(
-      (group) => group.groupKind === "space_editors"
-    );
-    expect(editorGroup).toBeDefined();
+    const editorGroup = await pod.fetchManualEditorGroup(auth);
+    expect(editorGroup).not.toBeNull();
 
     const staleAuth = await Authenticator.fromJSON(staleAuthJson);
-    expect(staleAuth.hasGroupByModelId(editorGroup!.groupId)).toBe(false);
+    expect(staleAuth.hasGroupByModelId(editorGroup!.id)).toBe(false);
 
     const freshAuth =
       await Authenticator.fromJsonWithRefrehedGroups(staleAuthJson);
-    expect(freshAuth.hasGroupByModelId(editorGroup!.groupId)).toBe(true);
+    expect(freshAuth.hasGroupByModelId(editorGroup!.id)).toBe(true);
   });
 });

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -27,7 +27,6 @@ import {
   isGroupPermissionResourceType,
   WHOLE_TYPE_RESOURCE_ID,
 } from "@app/types/group_permissions";
-import type { GroupKind } from "@app/types/groups";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
@@ -284,16 +283,11 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
       grantType,
       resourceType,
       resourceId,
-      // Transitional: while space editor groups are being migrated off the "space_editors" kind
-      // onto "regular_auto", callers pass ["regular_auto", "space_editors"] so the lookup also
-      // finds not-yet-backfilled editor groups. Drop the override once "space_editors" is removed.
-      groupKinds = ["regular_auto"],
       transaction,
     }: {
       grantType: GrantType;
       resourceType: GroupPermissionResourceType;
       resourceId: number;
-      groupKinds?: GroupKind[];
       transaction?: Transaction;
     }
   ): Promise<GroupResource | null> {
@@ -313,7 +307,7 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
 
     const groupIds = [...new Set(grants.map((grant) => grant.groupId))];
     const autoGroups = await GroupResource.fetchByModelIds(auth, groupIds, {
-      groupKinds,
+      groupKinds: ["regular_auto"],
       transaction,
     });
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1098,9 +1098,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     options: { groupKinds?: GroupKind[] } = {}
   ): Promise<GroupResource[]> {
-    const {
-      groupKinds = ["global", "regular_auto", "space_editors", "provisioned"],
-    } = options;
+    const { groupKinds = ["global", "regular_auto", "provisioned"] } = options;
     const groups = await this.baseFetch(auth, {
       where: {
         kind: {
@@ -1653,7 +1651,6 @@ export class GroupResource extends BaseResource<GroupModel> {
     assert(
       this.isRegularAuto() ||
         this.isRegularManual() ||
-        this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
         (allowProvisionedGroups && this.kind === "provisioned"),
@@ -1799,7 +1796,6 @@ export class GroupResource extends BaseResource<GroupModel> {
     assert(
       this.isRegularAuto() ||
         this.isRegularManual() ||
-        this.kind === "space_editors" ||
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
         (allowProvisionedGroups && this.kind === "provisioned"),
@@ -1919,7 +1915,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    * Unlike removeMembers(), this method does not require admin/editor permissions.
    * Users can always remove themselves from groups they are members of.
    *
-   * Only works for "regular_auto" and "space_editors" groups.
+   * Only works for "regular_auto" groups.
    * TODO(remy): Replace this with dangerouslyRemoveMembers once available
    */
   async leaveGroup(
@@ -1931,11 +1927,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     const user = auth.getNonNullableUser();
     const workspace = auth.getNonNullableWorkspace();
 
-    if (!this.isRegularAuto() && this.kind !== "space_editors") {
+    if (!this.isRegularAuto()) {
       return new Err(
         new DustError(
           "system_or_global_group",
-          "Users can only leave regular or space_editors groups."
+          "Users can only leave regular groups."
         )
       );
     }
@@ -2608,21 +2604,6 @@ export class GroupResource extends BaseResource<GroupModel> {
       ];
     }
 
-    if (this.kind === "space_editors") {
-      return [
-        {
-          groups: [
-            {
-              id: this.id,
-              permissions: ["admin", "read", "write"],
-            },
-          ],
-          roles: [{ role: "admin", permissions: ["read", "write", "admin"] }],
-          workspaceId: this.workspaceId,
-        },
-      ];
-    }
-
     if (this.isRegularManual()) {
       return [
         {
@@ -2701,10 +2682,6 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   isRegularManual(): boolean {
     return isRegularManualGroupKind(this.kind);
-  }
-
-  isSpaceEditor(): boolean {
-    return this.kind === "space_editors";
   }
 
   isProvisioned(): boolean {

--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -42,8 +42,8 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
   ): Promise<GroupSpaceEditorResource> {
     assert(space.isProject(), "Editor groups only apply to project spaces");
     assert(
-      group.isRegularAuto() || group.isSpaceEditor() || group.isProvisioned(),
-      "Only regular_auto, space_editors or provisioned groups can be an editor group"
+      group.isRegularAuto() || group.isProvisioned(),
+      "Only regular_auto or provisioned groups can be an editor group"
     );
     const groupSpace = await GroupSpaceModel.create(
       {
@@ -104,15 +104,13 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
         "One and only one group must exist for editor group space"
       );
       assert(
-        groupModel.kind === "regular_auto" ||
-          groupModel.kind === "space_editors" ||
-          groupModel.kind === "provisioned",
-        "Only regular_auto, space_editors or provisioned groups can be editor groups"
+        groupModel.kind === "regular_auto" || groupModel.kind === "provisioned",
+        "Only regular_auto or provisioned groups can be editor groups"
       );
 
       if (filterOnManagementMode) {
-        // Manual mode uses the auto editor group (regular_auto, or space_editors pre-migration);
-        // provisioned mode uses the provisioned group.
+        // Manual mode uses the regular_auto editor group; provisioned mode uses the provisioned
+        // group.
         const isProvisionedGroup = groupModel.kind === "provisioned";
         const keep =
           space.managementMode === "manual"
@@ -125,8 +123,8 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
 
       const group = new GroupResource(GroupModel, groupModel.get());
       assert(
-        group.isRegularAuto() || group.isSpaceEditor() || group.isProvisioned(),
-        "Only regular_auto, space editors or provisioned groups can be an editor group"
+        group.isRegularAuto() || group.isProvisioned(),
+        "Only regular_auto or provisioned groups can be an editor group"
       );
 
       return new this(GroupSpaceModel, groupSpace.get(), space, group);
@@ -153,7 +151,7 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       return false;
     }
     // Editing the editor group is gated on administrating the space; never rely on the editor
-    // group's own ACL / canWrite (the "space_editors" kind is being removed).
+    // group's own ACL / canWrite.
     return this.space.canAdministrate(auth);
   }
 
@@ -167,7 +165,7 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       return false;
     }
     // Editing the editor group is gated on administrating the space; never rely on the editor
-    // group's own ACL / canWrite (the "space_editors" kind is being removed).
+    // group's own ACL / canWrite.
     return this.space.canAdministrate(auth);
   }
 

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -101,10 +101,6 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
         groupModel,
         "One and only one group must exist for member group space"
       );
-      assert(
-        groupModel.kind !== "space_editors",
-        "Editors groups cannot be member groups"
-      );
       if (filterOnManagementMode) {
         // Keep only regular groups in manual mode, provisioned groups in provisioned mode
         const filterOnKind: GroupKind =

--- a/front/lib/resources/group_space_resource.test.ts
+++ b/front/lib/resources/group_space_resource.test.ts
@@ -126,7 +126,7 @@ describe("GroupSpaceEditorResource", () => {
     editorGroup = await GroupResource.makeNew({
       name: "Test Editor Group",
       workspaceId: workspace.id,
-      kind: "space_editors",
+      kind: "regular_auto",
     });
   });
 
@@ -155,7 +155,7 @@ describe("GroupSpaceEditorResource", () => {
           space: projectSpace,
         })
       ).rejects.toThrow(
-        "Only regular_auto, space_editors or provisioned groups can be an editor group"
+        "Only regular_auto or provisioned groups can be an editor group"
       );
     });
 
@@ -249,7 +249,7 @@ describe("GroupSpaceEditorResource", () => {
           space: projectSpace,
         })
       ).rejects.toThrow(
-        "Only regular_auto, space_editors or provisioned groups can be editor groups"
+        "Only regular_auto or provisioned groups can be editor groups"
       );
     });
   });

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -222,8 +222,8 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
         where: {
           id: this.groupId,
           workspaceId: auth.getNonNullableWorkspace().id,
-          // Delete the corresponding group if it's regular_auto or space_editors (system, global, provisioned groups should not be deleted)
-          kind: ["regular_auto", "space_editors"],
+          // Delete the corresponding group if it's regular_auto (system, global, provisioned groups should not be deleted)
+          kind: "regular_auto",
         },
         transaction,
       });

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -956,7 +956,7 @@ describe("SpaceResource", () => {
           projectEditorGroup = await GroupResource.makeNew({
             name: "Project Editors Group",
             workspaceId: workspace.id,
-            kind: "space_editors",
+            kind: "regular_auto",
           });
 
           projectSpace = await SpaceResource.makeNew(
@@ -1192,7 +1192,7 @@ describe("SpaceResource", () => {
           projectEditorGroup = await GroupResource.makeNew({
             name: "Project Editors Group",
             workspaceId: workspace.id,
-            kind: "space_editors",
+            kind: "regular_auto",
           });
 
           projectSpace = await SpaceResource.makeNew(

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -31,7 +31,6 @@ import { SPACE_EDITOR_GRANT_TYPE } from "@app/types/group_permissions";
 import type { GroupKind, GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
-  MIGRATING_SPACE_EDITOR_GROUP_KINDS,
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
   SPACE_GROUP_PREFIX,
@@ -1728,7 +1727,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           grantType: SPACE_EDITOR_GRANT_TYPE,
           resourceType: "space",
           resourceId: this.id,
-          groupKinds: MIGRATING_SPACE_EDITOR_GROUP_KINDS,
           transaction,
         });
     }
@@ -1738,7 +1736,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   // The space's manual member group: the regular_auto group holding this space's membership. A
   // project space has two regular_auto groups (member + editor), so the editor group (identified
   // by its `admin` grant in `group_permissions`) is excluded; a regular space has exactly one.
-  private async fetchManualMemberGroup(
+  async fetchManualMemberGroup(
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<GroupResource> {
@@ -2338,8 +2336,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     allGroupMemberships: GroupMembershipModel[];
     editorGroupModelId: ModelId | null;
   }> {
-    const groupReferences = this.groups.filter(
-      (group) => group.isRegularAuto() || group.groupKind === "space_editors"
+    const groupReferences = this.groups.filter((group) =>
+      group.isRegularAuto()
     );
     const groupsToProcess = await this.fetchGroupResources(auth, {
       groupReferences,
@@ -2427,9 +2425,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const allGroupReferences = new Map<ModelId, SpaceGroupReference>();
     for (const space of spaces) {
       const groupReferences = space.groups.filter(
-        (group) =>
-          group.groupKind === "regular_auto" ||
-          group.groupKind === "space_editors"
+        (group) => group.groupKind === "regular_auto"
       );
       manualGroupReferencesBySpaceModelId.set(space.id, groupReferences);
       groupReferences.forEach((group) =>

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -29,46 +29,24 @@ makeScript(
           const auth = await Authenticator.internalAdminForWorkspace(w.sId);
           const pods = await SpaceResource.listProjectSpaces(auth);
           for (const pod of pods) {
-            const regularGroupReferences = pod.groups.filter((group) =>
-              group.isRegularAuto()
-            );
-            const spaceEditorGroupReferences = pod.groups.filter(
-              (group) => group.groupKind === "space_editors"
-            );
-            const groups = await pod.fetchGroupResources(auth, {
-              groupReferences: [
-                ...regularGroupReferences,
-                ...spaceEditorGroupReferences,
-              ],
-            });
-            const regularGroups = groups.slice(
-              0,
-              regularGroupReferences.length
-            );
-            const spaceEditorGroups = groups.slice(
-              regularGroupReferences.length
-            );
-
-            if (regularGroupReferences.length === 1) {
-              const [group] = regularGroups;
-              const newName = `${pod.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${pod.name}`;
-              if (execute) {
-                await group.updateName(auth, newName);
-              } else {
-                logger.info(
-                  `[Execute: ${execute}] Updating group ${group.id} to "${newName}"`
-                );
-              }
+            const memberGroup = await pod.fetchManualMemberGroup(auth);
+            const memberName = `${pod.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${pod.name}`;
+            if (execute) {
+              await memberGroup.updateName(auth, memberName);
+            } else {
+              logger.info(
+                `[Execute: ${execute}] Updating group ${memberGroup.id} to "${memberName}"`
+              );
             }
 
-            if (spaceEditorGroupReferences.length === 1) {
-              const [group] = spaceEditorGroups;
-              const newName = `${PROJECT_EDITOR_GROUP_PREFIX} ${pod.name}`;
+            const editorGroup = await pod.fetchManualEditorGroup(auth);
+            if (editorGroup) {
+              const editorName = `${PROJECT_EDITOR_GROUP_PREFIX} ${pod.name}`;
               if (execute) {
-                await group.updateName(auth, newName);
+                await editorGroup.updateName(auth, editorName);
               } else {
                 logger.info(
-                  `[Execute: ${execute}] Updating group ${group.id} to "${newName}"`
+                  `[Execute: ${execute}] Updating group ${editorGroup.id} to "${editorName}"`
                 );
               }
             }

--- a/front/scripts/dev/seed_conversations.ts
+++ b/front/scripts/dev/seed_conversations.ts
@@ -106,7 +106,7 @@ async function createProject(
       {
         name: editorGroupName,
         workspaceId: workspace.id,
-        kind: "space_editors",
+        kind: "regular_auto",
       },
       {
         memberIds: [creatorId],

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -111,7 +111,7 @@ export class SpaceFactory {
       {
         name: `${PROJECT_EDITOR_GROUP_PREFIX} ${name}`,
         workspaceId: workspace.id,
-        kind: "space_editors",
+        kind: "regular_auto",
       },
       {
         memberIds: [creatorId ?? defaultCreator.id],

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -34,8 +34,6 @@ import { isRoleType } from "./user";
 export const GROUP_KINDS = [
   "regular_auto",
   "regular_manual",
-  // space_editors is used to know if a member of a manual group can edit the group
-  "space_editors",
   "global",
   "system",
   "agent_editors",
@@ -90,15 +88,6 @@ export function isSkillEditorGroupKind(value: GroupKind): boolean {
   return value === "skill_editors";
 }
 
-// Transitional: space editor groups are being migrated from the "space_editors" kind to
-// "regular_auto". Until the backfill has run and the kind is removed, editor-group lookups must
-// accept both kinds. Remove this constant (and the "space_editors" entry) once the migration
-// completes.
-export const MIGRATING_SPACE_EDITOR_GROUP_KINDS: GroupKind[] = [
-  "regular_auto",
-  "space_editors",
-];
-
 export type GroupType = {
   id: ModelId;
   name: string;
@@ -117,7 +106,6 @@ export const GroupKindCodec = z.enum([
   "global",
   "regular_auto",
   "regular_manual",
-  "space_editors",
   "agent_editors",
   "skill_editors",
   "system",


### PR DESCRIPTION
## Description

Removes the now-unused `space_editors` group kind. Editor groups are `regular_auto` (created that way in #30818, backfilled in #30822) and editor identity comes from `group_permissions`, so the kind has no remaining purpose.

- Drops `space_editors` from `GROUP_KINDS` and `GroupKindCodec`.
- Deletes the dead usages: the `space_editors` branch in `GroupResource.getAccessControlLists`, `isSpaceEditor()`, the redundant clauses in the member add/remove allow-lists, `leaveGroup`, list/delete filters, and the `isEditor` chip case.
- Simplifies `GroupSpaceEditorResource` asserts/filter to `regular_auto | provisioned`.
- Drops the transitional `MIGRATING_SPACE_EDITOR_GROUP_KINDS` and reverts `findRegularAutoGroupForGrant` to `regular_auto` only.
- Updates the 2024 rename migration to resolve groups via `fetchManual*Group`.
- Updates tests/factory/seed to `regular_auto` and role-based group resolution.

Top of a 3-PR stack: #30818 → #30822 → **this**.

## Tests

Tests updated (assert messages, editor/member resolution via `fetchManual*Group` and `editorGroupModelId`) and passing; `tsgo --noEmit` clean on front and front-api; no `space_editors` references remain (aside from the backfill script's SQL in #30822).

## Risk

Removing `space_editors` from `GroupKindCodec` means any lingering `space_editors` row would fail to parse. This PR must therefore merge **only after** the #30822 backfill has run in prod and EU. Kept as a **draft** until then. `groups.kind` is a plain string column (no Postgres enum), so no schema migration is needed.

## Deploy Plan

1. Confirm #30818 is deployed and the #30822 backfill has completed in **prod** and **EU** (zero remaining `space_editors` rows).
2. Mark this PR ready and merge.