### PR TITLE
[front] refactor: use Sparkle ProgressBar in CreditUsageCard

### DIFF
--- a/front/components/app/CreditUsage.test.tsx
+++ b/front/components/app/CreditUsage.test.tsx
@@ -42,7 +42,7 @@ describe("CreditUsage", () => {
     const progressbar = rendered.getByRole("progressbar", {
       name: "Credits used",
     });
-    expect(progressbar.firstElementChild).toHaveStyle({ width: "100%" });
+    expect(progressbar.firstElementChild).toHaveStyle({ flexGrow: "100" });
     expect(progressbar.firstElementChild).toHaveClass("bg-red-500");
   });
 

--- a/front/components/app/CreditUsageCard.tsx
+++ b/front/components/app/CreditUsageCard.tsx
@@ -1,4 +1,4 @@
-import { CoinsStacked01, cn } from "@dust-tt/sparkle";
+import { CoinsStacked01, cn, ProgressBar } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
 export type CreditUsageTone = "on_target" | "elevated" | "critical";
@@ -49,19 +49,14 @@ export function CreditUsageCard({
           </div>
           <span className={TONE_TEXT_CLASSES[tone]}>{usedPercentage}%</span>
         </div>
-        <div
+        <ProgressBar
           aria-label={`${label} used`}
-          aria-valuemax={100}
-          aria-valuemin={0}
-          aria-valuenow={usedPercentage}
-          className="h-1 w-full overflow-hidden rounded-full bg-border"
-          role="progressbar"
-        >
-          <div
-            className={cn("h-full rounded-full", TONE_BAR_CLASSES[tone])}
-            style={{ width: `${usedPercentage}%` }}
-          />
-        </div>
+          className="h-1 bg-border"
+          values={[
+            { value: usedPercentage, className: TONE_BAR_CLASSES[tone] },
+            { value: 100 - usedPercentage, className: "bg-transparent" },
+          ]}
+        />
       </div>
       <div className="text-xs font-medium text-muted-foreground">
         {children}

--- a/front/components/app/CreditUsageCard.tsx
+++ b/front/components/app/CreditUsageCard.tsx
@@ -51,7 +51,7 @@ export function CreditUsageCard({
         </div>
         <ProgressBar
           aria-label={`${label} used`}
-          className="h-1 bg-border"
+          className="h-1 w-full bg-border"
           values={[
             { value: usedPercentage, className: TONE_BAR_CLASSES[tone] },
             { value: 100 - usedPercentage, className: "bg-transparent" },


### PR DESCRIPTION
## Description

Part of the same series as #30866 and #30867, migrating the app's remaining non-Sparkle progress bars to `@dust-tt/sparkle`'s `ProgressBar` component. `CreditUsageCard` (used by `CreditUsage` in the avatar/profile menu and sidebar companion widget, and by `FairUseCreditsUsage`) now renders its usage bar via `ProgressBar` instead of a hand-rolled `role="progressbar"` div with inline `style={{ width }}`.

Color-coding by tone (`on_target` / `elevated` / `critical`) is preserved using `ProgressBar`'s segmented `values` API: a colored "consumed" segment plus a `bg-transparent` "remaining" segment so the track color still shows through. A follow-up commit restores `w-full` on the bar, which had collapsed to zero width without an explicit width class.

## Tests

Updated `CreditUsage.test.tsx`: the segmented `ProgressBar` renders its fill with `flexGrow` instead of an inline `width` percentage, so the "clamps displayed usage" test's `toHaveStyle({ width: "100%" })` assertion no longer matched and was updated to `toHaveStyle({ flexGrow: "100" })`.

Manual: since `CreditUsageCard`'s usage is only wired up for credit-priced plans with a real Metronome contract (billing cycle resolution requires it), used `scripts/local/toggle_billing_profile.sh real_business` to attach the local workspace to Dust's persistent Metronome sandbox contract, then lowered the local user's `poolCapOverrideAwuCredits` to bring their real (small) consumed usage close to their spend limit. Verified the bar renders correctly with the `on_target`/`elevated`/`critical` tones in both the avatar profile menu and the sidebar companion widget. Also ran `npx tsgo --noEmit`.

## Risk

Low — presentational-only change, same rendering conditions and props for `CreditUsageCard` callers.

## Deploy Plan

- Deploy front
