### PR TITLE
[Activation] compact UI collapse frames display

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
+++ b/front/components/assistant/conversation/AgentMessage.compactUIView.test.tsx
@@ -2,13 +2,15 @@ import { AgentMessage } from "@app/components/assistant/conversation/AgentMessag
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import type { UiView } from "@app/components/assistant/conversation/types";
 import { makeInitialMessageStreamState } from "@app/components/assistant/conversation/types";
+import { useAutoOpenSidePanel } from "@app/components/assistant/conversation/useAutoOpenSidePanel";
 import { LightWorkspaceFactory } from "@app/tests/utils/LightWorkspaceFactory";
 import type { LightAgentMessageWithActionsType } from "@app/types/assistant/conversation";
+import { frameContentType } from "@app/types/files";
 import { Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/auth/AuthContext", () => ({
   useAuth: () => ({ vizUrl: null }),
@@ -73,7 +75,7 @@ vi.mock(
 );
 
 vi.mock("@app/components/assistant/conversation/useAutoOpenSidePanel", () => ({
-  useAutoOpenSidePanel: () => ({ interactiveFiles: [] }),
+  useAutoOpenSidePanel: vi.fn(() => ({ interactiveFiles: [] })),
 }));
 
 vi.mock(
@@ -225,6 +227,55 @@ function renderAgentMessage({
 }
 
 describe("AgentMessage compact UI view", () => {
+  afterEach(() => {
+    vi.mocked(useAutoOpenSidePanel).mockReturnValue({ interactiveFiles: [] });
+  });
+
+  describe("frames", () => {
+    const frameFile = {
+      title: "My Frame",
+      contentType: frameContentType,
+      fileId: "fil_frame_1",
+      filePath: undefined,
+    };
+
+    it("renders frames collapsed by default for compact UI conversations", () => {
+      vi.mocked(useAutoOpenSidePanel).mockReturnValue({
+        interactiveFiles: [frameFile],
+      });
+
+      renderAgentMessage({ uiView: "compact" });
+
+      expect(screen.getByRole("button", { name: "Frames" })).toBeVisible();
+      expect(screen.getByText("My Frame")).not.toBeVisible();
+    });
+
+    it("expands frames on click for compact UI conversations", () => {
+      vi.mocked(useAutoOpenSidePanel).mockReturnValue({
+        interactiveFiles: [frameFile],
+      });
+
+      renderAgentMessage({ uiView: "compact" });
+
+      fireEvent.click(screen.getByRole("button", { name: "Frames" }));
+
+      expect(screen.getByText("My Frame")).toBeVisible();
+    });
+
+    it("renders frames expanded for non-compact UI conversations", () => {
+      vi.mocked(useAutoOpenSidePanel).mockReturnValue({
+        interactiveFiles: [frameFile],
+      });
+
+      renderAgentMessage({ uiView: "standard" });
+
+      expect(
+        screen.queryByRole("button", { name: "Frames" })
+      ).not.toBeInTheDocument();
+      expect(screen.getByText("My Frame")).toBeVisible();
+    });
+  });
+
   describe("bottom citations", () => {
     it("hides the bottom citation list for compact UI conversations but keeps inline citations", () => {
       const { container } = renderAgentMessage({

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1422,6 +1422,7 @@ function AgentMessageContent({
         {blockedActionElement}
         <AgentMessageInteractiveContentGeneratedFiles
           files={interactiveFiles}
+          collapsible={uiView === "compact"}
         />
         {allImages.length > 0 && <InteractiveImageGrid images={allImages} />}
 

--- a/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
+++ b/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
@@ -124,6 +124,7 @@ export function AgentMessageInteractiveContentGeneratedFiles({
   return (
     <div className="flex flex-col text-sm">
       <button
+        type="button"
         className="self-start text-muted-foreground hover:text-foreground transition-colors duration-200 flex gap-1 items-center"
         onClick={() => setIsCollapsed((c) => !c)}
       >

--- a/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
+++ b/front/components/assistant/conversation/AgentMessageGeneratedFiles.tsx
@@ -1,3 +1,4 @@
+import { getCollapseAnimationStyle } from "@app/components/assistant/conversation/actions/inline/utils";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { formatCalendarDate } from "@app/lib/utils/timestamps";
 import type { LightAgentMessageType } from "@app/types/assistant/conversation";
@@ -8,12 +9,15 @@ import {
 import { getTime } from "@app/types/shared/utils/date_utils";
 import {
   ActionFrame,
+  ChevronRight,
   Citation,
   CitationDescription,
   CitationGrid,
   CitationTitle,
+  cn,
   Icon,
 } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 function getDescriptionForContentType(
   file: LightAgentMessageType["generatedFiles"][number]
@@ -33,20 +37,23 @@ interface AgentMessageInteractiveContentGeneratedFilesProps {
   files: LightAgentMessageType["generatedFiles"];
   onClick?: () => void;
   variant?: "list" | "grid";
+  collapsible?: boolean;
 }
 
 export function AgentMessageInteractiveContentGeneratedFiles({
   files,
   onClick,
   variant = "list",
+  collapsible = false,
 }: AgentMessageInteractiveContentGeneratedFilesProps) {
   const { openPanel } = useConversationSidePanelContext();
+  const [isCollapsed, setIsCollapsed] = useState(collapsible);
 
   if (files.length === 0) {
     return null;
   }
 
-  return (
+  const grid = (
     <CitationGrid variant={variant}>
       {files.map((file) => {
         if (!file.fileId) {
@@ -108,5 +115,34 @@ export function AgentMessageInteractiveContentGeneratedFiles({
         );
       })}
     </CitationGrid>
+  );
+
+  if (!collapsible) {
+    return grid;
+  }
+
+  return (
+    <div className="flex flex-col text-sm">
+      <button
+        className="self-start text-muted-foreground hover:text-foreground transition-colors duration-200 flex gap-1 items-center"
+        onClick={() => setIsCollapsed((c) => !c)}
+      >
+        Frames
+        <span
+          className={cn(
+            "transition-transform duration-200 ease-out",
+            isCollapsed ? "rotate-0" : "rotate-90"
+          )}
+        >
+          <Icon size="xs" visual={ChevronRight} />
+        </span>
+      </button>
+      <div
+        className="grid ease-out"
+        style={getCollapseAnimationStyle(isCollapsed)}
+      >
+        <div className="overflow-hidden">{grid}</div>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Description
Improve the compact conversation UI by collapsing generated Frames by default, as discussed in this pr (https://github.com/dust-tt/dust/pull/30258)

In compact conversations:
- Generated Frames are grouped under a collapsible “Frames” section.
- Frames remain hidden until the section is expanded.
- Users can expand and collapse the section interactively.

In standard conversations, Frames continue to render expanded as before.

<img width="676" height="399" alt="Screenshot 2026-08-19 at 18 28 59" src="https://github.com/user-attachments/assets/b3beaed7-b324-4d14-9002-3483eddbd65e" />

<img width="689" height="465" alt="Screenshot 2026-08-19 at 18 28 41" src="https://github.com/user-attachments/assets/30134941-6934-41df-9cfe-12504acdc52a" />



## Tests

Added component tests covering:
- Frames rendering collapsed by default in compact UI conversations.
- Expanding Frames on click.
- Frames remaining expanded in standard UI conversations.

## Risk

Low. This is a presentation-only change limited to generated Frame display in compact conversations. Standard UI behavior remains unchanged, and the change is easily reversible.

## Deploy Plan
Deploy front