### PR TITLE
dust-hive: add restricted and unpublished agent to governance seed

### DIFF
--- a/front/scripts/seed/factories/seedAgent.ts
+++ b/front/scripts/seed/factories/seedAgent.ts
@@ -3,6 +3,7 @@ import {
   searchAgentConfigurationsByName,
 } from "@app/lib/api/assistant/configuration/agent";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 
 import type { AgentAsset, CreatedAgent, SeedContext } from "./types";
@@ -10,6 +11,12 @@ import type { AgentAsset, CreatedAgent, SeedContext } from "./types";
 interface SeedAgentOptions {
   skills?: SkillResource[];
   additionalEditors?: UserResource[];
+  // Create the agent on behalf of this user, making them its author and only editor (on top of
+  // `additionalEditors`). Defaults to the context user.
+  owner?: UserResource;
+  // Spaces the agent requires access to. Users who are not members of these spaces do not see
+  // the agent at all.
+  spaces?: SpaceResource[];
 }
 
 export async function seedAgent(
@@ -18,7 +25,7 @@ export async function seedAgent(
   options: SeedAgentOptions = {}
 ): Promise<CreatedAgent | null> {
   const { auth, user, execute, logger } = ctx;
-  const { skills = [], additionalEditors = [] } = options;
+  const { skills = [], additionalEditors = [], owner, spaces = [] } = options;
 
   const existingAgents = await searchAgentConfigurationsByName(
     auth,
@@ -35,8 +42,13 @@ export async function seedAgent(
   }
 
   if (execute) {
-    // Determine editors: main user + additional editors if specified
-    const editors = [user.toJSON()];
+    // The agent is attributed to its author and editors, but written with the context user's
+    // admin auth: seeded authors are plain workspace members, who may not hold the workspace
+    // permission to create or publish agents.
+    const author = owner ?? user;
+
+    // Determine editors: author + additional editors if specified
+    const editors = [author.toJSON()];
     if (agentAsset.sharedWithAdditionalUsers) {
       for (const additionalUser of additionalEditors) {
         editors.push(additionalUser.toJSON());
@@ -50,7 +62,7 @@ export async function seedAgent(
       instructionsHtml: null,
       pictureUrl: agentAsset.pictureUrl,
       status: "active",
-      scope: "visible",
+      scope: agentAsset.scope ?? "visible",
       model: {
         providerId: "anthropic",
         modelId: "claude-sonnet-4-6",
@@ -58,10 +70,10 @@ export async function seedAgent(
         responseFormat: agentAsset.responseFormat,
       },
       templateId: null,
-      requestedSpaceIds: [],
+      requestedSpaceIds: spaces.map((space) => space.id),
       tags: [],
       editors,
-      authorId: user.id,
+      authorId: author.id,
     });
 
     if (result.isErr()) {

--- a/front/scripts/seed/factories/seedSpace.ts
+++ b/front/scripts/seed/factories/seedSpace.ts
@@ -8,13 +8,20 @@ const RESTRICTED_SPACE_NAME = "Restricted Space";
 
 interface SeedSpaceOptions {
   name?: string;
-  // Members to add on top of the context user, who is always a member.
+  // Members to add on top of the context user.
   members?: UserResource[];
+  // Whether the context user is a member of the space. Set to false to seed a space the context
+  // user cannot access.
+  withContextUser?: boolean;
 }
 
 export async function seedSpace(
   ctx: SeedContext,
-  { name = RESTRICTED_SPACE_NAME, members = [] }: SeedSpaceOptions = {}
+  {
+    name = RESTRICTED_SPACE_NAME,
+    members = [],
+    withContextUser = true,
+  }: SeedSpaceOptions = {}
 ): Promise<SpaceResource | undefined> {
   const { auth, workspace, user, execute, logger } = ctx;
 
@@ -53,7 +60,9 @@ export async function seedSpace(
     }
     // Add the users to the group so they can access the space
     const addMemberResult = await group.dangerouslyAddMembers(auth, {
-      users: [user, ...members].map((u) => u.toJSON()),
+      users: (withContextUser ? [user, ...members] : members).map((u) =>
+        u.toJSON()
+      ),
     });
     if (addMemberResult.isErr()) {
       throw new Error(

--- a/front/scripts/seed/factories/seedUsers.ts
+++ b/front/scripts/seed/factories/seedUsers.ts
@@ -20,6 +20,25 @@ export async function seedUsers(
         { sId: existingUser.sId, email: userAsset.email },
         "User already exists, skipping creation"
       );
+      // The user may exist without being a member of the workspace, for instance when a previous
+      // seed run created them and failed before the rest of the seed. Everything downstream needs
+      // the membership, so add it back.
+      const membership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user: existingUser,
+          workspace,
+        });
+      if (!membership && execute) {
+        await MembershipResource.createMembership({
+          user: existingUser,
+          workspace,
+          role: "user",
+        });
+        logger.info(
+          { sId: existingUser.sId, email: userAsset.email },
+          "Membership created for existing user"
+        );
+      }
       createdUsers.set(userAsset.sId, existingUser);
       continue;
     }

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -1,6 +1,7 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { Logger } from "@app/logger/logger";
+import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import type { TemplateTagCodeType } from "@app/types/assistant/templates";
 import type { AgentSuggestionData } from "@app/types/suggestions/agent_suggestion";
@@ -22,6 +23,8 @@ export interface AgentAsset {
   pictureUrl: string;
   sharedWithAdditionalUsers?: boolean;
   responseFormat?: string;
+  // Defaults to "visible" (published). "hidden" makes the agent visible to its editors only.
+  scope?: Exclude<AgentConfigurationScope, "global">;
 }
 
 export interface UserAsset {

--- a/front/scripts/seed/governance/assets/agents.json
+++ b/front/scripts/seed/governance/assets/agents.json
@@ -1,8 +1,21 @@
-[
-  {
+{
+  "incidentReporter": {
     "name": "IncidentReporter",
     "description": "Writes incident postmortems from raw notes.",
     "instructions": "You help engineers turn their raw incident notes into a clean postmortem. Follow the Incident Postmortem skill for the structure of the document.",
     "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
+  },
+  "alfredUnpublishedAgent": {
+    "name": "AlfredDraft",
+    "description": "Alfred's unpublished agent, only visible to its editors.",
+    "instructions": "You are Alfred's work in progress agent. You answer questions about the Wayne Manor operations.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png",
+    "scope": "hidden"
+  },
+  "alfredPrivateSpaceAgent": {
+    "name": "AlfredVault",
+    "description": "Alfred's published agent, restricted to a space the current user cannot access.",
+    "instructions": "You answer questions using the documents of the private space.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
   }
-]
+}

--- a/front/scripts/seed/governance/seed.test.ts
+++ b/front/scripts/seed/governance/seed.test.ts
@@ -1,9 +1,10 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type { SeedContext } from "@app/scripts/seed/factories";
 import {
-  seedAgents,
+  seedAgent,
   seedSkill,
   seedSpace,
   seedUsers,
@@ -25,6 +26,7 @@ const ALFRED_USER_ID = "SeedUserAlfred";
 const BOB_USER_ID = "SeedUserBob";
 const CHARLY_USER_ID = "SeedUserCharly";
 const RESTRICTED_SPACE_NAME = "Governance Restricted Space";
+const PRIVATE_SPACE_NAME = "Governance Private Space";
 
 // Load assets from JSON files (same as seed.ts)
 function loadAssets(): Assets {
@@ -75,6 +77,11 @@ describe("governance seed script integration test", () => {
       name: RESTRICTED_SPACE_NAME,
       members: [bob!],
     });
+    const privateSpace = await seedSpace(ctx, {
+      name: PRIVATE_SPACE_NAME,
+      members: [alfred!],
+      withContextUser: false,
+    });
 
     const alfredSkill = await seedSkill(ctx, assets.skills.alfredSkill, {
       owner: alfred,
@@ -87,9 +94,23 @@ describe("governance seed script integration test", () => {
         spaces: restrictedSpace ? [restrictedSpace] : [],
       }
     );
-    const createdAgents = await seedAgents(ctx, assets.agents, {
-      skills: alfredSkill ? [alfredSkill] : [],
-    });
+    const incidentReporter = await seedAgent(
+      ctx,
+      assets.agents.incidentReporter,
+      {
+        skills: alfredSkill ? [alfredSkill] : [],
+      }
+    );
+    const alfredUnpublishedAgent = await seedAgent(
+      ctx,
+      assets.agents.alfredUnpublishedAgent,
+      { owner: alfred }
+    );
+    const alfredPrivateSpaceAgent = await seedAgent(
+      ctx,
+      assets.agents.alfredPrivateSpaceAgent,
+      { owner: alfred, spaces: privateSpace ? [privateSpace] : [] }
+    );
 
     // The groups hold the expected members, with the expected kinds.
     for (const [name, kind, expectedMembers] of [
@@ -142,12 +163,10 @@ describe("governance seed script integration test", () => {
     );
 
     // The agent is created and uses Alfred's skill.
-    expect(createdAgents.size).toBe(assets.agents.length);
-    const agent = createdAgents.get(assets.agents[0].name);
-    expect(agent).toBeDefined();
+    expect(incidentReporter).toBeDefined();
 
     const agentConfiguration = await getAgentConfiguration(authenticator, {
-      agentId: agent!.sId,
+      agentId: incidentReporter!.sId,
       variant: "full",
     });
     expect(agentConfiguration).toBeDefined();
@@ -156,5 +175,40 @@ describe("governance seed script integration test", () => {
       agentConfiguration!
     );
     expect(agentSkills.map((s) => s.sId)).toEqual([alfredSkill!.sId]);
+
+    // The private space holds Alfred only: the current user is not a member.
+    expect(privateSpace).toBeDefined();
+    expect(privateSpace!.isRegularAndRestricted()).toBe(true);
+    const privateSpaceMembers =
+      await privateSpace!.fetchDistinctActiveManualGroupMembers(authenticator);
+    expect(new Set(privateSpaceMembers.map((m) => m.sId))).toEqual(
+      new Set([alfred!.sId])
+    );
+
+    // Alfred's two agents are authored by Alfred, unpublished for the first one and requiring the
+    // private space for the second one. Neither shows up in the current user's list view.
+    expect(alfredUnpublishedAgent).toBeDefined();
+    expect(alfredPrivateSpaceAgent).toBeDefined();
+
+    const alfredAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      alfred!.sId,
+      workspace.sId
+    );
+    const unpublishedConfiguration = await getAgentConfiguration(alfredAuth, {
+      agentId: alfredUnpublishedAgent!.sId,
+      variant: "light",
+    });
+    expect(unpublishedConfiguration!.scope).toBe("hidden");
+    expect(unpublishedConfiguration!.versionAuthorId).toBe(alfred!.id);
+
+    const privateSpaceConfiguration = await getAgentConfiguration(alfredAuth, {
+      agentId: alfredPrivateSpaceAgent!.sId,
+      variant: "light",
+    });
+    expect(privateSpaceConfiguration!.scope).toBe("visible");
+    expect(privateSpaceConfiguration!.versionAuthorId).toBe(alfred!.id);
+    expect(privateSpaceConfiguration!.requestedSpaceIds).toEqual([
+      privateSpace!.sId,
+    ]);
   });
 });

--- a/front/scripts/seed/governance/seed.ts
+++ b/front/scripts/seed/governance/seed.ts
@@ -7,7 +7,7 @@ import type {
 } from "@app/scripts/seed/factories";
 import {
   createSeedContext,
-  seedAgents,
+  seedAgent,
   seedSkill,
   seedSpace,
   seedUsers,
@@ -18,7 +18,11 @@ import * as fs from "fs";
 import * as path from "path";
 
 export interface Assets {
-  agents: AgentAsset[];
+  agents: {
+    incidentReporter: AgentAsset;
+    alfredUnpublishedAgent: AgentAsset;
+    alfredPrivateSpaceAgent: AgentAsset;
+  };
   users: UserAsset[];
   skills: {
     alfredSkill: SkillAsset;
@@ -45,6 +49,7 @@ const ALFRED_USER_ID = "SeedUserAlfred";
 const BOB_USER_ID = "SeedUserBob";
 const CHARLY_USER_ID = "SeedUserCharly";
 const RESTRICTED_SPACE_NAME = "Governance Restricted Space";
+const PRIVATE_SPACE_NAME = "Governance Private Space";
 
 makeScript({}, async ({ execute }, logger) => {
   const { agents, users, skills } = loadAssets();
@@ -73,11 +78,18 @@ makeScript({}, async ({ execute }, logger) => {
   logger.info("Seeding groups...");
   await seedGovernanceGroups(ctx, { alfred, bob, charly });
 
-  // 3. Create a restricted space holding the current user and Bob.
+  // 3. Create a restricted space holding the current user and Bob, and a private space holding
+  // Alfred only, which the current user cannot access.
   logger.info("Seeding the restricted space...");
   const restrictedSpace = await seedSpace(ctx, {
     name: RESTRICTED_SPACE_NAME,
     members: bob ? [bob] : [],
+  });
+  logger.info("Seeding the private space...");
+  const privateSpace = await seedSpace(ctx, {
+    name: PRIVATE_SPACE_NAME,
+    members: alfred ? [alfred] : [],
+    withContextUser: false,
   });
 
   // 4. Open skill creation to everyone
@@ -106,10 +118,19 @@ makeScript({}, async ({ execute }, logger) => {
     spaces: restrictedSpace ? [restrictedSpace] : [],
   });
 
-  // 6. Create an agent edited by the current user that uses Alfred's unpublished skill.
+  // 6. Create an agent edited by the current user that uses Alfred's unpublished skill, plus two
+  // agents owned by Alfred that the current user does not see: an unpublished one they do not
+  // edit, and a published one requiring the private space they are not a member of.
   logger.info("Seeding agents...");
-  await seedAgents(ctx, agents, {
+  await seedAgent(ctx, agents.incidentReporter, {
     skills: alfredSkill ? [alfredSkill] : [],
+  });
+  logger.info("Seeding Alfred's unpublished agent...");
+  await seedAgent(ctx, agents.alfredUnpublishedAgent, { owner: alfred });
+  logger.info("Seeding Alfred's private space agent...");
+  await seedAgent(ctx, agents.alfredPrivateSpaceAgent, {
+    owner: alfred,
+    spaces: privateSpace ? [privateSpace] : [],
   });
 
   logger.info("Governance seed completed");


### PR DESCRIPTION
## Description

related to https://github.com/dust-tt/tasks/issues/10131

Add 2 new agents in dust hive governance seed for easier manual testing:
 - one agent with a rstricted space the main user does not have access too
 - one agent which is owned by another user and unpublished

## Tests

 - unit test updated
 - tested the seed locally

## Risk

low, it's only dust-hive seed

## Deploy Plan

none
