### PR TITLE
[front] Poke: remove unused card subcomponents

### DIFF
--- a/front/components/poke/shadcn/ui/card.tsx
+++ b/front/components/poke/shadcn/ui/card.tsx
@@ -37,43 +37,8 @@ const CardTitle = React.forwardRef<
 ));
 CardTitle.displayName = "CardTitle";
 
-const CardDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <p
-    ref={ref}
-    className={cn("copy-sm text-muted-foreground", className)}
-    {...props}
-  />
-));
-CardDescription.displayName = "CardDescription";
-
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-));
-CardContent.displayName = "CardContent";
-
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
-));
-CardFooter.displayName = "CardFooter";
-
 export {
   Card as PokeCard,
-  CardContent as PokeCardContent,
-  CardDescription as PokeCardDescription,
-  CardFooter as PokeCardFooter,
   CardHeader as PokeCardHeader,
   CardTitle as PokeCardTitle,
 };


### PR DESCRIPTION
## Description

Remove the unused poke card subcomponents: `PokeCardDescription` (last usage removed in #30973), `PokeCardContent` and `PokeCardFooter` (never used).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
