### PR TITLE
[front] enh: revamp API keys admin page into table-based view

### DIFF
--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -29,14 +29,6 @@ interface APIKeysProps {
   owner: WorkspaceType;
 }
 
-function APIKeysLoading() {
-  return (
-    <div className="rounded-xl border border-border bg-panel-background p-4">
-      <DataTableLoadingSkeleton showSelectionColumn={false} showTrailingCell />
-    </div>
-  );
-}
-
 export function APIKeys({ owner }: APIKeysProps) {
   const { mutate } = useSWRConfig();
   const { subscription } = useAuth();
@@ -184,7 +176,14 @@ export function APIKeys({ owner }: APIKeysProps) {
     });
 
   if (isKeysLoading || isGroupsLoading) {
-    return <APIKeysLoading />;
+    return (
+      <div className="rounded-xl border border-border bg-panel-background p-4">
+        <DataTableLoadingSkeleton
+          showSelectionColumn={false}
+          showTrailingCell
+        />
+      </div>
+    );
   }
 
   if (isKeysError || isGroupsError) {

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -206,35 +206,36 @@ export function APIKeys({ owner }: APIKeysProps) {
         latestKey={keys[0]}
         workspace={owner}
       />
-      <Page.Horizontal align="stretch">
-        <div className="w-full" />
-        <Button
-          label="API reference"
-          size="sm"
-          variant="outline"
-          icon={BookOpen01}
-          href="https://docs.dust.tt/reference"
-          target="_blank"
-          rel="noreferrer"
-        />
-        <NewAPIKeyDialog
-          groups={groups}
-          isGenerating={isGenerating}
+      <Page.Vertical align="stretch" gap="xl">
+        <Page.Horizontal align="right">
+          <Button
+            label="API reference"
+            size="sm"
+            variant="outline"
+            icon={BookOpen01}
+            href="https://docs.dust.tt/reference"
+            target="_blank"
+            rel="noreferrer"
+          />
+          <NewAPIKeyDialog
+            groups={groups}
+            isGenerating={isGenerating}
+            isRevoking={isRevoking}
+            onCreate={handleGenerate}
+            showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
+          />
+        </Page.Horizontal>
+        <APIKeysList
+          keys={keys}
+          groupsById={groupsById}
           isRevoking={isRevoking}
-          onCreate={handleGenerate}
+          isGenerating={isGenerating}
+          onRevoke={handleRevoke}
+          onEditCap={setEditCapKey}
           showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
+          showCreditMonthlyCap={showCreditMonthlyCap}
         />
-      </Page.Horizontal>
-      <APIKeysList
-        keys={keys}
-        groupsById={groupsById}
-        isRevoking={isRevoking}
-        isGenerating={isGenerating}
-        onRevoke={handleRevoke}
-        onEditCap={setEditCapKey}
-        showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
-        showCreditMonthlyCap={showCreditMonthlyCap}
-      />
+      </Page.Vertical>
       {showLegacyUsdMonthlyCap && editCapKey && (
         <EditKeyCapDialog
           keyData={editCapKey}
@@ -261,17 +262,12 @@ export function APIKeysPage() {
   const owner = useWorkspace();
 
   return (
-    <>
-      <Page.Vertical gap="xl" align="stretch">
-        <Page.Header
-          title="API Keys"
-          description="API Keys allow you to securely connect to Dust from other applications and work with your data programmatically."
-        />
-        <Page.Vertical align="stretch" gap="md">
-          <APIKeys owner={owner} />
-        </Page.Vertical>
-      </Page.Vertical>
-      <div className="h-12" />
-    </>
+    <Page.Vertical gap="xl" align="stretch">
+      <Page.Header
+        title="API Keys"
+        description="API Keys allow you to securely connect to Dust from other applications and work with your data programmatically."
+      />
+      <APIKeys owner={owner} />
+    </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -15,13 +15,26 @@ import type { KeyType } from "@app/types/key";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
-import { BookOpen01, Button, Page, Spinner } from "@dust-tt/sparkle";
+import {
+  BookOpen01,
+  Button,
+  DataTableLoadingSkeleton,
+  Page,
+} from "@dust-tt/sparkle";
 import get from "lodash/get";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 
 interface APIKeysProps {
   owner: WorkspaceType;
+}
+
+function APIKeysLoading() {
+  return (
+    <div className="rounded-xl border border-border bg-panel-background p-4">
+      <DataTableLoadingSkeleton showSelectionColumn={false} showTrailingCell />
+    </div>
+  );
 }
 
 export function APIKeys({ owner }: APIKeysProps) {
@@ -32,8 +45,8 @@ export function APIKeys({ owner }: APIKeysProps) {
   const [isNewApiKeyCreatedOpen, setIsNewApiKeyCreatedOpen] = useState(false);
   const [editCapKey, setEditCapKey] = useState<KeyType | null>(null);
 
-  const { isValidating, keys } = useKeys(owner);
-  const { groups, isGroupsLoading } = useGroups({ owner });
+  const { isKeysError, isKeysLoading, keys } = useKeys(owner);
+  const { groups, isGroupsError, isGroupsLoading } = useGroups({ owner });
 
   const groupsById = useMemo(() => {
     return groups.reduce<Record<ModelId, GroupType>>((acc, group) => {
@@ -170,9 +183,16 @@ export function APIKeys({ owner }: APIKeysProps) {
       }
     });
 
-  // Show a loading spinner while API keys or groups are being fetched.
-  if (isValidating || isGroupsLoading) {
-    return <Spinner />;
+  if (isKeysLoading || isGroupsLoading) {
+    return <APIKeysLoading />;
+  }
+
+  if (isKeysError || isGroupsError) {
+    return (
+      <div className="rounded-xl border border-border bg-panel-background p-4 text-sm text-muted-foreground">
+        Failed to load API keys.
+      </div>
+    );
   }
 
   return (
@@ -190,13 +210,13 @@ export function APIKeys({ owner }: APIKeysProps) {
       <Page.Horizontal align="stretch">
         <div className="w-full" />
         <Button
-          label="Read the API reference"
+          label="API reference"
           size="sm"
           variant="outline"
           icon={BookOpen01}
-          onClick={() => {
-            window.open("https://docs.dust.tt/reference", "_blank");
-          }}
+          href="https://docs.dust.tt/reference"
+          target="_blank"
+          rel="noreferrer"
         />
         <NewAPIKeyDialog
           groups={groups}

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -15,13 +15,7 @@ import type { KeyType } from "@app/types/key";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
-import {
-  BookOpen01,
-  Button,
-  DataTableLoadingSkeleton,
-  LoadingBlock,
-  Page,
-} from "@dust-tt/sparkle";
+import { BookOpen01, Button, Page } from "@dust-tt/sparkle";
 import get from "lodash/get";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -40,6 +34,8 @@ export function APIKeys({ owner }: APIKeysProps) {
 
   const { isKeysError, isKeysLoading, keys } = useKeys(owner);
   const { groups, isGroupsError, isGroupsLoading } = useGroups({ owner });
+  const isDataLoading = isKeysLoading || isGroupsLoading;
+  const isDataError = Boolean(isKeysError || isGroupsError);
 
   const groupsById = useMemo(() => {
     return groups.reduce<Record<ModelId, GroupType>>((acc, group) => {
@@ -176,31 +172,6 @@ export function APIKeys({ owner }: APIKeysProps) {
       }
     });
 
-  if (isKeysLoading || isGroupsLoading) {
-    return (
-      <Page.Vertical align="stretch" gap="xl">
-        <Page.Horizontal align="right">
-          <LoadingBlock className="h-8 w-full rounded-xl sm:w-32" />
-          <LoadingBlock className="h-8 w-full rounded-xl sm:w-36" />
-        </Page.Horizontal>
-        <div className="rounded-xl border border-border bg-panel-background p-4">
-          <DataTableLoadingSkeleton
-            showSelectionColumn={false}
-            showTrailingCell
-          />
-        </div>
-      </Page.Vertical>
-    );
-  }
-
-  if (isKeysError || isGroupsError) {
-    return (
-      <div className="rounded-xl border border-border bg-panel-background p-4 text-sm text-muted-foreground">
-        Failed to load API keys.
-      </div>
-    );
-  }
-
   return (
     <>
       <APIKeyCreationSheet
@@ -226,6 +197,7 @@ export function APIKeys({ owner }: APIKeysProps) {
           />
           <NewAPIKeyDialog
             groups={groups}
+            disabled={isGroupsLoading || Boolean(isGroupsError)}
             isGenerating={isGenerating}
             isRevoking={isRevoking}
             onCreate={handleGenerate}
@@ -235,6 +207,8 @@ export function APIKeys({ owner }: APIKeysProps) {
         <APIKeysList
           keys={keys}
           groupsById={groupsById}
+          isLoading={isDataLoading}
+          isError={isDataError}
           isRevoking={isRevoking}
           isGenerating={isGenerating}
           onRevoke={handleRevoke}

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -19,6 +19,7 @@ import {
   BookOpen01,
   Button,
   DataTableLoadingSkeleton,
+  LoadingBlock,
   Page,
 } from "@dust-tt/sparkle";
 import get from "lodash/get";
@@ -177,12 +178,18 @@ export function APIKeys({ owner }: APIKeysProps) {
 
   if (isKeysLoading || isGroupsLoading) {
     return (
-      <div className="rounded-xl border border-border bg-panel-background p-4">
-        <DataTableLoadingSkeleton
-          showSelectionColumn={false}
-          showTrailingCell
-        />
-      </div>
+      <Page.Vertical align="stretch" gap="xl">
+        <Page.Horizontal align="right">
+          <LoadingBlock className="h-8 w-full rounded-xl sm:w-32" />
+          <LoadingBlock className="h-8 w-full rounded-xl sm:w-36" />
+        </Page.Horizontal>
+        <div className="rounded-xl border border-border bg-panel-background p-4">
+          <DataTableLoadingSkeleton
+            showSelectionColumn={false}
+            showTrailingCell
+          />
+        </div>
+      </Page.Vertical>
     );
   }
 

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -270,7 +270,7 @@ function buildColumns({
       header: capLabel,
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-20 @sm-table:table-cell",
+        className: "hidden h-16 w-20 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -286,7 +286,7 @@ function buildColumns({
       header: "Created",
       enableSorting: true,
       meta: {
-        className: "hidden h-16 w-28 @md-table:table-cell",
+        className: "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -1,4 +1,5 @@
 import { formatCredits } from "@app/lib/client/credits";
+import { timeAgoFrom } from "@app/lib/utils";
 import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -52,6 +53,8 @@ interface APIKeyRowData {
   secret: string;
   status: APIKeyStatus;
   monthlyCap: string;
+  createdAt: number;
+  lastUsedAt: number | null;
   menuItems: MenuItem[];
 }
 
@@ -135,6 +138,10 @@ function matchesAPIKeySearch(row: APIKeyRowData, search: string): boolean {
     row.status,
     ...row.spaces,
   ].some((value) => value.toLowerCase().includes(normalizedSearch));
+}
+
+function formatRelativeTime(timestamp: number): string {
+  return `${timeAgoFrom(timestamp, { useLongFormat: true })} ago`;
 }
 
 function buildColumns({
@@ -248,6 +255,36 @@ function buildColumns({
         <DataTable.BasicCellContent
           className="tabular-nums"
           label={info.row.original.monthlyCap}
+        />
+      ),
+    },
+    {
+      id: "createdAt",
+      accessorKey: "createdAt",
+      header: "Created",
+      enableSorting: false,
+      meta: { className: "h-16 w-32", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          className="whitespace-nowrap"
+          label={formatRelativeTime(info.row.original.createdAt)}
+        />
+      ),
+    },
+    {
+      id: "lastUsedAt",
+      accessorKey: "lastUsedAt",
+      header: "Last used",
+      enableSorting: false,
+      meta: { className: "h-16 w-32", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          className="whitespace-nowrap"
+          label={
+            info.row.original.lastUsedAt
+              ? formatRelativeTime(info.row.original.lastUsedAt)
+              : "Never"
+          }
         />
       ),
     },
@@ -373,6 +410,8 @@ export function APIKeysList({
             showLegacyUsdMonthlyCap,
             showCreditMonthlyCap,
           }),
+          createdAt: key.createdAt,
+          lastUsedAt: key.lastUsedAt,
           menuItems,
         };
       }),
@@ -497,9 +536,11 @@ export function APIKeysList({
             columns={columns}
             className="min-w-[720px]"
             columnsBreakpoints={{
-              key: "lg",
+              key: "xl",
               spaces: "md",
               monthlyCap: "sm",
+              createdAt: "lg",
+              lastUsedAt: "md",
             }}
           />
         </div>

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -26,6 +26,7 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import capitalize from "lodash/capitalize";
 import { useMemo, useState } from "react";
 import { prettifyGroupName } from "./utils";
 
@@ -307,13 +308,7 @@ function buildColumns({
                     ? "warning"
                     : "primary"
               }
-              label={
-                status === "active"
-                  ? "Active"
-                  : status === "capped"
-                    ? "Capped"
-                    : "Revoked"
-              }
+              label={capitalize(status)}
             />
           </DataTable.CellContent>
         );
@@ -486,13 +481,7 @@ export function APIKeysList({
             {(["active", "capped", "revoked"] as const).map((status) => (
               <DropdownMenuCheckboxItem
                 key={status}
-                label={
-                  status === "active"
-                    ? "Active"
-                    : status === "capped"
-                      ? "Capped"
-                      : "Revoked"
-                }
+                label={capitalize(status)}
                 checked={statusFilters.has(status)}
                 onCheckedChange={() => {
                   setStatusFilters((current) =>

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -208,12 +208,17 @@ function buildColumns({
         className: "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },
-      cell: (info) => (
-        <DataTable.BasicCellContent
-          className="font-mono text-muted-foreground"
-          label={info.row.original.secret}
-        />
-      ),
+      cell: (info) => {
+        const secret = info.row.original.secret;
+        const suffix = secret.slice(-4);
+
+        return (
+          <div className="flex w-full min-w-0 items-center font-mono text-sm text-muted-foreground">
+            <span className="min-w-0 truncate">{secret.slice(0, -4)}</span>
+            <span className="shrink-0">{suffix}</span>
+          </div>
+        );
+      },
     },
     {
       id: "spaces",

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -13,6 +13,7 @@ import {
   ChevronRight,
   Chip,
   DataTable,
+  DataTableLoadingSkeleton,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -22,6 +23,7 @@ import {
   Edit04,
   FilterFunnel01,
   Icon,
+  LoadingBlock,
   SearchInput,
   Separator,
   Tooltip,
@@ -38,6 +40,8 @@ type APIKeyStatus = "active" | "capped" | "revoked";
 interface APIKeysListProps {
   keys: KeyType[];
   groupsById: Record<ModelId, GroupType>;
+  isLoading: boolean;
+  isError: boolean;
   isRevoking: boolean;
   isGenerating: boolean;
   onRevoke: (key: KeyType) => Promise<void>;
@@ -354,6 +358,8 @@ function buildColumns({
 export function APIKeysList({
   keys,
   groupsById,
+  isLoading,
+  isError,
   isRevoking,
   isGenerating,
   onRevoke,
@@ -454,7 +460,10 @@ export function APIKeysList({
   };
 
   return (
-    <div className="flex flex-col gap-4 rounded-xl border border-border bg-panel-background p-4">
+    <div
+      className="flex flex-col gap-4 rounded-xl border border-border bg-panel-background p-4"
+      aria-busy={isLoading}
+    >
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <SearchInput
           name="api-keys-search"
@@ -511,73 +520,99 @@ export function APIKeysList({
         </DropdownMenu>
       </div>
 
-      {keys.length === 0 ? (
-        <div className="py-8 text-center text-sm text-muted-foreground">
-          Create an API key to start using Dust programmatically.
-        </div>
-      ) : filteredRows.length === 0 ? (
-        <div className="py-8 text-center text-sm text-muted-foreground">
-          No API keys match these filters.
-        </div>
-      ) : (
-        <div className="dd-privacy-mask overflow-x-auto">
-          <DataTable
-            data={paginatedRows}
-            columns={columns}
-            className="min-w-[720px]"
-            columnsBreakpoints={{
-              key: "xl",
-              spaces: "md",
-              monthlyCap: "sm",
-              createdAt: "lg",
-              lastUsedAt: "md",
-            }}
+      {isLoading ? (
+        <>
+          <DataTableLoadingSkeleton
+            showSelectionColumn={false}
+            showTrailingCell
           />
-        </div>
-      )}
-
-      <Separator />
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium text-foreground">
-          {filteredRows.length.toLocaleString()} API{" "}
-          {filteredRows.length === 1 ? "key" : "keys"}
-        </span>
-        {filteredRows.length > 0 && (
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-muted-foreground">
-              Page {pageIndex + 1} of {pageCount}
-            </span>
-            <div className="flex items-center gap-2">
-              <Button
-                icon={ChevronLeft}
-                aria-label="Previous page"
-                size="sm"
-                variant="outline"
-                disabled={pageIndex === 0}
-                onClick={() =>
-                  setPagination((current) => ({
-                    ...current,
-                    pageIndex: Math.max(0, pageIndex - 1),
-                  }))
-                }
-              />
-              <Button
-                icon={ChevronRight}
-                aria-label="Next page"
-                size="sm"
-                variant="outline"
-                disabled={pageIndex >= pageCount - 1}
-                onClick={() =>
-                  setPagination((current) => ({
-                    ...current,
-                    pageIndex: Math.min(pageCount - 1, pageIndex + 1),
-                  }))
-                }
-              />
+          <Separator />
+          <div className="flex items-center justify-between">
+            <LoadingBlock className="h-4 w-20" />
+            <div className="flex items-center gap-3">
+              <LoadingBlock className="h-4 w-24" />
+              <div className="flex items-center gap-2">
+                <LoadingBlock className="h-8 w-8 rounded-xl" />
+                <LoadingBlock className="h-8 w-8 rounded-xl" />
+              </div>
             </div>
           </div>
-        )}
-      </div>
+        </>
+      ) : isError ? (
+        <div className="py-8 text-center text-sm text-muted-foreground">
+          Failed to load API keys.
+        </div>
+      ) : (
+        <>
+          {keys.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              Create an API key to start using Dust programmatically.
+            </div>
+          ) : filteredRows.length === 0 ? (
+            <div className="py-8 text-center text-sm text-muted-foreground">
+              No API keys match these filters.
+            </div>
+          ) : (
+            <div className="dd-privacy-mask overflow-x-auto">
+              <DataTable
+                data={paginatedRows}
+                columns={columns}
+                className="min-w-[720px]"
+                columnsBreakpoints={{
+                  key: "xl",
+                  spaces: "md",
+                  monthlyCap: "sm",
+                  createdAt: "lg",
+                  lastUsedAt: "md",
+                }}
+              />
+            </div>
+          )}
+
+          <Separator />
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">
+              {filteredRows.length.toLocaleString()} API{" "}
+              {filteredRows.length === 1 ? "key" : "keys"}
+            </span>
+            {filteredRows.length > 0 && (
+              <div className="flex items-center gap-3">
+                <span className="text-sm text-muted-foreground">
+                  Page {pageIndex + 1} of {pageCount}
+                </span>
+                <div className="flex items-center gap-2">
+                  <Button
+                    icon={ChevronLeft}
+                    aria-label="Previous page"
+                    size="sm"
+                    variant="outline"
+                    disabled={pageIndex === 0}
+                    onClick={() =>
+                      setPagination((current) => ({
+                        ...current,
+                        pageIndex: Math.max(0, pageIndex - 1),
+                      }))
+                    }
+                  />
+                  <Button
+                    icon={ChevronRight}
+                    aria-label="Next page"
+                    size="sm"
+                    variant="outline"
+                    disabled={pageIndex >= pageCount - 1}
+                    onClick={() =>
+                      setPagination((current) => ({
+                        ...current,
+                        pageIndex: Math.min(pageCount - 1, pageIndex + 1),
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -265,7 +265,7 @@ function buildColumns({
       accessorKey: "createdAt",
       header: "Created",
       enableSorting: false,
-      meta: { className: "h-16 w-32", headerAlign: "left" },
+      meta: { className: "h-16 w-36 min-w-36", headerAlign: "left" },
       cell: (info) => (
         <DataTable.BasicCellContent
           className="whitespace-nowrap"
@@ -278,7 +278,7 @@ function buildColumns({
       accessorKey: "lastUsedAt",
       header: "Last used",
       enableSorting: false,
-      meta: { className: "h-16 w-32", headerAlign: "left" },
+      meta: { className: "h-16 w-36 min-w-36", headerAlign: "left" },
       cell: (info) => (
         <DataTable.BasicCellContent
           className="whitespace-nowrap"

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -22,6 +22,7 @@ import {
   FilterFunnel01,
   Icon,
   SearchInput,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
@@ -183,14 +184,29 @@ function buildColumns({
       header: "Spaces",
       enableSorting: false,
       meta: { className: "h-16 w-48", headerAlign: "left" },
-      cell: (info) => (
-        <DataTable.CellContent className="gap-2">
-          <Icon visual={Building07} size="sm" />
-          <span className="truncate">
-            {info.row.original.spaces.join(", ") || "No spaces"}
-          </span>
-        </DataTable.CellContent>
-      ),
+      cell: (info) => {
+        const spaces = info.row.original.spaces;
+        const spacesLabel = spaces.join(", ") || "No spaces";
+        const content = (
+          <div
+            className="flex min-w-0 items-center gap-2 rounded outline-hidden focus-visible:ring-2 focus-visible:ring-highlight-300"
+            tabIndex={spaces.length > 0 ? 0 : undefined}
+          >
+            <Icon visual={Building07} size="sm" className="shrink-0" />
+            <span className="truncate">{spacesLabel}</span>
+          </div>
+        );
+
+        return spaces.length > 0 ? (
+          <Tooltip
+            label={spacesLabel}
+            tooltipTriggerAsChild
+            trigger={content}
+          />
+        ) : (
+          content
+        );
+      },
     },
     {
       id: "monthlyCap",

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -237,7 +237,7 @@ function buildColumns({
       header: capLabel,
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-28 @xl-table:table-cell",
+        className: "hidden h-16 w-28 @md-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -23,6 +23,7 @@ import {
   FilterFunnel01,
   Icon,
   SearchInput,
+  Separator,
   Tooltip,
 } from "@dust-tt/sparkle";
 import type { ColumnDef, PaginationState } from "@tanstack/react-table";
@@ -453,8 +454,8 @@ export function APIKeysList({
   };
 
   return (
-    <div className="rounded-xl border border-border bg-panel-background p-4">
-      <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-center">
+    <div className="flex flex-col gap-4 rounded-xl border border-border bg-panel-background p-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <SearchInput
           name="api-keys-search"
           placeholder="Search API Key"
@@ -535,42 +536,45 @@ export function APIKeysList({
         </div>
       )}
 
-      <div className="mt-4 flex items-center justify-between border-t border-border pt-4">
+      <Separator />
+      <div className="flex items-center justify-between">
         <span className="text-sm font-medium text-foreground">
           {filteredRows.length.toLocaleString()} API{" "}
           {filteredRows.length === 1 ? "key" : "keys"}
         </span>
         {filteredRows.length > 0 && (
-          <div className="flex items-center gap-2">
-            <span className="mr-1 text-sm text-muted-foreground">
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground">
               Page {pageIndex + 1} of {pageCount}
             </span>
-            <Button
-              icon={ChevronLeft}
-              aria-label="Previous page"
-              size="sm"
-              variant="outline"
-              disabled={pageIndex === 0}
-              onClick={() =>
-                setPagination((current) => ({
-                  ...current,
-                  pageIndex: Math.max(0, pageIndex - 1),
-                }))
-              }
-            />
-            <Button
-              icon={ChevronRight}
-              aria-label="Next page"
-              size="sm"
-              variant="outline"
-              disabled={pageIndex >= pageCount - 1}
-              onClick={() =>
-                setPagination((current) => ({
-                  ...current,
-                  pageIndex: Math.min(pageCount - 1, pageIndex + 1),
-                }))
-              }
-            />
+            <div className="flex items-center gap-2">
+              <Button
+                icon={ChevronLeft}
+                aria-label="Previous page"
+                size="sm"
+                variant="outline"
+                disabled={pageIndex === 0}
+                onClick={() =>
+                  setPagination((current) => ({
+                    ...current,
+                    pageIndex: Math.max(0, pageIndex - 1),
+                  }))
+                }
+              />
+              <Button
+                icon={ChevronRight}
+                aria-label="Next page"
+                size="sm"
+                variant="outline"
+                disabled={pageIndex >= pageCount - 1}
+                onClick={() =>
+                  setPagination((current) => ({
+                    ...current,
+                    pageIndex: Math.min(pageCount - 1, pageIndex + 1),
+                  }))
+                }
+              />
+            </div>
           </div>
         )}
       </div>

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -4,6 +4,7 @@ import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { RoleType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
@@ -147,10 +148,6 @@ function matchesAPIKeySearch(row: APIKeyRowData, search: string): boolean {
     row.status,
     ...row.spaces,
   ].some((value) => value.toLowerCase().includes(normalizedSearch));
-}
-
-function formatRelativeTime(timestamp: number): string {
-  return `${timeAgoFrom(timestamp, { useLongFormat: true })} ago`;
 }
 
 function buildColumns({
@@ -298,7 +295,9 @@ function buildColumns({
           className="whitespace-nowrap"
           label={
             info.row.original.lastUsedAt
-              ? formatRelativeTime(info.row.original.lastUsedAt)
+              ? `${timeAgoFrom(info.row.original.lastUsedAt, {
+                  useLongFormat: true,
+                })} ago`
               : "Never"
           }
         />
@@ -602,8 +601,8 @@ export function APIKeysList({
           <Separator />
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium text-foreground">
-              {filteredRows.length.toLocaleString()} API{" "}
-              {filteredRows.length === 1 ? "key" : "keys"}
+              {filteredRows.length.toLocaleString()} API key
+              {pluralize(filteredRows.length)}
             </span>
             {filteredRows.length > 0 && (
               <div className="flex items-center gap-3">

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -47,7 +47,6 @@ interface APIKeyRowData {
   key: KeyType;
   name: string;
   creator: string;
-  searchText: string;
   spaces: string[];
   scope: string;
   secret: string;
@@ -120,6 +119,22 @@ function toggleSetValue<T>(current: ReadonlySet<T>, value: T): ReadonlySet<T> {
     next.add(value);
   }
   return next;
+}
+
+function matchesAPIKeySearch(row: APIKeyRowData, search: string): boolean {
+  const normalizedSearch = search.trim().toLowerCase();
+  if (!normalizedSearch) {
+    return true;
+  }
+
+  return [
+    row.name,
+    row.creator,
+    row.secret,
+    row.scope,
+    row.status,
+    ...row.spaces,
+  ].some((value) => value.toLowerCase().includes(normalizedSearch));
 }
 
 function buildColumns({
@@ -334,8 +349,7 @@ export function APIKeysList({
         const status = getKeyStatus(key);
         const creator = key.creator ?? "Unknown creator";
         const menuItems: MenuItem[] =
-          key.status === "active" &&
-          (showLegacyUsdMonthlyCap || showCreditMonthlyCap)
+          key.status === "active"
             ? [
                 {
                   kind: "item",
@@ -350,14 +364,6 @@ export function APIKeysList({
           key,
           name: key.name || "Unnamed",
           creator,
-          searchText: [
-            key.name,
-            creator,
-            key.secret,
-            scope,
-            status,
-            ...spaces,
-          ].join(" "),
           spaces,
           scope,
           secret: key.secret,
@@ -387,11 +393,8 @@ export function APIKeysList({
     [actionsDisabled, onRevoke, showCreditMonthlyCap]
   );
   const filteredRows = useMemo(() => {
-    const normalizedSearch = search.trim().toLowerCase();
     return rows.filter((row) => {
-      const matchesSearch =
-        normalizedSearch.length === 0 ||
-        row.searchText.toLowerCase().includes(normalizedSearch);
+      const matchesSearch = matchesAPIKeySearch(row, search);
       const matchesStatus =
         statusFilters.size === 0 || statusFilters.has(row.status);
       const matchesScope =

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -232,7 +232,7 @@ function buildColumns({
         return (
           <div className="flex min-w-0 items-center gap-2">
             <Icon visual={Building07} size="sm" className="shrink-0" />
-            <span className="min-w-0 truncate">
+            <span className="min-w-0 truncate text-sm">
               {firstSpace ?? "No spaces"}
             </span>
             {remainingSpaces.length > 0 && (

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -168,7 +168,7 @@ function buildColumns({
       accessorFn: (row) => row.name,
       header: "Name",
       enableSorting: true,
-      meta: { className: "h-16", headerAlign: "left" },
+      meta: { className: "h-16 w-40", headerAlign: "left" },
       cell: (info) => (
         <div className="flex flex-col justify-center">
           <span className="truncate text-sm font-medium text-foreground">
@@ -186,7 +186,7 @@ function buildColumns({
       header: "Scope",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-24 @sm-table:table-cell",
+        className: "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -205,7 +205,7 @@ function buildColumns({
       header: "Key",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-20 @md-table:table-cell",
+        className: "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -221,7 +221,7 @@ function buildColumns({
       header: "Spaces",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-24 @md-table:table-cell",
+        className: "hidden h-16 w-40 @md-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -269,7 +269,7 @@ function buildColumns({
       header: capLabel,
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-20 @lg-table:table-cell",
+        className: "hidden h-16 w-28 @xl-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -285,7 +285,7 @@ function buildColumns({
       header: "Last used",
       enableSorting: true,
       meta: {
-        className: "hidden h-16 w-28 @sm-table:table-cell",
+        className: "hidden h-16 w-32 @sm-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -304,7 +304,7 @@ function buildColumns({
       accessorKey: "status",
       header: "Status",
       enableSorting: false,
-      meta: { className: "h-16 w-16", headerAlign: "left" },
+      meta: { className: "h-16 w-20", headerAlign: "left" },
       cell: (info) => {
         const status = info.row.original.status;
         return (

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -186,25 +186,40 @@ function buildColumns({
       meta: { className: "h-16 w-48", headerAlign: "left" },
       cell: (info) => {
         const spaces = info.row.original.spaces;
-        const spacesLabel = spaces.join(", ") || "No spaces";
-        const content = (
-          <div
-            className="flex min-w-0 items-center gap-2 rounded outline-hidden focus-visible:ring-2 focus-visible:ring-highlight-300"
-            tabIndex={spaces.length > 0 ? 0 : undefined}
-          >
-            <Icon visual={Building07} size="sm" className="shrink-0" />
-            <span className="truncate">{spacesLabel}</span>
-          </div>
-        );
+        const [firstSpace, ...remainingSpaces] = spaces;
 
-        return spaces.length > 0 ? (
-          <Tooltip
-            label={spacesLabel}
-            tooltipTriggerAsChild
-            trigger={content}
-          />
-        ) : (
-          content
+        return (
+          <div className="flex min-w-0 items-center gap-2">
+            <Icon visual={Building07} size="sm" className="shrink-0" />
+            <span className="min-w-0 truncate">
+              {firstSpace ?? "No spaces"}
+            </span>
+            {remainingSpaces.length > 0 && (
+              <Tooltip
+                label={
+                  <div className="flex flex-col">
+                    {remainingSpaces.map((space, index) => (
+                      <span key={`${space}-${index}`}>{space}</span>
+                    ))}
+                  </div>
+                }
+                tooltipTriggerAsChild
+                trigger={
+                  <span
+                    className="shrink-0 rounded outline-hidden focus-visible:ring-2 focus-visible:ring-highlight-300"
+                    tabIndex={0}
+                    aria-label={`${remainingSpaces.length} more spaces`}
+                  >
+                    <Chip
+                      size="mini"
+                      color="primary"
+                      label={`+${remainingSpaces.length}`}
+                    />
+                  </span>
+                }
+              />
+            )}
+          </div>
         );
       },
     },

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -1,17 +1,37 @@
-import config from "@app/lib/api/config";
-import { timeAgoFrom } from "@app/lib/utils";
+import { formatCredits } from "@app/lib/client/credits";
 import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { RoleType } from "@app/types/user";
-import { Button, cn } from "@dust-tt/sparkle";
-import sortBy from "lodash/sortBy";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React from "react";
+import type { MenuItem } from "@dust-tt/sparkle";
+import {
+  Building07,
+  Button,
+  ChevronLeft,
+  ChevronRight,
+  Chip,
+  DataTable,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Edit04,
+  FilterFunnel01,
+  Icon,
+  SearchInput,
+} from "@dust-tt/sparkle";
+import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
 import { prettifyGroupName } from "./utils";
 
-type APIKeysListProps = {
+const API_KEYS_PAGE_SIZE = 10;
+
+type APIKeyStatus = "active" | "capped" | "revoked";
+
+interface APIKeysListProps {
   keys: KeyType[];
   groupsById: Record<ModelId, GroupType>;
   isRevoking: boolean;
@@ -20,16 +40,29 @@ type APIKeysListProps = {
   onEditCap: (key: KeyType) => void;
   showLegacyUsdMonthlyCap: boolean;
   showCreditMonthlyCap: boolean;
-};
+}
+
+interface APIKeyRowData {
+  key: KeyType;
+  name: string;
+  creator: string;
+  searchText: string;
+  spaces: string[];
+  scope: string;
+  secret: string;
+  status: APIKeyStatus;
+  monthlyCap: string;
+  menuItems: MenuItem[];
+}
 
 const getKeySpaces = (
   key: KeyType,
   groupsById: Record<ModelId, GroupType>
 ): string[] => {
   return key.groupIds
-    .map((gId) => groupsById[gId])
-    .filter((g): g is GroupType => g !== undefined)
-    .map((g) => prettifyGroupName(g));
+    .map((groupId) => groupsById[groupId])
+    .filter((group): group is GroupType => group !== undefined)
+    .map((group) => prettifyGroupName(group));
 };
 
 const formatKeyScope = (role: RoleType): string => {
@@ -49,7 +82,197 @@ const formatKeyScope = (role: RoleType): string => {
   }
 };
 
-export const APIKeysList = ({
+function getKeyStatus(key: KeyType): APIKeyStatus {
+  if (key.status !== "active") {
+    return "revoked";
+  }
+  return key.creditState === "capped" ? "capped" : "active";
+}
+
+function formatMonthlyCap({
+  key,
+  showLegacyUsdMonthlyCap,
+  showCreditMonthlyCap,
+}: {
+  key: KeyType;
+  showLegacyUsdMonthlyCap: boolean;
+  showCreditMonthlyCap: boolean;
+}): string {
+  if (showCreditMonthlyCap) {
+    return key.monthlyCapAwuCredits === null
+      ? "Unlimited"
+      : formatCredits(key.monthlyCapAwuCredits);
+  }
+  if (showLegacyUsdMonthlyCap) {
+    return key.monthlyCapMicroUsd === null
+      ? "Unlimited"
+      : `$${(key.monthlyCapMicroUsd / 1_000_000).toFixed(2)}`;
+  }
+  return "—";
+}
+
+function toggleSetValue<T>(current: ReadonlySet<T>, value: T): ReadonlySet<T> {
+  const next = new Set(current);
+  if (next.has(value)) {
+    next.delete(value);
+  } else {
+    next.add(value);
+  }
+  return next;
+}
+
+function buildColumns({
+  actionsDisabled,
+  capLabel,
+  onRevoke,
+}: {
+  actionsDisabled: boolean;
+  capLabel: string;
+  onRevoke: (key: KeyType) => Promise<void>;
+}): ColumnDef<APIKeyRowData>[] {
+  return [
+    {
+      id: "name",
+      accessorFn: (row) => row.name,
+      header: "Name",
+      enableSorting: false,
+      meta: { className: "h-16 w-56", headerAlign: "left" },
+      cell: (info) => (
+        <div className="flex flex-col justify-center">
+          <span className="truncate text-sm font-medium text-foreground">
+            {info.row.original.name}
+          </span>
+          <span className="truncate text-xs text-muted-foreground">
+            {info.row.original.creator}
+          </span>
+        </div>
+      ),
+    },
+    {
+      id: "scope",
+      accessorKey: "scope",
+      header: "Scope",
+      enableSorting: false,
+      meta: { className: "h-16 w-28", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.CellContent>
+          <Chip
+            size="xs"
+            color={info.row.original.scope === "Admin" ? "warning" : "primary"}
+            label={info.row.original.scope}
+          />
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "key",
+      accessorKey: "secret",
+      header: "Key",
+      enableSorting: false,
+      meta: { className: "h-16 w-40", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          className="font-mono text-muted-foreground"
+          label={info.row.original.secret}
+        />
+      ),
+    },
+    {
+      id: "spaces",
+      accessorFn: (row) => row.spaces.join(", "),
+      header: "Spaces",
+      enableSorting: false,
+      meta: { className: "h-16 w-48", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.CellContent className="gap-2">
+          <Icon visual={Building07} size="sm" />
+          <span className="truncate">
+            {info.row.original.spaces.join(", ") || "No spaces"}
+          </span>
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "monthlyCap",
+      accessorKey: "monthlyCap",
+      header: capLabel,
+      enableSorting: false,
+      meta: { className: "h-16 w-32", headerAlign: "left" },
+      cell: (info) => (
+        <DataTable.BasicCellContent
+          className="tabular-nums"
+          label={info.row.original.monthlyCap}
+        />
+      ),
+    },
+    {
+      id: "status",
+      accessorKey: "status",
+      header: "Status",
+      enableSorting: false,
+      meta: { className: "h-16 w-28", headerAlign: "left" },
+      cell: (info) => {
+        const status = info.row.original.status;
+        return (
+          <DataTable.CellContent>
+            <Chip
+              size="xs"
+              color={
+                status === "active"
+                  ? "success"
+                  : status === "capped"
+                    ? "warning"
+                    : "primary"
+              }
+              label={
+                status === "active"
+                  ? "Active"
+                  : status === "capped"
+                    ? "Capped"
+                    : "Revoked"
+              }
+            />
+          </DataTable.CellContent>
+        );
+      },
+    },
+    {
+      id: "revoke",
+      header: "",
+      enableSorting: false,
+      meta: { className: "h-16 w-24", headerAlign: "right" },
+      cell: (info) =>
+        info.row.original.key.status === "active" ? (
+          <DataTable.CellContent className="w-full justify-end">
+            <Button
+              label="Revoke"
+              size="sm"
+              variant="warning"
+              disabled={actionsDisabled}
+              onClick={() => void onRevoke(info.row.original.key)}
+            />
+          </DataTable.CellContent>
+        ) : null,
+    },
+    {
+      id: "actions",
+      header: "",
+      enableSorting: false,
+      meta: { className: "h-16 w-12" },
+      cell: (info) =>
+        info.row.original.menuItems.length > 0 ? (
+          <DataTable.CellContent className="w-full justify-end">
+            <DataTable.MoreButton
+              menuItems={info.row.original.menuItems}
+              disabled={actionsDisabled}
+            />
+          </DataTable.CellContent>
+        ) : null,
+    },
+  ];
+}
+
+export function APIKeysList({
   keys,
   groupsById,
   isRevoking,
@@ -58,158 +281,235 @@ export const APIKeysList = ({
   onEditCap,
   showLegacyUsdMonthlyCap,
   showCreditMonthlyCap,
-}: APIKeysListProps) => {
+}: APIKeysListProps) {
+  const [search, setSearch] = useState("");
+  const [statusFilters, setStatusFilters] = useState<ReadonlySet<APIKeyStatus>>(
+    new Set()
+  );
+  const [scopeFilters, setScopeFilters] = useState<ReadonlySet<string>>(
+    new Set()
+  );
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: API_KEYS_PAGE_SIZE,
+  });
+
+  const actionsDisabled = isRevoking || isGenerating;
+  const rows = useMemo<APIKeyRowData[]>(
+    () =>
+      keys.map((key) => {
+        const spaces = getKeySpaces(key, groupsById);
+        const scope = formatKeyScope(key.role);
+        const status = getKeyStatus(key);
+        const creator = key.creator ?? "Unknown creator";
+        const menuItems: MenuItem[] =
+          key.status === "active" &&
+          (showLegacyUsdMonthlyCap || showCreditMonthlyCap)
+            ? [
+                {
+                  kind: "item",
+                  label: "Edit monthly cap",
+                  icon: Edit04,
+                  onClick: () => onEditCap(key),
+                },
+              ]
+            : [];
+
+        return {
+          key,
+          name: key.name || "Unnamed",
+          creator,
+          searchText: [
+            key.name,
+            creator,
+            key.secret,
+            scope,
+            status,
+            ...spaces,
+          ].join(" "),
+          spaces,
+          scope,
+          secret: key.secret,
+          status,
+          monthlyCap: formatMonthlyCap({
+            key,
+            showLegacyUsdMonthlyCap,
+            showCreditMonthlyCap,
+          }),
+          menuItems,
+        };
+      }),
+    [groupsById, keys, onEditCap, showCreditMonthlyCap, showLegacyUsdMonthlyCap]
+  );
+
+  const scopeOptions = useMemo(
+    () => [...new Set(rows.map((row) => row.scope))].sort(),
+    [rows]
+  );
+  const columns = useMemo(
+    () =>
+      buildColumns({
+        actionsDisabled,
+        capLabel: showCreditMonthlyCap ? "Credits cap" : "Monthly cap",
+        onRevoke,
+      }),
+    [actionsDisabled, onRevoke, showCreditMonthlyCap]
+  );
+  const filteredRows = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    return rows.filter((row) => {
+      const matchesSearch =
+        normalizedSearch.length === 0 ||
+        row.searchText.toLowerCase().includes(normalizedSearch);
+      const matchesStatus =
+        statusFilters.size === 0 || statusFilters.has(row.status);
+      const matchesScope =
+        scopeFilters.size === 0 || scopeFilters.has(row.scope);
+      return matchesSearch && matchesStatus && matchesScope;
+    });
+  }, [rows, scopeFilters, search, statusFilters]);
+
+  const pageCount = Math.max(
+    1,
+    Math.ceil(filteredRows.length / pagination.pageSize)
+  );
+  const pageIndex = Math.min(pagination.pageIndex, pageCount - 1);
+  const paginatedRows = filteredRows.slice(
+    pageIndex * pagination.pageSize,
+    (pageIndex + 1) * pagination.pageSize
+  );
+  const appliedFilterCount = statusFilters.size + scopeFilters.size;
+
+  const resetPagination = () => {
+    setPagination((current) => ({ ...current, pageIndex: 0 }));
+  };
+
   return (
-    <div className="space-y-4 divide-y divide-primary-200">
-      <ul role="list" className="pt-4">
-        {sortBy(keys, (key) => key.status[0] + key.name).map((key) => (
-          <li key={key.secret} className="px-2 py-4">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center">
-                <div className="flex flex-col">
-                  <div className="flex flex-row">
-                    <div className="mr-2 mt-0.5 flex w-16 flex-shrink-0 flex-col items-start gap-0.5">
-                      <p
-                        className={cn(
-                          "inline-flex rounded-full px-2 text-xs font-semibold leading-5",
-                          key.status === "active"
-                            ? "bg-green-100 text-green-800"
-                            : "bg-muted text-foreground"
-                        )}
-                      >
-                        {key.status === "active" ? "active" : "revoked"}
-                      </p>
-                      {showCreditMonthlyCap && key.creditState === "capped" && (
-                        <p className="inline-flex rounded-full bg-red-100 px-2 text-xs font-semibold leading-5 text-red-800">
-                          capped
-                        </p>
-                      )}
-                    </div>
-                    <div className="dd-privacy-mask">
-                      <p
-                        className={cn(
-                          "truncate font-mono text-sm",
-                          "text-muted-foreground"
-                        )}
-                      >
-                        Name: <strong>{key.name ?? "Unnamed"}</strong>
-                      </p>
-                      <p
-                        className={cn(
-                          "truncate font-mono text-sm",
-                          "text-muted-foreground"
-                        )}
-                      >
-                        Domain: <strong>{config.getApiBaseUrl()}</strong>
-                      </p>
-                      <p
-                        className={cn(
-                          "truncate font-mono text-sm",
-                          "text-muted-foreground"
-                        )}
-                      >
-                        Spaces:{" "}
-                        <strong>
-                          {getKeySpaces(key, groupsById).join(", ")}
-                        </strong>
-                      </p>
-                      <p
-                        className={cn(
-                          "truncate font-mono text-sm",
-                          "text-muted-foreground"
-                        )}
-                      >
-                        Scope: <strong>{formatKeyScope(key.role)}</strong>
-                      </p>
-                      {showLegacyUsdMonthlyCap && (
-                        <p
-                          className={cn(
-                            "truncate font-mono text-sm",
-                            "text-muted-foreground"
-                          )}
-                        >
-                          Monthly cap:{" "}
-                          <strong>
-                            {key.monthlyCapMicroUsd !== null
-                              ? `$${(key.monthlyCapMicroUsd / 1_000_000).toFixed(2)}`
-                              : "Unlimited"}
-                          </strong>
-                        </p>
-                      )}
-                      {showCreditMonthlyCap && (
-                        <p
-                          className={cn(
-                            "truncate font-mono text-sm",
-                            "text-muted-foreground dark:text-muted-foreground-night"
-                          )}
-                        >
-                          Monthly credit cap:{" "}
-                          <strong>
-                            {key.monthlyCapAwuCredits !== null
-                              ? `${key.monthlyCapAwuCredits} credits`
-                              : "Unlimited"}
-                          </strong>
-                        </p>
-                      )}
-                      <pre className="text-sm">{key.secret}</pre>
-                      <p
-                        className={cn(
-                          "front-normal text-xs",
-                          "text-muted-foreground"
-                        )}
-                      >
-                        Created {key.creator ? `by ${key.creator} ` : ""}
-                        {timeAgoFrom(key.createdAt, {
-                          useLongFormat: true,
-                        })}{" "}
-                        ago.
-                      </p>
-                      <p
-                        className={cn(
-                          "front-normal text-xs",
-                          "text-muted-foreground"
-                        )}
-                      >
-                        {key.lastUsedAt ? (
-                          <>
-                            Last used&nbsp;
-                            {timeAgoFrom(key.lastUsedAt, {
-                              useLongFormat: true,
-                            })}{" "}
-                            ago.
-                          </>
-                        ) : (
-                          <>Never used</>
-                        )}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              {key.status === "active" ? (
-                <div className="flex gap-2">
-                  {(showLegacyUsdMonthlyCap || showCreditMonthlyCap) && (
-                    <Button
-                      variant="outline"
-                      disabled={isRevoking || isGenerating}
-                      onClick={() => onEditCap(key)}
-                      label="Edit cap"
-                    />
-                  )}
-                  <Button
-                    variant="warning"
-                    disabled={isRevoking || isGenerating}
-                    onClick={async () => {
-                      await onRevoke(key);
-                    }}
-                    label="Revoke"
-                  />
-                </div>
-              ) : null}
-            </div>
-          </li>
-        ))}
-      </ul>
+    <div className="rounded-xl border border-border bg-panel-background p-4">
+      <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-center">
+        <SearchInput
+          name="api-keys-search"
+          placeholder="Search API Key"
+          value={search}
+          onChange={(value) => {
+            setSearch(value);
+            resetPagination();
+          }}
+          className="dd-privacy-mask flex-1"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              icon={FilterFunnel01}
+              label="Filters"
+              size="sm"
+              variant="outline"
+              isCounter={appliedFilterCount > 0}
+              counterValue={String(appliedFilterCount)}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuLabel label="Status" />
+            {(["active", "capped", "revoked"] as const).map((status) => (
+              <DropdownMenuCheckboxItem
+                key={status}
+                label={
+                  status === "active"
+                    ? "Active"
+                    : status === "capped"
+                      ? "Capped"
+                      : "Revoked"
+                }
+                checked={statusFilters.has(status)}
+                onCheckedChange={() => {
+                  setStatusFilters((current) =>
+                    toggleSetValue(current, status)
+                  );
+                  resetPagination();
+                }}
+                onSelect={(event) => event.preventDefault()}
+              />
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel label="Scope" />
+            {scopeOptions.map((scope) => (
+              <DropdownMenuCheckboxItem
+                key={scope}
+                label={scope}
+                checked={scopeFilters.has(scope)}
+                onCheckedChange={() => {
+                  setScopeFilters((current) => toggleSetValue(current, scope));
+                  resetPagination();
+                }}
+                onSelect={(event) => event.preventDefault()}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {keys.length === 0 ? (
+        <div className="py-8 text-center text-sm text-muted-foreground">
+          Create an API key to start using Dust programmatically.
+        </div>
+      ) : filteredRows.length === 0 ? (
+        <div className="py-8 text-center text-sm text-muted-foreground">
+          No API keys match these filters.
+        </div>
+      ) : (
+        <div className="dd-privacy-mask overflow-x-auto">
+          <DataTable
+            data={paginatedRows}
+            columns={columns}
+            className="min-w-[720px]"
+            columnsBreakpoints={{
+              key: "lg",
+              spaces: "md",
+              monthlyCap: "sm",
+            }}
+          />
+        </div>
+      )}
+
+      <div className="mt-4 flex items-center justify-between border-t border-border pt-4">
+        <span className="text-sm font-medium text-foreground">
+          {filteredRows.length.toLocaleString()} API{" "}
+          {filteredRows.length === 1 ? "key" : "keys"}
+        </span>
+        {filteredRows.length > 0 && (
+          <div className="flex items-center gap-2">
+            <span className="mr-1 text-sm text-muted-foreground">
+              Page {pageIndex + 1} of {pageCount}
+            </span>
+            <Button
+              icon={ChevronLeft}
+              aria-label="Previous page"
+              size="sm"
+              variant="outline"
+              disabled={pageIndex === 0}
+              onClick={() =>
+                setPagination((current) => ({
+                  ...current,
+                  pageIndex: Math.max(0, pageIndex - 1),
+                }))
+              }
+            />
+            <Button
+              icon={ChevronRight}
+              aria-label="Next page"
+              size="sm"
+              variant="outline"
+              disabled={pageIndex >= pageCount - 1}
+              onClick={() =>
+                setPagination((current) => ({
+                  ...current,
+                  pageIndex: Math.min(pageCount - 1, pageIndex + 1),
+                }))
+              }
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
-};
+}

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -557,7 +557,7 @@ export function APIKeysList({
               <DataTable
                 data={paginatedRows}
                 columns={columns}
-                className="min-w-[720px]"
+                className="min-w-3xl"
                 columnsBreakpoints={{
                   key: "xl",
                   spaces: "md",

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -28,7 +28,11 @@ import {
   Separator,
   Tooltip,
 } from "@dust-tt/sparkle";
-import type { ColumnDef, PaginationState } from "@tanstack/react-table";
+import type {
+  ColumnDef,
+  PaginationState,
+  SortingState,
+} from "@tanstack/react-table";
 import capitalize from "lodash/capitalize";
 import { useMemo, useState } from "react";
 import { prettifyGroupName } from "./utils";
@@ -164,7 +168,7 @@ function buildColumns({
       id: "name",
       accessorFn: (row) => row.name,
       header: "Name",
-      enableSorting: false,
+      enableSorting: true,
       meta: { className: "h-16 w-56", headerAlign: "left" },
       cell: (info) => (
         <div className="flex flex-col justify-center">
@@ -268,7 +272,7 @@ function buildColumns({
       id: "createdAt",
       accessorKey: "createdAt",
       header: "Created",
-      enableSorting: false,
+      enableSorting: true,
       meta: { className: "h-16 w-36 min-w-36", headerAlign: "left" },
       cell: (info) => (
         <DataTable.BasicCellContent
@@ -281,7 +285,7 @@ function buildColumns({
       id: "lastUsedAt",
       accessorKey: "lastUsedAt",
       header: "Last used",
-      enableSorting: false,
+      enableSorting: true,
       meta: { className: "h-16 w-36 min-w-36", headerAlign: "left" },
       cell: (info) => (
         <DataTable.BasicCellContent
@@ -378,6 +382,7 @@ export function APIKeysList({
     pageIndex: 0,
     pageSize: API_KEYS_PAGE_SIZE,
   });
+  const [sorting, setSorting] = useState<SortingState>([]);
 
   const actionsDisabled = isRevoking || isGenerating;
   const rows = useMemo<APIKeyRowData[]>(
@@ -443,13 +448,35 @@ export function APIKeysList({
       return matchesSearch && matchesStatus && matchesScope;
     });
   }, [rows, scopeFilters, search, statusFilters]);
+  const sortedRows = useMemo(() => {
+    const activeSort = sorting[0];
+    if (!activeSort) {
+      return filteredRows;
+    }
+
+    return [...filteredRows].sort((left, right) => {
+      let comparison = 0;
+      switch (activeSort.id) {
+        case "name":
+          comparison = left.name.localeCompare(right.name);
+          break;
+        case "createdAt":
+          comparison = left.createdAt - right.createdAt;
+          break;
+        case "lastUsedAt":
+          comparison = (left.lastUsedAt ?? 0) - (right.lastUsedAt ?? 0);
+          break;
+      }
+      return activeSort.desc ? -comparison : comparison;
+    });
+  }, [filteredRows, sorting]);
 
   const pageCount = Math.max(
     1,
-    Math.ceil(filteredRows.length / pagination.pageSize)
+    Math.ceil(sortedRows.length / pagination.pageSize)
   );
   const pageIndex = Math.min(pagination.pageIndex, pageCount - 1);
-  const paginatedRows = filteredRows.slice(
+  const paginatedRows = sortedRows.slice(
     pageIndex * pagination.pageSize,
     (pageIndex + 1) * pagination.pageSize
   );
@@ -558,6 +585,12 @@ export function APIKeysList({
                 data={paginatedRows}
                 columns={columns}
                 className="min-w-3xl"
+                sorting={sorting}
+                setSorting={(nextSorting) => {
+                  setSorting(nextSorting);
+                  resetPagination();
+                }}
+                isServerSideSorting
                 columnsBreakpoints={{
                   key: "xl",
                   spaces: "md",

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -15,17 +15,9 @@ import {
   Chip,
   DataTable,
   DataTableLoadingSkeleton,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
   Edit04,
-  FilterFunnel01,
   Icon,
   LoadingBlock,
-  SearchInput,
   Separator,
   Tooltip,
 } from "@dust-tt/sparkle";
@@ -122,32 +114,6 @@ function formatMonthlyCap({
       : `$${(key.monthlyCapMicroUsd / 1_000_000).toFixed(2)}`;
   }
   return "—";
-}
-
-function toggleSetValue<T>(current: ReadonlySet<T>, value: T): ReadonlySet<T> {
-  const next = new Set(current);
-  if (next.has(value)) {
-    next.delete(value);
-  } else {
-    next.add(value);
-  }
-  return next;
-}
-
-function matchesAPIKeySearch(row: APIKeyRowData, search: string): boolean {
-  const normalizedSearch = search.trim().toLowerCase();
-  if (!normalizedSearch) {
-    return true;
-  }
-
-  return [
-    row.name,
-    row.creator,
-    row.secret,
-    row.scope,
-    row.status,
-    ...row.spaces,
-  ].some((value) => value.toLowerCase().includes(normalizedSearch));
 }
 
 function buildColumns({
@@ -379,13 +345,6 @@ export function APIKeysList({
   showLegacyUsdMonthlyCap,
   showCreditMonthlyCap,
 }: APIKeysListProps) {
-  const [search, setSearch] = useState("");
-  const [statusFilters, setStatusFilters] = useState<ReadonlySet<APIKeyStatus>>(
-    new Set()
-  );
-  const [scopeFilters, setScopeFilters] = useState<ReadonlySet<string>>(
-    new Set()
-  );
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: API_KEYS_PAGE_SIZE,
@@ -432,10 +391,6 @@ export function APIKeysList({
     [groupsById, keys, onEditCap, showCreditMonthlyCap, showLegacyUsdMonthlyCap]
   );
 
-  const scopeOptions = useMemo(
-    () => [...new Set(rows.map((row) => row.scope))].sort(),
-    [rows]
-  );
   const columns = useMemo(
     () =>
       buildColumns({
@@ -445,23 +400,13 @@ export function APIKeysList({
       }),
     [actionsDisabled, onRevoke, showCreditMonthlyCap]
   );
-  const filteredRows = useMemo(() => {
-    return rows.filter((row) => {
-      const matchesSearch = matchesAPIKeySearch(row, search);
-      const matchesStatus =
-        statusFilters.size === 0 || statusFilters.has(row.status);
-      const matchesScope =
-        scopeFilters.size === 0 || scopeFilters.has(row.scope);
-      return matchesSearch && matchesStatus && matchesScope;
-    });
-  }, [rows, scopeFilters, search, statusFilters]);
   const sortedRows = useMemo(() => {
     const activeSort = sorting[0];
     if (!activeSort) {
-      return filteredRows;
+      return rows;
     }
 
-    return [...filteredRows].sort((left, right) => {
+    return [...rows].sort((left, right) => {
       let comparison = 0;
       switch (activeSort.id) {
         case "name":
@@ -473,7 +418,7 @@ export function APIKeysList({
       }
       return activeSort.desc ? -comparison : comparison;
     });
-  }, [filteredRows, sorting]);
+  }, [rows, sorting]);
 
   const pageCount = Math.max(
     1,
@@ -484,8 +429,6 @@ export function APIKeysList({
     pageIndex * pagination.pageSize,
     (pageIndex + 1) * pagination.pageSize
   );
-  const appliedFilterCount = statusFilters.size + scopeFilters.size;
-
   const resetPagination = () => {
     setPagination((current) => ({ ...current, pageIndex: 0 }));
   };
@@ -495,62 +438,6 @@ export function APIKeysList({
       className="flex flex-col gap-4 rounded-xl border border-border bg-panel-background p-4"
       aria-busy={isLoading}
     >
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-        <SearchInput
-          name="api-keys-search"
-          placeholder="Search API Key"
-          value={search}
-          onChange={(value) => {
-            setSearch(value);
-            resetPagination();
-          }}
-          className="dd-privacy-mask flex-1"
-        />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              icon={FilterFunnel01}
-              label="Filters"
-              size="sm"
-              variant="outline"
-              isCounter={appliedFilterCount > 0}
-              counterValue={String(appliedFilterCount)}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-56">
-            <DropdownMenuLabel label="Status" />
-            {(["active", "capped", "revoked"] as const).map((status) => (
-              <DropdownMenuCheckboxItem
-                key={status}
-                label={capitalize(status)}
-                checked={statusFilters.has(status)}
-                onCheckedChange={() => {
-                  setStatusFilters((current) =>
-                    toggleSetValue(current, status)
-                  );
-                  resetPagination();
-                }}
-                onSelect={(event) => event.preventDefault()}
-              />
-            ))}
-            <DropdownMenuSeparator />
-            <DropdownMenuLabel label="Scope" />
-            {scopeOptions.map((scope) => (
-              <DropdownMenuCheckboxItem
-                key={scope}
-                label={scope}
-                checked={scopeFilters.has(scope)}
-                onCheckedChange={() => {
-                  setScopeFilters((current) => toggleSetValue(current, scope));
-                  resetPagination();
-                }}
-                onSelect={(event) => event.preventDefault()}
-              />
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-
       {isLoading ? (
         <>
           <DataTableLoadingSkeleton
@@ -579,10 +466,6 @@ export function APIKeysList({
             <div className="py-8 text-center text-sm text-muted-foreground">
               Create an API key to start using Dust programmatically.
             </div>
-          ) : filteredRows.length === 0 ? (
-            <div className="py-8 text-center text-sm text-muted-foreground">
-              No API keys match these filters.
-            </div>
           ) : (
             <div className="dd-privacy-mask">
               <DataTable
@@ -601,10 +484,10 @@ export function APIKeysList({
           <Separator />
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium text-foreground">
-              {filteredRows.length.toLocaleString()} API key
-              {pluralize(filteredRows.length)}
+              {rows.length.toLocaleString()} API key
+              {pluralize(rows.length)}
             </span>
-            {filteredRows.length > 0 && (
+            {rows.length > 0 && (
               <div className="flex items-center gap-3">
                 <span className="text-sm text-muted-foreground">
                   Page {pageIndex + 1} of {pageCount}

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -169,7 +169,7 @@ function buildColumns({
       accessorFn: (row) => row.name,
       header: "Name",
       enableSorting: true,
-      meta: { className: "h-16 w-56", headerAlign: "left" },
+      meta: { className: "h-16", headerAlign: "left" },
       cell: (info) => (
         <div className="flex flex-col justify-center">
           <span className="truncate text-sm font-medium text-foreground">
@@ -186,7 +186,10 @@ function buildColumns({
       accessorKey: "scope",
       header: "Scope",
       enableSorting: false,
-      meta: { className: "h-16 w-28", headerAlign: "left" },
+      meta: {
+        className: "hidden h-16 w-24 @sm-table:table-cell",
+        headerAlign: "left",
+      },
       cell: (info) => (
         <DataTable.CellContent>
           <Chip
@@ -202,7 +205,10 @@ function buildColumns({
       accessorKey: "secret",
       header: "Key",
       enableSorting: false,
-      meta: { className: "h-16 w-40", headerAlign: "left" },
+      meta: {
+        className: "hidden h-16 w-20 @md-table:table-cell",
+        headerAlign: "left",
+      },
       cell: (info) => (
         <DataTable.BasicCellContent
           className="font-mono text-muted-foreground"
@@ -215,7 +221,10 @@ function buildColumns({
       accessorFn: (row) => row.spaces.join(", "),
       header: "Spaces",
       enableSorting: false,
-      meta: { className: "h-16 w-48", headerAlign: "left" },
+      meta: {
+        className: "hidden h-16 w-24 @md-table:table-cell",
+        headerAlign: "left",
+      },
       cell: (info) => {
         const spaces = info.row.original.spaces;
         const [firstSpace, ...remainingSpaces] = spaces;
@@ -260,7 +269,10 @@ function buildColumns({
       accessorKey: "monthlyCap",
       header: capLabel,
       enableSorting: false,
-      meta: { className: "h-16 w-32", headerAlign: "left" },
+      meta: {
+        className: "hidden h-16 w-20 @sm-table:table-cell",
+        headerAlign: "left",
+      },
       cell: (info) => (
         <DataTable.BasicCellContent
           className="tabular-nums"
@@ -273,7 +285,10 @@ function buildColumns({
       accessorKey: "createdAt",
       header: "Created",
       enableSorting: true,
-      meta: { className: "h-16 w-36 min-w-36", headerAlign: "left" },
+      meta: {
+        className: "hidden h-16 w-28 @md-table:table-cell",
+        headerAlign: "left",
+      },
       cell: (info) => (
         <DataTable.BasicCellContent
           className="whitespace-nowrap"
@@ -286,7 +301,10 @@ function buildColumns({
       accessorKey: "lastUsedAt",
       header: "Last used",
       enableSorting: true,
-      meta: { className: "h-16 w-36 min-w-36", headerAlign: "left" },
+      meta: {
+        className: "hidden h-16 w-28 @sm-table:table-cell",
+        headerAlign: "left",
+      },
       cell: (info) => (
         <DataTable.BasicCellContent
           className="whitespace-nowrap"
@@ -303,7 +321,7 @@ function buildColumns({
       accessorKey: "status",
       header: "Status",
       enableSorting: false,
-      meta: { className: "h-16 w-28", headerAlign: "left" },
+      meta: { className: "h-16 w-16", headerAlign: "left" },
       cell: (info) => {
         const status = info.row.original.status;
         return (
@@ -327,7 +345,10 @@ function buildColumns({
       id: "revoke",
       header: "",
       enableSorting: false,
-      meta: { className: "h-16 w-24", headerAlign: "right" },
+      meta: {
+        className: "hidden h-16 w-20 @xs-table:table-cell",
+        headerAlign: "right",
+      },
       cell: (info) =>
         info.row.original.key.status === "active" ? (
           <DataTable.CellContent className="w-full justify-end">
@@ -345,7 +366,7 @@ function buildColumns({
       id: "actions",
       header: "",
       enableSorting: false,
-      meta: { className: "h-16 w-12" },
+      meta: { className: "h-16 w-10" },
       cell: (info) =>
         info.row.original.menuItems.length > 0 ? (
           <DataTable.CellContent className="w-full justify-end">
@@ -580,24 +601,16 @@ export function APIKeysList({
               No API keys match these filters.
             </div>
           ) : (
-            <div className="dd-privacy-mask overflow-x-auto">
+            <div className="dd-privacy-mask">
               <DataTable
                 data={paginatedRows}
                 columns={columns}
-                className="min-w-3xl"
                 sorting={sorting}
                 setSorting={(nextSorting) => {
                   setSorting(nextSorting);
                   resetPagination();
                 }}
                 isServerSideSorting
-                columnsBreakpoints={{
-                  key: "xl",
-                  spaces: "md",
-                  monthlyCap: "sm",
-                  createdAt: "lg",
-                  lastUsedAt: "md",
-                }}
               />
             </div>
           )}

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -63,7 +63,6 @@ interface APIKeyRowData {
   secret: string;
   status: APIKeyStatus;
   monthlyCap: string;
-  createdAt: number;
   lastUsedAt: number | null;
   menuItems: MenuItem[];
 }
@@ -281,22 +280,6 @@ function buildColumns({
       ),
     },
     {
-      id: "createdAt",
-      accessorKey: "createdAt",
-      header: "Created",
-      enableSorting: true,
-      meta: {
-        className: "hidden h-16 w-28 @lg-table:table-cell",
-        headerAlign: "left",
-      },
-      cell: (info) => (
-        <DataTable.BasicCellContent
-          className="whitespace-nowrap"
-          label={formatRelativeTime(info.row.original.createdAt)}
-        />
-      ),
-    },
-    {
       id: "lastUsedAt",
       accessorKey: "lastUsedAt",
       header: "Last used",
@@ -438,7 +421,6 @@ export function APIKeysList({
             showLegacyUsdMonthlyCap,
             showCreditMonthlyCap,
           }),
-          createdAt: key.createdAt,
           lastUsedAt: key.lastUsedAt,
           menuItems,
         };
@@ -480,9 +462,6 @@ export function APIKeysList({
       switch (activeSort.id) {
         case "name":
           comparison = left.name.localeCompare(right.name);
-          break;
-        case "createdAt":
-          comparison = left.createdAt - right.createdAt;
           break;
         case "lastUsedAt":
           comparison = (left.lastUsedAt ?? 0) - (right.lastUsedAt ?? 0);

--- a/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
+++ b/front/components/workspace/api-keys/NewAPIKeyDialog.tsx
@@ -51,6 +51,7 @@ type FormValues = z.infer<typeof formSchema>;
 
 interface NewAPIKeyDialogProps {
   groups: GroupType[];
+  disabled?: boolean;
   isGenerating: boolean;
   isRevoking: boolean;
   onCreate: (params: {
@@ -65,6 +66,7 @@ interface NewAPIKeyDialogProps {
 
 export const NewAPIKeyDialog = ({
   groups,
+  disabled,
   isGenerating,
   isRevoking,
   onCreate,
@@ -154,7 +156,7 @@ export const NewAPIKeyDialog = ({
         <Button
           label="Create API Key"
           icon={Plus}
-          disabled={isGenerating || isRevoking}
+          disabled={disabled || isGenerating || isRevoking}
         />
       </SheetTrigger>
       <SheetContent size="lg">


### PR DESCRIPTION
## Description

Implements the following [Figma](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=14115-10586&m=dev).

API keys are currently rendered as a long list with unbounded width, mono font at places, and where each key takes a lot of vertical space, which makes them hard to scan and manage.

This PR refactors the admin page into a table layout, with search and filters coming in the next PR, and a credit breakdown in the one after.

Only a UI change, feature-wise at parity.

Current live version

<img width="1151" height="910" alt="Screenshot 2026-08-21 at 7 21 11 AM" src="https://github.com/user-attachments/assets/6882b64e-6741-45ed-b1f3-df2b7491f318" />

Proposal

<img width="1135" height="1001" alt="Screenshot 2026-08-21 at 7 17 34 AM" src="https://github.com/user-attachments/assets/94e6adbc-d4da-4868-a2ec-d8e5785be1b4" />

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
