### PR TITLE
Public API: allow admin to retrieve all agents including unpublished and restricted

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -367,11 +367,12 @@
             "in": "query",
             "name": "view",
             "required": false,
-            "description": "The view to use when retrieving agents:\n- all: Retrieves all non-private agents (default if not authenticated)\n- list: Retrieves all active agents accessible to the user (default if authenticated)\n- published: Retrieves all agents with published scope\n- global: Retrieves all global agents\n- favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)\n",
+            "description": "The view to use when retrieving agents:\n- all: Retrieves all non-private agents (default if not authenticated)\n- list: Retrieves all active agents accessible to the user (default if authenticated)\n- published: Retrieves all agents with published scope\n- global: Retrieves all global agents\n- favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)\n- all_unrestricted: Retrieves every active agent of the workspace, including unpublished agents the caller does not edit and agents requesting spaces the caller cannot access. Requires an admin key.\n",
             "schema": {
               "type": "string",
               "enum": [
                 "all",
+                "all_unrestricted",
                 "list",
                 "workspace",
                 "published",
@@ -424,6 +425,9 @@
           },
           "401": {
             "description": "Unauthorized. Invalid or missing authentication token, or attempting to access restricted views without authentication."
+          },
+          "403": {
+            "description": "Forbidden. The all_unrestricted view requires a workspace admin."
           },
           "404": {
             "description": "Workspace not found."

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations.test.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations.test.ts
@@ -1,0 +1,115 @@
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function listAgents(
+  workspace: { sId: string },
+  key: { secret: string },
+  query: Record<string, string> = {}
+) {
+  const qs = new URLSearchParams(query).toString();
+  return honoApp.request(
+    `/api/v1/w/${workspace.sId}/assistant/agent_configurations${qs ? `?${qs}` : ""}`,
+    { headers: { authorization: `Bearer ${key.secret}` } }
+  );
+}
+
+async function agentNames(response: Response): Promise<string[]> {
+  const {
+    agentConfigurations,
+  }: { agentConfigurations: LightAgentConfigurationType[] } =
+    await response.json();
+
+  return agentConfigurations.map((a) => a.name);
+}
+
+// Creates, as another workspace member, one published agent, one unpublished agent the API key
+// is not an editor of, and one published agent requesting a space the API key cannot read.
+async function setupTestAgents(workspace: WorkspaceType) {
+  const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  await SpaceFactory.defaults(internalAdminAuth);
+
+  const agentOwner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, agentOwner, { role: "builder" });
+  const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    agentOwner.sId,
+    workspace.sId
+  );
+
+  const restrictedSpace = await SpaceFactory.regular(workspace);
+
+  await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
+    name: "Published Agent",
+    scope: "visible",
+  });
+  await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
+    name: "Unpublished Agent",
+    scope: "hidden",
+  });
+  await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
+    name: "Restricted Space Agent",
+    scope: "visible",
+    requestedSpaceIds: [restrictedSpace.id],
+  });
+}
+
+describe("GET /api/v1/w/[wId]/assistant/agent_configurations", () => {
+  it("returns unpublished and restricted space agents with the all_unrestricted view", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    await setupTestAgents(workspace);
+
+    const response = await listAgents(workspace, key, {
+      view: "all_unrestricted",
+    });
+
+    expect(response.status).toBe(200);
+    const names = await agentNames(response);
+    expect(names).toContain("Published Agent");
+    expect(names).toContain("Unpublished Agent");
+    expect(names).toContain("Restricted Space Agent");
+  });
+
+  it("hides unpublished and restricted space agents with the all view", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "admin",
+    });
+    await setupTestAgents(workspace);
+
+    const response = await listAgents(workspace, key, { view: "all" });
+
+    expect(response.status).toBe(200);
+    const names = await agentNames(response);
+    expect(names).toContain("Published Agent");
+    expect(names).not.toContain("Unpublished Agent");
+    expect(names).not.toContain("Restricted Space Agent");
+  });
+
+  it("rejects the all_unrestricted view for non-admin keys", async () => {
+    const { workspace, key } = await createPublicApiMockRequest({
+      role: "builder",
+    });
+
+    const response = await listAgents(workspace, key, {
+      view: "all_unrestricted",
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: {
+        type: "app_auth_error",
+        message: "Only admins can list all agents of the workspace.",
+      },
+    });
+  });
+});

