### PR TITLE
[front] chore: remove unused @contentful/rich-text-types dependency

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
     "@anthropic-ai/vertex-sdk": "^0.19.0",
-    "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
     "@anthropic-ai/vertex-sdk": "^0.19.0",
-    "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
         "@anthropic-ai/vertex-sdk": "^0.19.0",
-        "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
         "@anthropic-ai/vertex-sdk": "^0.19.0",
-        "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.7.7",


### PR DESCRIPTION
## Description

Remove the unused `@contentful/rich-text-types` dependency from `front/package.json` and `package-lock.json`.

Like `@contentful/rich-text-react-renderer`, it was introduced in #18411 ([Acquisition] Blog from headless CMS, merged 2025-11-28) for the headless-CMS blog and became unused when the blog components were deleted in #27248 ([front] chore: trim front's marketing, merged 2026-06-12).

## Tests

Verified with `knip --dependencies` and a repo-wide grep that `@contentful/rich-text-types` is not imported anywhere under `front/`. Ran `npm install --package-lock-only -w front` to regenerate the lockfile; the `marketing` workspace, which still uses the package, keeps its own lockfile entry untouched.

## Risk

Low: dependency-only change with no runtime code changes.

## Deploy Plan

None — no runtime behavior change.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
