### PR TITLE
[front] feat: admin panel to set per-group workflow alert threshold

### DIFF
--- a/front-api/routes/w/[wId]/groups/[groupId]/workflow_alert_threshold.test.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/workflow_alert_threshold.test.ts
@@ -1,0 +1,192 @@
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+async function makeProvisionedGroup(
+  workspace: WorkspaceType
+): Promise<GroupResource> {
+  return GroupResource.makeNew({
+    name: "Sales",
+    workspaceId: workspace.id,
+    kind: "provisioned",
+    workOSGroupId: "fake-sales",
+  });
+}
+
+function groupWorkflowAlertThresholdUrl(wId: string, groupId: string) {
+  return `/api/w/${wId}/groups/${groupId}/workflow_alert_threshold`;
+}
+
+function putThreshold(
+  wId: string,
+  groupId: string,
+  body: Record<string, unknown>
+) {
+  return honoApp.request(groupWorkflowAlertThresholdUrl(wId, groupId), {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/w/[wId]/groups/[groupId]/workflow_alert_threshold", () => {
+  describe("auth", () => {
+    it("returns 403 when caller is neither an admin nor a manager", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const group = await makeProvisionedGroup(workspace);
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "user",
+        workspace,
+      });
+
+      const response = await putThreshold(workspace.sId, group.sId, {
+        kind: "enabled",
+        awuCredits: 1500,
+      });
+
+      expect(response.status).toBe(403);
+      expect((await response.json()).error.type).toBe("workspace_auth_error");
+    });
+
+    it("lets a manager set the threshold on a provisioned group", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const group = await makeProvisionedGroup(workspace);
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "manager",
+        workspace,
+      });
+
+      const response = await putThreshold(workspace.sId, group.sId, {
+        kind: "enabled",
+        awuCredits: 1500,
+      });
+
+      expect(response.status).toBe(200);
+
+      const reloaded = await GroupResource.fetchById(auth, group.sId);
+      if (reloaded.isErr()) {
+        throw reloaded.error;
+      }
+      expect(reloaded.value.workflowAlertThresholdAwuCredits).toBe(1500);
+    });
+  });
+
+  describe("input validation", () => {
+    it("returns 400 on out-of-bounds awuCredits", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const group = await makeProvisionedGroup(workspace);
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      for (const awuCredits of [-1, 1.5, 100_000_000]) {
+        const response = await putThreshold(workspace.sId, group.sId, {
+          kind: "enabled",
+          awuCredits,
+        });
+        expect(response.status).toBe(400);
+      }
+    });
+
+    it("returns 404 when the group does not exist", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putThreshold(
+        workspace.sId,
+        "nonexistent-group-id",
+        { kind: "enabled", awuCredits: 1500 }
+      );
+
+      expect(response.status).toBe(404);
+      expect((await response.json()).error.type).toBe("group_not_found");
+    });
+
+    it("returns 400 on a non-provisioned group", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const regularGroup = await GroupResource.makeNew({
+        name: "Space group",
+        workspaceId: workspace.id,
+        kind: "regular_auto",
+      });
+      await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putThreshold(workspace.sId, regularGroup.sId, {
+        kind: "enabled",
+        awuCredits: 1500,
+      });
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error.type).toBe("invalid_request_error");
+    });
+  });
+
+  describe("PUT", () => {
+    it("persists the threshold for enabled", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const group = await makeProvisionedGroup(workspace);
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+
+      const response = await putThreshold(workspace.sId, group.sId, {
+        kind: "enabled",
+        awuCredits: 25_000,
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        threshold: { kind: "enabled", awuCredits: 25_000 },
+      });
+
+      const reloaded = await GroupResource.fetchById(auth, group.sId);
+      if (reloaded.isErr()) {
+        throw reloaded.error;
+      }
+      expect(reloaded.value.workflowAlertThresholdAwuCredits).toBe(25_000);
+    });
+
+    it("clears the threshold for disabled", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const group = await makeProvisionedGroup(workspace);
+      const { auth } = await createPrivateApiMockRequest({
+        method: "PUT",
+        role: "admin",
+        workspace,
+      });
+      await group.updateWorkflowAlertThreshold(auth, 25_000);
+
+      const response = await putThreshold(workspace.sId, group.sId, {
+        kind: "disabled",
+      });
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        threshold: { kind: "disabled" },
+      });
+
+      const reloaded = await GroupResource.fetchById(auth, group.sId);
+      if (reloaded.isErr()) {
+        throw reloaded.error;
+      }
+      expect(reloaded.value.workflowAlertThresholdAwuCredits).toBeNull();
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/groups/[groupId]/workflow_alert_threshold.ts
+++ b/front-api/routes/w/[wId]/groups/[groupId]/workflow_alert_threshold.ts
@@ -1,0 +1,86 @@
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
+import {
+  type GroupWorkflowAlertThresholdError,
+  MAX_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS,
+  MIN_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS,
+  setGroupWorkflowAlertThreshold,
+} from "@app/lib/api/groups/workflow_alert_threshold";
+import type { PutGroupWorkflowAlertThresholdResponseBody } from "@app/types/api/groups/workflow_alert_threshold";
+import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsManager } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const UpdateGroupWorkflowAlertThresholdBodySchema = z.discriminatedUnion(
+  "kind",
+  [
+    z.object({ kind: z.literal("disabled") }),
+    z.object({
+      kind: z.literal("enabled"),
+      awuCredits: z
+        .number()
+        .int()
+        .min(MIN_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS)
+        .max(MAX_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS),
+    }),
+  ]
+);
+
+const ParamsSchema = z.object({
+  groupId: z.string(),
+});
+
+function workflowAlertThresholdErrorToApiError(
+  error: GroupWorkflowAlertThresholdError
+): APIErrorWithContentfulStatusCode {
+  switch (error.type) {
+    case "group_not_found":
+      return {
+        status_code: 404,
+        api_error: { type: "group_not_found", message: error.message },
+      };
+    case "invalid_group_kind":
+    case "invalid_threshold":
+      return {
+        status_code: 400,
+        api_error: { type: "invalid_request_error", message: error.message },
+      };
+    case "unauthorized":
+      return {
+        status_code: 403,
+        api_error: { type: "workspace_auth_error", message: error.message },
+      };
+    default:
+      assertNever(error.type);
+  }
+}
+
+// Mounted at /api/w/:wId/groups/:groupId/workflow_alert_threshold.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.put(
+  "/",
+  validate("param", ParamsSchema),
+  ensureIsManager(),
+  validate("json", UpdateGroupWorkflowAlertThresholdBodySchema),
+  async (ctx): HandlerResult<PutGroupWorkflowAlertThresholdResponseBody> => {
+    const auth = ctx.get("auth");
+    const { groupId } = ctx.req.valid("param");
+
+    const result = await setGroupWorkflowAlertThreshold(auth, {
+      groupId,
+      threshold: ctx.req.valid("json"),
+      auditContext: getAuditLogContext(auth),
+    });
+    if (result.isErr()) {
+      return apiError(ctx, workflowAlertThresholdErrorToApiError(result.error));
+    }
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/groups/index.ts
+++ b/front-api/routes/w/[wId]/groups/index.ts
@@ -15,6 +15,7 @@ import { z } from "zod";
 
 import groupDetail from "./[groupId]";
 import spendLimit from "./[groupId]/spend_limit";
+import workflowAlertThreshold from "./[groupId]/workflow_alert_threshold";
 
 export type GetGroupsResponseBody = {
   groups: (GroupType & { memberCount: number })[];
@@ -120,6 +121,7 @@ app.post(
 );
 
 app.route("/:groupId/spend_limit", spendLimit);
+app.route("/:groupId/workflow_alert_threshold", workflowAlertThreshold);
 app.route("/:groupId", groupDetail);
 
 export default app;

--- a/front/admin/audit_log_schemas/group.workflow_alert_threshold_updated.json
+++ b/front/admin/audit_log_schemas/group.workflow_alert_threshold_updated.json
@@ -1,0 +1,15 @@
+{
+  "action": "group.workflow_alert_threshold_updated",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "group"
+    }
+  ],
+  "metadata": {
+    "kind": "string",
+    "awu_credits": "string"
+  }
+}

