### PR TITLE
[front] feat: route activation poke through Temporal eligibility gates

### DIFF
--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -16,19 +16,30 @@ import {
   DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT,
 } from "@app/temporal/activation_scheduler/config";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { isUserMessageType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockIsUserBlocked } = vi.hoisted(() => ({
-  mockIsUserBlocked: vi.fn(),
-}));
+const { mockIsUserBlocked, mockIsNonCreditPricedUserSpendLimitReached } =
+  vi.hoisted(() => ({
+    mockIsUserBlocked: vi.fn(),
+    mockIsNonCreditPricedUserSpendLimitReached: vi.fn(),
+  }));
 
 vi.mock("@app/lib/metronome/user_block", () => ({
   isUserBlocked: mockIsUserBlocked,
+}));
+
+vi.mock("@app/lib/api/users/spend_limit", () => ({
+  isNonCreditPricedUserSpendLimitReached:
+    mockIsNonCreditPricedUserSpendLimitReached,
 }));
 
 vi.mock("@app/temporal/agent_loop/client", () => ({
@@ -145,6 +156,8 @@ describe("isEligibleForNudge", () => {
   beforeEach(() => {
     mockIsUserBlocked.mockReset();
     mockIsUserBlocked.mockResolvedValue(null);
+    mockIsNonCreditPricedUserSpendLimitReached.mockReset();
+    mockIsNonCreditPricedUserSpendLimitReached.mockResolvedValue(false);
   });
 
   it("is eligible when the pod has never been nudged", async () => {
@@ -182,8 +195,8 @@ describe("isEligibleForNudge", () => {
     ).toBe(false);
   });
 
-  it("is not eligible when the pod's user is blocked, even if never nudged", async () => {
-    mockIsUserBlocked.mockResolvedValue("credits_exhausted");
+  it("is eligible on a legacy plan even when isUserBlocked would report no_seat", async () => {
+    mockIsUserBlocked.mockResolvedValue("no_seat");
     const { authenticator, user, globalSpace } = await createResourceTest({
       role: "admin",
     });
@@ -194,6 +207,170 @@ describe("isEligibleForNudge", () => {
         pod: globalSpace,
         activationPod,
         user,
+      })
+    ).toBe(true);
+    expect(mockIsUserBlocked).not.toHaveBeenCalled();
+  });
+
+  it("is not eligible on a legacy plan when the spend cap is reached", async () => {
+    mockIsNonCreditPricedUserSpendLimitReached.mockResolvedValue(true);
+    const { authenticator, user, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    await FeatureFlagFactory.basic(
+      authenticator,
+      "enforce_user_spend_limit_rate_cap"
+    );
+    const authWithFlag = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      authenticator.getNonNullableWorkspace().sId
+    );
+    const activationPod = await createActivationPod(authWithFlag, globalSpace);
+
+    expect(
+      await isEligibleForNudge(authWithFlag, {
+        pod: globalSpace,
+        activationPod,
+        user,
+      })
+    ).toBe(false);
+    expect(mockIsNonCreditPricedUserSpendLimitReached).toHaveBeenCalled();
+  });
+
+  it("is not eligible when a credit-priced user is blocked, even if never nudged", async () => {
+    mockIsUserBlocked.mockResolvedValue("credits_exhausted");
+    const workspace = await WorkspaceFactory.creditPriced();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const authenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const { globalSpace } = await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: globalSpace,
+        activationPod,
+        user,
+      })
+    ).toBe(false);
+    expect(mockIsUserBlocked).toHaveBeenCalled();
+  });
+
+  it("still blocks a credit-priced user when overrideChecks is set", async () => {
+    mockIsUserBlocked.mockResolvedValue("credits_exhausted");
+    const workspace = await WorkspaceFactory.creditPriced();
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const authenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const { globalSpace } = await SpaceFactory.defaults(
+      await Authenticator.internalAdminForWorkspace(workspace.sId)
+    );
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: globalSpace,
+        activationPod,
+        user,
+        overrideChecks: true,
+      })
+    ).toBe(false);
+  });
+
+  it("is not eligible on a BYOK workspace, even if never nudged", async () => {
+    const { authenticator, user, globalSpace } = await createResourceTest({
+      role: "admin",
+      isByok: true,
+    });
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: globalSpace,
+        activationPod,
+        user,
+      })
+    ).toBe(false);
+  });
+
+  it("is eligible on a BYOK workspace when overrideChecks is set", async () => {
+    const { authenticator, user, globalSpace } = await createResourceTest({
+      role: "admin",
+      isByok: true,
+    });
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: globalSpace,
+        activationPod,
+        user,
+        overrideChecks: true,
+      })
+    ).toBe(true);
+  });
+
+  it("skips the frequency cap when overrideChecks is set", async () => {
+    const { authenticator, workspace, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+    await createNudge(authenticator, {
+      workspace,
+      pod: globalSpace,
+      nudgedAt: new Date(),
+    });
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: globalSpace,
+        activationPod,
+        user: null,
+        overrideChecks: true,
+      })
+    ).toBe(true);
+  });
+
+  it("still blocks an archived pod when overrideChecks is set", async () => {
+    const { authenticator, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+
+    // biome-ignore lint/plugin/noRawSql: only way to backdate a paranoid model's deletedAt in tests.
+    await frontSequelize.query(
+      `UPDATE vaults SET "deletedAt" = :deletedAt WHERE id = :id AND "workspaceId" = :workspaceId`,
+      {
+        replacements: {
+          deletedAt: new Date().toISOString(),
+          id: globalSpace.id,
+          workspaceId: authenticator.getNonNullableWorkspace().id,
+        },
+      }
+    );
+    const archivedPod = await SpaceResource.fetchById(
+      authenticator,
+      globalSpace.sId,
+      { includeDeleted: true }
+    );
+    if (!archivedPod) {
+      throw new Error("Expected the archived pod to still be fetchable.");
+    }
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: archivedPod,
+        activationPod,
+        user: null,
+        overrideChecks: true,
       })
     ).toBe(false);
   });
@@ -333,7 +510,7 @@ describe("isEligibleForNudge", () => {
     ).toBe(false);
   });
 
