### PR TITLE
remove isCompactUIView column & model

### DIFF
--- a/front/lib/models/activation/activation_pod.ts
+++ b/front/lib/models/activation/activation_pod.ts
@@ -16,8 +16,6 @@ export class ActivationPodModel extends WorkspaceAwareModel<ActivationPodModel> 
   declare spaceId: ForeignKey<SpaceModel["id"]>;
   // The user for whom we created the activation pod.
   declare userId: ForeignKey<UserModel["id"]>;
-  // Whether the Pod uses the compact UI variant.
-  declare isCompactUIView: CreationOptional<boolean>;
 
   declare projectMetadata?: NonAttribute<ProjectMetadataModel>;
 }
@@ -33,11 +31,6 @@ ActivationPodModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
-    },
-    isCompactUIView: {
-      type: DataTypes.BOOLEAN,
-      allowNull: false,
-      defaultValue: false,
     },
   },
   {

--- a/front/migrations/post-deploy/20260813105754_drop_compact_ui_view_from_activation_pods.sql
+++ b/front/migrations/post-deploy/20260813105754_drop_compact_ui_view_from_activation_pods.sql
@@ -1,0 +1,7 @@
+/*
+Statement 0
+  - DELETES_DATA: Deletes all values in the column
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."activation_pods" DROP COLUMN "isCompactUIView";


### PR DESCRIPTION
## Description
- Re-submit of the migration/model-cleanup commit from #30488, split out of the not-yet-ready phoebexu/activation-pod-ui/collapse-thinking stack so it can land on its own.
- Drops the obsolete isCompactUIView column from activation_pods; compact UI is now derived client-side from the conversation's uiView instead of being persisted on the Activation Pod record.
- Identical diff to what was already reviewed/approved in #30488.

## Tests

## Risk
Low, no code depends on this anymore.

## Deploy Plan
Follow post-deploy migration steps.
