### PR TITLE
[front] Collapse GroupSpace*Resource membership mutation onto group + group_permissions

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/join.ts
@@ -4,7 +4,6 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { withSpace } from "@front-api/middlewares/with_space";
@@ -61,24 +60,11 @@ app.post(
       });
     }
 
-    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
-      space,
-      filterOnManagementMode: true,
-    });
-
-    if (memberGroupSpaces.length !== 1) {
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "There should be exactly one member group for the Pod.",
-        },
-      });
-    }
-
-    const memberGroupSpace = memberGroupSpaces[0];
+    // The space is an open, manually-managed project and the caller is not yet a member (checked
+    // above), so self-join is authorized; add directly to the member group (from group_permissions).
+    const memberGroup = await space.fetchManualMemberGroup(auth);
     const user = auth.getNonNullableUser();
-    const result = await memberGroupSpace.addMembers(auth, {
+    const result = await memberGroup.dangerouslyAddMembers(auth, {
       users: [user.toJSON()],
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -5,7 +5,6 @@ import {
 } from "@app/lib/api/audit/workos_audit";
 import { PatchSpaceMembersRequestBodySchema } from "@app/lib/api/spaces/members";
 import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
-import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_member_resource";
 import { areOpenPodsAllowed } from "@app/lib/workspace_policies";
 import { auditLog } from "@app/logger/logger";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -70,15 +69,9 @@ app.patch(
     // Track current members before update to identify newly added ones.
     let currentMemberIds: Set<string> | undefined;
     if (space.isProject() && body.managementMode === "manual") {
-      const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
-        space,
-        filterOnManagementMode: true,
-      });
-      if (memberGroupSpaces.length === 1) {
-        const currentMembers =
-          await memberGroupSpaces[0].group.getActiveMembers(auth);
-        currentMemberIds = new Set(currentMembers.map((m) => m.sId));
-      }
+      const memberGroup = await space.fetchManualMemberGroup(auth);
+      const currentMembers = await memberGroup.getActiveMembers(auth);
+      currentMemberIds = new Set(currentMembers.map((m) => m.sId));
     }
 
     const updateRes = await space.updatePermissions(auth, body);

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1241,13 +1241,8 @@ describe("SpaceResource", () => {
               workspaceId: workspace.id,
               managementMode: "manual",
             },
-            { members: [projectMemberGroup] }
+            { members: [projectMemberGroup], editors: [projectEditorGroup] }
           );
-
-          await GroupSpaceEditorResource.makeNew(adminAuth, {
-            group: projectEditorGroup,
-            space: projectSpace,
-          });
 
           await ProjectMetadataResource.makeNew(adminAuth, projectSpace, {
             description: "Admin controlled",

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1266,36 +1266,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
-  private async fetchManualMemberGroupSpace(): Promise<GroupSpaceMemberResource> {
-    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
-      space: this,
-      filterOnManagementMode: true,
-    });
-
-    assert(
-      memberGroupSpaces.length === 1,
-      "In manual management mode, there should be exactly one member group space."
-    );
-
-    return memberGroupSpaces[0];
-  }
-
-  private async fetchManualEditorGroupSpace(): Promise<GroupSpaceEditorResource> {
-    assert(this.isProject(), "Only projects can have editor groups.");
-
-    const editorGroupSpaces = await GroupSpaceEditorResource.fetchBySpace({
-      space: this,
-      filterOnManagementMode: true,
-    });
-
-    assert(
-      editorGroupSpaces.length === 1,
-      "In manual management mode, there should be exactly one editor group space."
-    );
-
-    return editorGroupSpaces[0];
-  }
-
   /**
    * When enabling admin-controlled mode: demote all editors to members.
    * When disabling: promote the oldest member to editor.
@@ -1334,10 +1304,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     return withTransaction(async (t: Transaction) => {
-      const editorGroupSpace = await this.fetchManualEditorGroupSpace();
-      const memberGroupSpace = await this.fetchManualMemberGroupSpace();
-      const editorGroup = editorGroupSpace.group;
-      const memberGroup = memberGroupSpace.group;
+      const editorGroup = await this.fetchManualEditorGroup(auth, t);
+      const memberGroup = await this.fetchManualMemberGroup(auth, t);
+      assert(editorGroup, "A project must have a manual editor group.");
 
       if (isAdminControlled) {
         const editors = await editorGroup.getActiveMembers(auth, {
@@ -1434,8 +1403,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [];
     }
 
-    const editorGroupSpace = await this.fetchManualEditorGroupSpace();
-    return editorGroupSpace.group.getActiveMembers(auth);
+    const editorGroup = await this.fetchManualEditorGroup(auth);
+    if (!editorGroup) {
+      return [];
+    }
+    return editorGroup.getActiveMembers(auth);
   }
 
   async addMembers(
@@ -1499,9 +1471,11 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       }
     }
 
-    const memberGroupSpace = await this.fetchManualMemberGroupSpace();
+    // Authorization is the space-level `canAdministrate` gate above; the member group is resolved
+    // from group_permissions and mutated directly.
+    const memberGroup = await this.fetchManualMemberGroup(auth);
 
-    const addMemberRes = await memberGroupSpace.addMembers(auth, {
+    const addMemberRes = await memberGroup.dangerouslyAddMembers(auth, {
       users: usersToAdd.map((user) => user.toJSON()),
     });
 
@@ -1570,8 +1544,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
     }
 
-    const editorGroupSpace = await this.fetchManualEditorGroupSpace();
-    const activeEditors = await editorGroupSpace.group.getActiveMembers(auth);
+    const editorGroup = await this.fetchManualEditorGroup(auth);
+    assert(editorGroup, "A project must have a manual editor group.");
+    const activeEditors = await editorGroup.getActiveMembers(auth);
     const activeEditorIds = new Set(activeEditors.map((user) => user.sId));
     const usersToAdd = users.filter((user) => !activeEditorIds.has(user.sId));
 
@@ -1579,15 +1554,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Ok([]);
     }
 
-    const memberGroupSpace = await this.fetchManualMemberGroupSpace();
-    const activeMembers = await memberGroupSpace.group.getActiveMembers(auth);
+    const memberGroup = await this.fetchManualMemberGroup(auth);
+    const activeMembers = await memberGroup.getActiveMembers(auth);
     const activeMemberIds = new Set(activeMembers.map((user) => user.sId));
     const usersToRemoveFromMembers = usersToAdd.filter((user) =>
       activeMemberIds.has(user.sId)
     );
 
     if (usersToRemoveFromMembers.length > 0) {
-      const removeMemberRes = await memberGroupSpace.removeMembers(auth, {
+      const removeMemberRes = await memberGroup.dangerouslyRemoveMembers(auth, {
         users: usersToRemoveFromMembers.map((user) => user.toJSON()),
       });
       if (removeMemberRes.isErr()) {
@@ -1595,7 +1570,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       }
     }
 
-    const addEditorRes = await editorGroupSpace.addMembers(auth, {
+    const addEditorRes = await editorGroup.dangerouslyAddMembers(auth, {
       users: usersToAdd.map((user) => user.toJSON()),
     });
 
@@ -1655,8 +1630,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(new DustError("user_not_found", "User not found"));
     }
 
-    const editorGroupSpace = await this.fetchManualEditorGroupSpace();
-    const activeEditors = await editorGroupSpace.group.getActiveMembers(auth);
+    const editorGroup = await this.fetchManualEditorGroup(auth);
+    assert(editorGroup, "A project must have a manual editor group.");
+    const activeEditors = await editorGroup.getActiveMembers(auth);
     const activeEditorIds = new Set(activeEditors.map((user) => user.sId));
     const usersToRemove = users.filter((user) => activeEditorIds.has(user.sId));
 
@@ -1673,7 +1649,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
     }
 
-    const removeEditorRes = await editorGroupSpace.removeMembers(auth, {
+    const removeEditorRes = await editorGroup.dangerouslyRemoveMembers(auth, {
       users: usersToRemove.map((user) => user.toJSON()),
     });
 
@@ -1718,9 +1694,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(new DustError("user_not_found", "User not found"));
     }
 
-    const memberGroupSpace = await this.fetchManualMemberGroupSpace();
+    const memberGroup = await this.fetchManualMemberGroup(auth);
 
-    const removeMemberRes = await memberGroupSpace.removeMembers(auth, {
+    const removeMemberRes = await memberGroup.dangerouslyRemoveMembers(auth, {
       users: users.map((user) => user.toJSON()),
     });
 


### PR DESCRIPTION
## Description

Collapse the standalone space membership-mutation paths off `group_vaults`: they now resolve the member/editor group from `group_permissions` (`fetchManual{Member,Editor}Group`) and mutate it directly via `group.dangerously{Add,Remove,Set}Members`. The space-level `canAdministrate` / admin-controlled / last-editor gates already authorize these paths, so the junction resources' per-user re-check was redundant.

- `SpaceResource`: `addMembers`, `addEditors`, `removeEditors`, `removeMembers`, `applyAdminControlledMembershipChange`, `fetchActiveEditorUsers` repointed; deleted the now-unused `fetchManual{Member,Editor}GroupSpace` helpers.
- `front-api`: `join.ts` (self-join open project) and `members.ts` (read current members) repointed.

**Deferred to the final "stop writing + drop table" PR** (still coupled to `group_vaults` writes): `updatePermissions`' member/editor setup (creates the editor group mid-transaction, before grants are synced), `fetchAssociatedGroups` (feeds `writeGroupPermissions` the current association set), the poke `update_pod_members` plugin (handles provisioned "group" mode, which the manual-only group_permissions helpers don't), and `GroupSpace*Resource.makeNew`/`fetchBySpace`/`delete` + `setMembers`. So the classes shrink but aren't deleted yet.

Fourth of the `group_vaults` removal stack, on top of #30890.

## Tests

`tsgo --noEmit` clean on front and front-api. Tests green: front `space_resource` (70), `spaces`+`permissions`+`workspace_user` (71); front-api `members`+`leave`+`spaces/[spaceId]` (9). One test-setup fix: the admin-controlled Pod is now created via `makeNew({ editors })` so the editor's `group_permissions` admin grant exists (it had been linked via `group_vaults` only).

## Risk

Behavior-preserving: the moved paths keep their space-level authorization gates; only the redundant junction re-check is dropped. Reads shift to `group_permissions` (validated equivalent to `group_vaults` in prod). `group_vaults` writes are unchanged. Rollback = code revert.

## Deploy Plan

Standard deploy after #30890.