### PR TITLE
feat: automations table new design

### DIFF
--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -64,17 +64,9 @@ function TypeCell({ trigger }: { trigger: AutomationTriggerRow }) {
     case "webhook":
       if (trigger.webhookSourceRestricted) {
         return (
-          <Tooltip
+          <TypeLabel
+            visual={getIcon("ActionLockIcon")}
             label="This webhook lives in a space you don't have access to."
-            tooltipTriggerAsChild
-            trigger={
-              <div>
-                <TypeLabel
-                  visual={getIcon("ActionLockIcon")}
-                  label="Restricted webhook"
-                />
-              </div>
-            }
           />
         );
       }
@@ -150,7 +142,6 @@ function TypeLabel({
       trigger={
         <div className="flex min-w-0 items-center gap-2">
           <Icon visual={visual} size="xs" className="text-muted-foreground" />
-          <span className="truncate text-sm">{label}</span>
         </div>
       }
     />
@@ -207,13 +198,14 @@ function EditorCell({ editor }: { editor: AutomationTriggerRow["editor"] }) {
       }
       tooltipTriggerAsChild
       trigger={
-        <div className="flex items-center">
+        <div className="flex gap-2 items-center">
           <Avatar
             name={editor.name}
             visual={editor.pictureUrl ?? undefined}
             size="xs"
             isRounded
           />
+          <span className="text-sm truncate">{editor.name}</span>
         </div>
       }
     />
@@ -230,10 +222,23 @@ function buildColumns({
       id: "name",
       accessorKey: "name",
       header: "Name",
-      meta: { className: "w-48", headerAlign: "left" },
+      meta: { className: "truncate", headerAlign: "left" },
       cell: (info) => (
         <DataTable.CellContent className="w-full justify-start text-left">
-          <span className="truncate text-sm">{info.row.original.name}</span>
+          <span className="truncate text-sm font-semibold">
+            {info.row.original.name}
+          </span>
+        </DataTable.CellContent>
+      ),
+    },
+    {
+      id: "editor",
+      header: "Editor",
+      enableSorting: false,
+      meta: { className: "w-36", headerAlign: "center" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-start">
+          <EditorCell editor={info.row.original.editor} />
         </DataTable.CellContent>
       ),
     },
@@ -249,23 +254,12 @@ function buildColumns({
       ),
     },
     {
-      id: "editor",
-      header: "Editor",
-      enableSorting: false,
-      meta: { className: "w-16", headerAlign: "center" },
-      cell: (info) => (
-        <DataTable.CellContent className="w-full justify-center">
-          <EditorCell editor={info.row.original.editor} />
-        </DataTable.CellContent>
-      ),
-    },
-    {
       id: "type",
       header: "Type",
       enableSorting: false,
-      meta: { headerAlign: "left" },
+      meta: { className: "w-8" },
       cell: (info) => (
-        <DataTable.CellContent className="w-full justify-start">
+        <DataTable.CellContent className="w-full justify-center">
           <TypeCell trigger={info.row.original} />
         </DataTable.CellContent>
       ),
@@ -285,7 +279,7 @@ function buildColumns({
       id: "status",
       header: "Enabled",
       enableSorting: false,
-      meta: { className: "w-24" },
+      meta: { className: "w-16" },
       cell: (info) => (
         <DataTable.CellContent className="w-full justify-center">
           <RunningCell row={info.row.original} />


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR implements the new design of the Automations analytics table.

Changes:
- The type that is now only an icon, with a tooltip
- Widths of several elements
- The name of the user back in the table
- The trigger's name now semibold as originally planned

<img width="1463" height="1021" alt="Capture d’écran 2026-08-20 à 10 46 08" src="https://github.com/user-attachments/assets/d09f81cf-67a1-42fe-a477-00ddcc285b4a" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front