### PR TITLE
[extension] fix: prevent legacy Chrome user memory crashes

### DIFF
--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -6,6 +6,7 @@ import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
 import { datadogLogs } from "@datadog/browser-logs";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { addClientVersionHeaders } from "@extension/shared/lib/fetcher";
 import type { StoredTokens } from "@extension/shared/services/auth";
 import {
   AuthError,
@@ -38,14 +39,15 @@ export const useAuthHook = () => {
         const accessToken = await platform.auth.getAccessToken();
         return {
           credentials: "omit",
-          headers: accessToken
-            ? { Authorization: `Bearer ${accessToken}` }
-            : {},
+          headers: addClientVersionHeaders(
+            accessToken ? { Authorization: `Bearer ${accessToken}` } : {}
+          ),
         };
       });
     } else {
       setDefaultInitResolver(async () => ({
         credentials: "omit",
+        headers: addClientVersionHeaders(),
       }));
     }
 

--- a/front-api/lib/api/assistant/legacy_chrome_extension_compatibility.ts
+++ b/front-api/lib/api/assistant/legacy_chrome_extension_compatibility.ts
@@ -1,0 +1,146 @@
+import { USER_MEMORY_SERVER_NAME } from "@app/lib/api/actions/servers/user_memory/metadata";
+import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AgentMessageContentView } from "@app/types/assistant/agent";
+import type {
+  InlineActivityStep,
+  LightAgentMessageType,
+} from "@app/types/assistant/conversation";
+
+// Chrome 0.1.13 bundled an internal-server registry that predates user_memory.
+// Returning a null server name keeps the tool data intact while making that
+// renderer use its generic icon instead of indexing the missing registry entry.
+const FIRST_CHROME_EXTENSION_VERSION_WITH_UNKNOWN_SERVER_GUARD = [
+  0, 1, 14,
+] as const;
+
+type AgentMessageStreamEvent = {
+  eventId: string;
+  data: AgentMessageEvents & { step: number };
+};
+
+function isVersionBefore(
+  version: readonly number[],
+  minimumVersion: readonly number[]
+): boolean {
+  for (let index = 0; index < minimumVersion.length; index++) {
+    const currentPart = version[index] ?? 0;
+    const minimumPart = minimumVersion[index] ?? 0;
+    if (currentPart !== minimumPart) {
+      return currentPart < minimumPart;
+    }
+  }
+
+  return false;
+}
+
+export function isLegacyChromeExtensionRequest({
+  origin,
+  extensionVersion,
+}: {
+  origin: string | undefined;
+  extensionVersion: string | undefined;
+}): boolean {
+  const hasChromeOrigin = origin?.startsWith("chrome-extension://") ?? false;
+  const hasChromeVersion = extensionVersion?.startsWith("chrome-") ?? false;
+
+  if (!hasChromeOrigin && !hasChromeVersion) {
+    return false;
+  }
+
+  // Chrome 0.1.13 did not attach its version header to direct fetches or SSE.
+  // Treat a Chrome-origin request without a parseable version as legacy.
+  const versionMatch = extensionVersion?.match(/^chrome-(\d+)\.(\d+)\.(\d+)$/);
+  if (!versionMatch) {
+    return true;
+  }
+
+  const version = versionMatch.slice(1).map(Number);
+  return isVersionBefore(
+    version,
+    FIRST_CHROME_EXTENSION_VERSION_WITH_UNKNOWN_SERVER_GUARD
+  );
+}
+
+function makeActionCompatible(
+  action: AgentMCPActionWithOutputType
+): AgentMCPActionWithOutputType {
+  if (action.internalMCPServerName !== USER_MEMORY_SERVER_NAME) {
+    return action;
+  }
+
+  return {
+    ...action,
+    internalMCPServerName: null,
+  };
+}
+
+function makeActivityStepsCompatible(
+  activitySteps: InlineActivityStep[]
+): InlineActivityStep[] {
+  return activitySteps.map((step) => {
+    if (
+      step.type !== "action" ||
+      step.internalMCPServerName !== USER_MEMORY_SERVER_NAME
+    ) {
+      return step;
+    }
+
+    return {
+      ...step,
+      internalMCPServerName: null,
+    };
+  });
+}
+
+export function makeLegacyChromeExtensionLightMessageCompatible(
+  message: LightAgentMessageType
+): LightAgentMessageType {
+  return {
+    ...message,
+    activitySteps: makeActivityStepsCompatible(message.activitySteps),
+  };
+}
+
+function makeContentViewCompatible(
+  contentView: AgentMessageContentView
+): AgentMessageContentView {
+  return {
+    ...contentView,
+    activitySteps: makeActivityStepsCompatible(contentView.activitySteps),
+  };
+}
+
+export function makeLegacyChromeExtensionMessageEventCompatible(
+  event: AgentMessageStreamEvent
+): AgentMessageStreamEvent {
+  switch (event.data.type) {
+    case "agent_action_success":
+    case "tool_notification":
+    case "tool_params":
+      return {
+        ...event,
+        data: {
+          ...event.data,
+          action: makeActionCompatible(event.data.action),
+        },
+      };
+
+    case "agent_message_gracefully_stopped":
+    case "agent_message_success":
+      if (!event.data.contentView) {
+        return event;
+      }
+
+      return {
+        ...event,
+        data: {
+          ...event.data,
+          contentView: makeContentViewCompatible(event.data.contentView),
+        },
+      };
+
+    default:
+      return event;
+  }
+}

