### PR TITLE
[front] refactor: use Sparkle ProgressBar in TrialMessageUsage

### DIFF
--- a/front/components/app/TrialMessageUsage.test.tsx
+++ b/front/components/app/TrialMessageUsage.test.tsx
@@ -17,6 +17,17 @@ vi.mock("@dust-tt/sparkle", () => ({
   }) => <a href={href}>{children}</a>,
   cn: (...classes: Array<string | false | null | undefined>) =>
     classes.filter(Boolean).join(" "),
+  ProgressBar: ({
+    values,
+  }: {
+    values: Array<{ value: number; className?: string }>;
+  }) => (
+    <div>
+      {values.map((v, i) => (
+        <div key={i} data-value={v.value} className={v.className} />
+      ))}
+    </div>
+  ),
 }));
 
 const mockedUseTrialMessageUsage = vi.fn();

--- a/front/components/app/TrialMessageUsage.tsx
+++ b/front/components/app/TrialMessageUsage.tsx
@@ -67,7 +67,7 @@ export function TrialMessageUsage({
         </span>
       </div>
       <ProgressBar
-        className="h-2 bg-primary-100"
+        className="h-2 w-full bg-primary-100"
         values={[
           {
             value: Math.min(percentage * 100, 100),

--- a/front/components/app/TrialMessageUsage.tsx
+++ b/front/components/app/TrialMessageUsage.tsx
@@ -1,6 +1,6 @@
 import { AGENT_MESSAGE_COMPLETED_EVENT } from "@app/lib/notifications/events";
 import { useTrialMessageUsage } from "@app/lib/swr/trial_message_usage";
-import { Button, cn, LinkWrapper } from "@dust-tt/sparkle";
+import { Button, cn, LinkWrapper, ProgressBar } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 
 const MESSAGE_USAGE_CRITICAL_THRESHOLD = 0.9;
@@ -66,20 +66,19 @@ export function TrialMessageUsage({
           / {limit}
         </span>
       </div>
-      <div
-        className={cn(
-          "h-2 w-full overflow-hidden rounded-full",
-          "bg-primary-100"
-        )}
-      >
-        <div
-          className={cn(
-            "h-full rounded-full transition-all",
-            isCritical ? "bg-warning-700" : "bg-foreground"
-          )}
-          style={{ width: `${Math.min(percentage * 100, 100)}%` }}
-        />
-      </div>
+      <ProgressBar
+        className="h-2 bg-primary-100"
+        values={[
+          {
+            value: Math.min(percentage * 100, 100),
+            className: isCritical ? "bg-warning-700" : "bg-foreground",
+          },
+          {
+            value: 100 - Math.min(percentage * 100, 100),
+            className: "bg-transparent",
+          },
+        ]}
+      />
       {isAtLimit && isAdmin && (
         <div className="mt-3">
           <LinkWrapper


### PR DESCRIPTION
## Description

Part of a small series migrating the app's remaining non-Sparkle progress bars to `@dust-tt/sparkle`'s `ProgressBar` component (see #30866). `TrialMessageUsage` (sidebar, agent builder sidekick/preview) now renders its usage bar via `ProgressBar` instead of a hand-rolled div with inline `style={{ width }}`.

Color-coding (warning color at/above 90% consumed) is preserved using `ProgressBar`'s segmented `values` API: a colored "consumed" segment plus a `bg-transparent` "remaining" segment so the track color still shows through. A follow-up commit restores `w-full` on the bar, which had collapsed to zero width without an explicit width class.

## Tests

Manual: used `scripts/local/toggle_trial_message_usage.sh` to put a local workspace on a trialing subscription near its message limit, and verified the bar renders full-width with the correct color in the sidebar and agent builder sidekick/preview panels, including the critical (>=90%) warning color. Also updated `TrialMessageUsage.test.tsx`'s `@dust-tt/sparkle` mock to include `ProgressBar` (it was missing after the refactor, breaking CI) and ran `npx tsgo --noEmit`.

## Risk

Low — presentational-only change, same rendering conditions and props for `TrialMessageUsage` callers.

## Deploy Plan

- Deploy front
