### PR TITLE
[front] enh: align Automation and Analytics page layouts

### DIFF
--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -36,11 +36,11 @@ export function AnalyticsAutomationsPage() {
   }
 
   return (
-    <Page.Vertical align="stretch" gap="none">
+    <Page.Vertical align="stretch" gap="xl">
       <Page.Header
         title={
-          <div className="flex w-full flex-row justify-between gap-4">
             <div className="flex max-w-[700px] flex-col gap-1">
+          <div className="flex w-full flex-row justify-between">
               <Page.H variant="h3">Automations</Page.H>
               <Page.P variant="secondary">
                 Everything that runs on its own: who set it up, how often it
@@ -54,8 +54,10 @@ export function AnalyticsAutomationsPage() {
           </div>
         }
       />
-      <div className="flex flex-col gap-8 pb-8 pt-4">
-        <AutomationsOverview workspaceId={owner.sId} period={period} />
+
+      <AutomationsOverview owner={owner} period={period} />
+
+      <div className="flex flex-col gap-8">
         <AutomationsTriggersTable
           owner={owner}
           period={period}

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -39,8 +39,8 @@ export function AnalyticsAutomationsPage() {
     <Page.Vertical align="stretch" gap="xl">
       <Page.Header
         title={
-            <div className="flex max-w-[700px] flex-col gap-1">
           <div className="flex w-full flex-row justify-between">
+            <div className="flex flex-col gap-1">
               <Page.H variant="h3">Automations</Page.H>
               <Page.P variant="secondary">
                 Everything that runs on its own: who set it up, how often it
@@ -57,14 +57,12 @@ export function AnalyticsAutomationsPage() {
 
       <AutomationsOverview owner={owner} period={period} />
 
-      <div className="flex flex-col gap-8">
-        <AutomationsTriggersTable
-          owner={owner}
-          period={period}
-          filter={filter}
-          onFilterChange={setFilter}
-        />
-      </div>
+      <AutomationsTriggersTable
+        owner={owner}
+        period={period}
+        filter={filter}
+        onFilterChange={setFilter}
+      />
     </Page.Vertical>
   );
 }

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -104,16 +104,16 @@ export function AnalyticsConsumptionPage() {
     <Page.Vertical align="stretch" gap="xl">
       <Page.Header
         title={
-          <>
-            <div className="flex w-full flex-row justify-between">
+          <div className="flex w-full flex-row justify-between">
+            <div className="flex flex-col gap-1">
               <Page.H variant="h3">Analytics</Page.H>
-              <ConsumptionPeriodSelector
-                period={period}
-                onPeriodChange={setPeriod}
-              />
+              <ConsumptionOverview workspaceId={owner.sId} period={period} />
             </div>
-            <ConsumptionOverview workspaceId={owner.sId} period={period} />
-          </>
+            <ConsumptionPeriodSelector
+              period={period}
+              onPeriodChange={setPeriod}
+            />
+          </div>
         }
       />
 

--- a/front/components/workspace/analytics/automations/AutomationsOverview.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsOverview.tsx
@@ -2,7 +2,7 @@ import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { useAutomationsOverview } from "@app/hooks/useAutomationsOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatCredits } from "@app/lib/client/credits";
-import type {LightWorkspaceType} from "@app/types/user";
+import type { LightWorkspaceType } from "@app/types/user";
 
 interface AutomationsOverviewProps {
   owner: LightWorkspaceType;

--- a/front/components/workspace/analytics/automations/AutomationsOverview.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsOverview.tsx
@@ -2,18 +2,19 @@ import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { useAutomationsOverview } from "@app/hooks/useAutomationsOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatCredits } from "@app/lib/client/credits";
+import type {LightWorkspaceType} from "@app/types/user";
 
 interface AutomationsOverviewProps {
-  workspaceId: string;
+  owner: LightWorkspaceType;
   period: ConsumptionPeriodSelection;
 }
 
 export function AutomationsOverview({
-  workspaceId,
+  owner,
   period,
 }: AutomationsOverviewProps) {
   const { overview, isOverviewLoading, isOverviewError } =
-    useAutomationsOverview({ workspaceId, period });
+    useAutomationsOverview({ workspaceId: owner.sId, period });
 
   if (isOverviewLoading) {
     return (

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -2,6 +2,7 @@ import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import { timeAgoFrom } from "@app/lib/utils";
+import { Page } from "@dust-tt/sparkle";
 
 interface ConsumptionOverviewProps {
   workspaceId: string;
@@ -36,7 +37,7 @@ export function ConsumptionOverview({
   ];
 
   return (
-    <p className="text-sm text-muted-foreground">
+    <Page.P variant="secondary">
       {header.map((item, index) => (
         <span key={item}>
           {index > 0 && (
@@ -47,6 +48,6 @@ export function ConsumptionOverview({
           {item}
         </span>
       ))}
-    </p>
+    </Page.P>
   );
 }


### PR DESCRIPTION
## Description

The Automations and Analytics pages used different header structures and content spacing, making navigation between them feel inconsistent.

This PR aligns both pages on the exact same layout pixel by pixel.

## Tests

- Tested locally + preview.

## Risk

- Low.

## Deploy Plan

- Deploy front.
