### PR TITLE
[front] enh: Put the analytics consumption view in URL params

### DIFF
--- a/front/lib/analytics/view_params.test.ts
+++ b/front/lib/analytics/view_params.test.ts
@@ -1,0 +1,223 @@
+import { CONSUMPTION_DIMENSIONS } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import { USAGE_FILTER_CATEGORIES } from "@app/components/workspace/analytics/usageFilter";
+import { CONSUMPTION_PERIOD_OPTIONS } from "@app/lib/analytics/consumption_period";
+import type { AnalyticsViewState } from "@app/lib/analytics/view_params";
+import {
+  analyticsConsumptionHref,
+  analyticsViewQuery,
+  analyticsViewQueryString,
+  analyticsViewUrlQuery,
+  DEFAULT_ANALYTICS_VIEW_STATE,
+  MAX_ANALYTICS_URL_LENGTH,
+  readAnalyticsView,
+} from "@app/lib/analytics/view_params";
+import { CONSUMPTION_FILTER_MAX_VALUES_PER_DIMENSION } from "@app/lib/api/analytics/consumption/scope";
+import { describe, expect, it } from "vitest";
+
+const WORKSPACE_ID = "0ec9852c2f";
+
+function roundTripped(view: AnalyticsViewState): AnalyticsViewState {
+  const query = analyticsViewQueryString(analyticsViewQuery(view));
+  const readBack: Record<string, string[]> = {};
+  for (const [name, value] of new URLSearchParams(query)) {
+    readBack[name] = [...(readBack[name] ?? []), value];
+  }
+  return readAnalyticsView(readBack);
+}
+
+const VIEW_CASES: [query: string, state: AnalyticsViewState][] = [
+  ["", DEFAULT_ANALYTICS_VIEW_STATE],
+  [
+    "a=8oGtWFRlPa",
+    {
+      period: { kind: "cycle" },
+      dimension: "agent",
+      filter: { agent: ["8oGtWFRlPa"] },
+    },
+  ],
+  [
+    "p=30&d=model&a=8oGtWFRlPa&s=slack",
+    {
+      period: { kind: "days", days: 30 },
+      dimension: "model",
+      filter: { agent: ["8oGtWFRlPa"], source: ["slack"] },
+    },
+  ],
+  [
+    "k=Zapier+prod+*main*",
+    {
+      period: { kind: "cycle" },
+      dimension: "agent",
+      filter: { api_key: ["Zapier prod *main*"] },
+    },
+  ],
+];
+
+describe("analytics view params", () => {
+  it.each(VIEW_CASES)("writes %s", (query, state) => {
+    expect(analyticsViewQueryString(analyticsViewQuery(state))).toBe(query);
+  });
+
+  it.each(VIEW_CASES)("reads %s", (query, state) => {
+    expect(roundTripped(state)).toEqual(state);
+  });
+
+  it("spends nothing on a field that is already on its default", () => {
+    expect(
+      analyticsViewQueryString(
+        analyticsViewQuery({
+          ...DEFAULT_ANALYTICS_VIEW_STATE,
+          filter: { model: [], source: ["slack"] },
+        })
+      )
+    ).toBe("s=slack");
+  });
+
+  it("clears the params a field no longer needs", () => {
+    expect(
+      analyticsViewQuery({
+        ...DEFAULT_ANALYTICS_VIEW_STATE,
+        filter: { source: ["slack"] },
+      })
+    ).toEqual({
+      p: undefined,
+      d: undefined,
+      a: undefined,
+      u: undefined,
+      g: undefined,
+      m: undefined,
+      t: undefined,
+      sk: undefined,
+      s: ["slack"],
+      k: undefined,
+    });
+  });
+});
+
+describe("every axis of the view survives the round trip", () => {
+  it.each(CONSUMPTION_PERIOD_OPTIONS)("period %o", (period) => {
+    const view = { ...DEFAULT_ANALYTICS_VIEW_STATE, period };
+
+    expect(roundTripped(view)).toEqual(view);
+  });
+
+  it.each(CONSUMPTION_DIMENSIONS)("dimension %s", (dimension) => {
+    const view = { ...DEFAULT_ANALYTICS_VIEW_STATE, dimension };
+
+    expect(roundTripped(view)).toEqual(view);
+  });
+
+  it.each(USAGE_FILTER_CATEGORIES)("category %s", (category) => {
+    const view = {
+      ...DEFAULT_ANALYTICS_VIEW_STATE,
+      filter: { [category]: ["id-1", "id 2", "a&b=c"] },
+    };
+
+    expect(roundTripped(view)).toEqual(view);
+  });
+});
+
+describe("readAnalyticsView", () => {
+  it("renders the default view for anything it cannot read", () => {
+    expect(readAnalyticsView({})).toEqual(DEFAULT_ANALYTICS_VIEW_STATE);
+    expect(readAnalyticsView({ p: "45", d: "nope", a: "" })).toEqual(
+      DEFAULT_ANALYTICS_VIEW_STATE
+    );
+    expect(readAnalyticsView({ p: ["30", "7"] }).period).toEqual({
+      kind: "days",
+      days: 30,
+    });
+  });
+
+  it("ignores a param it does not own", () => {
+    expect(readAnalyticsView({ tab: "explore", v: "1pd30" })).toEqual(
+      DEFAULT_ANALYTICS_VIEW_STATE
+    );
+  });
+
+  it("caps a category at what the API accepts", () => {
+    const agents = Array.from({ length: 900 }, (_, index) => `agent-${index}`);
+
+    expect(readAnalyticsView({ a: agents }).filter.agent).toHaveLength(
+      CONSUMPTION_FILTER_MAX_VALUES_PER_DIMENSION
+    );
+  });
+});
+
+describe("analyticsViewUrlQuery", () => {
+  it("rebuilds the query from the unowned head and complete view tail", () => {
+    expect(
+      analyticsViewUrlQuery(
+        `/w/${WORKSPACE_ID}/analytics/consumption`,
+        { tab: "explore", a: "old-agent" },
+        {
+          ...DEFAULT_ANALYTICS_VIEW_STATE,
+          dimension: "model",
+          filter: { source: ["slack"] },
+        }
+      )
+    ).toEqual({
+      tab: "explore",
+      p: undefined,
+      d: "model",
+      a: undefined,
+      u: undefined,
+      g: undefined,
+      m: undefined,
+      t: undefined,
+      sk: undefined,
+      s: ["slack"],
+      k: undefined,
+    });
+  });
+
+  it("drops the whole query when the URL would be too long", () => {
+    const query = analyticsViewUrlQuery(
+      `/w/${WORKSPACE_ID}/analytics/consumption`,
+      { tab: "explore", a: "old-agent" },
+      {
+        ...DEFAULT_ANALYTICS_VIEW_STATE,
+        filter: { source: ["x".repeat(MAX_ANALYTICS_URL_LENGTH)] },
+      }
+    );
+
+    expect(query).toEqual({});
+  });
+});
+
+describe("analyticsConsumptionHref", () => {
+  it("omits the query string for the default view", () => {
+    expect(analyticsConsumptionHref(WORKSPACE_ID)).toBe(
+      `/w/${WORKSPACE_ID}/analytics/consumption`
+    );
+  });
+
+  it("builds a link other pages can hand to the router", () => {
+    expect(
+      analyticsConsumptionHref(WORKSPACE_ID, {
+        period: { kind: "days", days: 30 },
+        dimension: "model",
+        filter: { agent: ["8oGtWFRlPa"] },
+      })
+    ).toBe(
+      `/w/${WORKSPACE_ID}/analytics/consumption?p=30&d=model&a=8oGtWFRlPa`
+    );
+  });
+
+  it("leaves escaping to the serializer", () => {
+    const href = analyticsConsumptionHref(WORKSPACE_ID, {
+      filter: { api_key: ["Zapier prod *main*", "a&b"] },
+    });
+    const url = new URL(href, "https://dust.tt");
+
+    expect(url.searchParams.getAll("k")).toEqual(["Zapier prod *main*", "a&b"]);
+  });
+
+  it("omits the query string when the URL would be too long", () => {
+    expect(
+      analyticsConsumptionHref(WORKSPACE_ID, {
+        filter: { source: ["x".repeat(MAX_ANALYTICS_URL_LENGTH)] },
+      })
+    ).toBe(`/w/${WORKSPACE_ID}/analytics/consumption`);
+  });
+});

