### PR TITLE
[front] enh: polish conversation consumption breakdown

### DIFF
--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
@@ -62,6 +62,12 @@ describe("ConversationCreditUsageBreakdown", () => {
       <ConversationCreditUsageBreakdown billedCredits={20} details={details} />
     );
 
+    expect(
+      screen.getByRole("heading", { name: "Total consumption" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Per Models" })
+    ).toBeInTheDocument();
     expect(screen.getByText("Calendar tool")).toBeInTheDocument();
     expect(screen.getByText("6.5 credits")).toBeInTheDocument();
     expect(screen.getByText("4.5 credits")).toBeInTheDocument();
@@ -74,6 +80,9 @@ describe("ConversationCreditUsageBreakdown", () => {
     expect(screen.getByText("GPT-5 Mini")).toBeInTheDocument();
     expect(screen.getByText("15 credits")).toBeInTheDocument();
     expect(screen.queryByText("Research agent")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Per Agents" })
+    ).not.toBeInTheDocument();
   });
 
   it("collapses agent breakdowns by default in multi-agent conversations", () => {
@@ -110,6 +119,9 @@ describe("ConversationCreditUsageBreakdown", () => {
 
     expect(screen.getByText("Research agent")).toBeInTheDocument();
     expect(screen.getByText("Writing agent")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Per Agents" })
+    ).toBeInTheDocument();
     expect(screen.queryByText("Search tool")).not.toBeInTheDocument();
     expect(screen.queryByText("Writing tool")).not.toBeInTheDocument();
 

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
@@ -85,7 +85,7 @@ describe("ConversationCreditUsageBreakdown", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("collapses agent breakdowns by default in multi-agent conversations", () => {
+  it("collapses agent breakdowns by default and expands them from the row", () => {
     const agent = {
       pictureUrl: null,
       billedCredits: 10,
@@ -125,11 +125,7 @@ describe("ConversationCreditUsageBreakdown", () => {
     expect(screen.queryByText("Search tool")).not.toBeInTheDocument();
     expect(screen.queryByText("Writing tool")).not.toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "Expand credit details for Research agent",
-      })
-    );
+    fireEvent.click(screen.getByText("Research agent"));
 
     expect(screen.getByText("Search tool")).toBeInTheDocument();
     expect(screen.queryByText("Writing tool")).not.toBeInTheDocument();

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -191,7 +191,7 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
     >
       <CollapsibleTrigger
         aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
-        className="min-h-11 flex-row-reverse justify-between rounded-xl px-2 text-left focus-visible:ring-2 focus-visible:ring-ring"
+        className="min-h-11 flex-row-reverse justify-between rounded-xl p-2 text-left focus-visible:ring-2 focus-visible:ring-ring"
       >
         <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2">
@@ -209,7 +209,7 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
           </span>
         </div>
       </CollapsibleTrigger>
-      <CollapsibleContent className="px-2 pb-2 pt-2">
+      <CollapsibleContent className="p-2">
         <ToolBreakdownCards
           agentWorkCredits={agent.agentWorkCredits}
           tools={agent.tools}
@@ -224,6 +224,7 @@ interface AgentsBreakdownProps {
 }
 
 function AgentsBreakdown({ agents }: AgentsBreakdownProps) {
+  // We hide the section entirely if there is only one agent.
   if (agents.length <= 1) {
     return null;
   }
@@ -258,7 +259,7 @@ export function ConversationCreditUsageBreakdown({
           <h2 className="text-base font-semibold text-foreground">
             Total consumption
           </h2>
-          <div className="mt-1 flex items-end gap-1">
+          <div className="flex items-end gap-1">
             <span className="text-2xl font-semibold leading-8 text-foreground">
               {formatCredits(billedCredits)}
             </span>

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -161,8 +161,8 @@ function ModelsBreakdown({ isDark, models }: ModelsBreakdownProps) {
   }
 
   return (
-    <section className="space-y-4">
-      <h3 className="text-xs font-semibold text-muted-foreground">Models</h3>
+    <section className="mt-6 space-y-4 border-t border-border pt-6">
+      <h3 className="text-base font-semibold text-foreground">Per Models</h3>
       <div className="space-y-2">
         {models.map((model) => (
           <ModelRow
@@ -184,34 +184,59 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <section className="space-y-4">
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <div className="flex min-w-0 items-center justify-between gap-3">
-          <div className="flex min-w-0 items-center gap-2">
-            <CollapsibleTrigger
-              aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
-              className="size-11 shrink-0 justify-center rounded-lg focus-visible:ring-2 focus-visible:ring-ring"
-            />
-            <Avatar
-              name={agent.name}
-              visual={agent.pictureUrl ?? undefined}
-              size="xs"
-            />
-            <h3 className="truncate text-base font-medium text-foreground">
-              {agent.name}
-            </h3>
-          </div>
-          <span className="shrink-0 text-base text-muted-foreground">
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className="rounded-xl border border-border bg-background"
+    >
+      <div className="flex min-w-0 items-center justify-between gap-3 px-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Avatar
+            name={agent.name}
+            visual={agent.pictureUrl ?? undefined}
+            size="xs"
+          />
+          <h4 className="truncate text-base font-medium text-foreground">
+            {agent.name}
+          </h4>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <span className="text-base text-muted-foreground">
             {formatCreditValue(agent.billedCredits)}
           </span>
-        </div>
-        <CollapsibleContent className="pt-4">
-          <ToolBreakdownCards
-            agentWorkCredits={agent.agentWorkCredits}
-            tools={agent.tools}
+          <CollapsibleTrigger
+            aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
+            className="size-11 shrink-0 justify-center rounded-lg focus-visible:ring-2 focus-visible:ring-ring"
           />
-        </CollapsibleContent>
-      </Collapsible>
+        </div>
+      </div>
+      <CollapsibleContent className="px-2 pb-2 pt-2">
+        <ToolBreakdownCards
+          agentWorkCredits={agent.agentWorkCredits}
+          tools={agent.tools}
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+interface AgentsBreakdownProps {
+  agents: ConversationConsumptionAgentDetails[];
+}
+
+function AgentsBreakdown({ agents }: AgentsBreakdownProps) {
+  if (agents.length <= 1) {
+    return null;
+  }
+
+  return (
+    <section className="mt-6 space-y-4 border-t border-border pt-6">
+      <h3 className="text-base font-semibold text-foreground">Per Agents</h3>
+      <div className="space-y-2">
+        {agents.map((agent) => (
+          <AgentBreakdown key={agent.agentId} agent={agent} />
+        ))}
+      </div>
     </section>
   );
 }
@@ -228,10 +253,12 @@ export function ConversationCreditUsageBreakdown({
   const { isDark } = useTheme();
 
   return (
-    <div className="space-y-6 px-4 py-6">
+    <div className="px-4 py-6">
       <section className="space-y-4">
         <div>
-          <h2 className="text-sm font-semibold text-foreground">Total</h2>
+          <h2 className="text-base font-semibold text-foreground">
+            Total consumption
+          </h2>
           <div className="mt-1 flex items-end gap-1">
             <span className="text-2xl font-semibold leading-8 text-foreground">
               {formatCredits(billedCredits)}
@@ -249,10 +276,7 @@ export function ConversationCreditUsageBreakdown({
 
       <ModelsBreakdown isDark={isDark} models={details.models} />
 
-      {details.agents.length > 1 &&
-        details.agents.map((agent) => (
-          <AgentBreakdown key={agent.agentId} agent={agent} />
-        ))}
+      <AgentsBreakdown agents={details.agents} />
     </div>
   );
 }

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -201,7 +201,7 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
           </h4>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <span className="text-base text-muted-foreground">
+          <span className="text-base font-semibold text-muted-foreground">
             {formatCreditValue(agent.billedCredits)}
           </span>
           <CollapsibleTrigger

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -189,27 +189,26 @@ function AgentBreakdown({ agent }: AgentBreakdownProps) {
       onOpenChange={setIsOpen}
       className="rounded-xl border border-border bg-background"
     >
-      <div className="flex min-w-0 items-center justify-between gap-3 px-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <Avatar
-            name={agent.name}
-            visual={agent.pictureUrl ?? undefined}
-            size="xs"
-          />
-          <h4 className="truncate text-base font-medium text-foreground">
-            {agent.name}
-          </h4>
-        </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <span className="text-base font-semibold text-muted-foreground">
+      <CollapsibleTrigger
+        aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
+        className="min-h-11 flex-row-reverse justify-between rounded-xl px-2 text-left focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <div className="flex min-w-0 flex-1 items-center justify-between gap-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <Avatar
+              name={agent.name}
+              visual={agent.pictureUrl ?? undefined}
+              size="xs"
+            />
+            <span className="truncate text-base font-medium text-foreground">
+              {agent.name}
+            </span>
+          </div>
+          <span className="shrink-0 text-base font-semibold text-muted-foreground">
             {formatCreditValue(agent.billedCredits)}
           </span>
-          <CollapsibleTrigger
-            aria-label={`${isOpen ? "Collapse" : "Expand"} credit details for ${agent.name}`}
-            className="size-11 shrink-0 justify-center rounded-lg focus-visible:ring-2 focus-visible:ring-ring"
-          />
         </div>
-      </div>
+      </CollapsibleTrigger>
       <CollapsibleContent className="px-2 pb-2 pt-2">
         <ToolBreakdownCards
           agentWorkCredits={agent.agentWorkCredits}


### PR DESCRIPTION
## Description

Implements the following [Figma](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=14130-34475&m=dev).

This PR aims at adding a better hierarchy to the conversation consumption breakdown.

Renames the headings, adds dividers between sections, adds a border around each agent breakdown (kept when collapsing/uncollapsing).

Single-agent conversations continue to omit the agent section, and multi-agent details remain collapsed by default.

One principle followed here is that there are now a few clear sections (clear because divided by dividers), and the sum of the credits in each sections amounts to the total shown at the top. Separating makes it clear that these are different ways to look at the same thing, rather than something additive: we don't want users surprised that the sum of models + agents is higher (twice actually) the total credits.

Mockup

<img width="306" height="995" alt="image" src="https://github.com/user-attachments/assets/2d952cdb-5ff6-43a1-a9ba-b7d787a0a924" />

Current live version

<img width="886" height="719" alt="image" src="https://github.com/user-attachments/assets/3dce8faf-d95f-43dc-865d-4aa159a9ffc7" />

Proposal

<img width="868" height="1247" alt="image" src="https://github.com/user-attachments/assets/477b8cfd-38d1-47e5-9a96-3bebac7bac00" />

## Tests

- Updated existing tests.
- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
