### PR TITLE
[front] feat: per-step workflow alert threshold check and popup

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1492,6 +1492,10 @@ function AgentMessageContent({
         {agentMessage.status === "cancelled" && (
           <div className="text-sm text-faint">Generation stopped.</div>
         )}
+        {agentMessage.status === "gracefully_stopped" &&
+          agentMessage.stoppedBySmoothShutdown && (
+            <div className="text-sm text-faint">Stopped by user.</div>
+          )}
         {agentMessage.status === "interrupted" && (
           <div className="flex flex-col gap-2">
             <div className="text-sm text-faint">

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -28,6 +28,7 @@ import {
   makeInitialMessageStreamState,
 } from "@app/components/assistant/conversation/types";
 import { useAutoOpenSidePanel } from "@app/components/assistant/conversation/useAutoOpenSidePanel";
+import { WorkflowAlertThresholdDialog } from "@app/components/assistant/conversation/WorkflowAlertThresholdDialog";
 import { ConfirmContext } from "@app/components/Confirm";
 import { getActionCardPlugin } from "@app/components/markdown/ActionCardDirective";
 import {
@@ -434,6 +435,7 @@ export function AgentMessage({
           case "tool_notification":
           case "tool_params":
           case "agent_context_pruned":
+          case "agent_workflow_alert_threshold_crossed":
             break;
           default:
             assertNeverAndIgnore(eventPayload.data);
@@ -456,6 +458,22 @@ export function AgentMessage({
   const isDeleted = agentMessage.visibility === "deleted";
   const isGracefullyStopped = agentMessage.status === "gracefully_stopped";
   const cancelMessage = useCancelMessage({ owner, conversationId });
+
+  const [dismissedWorkflowAlertThreshold, setDismissedWorkflowAlertThreshold] =
+    useState(false);
+  const showWorkflowAlertThresholdDialog =
+    !!agentMessage.workflowAlertThresholdCrossed &&
+    !dismissedWorkflowAlertThreshold &&
+    agentMessage.status === "created";
+
+  const handleContinuePastWorkflowAlertThreshold = useCallback(() => {
+    setDismissedWorkflowAlertThreshold(true);
+  }, []);
+
+  const handleStopAtWorkflowAlertThreshold = useCallback(() => {
+    setDismissedWorkflowAlertThreshold(true);
+    void cancelMessage([agentMessage.sId], "smooth_shutdown");
+  }, [cancelMessage, agentMessage.sId]);
 
   const references = useMemo(
     () =>
@@ -1104,32 +1122,44 @@ export function AgentMessage({
   };
 
   return (
-    <ConversationMessageContainer messageType="agent" type="agent">
-      {!hideHeader && (
-        <div className="inline-flex items-center gap-2">
-          <ConversationMessageAvatar
-            avatarUrl={agentConfiguration.pictureUrl}
-            name={agentConfiguration.name}
-            isBusy={agentMessage.status === "created"}
-            isDisabled={isArchived}
-            type="agent"
-          />
-          <ConversationMessageTitle
-            name={agentConfiguration.name}
-            timestamp={timestamp}
-            infoChip={
-              agentMessage.prunedContext ? <PrunedContextChip /> : undefined
-            }
-            completionStatus={undefined}
-            renderName={renderName}
-          />
-        </div>
-      )}
+    <>
+      <ConversationMessageContainer messageType="agent" type="agent">
+        {!hideHeader && (
+          <div className="inline-flex items-center gap-2">
+            <ConversationMessageAvatar
+              avatarUrl={agentConfiguration.pictureUrl}
+              name={agentConfiguration.name}
+              isBusy={agentMessage.status === "created"}
+              isDisabled={isArchived}
+              type="agent"
+            />
+            <ConversationMessageTitle
+              name={agentConfiguration.name}
+              timestamp={timestamp}
+              infoChip={
+                agentMessage.prunedContext ? <PrunedContextChip /> : undefined
+              }
+              completionStatus={undefined}
+              renderName={renderName}
+            />
+          </div>
+        )}
 
-      <div className="group flex w-full min-w-0 flex-col gap-2">
-        {renderMessageContent()}
-      </div>
-    </ConversationMessageContainer>
+        <div className="group flex w-full min-w-0 flex-col gap-2">
+          {renderMessageContent()}
+        </div>
+      </ConversationMessageContainer>
+      {agentMessage.workflowAlertThresholdCrossed && (
+        <WorkflowAlertThresholdDialog
+          isOpen={showWorkflowAlertThresholdDialog}
+          thresholdAwuCredits={
+            agentMessage.workflowAlertThresholdCrossed.thresholdAwuCredits
+          }
+          onContinue={handleContinuePastWorkflowAlertThreshold}
+          onStop={handleStopAtWorkflowAlertThreshold}
+        />
+      )}
+    </>
   );
 }
 

--- a/front/components/assistant/conversation/WorkflowAlertThresholdDialog.tsx
+++ b/front/components/assistant/conversation/WorkflowAlertThresholdDialog.tsx
@@ -1,0 +1,54 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@dust-tt/sparkle";
+
+interface WorkflowAlertThresholdDialogProps {
+  isOpen: boolean;
+  thresholdAwuCredits: number;
+  onContinue: () => void;
+  onStop: () => void;
+}
+
+// Shown at most once per message, the first time its generation crosses the user's workflow
+// alert threshold. "Yes" dismisses and lets the agent keep going; "No" triggers a smooth
+// shutdown (the agent finishes its current step, summarizes progress, then stops).
+export function WorkflowAlertThresholdDialog({
+  isOpen,
+  thresholdAwuCredits,
+  onContinue,
+  onStop,
+}: WorkflowAlertThresholdDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onContinue()}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>Keep going?</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <p>
+            This task has used more than{" "}
+            {thresholdAwuCredits.toLocaleString("en-US")} credits so far. Do you
+            want it to continue?
+          </p>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "No, stop",
+            variant: "outline",
+            onClick: onStop,
+          }}
+          rightButtonProps={{
+            label: "Yes, continue",
+            variant: "primary",
+            onClick: onContinue,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/hooks/conversations/useCancelMessage.ts
+++ b/front/hooks/conversations/useCancelMessage.ts
@@ -13,7 +13,10 @@ export function useCancelMessage({
   const sendNotification = useSendNotification();
 
   return useCallback(
-    async (messageIds: string[], action: "cancel" | "interrupt" = "cancel") => {
+    async (
+      messageIds: string[],
+      action: "cancel" | "interrupt" | "smooth_shutdown" = "cancel"
+    ) => {
       if (!conversationId || messageIds.length === 0) {
         return;
       }

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -756,6 +756,24 @@ export function useAgentMessageStream({
           );
           break;
 
+        case "agent_workflow_alert_threshold_crossed": {
+          const thresholdData = eventPayload.data;
+          if (thresholdData.type !== "agent_workflow_alert_threshold_crossed") {
+            break;
+          }
+          mapMessagesWithAutoScroll((m) =>
+            isAgentMessageWithStreaming(m) && m.sId === sId
+              ? {
+                  ...m,
+                  workflowAlertThresholdCrossed: {
+                    thresholdAwuCredits: thresholdData.thresholdAwuCredits,
+                  },
+                }
+              : m
+          );
+          break;
+        }
+
         case "agent_generation_cancelled": {
           isStreamTerminated.current = true;
           updateMessageThrottled.cancel();

--- a/front/hooks/useChildAgentStream.ts
+++ b/front/hooks/useChildAgentStream.ts
@@ -169,6 +169,7 @@ function childAgentStreamReducer(
     case "end-of-stream":
     case "tool_notification":
     case "agent_context_pruned":
+    case "agent_workflow_alert_threshold_crossed":
     case "tool_approve_execution":
     case "tool_personal_auth_required":
     case "tool_file_auth_required":

--- a/front/lib/api/assistant/credit_check.test.ts
+++ b/front/lib/api/assistant/credit_check.test.ts
@@ -1,4 +1,7 @@
-import { checkPoolCreditGate } from "@app/lib/api/assistant/credit_check";
+import {
+  checkPoolCreditGate,
+  checkWorkflowAlertThresholdGate,
+} from "@app/lib/api/assistant/credit_check";
 import type { Authenticator } from "@app/lib/auth";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,11 +11,17 @@ const {
   mockIsApiBlocked,
   mockIsProgrammaticApiBlocked,
   mockIsProgrammaticUsage,
+  mockListMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace,
+  mockResolveSpendLimitCycleBounds,
+  mockIsSpendCapCounterReached,
 } = vi.hoisted(() => ({
   mockIsUserBlocked: vi.fn(),
   mockIsApiBlocked: vi.fn(),
   mockIsProgrammaticApiBlocked: vi.fn(),
   mockIsProgrammaticUsage: vi.fn(),
+  mockListMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace: vi.fn(),
+  mockResolveSpendLimitCycleBounds: vi.fn(),
+  mockIsSpendCapCounterReached: vi.fn(),
 }));
 
 vi.mock("@app/lib/metronome/user_block", () => ({
@@ -28,6 +37,21 @@ vi.mock("@app/lib/api/programmatic_usage/tracking", () => ({
 vi.mock("@app/types/plan", () => ({
   isCreditPricedPlan: (plan: { code: string }) =>
     plan.code.startsWith("ENT_NEW"),
+}));
+
+vi.mock("@app/lib/resources/group_resource", () => ({
+  GroupResource: {
+    listMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace:
+      mockListMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace,
+  },
+}));
+
+vi.mock("@app/lib/spend_limits/cycle", () => ({
+  resolveSpendLimitCycleBounds: mockResolveSpendLimitCycleBounds,
+}));
+
+vi.mock("@app/lib/api/users/spend_limit", () => ({
+  isSpendCapCounterReached: mockIsSpendCapCounterReached,
 }));
 
 // Minimal stand-in for the Authenticator class exposing only the members the gate reads. A class
@@ -49,7 +73,7 @@ function makeAuth({
   return {
     getNonNullableWorkspace: () => ({ sId: "ws_test", metronomeCustomerId }),
     subscription: () => ({ plan }),
-    user: () => (hasUser ? { sId: "user_test" } : null),
+    user: () => (hasUser ? { id: 42, sId: "user_test" } : null),
   } as unknown as Authenticator;
 }
 
@@ -153,5 +177,70 @@ describe("checkPoolCreditGate", () => {
     mockIsUserBlocked.mockRejectedValue(new Error("redis unavailable"));
     const auth = makeAuth();
     await expect(callGate(auth)).rejects.toThrow("redis unavailable");
+  });
+});
+
+describe("checkWorkflowAlertThresholdGate", () => {
+  const FAKE_BOUNDS = { startMs: 0, endMs: 1 } as never;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockResolveSpendLimitCycleBounds.mockResolvedValue(FAKE_BOUNDS);
+    mockIsSpendCapCounterReached.mockResolvedValue(false);
+  });
+
+  it("does not notify when there is no user", async () => {
+    const auth = makeAuth({ hasUser: false });
+    const result = await checkWorkflowAlertThresholdGate(auth);
+    expect(result).toEqual({ crossed: false });
+    expect(
+      mockListMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace
+    ).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when the user has no group threshold", async () => {
+    mockListMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace.mockResolvedValue(
+      new Map()
+    );
+    const auth = makeAuth({ hasUser: true });
+    const result = await checkWorkflowAlertThresholdGate(auth);
+    expect(result).toEqual({ crossed: false });
+    expect(mockResolveSpendLimitCycleBounds).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when the billing cycle can't be resolved", async () => {
+    mockListMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace.mockResolvedValue(
+      new Map([[42, 1000]])
+    );
+    mockResolveSpendLimitCycleBounds.mockResolvedValue(null);
+    const auth = makeAuth({ hasUser: true });
+    const result = await checkWorkflowAlertThresholdGate(auth);
+    expect(result).toEqual({ crossed: false });
+    expect(mockIsSpendCapCounterReached).not.toHaveBeenCalled();
+  });
+
+  it("does not notify when the counter has not reached the threshold", async () => {
+    mockListMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace.mockResolvedValue(
+      new Map([[42, 1000]])
+    );
+    mockIsSpendCapCounterReached.mockResolvedValue(false);
+    const auth = makeAuth({ hasUser: true });
+    const result = await checkWorkflowAlertThresholdGate(auth);
+    expect(result).toEqual({ crossed: false });
+  });
+
+  it("notifies with the resolved threshold once the counter crosses it", async () => {
+    mockListMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace.mockResolvedValue(
+      new Map([[42, 1000]])
+    );
+    mockIsSpendCapCounterReached.mockResolvedValue(true);
+    const auth = makeAuth({ hasUser: true });
+    const result = await checkWorkflowAlertThresholdGate(auth);
+    expect(result).toEqual({ crossed: true, thresholdAwuCredits: 1000 });
+    expect(mockIsSpendCapCounterReached).toHaveBeenCalledWith(auth, {
+      user: { id: 42, sId: "user_test" },
+      thresholdAwuCredits: 1000,
+      bounds: FAKE_BOUNDS,
+    });
   });
 });

--- a/front/lib/api/assistant/credit_check.ts
+++ b/front/lib/api/assistant/credit_check.ts
@@ -1,10 +1,13 @@
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
+import { isSpendCapCounterReached } from "@app/lib/api/users/spend_limit";
 import type { Authenticator } from "@app/lib/auth";
 import {
   isApiBlocked,
   isProgrammaticApiBlocked,
   isUserBlocked,
 } from "@app/lib/metronome/user_block";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { isCreditPricedPlan } from "@app/types/plan";
 
@@ -52,4 +55,51 @@ export async function checkPoolCreditGate(
   }
 
   return DO_NOT_STOP;
+}
+
+export type WorkflowAlertThresholdCheckResult =
+  | { crossed: false }
+  | { crossed: true; thresholdAwuCredits: number };
+
+const DO_NOT_NOTIFY: WorkflowAlertThresholdCheckResult = { crossed: false };
+
+/**
+ * Determines whether the user's current spend has crossed their workflow alert threshold
+ * (the highest `workflowAlertThresholdAwuCredits` across the groups they belong to, see
+ * `GroupResource.listMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace`). Unlike
+ * `checkPoolCreditGate`, crossing this threshold never stops the agent loop by itself — it
+ * only notifies the client, which offers the user a choice to continue or trigger a smooth
+ * shutdown. Fails open (does not notify) when there is no threshold, no billing cycle can be
+ * resolved, or the counter read fails.
+ */
+export async function checkWorkflowAlertThresholdGate(
+  auth: Authenticator
+): Promise<WorkflowAlertThresholdCheckResult> {
+  const user = auth.user();
+  if (!user) {
+    return DO_NOT_NOTIFY;
+  }
+  const workspace = auth.getNonNullableWorkspace();
+
+  const thresholdByUserModelId =
+    await GroupResource.listMaxWorkflowAlertThresholdAwuCreditsByUserModelIdInWorkspace(
+      { workspace, userModelIds: [user.id] }
+    );
+  const thresholdAwuCredits = thresholdByUserModelId.get(user.id);
+  if (thresholdAwuCredits === undefined) {
+    return DO_NOT_NOTIFY;
+  }
+
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return DO_NOT_NOTIFY;
+  }
+
+  const reached = await isSpendCapCounterReached(auth, {
+    user,
+    thresholdAwuCredits,
+    bounds,
+  });
+
+  return reached ? { crossed: true, thresholdAwuCredits } : DO_NOT_NOTIFY;
 }

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -110,6 +110,7 @@ function isMessageEventParams(
   switch (eventType) {
     case "agent_action_success":
     case "agent_context_pruned":
+    case "agent_workflow_alert_threshold_crossed":
     case "agent_error":
     case "agent_generation_cancelled":
     case "agent_message_success":

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -14,6 +14,7 @@ import type {
   AgentMessageGracefullyStoppedEvent,
   AgentMessageSuccessEvent,
   AgentToolCallStartedEvent,
+  AgentWorkflowAlertThresholdCrossedEvent,
   ToolErrorEvent,
 } from "@app/types/assistant/agent";
 import type {
@@ -38,6 +39,7 @@ export type AgentMessageEvents =
   | AgentMessageGracefullyStoppedEvent
   | AgentMessageSuccessEvent
   | AgentToolCallStartedEvent
+  | AgentWorkflowAlertThresholdCrossedEvent
   | GenerationTokensEvent
   | ToolErrorEvent
   | AgentLoopToolAskUserQuestionEvent

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -541,7 +541,7 @@ async function readSpendLimitCountWithLazySeed(
  * which differ only in how the threshold and the cycle are resolved. Fails open
  * (returns `false`) on a Redis read error.
  */
-async function isSpendCapCounterReached(
+export async function isSpendCapCounterReached(
   auth: Authenticator,
   {
     user,

--- a/front/temporal/agent_loop/activities/credit_check.test.ts
+++ b/front/temporal/agent_loop/activities/credit_check.test.ts
@@ -1,9 +1,23 @@
-import { checkCreditsActivity } from "@app/temporal/agent_loop/activities/credit_check";
+import {
+  checkCreditsActivity,
+  checkWorkflowAlertThresholdActivity,
+} from "@app/temporal/agent_loop/activities/credit_check";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockFromJson, mockCheckPoolCreditGate } = vi.hoisted(() => ({
+const {
+  mockFromJson,
+  mockCheckPoolCreditGate,
+  mockCheckWorkflowAlertThresholdGate,
+  mockGetAgentLoopData,
+  mockIsAgentLoopDataSoftDeleteError,
+  mockPublishConversationRelatedEvent,
+} = vi.hoisted(() => ({
   mockFromJson: vi.fn(),
   mockCheckPoolCreditGate: vi.fn(),
+  mockCheckWorkflowAlertThresholdGate: vi.fn(),
+  mockGetAgentLoopData: vi.fn(),
+  mockIsAgentLoopDataSoftDeleteError: vi.fn(),
+  mockPublishConversationRelatedEvent: vi.fn(),
 }));
 
 vi.mock("@app/lib/auth", () => ({
@@ -12,6 +26,16 @@ vi.mock("@app/lib/auth", () => ({
 
 vi.mock("@app/lib/api/assistant/credit_check", () => ({
   checkPoolCreditGate: mockCheckPoolCreditGate,
+  checkWorkflowAlertThresholdGate: mockCheckWorkflowAlertThresholdGate,
+}));
+
+vi.mock("@app/lib/api/assistant/streaming/events", () => ({
+  publishConversationRelatedEvent: mockPublishConversationRelatedEvent,
+}));
+
+vi.mock("@app/types/assistant/agent_run", () => ({
+  getAgentLoopData: mockGetAgentLoopData,
+  isAgentLoopDataSoftDeleteError: mockIsAgentLoopDataSoftDeleteError,
 }));
 
 const FAKE_AUTH = {
@@ -78,5 +102,78 @@ describe("checkCreditsActivity (pure decision)", () => {
     expect(mockCheckPoolCreditGate).toHaveBeenCalledWith(FAKE_AUTH, {
       userMessageOrigin: null,
     });
+  });
+});
+
+describe("checkWorkflowAlertThresholdActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFromJson.mockResolvedValue(FAKE_AUTH);
+  });
+
+  it("does not load the conversation or publish when the gate says not crossed", async () => {
+    mockCheckWorkflowAlertThresholdGate.mockResolvedValue({ crossed: false });
+
+    const result = await checkWorkflowAlertThresholdActivity({} as never, {
+      agentLoopArgs: {} as never,
+    });
+
+    expect(result).toEqual({ crossed: false });
+    expect(mockGetAgentLoopData).not.toHaveBeenCalled();
+    expect(mockPublishConversationRelatedEvent).not.toHaveBeenCalled();
+  });
+
+  it("loads the conversation and publishes a notification event when crossed", async () => {
+    mockCheckWorkflowAlertThresholdGate.mockResolvedValue({
+      crossed: true,
+      thresholdAwuCredits: 1500,
+    });
+    mockGetAgentLoopData.mockResolvedValue({
+      isErr: () => false,
+      value: {
+        agentConfiguration: { sId: "agent_config_id" },
+        agentMessage: { sId: "msg_id", contents: [{ step: 2 }] },
+        conversation: { sId: "conv_id" },
+      },
+    });
+
+    const result = await checkWorkflowAlertThresholdActivity({} as never, {
+      agentLoopArgs: {
+        conversationId: "conv_id",
+        agentMessageId: "msg_id",
+      } as never,
+    });
+
+    expect(result).toEqual({ crossed: true });
+    expect(mockPublishConversationRelatedEvent).toHaveBeenCalledWith({
+      conversationId: "conv_id",
+      step: 2,
+      event: {
+        type: "agent_workflow_alert_threshold_crossed",
+        created: expect.any(Number),
+        configurationId: "agent_config_id",
+        messageId: "msg_id",
+        thresholdAwuCredits: 1500,
+      },
+    });
+  });
+
+  it("still reports crossed but skips publishing when the message was soft-deleted", async () => {
+    mockCheckWorkflowAlertThresholdGate.mockResolvedValue({
+      crossed: true,
+      thresholdAwuCredits: 1500,
+    });
+    mockGetAgentLoopData.mockResolvedValue({
+      isErr: () => true,
+      error: new Error("agent_message_deleted"),
+    });
+    mockIsAgentLoopDataSoftDeleteError.mockReturnValue(true);
+
+    const result = await checkWorkflowAlertThresholdActivity({} as never, {
+      agentLoopArgs: {} as never,
+    });
+
+    expect(result).toEqual({ crossed: true });
+    expect(mockPublishConversationRelatedEvent).not.toHaveBeenCalled();
   });
 });

--- a/front/temporal/agent_loop/activities/credit_check.ts
+++ b/front/temporal/agent_loop/activities/credit_check.ts
@@ -1,8 +1,18 @@
 import type { CreditCheckResult } from "@app/lib/api/assistant/credit_check";
-import { checkPoolCreditGate } from "@app/lib/api/assistant/credit_check";
+import {
+  checkPoolCreditGate,
+  checkWorkflowAlertThresholdGate,
+} from "@app/lib/api/assistant/credit_check";
+import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import type { AgentLoopArgsWithTiming } from "@app/types/assistant/agent_run";
+import {
+  getAgentLoopData,
+  isAgentLoopDataSoftDeleteError,
+} from "@app/types/assistant/agent_run";
+import maxBy from "lodash/maxBy";
 
 export async function checkCreditsActivity(
   authType: AuthenticatorType,
@@ -13,4 +23,56 @@ export async function checkCreditsActivity(
   return checkPoolCreditGate(auth, {
     userMessageOrigin: agentLoopArgs.userMessageOrigin ?? null,
   });
+}
+
+/**
+ * Cheap per-step check (no conversation fetch): does the current user's spend cross their
+ * workflow alert threshold? Only on the step it first crosses does this load the conversation
+ * and publish a notification event — the workflow guards against calling this again for the
+ * same message once it returns `crossed: true`, so the heavier fetch happens at most once.
+ */
+export async function checkWorkflowAlertThresholdActivity(
+  authType: AuthenticatorType,
+  { agentLoopArgs }: { agentLoopArgs: AgentLoopArgsWithTiming }
+): Promise<{ crossed: boolean }> {
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+
+  const result = await checkWorkflowAlertThresholdGate(auth);
+  if (!result.crossed) {
+    return { crossed: false };
+  }
+
+  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  if (runAgentDataRes.isErr()) {
+    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      return { crossed: true };
+    }
+    logger.error(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+        error: runAgentDataRes.error,
+      },
+      "[WorkflowAlertThreshold] Failed to load agent loop data; skipping notification"
+    );
+    return { crossed: true };
+  }
+  const { agentConfiguration, agentMessage, conversation } =
+    runAgentDataRes.value;
+
+  const step = maxBy(agentMessage.contents, "step")?.step ?? 0;
+
+  await publishConversationRelatedEvent({
+    conversationId: conversation.sId,
+    step,
+    event: {
+      type: "agent_workflow_alert_threshold_crossed",
+      created: Date.now(),
+      configurationId: agentConfiguration.sId,
+      messageId: agentMessage.sId,
+      thresholdAwuCredits: result.thresholdAwuCredits,
+    },
+  });
+
+  return { crossed: true };
 }

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -11,7 +11,10 @@ import {
   compactionActivity,
   compactionCleanupActivity,
 } from "@app/temporal/agent_loop/activities/compaction";
-import { checkCreditsActivity } from "@app/temporal/agent_loop/activities/credit_check";
+import {
+  checkCreditsActivity,
+  checkWorkflowAlertThresholdActivity,
+} from "@app/temporal/agent_loop/activities/credit_check";
 import { ensureConversationTitleActivity } from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import {
   finalizeCancelledAgentLoopActivity,
@@ -115,6 +118,7 @@ async function runAgentLoopWorkerForQueue({
       finalizeErroredAgentLoopActivity,
       finalizeErroredSandboxChildToolActivity,
       checkCreditsActivity,
+      checkWorkflowAlertThresholdActivity,
       publishDeferredEventsActivity,
       runModelAndCreateActionsActivity,
       runToolActivity,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -150,6 +150,15 @@ const { checkCreditsActivity } = proxyActivities<typeof creditCheckActivities>({
   },
 });
 
+const { checkWorkflowAlertThresholdActivity } = proxyActivities<
+  typeof creditCheckActivities
+>({
+  startToCloseTimeout: "2 minutes",
+  retry: {
+    maximumAttempts: 3,
+  },
+});
+
 const { metrics } = proxySinks<AgentLoopInstrumentationSinks>();
 
 const { ensureConversationTitleActivity } = proxyActivities<
@@ -296,6 +305,10 @@ export async function agentLoopWorkflow({
   // Credit stop: the per-step gate found the workspace pool exhausted.
   let creditStopRequested = false;
 
+  // Workflow alert: the per-step gate found the user's spend past their workflow alert
+  // threshold. Never stops the loop by itself; once notified, stop re-checking for this message.
+  let workflowAlertThresholdNotified = false;
+
   const runIds: string[] = [];
 
   try {
@@ -391,6 +404,21 @@ export async function agentLoopWorkflow({
         if (creditCheckResult.shouldStop) {
           creditStopRequested = true;
           break;
+        }
+
+        if (!workflowAlertThresholdNotified) {
+          const workflowAlertResult = await checkWorkflowAlertThresholdActivity(
+            authType,
+            {
+              agentLoopArgs: {
+                ...agentLoopArgs,
+                initialStartTime,
+              },
+            }
+          );
+          if (workflowAlertResult.crossed) {
+            workflowAlertThresholdNotified = true;
+          }
         }
       }
 

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -407,17 +407,20 @@ export async function agentLoopWorkflow({
         }
 
         if (!workflowAlertThresholdNotified) {
-          const workflowAlertResult = await checkWorkflowAlertThresholdActivity(
-            authType,
-            {
-              agentLoopArgs: {
-                ...agentLoopArgs,
-                initialStartTime,
-              },
+          try {
+            const workflowAlertResult =
+              await checkWorkflowAlertThresholdActivity(authType, {
+                agentLoopArgs: {
+                  ...agentLoopArgs,
+                  initialStartTime,
+                },
+              });
+            if (workflowAlertResult.crossed) {
+              workflowAlertThresholdNotified = true;
             }
-          );
-          if (workflowAlertResult.crossed) {
-            workflowAlertThresholdNotified = true;
+          } catch {
+            // Non-critical: the smooth shutdown notification is best-effort and must never
+            // fail the agent loop.
           }
         }
       }

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -396,3 +396,15 @@ export type AgentContextPrunedEvent = {
   configurationId: string;
   messageId: string;
 };
+
+// Fired at most once per message, the first time the current user's spend crosses their
+// workflow alert threshold (see GroupModel.workflowAlertThresholdAwuCredits). Unlike credit-stop
+// events, this never stops the agent loop by itself: the client offers the user a choice to
+// continue or trigger a smooth shutdown (POST .../cancel with action "smooth_shutdown").
+export type AgentWorkflowAlertThresholdCrossedEvent = {
+  type: "agent_workflow_alert_threshold_crossed";
+  created: number;
+  configurationId: string;
+  messageId: string;
+  thresholdAwuCredits: number;
+};

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -359,6 +359,9 @@ export type BaseAgentMessageType = {
   // the smooth-shutdown workflow-alert-threshold popup, as opposed to the other graceful-stop
   // reasons (queued-message preemption, orphan cleanup, message deletion).
   stoppedBySmoothShutdown?: boolean;
+  // Set client-side (streaming only) the first time this message's generation crosses the
+  // user's workflow alert threshold. Drives the smooth shutdown prompt.
+  workflowAlertThresholdCrossed?: { thresholdAwuCredits: number };
   costCredits: number | null;
   // Aggregated credit cost of all sub-agents (run_agent / agent_handover) spawned
   // (recursively) by this message, separate from `costCredits` (this message's own


### PR DESCRIPTION
Adds a cheap per-step check (no conversation fetch) alongside the
existing hard credit-cap gate: does the user's current spend cross
their workflow alert threshold (max across their groups, from the
earlier per-group setting)? Unlike the credit-cap gate this never
stops the loop by itself — it publishes a one-time notification
event once crossed (loading the conversation only on that single
occasion), which the client surfaces as a dialog offering to
continue or trigger the smooth shutdown flow added previously.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
