### PR TITLE
[front] Sandbox: do not fail the invocation workflow on exec timeout

### DIFF
--- a/front/lib/api/sandbox/provider.ts
+++ b/front/lib/api/sandbox/provider.ts
@@ -111,6 +111,27 @@ export class SandboxNotFoundError extends Error {
   }
 }
 
+/**
+ * Returned when a command ran past its execution timeout and was killed by the
+ * provider. The command may have partially executed.
+ */
+export class SandboxExecTimeoutError extends Error {
+  constructor(timeoutMs?: number) {
+    super(
+      timeoutMs === undefined
+        ? "The sandbox command timed out."
+        : `The sandbox command timed out after ${timeoutMs}ms.`
+    );
+    this.name = "SandboxExecTimeoutError";
+  }
+}
+
+export function isSandboxExecTimeoutError(
+  error: Error
+): error is SandboxExecTimeoutError {
+  return error instanceof SandboxExecTimeoutError;
+}
+
 // ---------------------------------------------------------------------------
 // Provider interface
 // ---------------------------------------------------------------------------

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -64,9 +64,12 @@ vi.mock("e2b", () => {
 
   class NotFoundError extends Error {}
 
+  class TimeoutError extends Error {}
+
   return {
     CommandExitError,
     NotFoundError,
+    TimeoutError,
     Sandbox: {
       connect: mockConnect,
       create: mockCreate,
@@ -75,7 +78,7 @@ vi.mock("e2b", () => {
   };
 });
 
-import { CommandExitError, NotFoundError } from "e2b";
+import { CommandExitError, NotFoundError, TimeoutError } from "e2b";
 
 import {
   SANDBOX_AGENT_PROXIED_SAFE_PATH,
@@ -83,6 +86,7 @@ import {
   SANDBOX_AGENT_SERVICE_HOME,
   SANDBOX_ROOT_SAFE_PATH,
 } from "../hardening";
+import { SandboxExecTimeoutError } from "../provider";
 import { rootCommand } from "../root_command";
 import { E2BSandboxProvider } from "./e2b";
 
@@ -303,6 +307,31 @@ describe("E2BSandboxProvider", () => {
         user: "agent",
       })
     );
+  });
+
+  it("maps the E2B timeout error when a command runs past its exec timeout", async () => {
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+    mockCommandHandleWait.mockRejectedValue(
+      new TimeoutError("[deadline_exceeded] the operation timed out")
+    );
+
+    const result = await provider.exec(
+      "provider-id",
+      "sleep 999",
+      { timeoutMs: 120_000 },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(SandboxExecTimeoutError);
+      expect(result.error.message).toBe(
+        new SandboxExecTimeoutError(120_000).message
+      );
+    }
   });
 
   it("runs agent-proxied workload commands in a clean shell with its own home", async () => {

--- a/front/lib/api/sandbox/providers/e2b.test.ts
+++ b/front/lib/api/sandbox/providers/e2b.test.ts
@@ -553,6 +553,44 @@ describe("E2BSandboxProvider", () => {
     });
   });
 
+  it("does not classify a streamed-stdin delivery timeout as an exec timeout", async () => {
+    const mockHandleKill = vi.fn().mockResolvedValue(true);
+    mockRun.mockResolvedValueOnce({
+      pid: 123,
+      wait: mockCommandHandleWait,
+      kill: mockHandleKill,
+    });
+    mockSendStdin.mockRejectedValueOnce(
+      new TimeoutError("timeout of 30000ms exceeded")
+    );
+
+    const provider = new E2BSandboxProvider({
+      apiKey: "api-key",
+      domain: undefined,
+    });
+
+    const result = await provider.exec(
+      "provider-id",
+      "/opt/bin/dsbx function run big",
+      {
+        stdin: "x".repeat(64 * 1_024),
+        allowStdinInEnvironment: true,
+        timeoutMs: 120_000,
+        user: "agent-proxied",
+      },
+      { workspaceId: "workspace-id" }
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).not.toBeInstanceOf(SandboxExecTimeoutError);
+      expect(result.error.message).toContain(
+        "Failed to deliver stdin to the sandbox command"
+      );
+    }
+    expect(mockHandleKill).toHaveBeenCalledTimes(1);
+  });
+
   it("kills the background handle when sendStdin fails to avoid orphaned commands", async () => {
     const mockHandleKill = vi.fn().mockResolvedValue(true);
     mockRun.mockResolvedValueOnce({

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -21,6 +21,7 @@ import type {
 } from "@app/lib/api/sandbox/provider";
 import {
   isSandboxExecUser,
+  SandboxExecTimeoutError,
   SandboxNotFoundError,
   traceSandboxOperation,
 } from "@app/lib/api/sandbox/provider";
@@ -36,7 +37,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { CommandHandle } from "e2b";
-import { CommandExitError, NotFoundError, Sandbox } from "e2b";
+import { CommandExitError, NotFoundError, Sandbox, TimeoutError } from "e2b";
 
 const ONE_HOUR_MS = 60 * 60 * 1_000;
 
@@ -565,6 +566,11 @@ export class E2BSandboxProvider implements SandboxProvider {
               stdout: err.stdout,
               stderr: err.stderr,
             });
+          }
+          // The command ran past `timeoutMs`. Map to our own error so callers
+          // can tell an exec timeout from an infra failure.
+          if (err instanceof TimeoutError) {
+            return new Err(new SandboxExecTimeoutError(start.opts.timeoutMs));
           }
           return new Err(normalizeError(err));
         }

--- a/front/lib/api/sandbox/providers/e2b.ts
+++ b/front/lib/api/sandbox/providers/e2b.ts
@@ -291,6 +291,7 @@ async function sendStdinAndWait(
   handle: CommandHandle,
   stdin: string | Uint8Array
 ) {
+  let stdinDelivered = false;
   try {
     // Per-RPC timeout, not the command's total runtime — clamping to the
     // overall timeoutMs would block sendStdin/closeStdin for the entire
@@ -301,6 +302,7 @@ async function sendStdinAndWait(
     await sandbox.commands.closeStdin(handle.pid, {
       requestTimeoutMs: REQUEST_TIMEOUT_MS,
     });
+    stdinDelivered = true;
     return await handle.wait();
   } catch (err) {
     if (err instanceof NotFoundError) {
@@ -315,6 +317,14 @@ async function sendStdinAndWait(
       await handle.kill();
     } catch {
       // Best-effort: caller already has a real error to surface.
+    }
+    if (!stdinDelivered && err instanceof TimeoutError) {
+      // A per-RPC stdin timeout is an input-delivery failure, not the command
+      // running past its ceiling: rewrap so the caller does not map it to
+      // SandboxExecTimeoutError.
+      throw new Error(
+        `Failed to deliver stdin to the sandbox command: ${err.message}`
+      );
     }
     throw err;
   }

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.test.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.test.ts
@@ -1,3 +1,4 @@
+import { SandboxExecTimeoutError } from "@app/lib/api/sandbox/provider";
 import { publishSandboxFunctionInvocationEvent } from "@app/lib/api/sandbox_functions/events";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
@@ -129,6 +130,40 @@ describe("runSandboxFunctionInvocationActivity", () => {
         type: "sandbox_function_invocation_error",
         invocationId: invocation.sId,
         error: { code: "invocation_failed", message: "sandbox unavailable" },
+      }),
+      { invocationId: invocation.sId }
+    );
+  });
+
+  it("fails the invocation without throwing when execution times out", async () => {
+    const { adminAuth, authenticator, sandboxFunction, invocation } =
+      await setup();
+    const timeoutError = new SandboxExecTimeoutError(120_000);
+    vi.spyOn(
+      SandboxFunctionInvocationResource.prototype,
+      "execute"
+    ).mockResolvedValue(new Err(timeoutError));
+
+    await expect(
+      runSandboxFunctionInvocationActivity(authenticator.toJSON(), {
+        sandboxFunctionId: sandboxFunction.sId,
+        invocationId: invocation.sId,
+      })
+    ).resolves.toBeUndefined();
+
+    const refetched = await SandboxFunctionInvocationResource.fetchById(
+      adminAuth,
+      { sandboxFunction, invocationId: invocation.sId }
+    );
+    expect(refetched?.status).toBe("errored");
+    expect(publishSandboxFunctionInvocationEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "sandbox_function_invocation_error",
+        invocationId: invocation.sId,
+        error: {
+          code: "invocation_failed",
+          message: timeoutError.message,
+        },
       }),
       { invocationId: invocation.sId }
     );

--- a/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
+++ b/front/temporal/sandbox_functions/activities/run_sandbox_function_invocation.ts
@@ -1,3 +1,4 @@
+import { isSandboxExecTimeoutError } from "@app/lib/api/sandbox/provider";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { SandboxFunctionInvocationResource } from "@app/lib/resources/sandbox_function_invocation_resource";
@@ -40,6 +41,12 @@ export async function runSandboxFunctionInvocationActivity(
   const executionResult = await invocation.execute(auth);
   if (executionResult.isErr()) {
     await invocation.fail(executionResult.error);
+    // A function running past its exec ceiling is an expected outcome, not a workflow
+    // failure: fail() above recorded it and listeners settled. Rethrow everything else
+    // so real problems keep failing the workflow.
+    if (isSandboxExecTimeoutError(executionResult.error)) {
+      return;
+    }
     throw executionResult.error;
   }
 }


### PR DESCRIPTION
## Description

[`runSandboxFunctionInvocationWorkflow` fails](https://cloud.temporal.io/namespaces/dust-prod.gmnlm/workflows?query=ExecutionStatus%3D%22Failed%22) when a Pod function runs past its 2-minute exec ceiling: E2B throws `TimeoutError`, the activity records the outcome via `invocation.fail()` (error event published, listeners settle) but then rethrows, failing the workflow. A function running too long is an expected outcome, not a workflow failure.

Fix, scoped to timeouts only so real problems keep failing the workflow:

- The E2B provider maps the SDK's `TimeoutError` to a new `SandboxExecTimeoutError` (it was leaking through `normalizeError` despite the "callers never see E2B types" contract). The message carries the ceiling that was hit.
- Streamed-stdin delivery timeouts (separate 30s per-RPC deadline, also surfaced as `TimeoutError` by E2B) are rewrapped in `sendStdinAndWait` so an input-delivery failure is not classified as the command running past its ceiling.
- The invocation activity returns instead of rethrowing for `SandboxExecTimeoutError`, after `fail()` recorded the outcome. Everything else still throws.

## Tests

Provider tests pin the `TimeoutError -> SandboxExecTimeoutError` mapping and that a streamed-stdin delivery timeout is not classified as an exec timeout. Activity test asserts a timeout resolves without throwing while the invocation is marked `errored` and the error event is published.

## Risk

Worst case, a connection-level E2B timeout surfaced by `handle.wait()` is classified as an exec timeout and does not fail the workflow (the invocation is still marked errored either way). Safe to rollback.

## Deploy Plan

- [ ] Deploy front
