### PR TITLE
[front] enh: add Poke links in new Poke analytics

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -27,6 +27,7 @@ import type {
 } from "@app/lib/api/analytics/consumption/scope";
 import { CONSUMPTION_DIMENSION_FILTER_KEYS } from "@app/lib/api/analytics/consumption/scope";
 import { formatCredits } from "@app/lib/client/credits";
+import { LinkWrapper } from "@app/lib/platform";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import {
   ArrowNarrowDownRight,
@@ -281,6 +282,22 @@ function buildColumns({
           ) : (
             <span className="truncate text-sm">{name}</span>
           );
+        const interactiveContent = row.detailsHref ? (
+          <LinkWrapper
+            href={row.detailsHref}
+            className={cn(
+              "inline-flex min-h-11 min-w-11 max-w-full items-center rounded-sm",
+              "text-highlight-500 outline-hidden ring-offset-background",
+              "pointer-fine:hover:text-highlight-600 pointer-fine:hover:underline",
+              "focus-visible:ring-2 focus-visible:ring-highlight-300 focus-visible:ring-offset-1"
+            )}
+            onClick={(event) => event.stopPropagation()}
+          >
+            {content}
+          </LinkWrapper>
+        ) : (
+          content
+        );
 
         return (
           <DataTable.CellContent className="w-full justify-start text-left">
@@ -291,10 +308,10 @@ function buildColumns({
                 }
                 className="p-3"
                 tooltipTriggerAsChild
-                trigger={content}
+                trigger={interactiveContent}
               />
             ) : (
-              content
+              interactiveContent
             )}
           </DataTable.CellContent>
         );

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -36,6 +36,7 @@ const CONSUMPTION_TOP_ENDPOINTS = {
 export type ConsumptionTopRow = {
   id: string;
   name: string;
+  detailsHref?: string;
   pictureUrl: string | null;
   description: string | null;
   icon: string | null;

--- a/front/poke/swr/consumption.ts
+++ b/front/poke/swr/consumption.ts
@@ -53,6 +53,41 @@ const CONSUMPTION_TOP_ENDPOINTS = {
   api_key: "top-api-keys",
 } as const satisfies Record<ConsumptionDimension, string>;
 
+function toPokeConsumptionTopRows(
+  data: ConsumptionTopResponse,
+  workspaceId: string
+): ConsumptionTopRow[] {
+  const rows = toConsumptionTopRows(data);
+  if ("agents" in data) {
+    return rows.map((row) => ({
+      ...row,
+      detailsHref: row.modelId
+        ? `/poke/${workspaceId}/assistants/${row.id}`
+        : undefined,
+    }));
+  }
+  if ("groups" in data) {
+    return rows.map((row) => ({
+      ...row,
+      detailsHref:
+        row.name !== row.id
+          ? `/poke/${workspaceId}/groups/${row.id}`
+          : undefined,
+    }));
+  }
+  if ("skills" in data) {
+    return rows.map((row) => ({
+      ...row,
+      detailsHref:
+        row.name !== row.id
+          ? `/poke/${workspaceId}/skills/${row.id}`
+          : undefined,
+    }));
+  }
+
+  return rows;
+}
+
 type ConsumptionTimeseriesBody = ConsumptionBody & {
   mode: ConsumptionTimeseriesMode;
   breakdownBy?: ConsumptionBreakdownDimension;
@@ -180,8 +215,11 @@ export function usePokeConsumptionTop({
   >({ url, body, disabled });
 
   const rows = useMemo(
-    () => (data ? toConsumptionTopRows(data) : emptyArray<ConsumptionTopRow>()),
-    [data]
+    () =>
+      data
+        ? toPokeConsumptionTopRows(data, workspaceId)
+        : emptyArray<ConsumptionTopRow>(),
+    [data, workspaceId]
   );
 
   return {


### PR DESCRIPTION
## Description

This PR adds links to relevant poke pages (agents, groups, skills) in the new Poke analytics page.

We actually already have the links, so this PR is front-end only. 

We can't really add tools here; analytics stores a server display name rather than a unique MCP view ID.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
