### PR TITLE
[front] Source a space's associated groups from group_permissions

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -38,12 +38,7 @@ app.get(
 
     const members: Record<string, UserTypeWithWorkspaces[]> = {};
 
-    const groupReferences = space.groups.filter((group) =>
-      space.managementMode === "manual"
-        ? group.isRegularAuto()
-        : group.isProvisioned()
-    );
-    const groups = await space.fetchGroupResources(auth, { groupReferences });
+    const groups = await space.fetchMembershipGroups(auth);
 
     const memberships = await getMembers(auth);
     const memberById = new Map(memberships.members.map((m) => [m.sId, m]));

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -41,10 +41,7 @@ app.delete(
       });
     }
 
-    if (
-      space.managementMode === "group" ||
-      space.groups.some((group) => group.isGlobal())
-    ) {
+    if (space.managementMode === "group" || space.isOpen()) {
       return apiError(ctx, {
         status_code: 404,
         api_error: {

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -58,10 +58,7 @@ const withEditableSpace = createMiddleware<
     });
   }
 
-  if (
-    space.managementMode === "group" ||
-    space.groups.some((group) => group.isGlobal())
-  ) {
+  if (space.managementMode === "group" || space.isOpen()) {
     return apiError(ctx, {
       status_code: 404,
       api_error: {

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -150,9 +150,7 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     const member2 = await UserFactory.basic();
     await MembershipFactory.associate(workspace, member2, { role: "user" });
 
-    const [projectGroup] = await space.fetchGroupResources(adminAuth, {
-      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
-    });
+    const [projectGroup] = await space.fetchRegularAutoGroups(adminAuth);
     if (!projectGroup) {
       throw new Error("Expected the project member group to exist.");
     }

--- a/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
+++ b/front-api/routes/w/[wId]/files/[fileId]/edit-text.test.ts
@@ -230,9 +230,7 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
     });
 
     const space = await SpaceFactory.regular(workspace);
-    const [memberGroup] = await space.fetchGroupResources(auth, {
-      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
-    });
+    const [memberGroup] = await space.fetchRegularAutoGroups(auth);
     await memberGroup?.dangerouslyAddMembers(auth, { users: [user.toJSON()] });
 
     const file = await FileFactory.create(auth, user, {
@@ -296,9 +294,7 @@ describe("POST /api/w/:wId/files/:fileId/edit-text", () => {
 
     const otherUser = await UserFactory.basic();
     const space = await SpaceFactory.regular(workspace);
-    const [memberGroup] = await space.fetchGroupResources(auth, {
-      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
-    });
+    const [memberGroup] = await space.fetchRegularAutoGroups(auth);
     await memberGroup?.dangerouslyAddMembers(auth, {
       users: [otherUser.toJSON()],
     });

--- a/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
+++ b/front-api/routes/w/[wId]/pods/[podId]/tasks/seed.test.ts
@@ -51,9 +51,7 @@ describe("POST /api/w/:wId/pods/:podId/tasks/seed", () => {
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const [spaceGroup] = await project.fetchGroupResources(adminAuth, {
-      groupReferences: project.groups.filter((group) => group.isRegularAuto()),
-    });
+    const [spaceGroup] = await project.fetchRegularAutoGroups(adminAuth);
     if (!spaceGroup) {
       throw new Error("Expected the project member group to exist.");
     }
@@ -76,11 +74,7 @@ describe("POST /api/w/:wId/pods/:podId/tasks/seed", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
-      groupReferences: regularSpace.groups.filter((group) =>
-        group.isRegularAuto()
-      ),
-    });
+    const [memberGroup] = await regularSpace.fetchRegularAutoGroups(adminAuth);
     if (memberGroup) {
       await memberGroup.dangerouslyAddMembers(adminAuth, {
         users: [user.toJSON()],

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.test.ts
@@ -142,9 +142,7 @@ async function setupSandboxFunction({
     workspace,
   });
   if (addCallerToSpace) {
-    const [memberGroup] = await space.fetchGroupResources(adminAuth, {
-      groupReferences: space.groups.filter((group) => group.isRegularAuto()),
-    });
+    const [memberGroup] = await space.fetchRegularAutoGroups(adminAuth);
     if (!memberGroup) {
       throw new Error("Expected the project member group to exist.");
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -46,11 +46,8 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       );
 
       const regularSpace = await SpaceFactory.regular(workspace);
-      const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
-        groupReferences: regularSpace.groups.filter((group) =>
-          group.isRegularAuto()
-        ),
-      });
+      const [memberGroup] =
+        await regularSpace.fetchRegularAutoGroups(adminAuth);
       if (memberGroup) {
         await memberGroup.dangerouslyAddMembers(adminAuth, {
           users: [user.toJSON()],
@@ -126,11 +123,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/leave", () => {
       expect(response.status).toBe(200);
       expect((await response.json()).success).toBe(true);
 
-      const [memberGroup] = await project.fetchGroupResources(adminAuth, {
-        groupReferences: project.groups.filter((group) =>
-          group.isRegularAuto()
-        ),
-      });
+      const [memberGroup] = await project.fetchRegularAutoGroups(adminAuth);
       if (memberGroup) {
         const isMember = await memberGroup.isMember(user);
         expect(isMember).toBe(false);

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/leave.ts
@@ -40,12 +40,7 @@ app.post(
 
     const user = auth.getNonNullableUser();
 
-    const groupReferencesToLeave = space.groups.filter((group) =>
-      group.isRegularAuto()
-    );
-    const groupsToLeave = await space.fetchGroupResources(auth, {
-      groupReferences: groupReferencesToLeave,
-    });
+    const groupsToLeave = await space.fetchRegularAutoGroups(auth);
     const editorGroup = await space.fetchManualEditorGroup(auth);
 
     if (editorGroup) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/mcp_views/index.test.ts
@@ -95,11 +95,7 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/mcp_views/:svId", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
-      groupReferences: regularSpace.groups.filter((group) =>
-        group.isRegularAuto()
-      ),
-    });
+    const [memberGroup] = await regularSpace.fetchRegularAutoGroups(adminAuth);
     if (!memberGroup) {
       throw new Error("Expected the space member group to exist.");
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -105,11 +105,7 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_metadata", () => {
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const [spaceGroup] = await projectSpace.fetchGroupResources(adminAuth, {
-      groupReferences: projectSpace.groups.filter((group) =>
-        group.isRegularAuto()
-      ),
-    });
+    const [spaceGroup] = await projectSpace.fetchRegularAutoGroups(adminAuth);
     if (!spaceGroup) {
       throw new Error("Expected the project member group to exist.");
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/[taskId]/index.test.ts
@@ -159,9 +159,7 @@ describe("PATCH /api/w/:wId/spaces/:spaceId/project_tasks/:taskId", () => {
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const [memberGroup] = await project.fetchGroupResources(adminAuth, {
-      groupReferences: project.groups.filter((group) => group.isRegularAuto()),
-    });
+    const [memberGroup] = await project.fetchRegularAutoGroups(adminAuth);
     if (!memberGroup) {
       throw new Error("Expected the project member group to exist.");
     }

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/project_tasks/index.test.ts
@@ -91,11 +91,7 @@ describe("POST /api/w/:wId/spaces/:spaceId/project_tasks/mark_read", () => {
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
-      groupReferences: regularSpace.groups.filter((group) =>
-        group.isRegularAuto()
-      ),
-    });
+    const [memberGroup] = await regularSpace.fetchRegularAutoGroups(adminAuth);
     if (memberGroup) {
       await memberGroup.dangerouslyAddMembers(adminAuth, {
         users: [user.toJSON()],

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/webhook_source_views/index.test.ts
@@ -239,11 +239,7 @@ describe("DELETE /api/w/:wId/spaces/:spaceId/webhook_source_views/:webhookSource
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    const [memberGroup] = await regularSpace.fetchGroupResources(adminAuth, {
-      groupReferences: regularSpace.groups.filter((group) =>
-        group.isRegularAuto()
-      ),
-    });
+    const [memberGroup] = await regularSpace.fetchRegularAutoGroups(adminAuth);
     if (!memberGroup) {
       throw new Error("Expected the space member group to exist.");
     }

--- a/front/components/spaces/RestrictedAccessBody.tsx
+++ b/front/components/spaces/RestrictedAccessBody.tsx
@@ -103,7 +103,7 @@ export function RestrictedAccessBody({
         title: "Switch to members",
         message:
           "This switches from group-based access to manual member management. " +
-          "Your current group settings will be saved but no longer active.",
+          "Your current group selection will be removed; you'll need to re-select groups to switch back.",
         validateLabel: "Confirm",
         validateVariant: "primary",
       });

--- a/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
+++ b/front/lib/api/actions/servers/agent_sidekick_context/agent_sidekick_context.test.ts
@@ -2216,15 +2216,10 @@ describe("agent_sidekick_context tools", () => {
         restrictedSpace.sId
       );
       if (fetchedSpace) {
-        const groupReference = fetchedSpace.groups.find((group) =>
-          group.isRegularAuto()
-        );
-        if (!groupReference) {
+        const [group] = await fetchedSpace.fetchRegularAutoGroups(internalAuth);
+        if (!group) {
           throw new Error("Expected a regular group on the restricted space");
         }
-        const [group] = await fetchedSpace.fetchGroupResources(internalAuth, {
-          groupReferences: [groupReference],
-        });
         await group.dangerouslyAddMember(internalAuth, {
           user: user1.toJSON(),
         });

--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -118,14 +118,8 @@ async function fetchRegularAutoGroup(
   space: SpaceResource,
   auth: Authenticator
 ) {
-  const groupReference = space.groups.find((group) => group.isRegularAuto());
-  if (!groupReference) {
-    return null;
-  }
-  const [group] = await space.fetchGroupResources(auth, {
-    groupReferences: [groupReference],
-  });
-  return group;
+  const [group] = await space.fetchRegularAutoGroups(auth);
+  return group ?? null;
 }
 
 async function createActiveProgrammaticCredit(
@@ -2633,6 +2627,12 @@ describe("postUserMessage", () => {
         group: globalGroup,
         space: projectSpace,
       });
+      // Sync group_permissions so the space reads as open (production does this after attaching the
+      // viewer via `syncGroupPermissions`); `isOpen` is now sourced from grants.
+      await projectSpace.writeGroupPermissions(
+        internalAdminAuth,
+        await projectSpace.fetchAssociatedGroups()
+      );
 
       const apiKey = await KeyFactory.regular(globalGroup);
       const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(
@@ -2681,6 +2681,12 @@ describe("postUserMessage", () => {
         group: globalGroup,
         space: projectSpace,
       });
+      // Sync group_permissions so the space reads as open (production does this after attaching the
+      // viewer via `syncGroupPermissions`); `isOpen` is now sourced from grants.
+      await projectSpace.writeGroupPermissions(
+        internalAdminAuth,
+        await projectSpace.fetchAssociatedGroups()
+      );
 
       const apiKey = await KeyFactory.regular(globalGroup);
       const { workspaceAuth: apiKeyAuth } = await Authenticator.fromKey(

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -262,10 +262,8 @@ export const suggestionsOfMentions = async (
   // This aims to prioritize them in the suggestions
   if (spaceId) {
     const conversationSpace = await SpaceResource.fetchById(auth, spaceId);
-    const groupReferences =
-      conversationSpace?.groups.filter((group) => !group.isGlobal()) ?? [];
     const conversationGroups = conversationSpace
-      ? await conversationSpace.fetchGroupResources(auth, { groupReferences })
+      ? await conversationSpace.fetchMembershipGroups(auth)
       : [];
 
     const allMembers = await concurrentExecutor(

--- a/front/lib/api/assistant/conversation/permissions.test.ts
+++ b/front/lib/api/assistant/conversation/permissions.test.ts
@@ -48,15 +48,11 @@ describe("canAgentBeUsedInProjectConversation", () => {
       ReturnType<Authenticator["getNonNullableUser"]>["toJSON"]
     >
   ) {
-    const regularGroupReference = space.groups.find((group) =>
-      group.isRegularAuto()
-    );
-    if (!regularGroupReference) {
+    const [regularGroup] =
+      await space.fetchRegularAutoGroups(internalAdminAuth);
+    if (!regularGroup) {
       throw new Error("Expected a regular group on the space");
     }
-    const [regularGroup] = await space.fetchGroupResources(internalAdminAuth, {
-      groupReferences: [regularGroupReference],
-    });
     const addRes = await regularGroup.dangerouslyAddMember(internalAdminAuth, {
       user: userJson,
     });
@@ -740,26 +736,10 @@ describe("updateConversationRequirements", () => {
     const user = auth.getNonNullableUser();
     const userJson = user.toJSON();
 
-    const projectSpaceGroupReference = projectSpace.groups.find((group) =>
-      group.isRegularAuto()
-    );
-    const anotherProjectSpaceGroupReference = anotherProjectSpace.groups.find(
-      (group) => group.isRegularAuto()
-    );
-    const [projectSpaceGroup] = await projectSpace.fetchGroupResources(
-      internalAdminAuth,
-      {
-        groupReferences: projectSpaceGroupReference
-          ? [projectSpaceGroupReference]
-          : [],
-      }
-    );
+    const [projectSpaceGroup] =
+      await projectSpace.fetchRegularAutoGroups(internalAdminAuth);
     const [anotherProjectSpaceGroup] =
-      await anotherProjectSpace.fetchGroupResources(internalAdminAuth, {
-        groupReferences: anotherProjectSpaceGroupReference
-          ? [anotherProjectSpaceGroupReference]
-          : [],
-      });
+      await anotherProjectSpace.fetchRegularAutoGroups(internalAdminAuth);
 
     if (projectSpaceGroup) {
       const addRes = await projectSpaceGroup.dangerouslyAddMember(
@@ -1386,15 +1366,10 @@ describe("rebuildConversationRequirements", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, regularSpace, anotherRegularSpace]) {
-      const groupReference = space.groups.find((group) =>
-        group.isRegularAuto()
-      );
-      if (!groupReference) {
+      const [group] = await space.fetchRegularAutoGroups(internalAdminAuth);
+      if (!group) {
         continue;
       }
-      const [group] = await space.fetchGroupResources(internalAdminAuth, {
-        groupReferences: [groupReference],
-      });
       const addRes = await group.dangerouslyAddMember(internalAdminAuth, {
         user: userJson,
       });

--- a/front/lib/api/assistant/conversation/selected_spaces.test.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.test.ts
@@ -82,13 +82,10 @@ describe("selected conversation Spaces", () => {
   }
 
   async function regularGroup(space: SpaceResource, auth: Authenticator) {
-    const groupReference = space.groups.find((group) => group.isRegularAuto());
-    if (!groupReference) {
+    const [group] = await space.fetchRegularAutoGroups(auth);
+    if (!group) {
       throw new Error("Expected regular member group on Space");
     }
-    const [group] = await space.fetchGroupResources(auth, {
-      groupReferences: [groupReference],
-    });
     return group;
   }
 

--- a/front/lib/api/assistant/conversation/skill_permissions.test.ts
+++ b/front/lib/api/assistant/conversation/skill_permissions.test.ts
@@ -31,13 +31,8 @@ describe("updateConversationRequirementsForSkills", () => {
     const userJson = auth.getNonNullableUser().toJSON();
 
     for (const space of [projectSpace, anotherProjectSpace]) {
-      const groupReference = space.groups.find((group) =>
-        group.isRegularAuto()
-      );
-      if (groupReference) {
-        const [group] = await space.fetchGroupResources(internalAdminAuth, {
-          groupReferences: [groupReference],
-        });
+      const [group] = await space.fetchRegularAutoGroups(internalAdminAuth);
+      if (group) {
         const addRes = await group.dangerouslyAddMember(internalAdminAuth, {
           user: userJson,
         });

--- a/front/lib/api/assistant/conversation/validate_agent_mention.test.ts
+++ b/front/lib/api/assistant/conversation/validate_agent_mention.test.ts
@@ -42,13 +42,7 @@ async function fetchRegularAutoGroup(
   space: SpaceResource,
   auth: Authenticator
 ) {
-  const groupReference = space.groups.find((group) => group.isRegularAuto());
-  if (!groupReference) {
-    return null;
-  }
-  const [group] = await space.fetchGroupResources(auth, {
-    groupReferences: [groupReference],
-  });
+  const [group] = await space.fetchRegularAutoGroups(auth);
   return group ?? null;
 }
 

--- a/front/lib/api/projects/conversations.test.ts
+++ b/front/lib/api/projects/conversations.test.ts
@@ -32,14 +32,8 @@ async function fetchRegularAutoGroup(
   space: SpaceResource,
   auth: Authenticator
 ) {
-  const groupReference = space.groups.find((group) => group.isRegularAuto());
-  if (!groupReference) {
-    return null;
-  }
-  const [group] = await space.fetchGroupResources(auth, {
-    groupReferences: [groupReference],
-  });
-  return group;
+  const [group] = await space.fetchRegularAutoGroups(auth);
+  return group ?? null;
 }
 
 async function markConversationAgentMessagesAsSucceeded(

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -49,8 +49,9 @@ function getSpaceAccessPriority(space: SpaceResource) {
     return 2;
   }
 
-  // For restricted spaces: provisioned groups get higher priority than manual membership.
-  if (space.groups.some((g) => g.isProvisioned())) {
+  // For restricted spaces: provisioned groups get higher priority than manual membership. A space
+  // in group management mode is backed by provisioned (IdP-owned) groups.
+  if (space.managementMode === "group") {
     return 1;
   }
 

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -32,14 +32,8 @@ import { SPACE_KINDS } from "@app/types/space";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 async function fetchNonGlobalGroup(space: SpaceResource, auth: Authenticator) {
-  const groupReference = space.groups.find((group) => !group.isGlobal());
-  if (!groupReference) {
-    return null;
-  }
-  const [group] = await space.fetchGroupResources(auth, {
-    groupReferences: [groupReference],
-  });
-  return group;
+  const [group] = await space.fetchRegularAutoGroups(auth);
+  return group ?? null;
 }
 
 describe("createSpaceAndGroup", () => {
@@ -1219,7 +1213,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
           space.sId
         );
         // Verify the space has the global group
-        expect(reloadedSpace!.groups.some((g) => g.isGlobal())).toBe(true);
+        expect(reloadedSpace!.groups.some((g) => g.isReader())).toBe(true);
 
         // Create an active API key for the global group
         await KeyFactory.regular(globalGroup);
@@ -1256,7 +1250,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
           space.sId
         );
         // Verify the space has the global group
-        expect(reloadedSpace!.groups.some((g) => g.isGlobal())).toBe(true);
+        expect(reloadedSpace!.groups.some((g) => g.isReader())).toBe(true);
 
         // Create an active API key for the global group
         await KeyFactory.regular(globalGroup);

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -578,14 +578,9 @@ export async function hardDeleteSpace(
   }
 
   await withTransaction(async (t) => {
-    // Delete all spaces groups.
-    const groupReferences = space.groups.filter(
-      (group) => !space.isRegular() || !group.isGlobal()
-    );
-    const groups = await space.fetchGroupResources(auth, {
-      groupReferences,
-      transaction: t,
-    });
+    // Delete only the space's own auto-created (regular_auto) groups. The workspace global group and
+    // provisioned (IdP-owned) groups are shared and must never be deleted with a space.
+    const groups = await space.fetchRegularAutoGroups(auth, t);
     for (const group of groups) {
       const res = await group.delete(auth, { transaction: t });
       if (res.isErr()) {

--- a/front/lib/api/viz/publish_frame.test.ts
+++ b/front/lib/api/viz/publish_frame.test.ts
@@ -170,11 +170,8 @@ async function setupPodTestContext() {
     user,
   } = await createResourceTest({ role: "admin" });
   const space = await SpaceFactory.project(workspace, user.id);
-  const groupReference = space.groups.find((group) => group.isRegularAuto());
-  assert(groupReference);
-  const [group] = await space.fetchGroupResources(workspaceAdminAuth, {
-    groupReferences: [groupReference],
-  });
+  const [group] = await space.fetchRegularAutoGroups(workspaceAdminAuth);
+  assert(group);
   const addMemberResult = await group.dangerouslyAddMember(workspaceAdminAuth, {
     user: user.toJSON(),
   });

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -39,7 +39,7 @@ import {
 } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ProviderCredentialResource } from "@app/lib/resources/provider_credential_resource";
-import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import {
   getResourceIdFromSId,
@@ -784,16 +784,17 @@ export class Authenticator {
       requestedSpaceIds.add(spaceId);
     }
 
-    const spaceGroups = await GroupSpaceModel.findAll({
+    const spaceGrants = await GroupPermissionModel.findAll({
       where: {
-        vaultId: [...requestedSpaceIds],
+        resourceType: "space",
+        resourceId: [...requestedSpaceIds],
         workspaceId,
       },
       attributes: ["groupId"],
     });
 
     const allowedGroupIds = new Set(
-      spaceGroups.map((sg) => Number(sg.groupId) as ModelId)
+      spaceGrants.map((grant) => Number(grant.groupId) as ModelId)
     );
 
     return new Ok(userGroupIds.filter((id) => allowedGroupIds.has(id)));
@@ -860,16 +861,17 @@ export class Authenticator {
       }
     }
 
-    const spaceGroups = await GroupSpaceModel.findAll({
+    const spaceGrants = await GroupPermissionModel.findAll({
       where: {
-        vaultId: [...allowedSpaceIds],
+        resourceType: "space",
+        resourceId: [...allowedSpaceIds],
         workspaceId,
       },
       attributes: ["groupId"],
     });
 
     const allowedGroupIds = new Set(
-      spaceGroups.map((sg) => Number(sg.groupId) as ModelId)
+      spaceGrants.map((grant) => Number(grant.groupId) as ModelId)
     );
 
     return new Ok(userGroupIds.filter((id) => allowedGroupIds.has(id)));

--- a/front/lib/resources/conversation_selected_space_resource.test.ts
+++ b/front/lib/resources/conversation_selected_space_resource.test.ts
@@ -26,15 +26,10 @@ describe("ConversationSelectedSpaceResource", () => {
     const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId
     );
-    const memberGroupReference = space.groups.find((group) =>
-      group.isRegularAuto()
-    );
-    if (!memberGroupReference) {
+    const [memberGroup] = await space.fetchRegularAutoGroups(internalAdminAuth);
+    if (!memberGroup) {
       throw new Error("Expected regular member group on Space");
     }
-    const [memberGroup] = await space.fetchGroupResources(internalAdminAuth, {
-      groupReferences: [memberGroupReference],
-    });
 
     await memberGroup.dangerouslyAddMembers(internalAdminAuth, {
       users: [user],

--- a/front/lib/resources/group_permission_resource.test.ts
+++ b/front/lib/resources/group_permission_resource.test.ts
@@ -1007,6 +1007,106 @@ describe("GroupPermissionResource", () => {
     });
   });
 
+  describe("listRegularAutoGroupsForResource", () => {
+    const onSpace = (resourceId: number) => ({
+      resourceType: "space" as const,
+      resourceId,
+    });
+
+    it("returns every regular_auto group with a grant on the resource, regardless of grant type", async () => {
+      // A space's member group holds `member` and its editor group holds `admin`; both are
+      // regular_auto and both must come back even though their grant types differ.
+      const memberGroup = await GroupFactory.regularAuto(workspace, "member");
+      const editorGroup = await GroupFactory.regularAuto(workspace, "editor");
+      await GroupPermissionResource.grant(auth, {
+        group: memberGroup,
+        grantType: "member",
+        ...onSpace(100),
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: editorGroup,
+        grantType: "admin",
+        ...onSpace(100),
+      });
+
+      const groups =
+        await GroupPermissionResource.listRegularAutoGroupsForResource(
+          auth,
+          onSpace(100)
+        );
+      expect(groups.map((g) => g.id).sort()).toEqual(
+        [memberGroup.id, editorGroup.id].sort()
+      );
+    });
+
+    it("returns a regular_auto group even when it holds only a reader grant", async () => {
+      // On an open regular space the member group (regular_auto) holds a `reader` grant just like the
+      // global group; grant type can't tell them apart, so it must still be found by kind.
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        grantType: "reader",
+        ...onSpace(101),
+      });
+
+      const groups =
+        await GroupPermissionResource.listRegularAutoGroupsForResource(
+          auth,
+          onSpace(101)
+        );
+      expect(groups.map((g) => g.id)).toEqual([groupA.id]);
+    });
+
+    it("excludes non-regular_auto groups (manual, provisioned, global)", async () => {
+      const globalRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+      if (globalRes.isErr()) {
+        throw globalRes.error;
+      }
+      const globalGroup = globalRes.value;
+      const provisionedGroup = await GroupFactory.provisioned(
+        workspace,
+        "prov"
+      );
+
+      // Only groupA is regular_auto; the manual, provisioned, and global groups must be excluded.
+      await GroupPermissionResource.grant(auth, {
+        group: groupA,
+        grantType: "member",
+        ...onSpace(102),
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: groupB,
+        grantType: "member",
+        ...onSpace(102),
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: provisionedGroup,
+        grantType: "member",
+        ...onSpace(102),
+      });
+      await GroupPermissionResource.grant(auth, {
+        group: globalGroup,
+        grantType: "reader",
+        ...onSpace(102),
+      });
+
+      const groups =
+        await GroupPermissionResource.listRegularAutoGroupsForResource(
+          auth,
+          onSpace(102)
+        );
+      expect(groups.map((g) => g.id)).toEqual([groupA.id]);
+    });
+
+    it("returns an empty array when the resource has no grants", async () => {
+      expect(
+        await GroupPermissionResource.listRegularAutoGroupsForResource(
+          auth,
+          onSpace(999)
+        )
+      ).toEqual([]);
+    });
+  });
+
   describe("grantToEverybody / revokeFromEverybody", () => {
     it("grants and revokes an instance-level permission on the global group", async () => {
       const globalGroup = await GroupResource.internalFetchWorkspaceGlobalGroup(

--- a/front/lib/resources/group_permission_resource.ts
+++ b/front/lib/resources/group_permission_resource.ts
@@ -314,6 +314,42 @@ export class GroupPermissionResource extends BaseResource<GroupPermissionModel> 
     return autoGroups[0] ?? null;
   }
 
+  // All regular_auto groups holding any instance grant on the resource, regardless of grant type. A
+  // space's auto-created groups (its manual member group, and for projects its editor group) are
+  // regular_auto; the workspace global group (a viewer) and provisioned groups are excluded by kind.
+  // This is how callers recover a space's own groups: grant type alone cannot identify them because
+  // an open regular space's member group holds a `reader` grant like the global group.
+  static async listRegularAutoGroupsForResource(
+    auth: Authenticator,
+    {
+      resourceType,
+      resourceId,
+      transaction,
+    }: {
+      resourceType: GroupPermissionResourceType;
+      resourceId: number;
+      transaction?: Transaction;
+    }
+  ): Promise<GroupResource[]> {
+    const grants = await GroupPermissionModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        resourceType,
+        resourceId,
+      },
+      transaction,
+    });
+    const groupIds = [...new Set(grants.map((grant) => grant.groupId))];
+    if (groupIds.length === 0) {
+      return [];
+    }
+
+    return GroupResource.fetchByModelIds(auth, groupIds, {
+      groupKinds: ["regular_auto"],
+      transaction,
+    });
+  }
+
   // The regular_auto groups backing user-level grants, keyed by grant (see `grantKey`) — the
   // batched counterpart of `findRegularAutoGroupForGrant`.
   static async findRegularAutoGroupsForGrants(

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -194,16 +194,11 @@ describe("MCPServerViewResource", () => {
       // - User is NOT in any group for restrictedSpace
 
       // Add user to the group that accesses accessibleSpace
-      const accessibleGroupReference = accessibleSpace.groups.find((group) =>
-        group.isRegularAuto()
-      );
-      if (!accessibleGroupReference) {
+      const [accessibleGroup] =
+        await accessibleSpace.fetchRegularAutoGroups(adminAuth);
+      if (!accessibleGroup) {
         throw new Error("Expected a regular group on the accessible space");
       }
-      const [accessibleGroup] = await accessibleSpace.fetchGroupResources(
-        adminAuth,
-        { groupReferences: [accessibleGroupReference] }
-      );
       const addMemberResult = await accessibleGroup.dangerouslyAddMember(
         adminAuth,
         {
@@ -361,21 +356,11 @@ describe("MCPServerViewResource", () => {
       await MembershipFactory.associate(workspace, user, { role: "user" });
 
       // Add user to both groups
-      const group1Reference = space1.groups.find((group) =>
-        group.isRegularAuto()
-      );
-      const group2Reference = space2.groups.find((group) =>
-        group.isRegularAuto()
-      );
-      if (!group1Reference || !group2Reference) {
+      const [group1] = await space1.fetchRegularAutoGroups(adminAuth);
+      const [group2] = await space2.fetchRegularAutoGroups(adminAuth);
+      if (!group1 || !group2) {
         throw new Error("Expected regular groups on both spaces");
       }
-      const [group1] = await space1.fetchGroupResources(adminAuth, {
-        groupReferences: [group1Reference],
-      });
-      const [group2] = await space2.fetchGroupResources(adminAuth, {
-        groupReferences: [group2Reference],
-      });
       await group1.dangerouslyAddMember(adminAuth, {
         user: user.toJSON(),
       });

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -2,7 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { ResourceWithId } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import type { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import type {
@@ -99,13 +99,14 @@ export abstract class ResourceWithSpace<
       },
       include: [
         {
-          as: "groupSpaces",
-          model: GroupSpaceModel,
+          as: "spaceGrants",
+          model: GroupPermissionModel,
           // A where on an include implies required: true;
           // pass this required: false to keep the original behavior intact
           required: false,
           where: {
             workspaceId: blobWorkspaceIds,
+            resourceType: "space",
           },
         },
       ],

--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -152,16 +152,11 @@ describe("SandboxFunctionResource", () => {
 
     const user = await UserFactory.basic();
     await MembershipFactory.associate(workspace, user, { role: "user" });
-    const accessibleGroupReference = accessibleSpace.groups.find((group) =>
-      group.isRegularAuto()
-    );
-    if (!accessibleGroupReference) {
+    const [accessibleGroup] =
+      await accessibleSpace.fetchRegularAutoGroups(adminAuth);
+    if (!accessibleGroup) {
       throw new Error("Expected a regular group on the accessible space");
     }
-    const [accessibleGroup] = await accessibleSpace.fetchGroupResources(
-      adminAuth,
-      { groupReferences: [accessibleGroupReference] }
-    );
     const addMemberResult = await accessibleGroup.dangerouslyAddMember(
       adminAuth,
       {

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -11,6 +11,7 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { SandboxEnvVarModel } from "@app/lib/resources/storage/models/sandbox_env_var";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
@@ -742,6 +743,43 @@ describe("SpaceResource", () => {
       });
     });
 
+    it("re-attaches a provisioned group after switching group -> manual -> group", async () => {
+      // Regression: switching to manual drops the provisioned grant but leaves the group_vaults
+      // row; space.groups is now sourced from group_permissions, so re-attaching must still clean
+      // the stale group_vaults row or the (vaultId, groupId) unique constraint fires.
+      const provisioned = await GroupFactory.provisioned(workspace, "Prov");
+      let space = await SpaceFactory.regular(workspace);
+
+      const toGroup = await space.updatePermissions(adminAuth, {
+        name: space.name,
+        isRestricted: true,
+        managementMode: "group",
+        groupIds: [provisioned.sId],
+        editorGroupIds: [],
+      });
+      expect(toGroup.isOk()).toBe(true);
+
+      space = (await SpaceResource.fetchById(adminAuth, space.sId))!;
+      const toManual = await space.updatePermissions(adminAuth, {
+        name: space.name,
+        isRestricted: true,
+        managementMode: "manual",
+        memberIds: [],
+        editorIds: [],
+      });
+      expect(toManual.isOk()).toBe(true);
+
+      space = (await SpaceResource.fetchById(adminAuth, space.sId))!;
+      const toGroupAgain = await space.updatePermissions(adminAuth, {
+        name: space.name,
+        isRestricted: true,
+        managementMode: "group",
+        groupIds: [provisioned.sId],
+        editorGroupIds: [],
+      });
+      expect(toGroupAgain.isOk()).toBe(true);
+    });
+
     describe("restricted/open state changes", () => {
       it("should add global group when changing from restricted to open", async () => {
         // Start with restricted space (no global group)
@@ -767,11 +805,16 @@ describe("SpaceResource", () => {
       });
 
       it("should remove global group when changing from open to restricted", async () => {
-        // First add global group to make it open
-        await GroupSpaceMemberResource.makeNew(adminAuth, {
-          group: globalGroup,
-          space: regularSpace,
+        // First make it open through updatePermissions so both the group_vaults association and the
+        // group_permissions grant are written (space.groups is sourced from group_permissions).
+        const openResult = await regularSpace.updatePermissions(adminAuth, {
+          name: "Test Space",
+          isRestricted: false,
+          managementMode: "manual",
+          memberIds: [user1.sId],
+          editorIds: [],
         });
+        expect(openResult.isOk()).toBe(true);
 
         // Reload space to get updated groups
         const spaceWithGlobalGroup = await SpaceResource.fetchById(
@@ -1578,6 +1621,81 @@ describe("SpaceResource", () => {
     });
   });
 
+  describe("isOpen", () => {
+    let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+    let adminAuth: Authenticator;
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      const adminUser = await UserFactory.basic();
+      const { globalGroup, systemGroup } =
+        await GroupFactory.defaults(workspace);
+      await MembershipFactory.associate(workspace, adminUser, {
+        role: "admin",
+      });
+      const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceResource.makeDefaultsForWorkspace(internalAdminAuth, {
+        globalGroup,
+        systemGroup,
+      });
+      adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        adminUser.sId,
+        workspace.sId
+      );
+    });
+
+    // `isOpen` is read from the space's `group_permissions` grants, so re-fetch after each change
+    // rather than trusting the in-memory instance.
+    const refetchIsOpen = async (space: SpaceResource): Promise<boolean> => {
+      const refetched = await SpaceResource.fetchById(adminAuth, space.sId);
+      expect(refetched).not.toBeNull();
+      return refetched!.isOpen();
+    };
+
+    it("is false for a restricted space and true once opened", async () => {
+      const space = await SpaceFactory.regular(workspace);
+      expect(await refetchIsOpen(space)).toBe(false);
+
+      const openResult = await space.updatePermissions(adminAuth, {
+        name: space.name,
+        isRestricted: false,
+        managementMode: "manual",
+        memberIds: [],
+        editorIds: [],
+      });
+      expect(openResult.isOk()).toBe(true);
+
+      expect(await refetchIsOpen(space)).toBe(true);
+    });
+
+    it("flips back to false when an open space is restricted again", async () => {
+      const space = await SpaceFactory.regular(workspace);
+      const openResult = await space.updatePermissions(adminAuth, {
+        name: space.name,
+        isRestricted: false,
+        managementMode: "manual",
+        memberIds: [],
+        editorIds: [],
+      });
+      expect(openResult.isOk()).toBe(true);
+      expect(await refetchIsOpen(space)).toBe(true);
+
+      const opened = await SpaceResource.fetchById(adminAuth, space.sId);
+      const restrictResult = await opened!.updatePermissions(adminAuth, {
+        name: space.name,
+        isRestricted: true,
+        managementMode: "manual",
+        memberIds: [],
+        editorIds: [],
+      });
+      expect(restrictResult.isOk()).toBe(true);
+
+      expect(await refetchIsOpen(space)).toBe(false);
+    });
+  });
+
   describe("listWorkspaceSpaces", () => {
     let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
     let adminAuth: Authenticator;
@@ -1625,7 +1743,7 @@ describe("SpaceResource", () => {
       expect(spaces.some((s) => s.id === regularSpace.id)).toBe(true);
     });
 
-    it("hydrates group references directly from group vaults", async () => {
+    it("hydrates group references from the space's group_permissions grants", async () => {
       const regularSpace = await SpaceFactory.regular(workspace);
       const [groupReference] = regularSpace.groups;
       const findAllSpy = vi.spyOn(SpaceModel, "findAll");
@@ -1640,24 +1758,16 @@ describe("SpaceResource", () => {
         expect.objectContaining({
           include: expect.arrayContaining([
             expect.objectContaining({
-              as: "groupSpaces",
-              model: GroupSpaceModel,
+              as: "spaceGrants",
+              model: GroupPermissionModel,
             }),
-          ]),
-        })
-      );
-      expect(findAllSpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          include: expect.arrayContaining([
-            expect.objectContaining({ model: GroupResource.model }),
           ]),
         })
       );
       expect(fetchedSpace?.groups).toEqual([
         expect.objectContaining({
           groupId: groupReference.groupId,
-          groupKind: "regular_auto",
-          groupSpaceKind: "member",
+          grantType: "member",
           workspaceId: workspace.id,
         }),
       ]);
@@ -1888,12 +1998,8 @@ describe("SpaceResource", () => {
 
     it("should return project spaces only for members", async () => {
       const projectSpace = await SpaceFactory.project(workspace);
-      const projectGroupReference = projectSpace.groups.find((group) =>
-        group.isRegularAuto()
-      );
-      const [projectGroup] = await projectSpace.fetchGroupResources(adminAuth, {
-        groupReferences: projectGroupReference ? [projectGroupReference] : [],
-      });
+      const [projectGroup] =
+        await projectSpace.fetchRegularAutoGroups(adminAuth);
 
       // User is not a member, should not see it
       const userSpaces =
@@ -2514,11 +2620,7 @@ describe("SpaceResource group_permissions enforcement", () => {
   // grants nothing, so access flows purely through the group — isolating the group-vs-table check.
   async function setupRestrictedSpaceWithMember(): Promise<SpaceResource> {
     const space = await SpaceFactory.regular(workspace);
-    const memberGroupRef = space.groups.find((g) => g.isRegularAuto());
-    expect(memberGroupRef).toBeDefined();
-    const [memberGroup] = await GroupResource.fetchByModelIds(adminAuth, [
-      memberGroupRef!.groupId,
-    ]);
+    const [memberGroup] = await space.fetchRegularAutoGroups(adminAuth);
     expect(memberGroup).toBeDefined();
     await memberGroup.dangerouslyAddMember(adminAuth, {
       user: memberUser.toJSON(),

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -12,6 +12,7 @@ import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_
 import { GroupSpaceViewerResource } from "@app/lib/resources/group_space_viewer_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import { SandboxOwnerModel } from "@app/lib/resources/storage/models/sandbox";
@@ -25,9 +26,9 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import tracer from "@app/logger/tracer";
-import type { GrantVerb } from "@app/types/group_permissions";
+import type { GrantType, GrantVerb } from "@app/types/group_permissions";
 import { SPACE_EDITOR_GRANT_TYPE } from "@app/types/group_permissions";
-import type { GroupKind, GroupType } from "@app/types/groups";
+import type { GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
   PROJECT_EDITOR_GROUP_PREFIX,
@@ -43,7 +44,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { GroupSpaceKind, SpaceKind, SpaceType } from "@app/types/space";
+import type { SpaceKind, SpaceType } from "@app/types/space";
 import assert from "assert";
 import type {
   Attributes,
@@ -60,25 +61,22 @@ import { Op, Sequelize } from "sequelize";
 export interface SpaceResource extends ReadonlyAttributesType<SpaceModel> {}
 
 /**
- * Lightweight representation of a group_vaults join row. It carries enough
- * data to enforce space permissions without fetching the full group and adding
- * a second join. This is slated to be superseded by the upcoming
- * GroupPermission model.
+ * Lightweight representation of a space's associated group. Carries only what the space's grant row
+ * holds — the group id and the grant type it confers — so it can be built straight from a
+ * `group_permissions` row.
  */
 class SpaceGroupReference {
   constructor(
     readonly groupId: ModelId,
-    readonly groupKind: GroupKind,
-    readonly groupSpaceKind: GroupSpaceKind,
+    readonly grantType: GrantType,
     readonly workspaceId: ModelId
   ) {}
 
-  static fromGroupSpaceModel(groupSpace: GroupSpaceModel) {
+  static fromGrant(grant: GroupPermissionModel): SpaceGroupReference {
     return new SpaceGroupReference(
-      groupSpace.groupId,
-      groupSpace.groupKind,
-      groupSpace.kind,
-      groupSpace.workspaceId
+      grant.groupId,
+      grant.grantType,
+      grant.workspaceId
     );
   }
 
@@ -89,16 +87,12 @@ class SpaceGroupReference {
     });
   }
 
-  isGlobal(): boolean {
-    return this.groupKind === "global";
-  }
-
-  isRegularAuto(): boolean {
-    return this.groupKind === "regular_auto";
-  }
-
-  isProvisioned(): boolean {
-    return this.groupKind === "provisioned";
+  // A `reader` grant is read-only (viewer) access. It is held by the workspace global group on open
+  // spaces (attached as a viewer), and additionally by the member group on open *regular* spaces
+  // (where every group only reads — write comes from the role grants). Presence of any reader grant
+  // therefore means the space is open; such groups never confer membership by themselves.
+  isReader(): boolean {
+    return this.grantType === "reader";
   }
 }
 
@@ -130,10 +124,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static fromModel(space: SpaceModel) {
+    // Groups come from the space's `group_permissions` grants (the `spaceGrants` include), not
+    // `group_vaults`. Each grant is eager-loaded with its `group` so the reference carries the kind.
     return new SpaceResource(
       SpaceModel,
       space.get(),
-      space.groupSpaces.map(SpaceGroupReference.fromGroupSpaceModel)
+      (space.spaceGrants ?? []).map(SpaceGroupReference.fromGrant)
     );
   }
 
@@ -169,20 +165,18 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return withTransaction(async (t: Transaction) => {
       const space = await SpaceModel.create(blob, { transaction: t });
       const { members, editors = [] } = groups;
-      const groupSpaces: GroupSpaceModel[] = [];
 
+      // Dual-write the `group_vaults` association rows (kept in sync until the table is dropped).
       for (const memberGroup of members) {
-        groupSpaces.push(
-          await GroupSpaceModel.create(
-            {
-              groupId: memberGroup.id,
-              groupKind: memberGroup.kind,
-              vaultId: space.id,
-              workspaceId: space.workspaceId,
-              kind: "member",
-            },
-            { transaction: t }
-          )
+        await GroupSpaceModel.create(
+          {
+            groupId: memberGroup.id,
+            groupKind: memberGroup.kind,
+            vaultId: space.id,
+            workspaceId: space.workspaceId,
+            kind: "member",
+          },
+          { transaction: t }
         );
       }
       if (editors.length > 0) {
@@ -191,26 +185,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           "Only projects can have editor groups."
         );
         for (const editorGroup of editors) {
-          groupSpaces.push(
-            await GroupSpaceModel.create(
-              {
-                groupId: editorGroup.id,
-                groupKind: editorGroup.kind,
-                vaultId: space.id,
-                workspaceId: space.workspaceId,
-                kind: "project_editor",
-              },
-              { transaction: t }
-            )
+          await GroupSpaceModel.create(
+            {
+              groupId: editorGroup.id,
+              groupKind: editorGroup.kind,
+              vaultId: space.id,
+              workspaceId: space.workspaceId,
+              kind: "project_editor",
+            },
+            { transaction: t }
           );
         }
       }
 
-      const spaceResource = new this(
-        SpaceModel,
-        space.get(),
-        groupSpaces.map(SpaceGroupReference.fromGroupSpaceModel)
-      );
+      const spaceResource = new this(SpaceModel, space.get(), []);
 
       // Write group_permissions directly from the created associations, so a space is never
       // persisted without its grants. `auth` only needs to be in the space's workspace: the write
@@ -222,7 +210,22 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         transaction: t,
       });
 
-      return spaceResource;
+      // Re-read the grants just written so `this.groups` reflects the space's actual grant set
+      // (its source of truth). No `group` join needed: the reference only carries the grant type.
+      const spaceGrants = await GroupPermissionModel.findAll({
+        where: {
+          workspaceId: space.workspaceId,
+          resourceType: "space",
+          resourceId: space.id,
+        },
+        transaction: t,
+      });
+
+      return new this(
+        SpaceModel,
+        space.get(),
+        spaceGrants.map(SpaceGroupReference.fromGrant)
+      );
     }, transaction);
   }
 
@@ -352,12 +355,18 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   ) {
     const includeClauses: Includeable[] = [
       {
-        as: "groupSpaces",
-        model: GroupSpaceModel,
+        as: "spaceGrants",
+        model: GroupPermissionModel,
         // A where on an include implies required: true;
-        // pass this required: false to keep the original behavior intact
+        // pass this required: false to keep the original behavior intact.
         required: false,
-        where: { workspaceId: auth.getNonNullableWorkspace().id },
+        // workspaceId + resourceType make the (workspaceId, resourceType, resourceId) index usable
+        // for the join on resourceId; resourceType is also required for correctness since resourceId
+        // is polymorphic.
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          resourceType: "space",
+        },
       },
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       ...(includes || []),
@@ -538,12 +547,19 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     groups: (GroupResource | GroupType)[],
     options?: { includeConversationsSpace?: boolean }
   ) {
-    const groupSpaces = await GroupSpaceModel.findAll({
+    // The spaces these groups have any grant on (group -> spaces direction), from group_permissions.
+    // Served by the (workspaceId, groupId) index; resourceType pins it to space grants.
+    const spaceGrants = await GroupPermissionModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         groupId: groups.map((g) => g.id),
+        resourceType: "space",
       },
+      attributes: ["resourceId"],
     });
+    const grantedSpaceModelIds = [
+      ...new Set(spaceGrants.map((grant) => grant.resourceId)),
+    ];
 
     const allExceptConversations: Exclude<SpaceKind, "conversations">[] = [
       "system",
@@ -557,13 +573,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     if (options?.includeConversationsSpace) {
       spaces = await this.baseFetch(auth, {
         where: {
-          id: groupSpaces.map((v) => v.vaultId),
+          id: grantedSpaceModelIds,
         },
       });
     } else {
       spaces = await this.baseFetch(auth, {
         where: {
-          id: groupSpaces.map((v) => v.vaultId),
+          id: grantedSpaceModelIds,
           kind: {
             [Op.in]: allExceptConversations,
           },
@@ -713,8 +729,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       },
       include: [
         {
-          as: "groupSpaces",
-          model: GroupSpaceModel,
+          as: "spaceGrants",
+          model: GroupPermissionModel,
+          required: false,
+          // No workspaceId here (cross-workspace bypass); resourceType is still required since
+          // resourceId is polymorphic. Space ids are globally unique, so the join stays correct.
+          where: { resourceType: "space" },
         },
       ],
       includeDeleted: true,
@@ -751,14 +771,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     options: { hardDelete: boolean; transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
-    // Provisioned groups are not tied to any space, we don't delete them.
-    const groupReferencesToMaybeDelete = this.groups.filter(
-      (group) => !group.isProvisioned()
+    // Only the space's own auto-created (regular_auto) groups are deleted with it. The workspace
+    // global group and provisioned (IdP-owned) groups are shared and left untouched, so they are
+    // excluded here rather than relying on the association-count guard below.
+    const groupsToMaybeDelete = await this.fetchRegularAutoGroups(
+      auth,
+      transaction
     );
-    const groupsToMaybeDelete = await this.fetchGroupResources(auth, {
-      groupReferences: groupReferencesToMaybeDelete,
-      transaction,
-    });
 
     await GroupSpaceModel.destroy({
       where: {
@@ -1006,8 +1025,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
       // If the space should be restricted and was not restricted before, remove the global group.
       if (!wasRestricted && isRestricted) {
-        const globalGroupReference = this.groups.find((group) =>
-          group.isGlobal()
+        const globalGroupReference = this.groups.find(
+          (group) => group.groupId === globalGroup.id
         );
         assert(
           globalGroupReference,
@@ -1154,13 +1173,18 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         const groupIds = params.groupIds;
         const editorGroupIds = params.editorGroupIds;
 
-        // Remove existing external groups
-        const existingExternalGroups = this.groups.filter(
-          (g) => g.groupKind === "provisioned"
-        );
-        for (const group of existingExternalGroups) {
-          await this.removeGroup(auth, group, t);
-        }
+        // Remove existing provisioned associations, read straight from group_vaults rather than
+        // `this.groups` (now sourced from group_permissions). Switching to manual mode drops the
+        // provisioned grants but leaves the group_vaults rows, so `this.groups` would not list them
+        // and the re-insert below would hit the (vaultId, groupId) unique constraint.
+        await GroupSpaceModel.destroy({
+          where: {
+            vaultId: this.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+            groupKind: "provisioned",
+          },
+          transaction: t,
+        });
 
         // Add the new groups
         const selectedGroupsResult = await GroupResource.fetchByIds(
@@ -1731,6 +1755,34 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return this.cachedManualEditorGroup;
   }
 
+  // The space's auto-created (regular_auto) groups: its manual member group and, for projects, its
+  // editor group. Resolved from `group_permissions` (not `this.groups`, whose grant references
+  // cannot tell a regular_auto group from the global group by grant type). Empty in group management
+  // mode, where the space's groups are provisioned (IdP-owned) rather than auto-created.
+  async fetchRegularAutoGroups(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<GroupResource[]> {
+    return GroupPermissionResource.listRegularAutoGroupsForResource(auth, {
+      resourceType: "space",
+      resourceId: this.id,
+      transaction,
+    });
+  }
+
+  // The groups that make up this space's membership: its member group and, for projects, its editor
+  // group (regular_auto in manual mode, provisioned in group mode). Groups holding only a read-only
+  // (`reader`) grant are excluded — the workspace global group attached to open spaces as a viewer,
+  // and on open regular spaces the member group too, since an open space confers access to everyone
+  // rather than through a member group. Use this to list who actually belongs to the space.
+  async fetchMembershipGroups(
+    auth: Authenticator,
+    transaction?: Transaction
+  ): Promise<GroupResource[]> {
+    const groupReferences = this.groups.filter((group) => !group.isReader());
+    return this.fetchGroupResources(auth, { groupReferences, transaction });
+  }
+
   // The space's manual member group: the regular_auto group holding this space's membership. A
   // project space has two regular_auto groups (member + editor), so the editor group (identified
   // by its `admin` grant in `group_permissions`) is excluded; a regular space has exactly one.
@@ -1739,18 +1791,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     transaction?: Transaction
   ): Promise<GroupResource> {
     const editorGroup = await this.fetchManualEditorGroup(auth, transaction);
-    const memberReferences = this.groups.filter(
-      (group) => group.isRegularAuto() && group.groupId !== editorGroup?.id
+    const autoGroups = await this.fetchRegularAutoGroups(auth, transaction);
+    const memberGroups = autoGroups.filter(
+      (group) => group.id !== editorGroup?.id
     );
     assert(
-      memberReferences.length === 1,
-      `Expected exactly one member group for the space, but found ${memberReferences.length}.`
+      memberGroups.length === 1,
+      `Expected exactly one member group for the space, but found ${memberGroups.length}.`
     );
-    const [memberGroup] = await this.fetchGroupResources(auth, {
-      groupReferences: memberReferences,
-      transaction,
-    });
-    return memberGroup;
+    return memberGroups[0];
   }
 
   /**
@@ -1801,35 +1850,19 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // TODO(projects): update this method to check groups whose group_vaults relationship is
     // to remove the complexity of checking the global group based on the space type.
 
-    // Provisioned groups carry no grants on manually-managed spaces (see spaceGroupRoles).
-    const groups =
-      this.managementMode === "manual"
-        ? this.groups.filter((group) => !group.isProvisioned())
-        : this.groups;
+    const groups = this.groups;
 
     switch (this.kind) {
       case "regular":
-        for (const group of groups) {
-          // In regular spaces, having the global group means that you are a member.
-          if (group.isGlobal()) {
-            return true;
-          }
-          if (hasGroup(group.groupId)) {
-            return true;
-          }
-        }
-        return false;
+        // An open regular space grants membership to every workspace member.
+        return this.isOpen() || groups.some((group) => hasGroup(group.groupId));
       case "project":
-        for (const group of groups) {
-          // Ignore the global group for project spaces as it means that the group is public but not that you are a member.
-          if (group.isGlobal()) {
-            continue;
-          }
-          if (hasGroup(group.groupId)) {
-            return true;
-          }
-        }
-        return false;
+        // The global group is attached to open projects as a public viewer (a reader grant), which
+        // makes the project visible but does not make you a member; membership comes from the other
+        // groups.
+        return groups.some(
+          (group) => !group.isReader() && hasGroup(group.groupId)
+        );
       case "global":
         return true;
       case "conversations":
@@ -2183,7 +2216,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   isOpen() {
-    return this.groups.some((group) => group.isGlobal());
+    // A space is open when it has a reader (viewer) grant: the workspace global group is attached as
+    // a viewer on open spaces (restricted spaces have no reader grant). See
+    // `SpaceGroupReference.isReader`.
+    return this.groups.some((group) => group.isReader());
   }
 
   isDeletable() {
@@ -2206,9 +2242,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const memberGroup = await this.fetchManualMemberGroup(auth, transaction);
-    const editorGroup = await this.fetchManualEditorGroup(auth, transaction);
-    const groups = [memberGroup, ...(editorGroup ? [editorGroup] : [])];
+    const groups = await this.fetchRegularAutoGroups(auth, transaction);
 
     for (const group of groups) {
       await group.suspendMembers(auth, { transaction });
@@ -2222,9 +2256,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const memberGroup = await this.fetchManualMemberGroup(auth, transaction);
-    const editorGroup = await this.fetchManualEditorGroup(auth, transaction);
-    const groups = [memberGroup, ...(editorGroup ? [editorGroup] : [])];
+    const groups = await this.fetchRegularAutoGroups(auth, transaction);
 
     for (const group of groups) {
       await group.restoreMembers(auth, { transaction });
@@ -2249,12 +2281,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     allGroupMemberships: GroupMembershipModel[];
     editorGroupModelId: ModelId | null;
   }> {
-    const groupReferences = this.groups.filter((group) =>
-      group.isRegularAuto()
-    );
-    const groupsToProcess = await this.fetchGroupResources(auth, {
-      groupReferences,
-    });
+    const groupsToProcess = await this.fetchRegularAutoGroups(auth);
     const editorGroup = await this.fetchManualEditorGroup(auth);
     const editorGroupModelId = editorGroup?.id ?? null;
 
@@ -2330,30 +2357,42 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return result;
     }
 
-    // Manual group references (regular + editor) per space.
-    const manualGroupReferencesBySpaceModelId = new Map<
-      ModelId,
-      SpaceGroupReference[]
-    >();
-    const allGroupReferences = new Map<ModelId, SpaceGroupReference>();
+    // Fetch every space grant's group once, then keep the regular_auto ones (a space's manual
+    // member + editor groups). Grant type cannot identify them (an open regular space's member group
+    // holds a `reader` grant like the global group), so kind is resolved from the fetched groups.
+    const allGroupModelIds = new Set<ModelId>();
     for (const space of spaces) {
-      const groupReferences = space.groups.filter(
-        (group) => group.groupKind === "regular_auto"
-      );
-      manualGroupReferencesBySpaceModelId.set(space.id, groupReferences);
-      groupReferences.forEach((group) =>
-        allGroupReferences.set(group.groupId, group)
+      for (const group of space.groups) {
+        allGroupModelIds.add(group.groupId);
+      }
+    }
+    const allGroups = await GroupResource.fetchByModelIds(auth, [
+      ...allGroupModelIds,
+    ]);
+    const regularAutoGroups = allGroups.filter((group) =>
+      group.isRegularAuto()
+    );
+    const regularAutoGroupModelIds = new Set(
+      regularAutoGroups.map((group) => group.id)
+    );
+
+    // The regular_auto group ids per space.
+    const manualGroupModelIdsBySpaceModelId = new Map<ModelId, ModelId[]>();
+    for (const space of spaces) {
+      manualGroupModelIdsBySpaceModelId.set(
+        space.id,
+        space.groups
+          .map((group) => group.groupId)
+          .filter((groupId) => regularAutoGroupModelIds.has(groupId))
       );
     }
 
-    const allGroups = await GroupResource.fetchByModelIds(
-      auth,
-      [...allGroupReferences.values()].map((group) => group.groupId)
-    );
-
     // Single query for the active memberships across every group.
     const userModelIdsByGroupModelId =
-      await GroupResource.getActiveMembershipsForGroups(auth, allGroups);
+      await GroupResource.getActiveMembershipsForGroups(
+        auth,
+        regularAutoGroups
+      );
 
     // Single query for all the users referenced by those memberships.
     const allUserModelIds = new Set<ModelId>();
@@ -2367,10 +2406,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     // Reassemble the distinct member set for each space.
     for (const space of spaces) {
-      const groups = manualGroupReferencesBySpaceModelId.get(space.id) ?? [];
+      const groupModelIds =
+        manualGroupModelIdsBySpaceModelId.get(space.id) ?? [];
       const byId = new Map<ModelId, UserResource>();
-      for (const group of groups) {
-        for (const userModelId of userModelIdsByGroupModelId[group.groupId] ??
+      for (const groupModelId of groupModelIds) {
+        for (const userModelId of userModelIdsByGroupModelId[groupModelId] ??
           []) {
           const user = usersByModelId.get(userModelId);
           if (user && !byId.has(user.id)) {

--- a/front/lib/resources/storage/models/group_permissions.ts
+++ b/front/lib/resources/storage/models/group_permissions.ts
@@ -1,6 +1,7 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
   GrantType,
@@ -83,6 +84,16 @@ GroupPermissionModel.init(
         fields: ["workspaceId", "groupId"],
         concurrently: true,
       },
+      // Space-load direction: hydrating a space's groups (the hottest query after the cached auth
+      // path) joins on (workspaceId, resourceType='space', resourceId). A partial index scoped to
+      // space grants keeps that hot slice small and cache-resident, independent of how large the
+      // polymorphic table grows for other resource types.
+      {
+        name: "group_permissions_space_ws_rid",
+        fields: ["workspaceId", "resourceId"],
+        where: { resourceType: "space" },
+        concurrently: true,
+      },
     ],
   }
 );
@@ -94,4 +105,16 @@ GroupPermissionModel.belongsTo(GroupModel, {
 GroupModel.hasMany(GroupPermissionModel, {
   foreignKey: { name: "groupId", allowNull: false },
   sourceKey: "id",
+});
+
+// A space's instance-level grants, keyed on `resourceId` and pinned to `resourceType: "space"`.
+// `resourceId` is a polymorphic column (not a real FK), hence `constraints: false`; the scope keeps
+// the join from matching same-numbered ids of other resource types. Used to source a space's
+// associated groups from `group_permissions` instead of `group_vaults` (being removed).
+SpaceModel.hasMany(GroupPermissionModel, {
+  as: "spaceGrants",
+  foreignKey: "resourceId",
+  sourceKey: "id",
+  scope: { resourceType: "space" },
+  constraints: false,
 });

--- a/front/lib/resources/storage/models/group_spaces.ts
+++ b/front/lib/resources/storage/models/group_spaces.ts
@@ -59,10 +59,6 @@ GroupModel.belongsToMany(SpaceModel, {
   foreignKey: "groupId",
 });
 
-SpaceModel.hasMany(GroupSpaceModel, {
-  as: "groupSpaces",
-  foreignKey: "vaultId",
-});
 GroupSpaceModel.belongsTo(SpaceModel, {
   as: "space",
   foreignKey: "vaultId",

--- a/front/lib/resources/storage/models/spaces.ts
+++ b/front/lib/resources/storage/models/spaces.ts
@@ -1,6 +1,6 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes } from "@app/lib/resources/storage/data_types";
-import type { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import type { GroupPermissionModel } from "@app/lib/resources/storage/models/group_permissions";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { SpaceKind } from "@app/types/space";
 import { isUniqueSpaceKind } from "@app/types/space";
@@ -21,7 +21,8 @@ export class SpaceModel extends SoftDeletableWorkspaceAwareModel<SpaceModel> {
   // But in both modes we have "groups" associated to the space to hold the members.
   declare managementMode: CreationOptional<"manual" | "group">;
 
-  declare groupSpaces: NonAttribute<GroupSpaceModel[]>;
+  // The space's instance-level grants in group_permissions, with the grantee `group` nested.
+  declare spaceGrants?: NonAttribute<GroupPermissionModel[]>;
 }
 SpaceModel.init(
   {

--- a/front/migrations/pre-deploy/20260821160000_add_space_grants_index_to_group_permissions.sql
+++ b/front/migrations/pre-deploy/20260821160000_add_space_grants_index_to_group_permissions.sql
@@ -1,0 +1,10 @@
+/*
+Statement 0
+  - Partial index for the space-load path: hydrating a space's groups joins group_permissions on
+    (workspaceId, resourceType='space', resourceId). Scoping the index to space grants keeps the
+    hottest slice small and cache-resident regardless of how the polymorphic table grows.
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY group_permissions_space_ws_rid ON public.group_permissions USING btree ("workspaceId", "resourceId") WHERE ("resourceType" = 'space');


### PR DESCRIPTION
## Description

Source a space's associated groups from `group_permissions` instead of the `group_vaults` join, so nothing outside the write machinery reads `group_vaults`. **`group_vaults` writes are kept** until the drop-table PR.

- New scoped association `SpaceModel.hasMany(GroupPermissionModel, { as: "spaceGrants", foreignKey: "resourceId", scope: { resourceType: "space" }, constraints: false })`. **No join to `groups`** — `SpaceGroupReference` is built straight from the grant row, so the `groups` join PR #29266 deliberately removed stays removed.
- `SpaceGroupReference` now carries **`grantType`** (not the group's kind) plus `isReader()`. Grant type alone can't identify a group's kind — an open *regular* space's member group holds a `reader` grant just like the global group — so anything that needs the space's own groups by kind goes through a targeted lookup: new `GroupPermissionResource.listRegularAutoGroupsForResource` → `SpaceResource.fetchRegularAutoGroups` (the space's member + editor groups) and `SpaceResource.fetchMembershipGroups` (member/editor, excluding the read-only viewer).
- Repointed the reads: the space-fetch includes (`baseFetch`, `dangerouslyFetchByModelIds`, `resource_with_space`), `listForGroups`, and the two `auth.ts` sandbox lookups. `isOpen()` = "has a reader grant"; `isMemberByGroupPredicate` uses `isOpen`/`isReader`; `search.ts`'s provisioned check → `managementMode === "group"`; `fetchManualMemberGroup`/`fetchManualGroupsMemberships`/suspend/restore, front-api `leave`, poke `details`, and `mention_suggestions` resolve the space's own groups via `fetchRegularAutoGroups`/`fetchMembershipGroups`.
- `delete` and `hardDeleteSpace` now delete **only the space's own regular_auto groups** (via `fetchRegularAutoGroups`), never the shared global/provisioned groups. During full workspace teardown the global/system groups are still removed by the workspace-wide `GroupModel.destroy`.
- Removed the dead `groupSpaceKind` field and the dead `groupSpaces` association + `SpaceModel` field.
- **Not touched (flip in the drop-table PR):** `fetchAssociatedGroups` and the `GroupSpace*Resource` mutation machinery keep reading `group_vaults` — they feed `writeGroupPermissions` with the *current* association set, so reading grants there would clobber in-flight changes.

Second of the `group_vaults` removal stack, on top of #30889.

## Tests

`tsgo --noEmit` clean on front and front-api. Green: front `space_resource` (70), `spaces`, `group_space_resource`, `mcp_server_view_resource`, `permissions`, `conversation` (incl. the open-pod tests), `mention_suggestions`, `search`, plus the conversation/projects/viz suites; front-api `leave`, `members`, `spaces/[spaceId]`, poke `details`, `project_metadata`, `project_tasks`, `files`, `sandbox-functions`. ~25 test files were repointed from `space.groups.filter(isRegularAuto)` to `fetchRegularAutoGroups`. Fixes the pre-existing CI failure: the open-pod tests opened a pod via `GroupSpaceViewerResource.makeNew`, which writes the `group_vaults` row but no grant, so the space no longer read as open once `isOpen` moved to grants — they now sync grants after (mirroring production `syncGroupPermissions`).

## Risk

Equivalence of `group_vaults` and `group_permissions` was validated in prod (no active space with a live `regular_auto` group missing its grant). Targeted reads are served by existing indices `group_permissions_ws_rtype_rid` (workspaceId, resourceType, resourceId) and `group_permissions_ws_group` (workspaceId, groupId). `group_vaults` writes are unchanged, so rollback is a code revert.

## Deploy Plan

Standard deploy after #30889. One **pre-deploy** migration: `CREATE INDEX CONCURRENTLY group_permissions_space_ws_rid` — a partial index on `(workspaceId, resourceId) WHERE resourceType = 'space'` for the space-load path (the hottest query after the cached auth path, per review). Pre-deploy + `CONCURRENTLY` means it builds online, before the new code serves traffic.

