### PR TITLE
[front] fix: Show true number of membershipts in poke

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -132,6 +132,7 @@ export function WorkspacePage() {
     activeSubscription,
     hasDummyFeature,
     hasMetronomeFeature,
+    inactiveMembersCount,
     membersCount,
     metronomeCustomerId,
     pendingSubscription,
@@ -237,6 +238,7 @@ export function WorkspacePage() {
                 <WorkspaceInfoTable
                   owner={owner}
                   membersCount={membersCount}
+                  inactiveMembersCount={inactiveMembersCount}
                   metronomeCustomerId={metronomeCustomerId}
                   stripeCustomerId={stripeCustomerId}
                   workspaceVerifiedDomains={workspaceVerifiedDomains}

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -19,6 +19,7 @@ import { Chip, LinkWrapper } from "@dust-tt/sparkle";
 export function WorkspaceInfoTable({
   owner,
   membersCount,
+  inactiveMembersCount,
   metronomeCustomerId,
   stripeCustomerId,
   workspaceVerifiedDomains,
@@ -31,6 +32,7 @@ export function WorkspaceInfoTable({
 }: {
   owner: WorkspaceType;
   membersCount: number;
+  inactiveMembersCount: number;
   metronomeCustomerId: string | null;
   stripeCustomerId: string | null;
   workspaceVerifiedDomains: WorkspaceDomain[];
@@ -161,7 +163,9 @@ export function WorkspaceInfoTable({
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>Members count</PokeTableCell>
-              <PokeTableCell>{membersCount}</PokeTableCell>
+              <PokeTableCell>
+                {`${membersCount} active, ${inactiveMembersCount} inactive`}
+              </PokeTableCell>
             </PokeTableRow>
             <PokeTableRow>
               <PokeTableCell>SSO Enforced</PokeTableCell>

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -73,6 +73,7 @@ export type PokeWorkspaceInfo = {
   hasDummyFeature: boolean;
   hasMetronomeFeature: boolean;
   membersCount: number;
+  inactiveMembersCount: number;
   metronomeCustomerId: string | null;
   pendingSubscription: SubscriptionType | null;
   // Per-workspace overrides of the plan seat limits, or null when the workspace
@@ -230,10 +231,14 @@ export async function getPokeWorkspaceInfo(
 
   const planLimitOverride = await getWorkspacePlanLimitOverrides(auth);
 
-  const [membersCount, seatPlanResult] = await Promise.all([
+  const [membersCount, allMembersCount, seatPlanResult] = await Promise.all([
     MembershipResource.getMembersCountForWorkspace({
       workspace: owner,
       activeOnly: true,
+    }),
+    MembershipResource.getMembersCountForWorkspace({
+      workspace: owner,
+      activeOnly: false,
     }),
     getSeatPlan(auth),
   ]);
@@ -272,6 +277,7 @@ export async function getPokeWorkspaceInfo(
     hasDummyFeature,
     hasMetronomeFeature,
     membersCount,
+    inactiveMembersCount: allMembersCount - membersCount,
     metronomeCustomerId: workspaceResource.metronomeCustomerId ?? null,
     seatPlan,
     pendingSubscription,


### PR DESCRIPTION
## Description

We used to display only active memberships in poke, now we return both active and inactive

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
