### PR TITLE
[front] Poke: fix invisible panel borders

### DIFF
--- a/front/components/poke/PokeConditionalDataTables.tsx
+++ b/front/components/poke/PokeConditionalDataTables.tsx
@@ -83,8 +83,8 @@ export function PokeDataTableConditionalFetch<T, M>({
   }
 
   return (
-    <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="my-4 flex min-h-24 flex-col rounded-lg border bg-background">
+      <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">{header}</h2>
         {globalActions}
       </div>

--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -59,7 +59,9 @@ const PokeLayoutContent = ({
   const { regionData } = usePokeRegion();
   const regionUrls = regionData?.regionUrls;
   return (
-    <div className="min-h-dvh bg-muted-background text-foreground">
+    // Poke overrides the default border token with the form one: the subtle stone-100 border is
+    // invisible on dense backoffice pages, and per-component overrides do not scale.
+    <div className="min-h-dvh bg-background text-foreground [--color-border:var(--color-border-form)]">
       <PokeNavbar regionUrls={regionUrls} showRegionPicker={showRegionPicker} />
       <div className="flex flex-col p-6">{children}</div>
     </div>

--- a/front/components/poke/apps/view.tsx
+++ b/front/components/poke/apps/view.tsx
@@ -20,7 +20,7 @@ export function ViewAppTable({
   return (
     <div className="flex flex-col space-y-8">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+        <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>

--- a/front/components/poke/assistants/AgentOverviewTable.tsx
+++ b/front/components/poke/assistants/AgentOverviewTable.tsx
@@ -35,7 +35,7 @@ export function AgentOverviewTable({
 
   return (
     <>
-      <div className="border-material-200 flex grow flex-col rounded-lg border p-4">
+      <div className="flex grow flex-col rounded-lg border p-4">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-md grow pb-4 font-bold">
             {agentConfiguration.name}

--- a/front/components/poke/data_source_views/view.tsx
+++ b/front/components/poke/data_source_views/view.tsx
@@ -24,7 +24,7 @@ export function ViewDataSourceViewTable({
   return (
     <div className="flex flex-col space-y-8">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+        <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>

--- a/front/components/poke/data_sources/slack/table.tsx
+++ b/front/components/poke/data_sources/slack/table.tsx
@@ -84,8 +84,8 @@ export function SlackAutoReadPatternsTable({
       : "Slack Bot Auto Join Channels Patterns";
 
   return (
-    <div className="border-material-200 my-4 flex min-h-48 flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="my-4 flex min-h-48 flex-col rounded-lg border bg-background">
+      <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">{tableTitle}</h2>
       </div>
       <div className="flex flex-grow flex-col justify-center p-4">

--- a/front/components/poke/data_sources/view.tsx
+++ b/front/components/poke/data_sources/view.tsx
@@ -85,7 +85,7 @@ export function ViewDataSourceTable({
       />
       <div className="flex flex-col space-y-8">
         <div className="flex justify-between gap-3">
-          <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+          <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
               <Button

--- a/front/components/poke/group_permissions/table.tsx
+++ b/front/components/poke/group_permissions/table.tsx
@@ -50,8 +50,8 @@ export function GroupPermissionsDataTable({
   }
 
   return (
-    <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="my-4 flex min-h-24 flex-col rounded-lg border bg-background">
+      <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">Group Permissions</h2>
       </div>
       <div className="flex flex-grow flex-col justify-center p-4">

--- a/front/components/poke/groups/view.tsx
+++ b/front/components/poke/groups/view.tsx
@@ -13,7 +13,7 @@ export function ViewGroupTable({ group }: { group: GroupType }) {
   return (
     <div className="flex flex-col space-y-8">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+        <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-md flex-grow pb-4 font-bold">Group Details:</h2>
           </div>

--- a/front/components/poke/invitations/table.tsx
+++ b/front/components/poke/invitations/table.tsx
@@ -76,7 +76,7 @@ export function InvitationsDataTable({
 
   return (
     <>
-      <div className="border-material-200 my-4 flex w-full flex-col rounded-lg border p-4">
+      <div className="my-4 flex w-full flex-col rounded-lg border p-4">
         <div className="flex justify-between gap-3">
           <h2 className="text-md mb-4 font-bold">Pending Invitations:</h2>
         </div>

--- a/front/components/poke/mcp_server_views/space_availability.tsx
+++ b/front/components/poke/mcp_server_views/space_availability.tsx
@@ -21,7 +21,7 @@ export function MCPServerSpaceAvailabilityTable({
   spaceViews,
 }: MCPServerSpaceAvailabilityTableProps) {
   return (
-    <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+    <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
       <h2 className="text-md pb-4 font-bold">Available in spaces</h2>
       {spaceViews.length === 0 ? (
         <p className="text-sm text-muted-foreground">

--- a/front/components/poke/mcp_server_views/tools_config.tsx
+++ b/front/components/poke/mcp_server_views/tools_config.tsx
@@ -200,7 +200,7 @@ export function ToolsConfigTable({ mcpServerView }: ToolsConfigTableProps) {
     rows.find((row) => row.name === selectedToolName) ?? null;
 
   return (
-    <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+    <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
       <h2 className="text-md pb-4 font-bold">Tools configuration</h2>
       {rows.length === 0 ? (
         <p className="text-sm text-muted-foreground">

--- a/front/components/poke/mcp_server_views/view.tsx
+++ b/front/components/poke/mcp_server_views/view.tsx
@@ -25,7 +25,7 @@ export function ViewMCPServerViewTable({
   return (
     <div className="flex flex-col space-y-8">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+        <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -123,7 +123,7 @@ export function MembersDataTable({
 
   return (
     <>
-      <div className="border-material-200 my-4 flex w-full flex-col rounded-lg border p-4">
+      <div className="my-4 flex w-full flex-col rounded-lg border p-4">
         <div className="flex justify-between gap-3">
           <h2 className="text-md mb-4 font-bold">
             {groupName ? `"${groupName}" Members:` : "Members:"}

--- a/front/components/poke/pages/AppPage.tsx
+++ b/front/components/poke/pages/AppPage.tsx
@@ -134,8 +134,8 @@ function AppSpecification({
   };
 
   return (
-    <div className="border-material-200 my-4 flex min-h-48 flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="my-4 flex min-h-48 flex-col rounded-lg border bg-background">
+      <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">Specification :</h2>
         <div className="flex flex-row gap-2">
           {specificationHashes ? (

--- a/front/components/poke/pages/DataSourcePage.tsx
+++ b/front/components/poke/pages/DataSourcePage.tsx
@@ -148,7 +148,7 @@ function FolderDisplay({
         </div>
       </div>
 
-      <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
+      <div className="mb-4 flex flex-grow flex-col rounded-lg border p-4">
         {documents.length > 0 ? (
           <ContextItem.List>
             {documents.map((d) => (
@@ -235,7 +235,7 @@ function FolderDisplay({
         </div>
       </div>
 
-      <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
+      <div className="mb-4 flex flex-grow flex-col rounded-lg border p-4">
         {tables.length > 0 ? (
           <ContextItem.List>
             {tables.map((t) => (
@@ -1143,7 +1143,7 @@ export function DataSourcePage() {
           {["slack", "slack_bot"].includes(
             dataSource.connectorProvider ?? ""
           ) && (
-            <div className="border-material-200 mb-4 flex flex-grow flex-col rounded-lg border p-4">
+            <div className="mb-4 flex flex-grow flex-col rounded-lg border p-4">
               <SlackChannelPatternInput
                 initialValues={features.autoReadChannelPatterns || ""}
                 owner={owner}

--- a/front/components/poke/pages/DataSourceQueryPage.tsx
+++ b/front/components/poke/pages/DataSourceQueryPage.tsx
@@ -111,7 +111,7 @@ function QueryContent({ owner, dataSource }: QueryContentProps) {
 
       <div className="mt-6 flex flex-col gap-6">
         {/* Table Selection */}
-        <div className="border-material-200 rounded-lg border p-4">
+        <div className="rounded-lg border p-4">
           <h4 className="mb-3 text-lg font-semibold">Select Tables</h4>
           <div className="text-sm text-gray-600">
             {totalTables} table{totalTables !== 1 ? "s" : ""} available
@@ -156,7 +156,7 @@ function QueryContent({ owner, dataSource }: QueryContentProps) {
         </div>
 
         {/* Query Input */}
-        <div className="border-material-200 rounded-lg border p-4">
+        <div className="rounded-lg border p-4">
           <h4 className="mb-3 text-lg font-semibold">SQL Query</h4>
           <TextArea
             value={query}
@@ -192,7 +192,7 @@ function QueryContent({ owner, dataSource }: QueryContentProps) {
 
         {/* Results Display */}
         {queryResult && (
-          <div className="border-material-200 rounded-lg border p-4">
+          <div className="rounded-lg border p-4">
             <h4 className="mb-3 text-lg font-semibold">Results</h4>
             <div className="mb-2 text-sm text-gray-600">
               {queryResult.results.length} row

--- a/front/components/poke/pages/NotionRequestsPage.tsx
+++ b/front/components/poke/pages/NotionRequestsPage.tsx
@@ -151,7 +151,7 @@ export function NotionRequestsPage() {
 
       <div className="mt-6 flex flex-col gap-6">
         {/* Request Configuration */}
-        <div className="border-material-200 rounded-lg border p-4">
+        <div className="rounded-lg border p-4">
           <h4 className="mb-3 text-lg font-semibold">Request</h4>
 
           {/* Method Selector */}
@@ -231,7 +231,7 @@ export function NotionRequestsPage() {
 
         {/* Response Display */}
         {response && (
-          <div className="border-material-200 rounded-lg border p-4">
+          <div className="rounded-lg border p-4">
             <h4 className="mb-3 text-lg font-semibold">Response</h4>
             <div className="mb-3 flex items-center gap-2">
               <span className="text-sm font-medium">Status:</span>

--- a/front/components/poke/pages/SkillDetailsPage.tsx
+++ b/front/components/poke/pages/SkillDetailsPage.tsx
@@ -101,7 +101,7 @@ export function SkillDetailsPage() {
       </div>
 
       <div className="mt-4 flex flex-row gap-4">
-        <div className="border-material-200 flex-1 rounded-lg border p-4">
+        <div className="flex-1 rounded-lg border p-4">
           <h2 className="text-md pb-4 font-bold">User-facing description</h2>
           <TextArea
             value={skill.userFacingDescription}
@@ -111,7 +111,7 @@ export function SkillDetailsPage() {
             isDisplay
           />
         </div>
-        <div className="border-material-200 flex-1 rounded-lg border p-4">
+        <div className="flex-1 rounded-lg border p-4">
           <h2 className="text-md pb-4 font-bold">Agent-facing description</h2>
           <TextArea
             value={skill.agentFacingDescription}
@@ -124,7 +124,7 @@ export function SkillDetailsPage() {
       </div>
 
       <div className="mt-4">
-        <div className="border-material-200 rounded-lg border p-4">
+        <div className="rounded-lg border p-4">
           <h2 className="text-md pb-4 font-bold">Instructions</h2>
           <TextArea
             value={skill.instructions ?? ""}
@@ -136,7 +136,7 @@ export function SkillDetailsPage() {
       </div>
 
       <div className="mt-4">
-        <div className="border-material-200 rounded-lg border p-4">
+        <div className="rounded-lg border p-4">
           <h2 className="text-md pb-4 font-bold">Instructions HTML</h2>
           <TextArea
             value={skill.instructionsHtml ?? ""}
@@ -148,7 +148,7 @@ export function SkillDetailsPage() {
       </div>
 
       <div className="mt-4">
-        <div className="border-material-200 rounded-lg border p-4">
+        <div className="rounded-lg border p-4">
           <h2 className="text-md pb-4 font-bold">
             Tools ({skill.tools.length})
           </h2>
@@ -167,7 +167,7 @@ export function SkillDetailsPage() {
       </div>
 
       <div className="mt-4">
-        <div className="border-material-200 rounded-lg border p-4">
+        <div className="rounded-lg border p-4">
           <Collapsible defaultOpen={false}>
             <CollapsibleTrigger>
               <h2 className="text-md font-bold">
@@ -236,7 +236,7 @@ export function SkillDetailsPage() {
       <SkillSuggestionDataTable owner={owner} skillId={sId} />
 
       <div className="mt-4">
-        <div className="border-material-200 rounded-lg border p-4">
+        <div className="rounded-lg border p-4">
           <Collapsible defaultOpen={false}>
             <CollapsibleTrigger>
               <h2 className="text-md font-bold">
@@ -257,7 +257,7 @@ export function SkillDetailsPage() {
                   {versions.map((version) => (
                     <div
                       key={version.version}
-                      className="border-material-200 rounded-lg border p-4"
+                      className="rounded-lg border p-4"
                     >
                       <div className="mb-2 flex items-center gap-2">
                         <span className="font-bold">v{version.version}</span>

--- a/front/components/poke/pages/SpaceDataSourceViewPage.tsx
+++ b/front/components/poke/pages/SpaceDataSourceViewPage.tsx
@@ -79,7 +79,7 @@ export function SpaceDataSourceViewPage() {
               workspace: owner,
             }}
           />
-          <div className="border-material-200 my-4 rounded-lg border p-4">
+          <div className="my-4 rounded-lg border p-4">
             <DataSourceViewSelector
               owner={owner}
               readonly

--- a/front/components/poke/pages/WebhookSourceDetailsPage.tsx
+++ b/front/components/poke/pages/WebhookSourceDetailsPage.tsx
@@ -63,7 +63,7 @@ export function WebhookSourceDetailsPage() {
         {/* Left column: Overview table */}
         <div className="flex flex-col space-y-8">
           <div className="flex justify-between gap-3">
-            <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+            <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
               <h2 className="text-md pb-4 font-bold">Overview</h2>
               <PokeTable>
                 <PokeTableBody>
@@ -138,7 +138,7 @@ export function WebhookSourceDetailsPage() {
         {/* Right column: Views, Triggers, Request Stats */}
         <div className="mt-4 flex grow flex-col gap-4">
           {/* Views */}
-          <div className="border-material-200 flex flex-col rounded-lg border p-4">
+          <div className="flex flex-col rounded-lg border p-4">
             <h2 className="text-md pb-4 font-bold">Views ({views.length})</h2>
             {views.length === 0 ? (
               <p className="text-sm text-muted-foreground">No views found.</p>
@@ -166,7 +166,7 @@ export function WebhookSourceDetailsPage() {
           </div>
 
           {/* Connected Triggers */}
-          <div className="border-material-200 flex flex-col rounded-lg border p-4">
+          <div className="flex flex-col rounded-lg border p-4">
             <h2 className="text-md pb-4 font-bold">
               Connected Triggers ({triggers.length})
             </h2>
@@ -204,7 +204,7 @@ export function WebhookSourceDetailsPage() {
           </div>
 
           {/* Request Volume Stats */}
-          <div className="border-material-200 flex flex-col rounded-lg border p-4">
+          <div className="flex flex-col rounded-lg border p-4">
             <h2 className="text-md pb-4 font-bold">Request Volume</h2>
             <div className="flex gap-6">
               <div className="flex flex-col items-center">

--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -73,7 +73,7 @@ export function PluginList({ pluginResourceTarget }: PluginListProps) {
   }, [plugins, searchQuery]);
 
   return (
-    <div className="flex min-h-48 flex-col rounded-lg border border-separator bg-muted-background">
+    <div className="flex min-h-48 flex-col rounded-lg border bg-background">
       <div className="flex items-center justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <div className="flex items-center gap-3">
           <h2 className="text-md font-bold">Plugins</h2>

--- a/front/components/poke/projects/pod_functions/invocations.tsx
+++ b/front/components/poke/projects/pod_functions/invocations.tsx
@@ -94,8 +94,8 @@ export function PodFunctionInvocations({
   const hasMore = invocations.length === limit;
 
   return (
-    <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="my-4 flex min-h-24 flex-col rounded-lg border bg-background">
+      <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">Invocations</h2>
       </div>
       <div className="flex flex-grow flex-col gap-2 p-4">

--- a/front/components/poke/projects/pod_functions/source.tsx
+++ b/front/components/poke/projects/pod_functions/source.tsx
@@ -32,8 +32,8 @@ export function PodFunctionSource({
   });
 
   return (
-    <div className="border-material-200 my-4 flex flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="my-4 flex flex-col rounded-lg border bg-background">
+      <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">Bundle</h2>
       </div>
       <div className="flex flex-col p-4">

--- a/front/components/poke/projects/pod_functions/view.tsx
+++ b/front/components/poke/projects/pod_functions/view.tsx
@@ -20,7 +20,7 @@ export function ViewPodFunctionTable({
   return (
     <div className="flex flex-col space-y-8">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+        <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>

--- a/front/components/poke/projects/workflow/view.tsx
+++ b/front/components/poke/projects/workflow/view.tsx
@@ -26,8 +26,8 @@ export function ViewProjectWorkflowTable({
   });
 
   return (
-    <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="my-4 flex min-h-24 flex-col rounded-lg border bg-background">
+      <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">Task generation workflow</h2>
       </div>
       <div className="flex flex-grow flex-col justify-center p-4">

--- a/front/components/poke/skills/SkillOverviewTable.tsx
+++ b/front/components/poke/skills/SkillOverviewTable.tsx
@@ -22,7 +22,7 @@ export function SkillOverviewTable({
   spaces,
 }: SkillOverviewTableProps) {
   return (
-    <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
+    <div className="flex flex-grow flex-col rounded-lg border p-4">
       <div className="flex items-center justify-between gap-3">
         <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
       </div>

--- a/front/components/poke/spaces/view.tsx
+++ b/front/components/poke/spaces/view.tsx
@@ -19,7 +19,7 @@ export function ViewSpaceViewTable({ sandbox, space }: ViewSpaceTableProps) {
   return (
     <div className="flex flex-col space-y-8">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+        <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -157,7 +157,7 @@ function SubscriptionsDataTable({
   subscriptions,
 }: SubscriptionsDataTableProps) {
   return (
-    <div className="border-material-200 my-4 flex flex-col rounded-lg border p-4">
+    <div className="my-4 flex flex-col rounded-lg border p-4">
       <h2 className="text-md mb-4 font-bold">History of subscriptions:</h2>
       <PokeDataTable
         columns={makeColumnsForSubscriptions()}
@@ -470,7 +470,7 @@ export function PlanLimitationsTable({
   return (
     <div className="flex flex-col">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4 pb-2">
+        <div className="flex flex-grow flex-col rounded-lg border p-4 pb-2">
           <h2 className="text-md pb-4 font-bold">Plan limitations</h2>
           <PokeTable>
             <PokeTableBody>

--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -112,7 +112,7 @@ export function TemplatesDataTable() {
   const columns = makeColumnsForTemplates();
 
   return (
-    <div className="border-material-200 my-4 flex w-full flex-col gap-2 rounded-lg border p-4">
+    <div className="my-4 flex w-full flex-col gap-2 rounded-lg border p-4">
       <div className="flex w-full items-center justify-between gap-3">
         <h2 className="text-md flex-grow pb-4 font-bold">Templates:</h2>
         {(dustRegionSyncEnabled || isDevelopment()) && (

--- a/front/components/poke/triggers/ExecutionStats.tsx
+++ b/front/components/poke/triggers/ExecutionStats.tsx
@@ -18,7 +18,7 @@ export function ExecutionStats({ owner, triggerId }: ExecutionStatsProps) {
 
   if (isLoading) {
     return (
-      <div className="border-material-200 flex flex-col rounded-lg border p-4">
+      <div className="flex flex-col rounded-lg border p-4">
         <h2 className="text-md pb-4 font-bold">Execution Stats</h2>
         <div className="flex items-center justify-center py-4">
           <Spinner size="sm" />
@@ -29,7 +29,7 @@ export function ExecutionStats({ owner, triggerId }: ExecutionStatsProps) {
 
   if (isError || !data) {
     return (
-      <div className="border-material-200 flex flex-col rounded-lg border p-4">
+      <div className="flex flex-col rounded-lg border p-4">
         <h2 className="text-md pb-4 font-bold">Execution Stats</h2>
         <p className="text-sm text-muted-foreground">
           Error loading execution stats.
@@ -51,7 +51,7 @@ export function ExecutionStats({ owner, triggerId }: ExecutionStatsProps) {
   );
 
   return (
-    <div className="border-material-200 flex flex-col rounded-lg border p-4">
+    <div className="flex flex-col rounded-lg border p-4">
       <h2 className="text-md pb-4 font-bold">Execution Stats</h2>
 
       {/* Status Breakdown */}

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -42,8 +42,8 @@ export function PokeRecentWebhookRequests({
   const [isOpen, setIsOpen] = useState(defaultOpen);
 
   return (
-    <div className="border-material-200 my-4 flex min-h-24 flex-col rounded-lg border bg-muted-background">
-      <div className="flex justify-between gap-3 rounded-t-lg bg-primary-300 p-4">
+    <div className="my-4 flex min-h-24 flex-col rounded-lg border bg-background">
+      <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">Webhook Request History</h2>
       </div>
       <div className="flex flex-grow flex-col justify-center p-4">

--- a/front/components/poke/triggers/view.tsx
+++ b/front/components/poke/triggers/view.tsx
@@ -31,7 +31,7 @@ export function ViewTriggerTable({
   return (
     <div className="flex flex-col space-y-8">
       <div className="flex justify-between gap-3">
-        <div className="border-material-200 my-4 flex flex-grow flex-col rounded-lg border p-4">
+        <div className="my-4 flex flex-grow flex-col rounded-lg border p-4">
           <div className="flex items-center justify-between gap-3">
             <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
           </div>
@@ -168,7 +168,7 @@ export function ViewTriggerTable({
         </div>
       </div>
       {trigger.kind === "webhook" && (
-        <div className="border-material-200 flex flex-col rounded-lg border p-4">
+        <div className="flex flex-col rounded-lg border p-4">
           <h2 className="text-md pb-4 font-bold">Filter Expression</h2>
           {trigger.configuration.filter ? (
             <TriggerFilterRenderer data={trigger.configuration.filter} />

--- a/front/components/poke/workspace/table.tsx
+++ b/front/components/poke/workspace/table.tsx
@@ -81,7 +81,7 @@ export function WorkspaceInfoTable({
 
   return (
     <div className="flex justify-between gap-3">
-      <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4 pb-2">
+      <div className="flex flex-grow flex-col rounded-lg border p-4 pb-2">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-md flex-grow pb-4 font-bold">Workspace info</h2>
         </div>


### PR DESCRIPTION
## Description

Poke panel borders were invisible in both themes: `border-material-200` is a dead class (token defined nowhere), so panels fell back to the subtle default border on a same-color background.

- `PokeLayout`: page on `bg-background` (same canvas as the app) and a scoped override `--color-border: var(--color-border-form)`, so every default border in poke uses the visible form token (stone-300 / stone-700).
- Delete the dead `border-material-200` class (32 files).
- Table containers: white body + hairline under the header instead of grey `bg-muted-background` + `bg-primary-300` slab, matching the plugins panel.

## Risk

Poke-only styling. Safe to rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
