### PR TITLE
[front] feat: pool column in the automations table

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.test.ts
@@ -50,6 +50,7 @@ const TRIGGERS: GetAutomationTriggersResponse = {
       webhookIcon: null,
       runCount: 720,
       credits: 2448,
+      executionMode: "user_pool",
     },
     {
       triggerId: "trg2",
@@ -75,6 +76,7 @@ const TRIGGERS: GetAutomationTriggersResponse = {
       webhookIcon: "ActionFlagIcon",
       runCount: 12,
       credits: 48,
+      executionMode: "workspace_pool",
     },
   ],
 };

--- a/front-api/routes/w/[wId]/analytics/automations/triggers.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/triggers.ts
@@ -29,6 +29,7 @@ const CSV_HEADERS = [
   "editorEmail",
   "runs",
   "credits",
+  "pool",
 ] as const;
 
 function kindToLabel(kind: AutomationTriggerRow["kind"]): string {
@@ -52,6 +53,7 @@ function toCsvRow(trigger: AutomationTriggerRow) {
     editorEmail: trigger.editor.email ?? "",
     runs: trigger.runCount,
     credits: trigger.credits,
+    pool: trigger.executionMode,
   };
 }
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/execution_mode.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/execution_mode.test.ts
@@ -1,0 +1,242 @@
+import { Authenticator } from "@app/lib/auth";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function patchExecutionMode(
+  workspace: { sId: string },
+  aId: string,
+  tId: string,
+  body: unknown
+) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/${aId}/triggers/${tId}/execution_mode`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+async function createOtherEditorAuth(workspace: WorkspaceType) {
+  const otherUser = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+  return Authenticator.fromUserIdAndWorkspaceId(otherUser.sId, workspace.sId);
+}
+
+describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId/execution_mode", () => {
+  it("lets an admin move a trigger to the workspace pool", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+    });
+
+    const response = await patchExecutionMode(
+      workspace,
+      agent.sId,
+      trigger.sId,
+      { executionMode: "workspace_pool" }
+    );
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.executionMode).toBe("workspace_pool");
+  });
+
+  it("lets the editor move their own trigger back to their own pool", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+      executionMode: "workspace_pool",
+    });
+
+    const response = await patchExecutionMode(
+      workspace,
+      agent.sId,
+      trigger.sId,
+      { executionMode: "user_pool" }
+    );
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.executionMode).toBe("user_pool");
+  });
+
+  it("rejects a member without the workspace pool permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+    });
+
+    const response = await patchExecutionMode(
+      workspace,
+      agent.sId,
+      trigger.sId,
+      { executionMode: "workspace_pool" }
+    );
+
+    expect(response.status).toBe(403);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.executionMode).toBe("user_pool");
+  });
+
+  it("rejects a member who is neither manager nor editor", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const editorAuth = await createOtherEditorAuth(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth);
+    const trigger = await TriggerFactory.webhook(editorAuth, {
+      agentConfigurationId: agent.sId,
+      executionMode: "workspace_pool",
+    });
+
+    const response = await patchExecutionMode(
+      workspace,
+      agent.sId,
+      trigger.sId,
+      { executionMode: "user_pool" }
+    );
+
+    expect(response.status).toBe(403);
+    const updated = await TriggerResource.fetchById(editorAuth, trigger.sId);
+    expect(updated?.executionMode).toBe("workspace_pool");
+  });
+
+  it("returns 404 when the feature flag is off", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+    });
+
+    const response = await patchExecutionMode(
+      workspace,
+      agent.sId,
+      trigger.sId,
+      { executionMode: "workspace_pool" }
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 404 for an unknown trigger", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const response = await patchExecutionMode(workspace, agent.sId, "unknown", {
+      executionMode: "workspace_pool",
+    });
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when the trigger belongs to another agent", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const otherAgent = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Other Test Agent",
+    });
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: otherAgent.sId,
+    });
+
+    const response = await patchExecutionMode(
+      workspace,
+      agent.sId,
+      trigger.sId,
+      { executionMode: "workspace_pool" }
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects an unknown execution mode", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.webhook(auth, {
+      agentConfigurationId: agent.sId,
+    });
+
+    const response = await patchExecutionMode(
+      workspace,
+      agent.sId,
+      trigger.sId,
+      { executionMode: "team_pool" }
+    );
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/execution_mode.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/execution_mode.ts
@@ -1,0 +1,90 @@
+import { getFeatureFlags } from "@app/lib/auth";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import logger from "@app/logger/logger";
+import { PatchTriggerExecutionModeRequestBodySchema } from "@app/types/api/assistant/configuration/triggers";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const ParamsSchema = z.object({
+  aId: z.string(),
+  tId: z.string(),
+});
+
+// Mounted at /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId/execution_mode.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.patch(
+  "/",
+  validate("param", ParamsSchema),
+  validate("json", PatchTriggerExecutionModeRequestBodySchema),
+  async (ctx) => {
+    const auth = ctx.get("auth");
+    const { aId, tId } = ctx.req.valid("param");
+    const { executionMode } = ctx.req.valid("json");
+
+    const featureFlags = await getFeatureFlags(auth);
+    if (!featureFlags.includes("trigger_pool_choice")) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "feature_flag_not_found",
+          message: "The trigger pool choice feature is not enabled.",
+        },
+      });
+    }
+
+    const trigger = await TriggerResource.fetchById(auth, tId);
+    if (!trigger) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "trigger_not_found",
+          message: "Trigger not found.",
+        },
+      });
+    }
+
+    if (trigger.agentConfigurationId !== aId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Trigger does not belong to the specified agent configuration.",
+        },
+      });
+    }
+
+    if (!(await trigger.canSetExecutionMode(auth, executionMode))) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "workspace_auth_error",
+          message: "You don't have permission to change this trigger's pool.",
+        },
+      });
+    }
+
+    const result = await trigger.setExecutionMode(auth, executionMode);
+    if (result.isErr()) {
+      logger.error(
+        { error: result.error, aId, tId, executionMode },
+        "Error updating trigger execution mode"
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to update the trigger pool.",
+        },
+      });
+    }
+
+    return ctx.body(null, 204);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/execution_mode.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/execution_mode.ts
@@ -1,5 +1,8 @@
 import { getFeatureFlags } from "@app/lib/auth";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import {
+  TriggerExecutionModeForbiddenError,
+  TriggerResource,
+} from "@app/lib/resources/trigger_resource";
 import logger from "@app/logger/logger";
 import { PatchTriggerExecutionModeRequestBodySchema } from "@app/types/api/assistant/configuration/triggers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -58,18 +61,18 @@ app.patch(
       });
     }
 
-    if (!(await trigger.canSetExecutionMode(auth, executionMode))) {
-      return apiError(ctx, {
-        status_code: 403,
-        api_error: {
-          type: "workspace_auth_error",
-          message: "You don't have permission to change this trigger's pool.",
-        },
-      });
-    }
-
     const result = await trigger.setExecutionMode(auth, executionMode);
     if (result.isErr()) {
+      if (result.error instanceof TriggerExecutionModeForbiddenError) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: result.error.message,
+          },
+        });
+      }
+
       logger.error(
         { error: result.error, aId, tId, executionMode },
         "Error updating trigger execution mode"

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/index.ts
@@ -1,11 +1,13 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
+import executionMode from "./execution_mode";
 import status from "./status";
 import webhookRequests from "./webhook_requests";
 
 // Mounted under /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId.
 const app = workspaceApp();
 
+app.route("/execution_mode", executionMode);
 app.route("/status", status);
 app.route("/webhook_requests", webhookRequests);
 

--- a/front/admin/audit_log_schemas/trigger.pool_updated.json
+++ b/front/admin/audit_log_schemas/trigger.pool_updated.json
@@ -1,0 +1,17 @@
+{
+  "action": "trigger.pool_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "trigger"
+    }
+  ],
+  "metadata": {
+    "trigger_type": "string",
+    "agent_id": "string",
+    "previous_execution_mode": "string",
+    "execution_mode": "string"
+  }
+}

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.test.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.test.tsx
@@ -34,6 +34,7 @@ const TRIGGER: AutomationTriggerRow = {
   runCount: 0,
   credits: 0,
   status: "enabled",
+  executionMode: "user_pool",
 };
 
 describe("AutomationsTriggerBreakdown", () => {

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -24,6 +24,7 @@ import {
   useUpdateTriggerExecutionMode,
   useUpdateTriggerStatus,
 } from "@app/lib/swr/agent_triggers";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
 import type {
   TriggerExecutionMode,
@@ -72,7 +73,9 @@ const POOL_OPTIONS: { value: TriggerExecutionMode; label: string }[] = [
 ];
 
 function PoolCell({ row }: { row: TriggerRowData }) {
+  const { hasPermission } = useWorkspacePermissions();
   const isWorkspacePool = row.displayExecutionMode === "workspace_pool";
+  const canSetPool = hasPermission("use_workspace_pool", "trigger");
 
   return (
     <DropdownMenu>
@@ -81,7 +84,7 @@ function PoolCell({ row }: { row: TriggerRowData }) {
           variant="ghost"
           size="xs"
           isSelect
-          disabled={row.isExecutionModePending}
+          disabled={row.isExecutionModePending || !canSetPool}
           className={isWorkspacePool ? "text-highlight" : undefined}
           label={isWorkspacePool ? "Workspace" : "Member"}
         />

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -19,9 +19,16 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
 import type { AutomationTriggersBody } from "@app/lib/api/analytics/automations/schema";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
-import { useUpdateTriggerStatus } from "@app/lib/swr/agent_triggers";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import {
+  useUpdateTriggerExecutionMode,
+  useUpdateTriggerStatus,
+} from "@app/lib/swr/agent_triggers";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
-import type { TriggerStatus } from "@app/types/assistant/triggers";
+import type {
+  TriggerExecutionMode,
+  TriggerStatus,
+} from "@app/types/assistant/triggers";
 import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -33,6 +40,10 @@ import {
   Clock,
   DataTable,
   DataTableLoadingSkeleton,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
   Icon,
   Pagination,
   SearchInput,
@@ -50,6 +61,42 @@ interface TriggerRowData extends BaseTriggerRowData {
   displayStatus: TriggerStatus;
   isStatusPending: boolean;
   onToggleStatus: () => void;
+  displayExecutionMode: TriggerExecutionMode;
+  isExecutionModePending: boolean;
+  onSetExecutionMode: (executionMode: TriggerExecutionMode) => void;
+}
+
+const POOL_OPTIONS: { value: TriggerExecutionMode; label: string }[] = [
+  { value: "workspace_pool", label: "Workspace" },
+  { value: "user_pool", label: "Member" },
+];
+
+function PoolCell({ row }: { row: TriggerRowData }) {
+  const isWorkspacePool = row.displayExecutionMode === "workspace_pool";
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="xs"
+          isSelect
+          disabled={row.isExecutionModePending}
+          className={isWorkspacePool ? "text-highlight" : undefined}
+          label={isWorkspacePool ? "Workspace" : "Member"}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {POOL_OPTIONS.map(({ value, label }) => (
+          <DropdownMenuItem
+            key={value}
+            label={label}
+            onClick={() => row.onSetExecutionMode(value)}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }
 
 function TypeCell({ trigger }: { trigger: AutomationTriggerRow }) {
@@ -214,8 +261,10 @@ function EditorCell({ editor }: { editor: AutomationTriggerRow["editor"] }) {
 
 function buildColumns({
   expandedRowId,
+  showPoolColumn,
 }: {
   expandedRowId: string | null;
+  showPoolColumn: boolean;
 }): ColumnDef<TriggerRowData>[] {
   return [
     {
@@ -275,6 +324,21 @@ function buildColumns({
         </DataTable.CellContent>
       ),
     },
+    ...(showPoolColumn
+      ? [
+          {
+            id: "pool",
+            header: "Pool",
+            enableSorting: false,
+            meta: { className: "w-28" },
+            cell: (info) => (
+              <DataTable.CellContent className="w-full justify-start">
+                <PoolCell row={info.row.original} />
+              </DataTable.CellContent>
+            ),
+          } satisfies ColumnDef<TriggerRowData>,
+        ]
+      : []),
     {
       id: "status",
       header: "Enabled",
@@ -375,6 +439,9 @@ export function AutomationsTriggersTable({
 
   const confirm = useContext(ConfirmContext);
   const updateTriggerStatus = useUpdateTriggerStatus({ workspaceId });
+  const updateTriggerExecutionMode = useUpdateTriggerExecutionMode({
+    workspaceId,
+  });
 
   const exportBody: AutomationTriggersBody = {
     period: period.kind,
@@ -400,6 +467,12 @@ export function AutomationsTriggersTable({
     Record<string, TriggerStatus>
   >({});
   const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(new Set());
+  const [executionModeOverrides, setExecutionModeOverrides] = useState<
+    Record<string, TriggerExecutionMode>
+  >({});
+  const [pendingExecutionModeIds, setPendingExecutionModeIds] = useState<
+    ReadonlySet<string>
+  >(new Set());
 
   // Refetched rows (pagination, period change) already carry any status we
   // wrote, so overrides only need to live until the next fetch. Reset during
@@ -410,6 +483,7 @@ export function AutomationsTriggersTable({
   if (prevTriggers !== triggers) {
     setPrevTriggers(triggers);
     setStatusOverrides({});
+    setExecutionModeOverrides({});
   }
 
   const handleToggle = useCallback(
@@ -456,6 +530,32 @@ export function AutomationsTriggersTable({
     [confirm, updateTriggerStatus]
   );
 
+  const handleSetExecutionMode = useCallback(
+    async (
+      trigger: AutomationTriggerRow,
+      executionMode: TriggerExecutionMode
+    ) => {
+      setPendingExecutionModeIds((ids) => new Set([...ids, trigger.triggerId]));
+      const success = await updateTriggerExecutionMode({
+        agentConfigurationId: trigger.agent.agentId,
+        triggerId: trigger.triggerId,
+        executionMode,
+      });
+      if (success) {
+        setExecutionModeOverrides((overrides) => ({
+          ...overrides,
+          [trigger.triggerId]: executionMode,
+        }));
+      }
+      setPendingExecutionModeIds((ids) => {
+        const next = new Set(ids);
+        next.delete(trigger.triggerId);
+        return next;
+      });
+    },
+    [updateTriggerExecutionMode]
+  );
+
   const rows: TriggerRowData[] = useMemo(
     () =>
       triggers.map((trigger) => {
@@ -466,13 +566,28 @@ export function AutomationsTriggersTable({
           displayStatus,
           isStatusPending: pendingIds.has(trigger.triggerId),
           onToggleStatus: () => void handleToggle(trigger, displayStatus),
+          displayExecutionMode:
+            executionModeOverrides[trigger.triggerId] ?? trigger.executionMode,
+          isExecutionModePending: pendingExecutionModeIds.has(
+            trigger.triggerId
+          ),
+          onSetExecutionMode: (executionMode: TriggerExecutionMode) =>
+            void handleSetExecutionMode(trigger, executionMode),
           onClick: () =>
             setExpandedRowId((current) =>
               current === trigger.triggerId ? null : trigger.triggerId
             ),
         };
       }),
-    [triggers, statusOverrides, pendingIds, handleToggle]
+    [
+      triggers,
+      statusOverrides,
+      pendingIds,
+      handleToggle,
+      executionModeOverrides,
+      pendingExecutionModeIds,
+      handleSetExecutionMode,
+    ]
   );
 
   return (
@@ -545,9 +660,11 @@ function TriggersTableBody({
   period,
   expandedRowId,
 }: TriggersTableBodyProps) {
+  const { hasFeature } = useFeatureFlags();
+  const showPoolColumn = hasFeature("trigger_pool_choice");
   const columns = useMemo(
-    () => buildColumns({ expandedRowId }),
-    [expandedRowId]
+    () => buildColumns({ expandedRowId, showPoolColumn }),
+    [expandedRowId, showPoolColumn]
   );
 
   if (isLoading) {

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -26,7 +26,11 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
-import type { TriggerKind, TriggerStatus } from "@app/types/assistant/triggers";
+import type {
+  TriggerExecutionMode,
+  TriggerKind,
+  TriggerStatus,
+} from "@app/types/assistant/triggers";
 import { isScheduleTrigger } from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
@@ -58,6 +62,7 @@ export type AutomationTriggerRow = {
   webhookIcon: InternalAllowedIconType | CustomResourceIconType | null;
   runCount: number;
   credits: number;
+  executionMode: TriggerExecutionMode;
 };
 
 export type AutomationTriggers = {
@@ -403,6 +408,7 @@ export async function fetchAutomationTriggers(
       webhookIcon: webhookSource?.icon ?? null,
       runCount,
       credits,
+      executionMode: trigger.executionMode,
     };
   });
 

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -97,6 +97,7 @@
   "trigger.email_received": 3,
   "trigger.enabled": 2,
   "trigger.fired": 3,
+  "trigger.pool_updated": 1,
   "user.advanced_model_access_updated": 1,
   "user.identity_merged": 4,
   "user.login": 3,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -140,6 +140,7 @@ export const AUDIT_ACTIONS = [
   "trigger.enabled",
   "trigger.disabled",
   "trigger.fired",
+  "trigger.pool_updated",
   "trigger.email_received",
   // Wake-ups.
   "wake_up.cancelled",

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -1,9 +1,12 @@
+import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import * as temporalClient from "@app/temporal/triggers/schedule_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { Ok } from "@app/types/shared/result";
 import { describe, expect, it, vi } from "vitest";
 
@@ -460,6 +463,83 @@ describe("TriggerResource", () => {
         enabled: 0,
         total: 0,
       });
+    });
+  });
+  describe("setExecutionMode", () => {
+    it("refuses the workspace pool without the governance grant", async () => {
+      const { authenticator } = await createResourceTest({ role: "builder" });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+      const trigger = await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+      });
+
+      const result = await trigger.setExecutionMode(
+        authenticator,
+        "workspace_pool"
+      );
+
+      expect(result.isErr()).toBe(true);
+      const reloaded = await TriggerResource.fetchById(
+        authenticator,
+        trigger.sId
+      );
+      expect(reloaded?.executionMode).toBe("user_pool");
+    });
+
+    it("refuses a member who neither manages nor edits the trigger", async () => {
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+      const trigger = await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+        executionMode: "workspace_pool",
+      });
+
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+      const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      const result = await trigger.setExecutionMode(otherAuth, "user_pool");
+
+      expect(result.isErr()).toBe(true);
+      const reloaded = await TriggerResource.fetchById(
+        authenticator,
+        trigger.sId
+      );
+      expect(reloaded?.executionMode).toBe("workspace_pool");
+    });
+
+    it("lets an admin move a trigger to the workspace pool", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+      const trigger = await TriggerFactory.webhook(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+      });
+
+      const result = await trigger.setExecutionMode(
+        authenticator,
+        "workspace_pool"
+      );
+
+      expect(result.isOk()).toBe(true);
+      const reloaded = await TriggerResource.fetchById(
+        authenticator,
+        trigger.sId
+      );
+      expect(reloaded?.executionMode).toBe("workspace_pool");
     });
   });
 });

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -1048,7 +1048,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(undefined);
   }
 
-  async canSetExecutionMode(
+  private async canSetExecutionMode(
     auth: Authenticator,
     executionMode: TriggerExecutionMode
   ): Promise<boolean> {

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -1046,6 +1046,58 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(undefined);
   }
 
+  async canSetExecutionMode(
+    auth: Authenticator,
+    executionMode: TriggerExecutionMode
+  ): Promise<boolean> {
+    if (!auth.isManager() && this.editor !== auth.getNonNullableUser().id) {
+      return false;
+    }
+
+    switch (executionMode) {
+      case "user_pool":
+        return true;
+      case "workspace_pool":
+        return auth.hasWorkspacePermission("use_workspace_pool", "trigger");
+      default:
+        assertNever(executionMode);
+    }
+  }
+
+  async setExecutionMode(
+    auth: Authenticator,
+    executionMode: TriggerExecutionMode
+  ): Promise<Result<undefined, Error>> {
+    if (this.executionMode === executionMode) {
+      return new Ok(undefined);
+    }
+
+    const previousExecutionMode = this.executionMode;
+
+    try {
+      await this.update({ executionMode });
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+
+    void emitAuditLogEvent({
+      auth,
+      action: "trigger.pool_updated",
+      targets: [
+        buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        buildAuditLogTarget("trigger", { sId: this.sId, name: this.name }),
+      ],
+      metadata: {
+        trigger_type: this.kind,
+        agent_id: this.agentConfigurationId,
+        previous_execution_mode: previousExecutionMode,
+        execution_mode: executionMode,
+      },
+    });
+
+    return new Ok(undefined);
+  }
+
   /**
    * Updates webhook-specific settings (execution limit and mode).
    * Used by poke plugins for admin-level trigger configuration.

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -65,6 +65,8 @@ export async function resolveTriggerSpaceId(
   return new Ok(pod.id);
 }
 
+export class TriggerExecutionModeForbiddenError extends Error {}
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -1068,6 +1070,14 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     executionMode: TriggerExecutionMode
   ): Promise<Result<undefined, Error>> {
+    if (!(await this.canSetExecutionMode(auth, executionMode))) {
+      return new Err(
+        new TriggerExecutionModeForbiddenError(
+          "You don't have permission to change this trigger's pool."
+        )
+      );
+    }
+
     if (this.executionMode === executionMode) {
       return new Ok(undefined);
     }

--- a/front/lib/swr/agent_triggers.ts
+++ b/front/lib/swr/agent_triggers.ts
@@ -11,6 +11,7 @@ import type { GetTriggerEstimationResponseBody } from "@app/lib/triggers/trigger
 import type {
   GetTriggersResponseBody,
   GetUserTriggersResponseBody,
+  PatchTriggerExecutionModeRequestBody,
   PatchTriggerStatusRequestBody,
   PatchTriggersRequestBody,
   PostTextAsCronRuleRequestBody,
@@ -21,7 +22,10 @@ import type {
   PostWebhookFilterGeneratorRequestBody,
   PostWebhookFilterGeneratorResponseBody,
 } from "@app/types/api/assistant/configuration/triggers/webhook_filter_generator";
-import type { ScheduleConfig } from "@app/types/assistant/triggers";
+import type {
+  ScheduleConfig,
+  TriggerExecutionMode,
+} from "@app/types/assistant/triggers";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
@@ -306,6 +310,60 @@ export function useUpdateTriggerStatus({
   );
 
   return updateTriggerStatus;
+}
+
+export function useUpdateTriggerExecutionMode({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const updateTriggerExecutionMode = useCallback(
+    async ({
+      agentConfigurationId,
+      triggerId,
+      executionMode,
+    }: {
+      agentConfigurationId: string;
+      triggerId: string;
+      executionMode: TriggerExecutionMode;
+    }): Promise<boolean> => {
+      const response = await clientFetch(
+        `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/triggers/${triggerId}/execution_mode`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            executionMode,
+          } satisfies PatchTriggerExecutionModeRequestBody),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to update the trigger pool",
+          description: `Error: ${errorData.message}`,
+        });
+        return false;
+      }
+
+      sendNotification({
+        type: "success",
+        title: "Trigger pool updated",
+        description:
+          executionMode === "workspace_pool"
+            ? "This trigger now runs on the workspace's credits."
+            : "This trigger now runs on its editor's credits.",
+      });
+      return true;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return updateTriggerExecutionMode;
 }
 
 function responseToScheduleConfig(

--- a/front/types/api/assistant/configuration/triggers.ts
+++ b/front/types/api/assistant/configuration/triggers.ts
@@ -1,6 +1,7 @@
 import type { TriggerType } from "@app/types/assistant/triggers";
 import {
   FullTriggerSchema,
+  TRIGGER_EXECUTION_MODES,
   TriggerSchema,
 } from "@app/types/assistant/triggers";
 import { z } from "zod";
@@ -42,6 +43,13 @@ export const PatchTriggerStatusRequestBodySchema = z.object({
 });
 export type PatchTriggerStatusRequestBody = z.infer<
   typeof PatchTriggerStatusRequestBodySchema
+>;
+
+export const PatchTriggerExecutionModeRequestBodySchema = z.object({
+  executionMode: z.enum(TRIGGER_EXECUTION_MODES),
+});
+export type PatchTriggerExecutionModeRequestBody = z.infer<
+  typeof PatchTriggerExecutionModeRequestBodySchema
 >;
 
 export const PostTriggersRequestBodySchema = z.object({


### PR DESCRIPTION
## Description

Second PR of the trigger pool stack (#30860). Behind `trigger_pool_choice`, the automations table gets a Pool column: a dropdown switching a trigger between the workspace credits (highlight) and its editor's (regular). Backed by a new `execution_mode` PATCH route that only lets managers granted `use_workspace_pool` pick the workspace pool.

## Tests

Functional tests on the new route (permissions, flag off, mismatched agent, bad mode). Existing analytics trigger tests updated for the new field.

## Risk

Low, flagged off.

## Deploy Plan

Deploy front.