### PR TITLE
[front] enh: type the follow-up input bar placeholder like sidebar titles

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -806,6 +806,7 @@ export const InputBar = React.memo(function InputBar({
             placeholder={
               willQueueMessage ? INPUT_BAR_QUEUE_PLACEHOLDER : placeholder
             }
+            animatePlaceholder={willQueueMessage}
             onShake={handleShake}
             isCompact={effectiveIsCompact}
             onExpandInputBar={onExpandInputBar}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -205,6 +205,7 @@ export interface InputBarContainerProps {
   disableInput: boolean;
   submitBlockMessage: string | null;
   placeholder?: string;
+  animatePlaceholder?: boolean;
   onShake: () => void;
   conversation?: ConversationWithoutContentType;
   space?: SpaceType;
@@ -312,6 +313,7 @@ const InputBarContainer = ({
   disableInput,
   submitBlockMessage,
   placeholder,
+  animatePlaceholder,
   onShake,
   isCompact = false,
   onExpandInputBar,
@@ -801,6 +803,7 @@ const InputBarContainer = ({
       spaceIdRef,
     },
     placeholderOverride: disableInput ? submitBlockMessage : placeholder,
+    animatePlaceholder: !disableInput && animatePlaceholder,
     onSuggestionActiveChangeRef,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -290,18 +290,24 @@ describe("useCustomEditor placeholder override", () => {
     vi.useRealTimers();
   });
 
+  interface EditorHookProps {
+    placeholderOverride: string | null;
+    animatePlaceholder?: boolean;
+  }
+
   function renderEditorHook() {
-    const initialProps: { placeholderOverride: string | null } = {
+    const initialProps: EditorHookProps = {
       placeholderOverride: null,
     };
     const { result, rerender } = renderHook(
-      ({ placeholderOverride }: { placeholderOverride: string | null }) =>
+      ({ placeholderOverride, animatePlaceholder }: EditorHookProps) =>
         useCustomEditor({
           onEnterKeyDown: vi.fn(),
           disableAutoFocus: true,
           owner,
           conversationId: "cId",
           placeholderOverride,
+          animatePlaceholder,
         }),
       { initialProps }
     );
@@ -318,12 +324,15 @@ describe("useCustomEditor placeholder override", () => {
     return editor.view.dom.querySelector("p")?.getAttribute("data-placeholder");
   }
 
-  it("types the new placeholder without recreating the editor", () => {
+  it("types the animated placeholder without recreating the editor", () => {
     const { editor, result, rerender } = renderEditorHook();
 
     expect(getPlaceholderText(editor)).toBe("Get work done");
 
-    rerender({ placeholderOverride: "Add a follow-up..." });
+    rerender({
+      placeholderOverride: "Add a follow-up...",
+      animatePlaceholder: true,
+    });
 
     // Typing starts from the first character.
     expect(result.current.editor).toBe(editor);
@@ -334,12 +343,20 @@ describe("useCustomEditor placeholder override", () => {
     });
 
     expect(getPlaceholderText(editor)).toBe("Add a follow-up...");
+  });
 
-    rerender({ placeholderOverride: null });
+  it("swaps the placeholder instantly when not animated", () => {
+    const { editor, result, rerender } = renderEditorHook();
 
+    rerender({
+      placeholderOverride: "Add a follow-up...",
+      animatePlaceholder: true,
+    });
     act(() => {
       vi.runAllTimers();
     });
+
+    rerender({ placeholderOverride: null });
 
     expect(result.current.editor).toBe(editor);
     expect(getPlaceholderText(editor)).toBe("Get work done");
@@ -353,7 +370,10 @@ describe("useCustomEditor placeholder override", () => {
       editor.commands.setTextSelection(3);
     });
 
-    rerender({ placeholderOverride: "Add a follow-up..." });
+    rerender({
+      placeholderOverride: "Add a follow-up...",
+      animatePlaceholder: true,
+    });
 
     expect(result.current.editor).toBe(editor);
     expect(editor.getText()).toBe("hello");

--- a/front/components/editor/input_bar/useCustomEditor.test.ts
+++ b/front/components/editor/input_bar/useCustomEditor.test.ts
@@ -282,6 +282,14 @@ describe("useCustomEditor placeholder override", () => {
     vi.unstubAllGlobals();
   });
 
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   function renderEditorHook() {
     const initialProps: { placeholderOverride: string | null } = {
       placeholderOverride: null,
@@ -310,17 +318,28 @@ describe("useCustomEditor placeholder override", () => {
     return editor.view.dom.querySelector("p")?.getAttribute("data-placeholder");
   }
 
-  it("updates the placeholder without recreating the editor", () => {
+  it("types the new placeholder without recreating the editor", () => {
     const { editor, result, rerender } = renderEditorHook();
 
     expect(getPlaceholderText(editor)).toBe("Get work done");
 
     rerender({ placeholderOverride: "Add a follow-up..." });
 
+    // Typing starts from the first character.
     expect(result.current.editor).toBe(editor);
+    expect(getPlaceholderText(editor)).toBe("A");
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
     expect(getPlaceholderText(editor)).toBe("Add a follow-up...");
 
     rerender({ placeholderOverride: null });
+
+    act(() => {
+      vi.runAllTimers();
+    });
 
     expect(result.current.editor).toBe(editor);
     expect(getPlaceholderText(editor)).toBe("Get work done");

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -353,6 +353,8 @@ export interface CustomEditorProps {
   };
   // Override the default editor placeholder (e.g. to show a blocked-state reason).
   placeholderOverride?: string | null;
+  // When true, placeholder changes are typed character by character.
+  animatePlaceholder?: boolean;
   onSuggestionActiveChangeRef?: React.RefObject<
     ((active: boolean) => void) | undefined
   >;
@@ -541,6 +543,7 @@ const useCustomEditor = ({
   onFirstAgentMentionPasteRef,
   slashSuggestion,
   placeholderOverride,
+  animatePlaceholder,
   onSuggestionActiveChangeRef,
 }: CustomEditorProps) => {
   // Read through a ref so placeholder changes don't rebuild the editor.
@@ -595,13 +598,20 @@ const useCustomEditor = ({
     [conversationId]
   );
 
-  // Type the new placeholder character by character, like the sidebar
-  // conversation titles. The Placeholder extension only re-reads placeholderRef
-  // on a state update, so dispatch an empty transaction for each character.
-  // Skipped on mount since the ref starts in sync with the override.
+  // Apply placeholder changes. With animatePlaceholder, type the new
+  // placeholder character by character, like the sidebar conversation titles.
+  // The Placeholder extension only re-reads placeholderRef on a state update,
+  // so dispatch an empty transaction for each change. Skipped on mount since
+  // the ref starts in sync with the override.
   useEffect(() => {
     const target = placeholderOverride ?? INPUT_BAR_DEFAULT_PLACEHOLDER;
     if (!editor || editor.isDestroyed || placeholderRef.current === target) {
+      return;
+    }
+
+    if (!animatePlaceholder) {
+      placeholderRef.current = target;
+      editor.view.dispatch(editor.state.tr);
       return;
     }
 
@@ -621,7 +631,7 @@ const useCustomEditor = ({
     }, PLACEHOLDER_TYPING_INTERVAL_MS);
 
     return () => clearInterval(typingEffect);
-  }, [editor, placeholderOverride]);
+  }, [editor, placeholderOverride, animatePlaceholder]);
 
   const isMobileViewport = useIsMobile();
   const editorService = useEditorService(editor, isMobileViewport);

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -43,6 +43,8 @@ import { useEffect, useMemo, useRef } from "react";
 const DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD = 16000;
 const SUBMIT_COOLDOWN_MS = 750;
 export const INPUT_BAR_DEFAULT_PLACEHOLDER = "Get work done";
+// Matches the sidebar conversation title TypingAnimation cadence.
+const PLACEHOLDER_TYPING_INTERVAL_MS = 32;
 
 function isLongTextPaste(text: string, maxCharThreshold?: number) {
   const maxChars = maxCharThreshold ?? DEFAULT_LONG_TEXT_PASTE_CHARS_THRESHOLD;
@@ -368,7 +370,7 @@ export const buildEditorExtensions = ({
   onAgentSelect,
   onFirstAgentMentionPasteRef,
   slashSuggestion,
-  placeholderOverrideRef,
+  placeholderRef,
   onSuggestionActiveChangeRef,
 }: {
   owner: WorkspaceType;
@@ -384,7 +386,7 @@ export const buildEditorExtensions = ({
     ((agentId: string) => void) | undefined
   >;
   slashSuggestion?: CustomEditorProps["slashSuggestion"];
-  placeholderOverrideRef?: React.RefObject<string | null | undefined>;
+  placeholderRef?: React.RefObject<string>;
   onSuggestionActiveChangeRef?: CustomEditorProps["onSuggestionActiveChangeRef"];
 }) => {
   const notifySuggestionActiveChange = (active: boolean) => {
@@ -479,7 +481,7 @@ export const buildEditorExtensions = ({
         if (node.type.name !== "paragraph") {
           return "";
         }
-        return placeholderOverrideRef?.current ?? INPUT_BAR_DEFAULT_PLACEHOLDER;
+        return placeholderRef?.current ?? INPUT_BAR_DEFAULT_PLACEHOLDER;
       },
       emptyNodeClass:
         "first:before:text-faint dark:first:before:text-stone-400 first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
@@ -542,7 +544,9 @@ const useCustomEditor = ({
   onSuggestionActiveChangeRef,
 }: CustomEditorProps) => {
   // Read through a ref so placeholder changes don't rebuild the editor.
-  const placeholderOverrideRef = useRef(placeholderOverride);
+  const placeholderRef = useRef(
+    placeholderOverride ?? INPUT_BAR_DEFAULT_PLACEHOLDER
+  );
 
   const editor = useEditor(
     {
@@ -559,7 +563,7 @@ const useCustomEditor = ({
         onAgentSelect,
         onFirstAgentMentionPasteRef,
         slashSuggestion,
-        placeholderOverrideRef,
+        placeholderRef,
         onSuggestionActiveChangeRef,
       }),
       shouldRerenderOnTransaction: true, // necessary to update the editor state (and so the toolbar icons "activation") in real time
@@ -591,13 +595,32 @@ const useCustomEditor = ({
     [conversationId]
   );
 
-  // The Placeholder extension only re-reads placeholderOverrideRef on a state
-  // update, so dispatch an empty transaction when the override changes.
+  // Type the new placeholder character by character, like the sidebar
+  // conversation titles. The Placeholder extension only re-reads placeholderRef
+  // on a state update, so dispatch an empty transaction for each character.
+  // Skipped on mount since the ref starts in sync with the override.
   useEffect(() => {
-    placeholderOverrideRef.current = placeholderOverride;
-    if (editor && !editor.isDestroyed) {
-      editor.view.dispatch(editor.state.tr);
+    const target = placeholderOverride ?? INPUT_BAR_DEFAULT_PLACEHOLDER;
+    if (!editor || editor.isDestroyed || placeholderRef.current === target) {
+      return;
     }
+
+    // Start at one character, like TypingAnimation.
+    let length = 1;
+    placeholderRef.current = target.substring(0, length);
+    editor.view.dispatch(editor.state.tr);
+
+    const typingEffect = setInterval(() => {
+      if (editor.isDestroyed || length >= target.length) {
+        clearInterval(typingEffect);
+        return;
+      }
+      length += 1;
+      placeholderRef.current = target.substring(0, length);
+      editor.view.dispatch(editor.state.tr);
+    }, PLACEHOLDER_TYPING_INTERVAL_MS);
+
+    return () => clearInterval(typingEffect);
   }, [editor, placeholderOverride]);
 
   const isMobileViewport = useIsMobile();


### PR DESCRIPTION
## Description

Follow up of #30882.

When the input bar placeholder switches to **"Add a follow-up..."** (a message is generating, so a submitted message is queued), it now types in character by character — same feel and cadence (32ms/char) as the sidebar conversation title `TypingAnimation`. The placeholder is a TipTap decoration, so the animation is driven through the `placeholderRef` + empty-transaction mechanism from #30882 rather than the Sparkle component.

The animation only plays when switching **to** the follow-up placeholder (`animatePlaceholder` prop, passed as `willQueueMessage` from `InputBar`). Switching back to "Get work done" and blocked-state messages swap instantly.

Tests cover the typed transition (fake timers), the instant swap back, and that content/selection/editor instance survive placeholder changes.

## Risk

Worst case, a broken placeholder animation on the input bar. Safe to rollback.

## Deploy Plan

- [ ] Deploy front

🤖 Generated with [Claude Code](https://claude.com/claude-code)
