### PR TITLE
Bind Frames to database filesystem nodes

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -182,8 +182,9 @@ export function loadAllModels() {
     ProviderModel,
     CloneModel,
     KeyModel,
-    FileModel,
+    // FileSystemNodeModel first: files references it through fileSystemNodeId.
     FileSystemNodeModel,
+    FileModel,
     FileSystemMutationModel,
     FileSystemBlobCleanupModel,
     SandboxFunctionModel,

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -26,7 +26,7 @@ import { formatValidationWarningsForLLM } from "@app/lib/api/files/content_valid
 import { exportInteractiveContentFileAsPdf } from "@app/lib/api/files/pdf_export";
 import { screenshotInteractiveContentFile } from "@app/lib/api/files/screenshot";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
-import { publishFrame } from "@app/lib/api/viz/publish_frame";
+import { publishFrameFromFileSystem } from "@app/lib/api/viz/publish_frame";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { splitFrameEntryScopedPath } from "@app/types/mount_path";
@@ -411,7 +411,8 @@ export async function createInteractiveContentTools(
         );
       }
 
-      const result = await publishFrame(auth, {
+      const result = await publishFrameFromFileSystem(auth, {
+        dustFileSystem: fsResult.value,
         file,
         reader: createMountFrameSourceReader(fsResult.value, root),
         entryRelPath,

--- a/front/lib/api/file_system/backends/database_file_system_backend.test.ts
+++ b/front/lib/api/file_system/backends/database_file_system_backend.test.ts
@@ -3,14 +3,17 @@ import { text } from "node:stream/consumers";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import { FileSystemScope } from "@app/lib/api/file_system/namespace_scope";
 import { DATABASE_FILE_SYSTEM_POD_PREFIX } from "@app/lib/api/file_system/storage_mode";
+import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
 import { Authenticator } from "@app/lib/auth";
 import { FileSystemMutationResource } from "@app/lib/resources/file_system_mutation_resource";
 import { FileSystemNodeResource } from "@app/lib/resources/file_system_node_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { frameContentType } from "@app/types/files";
 import assert from "assert";
 import { describe, expect, it } from "vitest";
 
@@ -144,6 +147,148 @@ describe("DatabaseFileSystemBackend", () => {
       rootId: pod.sId,
       name: "report.txt",
     });
+  });
+
+  it("resolves a stored node id to wherever the file lives now", async () => {
+    const { conversation, dustFileSystem, pod } = await databaseFileSystem();
+    fileStorageMock.setFileMetadata(() => ({
+      size: "5",
+      contentType: "text/plain",
+      contentEncoding: "identity",
+    }));
+    const written = await dustFileSystem.write(
+      `conversation-${conversation.sId}/report.txt`,
+      "hello",
+      "text/plain"
+    );
+    assert(written.isOk() && written.value.nodeId !== null);
+    const { nodeId } = written.value;
+
+    // This is what a feature stores, and what it holds after the file moves.
+    expect(
+      await dustFileSystem.nodeIdForPath(
+        `conversation-${conversation.sId}/report.txt`
+      )
+    ).toEqual(expect.objectContaining({ value: nodeId }));
+
+    const moved = await dustFileSystem.move({
+      src: `conversation-${conversation.sId}/report.txt`,
+      dest: `pod-${pod.sId}/moved.txt`,
+    });
+    assert(moved.isOk());
+
+    const current = await dustFileSystem.pathForNodeId(nodeId);
+    expect(current).toEqual(
+      expect.objectContaining({ value: `pod-${pod.sId}/moved.txt` })
+    );
+  });
+
+  it("refuses to delete a node while a file is still bound to it", async () => {
+    const { auth, conversation, dustFileSystem } = await databaseFileSystem();
+    fileStorageMock.setFileMetadata(() => ({
+      size: "5",
+      contentType: "text/plain",
+      contentEncoding: "identity",
+    }));
+    const path = `conversation-${conversation.sId}/report.txt`;
+    const written = await dustFileSystem.write(path, "hello", "text/plain");
+    assert(written.isOk() && written.value.nodeId !== null);
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: "text/plain",
+      fileName: "report.txt",
+      fileSize: 5,
+      // Not "ready": deleting a ready file also clears its stored content, which
+      // this test has no reason to exercise.
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+    await file.bindToFileSystemNode(written.value.nodeId);
+
+    const blocked = await dustFileSystem.delete(path);
+
+    assert(blocked.isErr());
+  });
+
+  it("enriches a database file entry from its node id", async () => {
+    const { auth, conversation, dustFileSystem } = await databaseFileSystem();
+    fileStorageMock.setFileMetadata(() => ({
+      size: "5",
+      contentType: "text/typescript",
+      contentEncoding: "identity",
+    }));
+    const path = `conversation-${conversation.sId}/Frame.tsx`;
+    const written = await dustFileSystem.write(
+      path,
+      "hello",
+      "text/typescript"
+    );
+    assert(written.isOk() && written.value.nodeId !== null);
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: frameContentType,
+      fileName: "Frame.tsx",
+      fileSize: 5,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+    await file.bindToFileSystemNode(written.value.nodeId);
+
+    const listed = await dustFileSystem.list(
+      `conversation-${conversation.sId}`
+    );
+    assert(listed.isOk());
+    const enriched = await enrichListWithFileResourceIds(
+      auth,
+      dustFileSystem,
+      listed.value
+    );
+
+    expect(enriched).toContainEqual(
+      expect.objectContaining({
+        path,
+        fileSystemNodeId: written.value.nodeId,
+        fileId: file.sId,
+        contentType: frameContentType,
+      })
+    );
+  });
+
+  it("deletes a node once the file bound to it is gone", async () => {
+    const { auth, conversation, dustFileSystem } = await databaseFileSystem();
+    fileStorageMock.setFileMetadata(() => ({
+      size: "5",
+      contentType: "text/plain",
+      contentEncoding: "identity",
+    }));
+    const path = `conversation-${conversation.sId}/report.txt`;
+    const written = await dustFileSystem.write(path, "hello", "text/plain");
+    assert(written.isOk() && written.value.nodeId !== null);
+    const file = await FileFactory.create(auth, auth.getNonNullableUser(), {
+      contentType: "text/plain",
+      fileName: "report.txt",
+      fileSize: 5,
+      status: "created",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+    await file.bindToFileSystemNode(written.value.nodeId);
+
+    const deleted = await file.delete(auth);
+    assert(deleted.isOk());
+
+    expect((await dustFileSystem.delete(path)).isOk()).toBe(true);
+  });
+
+  it("reports not_found for a path with nothing on it", async () => {
+    const { conversation, dustFileSystem } = await databaseFileSystem();
+
+    const missing = await dustFileSystem.nodeIdForPath(
+      `conversation-${conversation.sId}/absent.txt`
+    );
+
+    assert(missing.isErr());
+    expect(missing.error.code).toBe("not_found");
   });
 
   it("preserves the inode while moving a file from a conversation to its Pod", async () => {

--- a/front/lib/api/file_system/backends/database_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/database_file_system_backend.ts
@@ -211,6 +211,7 @@ export class DatabaseFileSystemBackend implements FileSystemBackend {
         node.contentType ?? DEFAULT_CONTENT_TYPE
       ),
       lastModifiedMs: node.updatedAt.getTime(),
+      fileSystemNodeId: node.id,
       fileId: null,
       thumbnailUrl: null,
     };
@@ -336,6 +337,55 @@ export class DatabaseFileSystemBackend implements FileSystemBackend {
   ): Promise<Result<boolean, DustFileSystemError>> {
     try {
       return new Ok((await this.resolve(scopedPath)) !== null);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async nodeIdForPath(
+    scopedPath: string
+  ): Promise<Result<number | null, DustFileSystemError>> {
+    try {
+      const resolved = await this.resolve(scopedPath);
+      if (!resolved) {
+        return new Err(
+          new DustFileSystemError(
+            "not_found",
+            `No file or directory at: ${scopedPath}`
+          )
+        );
+      }
+      return new Ok(resolved.node.id);
+    } catch (error) {
+      return new Err(this.error(error));
+    }
+  }
+
+  async pathForNodeId(
+    nodeId: number
+  ): Promise<Result<string | null, DustFileSystemError>> {
+    try {
+      const node = await FileSystemNodeResource.fetchById(
+        this.auth,
+        this.scope,
+        nodeId
+      );
+      if (!node) {
+        return new Err(
+          new DustFileSystemError("not_found", "The node no longer exists.")
+        );
+      }
+      const path = (await node.pathSegmentsFromRoot()).join("/");
+      // The node may have moved to a root this file system does not mount.
+      if (!this.parse(path)) {
+        return new Err(
+          new DustFileSystemError(
+            "not_found",
+            "The node lives outside this file system."
+          )
+        );
+      }
+      return new Ok(path);
     } catch (error) {
       return new Err(this.error(error));
     }

--- a/front/lib/api/file_system/backends/file_system_backend.ts
+++ b/front/lib/api/file_system/backends/file_system_backend.ts
@@ -72,6 +72,24 @@ export interface FileSystemBackend {
   exists(scopedPath: string): Promise<Result<boolean, DustFileSystemError>>;
 
   /**
+   * The id of the node at `scopedPath`, or `Err("not_found")` when nothing is
+   * there. Backends without nodes return `Ok(null)`.
+   */
+  nodeIdForPath(
+    scopedPath: string
+  ): Promise<Result<number | null, DustFileSystemError>>;
+
+  /**
+   * The current scoped path of the node with this id, following every move and
+   * rename since the id was stored. `Err("not_found")` when the node no longer
+   * exists or lives outside this file system's mounts. Backends without nodes
+   * return `Ok(null)`.
+   */
+  pathForNodeId(
+    nodeId: number
+  ): Promise<Result<string | null, DustFileSystemError>>;
+
+  /**
    * When `content` is a `Readable`, the data is streamed to storage without buffering it in
    * memory; the stream is consumed (or destroyed on error) by the backend.
    */

--- a/front/lib/api/file_system/backends/gcs_file_system_backend.ts
+++ b/front/lib/api/file_system/backends/gcs_file_system_backend.ts
@@ -386,6 +386,14 @@ export class GCSFileSystemBackend implements FileSystemBackend {
     }
   }
 
+  async nodeIdForPath(): Promise<Result<number | null, DustFileSystemError>> {
+    return new Ok(null);
+  }
+
+  async pathForNodeId(): Promise<Result<string | null, DustFileSystemError>> {
+    return new Ok(null);
+  }
+
   async write(
     scopedPath: string,
     content: Buffer | string | Readable,

--- a/front/lib/api/file_system/dust_file_system.ts
+++ b/front/lib/api/file_system/dust_file_system.ts
@@ -250,6 +250,11 @@ export class DustFileSystem {
     );
   }
 
+  /** Whether this instance uses the database namespace rather than GCS paths. */
+  isDatabaseBacked(): boolean {
+    return this.storageMode === "database";
+  }
+
   // --------------------------------------------------------------------------
   // Factories
   // --------------------------------------------------------------------------
@@ -947,6 +952,32 @@ export class DustFileSystem {
    * When `content` is a `Readable`, the data is streamed to storage without buffering it in
    * memory; the stream is consumed (or destroyed on error) by the backend.
    */
+  async nodeIdForPath(
+    scopedPath: string
+  ): Promise<Result<number | null, DustFileSystemError>> {
+    const resolved = this.requireReadMount(scopedPath);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    return this.backend.nodeIdForPath(scopedPath);
+  }
+
+  async pathForNodeId(
+    nodeId: number
+  ): Promise<Result<string | null, DustFileSystemError>> {
+    const path = await this.backend.pathForNodeId(nodeId);
+    if (path.isErr() || path.value === null) {
+      return path;
+    }
+    // The mount check runs on the resolved path: the id may name a node in a
+    // root this caller cannot read.
+    const resolved = this.requireReadMount(path.value);
+    if (resolved.isErr()) {
+      return resolved;
+    }
+    return path;
+  }
+
   async write(
     scopedPath: string,
     content: Buffer | string | Readable,

--- a/front/lib/api/files/client_executable.ts
+++ b/front/lib/api/files/client_executable.ts
@@ -1,3 +1,4 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import {
   validateTailwindCode,
@@ -18,6 +19,7 @@ import { executeWithLock } from "@app/lib/lock";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
+import { conversationScopedPath } from "@app/types/file_system";
 import type { InteractiveContentFileContentType } from "@app/types/files";
 import {
   INTERACTIVE_CONTENT_FILE_FORMATS,
@@ -131,6 +133,31 @@ export async function createClientExecutableFile(
         lastEditedByAgentConfigurationId: createdByAgentConfigurationId,
       },
     });
+
+    // The GCS flow below already writes its mount copy from uploadFrameContent.
+    // The database filesystem needs an explicit node for the live source.
+    const scopedPath = conversationScopedPath({
+      conversationId,
+      rel: fileResource.fileName,
+    });
+    const fsResult = await DustFileSystem.fromScopedPath(auth, scopedPath);
+    if (fsResult.isErr()) {
+      return new Err({ message: fsResult.error.message, tracked: true });
+    }
+
+    if (fsResult.value.isDatabaseBacked()) {
+      const written = await fsResult.value.write(scopedPath, content, mimeType);
+      if (written.isErr()) {
+        return new Err({ message: written.error.message, tracked: true });
+      }
+      if (written.value.nodeId === null) {
+        return new Err({
+          message: "The database filesystem did not return a node id.",
+          tracked: true,
+        });
+      }
+      await fileResource.bindToFileSystemNode(written.value.nodeId);
+    }
 
     // Upload content directly.
     const uploadResult = await uploadFrameContent(auth, fileResource, content);

--- a/front/lib/api/files/file_system_ops.test.ts
+++ b/front/lib/api/files/file_system_ops.test.ts
@@ -1,0 +1,65 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { enrichListWithFileResourceIds } from "@app/lib/api/files/file_system_ops";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { FileSystemEntry } from "@app/types/api/file_system/types";
+import { frameContentType } from "@app/types/files";
+import assert from "assert";
+import { describe, expect, it } from "vitest";
+
+describe("enrichListWithFileResourceIds", () => {
+  it("keeps the mount-path lookup for GCS files", async () => {
+    const {
+      authenticator: auth,
+      user,
+      workspace,
+    } = await createResourceTest({});
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agent.sId,
+      messagesCreatedAt: [],
+    });
+    const dustFsRes = await DustFileSystem.forConversation(auth, conversation);
+    assert(dustFsRes.isOk());
+    expect(dustFsRes.value.isDatabaseBacked()).toBe(false);
+
+    const path = `conversation-${conversation.sId}/Frame.tsx`;
+    const mountFilePath =
+      `w/${workspace.sId}/conversations/${conversation.sId}` +
+      "/files/Frame.tsx";
+    const file = await FileFactory.create(auth, user, {
+      contentType: frameContentType,
+      fileName: "Frame.tsx",
+      fileSize: 10,
+      mountFilePath,
+      status: "ready",
+      useCase: "conversation",
+      useCaseMetadata: { conversationId: conversation.sId },
+    });
+    const entries: FileSystemEntry[] = [
+      {
+        isDirectory: false,
+        fileName: "Frame.tsx",
+        path,
+        sizeBytes: 10,
+        contentType: "text/typescript",
+        lastModifiedMs: Date.now(),
+        fileId: null,
+        thumbnailUrl: null,
+      },
+    ];
+
+    const enriched = await enrichListWithFileResourceIds(
+      auth,
+      dustFsRes.value,
+      entries
+    );
+
+    expect(enriched[0]).toMatchObject({
+      fileId: file.sId,
+      contentType: frameContentType,
+    });
+  });
+});

--- a/front/lib/api/files/file_system_ops.ts
+++ b/front/lib/api/files/file_system_ops.ts
@@ -1,5 +1,5 @@
 /**
- * High-level file system operations that combine DustFileSystem (GCS) with
+ * High-level file system operations that combine DustFileSystem with
  * FileResource (DB) sync. Used by the unified `/files/path/` endpoint and the
  * files MCP tools.
  */
@@ -9,7 +9,10 @@ import { decodeBuffer } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
-import type { FileSystemEntry } from "@app/types/api/file_system/types";
+import type {
+  FileSystemEntry,
+  FileSystemFileEntry,
+} from "@app/types/api/file_system/types";
 import {
   DustFileSystemError,
   SCOPED_PREFIX_CONVERSATION,
@@ -138,11 +141,12 @@ export async function streamThumbnail(
 // ---------------------------------------------------------------------------
 
 /**
- * Enrich a list of file entries with their linked FileResource sId (fileId).
- * A single batch DB query covers all entries; pod files probe the legacy projects/ path too.
+ * Enrich file entries with the linked FileResource id and content type.
+ * Database-backed files use their stable node id. Path-only GCS files keep the
+ * mount-path lookup, including the legacy projects/ variant for pod files.
  *
  * Intended for endpoints that expose file listings to the client (conversation files,
- * pod files) where the fileId is needed to open frames.
+ * pod files) where the FileResource marks a source file as a Frame.
  */
 export async function enrichListWithFileResourceIds(
   auth: Authenticator,
@@ -154,7 +158,56 @@ export async function enrichListWithFileResourceIds(
     return entries;
   }
 
-  // Collect all GCS paths to probe, including legacy projects/ variants for pod files.
+  if (dustFs.isDatabaseBacked()) {
+    return enrichDatabaseFileEntries(auth, entries, fileEntries);
+  }
+
+  return enrichGCSFileEntries(auth, dustFs, entries, fileEntries);
+}
+
+async function enrichDatabaseFileEntries(
+  auth: Authenticator,
+  entries: FileSystemEntry[],
+  fileEntries: FileSystemFileEntry[]
+): Promise<FileSystemEntry[]> {
+  const nodeIds = fileEntries.flatMap((entry) =>
+    entry.fileSystemNodeId === undefined ? [] : [entry.fileSystemNodeId]
+  );
+  if (nodeIds.length === 0) {
+    return entries;
+  }
+
+  const nodeFiles = await FileResource.fetchByFileSystemNodeIds(auth, nodeIds);
+
+  const byNodeId = new Map<number, FileResource>();
+  for (const file of nodeFiles) {
+    if (file.fileSystemNodeId !== null) {
+      byNodeId.set(file.fileSystemNodeId, file);
+    }
+  }
+
+  return entries.map((entry) => {
+    if (entry.isDirectory) {
+      return entry;
+    }
+    if (entry.fileSystemNodeId !== undefined) {
+      const file = byNodeId.get(entry.fileSystemNodeId);
+      return {
+        ...entry,
+        fileId: file?.sId ?? null,
+        contentType: file?.contentType ?? entry.contentType,
+      };
+    }
+    return entry;
+  });
+}
+
+async function enrichGCSFileEntries(
+  auth: Authenticator,
+  dustFs: DustFileSystem,
+  entries: FileSystemEntry[],
+  fileEntries: FileSystemFileEntry[]
+): Promise<FileSystemEntry[]> {
   const mountPaths: string[] = [];
   for (const entry of fileEntries) {
     const gcsPath = dustFs.toMountFilePath(entry.path);
@@ -166,21 +219,15 @@ export async function enrichListWithFileResourceIds(
       }
     }
   }
-
   if (mountPaths.length === 0) {
     return entries;
   }
 
-  const fileResources = await FileResource.fetchByMountFilePaths(
-    auth,
-    mountPaths
-  );
-
-  // Map every known mountFilePath to its FileResource sId.
-  const byMountPath = new Map<string, string>();
-  for (const fr of fileResources) {
-    if (fr.mountFilePath) {
-      byMountPath.set(fr.mountFilePath, fr.sId);
+  const pathFiles = await FileResource.fetchByMountFilePaths(auth, mountPaths);
+  const byMountPath = new Map<string, FileResource>();
+  for (const file of pathFiles) {
+    if (file.mountFilePath) {
+      byMountPath.set(file.mountFilePath, file);
     }
   }
 
@@ -193,9 +240,13 @@ export async function enrichListWithFileResourceIds(
       return entry;
     }
     const legacyPath = gcsPath.replace(/\/pods\//, "/projects/");
-    const fileId =
+    const file =
       byMountPath.get(gcsPath) ?? byMountPath.get(legacyPath) ?? null;
-    return { ...entry, fileId };
+    return {
+      ...entry,
+      fileId: file?.sId ?? null,
+      contentType: file?.contentType ?? entry.contentType,
+    };
   });
 }
 

--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -11,7 +11,7 @@ import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
-import { publishFrame } from "@app/lib/api/viz/publish_frame";
+import { publishFrameFromFileSystem } from "@app/lib/api/viz/publish_frame";
 import type { Authenticator } from "@app/lib/auth";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
@@ -614,7 +614,8 @@ export async function importPodApp(
       continue;
     }
 
-    const publishResult = await publishFrame(auth, {
+    const publishResult = await publishFrameFromFileSystem(auth, {
+      dustFileSystem: dustFs,
       file: created.file,
       reader: createMountFrameSourceReader(dustFs, destFolderPath),
       entryRelPath: created.fileName,

--- a/front/lib/api/viz/edit_frame_text.test.ts
+++ b/front/lib/api/viz/edit_frame_text.test.ts
@@ -43,8 +43,15 @@ beforeEach(() => {
 });
 
 // In-memory DustFileSystem standing in for the mount. Keys are full scoped paths.
-function mockMount(files: Map<string, string>) {
+function mockMount(
+  files: Map<string, string>,
+  {
+    databaseBacked = false,
+    nodePath = null,
+  }: { databaseBacked?: boolean; nodePath?: string | null } = {}
+) {
   const fakeFs = {
+    isDatabaseBacked: () => databaseBacked,
     readBuffer: async (p: string) =>
       new Ok(files.has(p) ? Buffer.from(files.get(p)!, "utf-8") : null),
     stat: async (p: string) =>
@@ -63,6 +70,8 @@ function mockMount(files: Map<string, string>) {
           .filter((p) => p.startsWith(`${root}/`))
           .map((p) => ({ path: p, isDirectory: false }))
       ),
+    pathForNodeId: async () => new Ok(nodePath),
+    nodeIdForPath: async () => new Ok(databaseBacked ? 42 : null),
   };
   vi.spyOn(DustFileSystem, "fromScopedPath").mockResolvedValue(
     new Ok(fakeFs as unknown as DustFileSystem)
@@ -127,6 +136,70 @@ describe("editFrameTextAtSource", () => {
       expect(uploadBundleSpy).toHaveBeenCalledTimes(1);
       expect(uploadBundleSpy.mock.calls[0][1]).toContain("Revenue");
       expect(file.getRenderableVersion()).toBe("processed");
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    "uses the entry node after the Frame is moved and renamed",
+    async () => {
+      const { authenticator: auth } = await createResourceTest({});
+      const file = await createPublishedFrame(auth);
+      const movedRoot = "conversation-conv_x/moved";
+      const movedEntry = `${movedRoot}/Renamed.tsx`;
+      const files = mockMount(new Map([[movedEntry, ENTRY_SOURCE]]), {
+        databaseBacked: true,
+        nodePath: movedEntry,
+      });
+      Object.defineProperty(file, "fileSystemNodeId", { value: 42 });
+
+      vi.spyOn(FileResource.prototype, "getSharedReadStream").mockReturnValue(
+        Readable.from([Buffer.from(ENTRY_SOURCE, "utf-8")])
+      );
+      const sourceSpy = vi
+        .spyOn(file, "setPublishedFrameSource")
+        .mockResolvedValue([1]);
+
+      const result = await editFrameTextAtSource(auth, {
+        file,
+        source: "Renamed.tsx:4:8",
+        oldText: "Sales",
+        newText: "Revenue",
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(files.get(movedEntry)).toContain("<h1>Revenue</h1>");
+      expect(sourceSpy).toHaveBeenCalledWith(
+        auth,
+        expect.objectContaining({ fileSystemNodeId: 42 })
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  it(
+    "does not use the old path when the entry node is gone",
+    async () => {
+      const { authenticator: auth } = await createResourceTest({});
+      const file = await createPublishedFrame(auth);
+      const files = mockMount(
+        new Map([[`${ROOT}/Dashboard.tsx`, ENTRY_SOURCE]]),
+        { databaseBacked: true, nodePath: null }
+      );
+      Object.defineProperty(file, "fileSystemNodeId", { value: 42 });
+
+      const result = await editFrameTextAtSource(auth, {
+        file,
+        source: "Dashboard.tsx:4:8",
+        oldText: "Sales",
+        newText: "Revenue",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("source_not_found");
+      }
+      expect(files.get(`${ROOT}/Dashboard.tsx`)).toBe(ENTRY_SOURCE);
     },
     TEST_TIMEOUT_MS
   );

--- a/front/lib/api/viz/edit_frame_text.ts
+++ b/front/lib/api/viz/edit_frame_text.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
@@ -5,7 +6,7 @@ import {
   parseSourceLocation,
   replaceJsxTextAtSourceLocation,
 } from "@app/lib/api/viz/edit_source_text";
-import { publishFrame } from "@app/lib/api/viz/publish_frame";
+import { publishFrameFromFileSystem } from "@app/lib/api/viz/publish_frame";
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { Result } from "@app/types/shared/result";
@@ -40,17 +41,17 @@ class EditFrameTextError extends Error {
  * SOURCE file in the mount, then rebuild the Frame so the rendered bundle reflects the change.
  *
  * Steps:
- * 1. Resolve the Frame's build root from `frameBundleRootPath` (only published Frames have one and
- *    thus carry `data-source` tags).
+ * 1. Resolve the Frame's current entry path from its file system node. Older Frames use the path
+ *    saved when they were published.
  * 2. Read the addressed source file from the mount and splice the new text by AST location.
  * 3. Write the updated source back to the mount (the durable source of truth).
- * 4. Rebuild via {@link publishFrame}, which re-reads the import graph, re-bundles, refreshes the
- *    rendered version, and recomputes the share allowlist. A text-only edit changes neither
- *    imports nor data refs, but rebuilding keeps the bundle and the source in lock-step.
+ * 4. Rebuild via {@link publishFrameFromFileSystem}, which re-reads the import graph, re-bundles,
+ *    refreshes the rendered version, and recomputes the share allowlist. A text-only edit changes
+ *    neither imports nor data refs, but rebuilding keeps the bundle and the source in lock-step.
  *
  * Note: the mount read/modify/write is not held under the publish lock (that lock is taken by
- * {@link publishFrame} and is not reentrant). Live edits are human-paced, so a concurrent edit to
- * the same file could lose an update, which is acceptable for now.
+ * {@link publishFrameFromFileSystem} and is not reentrant). Live edits are human-paced, so a
+ * concurrent edit to the same file could lose an update, which is acceptable for now.
  */
 export async function editFrameTextAtSource(
   auth: Authenticator,
@@ -68,8 +69,8 @@ export async function editFrameTextAtSource(
     editedByAgentConfigurationId?: string;
   }
 ): Promise<Result<{ warnings: ValidationWarning[] }, EditFrameTextError>> {
-  const root = file.useCaseMetadata?.frameBundleRootPath;
-  if (!file.isInteractiveContent || !root) {
+  const storedRoot = file.useCaseMetadata?.frameBundleRootPath;
+  if (!file.isInteractiveContent || !storedRoot) {
     return new Err(
       new EditFrameTextError(
         "not_published",
@@ -89,8 +90,8 @@ export async function editFrameTextAtSource(
   }
 
   try {
-    const rootScopedPath = root.replace(/\/+$/, "");
-    const scopedPath = `${rootScopedPath}/${location.relPath}`;
+    let rootScopedPath = storedRoot.replace(/\/+$/, "");
+    let entryRelPath = file.useCaseMetadata?.frameEntryRelPath ?? file.fileName;
 
     const fsResult = await DustFileSystem.fromScopedPath(auth, rootScopedPath);
     if (fsResult.isErr()) {
@@ -99,6 +100,34 @@ export async function editFrameTextAtSource(
       );
     }
     const dustFs = fsResult.value;
+
+    // The entry node follows the Frame when it is moved or renamed. The saved
+    // path is only used by Frames published before node ids were recorded.
+    const entryNodeId = file.fileSystemNodeId;
+    if (entryNodeId !== null) {
+      const currentEntryRes = await dustFs.pathForNodeId(entryNodeId);
+      if (currentEntryRes.isErr()) {
+        return new Err(
+          new EditFrameTextError(
+            "source_not_found",
+            currentEntryRes.error.message
+          )
+        );
+      }
+      if (currentEntryRes.value === null) {
+        return new Err(
+          new EditFrameTextError(
+            "source_not_found",
+            "The Frame source no longer exists."
+          )
+        );
+      }
+
+      rootScopedPath = path.posix.dirname(currentEntryRes.value);
+      entryRelPath = path.posix.basename(currentEntryRes.value);
+    }
+
+    const scopedPath = `${rootScopedPath}/${location.relPath}`;
 
     const bufferResult = await dustFs.readBuffer(scopedPath);
     if (bufferResult.isErr()) {
@@ -144,11 +173,8 @@ export async function editFrameTextAtSource(
       );
     }
 
-    // Falls back to fileName for Frames published before frameEntryRelPath existed.
-    const entryRelPath =
-      file.useCaseMetadata?.frameEntryRelPath ?? file.fileName;
-
-    const publishResult = await publishFrame(auth, {
+    const publishResult = await publishFrameFromFileSystem(auth, {
+      dustFileSystem: dustFs,
       file,
       reader: createMountFrameSourceReader(dustFs, rootScopedPath),
       entryRelPath,

--- a/front/lib/api/viz/publish_frame.ts
+++ b/front/lib/api/viz/publish_frame.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+import type { DustFileSystem } from "@app/lib/api/file_system";
 import type { ValidationWarning } from "@app/lib/api/files/content_validation";
 import {
   validateTailwindCode,
@@ -46,6 +48,69 @@ function shouldValidate(relPath: string): boolean {
 }
 
 /**
+ * Publish from a mounted source. Database files are bound to the entry node;
+ * GCS files keep using their saved path.
+ */
+export async function publishFrameFromFileSystem(
+  auth: Authenticator,
+  {
+    dustFileSystem,
+    file,
+    reader,
+    entryRelPath,
+    rootScopedPath,
+    publishedByAgentConfigurationId,
+  }: {
+    dustFileSystem: DustFileSystem;
+    file: FileResource;
+    reader: FrameSourceReader;
+    entryRelPath: string;
+    rootScopedPath: string;
+    publishedByAgentConfigurationId?: string;
+  }
+): Promise<Result<{ warnings: ValidationWarning[] }, PublishFrameError>> {
+  if (!dustFileSystem.isDatabaseBacked()) {
+    return publishFrame(auth, {
+      file,
+      reader,
+      entryRelPath,
+      rootScopedPath,
+      publishedByAgentConfigurationId,
+    });
+  }
+
+  const entryPath = path.posix.join(rootScopedPath, entryRelPath);
+  const entryNodeIdRes = await dustFileSystem.nodeIdForPath(entryPath);
+  if (entryNodeIdRes.isErr()) {
+    return new Err(
+      new PublishFrameError(
+        entryNodeIdRes.error.code === "not_found"
+          ? "entry_not_found"
+          : "internal",
+        entryNodeIdRes.error.message
+      )
+    );
+  }
+  if (entryNodeIdRes.value === null) {
+    return new Err(
+      new PublishFrameError(
+        "internal",
+        "The database filesystem did not return a node id."
+      )
+    );
+  }
+
+  return publishFrame(auth, {
+    file,
+    reader,
+    entryRelPath,
+    rootScopedPath,
+    entryNodeId: entryNodeIdRes.value,
+    publishedByAgentConfigurationId,
+  });
+}
+
+/**
  * Publish a Frame: build its source tree into a single bundle and make it the rendered version.
  *
  * Steps, under the per-file edit lock:
@@ -71,12 +136,15 @@ export async function publishFrame(
     reader,
     entryRelPath,
     rootScopedPath,
+    entryNodeId,
     publishedByAgentConfigurationId,
   }: {
     file: FileResource;
     reader: FrameSourceReader;
     entryRelPath: string;
     rootScopedPath: string;
+    // Only database-backed files have a stable entry node.
+    entryNodeId?: number;
     publishedByAgentConfigurationId?: string;
   }
 ): Promise<Result<{ warnings: ValidationWarning[] }, PublishFrameError>> {
@@ -188,7 +256,7 @@ export async function publishFrame(
       await file.uploadProcessed(auth, buildResult.value.code);
       // frameBundleRootPath and frameEntryRelPath flip rendering to the bundle and let live
       // edits rebuild later without a model in the loop.
-      await file.setUseCaseMetadata(auth, {
+      const metadata = {
         ...(file.useCaseMetadata ?? {}),
         frameBundleRootPath: rootScopedPath,
         frameEntryRelPath: entryRelPath,
@@ -197,7 +265,15 @@ export async function publishFrame(
               lastEditedByAgentConfigurationId: publishedByAgentConfigurationId,
             }
           : {}),
-      });
+      };
+      if (entryNodeId === undefined) {
+        await file.setUseCaseMetadata(auth, metadata);
+      } else {
+        await file.setPublishedFrameSource(auth, {
+          fileSystemNodeId: entryNodeId,
+          metadata,
+        });
+      }
 
       // 5. Recompute the allowlist against the rendered bundle.
       const allowlist = await ensureAuthorizedFileAccessForShare(auth, file);

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -2,11 +2,7 @@
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 import config from "@app/lib/api/config";
-import {
-  SCOPED_PREFIX_CONVERSATION,
-  SCOPED_PREFIX_POD,
-  sanitizeFileSystemName,
-} from "@app/lib/api/file_system";
+import { sanitizeFileSystemName } from "@app/lib/api/file_system";
 import { DustFileSystem } from "@app/lib/api/file_system/dust_file_system";
 import {
   getProcessedContentType,
@@ -54,6 +50,10 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import { CoreAPI } from "@app/types/core/core_api";
+import {
+  SCOPED_PREFIX_CONVERSATION,
+  SCOPED_PREFIX_POD,
+} from "@app/types/file_system";
 import type {
   AuthorizedFileAccessAllowlist,
   AuthorizedFileRef,
@@ -433,6 +433,24 @@ export class FileResource extends BaseResource<FileModel> {
     });
 
     return files.map((f) => new this(this.model, f.get()));
+  }
+
+  static async fetchByFileSystemNodeIds(
+    auth: Authenticator,
+    fileSystemNodeIds: number[]
+  ): Promise<FileResource[]> {
+    if (fileSystemNodeIds.length === 0) {
+      return [];
+    }
+
+    const files = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        fileSystemNodeId: { [Op.in]: fileSystemNodeIds },
+      },
+    });
+
+    return files.map((file) => new this(this.model, file.get()));
   }
 
   static async deleteAllForWorkspace(auth: Authenticator) {
@@ -1154,6 +1172,24 @@ export class FileResource extends BaseResource<FileModel> {
     return result;
   }
 
+  async setPublishedFrameSource(
+    auth: Authenticator,
+    {
+      metadata,
+      fileSystemNodeId,
+    }: {
+      metadata: FileUseCaseMetadata;
+      fileSystemNodeId: number;
+    }
+  ) {
+    const result = await this.update({
+      useCaseMetadata: metadata,
+      fileSystemNodeId,
+    });
+    await this.resolveAndSetMountFilePath(auth);
+    return result;
+  }
+
   /**
    * Public entry point to trigger mount path resolution. Idempotent — no-ops when a path is
    * already set or when the file's use case isn't mount-eligible. Used by backfill scripts.
@@ -1470,6 +1506,11 @@ export class FileResource extends BaseResource<FileModel> {
       fileName: sanitizeFileSystemName(newFileName),
       mountFilePath: newMountFilePath,
     });
+  }
+
+  // Binds this file to the Dust file system node holding its live source.
+  bindToFileSystemNode(fileSystemNodeId: number) {
+    return this.update({ fileSystemNodeId });
   }
 
   updateMount({

--- a/front/lib/resources/file_system_node_resource.ts
+++ b/front/lib/resources/file_system_node_resource.ts
@@ -496,6 +496,42 @@ export class FileSystemNodeResource extends BaseResource<FileSystemNodeModel> {
     });
   }
 
+  // The node names from the root row down to this node, root name included.
+  // Joined with "/" they form the node's scoped path, since a root row carries
+  // its scoped prefix as its name. Follows parentId with recursive SQL for the
+  // same reason as isAncestorOf below: each row only stores its parent.
+  async pathSegmentsFromRoot(): Promise<string[]> {
+    // biome-ignore lint/plugin/noRawSql: Sequelize cannot follow parentId until the root.
+    const rows = await frontSequelize.query<{ name: string; depth: number }>(
+      `
+        WITH RECURSIVE ancestors AS (
+          SELECT "id", "parentId", "name", 0 AS "depth"
+          FROM "file_system_nodes"
+          WHERE "workspaceId" = :workspaceId AND "id" = :nodeId
+
+          UNION ALL
+
+          SELECT parent."id", parent."parentId", parent."name", child."depth" + 1
+          FROM "file_system_nodes" parent
+          JOIN ancestors child ON parent."id" = child."parentId"
+          WHERE parent."workspaceId" = :workspaceId
+        )
+        SELECT "name", "depth"
+        FROM ancestors
+        ORDER BY "depth" DESC
+      `,
+      {
+        type: QueryTypes.SELECT,
+        replacements: {
+          workspaceId: this.workspaceId,
+          nodeId: this.id,
+        },
+      }
+    );
+
+    return rows.map((row) => row.name);
+  }
+
   private async isAncestorOf(
     possibleDescendant: FileSystemNodeResource,
     transaction: Transaction

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -10,6 +10,7 @@ import {
   literal,
   Op,
 } from "@app/lib/resources/storage/data_types";
+import { FileSystemNodeModel } from "@app/lib/resources/storage/models/file_system_node";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -36,6 +37,9 @@ export class FileModel extends WorkspaceAwareModel<FileModel> {
   declare mountFilePath: string | null;
 
   declare userId: ForeignKey<UserModel["id"]> | null;
+  // The file system node holding this file's live source. For a Frame this is
+  // the published entry file. The id survives every move and rename.
+  declare fileSystemNodeId: ForeignKey<FileSystemNodeModel["id"]> | null;
 
   declare user: NonAttribute<UserModel>;
 }
@@ -112,6 +116,13 @@ FileModel.init(
         unique: true,
         where: { mountFilePath: { [Op.ne]: null } },
       },
+      // Leads with the node id: deleting a node scans files by this column
+      // alone, without a workspace in hand.
+      {
+        fields: ["fileSystemNodeId"],
+        concurrently: true,
+        where: { fileSystemNodeId: { [Op.ne]: null } },
+      },
     ],
   }
 );
@@ -120,6 +131,17 @@ UserModel.hasMany(FileModel, {
   onDelete: "RESTRICT",
 });
 FileModel.belongsTo(UserModel);
+// RESTRICT: removing a node while a file still points at it fails. Deleting the
+// file record is a decision with consequences of its own (shares, grants,
+// published bundles), so the caller must deal with the file first rather than
+// have the binding silently disappear.
+FileSystemNodeModel.hasMany(FileModel, {
+  foreignKey: { name: "fileSystemNodeId", allowNull: true },
+  onDelete: "RESTRICT",
+});
+FileModel.belongsTo(FileSystemNodeModel, {
+  foreignKey: { name: "fileSystemNodeId", allowNull: true },
+});
 
 /**
  * Shared files logic.

--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -116,8 +116,6 @@ FileModel.init(
         unique: true,
         where: { mountFilePath: { [Op.ne]: null } },
       },
-      // Leads with the node id: deleting a node scans files by this column
-      // alone, without a workspace in hand.
       {
         fields: ["fileSystemNodeId"],
         concurrently: true,
@@ -131,10 +129,6 @@ UserModel.hasMany(FileModel, {
   onDelete: "RESTRICT",
 });
 FileModel.belongsTo(UserModel);
-// RESTRICT: removing a node while a file still points at it fails. Deleting the
-// file record is a decision with consequences of its own (shares, grants,
-// published bundles), so the caller must deal with the file first rather than
-// have the binding silently disappear.
 FileSystemNodeModel.hasMany(FileModel, {
   foreignKey: { name: "fileSystemNodeId", allowNull: true },
   onDelete: "RESTRICT",

--- a/front/migrations/pre-deploy/20260819134521_add_file_system_node_id_to_files.sql
+++ b/front/migrations/pre-deploy/20260819134521_add_file_system_node_id_to_files.sql
@@ -1,0 +1,35 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."files" ADD COLUMN "fileSystemNodeId" bigint;
+
+/*
+Statement 1
+CREATE INDEX CONCURRENTLY cannot run inside a transaction, and the runner
+applies this file through psql so the session settings above do not carry an
+open transaction.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY files_file_system_node_id ON public.files USING btree ("fileSystemNodeId") WHERE ("fileSystemNodeId" IS NOT NULL);
+
+/*
+Statement 2
+RESTRICT: a node cannot be removed while a file still points at it, so the
+ordering is enforced here rather than left to callers.
+
+NOT VALID then VALIDATE: the constraint applies to new rows immediately while
+the validation scan takes only a light lock on this large table.
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."files" ADD CONSTRAINT "files_fileSystemNodeId_fkey" FOREIGN KEY ("fileSystemNodeId") REFERENCES file_system_nodes(id) ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+/*
+Statement 3
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."files" VALIDATE CONSTRAINT "files_fileSystemNodeId_fkey";

--- a/front/types/api/file_system/types.ts
+++ b/front/types/api/file_system/types.ts
@@ -20,6 +20,8 @@ export type FileSystemDirectoryEntry = FileSystemEntryBase & {
 export type FileSystemFileEntry = FileSystemEntryBase & {
   isDirectory: false;
   contentType: string;
+  /** Stable database node identity when the backing filesystem has one. */
+  fileSystemNodeId?: number;
   /** sId of the corresponding FileResource record, or null when none exists. */
   fileId: string | null;
   thumbnailUrl: string | null;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR makes a Frame follow its source file by filesystem node ID instead of relying on a path that may change.

When the database-backed filesystem is enabled, creating or publishing a Frame records the node that holds its entry file. Publishing and live editing can then find the file’s current path after it has been moved or renamed.

The file explorer also joins filesystem entries with Files by node ID. This restores the Frame MIME type and File ID needed to open the Frame drawer. The lookup is batched for the full listing. Only accepted during the PoC obviously 🙃.

The existing GCS flow remains path-based and unchanged. The storage- mode choice is kept at the top of the create and publish flows rather than spread through the lower-level Frame code.

This PR covers creation, publication, editing, and file-explorer reads. Removing a bound Frame and handling rename-over are left for the following PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