--- a/front/lib/analytics/view_params.ts
+++ b/front/lib/analytics/view_params.ts
@@ -1,0 +1,195 @@
+import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import {
+  consumptionDimensionFromQueryParam,
+  DEFAULT_CONSUMPTION_DIMENSION,
+} from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import type { UsageFilterCategory } from "@app/components/workspace/analytics/usageFilter";
+import { USAGE_FILTER_CATEGORIES } from "@app/components/workspace/analytics/usageFilter";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import {
+  CONSUMPTION_PERIOD_DAY_OPTIONS,
+  DEFAULT_CONSUMPTION_PERIOD,
+} from "@app/lib/analytics/consumption_period";
+import { CONSUMPTION_FILTER_MAX_VALUES_PER_DIMENSION } from "@app/lib/api/analytics/consumption/scope";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export type AnalyticsViewState = {
+  period: ConsumptionPeriodSelection;
+  dimension: ConsumptionDimension;
+  filter: Partial<Record<UsageFilterCategory, string[]>>;
+};
+
+export const DEFAULT_ANALYTICS_VIEW_STATE: AnalyticsViewState = {
+  period: DEFAULT_CONSUMPTION_PERIOD,
+  dimension: DEFAULT_CONSUMPTION_DIMENSION,
+  filter: {},
+};
+
+export const MAX_ANALYTICS_URL_LENGTH = 2_048;
+
+const PERIOD_PARAM = "p";
+
+const DIMENSION_PARAM = "d";
+
+const CATEGORY_PARAM = {
+  agent: "a",
+  member: "u",
+  group: "g",
+  model: "m",
+  tool: "t",
+  skill: "sk",
+  source: "s",
+  api_key: "k",
+} as const satisfies Record<UsageFilterCategory, string>;
+
+export const ANALYTICS_VIEW_PARAMS: readonly string[] = [
+  PERIOD_PARAM,
+  DIMENSION_PARAM,
+  ...Object.values(CATEGORY_PARAM),
+];
+
+export type AnalyticsQuery = Record<string, string | string[] | undefined>;
+
+function readValues(value: string | string[] | undefined): string[] {
+  if (value === undefined) {
+    return [];
+  }
+  return (Array.isArray(value) ? value : [value]).filter(
+    (single) => single.length > 0
+  );
+}
+
+function periodParam(period: ConsumptionPeriodSelection): string | undefined {
+  switch (period.kind) {
+    case "cycle":
+      return undefined;
+    case "days":
+      return String(period.days);
+    default:
+      return assertNever(period);
+  }
+}
+
+function readPeriod(
+  value: string | string[] | undefined
+): ConsumptionPeriodSelection {
+  const [first] = readValues(value);
+  const days = CONSUMPTION_PERIOD_DAY_OPTIONS.find(
+    (option) => option === Number(first)
+  );
+  return days ? { kind: "days", days } : DEFAULT_CONSUMPTION_PERIOD;
+}
+
+/**
+ * Best effort: a value this build does not know falls back to the default for
+ * its field, and a filter longer than the API accepts is cut to fit, so a
+ * hand-written URL degrades instead of breaking the page.
+ */
+export function readAnalyticsView(query: AnalyticsQuery): AnalyticsViewState {
+  const filter: AnalyticsViewState["filter"] = {};
+  for (const category of USAGE_FILTER_CATEGORIES) {
+    const ids = readValues(query[CATEGORY_PARAM[category]]).slice(
+      0,
+      CONSUMPTION_FILTER_MAX_VALUES_PER_DIMENSION
+    );
+    if (ids.length > 0) {
+      filter[category] = ids;
+    }
+  }
+
+  // Spelled out rather than spread over the default, so a field added to the
+  // view state has to be read here before this compiles.
+  return {
+    period: readPeriod(query[PERIOD_PARAM]),
+    dimension: consumptionDimensionFromQueryParam(
+      readValues(query[DIMENSION_PARAM])[0]
+    ),
+    filter,
+  };
+}
+
+function filterQuery(filter: AnalyticsViewState["filter"]): AnalyticsQuery {
+  const query: AnalyticsQuery = {};
+  for (const category of USAGE_FILTER_CATEGORIES) {
+    query[CATEGORY_PARAM[category]] = filter[category]?.length
+      ? filter[category]
+      : undefined;
+  }
+  return query;
+}
+
+/**
+ * Every param the view owns, on `undefined` when the field is on its default,
+ * so merging this over the current query both writes and clears.
+ */
+export function analyticsViewQuery(view: AnalyticsViewState): AnalyticsQuery {
+  // Keyed on the view state so a field added to it has no home in the URL
+  // until someone gives it one.
+  const fields = {
+    period: { [PERIOD_PARAM]: periodParam(view.period) },
+    dimension: {
+      [DIMENSION_PARAM]:
+        view.dimension === DEFAULT_CONSUMPTION_DIMENSION
+          ? undefined
+          : view.dimension,
+    },
+    filter: filterQuery(view.filter),
+  } satisfies Record<keyof AnalyticsViewState, AnalyticsQuery>;
+
+  return Object.values(fields).reduce((all, part) => ({ ...all, ...part }), {});
+}
+
+// Serializes only the params the view owns, so the page can tell whether the
+// URL already says what the state says.
+export function analyticsViewQueryString(query: AnalyticsQuery): string {
+  return queryString(query, ANALYTICS_VIEW_PARAMS);
+}
+
+function queryString(query: AnalyticsQuery, names: readonly string[]): string {
+  const params = new URLSearchParams();
+  for (const name of names) {
+    for (const value of readValues(query[name])) {
+      params.append(name, value);
+    }
+  }
+  return params.toString();
+}
+
+function urlWithQuery(pathname: string, query: AnalyticsQuery): string {
+  const querySuffix = queryString(query, Object.keys(query));
+  return querySuffix ? `${pathname}?${querySuffix}` : pathname;
+}
+
+/**
+ * Rebuilds the URL from the query params the page does not own (`head`) and
+ * the complete analytics view (`tail`).
+ */
+export function analyticsViewUrlQuery(
+  pathname: string,
+  head: AnalyticsQuery,
+  view: AnalyticsViewState
+): AnalyticsQuery {
+  const tail = analyticsViewQuery(view);
+  const candidate = { ...head, ...tail };
+
+  if (urlWithQuery(pathname, candidate).length > MAX_ANALYTICS_URL_LENGTH) {
+    return {};
+  }
+
+  return candidate;
+}
+
+export function analyticsConsumptionHref(
+  workspaceId: string,
+  input: Partial<AnalyticsViewState> = {}
+): string {
+  const view: AnalyticsViewState = {
+    period: input.period ?? DEFAULT_ANALYTICS_VIEW_STATE.period,
+    dimension: input.dimension ?? DEFAULT_ANALYTICS_VIEW_STATE.dimension,
+    filter: input.filter ?? {},
+  };
+  const path = `/w/${workspaceId}/analytics/consumption`;
+  const query = analyticsViewUrlQuery(path, {}, view);
+
+  return urlWithQuery(path, query);
+}

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -65,6 +65,9 @@ export const CONSUMPTION_DIMENSION_UNIT: Record<
   source: "message",
 };
 
+// Bounds the `terms` clause each selected dimension turns into.
+export const CONSUMPTION_FILTER_MAX_VALUES_PER_DIMENSION = 500;
+
 export const CONSUMPTION_SCOPE_FILTER_KEYS = [
   "agents",
   "users",


### PR DESCRIPTION


## Description

This stack aims at adding to Analytics (new) page filters <> query params two way relationship
Caveat - we prioritize rendering the page consistently over guaranteeing two users will see the same data:

* if query params are too long, we drop it, it will not affect the page functionality.
* if a param is passed that cannot apply to the current users's (id no longer there, param does not exist anymore) => we drop it

## Tests

Tested locally (top of the stack)


## Risk

Low - dead code for now

## Deploy Plan

Merge