### PR TITLE
Fix sub-agent credits in message consumption

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -7287,7 +7287,7 @@
     "/api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/consumption": {
       "get": {
         "summary": "Get an agent message credit attribution",
-        "description": "Returns exact billed credits and an additive attribution reconciled exclusively through model input rows.",
+        "description": "Returns direct, recursively spawned sub-agent, and total billed credits, plus an additive attribution reconciled exclusively through model input rows.",
         "tags": [
           "Private Messages"
         ],
@@ -7337,7 +7337,15 @@
                     "billedCredits": {
                       "type": "number",
                       "nullable": true,
-                      "description": "Authoritative credits billed for this agent message."
+                      "description": "Authoritative credits billed directly for this agent message, excluding sub-agents."
+                    },
+                    "subAgentBilledCredits": {
+                      "type": "number",
+                      "description": "Credits billed by sub-agents recursively spawned from this message."
+                    },
+                    "totalBilledCredits": {
+                      "type": "number",
+                      "description": "Total credits billed by this message and its recursively spawned sub-agents."
                     },
                     "details": {
                       "type": "object",

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.test.ts
@@ -9,7 +9,8 @@ import { RunFactory } from "@app/tests/utils/RunFactory";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
-const BILLED_CREDITS = 7;
+const BILLED_CREDITS = 20;
+const SUB_AGENT_BILLED_CREDITS = 282;
 const PREVIOUS_ATTRIBUTION_VERSION =
   AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION - 1;
 
@@ -49,7 +50,14 @@ async function setupMessage() {
     costCredits: BILLED_CREDITS,
   });
 
-  return { auth, workspace, conversation, agentMessage, runUsageModelId };
+  return {
+    auth,
+    workspace,
+    conversation,
+    agentConfiguration,
+    agentMessage,
+    runUsageModelId,
+  };
 }
 
 function getConsumption({
@@ -81,6 +89,54 @@ describe("GET /api/w/:wId/assistant/conversations/:cId/messages/:mId/consumption
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({
       billedCredits: BILLED_CREDITS,
+      subAgentBilledCredits: 0,
+      totalBilledCredits: BILLED_CREDITS,
+      details: null,
+    });
+  });
+
+  it("includes credits billed by recursively spawned sub-agents", async () => {
+    const { auth, workspace, conversation, agentConfiguration, agentMessage } =
+      await setupMessage();
+    await FeatureFlagFactory.basic(auth, "conversation_consumption_details");
+
+    const childConversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: childUserMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation: childConversation,
+        content: "Run a sub-agent",
+        agenticMessageType: "run_agent",
+        agenticOriginMessageId: agentMessage.sId,
+      });
+    const { agentMessage: childAgentMessage } =
+      await ConversationFactory.createAgentMessage(auth, {
+        workspace,
+        conversation: childConversation,
+        agentConfig: agentConfiguration,
+        parentMessageModelId: childUserMessage.id,
+        rank: 1,
+      });
+    await ConversationResource.updateAgentMessageCostCredits(auth, {
+      agentMessageModelId: childAgentMessage.agentMessageId,
+      costCredits: SUB_AGENT_BILLED_CREDITS,
+    });
+
+    const response = await getConsumption({
+      workspaceId: workspace.sId,
+      conversationId: conversation.sId,
+      messageId: agentMessage.sId,
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      billedCredits: BILLED_CREDITS,
+      subAgentBilledCredits: SUB_AGENT_BILLED_CREDITS,
+      totalBilledCredits: BILLED_CREDITS + SUB_AGENT_BILLED_CREDITS,
       details: null,
     });
   });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/consumption.ts
@@ -22,7 +22,7 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  * /api/w/{wId}/assistant/conversations/{cId}/messages/{mId}/consumption:
  *   get:
  *     summary: Get an agent message credit attribution
- *     description: Returns exact billed credits and an additive attribution reconciled exclusively through model input rows.
+ *     description: Returns direct, recursively spawned sub-agent, and total billed credits, plus an additive attribution reconciled exclusively through model input rows.
  *     tags:
  *       - Private Messages
  *     parameters:
@@ -57,7 +57,13 @@ app.use(withFeatureFlag("conversation_consumption_details"));
  *                 billedCredits:
  *                   type: number
  *                   nullable: true