-  it("is not eligible when the target user left the workspace (dead)", async () => {
+  it("is not eligible when the target user no longer has an active membership", async () => {
     const { workspace, user, globalSpace } = await createResourceTest({
       role: "user",
     });
@@ -350,6 +527,28 @@ describe("isEligibleForNudge", () => {
         pod: globalSpace,
         activationPod,
         user: null,
+      })
+    ).toBe(false);
+  });
+
+  it("still blocks a revoked membership when overrideChecks is set", async () => {
+    const { workspace, user, globalSpace } = await createResourceTest({
+      role: "user",
+    });
+    const authenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+
+    await MembershipResource.revokeMembership({ user, workspace });
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: globalSpace,
+        activationPod,
+        user: null,
+        overrideChecks: true,
       })
     ).toBe(false);
   });

--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -339,42 +339,6 @@ describe("isEligibleForNudge", () => {
     ).toBe(true);
   });
 
-  it("still blocks an archived pod when overrideChecks is set", async () => {
-    const { authenticator, globalSpace } = await createResourceTest({
-      role: "admin",
-    });
-    const activationPod = await createActivationPod(authenticator, globalSpace);
-
-    // biome-ignore lint/plugin/noRawSql: only way to backdate a paranoid model's deletedAt in tests.
-    await frontSequelize.query(
-      `UPDATE vaults SET "deletedAt" = :deletedAt WHERE id = :id AND "workspaceId" = :workspaceId`,
-      {
-        replacements: {
-          deletedAt: new Date().toISOString(),
-          id: globalSpace.id,
-          workspaceId: authenticator.getNonNullableWorkspace().id,
-        },
-      }
-    );
-    const archivedPod = await SpaceResource.fetchById(
-      authenticator,
-      globalSpace.sId,
-      { includeDeleted: true }
-    );
-    if (!archivedPod) {
-      throw new Error("Expected the archived pod to still be fetchable.");
-    }
-
-    expect(
-      await isEligibleForNudge(authenticator, {
-        pod: archivedPod,
-        activationPod,
-        user: null,
-        overrideChecks: true,
-      })
-    ).toBe(false);
-  });
-
   it("is eligible when a user is provided but not blocked", async () => {
     mockIsUserBlocked.mockResolvedValue(null);
     const { authenticator, user, globalSpace } = await createResourceTest({

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -3,7 +3,8 @@ import {
   createConversation,
   postUserMessage,
 } from "@app/lib/api/assistant/conversation";
-import { Authenticator } from "@app/lib/auth";
+import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend_limit";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { isUserBlocked } from "@app/lib/metronome/user_block";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
@@ -19,6 +20,7 @@ import {
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { ACTIVATION_NUDGE_ORIGIN } from "@app/types/assistant/conversation";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -64,23 +66,21 @@ export function getActivationNudgeMaxUnansweredCount(
   return DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT;
 }
 
-// A pod is "dead" once it can no longer receive nudges for reasons unrelated
-// to nudge history: it was archived, or its target user was removed from or
-// left the workspace.
-async function isPodDead(
+function isPodDead(pod: SpaceResource): boolean {
+  return pod.deletedAt !== null;
+}
+
+// The pod owner is still an active, non-revoked member of this workspace
+// (membership has started and has not been ended).
+async function hasActivePodOwnerMembership(
   auth: Authenticator,
-  pod: SpaceResource,
   activationPod: ActivationPodResource
 ): Promise<boolean> {
-  if (pod.deletedAt !== null) {
-    return true;
-  }
-
   const [targetUser] = await UserResource.fetchByModelIds([
     activationPod.userId,
   ]);
   if (!targetUser) {
-    return true;
+    return false;
   }
 
   const activeMembership =
@@ -89,35 +89,71 @@ async function isPodDead(
       workspace: auth.getNonNullableWorkspace(),
     });
 
-  return activeMembership === null;
+  return activeMembership !== null;
 }
 
-// Gates re-nudging a pod on four conditions: the pod is dead, the user is
-// blocked on credit, the pod was nudged within the frequency cap window, or its
-// recent nudges went unanswered.
+function isCreditPricedWorkspace(auth: Authenticator): boolean {
+  const workspace = auth.getNonNullableWorkspace();
+  const plan = auth.plan();
+  return Boolean(
+    workspace.metronomeCustomerId && plan && isCreditPricedPlan(plan)
+  );
+}
+
+// Whether this pod can be nudged right now.
+// Always applied: archived pod; owner is not an active, non-revoked member;
+// credit/seat (or the legacy spend cap). Skipped when overrideChecks is set
+// (poke one-off): BYOK, frequency cap, unanswered-nudge limit.
 export async function isEligibleForNudge(
   auth: Authenticator,
   {
     pod,
     activationPod,
     user,
+    overrideChecks = false,
   }: {
     pod: SpaceResource;
     activationPod: ActivationPodResource;
     user: UserResource | null;
+    overrideChecks?: boolean;
   }
 ): Promise<boolean> {
-  if (await isPodDead(auth, pod, activationPod)) {
+  if (isPodDead(pod)) {
+    return false;
+  }
+
+  if (!(await hasActivePodOwnerMembership(auth, activationPod))) {
     return false;
   }
 
   if (user) {
-    const workspace = renderLightWorkspaceType({
-      workspace: auth.getNonNullableWorkspace(),
-    });
-    if (await isUserBlocked(workspace, user)) {
-      return false;
+    if (isCreditPricedWorkspace(auth)) {
+      const workspace = renderLightWorkspaceType({
+        workspace: auth.getNonNullableWorkspace(),
+      });
+      if (await isUserBlocked(workspace, user)) {
+        return false;
+      }
+    } else {
+      // Legacy plans: `seatType === "none"` is the backfill/default, not a
+      // block, so skip isUserBlocked. The matching conversation-posting gate
+      // is the non-CP spend cap when that flag is on.
+      const flags = await getFeatureFlags(auth);
+      if (
+        flags.includes("enforce_user_spend_limit_rate_cap") &&
+        (await isNonCreditPricedUserSpendLimitReached(auth, { user }))
+      ) {
+        return false;
+      }
     }
+  }
+
+  if (overrideChecks) {
+    return true;
+  }
+
+  if (auth.plan()?.isByok) {
+    return false;
   }
 
   const maxUnansweredCount = getActivationNudgeMaxUnansweredCount(auth);
@@ -192,8 +228,7 @@ function buildActivationNudgeContent(
  * executes under the target user's authenticator, so the agent sees exactly
  * what they can see, and they stay a participant of the conversation.
  *
- * Callers are expected to have gated on `isEligibleForNudge`, except for the
- * poke plugin, which nudges on demand.
+ * Callers are expected to have gated on `isEligibleForNudge`.
  */
 export async function postActivationNudge(
   auth: Authenticator,

--- a/front/lib/api/activation/orchestrator.test.ts
+++ b/front/lib/api/activation/orchestrator.test.ts
@@ -1,0 +1,133 @@
+import { determineEligibleActivationUsers } from "@app/lib/api/activation/orchestrator";
+import { Authenticator } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockEvaluateActivation } = vi.hoisted(() => ({
+  mockEvaluateActivation: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/activation/evaluator", () => ({
+  evaluateActivation: mockEvaluateActivation,
+}));
+
+function notActivated(userIds: string[]) {
+  return new Ok(
+    new Map(
+      userIds.map((userId) => [
+        userId,
+        {
+          activated: false,
+          hvucDays: 0,
+          hvucWeeks: 0,
+          minHvucDays: 6,
+          minDistinctWeeks: 3,
+          trailingWindowDays: 28,
+          evidence: { qualifyingDays: [], qualifyingWeeks: [] },
+        },
+      ])
+    )
+  );
+}
+
+beforeEach(() => {
+  mockEvaluateActivation.mockReset();
+  mockEvaluateActivation.mockImplementation(
+    async (_auth: unknown, { userIds }: { userIds: string[] }) =>
+      notActivated(userIds)
+  );
+});
+
+async function makeWorkspaceWithPod({ byok = false }: { byok?: boolean } = {}) {
+  const workspace = byok
+    ? await WorkspaceFactory.byok()
+    : await WorkspaceFactory.basic();
+  const owner = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, owner, { role: "admin" });
+
+  const { globalGroup, systemGroup } = await GroupFactory.defaults(workspace);
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId, {
+    dangerouslyRequestAllGroups: true,
+  });
+  await SpaceResource.makeDefaultsForWorkspace(auth, {
+    globalGroup,
+    systemGroup,
+  });
+
+  const pod = await SpaceFactory.project(workspace, owner.id);
+  await ProjectMetadataResource.makeNew(auth, pod, { description: null });
+  await ActivationPodResource.makeNew(auth, {
+    pod,
+    user: owner,
+  });
+
+  return { workspace, owner, auth };
+}
+
+describe("determineEligibleActivationUsers", () => {
+  it("includes the pod owner when they have an active membership", async () => {
+    const { owner, auth } = await makeWorkspaceWithPod();
+
+    const result = await determineEligibleActivationUsers(auth);
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.eligible.map((e) => e.targetUserId)).toEqual([
+      owner.sId,
+    ]);
+  });
+
+  it("skips a pod whose owner no longer has an active workspace membership", async () => {
+    const { workspace, owner, auth } = await makeWorkspaceWithPod();
+    await MembershipResource.revokeMembership({
+      user: owner,
+      workspace,
+      allowLastAdminRevocation: true,
+    });
+
+    const result = await determineEligibleActivationUsers(auth);
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.eligible).toEqual([]);
+  });
+
+  it("returns no candidates for a BYOK workspace", async () => {
+    const { auth } = await makeWorkspaceWithPod({ byok: true });
+
+    const result = await determineEligibleActivationUsers(auth);
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.eligible).toEqual([]);
+    expect(mockEvaluateActivation).not.toHaveBeenCalled();
+  });
+
+  it("includes the pod owner on a BYOK workspace when overrideChecks is set", async () => {
+    const { owner, auth } = await makeWorkspaceWithPod({ byok: true });
+
+    const result = await determineEligibleActivationUsers(auth, {
+      overrideChecks: true,
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value.eligible.map((e) => e.targetUserId)).toEqual([
+      owner.sId,
+    ]);
+    expect(mockEvaluateActivation).not.toHaveBeenCalled();
+  });
+});

--- a/front/lib/api/activation/orchestrator.ts
+++ b/front/lib/api/activation/orchestrator.ts
@@ -6,6 +6,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -29,57 +30,105 @@ type OrchestratorResult = {
   skipped: SkippedUser[];
 };
 
+type Candidate = { podId: string; spaceId: string; userId: string };
+
+function toNudgePlan(candidate: Candidate): NudgePlan {
+  return {
+    podId: candidate.podId,
+    spaceId: candidate.spaceId,
+    targetUserId: candidate.userId,
+  };
+}
+
 /**
  * Determines which users are eligible for activation based on the workspace and user filter
  */
 export async function determineEligibleActivationUsers(
   auth: Authenticator,
-  { userId, asOf }: { userId: string | null; asOf?: Date }
+  {
+    userIds = null,
+    asOf,
+    overrideChecks = false,
+  }: {
+    userIds?: string[] | null;
+    asOf?: Date;
+    overrideChecks?: boolean;
+  } = {}
 ): Promise<Result<OrchestratorResult, Error>> {
-  const workspaceId = auth.getNonNullableWorkspace().sId;
+  if (auth.plan()?.isByok && !overrideChecks) {
+    return new Ok({ eligible: [], skipped: [] });
+  }
+
+  const workspace = auth.getNonNullableWorkspace();
+  const workspaceId = workspace.sId;
 
   const pods = await ActivationPodResource.listForWorkspace(auth);
+  if (pods.length === 0) {
+    return new Ok({ eligible: [], skipped: [] });
+  }
 
   const spaces = await SpaceResource.fetchByModelIds(
     auth,
     pods.map((p) => p.spaceId)
   );
   const spaceByModelId = new Map(spaces.map((space) => [space.id, space]));
-  const membersBySpaceModelId =
-    await SpaceResource.fetchDistinctActiveManualGroupMembersBySpaces(
-      auth,
-      spaces
-    );
 
-  // Build the candidate (pod, member) list and the deduped set of user sIds to
-  // evaluate in a single batch.
-  const candidates: { podId: string; spaceId: string; userId: string }[] = [];
-  const userIds = new Set<string>();
+  const owners = await UserResource.fetchByModelIds([
+    ...new Set(pods.map((pod) => pod.userId)),
+  ]);
+  if (owners.length === 0) {
+    return new Ok({ eligible: [], skipped: [] });
+  }
+  const ownerByModelId = new Map(owners.map((owner) => [owner.id, owner]));
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users: owners,
+    workspace,
+  });
+  const activeOwnerModelIds = new Set(
+    memberships.map((membership) => membership.userId)
+  );
+
+  const userIdFilter = userIds === null ? null : new Set(userIds);
+
+  // One candidate per live pod: its owner, and only if they still have an
+  // active workspace membership. Extra space-group members are not nudged.
+  const candidates: Candidate[] = [];
+  const candidateUserIds = new Set<string>();
   for (const pod of pods) {
-    const space = spaceByModelId.get(pod.spaceId);
-    if (!space) {
+    if (!activeOwnerModelIds.has(pod.userId)) {
       continue;
     }
-    const members = membersBySpaceModelId.get(pod.spaceId) ?? [];
-    for (const member of members) {
-      if (userId !== null && member.sId !== userId) {
-        continue;
-      }
-      candidates.push({
-        podId: pod.sId,
-        spaceId: space.sId,
-        userId: member.sId,
-      });
-      userIds.add(member.sId);
+    const space = spaceByModelId.get(pod.spaceId);
+    const owner = ownerByModelId.get(pod.userId);
+    if (!space || !owner) {
+      continue;
     }
+    if (userIdFilter !== null && !userIdFilter.has(owner.sId)) {
+      continue;
+    }
+    candidates.push({
+      podId: pod.sId,
+      spaceId: space.sId,
+      userId: owner.sId,
+    });
+    candidateUserIds.add(owner.sId);
   }
 
   if (candidates.length === 0) {
     return new Ok({ eligible: [], skipped: [] });
   }
 
+  // Poke override skips activation-status entirely: no need to evaluate.
+  if (overrideChecks) {
+    return new Ok({
+      eligible: candidates.map(toNudgePlan),
+      skipped: [],
+    });
+  }
+
   const activationResult = await evaluateActivation(auth, {
-    userIds: Array.from(userIds),
+    userIds: Array.from(candidateUserIds),
     asOf,
   });
   if (activationResult.isErr()) {
@@ -118,11 +167,7 @@ export async function determineEligibleActivationUsers(
       });
       continue;
     }
-    eligible.push({
-      podId: candidate.podId,
-      spaceId: candidate.spaceId,
-      targetUserId: candidate.userId,
-    });
+    eligible.push(toNudgePlan(candidate));
   }
 
   return new Ok({ eligible, skipped });
@@ -143,7 +188,7 @@ export async function runActivationForWorkspace(
   const workspaceId = auth.getNonNullableWorkspace().sId;
 
   const planResult = await determineEligibleActivationUsers(auth, {
-    userId,
+    userIds: userId ? [userId] : null,
     asOf,
   });
   if (planResult.isErr()) {

--- a/front/lib/api/poke/plugins/spaces/activation_management.test.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.test.ts
@@ -10,17 +10,13 @@ import { Err, Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
-  mockPostActivationNudge,
   mockListActivationPodsByUser,
   mockStartActivationWorkspaceSchedule,
+  mockStartActivationWorkspaceWorkflow,
 } = vi.hoisted(() => ({
-  mockPostActivationNudge: vi.fn(),
   mockListActivationPodsByUser: vi.fn(),
   mockStartActivationWorkspaceSchedule: vi.fn(),
-}));
-
-vi.mock("@app/lib/api/activation/nudge", () => ({
-  postActivationNudge: mockPostActivationNudge,
+  mockStartActivationWorkspaceWorkflow: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/activation/pods", () => ({
@@ -29,17 +25,20 @@ vi.mock("@app/lib/api/activation/pods", () => ({
 
 vi.mock("@app/temporal/activation_scheduler/client", () => ({
   startActivationWorkspaceSchedule: mockStartActivationWorkspaceSchedule,
+  startActivationWorkspaceWorkflow: mockStartActivationWorkspaceWorkflow,
 }));
 
 beforeEach(async () => {
-  mockPostActivationNudge.mockReset();
   mockListActivationPodsByUser.mockReset();
   mockStartActivationWorkspaceSchedule.mockReset();
+  mockStartActivationWorkspaceWorkflow.mockReset();
 
-  mockPostActivationNudge.mockResolvedValue(new Ok({ conversationId: "conv" }));
   // No user has a pod yet, so every target is provisioned fresh.
   mockListActivationPodsByUser.mockResolvedValue(new Map());
   mockStartActivationWorkspaceSchedule.mockResolvedValue(new Ok(undefined));
+  mockStartActivationWorkspaceWorkflow.mockResolvedValue(
+    new Ok("activation-workspace-test-manual-1")
+  );
 
   // The canonical ActivationPod row is orthogonal to the schedule lifecycle
   // under test. Stub it out.
@@ -55,8 +54,14 @@ beforeEach(async () => {
   ).mockResolvedValue(new Ok(undefined));
 });
 
-async function makeWorkspaceWithEditor() {
-  const workspace = await WorkspaceFactory.basic();
+async function makeWorkspaceWithEditor({
+  byok = false,
+}: {
+  byok?: boolean;
+} = {}) {
+  const workspace = byok
+    ? await WorkspaceFactory.byok()
+    : await WorkspaceFactory.basic();
   const editor = await UserFactory.basic();
   await MembershipFactory.associate(workspace, editor, { role: "admin" });
 
@@ -75,8 +80,22 @@ async function makeWorkspaceWithEditor() {
   return { workspace, adminAuth, editor };
 }
 
+const pluginArgs = {
+  groupId: [] as string[],
+  sessionGoal: "",
+  pushedResource: [] as string[],
+  workAreas: "",
+  activationPlaybook: "",
+  targetingMode: ["users"] as string[],
+  guidance: ["curated"] as string[],
+  pctActivated: 0,
+  pctNotActivated: 0,
+  forceRecreate: false,
+  overrideChecks: false,
+};
+
 describe("activationManagementPlugin.execute", () => {
-  it("starts the workspace's Activation schedule once provisioning succeeds", async () => {
+  it("starts the workspace's Activation schedule and queues a Temporal workflow", async () => {
     const { workspace, adminAuth, editor } = await makeWorkspaceWithEditor();
     const workAreas =
       "Enterprise account planning — Prepare account plans for strategic customers.";
@@ -84,31 +103,82 @@ describe("activationManagementPlugin.execute", () => {
       "Prioritize actions that reduce time spent preparing account plans.";
 
     const result = await activationManagementPlugin.execute(adminAuth, null, {
+      ...pluginArgs,
       targetUserIds: [editor.sId],
-      groupId: [],
-      sessionGoal: "",
-      pushedResource: [],
       workAreas,
       activationPlaybook,
-      targetingMode: ["users"],
-      guidance: ["curated"],
-      pctActivated: 0,
-      pctNotActivated: 0,
-      forceRecreate: false,
     });
 
     expect(result.isOk()).toBe(true);
     expect(mockStartActivationWorkspaceSchedule).toHaveBeenCalledWith({
       workspaceId: workspace.sId,
     });
-    expect(mockPostActivationNudge).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(mockStartActivationWorkspaceWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
+        workspaceId: workspace.sId,
+        userIds: [editor.sId],
+        overrideChecks: false,
         context: expect.objectContaining({ workAreas, activationPlaybook }),
       })
     );
 
     expect(ActivationPodResource.makeNew).toHaveBeenCalled();
+  });
+
+  it("forwards overrideChecks to the Temporal workflow", async () => {
+    const { workspace, adminAuth, editor } = await makeWorkspaceWithEditor();
+
+    const result = await activationManagementPlugin.execute(adminAuth, null, {
+      ...pluginArgs,
+      targetUserIds: [editor.sId],
+      overrideChecks: true,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockStartActivationWorkspaceWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: workspace.sId,
+        userIds: [editor.sId],
+        overrideChecks: true,
+      })
+    );
+  });
+
+  it("refuses BYOK workspaces without provisioning or starting a workflow", async () => {
+    const { adminAuth, editor } = await makeWorkspaceWithEditor({ byok: true });
+
+    const result = await activationManagementPlugin.execute(adminAuth, null, {
+      ...pluginArgs,
+      targetUserIds: [editor.sId],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("BYOK");
+    }
+    expect(mockStartActivationWorkspaceSchedule).not.toHaveBeenCalled();
+    expect(mockStartActivationWorkspaceWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("starts a one-off workflow for a BYOK workspace when overrideChecks is set", async () => {
+    const { workspace, adminAuth, editor } = await makeWorkspaceWithEditor({
+      byok: true,
+    });
+
+    const result = await activationManagementPlugin.execute(adminAuth, null, {
+      ...pluginArgs,
+      targetUserIds: [editor.sId],
+      overrideChecks: true,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockStartActivationWorkspaceWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: workspace.sId,
+        userIds: [editor.sId],
+        overrideChecks: true,
+      })
+    );
   });
 
   it("returns Err and does not report success when starting the schedule fails", async () => {
@@ -118,22 +188,14 @@ describe("activationManagementPlugin.execute", () => {
     );
 
     const result = await activationManagementPlugin.execute(adminAuth, null, {
+      ...pluginArgs,
       targetUserIds: [editor.sId],
-      groupId: [],
-      sessionGoal: "",
-      pushedResource: [],
-      workAreas: "",
-      activationPlaybook: "",
-      targetingMode: ["users"],
-      guidance: ["curated"],
-      pctActivated: 0,
-      pctNotActivated: 0,
-      forceRecreate: false,
     });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.message).toContain("temporal unavailable");
     }
+    expect(mockStartActivationWorkspaceWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -3,7 +3,6 @@ import type {
   ActivationNudgeContext,
   ActivationNudgePushedResourceType,
 } from "@app/lib/api/activation/nudge";
-import { postActivationNudge } from "@app/lib/api/activation/nudge";
 import { listActivationPodsByUser } from "@app/lib/api/activation/pods";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
@@ -22,7 +21,10 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
-import { startActivationWorkspaceSchedule } from "@app/temporal/activation_scheduler/client";
+import {
+  startActivationWorkspaceSchedule,
+  startActivationWorkspaceWorkflow,
+} from "@app/temporal/activation_scheduler/client";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -80,9 +82,9 @@ function learningSpaceNameForCreator(
   return `${label}${LEARNING_SPACE_NAME_SUFFIX}`;
 }
 
-function cohortBucket(workspaceSId: string, userSId: string): number {
+function cohortBucket(workspaceSId: string, userId: string): number {
   const digest = createHash("sha256")
-    .update(`${workspaceSId}:${userSId}`)
+    .update(`${workspaceSId}:${userId}`)
     .digest();
   return digest.readUInt32BE(0) % 100;
 }
@@ -248,7 +250,8 @@ async function provisionTrainingPod(
 
 type TargetOutcome = {
   name: string;
-  status: "provisioned" | "recreated" | "nudged" | "failed";
+  userId: string;
+  status: "provisioned" | "recreated" | "queued" | "failed";
   podLink?: string;
   message?: string;
 };
@@ -264,8 +267,10 @@ export const activationManagementPlugin = createPlugin({
       "them an async nudge — a message that opens a guided conversation moving " +
       "them one concrete step forward. " +
       "Use this tool to drive that by hand. Each user without a Pod gets one provisioned. " +
-      "Each user who already has one is reused, then " +
-      "everyone selected is nudged with the Session Goal. Use Work Areas to seed the user's " +
+      "Each user who already has one is reused, then the selected users are queued into " +
+      "the activation Temporal workflow so the same eligibility gates as the daily " +
+      "scheduler apply, and the nudge is sent immediately rather than waiting for " +
+      "a workday slot. Use Work Areas to seed the user's " +
       "Work Areas for the first conversation. Check 'Force " +
       "recreate' to delete and rebuild an existing Pod from scratch. " +
       "Use 'Who to target' to pick specific users, a group, or a deterministic " +
@@ -393,7 +398,17 @@ export const activationManagementPlugin = createPlugin({
         description:
           "Danger: when checked, any existing Pod for a selected user is " +
           "deleted (its space is scrubbed) and rebuilt from scratch before " +
-          "nudging. Leave unchecked to reuse existing Pods.",
+          "queuing a nudge. Leave unchecked to reuse existing Pods.",
+        defaultValue: false,
+      },
+      overrideChecks: {
+        type: "boolean",
+        label: "Override eligibility checks",
+        description:
+          "When checked, skip the frequency cap, unanswered-nudge limit, " +
+          "activation-status filter, BYOK skip, and per-run user cap for this " +
+          "run only. Daily schedules still apply every gate. Membership and " +
+          "credit/seat blocks still apply.",
         defaultValue: false,
       },
     },
@@ -457,9 +472,16 @@ export const activationManagementPlugin = createPlugin({
       pctActivated,
       pctNotActivated,
       forceRecreate,
+      overrideChecks,
     }
   ) => {
     const workspace = auth.getNonNullableWorkspace();
+
+    if (auth.plan()?.isByok && !overrideChecks) {
+      return new Err(
+        new Error("BYOK workspaces cannot be nudged by Activation.")
+      );
+    }
 
     const mode = targetingMode?.[0] ?? "users";
 
@@ -594,26 +616,14 @@ export const activationManagementPlugin = createPlugin({
       const existing = existingPodsByUser.get(user.id);
 
       // Reuse path: the user already has a Pod and we're not recreating it —
-      // just nudge it. Never fails on an existing Pod.
+      // queue them for the shared Temporal workflow.
       if (existing && !forceRecreate) {
-        const nudgeResult = await postActivationNudge(adminAuth, {
-          pod: existing.pod,
-          activationPod: existing.activationPod,
-          context,
+        outcomes.push({
+          name,
+          userId: user.sId,
+          status: "queued",
+          podLink: podLink(existing.pod),
         });
-        if (nudgeResult.isErr()) {
-          outcomes.push({
-            name,
-            status: "failed",
-            message: nudgeResult.error.message,
-          });
-        } else {
-          outcomes.push({
-            name,
-            status: "nudged",
-            podLink: podLink(existing.pod),
-          });
-        }
         continue;
       }
 
@@ -631,6 +641,7 @@ export const activationManagementPlugin = createPlugin({
         if (deleteResult.isErr()) {
           outcomes.push({
             name,
+            userId: user.sId,
             status: "failed",
             message: `failed to delete existing Pod: ${deleteResult.error.message}`,
           });
@@ -646,30 +657,17 @@ export const activationManagementPlugin = createPlugin({
       if (provisionResult.isErr()) {
         outcomes.push({
           name,
+          userId: user.sId,
           status: "failed",
           message: provisionResult.error.message,
         });
         continue;
       }
 
-      const { pod, activationPod } = provisionResult.value;
-      const nudgeResult = await postActivationNudge(adminAuth, {
-        pod,
-        activationPod,
-        context,
-      });
-      if (nudgeResult.isErr()) {
-        outcomes.push({
-          name,
-          status: "failed",
-          message: `${recreated ? "recreated" : "provisioned"} but failed to nudge: ${nudgeResult.error.message}`,
-          podLink: podLink(pod),
-        });
-        continue;
-      }
-
+      const { pod } = provisionResult.value;
       outcomes.push({
         name,
+        userId: user.sId,
         status: recreated ? "recreated" : "provisioned",
         podLink: podLink(pod),
       });
@@ -677,8 +675,27 @@ export const activationManagementPlugin = createPlugin({
 
     const provisioned = outcomes.filter((o) => o.status === "provisioned");
     const recreated = outcomes.filter((o) => o.status === "recreated");
-    const nudged = outcomes.filter((o) => o.status === "nudged");
+    const queued = outcomes.filter((o) => o.status === "queued");
     const failed = outcomes.filter((o) => o.status === "failed");
+    const toNudge = outcomes.filter((o) => o.status !== "failed");
+
+    let workflowId: string | null = null;
+    if (toNudge.length > 0) {
+      const workflowResult = await startActivationWorkspaceWorkflow({
+        workspaceId: workspace.sId,
+        userIds: toNudge.map((o) => o.userId),
+        overrideChecks: Boolean(overrideChecks),
+        context,
+      });
+      if (workflowResult.isErr()) {
+        return new Err(
+          new Error(
+            `Provisioned users but failed to start the activation workflow: ${workflowResult.error.message}`
+          )
+        );
+      }
+      workflowId = workflowResult.value;
+    }
 
     activationManagementLogger.info(
       {
@@ -687,11 +704,13 @@ export const activationManagementPlugin = createPlugin({
         targetCount: users.length,
         provisionedCount: provisioned.length,
         recreatedCount: recreated.length,
-        nudgedCount: nudged.length,
+        queuedCount: queued.length,
         failedCount: failed.length,
         forceRecreate: Boolean(forceRecreate),
+        overrideChecks: Boolean(overrideChecks),
         pushedResourceType: context.pushedResourceType,
         hasSessionGoal: context.sessionGoal !== null,
+        workflowId,
       },
       "Ran Activation Management via poke"
     );
@@ -707,6 +726,11 @@ export const activationManagementPlugin = createPlugin({
       `Processed ${users.length} user(s)` +
         (focus.length > 0 ? ` — ${focus.join(", ")}.` : ".")
     );
+    if (workflowId) {
+      lines.push(
+        `Queued ${toNudge.length} user(s) into activation workflow \`${workflowId}\`.`
+      );
+    }
     lines.push("");
     for (const outcome of outcomes) {
       const suffix = outcome.podLink ? ` ([Pod](${outcome.podLink}))` : "";
@@ -717,12 +741,7 @@ export const activationManagementPlugin = createPlugin({
       }
     }
 
-    if (
-      failed.length > 0 &&
-      provisioned.length === 0 &&
-      recreated.length === 0 &&
-      nudged.length === 0
-    ) {
+    if (failed.length > 0 && toNudge.length === 0) {
       return new Err(new Error(lines.join("\n")));
     }
 

--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -1,3 +1,4 @@
+import type { ActivationNudgeContext } from "@app/lib/api/activation/nudge";
 import {
   isEligibleForNudge,
   postActivationNudge,
@@ -14,6 +15,8 @@ import { ensureActivationWorkspaceSchedules } from "@app/temporal/activation_sch
 import {
   ACTIVATION_WORKDAY_WINDOW_MINUTES,
   ACTIVATION_WORKDAY_WINDOW_START_MINUTES,
+  applyActivationNudgePerRunCap,
+  DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN,
 } from "@app/temporal/activation_scheduler/config";
 import { getNudgeSlotAtMs } from "@app/temporal/activation_scheduler/slots";
 
@@ -28,15 +31,19 @@ export type EligiblePodNudge = {
 /**
  * Enumerates every (pod, target user) still eligible for activation in the
  * workspace, gates each on `isEligibleForNudge`, and assigns the eligible
- * ones a deterministic slot within the regional workday window. This is the
- * planning step: it does not send anything, since state can go stale between
- * this pass (run once at the start of the workday) and a pod's actual slot
- * later in the day.
+ * ones a deterministic slot within the regional workday window. Targeted
+ * one-offs (`userIds` set, i.e. poke) skip the window and fire immediately.
+ * This is the planning step: it does not send anything, since state can go
+ * stale between this pass and a pod's actual slot later in the day.
  */
 export async function enumerateEligiblePodsForNudgeActivity({
   workspaceId,
+  userIds = null,
+  overrideChecks = false,
 }: {
   workspaceId: string;
+  userIds?: string[] | null;
+  overrideChecks?: boolean;
 }): Promise<EligiblePodNudge[]> {
   // Activation conversations live in Pods, which are restricted spaces: request
   // all groups so admin auth can read/write them.
@@ -45,7 +52,8 @@ export async function enumerateEligiblePodsForNudgeActivity({
   });
 
   const planResult = await determineEligibleActivationUsers(auth, {
-    userId: null,
+    userIds: userIds ?? null,
+    overrideChecks,
   });
   if (planResult.isErr()) {
     throw planResult.error;
@@ -102,7 +110,14 @@ export async function enumerateEligiblePodsForNudgeActivity({
       }
 
       const user = userBySId.get(candidate.targetUserId) ?? null;
-      if (!(await isEligibleForNudge(auth, { pod, activationPod, user }))) {
+      if (
+        !(await isEligibleForNudge(auth, {
+          pod,
+          activationPod,
+          user,
+          overrideChecks,
+        }))
+      ) {
         logger.info(
           { workspaceId, spaceId: pod.sId, userId: candidate.targetUserId },
           "[ActivationScheduler] Pod is not eligible for a nudge, skipping."
@@ -113,19 +128,36 @@ export async function enumerateEligiblePodsForNudgeActivity({
       eligiblePods.push({
         podId: pod.sId,
         targetUserId: candidate.targetUserId,
-        slotAtMs: getNudgeSlotAtMs({
-          podModelId: pod.id,
-          timezone,
-          windowStartMinutes: ACTIVATION_WORKDAY_WINDOW_START_MINUTES,
-          windowMinutes: ACTIVATION_WORKDAY_WINDOW_MINUTES,
-          now,
-        }),
+        slotAtMs:
+          userIds != null
+            ? now.getTime()
+            : getNudgeSlotAtMs({
+                podModelId: pod.id,
+                timezone,
+                windowStartMinutes: ACTIVATION_WORKDAY_WINDOW_START_MINUTES,
+                windowMinutes: ACTIVATION_WORKDAY_WINDOW_MINUTES,
+                now,
+              }),
       });
     },
     { concurrency: ACTIVATION_PODS_CONCURRENCY }
   );
 
-  return eligiblePods.sort((a, b) => a.slotAtMs - b.slotAtMs);
+  const sorted = eligiblePods.sort((a, b) => a.slotAtMs - b.slotAtMs);
+  if (
+    !overrideChecks &&
+    sorted.length > DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN
+  ) {
+    logger.info(
+      {
+        workspaceId,
+        eligibleCount: sorted.length,
+        cap: DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN,
+      },
+      "[ActivationScheduler] Capping this run to the per-workflow user limit."
+    );
+  }
+  return applyActivationNudgePerRunCap(sorted, { overrideChecks });
 }
 
 /**
@@ -140,10 +172,14 @@ export async function reGateAndNudgePodActivity({
   workspaceId,
   podId,
   targetUserId,
+  overrideChecks = false,
+  context = null,
 }: {
   workspaceId: string;
   podId: string;
   targetUserId: string;
+  overrideChecks?: boolean;
+  context?: ActivationNudgeContext | null;
 }): Promise<void> {
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
     dangerouslyRequestAllGroups: true,
@@ -176,6 +212,7 @@ export async function reGateAndNudgePodActivity({
       pod,
       activationPod,
       user: user ?? null,
+      overrideChecks,
     }))
   ) {
     logger.info(
@@ -185,7 +222,11 @@ export async function reGateAndNudgePodActivity({
     return;
   }
 
-  const result = await postActivationNudge(auth, { pod, activationPod });
+  const result = await postActivationNudge(auth, {
+    pod,
+    activationPod,
+    ...(context ? { context } : {}),
+  });
   if (result.isErr()) {
     logger.error(
       {

--- a/front/temporal/activation_scheduler/client.ts
+++ b/front/temporal/activation_scheduler/client.ts
@@ -1,11 +1,14 @@
 import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
+import { Authenticator } from "@app/lib/auth";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { ActivationWorkspaceWorkflowArgs } from "@app/temporal/activation_scheduler/types";
 import type { Result } from "@app/types/shared/result";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import {
   ScheduleAlreadyRunning,
   ScheduleNotFoundError,
@@ -45,6 +48,15 @@ export async function startActivationWorkspaceSchedule({
 }: {
   workspaceId: string;
 }): Promise<Result<undefined, Error>> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  if (auth.plan()?.isByok) {
+    logger.info(
+      { workspaceId },
+      "[ActivationScheduler] Skipping schedule for BYOK workspace."
+    );
+    return new Ok(undefined);
+  }
+
   const client = await getTemporalClientForFrontNamespace();
   const region = config.getCurrentRegion();
   const timezone = REGION_TIMEZONES[region];
@@ -150,6 +162,39 @@ export async function triggerActivationWorkspaceWorkflow({
   logger.info(
     { workflowId, workspaceId },
     "[ActivationScheduler] Triggered workspace workflow."
+  );
+  return new Ok(workflowId);
+}
+
+/**
+ * One-off poke/admin run against the same workflow function as the daily
+ * schedule, but a distinct workflow id so it cannot no-op against an in-flight
+ * workday run. `overrideChecks` skips cadence, activation-status, BYOK, and
+ * the per-run user cap; membership and credit still apply.
+ */
+export async function startActivationWorkspaceWorkflow(
+  args: ActivationWorkspaceWorkflowArgs
+): Promise<Result<string, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = `${makeWorkspaceWorkflowId(args.workspaceId)}-manual-${Date.now()}`;
+
+  try {
+    await client.workflow.start(activationWorkspaceWorkflow, {
+      args: [args],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+    });
+  } catch (e) {
+    logger.error(
+      { workflowId, workspaceId: args.workspaceId, error: e },
+      "[ActivationScheduler] Failed starting on-demand workspace workflow."
+    );
+    return new Err(normalizeError(e));
+  }
+
+  logger.info(
+    { workflowId, workspaceId: args.workspaceId },
+    "[ActivationScheduler] Started on-demand workspace workflow."
   );
   return new Ok(workflowId);
 }

--- a/front/temporal/activation_scheduler/config.test.ts
+++ b/front/temporal/activation_scheduler/config.test.ts
@@ -1,0 +1,24 @@
+import {
+  applyActivationNudgePerRunCap,
+  DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN,
+} from "@app/temporal/activation_scheduler/config";
+import { describe, expect, it } from "vitest";
+
+describe("applyActivationNudgePerRunCap", () => {
+  const items = Array.from(
+    { length: DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN + 3 },
+    (_, i) => i
+  );
+
+  it("slices to the per-run cap", () => {
+    expect(
+      applyActivationNudgePerRunCap(items, { overrideChecks: false })
+    ).toEqual(items.slice(0, DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN));
+  });
+
+  it("does not slice when overrideChecks is set", () => {
+    expect(
+      applyActivationNudgePerRunCap(items, { overrideChecks: true })
+    ).toEqual(items);
+  });
+});

--- a/front/temporal/activation_scheduler/config.ts
+++ b/front/temporal/activation_scheduler/config.ts
@@ -15,3 +15,17 @@ export const DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS = 2;
 // nudge fired) after which the scheduler stops nudging a pod. Workspaces can
 // override this via the `activationNudgeMaxUnansweredCount` metadata key.
 export const DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT = 3;
+
+// Max users a single activation workspace workflow may nudge. Applied when
+// enumerating the run; poke can skip it via overrideChecks.
+export const DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN = 100;
+
+export function applyActivationNudgePerRunCap<T>(
+  items: T[],
+  { overrideChecks }: { overrideChecks: boolean }
+): T[] {
+  if (overrideChecks) {
+    return items;
+  }
+  return items.slice(0, DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN);
+}

--- a/front/temporal/activation_scheduler/types.ts
+++ b/front/temporal/activation_scheduler/types.ts
@@ -1,0 +1,14 @@
+export type ActivationNudgeWorkflowContext = {
+  sessionGoal: string | null;
+  pushedResourceType: "skill" | "agent" | null;
+  pushedResourceName: string | null;
+  workAreas: string | null;
+  activationPlaybook: string | null;
+};
+
+export type ActivationWorkspaceWorkflowArgs = {
+  workspaceId: string;
+  userIds?: string[] | null;
+  overrideChecks?: boolean;
+  context?: ActivationNudgeWorkflowContext | null;
+};

--- a/front/temporal/activation_scheduler/workflows.ts
+++ b/front/temporal/activation_scheduler/workflows.ts
@@ -1,4 +1,5 @@
 import type * as activities from "@app/temporal/activation_scheduler/activities";
+import type { ActivationWorkspaceWorkflowArgs } from "@app/temporal/activation_scheduler/types";
 import { proxyActivities, setHandler, sleep } from "@temporalio/workflow";
 
 import { runActivationSignal } from "./signals";
@@ -13,27 +14,35 @@ const {
 
 /**
  * Workspace-level workflow: one per workspace, triggered by the workspace's
- * Temporal Schedule at the start of the regional workday, and restartable
- * on demand via `signalWithStart` against the same deterministic workflow id
- * (see client.ts) so poke/admin-forced cycles go through this same code path.
+ * Temporal Schedule at the start of the regional workday. Poke/admin-forced
+ * cycles start a separate run (distinct workflow id) against this same
+ * function so every send goes through the same gates.
  *
  * Enumerates and gates every Activation Pod once, then visits each eligible
  * pod at its deterministic slot within the regional workday window,
  * re-gating right before sending since state (opt-out, credit, frequency cap)
  * can go stale between the morning enumeration and the pod's slot later in
- * the day.
+ * the day. Poke one-offs pass `userIds` and fire immediately.
+ *
+ * Extra activity fields are omitted when they match the pre-existing
+ * defaults so in-flight scheduled runs replay with the same payloads.
  */
 export async function activationWorkspaceWorkflow({
   workspaceId,
-}: {
-  workspaceId: string;
-}): Promise<void> {
+  userIds = null,
+  overrideChecks = false,
+  context = null,
+}: ActivationWorkspaceWorkflowArgs): Promise<void> {
   setHandler(runActivationSignal, () => {
     // Empty handler: signalWithStart only needs this to (re)start the
     // workflow when it isn't already running for this workspace.
   });
 
-  const pods = await enumerateEligiblePodsForNudgeActivity({ workspaceId });
+  const pods = await enumerateEligiblePodsForNudgeActivity({
+    workspaceId,
+    ...(userIds != null ? { userIds } : {}),
+    ...(overrideChecks ? { overrideChecks } : {}),
+  });
 
   for (const pod of pods) {
     const sleepMs = pod.slotAtMs - Date.now();
@@ -45,6 +54,8 @@ export async function activationWorkspaceWorkflow({
       workspaceId,
       podId: pod.podId,
       targetUserId: pod.targetUserId,
+      ...(overrideChecks ? { overrideChecks } : {}),
+      ...(context ? { context } : {}),
     });
   }
 }


### PR DESCRIPTION
## Summary
Activation poke used to post the nudge itself, so it skipped the checks the daily job uses (membership, BYOK, cadence, already-activated, etc.).

Poke now only creates or reuses the Learning Space, then starts a one-off Temporal run of the same workflow as the daily scheduler. The nudge goes out through that workflow.

Always enforced (even with the poke override checkbox):

Pod is not archived
Owner still has an active workspace membership
User is not credit/seat blocked (or over the legacy spend cap)

Skipped only when “Override eligibility checks” is checked:
BYOK workspaces
Frequency cap / unanswered-nudge limit
Already-activated users
100-user cap for that run
Daily runs are unchanged: they still spread nudges across the workday. Poke runs send immediately. Scheduled workflow arguments are unchanged so in-flight daily runs don’t break on deploy.

## Testing
1. Triggered poke
2. Confirmed it started temporal workflow with required checks

## Risk
Low (adding more governance around nudge behavior)

## Deploy
1. Deploy front