### PR TITLE
[front] enh: add theme selector to Poke

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -94,10 +94,10 @@ function PokeNavbar({ regionUrls, showRegionPicker = false }: PokeNavbarProps) {
         </div>
       </div>
       <div className="items-right flex items-center gap-4">
+        <PokeThemeSelector />
         <PokeFavoriteButton />
         {showRegionPicker && <PokeRegionDropdown regionUrls={regionUrls} />}
         <PokeSearchCommand />
-        <PokeThemeSelector />
       </div>
     </nav>
   );

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -3,6 +3,7 @@ import {
   PokeFavoritesCommandGroups,
 } from "@app/components/poke/PokeFavorites";
 import { PokeRegionDropdown } from "@app/components/poke/PokeRegionDropdown";
+import { PokeThemeSelector } from "@app/components/poke/PokeThemeSelector";
 import {
   PokeCommandDialog,
   PokeCommandInput,
@@ -96,6 +97,7 @@ function PokeNavbar({ regionUrls, showRegionPicker = false }: PokeNavbarProps) {
         <PokeFavoriteButton />
         {showRegionPicker && <PokeRegionDropdown regionUrls={regionUrls} />}
         <PokeSearchCommand />
+        <PokeThemeSelector />
       </div>
     </nav>
   );

--- a/front/components/poke/PokeThemeSelector.test.tsx
+++ b/front/components/poke/PokeThemeSelector.test.tsx
@@ -1,0 +1,82 @@
+import { PokeThemeSelector } from "@app/components/poke/PokeThemeSelector";
+import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+describe("PokeThemeSelector", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove("dark");
+
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it("selects and persists the Poke theme", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ThemeProvider>
+        <PokeThemeSelector />
+      </ThemeProvider>
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Theme: System" })
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Theme: System" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "Light" }));
+
+    await waitFor(() => {
+      expect(localStorage.getItem("theme")).toBe("light");
+    });
+    expect(
+      screen.getByRole("button", { name: "Theme: Light" })
+    ).toBeInTheDocument();
+    expect(document.documentElement).not.toHaveClass("dark");
+
+    await user.click(screen.getByRole("button", { name: "Theme: Light" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "Dark" }));
+
+    await waitFor(() => {
+      expect(localStorage.getItem("theme")).toBe("dark");
+    });
+    expect(
+      screen.getByRole("button", { name: "Theme: Dark" })
+    ).toBeInTheDocument();
+    expect(document.documentElement).toHaveClass("dark");
+
+    await user.click(screen.getByRole("button", { name: "Theme: Dark" }));
+    await user.click(screen.getByRole("menuitemradio", { name: "System" }));
+
+    await waitFor(() => {
+      expect(localStorage.getItem("theme")).toBe("system");
+    });
+    expect(
+      screen.getByRole("button", { name: "Theme: System" })
+    ).toBeInTheDocument();
+    expect(document.documentElement).not.toHaveClass("dark");
+  });
+});

