### PR TITLE
feat(agent_inactivity): preview and archive a workspace's unused agents

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/archive_inactive.test.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/archive_inactive.test.ts
@@ -1,0 +1,354 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { ONE_DAY_MS } from "@app/lib/api/assistant/inactivity/policy";
+import type { Authenticator } from "@app/lib/auth";
+import * as scheduleClient from "@app/temporal/triggers/schedule_client";
+import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MentionFactory } from "@app/tests/utils/MentionFactory";
+import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
+import {
+  ArchiveInactiveAgentsResponseBodySchema,
+  PreviewInactiveAgentsResponseBodySchema,
+} from "@app/types/api/assistant/configuration";
+import type { MembershipRoleType } from "@app/types/memberships";
+import { Ok } from "@app/types/shared/result";
+import { honoApp } from "@front-api/app";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+const THRESHOLD_DAYS = 30;
+
+/** Old enough to sit well before any cutoff a 30-day threshold can produce. */
+const LONG_AGO = new Date(Date.now() - 90 * ONE_DAY_MS);
+
+const ErrorBodySchema = z.object({
+  error: z.object({ message: z.string() }),
+});
+
+// Parsing rather than casting also asserts the response actually matches its published contract.
+async function previewBody(response: Response) {
+  return PreviewInactiveAgentsResponseBodySchema.parse(await response.json())
+    .preview;
+}
+
+async function archivalBody(response: Response) {
+  return ArchiveInactiveAgentsResponseBodySchema.parse(await response.json())
+    .archival;
+}
+
+async function errorBody(response: Response) {
+  return ErrorBodySchema.parse(await response.json()).error;
+}
+
+async function setupTest({
+  role = "admin",
+  withFeatureFlag = true,
+}: {
+  role?: MembershipRoleType;
+  withFeatureFlag?: boolean;
+} = {}) {
+  const { workspace, auth } = await createPrivateApiMockRequest({ role });
+
+  if (withFeatureFlag) {
+    await FeatureFlagFactory.basic(auth, "archive_inactive_agents");
+  }
+
+  return { workspace, auth };
+}
+
+function postPreview(wId: string, body: Record<string, unknown>) {
+  return honoApp.request(
+    `/api/w/${wId}/assistant/agent_configurations/archive_inactive/preview`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function postArchive(wId: string, body: Record<string, unknown>) {
+  return honoApp.request(
+    `/api/w/${wId}/assistant/agent_configurations/archive_inactive`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+/** Creating an enabled schedule, and archiving, both reach Temporal. */
+function mockTemporalClients() {
+  vi.spyOn(scheduleClient, "createOrUpdateAgentSchedule").mockResolvedValue(
+    new Ok("workflow-id")
+  );
+  vi.spyOn(scheduleClient, "deleteTriggerSchedule").mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.spyOn(
+    wakeUpClient,
+    "launchOrScheduleWakeUpTemporalWorkflow"
+  ).mockResolvedValue(new Ok(undefined));
+  vi.spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow").mockResolvedValue(
+    new Ok(undefined)
+  );
+}
+
+async function statusOf(auth: Authenticator, agentId: string) {
+  const agent = await getAgentConfiguration(auth, {
+    agentId,
+    variant: "light",
+  });
+
+  return agent?.status;
+}
+
+/** An agent old enough that only its mentions, triggers or status can save it. */
+async function createAgedAgent(auth: Authenticator, name: string) {
+  const agent = await AgentConfigurationFactory.createTestAgent(auth, { name });
+  await AgentConfigurationFactory.backdate(auth, agent.sId, LONG_AGO);
+
+  return agent;
+}
+
+describe("POST /api/w/:wId/assistant/agent_configurations/archive_inactive/preview", () => {
+  beforeEach(() => {
+    mockTemporalClients();
+  });
+
+  it("returns 403 for a non-admin member", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await postPreview(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 when the feature flag is off", async () => {
+    const { workspace } = await setupTest({ withFeatureFlag: false });
+
+    const response = await postPreview(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+
+    expect(response.status).toBe(403);
+    const { message } = await errorBody(response);
+    expect(message).toMatch(/archive_inactive_agents/);
+  });
+
+  it("returns 400 for a threshold below the floor", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await postPreview(workspace.sId, { thresholdDays: 1 });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("returns 400 for a threshold above the ceiling", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await postPreview(workspace.sId, { thresholdDays: 367 });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("counts what the executor would archive, and why it would spare the rest", async () => {
+    const { workspace, auth } = await setupTest();
+
+    await createAgedAgent(auth, "Idle Agent");
+
+    const recentlyUsed = await createAgedAgent(auth, "Recently Used Agent");
+    await MentionFactory.agentMentionedAt(auth, {
+      agentId: recentlyUsed.sId,
+      mentionedAt: new Date(Date.now() - ONE_DAY_MS),
+    });
+
+    const scheduled = await createAgedAgent(auth, "Scheduled Agent");
+    await TriggerFactory.schedule(auth, {
+      agentConfigurationId: scheduled.sId,
+      status: "enabled",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    // Not backdated: created now, so the age rule spares it.
+    await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Fresh Agent",
+    });
+
+    // Editing inserts a new version; what counts is when the first one appeared.
+    const edited = await createAgedAgent(auth, "Edited Agent");
+    await AgentConfigurationFactory.updateTestAgent(auth, edited.sId, {
+      name: "Edited Agent",
+      instructions: "Freshly edited, still unused.",
+    });
+
+    const response = await postPreview(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+
+    expect(response.status).toBe(200);
+    const preview = await previewBody(response);
+
+    expect(preview.eligibleCount).toBe(2);
+    // "Recently Used Agent" is not counted: the candidates query filters on the same cutoff, so a
+    // recently mentioned agent never reaches the rules to be spared by them.
+    expect(preview.skippedCountByReason).toEqual({
+      active_schedule: 1,
+      recent_creation: 1,
+    });
+  });
+
+  it("archives nothing", async () => {
+    const { workspace, auth } = await setupTest();
+    const agent = await createAgedAgent(auth, "Idle Agent");
+
+    const first = await postPreview(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+    expect((await previewBody(first)).eligibleCount).toBe(1);
+
+    // Still active, and still counted a second time: a dry run reports, it does not act.
+    const stillThere = await getAgentConfiguration(auth, {
+      agentId: agent.sId,
+      variant: "light",
+    });
+    expect(stillThere?.status).toBe("active");
+
+    const second = await postPreview(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+    expect((await previewBody(second)).eligibleCount).toBe(1);
+  });
+});
+
+describe("POST /api/w/:wId/assistant/agent_configurations/archive_inactive", () => {
+  beforeEach(() => {
+    mockTemporalClients();
+  });
+
+  it("returns 403 for a non-admin member", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await postArchive(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("returns 403 when the feature flag is off", async () => {
+    const { workspace, auth } = await setupTest({ withFeatureFlag: false });
+    const agent = await createAgedAgent(auth, "Idle Agent");
+
+    const response = await postArchive(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+
+    expect(response.status).toBe(403);
+    // The guard runs before anything is touched.
+    expect(await statusOf(auth, agent.sId)).toBe("active");
+  });
+
+  it("returns 400 for a threshold outside the bounds", async () => {
+    const { workspace } = await setupTest();
+
+    const belowFloor = await postArchive(workspace.sId, { thresholdDays: 1 });
+    expect(belowFloor.status).toBe(400);
+
+    const aboveCeiling = await postArchive(workspace.sId, {
+      thresholdDays: 367,
+    });
+    expect(aboveCeiling.status).toBe(400);
+  });
+
+  it("archives what the preview counted, and nothing else", async () => {
+    const { workspace, auth } = await setupTest();
+
+    const idle = await createAgedAgent(auth, "Idle Agent");
+
+    const recentlyUsed = await createAgedAgent(auth, "Recently Used Agent");
+    await MentionFactory.agentMentionedAt(auth, {
+      agentId: recentlyUsed.sId,
+      mentionedAt: new Date(Date.now() - ONE_DAY_MS),
+    });
+
+    const scheduled = await createAgedAgent(auth, "Scheduled Agent");
+    await TriggerFactory.schedule(auth, {
+      agentConfigurationId: scheduled.sId,
+      status: "enabled",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const fresh = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Fresh Agent",
+    });
+
+    const preview = await postPreview(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+    const previewed = await previewBody(preview);
+
+    const response = await postArchive(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+
+    expect(response.status).toBe(200);
+    const archival = await archivalBody(response);
+
+    expect(archival.archivedCount).toBe(previewed.eligibleCount);
+    expect(archival.archivedCount).toBe(1);
+    // "Recently Used Agent" is spared without being counted: the candidates query already filtered
+    // it out on the same cutoff.
+    expect(archival.skippedCountByReason).toEqual({
+      active_schedule: 1,
+      recent_creation: 1,
+    });
+
+    expect(await statusOf(auth, idle.sId)).toBe("archived");
+    expect(await statusOf(auth, recentlyUsed.sId)).toBe("active");
+    expect(await statusOf(auth, scheduled.sId)).toBe("active");
+    expect(await statusOf(auth, fresh.sId)).toBe("active");
+  });
+
+  it("archives nothing on a second call", async () => {
+    // An archived agent is no longer active, so it is not a candidate again.
+    const { workspace, auth } = await setupTest();
+    await createAgedAgent(auth, "Idle Agent");
+
+    const first = await postArchive(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+    expect((await archivalBody(first)).archivedCount).toBe(1);
+
+    const second = await postArchive(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+    const archival = await archivalBody(second);
+    expect(archival.archivedCount).toBe(0);
+    expect(archival.skippedCountByReason).toEqual({});
+  });
+
+  it("archives the whole workspace in one call", async () => {
+    const { workspace, auth } = await setupTest();
+    const agents = [];
+    for (const name of ["Idle A", "Idle B", "Idle C"]) {
+      agents.push(await createAgedAgent(auth, name));
+    }
+
+    const response = await postArchive(workspace.sId, {
+      thresholdDays: THRESHOLD_DAYS,
+    });
+
+    const archival = await archivalBody(response);
+    expect(archival.archivedCount).toBe(3);
+
+    for (const agent of agents) {
+      expect(await statusOf(auth, agent.sId)).toBe("archived");
+    }
+  });
+});

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/archive_inactive.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/archive_inactive.ts
@@ -1,0 +1,118 @@
+import { archiveInactiveWorkspaceAgents } from "@app/lib/api/assistant/inactivity/archive_inactive_agents";
+import { countSkipsByReason } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import type { AgentInactivityPolicyError } from "@app/lib/api/assistant/inactivity/policy";
+import {
+  MAX_INACTIVITY_THRESHOLD_DAYS,
+  MIN_INACTIVITY_THRESHOLD_DAYS,
+} from "@app/lib/api/assistant/inactivity/policy";
+import { previewInactiveAgents } from "@app/lib/api/assistant/inactivity/preview_inactive_agents";
+import type {
+  ArchiveInactiveAgentsResponseBody,
+  PreviewInactiveAgentsResponseBody,
+} from "@app/types/api/assistant/configuration";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import { z } from "zod";
+
+const PreviewBodySchema = z.object({
+  thresholdDays: z
+    .number()
+    .int()
+    .min(MIN_INACTIVITY_THRESHOLD_DAYS)
+    .max(MAX_INACTIVITY_THRESHOLD_DAYS),
+});
+
+// Archival takes the whole workspace, so it asks for nothing the preview does not.
+const ArchiveBodySchema = PreviewBodySchema;
+
+function policyErrorToApiError(error: AgentInactivityPolicyError) {
+  switch (error.type) {
+    case "invalid_threshold":
+      return {
+        status_code: 400 as const,
+        api_error: {
+          type: "invalid_request_error" as const,
+          message: error.message,
+        },
+      };
+    default:
+      assertNever(error.type);
+  }
+}
+
+// Mounted at /api/w/:wId/assistant/agent_configurations/archive_inactive.
+const app = workspaceApp();
+
+/** @ignoreswagger */
+app.post(
+  "/preview",
+  ensureIsAdmin(),
+  withFeatureFlag("archive_inactive_agents"),
+  validate("json", PreviewBodySchema),
+  async (ctx): HandlerResult<PreviewInactiveAgentsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const { thresholdDays } = ctx.req.valid("json");
+
+    const previewRes = await previewInactiveAgents(auth, {
+      thresholdDays,
+      evaluatedAt: new Date(),
+    });
+    if (previewRes.isErr()) {
+      return apiError(ctx, policyErrorToApiError(previewRes.error));
+    }
+
+    const { evaluatedAt, cutoffAt, eligibleAgentIds, skipped } =
+      previewRes.value;
+
+    return ctx.json({
+      preview: {
+        evaluatedAt: evaluatedAt.toISOString(),
+        cutoffAt: cutoffAt.toISOString(),
+        thresholdDays,
+        eligibleCount: eligibleAgentIds.length,
+        skippedCountByReason: countSkipsByReason(skipped),
+      },
+    });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  ensureIsAdmin(),
+  withFeatureFlag("archive_inactive_agents"),
+  validate("json", ArchiveBodySchema),
+  async (ctx): HandlerResult<ArchiveInactiveAgentsResponseBody> => {
+    const auth = ctx.get("auth");
+
+    const { thresholdDays } = ctx.req.valid("json");
+
+    const archivalRes = await archiveInactiveWorkspaceAgents(auth, {
+      thresholdDays,
+      evaluatedAt: new Date(),
+    });
+    if (archivalRes.isErr()) {
+      return apiError(ctx, policyErrorToApiError(archivalRes.error));
+    }
+
+    const { evaluatedAt, cutoffAt, archivedAgentIds, skipped } =
+      archivalRes.value;
+
+    return ctx.json({
+      archival: {
+        evaluatedAt: evaluatedAt.toISOString(),
+        cutoffAt: cutoffAt.toISOString(),
+        thresholdDays,
+        archivedCount: archivedAgentIds.length,
+        skippedCountByReason: countSkipsByReason(skipped),
+      },
+    });
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/index.ts
@@ -22,6 +22,7 @@ import keyBy from "lodash/keyBy";
 import omit from "lodash/omit";
 
 import agent from "./[aId]";
+import archiveInactive from "./archive_inactive";
 import batchUpdateModel from "./batch_update_model";
 import batchUpdateScope from "./batch_update_scope";
 import batchUpdateTags from "./batch_update_tags";
@@ -341,6 +342,7 @@ app.post(
 
 // Register static paths BEFORE `/:aId` so the param route does not swallow
 // these names as agent ids.
+app.route("/archive_inactive", archiveInactive);
 app.route("/batch_update_model", batchUpdateModel);
 app.route("/batch_update_scope", batchUpdateScope);
 app.route("/batch_update_tags", batchUpdateTags);

--- a/front-api/routes/w/[wId]/index.test.ts
+++ b/front-api/routes/w/[wId]/index.test.ts
@@ -237,3 +237,84 @@ describe("POST /api/w/:wId (workspace analytics opt-out)", () => {
     }
   });
 });
+
+describe("POST /api/w/:wId (inactive agent archival)", () => {
+  it("stores the threshold in workspace metadata", async () => {
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "archive_inactive_agents");
+
+    const response = await post(workspace, {
+      inactiveAgentArchivalThresholdDays: 90,
+    });
+
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(updated?.metadata?.inactiveAgentArchivalThresholdDays).toBe(90);
+  });
+
+  it("clears the threshold and preserves other metadata when passed null", async () => {
+    // Clearing it is how a workspace turns automatic archival off: the policy has no default, so an
+    // absent threshold means nothing is ever archived.
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "archive_inactive_agents");
+
+    await post(workspace, { reinforcementCapAwuCredits: 5_000 });
+    await post(workspace, { inactiveAgentArchivalThresholdDays: 90 });
+
+    const response = await post(workspace, {
+      inactiveAgentArchivalThresholdDays: null,
+    });
+    expect(response.status).toBe(200);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(
+      updated?.metadata?.inactiveAgentArchivalThresholdDays
+    ).toBeUndefined();
+    expect(updated?.metadata?.reinforcementCapAwuCredits).toBe(5_000);
+  });
+
+  it("returns 403 when the feature flag is off", async () => {
+    const { workspace } = await setup();
+
+    const response = await post(workspace, {
+      inactiveAgentArchivalThresholdDays: 90,
+    });
+
+    expect(response.status).toBe(403);
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(
+      updated?.metadata?.inactiveAgentArchivalThresholdDays
+    ).toBeUndefined();
+  });
+
+  it("returns 403 for a non-admin member", async () => {
+    const { workspace, auth } = await setup("user");
+    await FeatureFlagFactory.basic(auth, "archive_inactive_agents");
+
+    const response = await post(workspace, {
+      inactiveAgentArchivalThresholdDays: 90,
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects a threshold outside the allowed bounds", async () => {
+    const { workspace, auth } = await setup();
+    await FeatureFlagFactory.basic(auth, "archive_inactive_agents");
+
+    for (const thresholdDays of [1, 367, 30.5]) {
+      const response = await post(workspace, {
+        inactiveAgentArchivalThresholdDays: thresholdDays,
+      });
+
+      expect(response.status).toBe(400);
+    }
+
+    const updated = await WorkspaceResource.fetchById(workspace.sId);
+    expect(
+      updated?.metadata?.inactiveAgentArchivalThresholdDays
+    ).toBeUndefined();
+  });
+});

--- a/front-api/routes/w/[wId]/index.ts
+++ b/front-api/routes/w/[wId]/index.ts
@@ -1,4 +1,8 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import {
+  MAX_INACTIVITY_THRESHOLD_DAYS,
+  MIN_INACTIVITY_THRESHOLD_DAYS,
+} from "@app/lib/api/assistant/inactivity/policy";
 import { listActiveAgentsUsingNonRegionalModels } from "@app/lib/api/assistant/workspace_capabilities";
 import {
   buildAuditActor,
@@ -210,7 +214,18 @@ const WorkspaceDefaultAgentUpdateBodySchema = z.object({
   workspaceDefaultAgentId: z.string().nullable(),
 });
 
+const WorkspaceInactiveAgentArchivalUpdateBodySchema = z.object({
+  // Null turns automatic archival off: the policy is opt-in and has no default threshold.
+  inactiveAgentArchivalThresholdDays: z
+    .number()
+    .int()
+    .min(MIN_INACTIVITY_THRESHOLD_DAYS)
+    .max(MAX_INACTIVITY_THRESHOLD_DAYS)
+    .nullable(),
+});
+
 const PostWorkspaceRequestBodySchema = z.union([
+  WorkspaceInactiveAgentArchivalUpdateBodySchema,
   WorkspaceNameUpdateBodySchema,
   WorkspaceRegionalModelsOnlyUpdateBodySchema,
   WorkspaceProvidersUpdateBodySchema,
@@ -875,6 +890,44 @@ app.post(
         context: getAuditLogContext(auth),
         metadata: {
           enabled: String(!body.disableWorkspaceAnalytics),
+        },
+      });
+    } else if ("inactiveAgentArchivalThresholdDays" in body) {
+      if (!(await hasFeatureFlag(auth, "archive_inactive_agents"))) {
+        return apiError(ctx, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "The archive_inactive_agents feature is not enabled.",
+          },
+        });
+      }
+
+      // Null clears it, which is how the workspace turns automatic archival off.
+      const inactiveAgentArchivalThresholdDays =
+        body.inactiveAgentArchivalThresholdDays ?? undefined;
+      const updateRes = await updateWorkspaceMetadata(owner, {
+        inactiveAgentArchivalThresholdDays,
+      });
+      if (updateRes.isErr()) {
+        return apiError(ctx, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: updateRes.error.message,
+          },
+        });
+      }
+
+      void emitAuditLogEvent({
+        auth,
+        action: "workspace.inactive_agent_archival_updated",
+        targets: [buildAuditLogTarget("workspace", owner)],
+        context: getAuditLogContext(auth),
+        metadata: {
+          threshold_days: inactiveAgentArchivalThresholdDays
+            ? String(inactiveAgentArchivalThresholdDays)
+            : "disabled",
         },
       });
     } else if ("workspaceDefaultAgentId" in body) {

--- a/front/admin/audit_log_schemas/workspace.inactive_agent_archival_updated.json
+++ b/front/admin/audit_log_schemas/workspace.inactive_agent_archival_updated.json
@@ -1,0 +1,7 @@
+{
+  "action": "workspace.inactive_agent_archival_updated",
+  "targets": [{ "type": "workspace" }],
+  "metadata": {
+    "threshold_days": "string"
+  }
+}

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.test.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.test.ts
@@ -1,5 +1,6 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { archiveInactiveWorkspaceAgents } from "@app/lib/api/assistant/inactivity/archive_inactive_agents";
+import { ONE_DAY_MS } from "@app/lib/api/assistant/inactivity/policy";
 import type { Authenticator } from "@app/lib/auth";
 import * as scheduleClient from "@app/temporal/triggers/schedule_client";
 import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
@@ -9,8 +10,6 @@ import { MentionFactory } from "@app/tests/utils/MentionFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 const THRESHOLD_DAYS = 30;
 
@@ -36,11 +35,7 @@ function mockTemporalClients() {
 
 async function createUnusedAgent(auth: Authenticator, name: string) {
   const agent = await AgentConfigurationFactory.createTestAgent(auth, { name });
-  await AgentConfigurationFactory.setCreatedAtForTest(
-    auth,
-    agent.sId,
-    LONG_AGO
-  );
+  await AgentConfigurationFactory.backdate(auth, agent.sId, LONG_AGO);
 
   return agent;
 }
@@ -66,7 +61,6 @@ describe("archiveInactiveWorkspaceAgents", () => {
     const res = await archiveInactiveWorkspaceAgents(authenticator, {
       thresholdDays: THRESHOLD_DAYS,
       evaluatedAt: new Date(),
-      page: { cursor: null, limit: 50 },
     });
 
     expect(res.isOk()).toBe(true);
@@ -83,7 +77,6 @@ describe("archiveInactiveWorkspaceAgents", () => {
     const input = {
       thresholdDays: THRESHOLD_DAYS,
       evaluatedAt: new Date(),
-      page: { cursor: null, limit: 50 },
     };
 
     const first = await archiveInactiveWorkspaceAgents(authenticator, input);
@@ -106,7 +99,6 @@ describe("archiveInactiveWorkspaceAgents", () => {
     const res = await archiveInactiveWorkspaceAgents(authenticator, {
       thresholdDays: THRESHOLD_DAYS,
       evaluatedAt: new Date(),
-      page: { cursor: null, limit: 50 },
     });
 
     expect(res.isOk() && res.value.archivedAgentIds).toEqual([]);
@@ -127,7 +119,6 @@ describe("archiveInactiveWorkspaceAgents", () => {
     const res = await archiveInactiveWorkspaceAgents(authenticator, {
       thresholdDays: THRESHOLD_DAYS,
       evaluatedAt: new Date(),
-      page: { cursor: null, limit: 50 },
     });
 
     expect(res.isOk() && res.value.archivedAgentIds).toEqual([]);
@@ -141,7 +132,6 @@ describe("archiveInactiveWorkspaceAgents", () => {
     const res = await archiveInactiveWorkspaceAgents(authenticator, {
       thresholdDays: 1,
       evaluatedAt: new Date(),
-      page: { cursor: null, limit: 50 },
     });
 
     expect(res.isErr()).toBe(true);
@@ -149,71 +139,37 @@ describe("archiveInactiveWorkspaceAgents", () => {
     expect(await statusOf(authenticator, agent.sId)).toBe("active");
   });
 
-  it("advances past agents it cannot archive, so a driver terminates", async () => {
-    // Agents the rules always refuse stay candidates forever, so a cursor that did not advance
-    // would hand back the same page for eternity.
+  it("archives every eligible agent of the workspace in one call", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
-    for (const name of ["Scheduled one", "Scheduled two"]) {
-      const agent = await createUnusedAgent(authenticator, name);
-      await TriggerFactory.schedule(authenticator, {
-        agentConfigurationId: agent.sId,
-        status: "enabled",
-        configuration: { cron: "0 9 * * *", timezone: "UTC" },
-      });
+    await createUnusedAgent(authenticator, "Idle one");
+    await createUnusedAgent(authenticator, "Idle two");
+
+    const scheduled = await createUnusedAgent(authenticator, "Scheduled");
+    await TriggerFactory.schedule(authenticator, {
+      agentConfigurationId: scheduled.sId,
+      status: "enabled",
+      configuration: { cron: "0 9 * * *", timezone: "UTC" },
+    });
+
+    const res = await archiveInactiveWorkspaceAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+    });
+    if (res.isErr()) {
+      throw res.error;
     }
 
-    const skippedAgentIds: string[] = [];
-    let cursor: string | null = null;
-    let pages = 0;
+    expect(res.value.archivedAgentIds).toHaveLength(2);
+    expect(res.value.skipped).toEqual([
+      { agentId: scheduled.sId, reason: "active_schedule" },
+    ]);
 
-    do {
-      const res = await archiveInactiveWorkspaceAgents(authenticator, {
-        thresholdDays: THRESHOLD_DAYS,
-        evaluatedAt: new Date(),
-        // One at a time, so the failure cannot hide behind a page big enough to hold everything.
-        page: { cursor, limit: 1 },
-      });
-      if (res.isErr()) {
-        throw res.error;
-      }
-
-      expect(res.value.archivedAgentIds).toEqual([]);
-      skippedAgentIds.push(...res.value.skipped.map(({ agentId }) => agentId));
-      cursor = res.value.nextCursor;
-      pages += 1;
-    } while (cursor !== null && pages < 5);
-
-    expect(cursor).toBeNull();
-    expect(new Set(skippedAgentIds).size).toBe(2);
-    expect(skippedAgentIds).toHaveLength(2);
-  });
-
-  it("reports a cursor so the caller can drive the next page", async () => {
-    const { authenticator } = await createResourceTest({ role: "admin" });
-    await createUnusedAgent(authenticator, "Page one");
-    await createUnusedAgent(authenticator, "Page two");
-
-    const firstPage = await archiveInactiveWorkspaceAgents(authenticator, {
+    // A second call has nothing left: the archived ones are no longer candidates.
+    const again = await archiveInactiveWorkspaceAgents(authenticator, {
       thresholdDays: THRESHOLD_DAYS,
       evaluatedAt: new Date(),
-      page: { cursor: null, limit: 1 },
     });
 
-    expect(firstPage.isOk() && firstPage.value.archivedAgentIds).toHaveLength(
-      1
-    );
-    const nextCursor = firstPage.isOk() ? firstPage.value.nextCursor : null;
-    expect(nextCursor).not.toBeNull();
-
-    const secondPage = await archiveInactiveWorkspaceAgents(authenticator, {
-      thresholdDays: THRESHOLD_DAYS,
-      evaluatedAt: new Date(),
-      page: { cursor: nextCursor, limit: 1 },
-    });
-
-    expect(secondPage.isOk() && secondPage.value.archivedAgentIds).toHaveLength(
-      1
-    );
-    expect(secondPage.isOk() && secondPage.value.nextCursor).toBeNull();
+    expect(again.isOk() && again.value.archivedAgentIds).toEqual([]);
   });
 });

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
@@ -1,22 +1,13 @@
+import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { AgentArchivalSkip } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
 import {
-  archiveAgentConfiguration,
-  getAgentConfigurations,
-} from "@app/lib/api/assistant/configuration/agent";
-import type { AgentPageBound } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
-import { fetchInactiveAgents } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
-import type {
-  AgentArchivalExclusionReason,
-  AgentInactivityPolicyError,
-  AgentTriggerSnapshot,
-} from "@app/lib/api/assistant/inactivity/policy";
-import {
-  computeInactivityCutoffAt,
-  evaluateAgentArchivalEligibility,
-} from "@app/lib/api/assistant/inactivity/policy";
+  countSkipsByReason,
+  fetchArchivableAgents,
+} from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import type { AgentInactivityPolicyError } from "@app/lib/api/assistant/inactivity/policy";
+import { computeInactivityCutoffAt } from "@app/lib/api/assistant/inactivity/policy";
 import type { Authenticator } from "@app/lib/auth";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import logger from "@app/logger/logger";
-import type { AgentConfigurationStatus } from "@app/types/assistant/agent";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -26,24 +17,9 @@ import { Err, Ok } from "@app/types/shared/result";
  * every read is permission-filtered.
  */
 
-/** The rules' exclusions, plus the two outcomes only the mutation path can produce. */
-export type AgentArchivalSkipReason =
-  | AgentArchivalExclusionReason
-  // Gone, or not visible to this actor, since the fetch.
-  | "agent_not_found"
-  // The update matched no row: someone else archived it first.
-  | "archive_raced";
-
-export interface AgentArchivalSkip {
-  agentId: string;
-  reason: AgentArchivalSkipReason;
-}
-
 export interface InactiveAgentsArchivalInput {
   thresholdDays: number;
   evaluatedAt: Date;
-  // Which slice to walk, not what to decide: the caller owns the loop.
-  page: AgentPageBound;
 }
 
 export interface InactiveAgentsArchival {
@@ -51,8 +27,6 @@ export interface InactiveAgentsArchival {
   cutoffAt: Date;
   archivedAgentIds: string[];
   skipped: AgentArchivalSkip[];
-  // Paging, not outcome: null once the workspace is exhausted.
-  nextCursor: string | null;
 }
 
 export type InactiveAgentsArchivalResult = Result<
@@ -60,61 +34,10 @@ export type InactiveAgentsArchivalResult = Result<
   AgentInactivityPolicyError
 >;
 
-/** The facts the rules read about an agent, as they stand at the moment the page is judged. */
-interface AgentArchivalFacts {
-  status: AgentConfigurationStatus;
-  triggers: AgentTriggerSnapshot[];
-}
-
-type SkipCountsByReason = Partial<Record<AgentArchivalSkipReason, number>>;
-
-function countSkipsByReason(skipped: AgentArchivalSkip[]): SkipCountsByReason {
-  const counts: SkipCountsByReason = {};
-  for (const { reason } of skipped) {
-    counts[reason] = (counts[reason] ?? 0) + 1;
-  }
-
-  return counts;
-}
-
-/** A missing agent is one this actor cannot read. */
-async function fetchArchivalFacts(
-  auth: Authenticator,
-  agentIds: string[]
-): Promise<Map<string, AgentArchivalFacts>> {
-  if (agentIds.length === 0) {
-    return new Map();
-  }
-
-  const configurations = await getAgentConfigurations(auth, {
-    agentIds,
-    variant: "light",
-  });
-
-  const triggers = await TriggerResource.listByAgentConfigurationIds(
-    auth,
-    agentIds
-  );
-
-  const triggersByAgentId = new Map<string, AgentTriggerSnapshot[]>();
-  for (const { agentConfigurationId, kind, status } of triggers) {
-    const agentTriggers = triggersByAgentId.get(agentConfigurationId) ?? [];
-    agentTriggers.push({ kind, status });
-    triggersByAgentId.set(agentConfigurationId, agentTriggers);
-  }
-
-  return new Map(
-    configurations.map(({ sId, status }) => [
-      sId,
-      { status, triggers: triggersByAgentId.get(sId) ?? [] },
-    ])
-  );
-}
-
 /** Safe to call twice: a retry re-runs the fetch, and an archived agent is no longer a candidate. */
 export async function archiveInactiveWorkspaceAgents(
   auth: Authenticator,
-  { thresholdDays, evaluatedAt, page }: InactiveAgentsArchivalInput
+  { thresholdDays, evaluatedAt }: InactiveAgentsArchivalInput
 ): Promise<InactiveAgentsArchivalResult> {
   const workspace = auth.getNonNullableWorkspace();
 
@@ -132,40 +55,15 @@ export async function archiveInactiveWorkspaceAgents(
   }
   const cutoffAt = cutoffRes.value;
 
-  const { agents, nextCursor } = await fetchInactiveAgents(auth, {
+  const { eligible, skipped: refused } = await fetchArchivableAgents(auth, {
     cutoffAt,
-    page,
   });
 
-  const factsByAgentId = await fetchArchivalFacts(
-    auth,
-    agents.map(({ agentId }) => agentId)
-  );
-
   const archivedAgentIds: string[] = [];
-  // Counted in the run summary, not logged per agent: skips are the common case.
-  const skipped: AgentArchivalSkip[] = [];
+  const skipped = [...refused];
 
-  for (const agent of agents) {
-    const { agentId } = agent;
-
-    const facts = factsByAgentId.get(agentId);
-    if (!facts) {
-      skipped.push({ agentId, reason: "agent_not_found" });
-      continue;
-    }
-
-    const eligibility = evaluateAgentArchivalEligibility({
-      agent: { ...agent, ...facts },
-      cutoffAt,
-    });
-
-    if (!eligibility.eligible) {
-      skipped.push({ agentId, reason: eligibility.reason });
-      continue;
-    }
-
-    // Not a compare-and-set: an agent restored since the re-read is archived anyway. Reversible.
+  for (const { agentId, lastMentionedAt } of eligible) {
+    // Not a compare-and-set: an agent restored since the read is archived anyway. Reversible.
     const archived = await archiveAgentConfiguration(auth, agentId);
     if (!archived) {
       skipped.push({ agentId, reason: "archive_raced" });
@@ -177,7 +75,7 @@ export async function archiveInactiveWorkspaceAgents(
       {
         workspaceId: workspace.sId,
         agentId,
-        lastMentionedAt: agent.lastMentionedAt,
+        lastMentionedAt,
         cutoffAt,
         thresholdDays,
       },
@@ -194,7 +92,6 @@ export async function archiveInactiveWorkspaceAgents(
       archivedCount: archivedAgentIds.length,
       skippedCount: skipped.length,
       skippedCountByReason: countSkipsByReason(skipped),
-      hasMore: nextCursor !== null,
     },
     "Finished archiving inactive agents"
   );
@@ -204,6 +101,5 @@ export async function archiveInactiveWorkspaceAgents(
     cutoffAt,
     archivedAgentIds,
     skipped,
-    nextCursor,
   });
 }

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.test.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.test.ts
@@ -1,11 +1,10 @@
-import { fetchInactiveAgents } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import { fetchArchivableAgents } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import { ONE_DAY_MS } from "@app/lib/api/assistant/inactivity/policy";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MentionFactory } from "@app/tests/utils/MentionFactory";
 import { describe, expect, it } from "vitest";
-
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 const CUTOFF_AT = new Date("2026-07-19T00:00:00.000Z");
 
@@ -23,16 +22,12 @@ async function createAgedAgent(
   { name, createdAt }: { name: string; createdAt: Date }
 ) {
   const agent = await AgentConfigurationFactory.createTestAgent(auth, { name });
-  await AgentConfigurationFactory.setCreatedAtForTest(
-    auth,
-    agent.sId,
-    createdAt
-  );
+  await AgentConfigurationFactory.backdate(auth, agent.sId, createdAt);
 
   return agent;
 }
 
-describe("fetchInactiveAgents", () => {
+describe("fetchArchivableAgents", () => {
   it("returns an agent that has never been mentioned", async () => {
     const { authenticator } = await createResourceTest({ role: "admin" });
     const agent = await createAgedAgent(authenticator, {
@@ -40,17 +35,16 @@ describe("fetchInactiveAgents", () => {
       createdAt: daysBeforeCutoff(10),
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents).toHaveLength(1);
-    expect(page.agents[0]).toMatchObject({
+    expect(page.eligible).toHaveLength(1);
+    expect(page.eligible[0]).toMatchObject({
       agentId: agent.sId,
       lastMentionedAt: null,
     });
-    expect(page.nextCursor).toBeNull();
+    expect(page.skipped).toEqual([]);
   });
 
   it("returns an agent whose last mention predates the cutoff", async () => {
@@ -65,13 +59,12 @@ describe("fetchInactiveAgents", () => {
       mentionedAt,
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents).toHaveLength(1);
-    expect(page.agents[0]).toMatchObject({
+    expect(page.eligible).toHaveLength(1);
+    expect(page.eligible[0]).toMatchObject({
       agentId: agent.sId,
       lastMentionedAt: mentionedAt,
     });
@@ -88,12 +81,13 @@ describe("fetchInactiveAgents", () => {
       mentionedAt: daysAfterCutoff(1),
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents).toEqual([]);
+    // Filtered by the mentions query, so it is never a candidate the rules have to refuse.
+    expect(page.eligible).toEqual([]);
+    expect(page.skipped).toEqual([]);
   });
 
   it("takes the newest mention, not just any", async () => {
@@ -111,12 +105,11 @@ describe("fetchInactiveAgents", () => {
       mentionedAt: daysAfterCutoff(2),
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents).toEqual([]);
+    expect(page.eligible).toEqual([]);
   });
 
   it("counts a rejected mention as activity", async () => {
@@ -132,12 +125,11 @@ describe("fetchInactiveAgents", () => {
       status: "rejected",
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents).toEqual([]);
+    expect(page.eligible).toEqual([]);
   });
 
   it("still returns an agent that was edited recently", async () => {
@@ -152,85 +144,31 @@ describe("fetchInactiveAgents", () => {
       instructions: "Freshly edited, still unused.",
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents).toHaveLength(1);
-    expect(page.agents[0]).toMatchObject({ agentId: agent.sId });
+    expect(page.eligible).toHaveLength(1);
+    expect(page.eligible[0]).toMatchObject({ agentId: agent.sId });
   });
 
   it("excludes an agent created after the cutoff, however unused", async () => {
     // Archiving an agent the night it was built is the bug this guards.
     const { authenticator } = await createResourceTest({ role: "admin" });
-    await createAgedAgent(authenticator, {
+    const agent = await createAgedAgent(authenticator, {
       name: "Brand new",
       createdAt: daysAfterCutoff(1),
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents).toEqual([]);
-  });
-
-  it("paginates with a keyset cursor over the candidates", async () => {
-    const { authenticator } = await createResourceTest({ role: "admin" });
-    for (const name of ["Agent A", "Agent B", "Agent C"]) {
-      await createAgedAgent(authenticator, {
-        name,
-        createdAt: daysBeforeCutoff(10),
-      });
-    }
-
-    const firstPage = await fetchInactiveAgents(authenticator, {
-      cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 2 },
-    });
-    expect(firstPage.agents).toHaveLength(2);
-    expect(firstPage.nextCursor).toBe(firstPage.agents[1].agentId);
-
-    const secondPage = await fetchInactiveAgents(authenticator, {
-      cutoffAt: CUTOFF_AT,
-      page: { cursor: firstPage.nextCursor, limit: 2 },
-    });
-    expect(secondPage.agents).toHaveLength(1);
-    expect(secondPage.nextCursor).toBeNull();
-
-    const firstPageIds = firstPage.agents.map(({ agentId }) => agentId);
-    const secondPageIds = secondPage.agents.map(({ agentId }) => agentId);
-
-    expect(secondPageIds).not.toContain(firstPage.nextCursor);
-    expect(
-      secondPageIds.every((agentId) => !firstPageIds.includes(agentId))
-    ).toBe(true);
-    expect(new Set([...firstPageIds, ...secondPageIds]).size).toBe(3);
-
-    // Ordered by agent id, which is what makes the keyset cursor stable.
-    expect([...firstPageIds].sort()).toEqual(firstPageIds);
-    expect(
-      secondPageIds.every((agentId) => agentId > firstPage.nextCursor!)
-    ).toBe(true);
-  });
-
-  it("returns an empty page for a limit of zero", async () => {
-    // The lookahead finds a candidate, so a cursor read off the empty page has no element to read.
-    const { authenticator } = await createResourceTest({ role: "admin" });
-    await createAgedAgent(authenticator, {
-      name: "Out of budget",
-      createdAt: daysBeforeCutoff(10),
-    });
-
-    const page = await fetchInactiveAgents(authenticator, {
-      cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 0 },
-    });
-
-    expect(page.agents).toEqual([]);
-    expect(page.nextCursor).toBeNull();
+    // Unmentioned, so the query does return it; the rules are what refuse it.
+    expect(page.eligible).toEqual([]);
+    expect(page.skipped).toEqual([
+      { agentId: agent.sId, reason: "recent_creation" },
+    ]);
   });
 
   it("never returns a global agent, whatever its mentions", async () => {
@@ -245,12 +183,11 @@ describe("fetchInactiveAgents", () => {
       mentionedAt: daysBeforeCutoff(90),
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents.map(({ agentId }) => agentId)).toEqual([agent.sId]);
+    expect(page.eligible.map(({ agentId }) => agentId)).toEqual([agent.sId]);
   });
 
   it("does not return another workspace's agents", async () => {
@@ -261,11 +198,10 @@ describe("fetchInactiveAgents", () => {
       createdAt: daysBeforeCutoff(10),
     });
 
-    const page = await fetchInactiveAgents(authenticator, {
+    const page = await fetchArchivableAgents(authenticator, {
       cutoffAt: CUTOFF_AT,
-      page: { cursor: null, limit: 50 },
     });
 
-    expect(page.agents).toEqual([]);
+    expect(page.eligible).toEqual([]);
   });
 });

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
@@ -1,74 +1,152 @@
-import { fetchFirstVersionCreatedAtByAgentId } from "@app/lib/api/assistant/configuration/agent";
-import type { AgentInactivitySnapshot } from "@app/lib/api/assistant/inactivity/policy";
+import {
+  fetchFirstVersionCreatedAtByAgentId,
+  getAgentConfigurations,
+} from "@app/lib/api/assistant/configuration/agent";
+import type {
+  AgentArchivalExclusionReason,
+  AgentInactivitySnapshot,
+  AgentTriggerSnapshot,
+} from "@app/lib/api/assistant/inactivity/policy";
+import { evaluateAgentArchivalEligibility } from "@app/lib/api/assistant/inactivity/policy";
 import type { Authenticator } from "@app/lib/auth";
 import { MentionResource } from "@app/lib/resources/mention_resource";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import type { AgentConfigurationStatus } from "@app/types/assistant/agent";
 
 /**
- * Loads one page of a workspace's agents that have not been mentioned since the cutoff. One row
- * beyond `limit` is read and dropped, so `nextCursor` is non-null only when another candidate
- * exists rather than whenever a page happens to be full.
+ * Loads one page of a workspace's agents that the rules clear for archival.
  *
- * Status and triggers deliberately do not come from here — `fetchArchivalFacts` in the caller is
- * the permission-filtered read and the authority on those.
+ * The candidates come from the mentions query, the rules from `policy.ts`; this is where the two
+ * meet. Every read is permission-filtered, so two actors can legitimately get different answers for
+ * the same workspace.
+ *
+ * A workspace is the unit of work: the nightly run starts one activity per workspace, so there is
+ * nothing to page through here. Splitting the agents into batches would re-run the mentions query
+ * once per batch, and the cursor would have to survive between them, for no gain.
  */
 
-/** The part of a snapshot this provides; derived so the two cannot drift. */
-export type InactiveAgentCandidate = Pick<
+/** One logical agent the rules cleared. */
+export type ArchivableAgent = Pick<
   AgentInactivitySnapshot,
   "agentId" | "createdAt" | "lastMentionedAt"
 >;
 
-/**
- * Infrastructure, not policy: it is here so a Temporal workflow can walk a large workspace one
- * durable step at a time.
- */
-export interface AgentPageBound {
-  // Last agent id of the previous page, or null to start from the beginning.
-  cursor: string | null;
-  limit: number;
+/** The rules' exclusions, plus the two outcomes only a caller reading or mutating can produce. */
+export type AgentArchivalSkipReason =
+  | AgentArchivalExclusionReason
+  // Gone, or not visible to this actor, since the mentions read.
+  | "agent_not_found"
+  // The update matched no row: someone else archived it first. Only the executor emits this.
+  | "archive_raced";
+
+export interface AgentArchivalSkip {
+  agentId: string;
+  reason: AgentArchivalSkipReason;
 }
 
-export interface InactiveAgentsFetchInput {
+export interface ArchivableAgentsFetchInput {
   cutoffAt: Date;
-  page: AgentPageBound;
 }
 
-export interface InactiveAgentsPage {
-  agents: InactiveAgentCandidate[];
-  // Null once the workspace is exhausted.
-  nextCursor: string | null;
+export interface ArchivableAgents {
+  eligible: ArchivableAgent[];
+  skipped: AgentArchivalSkip[];
 }
 
-export async function fetchInactiveAgents(
+type SkipCountsByReason = Partial<Record<AgentArchivalSkipReason, number>>;
+
+export function countSkipsByReason(
+  skipped: AgentArchivalSkip[]
+): SkipCountsByReason {
+  const counts: SkipCountsByReason = {};
+  for (const { reason } of skipped) {
+    counts[reason] = (counts[reason] ?? 0) + 1;
+  }
+
+  return counts;
+}
+
+/** The facts the rules read about an agent, as they stand when the page is evaluated. */
+interface AgentArchivalFacts {
+  status: AgentConfigurationStatus;
+  triggers: AgentTriggerSnapshot[];
+}
+
+/** A missing agent is one this actor cannot read. */
+async function fetchArchivalFacts(
   auth: Authenticator,
-  { cutoffAt, page }: InactiveAgentsFetchInput
-): Promise<InactiveAgentsPage> {
+  agentIds: string[]
+): Promise<Map<string, AgentArchivalFacts>> {
+  if (agentIds.length === 0) {
+    return new Map();
+  }
+
+  const configurations = await getAgentConfigurations(auth, {
+    agentIds,
+    variant: "light",
+  });
+
+  const triggers = await TriggerResource.listByAgentConfigurationIds(
+    auth,
+    agentIds
+  );
+
+  const triggersByAgentId = new Map<string, AgentTriggerSnapshot[]>();
+  for (const { agentConfigurationId, kind, status } of triggers) {
+    const agentTriggers = triggersByAgentId.get(agentConfigurationId) ?? [];
+    agentTriggers.push({ kind, status });
+    triggersByAgentId.set(agentConfigurationId, agentTriggers);
+  }
+
+  return new Map(
+    configurations.map(({ sId, status }) => [
+      sId,
+      { status, triggers: triggersByAgentId.get(sId) ?? [] },
+    ])
+  );
+}
+
+export async function fetchArchivableAgents(
+  auth: Authenticator,
+  { cutoffAt }: ArchivableAgentsFetchInput
+): Promise<ArchivableAgents> {
   const idleAgents = await MentionResource.listAgentsNotMentionedSince(auth, {
     notMentionedSince: cutoffAt,
   });
 
-  // The cursor steps past agents the rules keep refusing, so a driver terminates.
-  const { cursor, limit } = page;
-  const fromCursor = cursor
-    ? idleAgents.filter(({ agentId }) => agentId > cursor)
-    : idleAgents;
-
-  const hasMore = fromCursor.length > limit;
-  const pageAgents = fromCursor.slice(0, limit);
-
+  const agentIds = idleAgents.map(({ agentId }) => agentId);
   const createdAtByAgentId = await fetchFirstVersionCreatedAtByAgentId(
     auth,
-    pageAgents.map(({ agentId }) => agentId)
+    agentIds
   );
+  const factsByAgentId = await fetchArchivalFacts(auth, agentIds);
 
-  // No first-version date: skip, rather than archive on a date we could not establish.
-  const agents = pageAgents.flatMap(({ agentId, lastMentionedAt }) => {
+  const eligible: ArchivableAgent[] = [];
+  // Skips are the common case, so callers count them in the run summary rather than log each one.
+  const skipped: AgentArchivalSkip[] = [];
+
+  for (const { agentId, lastMentionedAt } of idleAgents) {
     const createdAt = createdAtByAgentId.get(agentId);
+    const facts = factsByAgentId.get(agentId);
+    // No first version either means the agent is unreadable, or that we could not establish the
+    // date the age rule needs. Both are reasons not to archive it.
+    if (!createdAt || !facts) {
+      skipped.push({ agentId, reason: "agent_not_found" });
+      continue;
+    }
 
-    return createdAt ? [{ agentId, createdAt, lastMentionedAt }] : [];
-  });
+    const eligibility = evaluateAgentArchivalEligibility({
+      agent: { agentId, createdAt, lastMentionedAt, ...facts },
+      cutoffAt,
+    });
 
-  const nextCursor = hasMore ? pageAgents[pageAgents.length - 1].agentId : null;
+    if (!eligibility.eligible) {
+      skipped.push({ agentId, reason: eligibility.reason });
+      continue;
+    }
 
-  return { agents, nextCursor };
+    eligible.push({ agentId, createdAt, lastMentionedAt });
+  }
+
+  return { eligible, skipped };
 }

--- a/front/lib/api/assistant/inactivity/policy.test.ts
+++ b/front/lib/api/assistant/inactivity/policy.test.ts
@@ -7,12 +7,11 @@ import {
   evaluateAgentArchivalEligibility,
   MAX_INACTIVITY_THRESHOLD_DAYS,
   MIN_INACTIVITY_THRESHOLD_DAYS,
+  ONE_DAY_MS,
 } from "@app/lib/api/assistant/inactivity/policy";
 import type { AgentConfigurationStatus } from "@app/types/assistant/agent";
 import type { TriggerStatus } from "@app/types/assistant/triggers";
 import { describe, expect, it } from "vitest";
-
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 const EVALUATED_AT = new Date("2026-08-18T09:00:00.000Z");
 

--- a/front/lib/api/assistant/inactivity/policy.ts
+++ b/front/lib/api/assistant/inactivity/policy.ts
@@ -10,13 +10,9 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
  * infrastructure.
  */
 
-const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+export const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
-// One day would archive agents used weekly, or created over a weekend. Two is the agreed floor.
 export const MIN_INACTIVITY_THRESHOLD_DAYS = 2;
-
-// A year and a leap day. Guards a 3650-for-365 typo, and values large enough to overflow the cutoff
-// arithmetic into an Invalid Date.
 export const MAX_INACTIVITY_THRESHOLD_DAYS = 366;
 
 export class AgentInactivityPolicyError extends Error {
@@ -47,11 +43,11 @@ export interface AgentInactivitySnapshot {
   createdAt: Date;
   lastMentionedAt: Date | null;
   status: AgentConfigurationStatus;
-  // All of them: `doesTriggerPreventArchival` decides which protect.
+  // Every trigger the agent has; `doesTriggerPreventArchival` picks out the ones that protect it.
   triggers: AgentTriggerSnapshot[];
 }
 
-/** Not a `TriggerResource`: the rules only ask what kind of automation it is and whether it runs. */
+/** The rules read only a trigger's kind and status, so they take this rather than a `TriggerResource`. */
 export interface AgentTriggerSnapshot {
   kind: TriggerKind;
   status: TriggerStatus;
@@ -191,6 +187,9 @@ export function evaluateAgentArchivalEligibility({
     return { eligible: true };
   }
 
+  // `MentionResource.listAgentsNotMentionedSince` applies the same comparison in SQL, so callers
+  // reading candidates from it never see this reason. The rule stays here so this module remains the
+  // one place that states what "inactive" means.
   return {
     eligible: false,
     reason: "recent_mention",

--- a/front/lib/api/assistant/inactivity/preview_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/preview_inactive_agents.ts
@@ -1,0 +1,84 @@
+import type { AgentArchivalSkip } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import {
+  countSkipsByReason,
+  fetchArchivableAgents,
+} from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import type { AgentInactivityPolicyError } from "@app/lib/api/assistant/inactivity/policy";
+import { computeInactivityCutoffAt } from "@app/lib/api/assistant/inactivity/policy";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+/**
+ * What `archiveInactiveWorkspaceAgents` would archive, without archiving it. Same input, same reads,
+ * same rules, same output shape — the one difference is that `archivedAgentIds` is instead the
+ * `eligibleAgentIds` nothing was done to. Kept deliberately parallel so the two can be read side by
+ * side and seen to agree.
+ *
+ * It cannot mutate: `archiveAgentConfiguration` is not imported here.
+ */
+
+export interface InactiveAgentsPreviewInput {
+  thresholdDays: number;
+  evaluatedAt: Date;
+}
+
+export interface InactiveAgentsPreview {
+  evaluatedAt: Date;
+  cutoffAt: Date;
+  eligibleAgentIds: string[];
+  skipped: AgentArchivalSkip[];
+}
+
+export type InactiveAgentsPreviewResult = Result<
+  InactiveAgentsPreview,
+  AgentInactivityPolicyError
+>;
+
+export async function previewInactiveAgents(
+  auth: Authenticator,
+  { thresholdDays, evaluatedAt }: InactiveAgentsPreviewInput
+): Promise<InactiveAgentsPreviewResult> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const cutoffRes = computeInactivityCutoffAt({ thresholdDays, evaluatedAt });
+  if (cutoffRes.isErr()) {
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        thresholdDays,
+        err: cutoffRes.error,
+      },
+      "Cannot preview inactive agents: unusable workspace inactivity policy"
+    );
+    return new Err(cutoffRes.error);
+  }
+  const cutoffAt = cutoffRes.value;
+
+  const { eligible, skipped } = await fetchArchivableAgents(auth, {
+    cutoffAt,
+  });
+
+  const eligibleAgentIds = eligible.map(({ agentId }) => agentId);
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      thresholdDays,
+      evaluatedAt,
+      cutoffAt,
+      eligibleCount: eligibleAgentIds.length,
+      skippedCount: skipped.length,
+      skippedCountByReason: countSkipsByReason(skipped),
+    },
+    "Finished previewing inactive agents"
+  );
+
+  return new Ok({
+    evaluatedAt,
+    cutoffAt,
+    eligibleAgentIds,
+    skipped,
+  });
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -119,6 +119,7 @@
   "workspace.email_agents_updated": 1,
   "workspace.extension_mcp_tools_updated": 1,
   "workspace.governance_permission_updated": 1,
+  "workspace.inactive_agent_archival_updated": 1,
   "workspace.interactive_content_sharing_updated": 1,
   "workspace.manual_project_knowledge_management_updated": 1,
   "workspace.model_provider_settings_updated": 1,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -104,6 +104,7 @@ export const AUDIT_ACTIONS = [
   "workspace.email_agents_updated",
   "workspace.extension_mcp_tools_updated",
   "workspace.governance_permission_updated",
+  "workspace.inactive_agent_archival_updated",
   "workspace.interactive_content_sharing_updated",
   "workspace.manual_project_knowledge_management_updated",
   "workspace.model_provider_settings_updated",

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -590,6 +590,8 @@ export interface WorkspaceMetadata {
   dustMcpServerAllowedRedirectUris?: string[];
   disableAuditLogs?: boolean;
   disableWorkspaceAnalytics?: boolean;
+  // Absent means automatic archival is off.
+  inactiveAgentArchivalThresholdDays?: number;
   isBusiness?: boolean;
   phoneCountry?: string;
   sandboxAllowAgentEgressRequests?: boolean;

--- a/front/lib/resources/mention_resource.ts
+++ b/front/lib/resources/mention_resource.ts
@@ -3,6 +3,7 @@ import { MentionModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type {
@@ -60,6 +61,7 @@ export class MentionResource extends BaseResource<MentionModel> {
 
   /**
    * The workspace's active agents not mentioned since `notMentionedSince`, with when each last was.
+   *
    * Global agents cannot appear: they have no row in `agent_configurations`. Every mention counts,
    * whatever its status.
    */
@@ -98,7 +100,18 @@ export class MentionResource extends BaseResource<MentionModel> {
       }
     );
 
-    return rows.filter(isAgentIdleRow);
+    const agents = rows.filter(isAgentIdleRow);
+    if (agents.length !== rows.length) {
+      logger.warn(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          droppedCount: rows.length - agents.length,
+        },
+        "Dropped unrecognized rows while listing agents not mentioned since"
+      );
+    }
+
+    return agents;
   }
 
   async delete(

--- a/front/scripts/seed/factories/backdateAgent.ts
+++ b/front/scripts/seed/factories/backdateAgent.ts
@@ -1,0 +1,18 @@
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+
+import type { SeedContext } from "./types";
+
+export async function backdateAgent(
+  ctx: SeedContext,
+  { agentId, createdAt }: { agentId: string; createdAt: Date }
+): Promise<void> {
+  const { auth, execute, logger } = ctx;
+
+  logger.info({ agentId, createdAt }, "Backdating agent");
+
+  if (!execute) {
+    return;
+  }
+
+  await AgentConfigurationFactory.backdate(auth, agentId, createdAt);
+}

--- a/front/scripts/seed/factories/index.ts
+++ b/front/scripts/seed/factories/index.ts
@@ -1,3 +1,4 @@
+export * from "./backdateAgent";
 export * from "./seedAgent";
 export * from "./seedAgentSuggestions";
 export * from "./seedAnalytics";
@@ -8,6 +9,7 @@ export * from "./seedDataSources";
 export * from "./seedFeedbacks";
 export * from "./seedGroup";
 export * from "./seedMCPTools";
+export * from "./seedMention";
 export * from "./seedSkill";
 export * from "./seedSkillSuggestions";
 export * from "./seedSpace";

--- a/front/scripts/seed/factories/seedMention.ts
+++ b/front/scripts/seed/factories/seedMention.ts
@@ -1,0 +1,106 @@
+import type { MentionStatusType } from "@app/lib/models/agent/conversation";
+import {
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MentionResource } from "@app/lib/resources/mention_resource";
+
+import type { CreatedAgent, SeedContext } from "./types";
+
+export interface MentionAsset {
+  // Deterministic, so a second run finds the conversation instead of duplicating it.
+  conversationId: string;
+  agentName: string;
+  mentionedAt: Date;
+  status?: MentionStatusType;
+}
+
+/**
+ * Records that an agent was mentioned on a given date. A mention hangs off a message, so this
+ * creates the conversation and message it needs.
+ */
+export async function seedMentions(
+  ctx: SeedContext,
+  mentionAssets: MentionAsset[],
+  agents: Map<string, CreatedAgent>
+): Promise<void> {
+  const { auth, workspace, user, execute, logger } = ctx;
+
+  for (const asset of mentionAssets) {
+    const agent = agents.get(asset.agentName);
+    if (!agent) {
+      logger.warn(
+        { agentName: asset.agentName },
+        "Agent not found for mention, skipping"
+      );
+      continue;
+    }
+
+    logger.info(
+      { agentName: asset.agentName, mentionedAt: asset.mentionedAt },
+      "Creating mention"
+    );
+
+    if (!execute) {
+      continue;
+    }
+
+    const existing = await ConversationResource.fetchById(
+      auth,
+      asset.conversationId,
+      { dangerouslySkipPermissionFiltering: true, includeDeleted: true }
+    );
+    if (existing) {
+      logger.info(
+        { conversationId: asset.conversationId },
+        "Conversation already exists, skipping"
+      );
+      continue;
+    }
+
+    const conversation = await ConversationResource.makeNew(
+      auth,
+      {
+        sId: asset.conversationId,
+        title: `Mention of ${asset.agentName}`,
+        visibility: "unlisted",
+        depth: 0,
+        requestedSpaceIds: [],
+      },
+      null
+    );
+
+    const userMessageRow = await UserMessageModel.create({
+      userId: user.id,
+      conversationId: conversation.id,
+      workspaceId: workspace.id,
+      content: `@${asset.agentName}`,
+      userContextUsername: user.username ?? "dev-user",
+      userContextTimezone: "UTC",
+      userContextFullName: user.fullName() ?? "Dev User",
+      userContextEmail: user.email ?? "dev@dust.tt",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+
+    const messageRow = await MessageModel.create({
+      sId: `${asset.conversationId}Msg`,
+      rank: 0,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: userMessageRow.id,
+      workspaceId: workspace.id,
+      createdAt: asset.mentionedAt,
+    });
+
+    await MentionResource.makeNew({
+      messageId: messageRow.id,
+      agentConfigurationId: agent.sId,
+      workspaceId: workspace.id,
+      status: asset.status ?? "approved",
+      createdAt: asset.mentionedAt,
+    });
+  }
+}

--- a/front/scripts/seed/inactivity/README.md
+++ b/front/scripts/seed/inactivity/README.md
@@ -1,0 +1,39 @@
+# Inactivity Seed
+
+Seeds a workspace whose answer to "which agents would automatic archival take?" is known in advance,
+so the preview endpoint can be checked by hand.
+
+## What it creates
+
+Five agents. At a 30-day threshold, two are archivable and the other three are each spared by a
+different rule:
+
+| Agent | Setup | At 30 days |
+| --- | --- | --- |
+| `Idle Agent` | created 90d ago, never mentioned | **eligible** |
+| `Recently Used Agent` | created 90d ago, mentioned yesterday | not a candidate |
+| `Scheduled Agent` | created 90d ago, unmentioned, enabled schedule | `active_schedule` |
+| `Fresh Agent` | created today, never mentioned | `recent_creation` |
+| `Edited Agent` | first version 90d ago, edited today, unmentioned | **eligible** |
+
+## Prerequisites
+
+- `dust-hive` seed must have run, for the workspace and its admin.
+- Temporal must be reachable: creating the enabled schedule starts a workflow. Its cron is yearly, so
+  the seeded agent will not actually run.
+
+## Usage
+
+```bash
+npx tsx scripts/seed/inactivity/seed.ts --execute
+```
+
+The seed also enables the `archive_inactive_agents` feature flag on the workspace.
+
+To target a different workspace:
+
+```bash
+DEV_WORKSPACE_SID=MyWorkspace npx tsx scripts/seed/inactivity/seed.ts --execute
+```
+
+Idempotent: re-running skips the agents, the mention conversation, the trigger and the edit.

--- a/front/scripts/seed/inactivity/seed.test.ts
+++ b/front/scripts/seed/inactivity/seed.test.ts
@@ -1,0 +1,96 @@
+import { previewInactiveAgents } from "@app/lib/api/assistant/inactivity/preview_inactive_agents";
+import type { Authenticator } from "@app/lib/auth";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import type { SeedContext } from "@app/scripts/seed/factories";
+import { seedInactivity } from "@app/scripts/seed/inactivity/seedInactivity";
+import * as scheduleClient from "@app/temporal/triggers/schedule_client";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import type { LightWorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const THRESHOLD_DAYS = 30;
+
+describe("inactivity seed script integration test", () => {
+  let workspace: LightWorkspaceType;
+  let user: UserResource;
+  let authenticator: Authenticator;
+  let ctx: SeedContext;
+
+  beforeEach(async () => {
+    const testResources = await createResourceTest({ role: "admin" });
+    workspace = testResources.workspace;
+    user = testResources.user;
+    authenticator = testResources.authenticator;
+
+    ctx = { auth: authenticator, workspace, user, execute: true, logger };
+
+    // The seeded schedule is enabled, which reaches Temporal.
+    vi.spyOn(scheduleClient, "createOrUpdateAgentSchedule").mockResolvedValue(
+      new Ok("workflow-id")
+    );
+  });
+
+  it("builds a workspace whose archival answer is the documented one", async () => {
+    await seedInactivity(ctx);
+
+    const res = await previewInactiveAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+    });
+    if (res.isErr()) {
+      throw res.error;
+    }
+
+    // The README's promise: two archivable, and each of the others held back by its own rule.
+    expect(res.value.eligibleAgentIds).toHaveLength(2);
+    expect(res.value.skipped).toHaveLength(2);
+    expect(res.value.skipped.map(({ reason }) => reason).sort()).toEqual([
+      "active_schedule",
+      "recent_creation",
+    ]);
+  });
+
+  it("enables the feature flag the endpoints need", async () => {
+    await seedInactivity(ctx);
+
+    const flags = await FeatureFlagResource.listForWorkspace(workspace);
+
+    expect(flags.map(({ name }) => name)).toContain("archive_inactive_agents");
+  });
+
+  it("gives the same answer when run twice", async () => {
+    // Re-running must not create a second set of agents, nor a second version of the edited one:
+    // either would move the counts.
+    await seedInactivity(ctx);
+    await seedInactivity(ctx);
+
+    const res = await previewInactiveAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+    });
+    if (res.isErr()) {
+      throw res.error;
+    }
+
+    expect(res.value.eligibleAgentIds).toHaveLength(2);
+    expect(res.value.skipped).toHaveLength(2);
+  });
+
+  it("changes nothing without --execute", async () => {
+    await seedInactivity({ ...ctx, execute: false });
+
+    const res = await previewInactiveAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+    });
+    if (res.isErr()) {
+      throw res.error;
+    }
+
+    expect(res.value.eligibleAgentIds).toEqual([]);
+    expect(res.value.skipped).toEqual([]);
+  });
+});

--- a/front/scripts/seed/inactivity/seed.ts
+++ b/front/scripts/seed/inactivity/seed.ts
@@ -1,0 +1,9 @@
+import { makeScript } from "@app/scripts/helpers";
+import { createSeedContext } from "@app/scripts/seed/factories";
+import { seedInactivity } from "@app/scripts/seed/inactivity/seedInactivity";
+
+makeScript({}, async ({ execute }, logger) => {
+  const ctx = await createSeedContext({ execute, logger });
+
+  await seedInactivity(ctx);
+});

--- a/front/scripts/seed/inactivity/seedInactivity.ts
+++ b/front/scripts/seed/inactivity/seedInactivity.ts
@@ -1,0 +1,162 @@
+import {
+  createAgentConfiguration,
+  getAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
+import { ONE_DAY_MS } from "@app/lib/api/assistant/inactivity/policy";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
+import type {
+  AgentAsset,
+  CreatedAgent,
+  MentionAsset,
+  ScheduleTriggerAsset,
+  SeedContext,
+} from "@app/scripts/seed/factories";
+import {
+  backdateAgent,
+  seedAgents,
+  seedMentions,
+  seedTriggers,
+} from "@app/scripts/seed/factories";
+
+/** Old enough to sit well before any cutoff the allowed thresholds can produce. */
+const LONG_AGO = new Date(Date.now() - 90 * ONE_DAY_MS);
+
+const PICTURE_URL =
+  "https://dust.tt/static/systemavatar/claude_avatar_full.png";
+
+function agentAsset(name: string, description: string): AgentAsset {
+  return {
+    name,
+    description,
+    instructions: `You are ${name}, seeded to exercise inactive-agent archival.`,
+    pictureUrl: PICTURE_URL,
+  };
+}
+
+// At a 30-day threshold: "Idle Agent" and "Edited Agent" are archivable, the other three are each
+// spared by a different rule.
+const AGENTS: AgentAsset[] = [
+  agentAsset("Idle Agent", "Old and never mentioned: archivable."),
+  agentAsset("Recently Used Agent", "Old but mentioned yesterday."),
+  agentAsset(
+    "Scheduled Agent",
+    "Old and unmentioned, but a schedule drives it."
+  ),
+  agentAsset("Fresh Agent", "Created today, so too young to be disused."),
+  agentAsset(
+    "Edited Agent",
+    "First version is old; editing must not postpone archival."
+  ),
+];
+
+/** Every agent but "Fresh Agent", which has to look new. */
+const AGENTS_TO_BACKDATE = AGENTS.filter(({ name }) => name !== "Fresh Agent");
+
+const MENTIONS: MentionAsset[] = [
+  {
+    conversationId: "InactivityConv01",
+    agentName: "Recently Used Agent",
+    mentionedAt: new Date(Date.now() - ONE_DAY_MS),
+  },
+];
+
+const TRIGGERS: ScheduleTriggerAsset[] = [
+  {
+    name: "Yearly nudge",
+    kind: "schedule",
+    agentName: "Scheduled Agent",
+    customPrompt: null,
+    status: "enabled",
+    // Yearly, so the seeded agent does not actually run while it sits in a dev workspace.
+    configuration: { cron: "0 4 1 1 *", timezone: "UTC" },
+  },
+];
+
+/**
+ * Creates a new version of an agent, as editing it in the UI would, so the scenario contains an
+ * agent whose active row is young and whose first version is old. Local to this seed: nothing else
+ * needs it.
+ */
+async function editSeededAgent(
+  ctx: SeedContext,
+  agent: CreatedAgent,
+  asset: AgentAsset
+): Promise<void> {
+  const { auth, user, execute, logger } = ctx;
+
+  const existing = await getAgentConfiguration(auth, {
+    agentId: agent.sId,
+    variant: "light",
+  });
+  if (existing && existing.version > 0) {
+    logger.info({ agentId: agent.sId }, "Agent already edited, skipping");
+    return;
+  }
+
+  logger.info({ agentId: agent.sId }, "Editing agent");
+
+  if (!execute) {
+    return;
+  }
+
+  const result = await createAgentConfiguration(auth, {
+    name: asset.name,
+    description: asset.description,
+    instructions: "Edited today, still unused.",
+    instructionsHtml: null,
+    pictureUrl: asset.pictureUrl,
+    status: "active",
+    scope: "visible",
+    model: {
+      providerId: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      temperature: 0.7,
+    },
+    templateId: null,
+    requestedSpaceIds: [],
+    tags: [],
+    editors: [user.toJSON()],
+    authorId: user.id,
+    agentConfigurationId: agent.sId,
+  });
+
+  if (result.isErr()) {
+    throw result.error;
+  }
+}
+
+/**
+ * Builds the scenario. Exported so a test can assert the answer it promises, which the `makeScript`
+ * wrapper alone would hide.
+ */
+export async function seedInactivity(ctx: SeedContext): Promise<void> {
+  // Without the flag the endpoints answer 403, so the scenario would be unreachable.
+  ctx.logger.info("Enabling the archive_inactive_agents feature flag");
+  if (ctx.execute) {
+    await FeatureFlagResource.enableMany(ctx.workspace, [
+      "archive_inactive_agents",
+    ]);
+  }
+
+  const createdAgents = await seedAgents(ctx, AGENTS);
+
+  for (const asset of AGENTS_TO_BACKDATE) {
+    const agent = createdAgents.get(asset.name);
+    if (!agent) {
+      continue;
+    }
+    await backdateAgent(ctx, { agentId: agent.sId, createdAt: LONG_AGO });
+  }
+
+  await seedMentions(ctx, MENTIONS, createdAgents);
+  await seedTriggers(ctx, TRIGGERS, createdAgents);
+
+  // Backdated first, so only the version this creates carries today's date.
+  const editedAsset = AGENTS.find(({ name }) => name === "Edited Agent");
+  const editedAgent = createdAgents.get("Edited Agent");
+  if (editedAsset && editedAgent) {
+    await editSeededAgent(ctx, editedAgent, editedAsset);
+  }
+
+  ctx.logger.info("Inactivity seed completed");
+}

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -129,7 +129,7 @@ export class AgentConfigurationFactory {
   }
 
   /** Backdates every version of an agent, for features that treat a young agent differently. */
-  static async setCreatedAtForTest(
+  static async backdate(
     auth: Authenticator,
     agentId: string,
     createdAt: Date

--- a/front/types/api/assistant/configuration/index.ts
+++ b/front/types/api/assistant/configuration/index.ts
@@ -27,3 +27,33 @@ export const BatchUpdateAgentModelResponseBodySchema = z.object({
 export type BatchUpdateAgentModelResponseBody = z.infer<
   typeof BatchUpdateAgentModelResponseBodySchema
 >;
+
+// Inactive-agent archival. The skip reasons are the rules' exclusions plus the two outcomes only a
+// caller reading or mutating can produce; kept loose here so an older client tolerates a new one.
+const AgentArchivalSkipCountsSchema = z.record(z.string(), z.number().int());
+
+export const PreviewInactiveAgentsResponseBodySchema = z.object({
+  preview: z.object({
+    evaluatedAt: z.string(),
+    cutoffAt: z.string(),
+    thresholdDays: z.number().int(),
+    eligibleCount: z.number().int(),
+    skippedCountByReason: AgentArchivalSkipCountsSchema,
+  }),
+});
+export type PreviewInactiveAgentsResponseBody = z.infer<
+  typeof PreviewInactiveAgentsResponseBodySchema
+>;
+
+export const ArchiveInactiveAgentsResponseBodySchema = z.object({
+  archival: z.object({
+    evaluatedAt: z.string(),
+    cutoffAt: z.string(),
+    thresholdDays: z.number().int(),
+    archivedCount: z.number().int(),
+    skippedCountByReason: AgentArchivalSkipCountsSchema,
+  }),
+});
+export type ArchiveInactiveAgentsResponseBody = z.infer<
+  typeof ArchiveInactiveAgentsResponseBodySchema
+>;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -372,6 +372,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Disable the per-user fair-use AWU credit limit on this workspace: skip both the pre-message enforcement (read) and the usage recording (write). Escape hatch for workspaces that should not be subject to the fair-use cap.",
     stage: "on_demand",
   },
+  archive_inactive_agents: {
+    description:
+      "Allow this workspace to preview and archive agents that have not been mentioned for a configurable number of days.",
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -742,6 +742,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
   | "anthropic_cache_diagnostics"
+  | "archive_inactive_agents"
   | "audit_logs"
   | "claude_4_5_opus_feature"
   | "claude_4_opus_feature"


### PR DESCRIPTION
Adds the two endpoints and the workspace setting behind the `archive_inactive_agents` flag.

- `POST .../archive_inactive/preview` counts what archival would take and `POST .../archive_inactive` takes it. Both cover the whole workspace and share one body schema, so the dry run and the executor cannot drift.
- `policy.ts` holds the rules as pure functions, so the preview and the executor read the same rules rather than each holding a copy.
- `inactiveAgentArchivalThresholdDays` on the workspace carries both whether automatic archival is on and how many days, matching the policy's rule that with no threshold set nothing is ever archived.
- Seeds a workspace whose answer is known in advance: five agents, two eligible and three spared, one of them an agent edited today whose first version is old.

## Description

Workspaces accumulate agents nobody uses. Admins had no way to find them, and no way to clear them out without opening each one.

An agent is archivable when all of the following hold:

| Rule | Spared when |
| --- | --- |
| Status | not `active` |
| Schedule | an enabled (or `relocating`/`downgraded`) schedule trigger drives it |
| Age | its **first** version was created after the cutoff |
| Mentions | its last mention is at or after the cutoff |

The cutoff is `evaluatedAt - thresholdDays`, truncated to the UTC day so a preview and a later run judge every agent identically, and so a threshold of N days always leaves a full N days of grace. Thresholds are bounded to 2–366 days.

Two details worth calling out:

- **Age is read from version 0, not the active row.** Editing an agent inserts a new row, so the active row's `createdAt` is really the last edit. Reading it would let editing an agent postpone its archival forever.
- **A recently mentioned agent is spared without appearing in `skippedCountByReason`.** The candidates query (`MentionResource.listAgentsNotMentionedSince`) filters on the same cutoff, so such an agent never reaches the rules to be counted by them. The rule stays in `policy.ts` anyway, so that one module still states what "inactive" means.

Archiving goes through the existing `archiveAgentConfiguration`, which keeps trigger disabling, wake-up cancellation, editor-group suspension and the `agent.archived` audit event on the one path that already owned them.

**This PR is the API only.** The endpoints and the rules land here; the Governance setting, the manage-agents CTA and the archival modal come in a follow-up PR, and so does the nightly run. `inactiveAgentArchivalThresholdDays` can be written through `POST /api/w/:wId` but nothing reads it yet.

## Tests

- Endpoint tests for both routes: non-admin → 403, flag off → 403 and nothing touched, threshold outside the bounds → 400, the counts for a five-agent workspace, what actually gets archived, and a second call archiving nothing.
- Resource-level tests for `fetchArchivableAgents`: never mentioned, last mention before/after the cutoff, newest mention wins, a rejected mention still counts as activity, a recently edited agent still qualifies, an agent created after the cutoff does not, global agents never appear.
- Unit tests for `policy.ts` covering the cutoff arithmetic, the threshold bounds and every exclusion reason.
- `scripts/seed/inactivity/seed.ts` builds a workspace whose expected preview output is documented in its README, for checking the endpoints by hand.

## Risk

- **Off by default.** `archive_inactive_agents` is `on_demand`, so there is no behaviour change for any workspace until it is enabled. Both endpoints are admin-only.
- **Reversible.** Agents are archived, not deleted, and an admin can restore them. A revert of this PR does not un-archive anything already archived.
- **Unbounded work per request.** `POST .../archive_inactive` archives every eligible agent in one request, and each one disables its triggers, cancels its wake-ups (Temporal round-trips), suspends its editor group and emits an audit event. On a workspace with many idle agents that request will be slow; a workspace large enough could time out. The preview is a read but hydrates every idle agent's configuration.
- Archiving an agent suspends its editor group memberships, which is visible to those users.

## Deploy Plan

- [ ] Merge.
- [ ] Register the new audit action with WorkOS **before** deploying: `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`. Without it, `workspace.inactive_agent_archival_updated` emits with no schema version.
- [ ] Deploy `front-api` and `front`.
- [ ] Enable `archive_inactive_agents` on one internal workspace via Poke and check the preview counts before enabling it anywhere else.

`sdks/js` picks up `archive_inactive_agents` in its `WhitelistableFeature` union; this is an additive enum value on a system-key-only endpoint, so no client change is required.

## Follow-ups

- The UI: the Governance setting, the manage-agents CTA and the archival modal, with the SWR hooks that drive them.
- The nightly run that reads `inactiveAgentArchivalThresholdDays` and archives on its own.
- Bounding the work per archive request once the nightly run exists to drive it.
