### PR TITLE
ci: cache SDK/JS and Sparkle build output in setup-node-deps

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -54,14 +54,30 @@ runs:
       shell: bash
       run: npm ci
 
-    - name: Build SDK/JS
+    - name: Cache SDK/JS build output
+      id: cache-sdk-build
       if: inputs.build-sdks == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: sdks/js/dist
+        key: sdk-js-dist-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('sdks/js/src/**', 'sdks/js/package.json', 'sdks/js/tsconfig.json', 'sdks/js/esbuild.config.ts') }}
+
+    - name: Build SDK/JS
+      if: inputs.build-sdks == 'true' && steps.cache-sdk-build.outputs.cache-hit != 'true'
       working-directory: sdks/js
       shell: bash
       run: npm run build
 
-    - name: Build Sparkle
+    - name: Cache Sparkle build output
+      id: cache-sparkle-build
       if: inputs.build-sparkle == 'true'
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      with:
+        path: sparkle/dist
+        key: sparkle-dist-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('sparkle/src/**', 'sparkle/package.json', 'sparkle/tsconfig.json') }}
+
+    - name: Build Sparkle
+      if: inputs.build-sparkle == 'true' && steps.cache-sparkle-build.outputs.cache-hit != 'true'
       working-directory: sparkle
       shell: bash
       run: npm run build


### PR DESCRIPTION
## Summary
- Adds `actions/cache` steps in `.github/actions/setup-node-deps/action.yml` for `sdks/js/dist` and `sparkle/dist`, keyed on each package's source + config file hashes.
- Skips `npm run build` for a package when its build-output cache hits, so `build-and-test-front-api.yml` (6 test shards + tsgo job) no longer rebuilds the SDK/Sparkle bundles redundantly in every one of the 7 parallel jobs.
- No change to test/build/lint behavior — verified locally that both builds are deterministic (byte-identical output across reruns, ignoring source maps), so caching by source hash is safe.

Measured on a recent `main` run (build-and-test-front-api #32344315876, Shard 1): `Build SDK/JS` ~2.5s + `Build Sparkle` ~11s = ~13.5s per job, x7 jobs = ~94s of redundant compute per workflow run, ~81s avoidable via cache hits on 6/7 jobs.

## Test plan
- [x] actionlint passes (via pre-commit hook)
- [x] YAML validated
- [x] Confirmed sdks/js and sparkle builds produce identical dist output across reruns
- [ ] Observe this PR's own CI run: first run should be a cache miss (builds run normally); re-running the workflow should show cache hits and skipped build steps in "Setup Node Dependencies"