### PR TITLE
[front] enh: capitalize ID in tool display names

### DIFF
--- a/front/types/shared/utils/string_utils.test.ts
+++ b/front/types/shared/utils/string_utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { formatAsDisplayName } from "./string_utils";
+
+describe("formatAsDisplayName", () => {
+  it("formats special-case identifiers", () => {
+    expect(formatAsDisplayName("user_id")).toBe("User ID");
+    expect(formatAsDisplayName("github_mcp_server_id")).toBe(
+      "GitHub MCP server ID"
+    );
+  });
+
+  it("does not format special cases within words", () => {
+    expect(formatAsDisplayName("video_id")).toBe("Video ID");
+  });
+});

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -118,7 +118,7 @@ const SPECIAL_CASES = {
   id: "ID",
 };
 
-// Create a single regex pattern for all special cases
+// Match "id" in "user id", but not inside "video".
 const SPECIAL_CASES_PATTERN = new RegExp(
   `\\b(?:${Object.keys(SPECIAL_CASES).join("|")})\\b`,
   "g"

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -120,7 +120,7 @@ const SPECIAL_CASES = {
 
 // Create a single regex pattern for all special cases
 const SPECIAL_CASES_PATTERN = new RegExp(
-  Object.keys(SPECIAL_CASES).join("|"),
+  `\\b(?:${Object.keys(SPECIAL_CASES).join("|")})\\b`,
   "g"
 );
 

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -115,6 +115,7 @@ const SPECIAL_CASES = {
   github: "GitHub",
   hubspot: "HubSpot",
   mcp: "MCP",
+  id: "ID",
 };
 
 // Create a single regex pattern for all special cases


### PR DESCRIPTION
## Description

Display names generated from identifiers render `id` in lowercase. Add `id` to the shared display-name special cases so it is formatted as `ID`, consistently with `GitHub`, `HubSpot`, and `MCP`.

This will affect tool names that contain the string "id", for instance `get_current_user_id` -> `Get current user ID` instead of `Get current user id`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
