### PR TITLE
[front] enh: add table-shaped skeletons to Tools and Triggers

### DIFF
--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -29,8 +29,8 @@ import {
   DropdownMenuItem,
   DropdownMenuPortal,
   DropdownMenuTrigger,
+  LoadingBlock,
   SearchInput,
-  Spinner,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import keyBy from "lodash/keyBy";
@@ -50,6 +50,90 @@ interface UserTableRow {
 
 interface UserToolsTableProps {
   owner: LightWorkspaceType;
+}
+
+interface UserToolSkeletonRow {
+  actions: string;
+  name: string;
+  onClick?: () => void;
+}
+
+const USER_TOOL_SKELETON_ROWS: UserToolSkeletonRow[] = Array.from(
+  { length: 5 },
+  (_, index) => ({
+    actions: `action-${index}`,
+    name: `tool-${index}`,
+  })
+);
+
+const USER_TOOL_NAME_SKELETON_WIDTHS = ["w-28", "w-36", "w-24", "w-32", "w-40"];
+
+const USER_TOOL_DESCRIPTION_SKELETON_WIDTHS = [
+  "w-64",
+  "w-52",
+  "w-72",
+  "w-60",
+  "w-56",
+];
+
+const USER_TOOL_SKELETON_COLUMNS: ColumnDef<UserToolSkeletonRow>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+    cell: ({ row }) => (
+      <DataTable.CellContent grow>
+        <div className="flex flex-row items-center gap-3 py-3">
+          <LoadingBlock className="h-9 w-9 shrink-0 rounded-lg" />
+          <div className="flex min-w-0 flex-grow flex-col overflow-hidden">
+            <div className="flex h-5 items-center">
+              <LoadingBlock
+                className={classNames(
+                  "h-4 max-w-full",
+                  USER_TOOL_NAME_SKELETON_WIDTHS[row.index]
+                )}
+              />
+            </div>
+            <div className="flex h-5 items-center">
+              <LoadingBlock
+                className={classNames(
+                  "h-4 max-w-full",
+                  USER_TOOL_DESCRIPTION_SKELETON_WIDTHS[row.index]
+                )}
+              />
+            </div>
+          </div>
+          <LoadingBlock className="h-6 w-20 shrink-0 rounded-[9px]" />
+        </div>
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-full",
+    },
+  },
+  {
+    accessorKey: "actions",
+    header: "",
+    cell: () => (
+      <DataTable.CellContent>
+        <LoadingBlock className="h-8 w-8 rounded-xl" />
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-12",
+    },
+  },
+];
+
+function UserToolsTableSkeleton() {
+  return (
+    <div aria-hidden="true">
+      <DataTable
+        data={USER_TOOL_SKELETON_ROWS}
+        columns={USER_TOOL_SKELETON_COLUMNS}
+        sorting={[{ id: "name", desc: false }]}
+      />
+    </div>
+  );
 }
 
 export function UserToolsTable({ owner }: UserToolsTableProps) {
@@ -309,9 +393,7 @@ export function UserToolsTable({ owner }: UserToolsTableProps) {
       isHiddenMCPServerViewsLoading ||
       isConnectionsLoading ||
       isApprovalsLoading ? (
-        <div className="flex justify-center p-6">
-          <Spinner />
-        </div>
+        <UserToolsTableSkeleton />
       ) : actionsTableData.length > 0 ? (
         <DataTable
           data={actionsTableData}

--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -66,16 +66,6 @@ const USER_TOOL_SKELETON_ROWS: UserToolSkeletonRow[] = Array.from(
   })
 );
 
-const USER_TOOL_NAME_SKELETON_WIDTHS = ["w-28", "w-36", "w-24", "w-32", "w-40"];
-
-const USER_TOOL_DESCRIPTION_SKELETON_WIDTHS = [
-  "w-64",
-  "w-52",
-  "w-72",
-  "w-60",
-  "w-56",
-];
-
 const USER_TOOL_SKELETON_COLUMNS: ColumnDef<UserToolSkeletonRow>[] = [
   {
     accessorKey: "name",
@@ -89,7 +79,7 @@ const USER_TOOL_SKELETON_COLUMNS: ColumnDef<UserToolSkeletonRow>[] = [
               <LoadingBlock
                 className={classNames(
                   "h-4 max-w-full",
-                  USER_TOOL_NAME_SKELETON_WIDTHS[row.index]
+                  ["w-28", "w-36", "w-24", "w-32", "w-40"][row.index]
                 )}
               />
             </div>
@@ -97,7 +87,7 @@ const USER_TOOL_SKELETON_COLUMNS: ColumnDef<UserToolSkeletonRow>[] = [
               <LoadingBlock
                 className={classNames(
                   "h-4 max-w-full",
-                  USER_TOOL_DESCRIPTION_SKELETON_WIDTHS[row.index]
+                  ["w-64", "w-52", "w-72", "w-60", "w-56"][row.index]
                 )}
               />
             </div>

--- a/front/components/me/UserTriggersTable.tsx
+++ b/front/components/me/UserTriggersTable.tsx
@@ -52,22 +52,6 @@ const USER_TRIGGER_SKELETON_ROWS: UserTriggerSkeletonRow[] = Array.from(
   })
 );
 
-const USER_TRIGGER_NAME_SKELETON_WIDTHS = [
-  "w-28",
-  "w-36",
-  "w-24",
-  "w-40",
-  "w-32",
-];
-
-const USER_TRIGGER_DESCRIPTION_SKELETON_WIDTHS = [
-  "w-64",
-  "w-52",
-  "w-72",
-  "w-60",
-  "w-56",
-];
-
 const USER_TRIGGER_SKELETON_COLUMNS: ColumnDef<UserTriggerSkeletonRow>[] = [
   {
     accessorKey: "agentName",
@@ -92,12 +76,12 @@ const USER_TRIGGER_SKELETON_COLUMNS: ColumnDef<UserTriggerSkeletonRow>[] = [
         <div className="flex min-w-0 flex-col py-3">
           <div className="flex h-5 items-center">
             <LoadingBlock
-              className={`h-4 max-w-full ${USER_TRIGGER_NAME_SKELETON_WIDTHS[row.index]}`}
+              className={`h-4 max-w-full ${["w-28", "w-36", "w-24", "w-40", "w-32"][row.index]}`}
             />
           </div>
           <div className="flex h-5 items-center">
             <LoadingBlock
-              className={`h-4 max-w-full ${USER_TRIGGER_DESCRIPTION_SKELETON_WIDTHS[row.index]}`}
+              className={`h-4 max-w-full ${["w-64", "w-52", "w-72", "w-60", "w-56"][row.index]}`}
             />
           </div>
         </div>

--- a/front/components/me/UserTriggersTable.tsx
+++ b/front/components/me/UserTriggersTable.tsx
@@ -17,6 +17,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  LoadingBlock,
   SearchInput,
   Spinner,
   Trash01,
@@ -31,6 +32,117 @@ type UserTriggerRow = GetUserTriggersResponseBody["triggers"][number] & {
 
 interface UserTriggersTableProps {
   owner: LightWorkspaceType;
+}
+
+interface UserTriggerSkeletonRow {
+  actions: string;
+  agentName: string;
+  name: string;
+  onClick?: () => void;
+  status: string;
+}
+
+const USER_TRIGGER_SKELETON_ROWS: UserTriggerSkeletonRow[] = Array.from(
+  { length: 5 },
+  (_, index) => ({
+    actions: `action-${index}`,
+    agentName: `agent-${index}`,
+    name: `trigger-${index}`,
+    status: `status-${index}`,
+  })
+);
+
+const USER_TRIGGER_NAME_SKELETON_WIDTHS = [
+  "w-28",
+  "w-36",
+  "w-24",
+  "w-40",
+  "w-32",
+];
+
+const USER_TRIGGER_DESCRIPTION_SKELETON_WIDTHS = [
+  "w-64",
+  "w-52",
+  "w-72",
+  "w-60",
+  "w-56",
+];
+
+const USER_TRIGGER_SKELETON_COLUMNS: ColumnDef<UserTriggerSkeletonRow>[] = [
+  {
+    accessorKey: "agentName",
+    header: "Agent",
+    cell: () => (
+      <DataTable.CellContent>
+        <div className="flex min-w-0 items-center gap-2">
+          <LoadingBlock className="h-7 w-7 shrink-0 rounded-md" />
+          <LoadingBlock className="h-4 w-20 max-w-full" />
+        </div>
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-40",
+    },
+  },
+  {
+    accessorKey: "name",
+    header: "Trigger",
+    cell: ({ row }) => (
+      <DataTable.CellContent grow>
+        <div className="flex min-w-0 flex-col py-3">
+          <div className="flex h-5 items-center">
+            <LoadingBlock
+              className={`h-4 max-w-full ${USER_TRIGGER_NAME_SKELETON_WIDTHS[row.index]}`}
+            />
+          </div>
+          <div className="flex h-5 items-center">
+            <LoadingBlock
+              className={`h-4 max-w-full ${USER_TRIGGER_DESCRIPTION_SKELETON_WIDTHS[row.index]}`}
+            />
+          </div>
+        </div>
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-full",
+    },
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    cell: () => (
+      <DataTable.CellContent>
+        <LoadingBlock className="h-6 w-20 rounded-[9px]" />
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-36",
+    },
+  },
+  {
+    accessorKey: "actions",
+    header: "",
+    cell: () => (
+      <DataTable.CellContent>
+        <LoadingBlock className="h-6 w-20 rounded-[9px]" />
+      </DataTable.CellContent>
+    ),
+    meta: {
+      className: "w-24",
+    },
+  },
+];
+
+function UserTriggersTableSkeleton() {
+  return (
+    <div aria-hidden="true">
+      <DataTable
+        data={USER_TRIGGER_SKELETON_ROWS}
+        columns={USER_TRIGGER_SKELETON_COLUMNS}
+        sorting={[{ id: "agentName", desc: false }]}
+      />
+    </div>
+  );
 }
 
 export function UserTriggersTable({ owner }: UserTriggersTableProps) {
@@ -188,9 +300,7 @@ export function UserTriggersTable({ owner }: UserTriggersTableProps) {
       </div>
 
       {isTriggersLoading ? (
-        <div className="flex justify-center p-6">
-          <Spinner />
-        </div>
+        <UserTriggersTableSkeleton />
       ) : filteredTriggers.length > 0 ? (
         <DataTable
           data={filteredTriggers}


### PR DESCRIPTION
## Description

Loading the user Tools and Triggers dialog currently replaces each table with a centered spinner (not really centered: centered horizontally but not vertically).

Both tabs now render skeleton rows that match the target `DataTable` structure.

<img width="1089" height="808" alt="image" src="https://github.com/user-attachments/assets/bb940d4a-b124-4474-94f9-c46a39ffffd0" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
