### PR TITLE
[front] feat: pool picker in the trigger sheet

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/execution_mode.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/execution_mode.test.ts
@@ -1,4 +1,5 @@
 import { Authenticator } from "@app/lib/auth";
+import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -30,6 +31,16 @@ async function createOtherEditorAuth(workspace: WorkspaceType) {
   const otherUser = await UserFactory.basic();
   await MembershipFactory.associate(workspace, otherUser, { role: "user" });
   return Authenticator.fromUserIdAndWorkspaceId(otherUser.sId, workspace.sId);
+}
+
+async function grantWorkspacePoolToEverybody(workspace: WorkspaceType) {
+  const adminAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId
+  );
+  await GroupPermissionResource.setForEverybody(adminAuth, {
+    grantType: "use_workspace_pool",
+    resourceType: "trigger",
+  });
 }
 
 describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId/execution_mode", () => {
@@ -70,6 +81,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId/ex
       workspace.sId
     );
     await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    await grantWorkspacePoolToEverybody(workspace);
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const trigger = await TriggerFactory.webhook(auth, {
       agentConfigurationId: agent.sId,
@@ -125,6 +137,7 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers/:tId/ex
       workspace.sId
     );
     await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    await grantWorkspacePoolToEverybody(workspace);
     const editorAuth = await createOtherEditorAuth(workspace);
     const agent = await AgentConfigurationFactory.createTestAgent(editorAuth);
     const trigger = await TriggerFactory.webhook(editorAuth, {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.test.ts
@@ -2,6 +2,7 @@ import { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
@@ -475,5 +476,161 @@ describe("PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers (disabl
     const updated = await TriggerResource.fetchById(auth, trigger.sId);
     expect(updated?.name).toBe("renamed-trigger");
     expect(updated?.status).toBe("disabled_by_manager");
+  });
+});
+
+describe("POST/PATCH /api/w/:wId/assistant/agent_configurations/:aId/triggers (executionMode)", () => {
+  it("creates a trigger on the workspace pool for a permitted admin", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const body = scheduleTriggerBody(null);
+    const response = await postTriggers(workspace, agent.sId, {
+      triggers: [{ ...body.triggers[0], executionMode: "workspace_pool" }],
+    });
+
+    expect(response.status).toBe(204);
+    const triggers = await TriggerResource.listByAgentConfigurationId(
+      auth,
+      agent.sId
+    );
+    expect(triggers[0].executionMode).toBe("workspace_pool");
+  });
+
+  it("rejects creating a workspace pool trigger without the permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const body = scheduleTriggerBody(null);
+    const response = await postTriggers(workspace, agent.sId, {
+      triggers: [{ ...body.triggers[0], executionMode: "workspace_pool" }],
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("ignores the requested pool when the feature flag is off", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const body = scheduleTriggerBody(null);
+    const response = await postTriggers(workspace, agent.sId, {
+      triggers: [{ ...body.triggers[0], executionMode: "workspace_pool" }],
+    });
+
+    expect(response.status).toBe(204);
+    const triggers = await TriggerResource.listByAgentConfigurationId(
+      auth,
+      agent.sId
+    );
+    expect(triggers[0].executionMode).toBe("user_pool");
+  });
+
+  it("moves an existing trigger to the workspace pool on update", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+
+    const body = scheduleTriggerBody(null);
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [
+        {
+          ...body.triggers[0],
+          sId: trigger.sId,
+          executionMode: "workspace_pool",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.executionMode).toBe("workspace_pool");
+  });
+
+  it("rejects an update to the workspace pool without the permission", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "builder",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await createScheduleTrigger(workspace, agent.sId, null);
+
+    const body = scheduleTriggerBody(null);
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [
+        {
+          ...body.triggers[0],
+          sId: trigger.sId,
+          executionMode: "workspace_pool",
+        },
+      ],
+    });
+
+    expect(response.status).toBe(403);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.executionMode).toBe("user_pool");
+  });
+
+  it("keeps the pool untouched when the update omits executionMode", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.schedule(auth, {
+      agentConfigurationId: agent.sId,
+      configuration: { type: "cron", cron: "0 9 * * *", timezone: "UTC" },
+      executionMode: "workspace_pool",
+    });
+
+    const body = scheduleTriggerBody(null);
+    const response = await patchTriggers(workspace, agent.sId, {
+      triggers: [{ ...body.triggers[0], sId: trigger.sId }],
+    });
+
+    expect(response.status).toBe(204);
+    const updated = await TriggerResource.fetchById(auth, trigger.sId);
+    expect(updated?.executionMode).toBe("workspace_pool");
   });
 });

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -37,7 +37,7 @@ const PostTriggersRequestBodySchema = z.object({
 });
 
 function requestedExecutionMode(
-  trigger: { executionMode?: TriggerExecutionMode },
+  trigger: z.infer<typeof TriggerSchema>,
   featureFlags: WhitelistableFeature[]
 ): TriggerExecutionMode | undefined {
   if (!featureFlags.includes("trigger_pool_choice")) {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { getFeatureFlags } from "@app/lib/auth";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import {
   resolveTriggerSpaceId,
@@ -7,7 +8,9 @@ import {
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { GetTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
+import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
 import { TriggerSchema } from "@app/types/assistant/triggers";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -31,6 +34,17 @@ const PatchTriggersRequestBodySchema = z.object({
 const PostTriggersRequestBodySchema = z.object({
   triggers: z.array(TriggerSchema),
 });
+
+function requestedExecutionMode(
+  trigger: { executionMode?: TriggerExecutionMode },
+  featureFlags: WhitelistableFeature[]
+): TriggerExecutionMode | undefined {
+  if (!featureFlags.includes("trigger_pool_choice")) {
+    return undefined;
+  }
+
+  return trigger.executionMode;
+}
 
 function isWebhookTriggerData(trigger: {
   kind: string;
@@ -198,6 +212,7 @@ app.patch(
 
     const { triggers } = ctx.req.valid("json");
     const workspace = auth.getNonNullableWorkspace();
+    const featureFlags = await getFeatureFlags(auth);
 
     for (const triggerData of triggers) {
       const triggerToUpdate = userTriggers.find(
@@ -254,6 +269,23 @@ app.patch(
         ? getResourceIdFromSId(validatedTrigger.webhookSourceViewId)
         : null;
 
+      const executionMode = requestedExecutionMode(
+        validatedTrigger,
+        featureFlags
+      );
+      if (
+        executionMode &&
+        !(await triggerToUpdate.canSetExecutionMode(auth, executionMode))
+      ) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You don't have permission to change this trigger's pool.",
+          },
+        });
+      }
+
       const spaceIdRes = await resolveTriggerSpaceId(
         auth,
         validatedTrigger.spaceId
@@ -297,6 +329,31 @@ app.patch(
           },
         });
       }
+
+      if (executionMode) {
+        const executionModeRes = await triggerToUpdate.setExecutionMode(
+          auth,
+          executionMode
+        );
+        if (executionModeRes.isErr()) {
+          logger.error(
+            {
+              workspaceId: workspace.sId,
+              agentConfigurationId: aId,
+              triggerId: triggerData.sId,
+              error: executionModeRes.error,
+            },
+            "Failed to update trigger execution mode"
+          );
+          return apiError(ctx, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Failed to update trigger ${triggerData.name}.`,
+            },
+          });
+        }
+      }
     }
 
     return ctx.body(null, 204);
@@ -330,6 +387,7 @@ app.post(
 
     const { triggers } = ctx.req.valid("json");
     const workspace = auth.getNonNullableWorkspace();
+    const featureFlags = await getFeatureFlags(auth);
 
     for (const triggerData of triggers) {
       const triggerValidation = TriggerSchema.safeParse({
@@ -353,6 +411,18 @@ app.post(
       const executionPerDay = isWebhookTriggerData(validatedTrigger)
         ? validatedTrigger.executionPerDayLimitOverride
         : null;
+
+      const executionMode =
+        requestedExecutionMode(validatedTrigger, featureFlags) ?? "user_pool";
+      if (!(await TriggerResource.canUseExecutionMode(auth, executionMode))) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You don't have permission to use the workspace pool.",
+          },
+        });
+      }
 
       const spaceIdRes = await resolveTriggerSpaceId(
         auth,
@@ -380,7 +450,7 @@ app.post(
         editor: auth.getNonNullableUser().id,
         webhookSourceViewId,
         executionPerDayLimitOverride: executionPerDay,
-        executionMode: "user_pool",
+        executionMode,
         origin: "user",
         spaceId: spaceIdRes.value,
       });

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -274,19 +274,6 @@ app.patch(
         validatedTrigger,
         featureFlags
       );
-      if (
-        executionMode &&
-        !(await triggerToUpdate.canSetExecutionMode(auth, executionMode))
-      ) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "You don't have permission to change this trigger's pool.",
-          },
-        });
-      }
-
       const spaceIdRes = await resolveTriggerSpaceId(
         auth,
         validatedTrigger.spaceId
@@ -297,36 +284,6 @@ app.patch(
           api_error: {
             type: "invalid_request_error",
             message: spaceIdRes.error,
-          },
-        });
-      }
-
-      const updatedTrigger = await TriggerResource.update(
-        auth,
-        triggerData.sId,
-        {
-          ...validatedTrigger,
-          status: validatedTrigger.status ?? "enabled",
-          webhookSourceViewId,
-          spaceId: spaceIdRes.value,
-        }
-      );
-
-      if (updatedTrigger.isErr()) {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            agentConfigurationId: aId,
-            triggerId: triggerData.sId,
-            error: updatedTrigger.error,
-          },
-          "Failed to update trigger"
-        );
-        return apiError(ctx, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: `Failed to update trigger ${triggerData.name}.`,
           },
         });
       }
@@ -366,6 +323,36 @@ app.patch(
             },
           });
         }
+      }
+
+      const updatedTrigger = await TriggerResource.update(
+        auth,
+        triggerData.sId,
+        {
+          ...validatedTrigger,
+          status: validatedTrigger.status ?? "enabled",
+          webhookSourceViewId,
+          spaceId: spaceIdRes.value,
+        }
+      );
+
+      if (updatedTrigger.isErr()) {
+        logger.error(
+          {
+            workspaceId: workspace.sId,
+            agentConfigurationId: aId,
+            triggerId: triggerData.sId,
+            error: updatedTrigger.error,
+          },
+          "Failed to update trigger"
+        );
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to update trigger ${triggerData.name}.`,
+          },
+        });
       }
     }
 
@@ -427,15 +414,6 @@ app.post(
 
       const executionMode =
         requestedExecutionMode(validatedTrigger, featureFlags) ?? "user_pool";
-      if (!(await TriggerResource.canUseExecutionMode(auth, executionMode))) {
-        return apiError(ctx, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "You don't have permission to use the workspace pool.",
-          },
-        });
-      }
 
       const spaceIdRes = await resolveTriggerSpaceId(
         auth,
@@ -469,6 +447,16 @@ app.post(
       });
 
       if (newTrigger.isErr()) {
+        if (newTrigger.error instanceof TriggerExecutionModeForbiddenError) {
+          return apiError(ctx, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: newTrigger.error.message,
+            },
+          });
+        }
+
         logger.error(
           {
             workspaceId: workspace.sId,

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -3,6 +3,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import {
   resolveTriggerSpaceId,
+  TriggerExecutionModeForbiddenError,
   TriggerResource,
 } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -336,6 +337,18 @@ app.patch(
           executionMode
         );
         if (executionModeRes.isErr()) {
+          if (
+            executionModeRes.error instanceof TriggerExecutionModeForbiddenError
+          ) {
+            return apiError(ctx, {
+              status_code: 403,
+              api_error: {
+                type: "workspace_auth_error",
+                message: executionModeRes.error.message,
+              },
+            });
+          }
+
           logger.error(
             {
               workspaceId: workspace.sId,

--- a/front/components/agent_builder/AgentBuilderFormContext.tsx
+++ b/front/components/agent_builder/AgentBuilderFormContext.tsx
@@ -99,6 +99,7 @@ const scheduleTriggerSchema = z.object({
   configuration: scheduleConfigSchema,
   editor: z.number().nullable(),
   editorName: z.string().optional(),
+  executionMode: z.enum(TRIGGER_EXECUTION_MODES),
   spaceId: z.string().nullable().optional(),
 });
 

--- a/front/components/agent_builder/submitAgentBuilderForm.ts
+++ b/front/components/agent_builder/submitAgentBuilderForm.ts
@@ -223,6 +223,7 @@ function serializeTrigger(
         configuration: trigger.configuration,
         kind: trigger.kind,
         executionPerDayLimitOverride: trigger.executionPerDayLimitOverride,
+        executionMode: trigger.executionMode,
         webhookSourceViewId: trigger.webhookSourceViewId,
         spaceId: trigger.spaceId ?? null,
       };
@@ -235,6 +236,7 @@ function serializeTrigger(
         naturalLanguageDescription: trigger.naturalLanguageDescription,
         configuration: trigger.configuration,
         kind: trigger.kind,
+        executionMode: trigger.executionMode,
         spaceId: trigger.spaceId ?? null,
       };
     default:

--- a/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
+++ b/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
@@ -1,0 +1,76 @@
+import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
+import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+  Label,
+} from "@dust-tt/sparkle";
+import { useController, useFormContext } from "react-hook-form";
+
+const POOL_OPTIONS: { value: TriggerExecutionMode; label: string }[] = [
+  { value: "user_pool", label: "My credits" },
+  { value: "workspace_pool", label: "Workspace credits" },
+];
+
+interface TriggerPoolSelectorProps {
+  name: "schedule.executionMode" | "webhook.executionMode";
+  isEditor: boolean;
+}
+
+export function TriggerPoolSelector({
+  name,
+  isEditor,
+}: TriggerPoolSelectorProps) {
+  const { control } = useFormContext<TriggerViewsSheetFormValues>();
+  const { field } = useController({ control, name });
+  const { hasFeature } = useFeatureFlags();
+  const { hasPermission } = useWorkspacePermissions();
+
+  if (
+    !hasFeature("trigger_pool_choice") ||
+    !hasPermission("use_workspace_pool", "trigger")
+  ) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-1">
+      <Label htmlFor="trigger-pool">Credits</Label>
+      <p className="text-sm text-muted-foreground">
+        Where the credits spent by this trigger's runs are taken from.
+      </p>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            id="trigger-pool"
+            variant="outline"
+            isSelect
+            className="w-fit"
+            disabled={!isEditor}
+            label={
+              POOL_OPTIONS.find((option) => option.value === field.value)
+                ?.label ?? "Select"
+            }
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuLabel label="Charge to" />
+          {POOL_OPTIONS.map(({ value, label }) => (
+            <DropdownMenuItem
+              key={value}
+              label={label}
+              disabled={!isEditor}
+              onClick={() => field.onChange(value)}
+            />
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
+++ b/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
@@ -32,12 +32,11 @@ export function TriggerPoolSelector({
   const { hasFeature } = useFeatureFlags();
   const { hasPermission } = useWorkspacePermissions();
 
-  if (
-    !hasFeature("trigger_pool_choice") ||
-    !hasPermission("use_workspace_pool", "trigger")
-  ) {
+  if (!hasFeature("trigger_pool_choice")) {
     return null;
   }
+
+  const canSetPool = hasPermission("use_workspace_pool", "trigger");
 
   return (
     <div className="space-y-1">
@@ -52,7 +51,7 @@ export function TriggerPoolSelector({
             variant="outline"
             isSelect
             className="w-fit"
-            disabled={!isEditor}
+            disabled={!isEditor || !canSetPool}
             label={
               POOL_OPTIONS.find((option) => option.value === field.value)
                 ?.label ?? "Select"
@@ -65,7 +64,7 @@ export function TriggerPoolSelector({
             <DropdownMenuItem
               key={value}
               label={label}
-              disabled={!isEditor}
+              disabled={!isEditor || !canSetPool}
               onClick={() => field.onChange(value)}
             />
           ))}

--- a/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
+++ b/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
@@ -42,7 +42,7 @@ export function TriggerPoolSelector({
     <div className="space-y-1">
       <Label htmlFor="trigger-pool">Credits</Label>
       <p className="text-sm text-muted-foreground">
-        Where the credits spent by this trigger's runs are taken from.
+        Which pool this trigger's runs take credits from.
       </p>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionSheet.tsx
@@ -1,6 +1,7 @@
 import type { AgentBuilderScheduleTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ScheduleEditionScheduler } from "@app/components/agent_builder/triggers/schedule/ScheduleEditionScheduler";
 import { TriggerPodSelector } from "@app/components/agent_builder/triggers/TriggerPodSelector";
+import { TriggerPoolSelector } from "@app/components/agent_builder/triggers/TriggerPoolSelector";
 import { TriggerStatusToggle } from "@app/components/agent_builder/triggers/TriggerStatusToggle";
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -127,6 +128,10 @@ export function ScheduleEditionSheetContent({
         <ScheduleEditionScheduler isEditor={isEditor} owner={owner} />
         <Separator />
         <ScheduleEditionMessageInput isEditor={isEditor} />
+        <TriggerPoolSelector
+          name="schedule.executionMode"
+          isEditor={isEditor}
+        />
         <Separator />
         <ScheduleEditionPodSelector isEditor={isEditor} owner={owner} />
       </div>

--- a/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
@@ -7,6 +7,7 @@ import type { ScheduleConfig } from "@app/types/assistant/triggers";
 import {
   isCronScheduleConfig,
   isIntervalScheduleConfig,
+  TRIGGER_EXECUTION_MODES,
 } from "@app/types/assistant/triggers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { UserType } from "@app/types/user";
@@ -21,6 +22,7 @@ const commonFields = {
   naturalLanguageDescription: z.string().optional(),
   customPrompt: z.string(),
   timezone: z.string().min(1, "Timezone is required"),
+  executionMode: z.enum(TRIGGER_EXECUTION_MODES).default("user_pool"),
   spaceId: z.string().nullable(),
 };
 
@@ -56,6 +58,7 @@ export function getScheduleFormDefaultValues(
     status: trigger?.status ?? "enabled",
     naturalLanguageDescription: trigger?.naturalLanguageDescription ?? "",
     customPrompt: trigger?.customPrompt ?? "",
+    executionMode: trigger?.executionMode ?? "user_pool",
     spaceId: trigger?.spaceId ?? null,
   };
 
@@ -132,6 +135,7 @@ export function formValuesToScheduleTriggerData({
     naturalLanguageDescription:
       schedule.naturalLanguageDescription?.trim() ?? null,
     customPrompt: schedule.customPrompt?.trim() ?? null,
+    executionMode: schedule.executionMode,
     editorName:
       editTrigger?.kind === "schedule"
         ? editTrigger.editorName

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -1,10 +1,11 @@
 import type { AgentBuilderWebhookTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { RecentWebhookRequests } from "@app/components/agent_builder/triggers/RecentWebhookRequests";
 import { TriggerPodSelector } from "@app/components/agent_builder/triggers/TriggerPodSelector";
+import { TriggerPoolSelector } from "@app/components/agent_builder/triggers/TriggerPoolSelector";
 import { TriggerStatusToggle } from "@app/components/agent_builder/triggers/TriggerStatusToggle";
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import { WebhookEditionFilters } from "@app/components/agent_builder/triggers/webhook/WebhookEditionFilters";
-import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
 import type {
@@ -60,36 +61,64 @@ function WebhookEditionNameInput({ isEditor }: WebhookEditionNameInputProps) {
 }
 
 interface WebhookEditionExecutionLimitProps {
-  executionMode: TriggerExecutionMode;
+  isEditor: boolean;
 }
 
 function WebhookEditionExecutionLimit({
-  executionMode,
+  isEditor,
 }: WebhookEditionExecutionLimitProps) {
   const { control } = useFormContext<TriggerViewsSheetFormValues>();
+  const { hasFeature } = useFeatureFlags();
   const {
-    field: { value: executionLimit },
+    field: limitField,
+    fieldState: { error },
   } = useController({
     control,
     name: "webhook.executionPerDayLimitOverride",
   });
+  const {
+    field: { value: executionMode },
+  } = useController({ control, name: "webhook.executionMode" });
+
+  const quotaName =
+    executionMode === "user_pool" ? "fair use" : "programmatic usage";
+
+  if (!hasFeature("trigger_pool_choice")) {
+    return (
+      <div className="flex flex-col space-y-1">
+        <Label htmlFor="execution-limit">Rate limits</Label>
+        <p>Limits are set on a 24-hour window. </p>
+        <ContentMessage
+          variant="info"
+          size="lg"
+          icon={AlertCircle}
+          title={`Up to ${limitField.value} requests per day`}
+        >
+          This trigger can send a limited number of messages per day. This
+          prevents a single trigger from using up your workspace's message fair
+          use quota. This trigger is currently running on your workspace's{" "}
+          {quotaName} quota.
+          <br /> (
+          <LinkWrapper
+            href="https://docs.dust.tt/docs/rate-limiting#/"
+            target="_blank"
+            rel="noreferrer"
+            className="underline"
+          >
+            Learn more
+          </LinkWrapper>
+          )
+        </ContentMessage>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col space-y-1">
       <Label htmlFor="execution-limit">Rate limits</Label>
-      <p>Limits are set on a 24-hour window. </p>
-      <ContentMessage
-        variant="info"
-        size="lg"
-        icon={AlertCircle}
-        title={`Up to ${executionLimit} requests per day`}
-      >
-        This trigger can send a limited number of messages per day. This
-        prevents a single trigger from using up your workspace's message fair
-        use quota. This trigger is currently running on your workspace's{" "}
-        {executionMode === "user_pool" ? "fair use" : "programmatic usage"}{" "}
-        quota.
-        <br /> (
+      <p className="text-sm text-muted-foreground">
+        Maximum number of runs over a 24-hour window, on top of your workspace's{" "}
+        {quotaName} quota. (
         <LinkWrapper
           href="https://docs.dust.tt/docs/rate-limiting#/"
           target="_blank"
@@ -99,7 +128,20 @@ function WebhookEditionExecutionLimit({
           Learn more
         </LinkWrapper>
         )
-      </ContentMessage>
+      </p>
+      <Input
+        id="execution-limit"
+        type="number"
+        className="w-32"
+        disabled={!isEditor}
+        name={limitField.name}
+        value={String(limitField.value)}
+        onChange={(event) => limitField.onChange(event.target.valueAsNumber)}
+        onBlur={limitField.onBlur}
+        isError={!!error}
+        message={error?.message}
+        messageStatus="error"
+      />
     </div>
   );
 }
@@ -312,9 +354,9 @@ export function WebhookEditionSheetContent({
 
         <Separator />
 
-        <WebhookEditionExecutionLimit
-          executionMode={trigger?.executionMode ?? "user_pool"}
-        />
+        <TriggerPoolSelector name="webhook.executionMode" isEditor={isEditor} />
+
+        <WebhookEditionExecutionLimit isEditor={isEditor} />
 
         <Separator />
 

--- a/front/components/assistant/details/AgentDetailsSheet.tsx
+++ b/front/components/assistant/details/AgentDetailsSheet.tsx
@@ -65,6 +65,7 @@ function triggerTypeToBuilderType(
         naturalLanguageDescription: trigger.naturalLanguageDescription,
         configuration: trigger.configuration,
         editor: trigger.editor,
+        executionMode: trigger.executionMode,
         spaceId: trigger.spaceId,
       };
     case "webhook":

--- a/front/components/assistant/details/useTriggerSheetState.ts
+++ b/front/components/assistant/details/useTriggerSheetState.ts
@@ -175,6 +175,7 @@ export function useTriggerSheetState({
             naturalLanguageDescription: triggerData.naturalLanguageDescription,
             configuration: triggerData.configuration,
             status: triggerData.status,
+            executionMode: triggerData.executionMode,
             spaceId: triggerData.spaceId,
           };
 
@@ -211,6 +212,7 @@ export function useTriggerSheetState({
             webhookSourceViewId: triggerData.webhookSourceViewId ?? "",
             executionPerDayLimitOverride:
               triggerData.executionPerDayLimitOverride ?? 0,
+            executionMode: triggerData.executionMode,
             status: triggerData.status,
             spaceId: triggerData.spaceId,
           };

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -87,6 +87,14 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     blob: CreationAttributes<TriggerModel>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<TriggerResource, Error>> {
+    if (!(await this.canUseExecutionMode(auth, blob.executionMode))) {
+      return new Err(
+        new TriggerExecutionModeForbiddenError(
+          "You don't have permission to charge this trigger to the workspace."
+        )
+      );
+    }
+
     const trigger = await TriggerModel.create(blob, {
       transaction,
     });

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -1048,14 +1048,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(undefined);
   }
 
-  private async canSetExecutionMode(
+  private static async canUseExecutionMode(
     auth: Authenticator,
     executionMode: TriggerExecutionMode
   ): Promise<boolean> {
-    if (!auth.isManager() && this.editor !== auth.getNonNullableUser().id) {
-      return false;
-    }
-
     switch (executionMode) {
       case "user_pool":
         return true;
@@ -1064,6 +1060,17 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       default:
         assertNever(executionMode);
     }
+  }
+
+  private async canSetExecutionMode(
+    auth: Authenticator,
+    executionMode: TriggerExecutionMode
+  ): Promise<boolean> {
+    if (!auth.isManager() && this.editor !== auth.getNonNullableUser().id) {
+      return false;
+    }
+
+    return TriggerResource.canUseExecutionMode(auth, executionMode);
   }
 
   async setExecutionMode(

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -72,6 +72,20 @@ export class TriggerExecutionModeForbiddenError extends Error {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface TriggerResource extends ReadonlyAttributesType<TriggerModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+async function canUseExecutionMode(
+  auth: Authenticator,
+  executionMode: TriggerExecutionMode
+): Promise<boolean> {
+  switch (executionMode) {
+    case "user_pool":
+      return true;
+    case "workspace_pool":
+      return auth.hasWorkspacePermission("use_workspace_pool", "trigger");
+    default:
+      assertNever(executionMode);
+  }
+}
+
 export class TriggerResource extends BaseResource<TriggerModel> {
   static model: ModelStatic<TriggerModel> = TriggerModel;
 
@@ -87,7 +101,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     blob: CreationAttributes<TriggerModel>,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<TriggerResource, Error>> {
-    if (!(await this.canUseExecutionMode(auth, blob.executionMode))) {
+    if (!(await canUseExecutionMode(auth, blob.executionMode))) {
       return new Err(
         new TriggerExecutionModeForbiddenError(
           "You don't have permission to charge this trigger to the workspace."
@@ -1056,30 +1070,13 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(undefined);
   }
 
-  private static async canUseExecutionMode(
-    auth: Authenticator,
-    executionMode: TriggerExecutionMode
-  ): Promise<boolean> {
-    switch (executionMode) {
-      case "user_pool":
-        return true;
-      case "workspace_pool":
-        return auth.hasWorkspacePermission("use_workspace_pool", "trigger");
-      default:
-        assertNever(executionMode);
-    }
-  }
-
   async setExecutionMode(
     auth: Authenticator,
     executionMode: TriggerExecutionMode
   ): Promise<Result<undefined, Error>> {
     const isEditor =
       auth.isManager() || this.editor === auth.getNonNullableUser().id;
-    if (
-      !isEditor ||
-      !(await TriggerResource.canUseExecutionMode(auth, executionMode))
-    ) {
+    if (!isEditor || !(await canUseExecutionMode(auth, executionMode))) {
       return new Err(
         new TriggerExecutionModeForbiddenError(
           "You don't have permission to change this trigger's pool."

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -1070,22 +1070,16 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     }
   }
 
-  private async canSetExecutionMode(
-    auth: Authenticator,
-    executionMode: TriggerExecutionMode
-  ): Promise<boolean> {
-    if (!auth.isManager() && this.editor !== auth.getNonNullableUser().id) {
-      return false;
-    }
-
-    return TriggerResource.canUseExecutionMode(auth, executionMode);
-  }
-
   async setExecutionMode(
     auth: Authenticator,
     executionMode: TriggerExecutionMode
   ): Promise<Result<undefined, Error>> {
-    if (!(await this.canSetExecutionMode(auth, executionMode))) {
+    const isEditor =
+      auth.isManager() || this.editor === auth.getNonNullableUser().id;
+    if (
+      !isEditor ||
+      !(await TriggerResource.canUseExecutionMode(auth, executionMode))
+    ) {
       return new Err(
         new TriggerExecutionModeForbiddenError(
           "You don't have permission to change this trigger's pool."

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -133,6 +133,7 @@ export const TriggerSchema = z.discriminatedUnion("kind", [
     configuration: ScheduleConfigSchema,
     editor: z.number().optional(),
     status: TriggerStatusSchema.optional(),
+    executionMode: z.enum(TRIGGER_EXECUTION_MODES).optional(),
     spaceId: z.string().nullable().optional(),
   }),
   z.object({
@@ -145,6 +146,7 @@ export const TriggerSchema = z.discriminatedUnion("kind", [
     executionPerDayLimitOverride: z.number(),
     editor: z.number().optional(),
     status: TriggerStatusSchema.optional(),
+    executionMode: z.enum(TRIGGER_EXECUTION_MODES).optional(),
     spaceId: z.string().nullable().optional(),
   }),
 ]);


### PR DESCRIPTION
## Description

Third PR of the trigger pool stack (#30860). The schedule and webhook sheets get a Credits picker, disabled unless an admin granted `use_workspace_pool`, and webhooks get an editable daily run cap where the limit used to be read-only text. Schedules now carry an execution mode end to end; POST and PATCH honor it when the flag is on, and leave the stored pool alone when the field is absent.

## Tests

Functional tests on create and update: permitted admin, rejected builder, flag off, and an update that omits the field keeping the trigger's pool.

## Risk

Low, flagged off. Without the grant the picker is read-only and the server rejects the change.

## Deploy Plan

Deploy front.