### PR TITLE
feat(agent_inactivity): fetch inactive agent candidates from mentions 

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -287,6 +287,30 @@ async function fetchLatestWorkspaceAgentModels(
 }
 
 /**
+ * When each agent first appeared. Not the active row's `createdAt`: upgrading inserts a new row, so
+ * that date is really the last edit.
+ */
+export async function fetchFirstVersionCreatedAtByAgentId(
+  auth: Authenticator,
+  agentIds: string[]
+): Promise<Map<string, Date>> {
+  if (agentIds.length === 0) {
+    return new Map();
+  }
+
+  const firstVersions = await AgentConfigurationModel.findAll({
+    attributes: ["sId", "createdAt"],
+    where: {
+      workspaceId: auth.getNonNullableWorkspace().id,
+      sId: { [Op.in]: agentIds },
+      version: 0,
+    },
+  });
+
+  return new Map(firstVersions.map(({ sId, createdAt }) => [sId, createdAt]));
+}
+
+/**
  * Get the latest versions of multiple agents.
  */
 export async function getAgentConfigurations<V extends AgentFetchVariant>(

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.test.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.test.ts
@@ -76,9 +76,7 @@ describe("archiveInactiveWorkspaceAgents", () => {
   });
 
   it("archives nothing on a replay of the same input", async () => {
-    // A Temporal retry replays its input verbatim. The archived agent is no longer active, so it does
-    // not come back from the fetch at all: it cannot be archived twice, and no second
-    // `agent.archived` audit event is emitted.
+    // A retried activity re-runs the fetch, and an archived agent is no longer a candidate.
     const { authenticator } = await createResourceTest({ role: "admin" });
     const agent = await createUnusedAgent(authenticator, "Forgotten twice");
 
@@ -152,9 +150,8 @@ describe("archiveInactiveWorkspaceAgents", () => {
   });
 
   it("advances past agents it cannot archive, so a driver terminates", async () => {
-    // The failure this guards: agents the rules always refuse stay candidates forever, so a driver
-    // that did not advance its cursor would be handed the same page for eternity and never reach the
-    // rest of the workspace.
+    // Agents the rules always refuse stay candidates forever, so a cursor that did not advance
+    // would hand back the same page for eternity.
     const { authenticator } = await createResourceTest({ role: "admin" });
     for (const name of ["Scheduled one", "Scheduled two"]) {
       const agent = await createUnusedAgent(authenticator, name);
@@ -173,8 +170,7 @@ describe("archiveInactiveWorkspaceAgents", () => {
       const res = await archiveInactiveWorkspaceAgents(authenticator, {
         thresholdDays: THRESHOLD_DAYS,
         evaluatedAt: new Date(),
-        // One at a time, so a cursor that failed to advance would loop forever rather than hiding
-        // behind a page big enough to hold everything.
+        // One at a time, so the failure cannot hide behind a page big enough to hold everything.
         page: { cursor, limit: 1 },
       });
       if (res.isErr()) {
@@ -188,7 +184,6 @@ describe("archiveInactiveWorkspaceAgents", () => {
     } while (cursor !== null && pages < 5);
 
     expect(cursor).toBeNull();
-    // Each agent was seen once, and both were reached.
     expect(new Set(skippedAgentIds).size).toBe(2);
     expect(skippedAgentIds).toHaveLength(2);
   });

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.test.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.test.ts
@@ -1,0 +1,224 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { archiveInactiveWorkspaceAgents } from "@app/lib/api/assistant/inactivity/archive_inactive_agents";
+import type { Authenticator } from "@app/lib/auth";
+import * as scheduleClient from "@app/temporal/triggers/schedule_client";
+import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MentionFactory } from "@app/tests/utils/MentionFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const THRESHOLD_DAYS = 30;
+
+/** Old enough to sit well before any cutoff a 30-day threshold can produce. */
+const LONG_AGO = new Date(Date.now() - 90 * ONE_DAY_MS);
+
+/** Archiving disables triggers and cancels wake-ups, both of which reach Temporal. */
+function mockTemporalClients() {
+  vi.spyOn(scheduleClient, "createOrUpdateAgentSchedule").mockResolvedValue(
+    new Ok("workflow-id")
+  );
+  vi.spyOn(scheduleClient, "deleteTriggerSchedule").mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.spyOn(
+    wakeUpClient,
+    "launchOrScheduleWakeUpTemporalWorkflow"
+  ).mockResolvedValue(new Ok(undefined));
+  vi.spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow").mockResolvedValue(
+    new Ok(undefined)
+  );
+}
+
+async function createUnusedAgent(auth: Authenticator, name: string) {
+  const agent = await AgentConfigurationFactory.createTestAgent(auth, { name });
+  await AgentConfigurationFactory.setCreatedAtForTest(
+    auth,
+    agent.sId,
+    LONG_AGO
+  );
+
+  return agent;
+}
+
+async function statusOf(auth: Authenticator, agentId: string) {
+  const agent = await getAgentConfiguration(auth, {
+    agentId,
+    variant: "light",
+  });
+
+  return agent?.status;
+}
+
+describe("archiveInactiveWorkspaceAgents", () => {
+  beforeEach(() => {
+    mockTemporalClients();
+  });
+
+  it("archives an agent nobody has mentioned", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createUnusedAgent(authenticator, "Forgotten");
+
+    const res = await archiveInactiveWorkspaceAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(res.isOk()).toBe(true);
+    expect(res.isOk() && res.value.archivedAgentIds).toEqual([agent.sId]);
+    expect(res.isOk() && res.value.skipped).toEqual([]);
+    expect(await statusOf(authenticator, agent.sId)).toBe("archived");
+  });
+
+  it("archives nothing on a replay of the same input", async () => {
+    // A Temporal retry replays its input verbatim. The archived agent is no longer active, so it does
+    // not come back from the fetch at all: it cannot be archived twice, and no second
+    // `agent.archived` audit event is emitted.
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createUnusedAgent(authenticator, "Forgotten twice");
+
+    const input = {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+      page: { cursor: null, limit: 50 },
+    };
+
+    const first = await archiveInactiveWorkspaceAgents(authenticator, input);
+    expect(first.isOk() && first.value.archivedAgentIds).toEqual([agent.sId]);
+
+    const replay = await archiveInactiveWorkspaceAgents(authenticator, input);
+    expect(replay.isOk() && replay.value.archivedAgentIds).toEqual([]);
+    expect(await statusOf(authenticator, agent.sId)).toBe("archived");
+  });
+
+  it("leaves an agent an enabled schedule still drives", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createUnusedAgent(authenticator, "Scheduled");
+    await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: agent.sId,
+      status: "enabled",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const res = await archiveInactiveWorkspaceAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(res.isOk() && res.value.archivedAgentIds).toEqual([]);
+    expect(res.isOk() && res.value.skipped).toEqual([
+      { agentId: agent.sId, reason: "active_schedule" },
+    ]);
+    expect(await statusOf(authenticator, agent.sId)).toBe("active");
+  });
+
+  it("leaves an agent someone mentioned since the cutoff", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createUnusedAgent(authenticator, "Still wanted");
+    await MentionFactory.agentMentionedAt(authenticator, {
+      agentId: agent.sId,
+      mentionedAt: new Date(),
+    });
+
+    const res = await archiveInactiveWorkspaceAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(res.isOk() && res.value.archivedAgentIds).toEqual([]);
+    expect(await statusOf(authenticator, agent.sId)).toBe("active");
+  });
+
+  it("archives nothing when the threshold is unusable", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createUnusedAgent(authenticator, "Saved by validation");
+
+    const res = await archiveInactiveWorkspaceAgents(authenticator, {
+      thresholdDays: 1,
+      evaluatedAt: new Date(),
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(res.isErr()).toBe(true);
+    expect(res.isErr() && res.error.type).toBe("invalid_threshold");
+    expect(await statusOf(authenticator, agent.sId)).toBe("active");
+  });
+
+  it("advances past agents it cannot archive, so a driver terminates", async () => {
+    // The failure this guards: agents the rules always refuse stay candidates forever, so a driver
+    // that did not advance its cursor would be handed the same page for eternity and never reach the
+    // rest of the workspace.
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    for (const name of ["Scheduled one", "Scheduled two"]) {
+      const agent = await createUnusedAgent(authenticator, name);
+      await TriggerFactory.schedule(authenticator, {
+        agentConfigurationId: agent.sId,
+        status: "enabled",
+        configuration: { cron: "0 9 * * *", timezone: "UTC" },
+      });
+    }
+
+    const skippedAgentIds: string[] = [];
+    let cursor: string | null = null;
+    let pages = 0;
+
+    do {
+      const res = await archiveInactiveWorkspaceAgents(authenticator, {
+        thresholdDays: THRESHOLD_DAYS,
+        evaluatedAt: new Date(),
+        // One at a time, so a cursor that failed to advance would loop forever rather than hiding
+        // behind a page big enough to hold everything.
+        page: { cursor, limit: 1 },
+      });
+      if (res.isErr()) {
+        throw res.error;
+      }
+
+      expect(res.value.archivedAgentIds).toEqual([]);
+      skippedAgentIds.push(...res.value.skipped.map(({ agentId }) => agentId));
+      cursor = res.value.nextCursor;
+      pages += 1;
+    } while (cursor !== null && pages < 5);
+
+    expect(cursor).toBeNull();
+    // Each agent was seen once, and both were reached.
+    expect(new Set(skippedAgentIds).size).toBe(2);
+    expect(skippedAgentIds).toHaveLength(2);
+  });
+
+  it("reports a cursor so the caller can drive the next page", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    await createUnusedAgent(authenticator, "Page one");
+    await createUnusedAgent(authenticator, "Page two");
+
+    const firstPage = await archiveInactiveWorkspaceAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+      page: { cursor: null, limit: 1 },
+    });
+
+    expect(firstPage.isOk() && firstPage.value.archivedAgentIds).toHaveLength(
+      1
+    );
+    const nextCursor = firstPage.isOk() ? firstPage.value.nextCursor : null;
+    expect(nextCursor).not.toBeNull();
+
+    const secondPage = await archiveInactiveWorkspaceAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+      page: { cursor: nextCursor, limit: 1 },
+    });
+
+    expect(secondPage.isOk() && secondPage.value.archivedAgentIds).toHaveLength(
+      1
+    );
+    expect(secondPage.isOk() && secondPage.value.nextCursor).toBeNull();
+  });
+});

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
@@ -2,10 +2,11 @@ import {
   archiveAgentConfiguration,
   getAgentConfigurations,
 } from "@app/lib/api/assistant/configuration/agent";
