### PR TITLE
chore: make the members table bulk selection reusable

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -25,7 +25,7 @@ import { UsageNotificationsCard } from "@app/components/workspace/usage/UsageNot
 import { UsageProgrammaticLimitCard } from "@app/components/workspace/usage/UsageProgrammaticLimitCard";
 import { UsageSettingsCard } from "@app/components/workspace/usage/UsageSettingsCard";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
-import { useMembersSelection } from "@app/hooks/useMembersSelection";
+import { useTableRowsSelection } from "@app/hooks/useTableRowsSelection";
 import {
   cycleElapsedPercent,
   DEFAULT_CONSUMPTION_PERIOD,
@@ -622,7 +622,7 @@ export function UsagePage() {
     () => membersUsage.map((m) => m.sId),
     [membersUsage]
   );
-  const selection = useMembersSelection({
+  const selection = useTableRowsSelection({
     pageItemIds,
     totalCount: totalMembersUsage,
     resetKey: `${searchTerm}|${seatTypeFilter ?? ""}|${groupFilter ?? ""}`,
@@ -663,7 +663,7 @@ export function UsagePage() {
   const buildBulkSelectionBody = useCallback((): BulkMemberSelectionBody => {
     const descriptor = selection.descriptor();
     return descriptor.mode === "ids"
-      ? descriptor
+      ? { mode: "ids" as const, userIds: descriptor.ids }
       : {
           mode: "all" as const,
           filter: {
@@ -671,7 +671,7 @@ export function UsagePage() {
             groupId: groupFilter ?? undefined,
             search: searchTerm.trim() || undefined,
           },
-          excludeUserIds: descriptor.excludeUserIds,
+          excludeUserIds: descriptor.excludedIds,
         };
   }, [selection, seatTypeFilter, groupFilter, searchTerm]);
 
@@ -726,8 +726,8 @@ export function UsagePage() {
   const getBulkPendingMemberIds = useCallback((): string[] => {
     const descriptor = selection.descriptor();
     return descriptor.mode === "ids"
-      ? descriptor.userIds
-      : pageItemIds.filter((id) => !descriptor.excludeUserIds.includes(id));
+      ? descriptor.ids
+      : pageItemIds.filter((id) => !descriptor.excludedIds.includes(id));
   }, [selection, pageItemIds]);
 
   const handleBulkSpendLimitValidate = useCallback(

--- a/front/components/shared/TableSelectionBanner.tsx
+++ b/front/components/shared/TableSelectionBanner.tsx
@@ -1,0 +1,74 @@
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import {
+  ContentMessageAction,
+  ContentMessageInline,
+  Hoverable,
+} from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+interface TableSelectionBannerProps {
+  selectedCount: number;
+  pageCount: number;
+  totalCount: number;
+  itemLabel: string;
+  isAllAcrossPagesSelected: boolean;
+  hasMorePagesToSelect: boolean;
+  onSelectAllAcrossPages: () => void;
+  onClear: () => void;
+  disabled?: boolean;
+  // ContentMessageAction elements, rendered after "Clear".
+  children: ReactNode;
+}
+
+export function TableSelectionBanner({
+  selectedCount,
+  pageCount,
+  totalCount,
+  itemLabel,
+  isAllAcrossPagesSelected,
+  hasMorePagesToSelect,
+  onSelectAllAcrossPages,
+  onClear,
+  disabled = false,
+  children,
+}: TableSelectionBannerProps) {
+  if (selectedCount === 0) {
+    return null;
+  }
+
+  return (
+    <ContentMessageInline variant="info">
+      <div className="flex flex-row flex-wrap items-center gap-x-2 gap-y-1">
+        {isAllAcrossPagesSelected ? (
+          <span>
+            {selectedCount} {itemLabel}
+            {pluralize(selectedCount)} are selected.
+          </span>
+        ) : hasMorePagesToSelect ? (
+          <>
+            <span>
+              All {pageCount} {itemLabel}
+              {pluralize(pageCount)} on this page are selected.
+            </span>
+            <Hoverable variant="highlight" onClick={onSelectAllAcrossPages}>
+              Select all {totalCount} {itemLabel}
+              {pluralize(totalCount)}
+            </Hoverable>
+          </>
+        ) : (
+          <span>
+            {selectedCount} {itemLabel}
+            {pluralize(selectedCount)} selected
+          </span>
+        )}
+      </div>
+      <ContentMessageAction
+        variant="ghost"
+        label="Clear"
+        onClick={onClear}
+        disabled={disabled}
+      />
+      {children}
+    </ContentMessageInline>
+  );
+}

--- a/front/components/workspace/MembersSelectionBanner.tsx
+++ b/front/components/workspace/MembersSelectionBanner.tsx
@@ -1,8 +1,5 @@
-import {
-  ContentMessageAction,
-  ContentMessageInline,
-  Hoverable,
-} from "@dust-tt/sparkle";
+import { TableSelectionBanner } from "@app/components/shared/TableSelectionBanner";
+import { ContentMessageAction } from "@dust-tt/sparkle";
 
 interface MembersSelectionBannerProps {
   selectedCount: number;
@@ -18,10 +15,6 @@ interface MembersSelectionBannerProps {
   disabled?: boolean;
 }
 
-function membersLabel(count: number): string {
-  return count === 1 ? "member" : "members";
-}
-
 export function MembersSelectionBanner({
   selectedCount,
   pageCount,
@@ -34,39 +27,18 @@ export function MembersSelectionBanner({
   onBatchChangeSeat,
   disabled = false,
 }: MembersSelectionBannerProps) {
-  if (selectedCount === 0) {
-    return null;
-  }
-
   return (
-    <ContentMessageInline variant="info">
-      <div className="flex flex-row flex-wrap items-center gap-x-2 gap-y-1">
-        {isAllAcrossPagesSelected ? (
-          <span>
-            {selectedCount} {membersLabel(selectedCount)} are selected.
-          </span>
-        ) : hasMorePagesToSelect ? (
-          <>
-            <span>
-              All {pageCount} {membersLabel(pageCount)} on this page are
-              selected.
-            </span>
-            <Hoverable variant="highlight" onClick={onSelectAllAcrossPages}>
-              Select all {totalCount} {membersLabel(totalCount)}
-            </Hoverable>
-          </>
-        ) : (
-          <span>
-            {selectedCount} {membersLabel(selectedCount)} selected
-          </span>
-        )}
-      </div>
-      <ContentMessageAction
-        variant="ghost"
-        label="Clear"
-        onClick={onClear}
-        disabled={disabled}
-      />
+    <TableSelectionBanner
+      selectedCount={selectedCount}
+      pageCount={pageCount}
+      totalCount={totalCount}
+      itemLabel="member"
+      isAllAcrossPagesSelected={isAllAcrossPagesSelected}
+      hasMorePagesToSelect={hasMorePagesToSelect}
+      onSelectAllAcrossPages={onSelectAllAcrossPages}
+      onClear={onClear}
+      disabled={disabled}
+    >
       {onBatchChangeSeat && (
         <ContentMessageAction
           variant="primary"
@@ -81,6 +53,6 @@ export function MembersSelectionBanner({
         onClick={onBatchEditSpendLimit}
         disabled={disabled}
       />
-    </ContentMessageInline>
+    </TableSelectionBanner>
   );
 }

--- a/front/hooks/useTableRowsSelection.ts
+++ b/front/hooks/useTableRowsSelection.ts
@@ -1,17 +1,17 @@
 import type { RowSelectionState } from "@tanstack/react-table";
 import { useCallback, useMemo, useState } from "react";
 
-type MembersSelection =
+type TableRowsSelection =
   | { mode: "ids"; ids: Set<string> }
   | { mode: "all"; excludedIds: Set<string> };
 
-type MembersSelectionDescriptor =
-  | { mode: "ids"; userIds: string[] }
-  | { mode: "all"; excludeUserIds: string[] };
+export type TableRowsSelectionDescriptor =
+  | { mode: "ids"; ids: string[] }
+  | { mode: "all"; excludedIds: string[] };
 
-const EMPTY_SELECTION: MembersSelection = { mode: "ids", ids: new Set() };
+const EMPTY_SELECTION: TableRowsSelection = { mode: "ids", ids: new Set() };
 
-export function useMembersSelection({
+export function useTableRowsSelection({
   pageItemIds,
   totalCount,
   resetKey,
@@ -20,7 +20,8 @@ export function useMembersSelection({
   totalCount: number;
   resetKey: string;
 }) {
-  const [selection, setSelection] = useState<MembersSelection>(EMPTY_SELECTION);
+  const [selection, setSelection] =
+    useState<TableRowsSelection>(EMPTY_SELECTION);
 
   // Reset during render when the filter identity changes (the React-recommended
   // alternative to an effect for adjusting state on input change).
@@ -92,11 +93,11 @@ export function useMembersSelection({
     setSelection(EMPTY_SELECTION);
   }, []);
 
-  const descriptor = useCallback((): MembersSelectionDescriptor => {
+  const descriptor = useCallback((): TableRowsSelectionDescriptor => {
     if (selection.mode === "all") {
-      return { mode: "all", excludeUserIds: [...selection.excludedIds] };
+      return { mode: "all", excludedIds: [...selection.excludedIds] };
     }
-    return { mode: "ids", userIds: [...selection.ids] };
+    return { mode: "ids", ids: [...selection.ids] };
   }, [selection]);
 
   return {


### PR DESCRIPTION
## Description

The cross-page checkbox selection built for the members usage table was hardcoded to members. `useMembersSelection` becomes `useTableRowsSelection` with a generic id descriptor, and the banner is split into a generic `TableSelectionBanner` that `MembersSelectionBanner` now wraps.
No behavior change on `/w/:wId/usage`. This lays the groundwork for bulk edit on the automations table, which comes in the PR stacked on top of this one.

Lays out the ground work for #30919 

## Tests

Manually on `/w/:wId/usage`: select rows on a page, select all across pages, clear, and run both batch actions (role and spend limit). Same wording, same counts, same requests as before.

## Risk

Low. Renames and an extraction, no logic moved. The members page is the only consumer, and a regression there would be visible immediately in the selection banner.

## Deploy Plan

Deploy front.