### PR TITLE
Manage agents page: add a button for admin to access ALL agents

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6394,6 +6394,7 @@
                 "favorites",
                 "published",
                 "admin_internal",
+                "manage_unrestricted",
                 "global",
                 "workspace"
               ]

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_model.test.ts
@@ -2,13 +2,18 @@ import {
   archiveAgentConfiguration,
   getAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { setupAgentOwner } from "@app/tests/utils/AgentOwnerFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { honoApp } from "@front-api/app";
 import assert from "assert";
 import { describe, expect, it } from "vitest";
@@ -56,6 +61,68 @@ async function setupTest(role: "admin" | "user") {
 }
 
 describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_model", () => {
+  it("updates an agent of another member built on a restricted space, keeping its space and skills", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    // The agent is authored and edited by another member, and both the agent and its skill
+    // require a space the acting admin is not a member of: what "Show hidden agents" surfaces.
+    const agentOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, agentOwner, {
+      role: "builder",
+    });
+    const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      agentOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const skill = await SkillFactory.create(agentOwnerAuth, {
+      name: "Restricted skill",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      {
+        name: "Restricted space agent",
+        model: { ...INITIAL_MODEL },
+        requestedSpaceIds: [restrictedSpace.id],
+      }
+    );
+    await skill.addToAgent(agentOwnerAuth, agent);
+
+    const targetModel = await findTargetModel(auth);
+    const response = await postBatchUpdateModel(workspace, {
+      agentIds: [agent.sId],
+      modelId: targetModel.modelId,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      success: true,
+      updatedAgentIds: [agent.sId],
+      skippedAgentIds: [],
+    });
+
+    // Fetched as "full" so the skills of the new version can be listed from it below.
+    const updatedAgent = await getAgentConfiguration(auth, {
+      agentId: agent.sId,
+      variant: "full",
+      dangerouslySkipPermissionFiltering: true,
+    });
+    assert(updatedAgent);
+    expect(updatedAgent.model.modelId).toBe(targetModel.modelId);
+    expect(updatedAgent.version).toBe(agent.version + 1);
+    // The new version stays restricted to the space and keeps the skill.
+    expect(updatedAgent.requestedSpaceIds).toEqual([restrictedSpace.sId]);
+    const updatedSkills = await SkillResource.listByAgentConfiguration(
+      auth,
+      updatedAgent,
+      { dangerouslySkipPermissionFiltering: true }
+    );
+    expect(updatedSkills.map((s) => s.sId)).toEqual([skill.sId]);
+  });
+
   it("saves a new version of the selected agents with the new model", async () => {
     const { workspace, auth, agent, tag } = await setupTest("admin");
     const target = await findTargetModel(auth);

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_scope.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_scope.test.ts
@@ -1,0 +1,83 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { LightWorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function batchUpdateScope(workspace: { sId: string }, body: unknown) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/agent_configurations/batch_update_scope`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+// An agent authored and edited by another member, built on a space the acting admin is not a
+// member of: exactly what "Show hidden agents" surfaces on the manage agents page.
+async function createOtherMemberAgent(
+  workspace: LightWorkspaceType,
+  { name }: { name: string }
+) {
+  const agentOwner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, agentOwner, { role: "builder" });
+  const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    agentOwner.sId,
+    workspace.sId
+  );
+  const restrictedSpace = await SpaceFactory.regular(workspace);
+
+  return AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
+    name,
+    scope: "visible",
+    requestedSpaceIds: [restrictedSpace.id],
+  });
+}
+
+describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_scope", () => {
+  it("unpublishes an agent of another member built on a restricted space", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    const agent = await createOtherMemberAgent(workspace, {
+      name: "Restricted space agent",
+    });
+
+    const response = await batchUpdateScope(workspace, {
+      agentIds: [agent.sId],
+      scope: "hidden",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ success: true });
+
+    const updatedAgent = await getAgentConfiguration(auth, {
+      agentId: agent.sId,
+      variant: "light",
+      dangerouslySkipPermissionFiltering: true,
+    });
+    expect(updatedAgent?.scope).toBe("hidden");
+  });
+
+  it("returns 403 for non-admins", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "builder",
+    });
+
+    const response = await batchUpdateScope(workspace, {
+      agentIds: [],
+      scope: "hidden",
+    });
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.test.ts
@@ -1,7 +1,11 @@
+import { Authenticator } from "@app/lib/auth";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TagFactory } from "@app/tests/utils/TagFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import { Err } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -59,6 +63,42 @@ describe("POST /api/w/:wId/assistant/agent_configurations/batch_update_tags", ()
         tagToAdd.sId,
       ]);
     }
+  });
+
+  it("tags an unpublished agent of another member built on a restricted space", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+    // The agent is authored and edited by another member, is unpublished, and requires a space the
+    // acting admin is not a member of: exactly what "Show hidden agents" surfaces.
+    const agentOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, agentOwner, {
+      role: "builder",
+    });
+    const agentOwnerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      agentOwner.sId,
+      workspace.sId
+    );
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      agentOwnerAuth,
+      {
+        name: "Hidden agent",
+        scope: "hidden",
+        requestedSpaceIds: [restrictedSpace.id],
+      }
+    );
+    const tag = await TagFactory.create(workspace, { name: "governance" });
+
+    const response = await batchUpdateTags(workspace, {
+      agentIds: [agent.sId],
+      addTagIds: [tag.sId],
+    });
+
+    expect(response.status).toBe(200);
+    const tagsByAgent = await TagResource.listForAgents(auth, [agent.id]);
+    expect(tagsByAgent[agent.id]?.map((t) => t.sId)).toEqual([tag.sId]);
   });
 
   it("returns 400 when adding tags fails", async () => {

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -42,9 +42,13 @@ app.post(
       });
     }
 
+    // Admins may tag any agent of the workspace, including the ones built on spaces they cannot
+    // read (the manage agents page lists those behind "Show hidden agents"). Tagging touches
+    // nothing the spaces protect.
     const agents = await getAgentConfigurations(auth, {
       agentIds,
       variant: "light",
+      dangerouslySkipPermissionFiltering: auth.isAdmin(),
     });
     const editableAgents = agents.filter(
       (agent) => agent.canEdit || auth.isAdmin()

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -272,6 +272,60 @@ describe("GET /api/w/:wId/assistant/agent_configurations", () => {
     ).toEqual(["visible"]);
   });
 
+  it("lists unpublished and restricted space agents of other members in the manage_unrestricted view", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    // Both agents belong to another member: one is unpublished and the admin is not an editor,
+    // the other requires a space the admin is not a member of.
+    const { agentOwnerAuth } = await setupAgentOwner(workspace, "builder");
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
+      name: "Unpublished agent",
+      scope: "hidden",
+    });
+    await AgentConfigurationFactory.createTestAgent(agentOwnerAuth, {
+      name: "Restricted space agent",
+      scope: "visible",
+      requestedSpaceIds: [restrictedSpace.id],
+    });
+
+    const manageResponse = await listAgents(workspace, { view: "manage" });
+    expect(manageResponse.status).toBe(200);
+    const manageData: { agentConfigurations: LightAgentConfigurationType[] } =
+      await manageResponse.json();
+    const manageNames = manageData.agentConfigurations.map((a) => a.name);
+    expect(manageNames).not.toContain("Unpublished agent");
+    expect(manageNames).not.toContain("Restricted space agent");
+
+    const response = await listAgents(workspace, {
+      view: "manage_unrestricted",
+    });
+    expect(response.status).toBe(200);
+    const data: { agentConfigurations: LightAgentConfigurationType[] } =
+      await response.json();
+    const names = data.agentConfigurations.map((a) => a.name);
+    expect(names).toContain("Unpublished agent");
+    expect(names).toContain("Restricted space agent");
+  });
+
+  it("returns 403 for the manage_unrestricted view without admin role", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "builder",
+    });
+
+    const response = await listAgents(workspace, {
+      view: "manage_unrestricted",
+    });
+
+    expect(response.status).toBe(403);
+    const data = await response.json();
+    expect(data.error.type).toBe("app_auth_error");
+  });
+
   it("returns 404 for admin_internal view without super user", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "GET",

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
@@ -59,7 +59,7 @@ const app = workspaceApp();
  *         description: Filter agents by view
  *         schema:
  *           type: string
- *           enum: [all, analytics, list, favorites, published, admin_internal, global, workspace]
+ *           enum: [all, analytics, list, favorites, published, admin_internal, manage_unrestricted, global, workspace]
  *       - in: query
  *         name: limit
  *         required: false
@@ -199,6 +199,15 @@ app.get("/", async (ctx): HandlerResult<GetAgentConfigurationsResponseBody> => {
       api_error: {
         type: "app_auth_error",
         message: "Only Dust Super Users can see admin_internal agents.",
+      },
+    });
+  }
+  if (viewParam === "manage_unrestricted" && !auth.isAdmin()) {
+    return apiError(ctx, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only admins can list all agents of the workspace.",
       },
     });
   }

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -27,8 +27,10 @@ import {
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TagType } from "@app/types/tag";
 import {
+  Checkbox,
   Chip,
   EmptyCTA,
+  InfoCircle,
   Page,
   Plus,
   SearchInput,
@@ -36,6 +38,7 @@ import {
   Tabs,
   TabsList,
   TabsTrigger,
+  Tooltip,
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef, useState } from "react";
 
@@ -72,7 +75,7 @@ function isValidTab(tab: string): tab is AssistantManagerTabsType {
 
 export function ManageAgentsPage() {
   const owner = useWorkspace();
-  const { user } = useAuth();
+  const { user, isAdmin } = useAuth();
   const [assistantSearch, setAssistantSearch] = useState("");
   const [showDisabledFreeWorkspacePopup, setShowDisabledFreeWorkspacePopup] =
     useState<string | null>(null);
@@ -82,6 +85,7 @@ export function ManageAgentsPage() {
     []
   );
   const [selection, setSelection] = useState<string[]>([]);
+  const [showHiddenAgents, setShowHiddenAgents] = useState(false);
   const isMobile = useIsMobile();
 
   const { isDark } = useTheme();
@@ -89,6 +93,9 @@ export function ManageAgentsPage() {
   const { hasPermission } = useWorkspacePermissions();
 
   const canCreateAgent = hasPermission("create", "agent");
+  // Only admins may list the agents they neither edit nor share a space with.
+  const canShowHiddenAgents = isAdmin;
+  const isShowHiddenAgentsEnabled = canShowHiddenAgents && showHiddenAgents;
   const isSearchActive = assistantSearch.trim() !== "";
   const isFilterActive =
     isSearchActive || selectedTags.length > 0 || selectedModels.length > 0;
@@ -102,6 +109,7 @@ export function ManageAgentsPage() {
   const selectionScopeKey = [
     activeTab,
     assistantSearch,
+    String(isShowHiddenAgentsEnabled),
     selectedTags
       .map((t) => t.sId)
       .sort()
@@ -126,7 +134,7 @@ export function ManageAgentsPage() {
     isAgentConfigurationsLoading,
   } = useAgentConfigurations({
     workspaceId: owner.sId,
-    agentsGetView: "manage",
+    agentsGetView: isShowHiddenAgentsEnabled ? "manage_unrestricted" : "manage",
     includes: ["authors", "usage", "feedbacks", "editors"],
   });
 
@@ -379,6 +387,25 @@ export function ManageAgentsPage() {
                     counterValue={`${agentsByTab[tab.id].length}`}
                   />
                 ))}
+                {canShowHiddenAgents && (
+                  <span className="ml-auto flex gap-1 self-center text-sm text-muted-foreground">
+                    <label className="flex cursor-pointer flex-row items-center gap-2 whitespace-nowrap">
+                      <Checkbox
+                        checked={showHiddenAgents}
+                        onCheckedChange={(checked) =>
+                          setShowHiddenAgents(checked === true)
+                        }
+                      />
+                      Show hidden agents
+                    </label>
+                    <Tooltip
+                      label="Shows the agents of all members you can access as an admin, even if they are not published or if they use restricted spaces"
+                      trigger={
+                        <InfoCircle className="h-4 w-4 text-muted-foreground" />
+                      }
+                    />
+                  </span>
+                )}
               </TabsList>
             </Tabs>
             {isAgentConfigurationsLoading ||

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1632,9 +1632,13 @@ export async function updateAgentConfigurationsScope(
     return new Ok(undefined);
   }
 
+  // Admins may publish or unpublish any agent of the workspace, including the ones built on
+  // spaces they cannot read (the manage agents page lists those behind "Show hidden agents").
+  // Changing the scope touches nothing the spaces protect.
   const agentConfigs = await getAgentConfigurations(auth, {
     agentIds,
     variant: "light",
+    dangerouslySkipPermissionFiltering: auth.isAdmin(),
   });
 
   const editableAgents = agentConfigs.filter(

--- a/front/lib/api/assistant/configuration/context.ts
+++ b/front/lib/api/assistant/configuration/context.ts
@@ -39,13 +39,17 @@ function isActiveWorkspaceAgentConfiguration(
 
 export async function getActiveWorkspaceAgentConfiguration(
   auth: Authenticator,
-  agentId: string
+  agentId: string,
+  {
+    dangerouslySkipPermissionFiltering,
+  }: { dangerouslySkipPermissionFiltering?: boolean } = {}
 ): Promise<
   Result<ActiveWorkspaceAgentConfiguration, APIErrorWithContentfulStatusCode>
 > {
   const agentConfiguration = await getAgentConfiguration(auth, {
     agentId,
     variant: "full",
+    dangerouslySkipPermissionFiltering,
   });
 
   if (!agentConfiguration || (!agentConfiguration.canRead && !auth.isAdmin())) {
@@ -74,11 +78,26 @@ export async function getActiveWorkspaceAgentConfiguration(
 export async function getAgentConfigurationContext(
   auth: Authenticator,
   agentId: string,
-  { requireEditorGroup = false }: { requireEditorGroup?: boolean } = {}
+  {
+    requireEditorGroup = false,
+    dangerouslySkipPermissionFiltering,
+  }: {
+    requireEditorGroup?: boolean;
+    // Resolves the agent and its skills even when they request spaces the caller cannot read.
+    // Only for callers re-saving the agent as-is: dropping them would silently strip the agent's
+    // skills from the new version.
+    dangerouslySkipPermissionFiltering?: boolean;
+  } = {}
 ): Promise<
   Result<AgentConfigurationContext, APIErrorWithContentfulStatusCode>
 > {
-  const agentResult = await getActiveWorkspaceAgentConfiguration(auth, agentId);
+  const agentResult = await getActiveWorkspaceAgentConfiguration(
+    auth,
+    agentId,
+    {
+      dangerouslySkipPermissionFiltering,
+    }
+  );
   if (agentResult.isErr()) {
     return agentResult;
   }
@@ -87,7 +106,8 @@ export async function getAgentConfigurationContext(
 
   const skills = await SkillResource.listByAgentConfiguration(
     auth,
-    agentConfiguration
+    agentConfiguration,
+    { dangerouslySkipPermissionFiltering }
   );
   const editorsResult = await GroupResource.findEditorGroupForAgent(
     auth,

--- a/front/lib/api/assistant/configuration/create_or_upgrade.ts
+++ b/front/lib/api/assistant/configuration/create_or_upgrade.ts
@@ -41,11 +41,17 @@ export async function createOrUpgradeAgentConfiguration({
   assistant,
   agentConfigurationId,
   authorId,
+  dangerouslySkipPermissionFiltering,
 }: {
   auth: Authenticator;
   assistant: PostOrPatchAgentConfigurationRequestBody["assistant"];
   agentConfigurationId?: string;
   authorId?: ModelId;
+  // Keeps the requested spaces and the skills of an agent being re-saved even when the caller
+  // cannot read them. Only for callers that re-save an existing agent as-is (admin batch model
+  // updates): without it those spaces are rejected and those skills silently dropped, which would
+  // unrestrict the agent and strip its skills. It grants no access to what the spaces protect.
+  dangerouslySkipPermissionFiltering?: boolean;
 }): Promise<Result<AgentConfigurationType, Error>> {
   const skillsOnlyViews = await MCPServerViewResource.fetchByIds(
     auth,
@@ -101,7 +107,8 @@ export async function createOrUpgradeAgentConfiguration({
   if (assistant.skills && assistant.skills.length > 0) {
     skills = await SkillResource.fetchByIds(
       auth,
-      assistant.skills.map((s) => s.sId)
+      assistant.skills.map((s) => s.sId),
+      { dangerouslySkipPermissionFiltering }
     );
   }
 
@@ -126,18 +133,20 @@ export async function createOrUpgradeAgentConfiguration({
     );
 
     // Validate that all requested spaces were found and user can read them
-    const readableSpaceIds = new Set(
-      additionalSpaces.filter((s) => s.canRead(auth)).map((s) => s.sId)
-    );
-    const inaccessibleSpaces = assistant.additionalRequestedSpaceIds.filter(
-      (sId) => !readableSpaceIds.has(sId)
-    );
-    if (inaccessibleSpaces.length > 0) {
-      return new Err(
-        new Error(
-          `User does not have access to the following spaces: ${inaccessibleSpaces.join(", ")}`
-        )
+    if (!dangerouslySkipPermissionFiltering) {
+      const readableSpaceIds = new Set(
+        additionalSpaces.filter((s) => s.canRead(auth)).map((s) => s.sId)
       );
+      const inaccessibleSpaces = assistant.additionalRequestedSpaceIds.filter(
+        (sId) => !readableSpaceIds.has(sId)
+      );
+      if (inaccessibleSpaces.length > 0) {
+        return new Err(
+          new Error(
+            `User does not have access to the following spaces: ${inaccessibleSpaces.join(", ")}`
+          )
+        );
+      }
     }
 
     const additionalSpaceModelIds = removeNulls(

--- a/front/lib/api/assistant/configuration/model_update.ts
+++ b/front/lib/api/assistant/configuration/model_update.ts
@@ -125,10 +125,18 @@ async function upgradeAgentConfigurationModel(
     responseFormat?: string;
   }
 ): Promise<Result<void, Error>> {
+  // Admins may batch-update the model of any agent of the workspace, including the ones built on
+  // spaces they cannot read (the manage agents page lists those behind "Show hidden agents").
+  // A model change re-saves the whole configuration, so the agent's spaces and skills have to be
+  // resolved and kept as they are: dropping them would unrestrict the agent and strip its skills.
+  // Nothing the spaces protect is exposed to the caller.
+  const dangerouslySkipPermissionFiltering = auth.isAdmin();
+
   // Resolves the current configuration along with its editors and skills, and rejects agents
   // that cannot be re-saved as-is (archived, global).
   const contextResult = await getAgentConfigurationContext(auth, agentId, {
     requireEditorGroup: true,
+    dangerouslySkipPermissionFiltering,
   });
   if (contextResult.isErr()) {
     return new Err(new Error(contextResult.error.api_error.message));
@@ -167,6 +175,7 @@ async function upgradeAgentConfigurationModel(
       skills: skills.map((skill) => ({ sId: skill.sId })),
       additionalRequestedSpaceIds: agentConfiguration.requestedSpaceIds,
     },
+    dangerouslySkipPermissionFiltering,
   });
   if (res.isErr()) {
     return res;

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -68,6 +68,7 @@ function determineGlobalAgentIdsToFetch(
     case "global":
     case "list":
     case "manage":
+    case "manage_unrestricted":
     case "all":
     case "analytics":
     case "favorites":
@@ -107,7 +108,11 @@ async function fetchGlobalAgentConfigurationForView(
       !agentPrefix || a.name.toLowerCase().startsWith(agentPrefix.toLowerCase())
   );
 
-  if (agentsGetView === "global" || agentsGetView === "manage") {
+  if (
+    agentsGetView === "global" ||
+    agentsGetView === "manage" ||
+    agentsGetView === "manage_unrestricted"
+  ) {
     // All global agents in global and manage views.
     return matchingGlobalAgents;
   }
@@ -174,6 +179,9 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
 
   switch (agentsGetView) {
     case "admin_internal":
+    // The manage agents page lets admins list every agent of the workspace, including the ones
+    // they neither edit nor can read the spaces of. Space filtering is skipped below.
+    case "manage_unrestricted":
       return AgentConfigurationModel.findAll({
         ...baseAgentsSequelizeQuery,
         where: baseWhereConditions,
@@ -342,10 +350,12 @@ async function fetchWorkspaceAgentConfigurationsForView(
   );
 
   // Analytics counts credits for agents built on spaces a manager cannot read,
-  // so the manager analytics view has to list them as well.
+  // so the manager analytics view has to list them as well. The unrestricted manage view does the
+  // same for admins, and is gated on the role by its caller.
   const skipPermissionFiltering =
     dangerouslySkipPermissionFiltering ||
-    (agentsGetView === "analytics" && auth.isManager());
+    (agentsGetView === "analytics" && auth.isManager()) ||
+    agentsGetView === "manage_unrestricted";
 
   const allowedAgentModels = skipPermissionFiltering
     ? agentModels
@@ -412,6 +422,10 @@ export async function getAgentConfigurationsForView({
     throw new Error(
       "Superuser view is for dust superusers or internal admin auths only."
     );
+  }
+
+  if (agentsGetView === "manage_unrestricted" && !auth.isAdmin()) {
+    throw new Error("The unrestricted manage view is for admins only.");
   }
 
   if (

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -140,7 +140,12 @@ type ReplaceSkillReferenceTagsOptions = {
   html?: boolean;
 };
 
-type SkillFetchContext =
+type SkillFetchContext = {
+  // Returns skills requesting spaces the caller cannot read. Only for callers that must operate
+  // on a skill without gaining access to what its spaces protect, e.g. an admin re-saving an
+  // agent they do not edit: dropping the skill would silently strip it from the new version.
+  dangerouslySkipPermissionFiltering?: boolean;
+} & (
   | {
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds: string[];
@@ -148,7 +153,8 @@ type SkillFetchContext =
   | {
       agentLoopData?: never;
       effectiveSpaceIds?: string[];
-    };
+    }
+);
 
 type SkillResourceConstructorOptions =
   | {
@@ -668,6 +674,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     context: {
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds?: string[];
+      dangerouslySkipPermissionFiltering?: boolean;
       transaction?: Transaction;
     } = {}
   ): Promise<SkillResource[]> {
@@ -675,6 +682,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const {
       agentLoopData,
       effectiveSpaceIds: providedEffectiveSpaceIds,
+      dangerouslySkipPermissionFiltering,
       transaction,
     } = context;
 
@@ -718,9 +726,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // A missing/deleted requested space is treated as not readable (see `canReadRequestedSpaces`),
     // so skills referencing one are dropped here too.
-    const allowedCustomSkills = customSkills.filter((skill) =>
-      canReadRequestedSpaces(auth, spaceById, skill.requestedSpaceIds)
-    );
+    const allowedCustomSkills = dangerouslySkipPermissionFiltering
+      ? customSkills
+      : customSkills.filter((skill) =>
+          canReadRequestedSpaces(auth, spaceById, skill.requestedSpaceIds)
+        );
     const allowedCustomSkillIds = allowedCustomSkills.map((skill) => skill.id);
 
     let allowedCustomSkillsRes: SkillResource[] = [];
@@ -1046,6 +1056,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentLoopData,
       effectiveSpaceIds,
+      dangerouslySkipPermissionFiltering,
       onlyActive = false,
       withInstructions = true,
       withTools = true,
@@ -1091,7 +1102,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         withTools,
         withFileAttachments,
       },
-      { agentLoopData, effectiveSpaceIds }
+      { agentLoopData, effectiveSpaceIds, dangerouslySkipPermissionFiltering }
     );
   }
 
@@ -1234,6 +1245,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     {
       agentLoopData,
       effectiveSpaceIds,
+      dangerouslySkipPermissionFiltering,
       status,
       transaction,
       withInstructions,
@@ -1243,6 +1255,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }: {
       agentLoopData?: AgentLoopExecutionData;
       effectiveSpaceIds?: string[];
+      dangerouslySkipPermissionFiltering?: boolean;
       status?: SkillStatus | SkillStatus[];
       transaction?: Transaction;
       withInstructions?: boolean;
@@ -1267,7 +1280,12 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         withToolMetadata,
         withFileAttachments,
       },
-      { agentLoopData, effectiveSpaceIds, transaction }
+      {
+        agentLoopData,
+        effectiveSpaceIds,
+        dangerouslySkipPermissionFiltering,
+        transaction,
+      }
     );
   }
 
@@ -1386,7 +1404,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   static async listByAgentConfiguration(
     auth: Authenticator,
     agentConfiguration: AgentLoopExecutionData["agentConfiguration"],
-    { agentLoopData, effectiveSpaceIds }: SkillFetchContext = {}
+    {
+      agentLoopData,
+      effectiveSpaceIds,
+      dangerouslySkipPermissionFiltering,
+    }: SkillFetchContext = {}
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
       auth,
@@ -1400,6 +1422,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return this.fetchBySkillReferences(auth, refs, {
       agentLoopData,
       effectiveSpaceIds,
+      dangerouslySkipPermissionFiltering,
     });
   }
 

--- a/front/types/api/agent_configuration.ts
+++ b/front/types/api/agent_configuration.ts
@@ -23,6 +23,7 @@ export const GetAgentConfigurationsQuerySchema = z.object({
       "global",
       "list",
       "manage",
+      "manage_unrestricted",
       "published",
       "workspace",
     ])

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -95,6 +95,10 @@ export type AgentConfigurationScope =
  *   opens up with the caller's role.
  * - 'admin_internal': Grants access to all agents, including private ones.
  * - 'manage': Retrieves all agents for the manage agents view (same as list, but including disabled agents).
+ * - 'manage_unrestricted': Same as 'manage', but without the visibility
+ *   restrictions: every active agent of the workspace, whatever its scope,
+ *   whoever edits it, and whether or not the caller can read the spaces it is
+ *   built on. Admins only.
  * - 'archived': Retrieves all agents that are archived. Only available to super
  *   users. Intended strictly for internal use with necessary superuser or admin
  *   authorization.
@@ -106,6 +110,7 @@ export type AgentsGetViewType =
   | "list"
   | "all"
   | "analytics"
+  | "manage_unrestricted"
   | "published"
   | "global"
   | "admin_internal"


### PR DESCRIPTION
## Description

To be reviewed commit by commit 

Allow managers to display all agents, including the unpublished ones from other users and the ones with restricted space the admin does not belong too.

Also allow the admin to act on these agents by using the batch edit button to
 - change model
 - update tags
 - unpublish

<img width="2740" height="738" alt="image" src="https://github.com/user-attachments/assets/eb31b5da-a1e6-4266-960a-8093812b1c6f" />

<img width="2766" height="972" alt="image" src="https://github.com/user-attachments/assets/a2c84b5c-d95a-4fd9-9b3c-262cad67b3d4" />


## Tests

 - tested locally
 - added unit test to make sure all the batch edit endpoints work and only admin can do all these actions

## Risk

risk is to expose private agents to admin, but this is actually a diseried state.
Admin already have access to agents in the analytics
Here they can now act on these agents in case there is an issue (unpublish or change model for cheaper one)

## Deploy Plan

deploy front
