### PR TITLE
[front] enh: rename web tools in user-facing copy

### DIFF
--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -115,6 +115,8 @@ const SPECIAL_CASES = {
   github: "GitHub",
   hubspot: "HubSpot",
   mcp: "MCP",
+  webbrowser: "Web browsing",
+  websearch: "Web search",
   id: "ID",
 };
 


### PR DESCRIPTION
## Description

The web tools (search, browse) appear as one word in user-facing copy, notably in the message credit breakdown.

This PR renames them in favor of "websearch" -> "Web search" and "webbrowser" -> "Web browsing".

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
