### PR TITLE
[front] Wait for model activity cancellation before finalization

### DIFF
--- a/front/temporal/agent_loop/workflows.test.ts
+++ b/front/temporal/agent_loop/workflows.test.ts
@@ -1,19 +1,28 @@
 import type { AuthenticatorType } from "@app/lib/auth";
-import { runSandboxChildToolWorkflow } from "@app/temporal/agent_loop/workflows";
+import {
+  agentLoopWorkflow,
+  runSandboxChildToolWorkflow,
+} from "@app/temporal/agent_loop/workflows";
 import type { AgentLoopArgsWithTiming } from "@app/types/assistant/agent_run";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   patched,
   finalizeErroredSandboxChildToolActivity,
+  finalizeSuccessfulAgentLoopActivity,
   runToolActivity,
   runRetryableToolActivity,
+  runModelAndCreateActionsActivity,
+  runModelAndCreateActionsActivityWithExplicitCancellation,
   publishDeferredEventsActivity,
 } = vi.hoisted(() => ({
   patched: vi.fn(),
   finalizeErroredSandboxChildToolActivity: vi.fn(),
+  finalizeSuccessfulAgentLoopActivity: vi.fn(),
   runToolActivity: vi.fn(),
   runRetryableToolActivity: vi.fn(),
+  runModelAndCreateActionsActivity: vi.fn(),
+  runModelAndCreateActionsActivityWithExplicitCancellation: vi.fn(),
   publishDeferredEventsActivity: vi.fn(),
 }));
 
@@ -28,6 +37,12 @@ vi.mock("@temporalio/workflow", () => {
       static nonCancellable<T>(fn: () => Promise<T>) {
         return fn();
       }
+
+      run<T>(fn: () => Promise<T>) {
+        return fn();
+      }
+
+      cancel() {}
     },
     defineSignal: (name: string) => name,
     patched,
@@ -45,9 +60,12 @@ vi.mock("@temporalio/workflow", () => {
       finalizeErroredSandboxChildToolActivity,
       finalizeGracefullyStoppedAgentLoopActivity: unusedActivity,
       finalizeInterruptedAgentLoopActivity: unusedActivity,
-      finalizeSuccessfulAgentLoopActivity: unusedActivity,
+      finalizeSuccessfulAgentLoopActivity,
       publishDeferredEventsActivity,
-      runModelAndCreateActionsActivity: unusedActivity,
+      runModelAndCreateActionsActivity:
+        options.cancellationType === undefined
+          ? runModelAndCreateActionsActivity
+          : runModelAndCreateActionsActivityWithExplicitCancellation,
       runToolActivity:
         options.cancellationType === undefined &&
         options.retry?.maximumAttempts === 1
@@ -65,7 +83,10 @@ vi.mock("@temporalio/workflow", () => {
     }),
     setHandler: vi.fn(),
     startChild: vi.fn(),
-    workflowInfo: vi.fn(),
+    workflowInfo: vi.fn(() => ({
+      memo: {},
+      searchAttributes: {},
+    })),
   };
 });
 
@@ -197,5 +218,55 @@ describe("runSandboxChildToolWorkflow", () => {
     ).rejects.toBe(error);
 
     expect(finalizeErroredSandboxChildToolActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("agentLoopWorkflow model activity cancellation patch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const modelResult = {
+      actionBlobs: [],
+      runId: "run-1",
+    };
+    runModelAndCreateActionsActivity.mockResolvedValue(modelResult);
+    runModelAndCreateActionsActivityWithExplicitCancellation.mockResolvedValue(
+      modelResult
+    );
+    finalizeSuccessfulAgentLoopActivity.mockResolvedValue(undefined);
+  });
+
+  it("keeps the legacy model activity for old histories", async () => {
+    patched.mockImplementation(
+      (patchId: string) =>
+        patchId !== "wait-for-model-activity-before-finalization"
+    );
+
+    await agentLoopWorkflow({
+      agentLoopArgs: { ...agentLoopArgs, conversationTitle: "Existing" },
+      authType,
+      initialStartTime: 0,
+      startStep: 0,
+    });
+
+    expect(runModelAndCreateActionsActivity).toHaveBeenCalledOnce();
+    expect(
+      runModelAndCreateActionsActivityWithExplicitCancellation
+    ).not.toHaveBeenCalled();
+  });
+
+  it("waits for explicit model activity cancellation for new histories", async () => {
+    patched.mockReturnValue(true);
+
+    await agentLoopWorkflow({
+      agentLoopArgs: { ...agentLoopArgs, conversationTitle: "Existing" },
+      authType,
+      initialStartTime: 0,
+      startStep: 0,
+    });
+
+    expect(
+      runModelAndCreateActionsActivityWithExplicitCancellation
+    ).toHaveBeenCalledOnce();
+    expect(runModelAndCreateActionsActivity).not.toHaveBeenCalled();
   });
 });

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -83,6 +83,19 @@ const { runModelAndCreateActionsActivity } = proxyActivities<
   },
 });
 
+const {
+  runModelAndCreateActionsActivity:
+    runModelAndCreateActionsActivityWithExplicitCancellation,
+} = proxyActivities<typeof runModelAndCreateWrapperActivities>({
+  startToCloseTimeout: "10 minutes",
+  heartbeatTimeout: MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
+  cancellationType: ActivityCancellationType.WAIT_CANCELLATION_COMPLETED,
+  retry: {
+    maximumAttempts: RUN_MODEL_MAX_RETRIES,
+    backoffCoefficient: 1,
+  },
+});
+
 const { runToolActivity } = proxyActivities<typeof runToolActivities>({
   // Activity timeout keeps a short buffer above the tool timeout to detect worker restarts promptly.
   startToCloseTimeout: toolActivityStartToCloseTimeoutMs,
@@ -468,7 +481,13 @@ async function executeStepIteration({
   shouldContinue: boolean;
   retryWithoutTools?: boolean;
 }> {
-  const result = await runModelAndCreateActionsActivity({
+  const runModelActivity = patched(
+    "wait-for-model-activity-before-finalization"
+  )
+    ? runModelAndCreateActionsActivityWithExplicitCancellation
+    : runModelAndCreateActionsActivity;
+
+  const result = await runModelActivity({
     authType,
     checkForResume: currentStep === startStep, // Only run resume the first time.
     runAgentArgs: agentLoopArgs,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
When an agent loop is interrupted while `runModelAndCreateActionsActivity` is still running, Temporal's default `TRY_CANCEL` behavior lets the workflow schedule `finalizeInterruptedAgentLoopActivity` before the model activity has acknowledged cancellation and completed its usage cleanup.

This is the model-activity equivalent of #30530. In the diagnosed production history, cancellation was requested for the model activity and the interruption finalizer was scheduled immediately. The run usage was reported only after finalization completed.

I'll clean both patches (the one from the previous PR and this one, in a follow up PR).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->