### PR TITLE
[front] feat: backend for the smooth shutdown flow

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/[cId]/cancel.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/[cId]/cancel.ts
@@ -1,4 +1,7 @@
-import { gracefullyStopAgentLoop } from "@app/lib/api/assistant/pubsub";
+import {
+  gracefullyStopAgentLoop,
+  requestSmoothShutdownAgentLoop,
+} from "@app/lib/api/assistant/pubsub";
 import { terminateMessageGeneration } from "@app/lib/api/cancel";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { ConversationError } from "@app/types/assistant/conversation";
@@ -16,7 +19,7 @@ const ParamsSchema = z.object({
 });
 
 const PostMessageEventBodySchema = z.object({
-  action: z.enum(["cancel", "gracefully_stop", "interrupt"]),
+  action: z.enum(["cancel", "gracefully_stop", "interrupt", "smooth_shutdown"]),
   messageIds: z.array(z.string()),
 });
 
@@ -58,7 +61,7 @@ const app = workspaceApp();
  *             properties:
  *               action:
  *                 type: string
- *                 enum: [cancel, gracefully_stop, interrupt]
+ *                 enum: [cancel, gracefully_stop, interrupt, smooth_shutdown]
  *               messageIds:
  *                 type: array
  *                 items:
@@ -111,6 +114,12 @@ app.post(
         break;
       case "gracefully_stop":
         await gracefullyStopAgentLoop(auth, {
+          messageIds,
+          conversationId,
+        });
+        break;
+      case "smooth_shutdown":
+        await requestSmoothShutdownAgentLoop(auth, {
           messageIds,
           conversationId,
         });

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -197,6 +197,7 @@ export function getLightAgentMessageFromAgentMessage(
     completionDurationMs: agentMessage.completionDurationMs,
     reactions: agentMessage.reactions,
     prunedContext: agentMessage.prunedContext,
+    stoppedBySmoothShutdown: agentMessage.stoppedBySmoothShutdown,
     costCredits: agentMessage.costCredits,
     subAgentCostCredits: agentMessage.subAgentCostCredits,
     activitySteps: [],

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3229,12 +3229,16 @@ export async function updateAgentMessageWithFinalStatus(
     agentMessage,
     status,
     error,
+    stoppedBySmoothShutdown,
     dangerouslyBypassSameStepCheck = false,
   }: {
     conversation: ConversationWithoutContentType;
     agentMessage: AgentMessageType;
     status: Exclude<AgentMessageStatus, "created">;
     error?: ToolErrorEvent["error"];
+    // True only for the smooth-shutdown flavor of "gracefully_stopped" (user confirmed the
+    // workflow-alert-threshold popup), as opposed to the other graceful-stop reasons.
+    stoppedBySmoothShutdown?: boolean;
     // Force finalization even if the message is in an anomalous state (e.g. blocked actions
     // spanning multiple steps). Used by the unstick-conversation poke plugin to rescue genuinely
     // stuck conversations. Leave false everywhere else so invariant violations surface as errors.
@@ -3288,6 +3292,7 @@ export async function updateAgentMessageWithFinalStatus(
               errorMetadata: error.metadata,
             }
           : {}),
+        ...(stoppedBySmoothShutdown ? { stoppedBySmoothShutdown: true } : {}),
       },
       {
         where: {

--- a/front/lib/api/assistant/conversation/smooth_shutdown_summary.ts
+++ b/front/lib/api/assistant/conversation/smooth_shutdown_summary.ts
@@ -1,0 +1,112 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { renderConversationAsText } from "@app/lib/api/assistant/conversation/render_as_text";
+import { getFastestWhitelistedModel } from "@app/lib/api/assistant/models";
+import type { Authenticator } from "@app/lib/auth";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+const FUNCTION_NAME = "summarize_progress";
+
+const specifications: AgentActionSpecification[] = [
+  {
+    name: FUNCTION_NAME,
+    description: "Summarize the progress made so far in the conversation",
+    inputSchema: {
+      type: "object",
+      properties: {
+        summary: {
+          type: "string",
+          description:
+            "A short summary (2-4 sentences), addressed directly to the user, of what has " +
+            "been accomplished so far and a note that the process was stopped early to " +
+            "conserve credits.",
+        },
+      },
+      required: ["summary"],
+    },
+  },
+];
+
+/**
+ * Generates a short, user-facing summary of progress so far, for the smooth shutdown flow:
+ * the agent loop stops cooperatively before its normal completion (credit threshold reached),
+ * and this replaces the missing final answer with a one-shot summary of what was done.
+ *
+ * Deliberately a single lightweight model call outside the normal agent loop (no tools, no
+ * additional agent step) rather than another full agent turn.
+ */
+export async function generateSmoothShutdownSummary(
+  auth: Authenticator,
+  conversation: ConversationType
+): Promise<Result<string, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  const model = getFastestWhitelistedModel(auth);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model to generate summary")
+    );
+  }
+
+  const conv: ModelConversationTypeMultiActions = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `Here is the conversation so far.\n\n${renderConversationAsText(conversation, { includeTimestamps: true })}`,
+          },
+        ],
+        name: "",
+      },
+    ],
+  };
+
+  if (conv.messages.length === 0) {
+    return new Err(
+      new Error(
+        "Error generating smooth shutdown summary: rendered conversation is empty"
+      )
+    );
+  }
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      functionCall: FUNCTION_NAME,
+      useCache: false,
+    },
+    {
+      conversation: conv,
+      prompt:
+        "The agent's process is being stopped early because the workspace's credit " +
+        "threshold was reached. Summarize what has been accomplished so far for the user.",
+      specifications,
+      forceToolCall: FUNCTION_NAME,
+    },
+    {
+      context: {
+        operationType: "smooth_shutdown_summary",
+        conversationId: conversation.sId,
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  if (res.value.actions?.[0]?.arguments?.summary) {
+    return new Ok(res.value.actions[0].arguments.summary);
+  }
+
+  return new Err(new Error("No summary found in LLM response"));
+}

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -825,6 +825,7 @@ async function renderSingleAgentMessage(
     completionDurationMs: getCompletionDuration(created, completedTs, actions),
     reactions: reactionsByMessageId[message.id] ?? [],
     prunedContext: agentMessage.prunedContext ?? false,
+    stoppedBySmoothShutdown: agentMessage.stoppedBySmoothShutdown ?? false,
     costCredits: agentMessage.costCredits ?? null,
     // Aggregated only when rendering a single agent message (see
     // batchRenderAgentMessages), so it is `null` for bulk conversation rendering.

--- a/front/lib/api/assistant/pubsub.ts
+++ b/front/lib/api/assistant/pubsub.ts
@@ -13,6 +13,7 @@ import {
   cancelAgentLoopSignal,
   gracefullyStopAgentLoopSignal,
   interruptAgentLoopSignal,
+  requestSmoothShutdownAgentLoopSignal,
 } from "@app/temporal/agent_loop/signals";
 import type {
   AgentActionSuccessEvent,
@@ -173,6 +174,20 @@ export async function gracefullyStopAgentLoop(
     messageIds,
     conversationId,
     signal: gracefullyStopAgentLoopSignal,
+  });
+}
+
+export async function requestSmoothShutdownAgentLoop(
+  auth: Authenticator,
+  {
+    messageIds,
+    conversationId,
+  }: { messageIds: string[]; conversationId: string }
+): Promise<void> {
+  await signalAgentLoops(auth, {
+    messageIds,
+    conversationId,
+    signal: requestSmoothShutdownAgentLoopSignal,
   });
 }
 

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -35,6 +35,7 @@ interface LLMTraceContextBase {
     | "skill_builder_description_suggestion"
     | "skill_builder_icon_suggestion"
     | "skills_similarity_checker"
+    | "smooth_shutdown_summary"
     | "trigger_cron_timezone_generator"
     | "trigger_webhook_filter_generator"
     | "voice_agent_finder"

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -500,6 +500,11 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
   declare prunedContext: boolean | null;
   declare costCredits: number | null;
 
+  // Set only when a "gracefully_stopped" message was ended by the user confirming the
+  // smooth-shutdown workflow-alert-threshold popup, as opposed to the other graceful-stop
+  // reasons (queued-message preemption, orphan cleanup, message deletion).
+  declare stoppedBySmoothShutdown: boolean | null;
+
   // The concrete provider/model/effort triplet used by the message when
   // running the agent. Legacy: null when the message runs the agent's configured model.
   declare resolvedProviderId: string | null;
@@ -594,6 +599,11 @@ AgentMessageModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: true,
       defaultValue: false,
+    },
+    stoppedBySmoothShutdown: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: null,
     },
     costCredits: {
       type: DataTypes.INTEGER,

--- a/front/migrations/pre-deploy/20260821164021_add_stopped_by_smooth_shutdown_to_agent_messages.sql
+++ b/front/migrations/pre-deploy/20260821164021_add_stopped_by_smooth_shutdown_to_agent_messages.sql
@@ -1,0 +1,3 @@
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."agent_messages" ADD COLUMN "stoppedBySmoothShutdown" boolean;

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -1,5 +1,6 @@
 import { renderAgentMessageContentView } from "@app/lib/api/assistant/activity_steps";
 import { updateAgentMessageWithFinalStatus } from "@app/lib/api/assistant/conversation";
+import { generateSmoothShutdownSummary } from "@app/lib/api/assistant/conversation/smooth_shutdown_summary";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import { resolvedModelFromAgentMessageRow } from "@app/lib/api/assistant/models";
 import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
@@ -23,6 +24,7 @@ import type {
   LightAgentConfigurationType,
   ToolErrorEvent,
 } from "@app/types/assistant/agent";
+import type { AgentTextContentType } from "@app/types/assistant/agent_message_content";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import {
   getAgentLoopData,
@@ -828,6 +830,96 @@ export async function finalizeGracefulStop(
       conversationId: conversation.sId,
     },
     "Agent generation gracefully stopped"
+  );
+}
+
+/**
+ * Same cooperative stop as `finalizeGracefulStop`, triggered when the user declines to continue
+ * past a workflow alert credit threshold. Additionally generates a short summary of progress so
+ * far (a one-shot LLM call, see `generateSmoothShutdownSummary`) and persists it as one more text
+ * step on the message before publishing the terminal event, so it reads as the agent's final
+ * reply. Falls back to a plain graceful stop (no summary) if summary generation fails.
+ */
+export async function finalizeSmoothShutdown(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  if (runAgentDataRes.isErr()) {
+    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      logger.info(
+        {
+          conversationId: agentLoopArgs.conversationId,
+          agentMessageId: agentLoopArgs.agentMessageId,
+        },
+        "Message or conversation was deleted, exiting"
+      );
+      return;
+    }
+    throw new Error(
+      `Failed to get run agent data: ${runAgentDataRes.error.message}`
+    );
+  }
+  const { auth, agentConfiguration, agentMessage, conversation } =
+    runAgentDataRes.value;
+
+  const step = maxBy(agentMessage.contents, "step")?.step ?? 0;
+  const summaryStep = step + 1;
+
+  const summaryRes = await generateSmoothShutdownSummary(auth, conversation);
+
+  let messageToPublish = agentMessage;
+  if (summaryRes.isOk()) {
+    const summaryContent: AgentTextContentType = {
+      type: "text_content",
+      value: summaryRes.value,
+    };
+    await AgentStepContentResource.createNewVersion({
+      workspaceId: auth.getNonNullableWorkspace().id,
+      agentMessageId: agentMessage.agentMessageId,
+      step: summaryStep,
+      index: 0,
+      type: "text_content",
+      value: summaryContent,
+    });
+    messageToPublish = {
+      ...agentMessage,
+      contents: [
+        ...agentMessage.contents,
+        { step: summaryStep, content: summaryContent },
+      ],
+    };
+  } else {
+    logger.warn(
+      {
+        agentMessageId: agentMessage.sId,
+        conversationId: conversation.sId,
+        error: summaryRes.error,
+      },
+      "[SmoothShutdown] Failed to generate progress summary; stopping without one"
+    );
+  }
+
+  await updateResourceAndPublishEvent(auth, {
+    event: {
+      type: "agent_message_gracefully_stopped",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: messageToPublish.sId,
+      message: messageToPublish,
+      runIds: [],
+    },
+    agentMessage: messageToPublish,
+    conversation,
+    step: summaryStep,
+  });
+  logger.info(
+    {
+      agentMessageId: agentMessage.sId,
+      conversationId: conversation.sId,
+      hasSummary: summaryRes.isOk(),
+    },
+    "Agent generation stopped via smooth shutdown"
   );
 }
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -65,6 +65,7 @@ export async function updateAgentMessageDBAndMemory(
           | {
               type: "status";
               status: AgentMessageStatusUpdate;
+              stoppedBySmoothShutdown?: boolean;
             }
           | {
               type: "error";
@@ -120,6 +121,7 @@ export async function updateAgentMessageDBAndMemory(
           conversation,
           agentMessage,
           status: update.status,
+          stoppedBySmoothShutdown: update.stoppedBySmoothShutdown,
         });
         agentMessage.status = result.status;
         agentMessage.completedTs = result.completedTs;
@@ -345,6 +347,7 @@ export async function processEventForDatabase(
             event.type === "agent_message_gracefully_stopped"
               ? "gracefully_stopped"
               : "succeeded",
+          stoppedBySmoothShutdown: agentMessage.stoppedBySmoothShutdown,
         },
       });
 
