### PR TITLE
[front] feat: let Frames in regular conversations use pod functions

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -439,14 +439,12 @@ export const buildInteractiveContentInstructions = ({
       ? UPDATING_SECTION_COMPUTER_FIRST
       : UPDATING_SECTION_FILES_FIRST,
     validationFixExample: VALIDATION_FIX_EXAMPLE_SOURCE_EDIT,
-    podSections: joinPodSections(
-      isPod
-        ? [
-            POD_APP_SECTION,
-            ...(hasPodFunctions
-              ? [podStorageSection(podFunctionsSkillName)]
-              : []),
-          ]
-        : []
-    ),
+    // The app layout is Pod-shaped guidance and only makes sense with a Pod to lay it out in. The
+    // storage decision is not: a standalone conversation gets a hidden Pod of its own the moment it
+    // needs one, so the Frame's data belongs behind pod functions there too, and the model has to
+    // know that before it reaches for `useState`.
+    podSections: joinPodSections([
+      ...(isPod ? [POD_APP_SECTION] : []),
+      ...(hasPodFunctions ? [podStorageSection(podFunctionsSkillName)] : []),
+    ]),
   });

--- a/front/lib/api/actions/servers/pod_manager/helpers.ts
+++ b/front/lib/api/actions/servers/pod_manager/helpers.ts
@@ -17,6 +17,7 @@ import {
   listProjectContextAttachments,
 } from "@app/lib/api/projects/context";
 import { fetchProjectDataSourceView } from "@app/lib/api/projects/data_sources";
