### PR TITLE
[front] fix: keep tool validation details closed by default

### DIFF
--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -117,7 +117,7 @@ function ToolValidationDetailsDialog({
         className="gap-4 p-5"
         preventAutoFocusOnClose={false}
       >
-        <DialogHeader className="gap-1 p-0">
+        <DialogHeader className="static gap-1 p-0">
           <DialogTitle visual={<Avatar icon={icon} size="sm" />}>
             {approvalTitle}
           </DialogTitle>

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -101,10 +101,8 @@ function ToolValidationDetailsDialog({
   conversationId,
   isSubmitting,
 }: ToolValidationDetailsDialogProps) {
-  const toolOverride = getToolOverride(validationRequest.metadata);
-
   return (
-    <Dialog defaultOpen={toolOverride?.detailsOpen ?? false}>
+    <Dialog>
       <DialogTrigger asChild>
         <Button
           label="Review details"

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -6,8 +6,6 @@ import { ToolValidationDetails } from "@app/components/assistant/conversation/To
 import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { validateToolInputs } from "@app/lib/actions/mcp_internal_actions/constants";
-import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
@@ -176,21 +174,15 @@ export function ToolValidationCard({
   };
 
   const {
-    metadata: { agentName, mcpServerName, toolName },
+    metadata: { agentName, mcpServerName },
   } = validationRequest;
 
   const approvalTitle = `Allow ${agentName} to use ${asDisplayName(mcpServerName)}?`;
   const displayLabel =
-    validationRequest.metadata.displayLabel ?? asDisplayName(toolName);
+    validationRequest.metadata.displayLabel ??
+    asDisplayName(validationRequest.metadata.toolName);
   const showDetailsInline =
-    canCurrentUserRespond &&
-    mcpServerName === SANDBOX_TOOL_NAME &&
-    toolName === "add_egress_domain" &&
-    validateToolInputs(
-      SANDBOX_TOOL_NAME,
-      "add_egress_domain",
-      validationRequest.inputs
-    );
+    canCurrentUserRespond && toolOverride?.detailsInline === true;
 
   const canAlwaysAllow = ["low", "medium"].includes(
     validationRequest.stake ?? ""

--- a/front/components/actions/blocked/ToolValidationCard.tsx
+++ b/front/components/actions/blocked/ToolValidationCard.tsx
@@ -6,6 +6,8 @@ import { ToolValidationDetails } from "@app/components/assistant/conversation/To
 import { getIcon } from "@app/components/resources/resources_icons";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
+import { validateToolInputs } from "@app/lib/actions/mcp_internal_actions/constants";
+import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { canCurrentUserRespondToParentUserMessage } from "@app/lib/api/assistant/conversation/can_current_user_respond";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
@@ -174,13 +176,21 @@ export function ToolValidationCard({
   };
 
   const {
-    metadata: { agentName, mcpServerName },
+    metadata: { agentName, mcpServerName, toolName },
   } = validationRequest;
 
   const approvalTitle = `Allow ${agentName} to use ${asDisplayName(mcpServerName)}?`;
   const displayLabel =
-    validationRequest.metadata.displayLabel ??
-    asDisplayName(validationRequest.metadata.toolName);
+    validationRequest.metadata.displayLabel ?? asDisplayName(toolName);
+  const showDetailsInline =
+    canCurrentUserRespond &&
+    mcpServerName === SANDBOX_TOOL_NAME &&
+    toolName === "add_egress_domain" &&
+    validateToolInputs(
+      SANDBOX_TOOL_NAME,
+      "add_egress_domain",
+      validationRequest.inputs
+    );
 
   const canAlwaysAllow = ["low", "medium"].includes(
     validationRequest.stake ?? ""
@@ -202,6 +212,7 @@ export function ToolValidationCard({
         <div className="flex shrink-0 items-center gap-2">
           {approvalProgress && <ApprovalProgress {...approvalProgress} />}
           {canCurrentUserRespond &&
+            !showDetailsInline &&
             Object.keys(validationRequest.inputs).length > 0 && (
               <ToolValidationDetailsDialog
                 validationRequest={validationRequest}
@@ -218,6 +229,15 @@ export function ToolValidationCard({
       </div>
 
       <div className="text-base text-muted-foreground">{displayLabel}</div>
+
+      {showDetailsInline && (
+        <ToolValidationDetails
+          blockedAction={validationRequest}
+          user={currentUser}
+          owner={owner}
+          conversationId={conversationId}
+        />
+      )}
 
       {canCurrentUserRespond ? (
         <>

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -27,6 +27,7 @@ type ToolOverride = {
   title?: (inputs: Record<string, unknown>) => string;
   approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
+  detailsInline?: boolean;
 };
 
 // Display data needed to compute the title and always-allow label of a tool validation card, for
@@ -40,7 +41,7 @@ export type ToolValidationLabelData = Pick<
   | "argumentsRequiringApproval"
 >;
 
-/** Overrides validation labels for specific MCP tools. */
+/** Overrides validation labels and details placement for specific MCP tools. */
 const MCP_TOOL_OVERRIDES: Partial<
   Record<string, Partial<Record<string, ToolOverride>>>
 > = {
@@ -59,6 +60,7 @@ const MCP_TOOL_OVERRIDES: Partial<
   sandbox: {
     add_egress_domain: {
       title: () => `Allow agent to add a domain to the Computer?`,
+      detailsInline: true,
     },
   },
   [SANDBOX_FUNCTIONS_SERVER_NAME]: {

--- a/front/components/actions/blocked/toolValidationLabels.ts
+++ b/front/components/actions/blocked/toolValidationLabels.ts
@@ -27,7 +27,6 @@ type ToolOverride = {
   title?: (inputs: Record<string, unknown>) => string;
   approveLabel?: string;
   alwaysAllowLabel?: (inputs: Record<string, unknown>) => string;
-  detailsOpen?: boolean;
 };
 
 // Display data needed to compute the title and always-allow label of a tool validation card, for
@@ -41,7 +40,7 @@ export type ToolValidationLabelData = Pick<
   | "argumentsRequiringApproval"
 >;
 
-/** Overrides title, alwaysAllowLabel, and details expansion for specific MCP tools */
+/** Overrides validation labels for specific MCP tools. */
 const MCP_TOOL_OVERRIDES: Partial<
   Record<string, Partial<Record<string, ToolOverride>>>
 > = {
@@ -60,7 +59,6 @@ const MCP_TOOL_OVERRIDES: Partial<
   sandbox: {
     add_egress_domain: {
       title: () => `Allow agent to add a domain to the Computer?`,
-      detailsOpen: true,
     },
   },
   [SANDBOX_FUNCTIONS_SERVER_NAME]: {


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/10154
Closes https://github.com/dust-tt/tasks/issues/10153

Tool validation details could open automatically for the sandbox `add_egress_domain` tool, covering the approval card before the user chose to review them.

This removes the `detailsOpen` override, it was only used for this specific tool, and had been ported incorrectly from the behavior before the modal, where the details were expanded/collapsed inline in the card. The motivation then was to highlight the fact that for this specific tool the details were necessary to make a decision: we instead show the details inline.

Also fixes the position of the close button.

Current live version

<img width="569" height="222" alt="image" src="https://github.com/user-attachments/assets/ea6c9ee7-b4eb-4f6b-8536-2759cfe67487" />

Proposal

<img width="547" height="266" alt="image" src="https://github.com/user-attachments/assets/8f0c62cb-260c-4889-abfa-e6b06c212175" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
