### PR TITLE
[front] chore: remove unused webpack-stats-plugin dependency

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -79,7 +79,6 @@
     "@opentelemetry/semantic-conventions": "^1.38.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-label": "^2.0.2",
-    "@radix-ui/react-navigation-menu": "^1.1.4",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-visually-hidden": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -189,7 +189,6 @@
     "prosemirror-changeset": "^2.3.1",
     "re2-wasm": "^1.0.2",
     "react": "^18.3.1",
-    "react-beforeunload": "^2.5.3",
     "react-cookie": "^7.2.2",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.3",

--- a/front/package.json
+++ b/front/package.json
@@ -213,7 +213,6 @@
     "stripe": "^14.2.0",
     "swr": "^2.2.4",
     "tailwind-merge": "^2.2.1",
-    "tailwind-scrollbar-hide": "^1.1.7",
     "tailwindcss": "^4.3.0",
     "tldts": "^7.0.27",
     "tmp": "^0.2.5",

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
     "@anthropic-ai/vertex-sdk": "^0.19.0",
-    "@contentful/rich-text-react-renderer": "^16.1.6",
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",

--- a/front/package.json
+++ b/front/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.110.0",
     "@anthropic-ai/vertex-sdk": "^0.19.0",
-    "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
     "@dust-tt/sparkle": "^0.7.7",

--- a/front/package.json
+++ b/front/package.json
@@ -88,7 +88,6 @@
     "@slack/web-api": "^7.10.0",
     "@stripe/react-stripe-js": "^3.10.0",
     "@stripe/stripe-js": "^5.10.0",
-    "@tailwindcss/forms": "^0.5.9",
     "@tanstack/react-table": "^8.13.0",
     "@tanstack/table-core": "^8.13.0",
     "@temporalio/activity": "1.15.1",

--- a/front/package.json
+++ b/front/package.json
@@ -140,7 +140,6 @@
     "diff": "^8.0.2",
     "dompurify": "^3.2.7",
     "e2b": "^2.12.1",
-    "embla-carousel-react": "^8.0.1",
     "emoji-mart": "^5.6.0",
     "event-source-polyfill": "^1.0.31",
     "eventsource-parser": "^1.0.0",

--- a/front/package.json
+++ b/front/package.json
@@ -268,8 +268,7 @@
     "tsx": "^4.21.0",
     "vite": "^7.3.0",
     "vitest": "^4.0.16",
-    "vitest-canvas-mock": "^1.1.3",
-    "webpack-stats-plugin": "^1.1.3"
+    "vitest-canvas-mock": "^1.1.3"
   },
   "browser": {
     "net": false,

--- a/front/package.json
+++ b/front/package.json
@@ -161,7 +161,6 @@
     "io-ts-reporters": "^2.0.1",
     "io-ts-types": "^0.5.19",
     "iron-session": "^8.0.4",
-    "isomorphic-dompurify": "^2.32.0",
     "jsdom": "^26.0.0",
     "jsforce": "^3.8.2",
     "json-schema-to-typescript": "^15.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
         "@anthropic-ai/vertex-sdk": "^0.19.0",
-        "@contentful/rich-text-react-renderer": "^16.1.6",
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -403,7 +403,6 @@
         "diff": "^8.0.2",
         "dompurify": "^3.2.7",
         "e2b": "^2.12.1",
-        "embla-carousel-react": "^8.0.1",
         "emoji-mart": "^5.6.0",
         "event-source-polyfill": "^1.0.31",
         "eventsource-parser": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -306,7 +306,6 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.110.0",
         "@anthropic-ai/vertex-sdk": "^0.19.0",
-        "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
         "@dust-tt/sparkle": "^0.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -342,7 +342,6 @@
         "@opentelemetry/semantic-conventions": "^1.38.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-label": "^2.0.2",
-        "@radix-ui/react-navigation-menu": "^1.1.4",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-visually-hidden": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -452,7 +452,6 @@
         "prosemirror-changeset": "^2.3.1",
         "re2-wasm": "^1.0.2",
         "react": "^18.3.1",
-        "react-beforeunload": "^2.5.3",
         "react-cookie": "^7.2.2",
         "react-dom": "^18.3.1",
         "react-dropzone": "^14.2.3",
@@ -46550,15 +46549,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-beforeunload": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/react-beforeunload/-/react-beforeunload-2.7.0.tgz",
-      "integrity": "sha512-iyHA7CI2m76ECgOMC8WdPM5J6GKDmVzHj1oJ/1h8bKft+cqFggbU3/tUlZ4vCChH3vA4Jj1ciY2hquwGbB5VPA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/react-confetti": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -476,7 +476,6 @@
         "stripe": "^14.2.0",
         "swr": "^2.2.4",
         "tailwind-merge": "^2.2.1",
-        "tailwind-scrollbar-hide": "^1.1.7",
         "tailwindcss": "^4.3.0",
         "tldts": "^7.0.27",
         "tmp": "^0.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -424,7 +424,6 @@
         "io-ts-reporters": "^2.0.1",
         "io-ts-types": "^0.5.19",
         "iron-session": "^8.0.4",
-        "isomorphic-dompurify": "^2.32.0",
         "jsdom": "^26.0.0",
         "jsforce": "^3.8.2",
         "json-schema-to-typescript": "^15.0.4",
@@ -1192,12 +1191,6 @@
         "node": ">=24.16.0"
       }
     },
