### PR TITLE
[Activation] Delegate work-area MCP tools across administrable pods

### DIFF
--- a/front/lib/api/actions/servers/activation_recommendations/index.test.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.test.ts
@@ -1,3 +1,7 @@
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { Authenticator } from "@app/lib/auth";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
@@ -6,9 +10,15 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import assert from "assert";
 import { describe, expect, it } from "vitest";
 
 import { TOOLS } from ".";
+
+const WORK_AREA = {
+  title: "Pipeline management",
+  description: "Keep active opportunities moving toward close.",
+};
 
 function getTool(
   name:
@@ -18,17 +28,23 @@ function getTool(
     | "update_work_area"
 ) {
   const tool = TOOLS.find((candidate) => candidate.name === name);
-  if (!tool) {
-    throw new Error(`${name} tool not found`);
-  }
+  assert(tool);
   return tool;
 }
 
-function createTestExtra(auth: Authenticator) {
+function createTestExtra(auth: Authenticator): ToolHandlerExtra {
   return {
-    signal: new AbortController().signal,
     auth,
-  } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
+    requestId: "activation-work-area-test",
+    // These focused handlers do not read the run context.
+    // @ts-expect-error A registered MCP handler always receives one in production.
+    runContext: undefined,
+    sendNotification: async () => {},
+    sendRequest: async () => {
+      throw new Error("Unexpected MCP request");
+    },
+    signal: new AbortController().signal,
+  };
 }
 
 async function createActivationPod(
@@ -43,72 +59,93 @@ async function createActivationPod(
   return pod;
 }
 
+async function createUserActivationPod(
+  workspace: ReturnType<Authenticator["getNonNullableWorkspace"]>
+) {
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "user" });
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspace.sId
+  );
+  const pod = await createActivationPod(auth, workspace);
+  return { auth, pod };
+}
+
+function getText(result: ToolHandlerResult): string {
+  assert(result.isOk());
+  const [content] = result.value;
+  assert(content?.type === "text");
+  return content.text;
+}
+
 describe("activation recommendations work-area tools", () => {
-  it("creates and lists work areas for a pod the caller can administrate", async () => {
-    const { workspace, authenticator } = await createResourceTest({
+  it("lets an editor manage their pod but not another user's pod", async () => {
+    const { workspace, authenticator: auth } = await createResourceTest({
       role: "user",
     });
-    const pod = await createActivationPod(authenticator, workspace);
+    const ownPod = await createActivationPod(auth, workspace);
+    const { pod: otherPod } = await createUserActivationPod(workspace);
+    const extra = createTestExtra(auth);
+
+    const listedPods = JSON.parse(
+      getText(await getTool("list_activation_pods").handler({}, extra))
+    );
+    expect(listedPods).toEqual([{ podId: ownPod.sId, name: ownPod.name }]);
 
     const createResult = await getTool("create_work_areas").handler(
       {
-        assignments: [
-          {
-            podIds: [pod.sId],
-            workAreas: [
-              {
-                title: "Weekly planning",
-                description: "Plan and prioritize the week's recurring work.",
-              },
-            ],
-          },
-        ],
+        assignments: [{ podIds: [ownPod.sId], workAreas: [WORK_AREA] }],
       },
-      createTestExtra(authenticator)
+      extra
     );
-    expect(createResult.isOk()).toBe(true);
+    expect(getText(createResult)).toBe("Saved 1 work areas across 1 pod(s).");
 
-    const listResult = await getTool("list_work_areas").handler(
-      { podIds: [pod.sId] },
-      createTestExtra(authenticator)
+    const listedWorkAreas = JSON.parse(
+      getText(
+        await getTool("list_work_areas").handler(
+          { podIds: [ownPod.sId] },
+          extra
+        )
+      )
     );
-    expect(listResult.isOk()).toBe(true);
-    if (listResult.isOk()) {
-      const [content] = listResult.value;
-      expect(content.type).toBe("text");
-      if (content.type === "text") {
-        const payload = JSON.parse(content.text);
-        expect(payload).toEqual([
-          expect.objectContaining({
-            podId: pod.sId,
-            workAreas: [expect.objectContaining({ title: "Weekly planning" })],
-          }),
-        ]);
-      }
-    }
+    expect(listedWorkAreas).toEqual([
+      expect.objectContaining({
+        podId: ownPod.sId,
+        workAreas: [expect.objectContaining(WORK_AREA)],
+      }),
+    ]);
+
+    const unauthorized = await getTool("create_work_areas").handler(
+      {
+        assignments: [{ podIds: [otherPod.sId], workAreas: [WORK_AREA] }],
+      },
+      extra
+    );
+    assert(unauthorized.isErr());
+    expect(unauthorized.error.message).toContain(
+      "Not authorized to manage work areas"
+    );
   });
 
-  it("lets a workspace admin create and list work areas on other members' pods", async () => {
-    const { workspace, authenticator } = await createResourceTest({
+  it("lets a workspace admin manage multiple members' pods", async () => {
+    const { workspace, authenticator: auth } = await createResourceTest({
       role: "admin",
     });
-    const firstUser = await UserFactory.basic();
-    const secondUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, firstUser, { role: "user" });
-    await MembershipFactory.associate(workspace, secondUser, { role: "user" });
-    const firstPod = await createActivationPod(
-      await Authenticator.fromUserIdAndWorkspaceId(
-        firstUser.sId,
-        workspace.sId
-      ),
-      workspace
+    const [{ pod: firstPod }, { pod: secondPod }] = await Promise.all([
+      createUserActivationPod(workspace),
+      createUserActivationPod(workspace),
+    ]);
+    const extra = createTestExtra(auth);
+
+    const listedPods = JSON.parse(
+      getText(await getTool("list_activation_pods").handler({}, extra))
     );
-    const secondPod = await createActivationPod(
-      await Authenticator.fromUserIdAndWorkspaceId(
-        secondUser.sId,
-        workspace.sId
-      ),
-      workspace
+    expect(listedPods).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ podId: firstPod.sId }),
+        expect.objectContaining({ podId: secondPod.sId }),
+      ])
     );
 
     const createResult = await getTool("create_work_areas").handler(
@@ -116,183 +153,46 @@ describe("activation recommendations work-area tools", () => {
         assignments: [
           {
             podIds: [firstPod.sId, secondPod.sId],
-            workAreas: [
-              {
-                title: "Pipeline management",
-                description: "Keep active opportunities moving toward close.",
-              },
-            ],
+            workAreas: [WORK_AREA],
           },
         ],
       },
-      createTestExtra(authenticator)
+      extra
     );
-    expect(createResult.isOk()).toBe(true);
+    expect(getText(createResult)).toBe("Saved 2 work areas across 2 pod(s).");
 
-    const listResult = await getTool("list_work_areas").handler(
-      { podIds: [firstPod.sId, secondPod.sId] },
-      createTestExtra(authenticator)
+    const listedWorkAreas = JSON.parse(
+      getText(
+        await getTool("list_work_areas").handler(
+          { podIds: [firstPod.sId, secondPod.sId] },
+          extra
+        )
+      )
     );
-    expect(listResult.isOk()).toBe(true);
-    if (listResult.isOk()) {
-      const [content] = listResult.value;
-      expect(content.type).toBe("text");
-      if (content.type === "text") {
-        const payload = JSON.parse(content.text);
-        expect(payload).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              podId: firstPod.sId,
-              workAreas: [
-                expect.objectContaining({ title: "Pipeline management" }),
-              ],
-            }),
-            expect.objectContaining({
-              podId: secondPod.sId,
-              workAreas: [
-                expect.objectContaining({ title: "Pipeline management" }),
-              ],
-            }),
-          ])
-        );
-      }
-    }
-  });
-
-  it("rejects a caller who cannot administrate the pod", async () => {
-    const { workspace, authenticator } = await createResourceTest({
-      role: "user",
-    });
-    const targetUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
-    const targetPod = await createActivationPod(
-      await Authenticator.fromUserIdAndWorkspaceId(
-        targetUser.sId,
-        workspace.sId
-      ),
-      workspace
+    expect(listedWorkAreas).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          podId: firstPod.sId,
+          workAreas: [expect.objectContaining(WORK_AREA)],
+        }),
+        expect.objectContaining({
+          podId: secondPod.sId,
+          workAreas: [expect.objectContaining(WORK_AREA)],
+        }),
+      ])
     );
-
-    const result = await getTool("create_work_areas").handler(
-      {
-        assignments: [
-          {
-            podIds: [targetPod.sId],
-            workAreas: [
-              {
-                title: "Weekly pipeline review",
-                description:
-                  "Review pipeline movement and unblock active deals.",
-              },
-            ],
-          },
-        ],
-      },
-      createTestExtra(authenticator)
-    );
-
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.message).toContain(
-        "Not authorized to manage work areas"
-      );
-    }
-  });
-
-  it("lists only Activation Pods the caller can administrate", async () => {
-    const { workspace, authenticator } = await createResourceTest({
-      role: "user",
-    });
-    const ownPod = await createActivationPod(authenticator, workspace);
-    const otherUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
-    const otherPod = await createActivationPod(
-      await Authenticator.fromUserIdAndWorkspaceId(
-        otherUser.sId,
-        workspace.sId
-      ),
-      workspace
-    );
-
-    const result = await getTool("list_activation_pods").handler(
-      {},
-      createTestExtra(authenticator)
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      const [content] = result.value;
-      expect(content.type).toBe("text");
-      if (content.type === "text") {
-        const payload = JSON.parse(content.text);
-        expect(payload).toEqual([
-          expect.objectContaining({
-            podId: ownPod.sId,
-            name: ownPod.name,
-          }),
-        ]);
-        expect(payload).not.toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ podId: otherPod.sId }),
-          ])
-        );
-      }
-    }
-  });
-
-  it("lets a workspace admin list other members' Activation Pods", async () => {
-    const { workspace, authenticator } = await createResourceTest({
-      role: "admin",
-    });
-    const targetUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
-    const targetPod = await createActivationPod(
-      await Authenticator.fromUserIdAndWorkspaceId(
-        targetUser.sId,
-        workspace.sId
-      ),
-      workspace
-    );
-
-    const result = await getTool("list_activation_pods").handler(
-      {},
-      createTestExtra(authenticator)
-    );
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      const [content] = result.value;
-      expect(content.type).toBe("text");
-      if (content.type === "text") {
-        const payload = JSON.parse(content.text);
-        expect(payload).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              podId: targetPod.sId,
-              name: targetPod.name,
-            }),
-          ])
-        );
-      }
-    }
   });
 
   it("rejects a pod appearing in multiple assignments", async () => {
-    const { workspace, authenticator } = await createResourceTest({
+    const { workspace, authenticator: auth } = await createResourceTest({
       role: "user",
     });
-    const pod = await createActivationPod(authenticator, workspace);
+    const pod = await createActivationPod(auth, workspace);
 
     const result = await getTool("create_work_areas").handler(
       {
         assignments: [
-          {
-            podIds: [pod.sId],
-            workAreas: [
-              {
-                title: "Pipeline management",
-                description: "Keep active opportunities moving toward close.",
-              },
-            ],
-          },
+          { podIds: [pod.sId], workAreas: [WORK_AREA] },
           {
             podIds: [pod.sId],
             workAreas: [
@@ -305,52 +205,43 @@ describe("activation recommendations work-area tools", () => {
           },
         ],
       },
-      createTestExtra(authenticator)
+      createTestExtra(auth)
     );
 
-    expect(result.isErr()).toBe(true);
-    if (result.isErr()) {
-      expect(result.error.message).toContain("Each pod may appear in only one");
-    }
+    assert(result.isErr());
+    expect(result.error.message).toContain("Each pod may appear in only one");
   });
 
-  it("returns the same not-found error for missing and unauthorized work areas", async () => {
-    const { workspace, authenticator } = await createResourceTest({
+  it("returns the same not-found error for missing and unauthorized updates", async () => {
+    const { workspace, authenticator: auth } = await createResourceTest({
       role: "user",
     });
-    const targetUser = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
-    const targetAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      targetUser.sId,
-      workspace.sId
-    );
-    const targetPod = await createActivationPod(targetAuth, workspace);
+    const { auth: targetAuth, pod: targetPod } =
+      await createUserActivationPod(workspace);
     const targetActivationPod = await ActivationPodResource.fetchBySpace(
       targetAuth,
       targetPod
     );
-    expect(targetActivationPod).not.toBeNull();
+    assert(targetActivationPod);
 
     const workArea = await ActivationWorkAreaResource.makeNew(targetAuth, {
-      title: "Other user's area",
-      description: "Should not leak existence.",
-      podId: targetActivationPod!.id,
+      ...WORK_AREA,
+      podId: targetActivationPod.id,
     });
+    const extra = createTestExtra(auth);
 
     const missing = await getTool("update_work_area").handler(
       { workAreaId: "awa_does_not_exist", status: "dismissed" },
-      createTestExtra(authenticator)
+      extra
     );
     const unauthorized = await getTool("update_work_area").handler(
       { workAreaId: workArea.sId, status: "dismissed" },
-      createTestExtra(authenticator)
+      extra
     );
 
-    expect(missing.isErr()).toBe(true);
-    expect(unauthorized.isErr()).toBe(true);
-    if (missing.isErr() && unauthorized.isErr()) {
-      expect(missing.error.message).toBe("Work area not found.");
-      expect(unauthorized.error.message).toBe(missing.error.message);
-    }
+    assert(missing.isErr());
+    assert(unauthorized.isErr());
+    expect(missing.error.message).toBe("Work area not found.");
+    expect(unauthorized.error.message).toBe(missing.error.message);
   });
 });

--- a/front/lib/api/actions/servers/activation_recommendations/index.test.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.test.ts
@@ -1,0 +1,356 @@
+import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { describe, expect, it } from "vitest";
+
+import { TOOLS } from ".";
+
+function getTool(
+  name:
+    | "create_work_areas"
+    | "list_work_areas"
+    | "list_activation_pods"
+    | "update_work_area"
+) {
+  const tool = TOOLS.find((candidate) => candidate.name === name);
+  if (!tool) {
+    throw new Error(`${name} tool not found`);
+  }
+  return tool;
+}
+
+function createTestExtra(auth: Authenticator) {
+  return {
+    signal: new AbortController().signal,
+    auth,
+  } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
+}
+
+async function createActivationPod(
+  auth: Authenticator,
+  workspace: ReturnType<Authenticator["getNonNullableWorkspace"]>
+) {
+  const user = auth.getNonNullableUser();
+  const pod = await SpaceFactory.project(workspace, user.id);
+  await ProjectMetadataResource.makeNew(auth, pod, { description: null });
+  await ActivationPodResource.makeNew(auth, { pod, user });
+  await auth.refresh();
+  return pod;
+}
+
+describe("activation recommendations work-area tools", () => {
+  it("creates and lists work areas for a pod the caller can administrate", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "user",
+    });
+    const pod = await createActivationPod(authenticator, workspace);
+
+    const createResult = await getTool("create_work_areas").handler(
+      {
+        assignments: [
+          {
+            podIds: [pod.sId],
+            workAreas: [
+              {
+                title: "Weekly planning",
+                description: "Plan and prioritize the week's recurring work.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator)
+    );
+    expect(createResult.isOk()).toBe(true);
+
+    const listResult = await getTool("list_work_areas").handler(
+      { podIds: [pod.sId] },
+      createTestExtra(authenticator)
+    );
+    expect(listResult.isOk()).toBe(true);
+    if (listResult.isOk()) {
+      const [content] = listResult.value;
+      expect(content.type).toBe("text");
+      if (content.type === "text") {
+        const payload = JSON.parse(content.text);
+        expect(payload).toEqual([
+          expect.objectContaining({
+            podId: pod.sId,
+            workAreas: [expect.objectContaining({ title: "Weekly planning" })],
+          }),
+        ]);
+      }
+    }
+  });
+
+  it("lets a workspace admin create and list work areas on other members' pods", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const firstUser = await UserFactory.basic();
+    const secondUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, firstUser, { role: "user" });
+    await MembershipFactory.associate(workspace, secondUser, { role: "user" });
+    const firstPod = await createActivationPod(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        firstUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
+    const secondPod = await createActivationPod(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        secondUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
+
+    const createResult = await getTool("create_work_areas").handler(
+      {
+        assignments: [
+          {
+            podIds: [firstPod.sId, secondPod.sId],
+            workAreas: [
+              {
+                title: "Pipeline management",
+                description: "Keep active opportunities moving toward close.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator)
+    );
+    expect(createResult.isOk()).toBe(true);
+
+    const listResult = await getTool("list_work_areas").handler(
+      { podIds: [firstPod.sId, secondPod.sId] },
+      createTestExtra(authenticator)
+    );
+    expect(listResult.isOk()).toBe(true);
+    if (listResult.isOk()) {
+      const [content] = listResult.value;
+      expect(content.type).toBe("text");
+      if (content.type === "text") {
+        const payload = JSON.parse(content.text);
+        expect(payload).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              podId: firstPod.sId,
+              workAreas: [
+                expect.objectContaining({ title: "Pipeline management" }),
+              ],
+            }),
+            expect.objectContaining({
+              podId: secondPod.sId,
+              workAreas: [
+                expect.objectContaining({ title: "Pipeline management" }),
+              ],
+            }),
+          ])
+        );
+      }
+    }
+  });
+
+  it("rejects a caller who cannot administrate the pod", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "user",
+    });
+    const targetUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+    const targetPod = await createActivationPod(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        targetUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
+
+    const result = await getTool("create_work_areas").handler(
+      {
+        assignments: [
+          {
+            podIds: [targetPod.sId],
+            workAreas: [
+              {
+                title: "Weekly pipeline review",
+                description:
+                  "Review pipeline movement and unblock active deals.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Not authorized to manage work areas"
+      );
+    }
+  });
+
+  it("lists only Activation Pods the caller can administrate", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "user",
+    });
+    const ownPod = await createActivationPod(authenticator, workspace);
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherPod = await createActivationPod(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
+
+    const result = await getTool("list_activation_pods").handler(
+      {},
+      createTestExtra(authenticator)
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const [content] = result.value;
+      expect(content.type).toBe("text");
+      if (content.type === "text") {
+        const payload = JSON.parse(content.text);
+        expect(payload).toEqual([
+          expect.objectContaining({
+            podId: ownPod.sId,
+            name: ownPod.name,
+          }),
+        ]);
+        expect(payload).not.toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ podId: otherPod.sId }),
+          ])
+        );
+      }
+    }
+  });
+
+  it("lets a workspace admin list other members' Activation Pods", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "admin",
+    });
+    const targetUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+    const targetPod = await createActivationPod(
+      await Authenticator.fromUserIdAndWorkspaceId(
+        targetUser.sId,
+        workspace.sId
+      ),
+      workspace
+    );
+
+    const result = await getTool("list_activation_pods").handler(
+      {},
+      createTestExtra(authenticator)
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const [content] = result.value;
+      expect(content.type).toBe("text");
+      if (content.type === "text") {
+        const payload = JSON.parse(content.text);
+        expect(payload).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              podId: targetPod.sId,
+              name: targetPod.name,
+            }),
+          ])
+        );
+      }
+    }
+  });
+
+  it("rejects a pod appearing in multiple assignments", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "user",
+    });
+    const pod = await createActivationPod(authenticator, workspace);
+
+    const result = await getTool("create_work_areas").handler(
+      {
+        assignments: [
+          {
+            podIds: [pod.sId],
+            workAreas: [
+              {
+                title: "Pipeline management",
+                description: "Keep active opportunities moving toward close.",
+              },
+            ],
+          },
+          {
+            podIds: [pod.sId],
+            workAreas: [
+              {
+                title: "Renewal planning",
+                description:
+                  "Prepare account renewal strategies and next steps.",
+              },
+            ],
+          },
+        ],
+      },
+      createTestExtra(authenticator)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Each pod may appear in only one");
+    }
+  });
+
+  it("returns the same not-found error for missing and unauthorized work areas", async () => {
+    const { workspace, authenticator } = await createResourceTest({
+      role: "user",
+    });
+    const targetUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, targetUser, { role: "user" });
+    const targetAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      targetUser.sId,
+      workspace.sId
+    );
+    const targetPod = await createActivationPod(targetAuth, workspace);
+    const targetActivationPod = await ActivationPodResource.fetchBySpace(
+      targetAuth,
+      targetPod
+    );
+    expect(targetActivationPod).not.toBeNull();
+
+    const workArea = await ActivationWorkAreaResource.makeNew(targetAuth, {
+      title: "Other user's area",
+      description: "Should not leak existence.",
+      podId: targetActivationPod!.id,
+    });
+
+    const missing = await getTool("update_work_area").handler(
+      { workAreaId: "awa_does_not_exist", status: "dismissed" },
+      createTestExtra(authenticator)
+    );
+    const unauthorized = await getTool("update_work_area").handler(
+      { workAreaId: workArea.sId, status: "dismissed" },
+      createTestExtra(authenticator)
+    );
+
+    expect(missing.isErr()).toBe(true);
+    expect(unauthorized.isErr()).toBe(true);
+    if (missing.isErr() && unauthorized.isErr()) {
+      expect(missing.error.message).toBe("Work area not found.");
+      expect(unauthorized.error.message).toBe(missing.error.message);
+    }
+  });
+});

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -21,13 +21,91 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
+import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 type ToolExecutionMode = "auto" | "requires_approval" | "not_connected";
+
+async function resolveActivationPods(
+  auth: Authenticator,
+  podIds: string[]
+): Promise<
+  Result<
+    { activationPod: ActivationPodResource; space: SpaceResource }[],
+    MCPError
+  >
+> {
+  const spaces = await SpaceResource.fetchByIds(auth, podIds);
+  const foundIds = new Set(spaces.map((s) => s.sId));
+  const missingPodIds = podIds.filter((id) => !foundIds.has(id));
+  if (missingPodIds.length > 0) {
+    return new Err(
+      new MCPError(`Pod(s) not found: ${missingPodIds.join(", ")}.`)
+    );
+  }
+
+  const unauthorizedSpaces = spaces.filter((s) => !s.canAdministrate(auth));
+  if (unauthorizedSpaces.length > 0) {
+    return new Err(
+      new MCPError(
+        `Not authorized to manage work areas for pod(s): ${unauthorizedSpaces
+          .map((s) => s.sId)
+          .join(", ")}.`
+      )
+    );
+  }
+
+  const activationPods = await ActivationPodResource.fetchBySpaceModelIds(
+    auth,
+    spaces.map((s) => s.id)
+  );
+  const activationPodBySpaceModelId = new Map(
+    activationPods.map((p) => [p.spaceId, p])
+  );
+  const nonPodSpaces = spaces.filter(
+    (s) => !activationPodBySpaceModelId.has(s.id)
+  );
+  if (nonPodSpaces.length > 0) {
+    return new Err(
+      new MCPError(
+        `Space(s) are not Activation Pods: ${nonPodSpaces.map((s) => s.sId).join(", ")}.`
+      )
+    );
+  }
+
+  return new Ok(
+    spaces.flatMap((space) => {
+      const activationPod = activationPodBySpaceModelId.get(space.id);
+      return activationPod ? [{ space, activationPod }] : [];
+    })
+  );
+}
+
+async function listManagedActivationPods(
+  auth: Authenticator
+): Promise<{ activationPod: ActivationPodResource; space: SpaceResource }[]> {
+  const activationPods = await ActivationPodResource.listForWorkspace(auth);
+  if (activationPods.length === 0) {
+    return [];
+  }
+
+  const spaces = await SpaceResource.fetchByModelIds(
+    auth,
+    activationPods.map((p) => p.spaceId)
+  );
+  const spaceByModelId = new Map(spaces.map((s) => [s.id, s]));
+
+  return activationPods.flatMap((activationPod) => {
+    const space = spaceByModelId.get(activationPod.spaceId);
+    if (!space || !space.canAdministrate(auth)) {
+      return [];
+    }
+    return [{ activationPod, space }];
+  });
+}
 
 function connectionTypeForOAuthUseCase(
   oAuthUseCase: MCPOAuthUseCase
@@ -254,107 +332,97 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       ]);
     },
 
