### PR TITLE
[front] refactor: use Sparkle ProgressBar in ConsumptionProgressBar

### DIFF
--- a/front/components/pages/workspace/developers/ConsumptionProgressBar.tsx
+++ b/front/components/pages/workspace/developers/ConsumptionProgressBar.tsx
@@ -13,7 +13,7 @@ export function ConsumptionProgressBar({
 
   return (
     <ProgressBar
-      className="h-2 bg-muted-foreground/10"
+      className="h-2 w-full bg-muted-foreground/10"
       values={[
         {
           value: percentage,

--- a/front/components/pages/workspace/developers/ConsumptionProgressBar.tsx
+++ b/front/components/pages/workspace/developers/ConsumptionProgressBar.tsx
@@ -1,4 +1,4 @@
-import { cn, Page } from "@dust-tt/sparkle";
+import { Page, ProgressBar } from "@dust-tt/sparkle";
 
 interface ConsumptionProgressBarProps {
   consumed: number;
@@ -12,15 +12,16 @@ export function ConsumptionProgressBar({
   const percentage = total > 0 ? Math.min((consumed / total) * 100, 100) : 0;
 
   return (
-    <div className="h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10">
-      <div
-        className={cn(
-          "h-full rounded-full transition-all",
-          percentage > 80 ? "bg-warning-700" : "bg-primary"
-        )}
-        style={{ width: `${percentage}%` }}
-      />
-    </div>
+    <ProgressBar
+      className="h-2 bg-muted-foreground/10"
+      values={[
+        {
+          value: percentage,
+          className: percentage > 80 ? "bg-warning-700" : "bg-primary",
+        },
+        { value: 100 - percentage, className: "bg-transparent" },
+      ]}
+    />
   );
 }
 


### PR DESCRIPTION
## Description

Uniformizes progress/loading bars across the app now that Sparkle has a `ProgressBar` component: `ConsumptionProgressBar` / `ConsumptionProgressBarWithNumbers` (used on the Developers > Credits Usage and Self-Improving Skills pages) now render via `@dust-tt/sparkle`'s `ProgressBar` instead of hand-rolled divs with inline `style={{ width }}`.

Color-coding (warning color past 80% consumed) is preserved using `ProgressBar`'s segmented `values` API: a colored "consumed" segment plus a `bg-transparent` "remaining" segment so the track color still shows through.

Part of a small series doing the same migration for the other non-Sparkle progress bars found in the app (`TrialMessageUsage`, `CreditUsageCard`, `FreePlanSeatsSection`, `PokeUsageTab`).

## Tests

Manual: seeded local `credits` rows (free/committed/payg, partially consumed) for a local workspace and verified the bars render correctly on `/w/{wId}/developers/credits-usage`, including the >80% warning color threshold. Also ran `npx tsgo --noEmit` and lint via the pre-commit hook.

## Risk

Low — presentational-only change, same props/behavior for callers of `ConsumptionProgressBar`/`ConsumptionProgressBarWithNumbers`. 

## Deploy Plan

- Deploy front
