### PR TITLE
feat(front): serve a member their own automations and their credits

### DIFF
--- a/front-api/routes/w/[wId]/me/automations/index.ts
+++ b/front-api/routes/w/[wId]/me/automations/index.ts
@@ -1,0 +1,12 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+
+import triggerBreakdown from "./trigger-breakdown";
+import triggers from "./triggers";
+
+// Mounted under /api/w/:wId/me/automations.
+const app = workspaceApp();
+
+app.route("/triggers", triggers);
+app.route("/trigger-breakdown", triggerBreakdown);
+
+export default app;

--- a/front-api/routes/w/[wId]/me/automations/trigger-breakdown.test.ts
+++ b/front-api/routes/w/[wId]/me/automations/trigger-breakdown.test.ts
@@ -1,0 +1,106 @@
+import type { GetAutomationTriggerBreakdownResponse } from "@app/lib/api/analytics/automations/breakdown";
+import { fetchAutomationTriggerBreakdown } from "@app/lib/api/analytics/automations/breakdown";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  import("@app/lib/api/analytics/automations/breakdown"),
+  async (orig) => {
+    const mod = await orig();
+    return { ...mod, fetchAutomationTriggerBreakdown: vi.fn() };
+  }
+);
+
+const BREAKDOWN: GetAutomationTriggerBreakdownResponse = {
+  period: {
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+  },
+  creditDestination: {
+    dimension: "model",
+    key: "claude-opus-5",
+    name: "Claude Opus 5",
+    icon: null,
+    credits: 12,
+    share: 0.75,
+  },
+};
+
+function postBreakdownRequest(wId: string, body: Record<string, unknown>) {
+  return honoApp.request(`/api/w/${wId}/me/automations/trigger-breakdown`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function scheduleTrigger(
+  auth: Authenticator,
+  agentConfigurationId: string
+) {
+  return TriggerFactory.schedule(auth, {
+    agentConfigurationId,
+    name: "Competitor watch",
+    configuration: { cron: "0 9 * * *", timezone: "UTC" },
+  });
+}
+
+describe("POST /api/w/:wId/me/automations/trigger-breakdown", () => {
+  it("returns the breakdown of a trigger the caller edits", async () => {
+    vi.mocked(fetchAutomationTriggerBreakdown).mockResolvedValue(
+      new Ok(BREAKDOWN)
+    );
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await scheduleTrigger(auth, agent.sId);
+
+    const response = await postBreakdownRequest(workspace.sId, {
+      triggerId: trigger.sId,
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(BREAKDOWN);
+  });
+
+  it("returns 404 for a trigger edited by another member", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    const theirTrigger = await scheduleTrigger(otherAuth, agent.sId);
+
+    const response = await postBreakdownRequest(workspace.sId, {
+      triggerId: theirTrigger.sId,
+    });
+
+    expect(response.status).toBe(404);
+    expect(vi.mocked(fetchAutomationTriggerBreakdown)).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 for an unknown trigger", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await postBreakdownRequest(workspace.sId, {
+      triggerId: "trg_does_not_exist",
+    });
+
+    expect(response.status).toBe(404);
+    expect(vi.mocked(fetchAutomationTriggerBreakdown)).not.toHaveBeenCalled();
+  });
+});

--- a/front-api/routes/w/[wId]/me/automations/trigger-breakdown.ts
+++ b/front-api/routes/w/[wId]/me/automations/trigger-breakdown.ts
@@ -1,0 +1,67 @@
+import type { GetAutomationTriggerBreakdownResponse } from "@app/lib/api/analytics/automations/breakdown";
+import { fetchAutomationTriggerBreakdown } from "@app/lib/api/analytics/automations/breakdown";
+import { AutomationTriggerBreakdownBodySchema } from "@app/lib/api/analytics/automations/schema";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import logger from "@app/logger/logger";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+export type { GetAutomationTriggerBreakdownResponse };
+
+// Mounted at /api/w/:wId/me/automations/trigger-breakdown.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", AutomationTriggerBreakdownBodySchema),
+  async (ctx): HandlerResult<GetAutomationTriggerBreakdownResponse> => {
+    const auth = ctx.get("auth");
+    const { triggerId, ...periodQuery } = ctx.req.valid("json");
+
+    const trigger = await TriggerResource.fetchById(auth, triggerId);
+    if (!trigger || !trigger.isEditedBy(auth)) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "trigger_not_found",
+          message: "Trigger not found.",
+        },
+      });
+    }
+
+    const period = await resolveConsumptionPeriod(
+      auth,
+      toConsumptionPeriodInput(periodQuery)
+    );
+
+    const result = await fetchAutomationTriggerBreakdown(auth, {
+      triggerId,
+      period,
+    });
+    if (result.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          triggerId,
+          err: result.error,
+        },
+        "[AutomationsAnalytics] Failed to retrieve user trigger breakdown."
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to retrieve trigger breakdown.",
+        },
+      });
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/me/automations/triggers.test.ts
+++ b/front-api/routes/w/[wId]/me/automations/triggers.test.ts
@@ -1,0 +1,119 @@
+import { DEFAULT_AUTOMATION_TRIGGERS_LIMIT } from "@app/lib/api/analytics/automations/schema";
+import type { UserAutomationTriggers } from "@app/lib/api/analytics/automations/user_triggers";
+import { fetchUserAutomationTriggers } from "@app/lib/api/analytics/automations/user_triggers";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  import("@app/lib/api/analytics/automations/user_triggers"),
+  async (orig) => {
+    const mod = await orig();
+    return {
+      ...mod,
+      fetchUserAutomationTriggers: vi.fn(),
+    };
+  }
+);
+
+const TRIGGERS: UserAutomationTriggers = {
+  period: {
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+  },
+  totalCount: 1,
+  isConsumptionAvailable: true,
+  medianRunCount: 4,
+  medianCostPerRun: 2,
+  triggers: [
+    {
+      triggerId: "trg1",
+      name: "Competitor watch",
+      kind: "schedule",
+      status: "enabled",
+      agent: {
+        agentId: "agent1",
+        name: "deep-dive",
+        pictureUrl: null,
+        description: null,
+        modelId: null,
+        modelDisplayName: null,
+      },
+      editor: {
+        name: "Adrien Simon",
+        email: "adrien@dust.tt",
+        pictureUrl: null,
+      },
+      scheduleDescription: "Every day at 9:00",
+      webhookSourceName: null,
+      webhookSourceRestricted: false,
+      webhookIcon: null,
+      runCount: 8,
+      credits: 16,
+      executionMode: "user_pool",
+    },
+  ],
+};
+
+function postTriggersRequest(wId: string, body: Record<string, unknown> = {}) {
+  return honoApp.request(`/api/w/${wId}/me/automations/triggers`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/w/:wId/me/automations/triggers", () => {
+  it("returns the caller's own triggers, defaulting to the current cycle", async () => {
+    vi.mocked(fetchUserAutomationTriggers).mockResolvedValue(TRIGGERS);
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await postTriggersRequest(workspace.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(TRIGGERS);
+    expect(vi.mocked(fetchUserAutomationTriggers)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        limit: DEFAULT_AUTOMATION_TRIGGERS_LIMIT,
+        offset: 0,
+      })
+    );
+  });
+
+  it("forwards the period, page, search and filter", async () => {
+    vi.mocked(fetchUserAutomationTriggers).mockResolvedValue(TRIGGERS);
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await postTriggersRequest(workspace.sId, {
+      period: "days",
+      days: 7,
+      limit: 10,
+      offset: 20,
+      search: "  competitor  ",
+      filter: { agentIds: ["agent1"], kinds: ["schedule"] },
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchUserAutomationTriggers)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        limit: 10,
+        offset: 20,
+        search: "competitor",
+        filter: { agentIds: ["agent1"], kinds: ["schedule"] },
+      })
+    );
+  });
+
+  it("returns 400 on a negative offset", async () => {
+    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+
+    const response = await postTriggersRequest(workspace.sId, { offset: -1 });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+  });
+});