@@ -884,12 +887,14 @@ export async function finalizeSmoothShutdown(
     });
     messageToPublish = {
       ...agentMessage,
+      stoppedBySmoothShutdown: true,
       contents: [
         ...agentMessage.contents,
         { step: summaryStep, content: summaryContent },
       ],
     };
   } else {
+    messageToPublish = { ...agentMessage, stoppedBySmoothShutdown: true };
     logger.warn(
       {
         agentMessageId: agentMessage.sId,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -15,6 +15,7 @@ import {
   finalizeCreditStop,
   finalizeGracefulStop,
   finalizeInterruption,
+  finalizeSmoothShutdown,
   notifyWorkflowError,
 } from "@app/temporal/agent_loop/activities/common";
 import { handleMentions } from "@app/temporal/agent_loop/activities/mentions";
@@ -78,6 +79,27 @@ export async function finalizeGracefullyStoppedAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
   await finalizeGracefulStop(authType, agentLoopArgs);
+
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+
+  await Promise.all([
+    launchAgentMessageAnalytics(auth, agentLoopArgs),
+    launchAgentMessageConsumptionAttributionAfterPersistingInputs(
+      auth,
+      agentLoopArgs
+    ),
+    launchTrackProgrammaticUsage(auth, agentLoopArgs),
+    launchEmitMetronomeUsageEvents(auth, agentLoopArgs),
+    conversationUnreadNotification(auth, agentLoopArgs),
+    handleMentions(auth, agentLoopArgs),
+  ]);
+}
+
+export async function finalizeSmoothShutdownAgentLoopActivity(
+  authType: AuthenticatorType,
+  agentLoopArgs: AgentLoopArgs
+): Promise<void> {
+  await finalizeSmoothShutdown(authType, agentLoopArgs);
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 

--- a/front/temporal/agent_loop/signals.ts
+++ b/front/temporal/agent_loop/signals.ts
@@ -17,3 +17,11 @@ export const gracefullyStopAgentLoopSignal = defineSignal<[void]>(
 export const interruptAgentLoopSignal = defineSignal<[void]>(
   "interrupt_agent_loop_signal"
 );
+
+// Signal to request a smooth shutdown of the agent loop workflow: the user declined to continue
+// past a workflow alert credit threshold. Behaves like gracefullyStopAgentLoopSignal (in-flight
+// activities continue to completion, the loop exits at the next step boundary), but finalization
+// additionally generates and posts a short summary of progress so far.
+export const requestSmoothShutdownAgentLoopSignal = defineSignal<[void]>(
+  "request_smooth_shutdown_agent_loop_signal"
+);

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -19,6 +19,7 @@ import {
   finalizeErroredAgentLoopActivity,
   finalizeGracefullyStoppedAgentLoopActivity,
   finalizeInterruptedAgentLoopActivity,
+  finalizeSmoothShutdownAgentLoopActivity,
   finalizeSuccessfulAgentLoopActivity,
 } from "@app/temporal/agent_loop/activities/finalize";
 import { finalizeErroredSandboxChildToolActivity } from "@app/temporal/agent_loop/activities/finalize_sandbox_child_tool";
@@ -107,6 +108,7 @@ async function runAgentLoopWorkerForQueue({
       ensureConversationTitleActivity,
       finalizeSuccessfulAgentLoopActivity,
       finalizeGracefullyStoppedAgentLoopActivity,
+      finalizeSmoothShutdownAgentLoopActivity,
       finalizeCreditStoppedAgentLoopActivity,
       finalizeCancelledAgentLoopActivity,
       finalizeInterruptedAgentLoopActivity,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -29,6 +29,7 @@ import {
   cancelAgentLoopSignal,
   gracefullyStopAgentLoopSignal,
   interruptAgentLoopSignal,
+  requestSmoothShutdownAgentLoopSignal,
 } from "@app/temporal/agent_loop/signals";
 import type { AgentLoopInstrumentationSinks } from "@app/temporal/agent_loop/sinks";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
@@ -187,6 +188,14 @@ const {
   startToCloseTimeout: "1 minute",
 });
 
+// Longer timeout than the other finalize activities: this one makes an extra one-shot LLM
+// call to generate the progress summary.
+const { finalizeSmoothShutdownAgentLoopActivity } = proxyActivities<
+  typeof finalizeActivities
+>({
+  startToCloseTimeout: "2 minutes",
+});
+
 const { finalizeErroredSandboxChildToolActivity } = proxyActivities<
   typeof finalizeSandboxChildToolActivities
 >({
@@ -276,6 +285,14 @@ export async function agentLoopWorkflow({
     gracefulStopRequested = true;
   });
 
+  // Smooth shutdown: same cooperative stop as graceful stop, but the user declined to continue
+  // past a workflow alert credit threshold, so finalization also posts a progress summary.
+  let smoothShutdownRequested = false;
+
+  setHandler(requestSmoothShutdownAgentLoopSignal, () => {
+    smoothShutdownRequested = true;
+  });
+
   // Credit stop: the per-step gate found the workspace pool exhausted.
   let creditStopRequested = false;
 
@@ -357,7 +374,11 @@ export async function agentLoopWorkflow({
           }
         }
 
-        if (!shouldContinue || gracefulStopRequested) {
+        if (
+          !shouldContinue ||
+          gracefulStopRequested ||
+          smoothShutdownRequested
+        ) {
           break;
         }
 
@@ -395,7 +416,12 @@ export async function agentLoopWorkflow({
       };
 
       await CancellationScope.nonCancellable(async () => {
-        if (gracefulStopRequested) {
+        if (smoothShutdownRequested) {
+          await finalizeSmoothShutdownAgentLoopActivity(
+            authType,
+            argsWithRunIds
+          );
+        } else if (gracefulStopRequested) {
           await finalizeGracefullyStoppedAgentLoopActivity(
             authType,
             argsWithRunIds

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -355,6 +355,10 @@ export type BaseAgentMessageType = {
   completionDurationMs: number | null;
   reactions: MessageReactionType[];
   prunedContext?: boolean;
+  // Persisted: true only when a "gracefully_stopped" message was ended by the user confirming
+  // the smooth-shutdown workflow-alert-threshold popup, as opposed to the other graceful-stop
+  // reasons (queued-message preemption, orphan cleanup, message deletion).
+  stoppedBySmoothShutdown?: boolean;
   costCredits: number | null;
   // Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned
   // (recursively) by this message, separate from `costCredits` (this message's own


### PR DESCRIPTION
Adds a new "smooth shutdown" agent loop signal, reusing the existing
graceful-stop cooperative mechanism (finish the current step, then
exit at the next step boundary) but with its own finalize activity:
before publishing the terminal event, it generates a short one-shot
summary of progress so far (single lightweight LLM call, no tools,
mirroring the conversation-title-generation pattern) and persists it
as one more text step on the message, so it reads as the agent's
final reply. Falls back to a plain stop with no summary if the
summary call fails.

Exposes the trigger as a new "smooth_shutdown" action on the existing
POST /cancel endpoint, alongside cancel/gracefully_stop/interrupt.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
