### PR TITLE
[front] refactor: use LoadingBlock in AgentFeedback chart fallback

### DIFF
--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -5,6 +5,7 @@ import { isNavigationLocked } from "@app/lib/navigation-lock";
 import { useAgentAnalytics } from "@app/lib/swr/assistants";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  LoadingBlock,
   SafeSuspense,
   safeLazy,
   ThumbsDown,
@@ -23,7 +24,7 @@ const FeedbackDistributionChart = safeLazy(
 );
 
 function ChartFallback() {
-  return <div className="h-64 animate-pulse rounded-lg bg-muted-background" />;
+  return <LoadingBlock className="h-64 rounded-lg" />;
 }
 
 interface AgentFeedbackProps {


### PR DESCRIPTION
Same ChartFallback hand-rolled skeleton as AgentObservability, replaced
with the shared LoadingBlock primitive.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
