### PR TITLE
[front] Align agents batch edit with usage page selection UX

### DIFF
--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -1,6 +1,11 @@
 import { useBatchUpdateAgentTags } from "@app/lib/swr/assistants";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
-import { compareForFuzzySort, subFilter, tagsSorter } from "@app/lib/utils";
+import {
+  classNames,
+  compareForFuzzySort,
+  subFilter,
+  tagsSorter,
+} from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TagType } from "@app/types/tag";
 import type { WorkspaceType } from "@app/types/user";
@@ -13,9 +18,9 @@ import {
   DropdownMenuTagItem,
   DropdownMenuTagList,
   DropdownMenuTrigger,
+  Hoverable,
   Spinner,
   Tag01,
-  XClose,
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
@@ -23,17 +28,38 @@ import { DeleteAssistantsDialog } from "./DeleteAssistantsDialog";
 import { SetModelAssistantsDialog } from "./SetModelAssistantsDialog";
 import { UnpublishAssistantsDialog } from "./UnpublishAssistantsDialog";
 
+// Matches ContentMessageInline's "info" variant. ContentMessageInline itself can't be reused
+// here: it only slots literal `ContentMessageAction` elements into its action area, and the
+// dropdown/dialog triggers below aren't that.
+const BAR_CLASSNAME =
+  "flex items-center gap-2 rounded-xl border bg-orange-50 border-orange-100 p-3 dark:bg-golden-950 dark:border-golden-900";
+const BAR_TEXT_CLASSNAME = "text-xs text-orange-800 dark:text-golden-100";
+
 type AgentEditBarProps = {
-  onClose: () => void;
+  onClear: () => void;
+  onSelectAll: () => void;
   selectedAgents: LightAgentConfigurationType[];
+  pageCount: number;
+  totalCount: number;
+  isAllSelected: boolean;
+  hasMorePagesToSelect: boolean;
   owner: WorkspaceType;
   tags: TagType[];
   mutateAgentConfigurations: () => Promise<any>;
 };
 
+function agentsLabel(count: number): string {
+  return count === 1 ? "agent" : "agents";
+}
+
 export const AgentEditBar = ({
-  onClose,
+  onClear,
+  onSelectAll,
   selectedAgents,
+  pageCount,
+  totalCount,
+  isAllSelected,
+  hasMorePagesToSelect,
   owner,
   tags,
   mutateAgentConfigurations,
@@ -47,6 +73,12 @@ export const AgentEditBar = ({
 
   const { hasPermission } = useWorkspacePermissions();
   const canPublishAgents = hasPermission("publish", "agent");
+
+  const selectedCount = selectedAgents.length;
+
+  if (selectedCount === 0) {
+    return null;
+  }
 
   const filteredTags = tags
     .filter((t) => canPublishAgents || t.kind !== "protected")
@@ -66,103 +98,122 @@ export const AgentEditBar = ({
     });
 
   return (
-    <>
-      <div className="border-1 mb-2 flex flex-row items-center gap-2 rounded-xl bg-muted-background p-2">
-        <Button
-          size="xs"
-          variant="outline"
-          disabled={isLoading}
-          label="Close edition"
-          icon={XClose}
-          onClick={onClose}
-        />
-        {isLoading && <Spinner size="xs" variant="dark" />}
-        <div className="flex-1" />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              size="xs"
-              variant="outline"
-              isSelect
-              icon={Tag01}
-              label="Tag selection"
-              disabled={selectedAgents.length === 0 || isLoading}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="w-60"
-            dropdownHeaders={
-              <>
-                <DropdownMenuSearchbar
-                  name="tagSearch"
-                  placeholder="Search tags"
-                  value={tagSearch}
-                  onChange={setTagSearch}
-                />
-                <DropdownMenuSeparator />
-              </>
-            }
-          >
-            <DropdownMenuTagList>
-              {filteredTags.map((t) => {
-                return (
-                  <DropdownMenuTagItem
-                    key={t.sId}
-                    label={t.name}
-                    color="info"
-                    onClick={async () => {
-                      setIsLoading(true);
-                      const agentIds = selectedAgents.map((a) => a.sId);
-
-                      if (
-                        selectedAgents.every((a) =>
-                          a.tags.find((agentTag) => agentTag.sId === t.sId)
-                        )
-                      ) {
-                        // Remove tag from all selected agents
-                        await batchUpdateAgentTags(agentIds, {
-                          removeTagIds: [t.sId],
-                        });
-                      } else {
-                        // Add tag to agents that don't have it
-                        const toAdd = selectedAgents.filter(
-                          (a) =>
-                            !a.tags.find((agentTag) => agentTag.sId === t.sId)
-                        );
-                        await batchUpdateAgentTags(
-                          toAdd.map((a) => a.sId),
-                          {
-                            addTagIds: [t.sId],
-                          }
-                        );
-                      }
-                      void mutateAgentConfigurations();
-                      setIsLoading(false);
-                    }}
-                  />
-                );
-              })}
-            </DropdownMenuTagList>
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <SetModelAssistantsDialog
-          owner={owner}
-          agentConfigurations={selectedAgents}
-          disabled={selectedAgents.length === 0 || isLoading}
-        />
-        <UnpublishAssistantsDialog
-          owner={owner}
-          agentConfigurations={selectedAgents}
-          disabled={selectedAgents.length === 0 || isLoading}
-          onSave={onClose}
-        />
-        <DeleteAssistantsDialog
-          owner={owner}
-          agentConfigurations={selectedAgents}
-          disabled={selectedAgents.length === 0 || isLoading}
-          onSave={onClose}
-        />
+    <div className={classNames("mt-3 mb-2", BAR_CLASSNAME)}>
+      <div
+        className={classNames(
+          "flex flex-1 flex-row flex-wrap items-center gap-x-2 gap-y-1",
+          BAR_TEXT_CLASSNAME
+        )}
+      >
+        {isAllSelected ? (
+          <span>
+            {selectedCount} {agentsLabel(selectedCount)} selected.
+          </span>
+        ) : hasMorePagesToSelect ? (
+          <span>
+            All {pageCount} {agentsLabel(pageCount)} on this page are selected.
+          </span>
+        ) : (
+          <span>
+            {selectedCount} {agentsLabel(selectedCount)} selected
+          </span>
+        )}
+        {hasMorePagesToSelect && (
+          <Hoverable variant="highlight" onClick={onSelectAll}>
+            Select all {totalCount} {agentsLabel(totalCount)}
+          </Hoverable>
+        )}
+        <Hoverable variant="highlight" onClick={onClear}>
+          Clear
+        </Hoverable>
       </div>
-    </>
+      {isLoading && <Spinner size="xs" variant="dark" />}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="xs"
+            variant="primary"
+            isSelect
+            icon={Tag01}
+            label="Tag selection"
+            disabled={isLoading}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          className="w-60"
+          dropdownHeaders={
+            <>
+              <DropdownMenuSearchbar
+                name="tagSearch"
+                placeholder="Search tags"
+                value={tagSearch}
+                onChange={setTagSearch}
+              />
+              <DropdownMenuSeparator />
+            </>
+          }
+        >
+          <DropdownMenuTagList>
+            {filteredTags.map((t) => {
+              return (
+                <DropdownMenuTagItem
+                  key={t.sId}
+                  label={t.name}
+                  color="info"
+                  onClick={async () => {
+                    setIsLoading(true);
+                    const agentIds = selectedAgents.map((a) => a.sId);
+
+                    if (
+                      selectedAgents.every((a) =>
+                        a.tags.find((agentTag) => agentTag.sId === t.sId)
+                      )
+                    ) {
+                      // Remove tag from all selected agents
+                      await batchUpdateAgentTags(agentIds, {
+                        removeTagIds: [t.sId],
+                      });
+                    } else {
+                      // Add tag to agents that don't have it
+                      const toAdd = selectedAgents.filter(
+                        (a) =>
+                          !a.tags.find((agentTag) => agentTag.sId === t.sId)
+                      );
+                      await batchUpdateAgentTags(
+                        toAdd.map((a) => a.sId),
+                        {
+                          addTagIds: [t.sId],
+                        }
+                      );
+                    }
+                    void mutateAgentConfigurations();
+                    setIsLoading(false);
+                  }}
+                />
+              );
+            })}
+          </DropdownMenuTagList>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <SetModelAssistantsDialog
+        owner={owner}
+        agentConfigurations={selectedAgents}
+        disabled={isLoading}
+        variant="primary"
+      />
+      <UnpublishAssistantsDialog
+        owner={owner}
+        agentConfigurations={selectedAgents}
+        disabled={isLoading}
+        onSave={onClear}
+        variant="primary"
+      />
+      <DeleteAssistantsDialog
+        owner={owner}
+        agentConfigurations={selectedAgents}
+        disabled={isLoading}
+        onSave={onClear}
+      />
+    </div>
   );
 };

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -85,13 +85,16 @@ export const AgentEditBar = ({
     <div
       className={cn(
         "mt-3 mb-2 flex items-center gap-2 rounded-xl border p-3",
-        "border-warning-200 bg-warning-100"
+        // Same colors as the Usage page's selection banner (ContentMessageInline's
+        // "info" variant): the `warning` token is mapped to red/rose in this design
+        // system, not the yellow/orange used here.
+        "border-orange-100 bg-orange-50 dark:border-golden-900 dark:bg-golden-950"
       )}
     >
       <div
         className={cn(
           "flex flex-1 flex-row flex-wrap items-center gap-x-2 gap-y-1",
-          "text-xs text-warning-900"
+          "text-xs text-orange-800 dark:text-golden-100"
         )}
       >
         {isAllSelected ? (

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -1,16 +1,13 @@
 import { useBatchUpdateAgentTags } from "@app/lib/swr/assistants";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
-import {
-  classNames,
-  compareForFuzzySort,
-  subFilter,
-  tagsSorter,
-} from "@app/lib/utils";
+import { compareForFuzzySort, subFilter, tagsSorter } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { TagType } from "@app/types/tag";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuSearchbar,
@@ -28,10 +25,6 @@ import { DeleteAssistantsDialog } from "./DeleteAssistantsDialog";
 import { SetModelAssistantsDialog } from "./SetModelAssistantsDialog";
 import { UnpublishAssistantsDialog } from "./UnpublishAssistantsDialog";
 
-const BAR_CLASSNAME =
-  "flex items-center gap-2 rounded-xl border bg-orange-50 border-orange-100 p-3 dark:bg-golden-950 dark:border-golden-900";
-const BAR_TEXT_CLASSNAME = "text-xs text-orange-800 dark:text-golden-100";
-
 type AgentEditBarProps = {
   onClear: () => void;
   onSelectAll: () => void;
@@ -42,10 +35,6 @@ type AgentEditBarProps = {
   tags: TagType[];
   mutateAgentConfigurations: () => Promise<any>;
 };
-
-function agentsLabel(count: number): string {
-  return count === 1 ? "agent" : "agents";
-}
 
 export const AgentEditBar = ({
   onClear,
@@ -93,25 +82,30 @@ export const AgentEditBar = ({
     });
 
   return (
-    <div className={classNames("mt-3 mb-2", BAR_CLASSNAME)}>
+    <div
+      className={cn(
+        "mt-3 mb-2 flex items-center gap-2 rounded-xl border p-3",
+        "border-warning-200 bg-warning-100"
+      )}
+    >
       <div
-        className={classNames(
+        className={cn(
           "flex flex-1 flex-row flex-wrap items-center gap-x-2 gap-y-1",
-          BAR_TEXT_CLASSNAME
+          "text-xs text-warning-900"
         )}
       >
         {isAllSelected ? (
           <span>
-            {selectedCount} {agentsLabel(selectedCount)} are selected.
+            {selectedCount} agent{pluralize(selectedCount)} are selected.
           </span>
         ) : (
           <>
             <span>
-              {pageSelectedCount} {agentsLabel(pageSelectedCount)} selected on
-              this page
+              {pageSelectedCount} agent{pluralize(pageSelectedCount)} selected
+              on this page
             </span>
             <Hoverable variant="highlight" onClick={onSelectAll}>
-              Select all {totalCount} {agentsLabel(totalCount)}
+              Select all {totalCount} agent{pluralize(totalCount)}
             </Hoverable>
           </>
         )}

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -39,10 +39,8 @@ type AgentEditBarProps = {
   onClear: () => void;
   onSelectAll: () => void;
   selectedAgents: LightAgentConfigurationType[];
-  pageCount: number;
+  pageSelectedCount: number;
   totalCount: number;
-  isAllSelected: boolean;
-  hasMorePagesToSelect: boolean;
   owner: WorkspaceType;
   tags: TagType[];
   mutateAgentConfigurations: () => Promise<any>;
@@ -56,10 +54,8 @@ export const AgentEditBar = ({
   onClear,
   onSelectAll,
   selectedAgents,
-  pageCount,
+  pageSelectedCount,
   totalCount,
-  isAllSelected,
-  hasMorePagesToSelect,
   owner,
   tags,
   mutateAgentConfigurations,
@@ -79,6 +75,8 @@ export const AgentEditBar = ({
   if (selectedCount === 0) {
     return null;
   }
+
+  const isAllSelected = totalCount > 0 && selectedCount === totalCount;
 
   const filteredTags = tags
     .filter((t) => canPublishAgents || t.kind !== "protected")
@@ -107,27 +105,28 @@ export const AgentEditBar = ({
       >
         {isAllSelected ? (
           <span>
-            {selectedCount} {agentsLabel(selectedCount)} selected.
-          </span>
-        ) : hasMorePagesToSelect ? (
-          <span>
-            All {pageCount} {agentsLabel(pageCount)} on this page are selected.
+            {selectedCount} {agentsLabel(selectedCount)} are selected.
           </span>
         ) : (
-          <span>
-            {selectedCount} {agentsLabel(selectedCount)} selected
-          </span>
+          <>
+            <span>
+              {pageSelectedCount} {agentsLabel(pageSelectedCount)} selected on
+              this page
+            </span>
+            <Hoverable variant="highlight" onClick={onSelectAll}>
+              Select all {totalCount} {agentsLabel(totalCount)}
+            </Hoverable>
+          </>
         )}
-        {hasMorePagesToSelect && (
-          <Hoverable variant="highlight" onClick={onSelectAll}>
-            Select all {totalCount} {agentsLabel(totalCount)}
-          </Hoverable>
-        )}
-        <Hoverable variant="highlight" onClick={onClear}>
-          Clear
-        </Hoverable>
       </div>
       {isLoading && <Spinner size="xs" variant="dark" />}
+      <Button
+        size="xs"
+        variant="ghost"
+        label="Clear"
+        onClick={onClear}
+        disabled={isLoading}
+      />
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -28,9 +28,6 @@ import { DeleteAssistantsDialog } from "./DeleteAssistantsDialog";
 import { SetModelAssistantsDialog } from "./SetModelAssistantsDialog";
 import { UnpublishAssistantsDialog } from "./UnpublishAssistantsDialog";
 
-// Matches ContentMessageInline's "info" variant. ContentMessageInline itself can't be reused
-// here: it only slots literal `ContentMessageAction` elements into its action area, and the
-// dropdown/dialog triggers below aren't that.
 const BAR_CLASSNAME =
   "flex items-center gap-2 rounded-xl border bg-orange-50 border-orange-100 p-3 dark:bg-golden-950 dark:border-golden-900";
 const BAR_TEXT_CLASSNAME = "text-xs text-orange-800 dark:text-golden-100";

--- a/front/components/assistant/AgentEditBar.tsx
+++ b/front/components/assistant/AgentEditBar.tsx
@@ -85,9 +85,6 @@ export const AgentEditBar = ({
     <div
       className={cn(
         "mt-3 mb-2 flex items-center gap-2 rounded-xl border p-3",
-        // Same colors as the Usage page's selection banner (ContentMessageInline's
-        // "info" variant): the `warning` token is mapped to red/rose in this design
-        // system, not the yellow/orange used here.
         "border-orange-100 bg-orange-50 dark:border-golden-900 dark:bg-golden-950"
       )}
     >

--- a/front/components/assistant/SetModelAssistantsDialog.tsx
+++ b/front/components/assistant/SetModelAssistantsDialog.tsx
@@ -11,6 +11,7 @@ import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
+import type { ButtonProps } from "@dust-tt/sparkle";
 import {
   Button,
   CpuChip01,
@@ -37,12 +38,14 @@ interface SetModelAssistantsDialogProps {
   agentConfigurations: LightAgentConfigurationType[];
   disabled: boolean;
   owner: LightWorkspaceType;
+  variant?: ButtonProps["variant"];
 }
 
 export function SetModelAssistantsDialog({
   agentConfigurations,
   disabled,
   owner,
+  variant = "outline",
 }: SetModelAssistantsDialogProps) {
   const { isDark } = useTheme();
   const [isOpen, setIsOpen] = useState(false);
@@ -87,7 +90,7 @@ export function SetModelAssistantsDialog({
       <DialogTrigger asChild>
         <Button
           size="xs"
-          variant="outline"
+          variant={variant}
           icon={CpuChip01}
           label="Set model"
           disabled={disabled}

--- a/front/components/assistant/UnpublishAssistantsDialog.tsx
+++ b/front/components/assistant/UnpublishAssistantsDialog.tsx
@@ -5,6 +5,7 @@ import {
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
+import type { ButtonProps } from "@dust-tt/sparkle";
 import {
   Button,
   Dialog,
@@ -24,6 +25,7 @@ interface UnpublishAssistantsDialogProps {
   disabled: boolean;
   owner: LightWorkspaceType;
   onSave: () => void;
+  variant?: ButtonProps["variant"];
 }
 
 export function UnpublishAssistantsDialog({
@@ -31,6 +33,7 @@ export function UnpublishAssistantsDialog({
   disabled,
   owner,
   onSave,
+  variant = "outline",
 }: UnpublishAssistantsDialogProps) {
   const [isUnpublishing, setIsUnpublishing] = useState(false);
 
@@ -53,7 +56,7 @@ export function UnpublishAssistantsDialog({
       <DialogTrigger asChild>
         <Button
           size="xs"
-          variant="outline"
+          variant={variant}
           icon={EyeOff}
           label="Unpublish"
           disabled={disabled}

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -582,16 +582,18 @@ export function AssistantsTable({
     [rows]
   );
   const totalSelectableCount = selectableRowIds.length;
-  const pageSelectableIds = useMemo(() => {
+
+  // `rows` is exactly the `data` DataTable paginates over (no separate filtering happens
+  // before pagination), so slicing it directly matches the rows actually shown on this page.
+  const pageRows = useMemo(() => {
     const start = pagination.pageIndex * pagination.pageSize;
-    return selectableRowIds.slice(start, start + pagination.pageSize);
-  }, [selectableRowIds, pagination]);
-  const isAllSelected =
-    totalSelectableCount > 0 && selection.length === totalSelectableCount;
-  const hasMorePagesToSelect =
-    !isAllSelected &&
-    pageSelectableIds.length > 0 &&
-    pageSelectableIds.every((id) => selection.includes(id));
+    return rows.slice(start, start + pagination.pageSize);
+  }, [rows, pagination]);
+  const pageSelectedCount = useMemo(() => {
+    const selectionSet = new Set(selection);
+    return pageRows.filter((row) => row.canArchive && selectionSet.has(row.sId))
+      .length;
+  }, [pageRows, selection]);
 
   return (
     <>
@@ -611,10 +613,8 @@ export function AssistantsTable({
         selectedAgents={selectedAgents}
         tags={sortedTags}
         mutateAgentConfigurations={mutateAgentConfigurations}
-        pageCount={pageSelectableIds.length}
+        pageSelectedCount={pageSelectedCount}
         totalCount={totalSelectableCount}
-        isAllSelected={isAllSelected}
-        hasMorePagesToSelect={hasMorePagesToSelect}
         onClear={() => setSelection([])}
         onSelectAll={() => setSelection(selectableRowIds)}
       />
@@ -628,6 +628,7 @@ export function AssistantsTable({
             setPagination={setPagination}
             getRowId={(row) => row.sId}
             enableRowSelection={(row) => row.original.canArchive}
+            disableRowClickSelection
             rowSelection={rowSelection}
             setRowSelection={(newRowSelection) => {
               setSelection(

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -572,9 +572,11 @@ export function AssistantsTable({
     ]
   );
 
+  const selectionSet = useMemo(() => new Set(selection), [selection]);
+
   const selectedAgents = useMemo(
-    () => agents.filter((a) => selection.includes(a.sId)),
-    [agents, selection]
+    () => agents.filter((a) => selectionSet.has(a.sId)),
+    [agents, selectionSet]
   );
 
   const selectableRowIds = useMemo(
@@ -589,11 +591,12 @@ export function AssistantsTable({
     const start = pagination.pageIndex * pagination.pageSize;
     return rows.slice(start, start + pagination.pageSize);
   }, [rows, pagination]);
-  const pageSelectedCount = useMemo(() => {
-    const selectionSet = new Set(selection);
-    return pageRows.filter((row) => row.canArchive && selectionSet.has(row.sId))
-      .length;
-  }, [pageRows, selection]);
+  const pageSelectedCount = useMemo(
+    () =>
+      pageRows.filter((row) => row.canArchive && selectionSet.has(row.sId))
+        .length,
+    [pageRows, selectionSet]
+  );
 
   return (
     <>

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -100,28 +100,32 @@ const getTableColumns = ({
         ).some((isSelected) => isSelected);
 
         return (
-          <Checkbox
-            checked={
-              areAllPageRowsSelected ? true : hasSelection ? "partial" : false
-            }
-            disabled={
-              !info.table.getRowModel().rows.some((row) => row.getCanSelect())
-            }
-            tooltip={
-              areAllPageRowsSelected ? "Clear selection" : "Select all on page"
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-            }}
-            onCheckedChange={(checked) => {
-              if (checked) {
-                info.table.toggleAllPageRowsSelected(true);
-              } else {
-                // Unticking clears the whole selection across pages.
-                info.table.resetRowSelection();
+          <DataTable.CellContent className="size-full items-center justify-center">
+            <Checkbox
+              checked={
+                areAllPageRowsSelected ? true : hasSelection ? "partial" : false
               }
-            }}
-          />
+              disabled={
+                !info.table.getRowModel().rows.some((row) => row.getCanSelect())
+              }
+              tooltip={
+                areAllPageRowsSelected
+                  ? "Clear selection"
+                  : "Select all on page"
+              }
+              onClick={(e) => {
+                e.stopPropagation();
+              }}
+              onCheckedChange={(checked) => {
+                if (checked) {
+                  info.table.toggleAllPageRowsSelected(true);
+                } else {
+                  // Unticking clears the whole selection across pages.
+                  info.table.resetRowSelection();
+                }
+              }}
+            />
+          </DataTable.CellContent>
         );
       },
       accessorKey: "select",
@@ -131,6 +135,7 @@ const getTableColumns = ({
         }
 
         const checkboxId = `select-agent-${info.row.id}`;
+        const agentName = info.row.original.name;
 
         return (
           // A `label` wrapping the checkbox makes the whole cell (not just the
@@ -138,27 +143,31 @@ const getTableColumns = ({
           // keyboard handling to maintain. `stopPropagation` only keeps the
           // click from also reaching the row's `onClick`, which opens the
           // agent details panel; the actual toggle happens through
-          // `Checkbox`'s own `onCheckedChange`.
+          // `Checkbox`'s own `onCheckedChange`. The column drops the cell's
+          // default padding (see `meta.className` below) so this label fills
+          // the entire cell, matching the hover treatment other full-cell
+          // controls (e.g. the attribution table's filter button) use.
           <Label
             htmlFor={checkboxId}
-            className="flex size-full cursor-pointer items-center justify-center"
+            className="flex size-full cursor-pointer items-center justify-center hover:bg-muted-background"
             onClick={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
           >
-            <DataTable.CellContent>
-              <Checkbox
-                id={checkboxId}
-                checked={info.row.getIsSelected()}
-                onCheckedChange={(checked) =>
-                  info.row.toggleSelected(!!checked)
-                }
-              />
-            </DataTable.CellContent>
+            <Checkbox
+              id={checkboxId}
+              aria-label={
+                info.row.getIsSelected()
+                  ? `Deselect ${agentName}`
+                  : `Select ${agentName}`
+              }
+              checked={info.row.getIsSelected()}
+              onCheckedChange={(checked) => info.row.toggleSelected(!!checked)}
+            />
           </Label>
         );
       },
       meta: {
-        className: "w-10",
+        className: "w-10 p-0",
       },
       enableSorting: false,
     },

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -138,15 +138,8 @@ const getTableColumns = ({
         const agentName = info.row.original.name;
 
         return (
-          // A `label` wrapping the checkbox makes the whole cell (not just the
-          // small checkbox) toggle selection, natively and with no separate
-          // keyboard handling to maintain. `stopPropagation` only keeps the
-          // click from also reaching the row's `onClick`, which opens the
-          // agent details panel; the actual toggle happens through
-          // `Checkbox`'s own `onCheckedChange`. The column drops the cell's
-          // default padding (see `meta.className` below) so this label fills
-          // the entire cell, matching the hover treatment other full-cell
-          // controls (e.g. the attribution table's filter button) use.
+          // `stopPropagation` keeps the click from also reaching the row's `onClick`, which opens the
+          // agent details panel
           <Label
             htmlFor={checkboxId}
             className="flex size-full cursor-pointer items-center justify-center hover:bg-muted-background"

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -585,9 +585,6 @@ export function AssistantsTable({
     [agents]
   );
 
-  // Only rows that are actually selectable (`canArchive`) can end up in bulk actions, even if
-  // `selection` (owned by the parent, and not reset on every scope change) still references an
-  // agent that is no longer selectable in the current view.
   const selectedAgents = useMemo(
     () =>
       selectableRowIds
@@ -597,8 +594,6 @@ export function AssistantsTable({
     [selectableRowIds, selectionSet, agentsBySId]
   );
 
-  // `rows` is exactly the `data` DataTable paginates over (no separate filtering happens
-  // before pagination), so slicing it directly matches the rows actually shown on this page.
   const pageRows = useMemo(() => {
     const start = pagination.pageIndex * pagination.pageSize;
     return rows.slice(start, start + pagination.pageSize);

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -124,22 +124,31 @@ const getTableColumns = ({
         );
       },
       accessorKey: "select",
-      cell: (info: CellContext<RowData, boolean>) => (
-        // Selecting a row must not also trigger the row's `onClick` (which opens
-        // the agent details panel).
-        <div
-          onClick={(e) => e.stopPropagation()}
-          onPointerDown={(e) => e.stopPropagation()}
-        >
-          <DataTable.CellContent>
-            <Checkbox
-              checked={info.row.getIsSelected()}
-              disabled={!info.row.getCanSelect()}
-              onCheckedChange={(checked) => info.row.toggleSelected(!!checked)}
-            />
-          </DataTable.CellContent>
-        </div>
-      ),
+      cell: (info: CellContext<RowData, boolean>) => {
+        if (!info.row.getCanSelect()) {
+          return null;
+        }
+
+        return (
+          // The whole cell (not just the checkbox) toggles selection, since the
+          // checkbox alone is a small target and a missclick opens the agent
+          // details panel via the row's `onClick`. The click also reaches the
+          // checkbox itself, so the toggle is only handled here to avoid
+          // double-toggling.
+          <div
+            className="flex size-full items-center justify-center"
+            onClick={(e) => {
+              e.stopPropagation();
+              info.row.toggleSelected();
+            }}
+            onPointerDown={(e) => e.stopPropagation()}
+          >
+            <DataTable.CellContent>
+              <Checkbox checked={info.row.getIsSelected()} />
+            </DataTable.CellContent>
+          </div>
+        );
+      },
       meta: {
         className: "w-10",
       },
@@ -580,18 +589,11 @@ export function AssistantsTable({
   );
   const totalSelectableCount = selectableRowIds.length;
 
-  const agentsBySId = useMemo(
-    () => new Map(agents.map((a) => [a.sId, a])),
-    [agents]
-  );
-
+  // Selection only ever contains selectable rows (only those render a
+  // checkbox), so no extra filtering is needed here.
   const selectedAgents = useMemo(
-    () =>
-      selectableRowIds
-        .filter((sId) => selectionSet.has(sId))
-        .map((sId) => agentsBySId.get(sId))
-        .filter((a): a is LightAgentConfigurationType => !!a),
-    [selectableRowIds, selectionSet, agentsBySId]
+    () => agents.filter((a) => selectionSet.has(a.sId)),
+    [agents, selectionSet]
   );
 
   const pageRows = useMemo(() => {

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -1,3 +1,4 @@
+import { AgentEditBar } from "@app/components/assistant/AgentEditBar";
 import { DeleteAgentDialog } from "@app/components/assistant/DeleteAgentDialog";
 import { SCOPE_INFO } from "@app/components/assistant/details/AgentDetailsSheet";
 import { GlobalAgentAction } from "@app/components/assistant/manager/GlobalAgentAction";
@@ -66,25 +67,18 @@ type RowData = {
   canEdit: boolean;
 };
 
-// Global agents (canArchive: false) cannot be edited, so we disable them in batch edit.
-function isDisabled(canArchive: boolean, isBatchEdit: boolean): boolean {
-  return !canArchive && isBatchEdit;
-}
-
 const getTableColumns = ({
   owner,
   tags,
-  isBatchEdit,
   mutateAgentConfigurations,
 }: {
   owner: WorkspaceType;
   tags: TagType[];
-  isBatchEdit: boolean;
   mutateAgentConfigurations: () => Promise<any>;
 }) => {
   /**
    * Columns order:
-   * - Select (if batch edit)
+   * - Select
    * - Name (always)
    * - Model (hidden on mobile)
    * - Access (hidden on mobile)
@@ -97,74 +91,65 @@ const getTableColumns = ({
    */
 
   return [
-    ...(isBatchEdit
-      ? [
-          {
-            header: (info: HeaderContext<RowData, boolean>) => {
-              const areAllPageRowsSelected =
-                info.table.getIsAllPageRowsSelected();
-              const hasSelection = Object.values(
-                info.table.getState().rowSelection
-              ).some((isSelected) => isSelected);
+    {
+      header: (info: HeaderContext<RowData, boolean>) => {
+        const areAllPageRowsSelected = info.table.getIsAllPageRowsSelected();
+        const hasSelection = Object.values(
+          info.table.getState().rowSelection
+        ).some((isSelected) => isSelected);
 
-              return (
-                <Checkbox
-                  checked={
-                    areAllPageRowsSelected
-                      ? true
-                      : hasSelection
-                        ? "partial"
-                        : false
-                  }
-                  disabled={
-                    !info.table
-                      .getRowModel()
-                      .rows.some((row) => row.getCanSelect())
-                  }
-                  tooltip={
-                    areAllPageRowsSelected
-                      ? "Clear selection"
-                      : "Select all on page"
-                  }
-                  onClick={(e) => {
-                    e.stopPropagation();
-                  }}
-                  onCheckedChange={(checked) => {
-                    if (checked) {
-                      info.table.toggleAllPageRowsSelected(true);
-                    } else {
-                      // Unticking clears the whole selection across pages.
-                      info.table.resetRowSelection();
-                    }
-                  }}
-                />
-              );
-            },
-            accessorKey: "select",
-            cell: (info: CellContext<RowData, boolean>) => (
-              <DataTable.CellContent
-                disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-              >
-                <Checkbox
-                  checked={info.row.getIsSelected()}
-                  disabled={!info.row.getCanSelect()}
-                />
-              </DataTable.CellContent>
-            ),
-            meta: {
-              className: "w-10",
-            },
-            enableSorting: false,
-          },
-        ]
-      : []),
+        return (
+          <Checkbox
+            checked={
+              areAllPageRowsSelected ? true : hasSelection ? "partial" : false
+            }
+            disabled={
+              !info.table.getRowModel().rows.some((row) => row.getCanSelect())
+            }
+            tooltip={
+              areAllPageRowsSelected ? "Clear selection" : "Select all on page"
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            onCheckedChange={(checked) => {
+              if (checked) {
+                info.table.toggleAllPageRowsSelected(true);
+              } else {
+                // Unticking clears the whole selection across pages.
+                info.table.resetRowSelection();
+              }
+            }}
+          />
+        );
+      },
+      accessorKey: "select",
+      cell: (info: CellContext<RowData, boolean>) => (
+        // Selecting a row must not also trigger the row's `onClick` (which opens
+        // the agent details panel).
+        <div
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          <DataTable.CellContent>
+            <Checkbox
+              checked={info.row.getIsSelected()}
+              disabled={!info.row.getCanSelect()}
+              onCheckedChange={(checked) => info.row.toggleSelected(!!checked)}
+            />
+          </DataTable.CellContent>
+        </div>
+      ),
+      meta: {
+        className: "w-10",
+      },
+      enableSorting: false,
+    },
     {
       header: "Name",
       accessorKey: "name",
       cell: (info: CellContext<RowData, string>) => (
-        <DataTable.CellContent
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-        >
+        <DataTable.CellContent>
           <div className={classNames("flex flex-row items-center gap-2 py-3")}>
             <div>
               <Avatar visual={info.row.original.pictureUrl} size="sm" />
@@ -198,10 +183,6 @@ const getTableColumns = ({
             trigger={
               <div className="inline-flex">
                 <DataTable.CellContent
-                  disabled={isDisabled(
-                    info.row.original.canArchive,
-                    isBatchEdit
-                  )}
                   icon={modelIcon}
                   iconClassName="mr-0 @xl:mr-2"
                 >
@@ -221,9 +202,7 @@ const getTableColumns = ({
       header: "Access",
       accessorKey: "scope",
       cell: (info: CellContext<RowData, AgentConfigurationScope>) => (
-        <DataTable.CellContent
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-        >
+        <DataTable.CellContent>
           {info.getValue() !== "hidden" && (
             <Chip
               size="xs"
@@ -245,12 +224,7 @@ const getTableColumns = ({
         const { editors } = info.row.original;
 
         if (!editors) {
-          return (
-            <DataTable.BasicCellContent
-              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-              label="-"
-            />
-          );
+          return <DataTable.BasicCellContent label="-" />;
         }
 
         return (
@@ -277,7 +251,6 @@ const getTableColumns = ({
         <DataTable.CellContent
           grow
           className={classNames("flex flex-row items-center")}
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
         >
           <div className="group flex flex-row items-center gap-1">
             <div className="truncate text-muted-foreground">
@@ -311,7 +284,6 @@ const getTableColumns = ({
       cell: (info: CellContext<RowData, AgentUsageType | undefined>) => (
         <DataTable.BasicCellContent
           className="font-mono"
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           tooltip={assistantUsageMessage({
             assistantName: info.row.original.name,
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -343,7 +315,6 @@ const getTableColumns = ({
           return (
             <DataTable.BasicCellContent
               className="font-mono"
-              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
               tooltip={feedbacksCount}
               label={`${f.up + f.down}`}
             />
@@ -360,7 +331,6 @@ const getTableColumns = ({
       accessorKey: "lastUpdate",
       cell: (info: CellContext<RowData, number>) => (
         <DataTable.BasicCellContent
-          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
           tooltip={
             info.getValue()
               ? formatTimestampToFriendlyDate(info.getValue(), "long")
@@ -381,19 +351,12 @@ const getTableColumns = ({
       cell: (info: CellContext<RowData, number>) => {
         if (info.row.original.scope === "global") {
           return (
-            <DataTable.CellContent
-              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-            >
+            <DataTable.CellContent>
               {info.row.original.action}
             </DataTable.CellContent>
           );
         }
-        return (
-          <DataTable.MoreButton
-            menuItems={info.row.original.menuItems}
-            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-          />
-        );
+        return <DataTable.MoreButton menuItems={info.row.original.menuItems} />;
       },
       meta: {
         className: "hidden @md:table-cell @md:w-14",
@@ -411,7 +374,6 @@ type AssistantsTableProps = {
   ) => Promise<void>;
   showDisabledFreeWorkspacePopup: string | null;
   setShowDisabledFreeWorkspacePopup: (s: string | null) => void;
-  isBatchEdit: boolean;
   selection: string[];
   setSelection: (selection: string[]) => void;
   mutateAgentConfigurations: () => Promise<any>;
@@ -424,7 +386,6 @@ export function AssistantsTable({
   handleToggleAgentStatus,
   showDisabledFreeWorkspacePopup,
   setShowDisabledFreeWorkspacePopup,
-  isBatchEdit,
   selection,
   setSelection,
   mutateAgentConfigurations,
@@ -437,10 +398,9 @@ export function AssistantsTable({
       getTableColumns({
         owner,
         tags: sortedTags,
-        isBatchEdit,
         mutateAgentConfigurations,
       }),
-    [owner, sortedTags, isBatchEdit]
+    [owner, sortedTags]
   );
 
   const { isDark } = useTheme();
@@ -520,13 +480,9 @@ export function AssistantsTable({
                 }
               />
             ) : undefined,
-          // In batch edit, row clicks toggle the selection, which the table
-          // handles through `enableRowSelection`.
-          onClick: isBatchEdit
-            ? undefined
-            : () => {
-                setDetailedAgentId(agentConfiguration.sId);
-              },
+          onClick: () => {
+            setDetailedAgentId(agentConfiguration.sId);
+          },
           menuItems:
             agentConfiguration.scope !== "global" &&
             agentConfiguration.status !== "archived"
@@ -611,11 +567,31 @@ export function AssistantsTable({
       setDetailedAgentId,
       setShowDisabledFreeWorkspacePopup,
       showDisabledFreeWorkspacePopup,
-      isBatchEdit,
       isDark,
       canCreateAgent,
     ]
   );
+
+  const selectedAgents = useMemo(
+    () => agents.filter((a) => selection.includes(a.sId)),
+    [agents, selection]
+  );
+
+  const selectableRowIds = useMemo(
+    () => rows.filter((row) => row.canArchive).map((row) => row.sId),
+    [rows]
+  );
+  const totalSelectableCount = selectableRowIds.length;
+  const pageSelectableIds = useMemo(() => {
+    const start = pagination.pageIndex * pagination.pageSize;
+    return selectableRowIds.slice(start, start + pagination.pageSize);
+  }, [selectableRowIds, pagination]);
+  const isAllSelected =
+    totalSelectableCount > 0 && selection.length === totalSelectableCount;
+  const hasMorePagesToSelect =
+    !isAllSelected &&
+    pageSelectableIds.length > 0 &&
+    pageSelectableIds.every((id) => selection.includes(id));
 
   return (
     <>
@@ -630,6 +606,18 @@ export function AssistantsTable({
           }));
         }}
       />
+      <AgentEditBar
+        owner={owner}
+        selectedAgents={selectedAgents}
+        tags={sortedTags}
+        mutateAgentConfigurations={mutateAgentConfigurations}
+        pageCount={pageSelectableIds.length}
+        totalCount={totalSelectableCount}
+        isAllSelected={isAllSelected}
+        hasMorePagesToSelect={hasMorePagesToSelect}
+        onClear={() => setSelection([])}
+        onSelectAll={() => setSelection(selectableRowIds)}
+      />
       <div>
         {rows.length > 0 && (
           <DataTable
@@ -639,9 +627,7 @@ export function AssistantsTable({
             pagination={pagination}
             setPagination={setPagination}
             getRowId={(row) => row.sId}
-            enableRowSelection={
-              isBatchEdit ? (row) => row.original.canArchive : false
-            }
+            enableRowSelection={(row) => row.original.canArchive}
             rowSelection={rowSelection}
             setRowSelection={(newRowSelection) => {
               setSelection(

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -574,16 +574,28 @@ export function AssistantsTable({
 
   const selectionSet = useMemo(() => new Set(selection), [selection]);
 
-  const selectedAgents = useMemo(
-    () => agents.filter((a) => selectionSet.has(a.sId)),
-    [agents, selectionSet]
-  );
-
   const selectableRowIds = useMemo(
     () => rows.filter((row) => row.canArchive).map((row) => row.sId),
     [rows]
   );
   const totalSelectableCount = selectableRowIds.length;
+
+  const agentsBySId = useMemo(
+    () => new Map(agents.map((a) => [a.sId, a])),
+    [agents]
+  );
+
+  // Only rows that are actually selectable (`canArchive`) can end up in bulk actions, even if
+  // `selection` (owned by the parent, and not reset on every scope change) still references an
+  // agent that is no longer selectable in the current view.
+  const selectedAgents = useMemo(
+    () =>
+      selectableRowIds
+        .filter((sId) => selectionSet.has(sId))
+        .map((sId) => agentsBySId.get(sId))
+        .filter((a): a is LightAgentConfigurationType => !!a),
+    [selectableRowIds, selectionSet, agentsBySId]
+  );
 
   // `rows` is exactly the `data` DataTable paginates over (no separate filtering happens
   // before pagination), so slicing it directly matches the rows actually shown on this page.

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -39,6 +39,7 @@ import {
   DataTable,
   Edit04,
   Eye,
+  Label,
   Tooltip,
   Trash01,
 } from "@dust-tt/sparkle";
@@ -129,24 +130,31 @@ const getTableColumns = ({
           return null;
         }
 
+        const checkboxId = `select-agent-${info.row.id}`;
+
         return (
-          // The whole cell (not just the checkbox) toggles selection, since the
-          // checkbox alone is a small target and a missclick opens the agent
-          // details panel via the row's `onClick`. The click also reaches the
-          // checkbox itself, so the toggle is only handled here to avoid
-          // double-toggling.
-          <div
-            className="flex size-full items-center justify-center"
-            onClick={(e) => {
-              e.stopPropagation();
-              info.row.toggleSelected();
-            }}
+          // A `label` wrapping the checkbox makes the whole cell (not just the
+          // small checkbox) toggle selection, natively and with no separate
+          // keyboard handling to maintain. `stopPropagation` only keeps the
+          // click from also reaching the row's `onClick`, which opens the
+          // agent details panel; the actual toggle happens through
+          // `Checkbox`'s own `onCheckedChange`.
+          <Label
+            htmlFor={checkboxId}
+            className="flex size-full cursor-pointer items-center justify-center"
+            onClick={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
           >
             <DataTable.CellContent>
-              <Checkbox checked={info.row.getIsSelected()} />
+              <Checkbox
+                id={checkboxId}
+                checked={info.row.getIsSelected()}
+                onCheckedChange={(checked) =>
+                  info.row.toggleSelected(!!checked)
+                }
+              />
             </DataTable.CellContent>
-          </div>
+          </Label>
         );
       },
       meta: {

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -1,4 +1,3 @@
-import { AgentEditBar } from "@app/components/assistant/AgentEditBar";
 import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetailsSheet";
@@ -27,12 +26,9 @@ import {
 } from "@app/lib/utils";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TagType } from "@app/types/tag";
-import { isAdmin } from "@app/types/user";
 import {
-  Button,
   Chip,
   EmptyCTA,
-  ListSelect,
   Page,
   Plus,
   SearchInput,
@@ -85,7 +81,6 @@ export function ManageAgentsPage() {
   const [selectedModels, setSelectedModels] = useState<AgentModelFilterType[]>(
     []
   );
-  const [isBatchEdit, setIsBatchEdit] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
   const isMobile = useIsMobile();
 
@@ -113,10 +108,6 @@ export function ManageAgentsPage() {
     agentsGetView: "manage",
     includes: ["authors", "usage", "feedbacks", "editors"],
   });
-
-  const selectedAgents = agentConfigurations.filter((a) =>
-    selection.includes(a.sId)
-  );
 
   const {
     agentConfigurations: archivedAgentConfigurations,
@@ -296,41 +287,28 @@ export function ManageAgentsPage() {
                 setAssistantSearch(s);
               }}
             />
-            {!isBatchEdit && (
-              <div className="flex gap-2">
-                {isAdmin(owner) && (
-                  <Button
-                    variant="outline"
-                    icon={ListSelect}
-                    label={isMobile ? undefined : "Batch edit"}
-                    tooltip={isMobile ? "Batch edit" : undefined}
-                    onClick={() => {
-                      setIsBatchEdit(true);
-                    }}
-                  />
-                )}
-                <ModelsFilterMenu
-                  models={uniqueModels}
-                  selectedModels={selectedModels}
-                  setSelectedModels={setSelectedModels}
-                  isCompact={isMobile}
-                />
-                <TagsFilterMenu
-                  tags={uniqueTags}
-                  selectedTags={selectedTags}
-                  setSelectedTags={setSelectedTags}
+            <div className="flex gap-2">
+              <ModelsFilterMenu
+                models={uniqueModels}
+                selectedModels={selectedModels}
+                setSelectedModels={setSelectedModels}
+                isCompact={isMobile}
+              />
+              <TagsFilterMenu
+                tags={uniqueTags}
+                selectedTags={selectedTags}
+                setSelectedTags={setSelectedTags}
+                owner={owner}
+                isCompact={isMobile}
+              />
+              {canCreateAgent && (
+                <CreateDropdown
                   owner={owner}
+                  dataGtmLocation="assistantsWorkspace"
                   isCompact={isMobile}
                 />
-                {canCreateAgent && (
-                  <CreateDropdown
-                    owner={owner}
-                    dataGtmLocation="assistantsWorkspace"
-                    isCompact={isMobile}
-                  />
-                )}
-              </div>
-            )}
+              )}
+            </div>
           </div>
           {(selectedModels.length > 0 || selectedTags.length > 0) && (
             <div className="flex flex-row flex-wrap gap-2">
@@ -362,39 +340,26 @@ export function ManageAgentsPage() {
             </div>
           )}
           <div className="flex flex-col pt-3">
-            {isBatchEdit ? (
-              <AgentEditBar
-                onClose={() => {
-                  setIsBatchEdit(false);
-                  setSelection([]);
-                }}
-                owner={owner}
-                selectedAgents={selectedAgents}
-                tags={uniqueTags}
-                mutateAgentConfigurations={mutateAgentConfigurations}
-              />
-            ) : (
-              <Tabs value={activeTab}>
-                <TabsList>
-                  {AGENT_MANAGER_TABS.map((tab) => (
-                    <TabsTrigger
-                      key={tab.id}
-                      value={tab.id}
-                      label={tab.label}
-                      onClick={() => {
-                        setSelectedTab(tab.id);
-                      }}
-                      tooltip={
-                        AGENT_MANAGER_TABS.find((t) => t.id === tab.id)
-                          ?.description
-                      }
-                      isCounter={tab.id !== "archived"}
-                      counterValue={`${agentsByTab[tab.id].length}`}
-                    />
-                  ))}
-                </TabsList>
-              </Tabs>
-            )}
+            <Tabs value={activeTab}>
+              <TabsList>
+                {AGENT_MANAGER_TABS.map((tab) => (
+                  <TabsTrigger
+                    key={tab.id}
+                    value={tab.id}
+                    label={tab.label}
+                    onClick={() => {
+                      setSelectedTab(tab.id);
+                    }}
+                    tooltip={
+                      AGENT_MANAGER_TABS.find((t) => t.id === tab.id)
+                        ?.description
+                    }
+                    isCounter={tab.id !== "archived"}
+                    counterValue={`${agentsByTab[tab.id].length}`}
+                  />
+                ))}
+              </TabsList>
+            </Tabs>
             {isAgentConfigurationsLoading ||
             isArchivedAgentConfigurationsLoading ? (
               <div className="mt-8 flex justify-center">
@@ -409,7 +374,6 @@ export function ManageAgentsPage() {
               </div>
             ) : agentsByTab[activeTab].length > 0 ? (
               <AssistantsTable
-                isBatchEdit={isBatchEdit}
                 selection={selection}
                 setSelection={setSelection}
                 owner={owner}

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -97,6 +97,27 @@ export function ManageAgentsPage() {
     return selectedTab && isValidTab(selectedTab) ? selectedTab : "all_custom";
   }, [selectedTab]);
 
+  // The selection is scoped to the current tab/search/filter combination: an agent that drops
+  // out of view (tab switch, search, or filter change) should drop out of the selection too.
+  const selectionScopeKey = [
+    activeTab,
+    assistantSearch,
+    selectedTags
+      .map((t) => t.sId)
+      .sort()
+      .join(","),
+    selectedModels
+      .map((m) => m.modelId)
+      .sort()
+      .join(","),
+  ].join("|");
+  const [prevSelectionScopeKey, setPrevSelectionScopeKey] =
+    useState(selectionScopeKey);
+  if (selectionScopeKey !== prevSelectionScopeKey) {
+    setPrevSelectionScopeKey(selectionScopeKey);
+    setSelection([]);
+  }
+
   // only fetch the agents that are relevant to the current scope, except when
   // user searches: search across all agents
   const {

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -116,6 +116,13 @@ interface DataTableProps<TData extends TBaseData> {
   enableSortingRemoval?: boolean;
   /** Omit the default bottom divider on tbody rows (e.g. dense custom lists). */
   hideRowDivider?: boolean;
+  /**
+   * When `enableRowSelection` is set and the row also has an `onClick` (e.g. to open a
+   * details panel), clicking anywhere in the row toggles selection by default. Set this to
+   * restrict selection toggling to the selection column's checkbox, leaving the rest of the
+   * row free to trigger `onClick`.
+   */
+  disableRowClickSelection?: boolean;
 }
 
 export function DataTable<TData extends TBaseData>({
@@ -141,6 +148,7 @@ export function DataTable<TData extends TBaseData>({
   getRowId,
   enableSortingRemoval = true,
   hideRowDivider = false,
+  disableRowClickSelection = false,
 }: DataTableProps<TData>) {
   const windowSize = useWindowSize();
 
@@ -299,7 +307,9 @@ export function DataTable<TData extends TBaseData>({
                 key={row.id}
                 hideBottomBorder={hideRowDivider}
                 onClick={
-                  enableRowSelection ? handleRowClick : row.original.onClick
+                  enableRowSelection && !disableRowClickSelection
+                    ? handleRowClick
+                    : row.original.onClick
                 }
                 onDoubleClick={row.original.onDoubleClick}
                 rowData={row.original}
@@ -376,6 +386,7 @@ export function ScrollableDataTable<TData extends TBaseData>({
   getRowId,
   containerRef,
   hideRowDivider = false,
+  disableRowClickSelection = false,
 }: ScrollableDataTableProps<TData>) {
   const windowSize = useWindowSize();
   const loadMoreRef = useRef<HTMLDivElement>(null);
@@ -657,7 +668,9 @@ export function ScrollableDataTable<TData extends TBaseData>({
                   widthClassName={widthClassName}
                   hideBottomBorder={hideRowDivider}
                   onClick={
-                    enableRowSelection ? handleRowClick : row.original.onClick
+                    enableRowSelection && !disableRowClickSelection
+                      ? handleRowClick
+                      : row.original.onClick
                   }
                   onDoubleClick={row.original.onDoubleClick}
                   rowData={row.original}


### PR DESCRIPTION
## Description

The agents batch edit UX (Manage Agents page) had drifted from the batch edit pattern already established on the Usage page (member selection). This PR aligns the two: same interaction model, same visual language.

- Removes the separate "Batch edit" mode: the selection checkbox column is now always visible for selectable agents, matching the Usage page where selection is never gated behind a toggle.
- Selecting one or more agents opens a bulk-action bar above the table, styled and worded like the Usage page's selection banner ("N agents selected on this page", "Select all N agents", "N agents are selected." once everything is selected, a neutral "Clear" action next to the other buttons).
- Existing tag, model, unpublish, and delete actions are preserved, restyled to match the Usage page's action button variants.
- Agent rows continue to open the details panel when clicked outside the checkbox. The shared `DataTable` component gained an option to opt out of row-click selection so checkbox-only selection can coexist with row actions. Global (non-editable) agents remain non-selectable.

**Now:**
<img width="1172" height="746" alt="Capture d’écran 2026-08-20 à 10 25 32" src="https://github.com/user-attachments/assets/cb3a43da-d294-48c8-a46a-314f8091dd45" />
<img width="1167" height="424" alt="Capture d’écran 2026-08-20 à 10 26 05" src="https://github.com/user-attachments/assets/3999ef35-418d-4f64-b342-74922336e0d1" />
<img width="1173" height="692" alt="Capture d’écran 2026-08-20 à 10 27 58" src="https://github.com/user-attachments/assets/8a50482d-12ff-4d69-9b57-8d3f499bb906" />
<img width="1165" height="641" alt="Capture d’écran 2026-08-20 à 10 28 08" src="https://github.com/user-attachments/assets/b06766d9-00f3-4d6b-b127-b0f6b94d268c" />

**Before:**
<img width="1181" height="761" alt="Capture d’écran 2026-08-20 à 10 29 10" src="https://github.com/user-attachments/assets/1c6ba94e-4cf9-4eb9-af24-4ffad7b73619" />
<img width="1163" height="752" alt="Capture d’écran 2026-08-20 à 10 29 20" src="https://github.com/user-attachments/assets/b24e4db3-e87e-4c7f-a90d-594d0c14ab42" />
<img width="1149" height="702" alt="Capture d’écran 2026-08-20 à 10 29 41" src="https://github.com/user-attachments/assets/246ae83b-59db-4f7a-91e6-6b45b29f22a8" />

## Tests


## Risk

This is a frontend-only interaction and styling change in the agent manager, plus a shared `DataTable` behavior option. The main risk is incorrect selection behavior across pagination or unintended interaction between row clicks and checkbox selection. No backend, schema, or data migration changes are included, and the change can be rolled back by reverting the PR.

## Deploy Plan

- Deploy front
