### PR TITLE
[front] Batch project member space access check in agent mention permissions

### DIFF
--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -10,6 +10,8 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
@@ -401,6 +403,50 @@ describe("canAgentBeUsedInProjectConversation", () => {
         conversation: conversationJson,
       })
     ).resolves.toBe(true);
+  });
+
+  it("rejects the agent when a project member reaches the restricted space only through a provisioned group on a manually-managed space", async () => {
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+
+    const projectSpace = await SpaceFactory.project(workspace, user.id);
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+
+    await addUserToSpaceRegularGroup(internalAdminAuth, projectSpace, userJson);
+
+    // The user's only link to the restricted space is a provisioned group. Provisioned groups
+    // carry no grants on manually-managed spaces (see spaceGroupRoles), so the user is not a
+    // member of the space.
+    const provisionedGroup = await GroupFactory.provisioned(
+      workspace,
+      faker.string.alphanumeric(8)
+    );
+    await GroupFactory.withMembers(internalAdminAuth, provisionedGroup, [user]);
+    await GroupSpaceFactory.associate(restrictedSpace, provisionedGroup);
+
+    await auth.refresh();
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      spaceId: projectSpace.id,
+    });
+    const conversationJson = await fetchConversationWithoutContent(
+      conversation.sId
+    );
+
+    await expect(
+      canAgentBeUsedInProjectConversation(auth, {
+        configuration: lightConfiguration([
+          projectSpace.sId,
+          restrictedSpace.sId,
+        ]),
+        conversation: conversationJson,
+      })
+    ).resolves.toBe(false);
   });
 
   it("allows the agent when all project members belong to required restricted spaces mixed with open spaces", async () => {

--- a/front/lib/api/assistant/conversation/permissions.ts
+++ b/front/lib/api/assistant/conversation/permissions.ts
@@ -1,5 +1,6 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getContentFragmentsSpaceIds } from "@app/lib/api/assistant/permissions";
+import { listUsersWithoutAccessToSpaceResources } from "@app/lib/api/spaces/access";
 import { Authenticator } from "@app/lib/auth";
 import type { ConversationAccessType } from "@app/lib/resources/conversation_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -135,23 +136,12 @@ export async function canAgentBeUsedInProjectConversation(
           await project.fetchDistinctActiveManualGroupMembers(auth);
 
         if (restrictedAgentSpaces.length > 0 && projectMembers.length > 0) {
-          const workspaceId = auth.getNonNullableWorkspace().sId;
-          const memberAuths = await Promise.all(
-            projectMembers.map((member) =>
-              Authenticator.fromUserIdAndWorkspaceId(member.sId, workspaceId)
-            )
-          );
-
-          // O(n×m) sync membership checks; both arrays are small (Pod members and
-          // agent restricted spaces are typically each well under 100 elements).
-          for (const restrictedSpace of restrictedAgentSpaces) {
-            for (const memberAuth of memberAuths) {
-              if (!memberAuth || !restrictedSpace.isMember(memberAuth)) {
-                return false;
-              }
-            }
-          }
-          return true;
+          const membersWithoutAccess =
+            await listUsersWithoutAccessToSpaceResources(auth, {
+              spaces: restrictedAgentSpaces,
+              users: projectMembers,
+            });
+          return membersWithoutAccess.length === 0;
         }
       }
 

--- a/front/lib/api/spaces/access.ts
+++ b/front/lib/api/spaces/access.ts
@@ -51,8 +51,8 @@ export interface UserWithoutSpaceAccess {
  * For each of `users`, the spaces among `spaces` they cannot read.
  *
  * Unlike {@link listUsersWithoutAccessToSpaces} this takes already-fetched resources and performs
- * no permission check of its own: it is meant for callers that hold the spaces because they are
- * about to write them (skill requirements, editor lists), and that have established their own
+ * no permission check of its own: it is meant for callers that already hold the spaces (skill
+ * requirements, editor lists, project agent mention checks) and that have established their own
  * access separately. Users are assumed to be active workspace members.
  */
 export async function listUsersWithoutAccessToSpaceResources(

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1783,9 +1783,16 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   ): boolean {
     // TODO(projects): update this method to check groups whose group_vaults relationship is
     // to remove the complexity of checking the global group based on the space type.
+
+    // Provisioned groups carry no grants on manually-managed spaces (see spaceGroupRoles).
+    const groups =
+      this.managementMode === "manual"
+        ? this.groups.filter((group) => !group.isProvisioned())
+        : this.groups;
+
     switch (this.kind) {
       case "regular":
-        for (const group of this.groups) {
+        for (const group of groups) {
           // In regular spaces, having the global group means that you are a member.
           if (group.isGlobal()) {
             return true;
@@ -1796,7 +1803,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         }
         return false;
       case "project":
-        for (const group of this.groups) {
+        for (const group of groups) {
           // Ignore the global group for project spaces as it means that the group is public but not that you are a member.
           if (group.isGlobal()) {
             continue;


### PR DESCRIPTION
## Problem

`canAgentBeUsedInProjectConversation` (mention validation on `postUserMessage` / `editUserMessage` in project conversations) built one full `Authenticator` per project member via an unbounded `Promise.all`. Each `Authenticator.fromUserIdAndWorkspaceId` costs ~5-8 queries, so a 50-member project fired ~250-400 concurrent queries into the pod's 10-connection Sequelize pool before the message could be created; a 200-member project would exceed 1,000. This both slows message posting in large projects and can starve the whole pod's pool (same failure class as the recent connection pool acquisition delay alerts).

## Fix

- Replace the fan-out with the existing batched helper `listUsersWithoutAccessToSpaceResources` (one workspace-scoped `group_memberships` query for all members and spaces, then in-memory checks via `isMemberByGroupModelIds`). Cost is now O(1) queries regardless of project size.
- Align `isMemberByGroupPredicate` with the grant-write rule from `spaceGroupRoles`: provisioned groups carry no membership on manually-managed spaces. Without this, the swap from the grants path to the group-predicate path would false-allow an agent when a project member's only link to a required restricted space is a leftover provisioned group (a real state after a group -> manual management switch). A regression test pins this case: it passes on the old grants-based code, fails on the naive batched version, and passes with the predicate fix.

## Behavior change beyond the perf fix

Tightening `isMemberByGroupPredicate` also affects its two other consumers, the `POST /spaces/access-check` endpoint and skill space requirement checks (`findSkillEditorsWithoutSpaceAccess`). Both previously over-reported access for users reachable only through a provisioned group on a manual-mode space, while the grants that actually gate reads (and the legacy ACL path, which applies the same provisioned filter) deny it. They now answer from the same rule as the read gate. This is fail-closed: users are only ever moved from "has access" to "does not".

## Risk / rollback

Membership semantics for every other kind x managementMode combination are unchanged (grants and predicate paths verified case by case: regular open/restricted, project editor/member/global-viewer, system/conversations/global, suspended memberships, revoked workspace members). Single-commit revert restores the previous behavior.

## Tests

- New regression test: provisioned group on a manually-managed restricted space -> agent rejected.
- `permissions.test.ts` 28/28, `messages.test.ts` 28/28, `spaces.test.ts` 39/39, front-api `access-check.test.ts` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