+import { fetchOrCreateHiddenPodForConversation } from "@app/lib/api/projects/hidden_pod";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -103,7 +104,11 @@ export async function buildProjectRetrieveDataSources(
  */
 export async function getPod(
   auth: Authenticator,
-  from: { toolContext?: ToolContext } | { dustPod?: DustPodConfigurationType }
+  from: { toolContext?: ToolContext } | { dustPod?: DustPodConfigurationType },
+  // When set, a standalone conversation resolves to its hidden pod (created on first need)
+  // instead of erroring. Only the pod app tools pass it: managing a Pod's context, members or
+  // tasks from outside a Pod is meaningless, while a Frame's app needs a pod wherever it runs.
+  { hiddenPodFallback = false }: { hiddenPodFallback?: boolean } = {}
 ): Promise<Result<PodContext, MCPError>> {
   if ("dustPod" in from && from.dustPod) {
     const { dustPod } = from;
@@ -159,12 +164,31 @@ export async function getPod(
       const conversation = toolContext.runContext.conversation;
 
       if (!isPodConversation(conversation)) {
-        return new Err(
-          new MCPError(
-            "This conversation is not in a Pod. Pod context management is only available in Pod conversations.",
-            { tracked: false }
-          )
+        if (!hiddenPodFallback) {
+          return new Err(
+            new MCPError(
+              "This conversation is not in a Pod. Pod context management is only available in Pod conversations.",
+              { tracked: false }
+            )
+          );
+        }
+
+        // A standalone conversation has no pod of its own, but its Frames still need one to hold
+        // their app: the Frame's source, its published functions and their databases. Create it
+        // lazily and invisibly, so the caller gets the same PodContext a Pod conversation gives it.
+        const hiddenPodResult = await fetchOrCreateHiddenPodForConversation(
+          auth,
+          conversation.sId
         );
+        if (hiddenPodResult.isErr()) {
+          return new Err(
+            new MCPError(
+              `Could not prepare this conversation's app runtime: ${hiddenPodResult.error.message}`
+            )
+          );
+        }
+
+        return new Ok({ pod: hiddenPodResult.value });
       }
 
       const space = await SpaceResource.fetchById(auth, conversation.spaceId);
@@ -208,9 +232,10 @@ function checkWritePermission(
  */
 export async function getWritablePodContext(
   auth: Authenticator,
-  from: { toolContext?: ToolContext } | { dustPod?: DustPodConfigurationType }
+  from: { toolContext?: ToolContext } | { dustPod?: DustPodConfigurationType },
+  options: { hiddenPodFallback?: boolean } = {}
 ): Promise<Result<PodContext, MCPError>> {
-  const contextRes = await getPod(auth, from);
+  const contextRes = await getPod(auth, from, options);
   if (contextRes.isErr()) {
     return contextRes;
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/call.ts
@@ -13,7 +13,13 @@ export async function callHandler(
   { slug, input }: { slug: string; input?: Record<string, unknown> },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(
+    auth,
+    { toolContext: { runContext } },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_list.ts
@@ -26,7 +26,13 @@ export async function dbListHandler(
   _params: Record<string, never>,
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(
+    auth,
+    { toolContext: { runContext } },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_query.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_query.ts
@@ -32,9 +32,15 @@ export async function dbQueryHandler(
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
   // Write gate: db_query runs DML, not just reads.
-  const podResult = await getWritablePodContext(auth, {
-    toolContext: { runContext },
-  });
+  const podResult = await getWritablePodContext(
+    auth,
+    {
+      toolContext: { runContext },
+    },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_reconcile.ts
@@ -24,9 +24,15 @@ export async function dbReconcileHandler(
   { database, path }: { database: string; path: string },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getWritablePodContext(auth, {
-    toolContext: { runContext },
-  });
+  const podResult = await getWritablePodContext(
+    auth,
+    {
+      toolContext: { runContext },
+    },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/db_schema.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/db_schema.ts
@@ -11,7 +11,13 @@ export async function dbSchemaHandler(
   { database }: { database: string },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(
+    auth,
+    { toolContext: { runContext } },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/get.ts
@@ -26,7 +26,13 @@ export async function getHandler(
   { slug }: { slug: string },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(
+    auth,
+    { toolContext: { runContext } },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations.ts
@@ -30,7 +30,13 @@ export async function inspectInvocationsHandler(
   { slug, limit }: { slug: string; limit: number },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(
+    auth,
+    { toolContext: { runContext } },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/list.ts
@@ -30,17 +30,26 @@ export async function listHandler(
   _params: Record<string, never>,
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getPod(auth, { toolContext: { runContext } });
+  const podResult = await getPod(
+    auth,
+    { toolContext: { runContext } },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }
 
-  const sandboxFunctions = await SandboxFunctionResource.listBySpace(
-    auth,
-    podResult.value.pod
-  );
+  const { pod } = podResult.value;
+  const sandboxFunctions = await SandboxFunctionResource.listBySpace(auth, pod);
 
+  // The pod's id leads the listing: a Frame's fully qualified references need it, and in a
+  // standalone conversation this is where the model learns which pod its app lives in at all.
   return new Ok([
-    { type: "text", text: formatSandboxFunctionsList(sandboxFunctions) },
+    {
+      type: "text",
+      text: `Pod: ${pod.sId} (app root \`pod-${pod.sId}\`)\n\n${formatSandboxFunctionsList(sandboxFunctions)}`,
+    },
   ]);
 }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish.ts
@@ -35,9 +35,15 @@ export async function publishHandler(
   },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getWritablePodContext(auth, {
-    toolContext: { runContext },
-  });
+  const podResult = await getWritablePodContext(
+    auth,
+    {
+      toolContext: { runContext },
+    },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/unpublish.ts
@@ -11,9 +11,15 @@ export async function unpublishHandler(
   { slug }: { slug: string },
   { auth, runContext }: ToolHandlerExtra
 ): Promise<ToolHandlerResult> {
-  const podResult = await getWritablePodContext(auth, {
-    toolContext: { runContext },
-  });
+  const podResult = await getWritablePodContext(
+    auth,
+    {
+      toolContext: { runContext },
+    },
+    {
+      hiddenPodFallback: true,
+    }
+  );
   if (podResult.isErr()) {
     return new Err(podResult.error);
   }

--- a/front/lib/api/projects/constants.ts
+++ b/front/lib/api/projects/constants.ts
@@ -12,3 +12,20 @@ export const POD_AGENTS_MD_MAX_CHARACTER_COUNT = 8192;
 export function getPodAgentsMdScopedPath(podId: string): string {
   return podScopedPath(podId, POD_AGENTS_MD_FILENAME);
 }
+
+/**
+ * A hidden pod backs a Frame created in a standalone conversation: the Frame's app (its source,
+ * published functions and databases) has to live in a pod, but the conversation is not in one, so
+ * the platform creates one lazily and keeps it out of every pod listing. The marker is a name
+ * prefix rather than a column, the same way `isDatabaseFileSystemPodName` drives a pod's
+ * filesystem off its name.
+ */
+export const HIDDEN_POD_NAME_PREFIX = "[Frame runtime] ";
+
+export function hiddenPodNameForConversation(conversationId: string): string {
+  return `${HIDDEN_POD_NAME_PREFIX}${conversationId}`;
+}
+
+export function isHiddenPodName(name: string): boolean {
+  return name.startsWith(HIDDEN_POD_NAME_PREFIX);
+}

--- a/front/lib/api/projects/hidden_pod.ts
+++ b/front/lib/api/projects/hidden_pod.ts
@@ -1,0 +1,73 @@
+import { hiddenPodNameForConversation } from "@app/lib/api/projects/constants";
+import { createSpaceAndGroup } from "@app/lib/api/spaces";
+import type { Authenticator } from "@app/lib/auth";
+import { executeWithLock } from "@app/lib/lock";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const HIDDEN_POD_CREATION_LOCK_TIMEOUT_MS = 30_000;
+
+/**
+ * The hidden pod backing a standalone conversation's Frame apps, or null when it has none yet.
+ * Read-only: use this wherever a conversation's app runtime must be observed without bringing one
+ * into existence (listings, the move guard).
+ */
+export async function fetchHiddenPodForConversation(
+  auth: Authenticator,
+  conversationId: string
+): Promise<SpaceResource | null> {
+  return SpaceResource.fetchByName(
+    auth,
+    hiddenPodNameForConversation(conversationId)
+  );
+}
+
+/**
+ * The hidden pod backing a standalone conversation's Frame apps, created on first need.
+ *
+ * Non-restricted on purpose: the pod's function bundles are resolved through the space permission
+ * filter, so a restricted pod would break the Frame for everyone but its author — including other
+ * readers of the same conversation. Only the creator lands in the pod's editor group, so
+ * `pod_member_required` still means the conversation's owner and not the whole workspace.
+ */
+export async function fetchOrCreateHiddenPodForConversation(
+  auth: Authenticator,
+  conversationId: string
+): Promise<Result<SpaceResource, Error>> {
+  const existing = await fetchHiddenPodForConversation(auth, conversationId);
+  if (existing) {
+    return new Ok(existing);
+  }
+
+  // Several tool calls in one agent loop can race here, and the space name carries a uniqueness
+  // constraint, so the loser would fail rather than reuse the winner's pod.
+  return executeWithLock(
+    `hidden_pod:${conversationId}`,
+    async () => {
+      const raced = await fetchHiddenPodForConversation(auth, conversationId);
+      if (raced) {
+        return new Ok(raced);
+      }
+
+      const result = await createSpaceAndGroup(
+        auth,
+        {
+          name: hiddenPodNameForConversation(conversationId),
+          isRestricted: false,
+          spaceKind: "project",
+          memberIds: [],
+          managementMode: "manual",
+        },
+        // The user never asked for this pod, so it must not consume their pod allowance.
+        { ignoreWorkspaceLimit: true }
+      );
+      if (result.isErr()) {
+        return new Err(new Error(result.error.message));
+      }
+
+      return new Ok(result.value);
+    },
+    HIDDEN_POD_CREATION_LOCK_TIMEOUT_MS
+  );
+}

--- a/front/lib/resources/skill/code_defined/global/frames.test.ts
+++ b/front/lib/resources/skill/code_defined/global/frames.test.ts
@@ -110,7 +110,7 @@ describe("framesSkill.fetchInstructions", () => {
     expect(instructions).not.toContain(EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME);
   });
 
-  it("keeps Frames in the conversation outside a Pod", async () => {
+  it("teaches the storage decision but not the Pod app layout outside a Pod", async () => {
     const { authenticator: auth } = await createResourceTest({});
     await FeatureFlagFactory.basic(auth, "sandbox_functions");
 
@@ -119,8 +119,10 @@ describe("framesSkill.fetchInstructions", () => {
       agentLoopData: agentLoopDataInPod(null),
     });
 
+    // A standalone conversation gets a hidden Pod of its own when a Frame needs one, so the
+    // storage decision applies; the app layout does not, since there is no Pod to lay out yet.
     expect(instructions).not.toContain(POD_APP_MARKER);
-    expect(instructions).not.toContain(POD_STORAGE_MARKER);
+    expect(instructions).toContain(POD_STORAGE_MARKER);
   });
 
   it("teaches the Pod app layout and storage decision in a Pod", async () => {

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -51,7 +51,52 @@ export const podFunctionsSkill = {
     "Frame whose entries users add and expect to find again), or whenever a Frame needs a " +
     "server-side capability it cannot hold itself, such as calling another tool or using a " +
     "workspace secret.",
-  instructions: `Pod functions are versioned, typed functions published on the Pod's own
+  mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
+  version: 9,
+  icon: "PuzzleIcon",
+  isRestricted: async (auth: Authenticator) => {
+    const flags = await getFeatureFlags(auth);
+
+    return !flags.includes("sandbox_functions");
+  },
+  // Functions belong to a pod, but a standalone conversation gets a hidden one of its own, so the
+  // skill is available wherever there is a conversation to hang that pod off.
+  isDisabledForAgentLoop: (agentLoopData) => !agentLoopData.conversation,
+  // Equipped in conversations but not auto-enabled.
+  getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
+  fetchInstructions: async (_auth, params) => {
+    const conversation = params.agentLoopData?.conversation;
+    if (!conversation || isPodConversation(conversation)) {
+      return POD_FUNCTIONS_INSTRUCTIONS;
+    }
+
+    return `${HIDDEN_POD_PREAMBLE}\n${POD_FUNCTIONS_INSTRUCTIONS}`;
+  },
+} as const satisfies GlobalSkillDefinition;
+
+/**
+ * Prepended when the conversation is not in a Pod: it still gets the whole pod-functions contract
+ * below, addressed at the Pod the platform keeps for it alone. The Pod's id is not known here —
+ * it is created on the first app tool call and reported by the list tool — so the preamble sends
+ * the model there rather than naming it.
+ */
+const HIDDEN_POD_PREAMBLE = `\
+#### This conversation's app runtime
+
+This conversation is not in a Pod, but it still has one of its own to hold its apps, created for
+this conversation and nothing else. Call \`${toolName("list")}\` before anything else: it reports
+that Pod's id, and wherever the contract below says \`pod-<podId>\`, it means that id. Keep this
+conversation's whole app in \`pod-<podId>/<AppName>/\` exactly as described below.
+
+That Pod is invisible: the user does not see it, cannot open it, and has no idea it exists. So never
+mention it, and never explain Pods, pod functions or publishing to the user. From their side the
+Frame simply works and remembers what they put into it.
+
+\`${CREATE_FRAME_TOOL}\` still creates the Frame in the conversation, so move it into its app folder
+with \`${FILES_MOVE_TOOL}\` before \`${PUBLISH_FRAME_TOOL}\`, exactly as below.
+`;
+
+const POD_FUNCTIONS_INSTRUCTIONS = `Pod functions are versioned, typed functions published on the Pod's own
 Computer: a persistent environment shared across every conversation in the Pod, not the one
 scoped to this conversation. Each one is a TypeScript module with zod-typed input and output,
 bundled at publish time and reusable across conversations in the same Pod, callable from a
@@ -472,19 +517,4 @@ Split capabilities across functions rather than branching inside one. A \`list-n
 one \`notes\` function taking an \`action\` field is not. If a capability must be restricted to an
 app-specific subset of users, keep that list in the database and check it against
 \`currentUser().sId\` — the platform tells you the caller's standing (workspace member, Pod
-member, Pod editor), not what your app allows them to do.`,
-  mcpServers: [{ name: SANDBOX_FUNCTIONS_SERVER_NAME }],
-  version: 8,
-  icon: "PuzzleIcon",
-  isRestricted: async (auth: Authenticator) => {
-    const flags = await getFeatureFlags(auth);
-
-    return !flags.includes("sandbox_functions");
-  },
-  // Functions are Pod-scoped, so the skill is hidden outside a Pod conversation.
-  isDisabledForAgentLoop: (agentLoopData) =>
-    !agentLoopData.conversation ||
-    !isPodConversation(agentLoopData.conversation),
-  // Equipped in Pod conversations but not auto-enabled.
-  getAutoEnabledOrEquippedForAgentLoop: () => "equipped",
-} as const satisfies GlobalSkillDefinition;
+member, Pod editor), not what your app allows them to do.`;

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1,5 +1,6 @@
 import { isDatabaseFileSystemPodName } from "@app/lib/api/file_system/storage_mode";
 import { isLegacyAclsEnabled } from "@app/lib/api/permissions/legacy_acls";
+import { HIDDEN_POD_NAME_PREFIX } from "@app/lib/api/projects/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentProjectConfigurationModel } from "@app/lib/models/agent/actions/projects";
@@ -112,6 +113,13 @@ class SpaceGroupReference {
 //   project's editor (`admin`) and member (`member`) groups, so it is what marks an actual member.
 const REGULAR_SPACE_MEMBERSHIP_VERB: GrantVerb = "read";
 const POD_SPACE_MEMBERSHIP_VERB: GrantVerb = "write";
+
+// Hidden pods exist only to hold a standalone conversation's Frame apps, so they are left out of
+// every listing that shows a user their Pods. They are still fetchable by id and by name, which is
+// all their owning conversation and the app tools need.
+const EXCLUDE_HIDDEN_PODS = {
+  name: { [Op.notILike]: `${HIDDEN_POD_NAME_PREFIX}%` },
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SpaceResource extends BaseResource<SpaceModel> {
@@ -445,6 +453,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           ? { id: { [Op.in]: podSpaces.resourceIds } }
           : {}),
         kind: "project",
+        ...EXCLUDE_HIDDEN_PODS,
       },
     });
   }
@@ -453,7 +462,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator
   ): Promise<SpaceResource[]> {
     return this.baseFetch(auth, {
-      where: { kind: "project" },
+      where: { kind: "project", ...EXCLUDE_HIDDEN_PODS },
     });
   }
 
@@ -484,7 +493,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     const spaces = await this.baseFetch(auth, {
       where: {
         kind: "project",
-        ...(query?.trim() && { name: { [Op.iLike]: `%${query}%` } }),
+        name: {
+          ...EXCLUDE_HIDDEN_PODS.name,
+          ...(query?.trim() && { [Op.iLike]: `%${query}%` }),
+        },
         ...(pagination.lastValue && {
           [Op.and]: [
             Sequelize.where(


### PR DESCRIPTION
## Why

Today a Frame that needs to persist data, or to reach a server-side capability it cannot hold itself, requires a Pod: the user has to create one and move the conversation into it before anything works. That's a lot of ceremony for "I want this dashboard to remember what I typed into it".

This lets Frames created in regular conversations use pod functions and databases, with no Pod in sight.

## How

A standalone conversation gets a **hidden Pod of its own**, created lazily the first time one of the app tools runs. The conversation stays a normal standalone conversation; the Pod exists only to hold the Frame's app — its source, its published functions and their databases — and from there everything proceeds exactly as it does in a real Pod.

- **New `front/lib/api/projects/hidden_pod.ts`** — `fetchOrCreateHiddenPodForConversation`, locked per conversation so parallel tool calls in one agent loop don't race the space-name uniqueness constraint. Created non-restricted and with `ignoreWorkspaceLimit`: workspace members can resolve the app's functions (otherwise the Frame breaks for every reader but its author), while only the creator lands in the Pod's editor group, so `pod_member_required` still means the conversation's owner.
- **No migration.** The Pod is identified and hidden by a name prefix, `[Frame runtime] <conversationId>` — the same trick `isDatabaseFileSystemPodName` already plays. `space_resource.ts` excludes the prefix from `listWorkspacePodsAsMember`, `listProjectSpaces` and `searchProjectsByNamePaginated`, so it never surfaces in a listing.
- **`getPod()` takes a `hiddenPodFallback` option**, passed only by the ten `sandbox_functions` tools. The `pod_manager` tools keep erroring outside a Pod: managing a Pod's members, context or tasks from outside one is meaningless, while a Frame's app needs a Pod wherever it runs.
- **Skill wiring** — `pod_functions` is no longer gated on being in a Pod, and its instructions gain a preamble for standalone conversations: call `list` first to learn the Pod's id (it isn't knowable at instruction-fetch time, and the `list` tool now reports it), and never mention the Pod to the user. The frames instructions now include the storage section independently of `isPod`, so a standalone conversation's Frame is told its data belongs behind functions rather than in `useState`.

Execution is deliberately untouched — functions still run in that Pod's own sandbox via `PodSandboxAdapter`, and `DustFileSystem.forAgentLoop` already mounts a referenced Pod the caller can access, so authoring into `pod-<hiddenId>/MyApp/` needed no filesystem change.

## Caveats

This is a prototype for a demo, and it is rough on purpose:

- **Two sandboxes per conversation** when a Frame uses functions: the conversation's own Computer plus the hidden Pod's. That is the cost of leaving the execution path alone; folding them into one is the obvious follow-up.
- **Moving such a conversation into a real Pod is still allowed**, and afterwards its Frame keeps calling the hidden Pod. Should be blocked (or migrated) before this is real.
- **No new tests and no audit events.** The only test change is one existing assertion in `frames.test.ts` that encoded the old "no storage section outside a Pod" behavior.
- The hidden Pod's lifetime is not tied to anything yet — it is not cleaned up when the conversation goes away.

## Verification

`npx tsgo --noEmit` clean, biome clean, and 177 existing tests across the touched areas pass (`sandbox_functions`, `pod_manager`, `interactive_content`, `space_resource`, `lib/api/projects`, code-defined skills).
