### PR TITLE
[front] Read attributed agent in consumption analytics

### DIFF
--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -18,14 +18,6 @@ import type { estypes } from "@elastic/elasticsearch";
 
 const EXPORT_PAGE_SIZE = 10_000;
 
-function getAttributedAgentId(
-  agent: AgentMessageConsumptionAnalyticsData["agent"]
-): string {
-  // Documents indexed before the attributed identity migration can still be
-  // returned while the asynchronous backfill is completing.
-  return agent.attributed_id ?? agent.id;
-}
-
 type ConsumptionLineExportRow = {
   completedAt: string;
   conversationId: string;
@@ -169,7 +161,7 @@ async function buildConsumptionLineExportRows(
     sourceLabels,
   ] = await Promise.all([
     resolveDimensionLabels(auth, "agent", [
-      ...new Set(docs.map((doc) => getAttributedAgentId(doc.agent))),
+      ...new Set(docs.map((doc) => doc.agent.attributed_id)),
     ]),
     resolveDimensionLabels(auth, "user", [
       ...new Set(removeNulls(docs.map((doc) => doc.user?.id))),
@@ -193,7 +185,7 @@ async function buildConsumptionLineExportRows(
 
   return docs.map((doc) => {
     const { agent, model, user, tool } = doc;
-    const agentId = getAttributedAgentId(agent);
+    const agentId = agent.attributed_id;
     // Older documents indexed before these buckets shipped don't carry them.
     const gross = doc.gross_credit_micro ?? {
       system: 0,

--- a/front/lib/api/analytics/consumption/export_lines.ts
+++ b/front/lib/api/analytics/consumption/export_lines.ts
@@ -18,6 +18,14 @@ import type { estypes } from "@elastic/elasticsearch";
 
 const EXPORT_PAGE_SIZE = 10_000;
 
+function getAttributedAgentId(
+  agent: AgentMessageConsumptionAnalyticsData["agent"]
+): string {
+  // Documents indexed before the attributed identity migration can still be
+  // returned while the asynchronous backfill is completing.
+  return agent.attributed_id ?? agent.id;
+}
+
 type ConsumptionLineExportRow = {
   completedAt: string;
   conversationId: string;
@@ -161,7 +169,7 @@ async function buildConsumptionLineExportRows(
     sourceLabels,
   ] = await Promise.all([
     resolveDimensionLabels(auth, "agent", [
-      ...new Set(docs.map((doc) => doc.agent.id)),
+      ...new Set(docs.map((doc) => getAttributedAgentId(doc.agent))),
     ]),
     resolveDimensionLabels(auth, "user", [
       ...new Set(removeNulls(docs.map((doc) => doc.user?.id))),
@@ -185,6 +193,7 @@ async function buildConsumptionLineExportRows(
 
   return docs.map((doc) => {
     const { agent, model, user, tool } = doc;
+    const agentId = getAttributedAgentId(agent);
     // Older documents indexed before these buckets shipped don't carry them.
     const gross = doc.gross_credit_micro ?? {
       system: 0,
@@ -202,8 +211,8 @@ async function buildConsumptionLineExportRows(
       spaceId: doc.space_id ?? "",
       agentMessageId: doc.agent_message_id,
       consumptionType: doc.consumption_type,
-      agentId: agent.id,
-      agentName: agentLabels.get(agent.id)?.name ?? agent.id,
+      agentId,
+      agentName: agentLabels.get(agentId)?.name ?? agentId,
       agentVersion: agent.version ?? "",
       agentTagIds: (agent.tag_ids ?? []).join("; "),
       agentRootId: agent.root_id ?? "",

--- a/front/lib/api/analytics/consumption/facet_catalog.test.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.test.ts
@@ -11,9 +11,31 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { describe, expect, it } from "vitest";
 
 describe("listConsumptionFacetCatalog", () => {
+  it("omits hidden helper agents", async () => {
+    const { authenticator } = await createResourceTest({ role: "manager" });
+
+    const agents = await listConsumptionFacetCatalogDimension(
+      authenticator,
+      "agent"
+    );
+
+    expect(agents).not.toContainEqual(
+      expect.objectContaining({ value: GLOBAL_AGENTS_SID.DUST_TASK })
+    );
+    expect(agents).not.toContainEqual(
+      expect.objectContaining({ value: GLOBAL_AGENTS_SID.DUST_PLANNING })
+    );
+    expect(agents).not.toContainEqual(
+      expect.objectContaining({
+        value: GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY,
+      })
+    );
+  });
+
   it("includes active workspace members before they generate consumption", async () => {
     const { authenticator, user } = await createResourceTest({
       role: "manager",

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -17,6 +17,7 @@ import { ModelsTierResource } from "@app/lib/resources/models_tier_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import tracer from "@app/logger/tracer";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
+import { isHiddenHelperSubAgentId } from "@app/types/assistant/assistant";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
@@ -190,12 +191,14 @@ async function listConsumptionFacetCatalogWithoutTracing(
   );
 
   return {
-    agent: agents.map((agent) => ({
-      value: agent.sId,
-      label: agent.name,
-      pictureUrl: agent.pictureUrl,
-      scope: agent.scope,
-    })),
+    agent: agents
+      .filter((agent) => !isHiddenHelperSubAgentId(agent.sId))
+      .map((agent) => ({
+        value: agent.sId,
+        label: agent.name,
+        pictureUrl: agent.pictureUrl,
+        scope: agent.scope,
+      })),
     user: members.map((member) => ({
       value: member.sId,
       label: member.fullName,

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -103,7 +103,7 @@ describe("fetchConsumptionFacets", () => {
         const composite = options?.aggregations?.values?.composite;
         const field = composite?.sources?.[0]?.value?.terms?.field;
 
-        if (field === "agent.id" && composite?.after) {
+        if (field === "agent.attributed_id" && composite?.after) {
           return esResponse({
             values: {
               buckets: [
@@ -117,7 +117,7 @@ describe("fetchConsumptionFacets", () => {
           });
         }
 
-        if (field === "agent.id") {
+        if (field === "agent.attributed_id") {
           return esResponse({
             values: {
               buckets: [
@@ -221,7 +221,7 @@ describe("fetchConsumptionFacets", () => {
     expect(options?.size).toBe(0);
     expect(options?.aggregations?.values?.composite).toMatchObject({
       size: 1_000,
-      sources: [{ value: { terms: { field: "agent.id" } } }],
+      sources: [{ value: { terms: { field: "agent.attributed_id" } } }],
     });
 
     const agentContext = options?.aggregations?.values?.aggs?.contextual;
@@ -232,7 +232,7 @@ describe("fetchConsumptionFacets", () => {
       term: { normalized_origin: "slack" },
     });
     expect(agentContext?.filter?.bool?.filter).not.toContainEqual({
-      term: { "agent.id": "agent_enabled" },
+      term: { "agent.attributed_id": "agent_enabled" },
     });
 
     const secondAgentCall = vi
@@ -256,7 +256,7 @@ describe("fetchConsumptionFacets", () => {
     const userOptions = userCall?.[1];
     const userContext = userOptions?.aggregations?.values?.aggs?.contextual;
     expect(userContext?.filter?.bool?.filter).toContainEqual({
-      term: { "agent.id": "agent_enabled" },
+      term: { "agent.attributed_id": "agent_enabled" },
     });
     expect(userContext?.filter?.bool?.filter).not.toContainEqual({
       term: { "user.id": "user_1" },
@@ -272,7 +272,7 @@ describe("fetchConsumptionFacets", () => {
     expect(queriedFields).toHaveLength(9);
     expect(new Set(queriedFields)).toEqual(
       new Set([
-        "agent.id",
+        "agent.attributed_id",
         "user.id",
         "api_key_name",
         "user.group_ids",
@@ -282,9 +282,9 @@ describe("fetchConsumptionFacets", () => {
         "normalized_origin",
       ])
     );
-    expect(queriedFields.filter((field) => field === "agent.id")).toHaveLength(
-      2
-    );
+    expect(
+      queriedFields.filter((field) => field === "agent.attributed_id")
+    ).toHaveLength(2);
   });
 
   it("limits concurrent dimension queries", async () => {

--- a/front/lib/api/analytics/consumption/scope.test.ts
+++ b/front/lib/api/analytics/consumption/scope.test.ts
@@ -52,7 +52,7 @@ describe("buildConsumptionScopeQuery", () => {
     expect(query.bool?.filter).toEqual([
       { term: { workspace_id: authenticator.getNonNullableWorkspace().sId } },
       expect.objectContaining({ range: expect.anything() }),
-      { term: { "agent.id": "a1" } },
+      { term: { "agent.attributed_id": "a1" } },
       { terms: { "user.id": ["u1", "u2"] } },
       { term: { api_key_name: "Production key" } },
       { term: { "user.group_ids": "group1" } },

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -30,7 +30,7 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
   ConsumptionScopeDimension,
   string
 > = {
-  agent: "agent.id",
+  agent: "agent.attributed_id",
   user: "user.id",
   api_key: "api_key_name",
   // Multi-valued: a member can belong to several groups at once.

--- a/front/lib/api/analytics/consumption/timeseries.test.ts
+++ b/front/lib/api/analytics/consumption/timeseries.test.ts
@@ -190,7 +190,7 @@ describe("fetchConsumptionTimeseries", () => {
     const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
     expect(query.bool?.filter).toEqual(
       expect.arrayContaining([
-        { term: { "agent.id": "a1" } },
+        { term: { "agent.attributed_id": "a1" } },
         { term: { "tool.attributed_skill_ids": "s1" } },
         { terms: { normalized_origin: ["web", "slack"] } },
       ])

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -182,14 +182,14 @@ describe("consumption top rankings", () => {
       },
     ]);
 
-    // Ranked on agent.id by gross credits, with a per-message cardinality
+    // Ranked on the attributed agent by gross credits, with a per-message cardinality
     // sub-agg — a message spans several documents.
     const [query, options] = rankingSearchCall();
     expect(query.bool?.filter).toContainEqual({
       range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },
     });
     expect(options?.aggregations?.by_group?.terms).toMatchObject({
-      field: "agent.id",
+      field: "agent.attributed_id",
       size: 10,
       order: { credit_micro: "desc" },
     });
@@ -203,7 +203,7 @@ describe("consumption top rankings", () => {
       "credit_micro"
     );
     expect(options?.aggregations?.total_count?.cardinality).toEqual({
-      field: "agent.id",
+      field: "agent.attributed_id",
       precision_threshold: 40_000,
     });
     expect(options?.aggregations?.ranking).toBeUndefined();
@@ -253,7 +253,7 @@ describe("consumption top rankings", () => {
   });
 
   it.each([
-    ["AGENT 080", { terms: { "agent.id": ["agent80"] } }],
+    ["AGENT 080", { terms: { "agent.attributed_id": ["agent80"] } }],
     ["missing", { match_none: {} }],
   ])("filters the ranking for search %s", async (search, expectedFilter) => {
     const { auth } = await setup();
@@ -321,8 +321,10 @@ describe("consumption top rankings", () => {
     }
 
     expect(termsClauses).toHaveLength(2);
-    expect(termsClauses[0]?.terms?.["agent.id"]).toHaveLength(65_536);
-    expect(termsClauses[1]?.terms?.["agent.id"]).toHaveLength(1);
+    expect(termsClauses[0]?.terms?.["agent.attributed_id"]).toHaveLength(
+      65_536
+    );
+    expect(termsClauses[1]?.terms?.["agent.attributed_id"]).toHaveLength(1);
   });
 
   it("counts tool invocations as documents, with no message sub-agg", async () => {

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -183,7 +183,7 @@ describe("consumption top rankings", () => {
     ]);
 
     // Ranked on the attributed agent by gross credits, with a per-message cardinality
-    // sub-agg — a message spans several documents.
+    // sub-aggregation because a message spans several documents.
     const [query, options] = rankingSearchCall();
     expect(query.bool?.filter).toContainEqual({
       range: { completed_at: { gte: PERIOD.startDate, lt: PERIOD.endDate } },


### PR DESCRIPTION
## Description

PR #30788 added `agent.attributed_id` to consumption analytics documents and started attributing hidden helper usage to the visible parent agent.

The production backfill has completed. This follow-up switches analytics readers to the attributed agent identity.

**Before**

<img width="1227" height="465" alt="image" src="https://github.com/user-attachments/assets/c78477f6-bdcf-4acb-bfec-70b3cda8ea56" />

**After**

<img width="1115" height="339" alt="image" src="https://github.com/user-attachments/assets/f07450fc-9c6d-44ae-87f6-d2cad821f09f" />

## Deploy.

Will wait for the backfill to be completed. 