### PR TITLE
[front] feat: add consumption analytics in Poke

### DIFF
--- a/front-spa/src/poke/routes.tsx
+++ b/front-spa/src/poke/routes.tsx
@@ -1,4 +1,5 @@
 import Custom404 from "@dust-tt/front/components/pages/Custom404";
+import { AnalyticsPage } from "@dust-tt/front/components/poke/pages/AnalyticsPage";
 import { AppPage } from "@dust-tt/front/components/poke/pages/AppPage";
 import { AssistantDetailsPage } from "@dust-tt/front/components/poke/pages/AssistantDetailsPage";
 import { AssistantInstructionsPage } from "@dust-tt/front/components/poke/pages/AssistantInstructionsPage";
@@ -97,6 +98,7 @@ export const routes: RouteObject[] = [
         element: <PokeWorkspacePage />,
         children: [
           { index: true, element: <WorkspacePage /> },
+          { path: "analytics", element: <AnalyticsPage /> },
           { path: "memberships", element: <MembershipsPage /> },
           { path: "llm-traces/:runId", element: <LLMTracePage /> },
           {

--- a/front/components/poke/analytics/PokeConsumptionAttributionTable.tsx
+++ b/front/components/poke/analytics/PokeConsumptionAttributionTable.tsx
@@ -1,0 +1,131 @@
+import type {
+  ConsumptionAttributionBreakdownColumnProps,
+  ConsumptionAttributionBreakdownProps,
+} from "@app/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown";
+import {
+  CONSUMPTION_ATTRIBUTION_BREAKDOWN_LIMIT,
+  ConsumptionAttributionBreakdownColumnView,
+  ConsumptionAttributionBreakdownView,
+} from "@app/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown";
+import type { ConsumptionAttributionRowsTableProps } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable";
+import { ConsumptionAttributionRowsTableView } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable";
+import type {
+  ConsumptionAttributionRowsProps,
+  ConsumptionAttributionTableProps,
+} from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
+import {
+  ConsumptionAttributionRowsView,
+  ConsumptionAttributionTableView,
+  useConsumptionAttributionRowsQueryState,
+} from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
+import { usePokeConsumptionTop } from "@app/poke/swr/consumption";
+
+function PokeConsumptionAttributionBreakdownColumn({
+  workspaceId,
+  dimension,
+  period,
+  filter,
+  selectedRowName,
+  onViewAll,
+}: ConsumptionAttributionBreakdownColumnProps) {
+  const { rows, totalCredits, isTopLoading, isTopError } =
+    usePokeConsumptionTop({
+      workspaceId,
+      dimension,
+      period,
+      limit: CONSUMPTION_ATTRIBUTION_BREAKDOWN_LIMIT,
+      filter,
+    });
+
+  return (
+    <ConsumptionAttributionBreakdownColumnView
+      dimension={dimension}
+      selectedRowName={selectedRowName}
+      onViewAll={onViewAll}
+      rows={rows}
+      totalCredits={totalCredits}
+      isTopLoading={isTopLoading}
+      isTopError={Boolean(isTopError)}
+    />
+  );
+}
+
+function PokeConsumptionAttributionBreakdown(
+  props: ConsumptionAttributionBreakdownProps
+) {
+  return (
+    <ConsumptionAttributionBreakdownView
+      {...props}
+      BreakdownColumnComponent={PokeConsumptionAttributionBreakdownColumn}
+    />
+  );
+}
+
+function PokeConsumptionAttributionRowsTable(
+  props: ConsumptionAttributionRowsTableProps
+) {
+  return (
+    <ConsumptionAttributionRowsTableView
+      {...props}
+      BreakdownComponent={PokeConsumptionAttributionBreakdown}
+    />
+  );
+}
+
+function PokeConsumptionAttributionRows(
+  props: ConsumptionAttributionRowsProps
+) {
+  const queryState = useConsumptionAttributionRowsQueryState();
+  const isFiltered = Object.values(props.filter ?? {}).some(
+    (values) => values.length > 0
+  );
+  const {
+    rows,
+    totalCredits,
+    totalCount,
+    isTopLoading,
+    isTopError,
+    isTopValidating,
+  } = usePokeConsumptionTop({
+    workspaceId: props.workspaceId,
+    dimension: props.dimension,
+    period: props.period,
+    limit: queryState.pagination.pageSize,
+    offset: queryState.pagination.pageIndex * queryState.pagination.pageSize,
+    search: props.search,
+    filter: props.filter,
+    sortOrder: queryState.sortOrder,
+  });
+
+  return (
+    <ConsumptionAttributionRowsView
+      {...props}
+      data={{
+        rows,
+        totalCredits,
+        totalCount,
+        isTopLoading,
+        isTopError: Boolean(isTopError),
+        isTopValidating,
+      }}
+      emptyMessage={
+        isFiltered
+          ? "No consumption matches the current filters."
+          : "No consumption over this period."
+      }
+      queryState={queryState}
+      RowsTableComponent={PokeConsumptionAttributionRowsTable}
+    />
+  );
+}
+
+export function PokeConsumptionAttributionTable(
+  props: ConsumptionAttributionTableProps
+) {
+  return (
+    <ConsumptionAttributionTableView
+      {...props}
+      AttributionRowsComponent={PokeConsumptionAttributionRows}
+    />
+  );
+}

--- a/front/components/poke/analytics/PokeConsumptionChart.tsx
+++ b/front/components/poke/analytics/PokeConsumptionChart.tsx
@@ -1,0 +1,145 @@
+import { ConsumptionBurnUpChart } from "@app/components/workspace/analytics/consumption/ConsumptionBurnUpChart";
+import type { ConsumptionChartProps } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
+import {
+  CONSUMPTION_CHART_BREAKDOWN_COUNT,
+  ConsumptionDailyChart,
+} from "@app/components/workspace/analytics/consumption/ConsumptionChart";
+import type { ConsumptionTimeseriesMode } from "@app/lib/api/analytics/consumption/timeseries";
+import {
+  usePokeConsumptionOverview,
+  usePokeConsumptionTimeseries,
+} from "@app/poke/swr/consumption";
+import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+import { useState } from "react";
+
+interface PokeConsumptionDailyChartProps extends ConsumptionChartProps {
+  additionalControls: ReactNode;
+}
+
+function PokeConsumptionDailyChart({
+  workspaceId,
+  period,
+  dimension,
+  filter,
+  additionalControls,
+}: PokeConsumptionDailyChartProps) {
+  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
+    usePokeConsumptionTimeseries({
+      workspaceId,
+      period,
+      mode: "daily",
+      breakdownBy: dimension,
+      breakdownCount: CONSUMPTION_CHART_BREAKDOWN_COUNT,
+      filter,
+    });
+  const isFiltered = Object.values(filter ?? {}).some(
+    (values) => values.length > 0
+  );
+
+  return (
+    <ConsumptionDailyChart
+      timeseries={timeseries}
+      isTimeseriesLoading={isTimeseriesLoading}
+      isTimeseriesError={Boolean(isTimeseriesError)}
+      emptyMessage={
+        isFiltered
+          ? "No consumption matches the current filters."
+          : "No consumption over this period."
+      }
+      additionalControls={additionalControls}
+    />
+  );
+}
+
+interface PokeConsumptionBurnUpChartProps
+  extends Omit<ConsumptionChartProps, "dimension"> {
+  additionalControls: ReactNode;
+}
+
+function PokeConsumptionBurnUpChart({
+  workspaceId,
+  period,
+  filter,
+  additionalControls,
+}: PokeConsumptionBurnUpChartProps) {
+  const { overview } = usePokeConsumptionOverview({
+    workspaceId,
+    period,
+    filter,
+  });
+  const isFiltered = Object.values(filter ?? {}).some(
+    (values) => values.length > 0
+  );
+  // A cap only exists on a billing cycle, when there's no filter. Gating on the
+  // selection rather than on the response alone keeps a previous cycle's cap —
+  // kept around by `keepPreviousData` while the new request lands — from drawing
+  // a target over a period that has none.
+  const capCredits =
+    period.kind === "cycle" && !isFiltered
+      ? (overview?.creditUsage?.capCredits ?? null)
+      : null;
+
+  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
+    usePokeConsumptionTimeseries({
+      workspaceId,
+      period,
+      mode: "cumulative",
+      filter,
+    });
+
+  return (
+    <ConsumptionBurnUpChart
+      timeseries={timeseries}
+      capCredits={capCredits}
+      isTimeseriesLoading={isTimeseriesLoading}
+      isTimeseriesError={Boolean(isTimeseriesError)}
+      emptyMessage={
+        isFiltered
+          ? "No consumption matches the current filters."
+          : "No consumption over this period."
+      }
+      additionalControls={additionalControls}
+    />
+  );
+}
+
+export function PokeConsumptionChart({
+  workspaceId,
+  period,
+  dimension,
+  filter,
+}: ConsumptionChartProps) {
+  const [mode, setMode] = useState<ConsumptionTimeseriesMode>("daily");
+  const modeSelector = (
+    <ButtonsSwitchList value={mode} size="xs">
+      <ButtonsSwitch
+        value="daily"
+        label="Daily"
+        onClick={() => setMode("daily")}
+      />
+      <ButtonsSwitch
+        value="cumulative"
+        label="Cumulative"
+        onClick={() => setMode("cumulative")}
+      />
+    </ButtonsSwitchList>
+  );
+
+  return mode === "cumulative" ? (
+    <PokeConsumptionBurnUpChart
+      workspaceId={workspaceId}
+      period={period}
+      filter={filter}
+      additionalControls={modeSelector}
+    />
+  ) : (
+    <PokeConsumptionDailyChart
+      workspaceId={workspaceId}
+      period={period}
+      dimension={dimension}
+      filter={filter}
+      additionalControls={modeSelector}
+    />
+  );
+}

--- a/front/components/poke/analytics/PokeConsumptionOverview.tsx
+++ b/front/components/poke/analytics/PokeConsumptionOverview.tsx
@@ -1,0 +1,22 @@
+import type { ConsumptionOverviewProps } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
+import { ConsumptionOverviewView } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
+import { usePokeConsumptionOverview } from "@app/poke/swr/consumption";
+
+export function PokeConsumptionOverview({
+  workspaceId,
+  period,
+  showError = false,
+}: ConsumptionOverviewProps) {
+  const { overview, isOverviewLoading, isOverviewError } =
+    usePokeConsumptionOverview({ workspaceId, period });
+
+  return (
+    <ConsumptionOverviewView
+      overview={overview}
+      isOverviewLoading={isOverviewLoading}
+      isOverviewError={Boolean(isOverviewError)}
+      showError={showError}
+      showIndexingDetails
+    />
+  );
+}

--- a/front/components/poke/analytics/PokeConsumptionPreview.tsx
+++ b/front/components/poke/analytics/PokeConsumptionPreview.tsx
@@ -1,0 +1,61 @@
+import type { AnalyticsConsumptionComponents } from "@app/components/pages/workspace/AnalyticsConsumptionPage";
+import {
+  AnalyticsConsumptionContent,
+  useAnalyticsConsumptionState,
+} from "@app/components/pages/workspace/AnalyticsConsumptionPage";
+import { PokeConsumptionAttributionTable } from "@app/components/poke/analytics/PokeConsumptionAttributionTable";
+import { PokeConsumptionOverview } from "@app/components/poke/analytics/PokeConsumptionOverview";
+import { PokeConsumptionSummary } from "@app/components/poke/analytics/PokeConsumptionSummary";
+import { PokeCustomerVisibilityChip } from "@app/components/poke/analytics/PokeCustomerVisibilityChip";
+import { PokeUsageFilterPanel } from "@app/components/poke/analytics/PokeUsageFilterPanel";
+import { isNavigationLocked } from "@app/lib/navigation-lock";
+import type { WorkspaceType } from "@app/types/user";
+import { safeLazy } from "@dust-tt/sparkle";
+
+const canReload = () => !isNavigationLocked();
+
+// Keep Recharts out of the initial Poke bundle until the analytics preview is
+// rendered.
+const PokeConsumptionChart = safeLazy(
+  () =>
+    import("@app/components/poke/analytics/PokeConsumptionChart").then(
+      (mod) => ({ default: mod.PokeConsumptionChart })
+    ),
+  { canReload }
+);
+
+const POKE_CONSUMPTION_COMPONENTS: AnalyticsConsumptionComponents = {
+  AttributionTable: PokeConsumptionAttributionTable,
+  Chart: PokeConsumptionChart,
+  Overview: PokeConsumptionOverview,
+  Summary: PokeConsumptionSummary,
+  UsageFilterPanel: PokeUsageFilterPanel,
+};
+
+interface PokeConsumptionPreviewProps {
+  owner: WorkspaceType;
+}
+
+export function PokeConsumptionPreview({ owner }: PokeConsumptionPreviewProps) {
+  const state = useAnalyticsConsumptionState();
+
+  return (
+    <AnalyticsConsumptionContent
+      components={POKE_CONSUMPTION_COMPONENTS}
+      owner={owner}
+      embedded
+      headerBadge={
+        <PokeCustomerVisibilityChip
+          feature="enable_analytics_consumption"
+          owner={owner}
+        />
+      }
+      showExport={false}
+      showMemberGroupFilter={false}
+      showOverviewError
+      state={state}
+      usageHref={`/poke/${owner.sId}?tab=usage`}
+      usageLinkLabel="View Usage"
+    />
+  );
+}

--- a/front/components/poke/analytics/PokeConsumptionSummary.tsx
+++ b/front/components/poke/analytics/PokeConsumptionSummary.tsx
@@ -1,0 +1,24 @@
+import type { ConsumptionSummaryProps } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
+import { ConsumptionSummaryView } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
+import { usePokeConsumptionOverview } from "@app/poke/swr/consumption";
+
+export function PokeConsumptionSummary({
+  workspaceId,
+  period,
+  usageHref = `/poke/${workspaceId}?tab=usage`,
+  usageLinkLabel = "View Usage",
+}: ConsumptionSummaryProps) {
+  const { overview, isOverviewLoading, isOverviewError } =
+    usePokeConsumptionOverview({ workspaceId, period });
+
+  return (
+    <ConsumptionSummaryView
+      overview={overview}
+      isOverviewLoading={isOverviewLoading}
+      isOverviewError={Boolean(isOverviewError)}
+      usageHref={usageHref}
+      usageLinkLabel={usageLinkLabel}
+      responsiveLayout
+    />
+  );
+}

--- a/front/components/poke/analytics/PokeCustomerVisibilityChip.tsx
+++ b/front/components/poke/analytics/PokeCustomerVisibilityChip.tsx
@@ -1,0 +1,39 @@
+import { usePokeFeatureFlags } from "@app/lib/swr/poke";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Chip } from "@dust-tt/sparkle";
+
+interface PokeCustomerVisibilityChipProps {
+  feature: WhitelistableFeature;
+  owner: LightWorkspaceType;
+}
+
+export function PokeCustomerVisibilityChip({
+  feature,
+  owner,
+}: PokeCustomerVisibilityChipProps) {
+  const {
+    data: featureFlags,
+    isError,
+    isLoading,
+  } = usePokeFeatureFlags({
+    owner,
+  });
+  const isEnabled = featureFlags.some((flag) => flag.name === feature);
+
+  if (isLoading) {
+    return <Chip label="Checking feature" color="info" size="mini" isBusy />;
+  }
+
+  if (isError) {
+    return <Chip label="Feature unknown" color="warning" size="mini" />;
+  }
+
+  return (
+    <Chip
+      label={isEnabled ? "Enabled" : "Feature disabled"}
+      color={isEnabled ? "success" : "primary"}
+      size="mini"
+    />
+  );
+}

--- a/front/components/poke/analytics/PokeUsageFilterPanel.tsx
+++ b/front/components/poke/analytics/PokeUsageFilterPanel.tsx
@@ -1,0 +1,44 @@
+import type { UsageFilterPanelProps } from "@app/components/workspace/analytics/UsageFilterPanel";
+import {
+  UsageFilterPanelView,
+  useUsageFilterPanelState,
+} from "@app/components/workspace/analytics/UsageFilterPanel";
+import { usePokeConsumptionFacets } from "@app/poke/swr/consumption";
+
+export function PokeUsageFilterPanel({
+  owner,
+  period,
+  filter,
+  onFilterChange,
+  showMemberGroupFilter = false,
+}: UsageFilterPanelProps) {
+  const state = useUsageFilterPanelState({
+    owner,
+    filter,
+    showMemberGroupFilter,
+  });
+  const {
+    options: categoryOptions,
+    isFacetsLoading,
+    isFacetsError,
+    isFacetsValidating,
+  } = usePokeConsumptionFacets({
+    workspaceId: owner.sId,
+    period,
+    filter: state.draftScopeFilter,
+    disabled: !state.isOpen,
+  });
+
+  return (
+    <UsageFilterPanelView
+      filter={filter}
+      onFilterChange={onFilterChange}
+      showMemberGroupFilter={showMemberGroupFilter}
+      state={state}
+      categoryOptions={categoryOptions}
+      isFacetsLoading={isFacetsLoading}
+      isFacetsError={Boolean(isFacetsError)}
+      isFacetsValidating={isFacetsValidating}
+    />
+  );
+}

--- a/front/components/poke/pages/AnalyticsPage.tsx
+++ b/front/components/poke/pages/AnalyticsPage.tsx
@@ -1,0 +1,27 @@
+import { PokeConsumptionPreview } from "@app/components/poke/analytics/PokeConsumptionPreview";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { usePokePageMetadata } from "@app/poke/swr/currentPage";
+import { LinkWrapper } from "@dust-tt/sparkle";
+
+export function AnalyticsPage() {
+  const owner = useWorkspace();
+  usePokePageMetadata({ name: owner.name, subtitle: "Analytics" });
+
+  return (
+    <main className="mx-auto w-full max-w-7xl">
+      <h1 className="text-2xl font-bold">
+        Analytics for workspace{" "}
+        <LinkWrapper href={`/poke/${owner.sId}`} className="text-highlight-500">
+          {owner.name}
+        </LinkWrapper>
+      </h1>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Poke uses workspace-admin visibility, so resolved labels may differ from
+        a customer manager&apos;s view.
+      </p>
+      <div className="min-w-0 py-6">
+        <PokeConsumptionPreview owner={owner} />
+      </div>
+    </main>
+  );
+}

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -26,6 +26,7 @@ import { TriggerDataTable } from "@app/components/poke/triggers/table";
 import { WebhookSourceDataTable } from "@app/components/poke/webhook_sources/table";
 import { WorkspaceMetadataTab } from "@app/components/poke/workspace/MetadataTab";
 import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
+import { WorkspaceAnalyticsButton } from "@app/components/poke/workspace/WorkspaceAnalyticsButton";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
@@ -235,20 +236,23 @@ export function WorkspacePage() {
                 <TabsTrigger value="planlimitations" label="Plan Limitations" />
               </TabsList>
               <TabsContent value="workspace">
-                <WorkspaceInfoTable
-                  owner={owner}
-                  membersCount={membersCount}
-                  inactiveMembersCount={inactiveMembersCount}
-                  metronomeCustomerId={metronomeCustomerId}
-                  stripeCustomerId={stripeCustomerId}
-                  workspaceVerifiedDomains={workspaceVerifiedDomains}
-                  workspaceCreationDay={workspaceCreationDay}
-                  extensionConfig={extensionConfig}
-                  dataRetention={dataRetention}
-                  workosEnvironmentId={workosEnvironmentId}
-                  hasDummyFeature={hasDummyFeature}
-                  temporalFrontNamespace={temporalFrontNamespace}
-                />
+                <div className="flex flex-col gap-3">
+                  <WorkspaceInfoTable
+                    owner={owner}
+                    membersCount={membersCount}
+                    inactiveMembersCount={inactiveMembersCount}
+                    metronomeCustomerId={metronomeCustomerId}
+                    stripeCustomerId={stripeCustomerId}
+                    workspaceVerifiedDomains={workspaceVerifiedDomains}
+                    workspaceCreationDay={workspaceCreationDay}
+                    extensionConfig={extensionConfig}
+                    dataRetention={dataRetention}
+                    workosEnvironmentId={workosEnvironmentId}
+                    hasDummyFeature={hasDummyFeature}
+                    temporalFrontNamespace={temporalFrontNamespace}
+                  />
+                  <WorkspaceAnalyticsButton workspaceId={owner.sId} />
+                </div>
               </TabsContent>
               <TabsContent value="subscriptions">
                 <ActiveSubscriptionTable

--- a/front/components/poke/workspace/WorkspaceAnalyticsButton.tsx
+++ b/front/components/poke/workspace/WorkspaceAnalyticsButton.tsx
@@ -1,0 +1,263 @@
+import { cn } from "@app/components/poke/shadcn/lib/utils";
+import { ArrowRight, BarLineChart, Icon, LinkWrapper } from "@dust-tt/sparkle";
+import type { MotionValue } from "framer-motion";
+import {
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useSpring,
+  useTransform,
+} from "framer-motion";
+import type { PointerEvent } from "react";
+
+const ANALYTICS_BARS = [
+  { position: 0, defaultHeight: 0.38, className: "bg-highlight-300" },
+  {
+    position: 1 / 3,
+    defaultHeight: 0.62,
+    className: "bg-highlight-300",
+  },
+  {
+    position: 2 / 3,
+    defaultHeight: 0.5,
+    className: "bg-highlight-400",
+  },
+  { position: 1, defaultHeight: 0.88, className: "bg-highlight-500" },
+] as const;
+const ANALYTICS_BAR_HEIGHT = 32;
+const ANALYTICS_BAR_MIN_HEIGHT = 0.35;
+const ANALYTICS_BAR_MAX_HEIGHT = 1;
+const ANALYTICS_BAR_FALLOFF = 2.4;
+const ANALYTICS_CURSOR_REST_POSITION = -1;
+const ANALYTICS_BAR_SPRING = {
+  damping: 32,
+  mass: 0.5,
+  stiffness: 500,
+};
+const ANALYTICS_GRADIENT_REST_POSITION = 0.72;
+const ANALYTICS_GRADIENT_OFFSET_FACTOR = 0.08;
+const ANALYTICS_GRADIENT_MAX_STRETCH = 1.32;
+const ANALYTICS_GRADIENT_POSITION_SPRING = {
+  damping: 28,
+  mass: 0.65,
+  stiffness: 180,
+};
+const ANALYTICS_GRADIENT_STRETCH_SPRING = {
+  damping: 30,
+  mass: 0.4,
+  stiffness: 260,
+};
+
+function getAnalyticsBarOffset(
+  cursorPosition: number,
+  barPosition: number,
+  defaultHeight: number
+) {
+  if (cursorPosition === ANALYTICS_CURSOR_REST_POSITION) {
+    return (1 - defaultHeight) * ANALYTICS_BAR_HEIGHT;
+  }
+
+  const influence = Math.max(
+    0,
+    1 - Math.abs(cursorPosition - barPosition) * ANALYTICS_BAR_FALLOFF
+  );
+  const height =
+    ANALYTICS_BAR_MIN_HEIGHT +
+    influence * (ANALYTICS_BAR_MAX_HEIGHT - ANALYTICS_BAR_MIN_HEIGHT);
+
+  return (1 - height) * ANALYTICS_BAR_HEIGHT;
+}
+
+function updateAnalyticsBars(
+  event: PointerEvent<HTMLDivElement>,
+  cursorPosition: MotionValue<number>,
+  shouldReduceMotion: boolean
+) {
+  if (event.pointerType !== "mouse" || shouldReduceMotion) {
+    return;
+  }
+
+  const bounds = event.currentTarget.getBoundingClientRect();
+  if (bounds.width === 0) {
+    return;
+  }
+
+  cursorPosition.set(
+    Math.min(1, Math.max(0, (event.clientX - bounds.left) / bounds.width))
+  );
+}
+
+interface AnalyticsBarProps {
+  className: string;
+  cursorPosition: MotionValue<number>;
+  defaultHeight: number;
+  position: number;
+  shouldReduceMotion: boolean;
+}
+
+function AnalyticsBar({
+  className,
+  cursorPosition,
+  defaultHeight,
+  position,
+  shouldReduceMotion,
+}: AnalyticsBarProps) {
+  const defaultOffset = getAnalyticsBarOffset(
+    ANALYTICS_CURSOR_REST_POSITION,
+    position,
+    defaultHeight
+  );
+  const targetOffset = useTransform(cursorPosition, (value) =>
+    getAnalyticsBarOffset(value, position, defaultHeight)
+  );
+  const springOffset = useSpring(targetOffset, ANALYTICS_BAR_SPRING);
+
+  return (
+    <span
+      className="relative w-1.5 shrink-0 overflow-hidden rounded-full"
+      style={{ height: ANALYTICS_BAR_HEIGHT }}
+    >
+      <motion.span
+        className={`absolute inset-0 rounded-full will-change-transform ${className}`}
+        style={{ y: shouldReduceMotion ? defaultOffset : springOffset }}
+      />
+    </span>
+  );
+}
+
+function getAnalyticsGradientPosition(cursorPosition: number) {
+  if (cursorPosition === ANALYTICS_CURSOR_REST_POSITION) {
+    return ANALYTICS_GRADIENT_REST_POSITION;
+  }
+
+  return (
+    cursorPosition + (0.5 - cursorPosition) * ANALYTICS_GRADIENT_OFFSET_FACTOR
+  );
+}
+
+interface AnalyticsCursorGradientProps {
+  cursorPosition: MotionValue<number>;
+  shouldReduceMotion: boolean;
+}
+
+function AnalyticsCursorGradient({
+  cursorPosition,
+  shouldReduceMotion,
+}: AnalyticsCursorGradientProps) {
+  const targetPosition = useTransform(
+    cursorPosition,
+    getAnalyticsGradientPosition
+  );
+  const position = useSpring(
+    targetPosition,
+    ANALYTICS_GRADIENT_POSITION_SPRING
+  );
+  const x = useTransform(
+    position,
+    (value) => `${((value - 0.25) / 0.5) * 100}%`
+  );
+  const targetStretch = useTransform<number, number>(
+    [cursorPosition, position],
+    ([cursor, gradient]) => {
+      if (cursor === ANALYTICS_CURSOR_REST_POSITION) {
+        return 1;
+      }
+
+      const edgeStretch = Math.abs(cursor - 0.5) * 0.18;
+      const lagStretch = Math.min(Math.abs(cursor - gradient), 0.25) * 0.9;
+
+      return Math.min(
+        ANALYTICS_GRADIENT_MAX_STRETCH,
+        1 + edgeStretch + lagStretch
+      );
+    }
+  );
+  const scaleX = useSpring(targetStretch, ANALYTICS_GRADIENT_STRETCH_SPRING);
+
+  return (
+    <motion.span
+      aria-hidden="true"
+      className={cn(
+        "pointer-events-none absolute inset-y-0 left-0 w-1/2",
+        "opacity-0 transition-opacity duration-200 ease-out will-change-transform",
+        "pointer-fine:group-hover:opacity-40 motion-reduce:hidden",
+        "[background:linear-gradient(90deg,transparent_0%,var(--color-highlight-50)_18%,var(--color-highlight-100)_48%,var(--color-highlight-50)_72%,transparent_100%)]"
+      )}
+      style={{
+        x: shouldReduceMotion ? "94%" : x,
+        scaleX: shouldReduceMotion ? 1 : scaleX,
+      }}
+    />
+  );
+}
+
+interface WorkspaceAnalyticsButtonProps {
+  workspaceId: string;
+}
+
+export function WorkspaceAnalyticsButton({
+  workspaceId,
+}: WorkspaceAnalyticsButtonProps) {
+  const cursorPosition = useMotionValue(ANALYTICS_CURSOR_REST_POSITION);
+  const shouldReduceMotion = Boolean(useReducedMotion());
+
+  return (
+    <div
+      className="w-full"
+      onPointerLeave={() => cursorPosition.set(ANALYTICS_CURSOR_REST_POSITION)}
+      onPointerMove={(event) =>
+        updateAnalyticsBars(event, cursorPosition, shouldReduceMotion)
+      }
+    >
+      <LinkWrapper
+        href={`/poke/${workspaceId}/analytics`}
+        className={cn(
+          "group relative isolate flex min-h-20 w-full items-center gap-3 overflow-hidden",
+          "rounded-lg border border-highlight-200 bg-linear-to-r from-background via-background to-highlight-50/50",
+          "p-4 text-left shadow-sm outline-hidden",
+          "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted-background"
+        )}
+      >
+        <AnalyticsCursorGradient
+          cursorPosition={cursorPosition}
+          shouldReduceMotion={shouldReduceMotion}
+        />
+        <div
+          aria-hidden="true"
+          className={cn(
+            "relative z-10 flex h-11 w-11 shrink-0 items-center justify-center",
+            "rounded-lg border border-highlight-200 bg-background text-highlight-500 shadow-sm"
+          )}
+        >
+          <Icon visual={BarLineChart} size="md" />
+        </div>
+        <div className="relative z-10 flex min-w-0 flex-1 flex-col">
+          <span className="text-sm font-semibold text-foreground">
+            Analytics
+          </span>
+          <span className="text-xs text-muted-foreground">
+            Explore credit usage and attribution.
+          </span>
+        </div>
+        <div
+          aria-hidden="true"
+          className="relative z-10 ml-auto hidden h-9 items-end gap-1.5 opacity-70 sm:flex"
+        >
+          {ANALYTICS_BARS.map((bar) => (
+            <AnalyticsBar
+              key={bar.position}
+              {...bar}
+              cursorPosition={cursorPosition}
+              shouldReduceMotion={shouldReduceMotion}
+            />
+          ))}
+        </div>
+        <Icon
+          visual={ArrowRight}
+          size="sm"
+          className="relative z-10 text-highlight-500"
+        />
+      </LinkWrapper>
+    </div>
+  );
+}

--- a/front/components/poke/workspace/WorkspaceAnalyticsButton.tsx
+++ b/front/components/poke/workspace/WorkspaceAnalyticsButton.tsx
@@ -35,17 +35,11 @@ const ANALYTICS_BAR_SPRING = {
   stiffness: 500,
 };
 const ANALYTICS_GRADIENT_REST_POSITION = 0.72;
-const ANALYTICS_GRADIENT_OFFSET_FACTOR = 0.08;
-const ANALYTICS_GRADIENT_MAX_STRETCH = 1.32;
+const ANALYTICS_GRADIENT_CURSOR_OFFSET = 0.1;
 const ANALYTICS_GRADIENT_POSITION_SPRING = {
   damping: 28,
   mass: 0.65,
   stiffness: 180,
-};
-const ANALYTICS_GRADIENT_STRETCH_SPRING = {
-  damping: 30,
-  mass: 0.4,
-  stiffness: 260,
 };
 
 function getAnalyticsBarOffset(
@@ -131,18 +125,16 @@ function getAnalyticsGradientPosition(cursorPosition: number) {
   }
 
   return (
-    cursorPosition + (0.5 - cursorPosition) * ANALYTICS_GRADIENT_OFFSET_FACTOR
+    cursorPosition + (1 - cursorPosition) * ANALYTICS_GRADIENT_CURSOR_OFFSET
   );
 }
 
 interface AnalyticsCursorGradientProps {
   cursorPosition: MotionValue<number>;
-  shouldReduceMotion: boolean;
 }
 
 function AnalyticsCursorGradient({
   cursorPosition,
-  shouldReduceMotion,
 }: AnalyticsCursorGradientProps) {
   const targetPosition = useTransform(
     cursorPosition,
@@ -152,41 +144,22 @@ function AnalyticsCursorGradient({
     targetPosition,
     ANALYTICS_GRADIENT_POSITION_SPRING
   );
-  const x = useTransform(
-    position,
-    (value) => `${((value - 0.25) / 0.5) * 100}%`
-  );
-  const targetStretch = useTransform<number, number>(
-    [cursorPosition, position],
-    ([cursor, gradient]) => {
-      if (cursor === ANALYTICS_CURSOR_REST_POSITION) {
-        return 1;
-      }
+  const background = useTransform(position, (value) => {
+    const middle = value * 100;
+    const leadingColor = middle * 0.45;
 
-      const edgeStretch = Math.abs(cursor - 0.5) * 0.18;
-      const lagStretch = Math.min(Math.abs(cursor - gradient), 0.25) * 0.9;
-
-      return Math.min(
-        ANALYTICS_GRADIENT_MAX_STRETCH,
-        1 + edgeStretch + lagStretch
-      );
-    }
-  );
-  const scaleX = useSpring(targetStretch, ANALYTICS_GRADIENT_STRETCH_SPRING);
+    return `linear-gradient(90deg, transparent 0%, var(--color-highlight-50) ${leadingColor}%, var(--color-highlight-100) ${middle}%, var(--color-highlight-50) 100%)`;
+  });
 
   return (
     <motion.span
       aria-hidden="true"
       className={cn(
-        "pointer-events-none absolute inset-y-0 left-0 w-1/2",
-        "opacity-0 transition-opacity duration-200 ease-out will-change-transform",
-        "pointer-fine:group-hover:opacity-40 motion-reduce:hidden",
-        "[background:linear-gradient(90deg,transparent_0%,var(--color-highlight-50)_18%,var(--color-highlight-100)_48%,var(--color-highlight-50)_72%,transparent_100%)]"
+        "pointer-events-none absolute inset-0",
+        "opacity-[0.18] transition-opacity duration-200 ease-out motion-reduce:transition-none",
+        "pointer-fine:group-hover:opacity-[0.3]"
       )}
-      style={{
-        x: shouldReduceMotion ? "94%" : x,
-        scaleX: shouldReduceMotion ? 1 : scaleX,
-      }}
+      style={{ background }}
     />
   );
 }
@@ -218,10 +191,7 @@ export function WorkspaceAnalyticsButton({
           "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-muted-background"
         )}
       >
-        <AnalyticsCursorGradient
-          cursorPosition={cursorPosition}
-          shouldReduceMotion={shouldReduceMotion}
-        />
+        <AnalyticsCursorGradient cursorPosition={cursorPosition} />
         <div
           aria-hidden="true"
           className={cn(

--- a/front/poke/swr/consumption.ts
+++ b/front/poke/swr/consumption.ts
@@ -1,0 +1,196 @@
+import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import type {
+  ConsumptionFacetOptions,
+  UseConsumptionFacetsParams,
+} from "@app/hooks/useConsumptionFacets";
+import { toConsumptionFacetOptions } from "@app/hooks/useConsumptionFacets";
+import type { UseConsumptionOverviewParams } from "@app/hooks/useConsumptionOverview";
+import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
+import type { UseConsumptionTimeseriesParams } from "@app/hooks/useConsumptionTimeseries";
+import type {
+  ConsumptionTopResponse,
+  ConsumptionTopRow,
+  UseConsumptionTopParams,
+} from "@app/hooks/useConsumptionTop";
+import { toConsumptionTopRows } from "@app/hooks/useConsumptionTop";
+import {
+  DEFAULT_CONSUMPTION_PERIOD_DAYS,
+  normalizedConsumptionFilter,
+} from "@app/lib/analytics/consumption_period";
+import type { GetConsumptionFacetsResponse } from "@app/lib/api/analytics/consumption/facets";
+import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
+import type {
+  ConsumptionBody,
+  ConsumptionTopBody,
+} from "@app/lib/api/analytics/consumption/schema";
+import type {
+  ConsumptionBreakdownDimension,
+  ConsumptionTimeseriesMode,
+  GetConsumptionTimeseriesResponse,
+} from "@app/lib/api/analytics/consumption/timeseries";
+import { emptyArray } from "@app/lib/swr/swr";
+import { useMemo } from "react";
+
+const EMPTY_FACET_OPTIONS: ConsumptionFacetOptions = {
+  agent: [],
+  member: [],
+  group: [],
+  model: [],
+  tool: [],
+  skill: [],
+  source: [],
+  api_key: [],
+};
+
+const CONSUMPTION_TOP_ENDPOINTS = {
+  agent: "top-agents",
+  user: "top-users",
+  group: "top-groups",
+  model: "top-models",
+  tool: "top-tools",
+  skill: "top-skills",
+  source: "top-sources",
+  api_key: "top-api-keys",
+} as const satisfies Record<ConsumptionDimension, string>;
+
+type ConsumptionTimeseriesBody = ConsumptionBody & {
+  mode: ConsumptionTimeseriesMode;
+  breakdownBy?: ConsumptionBreakdownDimension;
+  breakdownCount?: number;
+};
+
+export function usePokeConsumptionOverview({
+  workspaceId,
+  period,
+  filter,
+  disabled,
+}: UseConsumptionOverviewParams) {
+  const url = `/api/poke/workspaces/${workspaceId}/analytics/consumption/overview`;
+  const body: ConsumptionBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+  };
+
+  const { data, error, isLoading, isValidating } = useConsumptionQuery<
+    ConsumptionBody,
+    GetConsumptionOverviewResponse
+  >({ url, body, disabled });
+
+  return {
+    overview: data ?? null,
+    isOverviewLoading: isLoading,
+    isOverviewError: error,
+    isOverviewValidating: isValidating,
+  };
+}
+
+export function usePokeConsumptionFacets({
+  workspaceId,
+  period,
+  filter,
+  disabled,
+}: UseConsumptionFacetsParams) {
+  const url = `/api/poke/workspaces/${workspaceId}/analytics/consumption/facets`;
+  const body: ConsumptionBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+  };
+
+  const { data, error, isValidating } = useConsumptionQuery<
+    ConsumptionBody,
+    GetConsumptionFacetsResponse
+  >({ url, body, disabled });
+
+  const options = useMemo(
+    () => (data ? toConsumptionFacetOptions(data) : EMPTY_FACET_OPTIONS),
+    [data]
+  );
+
+  return {
+    options,
+    isFacetsLoading: !error && !data && !disabled,
+    isFacetsError: error,
+    isFacetsValidating: isValidating,
+  };
+}
+
+export function usePokeConsumptionTimeseries({
+  workspaceId,
+  period,
+  mode,
+  breakdownBy,
+  breakdownCount,
+  filter,
+  disabled,
+}: UseConsumptionTimeseriesParams) {
+  const url = `/api/poke/workspaces/${workspaceId}/analytics/consumption/timeseries`;
+  const body: ConsumptionTimeseriesBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+    mode,
+    breakdownBy,
+    breakdownCount,
+  };
+
+  const { data, error, isValidating } = useConsumptionQuery<
+    ConsumptionTimeseriesBody,
+    GetConsumptionTimeseriesResponse
+  >({ url, body, disabled });
+
+  return {
+    timeseries: data ?? null,
+    isTimeseriesLoading: !error && !data && !disabled,
+    isTimeseriesError: error,
+    isTimeseriesValidating: isValidating,
+  };
+}
+
+export function usePokeConsumptionTop({
+  workspaceId,
+  dimension,
+  period,
+  limit,
+  offset = 0,
+  search,
+  filter,
+  sortOrder = "desc",
+  disabled,
+}: UseConsumptionTopParams) {
+  const url = `/api/poke/workspaces/${workspaceId}/analytics/consumption/${CONSUMPTION_TOP_ENDPOINTS[dimension]}`;
+  const body: ConsumptionTopBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+    limit,
+    offset,
+    search: search?.trim(),
+    sortOrder,
+  };
+
+  const { data, error, isLoading, isValidating } = useConsumptionQuery<
+    ConsumptionTopBody,
+    ConsumptionTopResponse
+  >({ url, body, disabled });
+
+  const rows = useMemo(
+    () => (data ? toConsumptionTopRows(data) : emptyArray<ConsumptionTopRow>()),
+    [data]
+  );
+
+  return {
+    rows,
+    totalCredits: data?.totalCredits ?? 0,
+    totalCount: data?.totalCount ?? 0,
+    hasMore: data?.hasMore ?? false,
+    isTopLoading: !error && isLoading,
+    isTopError: error,
+    isTopValidating: isValidating,
+  };
+}


### PR DESCRIPTION
## Description

The goal of this PR, the ones before and few PR that will follow is to give a way for us to both inspect what the users will see in the analytics page and to use them for monitoring workspace health and adoption patterns.

This PR adds the same view users will see in the new analytics page to poke.

<img width="1194" height="995" alt="image" src="https://github.com/user-attachments/assets/d15d31aa-ba87-488e-b0dc-9d5dc9227d4a" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
