### PR TITLE
feat(triggers): govern who can charge a trigger to the workspace pool

### DIFF
--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -41,6 +41,7 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import type { WorkspaceSharingPolicy } from "@app/types/user";
 import {
   ActionFrame,
+  Clock,
   CloudArrowLeftRight,
   ContentMessage,
   Cube01,
@@ -83,6 +84,7 @@ function groupGovernancePermissionsBySection(
   skills: GovernancePermission[];
   frames: GovernancePermission[];
   billingAndSecurity: GovernancePermission[];
+  triggers: GovernancePermission[];
 } {
   const resolve = (specs: CapabilitySpec[]): GovernancePermission[] =>
     removeNulls(
@@ -94,6 +96,7 @@ function groupGovernancePermissionsBySection(
     skills: resolve(GOVERNANCE_CAPABILITIES.skill),
     frames: resolve(GOVERNANCE_CAPABILITIES.frame),
     billingAndSecurity: resolve(GOVERNANCE_CAPABILITIES.billingAndSecurity),
+    triggers: resolve(GOVERNANCE_CAPABILITIES.trigger),
   };
 }
 
@@ -117,7 +120,7 @@ export const GovernancePage = () => {
   const isLoading = isGroupsLoading || isGovernancePermissionsLoading;
   const isError = isGroupsError || isGovernancePermissionsError;
 
-  const { agents, skills, frames, billingAndSecurity } =
+  const { agents, skills, frames, billingAndSecurity, triggers } =
     groupGovernancePermissionsBySection(governancePermissions);
 
   const framePermissions = frames.filter((permission) =>
@@ -130,7 +133,7 @@ export const GovernancePage = () => {
   };
 
   const sections: {
-    id: "agents" | "skills" | "frame" | "billing";
+    id: "agents" | "skills" | "frame" | "automations" | "billing";
     label: string;
     icon: ComponentType;
     governancePermissions: GovernancePermission[];
@@ -147,6 +150,16 @@ export const GovernancePage = () => {
       icon: PuzzlePiece01,
       governancePermissions: skills,
     },
+    ...(triggers.length > 0
+      ? [
+          {
+            id: "automations" as const,
+            label: "Automations",
+            icon: Clock,
+            governancePermissions: triggers,
+          },
+        ]
+      : []),
     ...(framePermissions.length > 0 || isAdmin
       ? [
           {

--- a/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRow.tsx
@@ -70,6 +70,11 @@ const GOVERNANCE_SETTING_METADATA: Partial<
     description: "Who can manage user access, identities, and provisioning",
     isGroupsOnly: true,
   },
+  "use_workspace_pool:trigger": {
+    label: "Charge automations to the workspace",
+    description:
+      "Who can run a trigger on the workspace credit pool instead of their own",
+  },
 };
 
 const PERMISSION_SCOPE_OPTIONS: {

--- a/front/lib/api/permissions/governance.ts
+++ b/front/lib/api/permissions/governance.ts
@@ -4,6 +4,7 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { CapabilityState } from "@app/lib/resources/group_permission_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
@@ -19,6 +20,7 @@ import {
   GOVERNANCE_CAPABILITIES,
 } from "@app/types/group_permissions";
 import { isManageableGroupKind } from "@app/types/groups";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -39,13 +41,20 @@ const ADMIN_CAPABILITIES: CapabilitySpec[] = [
 
 // The capabilities the caller's role is allowed to see and manage. Admins get everything; business
 // admins get every domain except billing/identity; no other role manages any governance capability.
-function capabilitiesForRole(auth: Authenticator): CapabilitySpec[] {
+function capabilitiesForRole(
+  auth: Authenticator,
+  featureFlags: WhitelistableFeature[]
+): CapabilitySpec[] {
+  const flagged = featureFlags.includes("trigger_pool_choice")
+    ? GOVERNANCE_CAPABILITIES.trigger
+    : [];
+
   const role = auth.role();
   switch (role) {
     case "admin":
-      return ADMIN_CAPABILITIES;
+      return [...ADMIN_CAPABILITIES, ...flagged];
     case "manager":
-      return MANAGER_CAPABILITIES;
+      return [...MANAGER_CAPABILITIES, ...flagged];
     case "builder":
     case "user":
     case "none":
@@ -75,7 +84,7 @@ function toConfiguration(
 export async function getWorkspaceGovernancePermissions(
   auth: Authenticator
 ): Promise<GovernancePermissionsByKey> {
-  const capabilities = capabilitiesForRole(auth);
+  const capabilities = capabilitiesForRole(auth, await getFeatureFlags(auth));
 
   const stateByKey = await GroupPermissionResource.getCapabilitiesState(
     auth,
@@ -111,7 +120,7 @@ export async function setWorkspaceGovernancePermission(
 > {
   const capability: CapabilitySpec = { grantType, resourceType };
 
-  const canManage = capabilitiesForRole(auth).some(
+  const canManage = capabilitiesForRole(auth, await getFeatureFlags(auth)).some(
     (c) => c.grantType === grantType && c.resourceType === resourceType
   );
   if (!canManage) {

--- a/front/lib/auth.workspace_permission.test.ts
+++ b/front/lib/auth.workspace_permission.test.ts
@@ -143,6 +143,7 @@ describe("Authenticator.getWorkspacePermissions", () => {
       billing: ["admin"],
       security: ["admin"],
       dust_app: ["admin"],
+      trigger: ["use_workspace_pool"],
     });
   });
 

--- a/front/lib/resources/group_permission_registry.ts
+++ b/front/lib/resources/group_permission_registry.ts
@@ -82,6 +82,9 @@ export const ROLE_REGISTRY: Record<
   dust_app: {
     admin: { verbs: ["admin"], levels: ["type"] },
   },
+  trigger: {
+    use_workspace_pool: { verbs: ["use_workspace_pool"], levels: ["type"] },
+  },
 };
 
 interface GrantSpec {

--- a/front/types/group_permissions.ts
+++ b/front/types/group_permissions.ts
@@ -27,6 +27,7 @@ export const GRANT_VERBS = [
   "invite",
   "use",
   "make_discoverable",
+  "use_workspace_pool",
 ] as const;
 export type GrantVerb = (typeof GRANT_VERBS)[number];
 
@@ -42,6 +43,7 @@ export const GRANT_TYPES = [
   "invite",
   "use",
   "make_discoverable",
+  "use_workspace_pool",
   "*",
 ] as const;
 export type GrantType = (typeof GRANT_TYPES)[number];
@@ -56,6 +58,7 @@ export const GROUP_PERMISSION_RESOURCE_TYPES = [
   "security",
   "models_tier",
   "dust_app",
+  "trigger",
   "*",
 ] as const;
 export type GroupPermissionResourceType =
@@ -139,6 +142,7 @@ export function emptyWorkspacePermissions(): WorkspacePermissions {
     security: [],
     models_tier: [],
     dust_app: [],
+    trigger: [],
   };
 }
 
@@ -191,4 +195,5 @@ export const GOVERNANCE_CAPABILITIES = {
     { grantType: "admin", resourceType: "billing" },
     { grantType: "admin", resourceType: "security" },
   ],
+  trigger: [{ grantType: "use_workspace_pool", resourceType: "trigger" }],
 } satisfies Record<string, CapabilitySpec[]>;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -376,6 +376,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Allow editing tool inputs before approving a tool call in the tool validation UI.",
     stage: "dust_only",
   },
+  trigger_pool_choice: {
+    description:
+      "Let trigger editors pick the credit pool (workspace or member) a trigger runs on, and let admins govern who may pick the workspace pool.",
+    stage: "dust_only",
+  },
   skip_free_usage_rate_limit: {
     description:
       "Skip the per-user daily free-usage cost cap enforced at the LLM call site. Escape hatch to unstick legitimate workspaces that legitimately exceed the free-usage limit.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -821,6 +821,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "enforce_premium_model_message_limit"
   | "editable_tool_inputs"
   | "skip_free_usage_rate_limit"
+  | "trigger_pool_choice"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

Stack for letting trigger editors pick which credit pool a trigger runs on:
1. **this PR** : `trigger_pool_choice` flag plus the `use_workspace_pool` governance capability (Automations section on Settings & Governance).
2. #30861 : Pool column on the Automations page table, editable inline.
3. #30862 : Pool picker in the trigger sheet's rate-limit section, for schedules and webhooks.

This implements the new feature flag and the governance setting for the feature.

## Tests

Existing `governance-permissions` and `group_permission_resource` suites pass with the new resource type. Checked the section shows up on Settings & Governance with the flag on and stays hidden with it off.

## Risk

Low. New verb is appended to `GRANT_VERBS`. Nothing reads the capability yet.

## Deploy Plan

Deploy front.