### PR TITLE
[connectors] Downgrade ERR_STREAM_UNABLE_TO_PIPE unhandled rejections to warn

### DIFF
--- a/connectors/src/types/shared/utils/global_error_handler.ts
+++ b/connectors/src/types/shared/utils/global_error_handler.ts
@@ -22,6 +22,18 @@ export function setupGlobalErrorHandler(logger: LoggerInterface) {
       return;
     }
 
+    // The GCS client (teeny-request) connects a response to its stream only once the
+    // response arrives. If we closed that stream in the meantime, the connect throws
+    // in a place no caller can catch. Harmless timing issue, so warn instead of panic.
+    if (
+      reason instanceof Error &&
+      "code" in reason &&
+      reason.code === "ERR_STREAM_UNABLE_TO_PIPE"
+    ) {
+      logger.warn({ error: reason }, "Stream teardown race (ignored)");
+      return;
+    }
+
     // uuid here serves as a correlation id for the console.error and the logger.error.
     const uuid = uuidv4();
     // console.log here is important because the promise.catch() below could fail.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1787303916318309).

The GCS client's streaming transport, `teeny-request`, pipes an HTTP response into its request stream only once the response arrives. When our side has destroyed that stream in the meantime, which is what a failed tarball extraction attempt's teardown legitimately does to in-flight reads and uploads, the deferred pipe throws inside the library's own promise continuation where no caller can catch it, and surfaces as an unhandled rejection logged as a panic.

The error code has a single meaning, piping into an already-destroyed stream, so matching it narrowly cannot mask a genuine failure.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

