### PR TITLE
[front] enh: run @analyst on the Standard auto stream

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
@@ -3,9 +3,8 @@ import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_age
 import { Authenticator } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { GROK_4_6_MODEL_CONFIG } from "@app/types/assistant/models/xai";
+import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { describe, expect, it } from "vitest";
 
@@ -25,18 +24,11 @@ async function fetchAnalyst(role: MembershipRoleType, optedOut = false) {
 }
 
 describe("analyst global agent visibility", () => {
-  it("uses Grok 4.6 when xAI is the enabled provider", async () => {
-    const workspace = await WorkspaceFactory.enterprise({
-      whiteListedProviders: ["xai"],
-    });
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  it("runs on the Standard auto stream", () => {
+    const analyst = _getAnalystGlobalAgent();
 
-    const analyst = _getAnalystGlobalAgent({
-      auth,
-      featureFlags: ["xai_feature"],
-    });
-
-    expect(analyst.model.modelId).toBe(GROK_4_6_MODEL_CONFIG.modelId);
+    expect(analyst.model.modelId).toBe(AUTO_MODEL_ID);
+    expect(analyst.status).toBe("active");
   });
 
   it("is available to admins by default", async () => {

--- a/front/lib/api/assistant/global_agents/configurations/analyst.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.ts
@@ -1,26 +1,14 @@
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
-import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import {
-  getLargeWhitelistedModel,
-  getSmallWhitelistedModel,
-} from "@app/lib/api/assistant/models";
-import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 
-export function _getAnalystGlobalAgent({
-  auth,
-  featureFlags,
-}: {
-  auth: Authenticator;
-  featureFlags: WhitelistableFeature[];
-}): AgentConfigurationType {
+export function _getAnalystGlobalAgent(): AgentConfigurationType {
   const prompt = `<primary_goal>
 You are @analyst, an analytics assistant for workspace admins and managers. You help them understand how their Dust workspace is being used by answering questions with data retrieved through your tools.
 </primary_goal>
@@ -33,19 +21,14 @@ You are @analyst, an analytics assistant for workspace admins and managers. You 
 5. Be concise and lead with the answer; add brief context only when it helps interpretation.
 </guidelines>`;
 
-  const modelConfiguration = auth.isUpgraded()
-    ? getLargeWhitelistedModel(auth, undefined, { featureFlags })
-    : getSmallWhitelistedModel(auth, undefined, { featureFlags });
-
-  const model: AgentModelConfigurationType = modelConfiguration
-    ? {
-        providerId: modelConfiguration.providerId,
-        modelId: modelConfiguration.modelId,
-        temperature: 0.2,
-        reasoningEffort: modelConfiguration.defaultReasoningEffort,
-      }
-    : dummyModelConfiguration;
-  const status = modelConfiguration ? "active" : "disabled_by_admin";
+  // Use the Standard auto stream: the sentinel is resolved to a concrete model
+  // + effort at message-send time by resolveModel().
+  const model: AgentModelConfigurationType = {
+    providerId: AUTO_MODEL_CONFIG.providerId,
+    modelId: AUTO_MODEL_CONFIG.modelId,
+    temperature: 0.2,
+    reasoningEffort: AUTO_MODEL_CONFIG.defaultReasoningEffort,
+  };
 
   const sId = GLOBAL_AGENTS_SID.ANALYST;
   const metadata = getGlobalAgentMetadata(sId);
@@ -61,7 +44,7 @@ You are @analyst, an analytics assistant for workspace admins and managers. You 
     instructions: prompt + globalAgentGuidelines,
     instructionsHtml: null,
     pictureUrl: metadata.pictureUrl,
-    status,
+    status: "active",
     userFavorite: false,
     scope: "global",
     model,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -928,7 +928,7 @@ function getGlobalAgent({
       agentConfiguration = _getReinforcementGlobalAgent();
       break;
     case GLOBAL_AGENTS_SID.ANALYST:
-      agentConfiguration = _getAnalystGlobalAgent({ auth, featureFlags });
+      agentConfiguration = _getAnalystGlobalAgent();
       break;
     case GLOBAL_AGENTS_SID.NOOP:
       agentConfiguration = _getNoopAgent();


### PR DESCRIPTION
## Description

The `@analyst` (workspace analytics) global agent resolved its model at configuration-build time via `getLargeWhitelistedModel` / `getSmallWhitelistedModel`, keyed on `auth.isUpgraded()`. It now runs on the **Standard** auto stream (`AUTO_MODEL_CONFIG` / `auto` sentinel) instead — the same pattern sidekick uses for follow-up turns.

Consequences:
- The concrete model + reasoning effort are picked at message-send time by `resolveModel()`, walking the `auto` stream's candidate pool and honoring the workspace's allowed model tiers.
- `status` becomes unconditionally `"active"`: the sentinel is never null, and `resolveModel()` already falls back to `PREFERRED_LARGE_MODEL_CONFIGS` when no stream candidate is available to the workspace, so the old `"disabled_by_admin"` branch was dead.
- `_getAnalystGlobalAgent()` no longer needs `auth` / `featureFlags`, so the params and the call site in `global_agents.ts` were simplified.
- Temperature stays at `0.2`.

No UI change.

## Tests

- Updated `analyst.test.ts`: the "uses Grok 4.6 when xAI is the enabled provider" test no longer applies (provider whitelisting is now handled inside stream resolution) and is replaced by one asserting the agent is on the `auto` stream and `active`. The visibility tests (admin/manager/builder/user, workspace opt-out) are untouched.
- `npx tsgo --noEmit` reports no errors in the touched files, and biome is clean.
- I could not execute the vitest suite locally: every `front` suite currently fails at import with `Failed to resolve import "@novu/framework"` (declared in `front/package.json` but absent from the installed `node_modules`), plus stale `openai` / `@notionhq/client` typings. That is pre-existing on this checkout and unrelated to this change — CI should cover it.

## Risk

Low, and scoped to one global agent that is only visible to workspace admins and managers.

- Behavior change: the model backing `@analyst` may differ from before for a given workspace (it now follows the Standard tier pool rather than the whitelisted large/small pick). Answer quality/cost shifts accordingly.
- Note that `AUTO_MODEL_CONFIG` is declared with `availableIfOneOf: { featureFlag: "models_picker" }`; workspaces without that flag fall through `resolveStreamModel` to the generic preferred-large-model fallback, so they keep getting a working model — worth a reviewer's eye since this is the main behavioral edge.
- Fully rollback-safe: no schema or persisted state involved, global agent configs are computed on read.

## Deploy Plan

Standard deploy of `front`. No migration, no ordering constraint, no follow-up step.