- *                   description: Authoritative credits billed for this agent message.
+ *                   description: Authoritative credits billed directly for this agent message, excluding sub-agents.
+ *                 subAgentBilledCredits:
+ *                   type: number
+ *                   description: Credits billed by sub-agents recursively spawned from this message.
+ *                 totalBilledCredits:
+ *                   type: number
+ *                   description: Total credits billed by this message and its recursively spawned sub-agents.
  *                 details:
  *                   type: object
  *                   nullable: true

--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -175,6 +175,28 @@ describe("CreditCostPopover", () => {
     expect(screen.getByText("7 credits")).toBeInTheDocument();
   });
 
+  it("uses the authoritative sub-agent total returned by the endpoint", () => {
+    mockUseAgentMessageConsumption.mockReturnValue({
+      consumption: {
+        billedCredits: 20,
+        subAgentBilledCredits: 282,
+        totalBilledCredits: 302,
+        details: {
+          attributionVersion: 3,
+          agentWorkCredits: 20,
+          tools: [],
+        },
+      },
+      isConsumptionLoading: false,
+      mutateConsumption: vi.fn(),
+    });
+
+    render(<CreditCostPopover {...defaultProps} subAgentCredits={0} />);
+
+    expect(screen.getByText("302 credits")).toBeInTheDocument();
+    expect(screen.getByText("282 credits")).toBeInTheDocument();
+  });
+
   it("hides the conversation consumption button when the credits panel is open", () => {
     mockSidePanelContext.currentPanel = "credits";
     mockUseAgentMessageConsumption.mockReturnValue({

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -98,8 +98,10 @@ export function CreditCostPopover({
     });
 
   const ownCredits = consumption?.billedCredits ?? credits ?? 0;
-  const childCredits = subAgentCredits ?? 0;
-  const totalCredits = ownCredits + childCredits;
+  const childCredits =
+    consumption?.subAgentBilledCredits ?? subAgentCredits ?? 0;
+  const totalCredits =
+    consumption?.totalBilledCredits ?? ownCredits + childCredits;
   const details = consumption?.details;
 
   if (totalCredits <= 0) {

--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.ts
@@ -2,7 +2,7 @@ import { AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION } from "@app/lib/api/assi
 import { buildLatestAvailableMessageConsumptionDetails } from "@app/lib/api/assistant/agent_message_consumption_attribution/message_details";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageConsumptionItemResource as ConsumptionItemResource } from "@app/lib/resources/agent_message_consumption_item_resource";
-import type { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import type { AgentMessageConsumptionResponse } from "@app/types/assistant/agent_message_consumption";
 
@@ -34,8 +34,16 @@ export async function getAgentMessageConsumption(
     return null;
   }
 
+  const subAgentBilledCredits =
+    await ConversationResource.sumSubAgentCostCreditsByMessageId(auth, {
+      agentMessageId,
+    });
+  const totalBilledCredits = (facts.billedCredits ?? 0) + subAgentBilledCredits;
+
   const unavailableResponse: AgentMessageConsumptionResponse = {
     billedCredits: facts.billedCredits,
+    subAgentBilledCredits,
+    totalBilledCredits,
     details: null,
   };
   if (facts.items.length === 0 || facts.dustRunIds.length === 0) {
@@ -66,6 +74,8 @@ export async function getAgentMessageConsumption(
 
   return {
     billedCredits: facts.billedCredits,
+    subAgentBilledCredits,
+    totalBilledCredits,
     details: messageDetails,
   };
 }

--- a/front/types/assistant/agent_message_consumption.ts
+++ b/front/types/assistant/agent_message_consumption.ts
@@ -42,5 +42,9 @@ export type AgentMessageConsumptionDetails = {
 
 export type AgentMessageConsumptionResponse = {
   billedCredits: number | null;
+  /** Credits billed by sub-agents spawned from this message. */
+  subAgentBilledCredits?: number;
+  /** Total credits billed by this message and its recursively spawned sub-agents. */
+  totalBilledCredits?: number;
   details: AgentMessageConsumptionDetails | null;
 };


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes the message credit breakdown to load the full consumption in the API endpoint over relying on the agent message in the UI. When bulk fetching we don't always have it available. This ensures we always get the same view on credit breakdown.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