--- a/front-api/routes/w/[wId]/me/automations/triggers.test.ts
+++ b/front-api/routes/w/[wId]/me/automations/triggers.test.ts
@@ -1,59 +1,15 @@
-import { DEFAULT_AUTOMATION_TRIGGERS_LIMIT } from "@app/lib/api/analytics/automations/schema";
-import type { UserAutomationTriggers } from "@app/lib/api/analytics/automations/user_triggers";
-import { fetchUserAutomationTriggers } from "@app/lib/api/analytics/automations/user_triggers";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock(
-  import("@app/lib/api/analytics/automations/user_triggers"),
-  async (orig) => {
-    const mod = await orig();
-    return {
-      ...mod,
-      fetchUserAutomationTriggers: vi.fn(),
-    };
-  }
-);
-
-const TRIGGERS: UserAutomationTriggers = {
-  period: {
-    startDate: "2026-07-01T00:00:00.000Z",
-    endDate: "2026-08-01T00:00:00.000Z",
-  },
-  totalCount: 1,
-  isConsumptionAvailable: true,
-  medianRunCount: 4,
-  medianCostPerRun: 2,
-  triggers: [
-    {
-      triggerId: "trg1",
-      name: "Competitor watch",
-      kind: "schedule",
-      status: "enabled",
-      agent: {
-        agentId: "agent1",
-        name: "deep-dive",
-        pictureUrl: null,
-        description: null,
-        modelId: null,
-        modelDisplayName: null,
-      },
-      editor: {
-        name: "Adrien Simon",
-        email: "adrien@dust.tt",
-        pictureUrl: null,
-      },
-      scheduleDescription: "Every day at 9:00",
-      webhookSourceName: null,
-      webhookSourceRestricted: false,
-      webhookIcon: null,
-      runCount: 8,
-      credits: 16,
-      executionMode: "user_pool",
-    },
-  ],
-};
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
 
 function postTriggersRequest(wId: string, body: Record<string, unknown> = {}) {
   return honoApp.request(`/api/w/${wId}/me/automations/triggers`, {
@@ -63,56 +19,81 @@ function postTriggersRequest(wId: string, body: Record<string, unknown> = {}) {
   });
 }
 
+function mockConsumption() {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      took: 1,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: {
+        total: { value: 0, relation: "eq" },
+        max_score: null,
+        hits: [],
+      },
+      aggregations: {
+        by_trigger: { buckets: [] },
+        total_count: { value: 0 },
+      },
+    })
+  );
+}
+
 describe("POST /api/w/:wId/me/automations/triggers", () => {
-  it("returns the caller's own triggers, defaulting to the current cycle", async () => {
-    vi.mocked(fetchUserAutomationTriggers).mockResolvedValue(TRIGGERS);
-    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+  afterEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("returns the caller's own triggers", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    const trigger = await TriggerFactory.schedule(auth, {
+      agentConfigurationId: agent.sId,
+      name: "Competitor watch",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+    mockConsumption();
 
     const response = await postTriggersRequest(workspace.sId);
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(TRIGGERS);
-    expect(vi.mocked(fetchUserAutomationTriggers)).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        limit: DEFAULT_AUTOMATION_TRIGGERS_LIMIT,
-        offset: 0,
-      })
-    );
-  });
-
-  it("forwards the period, page, search and filter", async () => {
-    vi.mocked(fetchUserAutomationTriggers).mockResolvedValue(TRIGGERS);
-    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
-
-    const response = await postTriggersRequest(workspace.sId, {
-      period: "days",
-      days: 7,
-      limit: 10,
-      offset: 20,
-      search: "  competitor  ",
-      filter: { agentIds: ["agent1"], kinds: ["schedule"] },
+    await expect(response.json()).resolves.toMatchObject({
+      totalCount: 1,
+      isConsumptionAvailable: true,
+      triggers: [
+        expect.objectContaining({
+          triggerId: trigger.sId,
+          name: "Competitor watch",
+          runCount: 0,
+          credits: 0,
+        }),
+      ],
     });
-
-    expect(response.status).toBe(200);
-    expect(vi.mocked(fetchUserAutomationTriggers)).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        limit: 10,
-        offset: 20,
-        search: "competitor",
-        filter: { agentIds: ["agent1"], kinds: ["schedule"] },
-      })
-    );
   });
 
-  it("returns 400 on a negative offset", async () => {
-    const { workspace } = await createPrivateApiMockRequest({ role: "user" });
+  it("applies filters and validates the request", async () => {
+    const { workspace, auth } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const agent = await AgentConfigurationFactory.createTestAgent(auth);
+    await TriggerFactory.schedule(auth, {
+      agentConfigurationId: agent.sId,
+      name: "Competitor watch",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+    mockConsumption();
 
-    const response = await postTriggersRequest(workspace.sId, { offset: -1 });
+    const filtered = await postTriggersRequest(workspace.sId, {
+      search: "  competitor  ",
+      filter: { agentIds: [agent.sId], kinds: ["schedule"] },
+    });
+    expect(filtered.status).toBe(200);
+    await expect(filtered.json()).resolves.toMatchObject({ totalCount: 1 });
 
-    expect(response.status).toBe(400);
-    expect(await response.json()).toMatchObject({
+    const invalid = await postTriggersRequest(workspace.sId, { offset: -1 });
+    expect(invalid.status).toBe(400);
+    await expect(invalid.json()).resolves.toMatchObject({
       error: { type: "invalid_request_error" },
     });
   });

--- a/front-api/routes/w/[wId]/me/automations/triggers.ts
+++ b/front-api/routes/w/[wId]/me/automations/triggers.ts
@@ -1,0 +1,41 @@
+import { UserAutomationTriggersBodySchema } from "@app/lib/api/analytics/automations/schema";
+import type { UserAutomationTriggers } from "@app/lib/api/analytics/automations/user_triggers";
+import { fetchUserAutomationTriggers } from "@app/lib/api/analytics/automations/user_triggers";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+
+export type GetUserAutomationTriggersResponse = UserAutomationTriggers;
+
+// Mounted at /api/w/:wId/me/automations/triggers.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", UserAutomationTriggersBodySchema),
+  async (ctx): HandlerResult<GetUserAutomationTriggersResponse> => {
+    const auth = ctx.get("auth");
+    const { limit, offset, search, filter, ...periodQuery } =
+      ctx.req.valid("json");
+
+    const period = await resolveConsumptionPeriod(
+      auth,
+      toConsumptionPeriodInput(periodQuery)
+    );
+
+    const triggers = await fetchUserAutomationTriggers(auth, {
+      period,
+      limit,
+      offset,
+      search,
+      filter,
+    });
+
+    return ctx.json(triggers);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/me/index.ts
+++ b/front-api/routes/w/[wId]/me/index.ts
@@ -1,6 +1,7 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
 
 import approvals from "./approvals";
+import automations from "./automations";
 import memory from "./memory";
 import pendingInvitations from "./pending-invitations";
 import slackNotifications from "./slack-notifications";
@@ -10,6 +11,7 @@ import triggers from "./triggers";
 const app = workspaceApp();
 
 app.route("/approvals", approvals);
+app.route("/automations", automations);
 app.route("/memory", memory);
 app.route("/pending-invitations", pendingInvitations);
 app.route("/slack-notifications", slackNotifications);

--- a/front/lib/api/analytics/automations/schema.ts
+++ b/front/lib/api/analytics/automations/schema.ts
@@ -46,6 +46,31 @@ export type AutomationTriggersBody = z.infer<
   typeof AutomationTriggersBodySchema
 >;
 
+export const UserAutomationTriggersFilterSchema = z.object({
+  agentIds: z.array(z.string()).optional(),
+  kinds: z.array(z.enum(["schedule", "webhook"])).optional(),
+});
+
+export type UserAutomationTriggersFilter = z.infer<
+  typeof UserAutomationTriggersFilterSchema
+>;
+
+export const UserAutomationTriggersBodySchema = ConsumptionPeriodSchema.extend({
+  search: z.string().trim().optional(),
+  filter: UserAutomationTriggersFilterSchema.optional(),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .default(DEFAULT_AUTOMATION_TRIGGERS_LIMIT),
+  offset: z.number().int().nonnegative().default(0),
+});
+
+export type UserAutomationTriggersBody = z.infer<
+  typeof UserAutomationTriggersBodySchema
+>;
+
 export const AutomationTriggerBreakdownBodySchema =
   ConsumptionPeriodSchema.extend({
     triggerId: z.string().min(1),

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -158,7 +158,7 @@ async function resolveTriggerIdsForSearch(
  * always compare against the full active set, never just the triggers
  * ranked ahead of it.
  */
-async function fetchTriggersRanking(
+export async function fetchTriggersRanking(
   auth: Authenticator,
   {
     period,
@@ -166,12 +166,14 @@ async function fetchTriggersRanking(
     offset,
     search,
     filter,
+    consumptionScopeFilter = {},
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset: number;
     search?: string;
     filter?: AutomationTriggersFilter;
+    consumptionScopeFilter?: ConsumptionScopeFilter;
   }
 ): Promise<
   Result<
@@ -184,7 +186,7 @@ async function fetchTriggersRanking(
     ElasticsearchError
   >
 > {
-  const scopeFilter: ConsumptionScopeFilter = {};
+  const scopeFilter: ConsumptionScopeFilter = { ...consumptionScopeFilter };
   if (filter?.agentIds?.length) {
     scopeFilter.agents = filter.agentIds;
   }

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -243,7 +243,7 @@ export async function fetchTriggersRanking(
   );
   const ranked = buckets.map((bucket) => ({
     triggerId: String(bucket.key),
-    runCount: Math.round(bucket[RUNS_AGG]?.value ?? 0),
+    runCount: bucket[RUNS_AGG]?.value ?? 0,
     credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
   }));
   // Triggers that never ran have nothing to compare a "how often" or "per

--- a/front/lib/api/analytics/automations/user_triggers.test.ts
+++ b/front/lib/api/analytics/automations/user_triggers.test.ts
@@ -1,0 +1,181 @@
+import { fetchUserAutomationTriggers } from "@app/lib/api/analytics/automations/user_triggers";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  ElasticsearchError,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+
+const PERIOD: ConsumptionPeriod = {
+  startDate: "2026-07-01T00:00:00.000Z",
+  endDate: "2026-08-01T00:00:00.000Z",
+};
+
+function mockConsumption(
+  buckets: { key: string; runs: number; creditMicro: number }[]
+) {
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+    new Ok({
+      aggregations: {
+        by_trigger: {
+          buckets: buckets.map(({ key, runs, creditMicro }) => ({
+            key,
+            credit_micro: { value: creditMicro },
+            runs: { value: runs },
+          })),
+        },
+      },
+    }) as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+  );
+}
+
+async function scheduleTrigger(
+  auth: Authenticator,
+  { agentConfigurationId, name }: { agentConfigurationId: string; name: string }
+) {
+  return TriggerFactory.schedule(auth, {
+    agentConfigurationId,
+    name,
+    configuration: { cron: "0 9 * * *", timezone: "UTC" },
+  });
+}
+
+describe("fetchUserAutomationTriggers", () => {
+  afterEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("lists the triggers that never ran after the ones that consumed", async () => {
+    const { authenticator } = await createResourceTest({ role: "user" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const consuming = await scheduleTrigger(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Competitor watch",
+    });
+    const idle = await scheduleTrigger(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Never ran",
+    });
+    mockConsumption([{ key: consuming.sId, runs: 4, creditMicro: 8_000_000 }]);
+
+    const result = await fetchUserAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 25,
+      offset: 0,
+    });
+
+    const { triggers, totalCount, isConsumptionAvailable } = result;
+    expect(totalCount).toBe(2);
+    expect(isConsumptionAvailable).toBe(true);
+    expect(triggers.map((trigger) => trigger.triggerId)).toEqual([
+      consuming.sId,
+      idle.sId,
+    ]);
+    expect(triggers[0]).toMatchObject({ runCount: 4, credits: 8 });
+    expect(triggers[1]).toMatchObject({ runCount: 0, credits: 0 });
+  });
+
+  it("leaves out the triggers of other members", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "user",
+    });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const mine = await scheduleTrigger(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Mine",
+    });
+
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, { role: "user" });
+    const otherAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+    await scheduleTrigger(otherAuth, {
+      agentConfigurationId: agent.sId,
+      name: "Theirs",
+    });
+
+    mockConsumption([]);
+
+    const result = await fetchUserAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 25,
+      offset: 0,
+    });
+
+    const { triggers, totalCount } = result;
+    expect(totalCount).toBe(1);
+    expect(triggers.map((trigger) => trigger.triggerId)).toEqual([mine.sId]);
+  });
+
+  it("still lists the triggers when the consumption query fails", async () => {
+    const { authenticator } = await createResourceTest({ role: "user" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const trigger = await scheduleTrigger(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Competitor watch",
+    });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+
+    const result = await fetchUserAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 25,
+      offset: 0,
+    });
+
+    expect(result.isConsumptionAvailable).toBe(false);
+    expect(result.triggers.map((t) => t.triggerId)).toEqual([trigger.sId]);
+    expect(result.triggers[0]).toMatchObject({ runCount: 0, credits: 0 });
+  });
+
+  it("filters on kind and name search", async () => {
+    const { authenticator } = await createResourceTest({ role: "user" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const schedule = await scheduleTrigger(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Morning digest",
+    });
+    await TriggerFactory.webhook(authenticator, {
+      agentConfigurationId: agent.sId,
+      name: "Inbound digest",
+    });
+    mockConsumption([]);
+
+    const kindFiltered = await fetchUserAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 25,
+      offset: 0,
+      filter: { kinds: ["schedule"] },
+    });
+    expect(kindFiltered.triggers.map((t) => t.triggerId)).toEqual([
+      schedule.sId,
+    ]);
+
+    const searched = await fetchUserAutomationTriggers(authenticator, {
+      period: PERIOD,
+      limit: 25,
+      offset: 0,
+      search: "morning",
+    });
+    expect(searched.triggers.map((t) => t.triggerId)).toEqual([schedule.sId]);
+  });
+});

--- a/front/lib/api/analytics/automations/user_triggers.test.ts
+++ b/front/lib/api/analytics/automations/user_triggers.test.ts
@@ -28,6 +28,14 @@ function mockConsumption(
 ) {
   vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
     new Ok({
+      took: 1,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: {
+        total: { value: 0, relation: "eq" },
+        max_score: null,
+        hits: [],
+      },
       aggregations: {
         by_trigger: {
           buckets: buckets.map(({ key, runs, creditMicro }) => ({
@@ -36,8 +44,9 @@ function mockConsumption(
             runs: { value: runs },
           })),
         },
+        total_count: { value: buckets.length },
       },
-    }) as Awaited<ReturnType<typeof searchConsumptionAnalytics>>
+    })
   );
 }
 
@@ -121,6 +130,16 @@ describe("fetchUserAutomationTriggers", () => {
     const { triggers, totalCount } = result;
     expect(totalCount).toBe(1);
     expect(triggers.map((trigger) => trigger.triggerId)).toEqual([mine.sId]);
+    expect(vi.mocked(searchConsumptionAnalytics)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bool: {
+          filter: expect.arrayContaining([
+            { term: { "user.id": authenticator.getNonNullableUser().sId } },
+          ]),
+        },
+      }),
+      expect.anything()
+    );
   });
 
   it("still lists the triggers when the consumption query fails", async () => {

--- a/front/lib/api/analytics/automations/user_triggers.test.ts
+++ b/front/lib/api/analytics/automations/user_triggers.test.ts
@@ -165,7 +165,7 @@ describe("fetchUserAutomationTriggers", () => {
     expect(result.triggers[0]).toMatchObject({ runCount: 0, credits: 0 });
   });
 
-  it("filters on kind and name search", async () => {
+  it("filters agents in Elasticsearch and applies kind and name filters", async () => {
     const { authenticator } = await createResourceTest({ role: "user" });
     const agent =
       await AgentConfigurationFactory.createTestAgent(authenticator);
@@ -183,11 +183,21 @@ describe("fetchUserAutomationTriggers", () => {
       period: PERIOD,
       limit: 25,
       offset: 0,
-      filter: { kinds: ["schedule"] },
+      filter: { agentIds: [agent.sId], kinds: ["schedule"] },
     });
     expect(kindFiltered.triggers.map((t) => t.triggerId)).toEqual([
       schedule.sId,
     ]);
+    expect(vi.mocked(searchConsumptionAnalytics)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        bool: {
+          filter: expect.arrayContaining([
+            { term: { "agent.attributed_id": agent.sId } },
+          ]),
+        },
+      }),
+      expect.anything()
+    );
 
     const searched = await fetchUserAutomationTriggers(authenticator, {
       period: PERIOD,

--- a/front/lib/api/analytics/automations/user_triggers.ts
+++ b/front/lib/api/analytics/automations/user_triggers.ts
@@ -72,7 +72,10 @@ export async function fetchUserAutomationTriggers(
     period,
     limit: CARDINALITY_PRECISION_THRESHOLD,
     offset: 0,
-    consumptionScopeFilter: { users: [auth.getNonNullableUser().sId] },
+    consumptionScopeFilter: {
+      users: [auth.getNonNullableUser().sId],
+      agents: filter?.agentIds,
+    },
   });
   const consumptionByTriggerId: Map<string, TriggerConsumption> =
     rankingResult.isOk()

--- a/front/lib/api/analytics/automations/user_triggers.ts
+++ b/front/lib/api/analytics/automations/user_triggers.ts
@@ -1,0 +1,200 @@
+import type { UserAutomationTriggersFilter } from "@app/lib/api/analytics/automations/schema";
+import type {
+  AutomationTriggers,
+  RankedTriggerWithResource,
+} from "@app/lib/api/analytics/automations/triggers";
+import {
+  buildAutomationTriggerRows,
+  median,
+} from "@app/lib/api/analytics/automations/triggers";
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  buildConsumptionScopeQuery,
+  CONVERSATION_ID_FIELD,
+  CREDIT_MICRO_FIELD,
+  TRIGGER_ID_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
+  bucketsToArray,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import logger from "@app/logger/logger";
+import type { estypes } from "@elastic/elasticsearch";
+
+const CREDIT_AGG = "credit_micro";
+const RUNS_AGG = "runs";
+
+type TriggerBucket = {
+  key: string;
+  [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
+  [RUNS_AGG]?: estypes.AggregationsCardinalityAggregate;
+};
+
+type TriggerAggs = {
+  by_trigger?: estypes.AggregationsMultiBucketAggregateBase<TriggerBucket>;
+};
+
+type TriggerConsumption = { runCount: number; credits: number };
+
+export type UserAutomationTriggers = AutomationTriggers & {
+  // False when the consumption query failed: the rows are still listed, with
+  // their credits and runs left at zero.
+  isConsumptionAvailable: boolean;
+};
+
+/**
+ * Credits and runs over the period for a known set of triggers. Unlike the
+ * workspace-wide ranking, the set comes from the database, so a trigger that
+ * never ran still gets a row — with zeroes.
+ */
+async function fetchTriggersConsumption(
+  auth: Authenticator,
+  { period, triggerIds }: { period: ConsumptionPeriod; triggerIds: string[] }
+): Promise<Map<string, TriggerConsumption> | null> {
+  if (triggerIds.length === 0) {
+    return new Map();
+  }
+
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+    extraFilters: [{ terms: { [TRIGGER_ID_FIELD]: triggerIds } }],
+  });
+
+  const result = await searchConsumptionAnalytics<never, TriggerAggs>(query, {
+    aggregations: {
+      by_trigger: {
+        terms: {
+          field: TRIGGER_ID_FIELD,
+          size: triggerIds.length,
+          order: { [CREDIT_AGG]: "desc" },
+        },
+        aggs: {
+          [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
+          // One trigger run is one conversation.
+          [RUNS_AGG]: { cardinality: { field: CONVERSATION_ID_FIELD } },
+        },
+      },
+    },
+    size: 0,
+  });
+  if (result.isErr()) {
+    logger.error(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        err: result.error,
+      },
+      "[AutomationsAnalytics] Failed to retrieve user trigger consumption."
+    );
+    return null;
+  }
+
+  const buckets = bucketsToArray<TriggerBucket>(
+    result.value.aggregations?.by_trigger?.buckets
+  );
+
+  return new Map(
+    buckets.map((bucket) => [
+      String(bucket.key),
+      {
+        runCount: Math.round(bucket[RUNS_AGG]?.value ?? 0),
+        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
+      },
+    ])
+  );
+}
+
+function matchesFilter(
+  trigger: TriggerResource,
+  {
+    searchTerm,
+    filter,
+  }: { searchTerm?: string; filter?: UserAutomationTriggersFilter }
+): boolean {
+  if (filter?.kinds?.length && !filter.kinds.includes(trigger.kind)) {
+    return false;
+  }
+  if (
+    filter?.agentIds?.length &&
+    !filter.agentIds.includes(trigger.agentConfigurationId)
+  ) {
+    return false;
+  }
+  if (searchTerm && !trigger.name.toLowerCase().includes(searchTerm)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * The caller's own automations, ranked by gross credits over the period like
+ * the workspace-wide view, with the ones that did not consume last.
+ */
+export async function fetchUserAutomationTriggers(
+  auth: Authenticator,
+  {
+    period,
+    limit,
+    offset,
+    search,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    limit: number;
+    offset: number;
+    search?: string;
+    filter?: UserAutomationTriggersFilter;
+  }
+): Promise<UserAutomationTriggers> {
+  const editorTriggers = await TriggerResource.listByUserEditor(
+    auth,
+    auth.getNonNullableUser()
+  );
+
+  const searchTerm = search?.toLowerCase();
+
+  const consumption = await fetchTriggersConsumption(auth, {
+    period,
+    triggerIds: editorTriggers.map((trigger) => trigger.sId),
+  });
+  const consumptionByTriggerId: Map<string, TriggerConsumption> =
+    consumption ?? new Map();
+
+  const ranked: RankedTriggerWithResource[] = editorTriggers
+    .filter((trigger) => matchesFilter(trigger, { searchTerm, filter }))
+    .map((trigger) => ({
+      trigger,
+      runCount: consumptionByTriggerId.get(trigger.sId)?.runCount ?? 0,
+      credits: consumptionByTriggerId.get(trigger.sId)?.credits ?? 0,
+    }))
+    .sort(
+      (a, b) =>
+        b.credits - a.credits ||
+        b.runCount - a.runCount ||
+        a.trigger.name.localeCompare(b.trigger.name)
+    );
+
+  // Triggers that never ran have nothing to compare a "how often" or "per run
+  // cost" stat against, so the baseline only looks at the ones that did.
+  const active = [...consumptionByTriggerId.values()].filter(
+    (entry) => entry.runCount > 0
+  );
+
+  const rows = await buildAutomationTriggerRows(
+    auth,
+    ranked.slice(offset, offset + limit)
+  );
+
+  return {
+    period,
+    totalCount: ranked.length,
+    triggers: rows,
+    medianRunCount: median(active.map((c) => c.runCount)),
+    medianCostPerRun: median(active.map((c) => c.credits / c.runCount)),
+    isConsumptionAvailable: consumption !== null,
+  };
+}

--- a/front/lib/api/analytics/automations/user_triggers.ts
+++ b/front/lib/api/analytics/automations/user_triggers.ts
@@ -5,108 +5,19 @@ import type {
 } from "@app/lib/api/analytics/automations/triggers";
 import {
   buildAutomationTriggerRows,
+  fetchTriggersRanking,
   median,
 } from "@app/lib/api/analytics/automations/triggers";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import {
-  buildConsumptionScopeQuery,
-  CONVERSATION_ID_FIELD,
-  CREDIT_MICRO_FIELD,
-  TRIGGER_ID_FIELD,
-} from "@app/lib/api/analytics/consumption/scope";
-import {
-  bucketsToArray,
-  searchConsumptionAnalytics,
-} from "@app/lib/api/elasticsearch";
+import { CARDINALITY_PRECISION_THRESHOLD } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator } from "@app/lib/auth";
-import { microCreditsToCredits } from "@app/lib/credits/units";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
-import logger from "@app/logger/logger";
-import type { estypes } from "@elastic/elasticsearch";
-
-const CREDIT_AGG = "credit_micro";
-const RUNS_AGG = "runs";
-
-type TriggerBucket = {
-  key: string;
-  [CREDIT_AGG]?: estypes.AggregationsSumAggregate;
-  [RUNS_AGG]?: estypes.AggregationsCardinalityAggregate;
-};
-
-type TriggerAggs = {
-  by_trigger?: estypes.AggregationsMultiBucketAggregateBase<TriggerBucket>;
-};
 
 type TriggerConsumption = { runCount: number; credits: number };
 
 export type UserAutomationTriggers = AutomationTriggers & {
-  // False when the consumption query failed: the rows are still listed, with
-  // their credits and runs left at zero.
   isConsumptionAvailable: boolean;
 };
-
-/**
- * Credits and runs over the period for a known set of triggers. Unlike the
- * workspace-wide ranking, the set comes from the database, so a trigger that
- * never ran still gets a row — with zeroes.
- */
-async function fetchTriggersConsumption(
-  auth: Authenticator,
-  { period, triggerIds }: { period: ConsumptionPeriod; triggerIds: string[] }
-): Promise<Map<string, TriggerConsumption> | null> {
-  if (triggerIds.length === 0) {
-    return new Map();
-  }
-
-  const query = buildConsumptionScopeQuery({
-    auth,
-    startDate: period.startDate,
-    endDate: period.endDate,
-    extraFilters: [{ terms: { [TRIGGER_ID_FIELD]: triggerIds } }],
-  });
-
-  const result = await searchConsumptionAnalytics<never, TriggerAggs>(query, {
-    aggregations: {
-      by_trigger: {
-        terms: {
-          field: TRIGGER_ID_FIELD,
-          size: triggerIds.length,
-          order: { [CREDIT_AGG]: "desc" },
-        },
-        aggs: {
-          [CREDIT_AGG]: { sum: { field: CREDIT_MICRO_FIELD } },
-          // One trigger run is one conversation.
-          [RUNS_AGG]: { cardinality: { field: CONVERSATION_ID_FIELD } },
-        },
-      },
-    },
-    size: 0,
-  });
-  if (result.isErr()) {
-    logger.error(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        err: result.error,
-      },
-      "[AutomationsAnalytics] Failed to retrieve user trigger consumption."
-    );
-    return null;
-  }
-
-  const buckets = bucketsToArray<TriggerBucket>(
-    result.value.aggregations?.by_trigger?.buckets
-  );
-
-  return new Map(
-    buckets.map((bucket) => [
-      String(bucket.key),
-      {
-        runCount: Math.round(bucket[RUNS_AGG]?.value ?? 0),
-        credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-      },
-    ])
-  );
-}
 
 function matchesFilter(
   trigger: TriggerResource,
@@ -157,12 +68,23 @@ export async function fetchUserAutomationTriggers(
 
   const searchTerm = search?.toLowerCase();
 
-  const consumption = await fetchTriggersConsumption(auth, {
+  const rankingResult = await fetchTriggersRanking(auth, {
     period,
-    triggerIds: editorTriggers.map((trigger) => trigger.sId),
+    limit: CARDINALITY_PRECISION_THRESHOLD,
+    offset: 0,
+    consumptionScopeFilter: { users: [auth.getNonNullableUser().sId] },
   });
   const consumptionByTriggerId: Map<string, TriggerConsumption> =
-    consumption ?? new Map();
+    rankingResult.isOk()
+      ? new Map(
+          rankingResult.value.ranking.map(
+            ({ triggerId, runCount, credits }) => [
+              triggerId,
+              { runCount, credits },
+            ]
+          )
+        )
+      : new Map();
 
   const ranked: RankedTriggerWithResource[] = editorTriggers
     .filter((trigger) => matchesFilter(trigger, { searchTerm, filter }))
@@ -180,9 +102,7 @@ export async function fetchUserAutomationTriggers(
 
   // Triggers that never ran have nothing to compare a "how often" or "per run
   // cost" stat against, so the baseline only looks at the ones that did.
-  const active = [...consumptionByTriggerId.values()].filter(
-    (entry) => entry.runCount > 0
-  );
+  const active = ranked.filter((entry) => entry.runCount > 0);
 
   const rows = await buildAutomationTriggerRows(
     auth,
@@ -193,8 +113,10 @@ export async function fetchUserAutomationTriggers(
     period,
     totalCount: ranked.length,
     triggers: rows,
-    medianRunCount: median(active.map((c) => c.runCount)),
-    medianCostPerRun: median(active.map((c) => c.credits / c.runCount)),
-    isConsumptionAvailable: consumption !== null,
+    medianRunCount: median(active.map(({ runCount }) => runCount)),
+    medianCostPerRun: median(
+      active.map(({ credits, runCount }) => credits / runCount)
+    ),
+    isConsumptionAvailable: rankingResult.isOk(),
   };
 }


### PR DESCRIPTION
## Description

A member currently has no way to see what their own automations cost: the `/automations` analytics page is manager-only. This adds `POST /api/w/:wId/me/automations/triggers` and its `trigger-breakdown` sibling, returning the same rows the admin table shows but only for the caller's triggers.
The list starts reuses the generic consumption ES, by scoping on a specific user.

Second of three, stacked on #30974. The user-menu entry that consumes this comes next.

## Tests

- `user_triggers.test.ts`: never-run triggers rank last, other members' triggers are excluded, kind and name filters apply, and a failed consumption query still returns the rows with `isConsumptionAvailable: false`.
- `me/automations/triggers.test.ts`: a plain `user` role gets a 200, period/paging/search/filter are forwarded, a negative offset is a 400.
- `me/automations/trigger-breakdown.test.ts`: 200 for the trigger's editor, 404 for a trigger another member edits, 404 for an unknown id. These use real triggers rather than mocking the authorization check, since it is the only gate on the route.

## Risk

Both routes are deliberately not role-gated, so authorization rests entirely on `listByUserEditor` for the list and `isEditedBy` for the breakdown. That is the part to review. Nothing existing changes behavior: the endpoints are new and unused until the next PR lands.

Elasticsearch failures no longer fail the request, they return the rows with credits at zero and a flag saying so. That is deliberate, so an ES incident does not take away a member's ability to see and manage their automations, but it does mean a member can see zeroes during one.

## Deploy Plan

Deploy front.