### PR TITLE
Analytics: migrate the analyst agent to standard tier

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
@@ -3,9 +3,8 @@ import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_age
 import { Authenticator } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { GROK_4_6_MODEL_CONFIG } from "@app/types/assistant/models/xai";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { describe, expect, it } from "vitest";
 
@@ -25,18 +24,12 @@ async function fetchAnalyst(role: MembershipRoleType, optedOut = false) {
 }
 
 describe("analyst global agent visibility", () => {
-  it("uses Grok 4.6 when xAI is the enabled provider", async () => {
-    const workspace = await WorkspaceFactory.enterprise({
-      whiteListedProviders: ["xai"],
-    });
-    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  it("uses the Standard auto stream", () => {
+    const analyst = _getAnalystGlobalAgent();
 
-    const analyst = _getAnalystGlobalAgent({
-      auth,
-      featureFlags: ["xai_feature"],
-    });
-
-    expect(analyst.model.modelId).toBe(GROK_4_6_MODEL_CONFIG.modelId);
+    expect(analyst.model.providerId).toBe(AUTO_MODEL_CONFIG.providerId);
+    expect(analyst.model.modelId).toBe(AUTO_MODEL_CONFIG.modelId);
+    expect(analyst.status).toBe("active");
   });
 
   it("is available to admins by default", async () => {

--- a/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.test.ts
@@ -3,8 +3,12 @@ import { getGlobalAgents } from "@app/lib/api/assistant/global_agents/global_age
 import { Authenticator } from "@app/lib/auth";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
+import {
+  AUTO_FAST_MODEL_CONFIG,
+  AUTO_MODEL_CONFIG,
+} from "@app/types/assistant/models/auto";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { describe, expect, it } from "vitest";
 
@@ -24,12 +28,25 @@ async function fetchAnalyst(role: MembershipRoleType, optedOut = false) {
 }
 
 describe("analyst global agent visibility", () => {
-  it("uses the Standard auto stream", () => {
-    const analyst = _getAnalystGlobalAgent();
+  it("uses the Standard auto stream on upgraded workspaces", async () => {
+    const workspace = await WorkspaceFactory.enterprise();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const analyst = _getAnalystGlobalAgent({ auth });
 
     expect(analyst.model.providerId).toBe(AUTO_MODEL_CONFIG.providerId);
     expect(analyst.model.modelId).toBe(AUTO_MODEL_CONFIG.modelId);
     expect(analyst.status).toBe("active");
+  });
+
+  it("uses the Basic auto stream on non-upgraded workspaces", async () => {
+    const workspace = await WorkspaceFactory.freeNoProductAccess();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const analyst = _getAnalystGlobalAgent({ auth });
+
+    expect(analyst.model.providerId).toBe(AUTO_FAST_MODEL_CONFIG.providerId);
+    expect(analyst.model.modelId).toBe(AUTO_FAST_MODEL_CONFIG.modelId);
   });
 
   it("is available to admins by default", async () => {

--- a/front/lib/api/assistant/global_agents/configurations/analyst.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.ts
@@ -1,26 +1,14 @@
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
-import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
-import {
-  getLargeWhitelistedModel,
-  getSmallWhitelistedModel,
-} from "@app/lib/api/assistant/models";
-import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
+import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
 
-export function _getAnalystGlobalAgent({
-  auth,
-  featureFlags,
-}: {
-  auth: Authenticator;
-  featureFlags: WhitelistableFeature[];
-}): AgentConfigurationType {
+export function _getAnalystGlobalAgent(): AgentConfigurationType {
   const prompt = `<primary_goal>
 You are @analyst, an analytics assistant for workspace admins and managers. You help them understand how their Dust workspace is being used by answering questions with data retrieved through your tools.
 </primary_goal>
@@ -33,19 +21,14 @@ You are @analyst, an analytics assistant for workspace admins and managers. You 
 5. Be concise and lead with the answer; add brief context only when it helps interpretation.
 </guidelines>`;
 
-  const modelConfiguration = auth.isUpgraded()
-    ? getLargeWhitelistedModel(auth, undefined, { featureFlags })
-    : getSmallWhitelistedModel(auth, undefined, { featureFlags });
-
-  const model: AgentModelConfigurationType = modelConfiguration
-    ? {
-        providerId: modelConfiguration.providerId,
-        modelId: modelConfiguration.modelId,
-        temperature: 0.2,
-        reasoningEffort: modelConfiguration.defaultReasoningEffort,
-      }
-    : dummyModelConfiguration;
-  const status = modelConfiguration ? "active" : "disabled_by_admin";
+  // Use the Standard auto stream: the sentinel is resolved to a concrete model +
+  // effort at message-send time by resolveModel().
+  const model: AgentModelConfigurationType = {
+    providerId: AUTO_MODEL_CONFIG.providerId,
+    modelId: AUTO_MODEL_CONFIG.modelId,
+    temperature: 0.2,
+    reasoningEffort: AUTO_MODEL_CONFIG.defaultReasoningEffort,
+  };
 
   const sId = GLOBAL_AGENTS_SID.ANALYST;
   const metadata = getGlobalAgentMetadata(sId);
@@ -61,7 +44,7 @@ You are @analyst, an analytics assistant for workspace admins and managers. You 
     instructions: prompt + globalAgentGuidelines,
     instructionsHtml: null,
     pictureUrl: metadata.pictureUrl,
-    status,
+    status: "active",
     userFavorite: false,
     scope: "global",
     model,

--- a/front/lib/api/assistant/global_agents/configurations/analyst.ts
+++ b/front/lib/api/assistant/global_agents/configurations/analyst.ts
@@ -1,14 +1,22 @@
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
+import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
 } from "@app/types/assistant/agent";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { AUTO_MODEL_CONFIG } from "@app/types/assistant/models/auto";
+import {
+  AUTO_FAST_MODEL_CONFIG,
+  AUTO_MODEL_CONFIG,
+} from "@app/types/assistant/models/auto";
 
-export function _getAnalystGlobalAgent(): AgentConfigurationType {
+export function _getAnalystGlobalAgent({
+  auth,
+}: {
+  auth: Authenticator;
+}): AgentConfigurationType {
   const prompt = `<primary_goal>
 You are @analyst, an analytics assistant for workspace admins and managers. You help them understand how their Dust workspace is being used by answering questions with data retrieved through your tools.
 </primary_goal>
@@ -21,13 +29,18 @@ You are @analyst, an analytics assistant for workspace admins and managers. You 
 5. Be concise and lead with the answer; add brief context only when it helps interpretation.
 </guidelines>`;
 
-  // Use the Standard auto stream: the sentinel is resolved to a concrete model +
-  // effort at message-send time by resolveModel().
+  // Standard auto stream for upgraded workspaces, Basic one otherwise. Both
+  // sentinels are resolved to a concrete model + effort at message-send time by
+  // resolveModel().
+  const modelConfiguration = auth.isUpgraded()
+    ? AUTO_MODEL_CONFIG
+    : AUTO_FAST_MODEL_CONFIG;
+
   const model: AgentModelConfigurationType = {
-    providerId: AUTO_MODEL_CONFIG.providerId,
-    modelId: AUTO_MODEL_CONFIG.modelId,
+    providerId: modelConfiguration.providerId,
+    modelId: modelConfiguration.modelId,
     temperature: 0.2,
-    reasoningEffort: AUTO_MODEL_CONFIG.defaultReasoningEffort,
+    reasoningEffort: modelConfiguration.defaultReasoningEffort,
   };
 
   const sId = GLOBAL_AGENTS_SID.ANALYST;

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -928,7 +928,7 @@ function getGlobalAgent({
       agentConfiguration = _getReinforcementGlobalAgent();
       break;
     case GLOBAL_AGENTS_SID.ANALYST:
-      agentConfiguration = _getAnalystGlobalAgent({ auth, featureFlags });
+      agentConfiguration = _getAnalystGlobalAgent();
       break;
     case GLOBAL_AGENTS_SID.NOOP:
       agentConfiguration = _getNoopAgent();

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -928,7 +928,7 @@ function getGlobalAgent({
       agentConfiguration = _getReinforcementGlobalAgent();
       break;
     case GLOBAL_AGENTS_SID.ANALYST:
-      agentConfiguration = _getAnalystGlobalAgent();
+      agentConfiguration = _getAnalystGlobalAgent({ auth });
       break;
     case GLOBAL_AGENTS_SID.NOOP:
       agentConfiguration = _getNoopAgent();


### PR DESCRIPTION
## Description

It makes no sense to be stuck on sonnet 4.6 for the analyst agent.
Standard tier is more up to date and resolve correctly if the standard tier is not available

<img width="1498" height="1064" alt="image" src="https://github.com/user-attachments/assets/bf663e50-9bff-46c1-945d-d06752b362e8" />


## Tests

tested locally

## Risk

low, easy to revert
## Deploy Plan

deploy front
