### PR TITLE
[front] chore: remove unused embla-carousel-react dependency

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -79,7 +79,6 @@
     "@opentelemetry/semantic-conventions": "^1.38.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-label": "^2.0.2",
-    "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-visually-hidden": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
     "@anthropic-ai/vertex-sdk": "^0.19.0",
-    "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
     "@anthropic-ai/vertex-sdk": "^0.19.0",
-    "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.7.7",

--- a/front/package.json
+++ b/front/package.json
@@ -88,7 +88,6 @@
     "@slack/web-api": "^7.10.0",
     "@stripe/react-stripe-js": "^3.10.0",
     "@stripe/stripe-js": "^5.10.0",
-    "@tailwindcss/forms": "^0.5.9",
     "@tanstack/react-table": "^8.13.0",
     "@tanstack/table-core": "^8.13.0",
     "@temporalio/activity": "1.15.1",

--- a/front/package.json
+++ b/front/package.json
@@ -140,7 +140,6 @@
     "diff": "^8.0.2",
     "dompurify": "^3.2.7",
     "e2b": "^2.12.1",
-    "embla-carousel-react": "^8.0.1",
     "emoji-mart": "^5.6.0",
     "event-source-polyfill": "^1.0.31",
     "eventsource-parser": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
         "@anthropic-ai/vertex-sdk": "^0.19.0",
-        "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -403,7 +403,6 @@
         "diff": "^8.0.2",
         "dompurify": "^3.2.7",
         "e2b": "^2.12.1",
-        "embla-carousel-react": "^8.0.1",
         "emoji-mart": "^5.6.0",
         "event-source-polyfill": "^1.0.31",
         "eventsource-parser": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
         "@anthropic-ai/vertex-sdk": "^0.19.0",
-        "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,7 +342,6 @@
         "@opentelemetry/semantic-conventions": "^1.38.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-label": "^2.0.2",
-        "@radix-ui/react-navigation-menu": "^1.1.4",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-visually-hidden": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -351,7 +351,6 @@
         "@slack/web-api": "^7.10.0",
         "@stripe/react-stripe-js": "^3.10.0",
         "@stripe/stripe-js": "^5.10.0",
-        "@tailwindcss/forms": "^0.5.9",
         "@tanstack/react-table": "^8.13.0",
         "@tanstack/table-core": "^8.13.0",
         "@temporalio/activity": "1.15.1",


### PR DESCRIPTION
## Description

Remove the unused `embla-carousel-react` dependency from `front/package.json` and `package-lock.json`.

It was introduced in #4567 (WIP New Website, merged 2024-04-16) for the marketing site's carousel component. Its last import was removed in #27248 ([front] chore: trim front's marketing, merged 2026-06-12), when `front/components/home/Carousel.tsx` (which imported `useEmblaCarousel`) was deleted along with the rest of the marketing pages.

## Tests

Verified with `knip --dependencies` and a repo-wide grep that `embla-carousel-react` is not referenced anywhere under `front/`. Ran `npm install --package-lock-only -w front` to regenerate the lockfile.

## Risk

Low: dependency-only change with no runtime code changes.

## Deploy Plan

None — no runtime behavior change.
