### PR TITLE
[front] Poke: name-only plugin cards

### DIFF
--- a/front/components/poke/plugins/PluginList.tsx
+++ b/front/components/poke/plugins/PluginList.tsx
@@ -2,7 +2,6 @@ import { PluginRunsList } from "@app/components/poke/plugins/PluginRunsList";
 import { RunPluginDialog } from "@app/components/poke/plugins/RunPluginDialog";
 import {
   PokeCard,
-  PokeCardDescription,
   PokeCardHeader,
   PokeCardTitle,
 } from "@app/components/poke/shadcn/ui/card";
@@ -21,16 +20,13 @@ interface PluginCardProps {
 function PluginCard({ onClick, plugin }: PluginCardProps) {
   return (
     <PokeCard
-      className="flex h-20 w-44 cursor-pointer hover:bg-muted-background"
+      className="flex h-16 w-full cursor-pointer items-center hover:bg-muted-background"
       onClick={onClick}
     >
-      <PokeCardHeader className="flex space-y-2 overflow-hidden p-2 text-left">
+      <PokeCardHeader className="flex overflow-hidden p-2 text-left">
         <PokeCardTitle className="text-sm font-medium">
           {plugin.name}
         </PokeCardTitle>
-        <PokeCardDescription className="overflow-hidden truncate whitespace-normal text-sm">
-          {plugin.description}
-        </PokeCardDescription>
       </PokeCardHeader>
     </PokeCard>
   );
@@ -109,8 +105,8 @@ export function PluginList({ pluginResourceTarget }: PluginListProps) {
               </div>
             ) : (
               <div
-                className="grid w-full gap-3 p-4"
-                // 11rem is the fixed width of the card.
+                className="grid w-full gap-3 p-3"
+                // 11rem is the minimum card width.
                 style={{
                   gridTemplateColumns: "repeat(auto-fill, minmax(11rem, 1fr))",
                 }}

--- a/front/components/poke/shadcn/ui/card.tsx
+++ b/front/components/poke/shadcn/ui/card.tsx
@@ -7,10 +7,7 @@ const Card = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      "bg-background text-foreground rounded-lg border shadow-sm",
-      className
-    )}
+    className={cn("bg-background text-foreground rounded-lg border", className)}
     {...props}
   />
 ));


### PR DESCRIPTION
## Description

Plugin cards show only the name: the description is already in the hover tooltip. Uniform card height, cards fill their grid column, spacing between cards matches the container padding, and the card shadow is dropped (borders do the separation since #30971).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
