### PR TITLE
[front] feat: add per-group workflow alert threshold column

### DIFF
--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -929,6 +929,114 @@ describe("GroupResource", () => {
     });
   });
 
+  describe("updateWorkflowAlertThreshold", () => {
+    it("persists a threshold and clears it with null", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Workflow Alert Group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      expect(regularGroup.workflowAlertThresholdAwuCredits).toBeNull();
+
+      const setResult = await regularGroup.updateWorkflowAlertThreshold(
+        authenticator,
+        5000
+      );
+      expect(setResult.isOk()).toBe(true);
+
+      const afterSet = await GroupResource.fetchById(
+        authenticator,
+        regularGroup.sId
+      );
+      if (afterSet.isErr()) {
+        throw afterSet.error;
+      }
+      expect(afterSet.value.workflowAlertThresholdAwuCredits).toBe(5000);
+
+      const clearResult = await regularGroup.updateWorkflowAlertThreshold(
+        authenticator,
+        null
+      );
+      expect(clearResult.isOk()).toBe(true);
+
+      const afterClear = await GroupResource.fetchById(
+        authenticator,
+        regularGroup.sId
+      );
+      if (afterClear.isErr()) {
+        throw afterClear.error;
+      }
+      expect(afterClear.value.workflowAlertThresholdAwuCredits).toBeNull();
+    });
+  });
+
+  describe("listMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace", () => {
+    it("returns the highest threshold across a user's provisioned groups, ignoring unset and non-provisioned groups", async () => {
+      const user2 = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user2, { role: "user" });
+
+      // Provisioned groups are synced from WorkOS; members are seeded directly.
+      const alert500 = await GroupResource.makeNew(
+        {
+          name: "Alert 500",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-alert-500",
+        },
+        { memberIds: [user.id] }
+      );
+      await alert500.updateWorkflowAlertThreshold(authenticator, 500);
+
+      const alert800 = await GroupResource.makeNew(
+        {
+          name: "Alert 800",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-alert-800",
+        },
+        { memberIds: [user.id] }
+      );
+      await alert800.updateWorkflowAlertThreshold(authenticator, 800);
+
+      // No threshold set: user2 belongs only here, so they have no group threshold.
+      await GroupResource.makeNew(
+        {
+          name: "No threshold",
+          workspaceId: workspace.id,
+          kind: "provisioned",
+          workOSGroupId: "fake-no-threshold",
+        },
+        { memberIds: [user.id, user2.id] }
+      );
+
+      // Regular (Space-backed) groups are not cap-eligible: even with a higher
+      // threshold, they must not contribute to any member's group threshold.
+      const regularGroup = await GroupResource.makeNew(
+        {
+          name: "Regular with threshold",
+          workspaceId: workspace.id,
+          kind: "regular_auto",
+        },
+        { memberIds: [user.id, user2.id] }
+      );
+      await regularGroup.updateWorkflowAlertThreshold(authenticator, 10_000);
+
+      const result =
+        await GroupResource.listMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace(
+          {
+            workspace,
+            userModelIds: [user.id, user2.id],
+          }
+        );
+
+      // user is in both provisioned groups with a threshold → the highest wins;
+      // the regular group's higher threshold is ignored.
+      expect(result.get(user.id)).toBe(800);
+      // user2 is only in groups with no threshold / non-eligible groups → absent.
+      expect(result.has(user2.id)).toBe(false);
+    });
+  });
+
   describe("listWorkspaceGroupsFromKey", () => {
     it("system key: populates cache on first call and serves from cache on second", async () => {
       const key = await KeyFactory.system(systemGroup);

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -85,6 +85,7 @@ type CachedGroup = {
   workspaceId: ModelId;
   workOSGroupId: string | null;
   poolCapAwuCredits: number | null;
+  workflowAlertThresholdAwuCredits: number | null;
   createdAt: number;
   updatedAt: number;
 };
@@ -140,6 +141,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: g.workspaceId,
       workOSGroupId: g.workOSGroupId,
       poolCapAwuCredits: g.poolCapAwuCredits,
+      workflowAlertThresholdAwuCredits: g.workflowAlertThresholdAwuCredits,
       createdAt: g.createdAt.getTime(),
       updatedAt: g.updatedAt.getTime(),
     }));
@@ -180,6 +182,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       workspaceId: data.workspaceId,
       workOSGroupId: data.workOSGroupId,
       poolCapAwuCredits: data.poolCapAwuCredits,
+      workflowAlertThresholdAwuCredits: data.workflowAlertThresholdAwuCredits,
       createdAt: new Date(data.createdAt),
       updatedAt: new Date(data.updatedAt),
     });
@@ -1434,6 +1437,64 @@ export class GroupResource extends BaseResource<GroupModel> {
     return result;
   }
 
