### PR TITLE
[ci] disable redundant npm cache in setup-node-deps

### DIFF
--- a/.github/actions/setup-node-deps/action.yml
+++ b/.github/actions/setup-node-deps/action.yml
@@ -24,6 +24,10 @@ runs:
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ inputs.node-version }}
+        # node_modules are already restored below via actions/cache, so npm ci
+        # is skipped on cache hit and this cache is never read. Downloading it
+        # anyway costs ~15s per job for nothing.
+        package-manager-cache: false
 
     - name: Upgrade npm
       shell: bash


### PR DESCRIPTION
## Description

`setup-node-deps` restores `node_modules` directly via `actions/cache`, keyed on the `package-lock.json` hash, and skips `npm ci` entirely whenever that cache hits — which is the near-universal case.

`actions/setup-node` was still running its own `package-manager-cache` step (enabled by default since `package.json` declares a `packageManager` field). That downloads/extracts a separate ~800MB npm cache blob that is never actually read once `npm ci` is skipped. Confirmed via job logs (`Setup Node Dependencies` step on recent `build-and-test-front` runs) that this costs ~15s per job for no benefit.

This composite action is used across ~20 workflows and many jobs per push (front: 8 jobs, front-api: 8 jobs, etc.), so disabling the redundant cache shaves a fixed ~15s off nearly every CI job.

Disabled `package-manager-cache` on the `actions/setup-node` step.

## Tests

Manual: inspected job step timings/logs from recent `build-and-test-front` runs to confirm (a) the npm-cache download happens even when the `node_modules` cache hits, and (b) `npm ci` is skipped in that case, so the download is unused. This PR's own CI run exercises `setup-node-deps` and will show the step no longer downloads the npm cache.

## Risk

Low. `package-manager-cache` only affects whether `actions/setup-node` restores/saves the global npm cache — it does not change dependency resolution or what gets installed. Worst case if this assumption is ever wrong (e.g. a future change makes `npm ci` run more often), `npm ci` just resolves against the registry instead of a warm npm cache, which is the same behavior as any `node_modules` cache miss today.

## Deploy Plan

None — CI-only change, takes effect on merge for subsequent workflow runs.