-    "node_modules/@acemir/cssom": {
-      "version": "0.9.31",
-      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
-      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "license": "MIT"
-    },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
@@ -1465,53 +1458,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
-    },
-    "node_modules/@asamuzakjp/dom-selector": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
-      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/nwsapi": "^2.3.9",
-        "bidi-js": "^1.0.3",
-        "css-tree": "^3.1.0",
-        "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.6"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@asamuzakjp/dom-selector/node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "license": "CC0-1.0"
-    },
-    "node_modules/@asamuzakjp/nwsapi": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
-      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "license": "MIT"
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -3260,37 +3206,6 @@
       "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
       "license": "MIT"
     },
-    "node_modules/@bramus/specificity": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.0.0"
-      },
-      "bin": {
-        "specificity": "bin/cli.js"
-      }
-    },
-    "node_modules/@bramus/specificity/node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@bramus/specificity/node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "license": "CC0-1.0"
-    },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
@@ -4192,22 +4107,6 @@
       "peerDependencies": {
         "@csstools/css-tokenizer": "^3.0.4"
       }
-    },
-    "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.29",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.29.tgz",
-      "integrity": "sha512-jx9GjkkP5YHuTmko2eWAvpPnb0mB4mGRr2U7XwVNwevm8nlpobZEVk+GNmiYMk2VuA75v+plfXWyroWKmICZXg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0"
     },
     "node_modules/@csstools/css-tokenizer": {
       "version": "3.0.4",
@@ -5454,23 +5353,6 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
-    },
-    "node_modules/@exodus/bytes": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
-      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/@faker-js/faker": {
@@ -24050,15 +23932,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/bidi-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
-      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "license": "MIT",
-      "dependencies": {
-        "require-from-string": "^2.0.2"
-      }
-    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -35015,342 +34888,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-2.36.0.tgz",
-      "integrity": "sha512-E8YkGyPY3a/U5s0WOoc8Ok+3SWL/33yn2IHCoxCFLBUUPVy9WGa++akJZFxQCcJIhI+UvYhbrbnTIFQkHKZbgA==",
-      "license": "MIT",
-      "dependencies": {
-        "dompurify": "^3.3.1",
-        "jsdom": "^28.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.5"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/@asamuzakjp/css-color": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
-      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0",
-        "lru-cache": "^11.2.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/csstools"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/csstools"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "license": "MIT",
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/cssstyle": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
-      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
-      "license": "MIT",
-      "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.1",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
-        "css-tree": "^3.1.0",
-        "lru-cache": "^11.2.6"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/html-encoding-sniffer": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
-      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.6.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/jsdom": {
-      "version": "28.1.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
-      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
-      "license": "MIT",
-      "dependencies": {
-        "@acemir/cssom": "^0.9.31",
-        "@asamuzakjp/dom-selector": "^6.8.1",
-        "@bramus/specificity": "^2.4.2",
-        "@exodus/bytes": "^1.11.0",
-        "cssstyle": "^6.0.1",
-        "data-urls": "^7.0.0",
-        "decimal.js": "^10.6.0",
-        "html-encoding-sniffer": "^6.0.0",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6",
-        "is-potential-custom-element-name": "^1.0.1",
-        "parse5": "^8.0.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.0",
-        "undici": "^7.21.0",
-        "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0",
-        "xml-name-validator": "^5.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "license": "CC0-1.0"
-    },
-    "node_modules/isomorphic-dompurify/node_modules/parse5": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
-      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^6.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tldts": "^7.0.5"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/isomorphic-dompurify/node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
-      "license": "MIT",
-      "dependencies": {
-        "@exodus/bytes": "^1.11.0",
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/istanbul-lib-coverage": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -531,8 +531,7 @@
         "tsx": "^4.21.0",
         "vite": "^7.3.0",
         "vitest": "^4.0.16",
-        "vitest-canvas-mock": "^1.1.3",
-        "webpack-stats-plugin": "^1.1.3"
+        "vitest-canvas-mock": "^1.1.3"
       },
       "engines": {
         "node": ">=24.16.0"
@@ -56825,13 +56824,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "node_modules/webpack-stats-plugin": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/webpack-stats-plugin/-/webpack-stats-plugin-1.1.3.tgz",
-      "integrity": "sha512-yUKYyy+e0iF/w31QdfioRKY+h3jDBRpthexBOWGKda99iu2l/wxYsI/XqdlP5IU58/0KB9CsJZgWNAl+/MPkRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/webpack-virtual-modules": {
       "version": "0.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -351,7 +351,6 @@
         "@slack/web-api": "^7.10.0",
         "@stripe/react-stripe-js": "^3.10.0",
         "@stripe/stripe-js": "^5.10.0",
-        "@tailwindcss/forms": "^0.5.9",
         "@tanstack/react-table": "^8.13.0",
         "@tanstack/table-core": "^8.13.0",
         "@temporalio/activity": "1.15.1",


### PR DESCRIPTION
## Description

Remove the unused `webpack-stats-plugin` devDependency from `front/package.json` and `package-lock.json`.

It was introduced in #16369 ([front] dev: Add bundle analyzers, merged 2025-09-29) to write bundle stats from `front/next.config.js`'s webpack config. That file (601 lines) was deleted wholesale in #27248 ([front] chore: trim front's marketing, merged 2026-06-12) as part of moving `front` off Next.js webpack builds onto the Vite-based `front-spa`. Sibling packages from the same original PR (`@next/bundle-analyzer`, `@statoscope/webpack-plugin`) were correctly dropped from `package.json` in the trim-marketing commit — `webpack-stats-plugin` was simply missed.

## Tests

Verified with `knip --dependencies` and a repo-wide grep that `webpack-stats-plugin` / `StatsWriterPlugin` is not referenced anywhere in the repo outside `package.json` and `package-lock.json`. Ran `npm install --package-lock-only -w front` to regenerate the lockfile.

## Risk

Low: dependency-only change with no runtime code changes.

## Deploy Plan

None — no runtime behavior change.