### PR TITLE
[sparkle] enh: improve data table loading skeleton

### DIFF
--- a/sparkle/src/components/DataTableLoadingSkeleton.tsx
+++ b/sparkle/src/components/DataTableLoadingSkeleton.tsx
@@ -25,19 +25,40 @@ function DataTableLoadingSkeleton({
       className={cn("flex w-full flex-col", className)}
       {...props}
     >
+      <div className="flex h-8 items-center border-b border-separator">
+        {showSelectionColumn && (
+          <div className="flex w-10 shrink-0 items-center px-2">
+            <LoadingBlock className="h-4 w-4 rounded-md" />
+          </div>
+        )}
+        <div className="flex min-w-0 flex-1 items-center px-2">
+          <LoadingBlock className="h-3 w-20" />
+        </div>
+        {showTrailingCell && (
+          <div className="flex w-28 shrink-0 items-center px-2">
+            <LoadingBlock className="h-3 w-16" />
+          </div>
+        )}
+      </div>
       {Array.from({ length: rows }, (_, i) => (
         <div
           key={i}
-          className="flex h-12 items-center gap-3 border-b border-separator px-2"
+          className="flex h-12 items-center border-b border-separator"
         >
           {showSelectionColumn && (
-            <LoadingBlock className="h-5 w-5 shrink-0 rounded-md" />
+            <div className="flex w-10 shrink-0 items-center px-2">
+              <LoadingBlock className="h-4 w-4 rounded-md" />
+            </div>
           )}
-          <LoadingBlock
-            className={cn("h-4", LABEL_WIDTHS[i % LABEL_WIDTHS.length])}
-          />
+          <div className="flex min-w-0 flex-1 items-center px-2">
+            <LoadingBlock
+              className={cn("h-4", LABEL_WIDTHS[i % LABEL_WIDTHS.length])}
+            />
+          </div>
           {showTrailingCell && (
-            <LoadingBlock className="ml-auto h-5 w-24 rounded-full" />
+            <div className="flex w-28 shrink-0 items-center px-2">
+              <LoadingBlock className="h-5 w-24 rounded-full" />
+            </div>
           )}
         </div>
       ))}

--- a/sparkle/src/stories/DataTableLoadingSkeleton.stories.tsx
+++ b/sparkle/src/stories/DataTableLoadingSkeleton.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: `A skeleton placeholder that mirrors the layout of a **DataTable** / **ScrollableDataTable** list (rows with an optional selection checkbox, a label, and an optional trailing cell). Built on **LoadingBlock**, it reserves the list's shape while rows are being fetched, so the swap to real content feels seamless.
+        component: `A skeleton placeholder that mirrors the layout of a **DataTable** / **ScrollableDataTable** (header and rows with an optional selection checkbox, a label, and an optional trailing cell). Built on **LoadingBlock**, it reserves the table's shape while rows are being fetched, so the swap to real content feels seamless.
 
 **When to use**
 - While loading rows whose shape is known ahead of time (selectable lists, tables).

--- a/sparkle/src/stories/DataTableLoadingSkeleton.stories.tsx
+++ b/sparkle/src/stories/DataTableLoadingSkeleton.stories.tsx
@@ -16,6 +16,7 @@ const meta = {
 
 **Guidelines**
 - Toggle \`showSelectionColumn\` and \`showTrailingCell\` to match the real table's columns.
+- Treat this as a reasonable default. Since cells can render arbitrary custom components, prefer a table-specific skeleton when you need the loading state to match their exact shape.
 - For an indeterminate load with no known layout, use a **Spinner** instead.`,
       },
     },


### PR DESCRIPTION
## Description

Data table loading skeletons currently omit the header, so their rows shift down when the loaded table replaces them.

This PR adds a header placeholder with the same height as the real table and aligns the selection and trailing cells with the destination columns.

The goal is to provide a correct drop-in default, but for the best experience it is still recommended to fine tune the skeleton to the exact target layout.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
