### PR TITLE
Use concise OpenAI reasoning summaries

### DIFF
--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -102,21 +102,6 @@ pub struct OpenAIResponseReasoningConfig {
     pub summary: Option<String>,
 }
 
-fn reasoning_summary_for_model(model_id: &str) -> &'static str {
-    let supports_concise = ["gpt-5.2", "gpt-5.4", "gpt-5.5", "gpt-5.6"]
-        .iter()
-        .any(|family| {
-            model_id == *family
-                || matches!(model_id.strip_prefix(family), Some(suffix) if suffix.starts_with('-'))
-        });
-
-    if supports_concise {
-        "concise"
-    } else {
-        "auto"
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct OpenAIResponseAPITool {
     #[serde(rename = "type")]
@@ -598,7 +583,7 @@ pub async fn openai_responses_api_completion(
         (
             Some(OpenAIResponseReasoningConfig {
                 effort: reasoning_effort,
-                summary: Some(reasoning_summary_for_model(&model_id).to_string()),
+                summary: Some("auto".to_string()),
             }),
             Some(vec!["reasoning.encrypted_content".to_string()]),
         )
@@ -1276,13 +1261,6 @@ mod tests {
         TextContentType, UserChatMessage,
     };
     use crate::providers::llm::ChatMessageRole;
-
-    #[test]
-    fn test_reasoning_summary_for_model() {
-        assert_eq!(reasoning_summary_for_model("gpt-5.2"), "concise");
-        assert_eq!(reasoning_summary_for_model("gpt-5.1"), "auto");
-        assert_eq!(reasoning_summary_for_model("o4-mini"), "auto");
-    }
 
     #[test]
     fn test_simple_text_input() {

--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -103,7 +103,14 @@ pub struct OpenAIResponseReasoningConfig {
 }
 
 fn reasoning_summary_for_model(model_id: &str) -> &'static str {
-    if model_id.starts_with("gpt-5.") {
+    let supports_concise = ["gpt-5.2", "gpt-5.4", "gpt-5.5", "gpt-5.6"]
+        .iter()
+        .any(|family| {
+            model_id == *family
+                || matches!(model_id.strip_prefix(family), Some(suffix) if suffix.starts_with('-'))
+        });
+
+    if supports_concise {
         "concise"
     } else {
         "auto"
@@ -1272,8 +1279,8 @@ mod tests {
 
     #[test]
     fn test_reasoning_summary_for_model() {
-        assert_eq!(reasoning_summary_for_model("gpt-5.6-sol"), "concise");
-        assert_eq!(reasoning_summary_for_model("gpt-5"), "auto");
+        assert_eq!(reasoning_summary_for_model("gpt-5.2"), "concise");
+        assert_eq!(reasoning_summary_for_model("gpt-5.1"), "auto");
         assert_eq!(reasoning_summary_for_model("o4-mini"), "auto");
     }
 

--- a/core/src/providers/openai_responses_api_helpers.rs
+++ b/core/src/providers/openai_responses_api_helpers.rs
@@ -102,6 +102,14 @@ pub struct OpenAIResponseReasoningConfig {
     pub summary: Option<String>,
 }
 
+fn reasoning_summary_for_model(model_id: &str) -> &'static str {
+    if model_id.starts_with("gpt-5.") {
+        "concise"
+    } else {
+        "auto"
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct OpenAIResponseAPITool {
     #[serde(rename = "type")]
@@ -583,7 +591,7 @@ pub async fn openai_responses_api_completion(
         (
             Some(OpenAIResponseReasoningConfig {
                 effort: reasoning_effort,
-                summary: Some("auto".to_string()),
+                summary: Some(reasoning_summary_for_model(&model_id).to_string()),
             }),
             Some(vec!["reasoning.encrypted_content".to_string()]),
         )
@@ -1261,6 +1269,13 @@ mod tests {
         TextContentType, UserChatMessage,
     };
     use crate::providers::llm::ChatMessageRole;
+
+    #[test]
+    fn test_reasoning_summary_for_model() {
+        assert_eq!(reasoning_summary_for_model("gpt-5.6-sol"), "concise");
+        assert_eq!(reasoning_summary_for_model("gpt-5"), "auto");
+        assert_eq!(reasoning_summary_for_model("o4-mini"), "auto");
+    }
 
     #[test]
     fn test_simple_text_input() {

--- a/front/lib/api/llm/reasoning_summary.test.ts
+++ b/front/lib/api/llm/reasoning_summary.test.ts
@@ -1,0 +1,22 @@
+import { withConciseOpenAIReasoningSummary } from "@app/lib/api/llm/reasoning_summary";
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import { describe, expect, it } from "vitest";
+
+const CONFIG: InputConfig = { reasoning: { effort: "medium" } };
+
+describe("withConciseOpenAIReasoningSummary", () => {
+  it("keeps concise summaries disabled by default", () => {
+    expect(withConciseOpenAIReasoningSummary(CONFIG, [])).toEqual(CONFIG);
+  });
+
+  it("enables concise summaries for flagged workspaces", () => {
+    expect(
+      withConciseOpenAIReasoningSummary(CONFIG, [
+        "openai_concise_reasoning_summaries",
+      ])
+    ).toEqual({
+      ...CONFIG,
+      conciseReasoningSummary: true,
+    });
+  });
+});

--- a/front/lib/api/llm/reasoning_summary.ts
+++ b/front/lib/api/llm/reasoning_summary.ts
@@ -1,0 +1,16 @@
+import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+
+const OPENAI_CONCISE_REASONING_SUMMARIES =
+  "openai_concise_reasoning_summaries" as const satisfies WhitelistableFeature;
+
+export function withConciseOpenAIReasoningSummary(
+  config: InputConfig,
+  featureFlags: WhitelistableFeature[]
+): InputConfig {
+  if (!featureFlags.includes(OPENAI_CONCISE_REASONING_SUMMARIES)) {
+    return config;
+  }
+
+  return { ...config, conciseReasoningSummary: true };
+}

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -1,5 +1,6 @@
 import type { InferenceRegionType } from "@app/lib/api/assistant/token_pricing";
 import { LLM } from "@app/lib/api/llm/llm";
+import { withConciseOpenAIReasoningSummary } from "@app/lib/api/llm/reasoning_summary";
 import type {
   BatchDeletionOutcome,
   BatchResult,
@@ -29,6 +30,7 @@ import {
 } from "@app/lib/api/llm/utils";
 import { getPromptCacheKey } from "@app/lib/api/llm/utils/prompt_cache_key";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import type { DustBatchEndpointConstructor } from "@app/lib/llms/batch/dust_batch_endpoint";
 import type { DustStreamEndpointConstructor } from "@app/lib/llms/stream/dust_stream_endpoint";
 import type { BatchEndpointConstructor } from "@app/lib/model_constructors/batch/configuration";
@@ -86,6 +88,7 @@ import type {
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
 import { getMinimumReasoningEffort } from "@app/types/assistant/models/types";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -675,6 +678,22 @@ function convertBatchEventsToOld(
  */
 abstract class BaseTransition extends LLM {
   protected override readonly router = "new" as const;
+  private featureFlagsPromise: Promise<WhitelistableFeature[]> | undefined;
+
+  protected async withFeatureFlaggedInputConfig(
+    config: InputConfig,
+    host: Host
+  ): Promise<InputConfig> {
+    if (host !== OPENAI_RESPONSES_HOST) {
+      return config;
+    }
+
+    this.featureFlagsPromise ??= getFeatureFlags(this.authenticator);
+    return withConciseOpenAIReasoningSummary(
+      config,
+      await this.featureFlagsPromise
+    );
+  }
 
   // Builds the provider-agnostic conversation payload (system + messages) shared
   // by both the streaming and batch surfaces.
@@ -841,7 +860,7 @@ export class StreamEndpointTransition extends BaseTransition {
     };
   }
 
-  protected buildStreamRequestPayload(
+  protected async buildStreamRequestPayload(
     streamParameters: LLMStreamParameters,
     metadata?: LLMStreamMetadata
   ) {
@@ -856,14 +875,19 @@ export class StreamEndpointTransition extends BaseTransition {
     // https://docs.x.ai/developers/advanced-api-usage/prompt-caching/maximizing-cache-hits
     // (verified 2026-08-12). Other surfaces guard `cacheKey` to undefined.
     const cacheKey = getPromptCacheKeyForHost(api, metadata);
-    return this.model.buildRequestPayload(
-      this.buildPayload(streamParameters, { explicitTailBreakpoint }),
+    const config = await this.withFeatureFlaggedInputConfig(
       this.buildConfig(
         streamParameters,
         this.model.constructor.configSchema,
         this.endpointConstructor.configParsers,
         cacheKey
-      )
+      ),
+      api
+    );
+
+    return this.model.buildRequestPayload(
+      this.buildPayload(streamParameters, { explicitTailBreakpoint }),
+      config
     );
   }
 
@@ -913,9 +937,9 @@ export class NoopStreamTransition extends StreamEndpointTransition {
     this.noopMetaData = llmParameters.modelInfo.metaData;
   }
 
-  protected override buildStreamRequestPayload(
+  protected override async buildStreamRequestPayload(
     streamParameters: LLMStreamParameters
-  ): NoopRequest {
+  ): Promise<NoopRequest> {
     const request = this.noopModel.buildRequestPayload(
       this.buildPayload(streamParameters)
     );
@@ -1000,10 +1024,18 @@ export class BatchEndpointTransition extends BaseTransition {
 
   // Builds the per-request payload for tracing (the base class captures batch
   // inputs via this hook). Streaming itself is never invoked on a batch LLM.
-  protected buildStreamRequestPayload(streamParameters: LLMStreamParameters) {
+  protected async buildStreamRequestPayload(
+    streamParameters: LLMStreamParameters
+  ) {
+    const { host } = this.model.metadata();
+    const config = await this.withFeatureFlaggedInputConfig(
+      this.buildConfig(streamParameters, this.model.constructor.configSchema),
+      host
+    );
+
     return this.model.buildRequestPayload(
       this.buildPayload(streamParameters),
-      this.buildConfig(streamParameters, this.model.constructor.configSchema)
+      config
     );
   }
 
@@ -1016,13 +1048,17 @@ export class BatchEndpointTransition extends BaseTransition {
   protected override async internalSendBatchProcessing(
     conversations: Map<string, LLMStreamParameters>
   ): Promise<string> {
+    const { host } = this.model.metadata();
     const requests = new Map<string, BatchRequest>();
     for (const [customId, streamParameters] of conversations) {
       requests.set(customId, {
         payload: this.buildPayload(streamParameters),
-        config: this.buildConfig(
-          streamParameters,
-          this.model.constructor.configSchema
+        config: await this.withFeatureFlaggedInputConfig(
+          this.buildConfig(
+            streamParameters,
+            this.model.constructor.configSchema
+          ),
+          host
         ),
       });
     }

--- a/front/lib/model_constructors/batch/clients/openai_responses.ts
+++ b/front/lib/model_constructors/batch/clients/openai_responses.ts
@@ -3,6 +3,7 @@ import type {
   BatchStatus,
 } from "@app/lib/model_constructors/batch/endpoint";
 import { BatchEndpoint } from "@app/lib/model_constructors/batch/endpoint";
+import { openAIReasoningSummaryForModel } from "@app/lib/model_constructors/providers/openai/reasoning_summary";
 import { WithOpenAIResponsesInputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/input";
 import { WithOpenAIResponsesOutputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/output";
 import { responseToEvents } from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
@@ -10,6 +11,7 @@ import type { Credentials } from "@app/lib/model_constructors/types/credentials"
 import { OPENAI_RESPONSES_HOST } from "@app/lib/model_constructors/types/hosts";
 import type { InputConfig } from "@app/lib/model_constructors/types/input/configuration";
 import { OPENAI_LAB } from "@app/lib/model_constructors/types/labs";
+import type { Model } from "@app/lib/model_constructors/types/models";
 import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -66,6 +68,10 @@ export abstract class OpenAIResponsesBatch extends WithOpenAIResponsesInputConve
   constructor({ OPENAI_API_KEY }: Credentials) {
     super();
     this.apiKey = OPENAI_API_KEY;
+  }
+
+  protected override reasoningSummaryForModel(model: Model) {
+    return openAIReasoningSummaryForModel(model);
   }
 
   // Lazy: `baseUrl` is an abstract field, only set after subclass initializers run.

--- a/front/lib/model_constructors/batch/clients/openai_responses.ts
+++ b/front/lib/model_constructors/batch/clients/openai_responses.ts
@@ -70,8 +70,11 @@ export abstract class OpenAIResponsesBatch extends WithOpenAIResponsesInputConve
     this.apiKey = OPENAI_API_KEY;
   }
 
-  protected override reasoningSummaryForModel(model: Model) {
-    return openAIReasoningSummaryForModel(model);
+  protected override reasoningSummaryForModel(
+    model: Model,
+    conciseReasoningSummary: boolean
+  ) {
+    return openAIReasoningSummaryForModel(model, conciseReasoningSummary);
   }
 
   // Lazy: `baseUrl` is an abstract field, only set after subclass initializers run.

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six.test.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six.test.ts
@@ -1,6 +1,7 @@
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
 import { DustOpenAIGptFiveDotSixTerraLongContextGlobalOpenAIResponsesStream } from "@app/lib/llms/stream/endpoints/openai_gpt_five_dot_six_terra_long_context_global_openai_responses";
 import { isEndpointAvailable } from "@app/lib/llms/stream/utils/is_endpoint_available";
+import { OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch } from "@app/lib/model_constructors/batch/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses";
 import { OpenAIGptFiveDotSixLunaEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_eu_openai_responses";
 import { OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_luna_global_openai_responses";
 import { OpenAIGptFiveDotSixSolEuropeOpenAIResponsesStream } from "@app/lib/model_constructors/stream/endpoints/openai_gpt_five_dot_six_sol_eu_openai_responses";
@@ -88,6 +89,25 @@ describe("GPT 5.6 model configurations", () => {
     expect(GPT_5_6_TERRA_LONG_CONTEXT_MODEL_CONFIG.contextSize).toBe(1_050_000);
     expect(payload.model).toBe("gpt-5.6-terra");
     expect(payload.max_output_tokens).toBe(128_000);
+  });
+
+  it("requests concise reasoning summaries for streaming and batch", () => {
+    const config =
+      OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream.configSchema.parse({});
+    const payload = { conversation: { system: [], messages: [] } };
+    const stream = new OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream({
+      OPENAI_API_KEY: "test",
+    });
+    const batch = new OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesBatch({
+      OPENAI_API_KEY: "test",
+    });
+
+    expect(stream.buildRequestPayload(payload, config).reasoning?.summary).toBe(
+      "concise"
+    );
+    expect(batch.buildRequestPayload(payload, config).reasoning?.summary).toBe(
+      "concise"
+    );
   });
 
   it("gates the Terra long-context endpoint behind its feature flag", () => {

--- a/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six.test.ts
+++ b/front/lib/model_constructors/providers/openai/models/gpt_five_dot_six.test.ts
@@ -91,9 +91,10 @@ describe("GPT 5.6 model configurations", () => {
     expect(payload.max_output_tokens).toBe(128_000);
   });
 
-  it("requests concise reasoning summaries for streaming and batch", () => {
+  it("requests concise reasoning summaries for streaming and batch when enabled", () => {
     const config =
       OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream.configSchema.parse({});
+    const conciseConfig = { ...config, conciseReasoningSummary: true };
     const payload = { conversation: { system: [], messages: [] } };
     const stream = new OpenAIGptFiveDotSixLunaGlobalOpenAIResponsesStream({
       OPENAI_API_KEY: "test",
@@ -103,11 +104,14 @@ describe("GPT 5.6 model configurations", () => {
     });
 
     expect(stream.buildRequestPayload(payload, config).reasoning?.summary).toBe(
-      "concise"
+      "auto"
     );
-    expect(batch.buildRequestPayload(payload, config).reasoning?.summary).toBe(
-      "concise"
-    );
+    expect(
+      stream.buildRequestPayload(payload, conciseConfig).reasoning?.summary
+    ).toBe("concise");
+    expect(
+      batch.buildRequestPayload(payload, conciseConfig).reasoning?.summary
+    ).toBe("concise");
   });
 
   it("gates the Terra long-context endpoint behind its feature flag", () => {

--- a/front/lib/model_constructors/providers/openai/reasoning_summary.test.ts
+++ b/front/lib/model_constructors/providers/openai/reasoning_summary.test.ts
@@ -3,11 +3,12 @@ import { GPT_5_1, GPT_5_2 } from "@app/lib/model_constructors/types/models";
 import { describe, expect, it } from "vitest";
 
 describe("openAIReasoningSummaryForModel", () => {
-  it("uses concise summaries starting with GPT-5.2", () => {
-    expect(openAIReasoningSummaryForModel(GPT_5_2)).toBe("concise");
+  it("uses concise summaries for supported models when enabled", () => {
+    expect(openAIReasoningSummaryForModel(GPT_5_2, true)).toBe("concise");
   });
 
-  it("retains automatic summaries for GPT-5.1", () => {
-    expect(openAIReasoningSummaryForModel(GPT_5_1)).toBe("auto");
+  it("retains automatic summaries when disabled or unsupported", () => {
+    expect(openAIReasoningSummaryForModel(GPT_5_2, false)).toBe("auto");
+    expect(openAIReasoningSummaryForModel(GPT_5_1, true)).toBe("auto");
   });
 });

--- a/front/lib/model_constructors/providers/openai/reasoning_summary.test.ts
+++ b/front/lib/model_constructors/providers/openai/reasoning_summary.test.ts
@@ -1,0 +1,13 @@
+import { openAIReasoningSummaryForModel } from "@app/lib/model_constructors/providers/openai/reasoning_summary";
+import { GPT_5, GPT_5_6_SOL } from "@app/lib/model_constructors/types/models";
+import { describe, expect, it } from "vitest";
+
+describe("openAIReasoningSummaryForModel", () => {
+  it("uses concise summaries for OpenAI models after GPT-5", () => {
+    expect(openAIReasoningSummaryForModel(GPT_5_6_SOL)).toBe("concise");
+  });
+
+  it("retains automatic summaries for GPT-5", () => {
+    expect(openAIReasoningSummaryForModel(GPT_5)).toBe("auto");
+  });
+});

--- a/front/lib/model_constructors/providers/openai/reasoning_summary.test.ts
+++ b/front/lib/model_constructors/providers/openai/reasoning_summary.test.ts
@@ -1,13 +1,13 @@
 import { openAIReasoningSummaryForModel } from "@app/lib/model_constructors/providers/openai/reasoning_summary";
-import { GPT_5, GPT_5_6_SOL } from "@app/lib/model_constructors/types/models";
+import { GPT_5_1, GPT_5_2 } from "@app/lib/model_constructors/types/models";
 import { describe, expect, it } from "vitest";
 
 describe("openAIReasoningSummaryForModel", () => {
-  it("uses concise summaries for OpenAI models after GPT-5", () => {
-    expect(openAIReasoningSummaryForModel(GPT_5_6_SOL)).toBe("concise");
+  it("uses concise summaries starting with GPT-5.2", () => {
+    expect(openAIReasoningSummaryForModel(GPT_5_2)).toBe("concise");
   });
 
-  it("retains automatic summaries for GPT-5", () => {
-    expect(openAIReasoningSummaryForModel(GPT_5)).toBe("auto");
+  it("retains automatic summaries for GPT-5.1", () => {
+    expect(openAIReasoningSummaryForModel(GPT_5_1)).toBe("auto");
   });
 });

--- a/front/lib/model_constructors/providers/openai/reasoning_summary.ts
+++ b/front/lib/model_constructors/providers/openai/reasoning_summary.ts
@@ -25,11 +25,13 @@ const MODELS_WITH_CONCISE_REASONING_SUMMARIES: ReadonlySet<Model> = new Set([
 ]);
 
 export function openAIReasoningSummaryForModel(
-  model: Model
+  model: Model,
+  conciseReasoningSummary: boolean
 ): OpenAIReasoningSummary {
   // OpenAI introduced concise reasoning summaries with GPT-5.2.
   // https://developers.openai.com/api/docs/guides/reasoning#reasoning-summaries
-  return MODELS_WITH_CONCISE_REASONING_SUMMARIES.has(model)
+  return conciseReasoningSummary &&
+    MODELS_WITH_CONCISE_REASONING_SUMMARIES.has(model)
     ? "concise"
     : "auto";
 }

--- a/front/lib/model_constructors/providers/openai/reasoning_summary.ts
+++ b/front/lib/model_constructors/providers/openai/reasoning_summary.ts
@@ -1,0 +1,10 @@
+import type { OpenAIReasoningSummary } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
+import type { Model } from "@app/lib/model_constructors/types/models";
+
+export function openAIReasoningSummaryForModel(
+  model: Model
+): OpenAIReasoningSummary {
+  // Concise summaries are supported by OpenAI reasoning models after GPT-5.
+  // https://developers.openai.com/api/docs/guides/reasoning#reasoning-summaries
+  return model.startsWith("gpt-5.") ? "concise" : "auto";
+}

--- a/front/lib/model_constructors/providers/openai/reasoning_summary.ts
+++ b/front/lib/model_constructors/providers/openai/reasoning_summary.ts
@@ -1,10 +1,35 @@
 import type { OpenAIReasoningSummary } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
 import type { Model } from "@app/lib/model_constructors/types/models";
+import {
+  GPT_5_2,
+  GPT_5_4,
+  GPT_5_4_MINI,
+  GPT_5_4_NANO,
+  GPT_5_5,
+  GPT_5_6_LUNA,
+  GPT_5_6_SOL,
+  GPT_5_6_TERRA,
+  GPT_5_6_TERRA_LONG_CONTEXT,
+} from "@app/lib/model_constructors/types/models";
+
+const MODELS_WITH_CONCISE_REASONING_SUMMARIES: ReadonlySet<Model> = new Set([
+  GPT_5_2,
+  GPT_5_4,
+  GPT_5_4_MINI,
+  GPT_5_4_NANO,
+  GPT_5_5,
+  GPT_5_6_SOL,
+  GPT_5_6_TERRA,
+  GPT_5_6_TERRA_LONG_CONTEXT,
+  GPT_5_6_LUNA,
+]);
 
 export function openAIReasoningSummaryForModel(
   model: Model
 ): OpenAIReasoningSummary {
-  // Concise summaries are supported by OpenAI reasoning models after GPT-5.
+  // OpenAI introduced concise reasoning summaries with GPT-5.2.
   // https://developers.openai.com/api/docs/guides/reasoning#reasoning-summaries
-  return model.startsWith("gpt-5.") ? "concise" : "auto";
+  return MODELS_WITH_CONCISE_REASONING_SUMMARIES.has(model)
+    ? "concise"
+    : "auto";
 }

--- a/front/lib/model_constructors/providers/xai/models/grok_four_dot_six.test.ts
+++ b/front/lib/model_constructors/providers/xai/models/grok_four_dot_six.test.ts
@@ -71,6 +71,18 @@ describe("Grok 4.6 model configuration", () => {
     expect(payload.prompt_cache_key).toBe("workspace:agent");
   });
 
+  it("retains automatic reasoning summaries", () => {
+    const endpoint = new XaiGrokFourDotSixGlobalXaiStream({
+      XAI_API_KEY: "test",
+    });
+    const payload = endpoint.buildRequestPayload(
+      { conversation: { system: [], messages: [] } },
+      XaiGrokFourDotSixGlobalXaiStream.configSchema.parse({})
+    );
+
+    expect(payload.reasoning?.summary).toBe("auto");
+  });
+
   it("keeps short and long-context pricing in sync", () => {
     expect(XaiGrokFourDotSixGlobalXaiStream.tokenPricing).toEqual({
       cacheHit: 0.5,

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -55,7 +55,10 @@ export function WithOpenAIResponsesInputConverter<
       assistantProviderPassthroughMessageToInputItems;
     modelToHostModel = (modelId: Model): string => modelId;
 
-    protected reasoningSummaryForModel(_model: Model): OpenAIReasoningSummary {
+    protected reasoningSummaryForModel(
+      _model: Model,
+      _conciseReasoningSummary: boolean
+    ): OpenAIReasoningSummary {
       return "auto";
     }
 
@@ -86,11 +89,15 @@ export function WithOpenAIResponsesInputConverter<
         cacheKey,
         forceTool,
         toolSearchEnabled,
+        conciseReasoningSummary = false,
       } = config;
 
       const reasoningConfig = reasoningToOpenAIResponsesReasoning(
         reasoning,
-        this.reasoningSummaryForModel(this.constructor.model)
+        this.reasoningSummaryForModel(
+          this.constructor.model,
+          conciseReasoningSummary
+        )
       );
       const openAITools = toolSpecsToOpenAITools(tools, {
         forceTool,

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/index.ts
@@ -1,6 +1,9 @@
 import type { Client } from "@app/lib/model_constructors/client";
 import { includesOpenAIToolSearchTool } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/tool_search";
-import type { MessageItemConverters } from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
+import type {
+  MessageItemConverters,
+  OpenAIReasoningSummary,
+} from "@app/lib/model_constructors/sdk/openai_responses/converters/input/utils";
 import {
   assistantProviderPassthroughMessageToInputItems,
   assistantReasoningMessageToInputItems,
@@ -52,6 +55,10 @@ export function WithOpenAIResponsesInputConverter<
       assistantProviderPassthroughMessageToInputItems;
     modelToHostModel = (modelId: Model): string => modelId;
 
+    protected reasoningSummaryForModel(_model: Model): OpenAIReasoningSummary {
+      return "auto";
+    }
+
     conversationToInput(
       conversation: Payload["conversation"]
     ): ResponseInputItem[] {
@@ -81,7 +88,10 @@ export function WithOpenAIResponsesInputConverter<
         toolSearchEnabled,
       } = config;
 
-      const reasoningConfig = reasoningToOpenAIResponsesReasoning(reasoning);
+      const reasoningConfig = reasoningToOpenAIResponsesReasoning(
+        reasoning,
+        this.reasoningSummaryForModel(this.constructor.model)
+      );
       const openAITools = toolSpecsToOpenAITools(tools, {
         forceTool,
         toolSearchEnabled: toolSearchEnabled ?? false,

--- a/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/input/utils.ts
@@ -32,6 +32,8 @@ import type {
 } from "openai/resources/responses/responses";
 import type { Reasoning as OpenAIReasoning } from "openai/resources/shared";
 
+export type OpenAIReasoningSummary = NonNullable<OpenAIReasoning["summary"]>;
+
 type PromptCacheBreakpoint =
   | {
       prompt_cache_breakpoint: NonNullable<
@@ -368,15 +370,16 @@ export function outputFormatToResponseFormat(
 }
 
 export function reasoningToOpenAIResponsesReasoning(
-  reasoning: Reasoning | undefined
+  reasoning: Reasoning | undefined,
+  summary: OpenAIReasoningSummary = "auto"
 ): OpenAIReasoning | undefined {
   if (!reasoning) {
     return undefined;
   }
 
   if (reasoning.effort === "maximal") {
-    return { effort: "max", summary: "auto" };
+    return { effort: "max", summary };
   }
 
-  return { effort: reasoning.effort, summary: "auto" };
+  return { effort: reasoning.effort, summary };
 }

--- a/front/lib/model_constructors/stream/clients/openai_responses.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.ts
@@ -1,4 +1,5 @@
 import { OPENAI_SUPPORTED_REASONING_EFFORTS } from "@app/lib/model_constructors/providers/openai/reasoning_efforts";
+import { openAIReasoningSummaryForModel } from "@app/lib/model_constructors/providers/openai/reasoning_summary";
 import { WithOpenAIResponsesInputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/input";
 import { WithOpenAIResponsesOutputConverter } from "@app/lib/model_constructors/sdk/openai_responses/converters/output";
 import { rawOutputToEvents } from "@app/lib/model_constructors/sdk/openai_responses/converters/output/utils";
@@ -7,6 +8,7 @@ import type { Credentials } from "@app/lib/model_constructors/types/credentials"
 import { OPENAI_RESPONSES_HOST } from "@app/lib/model_constructors/types/hosts";
 import { inputConfigSchema } from "@app/lib/model_constructors/types/input/configuration";
 import { OPENAI_LAB } from "@app/lib/model_constructors/types/labs";
+import type { Model } from "@app/lib/model_constructors/types/models";
 import type { ModelResponseEvent } from "@app/lib/model_constructors/types/output/events";
 // Do not remove: front-api routes call into this client for the similar skill
 // and similar agent discovery features. Without an explicit version front-api can silently
@@ -47,6 +49,10 @@ export abstract class OpenAIResponsesStream extends WithOpenAIResponsesInputConv
   constructor({ OPENAI_API_KEY }: Credentials) {
     super();
     this.apiKey = OPENAI_API_KEY;
+  }
+
+  protected override reasoningSummaryForModel(model: Model) {
+    return openAIReasoningSummaryForModel(model);
   }
 
   // Lazy: `baseUrl` is an abstract field, only set after subclass initializers run.

--- a/front/lib/model_constructors/stream/clients/openai_responses.ts
+++ b/front/lib/model_constructors/stream/clients/openai_responses.ts
@@ -51,8 +51,11 @@ export abstract class OpenAIResponsesStream extends WithOpenAIResponsesInputConv
     this.apiKey = OPENAI_API_KEY;
   }
 
-  protected override reasoningSummaryForModel(model: Model) {
-    return openAIReasoningSummaryForModel(model);
+  protected override reasoningSummaryForModel(
+    model: Model,
+    conciseReasoningSummary: boolean
+  ) {
+    return openAIReasoningSummaryForModel(model, conciseReasoningSummary);
   }
 
   // Lazy: `baseUrl` is an abstract field, only set after subclass initializers run.

--- a/front/lib/model_constructors/types/input/configuration.ts
+++ b/front/lib/model_constructors/types/input/configuration.ts
@@ -41,6 +41,7 @@ export type ToolSpecification = z.infer<typeof toolSpecificationSchema>;
 export const inputConfigSchema = z.object({
   temperature: temperatureSchema.optional(),
   reasoning: reasoningSchema.optional(),
+  conciseReasoningSummary: z.boolean().optional(),
   tools: z.array(toolSpecificationSchema).optional(),
   forceTool: z.string().optional(),
   // When true, the tools are sent but the model is forbidden from calling them

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -131,6 +131,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "OpenAI tool for tracking API consumption and costs",
     stage: "on_demand",
   },
+  openai_concise_reasoning_summaries: {
+    description:
+      "Use concise reasoning summaries for supported OpenAI models in the new LLM router",
+    stage: "dust_only",
+  },
   salesforce_synced_queries: {
     description: "Salesforce Connection: retrieval on Synchronized queries",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -774,6 +774,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "noop_model_feature"
   | "notion_private_integration"
   | "allow_old_notion_mcp"
+  | "openai_concise_reasoning_summaries"
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"


### PR DESCRIPTION
## Description

Use concise reasoning summaries for supported OpenAI GPT-5.x models through the TypeScript router across streaming and batch requests when the `openai_concise_reasoning_summaries` feature flag is enabled. Keep automatic summaries when the flag is disabled, for unsupported OpenAI models, and for non-OpenAI providers.

## Tests

Added request-payload coverage for flagged and unflagged OpenAI streaming and batch requests, unsupported OpenAI models, and xAI compatibility.

## Risk

Low. The new behavior is disabled by default and limited to flagged workspaces using supported OpenAI models through the TypeScript router.

## Deploy Plan

Standard deploy. Enable the feature flag for selected workspaces after deployment.