### PR TITLE
[front] feat: add Poke consumption analytics endpoints

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/facets.ts
@@ -1,0 +1,46 @@
+import type { GetConsumptionFacetsResponse } from "@app/lib/api/analytics/consumption/facets";
+import { fetchConsumptionFacets } from "@app/lib/api/analytics/consumption/facets";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  ConsumptionBodySchema,
+  toConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/schema";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+// Mounted at /api/poke/workspaces/:wId/analytics/consumption/facets.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", ConsumptionBodySchema),
+  async (ctx): HandlerResult<GetConsumptionFacetsResponse> => {
+    const auth = ctx.get("auth");
+    const { filter, ...periodInput } = ctx.req.valid("json");
+    const period = await resolveConsumptionPeriod(
+      auth,
+      toConsumptionPeriodInput(periodInput)
+    );
+
+    const result = await fetchConsumptionFacets(auth, { period, filter });
+    if (result.isErr()) {
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to retrieve consumption facets.",
+          },
+        },
+        result.error
+      );
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/index.ts
@@ -1,0 +1,29 @@
+import { pokeApp } from "@front-api/middlewares/ctx";
+
+import facets from "./facets";
+import overview from "./overview";
+import timeseries from "./timeseries";
+import topAgents from "./top-agents";
+import topApiKeys from "./top-api-keys";
+import topGroups from "./top-groups";
+import topModels from "./top-models";
+import topSkills from "./top-skills";
+import topSources from "./top-sources";
+import topTools from "./top-tools";
+import topUsers from "./top-users";
+
+const app = pokeApp();
+
+app.route("/facets", facets);
+app.route("/overview", overview);
+app.route("/timeseries", timeseries);
+app.route("/top-agents", topAgents);
+app.route("/top-api-keys", topApiKeys);
+app.route("/top-groups", topGroups);
+app.route("/top-models", topModels);
+app.route("/top-skills", topSkills);
+app.route("/top-sources", topSources);
+app.route("/top-tools", topTools);
+app.route("/top-users", topUsers);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/overview.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/overview.ts
@@ -1,0 +1,44 @@
+import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
+import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/overview";
+import {
+  ConsumptionBodySchema,
+  toConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/schema";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+// Mounted at /api/poke/workspaces/:wId/analytics/consumption/overview.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", ConsumptionBodySchema),
+  async (ctx): HandlerResult<GetConsumptionOverviewResponse> => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const result = await fetchConsumptionOverview(auth, {
+      periodInput: toConsumptionPeriodInput(body),
+      filter: body.filter,
+    });
+    if (result.isErr()) {
+      return apiError(
+        ctx,
+        {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to retrieve overview.",
+          },
+        },
+        result.error
+      );
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/timeseries.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/timeseries.ts
@@ -5,21 +5,16 @@ import {
 } from "@app/lib/api/analytics/consumption/schema";
 import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
 import { fetchConsumptionTimeseries } from "@app/lib/api/analytics/consumption/timeseries";