--- a/front/components/poke/PokeThemeSelector.test.tsx
+++ b/front/components/poke/PokeThemeSelector.test.tsx
@@ -47,6 +47,9 @@ describe("PokeThemeSelector", () => {
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Theme: System" }));
+    expect(
+      screen.getAllByRole("menuitemradio").map((item) => item.textContent)
+    ).toEqual(["System", "Light", "Dark"]);
     await user.click(screen.getByRole("menuitemradio", { name: "Light" }));
 
     await waitFor(() => {

--- a/front/components/poke/PokeThemeSelector.test.tsx
+++ b/front/components/poke/PokeThemeSelector.test.tsx
@@ -43,43 +43,44 @@ describe("PokeThemeSelector", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Theme: System" })
-    ).toBeInTheDocument();
+      screen.getAllByRole("tab").map((item) => item.getAttribute("aria-label"))
+    ).toEqual(["Light theme", "System theme", "Dark theme"]);
+    expect(screen.getByRole("tab", { name: "System theme" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
 
-    await user.click(screen.getByRole("button", { name: "Theme: System" }));
-    expect(
-      screen.getAllByRole("menuitemradio").map((item) => item.textContent)
-    ).toEqual(["System", "Light", "Dark"]);
-    await user.click(screen.getByRole("menuitemradio", { name: "Light" }));
+    await user.click(screen.getByRole("tab", { name: "Light theme" }));
 
     await waitFor(() => {
       expect(localStorage.getItem("theme")).toBe("light");
     });
-    expect(
-      screen.getByRole("button", { name: "Theme: Light" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Light theme" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
     expect(document.documentElement).not.toHaveClass("dark");
 
-    await user.click(screen.getByRole("button", { name: "Theme: Light" }));
-    await user.click(screen.getByRole("menuitemradio", { name: "Dark" }));
+    await user.click(screen.getByRole("tab", { name: "Dark theme" }));
 
     await waitFor(() => {
       expect(localStorage.getItem("theme")).toBe("dark");
     });
-    expect(
-      screen.getByRole("button", { name: "Theme: Dark" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Dark theme" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
     expect(document.documentElement).toHaveClass("dark");
 
-    await user.click(screen.getByRole("button", { name: "Theme: Dark" }));
-    await user.click(screen.getByRole("menuitemradio", { name: "System" }));
+    await user.click(screen.getByRole("tab", { name: "System theme" }));
 
     await waitFor(() => {
       expect(localStorage.getItem("theme")).toBe("system");
     });
-    expect(
-      screen.getByRole("button", { name: "Theme: System" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "System theme" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
     expect(document.documentElement).not.toHaveClass("dark");
   });
 });

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -33,7 +33,10 @@ export function PokeThemeSelector() {
       size="sm"
       value={theme}
       onValueChange={handleThemeChange}
-      style={{ background: "transparent", borderColor: "transparent" }}
+      style={{
+        background: "transparent",
+        borderColor: "color-mix(in oklch, var(--color-brand) 80%, black)",
+      }}
     >
       {THEME_ORDER.map((themeOption) => {
         const option = THEME_OPTIONS[themeOption];

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -44,6 +44,7 @@ export function PokeThemeSelector() {
             icon={option.icon}
             aria-label={`${option.label} theme`}
             tooltip={`${option.label} theme`}
+            className="bg-none after:hidden hover:bg-transparent active:bg-transparent dark:hover:bg-transparent dark:active:bg-transparent"
           />
         );
       })}

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -1,0 +1,65 @@
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+  Monitor01,
+  Moon01,
+  Sun,
+} from "@dust-tt/sparkle";
+
+const THEME_OPTIONS = {
+  light: { label: "Light", icon: Sun },
+  system: { label: "System", icon: Monitor01 },
+  dark: { label: "Dark", icon: Moon01 },
+} as const;
+
+const THEME_ORDER = ["light", "system", "dark"] as const;
+
+export function PokeThemeSelector() {
+  const { theme, setTheme } = useTheme();
+  const currentTheme = THEME_OPTIONS[theme];
+
+  const handleThemeChange = (newTheme: string) => {
+    switch (newTheme) {
+      case "light":
+      case "system":
+      case "dark":
+        setTheme(newTheme);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          icon={currentTheme.icon}
+          label={currentTheme.label}
+          aria-label={`Theme: ${currentTheme.label}`}
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuRadioGroup value={theme} onValueChange={handleThemeChange}>
+          {THEME_ORDER.map((themeOption) => {
+            const option = THEME_OPTIONS[themeOption];
+
+            return (
+              <DropdownMenuRadioItem
+                key={themeOption}
+                value={themeOption}
+                icon={option.icon}
+                label={option.label}
+              />
+            );
+          })}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -33,6 +33,7 @@ export function PokeThemeSelector() {
       size="sm"
       value={theme}
       onValueChange={handleThemeChange}
+      style={{ background: "transparent" }}
     >
       {THEME_ORDER.map((themeOption) => {
         const option = THEME_OPTIONS[themeOption];

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -1,11 +1,7 @@
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
+  ButtonsSwitch,
+  ButtonsSwitchList,
   Monitor01,
   Moon01,
   Sun,
@@ -17,11 +13,10 @@ const THEME_OPTIONS = {
   dark: { label: "Dark", icon: Moon01 },
 } as const;
 
-const THEME_ORDER = ["system", "light", "dark"] as const;
+const THEME_ORDER = ["light", "system", "dark"] as const;
 
 export function PokeThemeSelector() {
   const { theme, setTheme } = useTheme();
-  const currentTheme = THEME_OPTIONS[theme];
 
   const handleThemeChange = (newTheme: string) => {
     switch (newTheme) {
@@ -33,33 +28,25 @@ export function PokeThemeSelector() {
   };
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size="sm"
-          icon={currentTheme.icon}
-          label={currentTheme.label}
-          aria-label={`Theme: ${currentTheme.label}`}
-          isSelect
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuRadioGroup value={theme} onValueChange={handleThemeChange}>
-          {THEME_ORDER.map((themeOption) => {
-            const option = THEME_OPTIONS[themeOption];
+    <ButtonsSwitchList
+      aria-label="Theme"
+      size="sm"
+      value={theme}
+      onValueChange={handleThemeChange}
+    >
+      {THEME_ORDER.map((themeOption) => {
+        const option = THEME_OPTIONS[themeOption];
 
-            return (
-              <DropdownMenuRadioItem
-                key={themeOption}
-                value={themeOption}
-                icon={option.icon}
-                label={option.label}
-              />
-            );
-          })}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        return (
+          <ButtonsSwitch
+            key={themeOption}
+            value={themeOption}
+            icon={option.icon}
+            aria-label={`${option.label} theme`}
+            tooltip={`${option.label} theme`}
+          />
+        );
+      })}
+    </ButtonsSwitchList>
   );
 }

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -44,7 +44,8 @@ export function PokeThemeSelector() {
             icon={option.icon}
             aria-label={`${option.label} theme`}
             tooltip={`${option.label} theme`}
-            className="bg-none after:hidden hover:bg-transparent active:bg-transparent dark:hover:bg-transparent dark:active:bg-transparent"
+            className="after:hidden"
+            style={{ background: "transparent" }}
           />
         );
       })}

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -45,7 +45,7 @@ export function PokeThemeSelector() {
             icon={option.icon}
             aria-label={`${option.label} theme`}
             tooltip={`${option.label} theme`}
-            className="after:hidden"
+            className="border-transparent text-muted-foreground shadow-none after:hidden aria-selected:text-foreground [&_svg]:drop-shadow-none"
             style={{ background: "transparent" }}
           />
         );

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -33,7 +33,7 @@ export function PokeThemeSelector() {
       size="sm"
       value={theme}
       onValueChange={handleThemeChange}
-      style={{ background: "transparent" }}
+      style={{ background: "transparent", borderColor: "transparent" }}
     >
       {THEME_ORDER.map((themeOption) => {
         const option = THEME_OPTIONS[themeOption];

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -45,7 +45,7 @@ export function PokeThemeSelector() {
             icon={option.icon}
             aria-label={`${option.label} theme`}
             tooltip={`${option.label} theme`}
-            className="border-transparent text-muted-foreground shadow-none after:hidden aria-selected:text-foreground [&_svg]:drop-shadow-none"
+            className="border-transparent text-muted-foreground shadow-none after:hidden hover:text-foreground aria-selected:text-foreground [&_svg]:drop-shadow-none"
             style={{ background: "transparent" }}
           />
         );

--- a/front/components/poke/PokeThemeSelector.tsx
+++ b/front/components/poke/PokeThemeSelector.tsx
@@ -17,7 +17,7 @@ const THEME_OPTIONS = {
   dark: { label: "Dark", icon: Moon01 },
 } as const;
 
-const THEME_ORDER = ["light", "system", "dark"] as const;
+const THEME_ORDER = ["system", "light", "dark"] as const;
 
 export function PokeThemeSelector() {
   const { theme, setTheme } = useTheme();


### PR DESCRIPTION
## Description

I did remember that poke had a light theme, but could not change back to it anywhere, turns out it's not possible (keeps the system theme by default).

This PR adds a theme selector to the top-right navbar.

<img width="297" height="114" alt="image" src="https://github.com/user-attachments/assets/85d5e9bd-b9d3-4251-96be-3aee5b547395" />

## Tests

- Added a small test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
