### PR TITLE
[front] fix: prevent partial access to Automations page to managers

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/overview.test.ts
@@ -45,13 +45,23 @@ function postOverviewRequest(wId: string, body: Record<string, unknown> = {}) {
 }
 
 describe("POST /api/w/:wId/analytics/automations/overview", () => {
-  it("returns 403 for managers", async () => {
-    const { workspace } = await setupTest({ role: "manager" });
+  it("returns 403 for regular users", async () => {
+    const { workspace } = await setupTest({ role: "user" });
 
     const response = await postOverviewRequest(workspace.sId);
 
     expect(response.status).toBe(403);
     expect(vi.mocked(fetchAutomationsOverview)).not.toHaveBeenCalled();
+  });
+
+  it("returns the overview for managers", async () => {
+    vi.mocked(fetchAutomationsOverview).mockResolvedValue(new Ok(OVERVIEW));
+    const { workspace } = await setupTest({ role: "manager" });
+
+    const response = await postOverviewRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(OVERVIEW);
   });
 
   it("returns the overview for admins, defaulting to the current cycle", async () => {

--- a/front-api/routes/w/[wId]/analytics/automations/overview.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/overview.ts
@@ -5,7 +5,7 @@ import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/per
 import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -17,7 +17,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsAdmin(),
+  ensureIsManager(),
   validate("json", AutomationsOverviewBodySchema),
   async (ctx): HandlerResult<GetAutomationsOverviewResponse> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/analytics/automations/trigger-breakdown.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/trigger-breakdown.test.ts
@@ -53,8 +53,8 @@ function postBreakdownRequest(wId: string, body: Record<string, unknown>) {
 }
 
 describe("POST /api/w/:wId/analytics/automations/trigger-breakdown", () => {
-  it("returns 403 for managers", async () => {
-    const { workspace } = await setupTest({ role: "manager" });
+  it("returns 403 for regular users", async () => {
+    const { workspace } = await setupTest({ role: "user" });
 
     const response = await postBreakdownRequest(workspace.sId, {
       triggerId: "trg1",
@@ -62,6 +62,20 @@ describe("POST /api/w/:wId/analytics/automations/trigger-breakdown", () => {
 
     expect(response.status).toBe(403);
     expect(vi.mocked(fetchAutomationTriggerBreakdown)).not.toHaveBeenCalled();
+  });
+
+  it("returns the breakdown for managers", async () => {
+    vi.mocked(fetchAutomationTriggerBreakdown).mockResolvedValue(
+      new Ok(BREAKDOWN)
+    );
+    const { workspace } = await setupTest({ role: "manager" });
+
+    const response = await postBreakdownRequest(workspace.sId, {
+      triggerId: "trg1",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(BREAKDOWN);
   });
 
   it("returns the breakdown for admins", async () => {

--- a/front-api/routes/w/[wId]/analytics/automations/trigger-breakdown.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/trigger-breakdown.ts
@@ -5,7 +5,7 @@ import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/per
 import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
 import logger from "@app/logger/logger";
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
@@ -17,7 +17,7 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsAdmin(),
+  ensureIsManager(),
   validate("json", AutomationTriggerBreakdownBodySchema),
   async (ctx): HandlerResult<GetAutomationTriggerBreakdownResponse> => {
     const auth = ctx.get("auth");

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.test.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.test.tsx
@@ -1,15 +1,12 @@
+import { useAutomationsTriggerBreakdown } from "@app/hooks/useAutomationsTriggerBreakdown";
+import type { AutomationTriggerCreditDestination } from "@app/lib/api/analytics/automations/breakdown";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AutomationsTriggerBreakdown } from "./AutomationsTriggerBreakdown";
 
 vi.mock(import("@app/hooks/useAutomationsTriggerBreakdown"), () => ({
-  useAutomationsTriggerBreakdown: vi.fn(() => ({
-    creditDestination: null,
-    isBreakdownLoading: false,
-    isBreakdownError: false,
-    isBreakdownValidating: false,
-  })),
+  useAutomationsTriggerBreakdown: vi.fn(),
 }));
 
 const PERIOD = { kind: "days", days: 30 } as const;
@@ -38,6 +35,15 @@ const TRIGGER: AutomationTriggerRow = {
 };
 
 describe("AutomationsTriggerBreakdown", () => {
+  beforeEach(() => {
+    vi.mocked(useAutomationsTriggerBreakdown).mockReturnValue({
+      creditDestination: null,
+      isBreakdownLoading: false,
+      isBreakdownError: false,
+      isBreakdownValidating: false,
+    });
+  });
+
   it("shows no comparison for a trigger with zero run count, instead of an Infinity ratio", () => {
     render(
       <AutomationsTriggerBreakdown
@@ -65,5 +71,37 @@ describe("AutomationsTriggerBreakdown", () => {
     );
 
     expect(screen.getByText("2x more than most")).toBeInTheDocument();
+  });
+
+  it.each<[AutomationTriggerCreditDestination["dimension"], string]>([
+    ["tool", "What tool is used"],
+    ["model", "What model is used"],
+    ["skill", "What skill is used"],
+  ])("labels a %s credit destination accurately", (dimension, label) => {
+    vi.mocked(useAutomationsTriggerBreakdown).mockReturnValue({
+      creditDestination: {
+        dimension,
+        key: `${dimension}-id`,
+        name: `${dimension} name`,
+        icon: null,
+        credits: 42,
+        share: 0.75,
+      },
+      isBreakdownLoading: false,
+      isBreakdownError: false,
+      isBreakdownValidating: false,
+    });
+
+    render(
+      <AutomationsTriggerBreakdown
+        workspaceId="w1"
+        trigger={TRIGGER}
+        period={PERIOD}
+        medianRunCount={366}
+        medianCostPerRun={3.4}
+      />
+    );
+
+    expect(screen.getByText(label)).toBeInTheDocument();
   });
 });

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
@@ -1,7 +1,9 @@
 import { useAutomationsTriggerBreakdown } from "@app/hooks/useAutomationsTriggerBreakdown";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { AutomationTriggerCreditDestination } from "@app/lib/api/analytics/automations/breakdown";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { formatCredits } from "@app/lib/client/credits";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { LoadingBlock, Tooltip } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
@@ -10,6 +12,23 @@ const CAPTION_TOOLTIP_LABEL =
 
 const RATIO_MORE_THRESHOLD = 1.5;
 const RATIO_LESS_THRESHOLD = 1 / RATIO_MORE_THRESHOLD;
+const CREDIT_DESTINATION_FALLBACK_LABEL = "What consumes credits";
+
+function creditDestinationLabel(
+  dimension: AutomationTriggerCreditDestination["dimension"]
+): string {
+  switch (dimension) {
+    case "tool":
+      return "What tool is used";
+    case "model":
+      return "What model is used";
+    case "skill":
+      return "What skill is used";
+    default:
+      assertNeverAndIgnore(dimension);
+      return CREDIT_DESTINATION_FALLBACK_LABEL;
+  }
+}
 
 function ratioCaption(value: number, median: number): string {
   if (value <= 0 || median <= 0) {
@@ -77,7 +96,7 @@ function CreditDestinationBlock({
     return (
       <div className="flex min-w-0 flex-col gap-2">
         <h4 className="text-xs font-semibold text-muted-foreground">
-          What model is used
+          {CREDIT_DESTINATION_FALLBACK_LABEL}
         </h4>
         <div className="min-w-0 text-xs">
           <LoadingBlock className="h-4 w-24" />
@@ -91,7 +110,7 @@ function CreditDestinationBlock({
     return (
       <div className="flex min-w-0 flex-col gap-2">
         <h4 className="text-xs font-semibold text-muted-foreground">
-          What model is used
+          {CREDIT_DESTINATION_FALLBACK_LABEL}
         </h4>
         <span className="text-xs text-muted-foreground">
           {isBreakdownError
@@ -106,7 +125,7 @@ function CreditDestinationBlock({
 
   return (
     <StatBlock
-      label="What model is used"
+      label={creditDestinationLabel(creditDestination.dimension)}
       primaryText={
         <span className="font-semibold text-foreground">
           {creditDestination.name}


### PR DESCRIPTION
## Description

Managers can open the Automations page, but the overview and expanded trigger credit breakdown still require admin access, leaving the page partially unavailable to them.

This aligns both endpoints with the page's manager-level access while continuing to reject regular users. It also labels each credit destination by its actual dimension (`tool`, `model`, or `skill`) instead of always calling it a model.

## Tests

- Updated API permission and trigger breakdown component tests.
- Tested locally.

## Risk

- Low. Manager access is additive; regular-user restrictions remain unchanged.

## Deploy Plan

- Deploy front.
