### PR TITLE
Microsoft: use a lean delta projection to reduce worker memory

### DIFF
--- a/connectors/src/connectors/microsoft/lib/graph_api.ts
+++ b/connectors/src/connectors/microsoft/lib/graph_api.ts
@@ -7,6 +7,7 @@ import type {
   MicrosoftNode,
 } from "@connectors/connectors/microsoft/lib/types";
 import {
+  DRIVE_ITEM_DELTA_SELECTS,
   DRIVE_ITEM_EXPANDS_AND_SELECTS,
   DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS,
 } from "@connectors/connectors/microsoft/lib/types";
@@ -209,12 +210,10 @@ export async function getDeltaResults({
   parentInternalId,
   nextLink,
   token,
-  withLabels = false,
 }: {
   logger: LoggerInterface;
   client: Client;
   parentInternalId: string;
-  withLabels?: boolean;
 } & (
   | { nextLink?: string; token?: never }
   | { nextLink?: never; token: string }
@@ -234,13 +233,13 @@ export async function getDeltaResults({
     { parentInternalId, itemAPIPath, nextLink, token },
     "Getting delta"
   );
-  const expandsAndSelects = withLabels
-    ? DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS
-    : DRIVE_ITEM_EXPANDS_AND_SELECTS;
+  // Delta pagination uses the lean projection: every returned item is retained in the
+  // in-memory dedup map until pagination completes, and the heavy list-item fields and
+  // download URL are re-hydrated per file by `syncOneFile` when actually needed.
   const deltaPath =
     (nodeType === "folder"
-      ? `${itemAPIPath}/delta?${expandsAndSelects}`
-      : `${itemAPIPath}/root/delta?${expandsAndSelects}`) +
+      ? `${itemAPIPath}/delta?${DRIVE_ITEM_DELTA_SELECTS}`
+      : `${itemAPIPath}/root/delta?${DRIVE_ITEM_DELTA_SELECTS}`) +
     (token ? `&token=${token}` : "");
 
   const res = nextLink

--- a/connectors/src/connectors/microsoft/lib/types.ts
+++ b/connectors/src/connectors/microsoft/lib/types.ts
@@ -29,6 +29,19 @@ export const DRIVE_ITEM_EXPANDS_AND_SELECTS =
 export const DRIVE_ITEM_EXPANDS_AND_SELECTS_WITH_LABELS =
   "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds&$expand=listItem($expand=fields($select=_IpLabelId))&select=@microsoft.graph.downloadUrl";
 
+// Lean projection used for delta pagination. Unlike the projections above it omits
+// the `$expand=listItem($expand=fields)` expansion and the `@microsoft.graph.downloadUrl`
+// select. Those two are the memory-heavy parts of a `DriveItem`: expanded SharePoint
+// custom-column payloads and a per-item download URL. `getFullDeltaResults` keeps every
+// latest `DriveItem` in an in-memory map until pagination completes, so carrying that
+// metadata for every folder, root marker and deleted entry (none of which need it)
+// inflates the worker's footprint and can OOM the pod on large drives.
+// `syncOneFile` already re-hydrates the download URL and list-item fields per file on
+// demand (see connectors/src/connectors/microsoft/temporal/file.ts), so files that are
+// actually synced still get the full metadata.
+export const DRIVE_ITEM_DELTA_SELECTS =
+  "$select=id,name,parentReference,webUrl,file,folder,root,deleted,createdBy,lastModifiedBy,createdDateTime,lastModifiedDateTime,size,sharepointIds";
+
 // Value stored in `microsoft_nodes.skipReason` when a file is excluded by sensitivity label allowlist.
 export const MICROSOFT_SKIP_REASON_SENSITIVITY_LABEL_NOT_ALLOWED =
   "sensitivity_label_not_allowed" as const;

--- a/connectors/src/connectors/microsoft/temporal/file.ts
+++ b/connectors/src/connectors/microsoft/temporal/file.ts
@@ -256,12 +256,11 @@ export async function syncOneFile({
   const allowedLabels = providerConfig.allowedSensitivityLabels ?? [];
 
   if (!url || !fields) {
-    if (!url) {
-      statsDClient.increment("microsoft.file.missing_download_url");
-    }
-    if (!fields) {
-      statsDClient.increment("microsoft.file.missing_fields");
-    }
+    // The delta projection is lean and never carries the download URL or list-item
+    // fields (see DRIVE_ITEM_DELTA_SELECTS), so hydrating them here is the expected
+    // path for incrementally-synced files rather than an anomaly. This counter tracks
+    // the resulting extra Graph calls so we can monitor the API-volume tradeoff.
+    statsDClient.increment("microsoft.file.metadata_hydration");
 
     let item: DriveItem;
     try {


### PR DESCRIPTION
## Description

Incremental Microsoft sync workers were OOM-killed (`OOMKilled`, exit 137) during `fetchDeltaForRootNodesInDrive` on large drives.

`getFullDeltaResults` keeps every latest `DriveItem` in an in-memory map until delta pagination completes. The default delta projection expands `listItem($expand=fields)` (full SharePoint custom-column payloads) and selects `@microsoft.graph.downloadUrl` on **every** item — including folders, root markers and deleted entries that never need them. That inflates the retained map enough to exhaust the container memory limit.

This PR fetches delta pages with a lean projection (`DRIVE_ITEM_DELTA_SELECTS`) that omits the `listItem` fields expansion and the download URL. `syncOneFile` already re-hydrates both per file on demand via `getItem` when they are absent, so files that are actually synced still get full metadata; folders, deleted items and roots no longer carry SharePoint field payloads through the dedup map.

Also:
- Collapses the now-expected `missing_download_url`/`missing_fields` stats into a single `microsoft.file.metadata_hydration` counter (hydration is the expected path for incrementally-synced files, no longer an anomaly).
- Drops the dead `withLabels` parameter from `getDeltaResults` (no caller passed it; the full-sync `getFilesAndFolders` path is unchanged).

## Tests

`tsc --noEmit` passes. Change is behaviorally covered by the existing `syncOneFile` hydration fallback, which already runs in production whenever Graph omits `downloadUrl`/`fields`. Verified the delta consumer never reads `listItem.fields`/`downloadUrl` directly off delta items: folders/roots go through `itemToMicrosoftNode` (name/webUrl/parentReference only), deleted items use only the internalId, and only real files reach `syncOneFile`.

## Risk

Low. Tradeoff is one extra Graph `GET` per *changed file* per incremental cycle (folders/deleted/roots cost nothing extra); changed-file counts per incremental cycle are normally small. Fully rollback-safe — reverting restores the previous projection. Monitor `microsoft.file.metadata_hydration` (extra API volume) and worker RSS after deploy.

## Deploy Plan

Standard connectors deploy.