### PR TITLE
[front] Add a workspace setting to disable conversation email and Slack

### DIFF
--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -135,6 +135,10 @@ const WorkspaceEmailAgentsUpdateBodySchema = z.object({
   allowEmailAgents: z.boolean(),
 });
 
+const WorkspaceConversationExternalNotificationsUpdateBodySchema = z.object({
+  allowConversationExternalNotifications: z.boolean(),
+});
+
 const WorkspaceAgentReinforcementUpdateBodySchema = z.object({
   allowReinforcement: z.boolean(),
 });
@@ -215,6 +219,7 @@ const PostWorkspaceRequestBodySchema = z.union([
   WorkspaceVoiceTranscriptionUpdateBodySchema,
   WorkspacePrivateConversationUrlsUpdateBodySchema,
   WorkspaceEmailAgentsUpdateBodySchema,
+  WorkspaceConversationExternalNotificationsUpdateBodySchema,
   WorkspaceAgentReinforcementUpdateBodySchema,
   WorkspaceReinforcementBatchModeUpdateBodySchema,
   WorkspaceExtensionMcpToolsUpdateBodySchema,
@@ -944,6 +949,25 @@ app.post(
         context: getAuditLogContext(auth),
         metadata: {
           enabled: String(body.slackPersonalAllowFooterRemoval),
+        },
+      });
+    } else if ("allowConversationExternalNotifications" in body) {
+      const previousMetadata = owner.metadata ?? {};
+      const newMetadata = {
+        ...previousMetadata,
+        allowConversationExternalNotifications:
+          body.allowConversationExternalNotifications,
+      };
+      await workspace.updateWorkspaceSettings({ metadata: newMetadata });
+      owner.metadata = newMetadata;
+
+      void emitAuditLogEvent({
+        auth,
+        action: "workspace.conversation_external_notifications_updated",
+        targets: [buildAuditLogTarget("workspace", owner)],
+        context: getAuditLogContext(auth),
+        metadata: {
+          enabled: String(body.allowConversationExternalNotifications),
         },
       });
     }