--- a/front-api/routes/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.test.ts
+++ b/front-api/routes/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.test.ts
@@ -2,6 +2,7 @@ import { fetchConversationMessages } from "@app/lib/api/assistant/messages";
 import type { MessageStreamEvent } from "@app/lib/api/assistant/pubsub";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { mockAction } from "@app/tests/utils/conversation_test_factories";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { honoApp } from "@front-api/app";
@@ -13,8 +14,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Smoke coverage only: the handler logic (conversation/message resolution,
 // agent-message validation, error codepaths) lives in and is tested against the
-// v1 sibling. These tests confirm the private route wires workspace auth +
-// the private (identity) transform.
+// v1 sibling. These tests confirm the private route wires workspace auth and
+// its private compatibility transform.
 
 async function getMessageSIdByRank(
   auth: Authenticator,
@@ -51,10 +52,12 @@ import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
 function getMessageEvents(
   workspaceId: string,
   conversationId: string,
-  messageId: string
+  messageId: string,
+  headers?: Record<string, string>
 ) {
   return honoApp.request(
-    `/api/sse/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/events`
+    `/api/sse/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/events`,
+    { headers }
   );
 }
 
@@ -110,5 +113,50 @@ describe("GET /api/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/even
     expect(response.status).toBe(200);
     const payloads = parseSseDataPayloads(await response.text());
     expect(payloads.map((p) => JSON.parse(p).data.text)).toEqual(["hello"]);
+  });
+
+  it("hides user-memory server identity from legacy Chrome streams", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest();
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      messagesCreatedAt: [new Date()],
+    });
+    const agentMessageSId = await getMessageSIdByRank(
+      auth,
+      conversation.sId,
+      1
+    );
+
+    const event: MessageStreamEvent = {
+      eventId: "evt",
+      data: {
+        type: "agent_action_success",
+        created: 0,
+        configurationId: "dust",
+        messageId: agentMessageSId,
+        action: mockAction({
+          functionCallName: "user_memory__read",
+          internalMCPServerName: "user_memory",
+          status: "succeeded",
+          toolName: "read",
+        }),
+        step: 0,
+      },
+    };
+    vi.mocked(getMessagesEvents).mockImplementation(asyncIteratorFrom([event]));
+
+    const response = await getMessageEvents(
+      workspace.sId,
+      conversation.sId,
+      agentMessageSId,
+      { origin: "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn" }
+    );
+
+    expect(response.status).toBe(200);
+    const [payload] = parseSseDataPayloads(await response.text());
+    expect(JSON.parse(payload).data.action).toMatchObject({
+      internalMCPServerName: null,
+      toolName: "read",
+    });
   });
 });

