### PR TITLE
[front] fix: duplicated agent browser sections when no tags defined

### DIFF
--- a/front/components/assistant/conversation/agent_browser/AgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/AgentBrowser.tsx
@@ -99,22 +99,23 @@ export function AgentBrowser({
     useMemo(() => {
       const tags = agentConfigurations.flatMap((a) => a.tags);
       // Remove duplicate tags by unique sId
-      const uniqueTags = Array.from(
+      const workspaceTags = Array.from(
         new Map(tags.map((tag) => [tag.sId, tag])).values()
       ).sort(tagsSorter);
 
-      uniqueTags.unshift(ALL_TAG);
-      uniqueTags.unshift(MOST_POPULAR_TAG);
+      const noTagsDefined = workspaceTags.length === 0;
 
-      // Always append others at the end
-      uniqueTags.push(OTHERS_TAG);
+      // Without tags, "Most popular" and "Others" would only duplicate "All".
+      const uniqueTags = noTagsDefined
+        ? [ALL_TAG]
+        : [MOST_POPULAR_TAG, ALL_TAG, ...workspaceTags, OTHERS_TAG];
 
       if (assistantSearch.trim() === "") {
         return {
           filteredAgents: [],
           filteredTags: [],
           uniqueTags,
-          noTagsDefined: uniqueTags.length === 3, // Only all, most popular and others
+          noTagsDefined,
         };
       }
       const search = assistantSearch.toLowerCase().trim().replace(/^@/, "");
@@ -147,7 +148,7 @@ export function AgentBrowser({
         filteredAgents,
         filteredTags,
         uniqueTags,
-        noTagsDefined: uniqueTags.length === 2, // Only most popular and others
+        noTagsDefined,
       };
     }, [agentConfigurations, assistantSearch, selectedTag]);
 

--- a/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
+++ b/front/components/assistant/conversation/agent_browser/WebAgentBrowser.tsx
@@ -161,7 +161,7 @@ export function WebAgentBrowser({
           handleAgentClick={handleAgentClick}
           setDisplayedAssistantId={setDisplayedAssistantId}
           owner={owner}
-          showTagHeadings={true}
+          showTagHeadings={!noTagsDefined}
           trackAgentBrowserEvents
         />
       ) : (

--- a/front/components/assistant/conversation/agent_browser/shared.tsx
+++ b/front/components/assistant/conversation/agent_browser/shared.tsx
@@ -443,8 +443,7 @@ export function AllTabContent({
                       agentsByTab.most_popular.some(
                         (ap) => ap.sId === a.sId
                       )) ||
-                    (tag.sId === ALL_TAG.sId &&
-                      agentsByTab.all.some((ap) => ap.sId === a.sId))
+                    tag.sId === ALL_TAG.sId
                   );
                 })}
                 handleAssistantClick={handleAgentClick}


### PR DESCRIPTION
## Description

In workspaces with no agent tags, the "All agents" tab stacked three pseudo-sections ("Most popular", "All", "Others"), so every agent appeared two or three times. When no tags are defined, only render a single "All" section (without the redundant heading on web).

Also fixes `noTagsDefined` being computed as `uniqueTags.length === 2` in the search branch (stale since `ALL_TAG` was added), and trims the tautological `agentsByTab.all.some(...)` lookup in the `ALL` section filter.

Tagged workspaces are unchanged. 

| Before | After |
| --- | --- |
| <kbd><img alt="Before: duplicated Most popular / All / Others sections" src="https://github.com/user-attachments/assets/144919c5-ad40-4da9-922a-b6acdef469f2" /></kbd> | <kbd><img alt="After: single flat agent grid" src="https://github.com/user-attachments/assets/08e58cc2-30f0-4413-abbc-e4e35c075492" /></kbd> |

## Risk

Display-only. Worst case, the agent browser grid is mis-sectioned for untagged workspaces. Safe to rollback.
