### PR TITLE
[front] fix: message consumption update tests

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/read.test.ts
@@ -146,6 +146,8 @@ describe("getAgentMessageConsumption", () => {
 
     expect(consumption).toEqual({
       billedCredits: BILLED_CREDITS,
+      subAgentBilledCredits: 0,
+      totalBilledCredits: BILLED_CREDITS,
       details: {
         attributionVersion: AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION,
         agentWorkCredits: 3,
@@ -255,7 +257,12 @@ describe("getAgentMessageConsumption", () => {
         conversation,
         agentMessageId: agentMessage.sId,
       })
-    ).resolves.toEqual({ billedCredits: BILLED_CREDITS, details: null });
+    ).resolves.toEqual({
+      billedCredits: BILLED_CREDITS,
+      subAgentBilledCredits: 0,
+      totalBilledCredits: BILLED_CREDITS,
+      details: null,
+    });
   });
 
   it("falls back to the newest complete previous attribution", async () => {
@@ -310,6 +317,11 @@ describe("getAgentMessageConsumption", () => {
         conversation,
         agentMessageId: agentMessage.sId,
       })
-    ).resolves.toEqual({ billedCredits: BILLED_CREDITS, details: null });
+    ).resolves.toEqual({
+      billedCredits: BILLED_CREDITS,
+      subAgentBilledCredits: 0,
+      totalBilledCredits: BILLED_CREDITS,
+      details: null,
+    });
   });
 });


### PR DESCRIPTION
## Description

The message consumption response now includes sub-agent and total billed credits (added recently), but three exact assertions still expected the previous response format w/o them and fail.

This PR update the tests to expect the right format with the new fields.

## Tests

- Updated existing tests.

## Risk

- Low.

## Deploy Plan

- No deploy.