-    list_work_areas: async ({ podId, status }, { auth, runContext }) => {
-      const podSpaceId = isAgentLoopRunContext(runContext)
-        ? runContext.conversation.spaceId
-        : null;
-      const pod = podSpaceId
-        ? await SpaceResource.fetchById(auth, podSpaceId)
-        : null;
-      const activationPod = pod
-        ? await ActivationPodResource.fetchBySpace(auth, pod)
-        : null;
-
-      if (!pod || !activationPod) {
-        return new Err(
-          new MCPError(
-            "Work areas are only available inside an Activation Pod conversation."
-          )
-        );
-      }
-      if (pod.sId !== podId) {
-        return new Err(
-          new MCPError(
-            "podId must match the current Activation Pod conversation."
-          )
-        );
-      }
-      if (!pod.canAdministrate(auth)) {
-        return new Err(
-          new MCPError("Not authorized to manage work areas for this pod.")
-        );
-      }
-
-      const rows = await ActivationWorkAreaResource.listByActivationPods(auth, {
-        activationPods: [activationPod],
-        status,
-      });
-
-      if (rows.length === 0) {
+    list_activation_pods: async (_params, { auth }) => {
+      const pods = await listManagedActivationPods(auth);
+      if (pods.length === 0) {
         return new Ok([
           {
             type: "text" as const,
-            text: "No work areas found.",
+            text: "No Activation Pods you can manage.",
           },
         ]);
       }
 
-      const lines = rows.map((r, i) => {
-        const workArea = r.toJSON();
-        return `${i + 1}. [${workArea.status}] ${workArea.sId} — "${workArea.title}": ${workArea.description}`;
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            pods.map(({ space }) => ({
+              podId: space.sId,
+              name: space.name,
+            }))
+          ),
+        },
+      ]);
+    },
+
+    list_work_areas: async ({ podIds, status }, { auth }) => {
+      const resolved = await resolveActivationPods(auth, podIds);
+      if (resolved.isErr()) {
+        return resolved;
+      }
+
+      const rows = await ActivationWorkAreaResource.listByActivationPods(auth, {
+        activationPods: resolved.value.map((p) => p.activationPod),
+        status,
       });
 
       return new Ok([
         {
           type: "text" as const,
-          text: `Work areas (${rows.length}):\n${lines.join("\n")}`,
+          text: JSON.stringify(
+            resolved.value.map(({ activationPod, space }) => ({
+              podId: space.sId,
+              workAreas: rows
+                .filter((row) => row.podId === activationPod.id)
+                .map((row) => row.toJSON()),
+            }))
+          ),
         },
       ]);
     },
 
