### PR TITLE
Add /conversation/:id pageviews in PostHog

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -442,14 +442,6 @@ function PostHogTrackerInner({ authenticated }: PostHogTrackerInnerProps) {
 
       lastPageviewPathnameRef.current = pathname;
 
-      // Don't track pageviews on conversation pages (/conversation/[cId]), but track /conversation/new.
-      const isConversationPage = /\/conversation\/(?!new$)[^/]+$/.test(
-        pathname
-      );
-      if (isConversationPage) {
-        return;
-      }
-
       posthog.capture("$pageview");
     };
 


### PR DESCRIPTION
## Description

Previously we were filtering these out, out of concern for event tracking volume.
We don't think this is a necessity anymore

## Tests

## Risk

Low, safe to rollback

## Deploy Plan

N/A