--- a/front/components/workspace/GroupsUsageTable.tsx
+++ b/front/components/workspace/GroupsUsageTable.tsx
@@ -1,7 +1,12 @@
 import { GroupModelTierPickerDropdown } from "@app/components/workspace/GroupModelTierPickerDropdown";
 import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
-import { useGroups, useUpdateGroupSpendLimit } from "@app/lib/swr/groups";
+import {
+  useGroups,
+  useUpdateGroupSpendLimit,
+  useUpdateGroupWorkflowAlertThreshold,
+} from "@app/lib/swr/groups";
 import type { GroupSpendLimit } from "@app/types/api/groups/spend_limit";
+import type { GroupWorkflowAlertThreshold } from "@app/types/api/groups/workflow_alert_threshold";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
 import { DataTable, InputWithSave, Spinner, Users01 } from "@dust-tt/sparkle";
@@ -19,6 +24,7 @@ type GroupRowData = {
   name: string;
   memberCount: number;
   poolCapAwuCredits: number | null;
+  workflowAlertThresholdAwuCredits: number | null;
   onClick?: () => void;
 };
 
@@ -74,6 +80,64 @@ function GroupCapCell({ group, readOnly, onSave }: GroupCapCellProps) {
   );
 }
 
+interface WorkflowAlertThresholdCellProps {
+  group: GroupRowData;
+  readOnly: boolean;
+  onSave: (
+    group: GroupRowData,
+    threshold: GroupWorkflowAlertThreshold
+  ) => Promise<void>;
+}
+
+// Per-row editable smooth shutdown threshold cell. Empty input disables the
+// smooth shutdown flow for the group; a non-negative integer enables it at
+// that credit threshold. Reverts to the current value when nothing is
+// persisted.
+function WorkflowAlertThresholdCell({
+  group,
+  readOnly,
+  onSave,
+}: WorkflowAlertThresholdCellProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const current = group.workflowAlertThresholdAwuCredits;
+
+  const handleSave = async (newValue: string) => {
+    const trimmed = newValue.trim();
+    if (trimmed === "") {
+      if (current === null) {
+        return;
+      }
+      await onSave(group, { kind: "disabled" });
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed === current) {
+      return;
+    }
+    await onSave(group, { kind: "enabled", awuCredits: parsed });
+  };
+
+  return (
+    <div className="w-60">
+      <InputWithSave
+        inputMode="numeric"
+        pattern="[0-9]*"
+        placeholder="Disabled"
+        value={current === null ? "" : current.toLocaleString()}
+        unit={current === null && !isEditing ? undefined : "credits"}
+        normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+        formatValue={(value) =>
+          value ? Number(value).toLocaleString() : value
+        }
+        onSave={handleSave}
+        onFocus={() => setIsEditing(true)}
+        onBlur={() => setIsEditing(false)}
+        disabled={readOnly}
+      />
+    </div>
+  );
+}
+
 export function GroupsUsageTable({
   owner,
   readOnly,
@@ -86,6 +150,10 @@ export function GroupsUsageTable({
   const { doUpdateGroupSpendLimit } = useUpdateGroupSpendLimit({
     workspaceId: owner.sId,
   });
+  const { doUpdateGroupWorkflowAlertThreshold } =
+    useUpdateGroupWorkflowAlertThreshold({
+      workspaceId: owner.sId,
+    });
 
   const rows: GroupRowData[] = useMemo(
     () =>
@@ -94,6 +162,8 @@ export function GroupsUsageTable({
         name: group.name,
         memberCount: group.memberCount,
         poolCapAwuCredits: group.poolCapAwuCredits,
+        workflowAlertThresholdAwuCredits:
+          group.workflowAlertThresholdAwuCredits,
       })),
     [groups]
   );
@@ -142,6 +212,25 @@ export function GroupsUsageTable({
         ),
         enableSorting: false,
       },
+      {
+        id: "workflowAlertThreshold",
+        header: "Smooth shutdown threshold",
+        meta: { className: "w-64" },
+        cell: (info: GroupInfo) => (
+          <WorkflowAlertThresholdCell
+            group={info.row.original}
+            readOnly={readOnly}
+            onSave={async (group, threshold) => {
+              await doUpdateGroupWorkflowAlertThreshold({
+                groupId: group.groupId,
+                groupName: group.name,
+                threshold,
+              });
+            }}
+          />
+        ),
+        enableSorting: false,
+      },
       ...(showModelTiersColumn
         ? [
             {
@@ -165,7 +254,13 @@ export function GroupsUsageTable({
           ]
         : []),
     ],
-    [owner, readOnly, showModelTiersColumn, doUpdateGroupSpendLimit]
+    [
+      owner,
+      readOnly,
+      showModelTiersColumn,
+      doUpdateGroupSpendLimit,
+      doUpdateGroupWorkflowAlertThreshold,
+    ]
   );
 
   if (isGroupsLoading) {

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -56,6 +56,7 @@ export const AUDIT_ACTIONS = [
   "group.member_added",
   "group.member_removed",
   "group.spend_limit_updated",
+  "group.workflow_alert_threshold_updated",
   "membership.upgrade_request_created",
   "membership.upgrade_request_resolved",
   "membership.seat_auto_upgraded",

--- a/front/lib/api/groups/workflow_alert_threshold.ts
+++ b/front/lib/api/groups/workflow_alert_threshold.ts
@@ -1,0 +1,129 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
+import type { AuditLogContext } from "@app/lib/api/workos/organization";
+import type { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type {
+  GroupWorkflowAlertThreshold,
+  SetGroupWorkflowAlertThresholdResponse,
+} from "@app/types/api/groups/workflow_alert_threshold";
+import { isCapEligibleGroupKind } from "@app/types/groups";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export const MIN_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS = 0;
+export const MAX_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS = 2_000_000;
+
+type GroupWorkflowAlertThresholdErrorType =
+  | "group_not_found"
+  | "invalid_group_kind"
+  | "unauthorized"
+  | "invalid_threshold";
+
+export class GroupWorkflowAlertThresholdError extends Error {
+  constructor(
+    readonly type: GroupWorkflowAlertThresholdErrorType,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+/**
+ * Set or clear a group's smooth shutdown credit threshold.
+ *
+ * When a member's spend crosses the highest threshold across their groups,
+ * the agent loop offers to summarize progress and stop rather than hit the
+ * hard spend limit. `threshold.kind === "disabled"` clears the threshold
+ * (smooth shutdown stays off for this group).
+ */
+export async function setGroupWorkflowAlertThreshold(
+  auth: Authenticator,
+  {
+    groupId,
+    threshold,
+    auditContext,
+  }: {
+    groupId: string;
+    threshold: GroupWorkflowAlertThreshold;
+    auditContext: AuditLogContext;
+  }
+): Promise<
+  Result<
+    SetGroupWorkflowAlertThresholdResponse,
+    GroupWorkflowAlertThresholdError
+  >
+> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  if (
+    threshold.kind === "enabled" &&
+    (!Number.isInteger(threshold.awuCredits) ||
+      threshold.awuCredits < MIN_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS ||
+      threshold.awuCredits > MAX_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS)
+  ) {
+    return new Err(
+      new GroupWorkflowAlertThresholdError(
+        "invalid_threshold",
+        `awuCredits must be an integer between ${MIN_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS} and ${MAX_GROUP_WORKFLOW_ALERT_THRESHOLD_AWU_CREDITS}.`
+      )
+    );
+  }
+
+  const groupRes = await GroupResource.fetchById(auth, groupId);
+  if (groupRes.isErr()) {
+    return new Err(
+      new GroupWorkflowAlertThresholdError(
+        "group_not_found",
+        "Could not find the group in this workspace."
+      )
+    );
+  }
+  const group = groupRes.value;
+
+  if (!isCapEligibleGroupKind(group.kind)) {
+    return new Err(
+      new GroupWorkflowAlertThresholdError(
+        "invalid_group_kind",
+        `Group of kind '${group.kind}' cannot carry a workflow alert threshold.`
+      )
+    );
+  }
+
+  const workflowAlertThresholdAwuCredits =
+    threshold.kind === "enabled" ? threshold.awuCredits : null;
+
+  const updateResult = await group.updateWorkflowAlertThreshold(
+    auth,
+    workflowAlertThresholdAwuCredits
+  );
+  if (updateResult.isErr()) {
+    return new Err(
+      new GroupWorkflowAlertThresholdError(
+        "unauthorized",
+        updateResult.error.message
+      )
+    );
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "group.workflow_alert_threshold_updated",
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      buildAuditLogTarget("group", { sId: group.sId, name: group.name }),
+    ],
+    context: auditContext,
+    metadata: {
+      kind: threshold.kind,
+      awu_credits:
+        threshold.kind === "enabled"
+          ? String(threshold.awuCredits)
+          : "disabled",
+    },
+  });
+
+  return new Ok({ threshold });
+}

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -11,6 +11,7 @@ import type {
   PostMemberGroupResponseBody,
 } from "@app/types/api/groups/manage";
 import type { PutGroupSpendLimitResponseBody } from "@app/types/api/groups/spend_limit";
+import type { PutGroupWorkflowAlertThresholdResponseBody } from "@app/types/api/groups/workflow_alert_threshold";
 import type { GroupKind } from "@app/types/groups";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
@@ -588,4 +589,97 @@ export function useUpdateGroupSpendLimit({
   );
 
   return { doUpdateGroupSpendLimit };
+}
+
+function groupWorkflowAlertThresholdUrl(
+  workspaceId: string,
+  groupId: string
+): string {
+  return `/api/w/${workspaceId}/groups/${groupId}/workflow_alert_threshold`;
+}
+
+const GroupWorkflowAlertThresholdResponseSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("disabled") }),
+  z.object({ kind: z.literal("enabled"), awuCredits: z.number() }),
+]);
+
+const PutGroupWorkflowAlertThresholdResponseSchema = z.object({
+  threshold: GroupWorkflowAlertThresholdResponseSchema,
+});
+
+export function useUpdateGroupWorkflowAlertThreshold({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+
+  const doUpdateGroupWorkflowAlertThreshold = useCallback(
+    async ({
+      groupId,
+      groupName,
+      threshold,
+    }: {
+      groupId: string;
+      groupName: string;
+      threshold: { kind: "disabled" } | { kind: "enabled"; awuCredits: number };
+    }): Promise<PutGroupWorkflowAlertThresholdResponseBody | null> => {
+      const res = await clientFetch(
+        groupWorkflowAlertThresholdUrl(workspaceId, groupId),
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(threshold),
+        }
+      );
+
+      if (!res.ok) {
+        const error = await res.json();
+        sendNotification({
+          type: "error",
+          title: "Failed to update workflow alert threshold",
+          description: error?.error?.message ?? "An unexpected error occurred.",
+        });
+        return null;
+      }
+
+      const parsed = PutGroupWorkflowAlertThresholdResponseSchema.safeParse(
+        await res.json()
+      );
+      if (!parsed.success) {
+        await invalidateWorkspaceGroups(workspaceId);
+        sendNotification({
+          type: "error",
+          title: "Workflow alert threshold status unknown",
+          description:
+            "The update was submitted but the server response could not be read. The table has been refreshed with the current state.",
+        });
+        return null;
+      }
+      const body = parsed.data;
+      let description: string;
+      switch (threshold.kind) {
+        case "disabled":
+          description = `${groupName}'s workflow alert threshold has been removed.`;
+          break;
+        case "enabled":
+          description = `${groupName}'s workflow alert threshold has been set to ${threshold.awuCredits.toLocaleString("en-US")} credits.`;
+          break;
+        default:
+          assertNeverAndIgnore(threshold);
+          description = "";
+      }
+      sendNotification({
+        type: "success",
+        title: "Workflow alert threshold updated",
+        description,
+      });
+
+      await invalidateWorkspaceGroups(workspaceId);
+      return body;
+    },
+    [workspaceId, sendNotification]
+  );
+
+  return { doUpdateGroupWorkflowAlertThreshold };
 }

--- a/front/types/api/groups/workflow_alert_threshold.ts
+++ b/front/types/api/groups/workflow_alert_threshold.ts
@@ -1,0 +1,10 @@
+export type GroupWorkflowAlertThreshold =
+  | { kind: "disabled" }
+  | { kind: "enabled"; awuCredits: number };
+
+export type SetGroupWorkflowAlertThresholdResponse = {
+  threshold: GroupWorkflowAlertThreshold;
+};
+
+export type PutGroupWorkflowAlertThresholdResponseBody =
+  SetGroupWorkflowAlertThresholdResponse;


### PR DESCRIPTION
Adds a PUT /api/w/:wId/groups/:groupId/workflow_alert_threshold
endpoint and a new "Smooth shutdown threshold" column in the groups
usage table, mirroring the existing per-group spend limit pattern
(inline InputWithSave cell, empty = disabled). Unlike the spend
limit, this threshold has no Metronome billing enforcement — it only
persists admin intent for the agent loop to read.

Needs a manual follow-up before merge: run
`npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`
to register the new group.workflow_alert_threshold_updated schema
with WorkOS and commit the regenerated schema_versions.json —
audit_log_schemas.test.ts will fail until that's done.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