-    create_work_areas: async ({ workAreas }, { auth, runContext }) => {
-      const podSpaceId = isAgentLoopRunContext(runContext)
-        ? runContext.conversation.spaceId
-        : null;
-      const pod = podSpaceId
-        ? await SpaceResource.fetchById(auth, podSpaceId)
-        : null;
-      const activationPod = pod
-        ? await ActivationPodResource.fetchBySpace(auth, pod)
-        : null;
-
-      if (!pod || !activationPod) {
+    create_work_areas: async ({ assignments }, { auth }) => {
+      const allPodIds = assignments.flatMap((a) => a.podIds);
+      const uniquePodIds = [...new Set(allPodIds)];
+      if (uniquePodIds.length !== allPodIds.length) {
         return new Err(
-          new MCPError(
-            "Work areas can only be created inside an Activation Pod conversation."
-          )
-        );
-      }
-      if (!pod.canAdministrate(auth)) {
-        return new Err(
-          new MCPError("Not authorized to manage work areas for this pod.")
+          new MCPError("Each pod may appear in only one work-area assignment.")
         );
       }
 
-      const created = await concurrentExecutor(
-        workAreas,
-        (item) =>
-          ActivationWorkAreaResource.makeNew(auth, {
-            title: item.title,
-            description: item.description,
-            podId: activationPod.id,
-          }),
-        { concurrency: 8 }
+      const resolved = await resolveActivationPods(auth, uniquePodIds);
+      if (resolved.isErr()) {
+        return resolved;
+      }
+
+      const activationPodBySId = new Map(
+        resolved.value.map(({ space, activationPod }) => [
+          space.sId,
+          activationPod,
+        ])
       );
 
-      const lines = created.map(
-        (r) => `${r.sId} — "${r.title}" (status: suggested)`
+      const items = assignments.flatMap((assignment) =>
+        assignment.podIds.flatMap((podId) => {
+          const activationPod = activationPodBySId.get(podId);
+          if (!activationPod) {
+            return [];
+          }
+          return assignment.workAreas.map((workArea) => ({
+            activationPod,
+            title: workArea.title,
+            description: workArea.description,
+          }));
+        })
       );
+
+      const created = await ActivationWorkAreaResource.makeNewMany(auth, items);
 
       return new Ok([
         {
           type: "text" as const,
-          text: `Created ${created.length} work areas:\n${lines.join("\n")}`,
+          text: `Saved ${created.length} work areas across ${uniquePodIds.length} pod(s).`,
         },
       ]);
     },
@@ -474,14 +542,18 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
     },
   };
 
+export const TOOLS = buildTools(
+  ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA,
+  handlers
+);
+
 function createServer(
   auth: Authenticator,
   toolContext?: ToolContext
 ): McpServer {
   const server = makeInternalMCPServer(ACTIVATION_RECOMMENDATIONS_SERVER_NAME);
 
-  const tools = buildTools(ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA, handlers);
-  for (const tool of tools) {
+  for (const tool of TOOLS) {
     registerTool(auth, toolContext, server, tool, {
       monitoringName: ACTIVATION_RECOMMENDATIONS_SERVER_NAME,
     });

--- a/front/lib/api/actions/servers/activation_recommendations/metadata.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/metadata.ts
@@ -5,6 +5,19 @@ import { z } from "zod";
 export const ACTIVATION_RECOMMENDATIONS_SERVER_NAME =
   "activation_recommendations" as const;
 
+const WORK_AREA_INPUT_SCHEMA = z.object({
+  title: z
+    .string()
+    .max(255)
+    .describe(
+      "Short name of the work area (e.g. 'Weekly pipeline reporting')."
+    ),
+  description: z
+    .string()
+    .max(512)
+    .describe("One sentence describing what the work area covers."),
+});
+
 export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "create_recommendation",
@@ -180,16 +193,26 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
     },
   },
   {
+    name: "list_activation_pods",
+    description:
+      "List Activation Pods the caller can administrate. Use the returned podIds with " +
+      "list_work_areas and create_work_areas.",
+    schema: {},
+    stake: "never_ask",
+    toolCostCategory: "basic",
+    freeUsage: true,
+    displayLabels: {
+      running: "Fetching Activation Pods",
+      done: "Activation Pods fetched",
+    },
+  },
+  {
     name: "list_work_areas",
     description:
-      "List work areas for the current Activation Pod. Returns each work area's id, " +
-      "title, description, and status.",
+      "List work areas for one or more Activation Pods. Pass pod IDs from " +
+      "list_activation_pods. Requires editor access to each pod.",
     schema: {
-      podId: z
-        .string()
-        .describe(
-          "The current Pod ID from the activation context. Always pass it to scope results to this Pod."
-        ),
+      podIds: z.array(z.string()).min(1).max(100).describe("Pod IDs to query."),
       status: z
         .enum(["suggested", "dismissed"])
         .optional()
@@ -206,27 +229,32 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   {
     name: "create_work_areas",
     description:
-      "Create one or more work areas for the current Activation Pod. Each is created " +
-      "with status 'suggested'. Returns the created work areas with their ids.",
+      "Create work areas for one or more Activation Pods. Each assignment " +
+      "applies the same list independently to every listed pod. Pass pod IDs " +
+      "from list_activation_pods. Requires editor access to each pod. A pod " +
+      "may appear in only one assignment.",
     schema: {
-      workAreas: z
+      assignments: z
         .array(
           z.object({
-            title: z
-              .string()
-              .max(255)
+            podIds: z
+              .array(z.string())
+              .min(1)
+              .describe("Pod IDs (space sIds) that share this work-area list."),
+            workAreas: z
+              .array(WORK_AREA_INPUT_SCHEMA)
+              .min(1)
+              .max(10)
               .describe(
-                "Short name of the work area (e.g. 'Weekly pipeline reporting')."
+                "Work areas to create independently on every pod in this assignment."
               ),
-            description: z
-              .string()
-              .max(512)
-              .describe("One sentence describing what the work area covers."),
           })
         )
         .min(1)
-        .max(10)
-        .describe("The work areas to create."),
+        .max(100)
+        .describe(
+          "Work-area lists to create. A pod may appear in only one assignment."
+        ),
     },
     stake: "never_ask",
     toolCostCategory: "basic",
@@ -238,7 +266,8 @@ export const ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA = [
   },
   {
     name: "update_work_area",
-    description: "Update a single work area's status, title, or description.",
+    description:
+      "Update a work area's status, title, or description. Requires editor access to its pod.",
     schema: {
       workAreaId: z.string().describe("The id of the work area to update."),
       status: z

--- a/front/lib/resources/activation_work_area_resource.ts
+++ b/front/lib/resources/activation_work_area_resource.ts
@@ -97,6 +97,32 @@ export class ActivationWorkAreaResource extends BaseResource<ActivationWorkAreaM
     return new this(this.model, row.get());
   }
 
+  static async makeNewMany(
+    auth: Authenticator,
+    items: {
+      activationPod: ActivationPodResource;
+      title: string;
+      description: string;
+    }[]
+  ): Promise<ActivationWorkAreaResource[]> {
+    if (items.length === 0) {
+      return [];
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+    const rows = await this.model.bulkCreate(
+      items.map(({ activationPod, title, description }) => ({
+        workspaceId: workspace.id,
+        status: "suggested" as const,
+        title,
+        description,
+        podId: activationPod.id,
+      }))
+    );
+
+    return rows.map((row) => new this(this.model, row.get()));
+  }
+
   static async fetchById(
     auth: Authenticator,
     sId: string


### PR DESCRIPTION
Stacked on #30833.

## Summary
- Add `list_activation_pods` for Learning Spaces the caller can administrate (`space.canAdministrate`).
- `list_work_areas` / `create_work_areas` take `podIds` / assignments instead of the current conversation's pod.
- Bulk-create with `makeNewMany`; auth stays the same editor/admin check as #30833.
- MCP tests use the same `TOOLS.find` + slim extra stub as poke / workspace analytics.

## Test plan
- [ ] Confirm `list_activation_pods` returns the caller's Learning Space and not another member's
- [ ] Confirm a workspace admin can list and create work areas on another member's Learning Space
- [ ] Confirm a user who is not an editor cannot create work areas on someone else's pod
- [ ] Confirm duplicate pod IDs across assignments are rejected
- [ ] Confirm `update_work_area` still returns the same not-found error for missing and unauthorized rows


Made with [Cursor](https://cursor.com)