+import type { AgentPageBound } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import { fetchInactiveAgents } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
 import type {
   AgentArchivalExclusionReason,
   AgentInactivityPolicyError,
-  AgentInactivitySnapshot,
   AgentTriggerSnapshot,
 } from "@app/lib/api/assistant/inactivity/policy";
 import {
@@ -20,33 +21,24 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 /**
- * Archives a workspace's inactive agents: resolve the threshold into a cutoff, load the agents,
- * judge each one against the rules in `policy.ts`, and archive those that are eligible.
+ * Archives a workspace's inactive agents. Both the manual endpoints and the nightly Temporal activity
+ * enter here, so the rules cannot drift between them; the population still differs, since every read
+ * is permission-filtered.
  *
- * The manual endpoints and the nightly Temporal activity both enter here, so the rules cannot drift
- * between them. The population can: every read is permission-filtered, so a manual run only ever
- * considers the agents its caller can see, where the nightly run sees the whole workspace.
+ * The page's facts are re-read before it is judged, which closes the window in which an agent can be
+ * restored, archived by someone else, or given a schedule. A retry is safe for a different reason: it
+ * re-runs the fetch, and an agent the first attempt archived is no longer active, so it is not a
+ * candidate again.
  *
- * The rules are applied against state re-read for the page rather than against what the fetch
- * loaded, because the two do not answer the same question: the fetch finds candidates, the re-read
- * goes through `getAgentConfigurations` and is therefore permission-filtered. That is also what
- * makes a Temporal retry safe — replaying the same input re-reads an agent the first attempt
- * archived, sees `archived`, and skips it instead of emitting a second `agent.archived` audit event.
- *
- * Archiving itself stays the existing `archiveAgentConfiguration` primitive, which owns the side
- * effects (trigger disabling, wake-up cancellation, editor group suspension, audit event).
+ * Archiving stays `archiveAgentConfiguration`, which owns the side effects.
  */
 
-/**
- * Why an agent this operation looked at was not archived: the rules' own exclusions, plus the two
- * outcomes only the mutation path can produce and that the rules therefore never see.
- */
+/** The rules' exclusions, plus the two outcomes only the mutation path can produce. */
 export type AgentArchivalSkipReason =
   | AgentArchivalExclusionReason
-  // The configuration disappeared, or is not visible to this actor, between the fetch and the
-  // re-read.
+  // Gone, or not visible to this actor, since the fetch.
   | "agent_not_found"
-  // The archival update matched no row: someone else archived the agent in the meantime.
+  // The update matched no row: someone else archived it first.
   | "archive_raced";
 
 export interface AgentArchivalSkip {
@@ -57,6 +49,8 @@ export interface AgentArchivalSkip {
 export interface InactiveAgentsArchivalInput {
   thresholdDays: number;
   evaluatedAt: Date;
+  // Which slice to walk, not what to decide. The caller owns the loop.
+  page: AgentPageBound;
 }
 
 export interface InactiveAgentsArchival {
@@ -64,6 +58,8 @@ export interface InactiveAgentsArchival {
   cutoffAt: Date;
   archivedAgentIds: string[];
   skipped: AgentArchivalSkip[];
+  // Paging, not outcome: null once the workspace is exhausted.
+  nextCursor: string | null;
 }
 
 export type InactiveAgentsArchivalResult = Result<
@@ -88,10 +84,7 @@ function countSkipsByReason(skipped: AgentArchivalSkip[]): SkipCountsByReason {
   return counts;
 }
 
-/**
- * Re-reads the whole page's facts in two batched queries, before any agent of it is judged. An
- * agent missing from the returned map is one this actor cannot currently read.
- */
+/** Two batched queries for the whole page. A missing agent is one this actor cannot read. */
 async function fetchArchivalFacts(
   auth: Authenticator,
   agentIds: string[]
@@ -132,7 +125,7 @@ async function fetchArchivalFacts(
  */
 export async function archiveInactiveWorkspaceAgents(
   auth: Authenticator,
-  { thresholdDays, evaluatedAt }: InactiveAgentsArchivalInput
+  { thresholdDays, evaluatedAt, page }: InactiveAgentsArchivalInput
 ): Promise<InactiveAgentsArchivalResult> {
   const workspace = auth.getNonNullableWorkspace();
 
@@ -150,17 +143,10 @@ export async function archiveInactiveWorkspaceAgents(
   }
   const cutoffAt = cutoffRes.value;
 
-  // TODO(2026-08-19 INACTIVE_AGENT_ARCHIVAL): load the workspace's candidate agents and, for each,
-  // when it was last mentioned. Deferred until the mentions query exists; the page bound (cursor,
-  // limit) becomes an input of this use case then, and `nextCursor` part of its result, so the
-  // caller keeps owning the loop. Status and triggers do not need to come back with it —
-  // `fetchArchivalFacts` is the authority on those, since it is the permission-filtered read.
-  //
-  // Read from the `mentions` table, not from `agentMentionsCount` in `agent_usage.ts`: its Redis
-  // cache only goes back 30 days, which is shorter than the thresholds this feature exists for, and
-  // the Elasticsearch index behind it is best-effort. Neither is a basis for a destructive decision.
-  // const { agents, nextCursor } = await fetchInactiveAgents(auth, { cutoffAt, cursor, limit });
-  const agents: AgentInactivitySnapshot[] = [];
+  const { agents, nextCursor } = await fetchInactiveAgents(auth, {
+    cutoffAt,
+    page,
+  });
 
   const factsByAgentId = await fetchArchivalFacts(
     auth,
@@ -168,8 +154,7 @@ export async function archiveInactiveWorkspaceAgents(
   );
 
   const archivedAgentIds: string[] = [];
-  // Skips are not logged per agent: they are the common case, and one line per agent per night
-  // would drown the archivals. The run summary below carries the counts by reason.
+  // Counted in the run summary, not logged per agent: skips are the common case.
   const skipped: AgentArchivalSkip[] = [];
 
   for (const agent of agents) {
@@ -191,13 +176,7 @@ export async function archiveInactiveWorkspaceAgents(
       continue;
     }
 
-    // The decision comes from the page's re-read, so the window before this mutation is the page's
-    // processing time: an agent mentioned or restored during it is archived anyway, and has to be
-    // restored by hand. Closing that window properly means a compare-and-set in
-    // `archiveAgentConfiguration` — an `expectedStatus` narrowing its `where` clause, which would
-    // make the mutation itself refuse an agent that stopped being active. Deliberately not done:
-    // it moves a business rule out of `policy.ts` and into a SQL predicate, and the exposure is one
-    // reversible archival on a page that takes seconds. Revisit if pages get long.
+    // Not a compare-and-set: an agent restored since the re-read is archived anyway. Reversible.
     const archived = await archiveAgentConfiguration(auth, agentId);
     if (!archived) {
       skipped.push({ agentId, reason: "archive_raced" });
@@ -226,9 +205,16 @@ export async function archiveInactiveWorkspaceAgents(
       archivedCount: archivedAgentIds.length,
       skippedCount: skipped.length,
       skippedCountByReason: countSkipsByReason(skipped),
+      hasMore: nextCursor !== null,
     },
     "Finished archiving inactive agents"
   );
 
-  return new Ok({ evaluatedAt, cutoffAt, archivedAgentIds, skipped });
+  return new Ok({
+    evaluatedAt,
+    cutoffAt,
+    archivedAgentIds,
+    skipped,
+    nextCursor,
+  });
 }

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
@@ -21,16 +21,9 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 /**
- * Archives a workspace's inactive agents. Both the manual endpoints and the nightly Temporal activity
- * enter here, so the rules cannot drift between them; the population still differs, since every read
- * is permission-filtered.
- *
- * The page's facts are re-read before it is judged, which closes the window in which an agent can be
- * restored, archived by someone else, or given a schedule. A retry is safe for a different reason: it
- * re-runs the fetch, and an agent the first attempt archived is no longer active, so it is not a
- * candidate again.
- *
- * Archiving stays `archiveAgentConfiguration`, which owns the side effects.
+ * Archives a workspace's inactive agents. Both the manual endpoints and the nightly Temporal
+ * activity enter here, so the rules cannot drift between them; the population still differs, since
+ * every read is permission-filtered.
  */
 
 /** The rules' exclusions, plus the two outcomes only the mutation path can produce. */
@@ -49,7 +42,7 @@ export interface AgentArchivalSkip {
 export interface InactiveAgentsArchivalInput {
   thresholdDays: number;
   evaluatedAt: Date;
-  // Which slice to walk, not what to decide. The caller owns the loop.
+  // Which slice to walk, not what to decide: the caller owns the loop.
   page: AgentPageBound;
 }
 
@@ -84,7 +77,7 @@ function countSkipsByReason(skipped: AgentArchivalSkip[]): SkipCountsByReason {
   return counts;
 }
 
-/** Two batched queries for the whole page. A missing agent is one this actor cannot read. */
+/** A missing agent is one this actor cannot read. */
 async function fetchArchivalFacts(
   auth: Authenticator,
   agentIds: string[]
@@ -118,11 +111,7 @@ async function fetchArchivalFacts(
   );
 }
 
-/**
- * Safe to call twice: an agent archived by a first attempt re-reads as `archived` in a second and is
- * skipped, so a Temporal activity retry cannot double-archive or emit a second `agent.archived`
- * audit event.
- */
+/** Safe to call twice: a retry re-runs the fetch, and an archived agent is no longer a candidate. */
 export async function archiveInactiveWorkspaceAgents(
   auth: Authenticator,
   { thresholdDays, evaluatedAt, page }: InactiveAgentsArchivalInput

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.test.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.test.ts
@@ -1,0 +1,258 @@
+import { fetchInactiveAgents } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MentionFactory } from "@app/tests/utils/MentionFactory";
+import { describe, expect, it } from "vitest";
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const CUTOFF_AT = new Date("2026-07-19T00:00:00.000Z");
+
+function daysBeforeCutoff(days: number): Date {
+  return new Date(CUTOFF_AT.getTime() - days * ONE_DAY_MS);
+}
+
+function daysAfterCutoff(days: number): Date {
+  return new Date(CUTOFF_AT.getTime() + days * ONE_DAY_MS);
+}
+
+/** Every test needs its agent to predate the cutoff; a fresh one never qualifies. */
+async function createAgedAgent(
+  auth: Parameters<typeof AgentConfigurationFactory.setCreatedAtForTest>[0],
+  { name, createdAt }: { name: string; createdAt: Date }
+) {
+  const agent = await AgentConfigurationFactory.createTestAgent(auth, { name });
+  await AgentConfigurationFactory.setCreatedAtForTest(
+    auth,
+    agent.sId,
+    createdAt
+  );
+
+  return agent;
+}
+
+describe("fetchInactiveAgents", () => {
+  it("returns an agent that has never been mentioned", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createAgedAgent(authenticator, {
+      name: "Never used",
+      createdAt: daysBeforeCutoff(10),
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents).toHaveLength(1);
+    expect(page.agents[0]).toMatchObject({
+      agentId: agent.sId,
+      lastMentionedAt: null,
+    });
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("returns an agent whose last mention predates the cutoff", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createAgedAgent(authenticator, {
+      name: "Long unused",
+      createdAt: daysBeforeCutoff(90),
+    });
+    const mentionedAt = daysBeforeCutoff(5);
+    await MentionFactory.agentMentionedAt(authenticator, {
+      agentId: agent.sId,
+      mentionedAt,
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents).toHaveLength(1);
+    expect(page.agents[0]).toMatchObject({
+      agentId: agent.sId,
+      lastMentionedAt: mentionedAt,
+    });
+  });
+
+  it("excludes an agent mentioned after the cutoff", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createAgedAgent(authenticator, {
+      name: "Still used",
+      createdAt: daysBeforeCutoff(90),
+    });
+    await MentionFactory.agentMentionedAt(authenticator, {
+      agentId: agent.sId,
+      mentionedAt: daysAfterCutoff(1),
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents).toEqual([]);
+  });
+
+  it("takes the newest mention, not just any", async () => {
+    // One old mention and one recent one: the agent is in use, however long the older trace is.
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createAgedAgent(authenticator, {
+      name: "Used again",
+      createdAt: daysBeforeCutoff(90),
+    });
+    await MentionFactory.agentMentionedAt(authenticator, {
+      agentId: agent.sId,
+      mentionedAt: daysBeforeCutoff(40),
+    });
+    await MentionFactory.agentMentionedAt(authenticator, {
+      agentId: agent.sId,
+      mentionedAt: daysAfterCutoff(2),
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents).toEqual([]);
+  });
+
+  it("counts a rejected mention as activity", async () => {
+    // `status` is about whether the mentioning user was allowed to proceed, not about the run. Somebody
+    // still reached for the agent.
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createAgedAgent(authenticator, {
+      name: "Blocked but wanted",
+      createdAt: daysBeforeCutoff(90),
+    });
+    await MentionFactory.agentMentionedAt(authenticator, {
+      agentId: agent.sId,
+      mentionedAt: daysAfterCutoff(1),
+      status: "rejected",
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents).toEqual([]);
+  });
+
+  it("still returns an agent that was edited recently", async () => {
+    // Upgrading an agent archives the previous version and inserts a new row, so the active row's own
+    // `createdAt` is the date of the last edit. Reading that would make editing an agent postpone its
+    // archival, contradicting the rule that editing is not activity. What counts is the first version.
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createAgedAgent(authenticator, {
+      name: "Edited yesterday",
+      createdAt: daysBeforeCutoff(90),
+    });
+
+    await AgentConfigurationFactory.updateTestAgent(authenticator, agent.sId, {
+      instructions: "Freshly edited, still unused.",
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents).toHaveLength(1);
+    expect(page.agents[0]).toMatchObject({ agentId: agent.sId });
+  });
+
+  it("excludes an agent created after the cutoff, however unused", async () => {
+    // The threshold measures disuse. An agent that has not existed long enough to be used has not
+    // been disused, and archiving it the night it was built is the bug this guards.
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    await createAgedAgent(authenticator, {
+      name: "Brand new",
+      createdAt: daysAfterCutoff(1),
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents).toEqual([]);
+  });
+
+  it("paginates with a keyset cursor over the candidates", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    for (const name of ["Agent A", "Agent B", "Agent C"]) {
+      await createAgedAgent(authenticator, {
+        name,
+        createdAt: daysBeforeCutoff(10),
+      });
+    }
+
+    const firstPage = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 2 },
+    });
+    expect(firstPage.agents).toHaveLength(2);
+    expect(firstPage.nextCursor).toBe(firstPage.agents[1].agentId);
+
+    const secondPage = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: firstPage.nextCursor, limit: 2 },
+    });
+    expect(secondPage.agents).toHaveLength(1);
+    // A short page means the workspace is exhausted.
+    expect(secondPage.nextCursor).toBeNull();
+
+    const firstPageIds = firstPage.agents.map(({ agentId }) => agentId);
+    const secondPageIds = secondPage.agents.map(({ agentId }) => agentId);
+
+    // Resuming excludes everything at or before the cursor, and the two pages together cover the
+    // workspace exactly once.
+    expect(secondPageIds).not.toContain(firstPage.nextCursor);
+    expect(
+      secondPageIds.every((agentId) => !firstPageIds.includes(agentId))
+    ).toBe(true);
+    expect(new Set([...firstPageIds, ...secondPageIds]).size).toBe(3);
+
+    // Ordered by agent id, which is what makes the keyset cursor stable.
+    expect([...firstPageIds].sort()).toEqual(firstPageIds);
+    expect(
+      secondPageIds.every((agentId) => agentId > firstPage.nextCursor!)
+    ).toBe(true);
+  });
+
+  it("returns an empty page for a limit of zero", async () => {
+    // The lookahead finds a candidate, so a cursor read off the page has no element to read.
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    await createAgedAgent(authenticator, {
+      name: "Out of budget",
+      createdAt: daysBeforeCutoff(10),
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 0 },
+    });
+
+    expect(page.agents).toEqual([]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  it("does not return another workspace's agents", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const other = await createResourceTest({ role: "admin" });
+    await createAgedAgent(other.authenticator, {
+      name: "Foreign agent",
+      createdAt: daysBeforeCutoff(10),
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents).toEqual([]);
+  });
+});

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.test.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.test.ts
@@ -1,4 +1,5 @@
 import { fetchInactiveAgents } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MentionFactory } from "@app/tests/utils/MentionFactory";
@@ -18,7 +19,7 @@ function daysAfterCutoff(days: number): Date {
 
 /** Every test needs its agent to predate the cutoff; a fresh one never qualifies. */
 async function createAgedAgent(
-  auth: Parameters<typeof AgentConfigurationFactory.setCreatedAtForTest>[0],
+  auth: Authenticator,
   { name, createdAt }: { name: string; createdAt: Date }
 ) {
   const agent = await AgentConfigurationFactory.createTestAgent(auth, { name });
@@ -96,7 +97,6 @@ describe("fetchInactiveAgents", () => {
   });
 
   it("takes the newest mention, not just any", async () => {
-    // One old mention and one recent one: the agent is in use, however long the older trace is.
     const { authenticator } = await createResourceTest({ role: "admin" });
     const agent = await createAgedAgent(authenticator, {
       name: "Used again",
@@ -120,8 +120,7 @@ describe("fetchInactiveAgents", () => {
   });
 
   it("counts a rejected mention as activity", async () => {
-    // `status` is about whether the mentioning user was allowed to proceed, not about the run. Somebody
-    // still reached for the agent.
+    // `status` is about whether the mentioning user was allowed to proceed, not about the run.
     const { authenticator } = await createResourceTest({ role: "admin" });
     const agent = await createAgedAgent(authenticator, {
       name: "Blocked but wanted",
@@ -142,9 +141,7 @@ describe("fetchInactiveAgents", () => {
   });
 
   it("still returns an agent that was edited recently", async () => {
-    // Upgrading an agent archives the previous version and inserts a new row, so the active row's own
-    // `createdAt` is the date of the last edit. Reading that would make editing an agent postpone its
-    // archival, contradicting the rule that editing is not activity. What counts is the first version.
+    // Reading the active row's own `createdAt` would make editing an agent postpone its archival.
     const { authenticator } = await createResourceTest({ role: "admin" });
     const agent = await createAgedAgent(authenticator, {
       name: "Edited yesterday",
@@ -165,8 +162,7 @@ describe("fetchInactiveAgents", () => {
   });
 
   it("excludes an agent created after the cutoff, however unused", async () => {
-    // The threshold measures disuse. An agent that has not existed long enough to be used has not
-    // been disused, and archiving it the night it was built is the bug this guards.
+    // Archiving an agent the night it was built is the bug this guards.
     const { authenticator } = await createResourceTest({ role: "admin" });
     await createAgedAgent(authenticator, {
       name: "Brand new",
@@ -202,14 +198,11 @@ describe("fetchInactiveAgents", () => {
       page: { cursor: firstPage.nextCursor, limit: 2 },
     });
     expect(secondPage.agents).toHaveLength(1);
-    // A short page means the workspace is exhausted.
     expect(secondPage.nextCursor).toBeNull();
 
     const firstPageIds = firstPage.agents.map(({ agentId }) => agentId);
     const secondPageIds = secondPage.agents.map(({ agentId }) => agentId);
 
-    // Resuming excludes everything at or before the cursor, and the two pages together cover the
-    // workspace exactly once.
     expect(secondPageIds).not.toContain(firstPage.nextCursor);
     expect(
       secondPageIds.every((agentId) => !firstPageIds.includes(agentId))
@@ -224,7 +217,7 @@ describe("fetchInactiveAgents", () => {
   });
 
   it("returns an empty page for a limit of zero", async () => {
-    // The lookahead finds a candidate, so a cursor read off the page has no element to read.
+    // The lookahead finds a candidate, so a cursor read off the empty page has no element to read.
     const { authenticator } = await createResourceTest({ role: "admin" });
     await createAgedAgent(authenticator, {
       name: "Out of budget",

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.test.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.test.ts
@@ -240,6 +240,26 @@ describe("fetchInactiveAgents", () => {
     expect(page.nextCursor).toBeNull();
   });
 
+  it("never returns a global agent, whatever its mentions", async () => {
+    // Global agents have no row in `agent_configurations`, which is what the query selects from
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent = await createAgedAgent(authenticator, {
+      name: "Idle custom agent",
+      createdAt: daysBeforeCutoff(90),
+    });
+    await MentionFactory.agentMentionedAt(authenticator, {
+      agentId: "dust",
+      mentionedAt: daysBeforeCutoff(90),
+    });
+
+    const page = await fetchInactiveAgents(authenticator, {
+      cutoffAt: CUTOFF_AT,
+      page: { cursor: null, limit: 50 },
+    });
+
+    expect(page.agents.map(({ agentId }) => agentId)).toEqual([agent.sId]);
+  });
+
   it("does not return another workspace's agents", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const other = await createResourceTest({ role: "admin" });

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
@@ -1,3 +1,4 @@
+import { fetchFirstVersionCreatedAtByAgentId } from "@app/lib/api/assistant/configuration/agent";
 import type { AgentInactivitySnapshot } from "@app/lib/api/assistant/inactivity/policy";
 import type { Authenticator } from "@app/lib/auth";
 import { MentionResource } from "@app/lib/resources/mention_resource";
@@ -12,11 +13,6 @@ import { MentionResource } from "@app/lib/resources/mention_resource";
  * Status and triggers deliberately do not come from here — `fetchArchivalFacts` in the caller is the
  * permission-filtered read and the authority on those.
  */
-
-// TODO(2026-08-19 INACTIVE_AGENT_ARCHIVAL): run EXPLAIN (ANALYZE, BUFFERS) before enabling the
-// nightly workflow. Measured volumetry suggests nothing is needed — worst workspace ~7.3k active
-// agents, ~5.2k candidates at 30 days, two index seeks per agent — and the suspected bottleneck is the
-// `ORDER BY "sId"` sort, since no index covers (workspaceId, status, "sId"). Measure before adding it.
 
 /** The part of a snapshot this provides; derived so the two cannot drift. */
 export type InactiveAgentCandidate = Pick<
@@ -48,21 +44,34 @@ export interface InactiveAgentsPage {
 
 export async function fetchInactiveAgents(
   auth: Authenticator,
-  { cutoffAt, page: { cursor, limit } }: InactiveAgentsFetchInput
+  { cutoffAt, page }: InactiveAgentsFetchInput
 ): Promise<InactiveAgentsPage> {
-  const candidates = await MentionResource.listAgentsNotMentionedSince(auth, {
+  const idleAgents = await MentionResource.listAgentsNotMentionedSince(auth, {
     notMentionedSince: cutoffAt,
-    cursor,
-    // One extra row, to tell "this page is full" apart from "there is more after it".
-    limit: limit + 1,
   });
 
-  const hasMore = candidates.length > limit;
-  const agents = hasMore ? candidates.slice(0, limit) : candidates;
+  // The slice bounds what the caller mutates; the cursor steps past agents the rules keep refusing.
+  const { cursor, limit } = page;
+  const fromCursor = cursor
+    ? idleAgents.filter(({ agentId }) => agentId > cursor)
+    : idleAgents;
 
-  // From the last agent, not the page length: with `limit: 0` the lookahead still finds a candidate.
-  const lastAgent = agents.at(-1);
-  const nextCursor = hasMore && lastAgent ? lastAgent.agentId : null;
+  const hasMore = fromCursor.length > limit;
+  const pageAgents = fromCursor.slice(0, limit);
+
+  const createdAtByAgentId = await fetchFirstVersionCreatedAtByAgentId(
+    auth,
+    pageAgents.map(({ agentId }) => agentId)
+  );
+
+  // No first-version date: skip, rather than archive on a date we could not establish.
+  const agents = pageAgents.flatMap(({ agentId, lastMentionedAt }) => {
+    const createdAt = createdAtByAgentId.get(agentId);
+
+    return createdAt ? [{ agentId, createdAt, lastMentionedAt }] : [];
+  });
+
+  const nextCursor = hasMore ? pageAgents[pageAgents.length - 1].agentId : null;
 
   return { agents, nextCursor };
 }

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
@@ -1,0 +1,68 @@
+import type { AgentInactivitySnapshot } from "@app/lib/api/assistant/inactivity/policy";
+import type { Authenticator } from "@app/lib/auth";
+import { MentionResource } from "@app/lib/resources/mention_resource";
+
+/**
+ * Loads one page of a workspace's agents that have not been mentioned since the cutoff.
+ *
+ * The query is `MentionResource`'s; this owns the paging. One row beyond `limit` is fetched and
+ * dropped, so `nextCursor` is non-null only when another candidate exists rather than whenever a page
+ * happens to be full.
+ *
+ * Status and triggers deliberately do not come from here — `fetchArchivalFacts` in the caller is the
+ * permission-filtered read and the authority on those.
+ */
+
+// TODO(2026-08-19 INACTIVE_AGENT_ARCHIVAL): run EXPLAIN (ANALYZE, BUFFERS) before enabling the
+// nightly workflow. Measured volumetry suggests nothing is needed — worst workspace ~7.3k active
+// agents, ~5.2k candidates at 30 days, two index seeks per agent — and the suspected bottleneck is the
+// `ORDER BY "sId"` sort, since no index covers (workspaceId, status, "sId"). Measure before adding it.
+
+/** The part of a snapshot this provides; derived so the two cannot drift. */
+export type InactiveAgentCandidate = Pick<
+  AgentInactivitySnapshot,
+  "agentId" | "createdAt" | "lastMentionedAt"
+>;
+
+/**
+ * Where to resume and how much to take. Infrastructure, not policy: `policy.ts` does not know it
+ * exists. It is here so a Temporal workflow can walk a large workspace one durable step at a time.
+ */
+export interface AgentPageBound {
+  // Last agent id of the previous page, or null to start from the beginning.
+  cursor: string | null;
+  limit: number;
+}
+
+export interface InactiveAgentsFetchInput {
+  // Resolved once per operation by `computeInactivityCutoffAt`.
+  cutoffAt: Date;
+  page: AgentPageBound;
+}
+
+export interface InactiveAgentsPage {
+  agents: InactiveAgentCandidate[];
+  // Null once the workspace is exhausted.
+  nextCursor: string | null;
+}
+
+export async function fetchInactiveAgents(
+  auth: Authenticator,
+  { cutoffAt, page: { cursor, limit } }: InactiveAgentsFetchInput
+): Promise<InactiveAgentsPage> {
+  const candidates = await MentionResource.listAgentsNotMentionedSince(auth, {
+    notMentionedSince: cutoffAt,
+    cursor,
+    // One extra row, to tell "this page is full" apart from "there is more after it".
+    limit: limit + 1,
+  });
+
+  const hasMore = candidates.length > limit;
+  const agents = hasMore ? candidates.slice(0, limit) : candidates;
+
+  // From the last agent, not the page length: with `limit: 0` the lookahead still finds a candidate.
+  const lastAgent = agents.at(-1);
+  const nextCursor = hasMore && lastAgent ? lastAgent.agentId : null;
+
+  return { agents, nextCursor };
+}

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
@@ -4,14 +4,12 @@ import type { Authenticator } from "@app/lib/auth";
 import { MentionResource } from "@app/lib/resources/mention_resource";
 
 /**
- * Loads one page of a workspace's agents that have not been mentioned since the cutoff.
+ * Loads one page of a workspace's agents that have not been mentioned since the cutoff. One row
+ * beyond `limit` is read and dropped, so `nextCursor` is non-null only when another candidate
+ * exists rather than whenever a page happens to be full.
  *
- * The query is `MentionResource`'s; this owns the paging. One row beyond `limit` is fetched and
- * dropped, so `nextCursor` is non-null only when another candidate exists rather than whenever a page
- * happens to be full.
- *
- * Status and triggers deliberately do not come from here — `fetchArchivalFacts` in the caller is the
- * permission-filtered read and the authority on those.
+ * Status and triggers deliberately do not come from here — `fetchArchivalFacts` in the caller is
+ * the permission-filtered read and the authority on those.
  */
 
 /** The part of a snapshot this provides; derived so the two cannot drift. */
@@ -21,8 +19,8 @@ export type InactiveAgentCandidate = Pick<
 >;
 
 /**
- * Where to resume and how much to take. Infrastructure, not policy: `policy.ts` does not know it
- * exists. It is here so a Temporal workflow can walk a large workspace one durable step at a time.
+ * Infrastructure, not policy: it is here so a Temporal workflow can walk a large workspace one
+ * durable step at a time.
  */
 export interface AgentPageBound {
   // Last agent id of the previous page, or null to start from the beginning.
@@ -31,7 +29,6 @@ export interface AgentPageBound {
 }
 
 export interface InactiveAgentsFetchInput {
-  // Resolved once per operation by `computeInactivityCutoffAt`.
   cutoffAt: Date;
   page: AgentPageBound;
 }
@@ -50,7 +47,7 @@ export async function fetchInactiveAgents(
     notMentionedSince: cutoffAt,
   });
 
-  // The slice bounds what the caller mutates; the cursor steps past agents the rules keep refusing.
+  // The cursor steps past agents the rules keep refusing, so a driver terminates.
   const { cursor, limit } = page;
   const fromCursor = cursor
     ? idleAgents.filter(({ agentId }) => agentId > cursor)

--- a/front/lib/api/assistant/inactivity/policy.test.ts
+++ b/front/lib/api/assistant/inactivity/policy.test.ts
@@ -40,7 +40,6 @@ function daysBeforeEvaluation(days: number): Date {
   return new Date(EVALUATED_AT.getTime() - days * ONE_DAY_MS);
 }
 
-/** The cutoff for the 30-day threshold, which every eligibility test below evaluates against. */
 function cutoffFor(thresholdDays: number): Date {
   const cutoffRes = computeInactivityCutoffAt({
     thresholdDays,
@@ -80,7 +79,6 @@ describe("computeInactivityCutoffAt", () => {
   });
 
   it("ignores the time of day, so every run on one date shares a cutoff", () => {
-    // A nightly job at 02:00 and an admin previewing at 17:00 must judge every agent identically.
     const nightly = computeInactivityCutoffAt({
       thresholdDays: THRESHOLD_30_DAYS,
       evaluatedAt: new Date("2026-08-18T02:00:00.000Z"),
@@ -121,11 +119,10 @@ describe("computeInactivityCutoffAt", () => {
       2.5,
       NaN,
       Infinity,
-      // A year is fine; a decade is a typo that would silently archive nothing forever.
       MAX_INACTIVITY_THRESHOLD_DAYS + 1,
       3650,
-      // Large enough that the cutoff arithmetic overflows to an Invalid Date, which
-      // `Number.isInteger` alone would have let through and bound straight into SQL.
+      // Overflows the cutoff arithmetic to an Invalid Date, which `Number.isInteger` alone would
+      // have let through and bound straight into SQL.
       Number.MAX_SAFE_INTEGER,
     ];
 
@@ -154,8 +151,7 @@ describe("computeInactivityCutoffAt", () => {
 
 describe("evaluateAgentArchivalEligibility", () => {
   it("keeps an agent created after the cutoff, however unused", () => {
-    // A young agent has not existed long enough to have fallen out of use. Without this rule the
-    // first nightly run after somebody builds an agent archives it.
+    // Without this rule the first nightly run after somebody builds an agent archives it.
     expect(
       evaluateAgentArchivalEligibility({
         agent: agent({
@@ -246,9 +242,7 @@ describe("evaluateAgentArchivalEligibility", () => {
     });
 
     it("exempts an agent whose schedule Dust paused, not the workspace", () => {
-      // Workspace relocation and plan downgrade flip every enabled trigger of a workspace in bulk.
-      // Reading those as "no schedule" would archive every scheduled agent of a workspace that
-      // happens to be mid-relocation.
+      // Relocation and plan downgrade flip every enabled trigger of a workspace in bulk.
       const dustPausedStatuses: TriggerStatus[] = ["relocating", "downgraded"];
 
       for (const status of dustPausedStatuses) {
@@ -313,8 +307,8 @@ describe("evaluateAgentArchivalEligibility", () => {
   });
 
   it("does not exempt an agent that only has pending wake-ups", () => {
-    // Wake-ups are a delayed continuation of one conversation, not a durable automation, so they are
-    // not represented in the snapshot at all: an inactive agent stays eligible.
+    // A wake-up continues one conversation rather than driving the agent, so it is not in the
+    // snapshot at all.
     expect(
       evaluateAgentArchivalEligibility({
         agent: agent({
@@ -327,8 +321,7 @@ describe("evaluateAgentArchivalEligibility", () => {
   });
 
   it("excludes agents that are not active", () => {
-    // `disabled_by_admin`, `disabled_missing_datasource` and `disabled_free_workspace` only ever
-    // belong to global agents: a workspace policy has no business retiring an agent it does not own.
+    // The `disabled_*` statuses only ever belong to global agents, which a workspace does not own.
     const nonActiveStatuses: AgentConfigurationStatus[] = [
       "archived",
       "draft",
@@ -349,8 +342,7 @@ describe("evaluateAgentArchivalEligibility", () => {
   });
 
   it("reports the status exclusion before any activity-based reason", () => {
-    // An already-archived agent must never read as "recently used": a repeated run has to be a
-    // no-op for the same machine-readable reason every time.
+    // A repeated run has to be a no-op for the same machine-readable reason every time.
     expect(
       evaluateAgentArchivalEligibility({
         agent: agent({
@@ -377,8 +369,6 @@ describe("evaluateAgentArchivalEligibility", () => {
       lastMentionedAt: daysBeforeEvaluation(30),
     });
 
-    // Same agent, same cutoff: same decision. Evaluated a day later — i.e. against a cutoff that has
-    // moved past its last mention — the very same snapshot becomes eligible.
     expect(
       evaluateAgentArchivalEligibility({
         agent: snapshot,

--- a/front/lib/api/assistant/inactivity/policy.ts
+++ b/front/lib/api/assistant/inactivity/policy.ts
@@ -5,49 +5,23 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
- * Business rules for the "automatically archive inactive agents" feature.
- *
- * This module is deliberately pure: no database, no Temporal, no HTTP, no Authenticator. It only
- * answers one question — "given what we know about a logical agent, is it eligible for automatic
- * archival?" — so that the manual (synchronous API) path and the nightly (Temporal) path share the
- * exact same decision and can both be tested without infrastructure.
- *
- * The rules:
- *
- * - Opt-in per workspace : no threshold configured, nothing archived. There is no default.
- * - Threshold between 2 and 366 days : a whole number of days; anything else archives nothing.
- * - Mentions are the only activity : any mention resets it, whatever became of the run it started.
- * - Creating or editing an agent is not activity : only being reached for counts. Editing in
- *   particular must not push archival back, so what counts is when the agent first appeared, not
- *   when its current version was written.
- * - An agent must predate the cutoff : one created inside the window has not existed long enough to
- *   have fallen out of use, whatever its mentions say.
- * - Inactive means last mentioned before the cutoff : never mentioned counts as inactive.
- * - Only active agents are archivable : archived, draft and pending ones are left alone.
- * - Schedules are exempt : never archive an agent a schedule still drives, whatever its frequency —
- *   including one Dust itself paused (relocation, plan downgrade), which the workspace never chose
- *   to stop.
- * - Wake-ups are not exempt : a pending wake-up does not protect an agent, and archiving cancels it.
- *
- * Archival itself goes through the existing `archiveAgentConfiguration` primitive, which owns every
- * side effect (trigger disabling, wake-up cancellation, editor group suspension, audit event).
+ * Pure business rules for automatic archival of inactive agents: no database, no Temporal, no
+ * Authenticator, so the manual and nightly paths share one decision and both stay testable without
+ * infrastructure.
  */
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
-// Archiving after a single day of inactivity is never a legitimate policy: it would archive agents
-// used weekly, or an agent created over a weekend. Two days is the product-agreed floor.
+// One day would archive agents used weekly, or created over a weekend. Two is the agreed floor.
 export const MIN_INACTIVITY_THRESHOLD_DAYS = 2;
 
-// A year and a leap day. Guards a typo (3650 for 365), which would silently archive nothing forever,
-// and a value large enough to overflow the cutoff arithmetic into an Invalid Date.
+// A year and a leap day. Guards a 3650-for-365 typo, and values large enough to overflow the cutoff
+// arithmetic into an Invalid Date.
 export const MAX_INACTIVITY_THRESHOLD_DAYS = 366;
-
-type AgentInactivityPolicyErrorType = "invalid_threshold";
 
 export class AgentInactivityPolicyError extends Error {
   constructor(
-    readonly type: AgentInactivityPolicyErrorType,
+    readonly type: "invalid_threshold",
     message: string
   ) {
     super(message);
@@ -55,8 +29,7 @@ export class AgentInactivityPolicyError extends Error {
 }
 
 export interface AgentInactivityCutoffInput {
-  // The workspace-level threshold, owned by the workspace and configured in Governance. Always
-  // explicit — there is no fallback value in this module.
+  // Configured in Governance. Always explicit: this module has no default.
   thresholdDays: number;
   evaluatedAt: Date;
 }
@@ -69,13 +42,12 @@ export type AgentInactivityCutoffResult = Result<
 /** One logical agent — the stable `sId`, not a configuration version. */
 export interface AgentInactivitySnapshot {
   agentId: string;
-  // The earliest version's creation, not the active row's: upgrading inserts a new row, so the
-  // active row's date is the last edit, and editing must not postpone archival.
+  // The earliest version's date: upgrading inserts a new row, and editing must not postpone
+  // archival.
   createdAt: Date;
-  // Null means never mentioned.
   lastMentionedAt: Date | null;
   status: AgentConfigurationStatus;
-  // All of them. Which ones protect the agent is `doesTriggerPreventArchival`'s call.
+  // All of them: `doesTriggerPreventArchival` decides which protect.
   triggers: AgentTriggerSnapshot[];
 }
 
@@ -97,13 +69,10 @@ export type AgentArchivalEligibility =
 
 export interface AgentArchivalEvaluationInput {
   agent: AgentInactivitySnapshot;
-  // Resolved once per operation by `computeInactivityCutoffAt` and shared by every agent of that
-  // operation, so the cutoff cannot drift mid-batch.
+  // Shared by every agent of one operation, so the cutoff cannot drift mid-batch.
   cutoffAt: Date;
 }
 
-// Module-private: callers validate a threshold by resolving a cutoff from it, so there is one way to
-// be told a policy is unusable.
 function isValidInactivityThresholdDays(thresholdDays: number): boolean {
   return (
     Number.isInteger(thresholdDays) &&
@@ -113,11 +82,9 @@ function isValidInactivityThresholdDays(thresholdDays: number): boolean {
 }
 
 /**
- * The day an agent must have been inactive since to be archivable.
- *
- * A day boundary rather than an instant, because the threshold is in whole days: a nightly run at
- * 02:00 and an admin previewing at 17:00 then judge every agent identically, and truncating downwards
- * only ever grants more grace than asked for.
+ * The day an agent must have been inactive since to be archivable. Truncated to the UTC day so a
+ * 02:00 nightly run and a 17:00 preview judge every agent identically, and only ever grant more
+ * grace than asked for.
  */
 export function computeInactivityCutoffAt({
   thresholdDays,
@@ -140,7 +107,6 @@ export function computeInactivityCutoffAt({
   return new Ok(cutoffAt);
 }
 
-/** Only `active` agents are candidates. Drafts, pending and already-archived agents are not. */
 function isArchivableStatus(status: AgentConfigurationStatus): boolean {
   switch (status) {
     case "active":
@@ -159,11 +125,8 @@ function isArchivableStatus(status: AgentConfigurationStatus): boolean {
 
 /**
  * Only schedules protect an agent: they drive it on their own, so one nobody mentions can still run
- * every night.
- *
- * Protection drops only on a status the workspace itself chose. `relocating` and `downgraded` are set
- * in bulk by Dust on triggers meant to be enabled again, so reading them as "no schedule" would
- * archive every scheduled agent of a workspace mid-relocation.
+ * every night. `relocating` and `downgraded` are set in bulk by Dust on triggers meant to be enabled
+ * again, so reading them as "no schedule" would archive every scheduled agent mid-relocation.
  */
 export function doesTriggerPreventArchival({
   kind,
@@ -175,7 +138,6 @@ export function doesTriggerPreventArchival({
 
   switch (status) {
     case "enabled":
-    // Paused by Dust and not by the workspace: the schedule is expected to resume.
     case "relocating":
     case "downgraded":
       return true;
@@ -190,10 +152,6 @@ export function doesTriggerPreventArchival({
 /**
  * Decides whether one logical agent is eligible for automatic archival, against a cutoff already
  * resolved by `computeInactivityCutoffAt`.
- *
- * Both branches are legitimate business outcomes, so this returns a decision rather than a
- * `Result`: "not eligible" is an answer, not a failure. Exclusions are ordered from the cheapest and
- * most decisive check to the activity comparison.
  */
 export function evaluateAgentArchivalEligibility({
   agent,
@@ -213,8 +171,8 @@ export function evaluateAgentArchivalEligibility({
     };
   }
 
-  // Checked before the mentions, because a young agent is protected whatever they say: one created
-  // inside the window has not existed long enough to have fallen out of use.
+  // Before the mentions: a young agent has not existed long enough to have fallen out of use,
+  // whatever they say.
   if (agent.createdAt.getTime() >= cutoffAt.getTime()) {
     return {
       eligible: false,
@@ -222,13 +180,13 @@ export function evaluateAgentArchivalEligibility({
     };
   }
 
-  // Never mentioned: nothing has ever reset inactivity, so the agent is inactive.
+  // Never mentioned counts as inactive.
   if (!agent.lastMentionedAt) {
     return { eligible: true };
   }
 
-  // Strictly before the cutoff. A mention landing exactly on the cutoff counts as recent, so a
-  // threshold of N days always leaves a full N days of grace.
+  // Strict: a mention landing exactly on the cutoff counts as recent, so a threshold of N days
+  // always leaves a full N days of grace.
   if (agent.lastMentionedAt.getTime() < cutoffAt.getTime()) {
     return { eligible: true };
   }

--- a/front/lib/resources/mention_resource.ts
+++ b/front/lib/resources/mention_resource.ts
@@ -14,10 +14,9 @@ import type {
 } from "sequelize";
 import { QueryTypes } from "sequelize";
 
-/** One agent, with the two dates the archival rules compare against a cutoff. */
+/** One agent and when it was last mentioned, null if it never was. */
 export interface AgentIdleRow {
   agentId: string;
-  createdAt: Date;
   lastMentionedAt: Date | null;
 }
 
@@ -28,36 +27,24 @@ function isAgentIdleRow(row: unknown): row is AgentIdleRow {
     return false;
   }
 
-  if (
-    !("agentId" in row) ||
-    !("createdAt" in row) ||
-    !("lastMentionedAt" in row)
-  ) {
+  if (!("agentId" in row) || !("lastMentionedAt" in row)) {
     return false;
   }
 
   return (
     typeof row.agentId === "string" &&
-    row.createdAt instanceof Date &&
     (row.lastMentionedAt === null || row.lastMentionedAt instanceof Date)
   );
 }
 
 // Driven by the agents, with mentions as an anti-join: the set is defined by absence, and an agent
-// nobody ever mentioned has no row here to select. Hand-written because the query builder cannot
-// express an anti-join against an aggregate over another table.
+// nobody ever mentioned has no row here to select. The LATERAL reads one row per agent — the newest
+// mention — instead of every mention of every agent.
 const AGENTS_NOT_MENTIONED_SINCE_QUERY = `
   SELECT
     agent."sId" AS "agentId",
-    first_version."createdAt" AS "createdAt",
     last_mention."lastMentionedAt" AS "lastMentionedAt"
   FROM agent_configurations agent
-  JOIN LATERAL (
-    SELECT MIN(version_row."createdAt") AS "createdAt"
-    FROM agent_configurations version_row
-    WHERE version_row."workspaceId" = agent."workspaceId"
-      AND version_row."sId" = agent."sId"
-  ) first_version ON true
   LEFT JOIN LATERAL (
     SELECT MAX(mention."createdAt") AS "lastMentionedAt"
     FROM mentions mention
@@ -66,14 +53,11 @@ const AGENTS_NOT_MENTIONED_SINCE_QUERY = `
   ) last_mention ON true
   WHERE agent."workspaceId" = $workspaceId
     AND agent.status = 'active'
-    AND first_version."createdAt" < $notMentionedSince
-    AND ($cursor::text IS NULL OR agent."sId" > $cursor)
     AND (
       last_mention."lastMentionedAt" IS NULL
       OR last_mention."lastMentionedAt" < $notMentionedSince
     )
   ORDER BY agent."sId"
-  LIMIT $limit
 `;
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -100,27 +84,16 @@ export class MentionResource extends BaseResource<MentionModel> {
   }
 
   /**
-   * The workspace's active agents not mentioned since `notMentionedSince`, keyed from `cursor`, with
-   * when each was last mentioned. Every mention counts whatever its `status` or `dismissed` flag —
-   * somebody reached for the agent.
+   * The workspace's active agents not mentioned since `notMentionedSince`, with when each last was.
    *
-   * Also filters on `status = 'active'` (which leaves exactly one row per logical agent) and on the
-   * agent having first appeared before the cutoff. Both stay *broader or equal* to the rules in
-   * `lib/api/assistant/inactivity/policy.ts`, which remain the authority.
+   * Global agents cannot appear: they have no row in `agent_configurations`, which is what stops a
+   * workspace policy from archiving one. Every mention counts, whatever its status.
    */
   static async listAgentsNotMentionedSince(
     auth: Authenticator,
-    {
-      notMentionedSince,
-      cursor,
-      limit,
-    }: {
-      notMentionedSince: Date;
-      cursor: string | null;
-      limit: number;
-    }
+    { notMentionedSince }: { notMentionedSince: Date }
   ): Promise<AgentIdleRow[]> {
-    // biome-ignore lint/plugin/noRawSql: an anti-join the query builder cannot express, see above.
+    // biome-ignore lint/plugin/noRawSql: needs a LATERAL, which the query builder cannot express.
     const rows: unknown[] = await frontSequelize.query(
       AGENTS_NOT_MENTIONED_SINCE_QUERY,
       {
@@ -128,8 +101,6 @@ export class MentionResource extends BaseResource<MentionModel> {
         bind: {
           workspaceId: auth.getNonNullableWorkspace().id,
           notMentionedSince,
-          cursor,
-          limit,
         },
       }
     );

--- a/front/lib/resources/mention_resource.ts
+++ b/front/lib/resources/mention_resource.ts
@@ -14,14 +14,12 @@ import type {
 } from "sequelize";
 import { QueryTypes } from "sequelize";
 
-/** One agent and when it was last mentioned, null if it never was. */
 export interface AgentIdleRow {
   agentId: string;
   lastMentionedAt: Date | null;
 }
 
-// Narrowed rather than asserted, per [GEN4]. A row that fails is dropped, costing a missed candidate
-// rather than a malformed one.
+// Narrowed rather than asserted, per [GEN4]. A failing row is dropped rather than trusted.
 function isAgentIdleRow(row: unknown): row is AgentIdleRow {
   if (typeof row !== "object" || row === null) {
     return false;
@@ -36,29 +34,6 @@ function isAgentIdleRow(row: unknown): row is AgentIdleRow {
     (row.lastMentionedAt === null || row.lastMentionedAt instanceof Date)
   );
 }
-
-// Driven by the agents, with mentions as an anti-join: the set is defined by absence, and an agent
-// nobody ever mentioned has no row here to select. The LATERAL reads one row per agent — the newest
-// mention — instead of every mention of every agent.
-const AGENTS_NOT_MENTIONED_SINCE_QUERY = `
-  SELECT
-    agent."sId" AS "agentId",
-    last_mention."lastMentionedAt" AS "lastMentionedAt"
-  FROM agent_configurations agent
-  LEFT JOIN LATERAL (
-    SELECT MAX(mention."createdAt") AS "lastMentionedAt"
-    FROM mentions mention
-    WHERE mention."workspaceId" = agent."workspaceId"
-      AND mention."agentConfigurationId" = agent."sId"
-  ) last_mention ON true
-  WHERE agent."workspaceId" = $workspaceId
-    AND agent.status = 'active'
-    AND (
-      last_mention."lastMentionedAt" IS NULL
-      OR last_mention."lastMentionedAt" < $notMentionedSince
-    )
-  ORDER BY agent."sId"
-`;
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -85,17 +60,35 @@ export class MentionResource extends BaseResource<MentionModel> {
 
   /**
    * The workspace's active agents not mentioned since `notMentionedSince`, with when each last was.
-   *
-   * Global agents cannot appear: they have no row in `agent_configurations`, which is what stops a
-   * workspace policy from archiving one. Every mention counts, whatever its status.
+   * Global agents cannot appear: they have no row in `agent_configurations`. Every mention counts,
+   * whatever its status.
    */
   static async listAgentsNotMentionedSince(
     auth: Authenticator,
     { notMentionedSince }: { notMentionedSince: Date }
   ): Promise<AgentIdleRow[]> {
+    // Driven by the agents, of which there are far fewer than mentions.
     // biome-ignore lint/plugin/noRawSql: needs a LATERAL, which the query builder cannot express.
     const rows: unknown[] = await frontSequelize.query(
-      AGENTS_NOT_MENTIONED_SINCE_QUERY,
+      `
+        SELECT
+          agent."sId" AS "agentId",
+          last_mention."lastMentionedAt" AS "lastMentionedAt"
+        FROM agent_configurations agent
+        LEFT JOIN LATERAL (
+          SELECT MAX(mention."createdAt") AS "lastMentionedAt"
+          FROM mentions mention
+          WHERE mention."workspaceId" = agent."workspaceId"
+            AND mention."agentConfigurationId" = agent."sId"
+        ) last_mention ON true
+        WHERE agent."workspaceId" = $workspaceId
+          AND agent.status = 'active'
+          AND (
+            last_mention."lastMentionedAt" IS NULL
+            OR last_mention."lastMentionedAt" < $notMentionedSince
+          )
+        ORDER BY agent."sId"
+      `,
       {
         type: QueryTypes.SELECT,
         bind: {

--- a/front/lib/resources/mention_resource.ts
+++ b/front/lib/resources/mention_resource.ts
@@ -1,0 +1,154 @@
+import type { Authenticator } from "@app/lib/auth";
+import { MentionModel } from "@app/lib/models/agent/conversation";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { frontSequelize } from "@app/lib/resources/storage";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+  WhereOptions,
+} from "sequelize";
+import { QueryTypes } from "sequelize";
+
+/** One agent, with the two dates the archival rules compare against a cutoff. */
+export interface AgentIdleRow {
+  agentId: string;
+  createdAt: Date;
+  lastMentionedAt: Date | null;
+}
+
+// Narrowed rather than asserted, per [GEN4]. A row that fails is dropped, costing a missed candidate
+// rather than a malformed one.
+function isAgentIdleRow(row: unknown): row is AgentIdleRow {
+  if (typeof row !== "object" || row === null) {
+    return false;
+  }
+
+  if (
+    !("agentId" in row) ||
+    !("createdAt" in row) ||
+    !("lastMentionedAt" in row)
+  ) {
+    return false;
+  }
+
+  return (
+    typeof row.agentId === "string" &&
+    row.createdAt instanceof Date &&
+    (row.lastMentionedAt === null || row.lastMentionedAt instanceof Date)
+  );
+}
+
+// Driven by the agents, with mentions as an anti-join: the set is defined by absence, and an agent
+// nobody ever mentioned has no row here to select. Hand-written because the query builder cannot
+// express an anti-join against an aggregate over another table.
+const AGENTS_NOT_MENTIONED_SINCE_QUERY = `
+  SELECT
+    agent."sId" AS "agentId",
+    first_version."createdAt" AS "createdAt",
+    last_mention."lastMentionedAt" AS "lastMentionedAt"
+  FROM agent_configurations agent
+  JOIN LATERAL (
+    SELECT MIN(version_row."createdAt") AS "createdAt"
+    FROM agent_configurations version_row
+    WHERE version_row."workspaceId" = agent."workspaceId"
+      AND version_row."sId" = agent."sId"
+  ) first_version ON true
+  LEFT JOIN LATERAL (
+    SELECT MAX(mention."createdAt") AS "lastMentionedAt"
+    FROM mentions mention
+    WHERE mention."workspaceId" = agent."workspaceId"
+      AND mention."agentConfigurationId" = agent."sId"
+  ) last_mention ON true
+  WHERE agent."workspaceId" = $workspaceId
+    AND agent.status = 'active'
+    AND first_version."createdAt" < $notMentionedSince
+    AND ($cursor::text IS NULL OR agent."sId" > $cursor)
+    AND (
+      last_mention."lastMentionedAt" IS NULL
+      OR last_mention."lastMentionedAt" < $notMentionedSince
+    )
+  ORDER BY agent."sId"
+  LIMIT $limit
+`;
+
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface MentionResource extends ReadonlyAttributesType<MentionModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class MentionResource extends BaseResource<MentionModel> {
+  static model: ModelStatic<MentionModel> = MentionModel;
+
+  constructor(
+    model: ModelStatic<MentionModel>,
+    blob: Attributes<MentionModel>
+  ) {
+    super(MentionModel, blob);
+  }
+
+  static async makeNew(
+    blob: CreationAttributes<MentionModel>,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<MentionResource> {
+    const mention = await this.model.create(blob, { transaction });
+
+    return new this(this.model, mention.get());
+  }
+
+  /**
+   * The workspace's active agents not mentioned since `notMentionedSince`, keyed from `cursor`, with
+   * when each was last mentioned. Every mention counts whatever its `status` or `dismissed` flag —
+   * somebody reached for the agent.
+   *
+   * Also filters on `status = 'active'` (which leaves exactly one row per logical agent) and on the
+   * agent having first appeared before the cutoff. Both stay *broader or equal* to the rules in
+   * `lib/api/assistant/inactivity/policy.ts`, which remain the authority.
+   */
+  static async listAgentsNotMentionedSince(
+    auth: Authenticator,
+    {
+      notMentionedSince,
+      cursor,
+      limit,
+    }: {
+      notMentionedSince: Date;
+      cursor: string | null;
+      limit: number;
+    }
+  ): Promise<AgentIdleRow[]> {
+    // biome-ignore lint/plugin/noRawSql: an anti-join the query builder cannot express, see above.
+    const rows: unknown[] = await frontSequelize.query(
+      AGENTS_NOT_MENTIONED_SINCE_QUERY,
+      {
+        type: QueryTypes.SELECT,
+        bind: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          notMentionedSince,
+          cursor,
+          limit,
+        },
+      }
+    );
+
+    return rows.filter(isAgentIdleRow);
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<number, Error>> {
+    const deletedCount = await MentionModel.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      } as WhereOptions<MentionModel>,
+      transaction,
+    });
+
+    return new Ok(deletedCount);
+  }
+}

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -1,5 +1,6 @@
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
+import { frontSequelize } from "@app/lib/resources/storage";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ModelIdType,
@@ -125,5 +126,29 @@ export class AgentConfigurationFactory {
       instructionsHtml: overrides.instructionsHtml ?? null,
       actions: [],
     };
+  }
+
+  /**
+   * Backdates an agent's creation, for features that treat a young agent differently from an old one.
+   *
+   * Sequelize suppresses explicitly-provided values for managed timestamp fields, so raw SQL is the
+   * only reliable way to do this — same reason as `ConversationFactory.setUpdatedAtForTest`.
+   */
+  static async setCreatedAtForTest(
+    auth: Authenticator,
+    agentId: string,
+    createdAt: Date
+  ): Promise<void> {
+    // biome-ignore lint/plugin/noRawSql: managed timestamps cannot be set through the model
+    await frontSequelize.query(
+      `UPDATE agent_configurations SET "createdAt" = :createdAt WHERE "sId" = :agentId AND "workspaceId" = :workspaceId`,
+      {
+        replacements: {
+          createdAt: createdAt.toISOString(),
+          agentId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
   }
 }

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -1,6 +1,6 @@
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
-import { frontSequelize } from "@app/lib/resources/storage";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   ModelIdType,
@@ -128,24 +128,17 @@ export class AgentConfigurationFactory {
     };
   }
 
-  /**
-   * Backdates an agent's creation, for features that treat a young agent differently from an old one.
-   *
-   * Sequelize suppresses explicitly-provided values for managed timestamp fields, so raw SQL is the
-   * only reliable way to do this — same reason as `ConversationFactory.setUpdatedAtForTest`.
-   */
+  /** Backdates every version of an agent, for features that treat a young agent differently. */
   static async setCreatedAtForTest(
     auth: Authenticator,
     agentId: string,
     createdAt: Date
   ): Promise<void> {
-    // biome-ignore lint/plugin/noRawSql: managed timestamps cannot be set through the model
-    await frontSequelize.query(
-      `UPDATE agent_configurations SET "createdAt" = :createdAt WHERE "sId" = :agentId AND "workspaceId" = :workspaceId`,
+    await AgentConfigurationModel.update(
+      { createdAt },
       {
-        replacements: {
-          createdAt: createdAt.toISOString(),
-          agentId,
+        where: {
+          sId: agentId,
           workspaceId: auth.getNonNullableWorkspace().id,
         },
       }

--- a/front/tests/utils/MentionFactory.ts
+++ b/front/tests/utils/MentionFactory.ts
@@ -1,0 +1,49 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { MentionStatusType } from "@app/lib/models/agent/conversation";
+import { MentionResource } from "@app/lib/resources/mention_resource";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+
+export class MentionFactory {
+  /**
+   * Records that an agent was mentioned at a given time.
+   *
+   * A mention hangs off a message, so this creates the conversation and message it needs. Tests that
+   * only care about *when* an agent was last reached for should not have to say any of that.
+   */
+  static async agentMentionedAt(
+    auth: Authenticator,
+    {
+      agentId,
+      mentionedAt,
+      status = "approved",
+    }: {
+      agentId: string;
+      mentionedAt: Date;
+      status?: MentionStatusType;
+    }
+  ): Promise<MentionResource> {
+    const workspace = auth.getNonNullableWorkspace();
+
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentId,
+      messagesCreatedAt: [],
+      conversationCreatedAt: mentionedAt,
+    });
+
+    const { messageRow } = await ConversationFactory.createUserMessage({
+      auth,
+      workspace,
+      conversation,
+      content: `@agent`,
+      createdAt: mentionedAt,
+    });
+
+    return MentionResource.makeNew({
+      messageId: messageRow.id,
+      agentConfigurationId: agentId,
+      workspaceId: workspace.id,
+      status,
+      createdAt: mentionedAt,
+    });
+  }
+}

--- a/front/tests/utils/MentionFactory.ts
+++ b/front/tests/utils/MentionFactory.ts
@@ -5,10 +5,8 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 
 export class MentionFactory {
   /**
-   * Records that an agent was mentioned at a given time.
-   *
-   * A mention hangs off a message, so this creates the conversation and message it needs. Tests that
-   * only care about *when* an agent was last reached for should not have to say any of that.
+   * Records that an agent was mentioned at a given time. A mention hangs off a message, so this
+   * creates the conversation and message it needs.
    */
   static async agentMentionedAt(
     auth: Authenticator,


### PR DESCRIPTION
## Description

First brick of the opt-in "automatically archive inactive agents" feature: the business rules and the use case that applies them. No API, Temporal or Governance wiring yet — this only encodes and tests the agreed rules, plus the read path they run against.

- `inactivity/policy.ts`: domain rules. Threshold validation (integer, 2–366 days, no implicit default), cutoff resolution, per-agent eligibility (`agent_not_active`, `active_schedule`, `recent_creation`, `recent_mention`).
- `inactivity/archive_inactive_agents.ts`: the use case. Resolves the policy into a cutoff, fetches candidates, judges each against the rules, archives through the existing `archiveAgentConfiguration`.
- `inactivity/fetch_inactive_agents.ts` + `resources/mention_resource.ts`: the read path. Driven by the workspace's active agents, with mentions as an anti-join — an agent nobody ever mentioned has no row in `mentions` at all, so no query selecting from that table can return it.
- `configuration/agent.ts`: `fetchFirstVersionCreatedAtByAgentId`, batched lookup of an agent's earliest version.

An invalid threshold is returned as an `Err` for the whole operation rather than a per-agent exclusion, so a misconfigured workspace can never be mistaken for "no agent to archive".

Activity is read from mentions rather than agent messages: mention rows carry the stable agent `sId` with no configuration version, and `(workspaceId, agentConfigurationId, createdAt)` is already indexed. Any mention counts, whatever its status — a mention Dust blocked on space permissions still means somebody reached for the agent. Global agents can never be archived: they have no row in `agent_configurations`, which is what the read selects from.

An agent must also predate the cutoff, using the *first* version's `createdAt` rather than the active row's — upgrading an agent inserts a new row, so the active row's own date is the last edit, and reading that would let editing an agent postpone its archival.

## Performance

Two things measured on the read replica (workspace with 3,630 active agents, 809,715 mentions).

**Why the mentions read stays a hand-written `LATERAL` instead of a `GROUP BY` over a batched `IN`/`ANY` list.** Same index either way; the difference is that `GROUP BY` has to feed every row of a group to the aggregate (Postgres has no loose index scan), so it reads every mention of every agent instead of one row per agent.

<details>
<summary>EXPLAIN — LATERAL vs GROUP BY, same workspace and population</summary>

```
LATERAL (current):
  Index Only Scan ... rows=1 per agent
  3,630 rows scanned, 22,575 buffers, 1,080 ms

GROUP BY + ANY(array) batching:
  Index Only Scan ... rows=8,673 for a 100-agent batch (extrapolates to the full run)
  809,816 rows scanned, 510,266 buffers, 9,312 ms
```

On a workspace with few custom-agent mentions the two forms are roughly equivalent — the gap only opens once agents actually have mentions to aggregate over.
</details>

**A second `LATERAL` computing `MIN("createdAt")` for the agent's first version was the real cost — not the sort.** As a correlated subquery it made the planner build a `BitmapAnd` that re-scans the workspace's agents once per agent. Replaced with a batched `version = 0` lookup on the unique `(sId, version)` index.

<details>
<summary>EXPLAIN — before/after the version = 0 fix, same workspace</summary>

```
Before (MIN(createdAt) in a LATERAL):
  BitmapAnd ... rows=62,996 per agent, loops=3,630
  823,673 buffers, ~37 s

After (batched version = 0 lookup):
  Index Scan ... rows=1 per agent, loops=3,630
  18,013 buffers, 69 ms
```
</details>

Net effect: the full read went from ~845k buffers / 38.6s to ~40k buffers / ~1.15s on that workspace. The `ORDER BY "sId"` sort is negligible (quicksort, small memory), so no additional index is needed on `agent_configurations`.

## Tests

Domain and use-case unit tests, plus functional tests for the fetch and the executor through factories (`AgentConfigurationFactory`, `MentionFactory`, `TriggerFactory`).

## Risk

Not called from any endpoint or workflow yet — dead code path, no user-facing effect.

## Deploy Plan

None
