### PR TITLE
[front] Align skills batch edit with usage page selection UX

### DIFF
--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -18,11 +18,11 @@ import {
 import { ImportSkillsDialog } from "@app/components/skills/import/ImportSkillsDialog";
 import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
 import type { BatchAvailabilityAction } from "@app/components/skills/SkillsBatchEdit";
+import { BatchAvailabilityDialog } from "@app/components/skills/SkillsBatchEdit";
 import {
-  BatchAvailabilityDialog,
-  SkillsBatchEditBar,
-} from "@app/components/skills/SkillsBatchEdit";
-import { SkillsTable } from "@app/components/skills/SkillsTable";
+  isSkillSelectable,
+  SkillsTable,
+} from "@app/components/skills/SkillsTable";
 import { SuggestedSkillsSection } from "@app/components/skills/SuggestedSkillsSection";
 import {
   useSetContentWidth,
@@ -58,7 +58,6 @@ import {
   EmptyCTAButton,
   FolderOpen,
   InfoCircle,
-  ListSelect,
   Page,
   Plus,
   SearchInput,
@@ -92,7 +91,6 @@ export function ManageSkillsPage() {
   const [selectedTab, setSelectedTab] = useHashParam("selectedTab", "active");
   const [skillSearch, setSkillSearch] = useState("");
   const [skillIdParam, setSkillIdParam] = useHashParam("skillId");
-  const [isBatchEditing, setIsBatchEditing] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [pendingBatchAction, setPendingBatchAction] =
     useState<BatchAvailabilityAction | null>(null);
@@ -134,6 +132,18 @@ export function ManageSkillsPage() {
     }
     return "active";
   }, [selectedTab, skillManagerTabs]);
+
+  // The selection is scoped to the current tab/search/filter combination: a skill that drops
+  // out of view (tab switch, search, or filter change) should drop out of the selection too.
+  const selectionScopeKey = [activeTab, skillSearch, availabilityFilter].join(
+    "|"
+  );
+  const [prevSelectionScopeKey, setPrevSelectionScopeKey] =
+    useState(selectionScopeKey);
+  if (selectionScopeKey !== prevSelectionScopeKey) {
+    setPrevSelectionScopeKey(selectionScopeKey);
+    setRowSelection({});
+  }
 
   const canCreateSkill = hasPermission("create", "skill");
 
@@ -237,22 +247,30 @@ export function ManageSkillsPage() {
 
   const [isBatchUpdating, setIsBatchUpdating] = useState(false);
 
-  const selectedSkillIds = useMemo(
-    () =>
-      Object.entries(rowSelection)
-        .filter(([, selected]) => selected)
-        .map(([sId]) => sId),
-    [rowSelection]
-  );
-  const selectedSkills = useMemo(
-    () => activeSkills.filter((skill) => rowSelection[skill.sId]),
-    [activeSkills, rowSelection]
+  const isBatchEditionAvailable =
+    hasPermission("publish", "skill") && activeTab !== "archived";
+
+  const canMakeSkillAutoDiscoverable = hasPermission(
+    "make_discoverable",
+    "skill"
   );
 
-  const closeBatchEdition = () => {
-    setIsBatchEditing(false);
-    setRowSelection({});
-  };
+  // Only skills that are still selectable in the current tab can end up in bulk actions,
+  // even if `rowSelection` (not reset on every scope change) still references a skill that
+  // is no longer selectable in the current view.
+  const selectedSkills = useMemo(
+    () =>
+      skillsByTab[activeTab].filter(
+        (skill) =>
+          rowSelection[skill.sId] &&
+          isSkillSelectable(skill, canMakeSkillAutoDiscoverable)
+      ),
+    [skillsByTab, activeTab, rowSelection, canMakeSkillAutoDiscoverable]
+  );
+  const selectedSkillIds = useMemo(
+    () => selectedSkills.map((skill) => skill.sId),
+    [selectedSkills]
+  );
 
   const handleBatchAvailability = async (availability: SkillAvailability) => {
     if (selectedSkillIds.length === 0 || isBatchUpdating) {
@@ -271,14 +289,6 @@ export function ManageSkillsPage() {
       setIsBatchUpdating(false);
     }
   };
-
-  const isBatchEditionAvailable =
-    hasPermission("publish", "skill") && activeTab !== "archived";
-
-  const canMakeSkillAutoDiscoverable = hasPermission(
-    "make_discoverable",
-    "skill"
-  );
 
   const handleFavoriteChange = useCallback(
     async (
@@ -449,14 +459,6 @@ export function ManageSkillsPage() {
                 setSkillSearch(s);
               }}
             />
-            {isBatchEditionAvailable && !isBatchEditing && (
-              <Button
-                variant="outline"
-                label="Batch edit"
-                icon={ListSelect}
-                onClick={() => setIsBatchEditing(true)}
-              />
-            )}
             {canCreateSkill && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -477,16 +479,6 @@ export function ManageSkillsPage() {
               </DropdownMenu>
             )}
           </div>
-          {isBatchEditionAvailable && isBatchEditing && (
-            <SkillsBatchEditBar
-              selectedSkills={selectedSkills}
-              isUpdating={isBatchUpdating}
-              canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
-              owner={owner}
-              onClose={closeBatchEdition}
-              onSelectAction={setPendingBatchAction}
-            />
-          )}
           <div className="flex flex-col pt-3">
             <Tabs value={activeTab}>
               <TabsList>
@@ -570,9 +562,11 @@ export function ManageSkillsPage() {
                     onAgentClick={setAgentId}
                     onUsedBySkillClick={handleUsedBySkillSelect}
                     canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
-                    {...(isBatchEditionAvailable && isBatchEditing
-                      ? { rowSelection, setRowSelection }
-                      : {})}
+                    enableSelection={isBatchEditionAvailable}
+                    rowSelection={rowSelection}
+                    setRowSelection={setRowSelection}
+                    isBatchUpdating={isBatchUpdating}
+                    onSelectAvailabilityAction={setPendingBatchAction}
                   />
                 )}
               </>

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -1,4 +1,5 @@
 import { ArchiveSkillsDialog } from "@app/components/skills/ArchiveSkillsDialog";
+import { classNames } from "@app/lib/utils";
 import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type { SkillAvailability } from "@app/types/assistant/skill_configuration";
 import { pluralize } from "@app/types/shared/utils/string_utils";
@@ -15,8 +16,15 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  XClose,
+  Hoverable,
 } from "@dust-tt/sparkle";
+
+// Matches ContentMessageInline's "info" variant. ContentMessageInline itself can't be reused
+// here: it only slots literal `ContentMessageAction` elements into its action area, and the
+// dropdown/dialog triggers below aren't that.
+const BAR_CLASSNAME =
+  "flex items-center gap-2 rounded-xl border bg-orange-50 border-orange-100 p-3 dark:bg-golden-950 dark:border-golden-900";
+const BAR_TEXT_CLASSNAME = "text-xs text-orange-800 dark:text-golden-100";
 
 export type BatchAvailabilityAction = {
   label: string;
@@ -62,75 +70,111 @@ const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
 
 interface SkillsBatchEditBarProps {
   selectedSkills: GetSkillsWithRelationsResponseBody["skills"];
+  pageSelectedCount: number;
+  totalCount: number;
   isUpdating: boolean;
   canMakeSkillAutoDiscoverable: boolean;
   owner: LightWorkspaceType;
-  onClose: () => void;
+  onClear: () => void;
+  onSelectAll: () => void;
   onSelectAction: (action: BatchAvailabilityAction) => void;
+}
+
+function skillLabel(count: number): string {
+  return `skill${pluralize(count)}`;
 }
 
 export function SkillsBatchEditBar({
   selectedSkills,
+  pageSelectedCount,
+  totalCount,
   isUpdating,
   canMakeSkillAutoDiscoverable,
   owner,
-  onClose,
+  onClear,
+  onSelectAll,
   onSelectAction,
 }: SkillsBatchEditBarProps) {
   const selectedCount = selectedSkills.length;
+
+  if (selectedCount === 0) {
+    return null;
+  }
+
+  const isAllSelected = totalCount > 0 && selectedCount === totalCount;
   const canArchiveSelection = selectedSkills.every(
     (skill) => skill.canAdministrate
   );
 
   return (
-    <div className="flex flex-row items-center justify-between gap-2 rounded-xl bg-muted-background px-2 py-2 dark:bg-muted-background-night">
-      <Button
-        variant="outline"
-        size="xs"
-        icon={XClose}
-        label="Close edition"
-        onClick={onClose}
-      />
-      <div className="flex flex-row items-center gap-2">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="outline"
-              size="xs"
-              label="Set availability"
-              isSelect
-              isLoading={isUpdating}
-              disabled={selectedCount === 0 || isUpdating}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {BATCH_AVAILABILITY_ACTIONS.map((action) => {
-              const isActionDisabled =
-                action.availability === "users_and_agents" &&
-                !canMakeSkillAutoDiscoverable;
-              return (
-                <DropdownMenuItem
-                  key={action.availability}
-                  label={action.label}
-                  description={
-                    isActionDisabled
-                      ? "You don’t have permission to make skills auto-discoverable"
-                      : action.description
-                  }
-                  disabled={isActionDisabled}
-                  onClick={() => onSelectAction(action)}
-                />
-              );
-            })}
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <ArchiveSkillsDialog
-          skills={selectedSkills}
-          disabled={selectedCount === 0 || isUpdating || !canArchiveSelection}
-          owner={owner}
-          onSave={onClose}
-        />
+    <div className={classNames("mt-3 mb-2", BAR_CLASSNAME)}>
+      <div
+        className={classNames(
+          "flex flex-1 flex-row flex-wrap items-center gap-x-2 gap-y-1",
+          BAR_TEXT_CLASSNAME
+        )}
+      >
+        {isAllSelected ? (
+          <span>
+            {selectedCount} {skillLabel(selectedCount)} are selected.
+          </span>
+        ) : (
+          <>
+            <span>
+              {pageSelectedCount} {skillLabel(pageSelectedCount)} selected on
+              this page
+            </span>
+            <Hoverable variant="highlight" onClick={onSelectAll}>
+              Select all {totalCount} {skillLabel(totalCount)}
+            </Hoverable>
+          </>
+        )}
       </div>
+      <Button
+        size="xs"
+        variant="ghost"
+        label="Clear"
+        onClick={onClear}
+        disabled={isUpdating}
+      />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="primary"
+            size="xs"
+            label="Set availability"
+            isSelect
+            isLoading={isUpdating}
+            disabled={isUpdating}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {BATCH_AVAILABILITY_ACTIONS.map((action) => {
+            const isActionDisabled =
+              action.availability === "users_and_agents" &&
+              !canMakeSkillAutoDiscoverable;
+            return (
+              <DropdownMenuItem
+                key={action.availability}
+                label={action.label}
+                description={
+                  isActionDisabled
+                    ? "You don’t have permission to make skills auto-discoverable"
+                    : action.description
+                }
+                disabled={isActionDisabled}
+                onClick={() => onSelectAction(action)}
+              />
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <ArchiveSkillsDialog
+        skills={selectedSkills}
+        disabled={isUpdating || !canArchiveSelection}
+        owner={owner}
+        onSave={onClear}
+      />
     </div>
   );
 }

--- a/front/components/skills/SkillsBatchEdit.tsx
+++ b/front/components/skills/SkillsBatchEdit.tsx
@@ -19,9 +19,6 @@ import {
   Hoverable,
 } from "@dust-tt/sparkle";
 
-// Matches ContentMessageInline's "info" variant. ContentMessageInline itself can't be reused
-// here: it only slots literal `ContentMessageAction` elements into its action area, and the
-// dropdown/dialog triggers below aren't that.
 const BAR_CLASSNAME =
   "flex items-center gap-2 rounded-xl border bg-orange-50 border-orange-100 p-3 dark:bg-golden-950 dark:border-golden-900";
 const BAR_TEXT_CLASSNAME = "text-xs text-orange-800 dark:text-golden-100";

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -1,4 +1,6 @@
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
+import type { BatchAvailabilityAction } from "@app/components/skills/SkillsBatchEdit";
+import { SkillsBatchEditBar } from "@app/components/skills/SkillsBatchEdit";
 import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
@@ -12,8 +14,8 @@ import type { AgentsAndSkillsUsageType } from "@app/types/data_source";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
+  Checkbox,
   Chip,
-  createSelectionColumn,
   DataTable,
   Edit04,
   Eye,
@@ -23,10 +25,23 @@ import {
 import type {
   CellContext,
   ColumnDef,
+  HeaderContext,
   Row,
   RowSelectionState,
 } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
+
+// A Dust-provided skill can never be edited, and a "members and agents"
+// skill can only be batch-edited by someone who can make skills auto-discoverable.
+export function isSkillSelectable(
+  skill: { editedBy: number | null; availability: SkillAvailability },
+  canMakeSkillAutoDiscoverable: boolean
+): boolean {
+  return (
+    !isDustProvidedSkill(skill) &&
+    (canMakeSkillAutoDiscoverable || skill.availability !== "users_and_agents")
+  );
+}
 
 type RowData = {
   sId: string;
@@ -212,18 +227,73 @@ const menuColumn = {
   },
 };
 
+const selectionColumn = {
+  header: (info: HeaderContext<RowData, boolean>) => {
+    const areAllPageRowsSelected = info.table.getIsAllPageRowsSelected();
+    const hasSelection = Object.values(info.table.getState().rowSelection).some(
+      (isSelected) => isSelected
+    );
+
+    return (
+      <Checkbox
+        checked={
+          areAllPageRowsSelected ? true : hasSelection ? "partial" : false
+        }
+        disabled={
+          !info.table.getRowModel().rows.some((row) => row.getCanSelect())
+        }
+        tooltip={
+          areAllPageRowsSelected ? "Clear selection" : "Select all on page"
+        }
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        onCheckedChange={(checked) => {
+          if (checked) {
+            info.table.toggleAllPageRowsSelected(true);
+          } else {
+            // Unticking clears the whole selection across pages.
+            info.table.resetRowSelection();
+          }
+        }}
+      />
+    );
+  },
+  accessorKey: "select",
+  cell: (info: CellContext<RowData, boolean>) => (
+    // Selecting a row must not also trigger the row's `onClick` (which opens
+    // the skill details panel).
+    <div
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <DataTable.CellContent>
+        <Checkbox
+          checked={info.row.getIsSelected()}
+          disabled={!info.row.getCanSelect()}
+          onCheckedChange={(checked) => info.row.toggleSelected(!!checked)}
+        />
+      </DataTable.CellContent>
+    </div>
+  ),
+  meta: {
+    className: "w-10",
+  },
+  enableSorting: false,
+};
+
 const getTableColumns = ({
   onAgentClick,
   onUsedBySkillClick,
-  enableRowSelection,
+  enableSelection,
 }: {
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
-  enableRowSelection: boolean;
+  enableSelection: boolean;
 }) => {
   /**
    * Columns order:
-   * - Selection (batch edition only)
+   * - Selection (when batch edition is available)
    * - Name (always)
    * - Access (hidden on mobile)
    * - Used by (hidden on mobile)
@@ -234,7 +304,7 @@ const getTableColumns = ({
    */
 
   return [
-    ...(enableRowSelection ? [createSelectionColumn<RowData>()] : []),
+    ...(enableSelection ? [selectionColumn] : []),
     nameColumn,
     availabilityColumn,
     usedByColumn(onAgentClick, onUsedBySkillClick),
@@ -254,8 +324,11 @@ type SkillsTableProps = {
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
   canMakeSkillAutoDiscoverable?: boolean;
-  rowSelection?: RowSelectionState;
-  setRowSelection?: (selection: RowSelectionState) => void;
+  enableSelection: boolean;
+  rowSelection: RowSelectionState;
+  setRowSelection: (selection: RowSelectionState) => void;
+  isBatchUpdating: boolean;
+  onSelectAvailabilityAction: (action: BatchAvailabilityAction) => void;
 };
 
 export function SkillsTable({
@@ -265,16 +338,17 @@ export function SkillsTable({
   onAgentClick,
   onUsedBySkillClick,
   canMakeSkillAutoDiscoverable = false,
+  enableSelection,
   rowSelection,
   setRowSelection,
+  isBatchUpdating,
+  onSelectAvailabilityAction,
 }: SkillsTableProps) {
   const router = useAppRouter();
   const { pagination, setPagination } = usePaginationFromUrl({});
   const [skillToArchive, setSkillToArchive] = useState<
     GetSkillsWithRelationsResponseBody["skills"][number] | null
   >(null);
-
-  const isSelectionEnabled = rowSelection !== undefined;
 
   // Stable columns identity: rebuilding them on every selection change makes the
   // table re-render all rows.
@@ -283,9 +357,9 @@ export function SkillsTable({
       getTableColumns({
         onAgentClick,
         onUsedBySkillClick,
-        enableRowSelection: isSelectionEnabled,
+        enableSelection,
       }),
-    [onAgentClick, onUsedBySkillClick, isSelectionEnabled]
+    [onAgentClick, onUsedBySkillClick, enableSelection]
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -304,11 +378,6 @@ export function SkillsTable({
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
         onClick: () => {
-          // During batch edition the DataTable itself toggles the row selection on
-          // click; don't open the details panel on top of it.
-          if (isSelectionEnabled) {
-            return;
-          }
           onSkillClick(skill);
         },
         menuItems:
@@ -350,7 +419,56 @@ export function SkillsTable({
             : [],
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [skills, onSkillClick, owner.sId, isSelectionEnabled]
+    [skills, onSkillClick, owner.sId]
+  );
+
+  const selectionSet = useMemo(
+    () => new Set(Object.keys(rowSelection)),
+    [rowSelection]
+  );
+
+  const selectableRowIds = useMemo(
+    () =>
+      rows
+        .filter((row) => isSkillSelectable(row, canMakeSkillAutoDiscoverable))
+        .map((row) => row.sId),
+    [rows, canMakeSkillAutoDiscoverable]
+  );
+  const totalSelectableCount = selectableRowIds.length;
+
+  const skillsBySId = useMemo(
+    () => new Map(skills.map((skill) => [skill.sId, skill])),
+    [skills]
+  );
+
+  // Only rows that are actually selectable can end up in bulk actions, even if
+  // `rowSelection` (owned by the parent, and not reset on every scope change) still
+  // references a skill that is no longer selectable in the current view.
+  const selectedSkills = useMemo(
+    () =>
+      selectableRowIds
+        .filter((sId) => selectionSet.has(sId))
+        .map((sId) => skillsBySId.get(sId))
+        .filter(
+          (s): s is GetSkillsWithRelationsResponseBody["skills"][number] => !!s
+        ),
+    [selectableRowIds, selectionSet, skillsBySId]
+  );
+
+  // `rows` is exactly the `data` DataTable paginates over (no separate filtering happens
+  // before pagination), so slicing it directly matches the rows actually shown on this page.
+  const pageRows = useMemo(() => {
+    const start = pagination.pageIndex * pagination.pageSize;
+    return rows.slice(start, start + pagination.pageSize);
+  }, [rows, pagination]);
+  const pageSelectedCount = useMemo(
+    () =>
+      pageRows.filter(
+        (row) =>
+          isSkillSelectable(row, canMakeSkillAutoDiscoverable) &&
+          selectionSet.has(row.sId)
+      ).length,
+    [pageRows, canMakeSkillAutoDiscoverable, selectionSet]
   );
 
   if (rows.length === 0) {
@@ -369,20 +487,36 @@ export function SkillsTable({
           }}
         />
       )}
+      {enableSelection && (
+        <SkillsBatchEditBar
+          owner={owner}
+          selectedSkills={selectedSkills}
+          pageSelectedCount={pageSelectedCount}
+          totalCount={totalSelectableCount}
+          isUpdating={isBatchUpdating}
+          canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
+          onClear={() => setRowSelection({})}
+          onSelectAll={() =>
+            setRowSelection(
+              Object.fromEntries(selectableRowIds.map((sId) => [sId, true]))
+            )
+          }
+          onSelectAction={onSelectAvailabilityAction}
+        />
+      )}
       <DataTable
         className="relative"
         data={rows}
         columns={columns}
         pagination={pagination}
         setPagination={setPagination}
-        {...(rowSelection !== undefined && setRowSelection
+        disableRowClickSelection
+        {...(enableSelection
           ? {
               rowSelection,
               setRowSelection,
               enableRowSelection: (row: Row<RowData>) =>
-                !isDustProvidedSkill(row.original) &&
-                (canMakeSkillAutoDiscoverable ||
-                  row.original.availability !== "users_and_agents"),
+                isSkillSelectable(row.original, canMakeSkillAutoDiscoverable),
               getRowId: (row: RowData) => row.sId,
             }
           : {})}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -19,6 +19,7 @@ import {
   DataTable,
   Edit04,
   Eye,
+  Label,
   Tooltip,
   Trash01,
 } from "@dust-tt/sparkle";
@@ -235,49 +236,61 @@ const selectionColumn = {
     );
 
     return (
-      <Checkbox
-        checked={
-          areAllPageRowsSelected ? true : hasSelection ? "partial" : false
-        }
-        disabled={
-          !info.table.getRowModel().rows.some((row) => row.getCanSelect())
-        }
-        tooltip={
-          areAllPageRowsSelected ? "Clear selection" : "Select all on page"
-        }
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-        onCheckedChange={(checked) => {
-          if (checked) {
-            info.table.toggleAllPageRowsSelected(true);
-          } else {
-            // Unticking clears the whole selection across pages.
-            info.table.resetRowSelection();
+      <DataTable.CellContent className="size-full items-center justify-center">
+        <Checkbox
+          checked={
+            areAllPageRowsSelected ? true : hasSelection ? "partial" : false
           }
-        }}
-      />
+          disabled={
+            !info.table.getRowModel().rows.some((row) => row.getCanSelect())
+          }
+          tooltip={
+            areAllPageRowsSelected ? "Clear selection" : "Select all on page"
+          }
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+          onCheckedChange={(checked) => {
+            if (checked) {
+              info.table.toggleAllPageRowsSelected(true);
+            } else {
+              // Unticking clears the whole selection across pages.
+              info.table.resetRowSelection();
+            }
+          }}
+        />
+      </DataTable.CellContent>
     );
   },
   accessorKey: "select",
-  cell: (info: CellContext<RowData, boolean>) => (
-    // Selecting a row must not also trigger the row's `onClick` (which opens
-    // the skill details panel).
-    <div
-      onClick={(e) => e.stopPropagation()}
-      onPointerDown={(e) => e.stopPropagation()}
-    >
-      <DataTable.CellContent>
+  cell: (info: CellContext<RowData, boolean>) => {
+    const checkboxId = `select-skill-${info.row.id}`;
+    const skillName = info.row.original.name;
+
+    return (
+      // `stopPropagation` only keeps the click from also reaching the row's `onClick`
+      <Label
+        htmlFor={checkboxId}
+        className="flex size-full cursor-pointer items-center justify-center hover:bg-muted-background"
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
         <Checkbox
+          id={checkboxId}
+          aria-label={
+            info.row.getIsSelected()
+              ? `Deselect ${skillName}`
+              : `Select ${skillName}`
+          }
           checked={info.row.getIsSelected()}
           disabled={!info.row.getCanSelect()}
           onCheckedChange={(checked) => info.row.toggleSelected(!!checked)}
         />
-      </DataTable.CellContent>
-    </div>
-  ),
+      </Label>
+    );
+  },
   meta: {
-    className: "w-10",
+    className: "w-10 p-0",
   },
   enableSorting: false,
 };

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -441,9 +441,6 @@ export function SkillsTable({
     [skills]
   );
 
-  // Only rows that are actually selectable can end up in bulk actions, even if
-  // `rowSelection` (owned by the parent, and not reset on every scope change) still
-  // references a skill that is no longer selectable in the current view.
   const selectedSkills = useMemo(
     () =>
       selectableRowIds
@@ -455,8 +452,6 @@ export function SkillsTable({
     [selectableRowIds, selectionSet, skillsBySId]
   );
 
-  // `rows` is exactly the `data` DataTable paginates over (no separate filtering happens
-  // before pagination), so slicing it directly matches the rows actually shown on this page.
   const pageRows = useMemo(() => {
     const start = pagination.pageIndex * pagination.pageSize;
     return rows.slice(start, start + pagination.pageSize);

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -116,12 +116,6 @@ interface DataTableProps<TData extends TBaseData> {
   enableSortingRemoval?: boolean;
   /** Omit the default bottom divider on tbody rows (e.g. dense custom lists). */
   hideRowDivider?: boolean;
-  /**
-   * When `enableRowSelection` is set and the row also has an `onClick` (e.g. to open a
-   * details panel), clicking anywhere in the row toggles selection by default. Set this to
-   * restrict selection toggling to the selection column's checkbox, leaving the rest of the
-   * row free to trigger `onClick`.
-   */
   disableRowClickSelection?: boolean;
 }
 


### PR DESCRIPTION
## Description

Same motivation as #30846: the skills batch edit UX (Manage Skills page) had drifted from the pattern already established on the Usage page. This PR applies the identical alignment to skills.

- Removes the separate "Batch edit" mode: the selection checkbox column is now always visible whenever the user has permission to publish skills and isn't on the archived tab, instead of being gated behind a toggle button.
- Selecting one or more skills opens a bulk-action bar above the table, styled and worded like the Usage/Agents page's selection banner ("N skills selected on this page", "Select all N skills", "N skills are selected." once everything is selected, a neutral "Clear" action next to the other buttons).
- Existing "Set availability" and "Archive" actions are preserved, restyled to match the established action button variants.
- Skill rows continue to open the details panel when clicked outside the checkbox, via `DataTable`'s `disableRowClickSelection` option (introduced in #30846).
- Selection is scoped to the current tab/search/availability-filter view and resets when it changes, and `selectedSkills` is hardened to only include skills still selectable in the current view, so a stale selection can't reach bulk actions (mirrors the same fix already applied to agents).

**Now:**
<img width="1150" height="553" alt="Capture d’écran 2026-08-20 à 16 08 36" src="https://github.com/user-attachments/assets/646eff19-ac7e-46fc-92fc-dc8757170e64" />
<img width="1135" height="654" alt="Capture d’écran 2026-08-20 à 16 08 44" src="https://github.com/user-attachments/assets/dee31a48-b7dd-4dd0-8e13-1dd19a42f675" />
<img width="1119" height="694" alt="Capture d’écran 2026-08-20 à 16 09 00" src="https://github.com/user-attachments/assets/b3991afc-212e-4787-8f03-fc77111c52f7" />

**Before:**
<img width="1141" height="541" alt="Capture d’écran 2026-08-20 à 16 09 58" src="https://github.com/user-attachments/assets/33584ca7-749a-4a4b-bc56-74c7202003a7" />
<img width="1143" height="536" alt="Capture d’écran 2026-08-20 à 16 10 05" src="https://github.com/user-attachments/assets/58389e36-7544-457d-9909-e450a3f1626a" />
<img width="1141" height="500" alt="Capture d’écran 2026-08-20 à 16 10 09" src="https://github.com/user-attachments/assets/adf29d6d-c909-4e06-a44d-d810b0919843" />

## Tests


## Risk

Low - Frontend-only interaction and styling change in the skills manager.

## Deploy Plan

- Deploy front