### PR TITLE
[front] enh: add personal consumption analytics popover

### DIFF
--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -1,0 +1,166 @@
+import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
+import { ConsumptionChart } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
+import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
+import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
+import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import { DEFAULT_CONSUMPTION_DIMENSION } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
+import { UsageFilterSummary } from "@app/components/workspace/analytics/UsageFilterSummary";
+import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
+import {
+  addUsageFilterFromAttributionRow,
+  removeUsageFilterFromAttributionRow,
+  setUsageFilterFromAttributionRow,
+  toConsumptionScopeFilter,
+} from "@app/components/workspace/analytics/usageFilter";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  Button,
+  DialogClose,
+  DialogHeader,
+  DialogTitle,
+  Page,
+  XClose,
+} from "@dust-tt/sparkle";
+import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
+import { useMemo, useState } from "react";
+
+interface UserAnalyticsPopoverProps {
+  open: boolean;
+  owner: WorkspaceType;
+}
+
+export function UserAnalyticsPopover({
+  open,
+  owner,
+}: UserAnalyticsPopoverProps) {
+  const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
+    DEFAULT_CONSUMPTION_PERIOD
+  );
+  const [dimension, setDimension] = useState<ConsumptionDimension>(
+    DEFAULT_CONSUMPTION_DIMENSION
+  );
+  const [filter, setFilter] = useState<UsageFilter>({});
+  const scopeFilter = useMemo(() => toConsumptionScopeFilter(filter), [filter]);
+  const shouldReduceMotion = useReducedMotion();
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <DialogHeader hideButton className="p-5 sm:p-6">
+        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 gap-y-4 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
+          <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
+            <DialogTitle className="heading-2xl">Analytics</DialogTitle>
+            <ConsumptionOverview
+              workspaceId={owner.sId}
+              period={period}
+              personal
+              disabled={!open}
+            />
+          </div>
+          <div className="col-span-2 row-start-2 sm:col-span-1 sm:col-start-2 sm:row-start-1">
+            <ConsumptionPeriodSelector
+              period={period}
+              onPeriodChange={setPeriod}
+            />
+          </div>
+          <DialogClose asChild>
+            <Button
+              className="col-start-2 row-start-1 sm:col-start-3"
+              variant="ghost"
+              size="mini"
+              icon={XClose}
+              aria-label="Close analytics"
+            />
+          </DialogClose>
+        </div>
+      </DialogHeader>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 sm:px-6">
+        <Page.Vertical align="stretch" gap="xl">
+          <ConsumptionSummary
+            workspaceId={owner.sId}
+            period={period}
+            personal
+            disabled={!open}
+          />
+
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col">
+              <div className="flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold text-foreground">
+                  Explore
+                </h2>
+                <UsageFilterPanel
+                  owner={owner}
+                  period={period}
+                  filter={filter}
+                  personal
+                  onFilterChange={setFilter}
+                  showMemberGroupFilter={false}
+                />
+              </div>
+              <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
+            </div>
+            <LazyMotion features={domMax}>
+              <m.div
+                layout={!shouldReduceMotion}
+                transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
+                className="flex flex-col"
+              >
+                <ConsumptionChart
+                  workspaceId={owner.sId}
+                  period={period}
+                  dimension={dimension}
+                  filter={scopeFilter}
+                  personal
+                  disabled={!open}
+                />
+              </m.div>
+            </LazyMotion>
+          </div>
+
+          <ConsumptionAttributionTable
+            workspaceId={owner.sId}
+            period={period}
+            filter={scopeFilter}
+            personal
+            disabled={!open}
+            onAddFilter={(selectedRow) => {
+              setFilter((current) =>
+                addUsageFilterFromAttributionRow(
+                  current,
+                  dimension,
+                  selectedRow
+                )
+              );
+            }}
+            onRemoveFilter={(selectedRow) => {
+              setFilter((current) =>
+                removeUsageFilterFromAttributionRow(
+                  current,
+                  dimension,
+                  selectedRow
+                )
+              );
+            }}
+            dimension={dimension}
+            onDimensionChange={setDimension}
+            onViewAll={(nextDimension, selectedRow) => {
+              setFilter((current) =>
+                setUsageFilterFromAttributionRow(
+                  current,
+                  dimension,
+                  selectedRow
+                )
+              );
+              setDimension(nextDimension);
+            }}
+          />
+        </Page.Vertical>
+      </div>
+    </div>
+  );
+}

