### PR TITLE
feat: update swagger for datasource tables and agent configurations

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -896,6 +896,7 @@
                       "handle",
                       "description",
                       "scope",
+                      "avatar_url",
                       "max_steps_per_run",
                       "visualization_enabled"
                     ],
@@ -5780,9 +5781,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Table"
+                  "type": "object",
+                  "properties": {
+                    "tables": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Table"
+                      }
+                    }
                   }
                 }
               }
@@ -5882,7 +5888,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/Table"
+                  "type": "object",
+                  "properties": {
+                    "table": {
+                      "$ref": "#/components/schemas/Table"
+                    }
+                  }
                 }
               }
             }

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations/import.ts
@@ -38,6 +38,7 @@ import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
  *                   - handle
  *                   - description
  *                   - scope
+ *                   - avatar_url
  *                   - max_steps_per_run
  *                   - visualization_enabled
  *                 properties:

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/index.ts
@@ -63,9 +63,12 @@ const ParamsSchema = z.object({
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Table'
+ *               type: object
+ *               properties:
+ *                 tables:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Table'
  *       400:
  *         description: Invalid request
  *   post:
@@ -130,7 +133,10 @@ const ParamsSchema = z.object({
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/Table'
+ *               type: object
+ *               properties:
+ *                 table:
+ *                   $ref: '#/components/schemas/Table'
  *       400:
  *         description: Invalid request
  */


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10096

This PR updates the Swagger documentation to match the current API responses for datasource tables and agent configuration imports.

- Documents table list responses under `tables` and table creation responses under `table`.
- Adds `avatar_url` to the documented agent configuration import fields.

## Tests

Manually.

## Risks

Low.

## Deploy Plan

Standard deployment.