### PR TITLE
[front] qol refactor: use LoadingBlock in AgentObservability chart fallback

### DIFF
--- a/front/components/SuspensedCodeEditor.tsx
+++ b/front/components/SuspensedCodeEditor.tsx
@@ -1,13 +1,11 @@
 import { isNavigationLocked } from "@app/lib/navigation-lock";
-import { SafeSuspense, safeLazy } from "@dust-tt/sparkle";
+import { LoadingBlock, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
 import type { TextareaCodeEditorProps } from "@uiw/react-textarea-code-editor";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
 import React from "react";
 
 function CodeEditorFallback() {
-  return (
-    <div className="mt-5 h-32 animate-pulse rounded-md bg-muted-background" />
-  );
+  return <LoadingBlock className="mt-5 h-32" />;
 }
 
 const CodeEditor = safeLazy(

--- a/front/components/command_palette/CommandPaletteSearchPhase.tsx
+++ b/front/components/command_palette/CommandPaletteSearchPhase.tsx
@@ -9,7 +9,7 @@ import { getSpaceIcon } from "@app/lib/spaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { SkillWithoutInstructionsAndToolsType } from "@app/types/assistant/skill_configuration";
 import type { PodType } from "@app/types/space";
-import { Avatar, cn, Icon, SearchInput } from "@dust-tt/sparkle";
+import { Avatar, cn, Icon, LoadingBlock, SearchInput } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 
 export type CommandPaletteItem =
@@ -146,9 +146,9 @@ export function CommandPaletteSearchPhase({
           <div className="flex flex-col gap-1 p-1">
             {Array.from({ length: 9 }, (_, i) => (
               <div key={i} className="flex items-center gap-2.5 px-3 py-2.5">
-                <div className="h-6 w-6 shrink-0 animate-pulse rounded-full bg-muted-background" />
-                <div
-                  className="h-4 animate-pulse rounded bg-muted-background"
+                <LoadingBlock className="h-6 w-6 shrink-0 rounded-full" />
+                <LoadingBlock
+                  className="h-4"
                   style={{ width: `${30 + (i % 3) * 20}%` }}
                 />
               </div>

--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -5,6 +5,7 @@ import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { useAgentAnalytics } from "@app/lib/swr/assistants";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  LoadingBlock,
   SafeSuspense,
   safeLazy,
   ThumbsDown,
@@ -23,7 +24,7 @@ const FeedbackDistributionChart = safeLazy(
 );
 
 function ChartFallback() {
-  return <div className="h-64 animate-pulse rounded-lg bg-muted-background" />;
+  return <LoadingBlock className="h-64 rounded-lg" />;
 }
 
 interface AgentFeedbackProps {

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -96,7 +96,7 @@ const UsageMetricsChart = safeLazy(
 );
 
 function ChartFallback() {
-  return <div className="h-64 animate-pulse rounded-lg bg-muted-background" />;
+  return <LoadingBlock className="h-64 rounded-lg" />;
 }
 
 interface AgentObservabilityProps {

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -9,7 +9,7 @@ import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/a
 import { WorkspaceUserCreditsTable } from "@app/components/workspace/analytics/WorkspaceUserCreditsTable";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
-import { Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
+import { LoadingBlock, Page, SafeSuspense, safeLazy } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 // Dynamic imports for chart components to exclude recharts from server bundle.
@@ -63,7 +63,7 @@ const WorkspaceSkillUsageChart = safeLazy(
 );
 
 function ChartFallback() {
-  return <div className="h-64 animate-pulse rounded-lg bg-muted-background" />;
+  return <LoadingBlock className="h-64 rounded-lg" />;
 }
 
 export function AnalyticsPage() {

--- a/front/components/paywall/DontLoseSection.tsx
+++ b/front/components/paywall/DontLoseSection.tsx
@@ -3,6 +3,7 @@ import type { WorkspaceType } from "@app/types/user";
 import {
   CloudArrowLeftRight,
   Icon,
+  LoadingBlock,
   MessageChatSquare,
   Robot,
   Stars02,
@@ -29,10 +30,10 @@ function DontLoseItem({
   if (isLoading) {
     return (
       <div className="flex items-start gap-3">
-        <div className="h-5 w-5 animate-pulse rounded bg-muted-background" />
+        <LoadingBlock className="h-5 w-5" />
         <div className="flex flex-col gap-1">
-          <div className="h-5 w-32 animate-pulse rounded bg-muted-background" />
-          <div className="h-4 w-48 animate-pulse rounded bg-muted-background" />
+          <LoadingBlock className="h-5 w-32" />
+          <LoadingBlock className="h-4 w-48" />
         </div>
       </div>
     );

--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -4,7 +4,7 @@ import {
 } from "@app/components/poke/credits/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import type { PokeStripeSubscriptionWire } from "@app/lib/api/poke/workspace_info";
-import { safeLazy, Tooltip } from "@dust-tt/sparkle";
+import { LoadingBlock, safeLazy, Tooltip } from "@dust-tt/sparkle";
 import { Suspense } from "react";
 
 const PokeProgrammaticCostChart = safeLazy(() =>
@@ -16,7 +16,7 @@ const PokeProgrammaticCostChart = safeLazy(() =>
 );
 
 function PokeChartFallback() {
-  return <div className="h-96 animate-pulse rounded-lg bg-muted-background" />;
+  return <LoadingBlock className="h-96 rounded-lg" />;
 }
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";

--- a/front/components/workspace/analytics/automations/AutomationsOverview.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsOverview.tsx
@@ -3,6 +3,7 @@ import { useAutomationsOverview } from "@app/hooks/useAutomationsOverview";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { formatCredits } from "@app/lib/client/credits";
 import type { LightWorkspaceType } from "@app/types/user";
+import { LoadingBlock } from "@dust-tt/sparkle";
 
 interface AutomationsOverviewProps {
   owner: LightWorkspaceType;
@@ -17,9 +18,7 @@ export function AutomationsOverview({
     useAutomationsOverview({ workspaceId: owner.sId, period });
 
   if (isOverviewLoading) {
-    return (
-      <div className="h-24 w-full animate-pulse rounded-xl bg-muted-background" />
-    );
+    return <LoadingBlock className="h-24 w-full rounded-xl" />;
   }
 
   if (isOverviewError || !overview) {

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -3,7 +3,7 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { formatConsumptionDate } from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
 import { timeAgoFrom } from "@app/lib/utils";
-import { Page, Tooltip } from "@dust-tt/sparkle";
+import { LoadingBlock, Page, Tooltip } from "@dust-tt/sparkle";
 
 export interface ConsumptionOverviewProps {
   workspaceId: string;
@@ -45,9 +45,7 @@ export function ConsumptionOverviewView({
   showIndexingDetails = false,
 }: ConsumptionOverviewViewProps) {
   if (isOverviewLoading) {
-    return (
-      <div className="h-5 w-80 animate-pulse rounded bg-muted-background" />
-    );
+    return <LoadingBlock className="h-5 w-80" />;
   }
 
   if (isOverviewError || !overview) {

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -5,7 +5,7 @@ import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/cons
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { formatCredits } from "@app/lib/client/credits";
 import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
-import { ArrowUpRight, Button, Chip } from "@dust-tt/sparkle";
+import { ArrowUpRight, Button, Chip, LoadingBlock } from "@dust-tt/sparkle";
 
 const TARGET_CHIP: Record<
   CreditUsageTarget,
@@ -80,18 +80,14 @@ export function ConsumptionSummaryView({
             : "flex items-stretch gap-6"
         }
       >
-        <div
+        <LoadingBlock
           className={
-            responsiveLayout
-              ? "h-24 animate-pulse rounded-xl bg-muted-background"
-              : "h-24 flex-1 animate-pulse rounded-xl bg-muted-background"
+            responsiveLayout ? "h-24 rounded-xl" : "h-24 flex-1 rounded-xl"
           }
         />
-        <div
+        <LoadingBlock
           className={
-            responsiveLayout
-              ? "h-24 animate-pulse rounded-xl bg-muted-background"
-              : "h-24 flex-1 animate-pulse rounded-xl bg-muted-background"
+            responsiveLayout ? "h-24 rounded-xl" : "h-24 flex-1 rounded-xl"
           }
         />
       </div>


### PR DESCRIPTION
## Description

Several skeleton/loading placeholders across the codebase were still hand-rolled `<div className="animate-pulse rounded-* bg-muted-background" />` elements, left over from before `LoadingBlock` was introduced to Sparkle. This replaces them with `LoadingBlock` Sparkle.

## Tests

Manual: verified the loading states render the same skeleton visuals as before in the
command palette, analytics/consumption pages, agent observability, and paywall.

## Risk

Low. Purely a visual/markup swap to an existing sparkle primitive, no behavior or data
changes.

## Deploy Plan

- Deploy front
