### PR TITLE
[front] Remove the legacy ACL path and shadow-compare for spaces

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1538,11 +1538,14 @@ export class Authenticator {
   /**
    * Shadow-compare (#9479) for the group_permissions rollout: while the `group_permissions_shadow`
    * flag is on for the workspace, compare two composed decisions for the same check — the served
-   * `legacyAcls` and the `candidateAcls` (the same roles routed through the group_permissions
-   * table) — and log mismatches so a Datadog monitor can confirm parity before the flip (#9480).
-   * The caller builds both shapes. Fire-and-forget: never changes the served result and swallows its
-   * own failures. (Inlined rather than reusing `lib/api/permissions/shadow` to avoid an auth <->
-   * shadow import cycle.)
+   * `getAccessControlLists` and the `candidateAcls` (the same roles routed through the
+   * group_permissions table) — and log mismatches so a Datadog monitor can confirm parity before a
+   * flip. The caller builds both shapes. Fire-and-forget: never changes the served result and
+   * swallows its own failures. (Inlined rather than reusing `lib/api/permissions/shadow` to avoid an
+   * auth <-> shadow import cycle.)
+   *
+   * Retained (currently unused) for the remaining resource migrations onto group_permissions —
+   * spaces no longer shadow-compare, but other resource types still need to.
    */
   shadowComparePermission(
     verb: GrantVerb,

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1,5 +1,4 @@
 import { loadAllModels } from "@app/admin/db";
-import { isLegacyAclsEnabled } from "@app/lib/api/permissions/legacy_acls";
 import { hardDeleteSpace } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -30,10 +29,6 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WebhookSourceViewFactory } from "@app/tests/utils/WebhookSourceViewFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("@app/lib/api/permissions/legacy_acls", () => ({
-  isLegacyAclsEnabled: vi.fn(() => false),
-}));
 
 describe("SpaceResource", () => {
   describe("updatePermissions", () => {
@@ -2493,8 +2488,6 @@ describe("SpaceResource group_permissions enforcement", () => {
   let memberUser: UserResource;
 
   beforeEach(async () => {
-    vi.mocked(isLegacyAclsEnabled).mockReturnValue(false);
-
     workspace = await WorkspaceFactory.basic();
     const adminUser = await UserFactory.basic();
     memberUser = await UserFactory.basic();
@@ -2563,27 +2556,6 @@ describe("SpaceResource group_permissions enforcement", () => {
     );
 
     expect(space.canRead(memberAuth)).toBe(false);
-  });
-
-  it("falls back to the inline group when the use_legacy_acls kill switch is on", async () => {
-    const space = await setupRestrictedSpaceWithMember();
-    await GroupPermissionResource.deleteAllForResource(adminAuth, {
-      resourceType: "space",
-      resourceId: space.id,
-    });
-
-    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
-      memberUser.sId,
-      workspace.sId
-    );
-
-    // No grant row: the table-backed path denies.
-    expect(space.canRead(memberAuth)).toBe(false);
-
-    // The kill-switch restores the pre-migration decision, taken from group membership.
-    vi.mocked(isLegacyAclsEnabled).mockReturnValue(true);
-    expect(space.canRead(memberAuth)).toBe(true);
-    expect(space.canWrite(memberAuth)).toBe(true);
   });
 
   it("refreshes the caller's grant snapshot after opening a space", async () => {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1,5 +1,4 @@
 import { isDatabaseFileSystemPodName } from "@app/lib/api/file_system/storage_mode";
-import { isLegacyAclsEnabled } from "@app/lib/api/permissions/legacy_acls";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentProjectConfigurationModel } from "@app/lib/models/agent/actions/projects";
@@ -37,7 +36,6 @@ import {
 } from "@app/types/groups";
 import type {
   AccessControlList,
-  GroupGrant,
   RoleGrant,
 } from "@app/types/resource_permissions";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -1877,20 +1875,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     ];
   }
 
-  // The pre-migration inline-group ACL: the code role rules plus the space's `group_vaults`
-  // associations listed inline, filtered by the caller's membership at check time. Served only when
-  // the `use_legacy_acls` kill switch is on (see `hasSpacePermission`). Remove with the switch once
-  // the table is trusted.
-  private legacyAcls(): AccessControlList[] {
-    return [
-      {
-        workspaceId: this.workspaceId,
-        roles: this.spaceRoleGrants(),
-        groups: this.legacySpaceGroupGrants(),
-      },
-    ];
-  }
-
   // The verbs each workspace role holds on this space, by space kind.
   private spaceRoleGrants(): RoleGrant[] {
     // System space.
@@ -2004,65 +1988,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return groups.map((group) => ({
       groupId: group.id,
       grantType: "member",
-    }));
-  }
-
-  // The group grants this space confers, derived from its `group_vaults` associations in code, with
-  // the verbs stated literally as `GroupResource.getAccessControlLists` does. This is the legacy
-  // path: what `getAccessControlLists` serves until the flip.
-  private legacySpaceGroupGrants(): GroupGrant[] {
-    // System space: its groups manage the workspace's connections.
-    if (this.isSystem()) {
-      return this.groups.map((group) => ({
-        id: group.groupId,
-        permissions: ["read", "write"],
-      }));
-    }
-
-    // Global Workspace space and Conversations space: write comes from the role grants.
-    if (this.isGlobal() || this.isConversations()) {
-      return this.groups.map((group) => ({
-        id: group.groupId,
-        permissions: ["read"],
-      }));
-    }
-
-    // Provisioned groups do not carry grants on manually-managed spaces.
-    const groups =
-      this.managementMode === "manual"
-        ? this.groups.filter((group) => !group.isProvisioned())
-        : this.groups;
-
-    // Open regular space: every group only reads; write comes from the role grants.
-    if (this.isRegularAndOpen()) {
-      return groups.map((group) => ({
-        id: group.groupId,
-        permissions: ["read"],
-      }));
-    }
-
-    if (this.isProject()) {
-      return groups.map((group) => {
-        switch (group.groupSpaceKind) {
-          case "project_editor":
-            return {
-              id: group.groupId,
-              permissions: ["admin", "read", "write"],
-            };
-          case "member":
-            return { id: group.groupId, permissions: ["read", "write"] };
-          case "project_viewer":
-            return { id: group.groupId, permissions: ["read"] };
-          default:
-            assertNever(group.groupSpaceKind);
-        }
-      });
-    }
-
-    // Restricted regular space.
-    return groups.map((group) => ({
-      id: group.groupId,
-      permissions: ["read", "write"],
     }));
   }
 
@@ -2215,20 +2140,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return this.hasSpacePermission(auth, "read");
   }
 
-  // Serves the decision from `group_permissions` (see `getAccessControlLists`), unless the
-  // `use_legacy_acls` kill switch is on — then it falls back to the pre-migration inline-group ACL,
-  // where the space's groups are listed inline and membership decides. Remove the fallback (and the
-  // switch) once the table is trusted.
+  // Serves the space permission decision from `group_permissions` (see `getAccessControlLists`).
   private hasSpacePermission(auth: Authenticator, verb: GrantVerb): boolean {
-    auth.shadowComparePermission(verb, this, this.legacyAcls(), {
-      resource: "space",
-      spaceId: this.sId,
-    });
-
-    if (isLegacyAclsEnabled()) {
-      return auth.hasPermissionForAcls(verb, this.legacyAcls());
-    }
-
     return auth.hasPermission(verb, this);
   }
 


### PR DESCRIPTION
## Description

Retire the legacy ACL path for **spaces**. Space permission checks now always resolve from `group_permissions` (`getAccessControlLists` → `getGrantedVerbs`); the `use_legacy_acls` fallback and the per-check shadow-compare *call* are removed for spaces.

The `use_legacy_acls` kill switch and `isLegacyAclsEnabled` **stay** — skills still use them (`skill_resource.hasSkillPermission`). The generic `lib/api/permissions/shadow` util and the `group_permissions_shadow` flag are untouched.

- `space_resource`: `hasSpacePermission` → `auth.hasPermission` directly; delete `legacyAcls` and `legacySpaceGroupGrants` (the last readers of `group_vaults`' `groupSpaceKind`).
- `auth`: remove only the space-specific shadow-compare *call*. The generic `shadowComparePermission` / `runShadowComparePermission` methods are **kept** (currently unused) for the remaining resource migrations onto `group_permissions`.
- Tests: drop the kill-switch mock and the legacy-fallback test; the `group_permissions` enforcement tests remain.

First of a 3-PR stack removing `group_vaults`, on top of #30823: **this → #30890 (source space groups from group_permissions) → collapse `GroupSpace*Resource` → drop table**.

## Tests

`tsgo --noEmit` clean on front and front-api. Tests green: `space_resource` (69), `skill_resource` (77 — confirms the skill legacy path is intact), `shadow` (4).

## Risk

Removes the shadow-compare safety net for spaces, so it relies on governance grants matching `group_vaults` in prod — validated by querying `group_vaults` vs `group_permissions` (the only unmatched rows are stale: provisioned-on-manual and scrub-workspace orphans). Skills and other not-yet-migrated resources are unaffected (the shadow machinery remains available to them). Rollback = revert the code (no data changes).

## Deploy Plan

Standard deploy. Recommended to let the shadow monitor stay quiet for a bit before building the rest of the stack on top.