### PR TITLE
[front] refactor: use LoadingBlock in Poke credits chart fallback

### DIFF
--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -4,7 +4,7 @@ import {
 } from "@app/components/poke/credits/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import type { PokeStripeSubscriptionWire } from "@app/lib/api/poke/workspace_info";
-import { safeLazy, Tooltip } from "@dust-tt/sparkle";
+import { LoadingBlock, safeLazy, Tooltip } from "@dust-tt/sparkle";
 import { Suspense } from "react";
 
 const PokeProgrammaticCostChart = safeLazy(() =>
@@ -16,7 +16,7 @@ const PokeProgrammaticCostChart = safeLazy(() =>
 );
 
 function PokeChartFallback() {
-  return <div className="h-96 animate-pulse rounded-lg bg-muted-background" />;
+  return <LoadingBlock className="h-96 rounded-lg" />;
 }
 
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";


### PR DESCRIPTION
Same hand-rolled skeleton pattern, replaced with LoadingBlock.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