--- a/front-api/routes/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front-api/routes/sse/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -1,3 +1,7 @@
+import {
+  isLegacyChromeExtensionRequest,
+  makeLegacyChromeExtensionMessageEventCompatible,
+} from "@front-api/lib/api/assistant/legacy_chrome_extension_compatibility";
 import type { MessageEventsOptions } from "@front-api/lib/api/sse/message_events";
 import {
   MessageParamSchema,
@@ -11,10 +15,6 @@ import { validate } from "@front-api/middlewares/validator";
 // Mounted at /api/sse/w/:wId/assistant/conversations/:cId/messages/:mId/events.
 // Handler logic lives in `@front-api/lib/api/sse/message_events`.
 
-const PRIVATE_OPTIONS: MessageEventsOptions = {
-  transformEvent: (_auth, event) => event,
-};
-
 const app = workspaceApp();
 
 app.use("*", streamingTag);
@@ -26,11 +26,22 @@ app.get(
   (ctx) => {
     const { cId, mId } = ctx.req.valid("param");
     const { lastEventId } = ctx.req.valid("query");
+    const useLegacyChromeCompatibility = isLegacyChromeExtensionRequest({
+      origin: ctx.req.header("origin"),
+      extensionVersion: ctx.req.header("x-dust-extension-version"),
+    });
+    const options: MessageEventsOptions = {
+      transformEvent: (_auth, event) =>
+        useLegacyChromeCompatibility
+          ? makeLegacyChromeExtensionMessageEventCompatible(event)
+          : event,
+    };
+
     return streamMessageEventsForRoute(
       ctx,
       ctx.var.auth,
       { conversationId: cId, messageId: mId, lastEventId },
-      PRIVATE_OPTIONS
+      options
     );
   }
 );

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/[mId]/index.ts
@@ -10,9 +10,14 @@ import type {
 } from "@app/types/assistant/conversation";
 import {
   isAgentMessageType,
+  isLightAgentMessageType,
   isUserMessageType,
 } from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import {
+  isLegacyChromeExtensionRequest,
+  makeLegacyChromeExtensionLightMessageCompatible,
+} from "@front-api/lib/api/assistant/legacy_chrome_extension_compatibility";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -133,6 +138,10 @@ const app = workspaceApp();
 app.get("/", validate("param", ParamsSchema), async (ctx) => {
   const auth = ctx.get("auth");
   const { cId, mId } = ctx.req.valid("param");
+  const useLegacyChromeCompatibility = isLegacyChromeExtensionRequest({
+    origin: ctx.req.header("origin"),
+    extensionVersion: ctx.req.header("x-dust-extension-version"),
+  });
 
   const conversation = await ConversationResource.fetchById(auth, cId);
   if (!conversation) {
@@ -177,10 +186,15 @@ app.get("/", validate("param", ParamsSchema), async (ctx) => {
   }
 
   switch (viewType) {
-    case "light":
+    case "light": {
+      const message = renderedMessages.value[0] as LightMessageType;
       return ctx.json({
-        message: renderedMessages.value[0] as LightMessageType,
+        message:
+          useLegacyChromeCompatibility && isLightAgentMessageType(message)
+            ? makeLegacyChromeExtensionLightMessageCompatible(message)
+            : message,
       });
+    }
     case "full":
       return ctx.json({ message: renderedMessages.value[0] as MessageType });
     default:

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.test.ts
@@ -1,9 +1,12 @@
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { assert, describe, expect, it, vi } from "vitest";
@@ -45,6 +48,105 @@ function getTools(workspace: { sId: string }, conversationId: string) {
     `/api/w/${workspace.sId}/assistant/conversations/${conversationId}/tools`
   );
 }
+
+function getMessages(
+  workspace: { sId: string },
+  conversationId: string,
+  headers: Record<string, string>
+) {
+  return honoApp.request(
+    `/api/w/${workspace.sId}/assistant/conversations/${conversationId}/messages?newResponseFormat=1`,
+    { headers }
+  );
+}
+
+async function setupUserMemoryAction() {
+  const context = await setupTest("admin");
+  const agentMessage = context.conversation.content
+    .flat()
+    .find(isAgentMessageType);
+  assert(agentMessage, "Agent message not found");
+
+  await AgentMCPActionFactory.create(context.auth, {
+    workspace: context.workspace,
+    conversationModelId: context.conversation.id,
+    agentMessageModelId: agentMessage.agentMessageId,
+    status: "succeeded",
+    functionCallName: "user_memory__read",
+    toolName: "read",
+    mcpServerName: "user_memory",
+    toolServerId: autoInternalMCPServerNameToSId({
+      name: "user_memory",
+      workspaceId: context.workspace.id,
+    }),
+  });
+
+  return { ...context, agentMessage };
+}
+
+describe("GET /api/w/:wId/assistant/conversations/:cId/messages", () => {
+  it("hides user-memory server identity from legacy Chrome message responses", async () => {
+    const { workspace, conversation, agentMessage } =
+      await setupUserMemoryAction();
+    const headers = {
+      origin: "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn",
+    };
+
+    const listResponse = await getMessages(
+      workspace,
+      conversation.sId,
+      headers
+    );
+    expect(listResponse.status).toBe(200);
+    const listData = await listResponse.json();
+    expect(
+      listData.messages.find(
+        (message: { sId: string }) => message.sId === agentMessage.sId
+      ).activitySteps
+    ).toEqual([
+      expect.objectContaining({
+        internalMCPServerName: null,
+        toolName: "read",
+      }),
+    ]);
+
+    const singleResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations/${conversation.sId}/messages/${agentMessage.sId}?viewType=light`,
+      { headers }
+    );
+    expect(singleResponse.status).toBe(200);
+    const singleData = await singleResponse.json();
+    expect(singleData.message.activitySteps).toEqual([
+      expect.objectContaining({
+        internalMCPServerName: null,
+        toolName: "read",
+      }),
+    ]);
+  });
+
+  it("preserves user-memory server identity for Chrome 0.1.14", async () => {
+    const { workspace, conversation, agentMessage } =
+      await setupUserMemoryAction();
+
+    const response = await getMessages(workspace, conversation.sId, {
+      origin: "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn",
+      "x-dust-extension-version": "chrome-0.1.14",
+    });
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(
+      data.messages.find(
+        (message: { sId: string }) => message.sId === agentMessage.sId
+      ).activitySteps
+    ).toEqual([
+      expect.objectContaining({
+        internalMCPServerName: "user_memory",
+        toolName: "read",
+      }),
+    ]);
+  });
+});
 
 describe("POST /api/w/:wId/assistant/conversations/:cId/messages", () => {
   it("enables MCP server views when selectedMCPServerViewIds are provided", async () => {

--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -19,6 +19,10 @@ import type {
   LightMessageType,
 } from "@app/types/assistant/conversation";
 import { apiErrorForConversation } from "@front-api/lib/api/assistant/conversation/helper";
+import {
+  isLegacyChromeExtensionRequest,
+  makeLegacyChromeExtensionLightMessageCompatible,
+} from "@front-api/lib/api/assistant/legacy_chrome_extension_compatibility";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -197,6 +201,10 @@ app.get(
   > => {
     const auth = ctx.get("auth");
     const { cId: conversationId } = ctx.req.valid("param");
+    const useLegacyChromeCompatibility = isLegacyChromeExtensionRequest({
+      origin: ctx.req.header("origin"),
+      extensionVersion: ctx.req.header("x-dust-extension-version"),
+    });
 
     const messageStartTime = performance.now();
 
@@ -253,7 +261,16 @@ app.get(
       rawSize
     );
 
-    return ctx.json(messagesRes.value);
+    return ctx.json({
+      ...messagesRes.value,
+      messages: useLegacyChromeCompatibility
+        ? messagesRes.value.messages.map((message) =>
+            message.type === "agent_message"
+              ? makeLegacyChromeExtensionLightMessageCompatible(message)
+              : message
+          )
+        : messagesRes.value.messages,
+    });
   }
 );
 


### PR DESCRIPTION
## Description

Chrome extension 0.1.13 crashes when rendering a user memory action because its bundled internal-tool registry has no user_memory metadata.

Legacy Chrome requests now receive user-memory actions without the internal server name, preserving the tool data while making the extension fall back to its generic icon. Chrome 0.1.14 also sends its version on direct requests and streams, so current clients keep the full payload. Other clients and tools are unchanged.

## Tests

- Added route coverage for legacy message and stream responses, plus Chrome 0.1.14 behavior.

## Risk

- Low. Scoped to user-memory payloads for legacy Chrome requests.

## Deploy Plan

- Deploy front.
- Publish the Chrome extension.