### PR TITLE
Skills: correctly remove space from archived skill on space deletion

### DIFF
--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1363,6 +1363,46 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       expect(skillAfter!.requestedSpaceIds).toHaveLength(0);
     });
 
+    it("should clean an archived skill's requestedSpaceIds too", async () => {
+      // An archived skill keeps its references, and a dangling one makes it unfetchable — so it
+      // could never be restored. The cleanup must not be limited to active skills.
+      const spaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Space With Archived Skill",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(spaceResult.isOk()).toBe(true);
+      const space = spaceResult.isOk() ? spaceResult.value : null;
+      expect(space).not.toBeNull();
+
+      const skill = await SkillFactory.create(adminAuth, {
+        name: "Archived Skill Referencing A Space",
+        requestedSpaceIds: [space!.id],
+      });
+      await skill.archive(adminAuth);
+
+      const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+        adminAuth,
+        space!,
+        true // force delete
+      );
+      expect(deleteResult.isOk()).toBe(true);
+
+      // `fetchById` and friends default to active skills, so read it back as archived.
+      const archivedSkills = await SkillResource.listByWorkspace(adminAuth, {
+        status: "archived",
+      });
+      const skillAfter = archivedSkills.find((s) => s.id === skill.id);
+      expect(skillAfter).toBeDefined();
+      expect(skillAfter!.requestedSpaceIds).not.toContain(space!.id);
+    });
+
     it("should preserve additional skill requestedSpaceIds when deleting a dependency space", async () => {
       const toolSpaceResult = await createSpaceAndGroup(
         adminAuth,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -41,6 +41,7 @@ import {
 } from "@app/temporal/project_task/client";
 import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
 import type { SpaceCategoryInfo } from "@app/types/api/spaces";
+import { SKILL_STATUSES } from "@app/types/assistant/skill_configuration";
 import {
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
@@ -340,9 +341,18 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
       // (a skill can request a space without holding a live view in it).
       const [skillsWithMCPViews, skillsWithDataSourceViews, skillsWithSpace] =
         await Promise.all([
-          SkillResource.listByMCPServerViewIds(auth, mcpServerViewIds),
-          SkillResource.listByDataSourceViewIds(auth, dataSourceViewIds),
-          SkillResource.listByRequestedSpaceId(auth, space.id),
+          // Every status, not just active: an archived skill keeps its references, and leaving a
+          // deleted space in `requestedSpaceIds` makes the skill unfetchable — so it can never be
+          // restored, or even seen again.
+          SkillResource.listByMCPServerViewIds(auth, mcpServerViewIds, {
+            status: [...SKILL_STATUSES],
+          }),
+          SkillResource.listByDataSourceViewIds(auth, dataSourceViewIds, {
+            status: [...SKILL_STATUSES],
+          }),
+          SkillResource.listByRequestedSpaceId(auth, space.id, {
+            status: [...SKILL_STATUSES],
+          }),
         ]);
 
       // Merge and deduplicate skills.

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1601,12 +1601,13 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * List skills that use any of the given MCP server view IDs.
-   * Used during space deletion to find skills that need to be updated.
+   * List skills that use any of the given MCP server view IDs. Used during space deletion to find
+   * skills that need to be updated. Defaults to active skills; pass `status` to widen.
    */
   static async listByMCPServerViewIds(
     auth: Authenticator,
-    mcpServerViewIds: ModelId[]
+    mcpServerViewIds: ModelId[],
+    { status = "active" }: { status?: SkillStatus | SkillStatus[] } = {}
   ): Promise<SkillResource[]> {
     if (mcpServerViewIds.length === 0) {
       return [];
@@ -1636,7 +1637,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         id: {
           [Op.in]: skillIds,
         },
-        status: "active",
+        status,
       },
       onlyCustom: true,
     });
@@ -1650,13 +1651,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     dataSourceViewIds: ModelId[],
     {
+      status = "active",
       withInstructions = true,
       withTools = true,
       withFileAttachments = true,
     }: Pick<
       SkillConfigurationFindOptions,
       "withInstructions" | "withTools" | "withFileAttachments"
-    > = {}
+    > & { status?: SkillStatus | SkillStatus[] } = {}
   ): Promise<SkillResource[]> {
     if (dataSourceViewIds.length === 0) {
       return [];
@@ -1686,7 +1688,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         id: {
           [Op.in]: skillIds,
         },
-        status: "active",
+        status,
       },
       onlyCustom: true,
       withInstructions,
@@ -1748,20 +1750,22 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * List active skills whose requestedSpaceIds contains the given space. Used
-   * during space deletion to find skills that reference the space even when
-   * they have no MCP server view or data source view located in it.
+   * List skills whose requestedSpaceIds contains the given space. Used during space deletion to
+   * find skills that reference the space even when they have no MCP server view or data source
+   * view located in it. Defaults to active skills; pass `status` to widen (space deletion must
+   * clean archived skills too, or their dangling reference makes them unfetchable for good).
    */
   static async listByRequestedSpaceId(
     auth: Authenticator,
-    spaceModelId: ModelId
+    spaceModelId: ModelId,
+    { status = "active" }: { status?: SkillStatus | SkillStatus[] } = {}
   ): Promise<SkillResource[]> {
     return this.baseFetch(auth, {
       where: {
         requestedSpaceIds: {
           [Op.contains]: [spaceModelId],
         },
-        status: "active",
+        status,
       },
       onlyCustom: true,
     });

--- a/front/migrations/20260820_prune_skill_dangling_requested_spaces.ts
+++ b/front/migrations/20260820_prune_skill_dangling_requested_spaces.ts
@@ -1,0 +1,109 @@
+import { SkillConfigurationModel } from "@app/lib/models/skill";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
+
+// Prunes space ids from `requestedSpaceIds` that no longer point at a live space of the workspace.
+// A skill keeping a dangling id is dropped by `SkillResource.baseFetch` (which requires every
+// requested space to resolve), so it becomes invisible everywhere: unreadable in the product,
+// unrestorable, and unreachable through Poke. Spaces can be hard-deleted, and the cleanup on
+// soft-delete only covers active skills, so archived ones strand their references.
+//
+// Reads the models directly for that reason: the resource cannot fetch the very rows this repairs.
+async function pruneWorkspaceSkillRequestedSpaces(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  const skills = await SkillConfigurationModel.findAll({
+    attributes: ["id", "status", "requestedSpaceIds"],
+    where: {
+      workspaceId: workspace.id,
+      // Postgres: `<> '{}'` rather than a length check, so the filter stays index-friendly.
+      requestedSpaceIds: { [Op.ne]: [] },
+    },
+  });
+  if (skills.length === 0) {
+    return;
+  }
+
+  const requestedSpaceIds = [
+    ...new Set(skills.flatMap((skill) => skill.requestedSpaceIds)),
+  ];
+
+  // Soft-deleted spaces are excluded by the model's default scope, which is what we want: a
+  // soft-deleted space is as unreachable as a missing row.
+  const liveSpaces = await SpaceModel.findAll({
+    attributes: ["id"],
+    where: {
+      id: { [Op.in]: requestedSpaceIds },
+      workspaceId: workspace.id,
+    },
+  });
+  const liveSpaceIds = new Set(liveSpaces.map((space) => space.id));
+
+  for (const skill of skills) {
+    const danglingSpaceIds = skill.requestedSpaceIds.filter(
+      (spaceId) => !liveSpaceIds.has(spaceId)
+    );
+    if (danglingSpaceIds.length === 0) {
+      continue;
+    }
+
+    const prunedSpaceIds = skill.requestedSpaceIds.filter((spaceId) =>
+      liveSpaceIds.has(spaceId)
+    );
+    const context = {
+      workspaceId: workspace.sId,
+      skillModelId: skill.id,
+      skillStatus: skill.status,
+      requestedSpaceIds: skill.requestedSpaceIds,
+      danglingSpaceIds,
+      prunedSpaceIds,
+    };
+
+    if (!execute) {
+      logger.info(context, "Dry-run: would prune dangling requested space ids");
+      continue;
+    }
+
+    await skill.update({ requestedSpaceIds: prunedSpaceIds });
+
+    logger.info(context, "Pruned dangling requested space ids");
+  }
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting skill requested-space prune");
+
+    if (wId) {
+      const ws = await WorkspaceResource.fetchById(wId);
+      if (!ws) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      await pruneWorkspaceSkillRequestedSpaces(
+        execute,
+        logger,
+        renderLightWorkspaceType({ workspace: ws })
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await pruneWorkspaceSkillRequestedSpaces(execute, logger, workspace);
+        },
+        { concurrency: 4 }
+      );
+    }
+
+    logger.info("Skill requested-space prune completed");
+  }
+);


### PR DESCRIPTION
## Description

Currently deleted space are not removed from archived skills
This make skill unreachable from the skill resource as it checks for all the spaces

Fix the space deletion script + add a migration script to fix existing skills.

## Tests

added a test

## Risk

low

## Deploy Plan

deploy front