### PR TITLE
[front] enh: tweak conversation credit usage copy

### DIFF
--- a/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.accessibility.test.tsx
@@ -47,7 +47,7 @@ describe("CreditCostPopover accessibility", () => {
     });
   });
 
-  it("restores focus on Escape but not when opening conversation consumption", async () => {
+  it("restores focus on Escape but not when opening credit usage", async () => {
     const user = userEvent.setup();
     render(
       <CreditCostPopover
@@ -88,7 +88,7 @@ describe("CreditCostPopover accessibility", () => {
 
     await user.keyboard("{Enter}");
     await user.click(
-      await screen.findByRole("button", { name: "Conversation consumption" })
+      await screen.findByRole("button", { name: "Credit usage" })
     );
 
     await waitFor(() => {

--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -106,7 +106,7 @@ describe("CreditCostPopover", () => {
     mockUseAgentMessageConsumption.mockReset();
   });
 
-  it("shows the tool breakdown and opens conversation consumption", () => {
+  it("shows the tool breakdown and opens credit usage", () => {
     mockUseAgentMessageConsumption.mockReturnValue({
       consumption: {
         billedCredits: 12,
@@ -139,12 +139,10 @@ describe("CreditCostPopover", () => {
     expect(screen.getByText("Message consumption")).toBeInTheDocument();
     expect(screen.getByText("Charged")).toBeInTheDocument();
     expect(screen.getByText("15 credits")).toBeInTheDocument();
-    expect(screen.getByText("Agent work and context")).toBeInTheDocument();
+    expect(screen.getByText("Context and reasoning")).toBeInTheDocument();
     expect(screen.getByText("Sub-agents")).toBeInTheDocument();
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Conversation consumption" })
-    );
+    fireEvent.click(screen.getByRole("button", { name: "Credit usage" }));
 
     expect(mockOpenPanel).toHaveBeenCalledWith({ type: "credits" });
   });
@@ -197,7 +195,7 @@ describe("CreditCostPopover", () => {
     expect(screen.getByText("282 credits")).toBeInTheDocument();
   });
 
-  it("hides the conversation consumption button when the credits panel is open", () => {
+  it("hides the credit usage button when the credits panel is open", () => {
     mockSidePanelContext.currentPanel = "credits";
     mockUseAgentMessageConsumption.mockReturnValue({
       consumption: { billedCredits: 10, details: null },
@@ -208,7 +206,7 @@ describe("CreditCostPopover", () => {
     render(<CreditCostPopover {...defaultProps} />);
 
     expect(
-      screen.queryByRole("button", { name: "Conversation consumption" })
+      screen.queryByRole("button", { name: "Credit usage" })
     ).not.toBeInTheDocument();
   });
 

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -187,7 +187,7 @@ export function CreditCostPopover({
           ) : details ? (
             <dl>
               <CreditDetailRow
-                label="Agent work and context"
+                label="Context and reasoning"
                 value={formatCreditValue(details.agentWorkCredits)}
                 icon={InternalActionIcons.ActionBrainIcon}
               />
@@ -233,7 +233,7 @@ export function CreditCostPopover({
             <Button
               variant="highlight-ghost"
               size="sm"
-              label="Conversation consumption"
+              label="Credit usage"
               className="w-full"
               onClick={() => {
                 preventTriggerFocusOnCloseRef.current = true;

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.test.tsx
@@ -63,10 +63,16 @@ describe("ConversationCreditUsageBreakdown", () => {
     );
 
     expect(
-      screen.getByRole("heading", { name: "Total consumption" })
+      screen.getByRole("heading", { name: "Total credits consumed" })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("heading", { name: "Per Models" })
+      screen.getByRole("heading", { name: "By model" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Context and reasoning")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Agents use credits to process the conversation history and context. Longer conversations consume more credits."
+      )
     ).toBeInTheDocument();
     expect(screen.getByText("Calendar tool")).toBeInTheDocument();
     expect(screen.getByText("6.5 credits")).toBeInTheDocument();

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown.tsx
@@ -97,8 +97,8 @@ function ToolBreakdownCards({
     <div className="grid grid-cols-2 gap-4">
       <div className="col-span-2">
         <CreditBreakdownCard
-          label="Agent work and context"
-          description="Longer conversations require more context to process"
+          label="Context and reasoning"
+          description="Agents use credits to process the conversation history and context. Longer conversations consume more credits."
           value={agentWorkCredits}
           icon={InternalActionIcons.ActionBrainIcon}
         />
@@ -162,7 +162,7 @@ function ModelsBreakdown({ isDark, models }: ModelsBreakdownProps) {
 
   return (
     <section className="mt-6 space-y-4 border-t border-border pt-6">
-      <h3 className="text-base font-semibold text-foreground">Per Models</h3>
+      <h3 className="text-base font-semibold text-foreground">By model</h3>
       <div className="space-y-2">
         {models.map((model) => (
           <ModelRow
@@ -257,7 +257,7 @@ export function ConversationCreditUsageBreakdown({
       <section className="space-y-4">
         <div>
           <h2 className="text-base font-semibold text-foreground">
-            Total consumption
+            Total credits consumed
           </h2>
           <div className="flex items-end gap-1">
             <span className="text-2xl font-semibold leading-8 text-foreground">

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.test.tsx
@@ -62,7 +62,7 @@ describe("ConversationCreditUsagePanel", () => {
       <ConversationCreditUsagePanel conversation={conversation} owner={owner} />
     );
 
-    expect(screen.getByText("Conversation consumption")).toBeInTheDocument();
+    expect(screen.getByText("Credit usage")).toBeInTheDocument();
     expect(screen.getByText("No usage yet")).toBeInTheDocument();
     expect(
       screen.getByText("Updates once a message is fully processed.")

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.tsx
@@ -28,7 +28,7 @@ export function ConversationCreditUsagePanel({
     <div className="flex h-panel flex-col">
       <ConversationSidePanelHeader onClose={closePanel}>
         <span className="text-sm font-medium text-foreground">
-          Conversation consumption
+          Credit usage
         </span>
       </ConversationSidePanelHeader>
       <div className="min-h-0 flex-1 overflow-y-auto">
@@ -39,7 +39,7 @@ export function ConversationCreditUsagePanel({
         ) : isConsumptionError ? (
           <div className="flex h-full items-center justify-center px-5 py-4">
             <p className="text-sm text-muted-foreground">
-              Conversation consumption couldn’t be loaded.
+              Credit usage couldn’t be loaded.
             </p>
           </div>
         ) : hasNoCreditUsage ? (


### PR DESCRIPTION
## Description

Follow up on [this thread](https://dust4ai.slack.com/archives/C050A0S2Z7F/p1787236354884759?thread_ts=1787060289.560179&cid=C050A0S2Z7F).

This PR tweaks the copy of the conversation breakdown. The entry point and side panel now use "Credit usage", while the total, context and reasoning, and model breakdown labels use a friendlier wording.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
