### PR TITLE
[front] refactor: use Sparkle ProgressBar in PokeUsageTab

### DIFF
--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -20,7 +20,13 @@ import type {
 import type { SubscriptionType } from "@app/types/plan";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
-import { AlertCircle, Chip, ContentMessage, Spinner } from "@dust-tt/sparkle";
+import {
+  AlertCircle,
+  Chip,
+  ContentMessage,
+  ProgressBar,
+  Spinner,
+} from "@dust-tt/sparkle";
 
 interface PokeUsageTabProps {
   owner: WorkspaceType;
@@ -310,12 +316,13 @@ function PokeCreditPoolCard({ owner }: PokeCreditPoolCardProps) {
           credits
         </span>
       </div>
-      <div className="flex h-2 w-full overflow-hidden rounded-full bg-muted-foreground/10">
-        <div
-          className="h-full shrink-0 bg-highlight transition-all"
-          style={{ width: `${consumedPct}%` }}
-        />
-      </div>
+      <ProgressBar
+        className="h-2 bg-muted-foreground/10"
+        values={[
+          { value: consumedPct, className: "bg-highlight" },
+          { value: 100 - consumedPct, className: "bg-transparent" },
+        ]}
+      />
       <div className="flex flex-wrap gap-x-6 gap-y-1 text-xs text-muted-foreground">
         <span>{formatCredits(totalRemainingCredits)} credits remaining</span>
         {overageCredits !== null && overageCredits > 0 && (

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -317,7 +317,7 @@ function PokeCreditPoolCard({ owner }: PokeCreditPoolCardProps) {
         </span>
       </div>
       <ProgressBar
-        className="h-2 bg-muted-foreground/10"
+        className="h-2 w-full bg-muted-foreground/10"
         values={[
           { value: consumedPct, className: "bg-highlight" },
           { value: 100 - consumedPct, className: "bg-transparent" },


### PR DESCRIPTION
## Description

Part of the same series as #30866, #30867, #30868, and #30869, migrating the app's remaining non-Sparkle progress bars to `@dust-tt/sparkle`'s `ProgressBar` component. `PokeCreditPoolCard` (the Workspace Credits Pool card on the Poke internal admin tool's Usage tab, `PokeUsageTab.tsx`) now renders its consumed/remaining bar via `ProgressBar` instead of a hand-rolled flex div with inline `style={{ width }}`.

The consumed/remaining split is preserved using `ProgressBar`'s segmented `values` API: a `bg-highlight` "consumed" segment plus a `bg-transparent` "remaining" segment so the track color still shows through. A follow-up commit restores `w-full` on the bar, which had collapsed to zero width without an explicit width class.

## Tests

No existing unit test covers this component.

Manual: `PokeCreditPoolCard` is backed by live Metronome balance/invoice data (`getAwuPoolSummary`), not the local `credits` table, so it only renders for a workspace with a real Metronome contract attached. Used `scripts/local/toggle_billing_profile.sh real_business` to attach the local workspace to Dust's persistent Metronome sandbox contract and confirmed the "Usage" tab and card render without error on `/poke/{wId}`. Also ran `npx tsgo --noEmit`.

## Risk

Low — presentational-only change, same rendering conditions and props for `PokeCreditPoolCard`/`PokeUsageTab` callers.

## Deploy Plan

- Deploy front