--- a/front-api/routes/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/agent_configurations.ts
@@ -13,7 +13,15 @@ import search from "./agent_configurations/search";
 
 const GetAgentConfigurationsQuerySchema = z.object({
   view: z
-    .enum(["all", "list", "workspace", "published", "global", "favorites"])
+    .enum([
+      "all",
+      "all_unrestricted",
+      "list",
+      "workspace",
+      "published",
+      "global",
+      "favorites",
+    ])
     .optional(),
   withAuthors: z.enum(["true", "false"]).optional(),
 });
@@ -46,9 +54,10 @@ const viewRequiresUser = (view?: string): boolean =>
  *           - published: Retrieves all agents with published scope
  *           - global: Retrieves all global agents
  *           - favorites: Retrieves all agents marked as favorites by the user (only available to authenticated users)
+ *           - all_unrestricted: Retrieves every active agent of the workspace, including unpublished agents the caller does not edit and agents requesting spaces the caller cannot access. Requires an admin key.
  *         schema:
  *           type: string
- *           enum: [all, list, workspace, published, global, favorites]
+ *           enum: [all, all_unrestricted, list, workspace, published, global, favorites]
  *       - in: query
  *         name: withAuthors
  *         required: false
@@ -75,6 +84,8 @@ const viewRequiresUser = (view?: string): boolean =>
  *         description: Bad Request. Missing or invalid parameters.
  *       401:
  *         description: Unauthorized. Invalid or missing authentication token, or attempting to access restricted views without authentication.
+ *       403:
+ *         description: Forbidden. The all_unrestricted view requires a workspace admin.
  *       404:
  *         description: Workspace not found.
  *       500:
@@ -106,14 +117,31 @@ app.get(
       });
     }
 
+    if (view === "all_unrestricted" && !auth.isAdmin()) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only admins can list all agents of the workspace.",
+        },
+      });
+    }
+
     const defaultAgentGetView = auth.user() ? "list" : "all";
     const agentsGetView = view ?? defaultAgentGetView;
     const withAuthors = withAuthorsParam === "true";
 
+    // `admin_internal` lifts the scope restrictions (unpublished agents the caller does not
+    // edit), and skipping the permission filtering lifts the space ones.
+    const isUnrestricted = agentsGetView === "all_unrestricted";
+
     let agentConfigurations = await getAgentConfigurationsForView({
       auth,
-      agentsGetView: normalizeAgentView(agentsGetView),
+      agentsGetView: isUnrestricted
+        ? "admin_internal"
+        : normalizeAgentView(agentsGetView),
       variant: "light",
+      dangerouslySkipPermissionFiltering: isUnrestricted,
     });
 
     if (withAuthors) {

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -954,7 +954,13 @@ const AgentConfigurationScopeSchema = FlexibleEnumSchema<
 >();
 
 export const AgentConfigurationViewSchema = FlexibleEnumSchema<
-  "all" | "list" | "workspace" | "published" | "global" | "favorites"
+  | "all"
+  | "all_unrestricted"
+  | "list"
+  | "workspace"
+  | "published"
+  | "global"
+  | "favorites"
 >();
 
 export type AgentConfigurationViewType = z.infer<


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/10131

Add a new scope to the `GET /api/v1/w/{wId}/assistant/agent_configurations?view=list` API which is `all_unrestricted` and allows admin to fetch all agents, including the one not published (owned by other users) and the one with restricted spaces.


## Tests

 - add new unit tests
 - tested manually locally

## Risk

expose unpublished data to admin via API
OK because admin is already expected to have the ability to see everything

## Deploy Plan

deploy front
