### PR TITLE
refactor(front): make the automations triggers table reusable

### DIFF
--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -47,6 +47,7 @@ interface AutomationsFilterPanelProps {
   period: ConsumptionPeriodSelection;
   filter: AutomationsFilter;
   onFilterChange: (next: AutomationsFilter) => void;
+  categories?: readonly AutomationsFilterCategory[];
 }
 
 export function AutomationsFilterPanel({
@@ -54,6 +55,7 @@ export function AutomationsFilterPanel({
   period,
   filter,
   onFilterChange,
+  categories = AUTOMATIONS_FILTER_CATEGORIES,
 }: AutomationsFilterPanelProps) {
   const [isOpen, setIsOpen] = useState(false);
   const {
@@ -66,7 +68,7 @@ export function AutomationsFilterPanel({
     selectAllFiltered,
   } = useAutomationsFilter(filter);
   const [activeCategory, setActiveCategory] =
-    useState<AutomationsFilterCategory>("agent");
+    useState<AutomationsFilterCategory>(categories[0]);
   const [searchText, setSearchText] = useState("");
   const [contentScrollContainer, setContentScrollContainer] =
     useState<HTMLDivElement | null>(null);
@@ -133,21 +135,22 @@ export function AutomationsFilterPanel({
   const unselectedEnabledOptions = filteredOptions.filter(
     (option) => !option.disabled && !selectedIdsForActiveCategory.has(option.id)
   );
-  const appliedSelectionCount = automationsFilterSelectionCount(filter);
+  const appliedSelectionCount = automationsFilterSelectionCount(
+    filter,
+    categories
+  );
   const categoriesWithSelection = useMemo(
     () =>
-      AUTOMATIONS_FILTER_CATEGORIES.filter(
-        (category) => (draftFilter[category]?.length ?? 0) > 0
-      ),
-    [draftFilter]
+      categories.filter((category) => (draftFilter[category]?.length ?? 0) > 0),
+    [categories, draftFilter]
   );
   const categorySelectionCounts = useMemo(() => {
     const counts: Partial<Record<AutomationsFilterCategory, number>> = {};
-    for (const category of AUTOMATIONS_FILTER_CATEGORIES) {
+    for (const category of categories) {
       counts[category] = draftFilter[category]?.length ?? 0;
     }
     return counts;
-  }, [draftFilter]);
+  }, [categories, draftFilter]);
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
@@ -191,7 +194,7 @@ export function AutomationsFilterPanel({
       <PopoverContent fullWidth align="end" className="w-auto rounded-2xl p-0">
         <div className="flex h-96 flex-row divide-x divide-border">
           <FilterCategoryNav
-            categories={AUTOMATIONS_FILTER_CATEGORIES}
+            categories={categories}
             categoryLabels={AUTOMATIONS_FILTER_CATEGORY_LABEL}
             selectionCounts={categorySelectionCounts}
             activeCategory={activeCategory}

--- a/front/components/workspace/analytics/automations/AutomationsFilterSummary.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterSummary.tsx
@@ -1,4 +1,7 @@
-import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
+import type {
+  AutomationsFilter,
+  AutomationsFilterCategory,
+} from "@app/components/workspace/analytics/automationsFilter";
 import { getAutomationsFilterSummaries } from "@app/components/workspace/analytics/automationsFilter";
 import { FilterSummaryChips } from "@app/components/workspace/analytics/filterPanel/FilterSummaryChips";
 import { clearFilterCategory } from "@app/components/workspace/analytics/filterPanel/filterState";
@@ -6,15 +9,17 @@ import { clearFilterCategory } from "@app/components/workspace/analytics/filterP
 interface AutomationsFilterSummaryProps {
   filter: AutomationsFilter;
   onFilterChange: (filter: AutomationsFilter) => void;
+  categories?: readonly AutomationsFilterCategory[];
 }
 
 export function AutomationsFilterSummary({
   filter,
   onFilterChange,
+  categories,
 }: AutomationsFilterSummaryProps) {
   return (
     <FilterSummaryChips
-      summaries={getAutomationsFilterSummaries(filter)}
+      summaries={getAutomationsFilterSummaries(filter, categories)}
       onClearCategory={(category) =>
         onFilterChange(clearFilterCategory(filter, category))
       }

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.test.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.test.tsx
@@ -47,6 +47,7 @@ describe("AutomationsTriggerBreakdown", () => {
   it("shows no comparison for a trigger with zero run count, instead of an Infinity ratio", () => {
     render(
       <AutomationsTriggerBreakdown
+        scope="workspace"
         workspaceId="w1"
         trigger={TRIGGER}
         period={PERIOD}
@@ -62,6 +63,7 @@ describe("AutomationsTriggerBreakdown", () => {
   it("compares a trigger's stats against a non-zero median", () => {
     render(
       <AutomationsTriggerBreakdown
+        scope="workspace"
         workspaceId="w1"
         trigger={{ ...TRIGGER, runCount: 720, credits: 2448 }}
         period={PERIOD}
@@ -94,6 +96,7 @@ describe("AutomationsTriggerBreakdown", () => {
 
     render(
       <AutomationsTriggerBreakdown
+        scope="workspace"
         workspaceId="w1"
         trigger={TRIGGER}
         period={PERIOD}

--- a/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggerBreakdown.tsx
@@ -1,3 +1,4 @@
+import type { AutomationsScope } from "@app/hooks/useAutomationsTriggerBreakdown";
 import { useAutomationsTriggerBreakdown } from "@app/hooks/useAutomationsTriggerBreakdown";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { AutomationTriggerCreditDestination } from "@app/lib/api/analytics/automations/breakdown";
@@ -7,8 +8,10 @@ import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { LoadingBlock, Tooltip } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
-const CAPTION_TOOLTIP_LABEL =
-  "Compared to the median across all triggers for this period.";
+const CAPTION_TOOLTIP_LABEL: Record<AutomationsScope, string> = {
+  workspace: "Compared to the median across all triggers for this period.",
+  user: "Compared to the median across your triggers for this period.",
+};
 
 const RATIO_MORE_THRESHOLD = 1.5;
 const RATIO_LESS_THRESHOLD = 1 / RATIO_MORE_THRESHOLD;
@@ -84,13 +87,15 @@ function CreditDestinationBlock({
   workspaceId,
   triggerId,
   period,
+  scope,
 }: {
   workspaceId: string;
   triggerId: string;
   period: ConsumptionPeriodSelection;
+  scope: AutomationsScope;
 }) {
   const { creditDestination, isBreakdownLoading, isBreakdownError } =
-    useAutomationsTriggerBreakdown({ workspaceId, triggerId, period });
+    useAutomationsTriggerBreakdown({ workspaceId, triggerId, period, scope });
 
   if (isBreakdownLoading) {
     return (
@@ -140,6 +145,7 @@ interface AutomationsTriggerBreakdownProps {
   workspaceId: string;
   trigger: AutomationTriggerRow;
   period: ConsumptionPeriodSelection;
+  scope: AutomationsScope;
   medianRunCount: number;
   medianCostPerRun: number;
 }
@@ -148,6 +154,7 @@ export function AutomationsTriggerBreakdown({
   workspaceId,
   trigger,
   period,
+  scope,
   medianRunCount,
   medianCostPerRun,
 }: AutomationsTriggerBreakdownProps) {
@@ -167,7 +174,7 @@ export function AutomationsTriggerBreakdown({
           </>
         }
         caption={ratioCaption(trigger.runCount, medianRunCount)}
-        captionTooltipLabel={CAPTION_TOOLTIP_LABEL}
+        captionTooltipLabel={CAPTION_TOOLTIP_LABEL[scope]}
       />
       <StatBlock
         label="What each run costs"
@@ -185,6 +192,7 @@ export function AutomationsTriggerBreakdown({
         workspaceId={workspaceId}
         triggerId={trigger.triggerId}
         period={period}
+        scope={scope}
       />
     </div>
   );

--- a/front/components/workspace/analytics/automations/AutomationsTriggersRowsTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersRowsTable.tsx
@@ -1,4 +1,5 @@
 import { AutomationsTriggerBreakdown } from "@app/components/workspace/analytics/automations/AutomationsTriggerBreakdown";
+import type { AutomationsScope } from "@app/hooks/useAutomationsTriggerBreakdown";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import {
@@ -23,6 +24,8 @@ import { Fragment } from "react";
 
 // The id sparkle's createSelectionColumn gives its checkbox column.
 const SELECTION_COLUMN_ID = "select";
+
+const NO_ROW_SELECTION: RowSelectionState = {};
 
 export type TriggerRowData = AutomationTriggerRow & {
   onClick: () => void;
@@ -121,13 +124,14 @@ interface AutomationsTriggersRowsTableProps<T extends TriggerRowData> {
   columns: ColumnDef<T>[];
   workspaceId: string;
   period: ConsumptionPeriodSelection;
+  scope: AutomationsScope;
   expandedRowId: string | null;
   medianRunCount: number;
   medianCostPerRun: number;
   isLoading?: boolean;
   skeletonRowCount: number;
-  rowSelection: RowSelectionState;
-  onRowSelectionChange: (selection: RowSelectionState) => void;
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: (selection: RowSelectionState) => void;
 }
 
 export function AutomationsTriggersRowsTable<T extends TriggerRowData>({
@@ -135,12 +139,13 @@ export function AutomationsTriggersRowsTable<T extends TriggerRowData>({
   columns,
   workspaceId,
   period,
+  scope,
   expandedRowId,
   medianRunCount,
   medianCostPerRun,
   isLoading = false,
   skeletonRowCount,
-  rowSelection,
+  rowSelection = NO_ROW_SELECTION,
   onRowSelectionChange,
 }: AutomationsTriggersRowsTableProps<T>) {
   const table = useReactTable({
@@ -149,7 +154,7 @@ export function AutomationsTriggersRowsTable<T extends TriggerRowData>({
     state: { rowSelection },
     enableRowSelection: true,
     onRowSelectionChange: (updater) =>
-      onRowSelectionChange(
+      onRowSelectionChange?.(
         typeof updater === "function" ? updater(rowSelection) : updater
       ),
     getRowId: (row) => row.triggerId,
@@ -257,6 +262,7 @@ export function AutomationsTriggersRowsTable<T extends TriggerRowData>({
                       >
                         <AutomationsTriggerBreakdown
                           workspaceId={workspaceId}
+                          scope={scope}
                           trigger={row.original}
                           period={period}
                           medianRunCount={medianRunCount}

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -5,6 +5,7 @@ import { AutomationsFilterSummary } from "@app/components/workspace/analytics/au
 import type { TriggerRowData as BaseTriggerRowData } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
 import { AutomationsTriggersRowsTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
 import {
+  agentColumn,
   creditsColumn,
   detailsColumn,
   nameColumn,
@@ -15,10 +16,6 @@ import { POOL_OPTIONS } from "@app/components/workspace/analytics/automations/tr
 import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
 import { toAutomationsTriggersFilter } from "@app/components/workspace/analytics/automationsFilter";
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
-import {
-  AvatarNameCell,
-  EntityTooltipCard,
-} from "@app/components/workspace/analytics/creditsTableCells";
 import { useAutomationsTriggers } from "@app/hooks/useAutomationsTriggers";
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
@@ -153,45 +150,6 @@ function RunningCell({ row }: { row: TriggerRowData }) {
   }
 }
 
-function AgentCell({ agent }: { agent: AutomationTriggerRow["agent"] }) {
-  const content = (
-    <div className="min-w-0">
-      <AvatarNameCell
-        name={agent.name}
-        imageUrl={agent.pictureUrl}
-        size="xxs"
-      />
-    </div>
-  );
-
-  if (!agent.description) {
-    return content;
-  }
-
-  return (
-    <Tooltip
-      label={
-        <EntityTooltipCard
-          avatar={
-            <Avatar
-              name={agent.name}
-              visual={agent.pictureUrl ?? undefined}
-              size="xs"
-            />
-          }
-          name={agent.name}
-          description={agent.description}
-          modelId={agent.modelId}
-          modelDisplayName={agent.modelDisplayName}
-        />
-      }
-      className="p-3"
-      tooltipTriggerAsChild
-      trigger={content}
-    />
-  );
-}
-
 function EditorCell({ editor }: { editor: AutomationTriggerRow["editor"] }) {
   return (
     <Tooltip
@@ -257,17 +215,7 @@ function buildColumns({
         </DataTable.CellContent>
       ),
     },
-    {
-      id: "agent",
-      header: "Agent",
-      enableSorting: false,
-      meta: { className: "w-44", headerAlign: "left" },
-      cell: (info) => (
-        <DataTable.CellContent className="w-full justify-start">
-          <AgentCell agent={info.row.original.agent} />
-        </DataTable.CellContent>
-      ),
-    },
+    agentColumn(),
     typeColumn(),
     creditsColumn(),
     ...(showPoolColumn

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -1,10 +1,15 @@
 import { ConfirmContext } from "@app/components/Confirm";
-import { getIcon } from "@app/components/resources/resources_icons";
 import { TableSelectionBanner } from "@app/components/shared/TableSelectionBanner";
 import { AutomationsFilterPanel } from "@app/components/workspace/analytics/automations/AutomationsFilterPanel";
 import { AutomationsFilterSummary } from "@app/components/workspace/analytics/automations/AutomationsFilterSummary";
 import type { TriggerRowData as BaseTriggerRowData } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
 import { AutomationsTriggersRowsTable } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
+import {
+  creditsColumn,
+  detailsColumn,
+  nameColumn,
+  typeColumn,
+} from "@app/components/workspace/analytics/automations/automationsTriggerColumns";
 import { BulkTriggerPoolModal } from "@app/components/workspace/analytics/automations/BulkTriggerPoolModal";
 import { POOL_OPTIONS } from "@app/components/workspace/analytics/automations/trigger_pool_options";
 import type { AutomationsFilter } from "@app/components/workspace/analytics/automationsFilter";
@@ -12,7 +17,6 @@ import { toAutomationsTriggersFilter } from "@app/components/workspace/analytics
 import { CsvDownloadButton } from "@app/components/workspace/analytics/CsvDownloadButton";
 import {
   AvatarNameCell,
-  CreditsCell,
   EntityTooltipCard,
 } from "@app/components/workspace/analytics/creditsTableCells";
 import { useAutomationsTriggers } from "@app/hooks/useAutomationsTriggers";
@@ -34,7 +38,6 @@ import {
   useUpdateTriggerStatus,
 } from "@app/lib/swr/agent_triggers";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
-import { normalizeWebhookIcon } from "@app/lib/webhook_source";
 import type {
   TriggerExecutionMode,
   TriggerStatus,
@@ -45,9 +48,6 @@ import type { LightWorkspaceType } from "@app/types/user";
 import {
   Avatar,
   Button,
-  ChevronDown,
-  ChevronUp,
-  Clock,
   ContentMessageAction,
   createSelectionColumn,
   DataTable,
@@ -55,7 +55,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Icon,
   Pagination,
   SearchInput,
   SliderToggle,
@@ -67,7 +66,7 @@ import type {
   RowSelectionState,
 } from "@tanstack/react-table";
 import { flexRender } from "@tanstack/react-table";
-import type { ComponentProps, Dispatch, SetStateAction } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useContext, useMemo, useState } from "react";
 
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
@@ -112,40 +111,6 @@ function PoolCell({ row }: { row: TriggerRowData }) {
   );
 }
 
-function TypeCell({ trigger }: { trigger: AutomationTriggerRow }) {
-  switch (trigger.kind) {
-    case "schedule":
-      return (
-        <TypeLabel
-          visual={Clock}
-          label={trigger.scheduleDescription || "Schedule"}
-        />
-      );
-    case "webhook":
-      if (trigger.webhookSourceRestricted) {
-        return (
-          <TypeLabel
-            visual={getIcon("ActionLockIcon")}
-            label="This webhook lives in a space you don't have access to."
-          />
-        );
-      }
-      return (
-        <TypeLabel
-          visual={getIcon(normalizeWebhookIcon(trigger.webhookIcon))}
-          label={
-            trigger.webhookSourceName
-              ? `${trigger.webhookSourceName} webhook`
-              : "Webhook"
-          }
-        />
-      );
-    default:
-      assertNeverAndIgnore(trigger.kind);
-      return null;
-  }
-}
-
 function RunningCell({ row }: { row: TriggerRowData }) {
   switch (row.displayStatus) {
     case "enabled":
@@ -186,26 +151,6 @@ function RunningCell({ row }: { row: TriggerRowData }) {
         />
       );
   }
-}
-
-function TypeLabel({
-  visual,
-  label,
-}: {
-  visual: ComponentProps<typeof Icon>["visual"];
-  label: string;
-}) {
-  return (
-    <Tooltip
-      label={label}
-      tooltipTriggerAsChild
-      trigger={
-        <div className="flex min-w-0 items-center gap-2">
-          <Icon visual={visual} size="xs" className="text-muted-foreground" />
-        </div>
-      }
-    />
-  );
 }
 
 function AgentCell({ agent }: { agent: AutomationTriggerRow["agent"] }) {
@@ -300,19 +245,7 @@ function buildColumns({
 }): ColumnDef<TriggerRowData>[] {
   return [
     ...(showSelectionColumn ? [rowSelectionColumn()] : []),
-    {
-      id: "name",
-      accessorKey: "name",
-      header: "Name",
-      meta: { className: "truncate", headerAlign: "left" },
-      cell: (info) => (
-        <DataTable.CellContent className="w-full justify-start text-left">
-          <span className="truncate text-sm font-semibold">
-            {info.row.original.name}
-          </span>
-        </DataTable.CellContent>
-      ),
-    },
+    nameColumn(),
     {
       id: "editor",
       header: "Editor",
@@ -335,28 +268,8 @@ function buildColumns({
         </DataTable.CellContent>
       ),
     },
-    {
-      id: "type",
-      header: "Type",
-      enableSorting: false,
-      meta: { className: "w-8" },
-      cell: (info) => (
-        <DataTable.CellContent className="w-full justify-center">
-          <TypeCell trigger={info.row.original} />
-        </DataTable.CellContent>
-      ),
-    },
-    {
-      id: "credits",
-      accessorKey: "credits",
-      header: "Credits",
-      meta: { className: "w-24", headerAlign: "right" },
-      cell: (info) => (
-        <DataTable.CellContent className="w-full justify-end text-right">
-          <CreditsCell credits={info.row.original.credits} />
-        </DataTable.CellContent>
-      ),
-    },
+    typeColumn(),
+    creditsColumn(),
     ...(showPoolColumn
       ? [
           {
@@ -383,31 +296,7 @@ function buildColumns({
         </DataTable.CellContent>
       ),
     },
-    {
-      id: "details",
-      header: "",
-      enableSorting: false,
-      meta: { className: "w-12" },
-      cell: (info) => {
-        const row = info.row.original;
-        const isExpanded = expandedRowId === row.triggerId;
-        return (
-          <DataTable.CellContent className="w-full justify-end">
-            <Button
-              icon={isExpanded ? ChevronUp : ChevronDown}
-              variant="ghost-secondary"
-              size="xs"
-              aria-label={`${isExpanded ? "Collapse" : "Expand"} breakdown for ${row.name}`}
-              aria-expanded={isExpanded}
-              onClick={(event) => {
-                event.stopPropagation();
-                row.onClick();
-              }}
-            />
-          </DataTable.CellContent>
-        );
-      },
-    },
+    detailsColumn(expandedRowId),
   ];
 }
 
@@ -858,6 +747,7 @@ function TriggersTableBody({
           columns={columns}
           workspaceId={workspaceId}
           period={period}
+          scope="workspace"
           expandedRowId={expandedRowId}
           medianRunCount={medianRunCount}
           medianCostPerRun={medianCostPerRun}

--- a/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
+++ b/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
@@ -1,0 +1,145 @@
+import { getIcon } from "@app/components/resources/resources_icons";
+import type { TriggerRowData } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
+import { CreditsCell } from "@app/components/workspace/analytics/creditsTableCells";
+import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
+import { normalizeWebhookIcon } from "@app/lib/webhook_source";
+import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
+import {
+  Button,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  DataTable,
+  Icon,
+  Tooltip,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import type { ComponentProps } from "react";
+
+function TypeLabel({
+  visual,
+  label,
+}: {
+  visual: ComponentProps<typeof Icon>["visual"];
+  label: string;
+}) {
+  return (
+    <Tooltip
+      label={label}
+      tooltipTriggerAsChild
+      trigger={
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon visual={visual} size="xs" className="text-muted-foreground" />
+        </div>
+      }
+    />
+  );
+}
+
+export function TypeCell({ trigger }: { trigger: AutomationTriggerRow }) {
+  switch (trigger.kind) {
+    case "schedule":
+      return (
+        <TypeLabel
+          visual={Clock}
+          label={trigger.scheduleDescription || "Schedule"}
+        />
+      );
+    case "webhook":
+      if (trigger.webhookSourceRestricted) {
+        return (
+          <TypeLabel
+            visual={getIcon("ActionLockIcon")}
+            label="This webhook lives in a space you don't have access to."
+          />
+        );
+      }
+      return (
+        <TypeLabel
+          visual={getIcon(normalizeWebhookIcon(trigger.webhookIcon))}
+          label={
+            trigger.webhookSourceName
+              ? `${trigger.webhookSourceName} webhook`
+              : "Webhook"
+          }
+        />
+      );
+    default:
+      assertNeverAndIgnore(trigger.kind);
+      return null;
+  }
+}
+
+export function nameColumn<T extends TriggerRowData>(): ColumnDef<T> {
+  return {
+    id: "name",
+    accessorKey: "name",
+    header: "Name",
+    meta: { className: "truncate", headerAlign: "left" },
+    cell: (info) => (
+      <DataTable.CellContent className="w-full justify-start text-left">
+        <span className="truncate text-sm font-semibold">
+          {info.row.original.name}
+        </span>
+      </DataTable.CellContent>
+    ),
+  };
+}
+
+export function typeColumn<T extends TriggerRowData>(): ColumnDef<T> {
+  return {
+    id: "type",
+    header: "Type",
+    enableSorting: false,
+    meta: { className: "w-8" },
+    cell: (info) => (
+      <DataTable.CellContent className="w-full justify-center">
+        <TypeCell trigger={info.row.original} />
+      </DataTable.CellContent>
+    ),
+  };
+}
+
+export function creditsColumn<T extends TriggerRowData>(): ColumnDef<T> {
+  return {
+    id: "credits",
+    accessorKey: "credits",
+    header: "Credits",
+    meta: { className: "w-24", headerAlign: "right" },
+    cell: (info) => (
+      <DataTable.CellContent className="w-full justify-end text-right">
+        <CreditsCell credits={info.row.original.credits} />
+      </DataTable.CellContent>
+    ),
+  };
+}
+
+export function detailsColumn<T extends TriggerRowData>(
+  expandedRowId: string | null
+): ColumnDef<T> {
+  return {
+    id: "details",
+    header: "",
+    enableSorting: false,
+    meta: { className: "w-12" },
+    cell: (info) => {
+      const row = info.row.original;
+      const isExpanded = expandedRowId === row.triggerId;
+      return (
+        <DataTable.CellContent className="w-full justify-end">
+          <Button
+            icon={isExpanded ? ChevronUp : ChevronDown}
+            variant="ghost-secondary"
+            size="xs"
+            aria-label={`${isExpanded ? "Collapse" : "Expand"} breakdown for ${row.name}`}
+            aria-expanded={isExpanded}
+            onClick={(event) => {
+              event.stopPropagation();
+              row.onClick();
+            }}
+          />
+        </DataTable.CellContent>
+      );
+    },
+  };
+}

--- a/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
+++ b/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
@@ -1,10 +1,15 @@
 import { getIcon } from "@app/components/resources/resources_icons";
 import type { TriggerRowData } from "@app/components/workspace/analytics/automations/AutomationsTriggersRowsTable";
-import { CreditsCell } from "@app/components/workspace/analytics/creditsTableCells";
+import {
+  AvatarNameCell,
+  CreditsCell,
+  EntityTooltipCard,
+} from "@app/components/workspace/analytics/creditsTableCells";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { normalizeWebhookIcon } from "@app/lib/webhook_source";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import {
+  Avatar,
   Button,
   ChevronDown,
   ChevronUp,
@@ -14,15 +19,14 @@ import {
   Tooltip,
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-import type { ComponentProps } from "react";
+import type { ComponentType } from "react";
 
-function TypeLabel({
-  visual,
-  label,
-}: {
-  visual: ComponentProps<typeof Icon>["visual"];
+interface TypeLabelProps {
+  visual: ComponentType<{ className?: string }>;
   label: string;
-}) {
+}
+
+function TypeLabel({ visual, label }: TypeLabelProps) {
   return (
     <Tooltip
       label={label}
@@ -36,7 +40,11 @@ function TypeLabel({
   );
 }
 
-export function TypeCell({ trigger }: { trigger: AutomationTriggerRow }) {
+interface TypeCellProps {
+  trigger: AutomationTriggerRow;
+}
+
+export function TypeCell({ trigger }: TypeCellProps) {
   switch (trigger.kind) {
     case "schedule":
       return (
@@ -81,6 +89,63 @@ export function nameColumn<T extends TriggerRowData>(): ColumnDef<T> {
         <span className="truncate text-sm font-semibold">
           {info.row.original.name}
         </span>
+      </DataTable.CellContent>
+    ),
+  };
+}
+
+interface AgentCellProps {
+  agent: AutomationTriggerRow["agent"];
+}
+
+function AgentCell({ agent }: AgentCellProps) {
+  const content = (
+    <div className="min-w-0">
+      <AvatarNameCell
+        name={agent.name}
+        imageUrl={agent.pictureUrl}
+        size="xxs"
+      />
+    </div>
+  );
+
+  if (!agent.description) {
+    return content;
+  }
+
+  return (
+    <Tooltip
+      label={
+        <EntityTooltipCard
+          avatar={
+            <Avatar
+              name={agent.name}
+              visual={agent.pictureUrl ?? undefined}
+              size="xs"
+            />
+          }
+          name={agent.name}
+          description={agent.description}
+          modelId={agent.modelId}
+          modelDisplayName={agent.modelDisplayName}
+        />
+      }
+      className="p-3"
+      tooltipTriggerAsChild
+      trigger={content}
+    />
+  );
+}
+
+export function agentColumn<T extends TriggerRowData>(): ColumnDef<T> {
+  return {
+    id: "agent",
+    header: "Agent",
+    enableSorting: false,
+    meta: { className: "w-44", headerAlign: "left" },
+    cell: (info) => (
+      <DataTable.CellContent className="w-full justify-start">
+        <AgentCell agent={info.row.original.agent} />
       </DataTable.CellContent>
     ),
   };

--- a/front/components/workspace/analytics/automationsFilter.ts
+++ b/front/components/workspace/analytics/automationsFilter.ts
@@ -18,6 +18,12 @@ export const AUTOMATIONS_FILTER_CATEGORIES = [
 export type AutomationsFilterCategory =
   (typeof AUTOMATIONS_FILTER_CATEGORIES)[number];
 
+// A member filters their own automations, so the member category is dropped.
+export const USER_AUTOMATIONS_FILTER_CATEGORIES = [
+  "agent",
+  "type",
+] as const satisfies readonly AutomationsFilterCategory[];
+
 export const AUTOMATIONS_FILTER_CATEGORY_LABEL: Record<
   AutomationsFilterCategory,
   string
@@ -46,18 +52,22 @@ export type AutomationsFilter = CategoryFilter<
   AutomationsFilterOption
 >;
 
-export function getAutomationsFilterSummaries(filter: AutomationsFilter) {
+export function getAutomationsFilterSummaries(
+  filter: AutomationsFilter,
+  categories: readonly AutomationsFilterCategory[] = AUTOMATIONS_FILTER_CATEGORIES
+) {
   return getFilterSummaries(
     filter,
-    AUTOMATIONS_FILTER_CATEGORIES,
+    categories,
     AUTOMATIONS_FILTER_CATEGORY_SINGULAR_LABEL
   );
 }
 
 export function automationsFilterSelectionCount(
-  filter: AutomationsFilter
+  filter: AutomationsFilter,
+  categories: readonly AutomationsFilterCategory[] = AUTOMATIONS_FILTER_CATEGORIES
 ): number {
-  return filterSelectionCount(filter, AUTOMATIONS_FILTER_CATEGORIES);
+  return filterSelectionCount(filter, categories);
 }
 
 export type AutomationsTriggersFilter = {
@@ -101,5 +111,15 @@ export function toAutomationsTriggersFilter(
     ...(agentIds && agentIds.length > 0 ? { agentIds } : {}),
     ...(editorIds && editorIds.length > 0 ? { editorIds } : {}),
     ...(kinds && kinds.length > 0 ? { kinds } : {}),
+  };
+}
+
+export function toUserAutomationsTriggersFilter(
+  filter: AutomationsFilter
+): Omit<AutomationsTriggersFilter, "editorIds"> {
+  const { agentIds, kinds } = toAutomationsTriggersFilter(filter);
+  return {
+    ...(agentIds ? { agentIds } : {}),
+    ...(kinds ? { kinds } : {}),
   };
 }

--- a/front/hooks/useAutomationsTriggerBreakdown.ts
+++ b/front/hooks/useAutomationsTriggerBreakdown.ts
@@ -4,18 +4,27 @@ import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_
 import type { GetAutomationTriggerBreakdownResponse } from "@app/lib/api/analytics/automations/breakdown";
 import type { AutomationTriggerBreakdownBody } from "@app/lib/api/analytics/automations/schema";
 
+// A workspace-scoped breakdown reads the manager-only analytics endpoint; a
+// user-scoped one reads its own automations, whatever the caller's role.
+export type AutomationsScope = "workspace" | "user";
+
 export function useAutomationsTriggerBreakdown({
   workspaceId,
   triggerId,
   period,
+  scope,
   disabled,
 }: {
   workspaceId: string;
   triggerId: string;
   period: ConsumptionPeriodSelection;
+  scope: AutomationsScope;
   disabled?: boolean;
 }) {
-  const url = `/api/w/${workspaceId}/analytics/automations/trigger-breakdown`;
+  const url =
+    scope === "user"
+      ? `/api/w/${workspaceId}/me/automations/trigger-breakdown`
+      : `/api/w/${workspaceId}/analytics/automations/trigger-breakdown`;
   const body: AutomationTriggerBreakdownBody = {
     triggerId,
     period: period.kind,

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -101,7 +101,7 @@ type RankedTrigger = {
   credits: number;
 };
 
-function median(values: number[]): number {
+export function median(values: number[]): number {
   if (values.length === 0) {
     return 0;
   }
@@ -306,6 +306,77 @@ async function resolveWebhookSources(
   };
 }
 
+export type RankedTriggerWithResource = {
+  trigger: TriggerResource;
+  runCount: number;
+  credits: number;
+};
+
+export async function buildAutomationTriggerRows(
+  auth: Authenticator,
+  page: RankedTriggerWithResource[]
+): Promise<AutomationTriggerRow[]> {
+  const [agentLabels, editors, webhookSources] = await Promise.all([
+    resolveAnalyticsAgentLabels(auth, [
+      ...new Set(page.map(({ trigger }) => trigger.agentConfigurationId)),
+    ]),
+    UserResource.fetchByModelIds([
+      ...new Set(page.map(({ trigger }) => trigger.editor)),
+    ]),
+    resolveWebhookSources(
+      auth,
+      page.map(({ trigger }) => trigger)
+    ),
+  ]);
+  const editorsByModelId = new Map(
+    editors.map((editor) => [editor.id, editor])
+  );
+
+  return page.map(({ trigger, runCount, credits }) => {
+    const agentLabel = agentLabels.get(trigger.agentConfigurationId);
+    const editor = editorsByModelId.get(trigger.editor);
+    const webhookSource = trigger.webhookSourceViewId
+      ? webhookSources.labels.get(trigger.webhookSourceViewId)
+      : undefined;
+    const triggerJSON = trigger.toJSON();
+
+    return {
+      triggerId: trigger.sId,
+      name: trigger.name,
+      kind: trigger.kind,
+      status: trigger.status,
+      agent: {
+        agentId: trigger.agentConfigurationId,
+        name: agentLabel?.name ?? trigger.agentConfigurationId,
+        pictureUrl: agentLabel?.pictureUrl ?? null,
+        description: agentLabel?.description ?? null,
+        modelId: agentLabel?.modelId ?? null,
+        modelDisplayName: agentLabel?.modelDisplayName ?? null,
+      },
+      editor: {
+        name: getUserDisplayName(editor),
+        email: editor?.email ?? null,
+        pictureUrl: editor?.imageUrl ?? null,
+      },
+      scheduleDescription: isScheduleTrigger(triggerJSON)
+        ? describeScheduleConfig(triggerJSON.configuration)
+        : null,
+      webhookSourceName: webhookSource?.name ?? null,
+      // Restricted means the view still exists but the caller lacks read
+      // access to its space — as opposed to a deleted/missing view, which
+      // falls back to a generic "Webhook" label instead.
+      webhookSourceRestricted:
+        !webhookSource &&
+        !!trigger.webhookSourceViewId &&
+        webhookSources.existingIds.has(trigger.webhookSourceViewId),
+      webhookIcon: webhookSource?.icon ?? null,
+      runCount,
+      credits,
+      executionMode: trigger.executionMode,
+    };
+  });
+}
+
 export async function fetchAutomationTriggers(
   auth: Authenticator,
   {
@@ -352,65 +423,7 @@ export async function fetchAutomationTriggers(
     })
   );
 
-  const [agentLabels, editors, webhookSources] = await Promise.all([
-    resolveAnalyticsAgentLabels(auth, [
-      ...new Set(page.map(({ trigger }) => trigger.agentConfigurationId)),
-    ]),
-    UserResource.fetchByModelIds([
-      ...new Set(page.map(({ trigger }) => trigger.editor)),
-    ]),
-    resolveWebhookSources(
-      auth,
-      page.map(({ trigger }) => trigger)
-    ),
-  ]);
-  const editorsByModelId = new Map(
-    editors.map((editor) => [editor.id, editor])
-  );
-
-  const rows = page.map(({ trigger, runCount, credits }) => {
-    const agentLabel = agentLabels.get(trigger.agentConfigurationId);
-    const editor = editorsByModelId.get(trigger.editor);
-    const webhookSource = trigger.webhookSourceViewId
-      ? webhookSources.labels.get(trigger.webhookSourceViewId)
-      : undefined;
-    const triggerJSON = trigger.toJSON();
-
-    return {
-      triggerId: trigger.sId,
-      name: trigger.name,
-      kind: trigger.kind,
-      status: trigger.status,
-      agent: {
-        agentId: trigger.agentConfigurationId,
-        name: agentLabel?.name ?? trigger.agentConfigurationId,
-        pictureUrl: agentLabel?.pictureUrl ?? null,
-        description: agentLabel?.description ?? null,
-        modelId: agentLabel?.modelId ?? null,
-        modelDisplayName: agentLabel?.modelDisplayName ?? null,
-      },
-      editor: {
-        name: getUserDisplayName(editor),
-        email: editor?.email ?? null,
-        pictureUrl: editor?.imageUrl ?? null,
-      },
-      scheduleDescription: isScheduleTrigger(triggerJSON)
-        ? describeScheduleConfig(triggerJSON.configuration)
-        : null,
-      webhookSourceName: webhookSource?.name ?? null,
-      // Restricted means the view still exists but the caller lacks read
-      // access to its space — as opposed to a deleted/missing view, which
-      // falls back to a generic "Webhook" label instead.
-      webhookSourceRestricted:
-        !webhookSource &&
-        !!trigger.webhookSourceViewId &&
-        webhookSources.existingIds.has(trigger.webhookSourceViewId),
-      webhookIcon: webhookSource?.icon ?? null,
-      runCount,
-      credits,
-      executionMode: trigger.executionMode,
-    };
-  });
+  const rows = await buildAutomationTriggerRows(auth, page);
 
   return new Ok({
     period,

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -183,6 +183,10 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     });
   }
 
+  isEditedBy(auth: Authenticator): boolean {
+    return this.editor === auth.getNonNullableUser().id;
+  }
+
   canUpdateStatusTo(auth: Authenticator, to: TriggerStatus): boolean {
     if (this.status === to) {
       return true;
@@ -912,8 +916,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     const canUseTargetMode = await canUseExecutionMode(auth, executionMode);
     const updatable = canUseTargetMode
       ? triggers.filter(
-          (trigger) =>
-            auth.isManager() || trigger.editor === auth.getNonNullableUser().id
+          (trigger) => auth.isManager() || trigger.isEditedBy(auth)
         )
       : [];
 
@@ -1157,8 +1160,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     auth: Authenticator,
     executionMode: TriggerExecutionMode
   ): Promise<Result<undefined, Error>> {
-    const isEditor =
-      auth.isManager() || this.editor === auth.getNonNullableUser().id;
+    const isEditor = auth.isManager() || this.isEditedBy(auth);
     if (!isEditor || !(await canUseExecutionMode(auth, executionMode))) {
       return new Err(
         new TriggerExecutionModeForbiddenError(


### PR DESCRIPTION
## Description

Prep for a personal automations view, which needs the same table, filters and credit breakdown as the manager-only `/automations` page but scoped to a single member. Three things move out of their single call site: the row building in `automations/triggers.ts`, the name/type/credits/details column defs, and the "is this trigger mine" check, which becomes `TriggerResource.isEditedBy`. The filter panel and summary now take the list of categories to show, and the breakdown takes a scope that decides which endpoint it reads and how it words its median tooltip. No behavior change: the workspace page passes the full category list and `scope="workspace"`.

First of three. Follow-ups add the `/me/automations` endpoints, then the user-menu entry.

## Tests

Existing automations analytics and component suites pass unchanged (64 tests), including `AutomationsTriggerBreakdown.test.tsx` with the new required `scope`. No new tests: the extracted code has no new behavior of its own, and the callers are covered.

## Risk

Low, but it touches the shared table the `/automations` page renders. The one thing worth a close read is `AutomationsTriggersRowsTable`: `rowSelection` and `onRowSelectionChange` became optional, so a caller that forgets to wire them now silently gets no selection instead of a type error. The workspace table still passes both.

## Deploy Plan

Deploy front.