### PR TITLE
[front] refactor: use Sparkle ProgressBar in FreePlanSeatsSection

### DIFF
--- a/front/components/workspace/billing/FreePlanSeatsSection.tsx
+++ b/front/components/workspace/billing/FreePlanSeatsSection.tsx
@@ -1,7 +1,7 @@
 import { useFreeSeatCounts } from "@app/lib/swr/memberships";
 import type { SubscriptionType } from "@app/types/plan";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Icon, InfoSquare, Spinner } from "@dust-tt/sparkle";
+import { Icon, InfoSquare, ProgressBar, Spinner } from "@dust-tt/sparkle";
 
 interface FreePlanSeatsSectionProps {
   owner: LightWorkspaceType;
@@ -53,17 +53,13 @@ export function FreePlanSeatsSection({
         <p className="text-sm text-foreground">{description}</p>
       </div>
 
-      <div className="flex h-1 w-full gap-0.5">
-        {fillPercent > 0 && (
-          <div
-            className="h-full shrink-0 rounded-lg bg-foreground"
-            style={{ width: `${fillPercent}%` }}
-          />
-        )}
-        {!isAtCapacity && (
-          <div className="h-full min-w-0 flex-1 rounded-lg bg-black/[0.08]" />
-        )}
-      </div>
+      <ProgressBar
+        className="h-1"
+        values={[
+          { value: fillPercent, className: "bg-foreground" },
+          { value: 100 - fillPercent, className: "bg-black/[0.08]" },
+        ]}
+      />
     </div>
   );
 }

--- a/front/components/workspace/billing/FreePlanSeatsSection.tsx
+++ b/front/components/workspace/billing/FreePlanSeatsSection.tsx
@@ -54,7 +54,7 @@ export function FreePlanSeatsSection({
       </div>
 
       <ProgressBar
-        className="h-1"
+        className="h-1 w-full"
         values={[
           { value: fillPercent, className: "bg-foreground" },
           { value: 100 - fillPercent, className: "bg-black/[0.08]" },


### PR DESCRIPTION
## Description

Part of the same series as #30866, #30867, and #30868, migrating the app's remaining non-Sparkle progress bars to `@dust-tt/sparkle`'s `ProgressBar` component. `FreePlanSeatsSection` (shown on the Billing page for workspaces on the credit-priced free plan) now renders its lifetime-free-seats bar via `ProgressBar` instead of two hand-rolled flex divs with inline `style={{ width }}`.

The consumed/remaining split is preserved using `ProgressBar`'s segmented `values` API: a `bg-foreground` "used" segment plus a `bg-black/[0.08]` "remaining" segment. A follow-up commit restores `w-full` on the bar, which had collapsed to zero width without an explicit width class.

## Tests

No existing unit test covers this component.

Manual: `FreePlanSeatsSection` only renders for a credit-priced plan with `maxLifetimeFreeUsersInWorkspace > 0` (`CP_FREE_PLAN` locally), so switched the local workspace to `CP_FREE_PLAN` and set a few local memberships' `seatType` to `free` to get a partial lifetime-seat count. Verified the bar renders correctly at a partial fill on `/w/{wId}/billing`, and ran `npx tsgo --noEmit`.

## Risk

Low — presentational-only change, same rendering conditions and props for `FreePlanSeatsSection` callers.

## Deploy Plan

- Deploy front
