### PR TITLE
Log project file concurrency limits at info

### DIFF
--- a/front-api/lib/api/assistant/conversation/helper.ts
+++ b/front-api/lib/api/assistant/conversation/helper.ts
@@ -18,5 +18,5 @@ export function apiErrorForConversation(ctx: Context, error: Error) {
   if (error instanceof ConversationError) {
     return apiError(ctx, apiErr);
   }
-  return apiError(ctx, apiErr, error);
+  return apiError(ctx, apiErr, { error });
 }

--- a/front-api/lib/api/assistant/conversation/resolve_authentication.ts
+++ b/front-api/lib/api/assistant/conversation/resolve_authentication.ts
@@ -75,7 +75,7 @@ export function makeResolveAuthenticationApp(
                 message: `Failed to resolve ${label}`,
               },
             },
-            result.error
+            { error: result.error }
           );
       }
     }

--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -33,20 +33,16 @@ type ApiErrorOptions = {
  * handler — do not call `ctx.json({ error: ... }, status)` directly, so the
  * observability behavior stays consistent across Next and Hono.
  *
- * Pass an `Error` when forwarding an underlying exception so its message and
- * stack are captured in the log instead of the synthetic one. Pass options
- * with `isExpected` for a specific expected outcome that should be logged at
+ * Pass `options.error` when forwarding an underlying exception so its message
+ * and stack are captured in the log instead of the synthetic one. Set
+ * `options.isExpected` for a specific expected outcome that should be logged at
  * `info` without lowering the severity of every error sharing its type.
  */
 export function apiError(
   ctx: Context,
   err: APIErrorWithContentfulStatusCode,
-  errorOrOptions: Error | ApiErrorOptions = {}
+  options: ApiErrorOptions = {}
 ) {
-  const options =
-    errorOrOptions instanceof Error
-      ? { error: errorOrOptions }
-      : errorOrOptions;
   const { error } = options;
   const callstack = new Error().stack;
   const errorAttrs = {

--- a/front-api/middlewares/utils.ts
+++ b/front-api/middlewares/utils.ts
@@ -21,6 +21,11 @@ import { routePath } from "hono/route";
  */
 export type HandlerResult<T> = Promise<TypedResponse<T | APIErrorResponse>>;
 
+type ApiErrorOptions = {
+  error?: Error;
+  isExpected?: boolean;
+};
+
 /**
  * Returns a JSON error response from an `APIErrorWithStatusCode` and emits
  * the same logging / tracing / statsd side-effects as `apiError` in
@@ -28,14 +33,21 @@ export type HandlerResult<T> = Promise<TypedResponse<T | APIErrorResponse>>;
  * handler — do not call `ctx.json({ error: ... }, status)` directly, so the
  * observability behavior stays consistent across Next and Hono.
  *
- * Pass `error` when forwarding an underlying exception so its message and
- * stack are captured in the log instead of the synthetic one.
+ * Pass an `Error` when forwarding an underlying exception so its message and
+ * stack are captured in the log instead of the synthetic one. Pass options
+ * with `isExpected` for a specific expected outcome that should be logged at
+ * `info` without lowering the severity of every error sharing its type.
  */
 export function apiError(
   ctx: Context,
   err: APIErrorWithContentfulStatusCode,
-  error?: Error
+  errorOrOptions: Error | ApiErrorOptions = {}
 ) {
+  const options =
+    errorOrOptions instanceof Error
+      ? { error: errorOrOptions }
+      : errorOrOptions;
+  const { error } = options;
   const callstack = new Error().stack;
   const errorAttrs = {
     message: error?.message ?? err.api_error.message,
@@ -46,9 +58,10 @@ export function apiError(
   // Some error types are expected outcomes of normal operation (e.g. a region
   // redirect) rather than failures. Log those at `info` so they don't pollute
   // error monitoring.
-  const logLevel = EXPECTED_API_ERROR_TYPES.has(err.api_error.type)
-    ? "info"
-    : "error";
+  const logLevel =
+    options.isExpected || EXPECTED_API_ERROR_TYPES.has(err.api_error.type)
+      ? "info"
+      : "error";
 
   logger[logLevel](
     {

--- a/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/[functionId]/invocations.ts
+++ b/front-api/routes/poke/workspaces/[wId]/projects/[projectId]/pod-functions/[functionId]/invocations.ts
@@ -126,7 +126,7 @@ app.get(
                 message: "Failed to read the MCP action output.",
               },
             },
-            outputResult.error
+            { error: outputResult.error }
           );
         default:
           return assertNever(outputResult.error.type);

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
@@ -161,7 +161,7 @@ app.post(
                 message: "Failed to answer question",
               },
             },
-            result.error
+            { error: result.error }
           );
       }
     }

--- a/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front-api/routes/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -139,7 +139,7 @@ app.post(
                 message: "Failed to validate action",
               },
             },
-            result.error
+            { error: result.error }
           );
       }
     }

--- a/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
+++ b/front-api/routes/v1/w/[wId]/sandbox/actions/call.ts
@@ -163,7 +163,7 @@ app.post(
             message: result.error.message,
           },
         },