+  // For each user, the highest per-group workflow alert threshold among the
+  // cap-eligible (provisioned) groups they belong to. Users with no group
+  // enabling the smooth shutdown flow are absent from the map. Mirrors
+  // listMaxPoolCapAwuCreditsByUserModelIdInWorkspace: when a user belongs to
+  // multiple groups with a threshold set, the highest value applies.
+  static async listMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace({
+    workspace,
+    userModelIds,
+  }: {
+    workspace: LightWorkspaceType;
+    userModelIds: ModelId[];
+  }): Promise<Map<ModelId, number>> {
+    const result = new Map<ModelId, number>();
+    if (userModelIds.length === 0) {
+      return result;
+    }
+
+    const now = new Date();
+    const memberships = await GroupMembershipModel.findAll({
+      where: {
+        workspaceId: workspace.id,
+        userId: userModelIds,
+        status: "active",
+        startAt: { [Op.lte]: now },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+      },
+    });
+    if (memberships.length === 0) {
+      return result;
+    }
+
+    const groupModelIds = [...new Set(memberships.map((m) => m.groupId))];
+    const groups = await GroupModel.findAll({
+      where: {
+        id: groupModelIds,
+        workspaceId: workspace.id,
+        kind: [...CAP_ELIGIBLE_GROUP_KINDS],
+        workflowAlertThresholdAwuCredits: { [Op.ne]: null },
+      },
+    });
+    const thresholdByGroupId = new Map(
+      groups.map((g) => [g.id, g.workflowAlertThresholdAwuCredits])
+    );
+
+    for (const m of memberships) {
+      const threshold = thresholdByGroupId.get(m.groupId);
+      if (threshold === undefined || threshold === null) {
+        continue;
+      }
+      const existing = result.get(m.userId);
+      if (existing === undefined || threshold > existing) {
+        result.set(m.userId, threshold);
+      }
+    }
+
+    return result;
+  }
+
   static async getMemberCountsForGroups(
     auth: Authenticator,
     groups: GroupResource[]
@@ -2454,6 +2515,24 @@ export class GroupResource extends BaseResource<GroupModel> {
     return new Ok(undefined);
   }
 
+  // Per-group credit threshold that triggers the smooth shutdown flow for a member.
+  // Pass null to disable smooth shutdown for this group.
+  async updateWorkflowAlertThreshold(
+    auth: Authenticator,
+    workflowAlertThresholdAwuCredits: number | null
+  ): Promise<Result<undefined, Error>> {
+    if (!auth.isManager()) {
+      return new Err(
+        new Error(
+          "Only admins and managers can update group workflow alert thresholds."
+        )
+      );
+    }
+
+    await this.update({ workflowAlertThresholdAwuCredits });
+    return new Ok(undefined);
+  }
+
   // Deletion
 
   async delete(
@@ -2906,6 +2985,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       kind: this.kind,
       memberCount: 0, // Default value, use toJSONWithMemberCount for actual count
       poolCapAwuCredits: this.poolCapAwuCredits,
+      workflowAlertThresholdAwuCredits: this.workflowAlertThresholdAwuCredits,
     };
   }
 
@@ -2919,6 +2999,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       kind: this.kind,
       memberCount,
       poolCapAwuCredits: this.poolCapAwuCredits,
+      workflowAlertThresholdAwuCredits: this.workflowAlertThresholdAwuCredits,
     };
   }
 

--- a/front/lib/resources/storage/models/groups.ts
+++ b/front/lib/resources/storage/models/groups.ts
@@ -18,6 +18,10 @@ export class GroupModel extends WorkspaceAwareModel<GroupModel> {
   // Per-group usage spend limit (excluding seat allowance), applied per member.
   // null means the group carries no cap (falls back to the workspace default).
   declare poolCapAwuCredits: CreationOptional<number | null>;
+
+  // Per-group credit threshold that triggers the smooth shutdown flow for a member.
+  // null means the group has no threshold (smooth shutdown is disabled for that group).
+  declare workflowAlertThresholdAwuCredits: CreationOptional<number | null>;
 }
 
 GroupModel.init(
@@ -45,6 +49,10 @@ GroupModel.init(
       allowNull: true,
     },
     poolCapAwuCredits: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+    },
+    workflowAlertThresholdAwuCredits: {
       type: DataTypes.INTEGER,
       allowNull: true,
     },

--- a/front/migrations/pre-deploy/20260821142930_add_workflow_alert_threshold_to_groups.sql
+++ b/front/migrations/pre-deploy/20260821142930_add_workflow_alert_threshold_to_groups.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."groups" ADD COLUMN "workflowAlertThresholdAwuCredits" integer;

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -98,6 +98,9 @@ export type GroupType = {
   // Per-group usage spend limit (excluding seat allowance), applied per member.
   // null means the group carries no cap (falls back to the workspace default).
   poolCapAwuCredits: number | null;
+  // Per-group credit threshold that triggers the smooth shutdown flow for a member.
+  // null means the group has no threshold (smooth shutdown is disabled for that group).
+  workflowAlertThresholdAwuCredits: number | null;
   // Member sIds, only populated when explicitly requested
   memberIds?: string[];
 };


### PR DESCRIPTION
Adds workflowAlertThresholdAwuCredits on groups, mirroring the
poolCapAwuCredits pattern used for group spend limits. Null disables
the smooth shutdown flow for a group; when a user belongs to several
groups with a threshold set, the highest value applies.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