--- a/front/admin/audit_log_schemas/workspace.conversation_external_notifications_updated.json
+++ b/front/admin/audit_log_schemas/workspace.conversation_external_notifications_updated.json
@@ -1,0 +1,7 @@
+{
+  "action": "workspace.conversation_external_notifications_updated",
+  "targets": [{ "type": "workspace" }],
+  "metadata": {
+    "enabled": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/workspace.conversation_external_notifications_updated.json
+++ b/front/admin/audit_log_schemas/workspace.conversation_external_notifications_updated.json
@@ -2,6 +2,7 @@
   "action": "workspace.conversation_external_notifications_updated",
   "targets": [{ "type": "workspace" }],
   "metadata": {
-    "enabled": "string"
+    "enabled": "string",
+    "actor_type": "string"
   }
 }

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -743,8 +743,8 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
           {showNotificationPreferences && notif.status !== "error" && (
             <div className="flex flex-col gap-4">
               <Page.SectionHeader
-                title="Conversation notifications"
-                description="Choose how Dust notifies you about conversation activity"
+                title="Other channels"
+                description="Choose where else to receive notifications"
               />
               <NotificationPreferences
                 control={notif.control}

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -1,7 +1,6 @@
 import { UsageUpgradeButton } from "@app/components/credits/UsageUpgradeButton";
 import { MarkdownEditor } from "@app/components/editor/MarkdownEditor";
 import {
-  ForYouNotificationPreferences,
   NotificationPreferences,
   useNotificationPreferencesForm,
 } from "@app/components/me/NotificationPreferences";
@@ -35,6 +34,7 @@ import {
   useUserMemory,
   useWorkspaceUsageStatus,
 } from "@app/lib/swr/user";
+import { useAuthContext } from "@app/lib/swr/workspaces";
 import { getConversationRoute } from "@app/lib/utils/router";
 import {
   MAX_USER_MEMORY_CHARS,
@@ -43,7 +43,10 @@ import {
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
-import { ANONYMOUS_USER_IMAGE_URL } from "@app/types/user";
+import {
+  ANONYMOUS_USER_IMAGE_URL,
+  areConversationExternalNotificationsEnabled,
+} from "@app/types/user";
 import {
   Avatar,
   BarChart01,
@@ -731,37 +734,29 @@ function NotificationsSection({ owner }: { owner: WorkspaceType }) {
               disabled={sound.isLoading}
             />
           </div>
-          {showNotificationPreferences && (
+          {showNotificationPreferences && notif.status === "error" && (
+            <ContentMessageInline variant="warning" icon={InfoCircle}>
+              We couldn't load your notification settings. Please try again
+              later.
+            </ContentMessageInline>
+          )}
+          {showNotificationPreferences && notif.status !== "error" && (
             <div className="flex flex-col gap-4">
               <Page.SectionHeader
-                title="Other channels"
-                description="Choose where else to receive notifications"
+                title="Conversation notifications"
+                description="Choose how Dust notifies you about conversation activity"
               />
-              {notif.status === "error" ? (
-                <ContentMessageInline variant="warning" icon={InfoCircle}>
-                  We couldn't load your notification settings. Please try again
-                  later.
-                </ContentMessageInline>
-              ) : (
-                <NotificationPreferences
-                  control={notif.control}
-                  displaySlackOption={notif.displaySlackOption}
-                  workflowEnabled={notif.workflowEnabled}
-                />
-              )}
+              <NotificationPreferences
+                control={notif.control}
+                displaySlackOption={notif.displaySlackOption}
+                displayForYouOption={displayForYouOption}
+                workflowEnabled={notif.workflowEnabled}
+                conversationExternalNotificationsEnabled={areConversationExternalNotificationsEnabled(
+                  owner
+                )}
+              />
             </div>
           )}
-          {showNotificationPreferences &&
-            displayForYouOption &&
-            notif.status !== "error" && (
-              <div className="flex flex-col gap-4">
-                <Page.SectionHeader
-                  title="For you"
-                  description="Recommendation emails from your learning space"
-                />
-                <ForYouNotificationPreferences control={notif.control} />
-              </div>
-            )}
         </>
       )}
     </SectionContent>
@@ -936,6 +931,10 @@ export function UserSettingsPopover({
   const { pendingInvitations, isPendingInvitationsLoading } =
     usePendingInvitations({ workspaceId: owner.sId, disabled: !open });
   const hasPendingInvitations = pendingInvitations.length > 0;
+  const { mutateAuthContext } = useAuthContext({
+    workspaceId: owner.sId,
+    disabled: true,
+  });
 
   // "Memory" is gated on the user_memory feature flag; "Invitations" only
   // appears when the user has pending invitations.
@@ -956,8 +955,9 @@ export function UserSettingsPopover({
   useEffect(() => {
     if (open) {
       setActiveSection("personal");
+      void mutateAuthContext();
     }
-  }, [open]);
+  }, [open, mutateAuthContext]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -23,10 +23,13 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
+  ContentMessageInline,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  InfoCircle,
+  Lock01,
   SettingsList,
   SliderToggle,
 } from "@dust-tt/sparkle";
@@ -212,13 +215,17 @@ export function useNotificationPreferencesForm({
 interface NotificationPreferencesProps {
   control: Control<NotificationPreferencesFormValues>;
   displaySlackOption: boolean;
+  displayForYouOption: boolean;
   workflowEnabled: boolean;
+  conversationExternalNotificationsEnabled: boolean;
 }
 
 export function NotificationPreferences({
   control,
   displaySlackOption,
+  displayForYouOption,
   workflowEnabled,
+  conversationExternalNotificationsEnabled,
 }: NotificationPreferencesProps) {
   const { field: notifyConditionField } = useController({
     name: "notifyCondition",
@@ -231,139 +238,149 @@ export function NotificationPreferences({
   const { field: inAppField } = useController({ name: "inApp", control });
   const { field: slackField } = useController({ name: "slack", control });
   const { field: emailField } = useController({ name: "email", control });
+  const { field: forYouField } = useController({ name: "forYou", control });
 
   const [portalContainer] = useState<HTMLElement | undefined>(() =>
     typeof document !== "undefined" ? document.body : undefined
   );
 
   const notificationsDisabled = notifyConditionField.value === "never";
+  const externalChannelsDisabled = !conversationExternalNotificationsEnabled;
   const isInAppEnabled = inAppField.value && workflowEnabled;
-  const isSlackEnabled = slackField.value && workflowEnabled;
-  const isEmailEnabled = emailField.value && workflowEnabled;
-  const isEmailFrequencyEnabled = isEmailEnabled && !notificationsDisabled;
+  const isSlackEnabled =
+    slackField.value && workflowEnabled && !externalChannelsDisabled;
+  const isEmailEnabled =
+    emailField.value && workflowEnabled && !externalChannelsDisabled;
+  const isEmailFrequencyEnabled =
+    isEmailEnabled && !notificationsDisabled && !externalChannelsDisabled;
+  const slackEmailDisabled = notificationsDisabled || externalChannelsDisabled;
+  const isForYouEnabled = forYouField.value && !externalChannelsDisabled;
 
   return (
-    <SettingsList>
-      <SettingsList.Row
-        title="Notify me about"
-        description="Choose which activity sends you a notification"
-        action={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                isSelect
-                label={
-                  NOTIFICATION_CONDITION_LABELS[notifyConditionField.value]
-                }
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent mountPortalContainer={portalContainer}>
-              {NOTIFICATION_CONDITION_OPTIONS.map((condition) => (
-                <DropdownMenuItem
-                  key={condition}
-                  label={NOTIFICATION_CONDITION_LABELS[condition]}
-                  onClick={() => notifyConditionField.onChange(condition)}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
-      />
-
-      <SettingsList.Row
-        title="In-app popup"
-        description="Show a popup inside Dust"
-        action={
-          <SliderToggle
-            selected={isInAppEnabled}
-            disabled={notificationsDisabled}
-            onClick={() => inAppField.onChange(!isInAppEnabled)}
-          />
-        }
-      />
-
-      {displaySlackOption && (
+    <div className="flex flex-col gap-3">
+      <SettingsList>
         <SettingsList.Row
-          title="Slack"
-          description="A direct message in Slack"
+          title="Notify me about"
+          description="Applies to in-app popups, email, and Slack"
+          action={
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  isSelect
+                  label={
+                    NOTIFICATION_CONDITION_LABELS[notifyConditionField.value]
+                  }
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent mountPortalContainer={portalContainer}>
+                {NOTIFICATION_CONDITION_OPTIONS.map((condition) => (
+                  <DropdownMenuItem
+                    key={condition}
+                    label={NOTIFICATION_CONDITION_LABELS[condition]}
+                    onClick={() => notifyConditionField.onChange(condition)}
+                  />
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          }
+        />
+
+        <SettingsList.Row
+          title="In-app popup"
+          description="Show a popup inside Dust"
           action={
             <SliderToggle
-              selected={isSlackEnabled}
+              selected={isInAppEnabled}
               disabled={notificationsDisabled}
-              onClick={() => slackField.onChange(!isSlackEnabled)}
+              onClick={() => inAppField.onChange(!isInAppEnabled)}
             />
           }
         />
+      </SettingsList>
+
+      {externalChannelsDisabled && (
+        <ContentMessageInline variant="info" icon={InfoCircle}>
+          Email and Slack notifications are turned off for this workspace by an
+          admin.
+        </ContentMessageInline>
       )}
 
-      <SettingsList.Row
-        title="Email"
-        description="Receive a summary by email"
-        action={
-          <SliderToggle
-            selected={isEmailEnabled}
-            disabled={notificationsDisabled}
-            onClick={() => emailField.onChange(!isEmailEnabled)}
-          />
-        }
-      />
-
-      <SettingsList.Row
-        title="Email frequency"
-        description="How often to send email notification summaries"
-        action={
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                isSelect
-                disabled={!isEmailFrequencyEnabled}
-                label={
-                  NOTIFICATION_PREFERENCES_DELAY_LABELS[emailDelayField.value]
-                }
+      <SettingsList>
+        {displaySlackOption && (
+          <SettingsList.Row
+            title="Slack"
+            description="A direct message in Slack"
+            action={
+              <SliderToggle
+                selected={isSlackEnabled}
+                disabled={slackEmailDisabled}
+                icon={externalChannelsDisabled ? Lock01 : undefined}
+                onClick={() => slackField.onChange(!isSlackEnabled)}
               />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent mountPortalContainer={portalContainer}>
-              {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
-                <DropdownMenuItem
-                  key={delay}
-                  label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
-                  onClick={() => emailDelayField.onChange(delay)}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        }
-      />
-    </SettingsList>
-  );
-}
-
-export function ForYouNotificationPreferences({
-  control,
-}: {
-  control: Control<NotificationPreferencesFormValues>;
-}) {
-  const { field: forYouField } = useController({
-    name: "forYou",
-    control,
-  });
-
-  return (
-    <SettingsList>
-      <SettingsList.Row
-        title="For you"
-        description="Email when Dust has a new recommendation for you"
-        action={
-          <SliderToggle
-            selected={forYouField.value}
-            onClick={() => forYouField.onChange(!forYouField.value)}
+            }
           />
-        }
-      />
-    </SettingsList>
+        )}
+
+        <SettingsList.Row
+          title="Email"
+          description="Receive a summary by email"
+          action={
+            <SliderToggle
+              selected={isEmailEnabled}
+              disabled={slackEmailDisabled}
+              icon={externalChannelsDisabled ? Lock01 : undefined}
+              onClick={() => emailField.onChange(!isEmailEnabled)}
+            />
+          }
+        />
+
+        <SettingsList.Row
+          title="Email frequency"
+          description="How often to send email notification summaries"
+          action={
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild disabled={!isEmailFrequencyEnabled}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  isSelect
+                  disabled={!isEmailFrequencyEnabled}
+                  icon={externalChannelsDisabled ? Lock01 : undefined}
+                  label={
+                    NOTIFICATION_PREFERENCES_DELAY_LABELS[emailDelayField.value]
+                  }
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent mountPortalContainer={portalContainer}>
+                {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
+                  <DropdownMenuItem
+                    key={delay}
+                    label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
+                    onClick={() => emailDelayField.onChange(delay)}
+                  />
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          }
+        />
+
+        {displayForYouOption && (
+          <SettingsList.Row
+            title="For you"
+            description="Email when Dust has a new recommendation for you"
+            action={
+              <SliderToggle
+                selected={isForYouEnabled}
+                disabled={externalChannelsDisabled}
+                icon={externalChannelsDisabled ? Lock01 : undefined}
+                onClick={() => forYouField.onChange(!isForYouEnabled)}
+              />
+            }
+          />
+        )}
+      </SettingsList>
+    </div>
   );
 }

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -6,6 +6,7 @@ import { SkillDiscoverabilityWarning } from "@app/components/pages/workspace/gov
 import { ExtensionMcpToolsSection } from "@app/components/workspace/ExtensionMcpToolsSection";
 import { LinkedSectionNotice } from "@app/components/workspace/LinkedSectionNotice";
 import { AuditLogsGovernanceSection } from "@app/components/workspace/settings/AuditLogsToggle";
+import { ConversationExternalNotificationsToggle } from "@app/components/workspace/settings/ConversationExternalNotificationsToggle";
 import { DustMcpServerSettingsItem } from "@app/components/workspace/settings/DustMcpServerSettingsItem";
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
 import { InteractiveContentSharing } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
@@ -260,6 +261,7 @@ export const GovernancePage = () => {
               <WorkspaceDefaultAgentPicker owner={owner} />
               <VoiceTranscriptionToggle owner={owner} />
               <EmailAgentsToggle owner={owner} />
+              <ConversationExternalNotificationsToggle owner={owner} />
               <PrivateConversationUrlsToggle owner={owner} />
               <DustMcpServerSettingsItem owner={owner} />
               <ExtensionMcpToolsSection owner={owner} />

--- a/front/components/workspace/settings/ConversationExternalNotificationsToggle.tsx
+++ b/front/components/workspace/settings/ConversationExternalNotificationsToggle.tsx
@@ -5,7 +5,7 @@ import { SliderToggle } from "@dust-tt/sparkle";
 
 const LABEL = "Email and Slack notifications";
 const DESCRIPTION =
-  "Whether members can receive conversation unread notifications by email or Slack, and For you recommendation emails. In-app Dust notifications are not affected";
+  "Whether members can receive conversation notifications by email or Slack. In-app Dust notifications are not affected.";
 
 interface ConversationExternalNotificationsToggleProps {
   owner: WorkspaceType;

--- a/front/components/workspace/settings/ConversationExternalNotificationsToggle.tsx
+++ b/front/components/workspace/settings/ConversationExternalNotificationsToggle.tsx
@@ -1,0 +1,33 @@
+import { GovernanceSettingRowLayout } from "@app/components/pages/workspace/governance/GovernanceSettingRowLayout";
+import { useConversationExternalNotificationsToggle } from "@app/hooks/useConversationExternalNotificationsToggle";
+import type { WorkspaceType } from "@app/types/user";
+import { SliderToggle } from "@dust-tt/sparkle";
+
+const LABEL = "Email and Slack notifications";
+const DESCRIPTION =
+  "Whether members can receive conversation unread notifications by email or Slack, and For you recommendation emails. In-app Dust notifications are not affected";
+
+interface ConversationExternalNotificationsToggleProps {
+  owner: WorkspaceType;
+}
+
+export function ConversationExternalNotificationsToggle({
+  owner,
+}: ConversationExternalNotificationsToggleProps) {
+  const { isEnabled, isChanging, doToggleConversationExternalNotifications } =
+    useConversationExternalNotificationsToggle({ owner });
+
+  return (
+    <GovernanceSettingRowLayout
+      label={LABEL}
+      description={DESCRIPTION}
+      action={
+        <SliderToggle
+          selected={isEnabled}
+          disabled={isChanging}
+          onClick={doToggleConversationExternalNotifications}
+        />
+      }
+    />
+  );
+}

--- a/front/hooks/useConversationExternalNotificationsToggle.ts
+++ b/front/hooks/useConversationExternalNotificationsToggle.ts
@@ -1,0 +1,61 @@
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import { useAuthContext } from "@app/lib/swr/workspaces";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import { areConversationExternalNotificationsEnabled } from "@app/types/user";
+import { useState } from "react";
+
+interface UseConversationExternalNotificationsToggleProps {
+  owner: LightWorkspaceType;
+}
+
+export function useConversationExternalNotificationsToggle({
+  owner,
+}: UseConversationExternalNotificationsToggleProps) {
+  const [isChanging, setIsChanging] = useState(false);
+  const sendNotification = useSendNotification();
+  const { mutateAuthContext } = useAuthContext({
+    workspaceId: owner.sId,
+    disabled: true,
+  });
+  const isEnabled = areConversationExternalNotificationsEnabled(owner);
+
+  const doToggleConversationExternalNotifications = async () => {
+    setIsChanging(true);
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          allowConversationExternalNotifications: !isEnabled,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error(
+          "Failed to update conversation email and Slack notifications setting"
+        );
+      }
+      await mutateAuthContext();
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to update conversation email and Slack notifications",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsChanging(false);
+    }
+  };
+
+  return {
+    isEnabled,
+    isChanging,
+    doToggleConversationExternalNotifications,
+  };
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -111,6 +111,7 @@
   "workspace.advanced_model_access_updated": 1,
   "workspace.analytics_updated": 1,
   "workspace.audit_logs_updated": 1,
+  "workspace.conversation_external_notifications_updated": 1,
   "workspace.default_agent_updated": 1,
   "workspace.default_user_spend_limit_updated": 1,
   "workspace.deleted": 2,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -97,6 +97,7 @@ export const AUDIT_ACTIONS = [
   "workspace.audit_logs_updated",
   "workspace.analytics_updated",
   "workspace.advanced_model_access_updated",
+  "workspace.conversation_external_notifications_updated",
   "workspace.default_agent_updated",
   "workspace.default_user_spend_limit_updated",
   "workspace.domain_auto_join_updated",

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -572,6 +572,9 @@ export interface WorkspaceMetadata {
   killSwitched?: WorkspaceKillSwitchValue;
   allowContentCreationFileSharing?: boolean;
   allowEmailAgents?: boolean;
+  // When false, conversation unread email and Slack are not sent. Missing or
+  // true keeps per-user prefs. In-app notifications are not affected.
+  allowConversationExternalNotifications?: boolean;
   emailBlacklistedAgentIds?: string[];
   allowVoiceTranscription?: boolean;
   allowOpenProjects?: boolean;

--- a/front/lib/notifications/triggers/project-new-conversation.test.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.test.ts
@@ -11,6 +11,7 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -414,6 +415,19 @@ describe("notifyActivationConversationAgentReplied", () => {
 
   test("does not trigger the activation email when For You notifications are disabled", async () => {
     await user.setMetadata(FOR_YOU_NOTIFICATION_METADATA_KEY, "false");
+    const conversation = await createNudgeConversation();
+
+    await notifyActivationConversationAgentReplied(auth, {
+      conversationId: conversation.sId,
+    });
+
+    expect(vi.mocked(getNovuClient)).not.toHaveBeenCalled();
+  });
+
+  test("does not trigger the activation email when the workspace disables email and Slack", async () => {
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      allowConversationExternalNotifications: false,
+    });
     const conversation = await createNudgeConversation();
 
     await notifyActivationConversationAgentReplied(auth, {

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { getNovuClient } from "@app/lib/notifications";
 import { triggerActivationNewConversationEmail } from "@app/lib/notifications/workflows/activation-new-conversation";
+import { shouldSkipConversationExternalNotification } from "@app/lib/notifications/workflows/conversation-unread";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -252,13 +253,22 @@ export async function areForYouNotificationsEnabled(
  * the notification starts only after the reply exists.
  *
  * Runs only if the conversation belongs to an activation pod and was started
- * by the activation nudge workflow. Respects the target user's For You toggle
- * and "Notify me about" condition; Email frequency does not apply.
+ * by the activation nudge workflow. Respects the workspace email/Slack setting,
+ * the target user's For You toggle, and "Notify me about" condition; Email
+ * frequency does not apply.
  */
 export async function notifyActivationConversationAgentReplied(
   auth: Authenticator,
   { conversationId }: { conversationId: string }
 ): Promise<void> {
+  if (
+    await shouldSkipConversationExternalNotification(
+      auth.getNonNullableWorkspace().sId
+    )
+  ) {
+    return;
+  }
+
   const conversationResource = await ConversationResource.fetchById(
     auth,
     conversationId,

--- a/front/lib/notifications/workflows/activation-new-conversation.test.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.test.ts
@@ -4,6 +4,7 @@ import { shouldSkipActivationNewConversation } from "@app/lib/notifications/work
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -62,6 +63,22 @@ describe("shouldSkipActivationNewConversation", () => {
     expect(
       await shouldSkipActivationNewConversation({
         subscriberId: null,
+        payload: {
+          workspaceId: workspace.sId,
+          conversationId: conversation.sId,
+        },
+      })
+    ).toBe(true);
+  });
+
+  it("skips when the workspace disables email and Slack notifications", async () => {
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      allowConversationExternalNotifications: false,
+    });
+
+    expect(
+      await shouldSkipActivationNewConversation({
+        subscriberId: user.sId,
         payload: {
           workspaceId: workspace.sId,
           conversationId: conversation.sId,

--- a/front/lib/notifications/workflows/activation-new-conversation.ts
+++ b/front/lib/notifications/workflows/activation-new-conversation.ts
@@ -9,6 +9,7 @@ import {
   getActivationRecommendation,
   getConversationDetails,
 } from "@app/lib/notifications/helpers";
+import { shouldSkipConversationExternalNotification } from "@app/lib/notifications/workflows/conversation-unread";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { FOR_YOU_EMAIL_UTM } from "@app/lib/tracking/campaigns";
@@ -66,6 +67,10 @@ export const shouldSkipActivationNewConversation = async ({
   payload: activationNewConversationPayloadType;
 }): Promise<boolean> => {
   if (!subscriberId) {
+    return true;
+  }
+
+  if (await shouldSkipConversationExternalNotification(payload.workspaceId)) {
     return true;
   }
 

--- a/front/lib/notifications/workflows/conversation-unread.test.ts
+++ b/front/lib/notifications/workflows/conversation-unread.test.ts
@@ -13,11 +13,13 @@ import {
   getMessagePreviewText,
   shouldSendNotificationForAgentAnswer,
   shouldSkipConversation,
+  shouldSkipConversationExternalNotification,
   shouldSkipNewProjectConversation,
   triggerConversationUnreadNotifications,
 } from "@app/lib/notifications/workflows/conversation-unread";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -35,6 +37,7 @@ import {
 } from "@app/types/notification_preferences";
 import { Err, Ok } from "@app/types/shared/result";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types/user";
+import { areConversationExternalNotificationsEnabled } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock Novu client for notification sending tests
@@ -1592,5 +1595,56 @@ describe("getEmailSummary", () => {
     });
 
     expect(result).toBe(expectedStrippedSummary);
+  });
+});
+
+describe("areConversationExternalNotificationsEnabled", () => {
+  const owner = (
+    metadata: LightWorkspaceType["metadata"]
+  ): LightWorkspaceType => ({ metadata }) as LightWorkspaceType;
+
+  it("is enabled when metadata is missing", () => {
+    expect(areConversationExternalNotificationsEnabled(owner(null))).toBe(true);
+    expect(areConversationExternalNotificationsEnabled(owner(undefined))).toBe(
+      true
+    );
+    expect(areConversationExternalNotificationsEnabled(owner({}))).toBe(true);
+  });
+
+  it("is enabled when explicitly true", () => {
+    expect(
+      areConversationExternalNotificationsEnabled(
+        owner({ allowConversationExternalNotifications: true })
+      )
+    ).toBe(true);
+  });
+
+  it("is disabled when explicitly false", () => {
+    expect(
+      areConversationExternalNotificationsEnabled(
+        owner({ allowConversationExternalNotifications: false })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("shouldSkipConversationExternalNotification", () => {
+  it("does not skip by default", async () => {
+    const { workspace } = await createResourceTest({ role: "admin" });
+
+    expect(
+      await shouldSkipConversationExternalNotification(workspace.sId)
+    ).toBe(false);
+  });
+
+  it("skips when the workspace disables conversation email and Slack", async () => {
+    const { workspace } = await createResourceTest({ role: "admin" });
+    await WorkspaceResource.updateMetadata(workspace.id, {
+      allowConversationExternalNotifications: false,
+    });
+
+    expect(
+      await shouldSkipConversationExternalNotification(workspace.sId)
+    ).toBe(true);
   });
 });

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -22,8 +22,10 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserMetadataModel } from "@app/lib/resources/storage/models/user";
 import { UserProjectPreferencesResource } from "@app/lib/resources/user_project_preferences_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { isPodConversation } from "@app/types/assistant/conversation";
 import type { NotificationCondition } from "@app/types/notification_preferences";
@@ -44,6 +46,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { stripMarkdown } from "@app/types/shared/utils/markdown";
 import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { UserType } from "@app/types/user";
+import { areConversationExternalNotificationsEnabled } from "@app/types/user";
 import { workflow } from "@novu/framework";
 import assert from "assert";
 import { Op } from "sequelize";
@@ -51,6 +54,18 @@ import z from "zod";
 
 // The unread workflow operates on the shared conversation-details payload.
 export type ConversationUnreadPayloadType = ConversationDetailsPayload;
+
+export async function shouldSkipConversationExternalNotification(
+  workspaceId: string
+): Promise<boolean> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    return true;
+  }
+  return !areConversationExternalNotificationsEnabled(
+    renderLightWorkspaceType({ workspace })
+  );
+}
 
 export const shouldSendNotificationForAgentAnswer = (
   userMessageOrigin?: UserMessageOrigin | null
@@ -413,6 +428,13 @@ export const conversationUnreadWorkflow = workflow(
           if (!details) {
             return true;
           }
+          if (
+            await shouldSkipConversationExternalNotification(
+              payload.workspaceId
+            )
+          ) {
+            return true;
+          }
           const shouldSkip = await shouldSkipConversation({
             subscriberId: subscriber.subscriberId,
             payload,
@@ -446,7 +468,11 @@ export const conversationUnreadWorkflow = workflow(
       },
       {
         outputSchema: UserNotificationDelaySchema,
-        skip: async () => !details,
+        skip: async () =>
+          !details ||
+          (await shouldSkipConversationExternalNotification(
+            payload.workspaceId
+          )),
       }
     );
 
@@ -465,7 +491,11 @@ export const conversationUnreadWorkflow = workflow(
         // when the digest step's skip condition is evaluated (Novu framework bug).
         // All subscriber-based filtering (shouldSkipConversation) is handled in the
         // email step below, where subscriber context is properly available.
-        skip: async () => !details,
+        skip: async () =>
+          !details ||
+          (await shouldSkipConversationExternalNotification(
+            payload.workspaceId
+          )),
       }
     );
 
@@ -571,6 +601,13 @@ export const conversationUnreadWorkflow = workflow(
       {
         // No email from trigger until we give more control over the notification to the users.
         skip: async () => {
+          if (
+            await shouldSkipConversationExternalNotification(
+              payload.workspaceId
+            )
+          ) {
+            return true;
+          }
           const shouldSkip = await concurrentExecutor(
             events,
             async (event) => {

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -112,6 +112,14 @@ export function isWorkspaceAnalyticsEnabled(
   return owner.metadata?.disableWorkspaceAnalytics !== true;
 }
 
+// Conversation unread email and Slack are on by default. Admins can turn them
+// off workspace-wide; in-app Dust notifications are not affected.
+export function areConversationExternalNotificationsEnabled(
+  owner: LightWorkspaceType
+): boolean {
+  return owner.metadata?.allowConversationExternalNotifications !== false;
+}
+
 // When enabled, members can run published agents even if the agent's model
 // requires a tier above their own access. Disabled by default: such runs are
 // blocked. Admins can opt in via the workspace settings.


### PR DESCRIPTION
## Summary
- Adds a workspace admin toggle (Settings & Governance) that turns off conversation unread **email and Slack**, plus **For you** recommendation emails. In-app Dust popups, inbox sound, and billing/admin emails stay on.
- Missing metadata keeps the setting enabled (opt-out). Profile notifications lock the email/Slack/For you controls when the admin setting is off, and refresh workspace auth when the settings modal opens so the lock does not require a full page reload.
- Enforced in the conversation-unread Novu workflow (email/Slack steps only) and the For you activation-email path.

## Testing
<img width="772" height="573" alt="Screenshot 2026-08-20 at 4 18 13 PM" src="https://github.com/user-attachments/assets/e96d8df4-cc63-456b-94a2-073e24300e8d" />
<img width="886" height="147" alt="Screenshot 2026-08-20 at 4 18 03 PM" src="https://github.com/user-attachments/assets/2b90d92c-6f54-472c-bbf1-a58496670c28" />

## Risk
Low

## Deploy
1. Deploy front