-        result.error
+        { error: result.error }
       );
     }
 

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -651,7 +651,7 @@ app.post(
                 "There was an error enqueueing the the document for asynchronous upsert.",
             },
           },
-          enqueueRes.error
+          { error: enqueueRes.error }
         );
       }
       return ctx.json({

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -1,8 +1,9 @@
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import logger from "@app/logger/logger";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PROJECT_FILES_MAX_CONCURRENT_REQUESTS_PER_PROCESS } from ".";
 
@@ -44,6 +45,10 @@ function getProjectFiles(
 }
 
 describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(() => {
     getAllFilesByPrefixMock.mockReset();
     getAllFilesByPrefixMock.mockResolvedValue({ files: [], pageFetchCount: 1 });
@@ -167,6 +172,8 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
   });
 
   it("limits concurrent connector listings and releases slots", async () => {
+    const infoLog = vi.spyOn(logger, "info");
+    const errorLog = vi.spyOn(logger, "error");
     const { workspace, key } = await createPublicApiMockRequest({
       systemKey: true,
     });
@@ -202,6 +209,16 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_files", () => {
         message: "Too many concurrent project file listings. Retry later.",
       },
     });
+    expect(infoLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        statusCode: 429,
+        error: expect.objectContaining({
+          message: "Too many concurrent project file listings. Retry later.",
+        }),
+      }),
+      "API Error"
+    );
+    expect(errorLog).not.toHaveBeenCalled();
 
     releaseListings?.();
     const completedResponses = [];

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -73,13 +73,17 @@ app.get(
       PROJECT_FILES_MAX_CONCURRENT_REQUESTS_PER_PROCESS
     ) {
       ctx.header("Retry-After", "1");
-      return apiError(ctx, {
-        status_code: 429,
-        api_error: {
-          type: "rate_limit_error",
-          message: "Too many concurrent project file listings. Retry later.",
+      return apiError(
+        ctx,
+        {
+          status_code: 429,
+          api_error: {
+            type: "rate_limit_error",
+            message: "Too many concurrent project file listings. Retry later.",
+          },
         },
-      });
+        { isExpected: true }
+      );
     }
 
     activeProjectFilesRequests += 1;

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.ts
@@ -166,7 +166,7 @@ app.post(
             message: "Failed to retrieve consumption facets.",
           },
         },
-        result.error
+        { error: result.error }
       );
     }
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/batch_update_tags.ts
@@ -65,7 +65,7 @@ app.post(
             message: addTagsResult.error.message,
           },
         },
-        addTagsResult.error
+        { error: addTagsResult.error }
       );
     }
 
@@ -84,7 +84,7 @@ app.post(
             message: removeTagsResult.error.message,
           },
         },
-        removeTagsResult.error
+        { error: removeTagsResult.error }
       );
     }
 

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/text_as_cron_rule.ts
@@ -66,7 +66,7 @@ app.post(
             message: cleanMessage,
           },
         },
-        r.error
+        { error: r.error }
       );
     }
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/answer-question.ts
@@ -83,7 +83,7 @@ app.post(
                 message: "Failed to answer question",
               },
             },
-            result.error
+            { error: result.error }
           );
       }
     }

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/raw_content_fragment/index.ts
@@ -159,7 +159,7 @@ app.post("/", validate("param", ParamsSchema), async (ctx) => {
           message: "Error uploading file.",
         },
       },
-      normalizeError(error)
+      { error: normalizeError(error) }
     );
   }
 });

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/validate-action.ts
@@ -74,7 +74,7 @@ app.post(
                 message: "Failed to validate action",
               },
             },
-            result.error
+            { error: result.error }
           );
       }
     }

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -219,7 +219,7 @@ app.get(
             message: "Invalid pagination parameters",
           },
         },
-        paginationRes.error
+        { error: paginationRes.error }
       );
     }
 

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/plan_mode.ts
@@ -55,7 +55,7 @@ app.get(
             message: "Failed to read the plan content.",
           },
         },
-        contentRes.error
+        { error: contentRes.error }
       );
     }
 
@@ -94,7 +94,7 @@ app.delete(
             message: "Failed to close the plan.",
           },
         },
-        closeRes.error
+        { error: closeRes.error }
       );
     }
 

--- a/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
+++ b/front-api/routes/w/[wId]/sandbox-functions/[functionId]/invocations.ts
@@ -146,7 +146,7 @@ app.post(
             message: "Sandbox function invocation failed.",
           },
         },
-        invocationResult.error
+        { error: invocationResult.error }
       );
     }
 


### PR DESCRIPTION
## Description

Treat the project file listing concurrency guard as an expected API error so its intentional 429 is logged at info. `apiError` now uses one options bag for expected outcomes and attached errors, and the override remains scoped to this callsite.

## Tests

Added an assertion covering the 429 response and info log path.

## Risk

Low. Existing error-attaching callsites were migrated mechanically, and HTTP responses, metrics, and tracing behavior are unchanged. Rollback is a normal revert.

## Deploy Plan

Standard deploy.