### PR TITLE
Link Files to stable filesystem nodes

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -182,8 +182,9 @@ export function loadAllModels() {
     ProviderModel,
     CloneModel,
     KeyModel,
-    FileModel,
+    // FileSystemNodeModel first: files references it through fileSystemNodeId.
     FileSystemNodeModel,
+    FileModel,
     FileSystemMutationModel,
     FileSystemBlobCleanupModel,
     SandboxFunctionModel,

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -10,6 +10,7 @@ import {
   literal,
   Op,
 } from "@app/lib/resources/storage/data_types";
+import { FileSystemNodeModel } from "@app/lib/resources/storage/models/file_system_node";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -36,6 +37,9 @@ export class FileModel extends WorkspaceAwareModel<FileModel> {
   declare mountFilePath: string | null;
 
   declare userId: ForeignKey<UserModel["id"]> | null;
+  // The file system node holding this file's live source. For a Frame this is
+  // the published entry file. The id survives every move and rename.
+  declare fileSystemNodeId: ForeignKey<FileSystemNodeModel["id"]> | null;
 
   declare user: NonAttribute<UserModel>;
 }
@@ -112,6 +116,13 @@ FileModel.init(
         unique: true,
         where: { mountFilePath: { [Op.ne]: null } },
       },
+      // Leads with the node id: deleting a node scans files by this column
+      // alone, without a workspace in hand.
+      {
+        fields: ["fileSystemNodeId"],
+        concurrently: true,
+        where: { fileSystemNodeId: { [Op.ne]: null } },
+      },
     ],
   }
 );
@@ -120,6 +131,17 @@ UserModel.hasMany(FileModel, {
   onDelete: "RESTRICT",
 });
 FileModel.belongsTo(UserModel);
+// RESTRICT: removing a node while a file still points at it fails. Deleting the
+// file record is a decision with consequences of its own (shares, grants,
+// published bundles), so the caller must deal with the file first rather than
+// have the binding silently disappear.
+FileSystemNodeModel.hasMany(FileModel, {
+  foreignKey: { name: "fileSystemNodeId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+FileModel.belongsTo(FileSystemNodeModel, {
+  foreignKey: { name: "fileSystemNodeId", allowNull: true },
+});
 
 /**
  * Shared files logic.

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -116,8 +116,6 @@ FileModel.init(
         unique: true,
         where: { mountFilePath: { [Op.ne]: null } },
       },
-      // Leads with the node id: deleting a node scans files by this column
-      // alone, without a workspace in hand.
       {
         fields: ["fileSystemNodeId"],
         concurrently: true,
@@ -131,10 +129,6 @@ UserModel.hasMany(FileModel, {
   onDelete: "RESTRICT",
 });
 FileModel.belongsTo(UserModel);
-// RESTRICT: removing a node while a file still points at it fails. Deleting the
-// file record is a decision with consequences of its own (shares, grants,
-// published bundles), so the caller must deal with the file first rather than
-// have the binding silently disappear.
 FileSystemNodeModel.hasMany(FileModel, {
   foreignKey: { name: "fileSystemNodeId", allowNull: true },
   onDelete: "RESTRICT",

--- a/front/migrations/pre-deploy/20260819134521_add_file_system_node_id_to_files.sql
+++ b/front/migrations/pre-deploy/20260819134521_add_file_system_node_id_to_files.sql
@@ -1,0 +1,35 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."files" ADD COLUMN "fileSystemNodeId" bigint;
+
+/*
+Statement 1
+CREATE INDEX CONCURRENTLY cannot run inside a transaction, and the runner
+applies this file through psql so the session settings above do not carry an
+open transaction.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY files_file_system_node_id ON public.files USING btree ("fileSystemNodeId") WHERE ("fileSystemNodeId" IS NOT NULL);
+
+/*
+Statement 2
+RESTRICT: a node cannot be removed while a file still points at it, so the
+ordering is enforced here rather than left to callers.
+
+NOT VALID then VALIDATE: the constraint applies to new rows immediately while
+the validation scan takes only a light lock on this large table.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."files" ADD CONSTRAINT "files_fileSystemNodeId_fkey" FOREIGN KEY ("fileSystemNodeId") REFERENCES file_system_nodes(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."files" VALIDATE CONSTRAINT "files_fileSystemNodeId_fkey";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds the data model needed to associate a `FileResource` with its live source in the database-backed filesystem.

Today, Frames are linked to a mount path. That path changes when the source is moved or renamed. A filesystem node keeps the same ID across these operations, so `files.fileSystemNodeId` gives us a stable link between the shareable File and its source.

The new field is nullable, allowing the current GCS-based flow to continue unchanged. It has an index for node-based lookups and a foreign key using `ON DELETE RESTRICT`, so a filesystem node cannot disappear while a File still points to it.

This PR only introduces the schema and Sequelize association. Publishing, file-explorer enrichment, moves, and deletion behavior will follow in separate PRs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

 - [ ] Run SQL migration
 - [ ] Deploy front
