### PR TITLE
[front] refactor: extract reusable consumption analytics UI components

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -62,49 +62,49 @@ const WORKSPACE_CONSUMPTION_COMPONENTS: AnalyticsConsumptionComponents = {
   UsageFilterPanel,
 };
 
-function ChartFallback() {
-  return (
-    <div aria-hidden="true" className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <LoadingBlock className="h-5 w-28" />
-        <div className="rounded-2xl border border-border-dark bg-background p-1">
-          <LoadingBlock className="h-8 w-36 rounded-xl" />
-        </div>
-      </div>
-      <div className="rounded-lg border border-border bg-background p-4">
-        <div className="border-b border-border pb-3">
-          <LoadingBlock className="h-6 w-36" />
-        </div>
-        <LoadingBlock
-          className="mt-3 w-full"
-          style={{ height: CHART_HEIGHT }}
-        />
-        <div className="mt-3 flex h-5 items-center gap-6">
-          <LoadingBlock className="h-4 w-32" />
-          <LoadingBlock className="h-4 w-36" />
-        </div>
-      </div>
-    </div>
-  );
+interface ChartFallbackProps {
+  controlsInCard?: boolean;
 }
 
-function PokeChartFallback() {
-  return (
+function ChartFallback({ controlsInCard = false }: ChartFallbackProps) {
+  const controls = (
+    <div className="rounded-2xl border border-border-dark bg-background p-1">
+      <LoadingBlock className="h-8 w-36 rounded-xl" />
+    </div>
+  );
+  const chart = (
     <div
       aria-hidden="true"
       className="rounded-lg border border-border bg-background p-4"
     >
-      <div className="flex items-center justify-between gap-4 border-b border-border pb-3">
+      <div
+        className={cn(
+          "border-b border-border pb-3",
+          controlsInCard && "flex items-center justify-between gap-4"
+        )}
+      >
         <LoadingBlock className="h-6 w-36" />
-        <div className="rounded-2xl border border-border-dark bg-background p-1">
-          <LoadingBlock className="h-8 w-36 rounded-xl" />
-        </div>
+        {controlsInCard && controls}
       </div>
       <LoadingBlock className="mt-3 w-full" style={{ height: CHART_HEIGHT }} />
       <div className="mt-3 flex h-5 items-center gap-6">
         <LoadingBlock className="h-4 w-32" />
         <LoadingBlock className="h-4 w-36" />
       </div>
+    </div>
+  );
+
+  if (controlsInCard) {
+    return chart;
+  }
+
+  return (
+    <div aria-hidden="true" className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <LoadingBlock className="h-5 w-28" />
+        {controls}
+      </div>
+      {chart}
     </div>
   );
 }
@@ -237,7 +237,7 @@ export function AnalyticsConsumptionContent({
             className="flex flex-col"
           >
             <SafeSuspense
-              fallback={embedded ? <PokeChartFallback /> : <ChartFallback />}
+              fallback={<ChartFallback controlsInCard={embedded} />}
             >
               <ChartComponent
                 workspaceId={owner.sId}

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -1,10 +1,15 @@
 import { CHART_HEIGHT } from "@app/components/charts/constants";
+import type { ConsumptionAttributionTableProps } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
+import type { ConsumptionChartProps } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
+import type { ConsumptionOverviewProps } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import type { ConsumptionSummaryProps } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
 import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
 import { consumptionDimensionFromQueryParam } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import type { UsageFilterPanelProps } from "@app/components/workspace/analytics/UsageFilterPanel";
 import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
 import { UsageFilterSummary } from "@app/components/workspace/analytics/UsageFilterSummary";
 import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
@@ -19,6 +24,7 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useFeatureFlags, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   cn,
   LoadingBlock,
@@ -27,17 +33,34 @@ import {
   safeLazy,
 } from "@dust-tt/sparkle";
 import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
+import type { ComponentType, ReactNode } from "react";
 import { useMemo, useState } from "react";
 
 const canReload = () => !isNavigationLocked();
 
-const ConsumptionChart = safeLazy(
+const LazyConsumptionChart = safeLazy(
   () =>
     import(
       "@app/components/workspace/analytics/consumption/ConsumptionChart"
     ).then((mod) => ({ default: mod.ConsumptionChart })),
   { canReload }
 );
+
+export interface AnalyticsConsumptionComponents {
+  AttributionTable: ComponentType<ConsumptionAttributionTableProps>;
+  Chart: ComponentType<ConsumptionChartProps>;
+  Overview: ComponentType<ConsumptionOverviewProps>;
+  Summary: ComponentType<ConsumptionSummaryProps>;
+  UsageFilterPanel: ComponentType<UsageFilterPanelProps>;
+}
+
+const WORKSPACE_CONSUMPTION_COMPONENTS: AnalyticsConsumptionComponents = {
+  AttributionTable: ConsumptionAttributionTable,
+  Chart: LazyConsumptionChart,
+  Overview: ConsumptionOverview,
+  Summary: ConsumptionSummary,
+  UsageFilterPanel,
+};
 
 function ChartFallback() {
   return (
@@ -65,22 +88,32 @@ function ChartFallback() {
   );
 }
 
+function PokeChartFallback() {
+  return (
+    <div
+      aria-hidden="true"
+      className="rounded-lg border border-border bg-background p-4"
+    >
+      <div className="flex items-center justify-between gap-4 border-b border-border pb-3">
+        <LoadingBlock className="h-6 w-36" />
+        <div className="rounded-2xl border border-border-dark bg-background p-1">
+          <LoadingBlock className="h-8 w-36 rounded-xl" />
+        </div>
+      </div>
+      <LoadingBlock className="mt-3 w-full" style={{ height: CHART_HEIGHT }} />
+      <div className="mt-3 flex h-5 items-center gap-6">
+        <LoadingBlock className="h-4 w-32" />
+        <LoadingBlock className="h-4 w-36" />
+      </div>
+    </div>
+  );
+}
+
 export function AnalyticsConsumptionPage() {
   const owner = useWorkspace();
   const { hasFeature } = useFeatureFlags();
   const isEnabled = hasFeature("enable_analytics_consumption");
-  const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
-    DEFAULT_CONSUMPTION_PERIOD
-  );
-  const { dimension: dimensionParam } = useQueryParams(["dimension"]);
-  const dimension = consumptionDimensionFromQueryParam(dimensionParam.value);
-  const [filter, setFilter] = useState<UsageFilter>({});
-  const scopeFilter = useMemo(() => toConsumptionScopeFilter(filter), [filter]);
-  const shouldReduceMotion = useReducedMotion();
-
-  const handleDimensionChange = (nextDimension: ConsumptionDimension) => {
-    dimensionParam.setParam(nextDimension);
-  };
+  const state = useAnalyticsConsumptionState();
 
   if (!isEnabled) {
     return (
@@ -100,34 +133,99 @@ export function AnalyticsConsumptionPage() {
     );
   }
 
+  return <AnalyticsConsumptionContent owner={owner} state={state} />;
+}
+
+interface AnalyticsConsumptionContentProps {
+  components?: AnalyticsConsumptionComponents;
+  embedded?: boolean;
+  headerBadge?: ReactNode;
+  owner: LightWorkspaceType;
+  showExport?: boolean;
+  showMemberGroupFilter?: boolean;
+  showOverviewError?: boolean;
+  state: AnalyticsConsumptionState;
+  title?: string;
+  usageHref?: string;
+  usageLinkLabel?: string;
+}
+
+export function AnalyticsConsumptionContent({
+  components = WORKSPACE_CONSUMPTION_COMPONENTS,
+  embedded = false,
+  headerBadge,
+  owner,
+  showExport = true,
+  showMemberGroupFilter = true,
+  showOverviewError = false,
+  state,
+  title = "Analytics",
+  usageHref = `/w/${owner.sId}/usage`,
+  usageLinkLabel,
+}: AnalyticsConsumptionContentProps) {
+  const {
+    dimension,
+    filter,
+    handleDimensionChange,
+    period,
+    scopeFilter,
+    setFilter,
+    setPeriod,
+    shouldReduceMotion,
+  } = state;
+  const {
+    AttributionTable: AttributionTableComponent,
+    Chart: ChartComponent,
+    Overview: OverviewComponent,
+    Summary: SummaryComponent,
+    UsageFilterPanel: UsageFilterPanelComponent,
+  } = components;
+
+  const header = embedded ? (
+    <div className="flex w-full flex-col gap-4 sm:flex-row sm:justify-between">
+      <div className="flex flex-row flex-wrap items-center gap-2">
+        {headerBadge}
+        <OverviewComponent
+          workspaceId={owner.sId}
+          period={period}
+          showError={showOverviewError}
+        />
+      </div>
+      <ConsumptionPeriodSelector period={period} onPeriodChange={setPeriod} />
+    </div>
+  ) : (
+    <div className="flex w-full flex-row justify-between">
+      <div className="flex flex-col gap-1">
+        <Page.H variant="h3">{title}</Page.H>
+        <OverviewComponent workspaceId={owner.sId} period={period} />
+      </div>
+      <ConsumptionPeriodSelector period={period} onPeriodChange={setPeriod} />
+    </div>
+  );
+
   return (
     <Page.Vertical align="stretch" gap="xl">
-      <Page.Header
-        title={
-          <div className="flex w-full flex-row justify-between">
-            <div className="flex flex-col gap-1">
-              <Page.H variant="h3">Analytics</Page.H>
-              <ConsumptionOverview workspaceId={owner.sId} period={period} />
-            </div>
-            <ConsumptionPeriodSelector
-              period={period}
-              onPeriodChange={setPeriod}
-            />
-          </div>
-        }
+      {embedded ? header : <Page.Header title={header} />}
+
+      <SummaryComponent
+        workspaceId={owner.sId}
+        period={period}
+        usageHref={usageHref}
+        usageLinkLabel={usageLinkLabel}
       />
 
-      <ConsumptionSummary workspaceId={owner.sId} period={period} />
-
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col bg-panel-background">
+        <div
+          className={cn("flex flex-col", !embedded && "bg-panel-background")}
+        >
           <div className="flex items-center justify-between gap-4">
             <h2 className="text-lg font-semibold text-foreground">Explore</h2>
-            <UsageFilterPanel
+            <UsageFilterPanelComponent
               owner={owner}
               period={period}
               filter={filter}
               onFilterChange={setFilter}
+              showMemberGroupFilter={showMemberGroupFilter}
             />
           </div>
           <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
@@ -138,8 +236,10 @@ export function AnalyticsConsumptionPage() {
             transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
             className="flex flex-col"
           >
-            <SafeSuspense fallback={<ChartFallback />}>
-              <ConsumptionChart
+            <SafeSuspense
+              fallback={embedded ? <PokeChartFallback /> : <ChartFallback />}
+            >
+              <ChartComponent
                 workspaceId={owner.sId}
                 period={period}
                 dimension={dimension}
@@ -150,7 +250,7 @@ export function AnalyticsConsumptionPage() {
         </LazyMotion>
       </div>
 
-      <ConsumptionAttributionTable
+      <AttributionTableComponent
         workspaceId={owner.sId}
         period={period}
         filter={scopeFilter}
@@ -172,7 +272,38 @@ export function AnalyticsConsumptionPage() {
           );
           handleDimensionChange(nextDimension);
         }}
+        showExport={showExport}
       />
     </Page.Vertical>
   );
 }
+
+export function useAnalyticsConsumptionState() {
+  const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
+    DEFAULT_CONSUMPTION_PERIOD
+  );
+  const { dimension: dimensionParam } = useQueryParams(["dimension"]);
+  const dimension = consumptionDimensionFromQueryParam(dimensionParam.value);
+  const [filter, setFilter] = useState<UsageFilter>({});
+  const scopeFilter = useMemo(() => toConsumptionScopeFilter(filter), [filter]);
+  const shouldReduceMotion = useReducedMotion();
+
+  const handleDimensionChange = (nextDimension: ConsumptionDimension) => {
+    dimensionParam.setParam(nextDimension);
+  };
+
+  return {
+    dimension,
+    filter,
+    handleDimensionChange,
+    period,
+    scopeFilter,
+    setFilter,
+    setPeriod,
+    shouldReduceMotion,
+  };
+}
+
+type AnalyticsConsumptionState = ReturnType<
+  typeof useAnalyticsConsumptionState
+>;

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -22,6 +22,7 @@ import { UsageFilterModelComplexityControls } from "@app/components/workspace/an
 import { UsageFilterOptionIcon } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon";
 import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilter";
+import type { ConsumptionFacetOptions } from "@app/hooks/useConsumptionFacets";
 import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
@@ -41,11 +42,12 @@ import { useMemo, useState } from "react";
 
 const DEFAULT_MODEL_TIER: ModelsTierName = "balanced";
 
-interface UsageFilterPanelProps {
+export interface UsageFilterPanelProps {
   owner: LightWorkspaceType;
   period: ConsumptionPeriodSelection;
   filter: UsageFilter;
   onFilterChange: (next: UsageFilter) => void;
+  showMemberGroupFilter?: boolean;
 }
 
 export function UsageFilterPanel({
@@ -53,7 +55,50 @@ export function UsageFilterPanel({
   period,
   filter,
   onFilterChange,
+  showMemberGroupFilter = true,
 }: UsageFilterPanelProps) {
+  const state = useUsageFilterPanelState({
+    owner,
+    filter,
+    showMemberGroupFilter,
+  });
+  const {
+    options: categoryOptions,
+    isFacetsLoading,
+    isFacetsError,
+    isFacetsValidating,
+  } = useConsumptionFacets({
+    workspaceId: owner.sId,
+    period,
+    filter: state.draftScopeFilter,
+    disabled: !state.isOpen,
+  });
+
+  return (
+    <UsageFilterPanelView
+      filter={filter}
+      onFilterChange={onFilterChange}
+      showMemberGroupFilter={showMemberGroupFilter}
+      state={state}
+      categoryOptions={categoryOptions}
+      isFacetsLoading={isFacetsLoading}
+      isFacetsError={Boolean(isFacetsError)}
+      isFacetsValidating={isFacetsValidating}
+    />
+  );
+}
+
+interface UseUsageFilterPanelStateParams {
+  owner: LightWorkspaceType;
+  filter: UsageFilter;
+  showMemberGroupFilter: boolean;
+}
+
+export function useUsageFilterPanelState({
+  owner,
+  filter,
+  showMemberGroupFilter,
+}: UseUsageFilterPanelStateParams) {
   const [isOpen, setIsOpen] = useState(false);
   // Selections are staged while the panel is open and only propagated when
   // the user clicks Apply. Facet availability follows the staged query.
@@ -80,24 +125,12 @@ export function UsageFilterPanel({
     () => toConsumptionScopeFilter(draftFilter),
     [draftFilter]
   );
-  const {
-    options: categoryOptions,
-    isFacetsLoading,
-    isFacetsError,
-    isFacetsValidating,
-  } = useConsumptionFacets({
-    workspaceId: owner.sId,
-    period,
-    filter: draftScopeFilter,
-    disabled: !isOpen,
-  });
-
   const isMemberCategoryActive = isOpen && activeCategory === "member";
   const { groups: workspaceGroups } = useGroups({
     owner,
     kinds: MANAGEABLE_GROUP_KINDS,
     withMembers: true,
-    disabled: !isMemberCategoryActive,
+    disabled: !isMemberCategoryActive || !showMemberGroupFilter,
   });
 
   const groups = useMemo<UsageFilterGroup[]>(
@@ -109,6 +142,77 @@ export function UsageFilterPanel({
       })),
     [workspaceGroups]
   );
+
+  return {
+    isOpen,
+    setIsOpen,
+    draftFilter,
+    setDraftFilter,
+    clearAllCategories,
+    clearCategory,
+    toggleOption,
+    removeOption,
+    selectAllFiltered,
+    activeCategory,
+    setActiveCategory,
+    activeScope,
+    setActiveScope,
+    activeTier,
+    setActiveTier,
+    searchText,
+    setSearchText,
+    contentScrollContainer,
+    setContentScrollContainer,
+    selectedGroups,
+    draftScopeFilter,
+    groups,
+  };
+}
+
+interface UsageFilterPanelViewProps {
+  filter: UsageFilter;
+  onFilterChange: (next: UsageFilter) => void;
+  showMemberGroupFilter: boolean;
+  state: ReturnType<typeof useUsageFilterPanelState>;
+  categoryOptions: ConsumptionFacetOptions;
+  isFacetsLoading: boolean;
+  isFacetsError: boolean;
+  isFacetsValidating: boolean;
+}
+
+export function UsageFilterPanelView({
+  filter,
+  onFilterChange,
+  showMemberGroupFilter,
+  state,
+  categoryOptions,
+  isFacetsLoading,
+  isFacetsError,
+  isFacetsValidating,
+}: UsageFilterPanelViewProps) {
+  const {
+    isOpen,
+    setIsOpen,
+    draftFilter,
+    setDraftFilter,
+    clearAllCategories,
+    clearCategory,
+    toggleOption,
+    removeOption,
+    selectAllFiltered,
+    activeCategory,
+    setActiveCategory,
+    activeScope,
+    setActiveScope,
+    activeTier,
+    setActiveTier,
+    searchText,
+    setSearchText,
+    contentScrollContainer,
+    setContentScrollContainer,
+    selectedGroups,
+    groups,
+  } = state;
 
   const activeOptions = categoryOptions[activeCategory];
   const filteredOptions = useMemo(() => {
@@ -248,7 +352,7 @@ export function UsageFilterPanel({
               ref={setContentScrollContainer}
               className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
             >
-              {activeCategory === "member" && (
+              {activeCategory === "member" && showMemberGroupFilter && (
                 <UsageFilterMemberGroupsControls
                   groups={groups}
                   selectedGroups={selectedGroups.items}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -4,10 +4,11 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { Button, cn, LoadingBlock, ProgressBar } from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 import { CONSUMPTION_DIMENSION_CONFIG } from "./consumptionDimensions";
 
-const BREAKDOWN_LIMIT = 3;
+export const CONSUMPTION_ATTRIBUTION_BREAKDOWN_LIMIT = 3;
 
 const BREAKDOWN_DIMENSIONS = ["model", "tool", "user"] as const;
 type BreakdownDimension = (typeof BREAKDOWN_DIMENSIONS)[number];
@@ -46,7 +47,7 @@ function BreakdownColumnSkeleton() {
   );
 }
 
-interface BreakdownColumnProps {
+export interface ConsumptionAttributionBreakdownColumnProps {
   workspaceId: string;
   dimension: BreakdownDimension;
   period: ConsumptionPeriodSelection;
@@ -55,22 +56,25 @@ interface BreakdownColumnProps {
   onViewAll: () => void;
 }
 
-function BreakdownColumn({
-  workspaceId,
+interface ConsumptionAttributionBreakdownColumnViewProps {
+  dimension: BreakdownDimension;
+  selectedRowName: string;
+  onViewAll: () => void;
+  rows: ConsumptionTopRow[];
+  totalCredits: number;
+  isTopLoading: boolean;
+  isTopError: boolean;
+}
+
+export function ConsumptionAttributionBreakdownColumnView({
   dimension,
-  period,
-  filter,
   selectedRowName,
   onViewAll,
-}: BreakdownColumnProps) {
-  const { rows, totalCredits, isTopLoading, isTopError } = useConsumptionTop({
-    workspaceId,
-    dimension,
-    period,
-    limit: BREAKDOWN_LIMIT,
-    filter,
-  });
-
+  rows,
+  totalCredits,
+  isTopLoading,
+  isTopError,
+}: ConsumptionAttributionBreakdownColumnViewProps) {
   return (
     <div className="min-w-0">
       <div className="mb-2 flex h-6 items-center justify-between gap-2">
@@ -121,7 +125,36 @@ function BreakdownColumn({
   );
 }
 
-interface ConsumptionAttributionBreakdownProps {
+function WorkspaceConsumptionAttributionBreakdownColumn({
+  workspaceId,
+  dimension,
+  period,
+  filter,
+  selectedRowName,
+  onViewAll,
+}: ConsumptionAttributionBreakdownColumnProps) {
+  const { rows, totalCredits, isTopLoading, isTopError } = useConsumptionTop({
+    workspaceId,
+    dimension,
+    period,
+    limit: CONSUMPTION_ATTRIBUTION_BREAKDOWN_LIMIT,
+    filter,
+  });
+
+  return (
+    <ConsumptionAttributionBreakdownColumnView
+      dimension={dimension}
+      selectedRowName={selectedRowName}
+      onViewAll={onViewAll}
+      rows={rows}
+      totalCredits={totalCredits}
+      isTopLoading={isTopLoading}
+      isTopError={Boolean(isTopError)}
+    />
+  );
+}
+
+export interface ConsumptionAttributionBreakdownProps {
   workspaceId: string;
   selectedDimension: ConsumptionDimension;
   selectedRow: ConsumptionTopRow;
@@ -133,14 +166,20 @@ interface ConsumptionAttributionBreakdownProps {
   ) => void;
 }
 
-export function ConsumptionAttributionBreakdown({
+interface ConsumptionAttributionBreakdownViewProps
+  extends ConsumptionAttributionBreakdownProps {
+  BreakdownColumnComponent: ComponentType<ConsumptionAttributionBreakdownColumnProps>;
+}
+
+export function ConsumptionAttributionBreakdownView({
   workspaceId,
   selectedDimension,
   selectedRow,
   period,
   filter,
   onViewAll,
-}: ConsumptionAttributionBreakdownProps) {
+  BreakdownColumnComponent,
+}: ConsumptionAttributionBreakdownViewProps) {
   const selectedFilter: ConsumptionScopeFilter = {
     ...filter,
     [CONSUMPTION_DIMENSION_FILTER_KEYS[selectedDimension]]: [selectedRow.id],
@@ -158,7 +197,7 @@ export function ConsumptionAttributionBreakdown({
       )}
     >
       {visibleDimensions.map((dimension) => (
-        <BreakdownColumn
+        <BreakdownColumnComponent
           key={dimension}
           workspaceId={workspaceId}
           dimension={dimension}
@@ -169,5 +208,16 @@ export function ConsumptionAttributionBreakdown({
         />
       ))}
     </div>
+  );
+}
+
+export function ConsumptionAttributionBreakdown(
+  props: ConsumptionAttributionBreakdownProps
+) {
+  return (
+    <ConsumptionAttributionBreakdownView
+      {...props}
+      BreakdownColumnComponent={WorkspaceConsumptionAttributionBreakdownColumn}
+    />
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -23,7 +23,9 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import type { ComponentType } from "react";
 import { Fragment } from "react";
+import type { ConsumptionAttributionBreakdownProps } from "./ConsumptionAttributionBreakdown";
 import { ConsumptionAttributionBreakdown } from "./ConsumptionAttributionBreakdown";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 
@@ -100,7 +102,7 @@ function AttributionSkeletonCell({
   }
 }
 
-interface ConsumptionAttributionRowsTableProps {
+export interface ConsumptionAttributionRowsTableProps {
   data: AttributionRowData[];
   columns: ColumnDef<AttributionRowData>[];
   workspaceId: string;
@@ -120,7 +122,12 @@ interface ConsumptionAttributionRowsTableProps {
   onSortingChange: OnChangeFn<SortingState>;
 }
 
-export function ConsumptionAttributionRowsTable({
+interface ConsumptionAttributionRowsTableViewProps
+  extends ConsumptionAttributionRowsTableProps {
+  BreakdownComponent: ComponentType<ConsumptionAttributionBreakdownProps>;
+}
+
+export function ConsumptionAttributionRowsTableView({
   data,
   columns,
   workspaceId,
@@ -135,7 +142,8 @@ export function ConsumptionAttributionRowsTable({
   isAvatarRounded = false,
   sorting,
   onSortingChange,
-}: ConsumptionAttributionRowsTableProps) {
+  BreakdownComponent,
+}: ConsumptionAttributionRowsTableViewProps) {
   const table = useReactTable({
     data,
     columns,
@@ -243,7 +251,7 @@ export function ConsumptionAttributionRowsTable({
                           "data-[state=closed]:slide-out-to-top-1 data-[state=closed]:duration-exit"
                         )}
                       >
-                        <ConsumptionAttributionBreakdown
+                        <BreakdownComponent
                           workspaceId={workspaceId}
                           selectedDimension={dimension}
                           selectedRow={row.original}
@@ -259,5 +267,16 @@ export function ConsumptionAttributionRowsTable({
             ))}
       </DataTable.Body>
     </DataTable.Root>
+  );
+}
+
+export function ConsumptionAttributionRowsTable(
+  props: ConsumptionAttributionRowsTableProps
+) {
+  return (
+    <ConsumptionAttributionRowsTableView
+      {...props}
+      BreakdownComponent={ConsumptionAttributionBreakdown}
+    />
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -21,7 +21,10 @@ import {
   normalizedConsumptionFilter,
 } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionExportBody } from "@app/lib/api/analytics/consumption/schema";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type {
+  ConsumptionScopeFilter,
+  ConsumptionTopSortOrder,
+} from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
 import { getSkillAvatarIcon } from "@app/lib/skill";
@@ -49,6 +52,7 @@ import {
 } from "@dust-tt/sparkle";
 import type {
   ColumnDef,
+  OnChangeFn,
   PaginationState,
   SortingState,
 } from "@tanstack/react-table";
@@ -60,9 +64,12 @@ import {
   m,
   useReducedMotion,
 } from "framer-motion";
-import type { ReactNode } from "react";
+import type { ComponentType, Dispatch, ReactNode, SetStateAction } from "react";
 import { useMemo, useRef, useState } from "react";
-import type { AttributionRowData } from "./ConsumptionAttributionRowsTable";
+import type {
+  AttributionRowData,
+  ConsumptionAttributionRowsTableProps,
+} from "./ConsumptionAttributionRowsTable";
 import { ConsumptionAttributionRowsTable } from "./ConsumptionAttributionRowsTable";
 import type { ConsumptionDimension } from "./consumptionDimensions";
 import {
@@ -410,7 +417,7 @@ function buildColumns({
   ];
 }
 
-interface AttributionRowsProps {
+export interface ConsumptionAttributionRowsProps {
   workspaceId: string;
   dimension: ConsumptionDimension;
   period: ConsumptionPeriodSelection;
@@ -424,19 +431,24 @@ interface AttributionRowsProps {
   ) => void;
 }
 
-function AttributionRows({
-  workspaceId,
-  dimension,
-  period,
-  filter,
-  onAddFilter,
-  onRemoveFilter,
-  search,
-  onViewAll,
-}: AttributionRowsProps) {
-  const { hasAvatar, avgLabel } = CONSUMPTION_DIMENSION_CONFIG[dimension];
-  const { isDark } = useTheme();
-  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+export interface ConsumptionAttributionRowsData {
+  rows: ConsumptionTopRow[];
+  totalCredits: number;
+  totalCount: number;
+  isTopLoading: boolean;
+  isTopError: boolean;
+  isTopValidating: boolean;
+}
+
+export interface ConsumptionAttributionRowsQueryState {
+  pagination: PaginationState;
+  setPagination: Dispatch<SetStateAction<PaginationState>>;
+  sorting: SortingState;
+  onSortingChange: OnChangeFn<SortingState>;
+  sortOrder: ConsumptionTopSortOrder;
+}
+
+export function useConsumptionAttributionRowsQueryState(): ConsumptionAttributionRowsQueryState {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: ATTRIBUTION_PAGE_SIZE,
@@ -444,11 +456,10 @@ function AttributionRows({
   const [sorting, setSorting] = useState<SortingState>(
     DEFAULT_ATTRIBUTION_SORTING
   );
-  const shouldReduceMotion = useReducedMotion();
 
   // A new sort order invalidates the current page's offset into it, so jump
   // back to the first page whenever it changes.
-  const handleSortingChange: typeof setSorting = (updater) => {
+  const onSortingChange: OnChangeFn<SortingState> = (updater) => {
     setSorting(updater);
     setPagination((current) => ({ ...current, pageIndex: 0 }));
   };
@@ -465,25 +476,49 @@ function AttributionRows({
       ? "asc"
       : "desc";
 
-  const {
+  return {
+    pagination,
+    setPagination,
+    sorting,
+    onSortingChange,
+    sortOrder,
+  };
+}
+
+interface ConsumptionAttributionRowsViewProps
+  extends ConsumptionAttributionRowsProps {
+  data: ConsumptionAttributionRowsData;
+  emptyMessage: string;
+  queryState: ConsumptionAttributionRowsQueryState;
+  RowsTableComponent: ComponentType<ConsumptionAttributionRowsTableProps>;
+}
+
+export function ConsumptionAttributionRowsView({
+  workspaceId,
+  dimension,
+  period,
+  filter,
+  onAddFilter,
+  onRemoveFilter,
+  search,
+  onViewAll,
+  emptyMessage,
+  data: {
     rows,
     totalCredits,
     totalCount,
     isTopLoading,
     isTopError,
     isTopValidating,
-  } = useConsumptionTop({
-    workspaceId,
-    dimension,
-    period,
-    limit: pagination.pageSize,
-    offset: pagination.pageIndex * pagination.pageSize,
-    search,
-    filter,
-    sortOrder,
-  });
+  },
+  queryState: { pagination, setPagination, sorting, onSortingChange },
+  RowsTableComponent,
+}: ConsumptionAttributionRowsViewProps) {
+  const { hasAvatar, avgLabel } = CONSUMPTION_DIMENSION_CONFIG[dimension];
+  const { isDark } = useTheme();
+  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+  const shouldReduceMotion = useReducedMotion();
   const cappedRowCount = Math.min(totalCount, ATTRIBUTION_MAX_ROW_COUNT);
-
   const selectedIdSet = useMemo(
     () => new Set(filter?.[CONSUMPTION_DIMENSION_FILTER_KEYS[dimension]] ?? []),
     [dimension, filter]
@@ -551,7 +586,7 @@ function AttributionRows({
     content = (
       <div>
         <div className="overflow-x-auto">
-          <ConsumptionAttributionRowsTable
+          <RowsTableComponent
             data={data}
             columns={columns}
             workspaceId={workspaceId}
@@ -565,7 +600,7 @@ function AttributionRows({
             hasAvatar={hasAvatar}
             isAvatarRounded={dimension === "user"}
             sorting={sorting}
-            onSortingChange={handleSortingChange}
+            onSortingChange={onSortingChange}
           />
         </div>
         {paginationControls}
@@ -582,13 +617,11 @@ function AttributionRows({
       <div>
         {rows.length === 0 ? (
           <div className="text-sm text-muted-foreground">
-            {search.trim()
-              ? `No match for "${search.trim()}".`
-              : "No consumption over this period."}
+            {search.trim() ? `No match for "${search.trim()}".` : emptyMessage}
           </div>
         ) : (
           <div className="overflow-x-auto">
-            <ConsumptionAttributionRowsTable
+            <RowsTableComponent
               data={data}
               columns={columns}
               workspaceId={workspaceId}
@@ -598,7 +631,7 @@ function AttributionRows({
               onViewAll={onViewAll}
               expandedRowId={expandedRowId}
               sorting={sorting}
-              onSortingChange={handleSortingChange}
+              onSortingChange={onSortingChange}
             />
           </div>
         )}
@@ -626,7 +659,47 @@ function AttributionRows({
   );
 }
 
-interface ConsumptionAttributionTableProps {
+function WorkspaceConsumptionAttributionRows(
+  props: ConsumptionAttributionRowsProps
+) {
+  const queryState = useConsumptionAttributionRowsQueryState();
+  const {
+    rows,
+    totalCredits,
+    totalCount,
+    isTopLoading,
+    isTopError,
+    isTopValidating,
+  } = useConsumptionTop({
+    workspaceId: props.workspaceId,
+    dimension: props.dimension,
+    period: props.period,
+    limit: queryState.pagination.pageSize,
+    offset: queryState.pagination.pageIndex * queryState.pagination.pageSize,
+    search: props.search,
+    filter: props.filter,
+    sortOrder: queryState.sortOrder,
+  });
+
+  return (
+    <ConsumptionAttributionRowsView
+      {...props}
+      data={{
+        rows,
+        totalCredits,
+        totalCount,
+        isTopLoading,
+        isTopError: Boolean(isTopError),
+        isTopValidating,
+      }}
+      emptyMessage="No consumption over this period."
+      queryState={queryState}
+      RowsTableComponent={ConsumptionAttributionRowsTable}
+    />
+  );
+}
+
+export interface ConsumptionAttributionTableProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
@@ -639,9 +712,15 @@ interface ConsumptionAttributionTableProps {
     dimension: ConsumptionDimension,
     selectedRow: ConsumptionTopRow
   ) => void;
+  showExport?: boolean;
 }
 
-export function ConsumptionAttributionTable({
+interface ConsumptionAttributionTableViewProps
+  extends ConsumptionAttributionTableProps {
+  AttributionRowsComponent: ComponentType<ConsumptionAttributionRowsProps>;
+}
+
+export function ConsumptionAttributionTableView({
   workspaceId,
   period,
   filter,
@@ -650,7 +729,9 @@ export function ConsumptionAttributionTable({
   dimension,
   onDimensionChange,
   onViewAll,
-}: ConsumptionAttributionTableProps) {
+  showExport = true,
+  AttributionRowsComponent,
+}: ConsumptionAttributionTableViewProps) {
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
     delay: SEARCH_DEBOUNCE_DELAY_MS,
   });
@@ -676,10 +757,12 @@ export function ConsumptionAttributionTable({
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-4">
         <h3 className="text-base font-semibold text-foreground">Attribution</h3>
-        <ConsumptionExportPanel
-          workspaceId={workspaceId}
-          exportBody={exportBody}
-        />
+        {showExport && (
+          <ConsumptionExportPanel
+            workspaceId={workspaceId}
+            exportBody={exportBody}
+          />
+        )}
       </div>
       <div className="rounded-lg border border-border bg-panel-background p-4">
         <div className="flex flex-col gap-3">
@@ -741,7 +824,7 @@ export function ConsumptionAttributionTable({
                   exit="exit"
                 >
                   {/* Reset table state whenever its dataset or local search changes. */}
-                  <AttributionRows
+                  <AttributionRowsComponent
                     key={JSON.stringify({
                       period,
                       filter,
@@ -763,5 +846,16 @@ export function ConsumptionAttributionTable({
         </div>
       </div>
     </div>
+  );
+}
+
+export function ConsumptionAttributionTable(
+  props: ConsumptionAttributionTableProps
+) {
+  return (
+    <ConsumptionAttributionTableView
+      {...props}
+      AttributionRowsComponent={WorkspaceConsumptionAttributionRows}
+    />
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionBurnUpChart.tsx
@@ -2,15 +2,13 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
-import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
-import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
-import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import {
   findPartialTimestamp,
   formatConsumptionDate,
 } from "@app/lib/analytics/consumption_period";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 import {
   CartesianGrid,
@@ -94,37 +92,22 @@ function ConsumptionBurnUpTooltip({
 }
 
 interface ConsumptionBurnUpChartProps {
-  workspaceId: string;
-  period: ConsumptionPeriodSelection;
-  filter?: ConsumptionScopeFilter;
+  timeseries: GetConsumptionTimeseriesResponse | null;
+  capCredits: number | null;
+  isTimeseriesLoading: boolean;
+  isTimeseriesError: boolean;
+  emptyMessage: string;
+  additionalControls?: ReactNode;
 }
 
 export function ConsumptionBurnUpChart({
-  workspaceId,
-  period,
-  filter,
+  timeseries,
+  capCredits,
+  isTimeseriesLoading,
+  isTimeseriesError,
+  emptyMessage,
+  additionalControls,
 }: ConsumptionBurnUpChartProps) {
-  const { overview } = useConsumptionOverview({ workspaceId, period, filter });
-  const isFiltered = Object.values(filter ?? {}).some(
-    (values) => values.length > 0
-  );
-  // A cap only exists on a billing cycle, when there's no filter. Gating on the
-  // selection rather than on the response alone keeps a previous cycle's cap —
-  // kept around by `keepPreviousData` while the new request lands — from drawing
-  // a target over a period that has none.
-  const capCredits =
-    period.kind === "cycle" && !isFiltered
-      ? (overview?.creditUsage?.capCredits ?? null)
-      : null;
-
-  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
-    useConsumptionTimeseries({
-      workspaceId,
-      period,
-      mode: "cumulative",
-      filter,
-    });
-
   const chartData = useMemo<BurnUpPoint[]>(() => {
     const points = timeseries?.points ?? [];
     const partialTimestamp = findPartialTimestamp(points);
@@ -171,14 +154,13 @@ export function ConsumptionBurnUpChart({
   return (
     <ChartContainer
       title="Cumulative consumption"
+      additionalControls={additionalControls}
       isLoading={isTimeseriesLoading}
       errorMessage={
         isTimeseriesError ? "Failed to load consumption." : undefined
       }
       emptyMessage={
-        !isTimeseriesLoading && !hasConsumption
-          ? "No consumption over this period."
-          : undefined
+        !isTimeseriesLoading && !hasConsumption ? emptyMessage : undefined
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -2,6 +2,7 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { CHART_HEIGHT, CHART_MARGIN } from "@app/components/charts/constants";
+import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import { useConsumptionTimeseries } from "@app/hooks/useConsumptionTimeseries";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import {
@@ -13,9 +14,11 @@ import type {
   ConsumptionTimeseriesGroup,
   ConsumptionTimeseriesMode,
   ConsumptionTimeseriesPoint,
+  GetConsumptionTimeseriesResponse,
 } from "@app/lib/api/analytics/consumption/timeseries";
 import { formatCredits, formatCreditsCompact } from "@app/lib/client/credits";
 import { ButtonsSwitch, ButtonsSwitchList, cn } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import {
   Bar,
@@ -102,7 +105,8 @@ const CONSUMPTION_CHART_COLORS = [
 
 // Request the top five categories, leaving the sixth shade available when the
 // endpoint adds an aggregate "Others" category.
-const CONSUMPTION_CHART_BREAKDOWN_COUNT = CONSUMPTION_CHART_COLORS.length - 1;
+export const CONSUMPTION_CHART_BREAKDOWN_COUNT =
+  CONSUMPTION_CHART_COLORS.length - 1;
 
 function getConsumptionChartColor(index: number): string {
   return CONSUMPTION_CHART_COLORS[
@@ -183,28 +187,20 @@ function ConsumptionDailyTooltip({
 }
 
 interface ConsumptionDailyChartProps {
-  workspaceId: string;
-  period: ConsumptionPeriodSelection;
-  dimension: ConsumptionDimension;
-  filter?: ConsumptionScopeFilter;
+  timeseries: GetConsumptionTimeseriesResponse | null;
+  isTimeseriesLoading: boolean;
+  isTimeseriesError: boolean;
+  emptyMessage: string;
+  additionalControls?: ReactNode;
 }
 
-function ConsumptionDailyChart({
-  workspaceId,
-  period,
-  dimension,
-  filter,
+export function ConsumptionDailyChart({
+  timeseries,
+  isTimeseriesLoading,
+  isTimeseriesError,
+  emptyMessage,
+  additionalControls,
 }: ConsumptionDailyChartProps) {
-  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
-    useConsumptionTimeseries({
-      workspaceId,
-      period,
-      mode: "daily",
-      breakdownBy: dimension,
-      breakdownCount: CONSUMPTION_CHART_BREAKDOWN_COUNT,
-      filter,
-    });
-
   const groups = useMemo(() => timeseries?.groups ?? [], [timeseries]);
   const chartData = useMemo(() => timeseries?.points ?? [], [timeseries]);
 
@@ -263,18 +259,16 @@ function ConsumptionDailyChart({
   const hasConsumption = chartData.some((datum) =>
     Object.values(datum.values).some((credits) => credits > 0)
   );
-
   return (
     <ChartContainer
       title="Daily consumption"
+      additionalControls={additionalControls}
       isLoading={isTimeseriesLoading}
       errorMessage={
         isTimeseriesError ? "Failed to load consumption." : undefined
       }
       emptyMessage={
-        !isTimeseriesLoading && !hasConsumption
-          ? "No consumption over this period."
-          : undefined
+        !isTimeseriesLoading && !hasConsumption ? emptyMessage : undefined
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
@@ -352,11 +346,81 @@ function ConsumptionDailyChart({
   );
 }
 
-interface ConsumptionChartProps {
+export interface ConsumptionChartProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   dimension: ConsumptionDimension;
   filter?: ConsumptionScopeFilter;
+}
+
+function WorkspaceConsumptionDailyChart({
+  workspaceId,
+  period,
+  dimension,
+  filter,
+}: ConsumptionChartProps) {
+  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
+    useConsumptionTimeseries({
+      workspaceId,
+      period,
+      mode: "daily",
+      breakdownBy: dimension,
+      breakdownCount: CONSUMPTION_CHART_BREAKDOWN_COUNT,
+      filter,
+    });
+
+  return (
+    <ConsumptionDailyChart
+      timeseries={timeseries}
+      isTimeseriesLoading={isTimeseriesLoading}
+      isTimeseriesError={Boolean(isTimeseriesError)}
+      emptyMessage="No consumption over this period."
+    />
+  );
+}
+
+interface WorkspaceConsumptionBurnUpChartProps
+  extends Omit<ConsumptionChartProps, "dimension"> {}
+
+function WorkspaceConsumptionBurnUpChart({
+  workspaceId,
+  period,
+  filter,
+}: WorkspaceConsumptionBurnUpChartProps) {
+  const { overview } = useConsumptionOverview({
+    workspaceId,
+    period,
+    filter,
+  });
+  const isFiltered = Object.values(filter ?? {}).some(
+    (values) => values.length > 0
+  );
+  // A cap only exists on a billing cycle, when there's no filter. Gating on the
+  // selection rather than on the response alone keeps a previous cycle's cap —
+  // kept around by `keepPreviousData` while the new request lands — from drawing
+  // a target over a period that has none.
+  const capCredits =
+    period.kind === "cycle" && !isFiltered
+      ? (overview?.creditUsage?.capCredits ?? null)
+      : null;
+
+  const { timeseries, isTimeseriesLoading, isTimeseriesError } =
+    useConsumptionTimeseries({
+      workspaceId,
+      period,
+      mode: "cumulative",
+      filter,
+    });
+
+  return (
+    <ConsumptionBurnUpChart
+      timeseries={timeseries}
+      capCredits={capCredits}
+      isTimeseriesLoading={isTimeseriesLoading}
+      isTimeseriesError={Boolean(isTimeseriesError)}
+      emptyMessage="No consumption over this period."
+    />
+  );
 }
 
 export function ConsumptionChart({
@@ -385,13 +449,13 @@ export function ConsumptionChart({
         </ButtonsSwitchList>
       </div>
       {mode === "cumulative" ? (
-        <ConsumptionBurnUpChart
+        <WorkspaceConsumptionBurnUpChart
           workspaceId={workspaceId}
           period={period}
           filter={filter}
         />
       ) : (
-        <ConsumptionDailyChart
+        <WorkspaceConsumptionDailyChart
           workspaceId={workspaceId}
           period={period}
           dimension={dimension}

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -1,21 +1,49 @@
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
+import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
 import { timeAgoFrom } from "@app/lib/utils";
-import { Page } from "@dust-tt/sparkle";
+import { Page, Tooltip } from "@dust-tt/sparkle";
 
-interface ConsumptionOverviewProps {
+export interface ConsumptionOverviewProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  showError?: boolean;
 }
 
 export function ConsumptionOverview({
   workspaceId,
   period: periodSelection,
+  showError = false,
 }: ConsumptionOverviewProps) {
   const { overview, isOverviewLoading, isOverviewError } =
     useConsumptionOverview({ workspaceId, period: periodSelection });
 
+  return (
+    <ConsumptionOverviewView
+      overview={overview}
+      isOverviewLoading={isOverviewLoading}
+      isOverviewError={Boolean(isOverviewError)}
+      showError={showError}
+    />
+  );
+}
+
+interface ConsumptionOverviewViewProps {
+  overview: GetConsumptionOverviewResponse | null;
+  isOverviewLoading: boolean;
+  isOverviewError: boolean;
+  showError?: boolean;
+  showIndexingDetails?: boolean;
+}
+
+export function ConsumptionOverviewView({
+  overview,
+  isOverviewLoading,
+  isOverviewError,
+  showError = false,
+  showIndexingDetails = false,
+}: ConsumptionOverviewViewProps) {
   if (isOverviewLoading) {
     return (
       <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
@@ -23,7 +51,11 @@ export function ConsumptionOverview({
   }
 
   if (isOverviewError || !overview) {
-    return null;
+    return showError ? (
+      <Page.P variant="secondary">
+        Overview unavailable. Charts and attribution may still load.
+      </Page.P>
+    ) : null;
   }
 
   const { period, members, lastRecordAt } = overview;
@@ -32,7 +64,11 @@ export function ConsumptionOverview({
     `${formatConsumptionDate(period.startDate)} to ${formatConsumptionDate(period.endDate)}`,
     `${members.active.toLocaleString()} of ${members.total.toLocaleString()} members active`,
     ...(lastRecordAt
-      ? [`Updated ${timeAgoFrom(new Date(lastRecordAt).getTime())} ago`]
+      ? [
+          showIndexingDetails
+            ? `Latest indexed record ${timeAgoFrom(new Date(lastRecordAt).getTime())} ago`
+            : `Updated ${timeAgoFrom(new Date(lastRecordAt).getTime())} ago`,
+        ]
       : []),
   ];
 
@@ -45,7 +81,17 @@ export function ConsumptionOverview({
               |
             </span>
           )}
-          {item}
+          {showIndexingDetails &&
+          lastRecordAt &&
+          index === header.length - 1 ? (
+            <Tooltip
+              label={new Date(lastRecordAt).toLocaleString()}
+              tooltipTriggerAsChild
+              trigger={<span>{item}</span>}
+            />
+          ) : (
+            item
+          )}
         </span>
       ))}
     </Page.P>

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -1,6 +1,7 @@
 import { SummaryCard } from "@app/components/workspace/analytics/SummaryCard";
 import { useConsumptionOverview } from "@app/hooks/useConsumptionOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { formatCredits } from "@app/lib/client/credits";
 import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
@@ -26,23 +27,73 @@ function cycleElapsedPercent({
   return Math.round(Math.min(Math.max(elapsedRatio, 0), 1) * 100);
 }
 
-interface ConsumptionSummaryProps {
+export interface ConsumptionSummaryProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  usageHref?: string;
+  usageLinkLabel?: string;
 }
 
 export function ConsumptionSummary({
   workspaceId,
   period: periodSelection,
+  usageHref = `/w/${workspaceId}/usage`,
+  usageLinkLabel = "Manage in Usage",
 }: ConsumptionSummaryProps) {
   const { overview, isOverviewLoading, isOverviewError } =
     useConsumptionOverview({ workspaceId, period: periodSelection });
 
+  return (
+    <ConsumptionSummaryView
+      overview={overview}
+      isOverviewLoading={isOverviewLoading}
+      isOverviewError={Boolean(isOverviewError)}
+      usageHref={usageHref}
+      usageLinkLabel={usageLinkLabel}
+    />
+  );
+}
+
+interface ConsumptionSummaryViewProps {
+  overview: GetConsumptionOverviewResponse | null;
+  isOverviewLoading: boolean;
+  isOverviewError: boolean;
+  usageHref: string;
+  usageLinkLabel: string;
+  responsiveLayout?: boolean;
+}
+
+export function ConsumptionSummaryView({
+  overview,
+  isOverviewLoading,
+  isOverviewError,
+  usageHref,
+  usageLinkLabel,
+  responsiveLayout = false,
+}: ConsumptionSummaryViewProps) {
   if (isOverviewLoading) {
     return (
-      <div className="flex items-stretch gap-6">
-        <div className="h-24 flex-1 animate-pulse rounded-xl bg-muted-background" />
-        <div className="h-24 flex-1 animate-pulse rounded-xl bg-muted-background" />
+      <div
+        className={
+          responsiveLayout
+            ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+            : "flex items-stretch gap-6"
+        }
+      >
+        <div
+          className={
+            responsiveLayout
+              ? "h-24 animate-pulse rounded-xl bg-muted-background"
+              : "h-24 flex-1 animate-pulse rounded-xl bg-muted-background"
+          }
+        />
+        <div
+          className={
+            responsiveLayout
+              ? "h-24 animate-pulse rounded-xl bg-muted-background"
+              : "h-24 flex-1 animate-pulse rounded-xl bg-muted-background"
+          }
+        />
       </div>
     );
   }
@@ -56,7 +107,13 @@ export function ConsumptionSummary({
   return (
     <div className="flex flex-col gap-4">
       {creditUsage && (
-        <div className="flex items-center justify-between gap-4 rounded-xl border border-border bg-panel-background p-2">
+        <div
+          className={
+            responsiveLayout
+              ? "flex flex-col items-start justify-between gap-3 rounded-xl border border-border bg-panel-background p-2 sm:flex-row sm:items-center"
+              : "flex items-center justify-between gap-4 rounded-xl border border-border bg-panel-background p-2"
+          }
+        >
           <div className="flex items-center gap-2">
             <Chip
               size="mini"
@@ -69,15 +126,21 @@ export function ConsumptionSummary({
             </span>
           </div>
           <Button
-            label="Manage in Usage"
+            label={usageLinkLabel}
             variant="highlight-ghost"
             size="xs"
             iconRight={ArrowUpRight}
-            href={`/w/${workspaceId}/usage`}
+            href={usageHref}
           />
         </div>
       )}
-      <div className="flex items-stretch gap-6">
+      <div
+        className={
+          responsiveLayout
+            ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+            : "flex items-stretch gap-6"
+        }
+      >
         <SummaryCard
           label="Used this period"
           value={formatCredits(totalCredits)}

--- a/front/hooks/useConsumptionFacets.ts
+++ b/front/hooks/useConsumptionFacets.ts
@@ -37,6 +37,13 @@ const EMPTY_FACET_OPTIONS: ConsumptionFacetOptions = {
   api_key: [],
 };
 
+export interface UseConsumptionFacetsParams {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+  disabled?: boolean;
+}
+
 function baseOption(facet: {
   value: string;
   label: string;
@@ -49,7 +56,7 @@ function baseOption(facet: {
   };
 }
 
-function toFacetOptions(
+export function toConsumptionFacetOptions(
   data: GetConsumptionFacetsResponse
 ): ConsumptionFacetOptions {
   return {
@@ -103,12 +110,7 @@ export function useConsumptionFacets({
   period,
   filter,
   disabled,
-}: {
-  workspaceId: string;
-  period: ConsumptionPeriodSelection;
-  filter?: ConsumptionScopeFilter;
-  disabled?: boolean;
-}) {
+}: UseConsumptionFacetsParams) {
   const url = `/api/w/${workspaceId}/analytics/consumption/facets`;
   const body: ConsumptionBody = {
     period: period.kind,
@@ -123,7 +125,7 @@ export function useConsumptionFacets({
   >({ url, body, disabled });
 
   const options = useMemo(
-    () => (data ? toFacetOptions(data) : EMPTY_FACET_OPTIONS),
+    () => (data ? toConsumptionFacetOptions(data) : EMPTY_FACET_OPTIONS),
     [data]
   );
 

--- a/front/hooks/useConsumptionOverview.ts
+++ b/front/hooks/useConsumptionOverview.ts
@@ -8,17 +8,19 @@ import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/cons
 import type { ConsumptionBody } from "@app/lib/api/analytics/consumption/schema";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 
+export interface UseConsumptionOverviewParams {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+  disabled?: boolean;
+}
+
 export function useConsumptionOverview({
   workspaceId,
   period,
   filter,
   disabled,
-}: {
-  workspaceId: string;
-  period: ConsumptionPeriodSelection;
-  filter?: ConsumptionScopeFilter;
-  disabled?: boolean;
-}) {
+}: UseConsumptionOverviewParams) {
   const url = `/api/w/${workspaceId}/analytics/consumption/overview`;
   const body: ConsumptionBody = {
     period: period.kind,

--- a/front/hooks/useConsumptionTimeseries.ts
+++ b/front/hooks/useConsumptionTimeseries.ts
@@ -18,15 +18,7 @@ type ConsumptionTimeseriesBody = ConsumptionBody & {
   breakdownCount?: number;
 };
 
-export function useConsumptionTimeseries({
-  workspaceId,
-  period,
-  mode,
-  breakdownBy,
-  breakdownCount,
-  filter,
-  disabled,
-}: {
+export interface UseConsumptionTimeseriesParams {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   mode: ConsumptionTimeseriesMode;
@@ -35,7 +27,17 @@ export function useConsumptionTimeseries({
   breakdownCount?: number;
   filter?: ConsumptionScopeFilter;
   disabled?: boolean;
-}) {
+}
+
+export function useConsumptionTimeseries({
+  workspaceId,
+  period,
+  mode,
+  breakdownBy,
+  breakdownCount,
+  filter,
+  disabled,
+}: UseConsumptionTimeseriesParams) {
   const url = `/api/w/${workspaceId}/analytics/consumption/timeseries`;
   const body: ConsumptionTimeseriesBody = {
     period: period.kind,

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -46,7 +46,7 @@ export type ConsumptionTopRow = {
   previousCredits: number | null;
 };
 
-type ConsumptionTopResponse =
+export type ConsumptionTopResponse =
   | GetConsumptionTopAgentsResponse
   | GetConsumptionTopUsersResponse
   | GetConsumptionTopGroupsResponse
@@ -56,10 +56,24 @@ type ConsumptionTopResponse =
   | GetConsumptionTopSourcesResponse
   | GetConsumptionTopApiKeysResponse;
 
+export interface UseConsumptionTopParams {
+  workspaceId: string;
+  dimension: ConsumptionDimension;
+  period: ConsumptionPeriodSelection;
+  limit: number;
+  offset?: number;
+  search?: string;
+  filter?: ConsumptionScopeFilter;
+  sortOrder?: ConsumptionTopSortOrder;
+  disabled?: boolean;
+}
+
 // Narrowed on the collection each response carries rather than on the requested
 // dimension, so a row shape that drifts from its endpoint is a type error here
 // instead of a silently empty table.
-function toRows(data: ConsumptionTopResponse): ConsumptionTopRow[] {
+export function toConsumptionTopRows(
+  data: ConsumptionTopResponse
+): ConsumptionTopRow[] {
   if ("agents" in data) {
     return data.agents.map((row) => ({
       id: row.agentId,
@@ -186,17 +200,7 @@ export function useConsumptionTop({
   filter,
   sortOrder = "desc",
   disabled,
-}: {
-  workspaceId: string;
-  dimension: ConsumptionDimension;
-  period: ConsumptionPeriodSelection;
-  limit: number;
-  offset?: number;
-  search?: string;
-  filter?: ConsumptionScopeFilter;
-  sortOrder?: ConsumptionTopSortOrder;
-  disabled?: boolean;
-}) {
+}: UseConsumptionTopParams) {
   const url = `/api/w/${workspaceId}/analytics/consumption/${CONSUMPTION_TOP_ENDPOINTS[dimension]}`;
   const body: ConsumptionTopBody = {
     period: period.kind,
@@ -215,7 +219,7 @@ export function useConsumptionTop({
   >({ url, body, disabled });
 
   const rows = useMemo(
-    () => (data ? toRows(data) : emptyArray<ConsumptionTopRow>()),
+    () => (data ? toConsumptionTopRows(data) : emptyArray<ConsumptionTopRow>()),
     [data]
   );
 


### PR DESCRIPTION
## Description

The end goal of this PR, the one before and a few PRs that will follow is to give a way for us to both inspect what the users will see in the analytics page and to use them for monitoring workspace health and adoption patterns.

The consumption analytics UI needs a reusable boundary before it can be shown outside the customer workspace page.

This PR separates data fetching from the pure visual part for the overview, summary, filters, charts, and attribution table. The workspace wrappers just use the hooks currently used to then pass down the data to these new components, and the poke components will use different hooks but the same visual components.

No actual behavior change expected.
Nothing to see for now.

Next step will be to add the UI in poke.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
