### PR TITLE
[connectors] Slack: skip auto-read when workspace is unavailable

### DIFF
--- a/connectors/src/connectors/slack/auto_read_channel.test.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.test.ts
@@ -1,10 +1,22 @@
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import { DustAPI, Err } from "@dust-tt/client";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock(import("@connectors/connectors/slack/temporal/client"), () => ({
   launchJoinChannelWorkflow: vi.fn(),
 }));
+
+vi.mock(import("@connectors/lib/api/config"), async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    apiConfig: {
+      ...original.apiConfig,
+      getDustFrontAPIUrl: () => "https://dust.test",
+    },
+  };
+});
 
 import { launchJoinChannelWorkflow } from "@connectors/connectors/slack/temporal/client";
 
@@ -51,6 +63,25 @@ describe("autoReadChannel", () => {
       "C123",
       "slack_bot"
     );
+
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      expect(res.value).toBe(false);
+    }
+    expect(launchJoinChannelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("should skip channels whose workspace is unavailable", async () => {
+    await makeSlackConnector("T_UNAVAILABLE_WS");
+    vi.spyOn(DustAPI.prototype, "exists").mockResolvedValue(
+      new Err({
+        type: "plan_limit_error",
+        message:
+          "Your current plan does not allow API access. Please upgrade your plan.",
+      })
+    );
+
+    const res = await autoReadChannel("T_UNAVAILABLE_WS", logger, "C123");
 
     expect(res.isOk()).toBe(true);
     if (res.isOk()) {

--- a/connectors/src/connectors/slack/auto_read_channel.test.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.test.ts
@@ -1,5 +1,6 @@
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { SlackAutoReadPattern } from "@connectors/types";
 import { DustAPI, Err } from "@dust-tt/client";
 import { describe, expect, it, vi } from "vitest";
 
@@ -24,7 +25,10 @@ import { autoReadChannel } from "./auto_read_channel";
 
 const logger = mainLogger.child({});
 
-async function makeSlackConnector(slackTeamId: string) {
+async function makeSlackConnector(
+  slackTeamId: string,
+  autoReadChannelPatterns: SlackAutoReadPattern[] = []
+) {
   return ConnectorResource.makeNew(
     "slack",
     {
@@ -34,7 +38,7 @@ async function makeSlackConnector(slackTeamId: string) {
       workspaceId: "workspace-id",
     },
     {
-      autoReadChannelPatterns: [],
+      autoReadChannelPatterns,
       botEnabled: true,
       feedbackVisibleToAuthorOnly: true,
       restrictedSpaceAgentsEnabled: true,
@@ -72,8 +76,12 @@ describe("autoReadChannel", () => {
   });
 
   it("should skip channels whose workspace is unavailable", async () => {
-    await makeSlackConnector("T_UNAVAILABLE_WS");
-    vi.spyOn(DustAPI.prototype, "exists").mockResolvedValue(
+    // Configure a matching pattern so a healthy workspace would launch the
+    // join workflow: not launching it proves the skip.
+    await makeSlackConnector("T_UNAVAILABLE_WS", [
+      { pattern: "C.*", spaceId: "space-id" },
+    ]);
+    const existsSpy = vi.spyOn(DustAPI.prototype, "exists").mockResolvedValue(
       new Err({
         type: "plan_limit_error",
         message:
@@ -82,6 +90,7 @@ describe("autoReadChannel", () => {
     );
 
     const res = await autoReadChannel("T_UNAVAILABLE_WS", logger, "C123");
+    existsSpy.mockRestore();
 
     expect(res.isOk()).toBe(true);
     if (res.isOk()) {

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -67,7 +67,8 @@ export async function autoReadChannel(
   );
 
   // Probe the workspace: /exists does no work beyond authentication and
-  // returns an error when the workspace is gone, relocated or in maintenance.
+  // returns an error when the workspace is gone, relocated, in maintenance or
+  // on a plan without API access. Nothing to auto-read in those cases.
   const existsRes = await dustAPI.exists();
   if (existsRes.isErr()) {
     logger.info(
@@ -79,11 +80,7 @@ export async function autoReadChannel(
       },
       "Skipping auto-read channel: workspace API call failed (likely in maintenance)"
     );
-    return new Err(
-      new Error(
-        `Cannot auto-read channel: workspace is unavailable (${existsRes.error.message})`
-      )
-    );
+    return new Ok(false);
   }
 
   const { connectorId, autoReadChannelPatterns } = slackConfiguration;

--- a/connectors/src/connectors/slack/auto_read_channel.ts
+++ b/connectors/src/connectors/slack/auto_read_channel.ts
@@ -78,7 +78,7 @@ export async function autoReadChannel(
         workspaceId: dataSourceConfig.workspaceId,
         error: existsRes.error.message,
       },
-      "Skipping auto-read channel: workspace API call failed (likely in maintenance)"
+      "Skipping auto-read channel: workspace is unavailable"
     );
     return new Ok(false);
   }


### PR DESCRIPTION
## Description

Follow-up to #30755. [`slackWebhookEventWorkflow` still fails](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=ExecutionStatus%3D%22Failed%22) on `channel_created` events when the workspace `/exists` probe errors, e.g. `Cannot auto-read channel: workspace is unavailable (Your current plan does not allow API access. Please upgrade your plan.)`. Retrying can't help: there is nothing to auto-read for an unavailable workspace.

Fix: `autoReadChannel` now logs and returns `Ok(false)` when the probe fails, instead of `Err`. Same handling as `channel_message` events in `webhook_activities.ts`, and it also stops the slack_bot webhook from 500ing (and Slack from retrying) on the same condition.

## Tests

Added a test: connector with a matching auto-read pattern, `/exists` fails with the plan-limit error, returns `Ok(false)` without launching the join workflow.

## Risk

Worst case, a legitimate auto-read is silently skipped instead of surfacing an error. Safe to rollback.

## Deploy Plan

- [ ] Deploy connectors
