### PR TITLE
[front] enh: add credit usage to API keys

### DIFF
--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -41,20 +41,44 @@ const MAX_API_KEY_CONSUMPTION_ROWS = 100;
 
 interface APIKeysOverviewProps {
   keys: KeyType[];
-  totalCredits: number;
-  consumingKeyCount: number;
-  isConsumptionLoading: boolean;
-  isConsumptionError: boolean;
+  workspaceId: WorkspaceType["sId"];
+  period: ConsumptionPeriodSelection;
+  isKeysLoading: boolean;
 }
 
 function APIKeysOverview({
   keys,
-  totalCredits,
-  consumingKeyCount,
-  isConsumptionLoading,
-  isConsumptionError,
+  workspaceId,
+  period,
+  isKeysLoading,
 }: APIKeysOverviewProps) {
-  if (isConsumptionLoading) {
+  const apiKeyNames = useMemo(
+    () => [...new Set(keys.map((key) => key.name))].sort(),
+    [keys]
+  );
+  const consumptionFilter = useMemo<ConsumptionScopeFilter | undefined>(
+    () => (apiKeyNames.length > 0 ? { api_keys: apiKeyNames } : undefined),
+    [apiKeyNames]
+  );
+  const {
+    totalCredits,
+    totalCount: consumingKeyCount,
+    isTopLoading: isConsumptionLoading,
+    isTopError: consumptionError,
+  } = useConsumptionTop({
+    workspaceId,
+    dimension: "api_key",
+    period,
+    limit: Math.max(
+      1,
+      Math.min(apiKeyNames.length, MAX_API_KEY_CONSUMPTION_ROWS)
+    ),
+    filter: consumptionFilter,
+    disabled: apiKeyNames.length === 0,
+  });
+  const isConsumptionError = Boolean(consumptionError);
+
+  if (isKeysLoading || isConsumptionLoading) {
     return (
       <div className="grid gap-4 sm:grid-cols-2">
         <LoadingBlock className="h-24 rounded-xl" />
@@ -115,36 +139,6 @@ export function APIKeys({
   const { groups, isGroupsError, isGroupsLoading } = useGroups({ owner });
   const isDataLoading = isKeysLoading || isGroupsLoading;
   const isDataError = Boolean(isKeysError || isGroupsError);
-
-  const apiKeyNames = useMemo(
-    () => [...new Set(keys.map((key) => key.name))].sort(),
-    [keys]
-  );
-  const consumptionFilter = useMemo<ConsumptionScopeFilter | undefined>(
-    () => (apiKeyNames.length > 0 ? { api_keys: apiKeyNames } : undefined),
-    [apiKeyNames]
-  );
-  const {
-    rows: consumptionRows,
-    totalCredits,
-    totalCount: consumingKeyCount,
-    hasMore: hasMoreConsumptionRows,
-    isTopLoading: isConsumptionLoading,
-    isTopError: consumptionError,
-  } = useConsumptionTop({
-    workspaceId: owner.sId,
-    dimension: "api_key",
-    period,
-    limit: Math.max(
-      1,
-      Math.min(apiKeyNames.length, MAX_API_KEY_CONSUMPTION_ROWS)
-    ),
-    filter: consumptionFilter,
-    disabled:
-      !isAnalyticsConsumptionEnabled ||
-      isKeysLoading ||
-      apiKeyNames.length === 0,
-  });
 
   const groupsById = useMemo(() => {
     return groups.reduce<Record<ModelId, GroupType>>((acc, group) => {
@@ -316,21 +310,18 @@ export function APIKeys({
         {isAnalyticsConsumptionEnabled && !isKeysError && (
           <APIKeysOverview
             keys={keys}
-            totalCredits={totalCredits}
-            consumingKeyCount={consumingKeyCount}
-            isConsumptionLoading={isKeysLoading || isConsumptionLoading}
-            isConsumptionError={Boolean(consumptionError)}
+            workspaceId={owner.sId}
+            period={period}
+            isKeysLoading={isKeysLoading}
           />
         )}
         <APIKeysList
           keys={keys}
+          workspaceId={owner.sId}
+          period={period}
           groupsById={groupsById}
           isLoading={isDataLoading}
           isError={isDataError}
-          consumptionRows={consumptionRows}
-          isConsumptionLoading={isConsumptionLoading}
-          isConsumptionError={Boolean(consumptionError)}
-          hasMoreConsumptionRows={hasMoreConsumptionRows}
           showAnalyticsConsumption={isAnalyticsConsumptionEnabled}
           isRevoking={isRevoking}
           isGenerating={isGenerating}

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -1,7 +1,7 @@
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { APIKeyCreationSheet } from "@app/components/workspace/api-keys/APIKeyCreationSheet";
-import { APIKeysList } from "@app/components/workspace/api-keys/APIKeysList";
+import { APIKeysTable } from "@app/components/workspace/api-keys/APIKeysTable";
 import { EditKeyCapDialog } from "@app/components/workspace/api-keys/EditKeyCapDialog";
 import { EditKeyCreditCapDialog } from "@app/components/workspace/api-keys/EditKeyCreditCapDialog";
 import { NewAPIKeyDialog } from "@app/components/workspace/api-keys/NewAPIKeyDialog";
@@ -31,7 +31,7 @@ import get from "lodash/get";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 
-interface APIKeysProps {
+interface APIKeysPageContentProps {
   owner: WorkspaceType;
   period: ConsumptionPeriodSelection;
   isAnalyticsConsumptionEnabled: boolean;
@@ -123,11 +123,11 @@ function APIKeysOverview({
   );
 }
 
-export function APIKeys({
+export function APIKeysPageContent({
   owner,
   period,
   isAnalyticsConsumptionEnabled,
-}: APIKeysProps) {
+}: APIKeysPageContentProps) {
   const { mutate } = useSWRConfig();
   const { subscription } = useAuth();
   const showLegacyUsdMonthlyCap = !isCreditPricedPlan(subscription.plan);
@@ -315,7 +315,7 @@ export function APIKeys({
             isKeysLoading={isKeysLoading}
           />
         )}
-        <APIKeysList
+        <APIKeysTable
           keys={keys}
           workspaceId={owner.sId}
           period={period}
@@ -391,7 +391,7 @@ export function APIKeysPage() {
             : "API Keys allow you to securely connect to Dust from other applications and work with your data programmatically."
         }
       />
-      <APIKeys
+      <APIKeysPageContent
         owner={owner}
         period={period}
         isAnalyticsConsumptionEnabled={isAnalyticsConsumptionEnabled}

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -11,7 +11,11 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useAuth,
+  useFeatureFlags,
+  useWorkspace,
+} from "@app/lib/auth/AuthContext";
 import { formatCredits } from "@app/lib/client/credits";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -30,6 +34,7 @@ import { useSWRConfig } from "swr";
 interface APIKeysProps {
   owner: WorkspaceType;
   period: ConsumptionPeriodSelection;
+  isAnalyticsConsumptionEnabled: boolean;
 }
 
 const MAX_API_KEY_CONSUMPTION_ROWS = 100;
@@ -94,7 +99,11 @@ function APIKeysOverview({
   );
 }
 
-export function APIKeys({ owner, period }: APIKeysProps) {
+export function APIKeys({
+  owner,
+  period,
+  isAnalyticsConsumptionEnabled,
+}: APIKeysProps) {
   const { mutate } = useSWRConfig();
   const { subscription } = useAuth();
   const showLegacyUsdMonthlyCap = !isCreditPricedPlan(subscription.plan);
@@ -131,7 +140,10 @@ export function APIKeys({ owner, period }: APIKeysProps) {
       Math.min(apiKeyNames.length, MAX_API_KEY_CONSUMPTION_ROWS)
     ),
     filter: consumptionFilter,
-    disabled: isKeysLoading || apiKeyNames.length === 0,
+    disabled:
+      !isAnalyticsConsumptionEnabled ||
+      isKeysLoading ||
+      apiKeyNames.length === 0,
   });
 
   const groupsById = useMemo(() => {
@@ -301,7 +313,7 @@ export function APIKeys({ owner, period }: APIKeysProps) {
             showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
           />
         </Page.Horizontal>
-        {!isKeysError && (
+        {isAnalyticsConsumptionEnabled && !isKeysError && (
           <APIKeysOverview
             keys={keys}
             totalCredits={totalCredits}
@@ -320,6 +332,7 @@ export function APIKeys({ owner, period }: APIKeysProps) {
           isConsumptionLoading={isConsumptionLoading}
           isConsumptionError={Boolean(consumptionError)}
           hasMoreConsumptionRows={hasMoreConsumptionRows}
+          showAnalyticsConsumption={isAnalyticsConsumptionEnabled}
           isRevoking={isRevoking}
           isGenerating={isGenerating}
           onRevoke={handleRevoke}
@@ -352,6 +365,10 @@ export function APIKeys({ owner, period }: APIKeysProps) {
 
 export function APIKeysPage() {
   const owner = useWorkspace();
+  const { hasFeature } = useFeatureFlags();
+  const isAnalyticsConsumptionEnabled = hasFeature(
+    "enable_analytics_consumption"
+  );
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
   );
@@ -360,22 +377,35 @@ export function APIKeysPage() {
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
         title={
-          <div className="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-start">
-            <div className="flex max-w-2xl flex-col gap-1">
-              <Page.H variant="h3">API Keys</Page.H>
-              <Page.P variant="secondary">
-                Create and manage API keys, track what they consume, and control
-                their monthly spend.
-              </Page.P>
+          isAnalyticsConsumptionEnabled ? (
+            <div className="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-start">
+              <div className="flex max-w-2xl flex-col gap-1">
+                <Page.H variant="h3">API Keys</Page.H>
+                <Page.P variant="secondary">
+                  Create and manage API keys, track what they consume, and
+                  control their monthly spend.
+                </Page.P>
+              </div>
+              <ConsumptionPeriodSelector
+                period={period}
+                onPeriodChange={setPeriod}
+              />
             </div>
-            <ConsumptionPeriodSelector
-              period={period}
-              onPeriodChange={setPeriod}
-            />
-          </div>
+          ) : (
+            "API Keys"
+          )
+        }
+        description={
+          isAnalyticsConsumptionEnabled
+            ? undefined
+            : "API Keys allow you to securely connect to Dust from other applications and work with your data programmatically."
         }
       />
-      <APIKeys owner={owner} period={period} />
+      <APIKeys
+        owner={owner}
+        period={period}
+        isAnalyticsConsumptionEnabled={isAnalyticsConsumptionEnabled}
+      />
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -1,11 +1,18 @@
+import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { APIKeyCreationSheet } from "@app/components/workspace/api-keys/APIKeyCreationSheet";
 import { APIKeysList } from "@app/components/workspace/api-keys/APIKeysList";
 import { EditKeyCapDialog } from "@app/components/workspace/api-keys/EditKeyCapDialog";
 import { EditKeyCreditCapDialog } from "@app/components/workspace/api-keys/EditKeyCreditCapDialog";
 import { NewAPIKeyDialog } from "@app/components/workspace/api-keys/NewAPIKeyDialog";
 import type { KeyRole } from "@app/components/workspace/api-keys/utils";
+import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { formatCredits } from "@app/lib/client/credits";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { useKeys } from "@app/lib/swr/apps";
@@ -22,9 +29,72 @@ import { useSWRConfig } from "swr";
 
 interface APIKeysProps {
   owner: WorkspaceType;
+  period: ConsumptionPeriodSelection;
 }
 
-export function APIKeys({ owner }: APIKeysProps) {
+const MAX_API_KEY_CONSUMPTION_ROWS = 100;
+
+interface APIKeysOverviewProps {
+  keys: KeyType[];
+  totalCredits: number;
+  consumingKeyCount: number;
+  isConsumptionLoading: boolean;
+  isConsumptionError: boolean;
+}
+
+function APIKeysOverview({
+  keys,
+  totalCredits,
+  consumingKeyCount,
+  isConsumptionLoading,
+  isConsumptionError,
+}: APIKeysOverviewProps) {
+  if (isConsumptionLoading) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="h-24 animate-pulse rounded-xl bg-muted-background" />
+        <div className="h-24 animate-pulse rounded-xl bg-muted-background" />
+      </div>
+    );
+  }
+
+  const activeKeyCount = keys.filter((key) => key.status === "active").length;
+  const cappedKeyCount = keys.filter(
+    (key) => key.status === "active" && key.creditState === "capped"
+  ).length;
+  const revokedKeyCount = keys.length - activeKeyCount;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      <SummaryCard
+        label="Credits"
+        value={isConsumptionError ? "—" : formatCredits(totalCredits)}
+        hint={
+          isConsumptionError
+            ? "Credit consumption is temporarily unavailable"
+            : consumingKeyCount > 0
+              ? `${consumingKeyCount.toLocaleString()} API ${
+                  consumingKeyCount === 1 ? "key" : "keys"
+                } used this period`
+              : "No API key consumption this period"
+        }
+      />
+      <SummaryCard
+        label="Keys active"
+        value={`${activeKeyCount.toLocaleString()} / ${keys.length.toLocaleString()}`}
+        hint={
+          cappedKeyCount > 0
+            ? `${cappedKeyCount.toLocaleString()} at the monthly cap`
+            : revokedKeyCount > 0
+              ? `${revokedKeyCount.toLocaleString()} revoked`
+              : null
+        }
+      />
+    </div>
+  );
+}
+
+export function APIKeys({ owner, period }: APIKeysProps) {
   const { mutate } = useSWRConfig();
   const { subscription } = useAuth();
   const showLegacyUsdMonthlyCap = !isCreditPricedPlan(subscription.plan);
@@ -36,6 +106,33 @@ export function APIKeys({ owner }: APIKeysProps) {
   const { groups, isGroupsError, isGroupsLoading } = useGroups({ owner });
   const isDataLoading = isKeysLoading || isGroupsLoading;
   const isDataError = Boolean(isKeysError || isGroupsError);
+
+  const apiKeyNames = useMemo(
+    () => [...new Set(keys.map((key) => key.name))].sort(),
+    [keys]
+  );
+  const consumptionFilter = useMemo<ConsumptionScopeFilter | undefined>(
+    () => (apiKeyNames.length > 0 ? { api_keys: apiKeyNames } : undefined),
+    [apiKeyNames]
+  );
+  const {
+    rows: consumptionRows,
+    totalCredits,
+    totalCount: consumingKeyCount,
+    hasMore: hasMoreConsumptionRows,
+    isTopLoading: isConsumptionLoading,
+    isTopError: consumptionError,
+  } = useConsumptionTop({
+    workspaceId: owner.sId,
+    dimension: "api_key",
+    period,
+    limit: Math.max(
+      1,
+      Math.min(apiKeyNames.length, MAX_API_KEY_CONSUMPTION_ROWS)
+    ),
+    filter: consumptionFilter,
+    disabled: isKeysLoading || apiKeyNames.length === 0,
+  });
 
   const groupsById = useMemo(() => {
     return groups.reduce<Record<ModelId, GroupType>>((acc, group) => {
@@ -204,11 +301,25 @@ export function APIKeys({ owner }: APIKeysProps) {
             showLegacyUsdMonthlyCap={showLegacyUsdMonthlyCap}
           />
         </Page.Horizontal>
+        {!isKeysError && (
+          <APIKeysOverview
+            keys={keys}
+            totalCredits={totalCredits}
+            consumingKeyCount={consumingKeyCount}
+            isConsumptionLoading={isKeysLoading || isConsumptionLoading}
+            isConsumptionError={Boolean(consumptionError)}
+          />
+        )}
         <APIKeysList
           keys={keys}
           groupsById={groupsById}
           isLoading={isDataLoading}
           isError={isDataError}
+          consumptionRows={consumptionRows}
+          totalCredits={totalCredits}
+          isConsumptionLoading={isConsumptionLoading}
+          isConsumptionError={Boolean(consumptionError)}
+          hasMoreConsumptionRows={hasMoreConsumptionRows}
           isRevoking={isRevoking}
           isGenerating={isGenerating}
           onRevoke={handleRevoke}
@@ -241,14 +352,30 @@ export function APIKeys({ owner }: APIKeysProps) {
 
 export function APIKeysPage() {
   const owner = useWorkspace();
+  const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
+    DEFAULT_CONSUMPTION_PERIOD
+  );
 
   return (
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
-        title="API Keys"
-        description="API Keys allow you to securely connect to Dust from other applications and work with your data programmatically."
+        title={
+          <div className="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-start">
+            <div className="flex max-w-[700px] flex-col gap-1">
+              <Page.H variant="h3">API Keys</Page.H>
+              <Page.P variant="secondary">
+                Create and manage API keys, track what they consume, and control
+                their monthly spend.
+              </Page.P>
+            </div>
+            <ConsumptionPeriodSelector
+              period={period}
+              onPeriodChange={setPeriod}
+            />
+          </div>
+        }
       />
-      <APIKeys owner={owner} />
+      <APIKeys owner={owner} period={period} />
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -328,7 +328,6 @@ export function APIKeys({
           isLoading={isDataLoading}
           isError={isDataError}
           consumptionRows={consumptionRows}
-          totalCredits={totalCredits}
           isConsumptionLoading={isConsumptionLoading}
           isConsumptionError={Boolean(consumptionError)}
           hasMoreConsumptionRows={hasMoreConsumptionRows}

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -361,7 +361,7 @@ export function APIKeysPage() {
       <Page.Header
         title={
           <div className="flex w-full flex-col justify-between gap-4 sm:flex-row sm:items-start">
-            <div className="flex max-w-[700px] flex-col gap-1">
+            <div className="flex max-w-2xl flex-col gap-1">
               <Page.H variant="h3">API Keys</Page.H>
               <Page.P variant="secondary">
                 Create and manage API keys, track what they consume, and control

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -26,7 +26,7 @@ import type { KeyType } from "@app/types/key";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
-import { BookOpen01, Button, Page } from "@dust-tt/sparkle";
+import { BookOpen01, Button, LoadingBlock, Page } from "@dust-tt/sparkle";
 import get from "lodash/get";
 import { useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
@@ -57,8 +57,8 @@ function APIKeysOverview({
   if (isConsumptionLoading) {
     return (
       <div className="grid gap-4 sm:grid-cols-2">
-        <div className="h-24 animate-pulse rounded-xl bg-muted-background" />
-        <div className="h-24 animate-pulse rounded-xl bg-muted-background" />
+        <LoadingBlock className="h-24 rounded-xl" />
+        <LoadingBlock className="h-24 rounded-xl" />
       </div>
     );
   }

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -77,8 +77,6 @@ function APIKeysOverview({
     filter: consumptionFilter,
     disabled: apiKeyNames.length === 0,
   });
-  const isConsumptionError = Boolean(consumptionError);
-
   if (isKeysLoading || isConsumptionLoading) {
     return (
       <div className="grid gap-4 sm:grid-cols-2">
@@ -98,9 +96,9 @@ function APIKeysOverview({
     <div className="grid gap-4 sm:grid-cols-2">
       <SummaryCard
         label="Credits"
-        value={isConsumptionError ? "—" : formatCredits(totalCredits)}
+        value={consumptionError ? "—" : formatCredits(totalCredits)}
         hint={
-          isConsumptionError
+          consumptionError
             ? "Credit consumption is temporarily unavailable"
             : consumingKeyCount > 0
               ? `${consumingKeyCount.toLocaleString()} API key${pluralize(consumingKeyCount)} used this period`
@@ -137,7 +135,7 @@ export function APIKeysPageContent({
   const { isKeysError, isKeysLoading, keys } = useKeys(owner);
   const { groups, isGroupsError, isGroupsLoading } = useGroups({ owner });
   const isDataLoading = isKeysLoading || isGroupsLoading;
-  const isDataError = Boolean(isKeysError || isGroupsError);
+  const isDataError = !!isKeysError || isGroupsError;
 
   const groupsById = useMemo(() => {
     return groups.reduce<Record<ModelId, GroupType>>((acc, group) => {
@@ -299,7 +297,7 @@ export function APIKeysPageContent({
           />
           <NewAPIKeyDialog
             groups={groups}
-            disabled={isGroupsLoading || Boolean(isGroupsError)}
+            disabled={isGroupsLoading || isGroupsError}
             isGenerating={isGenerating}
             isRevoking={isRevoking}
             onCreate={handleGenerate}

--- a/front/components/pages/workspace/developers/APIKeysPage.tsx
+++ b/front/components/pages/workspace/developers/APIKeysPage.tsx
@@ -25,6 +25,7 @@ import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { ModelId } from "@app/types/shared/model_id";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { WorkspaceType } from "@app/types/user";
 import { BookOpen01, Button, LoadingBlock, Page } from "@dust-tt/sparkle";
 import get from "lodash/get";
@@ -102,9 +103,7 @@ function APIKeysOverview({
           isConsumptionError
             ? "Credit consumption is temporarily unavailable"
             : consumingKeyCount > 0
-              ? `${consumingKeyCount.toLocaleString()} API ${
-                  consumingKeyCount === 1 ? "key" : "keys"
-                } used this period`
+              ? `${consumingKeyCount.toLocaleString()} API key${pluralize(consumingKeyCount)} used this period`
               : "No API key consumption this period"
         }
       />

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -246,7 +246,7 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-24 @xl-table:table-cell"
+          ? "hidden h-16 w-24 @lg-table:table-cell"
           : "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },
@@ -355,7 +355,9 @@ function buildColumns({
       header: "Last used",
       enableSorting: true,
       meta: {
-        className: "hidden h-16 w-32 @sm-table:table-cell",
+        className: showAnalyticsConsumption
+          ? "hidden h-16 w-28 @sm-table:table-cell"
+          : "hidden h-16 w-32 @sm-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -376,7 +378,10 @@ function buildColumns({
       accessorKey: "status",
       header: "Status",
       enableSorting: false,
-      meta: { className: "h-16 w-20", headerAlign: "left" },
+      meta: {
+        className: showAnalyticsConsumption ? "h-16 w-18 px-1" : "h-16 w-20",
+        headerAlign: "left",
+      },
       cell: (info) => {
         const status = info.row.original.status;
         return (
@@ -402,7 +407,7 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-24 @xs-table:table-cell"
+          ? "hidden h-16 w-20 px-1 @xs-table:table-cell"
           : "hidden h-16 w-20 @xs-table:table-cell",
         headerAlign: "right",
       },

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -771,8 +771,6 @@ export function APIKeysList({
               />
             </div>
           )}
-
-          <Separator />
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium text-foreground">
               {filteredRows.length.toLocaleString()} API key
@@ -815,11 +813,6 @@ export function APIKeysList({
             )}
           </div>
         </>
-      )}
-      {showAnalyticsConsumption && (
-        <p className="text-xs text-muted-foreground">
-          Credit consumption is grouped by API key name for the selected period.
-        </p>
       )}
     </div>
   );

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -1,4 +1,3 @@
-import { CostShareCell } from "@app/components/workspace/analytics/creditsTableCells";
 import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { formatCredits } from "@app/lib/client/credits";
 import { timeAgoFrom } from "@app/lib/utils";
@@ -51,7 +50,6 @@ interface APIKeysListProps {
   isLoading: boolean;
   isError: boolean;
   consumptionRows: ConsumptionTopRow[];
-  totalCredits: number;
   isConsumptionLoading: boolean;
   isConsumptionError: boolean;
   hasMoreConsumptionRows: boolean;
@@ -73,7 +71,6 @@ interface APIKeyRowData {
   secret: string;
   status: APIKeyStatus;
   credits: number | null;
-  consumptionShare: number | null;
   monthlyCap: string;
   lastUsedAt: number | null;
   menuItems: MenuItem[];
@@ -159,10 +156,6 @@ function matchesAPIKeySearch(row: APIKeyRowData, search: string): boolean {
     row.status,
     ...row.spaces,
   ].some((value) => value.toLowerCase().includes(normalizedSearch));
-}
-
-function EmptyCell() {
-  return <span className="text-xs text-muted-foreground">—</span>;
 }
 
 interface ConsumptionCellProps {
@@ -320,28 +313,6 @@ function buildColumns({
       },
     },
     {
-      id: "consumptionShare",
-      accessorKey: "consumptionShare",
-      header: "Consumption share",
-      enableSorting: false,
-      meta: {
-        className: "hidden h-16 w-32 @lg-table:table-cell",
-        headerAlign: "left",
-        tooltip: "Share of credits consumed by API keys in this period",
-      },
-      cell: (info) => (
-        <ConsumptionCell isLoading={isConsumptionLoading} align="left">
-          <DataTable.CellContent className="w-full justify-start">
-            {info.row.original.consumptionShare === null ? (
-              <EmptyCell />
-            ) : (
-              <CostShareCell share={info.row.original.consumptionShare} />
-            )}
-          </DataTable.CellContent>
-        </ConsumptionCell>
-      ),
-    },
-    {
       id: "credits",
       accessorKey: "credits",
       header: "Credits",
@@ -355,11 +326,7 @@ function buildColumns({
               info.row.original.credits === null
                 ? "—"
                 : formatCredits(info.row.original.credits)
-            }/${
-              info.row.original.monthlyCap === "Unlimited"
-                ? "∞"
-                : info.row.original.monthlyCap
-            }`}
+            }/${info.row.original.monthlyCap}`}
           />
         </ConsumptionCell>
       ),
@@ -475,9 +442,7 @@ function buildColumns({
     return columns.filter((column) => column.id !== "monthlyCap");
   }
 
-  return columns.filter(
-    (column) => column.id !== "consumptionShare" && column.id !== "credits"
-  );
+  return columns.filter((column) => column.id !== "credits");
 }
 
 export function APIKeysList({
@@ -486,7 +451,6 @@ export function APIKeysList({
   isLoading,
   isError,
   consumptionRows,
-  totalCredits,
   isConsumptionLoading,
   isConsumptionError,
   hasMoreConsumptionRows,
@@ -550,10 +514,6 @@ export function APIKeysList({
           secret: key.secret,
           status,
           credits,
-          consumptionShare:
-            credits === null || totalCredits === 0
-              ? null
-              : credits / totalCredits,
           monthlyCap: formatMonthlyCap({
             key,
             showLegacyUsdMonthlyCap,
@@ -573,7 +533,6 @@ export function APIKeysList({
       showAnalyticsConsumption,
       showCreditMonthlyCap,
       showLegacyUsdMonthlyCap,
-      totalCredits,
     ]
   );
 

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -346,16 +346,20 @@ function buildColumns({
       accessorKey: "credits",
       header: "Credits",
       enableSorting: false,
-      meta: { className: "h-16 w-32", headerAlign: "right" },
+      meta: { className: "h-16 w-32", headerAlign: "left" },
       cell: (info) => (
-        <ConsumptionCell isLoading={isConsumptionLoading}>
+        <ConsumptionCell isLoading={isConsumptionLoading} align="left">
           <DataTable.BasicCellContent
-            className="justify-end text-right tabular-nums"
+            className="justify-start text-left tabular-nums"
             label={`${
               info.row.original.credits === null
                 ? "—"
                 : formatCredits(info.row.original.credits)
-            }/${info.row.original.monthlyCap}`}
+            }/${
+              info.row.original.monthlyCap === "Unlimited"
+                ? "∞"
+                : info.row.original.monthlyCap
+            }`}
           />
         </ConsumptionCell>
       ),

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -453,7 +453,9 @@ function buildColumns({
       header: "",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-20 @xs-table:table-cell",
+        className: showAnalyticsConsumption
+          ? "hidden h-16 w-24 @xs-table:table-cell"
+          : "hidden h-16 w-20 @xs-table:table-cell",
         headerAlign: "right",
       },
       cell: (info) =>

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -1,4 +1,6 @@
-import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
+import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { GroupType } from "@app/types/groups";
@@ -6,7 +8,7 @@ import type { KeyType } from "@app/types/key";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { pluralize } from "@app/types/shared/utils/string_utils";
-import type { RoleType } from "@app/types/user";
+import type { RoleType, WorkspaceType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
   Building07,
@@ -41,18 +43,17 @@ import { useMemo, useState } from "react";
 import { prettifyGroupName } from "./utils";
 
 const API_KEYS_PAGE_SIZE = 10;
+const MAX_API_KEY_CONSUMPTION_ROWS = 100;
 
 type APIKeyStatus = "active" | "capped" | "revoked";
 
 interface APIKeysListProps {
   keys: KeyType[];
+  workspaceId: WorkspaceType["sId"];
+  period: ConsumptionPeriodSelection;
   groupsById: Record<ModelId, GroupType>;
   isLoading: boolean;
   isError: boolean;
-  consumptionRows: ConsumptionTopRow[];
-  isConsumptionLoading: boolean;
-  isConsumptionError: boolean;
-  hasMoreConsumptionRows: boolean;
   showAnalyticsConsumption: boolean;
   isRevoking: boolean;
   isGenerating: boolean;
@@ -452,13 +453,11 @@ function buildColumns({
 
 export function APIKeysList({
   keys,
+  workspaceId,
+  period,
   groupsById,
   isLoading,
   isError,
-  consumptionRows,
-  isConsumptionLoading,
-  isConsumptionError,
-  hasMoreConsumptionRows,
   showAnalyticsConsumption,
   isRevoking,
   isGenerating,
@@ -479,6 +478,32 @@ export function APIKeysList({
     pageSize: API_KEYS_PAGE_SIZE,
   });
   const [sorting, setSorting] = useState<SortingState>([]);
+
+  const apiKeyNames = useMemo(
+    () => [...new Set(keys.map((key) => key.name))].sort(),
+    [keys]
+  );
+  const consumptionFilter = useMemo<ConsumptionScopeFilter | undefined>(
+    () => (apiKeyNames.length > 0 ? { api_keys: apiKeyNames } : undefined),
+    [apiKeyNames]
+  );
+  const {
+    rows: consumptionRows,
+    hasMore: hasMoreConsumptionRows,
+    isTopLoading: isConsumptionLoading,
+    isTopError: consumptionError,
+  } = useConsumptionTop({
+    workspaceId,
+    dimension: "api_key",
+    period,
+    limit: Math.max(
+      1,
+      Math.min(apiKeyNames.length, MAX_API_KEY_CONSUMPTION_ROWS)
+    ),
+    filter: consumptionFilter,
+    disabled: !showAnalyticsConsumption || apiKeyNames.length === 0,
+  });
+  const isConsumptionError = Boolean(consumptionError);
 
   const consumptionByName = useMemo(
     () => new Map(consumptionRows.map((row) => [row.name, row])),

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -1,3 +1,5 @@
+import { CostShareCell } from "@app/components/workspace/analytics/creditsTableCells";
+import type { ConsumptionTopRow } from "@app/hooks/useConsumptionTop";
 import { formatCredits } from "@app/lib/client/credits";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { GroupType } from "@app/types/groups";
@@ -35,6 +37,7 @@ import type {
   SortingState,
 } from "@tanstack/react-table";
 import capitalize from "lodash/capitalize";
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 import { prettifyGroupName } from "./utils";
 
@@ -47,6 +50,11 @@ interface APIKeysListProps {
   groupsById: Record<ModelId, GroupType>;
   isLoading: boolean;
   isError: boolean;
+  consumptionRows: ConsumptionTopRow[];
+  totalCredits: number;
+  isConsumptionLoading: boolean;
+  isConsumptionError: boolean;
+  hasMoreConsumptionRows: boolean;
   isRevoking: boolean;
   isGenerating: boolean;
   onRevoke: (key: KeyType) => Promise<void>;
@@ -63,6 +71,9 @@ interface APIKeyRowData {
   scope: string;
   secret: string;
   status: APIKeyStatus;
+  credits: number | null;
+  avgCredits: number | null;
+  consumptionShare: number | null;
   monthlyCap: string;
   lastUsedAt: number | null;
   menuItems: MenuItem[];
@@ -150,13 +161,45 @@ function matchesAPIKeySearch(row: APIKeyRowData, search: string): boolean {
   ].some((value) => value.toLowerCase().includes(normalizedSearch));
 }
 
+function EmptyCell() {
+  return <span className="text-xs text-muted-foreground">—</span>;
+}
+
+interface ConsumptionCellProps {
+  isLoading: boolean;
+  children: ReactNode;
+  align?: "left" | "right";
+}
+
+function ConsumptionCell({
+  isLoading,
+  children,
+  align = "right",
+}: ConsumptionCellProps) {
+  if (isLoading) {
+    return (
+      <DataTable.CellContent
+        className={
+          align === "right" ? "w-full justify-end" : "w-full justify-start"
+        }
+      >
+        <LoadingBlock className="h-3 w-16" />
+      </DataTable.CellContent>
+    );
+  }
+
+  return <>{children}</>;
+}
+
 function buildColumns({
   actionsDisabled,
   capLabel,
+  isConsumptionLoading,
   onRevoke,
 }: {
   actionsDisabled: boolean;
   capLabel: string;
+  isConsumptionLoading: boolean;
   onRevoke: (key: KeyType) => Promise<void>;
 }): ColumnDef<APIKeyRowData>[] {
   return [
@@ -165,7 +208,7 @@ function buildColumns({
       accessorFn: (row) => row.name,
       header: "Name",
       enableSorting: true,
-      meta: { className: "h-16 w-40", headerAlign: "left" },
+      meta: { className: "h-16 w-36", headerAlign: "left" },
       cell: (info) => (
         <div className="flex flex-col justify-center">
           <span className="truncate text-sm font-medium text-foreground">
@@ -183,7 +226,7 @@ function buildColumns({
       header: "Scope",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-28 @lg-table:table-cell",
+        className: "hidden h-16 w-24 @xl-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -202,7 +245,7 @@ function buildColumns({
       header: "Key",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-28 @lg-table:table-cell",
+        className: "hidden h-16 w-24 @xl-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -223,7 +266,7 @@ function buildColumns({
       header: "Spaces",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-40 @md-table:table-cell",
+        className: "hidden h-16 w-40 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -266,12 +309,75 @@ function buildColumns({
       },
     },
     {
+      id: "consumptionShare",
+      accessorKey: "consumptionShare",
+      header: "Consumption share",
+      enableSorting: false,
+      meta: {
+        className: "hidden h-16 w-32 @lg-table:table-cell",
+        headerAlign: "left",
+        tooltip: "Share of credits consumed by API keys in this period",
+      },
+      cell: (info) => (
+        <ConsumptionCell isLoading={isConsumptionLoading} align="left">
+          <DataTable.CellContent className="w-full justify-start">
+            {info.row.original.consumptionShare === null ? (
+              <EmptyCell />
+            ) : (
+              <CostShareCell share={info.row.original.consumptionShare} />
+            )}
+          </DataTable.CellContent>
+        </ConsumptionCell>
+      ),
+    },
+    {
+      id: "credits",
+      accessorKey: "credits",
+      header: "Total credits",
+      enableSorting: false,
+      meta: { className: "h-16 w-24", headerAlign: "right" },
+      cell: (info) => (
+        <ConsumptionCell isLoading={isConsumptionLoading}>
+          <DataTable.BasicCellContent
+            className="justify-end text-right tabular-nums"
+            label={
+              info.row.original.credits === null
+                ? "—"
+                : formatCredits(info.row.original.credits)
+            }
+          />
+        </ConsumptionCell>
+      ),
+    },
+    {
+      id: "avgCredits",
+      accessorKey: "avgCredits",
+      header: "Credits / message",
+      enableSorting: false,
+      meta: {
+        className: "hidden h-16 w-32 @lg-table:table-cell",
+        headerAlign: "right",
+      },
+      cell: (info) => (
+        <ConsumptionCell isLoading={isConsumptionLoading}>
+          <DataTable.BasicCellContent
+            className="justify-end text-right tabular-nums"
+            label={
+              info.row.original.avgCredits === null
+                ? "—"
+                : formatCredits(info.row.original.avgCredits)
+            }
+          />
+        </ConsumptionCell>
+      ),
+    },
+    {
       id: "monthlyCap",
       accessorKey: "monthlyCap",
       header: capLabel,
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-28 @md-table:table-cell",
+        className: "hidden h-16 w-24 @md-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -372,6 +478,11 @@ export function APIKeysList({
   groupsById,
   isLoading,
   isError,
+  consumptionRows,
+  totalCredits,
+  isConsumptionLoading,
+  isConsumptionError,
+  hasMoreConsumptionRows,
   isRevoking,
   isGenerating,
   onRevoke,
@@ -392,6 +503,10 @@ export function APIKeysList({
   });
   const [sorting, setSorting] = useState<SortingState>([]);
 
+  const consumptionByName = useMemo(
+    () => new Map(consumptionRows.map((row) => [row.name, row])),
+    [consumptionRows]
+  );
   const actionsDisabled = isRevoking || isGenerating;
   const rows = useMemo<APIKeyRowData[]>(
     () =>
@@ -400,6 +515,11 @@ export function APIKeysList({
         const scope = formatKeyScope(key.role);
         const status = getKeyStatus(key);
         const creator = key.creator ?? "Unknown creator";
+        const consumption = consumptionByName.get(key.name);
+        const isConsumptionKnown =
+          Boolean(consumption) ||
+          (!hasMoreConsumptionRows && !isConsumptionError);
+        const credits = consumption?.credits ?? (isConsumptionKnown ? 0 : null);
         const menuItems: MenuItem[] =
           key.status === "active"
             ? [
@@ -420,6 +540,12 @@ export function APIKeysList({
           scope,
           secret: key.secret,
           status,
+          credits,
+          avgCredits: consumption?.avgCredits ?? null,
+          consumptionShare:
+            credits === null || totalCredits === 0
+              ? null
+              : credits / totalCredits,
           monthlyCap: formatMonthlyCap({
             key,
             showLegacyUsdMonthlyCap,
@@ -429,7 +555,17 @@ export function APIKeysList({
           menuItems,
         };
       }),
-    [groupsById, keys, onEditCap, showCreditMonthlyCap, showLegacyUsdMonthlyCap]
+    [
+      consumptionByName,
+      groupsById,
+      hasMoreConsumptionRows,
+      isConsumptionError,
+      keys,
+      onEditCap,
+      showCreditMonthlyCap,
+      showLegacyUsdMonthlyCap,
+      totalCredits,
+    ]
   );
 
   const scopeOptions = useMemo(
@@ -441,9 +577,10 @@ export function APIKeysList({
       buildColumns({
         actionsDisabled,
         capLabel: showCreditMonthlyCap ? "Credits cap" : "Monthly cap",
+        isConsumptionLoading,
         onRevoke,
       }),
-    [actionsDisabled, onRevoke, showCreditMonthlyCap]
+    [actionsDisabled, isConsumptionLoading, onRevoke, showCreditMonthlyCap]
   );
   const filteredRows = useMemo(() => {
     return rows.filter((row) => {
@@ -642,6 +779,9 @@ export function APIKeysList({
           </div>
         </>
       )}
+      <p className="text-xs text-muted-foreground">
+        Credit consumption is grouped by API key name for the selected period.
+      </p>
     </div>
   );
 }

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -55,6 +55,7 @@ interface APIKeysListProps {
   isConsumptionLoading: boolean;
   isConsumptionError: boolean;
   hasMoreConsumptionRows: boolean;
+  showAnalyticsConsumption: boolean;
   isRevoking: boolean;
   isGenerating: boolean;
   onRevoke: (key: KeyType) => Promise<void>;
@@ -196,19 +197,24 @@ function buildColumns({
   capLabel,
   isConsumptionLoading,
   onRevoke,
+  showAnalyticsConsumption,
 }: {
   actionsDisabled: boolean;
   capLabel: string;
   isConsumptionLoading: boolean;
   onRevoke: (key: KeyType) => Promise<void>;
+  showAnalyticsConsumption: boolean;
 }): ColumnDef<APIKeyRowData>[] {
-  return [
+  const columns: ColumnDef<APIKeyRowData>[] = [
     {
       id: "name",
       accessorFn: (row) => row.name,
       header: "Name",
       enableSorting: true,
-      meta: { className: "h-16 w-36", headerAlign: "left" },
+      meta: {
+        className: showAnalyticsConsumption ? "h-16 w-36" : "h-16 w-40",
+        headerAlign: "left",
+      },
       cell: (info) => (
         <div className="flex flex-col justify-center">
           <span className="truncate text-sm font-medium text-foreground">
@@ -226,7 +232,9 @@ function buildColumns({
       header: "Scope",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-24 @xl-table:table-cell",
+        className: showAnalyticsConsumption
+          ? "hidden h-16 w-24 @xl-table:table-cell"
+          : "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -245,7 +253,9 @@ function buildColumns({
       header: "Key",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-24 @xl-table:table-cell",
+        className: showAnalyticsConsumption
+          ? "hidden h-16 w-24 @xl-table:table-cell"
+          : "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -266,7 +276,9 @@ function buildColumns({
       header: "Spaces",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-40 @lg-table:table-cell",
+        className: showAnalyticsConsumption
+          ? "hidden h-16 w-40 @lg-table:table-cell"
+          : "hidden h-16 w-40 @md-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -377,7 +389,9 @@ function buildColumns({
       header: capLabel,
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-24 @md-table:table-cell",
+        className: showAnalyticsConsumption
+          ? "hidden h-16 w-24 @md-table:table-cell"
+          : "hidden h-16 w-28 @md-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -471,6 +485,17 @@ function buildColumns({
         ) : null,
     },
   ];
+
+  if (showAnalyticsConsumption) {
+    return columns;
+  }
+
+  return columns.filter(
+    (column) =>
+      column.id !== "consumptionShare" &&
+      column.id !== "credits" &&
+      column.id !== "avgCredits"
+  );
 }
 
 export function APIKeysList({
@@ -483,6 +508,7 @@ export function APIKeysList({
   isConsumptionLoading,
   isConsumptionError,
   hasMoreConsumptionRows,
+  showAnalyticsConsumption,
   isRevoking,
   isGenerating,
   onRevoke,
@@ -517,8 +543,9 @@ export function APIKeysList({
         const creator = key.creator ?? "Unknown creator";
         const consumption = consumptionByName.get(key.name);
         const isConsumptionKnown =
-          Boolean(consumption) ||
-          (!hasMoreConsumptionRows && !isConsumptionError);
+          showAnalyticsConsumption &&
+          (Boolean(consumption) ||
+            (!hasMoreConsumptionRows && !isConsumptionError));
         const credits = consumption?.credits ?? (isConsumptionKnown ? 0 : null);
         const menuItems: MenuItem[] =
           key.status === "active"
@@ -562,6 +589,7 @@ export function APIKeysList({
       isConsumptionError,
       keys,
       onEditCap,
+      showAnalyticsConsumption,
       showCreditMonthlyCap,
       showLegacyUsdMonthlyCap,
       totalCredits,
@@ -579,8 +607,15 @@ export function APIKeysList({
         capLabel: showCreditMonthlyCap ? "Credits cap" : "Monthly cap",
         isConsumptionLoading,
         onRevoke,
+        showAnalyticsConsumption,
       }),
-    [actionsDisabled, isConsumptionLoading, onRevoke, showCreditMonthlyCap]
+    [
+      actionsDisabled,
+      isConsumptionLoading,
+      onRevoke,
+      showAnalyticsConsumption,
+      showCreditMonthlyCap,
+    ]
   );
   const filteredRows = useMemo(() => {
     return rows.filter((row) => {
@@ -779,9 +814,11 @@ export function APIKeysList({
           </div>
         </>
       )}
-      <p className="text-xs text-muted-foreground">
-        Credit consumption is grouped by API key name for the selected period.
-      </p>
+      {showAnalyticsConsumption && (
+        <p className="text-xs text-muted-foreground">
+          Credit consumption is grouped by API key name for the selected period.
+        </p>
+      )}
     </div>
   );
 }

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -73,7 +73,6 @@ interface APIKeyRowData {
   secret: string;
   status: APIKeyStatus;
   credits: number | null;
-  avgCredits: number | null;
   consumptionShare: number | null;
   monthlyCap: string;
   lastUsedAt: number | null;
@@ -362,28 +361,6 @@ function buildColumns({
       ),
     },
     {
-      id: "avgCredits",
-      accessorKey: "avgCredits",
-      header: "Credits / message",
-      enableSorting: false,
-      meta: {
-        className: "hidden h-16 w-32 @lg-table:table-cell",
-        headerAlign: "right",
-      },
-      cell: (info) => (
-        <ConsumptionCell isLoading={isConsumptionLoading}>
-          <DataTable.BasicCellContent
-            className="justify-end text-right tabular-nums"
-            label={
-              info.row.original.avgCredits === null
-                ? "—"
-                : formatCredits(info.row.original.avgCredits)
-            }
-          />
-        </ConsumptionCell>
-      ),
-    },
-    {
       id: "monthlyCap",
       accessorKey: "monthlyCap",
       header: capLabel,
@@ -475,7 +452,9 @@ function buildColumns({
       id: "actions",
       header: "",
       enableSorting: false,
-      meta: { className: "h-16 w-10" },
+      meta: {
+        className: showAnalyticsConsumption ? "h-16 w-12" : "h-16 w-10",
+      },
       cell: (info) =>
         info.row.original.menuItems.length > 0 ? (
           <DataTable.CellContent className="w-full justify-end">
@@ -493,10 +472,7 @@ function buildColumns({
   }
 
   return columns.filter(
-    (column) =>
-      column.id !== "consumptionShare" &&
-      column.id !== "credits" &&
-      column.id !== "avgCredits"
+    (column) => column.id !== "consumptionShare" && column.id !== "credits"
   );
 }
 
@@ -570,7 +546,6 @@ export function APIKeysList({
           secret: key.secret,
           status,
           credits,
-          avgCredits: consumption?.avgCredits ?? null,
           consumptionShare:
             credits === null || totalCredits === 0
               ? null

--- a/front/components/workspace/api-keys/APIKeysList.tsx
+++ b/front/components/workspace/api-keys/APIKeysList.tsx
@@ -232,7 +232,7 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-24 @xl-table:table-cell"
+          ? "hidden h-16 w-28 @md-table:table-cell"
           : "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },
@@ -344,18 +344,18 @@ function buildColumns({
     {
       id: "credits",
       accessorKey: "credits",
-      header: "Total credits",
+      header: "Credits",
       enableSorting: false,
-      meta: { className: "h-16 w-24", headerAlign: "right" },
+      meta: { className: "h-16 w-32", headerAlign: "right" },
       cell: (info) => (
         <ConsumptionCell isLoading={isConsumptionLoading}>
           <DataTable.BasicCellContent
             className="justify-end text-right tabular-nums"
-            label={
+            label={`${
               info.row.original.credits === null
                 ? "—"
                 : formatCredits(info.row.original.credits)
-            }
+            }/${info.row.original.monthlyCap}`}
           />
         </ConsumptionCell>
       ),
@@ -468,7 +468,7 @@ function buildColumns({
   ];
 
   if (showAnalyticsConsumption) {
-    return columns;
+    return columns.filter((column) => column.id !== "monthlyCap");
   }
 
   return columns.filter(

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -694,6 +694,7 @@ export function APIKeysTable({
       {isLoading ? (
         <>
           <DataTableLoadingSkeleton
+            className="pt-4"
             showSelectionColumn={false}
             showTrailingCell
           />

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -229,8 +229,8 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-26 px-1 @md-table:table-cell"
-          : "hidden h-16 w-28 @lg-table:table-cell",
+          ? "hidden h-16 w-24 px-1 @md-table:table-cell"
+          : "hidden h-16 w-26 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -250,8 +250,8 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-24 @lg-table:table-cell"
-          : "hidden h-16 w-28 @lg-table:table-cell",
+          ? "hidden h-16 w-26 @lg-table:table-cell"
+          : "hidden h-16 w-30 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -273,8 +273,8 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-16 @lg-table:table-cell"
-          : "hidden h-16 w-16 @md-table:table-cell",
+          ? "hidden h-16 w-14 @lg-table:table-cell"
+          : "hidden h-16 w-14 @md-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -285,25 +285,27 @@ function buildColumns({
           : Building04;
 
         return (
-          <Tooltip
-            label={
-              <div className="flex flex-col">
-                {spaceLabels.map((space, index) => (
-                  <span key={`${space}-${index}`}>{space}</span>
-                ))}
-              </div>
-            }
-            tooltipTriggerAsChild
-            trigger={
-              <span
-                className="inline-flex shrink-0 rounded outline-hidden focus-visible:ring-2 focus-visible:ring-highlight-300"
-                tabIndex={0}
-                aria-label={`Spaces: ${spaceLabels.join(", ")}`}
-              >
-                <Icon visual={spaceIcon} size="sm" />
-              </span>
-            }
-          />
+          <DataTable.CellContent className="w-full justify-center">
+            <Tooltip
+              label={
+                <div className="flex flex-col">
+                  {spaceLabels.map((space, index) => (
+                    <span key={`${space}-${index}`}>{space}</span>
+                  ))}
+                </div>
+              }
+              tooltipTriggerAsChild
+              trigger={
+                <span
+                  className="inline-flex shrink-0 rounded outline-hidden focus-visible:ring-2 focus-visible:ring-highlight-300"
+                  tabIndex={0}
+                  aria-label={`Spaces: ${spaceLabels.join(", ")}`}
+                >
+                  <Icon visual={spaceIcon} size="sm" />
+                </span>
+              }
+            />
+          </DataTable.CellContent>
         );
       },
     },

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -229,8 +229,8 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-24 px-1 @md-table:table-cell"
-          : "hidden h-16 w-26 @lg-table:table-cell",
+          ? "hidden h-16 w-20 px-1 @md-table:table-cell"
+          : "hidden h-16 w-20 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -503,8 +503,6 @@ export function APIKeysTable({
     filter: consumptionFilter,
     disabled: !showAnalyticsConsumption || apiKeyNames.length === 0,
   });
-  const isConsumptionError = Boolean(consumptionError);
-
   const consumptionByName = useMemo(
     () => new Map(consumptionRows.map((row) => [row.name, row])),
     [consumptionRows]
@@ -520,8 +518,8 @@ export function APIKeysTable({
         const consumption = consumptionByName.get(key.name);
         const isConsumptionKnown =
           showAnalyticsConsumption &&
-          (Boolean(consumption) ||
-            (!hasMoreConsumptionRows && !isConsumptionError));
+          (consumption !== undefined ||
+            (!hasMoreConsumptionRows && !consumptionError));
         const credits = consumption?.credits ?? (isConsumptionKnown ? 0 : null);
         const menuItems: MenuItem[] =
           key.status === "active"
@@ -555,9 +553,9 @@ export function APIKeysTable({
       }),
     [
       consumptionByName,
+      consumptionError,
       groupsById,
       hasMoreConsumptionRows,
-      isConsumptionError,
       keys,
       onEditCap,
       showAnalyticsConsumption,

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -226,7 +226,7 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-28 @md-table:table-cell"
+          ? "hidden h-16 w-26 px-1 @md-table:table-cell"
           : "hidden h-16 w-28 @lg-table:table-cell",
         headerAlign: "left",
       },

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -2,6 +2,7 @@ import { useConsumptionTop } from "@app/hooks/useConsumptionTop";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
+import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { GroupType } from "@app/types/groups";
 import type { KeyType } from "@app/types/key";
@@ -11,7 +12,7 @@ import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { RoleType, WorkspaceType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
-  Building07,
+  Building04,
   Button,
   ChevronLeft,
   ChevronRight,
@@ -28,9 +29,11 @@ import {
   FilterFunnel01,
   Icon,
   LoadingBlock,
+  Lock01,
   SearchInput,
   Separator,
   Tooltip,
+  Trash01,
 } from "@dust-tt/sparkle";
 import type {
   ColumnDef,
@@ -68,6 +71,7 @@ interface APIKeyRowData {
   name: string;
   creator: string;
   spaces: string[];
+  hasPrivateSpace: boolean;
   scope: string;
   secret: string;
   status: APIKeyStatus;
@@ -77,14 +81,13 @@ interface APIKeyRowData {
   menuItems: MenuItem[];
 }
 
-const getKeySpaces = (
+const getKeyGroups = (
   key: KeyType,
   groupsById: Record<ModelId, GroupType>
-): string[] => {
+): GroupType[] => {
   return key.groupIds
     .map((groupId) => groupsById[groupId])
-    .filter((group): group is GroupType => group !== undefined)
-    .map((group) => prettifyGroupName(group));
+    .filter((group): group is GroupType => group !== undefined);
 };
 
 const formatKeyScope = (role: RoleType): string => {
@@ -270,46 +273,37 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-40 @lg-table:table-cell"
-          : "hidden h-16 w-40 @md-table:table-cell",
+          ? "hidden h-16 w-16 @lg-table:table-cell"
+          : "hidden h-16 w-16 @md-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
         const spaces = info.row.original.spaces;
-        const [firstSpace, ...remainingSpaces] = spaces;
+        const spaceLabels = spaces.length > 0 ? spaces : ["No spaces"];
+        const spaceIcon = info.row.original.hasPrivateSpace
+          ? Lock01
+          : Building04;
 
         return (
-          <div className="flex min-w-0 items-center gap-2">
-            <Icon visual={Building07} size="sm" className="shrink-0" />
-            <span className="min-w-0 truncate text-sm">
-              {firstSpace ?? "No spaces"}
-            </span>
-            {remainingSpaces.length > 0 && (
-              <Tooltip
-                label={
-                  <div className="flex flex-col">
-                    {remainingSpaces.map((space, index) => (
-                      <span key={`${space}-${index}`}>{space}</span>
-                    ))}
-                  </div>
-                }
-                tooltipTriggerAsChild
-                trigger={
-                  <span
-                    className="shrink-0 rounded outline-hidden focus-visible:ring-2 focus-visible:ring-highlight-300"
-                    tabIndex={0}
-                    aria-label={`${remainingSpaces.length} more spaces`}
-                  >
-                    <Chip
-                      size="mini"
-                      color="primary"
-                      label={`+${remainingSpaces.length}`}
-                    />
-                  </span>
-                }
-              />
-            )}
-          </div>
+          <Tooltip
+            label={
+              <div className="flex flex-col">
+                {spaceLabels.map((space, index) => (
+                  <span key={`${space}-${index}`}>{space}</span>
+                ))}
+              </div>
+            }
+            tooltipTriggerAsChild
+            trigger={
+              <span
+                className="inline-flex shrink-0 rounded outline-hidden focus-visible:ring-2 focus-visible:ring-highlight-300"
+                tabIndex={0}
+                aria-label={`Spaces: ${spaceLabels.join(", ")}`}
+              >
+                <Icon visual={spaceIcon} size="sm" />
+              </span>
+            }
+          />
         );
       },
     },
@@ -408,21 +402,22 @@ function buildColumns({
       header: "",
       enableSorting: false,
       meta: {
-        className: showAnalyticsConsumption
-          ? "hidden h-16 w-20 px-1 @xs-table:table-cell"
-          : "hidden h-16 w-20 @xs-table:table-cell",
+        className: "hidden h-16 w-12 @xs-table:table-cell",
         headerAlign: "right",
       },
       cell: (info) =>
         info.row.original.key.status === "active" ? (
           <DataTable.CellContent className="w-full justify-end">
-            <Button
-              label="Revoke"
-              size="sm"
-              variant="warning"
-              disabled={actionsDisabled}
-              onClick={() => void onRevoke(info.row.original.key)}
-            />
+            <div className="pointer-fine:opacity-0 pointer-fine:group-hover/dt-row:opacity-100 pointer-fine:focus-within:opacity-100">
+              <Button
+                icon={Trash01}
+                tooltip="Revoke API key"
+                size="sm"
+                variant="warning"
+                disabled={actionsDisabled}
+                onClick={() => void onRevoke(info.row.original.key)}
+              />
+            </div>
           </DataTable.CellContent>
         ) : null,
     },
@@ -480,6 +475,18 @@ export function APIKeysTable({
   });
   const [sorting, setSorting] = useState<SortingState>([]);
 
+  const { spaces: workspaceSpaces, isSpacesLoading } = useSpacesAsAdmin({
+    workspaceId,
+  });
+  const privateSpaceGroupIds = useMemo(
+    () =>
+      new Set(
+        workspaceSpaces
+          .filter((space) => space.isRestricted)
+          .flatMap((space) => space.groupIds)
+      ),
+    [workspaceSpaces]
+  );
   const apiKeyNames = useMemo(
     () => [...new Set(keys.map((key) => key.name))].sort(),
     [keys]
@@ -512,7 +519,8 @@ export function APIKeysTable({
   const rows = useMemo<APIKeyRowData[]>(
     () =>
       keys.map((key) => {
-        const spaces = getKeySpaces(key, groupsById);
+        const keyGroups = getKeyGroups(key, groupsById);
+        const spaces = keyGroups.map((group) => prettifyGroupName(group));
         const scope = formatKeyScope(key.role);
         const status = getKeyStatus(key);
         const creator = key.creator ?? "Unknown creator";
@@ -539,6 +547,9 @@ export function APIKeysTable({
           name: key.name || "Unnamed",
           creator,
           spaces,
+          hasPrivateSpace: keyGroups.some((group) =>
+            privateSpaceGroupIds.has(group.sId)
+          ),
           scope,
           secret: key.secret,
           status,
@@ -559,6 +570,7 @@ export function APIKeysTable({
       hasMoreConsumptionRows,
       keys,
       onEditCap,
+      privateSpaceGroupIds,
       showAnalyticsConsumption,
       showCreditMonthlyCap,
       showLegacyUsdMonthlyCap,
@@ -634,7 +646,7 @@ export function APIKeysTable({
   return (
     <div
       className="flex flex-col gap-4 rounded-xl border border-border bg-panel-background p-4"
-      aria-busy={isLoading}
+      aria-busy={isLoading || isSpacesLoading}
     >
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
         <SearchInput
@@ -692,7 +704,7 @@ export function APIKeysTable({
         </DropdownMenu>
       </div>
 
-      {isLoading ? (
+      {isLoading || isSpacesLoading ? (
         <>
           <DataTableLoadingSkeleton
             className="pt-4"

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -47,7 +47,7 @@ const MAX_API_KEY_CONSUMPTION_ROWS = 100;
 
 type APIKeyStatus = "active" | "capped" | "revoked";
 
-interface APIKeysListProps {
+interface APIKeysTableProps {
   keys: KeyType[];
   workspaceId: WorkspaceType["sId"];
   period: ConsumptionPeriodSelection;
@@ -451,7 +451,7 @@ function buildColumns({
   return columns.filter((column) => column.id !== "credits");
 }
 
-export function APIKeysList({
+export function APIKeysTable({
   keys,
   workspaceId,
   period,
@@ -465,7 +465,7 @@ export function APIKeysList({
   onEditCap,
   showLegacyUsdMonthlyCap,
   showCreditMonthlyCap,
-}: APIKeysListProps) {
+}: APIKeysTableProps) {
   const [search, setSearch] = useState("");
   const [statusFilters, setStatusFilters] = useState<ReadonlySet<APIKeyStatus>>(
     new Set()

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -319,18 +319,19 @@ function buildColumns({
       header: "Credits",
       enableSorting: false,
       meta: { className: "h-16 w-32", headerAlign: "left" },
-      cell: (info) => (
-        <ConsumptionCell isLoading={isConsumptionLoading} align="left">
-          <DataTable.BasicCellContent
-            className="justify-start text-left tabular-nums"
-            label={`${
-              info.row.original.credits === null
-                ? "—"
-                : formatCredits(info.row.original.credits)
-            }/${info.row.original.monthlyCap}`}
-          />
-        </ConsumptionCell>
-      ),
+      cell: (info) => {
+        const { credits, monthlyCap } = info.row.original;
+        return (
+          <ConsumptionCell isLoading={isConsumptionLoading} align="left">
+            <DataTable.BasicCellContent
+              className="justify-start text-left tabular-nums"
+              label={`${
+                credits === null ? "—" : formatCredits(credits)
+              }/${monthlyCap === "Unlimited" ? "unlimited" : monthlyCap}`}
+            />
+          </ConsumptionCell>
+        );
+      },
     },
     {
       id: "monthlyCap",

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -357,7 +357,7 @@ function buildColumns({
       enableSorting: true,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-28 @sm-table:table-cell"
+          ? "hidden h-16 w-26 px-1 @sm-table:table-cell"
           : "hidden h-16 w-32 @sm-table:table-cell",
         headerAlign: "left",
       },

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -408,7 +408,7 @@ function buildColumns({
       cell: (info) =>
         info.row.original.key.status === "active" ? (
           <DataTable.CellContent className="w-full justify-end">
-            <div className="pointer-fine:opacity-0 pointer-fine:group-hover/dt-row:opacity-100 pointer-fine:focus-within:opacity-100">
+            <div className="transition-opacity duration-150 ease-out motion-reduce:transition-none pointer-fine:opacity-0 pointer-fine:group-hover/dt-row:opacity-100 pointer-fine:focus-within:opacity-100">
               <Button
                 icon={Trash01}
                 tooltip="Revoke API key"

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -273,8 +273,8 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-14 @lg-table:table-cell"
-          : "hidden h-16 w-14 @md-table:table-cell",
+          ? "hidden h-16 w-12 @lg-table:table-cell"
+          : "hidden h-16 w-12 @md-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {

--- a/front/components/workspace/api-keys/APIKeysTable.tsx
+++ b/front/components/workspace/api-keys/APIKeysTable.tsx
@@ -208,7 +208,7 @@ function buildColumns({
       header: "Name",
       enableSorting: true,
       meta: {
-        className: showAnalyticsConsumption ? "h-16 w-36" : "h-16 w-40",
+        className: showAnalyticsConsumption ? "h-16 w-40" : "h-16 w-44",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -250,8 +250,8 @@ function buildColumns({
       enableSorting: false,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-26 @lg-table:table-cell"
-          : "hidden h-16 w-30 @lg-table:table-cell",
+          ? "hidden h-16 w-28 @lg-table:table-cell"
+          : "hidden h-16 w-32 @lg-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -354,8 +354,8 @@ function buildColumns({
       enableSorting: true,
       meta: {
         className: showAnalyticsConsumption
-          ? "hidden h-16 w-26 px-1 @sm-table:table-cell"
-          : "hidden h-16 w-32 @sm-table:table-cell",
+          ? "hidden h-16 w-24 px-1 @sm-table:table-cell"
+          : "hidden h-16 w-30 @sm-table:table-cell",
         headerAlign: "left",
       },
       cell: (info) => (
@@ -377,7 +377,7 @@ function buildColumns({
       header: "Status",
       enableSorting: false,
       meta: {
-        className: showAnalyticsConsumption ? "h-16 w-18 px-1" : "h-16 w-20",
+        className: showAnalyticsConsumption ? "h-16 w-16 px-1" : "h-16 w-18",
         headerAlign: "left",
       },
       cell: (info) => {
@@ -404,7 +404,7 @@ function buildColumns({
       header: "",
       enableSorting: false,
       meta: {
-        className: "hidden h-16 w-12 @xs-table:table-cell",
+        className: "hidden h-16 w-10 px-1 @xs-table:table-cell",
         headerAlign: "right",
       },
       cell: (info) =>


### PR DESCRIPTION
## Description

This PR adds a credit breakdown to the API key admin page, mirroring what we have for automations. The typical UX flow this serves are about retrieving quickly resources identified by analyzing the charts in the new analytics page, and then actioning them (revoke, reach out to who created it).

Only affects workspaces that have the feature flag enabled.

<img width="1131" height="853" alt="Screenshot 2026-08-24 at 11 56 56 AM" src="https://github.com/user-attachments/assets/ef498d33-5a87-4c2d-8ad7-430f7bdea727" />

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
