### PR TITLE
Lower github worker activity concurrency to 8

### DIFF
--- a/connectors/src/connectors/github/temporal/worker.ts
+++ b/connectors/src/connectors/github/temporal/worker.ts
@@ -25,7 +25,7 @@ export async function runGithubWorker() {
       ...activitiesSyncCode,
     },
     taskQueue: QUEUE_NAME,
-    maxConcurrentActivityTaskExecutions: 16,
+    maxConcurrentActivityTaskExecutions: 8,
     maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
     connection,
     reuseV8Context: true,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
The github Temporal worker runs up to 16 concurrent activities on a single Node event loop, and the pods sit pinned at roughly one core regardless of their two core limit, which is the signature of a saturated JavaScript thread rather than a starved container. Profiling the code extraction path showed the pipeline itself is pretty efficient on an idle event loop, while the worker process extracts at much much much slower pace.

Halving the concurrency gives each activity roughly twice the loop time, which by the observed numbers should bring large repository extractions comfortably inside the activity timeout. I might had a few more replicas.

This is a mitigation rather than the full fix. The proper isolation is a dedicated task queue for code sync served by its own deployment at very low concurrency, so extractions run on a near-idle loop. That is left for a follow-up.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->