-import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
-export type { GetConsumptionTimeseriesResponse };
-
-// Mounted at /api/w/:wId/analytics/consumption/timeseries.
-const app = workspaceApp();
+// Mounted at /api/poke/workspaces/:wId/analytics/consumption/timeseries.
+const app = pokeApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTimeseriesBodySchema),
   async (ctx): HandlerResult<GetConsumptionTimeseriesResponse> => {
     const auth = ctx.get("auth");
@@ -48,20 +43,17 @@ app.post(
       filter,
     });
     if (result.isErr()) {
-      logger.error(
+      return apiError(
+        ctx,
         {
-          workspaceId: auth.getNonNullableWorkspace().sId,
-          err: result.error,
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to retrieve timeseries.",
+          },
         },
-        "[ConsumptionAnalytics] Failed to retrieve timeseries."
+        result.error
       );
-      return apiError(ctx, {
-        status_code: 500,
-        api_error: {
-          type: "internal_server_error",
-          message: "Failed to retrieve timeseries.",
-        },
-      });
     }
 
     return ctx.json(result.value);

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-agents.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-agents.ts
@@ -1,0 +1,10 @@
+import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
+
+import { createConsumptionTopRoute } from "./top";
+
+const app = createConsumptionTopRoute({
+  fetcher: fetchConsumptionTopAgents,
+  failureMessage: "Failed to retrieve top agents.",
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-api-keys.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-api-keys.ts
@@ -1,0 +1,10 @@
+import { fetchConsumptionTopApiKeys } from "@app/lib/api/analytics/consumption/top_api_keys";
+
+import { createConsumptionTopRoute } from "./top";
+
+const app = createConsumptionTopRoute({
+  fetcher: fetchConsumptionTopApiKeys,
+  failureMessage: "Failed to retrieve top API keys.",
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-groups.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-groups.ts
@@ -1,0 +1,10 @@
+import { fetchConsumptionTopGroups } from "@app/lib/api/analytics/consumption/top_groups";
+
+import { createConsumptionTopRoute } from "./top";
+
+const app = createConsumptionTopRoute({
+  fetcher: fetchConsumptionTopGroups,
+  failureMessage: "Failed to retrieve top groups.",
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-models.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-models.ts
@@ -1,0 +1,10 @@
+import { fetchConsumptionTopModels } from "@app/lib/api/analytics/consumption/top_models";
+
+import { createConsumptionTopRoute } from "./top";
+
+const app = createConsumptionTopRoute({
+  fetcher: fetchConsumptionTopModels,
+  failureMessage: "Failed to retrieve top models.",
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-skills.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-skills.ts
@@ -1,0 +1,10 @@
+import { fetchConsumptionTopSkills } from "@app/lib/api/analytics/consumption/top_skills";
+
+import { createConsumptionTopRoute } from "./top";
+
+const app = createConsumptionTopRoute({
+  fetcher: fetchConsumptionTopSkills,
+  failureMessage: "Failed to retrieve top skills.",
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-sources.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-sources.ts
@@ -1,0 +1,10 @@
+import { fetchConsumptionTopSources } from "@app/lib/api/analytics/consumption/top_sources";
+
+import { createConsumptionTopRoute } from "./top";
+
+const app = createConsumptionTopRoute({
+  fetcher: fetchConsumptionTopSources,
+  failureMessage: "Failed to retrieve top sources.",
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-tools.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-tools.ts
@@ -1,0 +1,10 @@
+import { fetchConsumptionTopTools } from "@app/lib/api/analytics/consumption/top_tools";
+
+import { createConsumptionTopRoute } from "./top";
+
+const app = createConsumptionTopRoute({
+  fetcher: fetchConsumptionTopTools,
+  failureMessage: "Failed to retrieve top tools.",
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-users.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top-users.ts
@@ -1,0 +1,10 @@
+import { fetchConsumptionTopUsers } from "@app/lib/api/analytics/consumption/top_users";
+
+import { createConsumptionTopRoute } from "./top";
+
+const app = createConsumptionTopRoute({
+  fetcher: fetchConsumptionTopUsers,
+  failureMessage: "Failed to retrieve top users.",
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/consumption/top.ts
@@ -1,0 +1,98 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  ConsumptionTopBodySchema,
+  toConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/schema";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
+import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
+import type { GetConsumptionTopApiKeysResponse } from "@app/lib/api/analytics/consumption/top_api_keys";
+import type { GetConsumptionTopGroupsResponse } from "@app/lib/api/analytics/consumption/top_groups";
+import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
+import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";
+import type { GetConsumptionTopSourcesResponse } from "@app/lib/api/analytics/consumption/top_sources";
+import type { GetConsumptionTopToolsResponse } from "@app/lib/api/analytics/consumption/top_tools";
+import type { GetConsumptionTopUsersResponse } from "@app/lib/api/analytics/consumption/top_users";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import type { Result } from "@app/types/shared/result";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+type ConsumptionTopResponse =
+  | GetConsumptionTopAgentsResponse
+  | GetConsumptionTopApiKeysResponse
+  | GetConsumptionTopGroupsResponse
+  | GetConsumptionTopModelsResponse
+  | GetConsumptionTopSkillsResponse
+  | GetConsumptionTopSourcesResponse
+  | GetConsumptionTopToolsResponse
+  | GetConsumptionTopUsersResponse;
+
+type ConsumptionTopFetcher = (
+  auth: Authenticator,
+  input: {
+    period: ConsumptionPeriod;
+    limit: number;
+    offset?: number;
+    search?: string;
+    filter?: ConsumptionScopeFilter;
+    sortOrder?: ConsumptionTopSortOrder;
+  }
+) => Promise<Result<ConsumptionTopResponse, ElasticsearchError>>;
+
+export function createConsumptionTopRoute({
+  fetcher,
+  failureMessage,
+}: {
+  fetcher: ConsumptionTopFetcher;
+  failureMessage: string;
+}) {
+  const app = pokeApp();
+
+  /** @ignoreswagger */
+  app.post(
+    "/",
+    validate("json", ConsumptionTopBodySchema),
+    async (ctx): HandlerResult<ConsumptionTopResponse> => {
+      const auth = ctx.get("auth");
+      const { limit, offset, search, filter, sortOrder, ...periodQuery } =
+        ctx.req.valid("json");
+
+      const period = await resolveConsumptionPeriod(
+        auth,
+        toConsumptionPeriodInput(periodQuery)
+      );
+
+      const result = await fetcher(auth, {
+        period,
+        limit,
+        offset,
+        search,
+        filter,
+        sortOrder,
+      });
+      if (result.isErr()) {
+        return apiError(
+          ctx,
+          {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: failureMessage,
+            },
+          },
+          result.error
+        );
+      }
+
+      return ctx.json(result.value);
+    }
+  );
+
+  return app;
+}

--- a/front-api/routes/poke/workspaces/[wId]/analytics/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/analytics/index.ts
@@ -2,6 +2,7 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 
 import activeUsers from "./active-users";
 import awuUsageAnalytics from "./awu-usage-analytics";
+import consumption from "./consumption";
 import programmaticCost from "./programmatic-cost";
 import usageMetrics from "./usage-metrics";
 
@@ -9,6 +10,7 @@ const app = pokeApp();
 
 app.route("/active-users", activeUsers);
 app.route("/awu-usage-analytics", awuUsageAnalytics);
+app.route("/consumption", consumption);
 app.route("/programmatic-cost", programmaticCost);
 app.route("/usage-metrics", usageMetrics);
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -1,8 +1,11 @@
 import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/period";
 import {
+  CONSUMPTION_METRICS,
+  CONSUMPTION_SCOPE_DIMENSIONS,
   CONSUMPTION_SCOPE_FILTER_KEYS,
   CONSUMPTION_TOP_SORT_ORDER,
+  DEFAULT_CONSUMPTION_METRIC,
 } from "@app/lib/api/analytics/consumption/scope";
 import { z } from "zod";
 
@@ -34,6 +37,29 @@ export const ConsumptionBodySchema = ConsumptionPeriodSchema.extend({
 });
 
 export type ConsumptionBody = z.infer<typeof ConsumptionBodySchema>;
+
+export const DEFAULT_CONSUMPTION_BREAKDOWN_COUNT = 10;
+
+export const ConsumptionTimeseriesBodySchema = ConsumptionBodySchema.extend({
+  granularity: z.enum(["day", "week", "month"]).optional().default("day"),
+  mode: z.enum(["daily", "cumulative"]).optional().default("daily"),
+  metric: z
+    .enum(CONSUMPTION_METRICS)
+    .optional()
+    .default(DEFAULT_CONSUMPTION_METRIC),
+  breakdownBy: z.enum(CONSUMPTION_SCOPE_DIMENSIONS).optional(),
+  breakdownCount: z
+    .number()
+    .int()
+    .positive()
+    .max(50)
+    .optional()
+    .default(DEFAULT_CONSUMPTION_BREAKDOWN_COUNT),
+});
+
+export type ConsumptionTimeseriesBody = z.infer<
+  typeof ConsumptionTimeseriesBodySchema
+>;
 
 // Every `top-*` endpoint takes the same body as any other consumption
 // endpoint, plus how many rows to rank.

--- a/front/lib/api/analytics/consumption/timeseries.ts
+++ b/front/lib/api/analytics/consumption/timeseries.ts
@@ -1,4 +1,5 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { DEFAULT_CONSUMPTION_BREAKDOWN_COUNT } from "@app/lib/api/analytics/consumption/schema";
 import type {
   ConsumptionGroupBucket,
   ConsumptionMetric,
@@ -25,6 +26,8 @@ import { Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
 import { resolveDimensionDisplayNames } from "./labels";
 
+export { DEFAULT_CONSUMPTION_BREAKDOWN_COUNT } from "@app/lib/api/analytics/consumption/schema";
+
 export type ConsumptionGranularity = "day" | "week" | "month";
 export type ConsumptionTimeseriesMode = "daily" | "cumulative";
 
@@ -33,8 +36,6 @@ export const TOTAL_GROUP_KEY = "total";
 export const OTHERS_GROUP_KEY = "others";
 
 export type ConsumptionBreakdownDimension = ConsumptionScopeDimension;
-
-export const DEFAULT_CONSUMPTION_BREAKDOWN_COUNT = 10;
 
 export type ConsumptionTimeseriesGroup = {
   groupKey: string;


### PR DESCRIPTION
## Description

The end goal of this PR and a few PRs that will follow is to give a way for us to both inspect what the users will see in the analytics page and to use them for monitoring workspace health and adoption patterns.

This PR adds the relevant endpoints, all more or less mimicking the existing ones, only scoped to poke (super admins) but querying data from the target workspace.

The UI is added in a follow up PR (some work required to share the components a bit better).

## Tests

- Tested locally.

## Risk

- Low. Additive internal endpoints.

## Deploy Plan

- Deploy front.
