### PR TITLE
[connectors] Disable resumable GCS uploads for small files and log upload queue depth

### DIFF
--- a/connectors/src/connectors/github/lib/code/gcs_repository.ts
+++ b/connectors/src/connectors/github/lib/code/gcs_repository.ts
@@ -196,6 +196,8 @@ export class GCSRepositoryManager {
         metadata: {
           contentType: options?.contentType || "text/plain",
         },
+        // Resumable uploads add a round trip per object, too slow for small files.
+        resumable: false,
       });
 
       if (options?.metadata) {

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -397,6 +397,8 @@ export async function extractGitHubTarballToGCS(
                   filesUploaded,
                   filesSkipped,
                   extractionDurationMs: Date.now() - extractionStartedAtMs,
+                  uploadsInFlight: uploadQueue.pending,
+                  uploadsQueued: uploadQueue.size,
                 },
                 "GitHub tarball extraction progress"
               );

--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -25,7 +25,7 @@ import { pipeline } from "stream/promises";
 import * as tar from "tar-stream";
 
 export const MAX_FILE_SIZE_BYTES = 3 * 1024 * 1024;
-const MAX_CONCURRENT_GCS_UPLOADS = 200;
+const MAX_CONCURRENT_GCS_UPLOADS = 400;
 const MAX_TARBALL_SPOOL_RETRIES = 3;
 const MAX_TARBALL_EXTRACTION_RETRIES = 3;
 const TARBALL_RETRY_BASE_DELAY_MS = 1000;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is a follow-up to the tarball spooling change https://github.com/dust-tt/dust/pull/30848. With the download decoupled (biggest repo taking ~ 3 minutes to download from GH and upload in GCS), the first few production runs showed the extraction phase still crawling at a very slow pace. Looking deeper all those files are small one entering the < 10MB buffering + direct upload.

Every buffered small file goes through the storage client's save method, which defaults to resumable uploads. The client's own documentation recommends disabling the resumable feature below a few megabytes because the extra session-creation round trip causes noticeable degradation across a series of small files. 

As we don't rely on GH stream anymore when uploading file, this PR also bumps concurrency from 200 to 400.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
