### PR TITLE
Adds a test that triggers always show agents even deprecated ones

### DIFF
--- a/front-api/routes/w/[wId]/me/triggers.test.ts
+++ b/front-api/routes/w/[wId]/me/triggers.test.ts
@@ -18,8 +18,6 @@ describe("GET /api/w/:wId/me/triggers", () => {
   it("lists a trigger on a deprecated (model-only) global agent such as gemini-pro", async () => {
     const { workspace, auth } = await createPrivateApiMockRequest();
 
-    // `models_picker` hides model-only global agents (gemini-pro included) from
-    // list views, which is what makes them "deprecated" for users.
     await FeatureFlagFactory.basic(auth, "models_picker");
 
     await TriggerFactory.schedule(auth, {
@@ -40,23 +38,5 @@ describe("GET /api/w/:wId/me/triggers", () => {
       isEditor: true,
     });
     expect(triggers[0].agentPictureUrl).toBeTruthy();
-  });
-
-  it("lists a trigger on a retired global agent such as claude-3-7-sonnet", async () => {
-    const { workspace, auth } = await createPrivateApiMockRequest();
-
-    await TriggerFactory.schedule(auth, {
-      name: "Retired agent trigger",
-      agentConfigurationId: GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET,
-      configuration: EVERY_MONDAY_9AM,
-    });
-
-    const response = await getUserTriggers(workspace.sId);
-    expect(response.status).toBe(200);
-
-    const { triggers } = await response.json();
-    expect(triggers.map((t: { agentName: string }) => t.agentName)).toEqual([
-      "claude-3.7",
-    ]);
   });
 });

--- a/front-api/routes/w/[wId]/me/triggers.test.ts
+++ b/front-api/routes/w/[wId]/me/triggers.test.ts
@@ -1,0 +1,62 @@
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+function getUserTriggers(wId: string) {
+  return honoApp.request(`/api/w/${wId}/me/triggers`);
+}
+
+const EVERY_MONDAY_9AM = {
+  cron: "0 9 * * 1",
+  timezone: "Europe/Paris",
+};
+
+describe("GET /api/w/:wId/me/triggers", () => {
+  it("lists a trigger on a deprecated (model-only) global agent such as gemini-pro", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest();
+
+    // `models_picker` hides model-only global agents (gemini-pro included) from
+    // list views, which is what makes them "deprecated" for users.
+    await FeatureFlagFactory.basic(auth, "models_picker");
+
+    await TriggerFactory.schedule(auth, {
+      name: "Weekly gemini digest",
+      agentConfigurationId: GLOBAL_AGENTS_SID.GEMINI_PRO,
+      configuration: EVERY_MONDAY_9AM,
+    });
+
+    const response = await getUserTriggers(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const { triggers } = await response.json();
+    expect(triggers).toHaveLength(1);
+    expect(triggers[0]).toMatchObject({
+      name: "Weekly gemini digest",
+      agentConfigurationId: GLOBAL_AGENTS_SID.GEMINI_PRO,
+      agentName: "gemini-pro",
+      isEditor: true,
+    });
+    expect(triggers[0].agentPictureUrl).toBeTruthy();
+  });
+
+  it("lists a trigger on a retired global agent such as claude-3-7-sonnet", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest();
+
+    await TriggerFactory.schedule(auth, {
+      name: "Retired agent trigger",
+      agentConfigurationId: GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET,
+      configuration: EVERY_MONDAY_9AM,
+    });
+
+    const response = await getUserTriggers(workspace.sId);
+    expect(response.status).toBe(200);
+
+    const { triggers } = await response.json();
+    expect(triggers.map((t: { agentName: string }) => t.agentName)).toEqual([
+      "claude-3.7",
+    ]);
+  });
+});


### PR DESCRIPTION
## Description

w/wId/me/triggers does not filter on the agent list and just resolves the name for each agentId. When you provide a specific agentId, the method does not test that the agents are retired or not.

Adding a test as it's an important behaviour moving forward

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Literally a test!

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Standard deploy