--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -48,7 +48,7 @@ export function UserAnalyticsPopover({
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <div className="flex h-full flex-col gap-1 overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden">
       <DialogHeader hideButton className="p-5 sm:p-6">
         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 gap-y-4 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
           <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
@@ -78,7 +78,7 @@ export function UserAnalyticsPopover({
         </div>
       </DialogHeader>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 sm:px-6">
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-1 sm:px-6">
         <Page.Vertical align="stretch" gap="xl">
           <ConsumptionSummary
             workspaceId={owner.sId}

--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -48,7 +48,7 @@ export function UserAnalyticsPopover({
   const shouldReduceMotion = useReducedMotion();
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="flex h-full flex-col gap-1 overflow-hidden">
       <DialogHeader hideButton className="p-5 sm:p-6">
         <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-x-2 gap-y-4 sm:grid-cols-[minmax(0,1fr)_auto_auto]">
           <div className="flex min-w-0 flex-col gap-1 overflow-hidden">
@@ -78,7 +78,7 @@ export function UserAnalyticsPopover({
         </div>
       </DialogHeader>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 pt-1 sm:px-6">
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 sm:px-6">
         <Page.Vertical align="stretch" gap="xl">
           <ConsumptionSummary
             workspaceId={owner.sId}

--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -78,7 +78,7 @@ export function UserAnalyticsPopover({
         </div>
       </DialogHeader>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 pt-1 sm:px-6">
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 pt-1 sm:px-6">
         <Page.Vertical align="stretch" gap="xl">
           <ConsumptionSummary
             workspaceId={owner.sId}

--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -78,7 +78,7 @@ export function UserAnalyticsPopover({
         </div>
       </DialogHeader>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 sm:px-6">
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 pt-1 sm:px-6">
         <Page.Vertical align="stretch" gap="xl">
           <ConsumptionSummary
             workspaceId={owner.sId}

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -4,6 +4,7 @@ import { InputBarContext } from "@app/components/assistant/conversation/input_ba
 import { useConversationDrafts } from "@app/components/assistant/conversation/input_bar/useConversationDrafts";
 import { UserAutomationsDialog } from "@app/components/me/UserAutomationsDialog";
 import { UserToolsDialog } from "@app/components/me/UserToolsDialog";
+import { UserAnalyticsPopover } from "@app/components/UserAnalyticsPopover";
 import { UserSettingsPopover } from "@app/components/UserSettingsPopover";
 import { WorkspacePickerRadioGroup } from "@app/components/WorkspacePicker";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
@@ -32,12 +33,15 @@ import { isOnlyAdmin, isOnlyManager, isOnlyUser } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import {
   Avatar,
+  BarChart01,
   Beaker02,
   BookOpen01,
   ChevronDown,
   ChromeLogo,
   Clock,
   cn,
+  Dialog,
+  DialogContent,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -84,6 +88,7 @@ export function UserMenu({
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [toolsOpen, setToolsOpen] = useState(false);
   const [automationsOpen, setAutomationsOpen] = useState(false);
+  const [analyticsOpen, setAnalyticsOpen] = useState(false);
 
   const sendNotification = useSendNotification();
   const devMode = useDevMode();
@@ -251,6 +256,15 @@ export function UserMenu({
         onOpenChange={setAutomationsOpen}
         owner={owner}
       />
+      <Dialog open={analyticsOpen} onOpenChange={setAnalyticsOpen}>
+        <DialogContent size="2xl" height="xl" className="focus:outline-none">
+          <UserAnalyticsPopover
+            key={owner.sId}
+            open={analyticsOpen}
+            owner={owner}
+          />
+        </DialogContent>
+      </Dialog>
       <DropdownMenu>
         <DropdownMenuTrigger className="hover:bg-hover data-[state=open]:bg-selected rounded-xl p-2 m-2">
           <div className="group flex cursor-pointer items-center justify-between gap-2">
@@ -412,6 +426,11 @@ export function UserMenu({
                 label="Automations"
                 icon={Clock}
                 onSelect={() => setAutomationsOpen(true)}
+              />
+              <DropdownMenuItem
+                label="Analytics"
+                icon={BarChart01}
+                onSelect={() => setAnalyticsOpen(true)}
               />
             </>
           )}

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -11,7 +11,7 @@ export function SummaryCard({ label, value, hint }: SummaryCardProps) {
     <div
       className={cn(
         "flex flex-1 flex-col justify-center h-24 gap-1 rounded-xl",
-        "border border-border bg-panel-background p-4"
+        "bg-panel-background p-4 ring-1 ring-inset ring-border"
       )}
     >
       <span className="text-xs font-semibold text-muted-foreground">

--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -11,7 +11,7 @@ export function SummaryCard({ label, value, hint }: SummaryCardProps) {
     <div
       className={cn(
         "flex flex-1 flex-col justify-center h-24 gap-1 rounded-xl",
-        "bg-panel-background p-4 ring-1 ring-inset ring-border"
+        "border border-border bg-panel-background p-4"
       )}
     >
       <span className="text-xs font-semibold text-muted-foreground">


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/30943 and https://github.com/dust-tt/dust/pull/30942.
The goal is to add a personal view for the analytics that shows the same thing as the analytics page, but scoped to the current user.

The previous PRs added a personal mode for the existing components + the backend part.
This PR adds a popover on the `UserMenu` that uses the existing components.

<img width="302" height="313" alt="image" src="https://github.com/user-attachments/assets/53a532c7-2dd6-405f-ad04-33ad92a9d823" />

<img width="948" height="718" alt="image" src="https://github.com/user-attachments/assets/fe38e9ba-059c-48b4-b8b4-7487deebe1ac" />

## Tests

- Tested locally.

## Risk

- Low

## Deploy Plan

- Deploy front.
