### PR TITLE
[front] feat: back the automations filter with consumption facets

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6189,6 +6189,15 @@
                     "minimum": 1,
                     "default": 30
                   },
+                  "scope": {
+                    "type": "string",
+                    "enum": [
+                      "all",
+                      "automations"
+                    ],
+                    "default": "all",
+                    "description": "Restricts which documents the facets are computed over. `automations` counts only trigger-originated runs."
+                  },
                   "filter": {
                     "type": "object",
                     "description": "Map of consumption dimensions to selected values.",

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6198,6 +6198,23 @@
                     "default": "all",
                     "description": "Restricts which documents the facets are computed over. `automations` counts only trigger-originated runs."
                   },
+                  "dimensions": {
+                    "type": "array",
+                    "description": "Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays.",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "agent",
+                        "user",
+                        "api_key",
+                        "group",
+                        "model",
+                        "tool",
+                        "skill",
+                        "source"
+                      ]
+                    }
+                  },
                   "filter": {
                     "type": "object",
                     "description": "Map of consumption dimensions to selected values.",

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
@@ -137,6 +137,64 @@ describe("POST /api/w/:wId/analytics/consumption/facets", () => {
     );
   });
 
+  it("forwards the requested dimensions and defaults to every dimension", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "manager",
+    });
+    vi.mocked(fetchConsumptionFacets).mockResolvedValue(new Ok(RESPONSE));
+
+    const subsetResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/analytics/consumption/facets`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ dimensions: ["agent", "user"] }),
+      }
+    );
+
+    expect(subsetResponse.status).toBe(200);
+    expect(fetchConsumptionFacets).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ dimensions: ["agent", "user"] })
+    );
+
+    const defaultResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/analytics/consumption/facets`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+
+    expect(defaultResponse.status).toBe(200);
+    expect(fetchConsumptionFacets).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ dimensions: undefined })
+    );
+  });
+
+  it.each([
+    ["an unknown dimension", { dimensions: ["not-a-dimension"] }],
+    ["an empty dimension list", { dimensions: [] }],
+  ])("rejects %s", async (_label, body) => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "manager",
+    });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/analytics/consumption/facets`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchConsumptionFacets).not.toHaveBeenCalled();
+  });
+
   it("rejects an unknown scope", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       role: "manager",

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
@@ -100,6 +100,61 @@ describe("POST /api/w/:wId/analytics/consumption/facets", () => {
     expect(failedResponse.status).toBe(500);
   });
 
+  it("forwards the requested scope and defaults to all", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "manager",
+    });
+    vi.mocked(fetchConsumptionFacets).mockResolvedValue(new Ok(RESPONSE));
+
+    const scopedResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/analytics/consumption/facets`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scope: "automations" }),
+      }
+    );
+
+    expect(scopedResponse.status).toBe(200);
+    expect(fetchConsumptionFacets).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: "automations" })
+    );
+
+    const defaultResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/analytics/consumption/facets`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      }
+    );
+
+    expect(defaultResponse.status).toBe(200);
+    expect(fetchConsumptionFacets).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: "all" })
+    );
+  });
+
+  it("rejects an unknown scope", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      role: "manager",
+    });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/analytics/consumption/facets`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scope: "not-a-scope" }),
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchConsumptionFacets).not.toHaveBeenCalled();
+  });
+
   it("rejects unknown filter dimensions", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       role: "manager",

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.ts
@@ -47,6 +47,12 @@ const app = workspaceApp();
  *                 enum: [all, automations]
  *                 default: all
  *                 description: Restricts which documents the facets are computed over. `automations` counts only trigger-originated runs.
+ *               dimensions:
+ *                 type: array
+ *                 description: Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays.
+ *                 items:
+ *                   type: string
+ *                   enum: [agent, user, api_key, group, model, tool, skill, source]
  *               filter:
  *                 type: object
  *                 description: Map of consumption dimensions to selected values.
@@ -154,7 +160,7 @@ app.post(
   validate("json", ConsumptionFacetsBodySchema),
   async (ctx): HandlerResult<GetConsumptionFacetsResponse> => {
     const auth = ctx.get("auth");
-    const { filter, scope, ...periodInput } = ctx.req.valid("json");
+    const { filter, scope, dimensions, ...periodInput } = ctx.req.valid("json");
     const period = await resolveConsumptionPeriod(
       auth,
       toConsumptionPeriodInput(periodInput)
@@ -164,6 +170,7 @@ app.post(
       period,
       filter,
       scope,
+      dimensions,
     });
     if (result.isErr()) {
       return apiError(

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.ts
@@ -2,7 +2,7 @@ import type { GetConsumptionFacetsResponse } from "@app/lib/api/analytics/consum
 import { fetchConsumptionFacets } from "@app/lib/api/analytics/consumption/facets";
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import {
-  ConsumptionBodySchema,
+  ConsumptionFacetsBodySchema,
   toConsumptionPeriodInput,
 } from "@app/lib/api/analytics/consumption/schema";
 import { workspaceApp } from "@front-api/middlewares/ctx";
@@ -42,6 +42,11 @@ const app = workspaceApp();
  *                 type: integer
  *                 minimum: 1
  *                 default: 30
+ *               scope:
+ *                 type: string
+ *                 enum: [all, automations]
+ *                 default: all
+ *                 description: Restricts which documents the facets are computed over. `automations` counts only trigger-originated runs.
  *               filter:
  *                 type: object
  *                 description: Map of consumption dimensions to selected values.
@@ -146,16 +151,20 @@ const app = workspaceApp();
 app.post(
   "/",
   ensureIsManager(),
-  validate("json", ConsumptionBodySchema),
+  validate("json", ConsumptionFacetsBodySchema),
   async (ctx): HandlerResult<GetConsumptionFacetsResponse> => {
     const auth = ctx.get("auth");
-    const { filter, ...periodInput } = ctx.req.valid("json");
+    const { filter, scope, ...periodInput } = ctx.req.valid("json");
     const period = await resolveConsumptionPeriod(
       auth,
       toConsumptionPeriodInput(periodInput)
     );
 
-    const result = await fetchConsumptionFacets(auth, { period, filter });
+    const result = await fetchConsumptionFacets(auth, {
+      period,
+      filter,
+      scope,
+    });
     if (result.isErr()) {
       return apiError(
         ctx,

--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -8,14 +8,15 @@ import {
   AUTOMATIONS_FILTER_CATEGORIES,
   AUTOMATIONS_FILTER_CATEGORY_LABEL,
   automationsFilterSelectionCount,
+  toAutomationsScopeFilter,
 } from "@app/components/workspace/analytics/automationsFilter";
 import { FilterCategoryNav } from "@app/components/workspace/analytics/filterPanel/FilterCategoryNav";
 import { FilterFooter } from "@app/components/workspace/analytics/filterPanel/FilterFooter";
 import { FilterOptionCheckboxList } from "@app/components/workspace/analytics/filterPanel/FilterOptionCheckboxList";
 import { FilterSelectionSummary } from "@app/components/workspace/analytics/filterPanel/FilterSelectionSummary";
 import { useAutomationsFilter } from "@app/components/workspace/analytics/useAutomationsFilter";
-import { useAgentConfigurations } from "@app/lib/swr/assistants";
-import { useSearchMembers } from "@app/lib/swr/memberships";
+import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -28,8 +29,6 @@ import {
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
-const MEMBERS_PAGE_SIZE = 25;
-
 const TYPE_OPTIONS: AutomationsFilterOption[] = [
   { id: "schedule", name: "Schedule", disabled: false, category: "type" },
   { id: "webhook", name: "Webhook", disabled: false, category: "type" },
@@ -37,12 +36,14 @@ const TYPE_OPTIONS: AutomationsFilterOption[] = [
 
 interface AutomationsFilterPanelProps {
   owner: LightWorkspaceType;
+  period: ConsumptionPeriodSelection;
   filter: AutomationsFilter;
   onFilterChange: (next: AutomationsFilter) => void;
 }
 
 export function AutomationsFilterPanel({
   owner,
+  period,
   filter,
   onFilterChange,
 }: AutomationsFilterPanelProps) {
@@ -54,6 +55,7 @@ export function AutomationsFilterPanel({
     clearCategory,
     toggleOption,
     removeOption,
+    selectAllFiltered,
   } = useAutomationsFilter(filter);
   const [activeCategory, setActiveCategory] =
     useState<AutomationsFilterCategory>("agent");
@@ -61,69 +63,66 @@ export function AutomationsFilterPanel({
   const [contentScrollContainer, setContentScrollContainer] =
     useState<HTMLDivElement | null>(null);
 
-  const isAgentCategoryActive = isOpen && activeCategory === "agent";
-  const { agentConfigurations, isAgentConfigurationsLoading } =
-    useAgentConfigurations({
-      workspaceId: owner.sId,
-      agentsGetView: isAgentCategoryActive ? "analytics" : null,
-      sort: "alphabetical",
-    });
-
-  const isMemberCategoryActive = isOpen && activeCategory === "member";
-  const { members, isLoading: isMembersLoading } = useSearchMembers({
+  const draftScopeFilter = useMemo(
+    () => toAutomationsScopeFilter(draftFilter),
+    [draftFilter]
+  );
+  const {
+    options: facetOptions,
+    isFacetsLoading,
+    isFacetsError,
+    isFacetsValidating,
+  } = useConsumptionFacets({
     workspaceId: owner.sId,
-    searchTerm: isMemberCategoryActive ? searchText : "",
-    pageIndex: 0,
-    pageSize: MEMBERS_PAGE_SIZE,
-    disabled: !isMemberCategoryActive,
+    period,
+    filter: draftScopeFilter,
+    scope: "automations",
+    disabled: !isOpen,
   });
 
   const categoryOptions = useMemo<
     Record<AutomationsFilterCategory, AutomationsFilterOption[]>
   >(
     () => ({
-      agent: agentConfigurations.map((agent) => ({
-        id: agent.sId,
-        name: agent.name,
-        disabled: false,
-        image: agent.pictureUrl,
+      agent: facetOptions.agent.map((option) => ({
+        id: option.id,
+        name: option.name,
+        disabled: option.disabled,
+        image: option.image,
         category: "agent",
       })),
-      member: members.map((member) => ({
-        id: member.sId,
-        name: member.fullName,
-        disabled: false,
-        image: member.image,
+      member: facetOptions.member.map((option) => ({
+        id: option.id,
+        name: option.name,
+        disabled: option.disabled,
+        image: option.image,
         category: "member",
       })),
       type: TYPE_OPTIONS,
     }),
-    [agentConfigurations, members]
+    [facetOptions]
   );
 
-  const isOptionsLoading =
-    (activeCategory === "agent" && isAgentConfigurationsLoading) ||
-    (activeCategory === "member" && isMembersLoading);
+  const isFacetBackedCategory = activeCategory !== "type";
+  const isOptionsLoading = isFacetBackedCategory && isFacetsLoading;
 
   const activeOptions = categoryOptions[activeCategory];
-  // Member search is applied server-side; agent and type options are
-  // filtered client-side against the small, already-fetched list.
   const filteredOptions = useMemo(() => {
-    if (activeCategory === "member") {
-      return activeOptions;
-    }
     const search = searchText.trim().toLowerCase();
     return search
       ? activeOptions.filter((option) =>
           option.name.toLowerCase().includes(search)
         )
       : activeOptions;
-  }, [activeOptions, activeCategory, searchText]);
+  }, [activeOptions, searchText]);
 
   const selectedIdsForActiveCategory = useMemo(
     () =>
       new Set((draftFilter[activeCategory] ?? []).map((option) => option.id)),
     [draftFilter, activeCategory]
+  );
+  const unselectedEnabledOptions = filteredOptions.filter(
+    (option) => !option.disabled && !selectedIdsForActiveCategory.has(option.id)
   );
   const appliedSelectionCount = automationsFilterSelectionCount(filter);
   const categoriesWithSelection = useMemo(
@@ -216,23 +215,40 @@ export function AutomationsFilterPanel({
               ref={setContentScrollContainer}
               className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
             >
-              <FilterOptionCheckboxList
-                key={`${isOpen}|${activeCategory}|${searchText}`}
-                idPrefix={`automations-filter-option-${activeCategory}`}
-                categoryLabel={
-                  AUTOMATIONS_FILTER_CATEGORY_LABEL[activeCategory]
-                }
-                options={filteredOptions}
-                selectedIds={selectedIdsForActiveCategory}
-                onToggleOption={(option) =>
-                  toggleOption(activeCategory, option)
-                }
-                renderIcon={(option) => (
-                  <AutomationsFilterOptionIcon option={option} />
-                )}
-                status={isOptionsLoading ? "loading" : "idle"}
-                scrollContainer={contentScrollContainer}
-              />
+              {isFacetBackedCategory && isFacetsError ? (
+                <div className="flex h-24 items-center justify-center text-sm text-muted-foreground">
+                  Failed to load filters.
+                </div>
+              ) : (
+                <FilterOptionCheckboxList
+                  key={`${isOpen}|${activeCategory}|${searchText}`}
+                  idPrefix={`automations-filter-option-${activeCategory}`}
+                  categoryLabel={
+                    AUTOMATIONS_FILTER_CATEGORY_LABEL[activeCategory]
+                  }
+                  options={filteredOptions}
+                  selectedIds={selectedIdsForActiveCategory}
+                  onToggleOption={(option) =>
+                    toggleOption(activeCategory, option)
+                  }
+                  onSelectAll={() =>
+                    selectAllFiltered(activeCategory, unselectedEnabledOptions)
+                  }
+                  selectAllLabel="Select all"
+                  hasSelectableOptions={unselectedEnabledOptions.length > 0}
+                  renderIcon={(option) => (
+                    <AutomationsFilterOptionIcon option={option} />
+                  )}
+                  status={
+                    isOptionsLoading
+                      ? "loading"
+                      : isFacetBackedCategory && isFacetsValidating
+                        ? "updating"
+                        : "idle"
+                  }
+                  scrollContainer={contentScrollContainer}
+                />
+              )}
             </div>
           </div>
           <FilterSelectionSummary<

--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -17,6 +17,7 @@ import { FilterSelectionSummary } from "@app/components/workspace/analytics/filt
 import { useAutomationsFilter } from "@app/components/workspace/analytics/useAutomationsFilter";
 import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -28,6 +29,13 @@ import {
   SearchInput,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
+
+// The panel only shows agents and members, so it skips the six other
+// dimensions rather than paying for their Elasticsearch sweeps and catalogs.
+const AUTOMATIONS_FACET_DIMENSIONS: ConsumptionScopeDimension[] = [
+  "agent",
+  "user",
+];
 
 const TYPE_OPTIONS: AutomationsFilterOption[] = [
   { id: "schedule", name: "Schedule", disabled: false, category: "type" },
@@ -77,6 +85,7 @@ export function AutomationsFilterPanel({
     period,
     filter: draftScopeFilter,
     scope: "automations",
+    dimensions: AUTOMATIONS_FACET_DIMENSIONS,
     disabled: !isOpen,
   });
 

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -605,6 +605,7 @@ export function AutomationsTriggersTable({
           />
           <AutomationsFilterPanel
             owner={owner}
+            period={period}
             filter={filter}
             onFilterChange={onFilterChange}
           />

--- a/front/components/workspace/analytics/automationsFilter.test.ts
+++ b/front/components/workspace/analytics/automationsFilter.test.ts
@@ -1,6 +1,7 @@
 import {
   automationsFilterSelectionCount,
   getAutomationsFilterSummaries,
+  toAutomationsScopeFilter,
   toAutomationsTriggersFilter,
 } from "@app/components/workspace/analytics/automationsFilter";
 import { describe, expect, it } from "vitest";
@@ -76,6 +77,39 @@ describe("toAutomationsTriggersFilter", () => {
     expect(toAutomationsTriggersFilter({ agent: [agentOption] })).toEqual({
       agentIds: ["agent-1"],
     });
+  });
+});
+
+describe("toAutomationsScopeFilter", () => {
+  it("maps agents and members to their consumption dimensions", () => {
+    expect(
+      toAutomationsScopeFilter({
+        agent: [agentOption],
+        member: [memberOption],
+      })
+    ).toEqual({
+      agents: ["agent-1"],
+      users: ["member-1"],
+    });
+  });
+
+  it("drops the type category, which is not a consumption dimension", () => {
+    expect(
+      toAutomationsScopeFilter({
+        type: [
+          {
+            id: "schedule",
+            name: "Schedule",
+            category: "type",
+            disabled: false,
+          },
+        ],
+      })
+    ).toEqual({});
+  });
+
+  it("omits empty categories", () => {
+    expect(toAutomationsScopeFilter({ agent: [], member: [] })).toEqual({});
   });
 });
 

--- a/front/components/workspace/analytics/automationsFilter.ts
+++ b/front/components/workspace/analytics/automationsFilter.ts
@@ -6,6 +6,7 @@ import {
   filterSelectionCount,
   getFilterSummaries,
 } from "@app/components/workspace/analytics/filterPanel/filterState";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { TriggerKind } from "@app/types/assistant/triggers";
 
 export const AUTOMATIONS_FILTER_CATEGORIES = [
@@ -64,6 +65,26 @@ export type AutomationsTriggersFilter = {
   editorIds?: string[];
   kinds?: TriggerKind[];
 };
+
+// Availability counts ignore the type filter: trigger kinds are not a
+// consumption dimension, so they cannot be expressed as a scope filter.
+export function toAutomationsScopeFilter(
+  filter: AutomationsFilter
+): ConsumptionScopeFilter {
+  const scopeFilter: ConsumptionScopeFilter = {};
+
+  const agentIds = filter.agent?.map((option) => option.id);
+  if (agentIds && agentIds.length > 0) {
+    scopeFilter.agents = agentIds;
+  }
+
+  const editorIds = filter.member?.map((option) => option.id);
+  if (editorIds && editorIds.length > 0) {
+    scopeFilter.users = editorIds;
+  }
+
+  return scopeFilter;
+}
 
 function isTriggerKind(id: string): id is TriggerKind {
   return id === "schedule" || id === "webhook";

--- a/front/hooks/useConsumptionFacets.ts
+++ b/front/hooks/useConsumptionFacets.ts
@@ -17,8 +17,11 @@ import {
   normalizedConsumptionFilter,
 } from "@app/lib/analytics/consumption_period";
 import type { GetConsumptionFacetsResponse } from "@app/lib/api/analytics/consumption/facets";
-import type { ConsumptionBody } from "@app/lib/api/analytics/consumption/schema";
-import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type { ConsumptionFacetsBody } from "@app/lib/api/analytics/consumption/schema";
+import type {
+  ConsumptionFacetScope,
+  ConsumptionScopeFilter,
+} from "@app/lib/api/analytics/consumption/scope";
 import { isConnectorProvider } from "@app/types/data_source";
 import { useMemo } from "react";
 
@@ -41,6 +44,7 @@ export interface UseConsumptionFacetsParams {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
+  scope?: ConsumptionFacetScope;
   disabled?: boolean;
 }
 
@@ -109,18 +113,20 @@ export function useConsumptionFacets({
   workspaceId,
   period,
   filter,
+  scope = "all",
   disabled,
 }: UseConsumptionFacetsParams) {
   const url = `/api/w/${workspaceId}/analytics/consumption/facets`;
-  const body: ConsumptionBody = {
+  const body: ConsumptionFacetsBody = {
     period: period.kind,
     days:
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
     filter: normalizedConsumptionFilter(filter),
+    scope,
   };
 
   const { data, error, isValidating } = useConsumptionQuery<
-    ConsumptionBody,
+    ConsumptionFacetsBody,
     GetConsumptionFacetsResponse
   >({ url, body, disabled });
 

--- a/front/hooks/useConsumptionFacets.ts
+++ b/front/hooks/useConsumptionFacets.ts
@@ -20,6 +20,7 @@ import type { GetConsumptionFacetsResponse } from "@app/lib/api/analytics/consum
 import type { ConsumptionFacetsBody } from "@app/lib/api/analytics/consumption/schema";
 import type {
   ConsumptionFacetScope,
+  ConsumptionScopeDimension,
   ConsumptionScopeFilter,
 } from "@app/lib/api/analytics/consumption/scope";
 import { isConnectorProvider } from "@app/types/data_source";
@@ -45,6 +46,7 @@ export interface UseConsumptionFacetsParams {
   period: ConsumptionPeriodSelection;
   filter?: ConsumptionScopeFilter;
   scope?: ConsumptionFacetScope;
+  dimensions?: ConsumptionScopeDimension[];
   disabled?: boolean;
 }
 
@@ -114,6 +116,7 @@ export function useConsumptionFacets({
   period,
   filter,
   scope = "all",
+  dimensions,
   disabled,
 }: UseConsumptionFacetsParams) {
   const url = `/api/w/${workspaceId}/analytics/consumption/facets`;
@@ -123,6 +126,7 @@ export function useConsumptionFacets({
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
     filter: normalizedConsumptionFilter(filter),
     scope,
+    dimensions,
   };
 
   const { data, error, isValidating } = useConsumptionQuery<

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -50,10 +50,13 @@ type ConsumptionFacetCatalogSource =
 function traceFacetCatalogLoad<T>(
   source: ConsumptionFacetCatalogSource,
   dimension: ConsumptionScopeDimension,
-  requestedDimension: ConsumptionScopeDimension | null,
+  requestedDimensions: ConsumptionScopeDimension[] | null,
   fn: () => Promise<T[]>
 ): Promise<T[]> {
-  if (requestedDimension !== null && requestedDimension !== dimension) {
+  if (
+    requestedDimensions !== null &&
+    !requestedDimensions.includes(dimension)
+  ) {
     return Promise.resolve([]);
   }
 
@@ -119,7 +122,7 @@ function toolFacetCatalogEntries(
 /** Lists current workspace entities that can be selected as consumption filters. */
 async function listConsumptionFacetCatalogWithoutTracing(
   auth: Authenticator,
-  requestedDimension: ConsumptionScopeDimension | null = null
+  requestedDimensions: ConsumptionScopeDimension[] | null = null
 ): Promise<ConsumptionFacetCatalog> {
   // TODO(2026-08-11 OBSERVABILITY): This eagerly loads several complete
   // workspace catalogs and is known to perform poorly on large workspaces.
@@ -128,7 +131,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
   const members = await traceFacetCatalogLoad(
     "members",
     "user",
-    requestedDimension,
+    requestedDimensions,
     async () => {
       const result = await getMembers(auth, { activeOnly: true });
       return result.members;
@@ -137,14 +140,14 @@ async function listConsumptionFacetCatalogWithoutTracing(
   const apiKeys = await traceFacetCatalogLoad(
     "api_keys",
     "api_key",
-    requestedDimension,
+    requestedDimensions,
     () =>
       KeyResource.listNonSystemKeysByWorkspace(auth.getNonNullableWorkspace())
   );
   const groups = await traceFacetCatalogLoad(
     "groups",
     "group",
-    requestedDimension,
+    requestedDimensions,
     () =>
       GroupResource.listAllWorkspaceGroups(auth, {
         groupKinds: [...MANAGEABLE_GROUP_KINDS],
@@ -153,7 +156,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
   const agents = await traceFacetCatalogLoad(
     "agents",
     "agent",
-    requestedDimension,
+    requestedDimensions,
     () =>
       getAgentConfigurationsForView({
         auth,
@@ -165,7 +168,7 @@ async function listConsumptionFacetCatalogWithoutTracing(
   const models = await traceFacetCatalogLoad(
     "models",
     "model",
-    requestedDimension,
+    requestedDimensions,
     async () => {
       const result = await getModelsForAuth(auth);
       return result.models;
@@ -174,13 +177,13 @@ async function listConsumptionFacetCatalogWithoutTracing(
   const mcpServerViews = await traceFacetCatalogLoad(
     "mcp_servers",
     "tool",
-    requestedDimension,
+    requestedDimensions,
     () => MCPServerViewResource.listDisplayMetadataByWorkspace(auth)
   );
   const skills = await traceFacetCatalogLoad(
     "skills",
     "skill",
-    requestedDimension,
+    requestedDimensions,
     () =>
       SkillResource.listByWorkspace(auth, {
         status: "active",
@@ -248,18 +251,18 @@ export async function listConsumptionFacetCatalogDimension(
   auth: Authenticator,
   dimension: ConsumptionScopeDimension
 ): Promise<ConsumptionFacetCatalogEntry[]> {
-  const catalog = await listConsumptionFacetCatalogWithoutTracing(
-    auth,
-    dimension
-  );
+  const catalog = await listConsumptionFacetCatalogWithoutTracing(auth, [
+    dimension,
+  ]);
   return catalog[dimension];
 }
 
 export async function listConsumptionFacetCatalog(
-  auth: Authenticator
+  auth: Authenticator,
+  dimensions: ConsumptionScopeDimension[] | null = null
 ): Promise<ConsumptionFacetCatalog> {
   return tracer.trace("analytics.consumption.facets.catalog", async (span) => {
     span?.setTag("workspace.id", auth.getNonNullableWorkspace().sId);
-    return listConsumptionFacetCatalogWithoutTracing(auth);
+    return listConsumptionFacetCatalogWithoutTracing(auth, dimensions);
   });
 }

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -325,6 +325,69 @@ describe("fetchConsumptionFacets", () => {
     expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(8);
   });
 
+  it("restricts the automations scope to trigger-originated documents", async () => {
+    const { authenticator } = await createResourceTest({ role: "manager" });
+    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
+      agent: [],
+      user: [],
+      api_key: [],
+      group: [],
+      model: [],
+      tool: [],
+      skill: [],
+      source: [],
+    });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({ values: { buckets: [] } })
+    );
+
+    const result = await fetchConsumptionFacets(authenticator, {
+      period: PERIOD,
+      filter: { users: ["user_1"] },
+      scope: "automations",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    const triggerExists = { exists: { field: "trigger_id" } };
+    for (const [query, options] of vi.mocked(searchConsumptionAnalytics).mock
+      .calls) {
+      // Both the value enumeration and the availability count must be scoped.
+      expect(query.bool?.filter).toContainEqual(triggerExists);
+      expect(
+        options?.aggregations?.values?.aggs?.contextual?.filter?.bool?.filter
+      ).toContainEqual(triggerExists);
+    }
+  });
+
+  it("leaves documents unscoped by default", async () => {
+    const { authenticator } = await createResourceTest({ role: "manager" });
+    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
+      agent: [],
+      user: [],
+      api_key: [],
+      group: [],
+      model: [],
+      tool: [],
+      skill: [],
+      source: [],
+    });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({ values: { buckets: [] } })
+    );
+
+    const result = await fetchConsumptionFacets(authenticator, {
+      period: PERIOD,
+    });
+
+    expect(result.isOk()).toBe(true);
+    for (const [query] of vi.mocked(searchConsumptionAnalytics).mock.calls) {
+      expect(query.bool?.filter).not.toContainEqual({
+        exists: { field: "trigger_id" },
+      });
+    }
+  });
+
   it("returns the Elasticsearch failure before resolving historical labels", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
     const error = new ElasticsearchError("query_error", "query failed");

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -388,6 +388,52 @@ describe("fetchConsumptionFacets", () => {
     }
   });
 
+  it("sweeps and resolves only the requested dimensions", async () => {
+    const { authenticator } = await createResourceTest({ role: "manager" });
+    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
+      agent: [{ value: "agent-1", label: "Agent one", pictureUrl: null }],
+      user: [{ value: "user-1", label: "User one", pictureUrl: null }],
+      api_key: [],
+      group: [],
+      model: [],
+      tool: [],
+      skill: [],
+      source: [],
+    });
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(new Map());
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({ values: { buckets: [] } })
+    );
+
+    const result = await fetchConsumptionFacets(authenticator, {
+      period: PERIOD,
+      dimensions: ["agent", "user"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(2);
+    expect(listConsumptionFacetCatalog).toHaveBeenCalledWith(authenticator, [
+      "agent",
+      "user",
+    ]);
+
+    const sweptFields = vi
+      .mocked(searchConsumptionAnalytics)
+      .mock.calls.map(
+        ([, options]) =>
+          options?.aggregations?.values?.composite?.sources?.[0]?.value?.terms
+            ?.field
+      );
+    expect(sweptFields.sort()).toEqual(["agent.attributed_id", "user.id"]);
+
+    if (result.isOk()) {
+      expect(result.value.facets.agent).toHaveLength(1);
+      expect(result.value.facets.user).toHaveLength(1);
+      expect(result.value.facets.model).toEqual([]);
+      expect(result.value.facets.tool).toEqual([]);
+    }
+  });
+
   it("returns the Elasticsearch failure before resolving historical labels", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
     const error = new ElasticsearchError("query_error", "query failed");

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -87,18 +87,6 @@ type FacetBuckets = {
   contextual: Map<string, number>;
 };
 
-function getFacetBuckets(
-  bucketsByDimension: ReadonlyMap<ConsumptionScopeDimension, FacetBuckets>,
-  dimension: ConsumptionScopeDimension
-): FacetBuckets {
-  const buckets = bucketsByDimension.get(dimension);
-  if (!buckets) {
-    throw new Error(`Missing consumption facet buckets for ${dimension}.`);
-  }
-
-  return buckets;
-}
-
 type CompositeFacetBucket = {
   key: { value: string };
   contextual?: estypes.AggregationsSingleBucketAggregateBase;
@@ -279,6 +267,20 @@ async function resolveFacets(
     );
 }
 
+async function resolveRequestedFacets(
+  auth: Authenticator,
+  dimension: ConsumptionScopeDimension,
+  bucketsByDimension: ReadonlyMap<ConsumptionScopeDimension, FacetBuckets>,
+  catalogEntries: ConsumptionFacetCatalogEntry[]
+) {
+  const buckets = bucketsByDimension.get(dimension);
+  if (!buckets) {
+    return [];
+  }
+
+  return resolveFacets(auth, dimension, buckets, catalogEntries);
+}
+
 /**
  * Lists current and historical consumption facets, marking whether each can
  * return a document in the selected context. Each facet applies all active
@@ -292,15 +294,18 @@ async function fetchConsumptionFacetsWithoutTracing(
     period,
     filter = {},
     scope = "all",
+    dimensions,
   }: {
     period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
     scope?: ConsumptionFacetScope;
+    dimensions?: ConsumptionScopeDimension[];
   }
 ): Promise<Result<ConsumptionFacets, ElasticsearchError>> {
+  const requestedDimensions = dimensions ?? [...CONSUMPTION_SCOPE_DIMENSIONS];
   const scopeFilters = facetScopeFilters(scope);
   const bucketResults = await concurrentExecutor(
-    CONSUMPTION_SCOPE_DIMENSIONS,
+    requestedDimensions,
     async (dimension) => ({
       dimension,
       result: await fetchDimensionFacetBuckets({
@@ -322,56 +327,56 @@ async function fetchConsumptionFacetsWithoutTracing(
     bucketsByDimension.set(dimension, result.value);
   }
 
-  const catalog = await listConsumptionFacetCatalog(auth);
+  const catalog = await listConsumptionFacetCatalog(auth, requestedDimensions);
   // TODO(2026-08-11 OBSERVABILITY): Historical label resolution still reads
   // from several database-backed resources. Store the relevant labels in the
   // consumption index so these lookups can stay within Elasticsearch.
-  const agentFacets = await resolveFacets(
+  const agentFacets = await resolveRequestedFacets(
     auth,
     "agent",
-    getFacetBuckets(bucketsByDimension, "agent"),
+    bucketsByDimension,
     catalog.agent
   );
-  const userFacets = await resolveFacets(
+  const userFacets = await resolveRequestedFacets(
     auth,
     "user",
-    getFacetBuckets(bucketsByDimension, "user"),
+    bucketsByDimension,
     catalog.user
   );
-  const apiKeyFacets = await resolveFacets(
+  const apiKeyFacets = await resolveRequestedFacets(
     auth,
     "api_key",
-    getFacetBuckets(bucketsByDimension, "api_key"),
+    bucketsByDimension,
     catalog.api_key
   );
-  const groupFacets = await resolveFacets(
+  const groupFacets = await resolveRequestedFacets(
     auth,
     "group",
-    getFacetBuckets(bucketsByDimension, "group"),
+    bucketsByDimension,
     catalog.group
   );
-  const modelFacets = await resolveFacets(
+  const modelFacets = await resolveRequestedFacets(
     auth,
     "model",
-    getFacetBuckets(bucketsByDimension, "model"),
+    bucketsByDimension,
     catalog.model
   );
-  const toolFacets = await resolveFacets(
+  const toolFacets = await resolveRequestedFacets(
     auth,
     "tool",
-    getFacetBuckets(bucketsByDimension, "tool"),
+    bucketsByDimension,
     catalog.tool
   );
-  const skillFacets = await resolveFacets(
+  const skillFacets = await resolveRequestedFacets(
     auth,
     "skill",
-    getFacetBuckets(bucketsByDimension, "skill"),
+    bucketsByDimension,
     catalog.skill
   );
-  const sourceFacets = await resolveFacets(
+  const sourceFacets = await resolveRequestedFacets(
     auth,
     "source",
-    getFacetBuckets(bucketsByDimension, "source"),
+    bucketsByDimension,
     catalog.source
   );
 
@@ -396,6 +401,7 @@ export async function fetchConsumptionFacets(
     period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
     scope?: ConsumptionFacetScope;
+    dimensions?: ConsumptionScopeDimension[];
   }
 ): Promise<Result<ConsumptionFacets, ElasticsearchError>> {
   return tracer.trace("analytics.consumption.facets", async (span) => {

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -3,6 +3,7 @@ import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type {
+  ConsumptionFacetScope,
   ConsumptionScopeDimension,
   ConsumptionScopeFilter,
 } from "@app/lib/api/analytics/consumption/scope";
@@ -11,6 +12,7 @@ import {
   CONSUMPTION_DIMENSION_FIELDS,
   CONSUMPTION_DIMENSION_FILTER_KEYS,
   CONSUMPTION_SCOPE_DIMENSIONS,
+  TRIGGER_ID_FIELD,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
@@ -25,6 +27,7 @@ import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { estypes } from "@elastic/elasticsearch";
 
 // The workspace catalog includes selectable entities that have never generated
@@ -32,6 +35,19 @@ import type { estypes } from "@elastic/elasticsearch";
 // users, agents, or skills are deleted.
 const FACET_COMPOSITE_PAGE_SIZE = 1_000;
 const FACET_ES_QUERY_CONCURRENCY = 6;
+
+function facetScopeFilters(
+  scope: ConsumptionFacetScope
+): estypes.QueryDslQueryContainer[] {
+  switch (scope) {
+    case "all":
+      return [];
+    case "automations":
+      return [{ exists: { field: TRIGGER_ID_FIELD } }];
+    default:
+      return assertNever(scope);
+  }
+}
 
 export type ConsumptionFacet = {
   value: string;
@@ -108,6 +124,7 @@ type FetchDimensionFacetBucketsArgs = {
   period: ConsumptionPeriod;
   filter: ConsumptionScopeFilter;
   dimension: ConsumptionScopeDimension;
+  scopeFilters: estypes.QueryDslQueryContainer[];
 };
 
 async function fetchDimensionFacetBuckets(
@@ -135,6 +152,7 @@ async function fetchDimensionFacetBucketsWithoutTracing({
   period,
   filter,
   dimension,
+  scopeFilters,
 }: FetchDimensionFacetBucketsArgs): Promise<
   Result<FacetBuckets, ElasticsearchError>
 > {
@@ -150,6 +168,7 @@ async function fetchDimensionFacetBucketsWithoutTracing({
         auth,
         startDate: period.startDate,
         endDate: period.endDate,
+        extraFilters: scopeFilters,
       }),
       {
         aggregations: {
@@ -174,6 +193,7 @@ async function fetchDimensionFacetBucketsWithoutTracing({
                   startDate: period.startDate,
                   endDate: period.endDate,
                   filter: filterWithoutDimension(filter, dimension),
+                  extraFilters: scopeFilters,
                 }),
               },
             },
@@ -271,11 +291,14 @@ async function fetchConsumptionFacetsWithoutTracing(
   {
     period,
     filter = {},
+    scope = "all",
   }: {
     period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
+    scope?: ConsumptionFacetScope;
   }
 ): Promise<Result<ConsumptionFacets, ElasticsearchError>> {
+  const scopeFilters = facetScopeFilters(scope);
   const bucketResults = await concurrentExecutor(
     CONSUMPTION_SCOPE_DIMENSIONS,
     async (dimension) => ({
@@ -285,6 +308,7 @@ async function fetchConsumptionFacetsWithoutTracing(
         period,
         filter,
         dimension,
+        scopeFilters,
       }),
     }),
     { concurrency: FACET_ES_QUERY_CONCURRENCY }
@@ -371,6 +395,7 @@ export async function fetchConsumptionFacets(
   input: {
     period: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
+    scope?: ConsumptionFacetScope;
   }
 ): Promise<Result<ConsumptionFacets, ElasticsearchError>> {
   return tracer.trace("analytics.consumption.facets", async (span) => {

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
 import type { ConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/period";
 import {
+  CONSUMPTION_FACET_SCOPES,
   CONSUMPTION_METRICS,
   CONSUMPTION_SCOPE_DIMENSIONS,
   CONSUMPTION_SCOPE_FILTER_KEYS,
@@ -37,6 +38,12 @@ export const ConsumptionBodySchema = ConsumptionPeriodSchema.extend({
 });
 
 export type ConsumptionBody = z.infer<typeof ConsumptionBodySchema>;
+
+export const ConsumptionFacetsBodySchema = ConsumptionBodySchema.extend({
+  scope: z.enum(CONSUMPTION_FACET_SCOPES).optional().default("all"),
+});
+
+export type ConsumptionFacetsBody = z.infer<typeof ConsumptionFacetsBodySchema>;
 
 export const DEFAULT_CONSUMPTION_BREAKDOWN_COUNT = 10;
 

--- a/front/lib/api/analytics/consumption/schema.ts
+++ b/front/lib/api/analytics/consumption/schema.ts
@@ -41,6 +41,7 @@ export type ConsumptionBody = z.infer<typeof ConsumptionBodySchema>;
 
 export const ConsumptionFacetsBodySchema = ConsumptionBodySchema.extend({
   scope: z.enum(CONSUMPTION_FACET_SCOPES).optional().default("all"),
+  dimensions: z.array(z.enum(CONSUMPTION_SCOPE_DIMENSIONS)).min(1).optional(),
 });
 
 export type ConsumptionFacetsBody = z.infer<typeof ConsumptionFacetsBodySchema>;

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -10,6 +10,13 @@ export const CONVERSATION_ID_FIELD = "conversation_id";
 
 export const TRIGGER_ID_FIELD = "trigger_id";
 
+export const CONSUMPTION_FACET_SCOPES = ["all", "automations"] as const;
+
+// Restricts which consumption documents facets are computed over. The
+// automations page filters the same index down to trigger-originated runs, so
+// its facets must count only those documents.
+export type ConsumptionFacetScope = (typeof CONSUMPTION_FACET_SCOPES)[number];
+
 export const CARDINALITY_PRECISION_THRESHOLD = 40_000;
 
 export const CONSUMPTION_SCOPE_DIMENSIONS = [


### PR DESCRIPTION
## Description

The agent and member lists in the `/automations` filter came from `useSearchMembers` and `useAgentConfigurations`, so options were unsorted and included people who never ran an automation.
They now come from the consumption facets endpoint, which already backs the `/analytics/consumption` filter, via a new `scope: "automations"` that restricts facet counts to trigger-originated documents (`exists: trigger_id`). Both tabs get consumption's sorting and the "No activity" label.

## Tests

Added unit tests for the scope filter, and the `scope` request validation on the facets route. Checked the panel by hand against a seeded local ES, including deleting a member's consumption docs to confirm they stay listed and greyed out.

<img width="1380" height="1506" alt="Capture d’écran 2026-08-21 à 15 52 51" src="https://github.com/user-attachments/assets/204dabb2-9544-499d-a9b2-5ef9a348197b" />

## Risk

Low, contained to the automations filter panel. `scope` defaults to `all` so the consumption page is unaffected. 
The type tab is unchanged: trigger kind isn't a consumption dimension, so selecting Schedule or Webhook doesn't narrow the availability counts on the other two tabs.

## Deploy Plan

Deploy front.