### PR TITLE
[front] feat: add personal consumption analytics API

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6155,7 +6155,7 @@
     "/api/w/{wId}/analytics/consumption/facets": {
       "post": {
         "summary": "List consumption analytics facets",
-        "description": "Lists current workspace entities and historical indexed values present in the selected period for each consumption dimension. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.",
+        "description": "Lists current entities and historical indexed values present in the selected period for each consumption dimension. The workspace route requires a manager; the /me route is restricted server-side to the authenticated member. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.",
         "tags": [
           "Private Analytics"
         ],
@@ -6200,7 +6200,7 @@
                   },
                   "dimensions": {
                     "type": "array",
-                    "description": "Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays.",
+                    "description": "Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays. The personal route omits user and group dimensions.",
                     "items": {
                       "type": "string",
                       "enum": [
@@ -6381,13 +6381,16 @@
             "description": "Invalid request body"
           },
           "403": {
-            "description": "Manager role required"
+            "description": "Not authorized for this analytics view"
           },
           "500": {
             "description": "Failed to retrieve consumption facets"
           }
         }
       }
+    },
+    "/api/w/{wId}/me/analytics/consumption/facets": {
+      "$ref": "#/paths/~1api~1w~1{wId}~1analytics~1consumption~1facets"
     },
     "/api/w/{wId}/assistant/agent_configurations": {
       "get": {

--- a/front-api/routes/w/[wId]/analytics/consumption/context.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/context.ts
@@ -1,0 +1,11 @@
+import { createHono } from "@front-api/lib/hono";
+import type { WorkspaceAwareCtx } from "@front-api/middlewares/ctx";
+
+type ConsumptionAnalyticsCtx = WorkspaceAwareCtx & {
+  Variables: {
+    consumptionUserId?: string;
+  };
+};
+
+export const consumptionAnalyticsApp = () =>
+  createHono<ConsumptionAnalyticsCtx>();

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -67,6 +67,14 @@ function getDownloadRequest(wId: string, name: string) {
 }
 
 describe("POST /api/w/:wId/analytics/consumption/export-raw/status", () => {
+  it("is refused to non-managers by default", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await postExportStatusRequest(workspace.sId, {});
+
+    expect(response.status).toBe(403);
+  });
+
   it("returns an empty list and not-generating/not-ready when nothing exists", async () => {
     fileStorageMock.setFilesByPrefix(() => []);
     const { workspace } = await setupTest();
@@ -148,6 +156,23 @@ describe("POST /api/w/:wId/analytics/consumption/export-raw/status", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.isReady).toBe(true);
+  });
+});
+
+describe("personal consumption exports", () => {
+  it("does not mount export routes", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/me/analytics/consumption/export-raw/status`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+
+    expect(response.status).toBe(404);
   });
 });
 

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
@@ -70,6 +70,35 @@ describe("POST /api/w/:wId/analytics/consumption/facets", () => {
     );
   });
 
+  it("lets members list only facets from their own consumption", async () => {
+    const { workspace, user } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    vi.mocked(fetchConsumptionFacets).mockResolvedValue(new Ok(RESPONSE));
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/me/analytics/consumption/facets`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          filter: { users: ["another-user"], sources: ["slack"] },
+          dimensions: ["agent", "user", "group"],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchConsumptionFacets).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: { users: [user.sId], sources: ["slack"] },
+        dimensions: ["agent"],
+        userId: user.sId,
+      })
+    );
+  });
+
   it("requires a manager and reports Elasticsearch failures", async () => {
     const memberRequest = await createPrivateApiMockRequest({ role: "user" });
     const forbiddenResponse = await honoApp.request(

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.ts
@@ -5,20 +5,21 @@ import {
   ConsumptionFacetsBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import { CONSUMPTION_SCOPE_DIMENSIONS } from "@app/lib/api/analytics/consumption/scope";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 // Mounted at /api/w/:wId/analytics/consumption/facets.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/facets.
+const app = consumptionAnalyticsApp();
 
 /**
  * @swagger
  * /api/w/{wId}/analytics/consumption/facets:
  *   post:
  *     summary: List consumption analytics facets
- *     description: Lists current workspace entities and historical indexed values present in the selected period for each consumption dimension. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.
+ *     description: Lists current entities and historical indexed values present in the selected period for each consumption dimension. The workspace route requires a manager; the /me route is restricted server-side to the authenticated member. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.
  *     tags:
  *       - Private Analytics
  *     parameters:
@@ -49,7 +50,7 @@ const app = workspaceApp();
  *                 description: Restricts which documents the facets are computed over. `automations` counts only trigger-originated runs.
  *               dimensions:
  *                 type: array
- *                 description: Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays.
+ *                 description: Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays. The personal route omits user and group dimensions.
  *                 items:
  *                   type: string
  *                   enum: [agent, user, api_key, group, model, tool, skill, source]
@@ -148,18 +149,20 @@ const app = workspaceApp();
  *                       items:
  *                         $ref: '#/components/schemas/PrivateConsumptionFacet'
  *       403:
- *         description: Manager role required
+ *         description: Not authorized for this analytics view
  *       400:
  *         description: Invalid request body
  *       500:
  *         description: Failed to retrieve consumption facets
+ * /api/w/{wId}/me/analytics/consumption/facets:
+ *   $ref: '#/paths/~1api~1w~1{wId}~1analytics~1consumption~1facets'
  */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionFacetsBodySchema),
   async (ctx): HandlerResult<GetConsumptionFacetsResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const { filter, scope, dimensions, ...periodInput } = ctx.req.valid("json");
     const period = await resolveConsumptionPeriod(
       auth,
@@ -168,9 +171,14 @@ app.post(
 
     const result = await fetchConsumptionFacets(auth, {
       period,
-      filter,
+      filter: userId ? { ...filter, users: [userId] } : filter,
       scope,
-      dimensions,
+      dimensions: userId
+        ? (dimensions ?? CONSUMPTION_SCOPE_DIMENSIONS).filter(
+            (dimension) => dimension !== "user" && dimension !== "group"
+          )
+        : dimensions,
+      userId,
     });
     if (result.isErr()) {
       return apiError(

--- a/front-api/routes/w/[wId]/analytics/consumption/index.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/index.ts
@@ -1,4 +1,8 @@
-import { workspaceApp } from "@front-api/middlewares/ctx";
+import {
+  ensureIsManager,
+  ensureIsUser,
+} from "@front-api/middlewares/ensure_role";
+import { consumptionAnalyticsApp } from "./context";
 import exportRawRoute from "./export-raw";
 import facets from "./facets";
 import overview from "./overview";
@@ -12,19 +16,44 @@ import topSources from "./top-sources";
 import topTools from "./top-tools";
 import topUsers from "./top-users";
 
-const app = workspaceApp();
+export function createWorkspaceConsumptionRoutes() {
+  const app = consumptionAnalyticsApp();
+  app.use(ensureIsManager());
+  app.route("/export-raw", exportRawRoute);
+  app.route("/facets", facets);
+  app.route("/overview", overview);
+  app.route("/timeseries", timeseries);
+  app.route("/top-agents", topAgents);
+  app.route("/top-api-keys", topApiKeys);
+  app.route("/top-models", topModels);
+  app.route("/top-skills", topSkills);
+  app.route("/top-sources", topSources);
+  app.route("/top-groups", topGroups);
+  app.route("/top-tools", topTools);
+  app.route("/top-users", topUsers);
 
-app.route("/export-raw", exportRawRoute);
-app.route("/facets", facets);
-app.route("/overview", overview);
-app.route("/timeseries", timeseries);
-app.route("/top-agents", topAgents);
-app.route("/top-api-keys", topApiKeys);
-app.route("/top-models", topModels);
-app.route("/top-skills", topSkills);
-app.route("/top-sources", topSources);
-app.route("/top-groups", topGroups);
-app.route("/top-tools", topTools);
-app.route("/top-users", topUsers);
+  return app;
+}
 
-export default app;
+export function createPersonalConsumptionRoutes() {
+  const app = consumptionAnalyticsApp();
+  app.use(ensureIsUser());
+  app.use(async (ctx, next) => {
+    const user = ctx.get("auth").getNonNullableUser();
+    ctx.set("consumptionUserId", user.sId);
+    await next();
+  });
+
+  // A single-user view does not need member or group ranking endpoints.
+  app.route("/facets", facets);
+  app.route("/overview", overview);
+  app.route("/timeseries", timeseries);
+  app.route("/top-agents", topAgents);
+  app.route("/top-api-keys", topApiKeys);
+  app.route("/top-models", topModels);
+  app.route("/top-skills", topSkills);
+  app.route("/top-sources", topSources);
+  app.route("/top-tools", topTools);
+
+  return app;
+}

--- a/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
@@ -42,12 +42,20 @@ async function setupTest({
   return createPrivateApiMockRequest({ role });
 }
 
-function postOverviewRequest(wId: string, body: Record<string, unknown> = {}) {
-  return honoApp.request(`/api/w/${wId}/analytics/consumption/overview`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
-  });
+function postOverviewRequest(
+  wId: string,
+  body: Record<string, unknown> = {},
+  personal = false
+) {
+  const analyticsPath = personal ? "me/analytics" : "analytics";
+  return honoApp.request(
+    `/api/w/${wId}/${analyticsPath}/consumption/overview`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
 }
 
 describe("POST /api/w/:wId/analytics/consumption/overview", () => {
@@ -58,6 +66,26 @@ describe("POST /api/w/:wId/analytics/consumption/overview", () => {
 
     expect(response.status).toBe(403);
     expect(vi.mocked(fetchConsumptionOverview)).not.toHaveBeenCalled();
+  });
+
+  it("lets members read only their own consumption", async () => {
+    vi.mocked(fetchConsumptionOverview).mockResolvedValue(new Ok(OVERVIEW));
+    const { workspace, user } = await setupTest({ role: "user" });
+
+    const response = await postOverviewRequest(
+      workspace.sId,
+      { filter: { users: ["another-user"], sources: ["slack"] } },
+      true
+    );
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchConsumptionOverview)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: { users: [user.sId], sources: ["slack"] },
+        includeWorkspaceContext: false,
+      })
+    );
   });
 
   it("returns the overview for managers, defaulting to the current cycle", async () => {

--- a/front-api/routes/w/[wId]/analytics/consumption/overview.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.ts
@@ -5,26 +5,27 @@ import {
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 // Mounted at /api/w/:wId/analytics/consumption/overview.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/overview.
+const app = consumptionAnalyticsApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionBodySchema),
   async (ctx): HandlerResult<GetConsumptionOverviewResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const body = ctx.req.valid("json");
 
     const result = await fetchConsumptionOverview(auth, {
       periodInput: toConsumptionPeriodInput(body),
-      filter: body.filter,
+      filter: userId ? { ...body.filter, users: [userId] } : body.filter,
+      includeWorkspaceContext: userId === undefined,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/timeseries.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/timeseries.test.ts
@@ -1,0 +1,93 @@
+import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
+import { fetchConsumptionTimeseries } from "@app/lib/api/analytics/consumption/timeseries";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  import("@app/lib/api/analytics/consumption/timeseries"),
+  async (orig) => {
+    const mod = await orig();
+    return { ...mod, fetchConsumptionTimeseries: vi.fn() };
+  }
+);
+
+const TIMESERIES: GetConsumptionTimeseriesResponse = {
+  period: {
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+  },
+  granularity: "day",
+  mode: "daily",
+  metric: "credit_micro",
+  breakdownBy: null,
+  groups: [{ groupKey: "total", name: "Total" }],
+  points: [],
+};
+
+function postTimeseriesRequest(
+  workspaceId: string,
+  body: Record<string, unknown> = {},
+  personal = false
+) {
+  const analyticsPath = personal ? "me/analytics" : "analytics";
+  return honoApp.request(
+    `/api/w/${workspaceId}/${analyticsPath}/consumption/timeseries`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+describe("POST /api/w/:wId/analytics/consumption/timeseries", () => {
+  it("keeps the workspace view manager-only", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await postTimeseriesRequest(workspace.sId);
+
+    expect(response.status).toBe(403);
+    expect(vi.mocked(fetchConsumptionTimeseries)).not.toHaveBeenCalled();
+  });
+
+  it("lets members read only their own timeseries", async () => {
+    vi.mocked(fetchConsumptionTimeseries).mockResolvedValue(new Ok(TIMESERIES));
+    const { workspace, user } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+
+    const response = await postTimeseriesRequest(
+      workspace.sId,
+      { filter: { users: ["another-user"], models: ["model-1"] } },
+      true
+    );
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchConsumptionTimeseries)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: { users: [user.sId], models: ["model-1"] },
+      })
+    );
+  });
+
+  it.each([
+    "user",
+    "group",
+  ] as const)("rejects the %s breakdown in personal analytics", async (breakdownBy) => {
+    vi.mocked(fetchConsumptionTimeseries).mockClear();
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await postTimeseriesRequest(
+      workspace.sId,
+      { breakdownBy },
+      true
+    );
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+    expect(vi.mocked(fetchConsumptionTimeseries)).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/analytics/consumption/timeseries.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/timeseries.ts
@@ -6,23 +6,23 @@ import {
 import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/consumption/timeseries";
 import { fetchConsumptionTimeseries } from "@app/lib/api/analytics/consumption/timeseries";
 import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 export type { GetConsumptionTimeseriesResponse };
 
 // Mounted at /api/w/:wId/analytics/consumption/timeseries.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/timeseries.
+const app = consumptionAnalyticsApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTimeseriesBodySchema),
   async (ctx): HandlerResult<GetConsumptionTimeseriesResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const {
       granularity,
       mode,
@@ -32,6 +32,17 @@ app.post(
       filter,
       ...periodQuery
     } = ctx.req.valid("json");
+
+    if (userId && (breakdownBy === "user" || breakdownBy === "group")) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Personal consumption analytics do not support user or group breakdowns.",
+        },
+      });
+    }
 
     const period = await resolveConsumptionPeriod(
       auth,
@@ -45,7 +56,7 @@ app.post(
       metric,
       breakdownBy,
       breakdownCount,
-      filter,
+      filter: userId ? { ...filter, users: [userId] } : filter,
     });
     if (result.isErr()) {
       logger.error(

--- a/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-agents.ts
@@ -6,23 +6,23 @@ import {
 import type { GetConsumptionTopAgentsResponse } from "@app/lib/api/analytics/consumption/top_agents";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
 import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 export type { GetConsumptionTopAgentsResponse };
 
 // Mounted at /api/w/:wId/analytics/consumption/top-agents.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/top-agents.
+const app = consumptionAnalyticsApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopAgentsResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
@@ -36,7 +36,7 @@ app.post(
       limit,
       offset,
       search,
-      filter,
+      filter: userId ? { ...filter, users: [userId] } : filter,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-api-keys.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-api-keys.ts
@@ -6,23 +6,23 @@ import {
 import type { GetConsumptionTopApiKeysResponse } from "@app/lib/api/analytics/consumption/top_api_keys";
 import { fetchConsumptionTopApiKeys } from "@app/lib/api/analytics/consumption/top_api_keys";
 import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 export type { GetConsumptionTopApiKeysResponse };
 
 // Mounted at /api/w/:wId/analytics/consumption/top-api-keys.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/top-api-keys.
+const app = consumptionAnalyticsApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopApiKeysResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
@@ -36,7 +36,7 @@ app.post(
       limit,
       offset,
       search,
-      filter,
+      filter: userId ? { ...filter, users: [userId] } : filter,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-models.ts
@@ -6,23 +6,23 @@ import {
 import type { GetConsumptionTopModelsResponse } from "@app/lib/api/analytics/consumption/top_models";
 import { fetchConsumptionTopModels } from "@app/lib/api/analytics/consumption/top_models";
 import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 export type { GetConsumptionTopModelsResponse };
 
 // Mounted at /api/w/:wId/analytics/consumption/top-models.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/top-models.
+const app = consumptionAnalyticsApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopModelsResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
@@ -36,7 +36,7 @@ app.post(
       limit,
       offset,
       search,
-      filter,
+      filter: userId ? { ...filter, users: [userId] } : filter,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-skills.ts
@@ -6,23 +6,23 @@ import {
 import type { GetConsumptionTopSkillsResponse } from "@app/lib/api/analytics/consumption/top_skills";
 import { fetchConsumptionTopSkills } from "@app/lib/api/analytics/consumption/top_skills";
 import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 export type { GetConsumptionTopSkillsResponse };
 
 // Mounted at /api/w/:wId/analytics/consumption/top-skills.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/top-skills.
+const app = consumptionAnalyticsApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSkillsResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
@@ -36,7 +36,7 @@ app.post(
       limit,
       offset,
       search,
-      filter,
+      filter: userId ? { ...filter, users: [userId] } : filter,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-sources.ts
@@ -6,23 +6,23 @@ import {
 import type { GetConsumptionTopSourcesResponse } from "@app/lib/api/analytics/consumption/top_sources";
 import { fetchConsumptionTopSources } from "@app/lib/api/analytics/consumption/top_sources";
 import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 export type { GetConsumptionTopSourcesResponse };
 
 // Mounted at /api/w/:wId/analytics/consumption/top-sources.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/top-sources.
+const app = consumptionAnalyticsApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopSourcesResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
@@ -36,7 +36,7 @@ app.post(
       limit,
       offset,
       search,
-      filter,
+      filter: userId ? { ...filter, users: [userId] } : filter,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-tools.ts
@@ -6,23 +6,23 @@ import {
 import type { GetConsumptionTopToolsResponse } from "@app/lib/api/analytics/consumption/top_tools";
 import { fetchConsumptionTopTools } from "@app/lib/api/analytics/consumption/top_tools";
 import logger from "@app/logger/logger";
-import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
 
 export type { GetConsumptionTopToolsResponse };
 
 // Mounted at /api/w/:wId/analytics/consumption/top-tools.
-const app = workspaceApp();
+// Also mounted at /api/w/:wId/me/analytics/consumption/top-tools.
+const app = consumptionAnalyticsApp();
 
 /** @ignoreswagger */
 app.post(
   "/",
-  ensureIsManager(),
   validate("json", ConsumptionTopBodySchema),
   async (ctx): HandlerResult<GetConsumptionTopToolsResponse> => {
     const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
     const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
 
@@ -36,7 +36,7 @@ app.post(
       limit,
       offset,
       search,
-      filter,
+      filter: userId ? { ...filter, users: [userId] } : filter,
       sortOrder,
     });
     if (result.isErr()) {

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -317,6 +317,10 @@ const RANKINGS = [
   },
 ];
 
+const PERSONAL_RANKINGS = RANKINGS.filter(
+  ({ path }) => path !== "top-users" && path !== "top-groups"
+);
+
 async function setupTest({
   role = "admin",
 }: {
@@ -328,9 +332,11 @@ async function setupTest({
 function postRankingRequest(
   wId: string,
   path: string,
-  body: Record<string, unknown> = {}
+  body: Record<string, unknown> = {},
+  personal = false
 ) {
-  return honoApp.request(`/api/w/${wId}/analytics/consumption/${path}`, {
+  const analyticsPath = personal ? "me/analytics" : "analytics";
+  return honoApp.request(`/api/w/${wId}/${analyticsPath}/consumption/${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -370,6 +376,42 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
     const response = await postRankingRequest(workspace.sId, path);
 
     expect(response.status).toBe(403);
+  });
+
+  it.each(
+    PERSONAL_RANKINGS
+  )("$path lets members read only their own consumption", async ({
+    path,
+    arrangeOk,
+    lastCall,
+  }) => {
+    arrangeOk();
+    const { workspace, user } = await setupTest({ role: "user" });
+
+    const response = await postRankingRequest(
+      workspace.sId,
+      path,
+      { filter: { users: ["another-user"], sources: ["slack"] } },
+      true
+    );
+
+    expect(response.status).toBe(200);
+    expect(lastCall()?.[1]).toEqual(
+      expect.objectContaining({
+        filter: { users: [user.sId], sources: ["slack"] },
+      })
+    );
+  });
+
+  it.each([
+    "top-users",
+    "top-groups",
+  ])("%s is not mounted for personal analytics", async (path) => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await postRankingRequest(workspace.sId, path, {}, true);
+
+    expect(response.status).toBe(404);
   });
 
   it("forwards the page, the period, the search and the filter", async () => {

--- a/front-api/routes/w/[wId]/analytics/index.ts
+++ b/front-api/routes/w/[wId]/analytics/index.ts
@@ -5,7 +5,7 @@ import agentCredits from "./agent-credits";
 import agentsExport from "./agents-export";
 import automations from "./automations";
 import awuUsageAnalytics from "./awu-usage-analytics";
-import consumption from "./consumption";
+import { createWorkspaceConsumptionRoutes } from "./consumption";
 import exportTableRoute from "./export";
 import overview from "./overview";
 import programmaticCost from "./programmatic-cost";
@@ -28,6 +28,7 @@ import usersExport from "./users-export";
 // Mounted at /api/w/:wId/analytics. workspaceAuth is applied by the parent
 // workspace sub-app.
 const app = workspaceApp();
+const consumption = createWorkspaceConsumptionRoutes();
 
 app.route("/active-users-export", activeUsersExport);
 app.route("/active-users", activeUsers);

--- a/front-api/routes/w/[wId]/me/analytics/index.ts
+++ b/front-api/routes/w/[wId]/me/analytics/index.ts
@@ -1,10 +1,13 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
+import { createPersonalConsumptionRoutes } from "../../analytics/consumption";
 import automations from "./automations";
 
 // Mounted under /api/w/:wId/me/analytics.
 const app = workspaceApp();
+const consumption = createPersonalConsumptionRoutes();
 
 app.route("/automations", automations);
+app.route("/consumption", consumption);
 
 export default app;

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -434,6 +434,41 @@ describe("fetchConsumptionFacets", () => {
     }
   });
 
+  it("keeps the user scope on every personal facet query and skips the workspace catalog", async () => {
+    const { authenticator, user } = await createResourceTest({ role: "user" });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({ values: { buckets: [] } })
+    );
+
+    const result = await fetchConsumptionFacets(authenticator, {
+      period: PERIOD,
+      filter: { users: [user.sId], agents: ["agent_1"] },
+      userId: user.sId,
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(listConsumptionFacetCatalog).not.toHaveBeenCalled();
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(8);
+
+    for (const [query] of vi.mocked(searchConsumptionAnalytics).mock.calls) {
+      expect(query.bool?.filter).toContainEqual({
+        term: { "user.id": user.sId },
+      });
+    }
+
+    const userCall = vi
+      .mocked(searchConsumptionAnalytics)
+      .mock.calls.find(
+        ([, options]) =>
+          options?.aggregations?.values?.composite?.sources?.[0]?.value?.terms
+            ?.field === "user.id"
+      );
+    expect(
+      userCall?.[1]?.aggregations?.values?.aggs?.contextual?.filter?.bool
+        ?.filter
+    ).toContainEqual({ term: { "user.id": user.sId } });
+  });
+
   it("returns the Elasticsearch failure before resolving historical labels", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
     const error = new ElasticsearchError("query_error", "query failed");

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -1,4 +1,7 @@
-import type { ConsumptionFacetCatalogEntry } from "@app/lib/api/analytics/consumption/facet_catalog";
+import type {
+  ConsumptionFacetCatalog,
+  ConsumptionFacetCatalogEntry,
+} from "@app/lib/api/analytics/consumption/facet_catalog";
 import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
@@ -48,6 +51,17 @@ function facetScopeFilters(
       return assertNever(scope);
   }
 }
+
+const EMPTY_FACET_CATALOG: ConsumptionFacetCatalog = {
+  agent: [],
+  user: [],
+  api_key: [],
+  group: [],
+  model: [],
+  tool: [],
+  skill: [],
+  source: [],
+};
 
 export type ConsumptionFacet = {
   value: string;
@@ -111,6 +125,7 @@ type FetchDimensionFacetBucketsArgs = {
   auth: Authenticator;
   period: ConsumptionPeriod;
   filter: ConsumptionScopeFilter;
+  userId?: string;
   dimension: ConsumptionScopeDimension;
   scopeFilters: estypes.QueryDslQueryContainer[];
 };
@@ -139,11 +154,13 @@ async function fetchDimensionFacetBucketsWithoutTracing({
   auth,
   period,
   filter,
+  userId,
   dimension,
   scopeFilters,
 }: FetchDimensionFacetBucketsArgs): Promise<
   Result<FacetBuckets, ElasticsearchError>
 > {
+  const userFilter = userId ? { users: [userId] } : undefined;
   const contextual = new Map<string, number>();
   let afterKey: { value: string } | undefined;
 
@@ -156,6 +173,7 @@ async function fetchDimensionFacetBucketsWithoutTracing({
         auth,
         startDate: period.startDate,
         endDate: period.endDate,
+        filter: userFilter,
         extraFilters: scopeFilters,
       }),
       {
@@ -180,7 +198,10 @@ async function fetchDimensionFacetBucketsWithoutTracing({
                   auth,
                   startDate: period.startDate,
                   endDate: period.endDate,
-                  filter: filterWithoutDimension(filter, dimension),
+                  filter: {
+                    ...filterWithoutDimension(filter, dimension),
+                    ...userFilter,
+                  },
                   extraFilters: scopeFilters,
                 }),
               },
@@ -295,11 +316,13 @@ async function fetchConsumptionFacetsWithoutTracing(
     filter = {},
     scope = "all",
     dimensions,
+    userId,
   }: {
     period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
     scope?: ConsumptionFacetScope;
     dimensions?: ConsumptionScopeDimension[];
+    userId?: string;
   }
 ): Promise<Result<ConsumptionFacets, ElasticsearchError>> {
   const requestedDimensions = dimensions ?? [...CONSUMPTION_SCOPE_DIMENSIONS];
@@ -312,6 +335,7 @@ async function fetchConsumptionFacetsWithoutTracing(
         auth,
         period,
         filter,
+        userId,
         dimension,
         scopeFilters,
       }),
@@ -327,7 +351,9 @@ async function fetchConsumptionFacetsWithoutTracing(
     bucketsByDimension.set(dimension, result.value);
   }
 
-  const catalog = await listConsumptionFacetCatalog(auth, requestedDimensions);
+  const catalog = userId
+    ? EMPTY_FACET_CATALOG
+    : await listConsumptionFacetCatalog(auth, requestedDimensions);
   // TODO(2026-08-11 OBSERVABILITY): Historical label resolution still reads
   // from several database-backed resources. Store the relevant labels in the
   // consumption index so these lookups can stay within Elasticsearch.
@@ -402,6 +428,7 @@ export async function fetchConsumptionFacets(
     filter?: ConsumptionScopeFilter;
     scope?: ConsumptionFacetScope;
     dimensions?: ConsumptionScopeDimension[];
+    userId?: string;
   }
 ): Promise<Result<ConsumptionFacets, ElasticsearchError>> {
   return tracer.trace("analytics.consumption.facets", async (span) => {

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -142,7 +142,12 @@ export async function fetchConsumptionOverview(
   {
     periodInput,
     filter,
-  }: { periodInput: ConsumptionPeriodInput; filter?: ConsumptionScopeFilter }
+    includeWorkspaceContext = true,
+  }: {
+    periodInput: ConsumptionPeriodInput;
+    filter?: ConsumptionScopeFilter;
+    includeWorkspaceContext?: boolean;
+  }
 ): Promise<Result<ConsumptionOverview, ElasticsearchError>> {
   const workspace = auth.getNonNullableWorkspace();
   const period = await resolveConsumptionPeriod(auth, periodInput);
@@ -173,8 +178,12 @@ export async function fetchConsumptionOverview(
       },
       size: 0,
     }),
-    MembershipResource.countActiveMembersForWorkspace({ workspace }),
-    fetchPoolCapCredits(auth, periodInput),
+    includeWorkspaceContext
+      ? MembershipResource.countActiveMembersForWorkspace({ workspace })
+      : Promise.resolve(0),
+    includeWorkspaceContext
+      ? fetchPoolCapCredits(auth, periodInput)
+      : Promise.resolve(null),
   ]);
 
   if (searchResult.isErr()) {
@@ -185,12 +194,13 @@ export async function fetchConsumptionOverview(
   const totalCredits = microCreditsToCredits(
     aggregations?.total_credit_micro?.value ?? 0
   );
+  const activeMembers = Math.round(aggregations?.active_members?.value ?? 0);
 
   return new Ok({
     period,
     members: {
-      active: Math.round(aggregations?.active_members?.value ?? 0),
-      total: totalMembers,
+      active: activeMembers,
+      total: includeWorkspaceContext ? totalMembers : activeMembers,
     },
     lastRecordAt: lastRecordAtFromAgg(aggregations?.last_completed_at),
     totalCredits,


### PR DESCRIPTION
## Description

The goal of this PR and the few ones that will follow is to add a personal view for the new analytics.
This new view will contain the same information as the page in the admin tab, but scoped to the current user (therefore drops anything relative to members or groups).

This PR introduces the endpoints required for this.

Instead of duplicating the numerous endpoints required here, this PR introduces a pattern where we mount the existing endpoints on `/api/w/:wId/me`, with an additional context passed to identify the user. The goal is to avoid re-creating 14 handlers for this and keep the behavior of the handlers in sync (i.e. if we change something for the admin page it should change for the personal page as well). The code path for the /me endpoint enforces the presence of the current user ID in the query. This is a rare case where we need a very large number of queries for a single page, open to suggestion on a better pattern to avoid duplicating the handlers.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
