### PR TITLE
[front] fix: bill GPT 5.5 and GPT 5.4 long-context prompts at the 2x tier

### DIFF
--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -58,13 +58,11 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     cache_read_input_tokens: 0.02,
   },
   // Verified 2026-08-21: https://developers.openai.com/api/docs/models/gpt-5.5
-  // Prompts above 272K input tokens cost 2x input and 1.5x output for the full request.
   "gpt-5.5": {
     input: 5.0,
     output: 30.0,
     cache_read_input_tokens: 0.5,
     long_context: {
-      // `computeTokensCostForUsageInMicroUsd` switches tiers inclusively.
       prompt_token_threshold: 272_001,
       input: 10.0,
       output: 45.0,
@@ -72,13 +70,11 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     },
   },
   // Verified 2026-08-21: https://developers.openai.com/api/docs/models/gpt-5.4
-  // Prompts above 272K input tokens cost 2x input and 1.5x output for the full request.
   "gpt-5.4": {
     input: 2.5,
     output: 15.0,
     cache_read_input_tokens: 0.25,
     long_context: {
-      // `computeTokensCostForUsageInMicroUsd` switches tiers inclusively.
       prompt_token_threshold: 272_001,
       input: 5.0,
       output: 22.5,

--- a/front/lib/api/assistant/token_pricing/global.ts
+++ b/front/lib/api/assistant/token_pricing/global.ts
@@ -57,16 +57,33 @@ const CURRENT_MODEL_PRICING: Record<StaticModelIdType, PricingEntry> = {
     cache_creation_input_tokens: 0.25,
     cache_read_input_tokens: 0.02,
   },
-  // https://openai.com/api/pricing
+  // Verified 2026-08-21: https://developers.openai.com/api/docs/models/gpt-5.5
+  // Prompts above 272K input tokens cost 2x input and 1.5x output for the full request.
   "gpt-5.5": {
     input: 5.0,
     output: 30.0,
     cache_read_input_tokens: 0.5,
+    long_context: {
+      // `computeTokensCostForUsageInMicroUsd` switches tiers inclusively.
+      prompt_token_threshold: 272_001,
+      input: 10.0,
+      output: 45.0,
+      cache_read_input_tokens: 1.0,
+    },
   },
+  // Verified 2026-08-21: https://developers.openai.com/api/docs/models/gpt-5.4
+  // Prompts above 272K input tokens cost 2x input and 1.5x output for the full request.
   "gpt-5.4": {
     input: 2.5,
     output: 15.0,
     cache_read_input_tokens: 0.25,
+    long_context: {
+      // `computeTokensCostForUsageInMicroUsd` switches tiers inclusively.
+      prompt_token_threshold: 272_001,
+      input: 5.0,
+      output: 22.5,
+      cache_read_input_tokens: 0.5,
+    },
   },
   // https://openai.com/api/pricing/
   "gpt-5.4-mini": {

--- a/front/lib/api/assistant/token_pricing/index.test.ts
+++ b/front/lib/api/assistant/token_pricing/index.test.ts
@@ -1,6 +1,7 @@
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import { EU_UPLIFT_MODEL_IDS } from "@app/lib/api/assistant/token_pricing/eu";
 import {
+  GPT_5_4_MODEL_ID,
   GPT_5_5_MODEL_ID,
   GPT_5_6_TERRA_LONG_CONTEXT_MODEL_ID,
   GPT_5_MODEL_ID,
@@ -39,7 +40,8 @@ describe("computeTokensCostForUsageInMicroUsd", () => {
   it("combines the OpenAI EU uplift with the batch discount", () => {
     const usage = {
       modelId: GPT_5_5_MODEL_ID,
-      promptTokens: 1_000_000,
+      // Kept below the long-context threshold so this only exercises uplift and batch.
+      promptTokens: 200_000,
       completionTokens: 1_000_000,
       cachedTokens: null,
       isBatch: true,
@@ -50,13 +52,13 @@ describe("computeTokensCostForUsageInMicroUsd", () => {
         ...usage,
         inferenceRegion: "global",
       })
-    ).toBe(17_500_000);
+    ).toBe(15_500_000);
     expect(
       computeTokensCostForUsageInMicroUsd({
         ...usage,
         inferenceRegion: "eu",
       })
-    ).toBe(19_250_000);
+    ).toBe(17_050_000);
   });
 
   it("does not uplift OpenAI models without regional premium pricing", () => {
@@ -78,6 +80,70 @@ describe("computeTokensCostForUsageInMicroUsd", () => {
         inferenceRegion: "global",
       })
     );
+  });
+
+  it("uses standard GPT 5.4 pricing through 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_4_MODEL_ID,
+        promptTokens: 272_000,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(695_000);
+  });
+
+  it("uses GPT 5.4 long-context pricing above 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_4_MODEL_ID,
+        promptTokens: 272_001,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(1_382_505);
+  });
+
+  it("uses standard GPT 5.5 pricing through 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_5_MODEL_ID,
+        promptTokens: 272_000,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(1_390_000);
+  });
+
+  it("uses GPT 5.5 long-context pricing above 272k prompt tokens", () => {
+    expect(
+      computeTokensCostForUsageInMicroUsd({
+        modelId: GPT_5_5_MODEL_ID,
+        promptTokens: 272_001,
+        completionTokens: 1_000,
+        cachedTokens: null,
+      })
+    ).toBe(2_765_010);
+  });
+
+  it("uses GPT 5.5 long-context cached input pricing with the EU uplift", () => {
+    const usage = {
+      modelId: GPT_5_5_MODEL_ID,
+      promptTokens: 272_001,
+      completionTokens: 1_000,
+      cachedTokens: 100_000,
+    };
+    const globalCostMicroUsd = computeTokensCostForUsageInMicroUsd({
+      ...usage,
+      inferenceRegion: "global",
+    });
+    const euCostMicroUsd = computeTokensCostForUsageInMicroUsd({
+      ...usage,
+      inferenceRegion: "eu",
+    });
+
+    expect(globalCostMicroUsd).toBe(1_865_010);
+    expect(euCostMicroUsd).toBeCloseTo(globalCostMicroUsd * 1.1, 6);
   });
 
   it("uses standard Terra pricing through 272k prompt tokens", () => {


### PR DESCRIPTION
## Description

`GPT 5.5` and `GPT 5.4` are both configured with a **1M context window** (`contextSize: 1_000_000` in `front/types/assistant/models/openai.ts`), but neither had a `long_context` entry in `front/lib/api/assistant/token_pricing/global.ts`. Prompts above 272K input tokens were therefore billed at the short-context rate — i.e. we were under-billing large-context requests on both models.

The pricing tables only list `gpt-5.5 (<272K context length)` with no companion `>272K` row, so the rates come from the model docs, which state the rule explicitly:

- [gpt-5.5](https://developers.openai.com/api/docs/models/gpt-5.5): "For GPT-5.5, prompts with >272K input tokens are priced at 2x input and 1.5x output for the full session for standard, batch, and flex."
- [gpt-5.4](https://developers.openai.com/api/docs/models/gpt-5.4): same rule for the 1.05M-context models (GPT-5.4 and GPT-5.4 Pro).

Cached input is scaled 2x alongside input, matching how the *published* `gpt-5.6-*` long-context tables scale (input, cached input and cache write ×2, output ×1.5).

| model | tier | input | cached | output |
|---|---|---|---|---|
| gpt-5.5 | ≤272K | 5.0 | 0.5 | 30.0 |
| gpt-5.5 | >272K | 10.0 | 1.0 | 45.0 |
| gpt-5.4 | ≤272K | 2.5 | 0.25 | 15.0 |
| gpt-5.4 | >272K | 5.0 | 0.5 | 22.5 |

Threshold is `272_001` because `computeTokensCostForUsageInMicroUsd` switches tiers inclusively (`promptTokens >= prompt_token_threshold`), consistent with the existing `gpt-5.6-terra-long-context` entry.

EU pricing picks up the new tiers automatically via `applyRegionalUplift` in `token_pricing/eu.ts` — both model IDs are already in `EU_UPLIFT_MODEL_IDS`, and that helper already forwards `long_context`.

Not touched: `gpt-5.4-mini` / `gpt-5.4-nano`. The docs note scopes the rule to the 1.05M-context models and those two aren't in it.

## Tests

`npm run test -- token_pricing` — 45 passed.

Added 4 tests in `token_pricing/index.test.ts`, mirroring the existing Terra/Grok long-context cases:

- standard GPT 5.5 pricing through 272k prompt tokens
- GPT 5.5 long-context pricing above 272k prompt tokens
- GPT 5.5 long-context cached input pricing combined with the EU uplift
- standard + long-context boundary pair for GPT 5.4

**One existing test had to be adjusted.** `"combines the OpenAI EU uplift with the batch discount"` used gpt-5.5 with 1M prompt tokens, which now lands in the long-context tier. I lowered it to 200K prompt tokens (with a comment) so it keeps testing uplift + batch rather than silently becoming a long-context test.

Typecheck is clean for both touched files. Note the `front-typecheck` pre-commit hook currently fails repo-wide on this machine for unrelated reasons — `@novu/framework` is declared in `front/package.json` but not installed locally, plus some `openai`/`@notionhq/client` SDK version drift. Those errors are pre-existing and untouched by this change; `npx tsgo --noEmit` reports zero errors under `token_pricing/`.

## Risk

Low, but it is a **billing behavior change** — this is the point of the PR, so worth calling out precisely:

- Requests to gpt-5.5 / gpt-5.4 with >272K prompt tokens now cost 2x input, 1.5x output, 2x cached read. Requests at or below 272K are completely unaffected.
- **`gpt-5.5` is `DEFAULT_PRICING_MODEL_ID`**, the fallback used for custom models not present in `MODEL_PRICING`. Custom models with >272K prompts therefore also pick up the long-context tier. That is more accurate than before, but it is a side effect beyond the two named models and reviewers should confirm it's desired.
- Pure constant/data change with no schema or API surface change, so rollback is a straight revert with no cleanup.

## Deploy Plan

Standard deploy, no migration and no ordering constraints. Takes effect for usage computed after rollout; no backfill of already-recorded usage is performed or intended.
