### PR TITLE
[front] enh: show "Add a follow-up" input bar placeholder while a message is generating

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -60,7 +60,7 @@ import React, {
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
 // Placeholder shown when a submitted message would be queued.
-const INPUT_BAR_QUEUE_PLACEHOLDER = "Add a follow-up";
+const INPUT_BAR_QUEUE_PLACEHOLDER = "Add a follow-up...";
 
 type SelectedSpacesState = {
   key: string;

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -255,12 +255,9 @@ export const InputBar = React.memo(function InputBar({
     isBlockedByAgentSwitch || submitBlockMessage !== null;
 
   // Same signal as the Stop button: a message sent while generating is queued.
-  const willQueueMessage = useMemo(
-    () =>
-      !!conversation &&
-      getConversationGeneratingMessages(conversation.sId).length > 0,
-    [conversation, getConversationGeneratingMessages]
-  );
+  const willQueueMessage =
+    !!conversation &&
+    getConversationGeneratingMessages(conversation.sId).length > 0;
 
   // Tools selection
 

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -59,8 +59,7 @@ import React, {
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
-// Placeholder shown while the agent is generating, when a submitted message
-// is queued as a follow-up.
+// Placeholder shown when a submitted message would be queued.
 const INPUT_BAR_QUEUE_PLACEHOLDER = "Add a follow-up";
 
 type SelectedSpacesState = {
@@ -255,8 +254,7 @@ export const InputBar = React.memo(function InputBar({
   const isBlockedForSubmission =
     isBlockedByAgentSwitch || submitBlockMessage !== null;
 
-  // A message submitted while the agent is generating (same signal as the Stop
-  // button) is queued as a follow-up.
+  // Same signal as the Stop button: a message sent while generating is queued.
   const willQueueMessage = useMemo(
     () =>
       !!conversation &&

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -59,6 +59,10 @@ import React, {
 
 const DEFAULT_INPUT_BAR_ACTIONS = [...INPUT_BAR_ACTIONS];
 
+// Placeholder shown while the agent is generating, when a submitted message
+// is queued as a follow-up.
+const INPUT_BAR_QUEUE_PLACEHOLDER = "Add a follow-up";
+
 type SelectedSpacesState = {
   key: string;
   spaceIds: string[];
@@ -250,6 +254,15 @@ export const InputBar = React.memo(function InputBar({
   const isBlockedByAgentSwitch = agentSwitchBlockMessage !== null;
   const isBlockedForSubmission =
     isBlockedByAgentSwitch || submitBlockMessage !== null;
+
+  // A message submitted while the agent is generating (same signal as the Stop
+  // button) is queued as a follow-up.
+  const willQueueMessage = useMemo(
+    () =>
+      !!conversation &&
+      getConversationGeneratingMessages(conversation.sId).length > 0,
+    [conversation, getConversationGeneratingMessages]
+  );
 
   // Tools selection
 
@@ -795,7 +808,9 @@ export const InputBar = React.memo(function InputBar({
             disableAgentSelector={isBlockedByAgentSwitch}
             disableInput={disableInput}
             submitBlockMessage={submitBlockMessage ?? agentSwitchBlockMessage}
-            placeholder={placeholder}
+            placeholder={
+              willQueueMessage ? INPUT_BAR_QUEUE_PLACEHOLDER : placeholder
+            }
             onShake={handleShake}
             isCompact={effectiveIsCompact}
             onExpandInputBar={onExpandInputBar}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -32,7 +32,9 @@ import {
 } from "@app/components/editor/extensions/shared/SlashCommandCapabilitiesItems";
 import type { SlashCommand } from "@app/components/editor/extensions/shared/slash_suggestion/SlashCommandDropdown";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
-import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
+import useCustomEditor, {
+  INPUT_BAR_DEFAULT_PLACEHOLDER,
+} from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
 import useUrlHandler from "@app/components/editor/input_bar/useUrlHandler";
 import type { Selection } from "@app/components/model_picker/modelPickerUtils";
@@ -1599,7 +1601,8 @@ const InputBarContainer = ({
   const showSendButton = !isVoiceActive || isSubmitting;
   const compactPreviewText = editorService.getTrimmedText();
   const compactDisplayPlaceholder =
-    (disableInput ? submitBlockMessage : placeholder) ?? "Get work done";
+    (disableInput ? submitBlockMessage : placeholder) ??
+    INPUT_BAR_DEFAULT_PLACEHOLDER;
 
   useEffect(() => {
     onVoiceActiveChange?.(isVoiceActive);

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -2,27 +2,40 @@ import {
   InputBarSlashSuggestionExtension,
   inputBarSlashSuggestionPluginKey,
 } from "@app/components/editor/extensions/input_bar/InputBarSlashSuggestionExtension";
-import { buildEditorExtensions } from "@app/components/editor/input_bar/useCustomEditor";
+import useCustomEditor, {
+  buildEditorExtensions,
+} from "@app/components/editor/input_bar/useCustomEditor";
 import type { WorkspaceType } from "@app/types/user";
+import { act, renderHook } from "@testing-library/react";
 import { Editor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const owner = {
+  id: 0,
+  sId: "wId",
+  name: "MeMeMe AlwaysMe",
+  role: "user",
+  segmentation: null,
+  whiteListedProviders: null,
+  defaultEmbeddingProvider: null,
+  metadata: null,
+  metronomeCustomerId: null,
+  sharingPolicy: "all_scopes",
+  regionalModelsOnly: false,
+} satisfies WorkspaceType;
 
 describe("buildEditorExtensions", () => {
   let editor: Editor;
-  const owner = {
-    id: 0,
-    sId: "wId",
-    name: "MeMeMe AlwaysMe",
-    role: "user",
-    segmentation: null,
-    whiteListedProviders: null,
-    defaultEmbeddingProvider: null,
-    metadata: null,
-    metronomeCustomerId: null,
-    sharingPolicy: "all_scopes",
-    regionalModelsOnly: false,
-  } satisfies WorkspaceType;
 
   function createSlashSuggestionEditor() {
     return new Editor({
@@ -248,5 +261,88 @@ describe("buildEditorExtensions", () => {
     expect(
       inputBarSlashSuggestionPluginKey.getState(editor.state)?.active
     ).toBe(false);
+  });
+});
+
+describe("useCustomEditor placeholder override", () => {
+  beforeAll(() => {
+    // jsdom does not implement matchMedia (used by useIsMobile).
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }))
+    );
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function renderEditorHook() {
+    const initialProps: { placeholderOverride: string | null } = {
+      placeholderOverride: null,
+    };
+    return renderHook(
+      ({ placeholderOverride }: { placeholderOverride: string | null }) =>
+        useCustomEditor({
+          onEnterKeyDown: vi.fn(),
+          disableAutoFocus: true,
+          owner,
+          conversationId: "cId",
+          placeholderOverride,
+        }),
+      { initialProps }
+    );
+  }
+
+  function getPlaceholderText(editor: Editor | null) {
+    return (
+      editor?.view.dom.querySelector("p")?.getAttribute("data-placeholder") ??
+      null
+    );
+  }
+
+  it("updates the placeholder without recreating the editor", () => {
+    const { result, rerender } = renderEditorHook();
+
+    const editor = result.current.editor;
+    expect(editor).not.toBeNull();
+    expect(getPlaceholderText(editor)).toBe("Get work done");
+
+    rerender({ placeholderOverride: "Add a follow-up" });
+
+    expect(result.current.editor).toBe(editor);
+    expect(getPlaceholderText(editor)).toBe("Add a follow-up");
+
+    rerender({ placeholderOverride: null });
+
+    expect(result.current.editor).toBe(editor);
+    expect(getPlaceholderText(editor)).toBe("Get work done");
+  });
+
+  it("preserves content and selection across placeholder changes", () => {
+    const { result, rerender } = renderEditorHook();
+
+    const editor = result.current.editor;
+    expect(editor).not.toBeNull();
+
+    act(() => {
+      editor?.commands.setContent("hello");
+      editor?.commands.setTextSelection(3);
+    });
+
+    rerender({ placeholderOverride: "Add a follow-up" });
+
+    expect(result.current.editor).toBe(editor);
+    expect(editor?.getText()).toBe("hello");
+    expect(editor?.state.selection.from).toBe(3);
   });
 });

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -269,15 +269,11 @@ describe("useCustomEditor placeholder override", () => {
     // jsdom does not implement matchMedia (used by useIsMobile).
     vi.stubGlobal(
       "matchMedia",
-      vi.fn().mockImplementation((query: string) => ({
+      vi.fn((query: string) => ({
         matches: false,
         media: query,
-        onchange: null,
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
-        addListener: vi.fn(),
-        removeListener: vi.fn(),
-        dispatchEvent: vi.fn(),
       }))
     );
   });
@@ -290,7 +286,7 @@ describe("useCustomEditor placeholder override", () => {
     const initialProps: { placeholderOverride: string | null } = {
       placeholderOverride: null,
     };
-    return renderHook(
+    const { result, rerender } = renderHook(
       ({ placeholderOverride }: { placeholderOverride: string | null }) =>
         useCustomEditor({
           onEnterKeyDown: vi.fn(),
@@ -301,20 +297,22 @@ describe("useCustomEditor placeholder override", () => {
         }),
       { initialProps }
     );
+
+    const editor = result.current.editor;
+    if (!editor) {
+      throw new Error("Editor was not initialized");
+    }
+
+    return { editor, result, rerender };
   }
 
-  function getPlaceholderText(editor: Editor | null) {
-    return (
-      editor?.view.dom.querySelector("p")?.getAttribute("data-placeholder") ??
-      null
-    );
+  function getPlaceholderText(editor: Editor) {
+    return editor.view.dom.querySelector("p")?.getAttribute("data-placeholder");
   }
 
   it("updates the placeholder without recreating the editor", () => {
-    const { result, rerender } = renderEditorHook();
+    const { editor, result, rerender } = renderEditorHook();
 
-    const editor = result.current.editor;
-    expect(editor).not.toBeNull();
     expect(getPlaceholderText(editor)).toBe("Get work done");
 
     rerender({ placeholderOverride: "Add a follow-up" });
@@ -329,20 +327,17 @@ describe("useCustomEditor placeholder override", () => {
   });
 
   it("preserves content and selection across placeholder changes", () => {
-    const { result, rerender } = renderEditorHook();
-
-    const editor = result.current.editor;
-    expect(editor).not.toBeNull();
+    const { editor, result, rerender } = renderEditorHook();
 
     act(() => {
-      editor?.commands.setContent("hello");
-      editor?.commands.setTextSelection(3);
+      editor.commands.setContent("hello");
+      editor.commands.setTextSelection(3);
     });
 
     rerender({ placeholderOverride: "Add a follow-up" });
 
     expect(result.current.editor).toBe(editor);
-    expect(editor?.getText()).toBe("hello");
-    expect(editor?.state.selection.from).toBe(3);
+    expect(editor.getText()).toBe("hello");
+    expect(editor.state.selection.from).toBe(3);
   });
 });

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -313,17 +313,17 @@ describe("useCustomEditor placeholder override", () => {
   it("updates the placeholder without recreating the editor", () => {
     const { editor, result, rerender } = renderEditorHook();
 
-    expect(getPlaceholderText(editor)).toBe("Get work done");
+    expect(getPlaceholderText(editor)).toBe("Get work done...");
 
-    rerender({ placeholderOverride: "Add a follow-up" });
+    rerender({ placeholderOverride: "Add a follow-up..." });
 
     expect(result.current.editor).toBe(editor);
-    expect(getPlaceholderText(editor)).toBe("Add a follow-up");
+    expect(getPlaceholderText(editor)).toBe("Add a follow-up...");
 
     rerender({ placeholderOverride: null });
 
     expect(result.current.editor).toBe(editor);
-    expect(getPlaceholderText(editor)).toBe("Get work done");
+    expect(getPlaceholderText(editor)).toBe("Get work done...");
   });
 
   it("preserves content and selection across placeholder changes", () => {
@@ -334,7 +334,7 @@ describe("useCustomEditor placeholder override", () => {
       editor.commands.setTextSelection(3);
     });
 
-    rerender({ placeholderOverride: "Add a follow-up" });
+    rerender({ placeholderOverride: "Add a follow-up..." });
 
     expect(result.current.editor).toBe(editor);
     expect(editor.getText()).toBe("hello");

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -313,7 +313,7 @@ describe("useCustomEditor placeholder override", () => {
   it("updates the placeholder without recreating the editor", () => {
     const { editor, result, rerender } = renderEditorHook();
 
-    expect(getPlaceholderText(editor)).toBe("Get work done...");
+    expect(getPlaceholderText(editor)).toBe("Get work done");
 
     rerender({ placeholderOverride: "Add a follow-up..." });
 
@@ -323,7 +323,7 @@ describe("useCustomEditor placeholder override", () => {
     rerender({ placeholderOverride: null });
 
     expect(result.current.editor).toBe(editor);
-    expect(getPlaceholderText(editor)).toBe("Get work done...");
+    expect(getPlaceholderText(editor)).toBe("Get work done");
   });
 
   it("preserves content and selection across placeholder changes", () => {

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -42,7 +42,7 @@ import { useEffect, useMemo, useRef } from "react";
 
 const DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD = 16000;
 const SUBMIT_COOLDOWN_MS = 750;
-const INPUT_BAR_DEFAULT_PLACEHOLDER = "Get work done";
+export const INPUT_BAR_DEFAULT_PLACEHOLDER = "Get work done";
 
 function isLongTextPaste(text: string, maxCharThreshold?: number) {
   const maxChars = maxCharThreshold ?? DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD;
@@ -368,7 +368,7 @@ export const buildEditorExtensions = ({
   onAgentSelect,
   onFirstAgentMentionPasteRef,
   slashSuggestion,
-  placeholderOverride,
+  placeholderOverrideRef,
   onSuggestionActiveChangeRef,
 }: {
   owner: WorkspaceType;
@@ -384,7 +384,7 @@ export const buildEditorExtensions = ({
     ((agentId: string) => void) | undefined
   >;
   slashSuggestion?: CustomEditorProps["slashSuggestion"];
-  placeholderOverride?: string | null;
+  placeholderOverrideRef?: React.RefObject<string | null | undefined>;
   onSuggestionActiveChangeRef?: CustomEditorProps["onSuggestionActiveChangeRef"];
 }) => {
   const notifySuggestionActiveChange = (active: boolean) => {
@@ -479,7 +479,7 @@ export const buildEditorExtensions = ({
         if (node.type.name !== "paragraph") {
           return "";
         }
-        return placeholderOverride ?? INPUT_BAR_DEFAULT_PLACEHOLDER;
+        return placeholderOverrideRef?.current ?? INPUT_BAR_DEFAULT_PLACEHOLDER;
       },
       emptyNodeClass:
         "first:before:text-faint dark:first:before:text-stone-400 first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
@@ -541,6 +541,9 @@ const useCustomEditor = ({
   placeholderOverride,
   onSuggestionActiveChangeRef,
 }: CustomEditorProps) => {
+  // Read through a ref so placeholder changes don't rebuild the editor.
+  const placeholderOverrideRef = useRef(placeholderOverride);
+
   const editor = useEditor(
     {
       autofocus: disableAutoFocus ? false : "end",
@@ -556,7 +559,7 @@ const useCustomEditor = ({
         onAgentSelect,
         onFirstAgentMentionPasteRef,
         slashSuggestion,
-        placeholderOverride,
+        placeholderOverrideRef,
         onSuggestionActiveChangeRef,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
@@ -585,9 +588,17 @@ const useCustomEditor = ({
       immediatelyRender: false,
     },
     // Important to watch for conversationId changes to reset the editor state when switching conversations.
-    // placeholderOverride is included so the placeholder text updates when the blocked-state reason changes.
-    [conversationId, placeholderOverride]
+    [conversationId]
   );
+
+  // The Placeholder extension only re-reads placeholderOverrideRef on a state
+  // update, so dispatch an empty transaction when the override changes.
+  useEffect(() => {
+    placeholderOverrideRef.current = placeholderOverride;
+    if (editor && !editor.isDestroyed) {
+      editor.view.dispatch(editor.state.tr);
+    }
+  }, [editor, placeholderOverride]);
 
   const isMobileViewport = useIsMobile();
   const editorService = useEditorService(editor, isMobileViewport);

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -42,7 +42,7 @@ import { useEffect, useMemo, useRef } from "react";
 
 const DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD = 16000;
 const SUBMIT_COOLDOWN_MS = 750;
-export const INPUT_BAR_DEFAULT_PLACEHOLDER = "Get work done";
+export const INPUT_BAR_DEFAULT_PLACEHOLDER = "Get work done...";
 
 function isLongTextPaste(text: string, maxCharThreshold?: number) {
   const maxChars = maxCharThreshold ?? DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD;

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -42,7 +42,7 @@ import { useEffect, useMemo, useRef } from "react";
 
 const DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD = 16000;
 const SUBMIT_COOLDOWN_MS = 750;
-export const INPUT_BAR_DEFAULT_PLACEHOLDER = "Get work done...";
+export const INPUT_BAR_DEFAULT_PLACEHOLDER = "Get work done";
 
 function isLongTextPaste(text: string, maxCharThreshold?: number) {
   const maxChars = maxCharThreshold ?? DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD;

--- a/front/components/pod/conversation/PodConversationsTab.tsx
+++ b/front/components/pod/conversation/PodConversationsTab.tsx
@@ -233,7 +233,6 @@ export function PodConversationsTab({
                 space={podInfo}
                 disableAutoFocus={false}
                 isFloating={false}
-                placeholder={`Get work done...`}
                 defaultAgentId={defaultAgentId}
                 isDefaultAgentLoading={isPodMetadataLoading}
                 defaultSkills={defaultSkills}


### PR DESCRIPTION
## Description

The input bar placeholder "Get work done" was duplicated in 3 places (editor default, compact pill fallback, Pod tab. This PR centralizes it into `INPUT_BAR_DEFAULT_PLACEHOLDER` and swaps the placeholder to **"Add a follow-up"** while a message is generating in the conversation since a message submitted then is queued.


Next step: add an animation to display the placeholder. 

## Risk

Worst case, wrong placeholder copy or a stale placeholder. Safe to rollback.

## Deploy Plan

- [ ] Deploy front

