### PR TITLE
Introduce cached resource store and refit WorkspaceResource onto it

### DIFF
--- a/front/lib/metronome/contracts.ts
+++ b/front/lib/metronome/contracts.ts
@@ -86,7 +86,6 @@ export async function ensureMetronomeCustomerForWorkspace({
     if (updateResult.isErr()) {
       return new Err(updateResult.error);
     }
-    await WorkspaceResource.invalidateCache(workspace.sId);
   }
 
   // If a Stripe customer is provided, make sure the Metronome customer has a

--- a/front/lib/resources/cached_resource_store.ts
+++ b/front/lib/resources/cached_resource_store.ts
@@ -317,6 +317,12 @@ export type CachedResourceStore<
     blob: Attributes<M>,
     transaction?: Transaction
   ) => Promise<void>;
+  // Key-based counterpart of invalidateBlob, for callers that only hold the cache key (e.g.
+  // invalidation after out-of-band writes such as a relocation).
+  invalidateCached: (
+    input: Attributes<M>[K],
+    transaction?: Transaction
+  ) => Promise<void>;
   createCacheOperations: <OperationsInput>(definition: {
     label: string;
     params: CacheOperationParam[];
@@ -423,6 +429,8 @@ export function defineCachedResourceStore<
       return resource;
     },
     invalidateBlob,
+    invalidateCached: (input, transaction) =>
+      blobLookup.invalidate(input, transaction),
     createCacheOperations: blobLookup.createCacheOperations,
   };
 }

--- a/front/lib/resources/cached_resource_store.ts
+++ b/front/lib/resources/cached_resource_store.ts
@@ -327,6 +327,11 @@ export type CachedResourceStore<
  * The cached snapshot shape follows the model implicitly: whenever the model gains, loses, or
  * retypes an attribute, bump `cache.version`. Entries have no TTL, so stale-shaped snapshots
  * otherwise live until the row is next invalidated.
+ *
+ * Only global models (no workspaceId column) may use this store. Workspace-scoped resources need
+ * a variant that takes an Authenticator and scopes every where clause to the workspace id, and
+ * that re-checks ownership on the blob after a cache read, since a cache hit skips the SQL
+ * scoping entirely.
  */
 export function defineCachedResourceStore<
   M extends Model,

--- a/front/lib/resources/cached_resource_store.ts
+++ b/front/lib/resources/cached_resource_store.ts
@@ -262,6 +262,15 @@ type SerializedBlob<M extends Model> = {
   [K in keyof Attributes<M>]: SerializedBlobValue<Attributes<M>[K]>;
 };
 
+// Models carrying a workspaceId are workspace-scoped and cannot use this store: they need a
+// variant that takes an Authenticator, scopes every where clause to the workspace id, and
+// re-checks blob ownership after cache reads (a cache hit skips the SQL scoping). Global models
+// such as workspace and user are the exception this store serves.
+type GlobalModelOnly<M extends Model> =
+  "workspaceId" extends keyof Attributes<M>
+    ? "this model is workspace-scoped: it requires the Authenticator-scoped store variant"
+    : unknown;
+
 // Attributes eligible as a cache key: string or number valued columns.
 type CacheKeyAttribute<M extends Model> = {
   [K in keyof Attributes<M>]: Attributes<M>[K] extends string | number
@@ -328,24 +337,17 @@ export type CachedResourceStore<
  * retypes an attribute, bump `cache.version`. Entries have no TTL, so stale-shaped snapshots
  * otherwise live until the row is next invalidated.
  *
- * Only global models (no workspaceId column) may use this store. Workspace-scoped resources need
- * a variant that takes an Authenticator and scopes every where clause to the workspace id, and
- * that re-checks ownership on the blob after a cache read, since a cache hit skips the SQL
- * scoping entirely.
+ * Only global models may use this store: passing a model with a workspaceId column is a type
+ * error (see GlobalModelOnly).
  */
 export function defineCachedResourceStore<
   M extends Model,
   K extends CacheKeyAttribute<M>,
   Resource,
->({
-  model,
-  materialize,
-  cache,
-}: CachedResourceStoreDefinition<M, K, Resource>): CachedResourceStore<
-  M,
-  K,
-  Resource
-> {
+>(
+  definition: CachedResourceStoreDefinition<M, K, Resource> & GlobalModelOnly<M>
+): CachedResourceStore<M, K, Resource> {
+  const { model, materialize, cache } = definition;
   const dateAttributeNames = Object.entries(model.getAttributes())
     .filter(([, attribute]) => attribute.type instanceof DataTypes.DATE)
     .map(([attributeName]) => attributeName);

--- a/front/lib/resources/cached_resource_store.ts
+++ b/front/lib/resources/cached_resource_store.ts
@@ -1,3 +1,4 @@
+import { DataTypes } from "@app/lib/resources/storage/data_types";
 import type { JsonSerializable } from "@app/lib/utils/cache";
 import {
   batchInvalidateCacheWithRedis,
@@ -13,7 +14,15 @@ import type {
 import { defineCacheOperations } from "@app/lib/utils/cache_operations";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { Transaction } from "sequelize";
+import type {
+  Attributes,
+  CreationAttributes,
+  FindOptions,
+  Model,
+  ModelStatic,
+  Transaction,
+  WhereOptions,
+} from "sequelize";
 import type { z } from "zod";
 
 type CacheKeyDefinition<Input> = {
@@ -102,10 +111,11 @@ class ResourceDatabaseLoadError {
 }
 
 /**
- * Use when a Resource lookup returns Resource instances. For counts or other query results,
- * use `defineCache` instead.
+ * Low-level single-value lookup with hand-written snapshots. Internal to this module: resources
+ * should declare a `defineCachedResourceStore` (single row, blob snapshot) or a
+ * `defineCachedResourceList` instead.
  */
-export function defineCachedResourceLookup<Input, Snapshot, Resource>({
+function defineCachedResourceLookup<Input, Snapshot, Resource>({
   id,
   version,
   key,
@@ -242,6 +252,159 @@ export function defineCachedResourceLookup<Input, Snapshot, Resource>({
           buildCacheWithRedisKey(cacheKey.cacheId, cacheKey.keyPattern)
         ),
       }),
+  };
+}
+
+// Serialized form of a model's attributes: DATE attributes are stored as epoch milliseconds,
+// everything else is cached as-is.
+type SerializedBlobValue<V> = V extends Date ? number : V;
+type SerializedBlob<M extends Model> = {
+  [K in keyof Attributes<M>]: SerializedBlobValue<Attributes<M>[K]>;
+};
+
+type CachedResourceStoreDefinition<Input, M extends Model, Resource> = {
+  model: ModelStatic<M>;
+  materialize: (blobs: Attributes<M>[]) => Promise<Resource[]>;
+  cache: {
+    id: string;
+    version: number;
+    key: (input: Input) => string;
+    loadWhere: (input: Input) => WhereOptions<Attributes<M>>;
+    // Must read only immutable attributes: invalidation derives the key from a blob that may
+    // predate or postdate the write it invalidates for.
+    keyOfBlob: (blob: Attributes<M>) => Input;
+    migration?: CacheKeyMigrationDefinition<Input>;
+  };
+};
+
+export type CachedResourceStore<Input, M extends Model, Resource> = {
+  // `attributes` projections are excluded: materialize requires full rows.
+  baseFetch: (
+    options?: Omit<FindOptions<Attributes<M>>, "attributes">
+  ) => Promise<Resource[]>;
+  fetchCached: (
+    input: Input,
+    transaction?: Transaction
+  ) => Promise<Resource | null>;
+  create: (
+    blob: CreationAttributes<M>,
+    transaction?: Transaction
+  ) => Promise<Resource>;
+  invalidate: (input: Input, transaction?: Transaction) => Promise<void>;
+  invalidateBlob: (
+    blob: Attributes<M>,
+    transaction?: Transaction
+  ) => Promise<void>;
+  invalidateMany: (
+    inputs: readonly Input[],
+    transaction?: Transaction
+  ) => Promise<void>;
+  createCacheOperations: <OperationsInput>(definition: {
+    label: string;
+    params: CacheOperationParam[];
+    inputSchema: z.ZodType<OperationsInput>;
+    toLookupInput: (input: OperationsInput) => Input;
+  }) => CacheOperations;
+};
+
+/**
+ * The row ↔ resource lifecycle of a Resource, declared once. This is a repository whose defining
+ * feature is the materialization boundary: the declared `materialize` runs on every path that
+ * yields resources to callers (cache hit, transaction bypass, Redis fallback, uncached query,
+ * creation). Caching is one capability on top. The store's internal currency is raw blobs: the
+ * cache stores the full set of model attributes, serialized from the model definition (blobs must
+ * be JSON-serializable apart from DATE attributes).
+ *
+ * The cached snapshot shape follows the model implicitly: whenever the model gains, loses, or
+ * retypes an attribute, bump `cache.version`. Entries have no TTL, so stale-shaped snapshots
+ * otherwise live until the row is next invalidated.
+ */
+export function defineCachedResourceStore<Input, M extends Model, Resource>({
+  model,
+  materialize,
+  cache,
+}: CachedResourceStoreDefinition<Input, M, Resource>): CachedResourceStore<
+  Input,
+  M,
+  Resource
+> {
+  const dateAttributeNames = Object.entries(model.getAttributes())
+    .filter(([, attribute]) => attribute.type instanceof DataTypes.DATE)
+    .map(([attributeName]) => attributeName);
+
+  const blobLookup = defineCachedResourceLookup<
+    Input,
+    SerializedBlob<M>,
+    Attributes<M>
+  >({
+    id: cache.id,
+    version: cache.version,
+    key: cache.key,
+    migration: cache.migration,
+    loadFromDatabase: async (input, transaction) => {
+      const row = await model.findOne({
+        where: cache.loadWhere(input),
+        transaction,
+      });
+      return row ? row.get() : null;
+    },
+    toSnapshot: (blob) => {
+      const snapshot: Record<string, unknown> = { ...blob };
+      for (const attributeName of dateAttributeNames) {
+        const value = snapshot[attributeName];
+        if (value instanceof Date) {
+          snapshot[attributeName] = value.getTime();
+        }
+      }
+      // The attribute-driven Date rewrite above cannot be expressed in the type system.
+      return snapshot as JsonSerializable<SerializedBlob<M>>;
+    },
+    fromSnapshot: (snapshot) => {
+      const blob: Record<string, unknown> = { ...snapshot };
+      for (const attributeName of dateAttributeNames) {
+        const value = blob[attributeName];
+        if (typeof value === "number") {
+          blob[attributeName] = new Date(value);
+        }
+      }
+      // The attribute-driven Date rewrite above cannot be expressed in the type system.
+      return blob as Attributes<M>;
+    },
+  });
+
+  const invalidateBlob = async (
+    blob: Attributes<M>,
+    transaction?: Transaction
+  ) => blobLookup.invalidate(cache.keyOfBlob(blob), transaction);
+
+  return {
+    baseFetch: async (options) => {
+      const rows = await model.findAll(options);
+      return materialize(rows.map((row) => row.get()));
+    },
+    fetchCached: async (input, transaction) => {
+      const blob = await blobLookup.fetch(input, transaction);
+      if (!blob) {
+        return null;
+      }
+      const [resource] = await materialize([blob]);
+      return resource ?? null;
+    },
+    create: async (blob, transaction) => {
+      const row = await model.create(blob, { transaction });
+      await invalidateBlob(row.get(), transaction);
+      const [resource] = await materialize([row.get()]);
+      if (!resource) {
+        throw new Error(
+          `materialize dropped the row just created in ${cache.id}`
+        );
+      }
+      return resource;
+    },
+    invalidate: blobLookup.invalidate,
+    invalidateBlob,
+    invalidateMany: blobLookup.invalidateMany,
+    createCacheOperations: blobLookup.createCacheOperations,
   };
 }
 

--- a/front/lib/resources/cached_resource_store.ts
+++ b/front/lib/resources/cached_resource_store.ts
@@ -262,48 +262,57 @@ type SerializedBlob<M extends Model> = {
   [K in keyof Attributes<M>]: SerializedBlobValue<Attributes<M>[K]>;
 };
 
-type CachedResourceStoreDefinition<Input, M extends Model, Resource> = {
+// Attributes eligible as a cache key: string or number valued columns.
+type CacheKeyAttribute<M extends Model> = {
+  [K in keyof Attributes<M>]: Attributes<M>[K] extends string | number
+    ? K
+    : never;
+}[keyof Attributes<M>] &
+  string;
+
+type CachedResourceStoreDefinition<
+  M extends Model,
+  K extends CacheKeyAttribute<M>,
+  Resource,
+> = {
   model: ModelStatic<M>;
   materialize: (blobs: Attributes<M>[]) => Promise<Resource[]>;
   cache: {
     id: string;
     version: number;
-    key: (input: Input) => string;
-    loadWhere: (input: Input) => WhereOptions<Attributes<M>>;
-    // Must read only immutable attributes: invalidation derives the key from a blob that may
-    // predate or postdate the write it invalidates for.
-    keyOfBlob: (blob: Attributes<M>) => Input;
-    migration?: CacheKeyMigrationDefinition<Input>;
+    // Column carrying the cache key. Must be unique and immutable: the Redis key, the cache-miss
+    // loader and blob invalidation are all derived from it.
+    keyAttribute: K;
+    migration?: CacheKeyMigrationDefinition<Attributes<M>[K]>;
   };
 };
 
-export type CachedResourceStore<Input, M extends Model, Resource> = {
+export type CachedResourceStore<
+  M extends Model,
+  K extends CacheKeyAttribute<M>,
+  Resource,
+> = {
   // `attributes` projections are excluded: materialize requires full rows.
   baseFetch: (
     options?: Omit<FindOptions<Attributes<M>>, "attributes">
   ) => Promise<Resource[]>;
   fetchCached: (
-    input: Input,
+    input: Attributes<M>[K],
     transaction?: Transaction
   ) => Promise<Resource | null>;
   create: (
     blob: CreationAttributes<M>,
     transaction?: Transaction
   ) => Promise<Resource>;
-  invalidate: (input: Input, transaction?: Transaction) => Promise<void>;
   invalidateBlob: (
     blob: Attributes<M>,
-    transaction?: Transaction
-  ) => Promise<void>;
-  invalidateMany: (
-    inputs: readonly Input[],
     transaction?: Transaction
   ) => Promise<void>;
   createCacheOperations: <OperationsInput>(definition: {
     label: string;
     params: CacheOperationParam[];
     inputSchema: z.ZodType<OperationsInput>;
-    toLookupInput: (input: OperationsInput) => Input;
+    toLookupInput: (input: OperationsInput) => Attributes<M>[K];
   }) => CacheOperations;
 };
 
@@ -319,13 +328,17 @@ export type CachedResourceStore<Input, M extends Model, Resource> = {
  * retypes an attribute, bump `cache.version`. Entries have no TTL, so stale-shaped snapshots
  * otherwise live until the row is next invalidated.
  */
-export function defineCachedResourceStore<Input, M extends Model, Resource>({
+export function defineCachedResourceStore<
+  M extends Model,
+  K extends CacheKeyAttribute<M>,
+  Resource,
+>({
   model,
   materialize,
   cache,
-}: CachedResourceStoreDefinition<Input, M, Resource>): CachedResourceStore<
-  Input,
+}: CachedResourceStoreDefinition<M, K, Resource>): CachedResourceStore<
   M,
+  K,
   Resource
 > {
   const dateAttributeNames = Object.entries(model.getAttributes())
@@ -333,17 +346,18 @@ export function defineCachedResourceStore<Input, M extends Model, Resource>({
     .map(([attributeName]) => attributeName);
 
   const blobLookup = defineCachedResourceLookup<
-    Input,
+    Attributes<M>[K],
     SerializedBlob<M>,
     Attributes<M>
   >({
     id: cache.id,
     version: cache.version,
-    key: cache.key,
+    key: (input) => String(input),
     migration: cache.migration,
     loadFromDatabase: async (input, transaction) => {
       const row = await model.findOne({
-        where: cache.loadWhere(input),
+        // Sequelize cannot type a computed generic key; the value is Attributes<M>[K].
+        where: { [cache.keyAttribute]: input } as WhereOptions<Attributes<M>>,
         transaction,
       });
       return row ? row.get() : null;
@@ -375,7 +389,7 @@ export function defineCachedResourceStore<Input, M extends Model, Resource>({
   const invalidateBlob = async (
     blob: Attributes<M>,
     transaction?: Transaction
-  ) => blobLookup.invalidate(cache.keyOfBlob(blob), transaction);
+  ) => blobLookup.invalidate(blob[cache.keyAttribute], transaction);
 
   return {
     baseFetch: async (options) => {
@@ -401,9 +415,7 @@ export function defineCachedResourceStore<Input, M extends Model, Resource>({
       }
       return resource;
     },
-    invalidate: blobLookup.invalidate,
     invalidateBlob,
-    invalidateMany: blobLookup.invalidateMany,
     createCacheOperations: blobLookup.createCacheOperations,
   };
 }

--- a/front/lib/resources/feature_flag_resource.ts
+++ b/front/lib/resources/feature_flag_resource.ts
@@ -1,7 +1,7 @@
-import { defineCachedResourceList } from "@app/lib/api/resources/cached_resource_lookup";
 import type { Authenticator } from "@app/lib/auth";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { defineCachedResourceList } from "@app/lib/resources/cached_resource_store";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";

--- a/front/lib/resources/global_feature_flag_resource.ts
+++ b/front/lib/resources/global_feature_flag_resource.ts
@@ -1,7 +1,7 @@
-import { defineCachedResourceList } from "@app/lib/api/resources/cached_resource_lookup";
 import type { Authenticator } from "@app/lib/auth";
 import { GlobalFeatureFlagModel } from "@app/lib/models/global_feature_flag";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { defineCachedResourceList } from "@app/lib/resources/cached_resource_store";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";

--- a/front/lib/resources/kill_switch_resource.ts
+++ b/front/lib/resources/kill_switch_resource.ts
@@ -3,8 +3,10 @@ import { BaseResource } from "@app/lib/resources/base_resource";
 import { KillSwitchModel } from "@app/lib/resources/storage/models/kill_switches";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { Attributes, ModelStatic } from "sequelize";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -72,7 +74,16 @@ export class KillSwitchResource extends BaseResource<KillSwitchModel> {
   }
 
   static async listEnabledKillSwitches(): Promise<KillSwitchType[]> {
-    return KillSwitchResource.listEnabledKillSwitchesCached();
+    try {
+      return await KillSwitchResource.listEnabledKillSwitchesCached();
+    } catch (err) {
+      // Kill switches gate every workspace fetch. A Redis outage must not take reads down.
+      logger.warn(
+        { err: normalizeError(err) },
+        "Kill switch cache read failed; falling back to the database"
+      );
+      return KillSwitchResource._listEnabledKillSwitchesUncached();
+    }
   }
 
   static async isKillSwitchEnabled(type: KillSwitchType): Promise<boolean> {

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -149,6 +149,7 @@ vi.mock("@app/lib/resources/kill_switch_resource", () => ({
   },
 }));
 
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
@@ -263,6 +264,59 @@ describe("WorkspaceResource", () => {
           "openai",
           "anthropic",
         ]);
+      });
+
+      // A v3 snapshot exactly as the previous deploy wrote it. Guards two things: entries written
+      // before a deploy must keep parsing (the cache has no TTL), and the fixture's key set must
+      // match the model's attributes. When the keys assertion fails, the model changed shape and
+      // WORKSPACE_CACHE_KEY_VERSION must be bumped along with this fixture.
+      it("parses snapshots written by the previous deploy", async () => {
+        const v3Snapshot = {
+          id: 987654321,
+          sId: "ws_fixture_v3",
+          name: "fixture-workspace",
+          description: null,
+          segmentation: null,
+          ssoEnforced: false,
+          regionalModelsOnly: false,
+          workOSOrganizationId: null,
+          whiteListedProviders: ["openai", "anthropic"],
+          defaultEmbeddingProvider: null,
+          metadata: { fixtureKey: "fixtureValue" },
+          sharingPolicy: "all_scopes",
+          conversationsRetentionDays: null,
+          metronomeCustomerId: null,
+          poolCreditState: "active",
+          programmaticCreditState: "active",
+          createdAt: 1755000000000,
+          updatedAt: 1755000000000,
+        };
+        inMemoryCache.set(
+          getCacheKeyForWorkspace(v3Snapshot.sId),
+          JSON.stringify(v3Snapshot)
+        );
+
+        const resource = await WorkspaceResource.fetchById(v3Snapshot.sId);
+
+        expect(Object.keys(v3Snapshot).sort()).toEqual(
+          Object.keys(WorkspaceModel.getAttributes()).sort()
+        );
+        expect(resource?.name).toBe("fixture-workspace");
+        expect(resource?.whiteListedProviders).toEqual(["openai", "anthropic"]);
+        expect(resource?.metadata).toEqual({ fixtureKey: "fixtureValue" });
+        expect(resource?.createdAt).toEqual(new Date(1755000000000));
+        expect(resource?.updatedAt).toEqual(new Date(1755000000000));
+      });
+
+      it("serves the same attributes from the cache as from the database", async () => {
+        await WorkspaceResource.fetchById(workspace.sId);
+
+        const cachedFetch = await WorkspaceResource.fetchById(workspace.sId);
+        const [databaseFetch] = await WorkspaceResource.fetchByIds([
+          workspace.sId,
+        ]);
+
+        expect(cachedFetch?.blob).toEqual(databaseFetch?.blob);
       });
     });
 
@@ -710,6 +764,17 @@ describe("WorkspaceResource", () => {
       expect(result).not.toContain("openai");
       expect(result).toContain("anthropic");
       expect(result).toContain("mistral");
+    });
+
+    it("applies provider kill switches on uncached fetch paths", async () => {
+      workspace = await WorkspaceFactory.basic({
+        whiteListedProviders: ["openai", "anthropic"],
+      });
+      listEnabledKillSwitches.mockResolvedValue(["global_blacklist_openai"]);
+
+      const [resource] = await WorkspaceResource.fetchByIds([workspace.sId]);
+
+      expect(resource?.whiteListedProviders).toEqual(["anthropic"]);
     });
   });
 

--- a/front/lib/resources/workspace_resource.test.ts
+++ b/front/lib/resources/workspace_resource.test.ts
@@ -148,6 +148,7 @@ vi.mock("@app/lib/resources/kill_switch_resource", () => ({
   },
 }));
 
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
@@ -262,6 +263,59 @@ describe("WorkspaceResource", () => {
           "openai",
           "anthropic",
         ]);
+      });
+
+      // A v3 snapshot exactly as the previous deploy wrote it. Guards two things: entries written
+      // before a deploy must keep parsing (the cache has no TTL), and the fixture's key set must
+      // match the model's attributes. When the keys assertion fails, the model changed shape and
+      // WORKSPACE_CACHE_KEY_VERSION must be bumped along with this fixture.
+      it("parses snapshots written by the previous deploy", async () => {
+        const v3Snapshot = {
+          id: 987654321,
+          sId: "ws_fixture_v3",
+          name: "fixture-workspace",
+          description: null,
+          segmentation: null,
+          ssoEnforced: false,
+          regionalModelsOnly: false,
+          workOSOrganizationId: null,
+          whiteListedProviders: ["openai", "anthropic"],
+          defaultEmbeddingProvider: null,
+          metadata: { fixtureKey: "fixtureValue" },
+          sharingPolicy: "all_scopes",
+          conversationsRetentionDays: null,
+          metronomeCustomerId: null,
+          poolCreditState: "active",
+          programmaticCreditState: "active",
+          createdAt: 1755000000000,
+          updatedAt: 1755000000000,
+        };
+        inMemoryCache.set(
+          getCacheKeyForWorkspace(v3Snapshot.sId),
+          JSON.stringify(v3Snapshot)
+        );
+
+        const resource = await WorkspaceResource.fetchById(v3Snapshot.sId);
+
+        expect(Object.keys(v3Snapshot).sort()).toEqual(
+          Object.keys(WorkspaceModel.getAttributes()).sort()
+        );
+        expect(resource?.name).toBe("fixture-workspace");
+        expect(resource?.whiteListedProviders).toEqual(["openai", "anthropic"]);
+        expect(resource?.metadata).toEqual({ fixtureKey: "fixtureValue" });
+        expect(resource?.createdAt).toEqual(new Date(1755000000000));
+        expect(resource?.updatedAt).toEqual(new Date(1755000000000));
+      });
+
+      it("serves the same attributes from the cache as from the database", async () => {
+        await WorkspaceResource.fetchById(workspace.sId);
+
+        const cachedFetch = await WorkspaceResource.fetchById(workspace.sId);
+        const [databaseFetch] = await WorkspaceResource.fetchByIds([
+          workspace.sId,
+        ]);
+
+        expect(cachedFetch?.blob).toEqual(databaseFetch?.blob);
       });
     });
 
@@ -709,6 +763,17 @@ describe("WorkspaceResource", () => {
       expect(result).not.toContain("openai");
       expect(result).toContain("anthropic");
       expect(result).toContain("mistral");
+    });
+
+    it("applies provider kill switches on uncached fetch paths", async () => {
+      workspace = await WorkspaceFactory.basic({
+        whiteListedProviders: ["openai", "anthropic"],
+      });
+      listEnabledKillSwitches.mockResolvedValue(["global_blacklist_openai"]);
+
+      const [resource] = await WorkspaceResource.fetchByIds([workspace.sId]);
+
+      expect(resource?.whiteListedProviders).toEqual(["anthropic"]);
     });
   });
 });

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -153,9 +153,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     cache: {
       id: "workspace_by_sid",
       version: WORKSPACE_CACHE_KEY_VERSION,
-      key: (workspaceId: string) => workspaceId,
-      loadWhere: (workspaceId) => ({ sId: workspaceId }),
-      keyOfBlob: (blob) => blob.sId,
+      keyAttribute: "sId",
       migration: {
         previousKey: {
           cacheId: "_fetchByIdUncached",
@@ -271,10 +269,6 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
           ),
         })
     );
-  }
-
-  static async invalidateCache(workspaceId: string): Promise<void> {
-    await WorkspaceResource.store.invalidate(workspaceId);
   }
 
   protected override async update(

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -1,4 +1,3 @@
-import { defineCachedResourceLookup } from "@app/lib/api/resources/cached_resource_lookup";
 import {
   listWorkOSOrganizationsWithDomain,
   removeWorkOSOrganizationDomain,
@@ -15,11 +14,13 @@ import {
   hasAnyPlanLimitOverride,
   OVERRIDABLE_PLAN_LIMITS,
 } from "@app/lib/plans/plan_limit_overrides";
+import type { KillSwitchType } from "@app/lib/poke/types";
 import type {
   ResourceLogJSON,
   ResourceUpdateBlob,
 } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { defineCachedResourceStore } from "@app/lib/resources/cached_resource_store";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -33,7 +34,6 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateAllAgentLoopWorkflowsForConversation } from "@app/temporal/agent_loop/terminate";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
-import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
 import type {
   WorkspacePoolCreditState,
   WorkspaceProgrammaticCreditState,
@@ -45,10 +45,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, isStringArray } from "@app/types/shared/utils/general";
-import type {
-  WorkspaceSegmentationType,
-  WorkspaceSharingPolicy,
-} from "@app/types/user";
+import type { WorkspaceSegmentationType } from "@app/types/user";
 import type { WorkspaceDomain } from "@app/types/workspace";
 import type {
   Attributes,
@@ -67,29 +64,6 @@ const WORKSPACE_CACHE_KEY_VERSION = 3;
 
 export type WorkspaceConversationKillSwitchValue = {
   conversationIds: string[];
-};
-
-// We use this to avoid accidentaly inflating the cache footprint
-// Add new attributes with caution
-type CachedWorkspaceData = {
-  id: ModelId;
-  sId: string;
-  name: string;
-  description: string | null;
-  segmentation: WorkspaceSegmentationType | null;
-  ssoEnforced: boolean;
-  regionalModelsOnly: boolean;
-  workOSOrganizationId: string | null;
-  whiteListedProviders: ModelProviderIdType[] | null;
-  defaultEmbeddingProvider: EmbeddingProviderIdType | null;
-  metadata: Record<string, string | number | boolean | object> | null;
-  sharingPolicy: WorkspaceSharingPolicy;
-  conversationsRetentionDays: number | null;
-  metronomeCustomerId: string | null;
-  poolCreditState: WorkspacePoolCreditState;
-  programmaticCreditState: WorkspaceProgrammaticCreditState;
-  createdAt: number;
-  updatedAt: number;
 };
 
 type WorkspaceModelIdBatchRow = {
@@ -173,88 +147,29 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     this.blob = blob;
   }
 
-  private toCacheSnapshot(): CachedWorkspaceData {
-    return {
-      id: this.id,
-      sId: this.sId,
-      name: this.name,
-      description: this.description,
-      segmentation: this.segmentation,
-      ssoEnforced: this.ssoEnforced ?? false,
-      regionalModelsOnly: this.regionalModelsOnly,
-      workOSOrganizationId: this.workOSOrganizationId,
-      whiteListedProviders: this.whiteListedProviders,
-      defaultEmbeddingProvider: this.defaultEmbeddingProvider,
-      metadata: this.metadata,
-      sharingPolicy: this.sharingPolicy,
-      conversationsRetentionDays: this.conversationsRetentionDays,
-      metronomeCustomerId: this.metronomeCustomerId ?? null,
-      poolCreditState: this.poolCreditState,
-      programmaticCreditState: this.programmaticCreditState,
-      createdAt: this.createdAt.getTime(),
-      updatedAt: this.updatedAt.getTime(),
-    };
-  }
-
-  private static fromCacheSnapshot(
-    data: CachedWorkspaceData
-  ): WorkspaceResource {
-    const blob: Attributes<WorkspaceModel> = {
-      id: data.id,
-      sId: data.sId,
-      name: data.name,
-      description: data.description,
-      segmentation: data.segmentation,
-      ssoEnforced: data.ssoEnforced,
-      regionalModelsOnly: data.regionalModelsOnly,
-      workOSOrganizationId: data.workOSOrganizationId,
-      whiteListedProviders: data.whiteListedProviders,
-      defaultEmbeddingProvider: data.defaultEmbeddingProvider,
-      metadata: data.metadata,
-      sharingPolicy: data.sharingPolicy,
-      conversationsRetentionDays: data.conversationsRetentionDays,
-      metronomeCustomerId: data.metronomeCustomerId ?? null,
-      poolCreditState: data.poolCreditState,
-      programmaticCreditState: data.programmaticCreditState,
-      createdAt: new Date(data.createdAt),
-      updatedAt: new Date(data.updatedAt),
-    };
-    return new WorkspaceResource(WorkspaceModel, blob);
-  }
-
-  private static async fetchByIdFromDatabase(
-    workspaceId: string,
-    transaction?: Transaction
-  ): Promise<WorkspaceResource | null> {
-    const workspace = await WorkspaceModel.findOne({
-      where: { sId: workspaceId },
-      transaction,
-    });
-    return workspace
-      ? new WorkspaceResource(WorkspaceModel, workspace.get())
-      : null;
-  }
-
-  private static readonly byIdCache = defineCachedResourceLookup({
-    id: "workspace_by_sid",
-    version: WORKSPACE_CACHE_KEY_VERSION,
-    key: (workspaceId: string) => workspaceId,
-    migration: {
-      previousKey: {
-        cacheId: "_fetchByIdUncached",
-        key: (workspaceId: string) => `workspace:v2:${workspaceId}`,
-        keyPattern: "workspace:v2:*",
+  private static readonly store = defineCachedResourceStore({
+    model: WorkspaceModel,
+    materialize: (blobs) => WorkspaceResource.materialize(blobs),
+    cache: {
+      id: "workspace_by_sid",
+      version: WORKSPACE_CACHE_KEY_VERSION,
+      key: (workspaceId: string) => workspaceId,
+      loadWhere: (workspaceId) => ({ sId: workspaceId }),
+      keyOfBlob: (blob) => blob.sId,
+      migration: {
+        previousKey: {
+          cacheId: "_fetchByIdUncached",
+          key: (workspaceId: string) => `workspace:v2:${workspaceId}`,
+          keyPattern: "workspace:v2:*",
+        },
+        readFrom: "new",
+        copyToOtherKey: "after_read",
       },
-      readFrom: "new",
-      copyToOtherKey: "after_read",
     },
-    loadFromDatabase: WorkspaceResource.fetchByIdFromDatabase,
-    toSnapshot: (workspace) => workspace.toCacheSnapshot(),
-    fromSnapshot: WorkspaceResource.fromCacheSnapshot,
   });
 
   static readonly byIdCacheOperations =
-    WorkspaceResource.byIdCache.createCacheOperations({
+    WorkspaceResource.store.createCacheOperations({
       label: "Workspace (by sId)",
       inputSchema: z.object({ wId: z.string().min(1) }),
       params: [
@@ -299,12 +214,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return killSwitched.conversationIds.includes(conversationId);
   }
 
-  public static async getWhiteListedProvidersFilteredByKillSwitches(
-    whiteListedProviders: ModelProviderIdType[] | null
-  ): Promise<ModelProviderIdType[] | null> {
-    const enabledKillSwitches =
-      await KillSwitchResource.listEnabledKillSwitches();
-
+  private static filterKillSwitchedProviders(
+    whiteListedProviders: ModelProviderIdType[] | null,
+    enabledKillSwitches: KillSwitchType[]
+  ): ModelProviderIdType[] | null {
     const isAnthropicBlacklisted = enabledKillSwitches.includes(
       "global_blacklist_anthropic"
     );
@@ -321,8 +234,47 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return whiteListedProviders;
   }
 
+  public static async getWhiteListedProvidersFilteredByKillSwitches(
+    whiteListedProviders: ModelProviderIdType[] | null
+  ): Promise<ModelProviderIdType[] | null> {
+    const enabledKillSwitches =
+      await KillSwitchResource.listEnabledKillSwitches();
+    return WorkspaceResource.filterKillSwitchedProviders(
+      whiteListedProviders,
+      enabledKillSwitches
+    );
+  }
+
+  // Materialization: the single seam where fetched blobs become resources, run by every fetch
+  // path (cached or not). This is where context outside the row is folded in: provider kill
+  // switches here, so a WorkspaceResource always carries the effective whiteListedProviders while
+  // the cache keeps the raw column value. Never persist whiteListedProviders read from a
+  // materialized resource: that would make a temporary kill switch permanent.
+  // TODO(2026-08-21 flav): Move the kill-switch overlay to its consumption points (Authenticator
+  // and model gating) so workspace fetches stay pure and this materialize becomes plain
+  // construction.
+  private static async materialize(
+    blobs: Attributes<WorkspaceModel>[]
+  ): Promise<WorkspaceResource[]> {
+    if (blobs.length === 0) {
+      return [];
+    }
+    const enabledKillSwitches =
+      await KillSwitchResource.listEnabledKillSwitches();
+    return blobs.map(
+      (blob) =>
+        new WorkspaceResource(WorkspaceModel, {
+          ...blob,
+          whiteListedProviders: WorkspaceResource.filterKillSwitchedProviders(
+            blob.whiteListedProviders,
+            enabledKillSwitches
+          ),
+        })
+    );
+  }
+
   static async invalidateCache(workspaceId: string): Promise<void> {
-    await WorkspaceResource.byIdCache.invalidate(workspaceId);
+    await WorkspaceResource.store.invalidate(workspaceId);
   }
 
   protected override async update(
@@ -342,66 +294,49 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     }
 
     const result = await super.update(blob, transaction);
-    await WorkspaceResource.byIdCache.invalidate(this.sId, transaction);
+    await WorkspaceResource.store.invalidateBlob(this.blob, transaction);
     return result;
   }
 
   static async makeNew(
     blob: CreationAttributes<WorkspaceModel>
   ): Promise<WorkspaceResource> {
-    const workspace = await this.model.create(blob);
-    const workspaceResource = new this(this.model, workspace.get());
-
-    await WorkspaceResource.byIdCache.invalidate(workspaceResource.sId);
-
-    return workspaceResource;
+    return WorkspaceResource.store.create(blob);
   }
 
   static async fetchById(
     wId: string,
     transaction?: Transaction
   ): Promise<WorkspaceResource | null> {
-    const workspace = await WorkspaceResource.byIdCache.fetch(wId, transaction);
-    if (!workspace) {
-      return null;
-    }
-    const whiteListedProviders =
-      await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
-        workspace.whiteListedProviders
-      );
-    return new WorkspaceResource(WorkspaceModel, {
-      ...workspace.blob,
-      whiteListedProviders,
-    });
+    return WorkspaceResource.store.fetchCached(wId, transaction);
   }
 
   static async fetchByName(name: string): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({
+    const [workspace] = await this.store.baseFetch({
       where: { name },
+      limit: 1,
     });
-    return workspace ? new this(this.model, workspace.get()) : null;
+    return workspace ?? null;
   }
 
   static async fetchByModelIds(ids: ModelId[]): Promise<WorkspaceResource[]> {
-    const workspaces = await this.model.findAll({
+    return this.store.baseFetch({
       where: {
         id: {
           [Op.in]: ids,
         },
       },
     });
-    return workspaces.map((workspace) => new this(this.model, workspace.get()));
   }
 
   static async fetchByIds(wIds: string[]): Promise<WorkspaceResource[]> {
-    const workspaces = await this.model.findAll({
+    return this.store.baseFetch({
       where: {
         sId: {
           [Op.in]: wIds,
         },
       },
     });
-    return workspaces.map((workspace) => new this(this.model, workspace.get()));
   }
 
   static async fetchModelIdsByIds(wIds: string[]): Promise<ModelId[]> {
@@ -431,8 +366,9 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       return null;
     }
 
-    const workspace = await this.model.findOne({
+    const [workspace] = await this.store.baseFetch({
       where: { id: workspaceDomain.workspaceId },
+      limit: 1,
     });
 
     if (!workspace) {
@@ -440,7 +376,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     }
 
     return {
-      workspace: new this(this.model, workspace.get()),
+      workspace,
       domainInfo: {
         domain: workspaceDomain.domain,
         domainAutoJoinEnabled: workspaceDomain.domainAutoJoinEnabled,
@@ -470,26 +406,27 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   static async fetchByMetronomeCustomerId(
     metronomeCustomerId: string
   ): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({
+    const [workspace] = await this.store.baseFetch({
       where: { metronomeCustomerId },
+      limit: 1,
     });
-    return workspace ? new this(this.model, workspace.get()) : null;
+    return workspace ?? null;
   }
 
   static async fetchByWorkOSOrganizationId(
     workOSOrganizationId: string
   ): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({
+    const [workspace] = await this.store.baseFetch({
       where: { workOSOrganizationId },
+      limit: 1,
     });
-    return workspace ? new this(this.model, workspace.get()) : null;
+    return workspace ?? null;
   }
 
   static async listAll(order?: "ASC" | "DESC"): Promise<WorkspaceResource[]> {
-    const workspaces = await this.model.findAll({
+    return this.store.baseFetch({
       ...(order && { order: [["id", order]] }),
     });
-    return workspaces.map((workspace) => new this(this.model, workspace.get()));
   }
 
   static async listAllModelIds(order?: "ASC" | "DESC"): Promise<ModelId[]> {
@@ -555,10 +492,9 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     if (workspaceModelIds.length === 0) {
       return [];
     }
-    const workspaces = await this.model.findAll({
+    return this.store.baseFetch({
       where: { id: { [Op.in]: workspaceModelIds } },
     });
-    return workspaces.map((w) => new this(this.model, w.get()));
   }
 
   async updateSegmentation(segmentation: WorkspaceSegmentationType) {
@@ -1143,7 +1079,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         where: { id: this.blob.id },
         transaction,
       });
-      await WorkspaceResource.byIdCache.invalidate(this.sId, transaction);
+      await WorkspaceResource.store.invalidateBlob(this.blob, transaction);
       return new Ok(deletedCount);
     } catch (error) {
       return new Err(normalizeError(error));

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -1,4 +1,3 @@
-import { defineCachedResourceLookup } from "@app/lib/api/resources/cached_resource_lookup";
 import {
   listWorkOSOrganizationsWithDomain,
   removeWorkOSOrganizationDomain,
@@ -10,11 +9,13 @@ import {
   isValidConversationsRetentionDays,
 } from "@app/lib/conversations_retention";
 import { FeatureFlagModel } from "@app/lib/models/feature_flag";
+import type { KillSwitchType } from "@app/lib/poke/types";
 import type {
   ResourceLogJSON,
   ResourceUpdateBlob,
 } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import { defineCachedResourceStore } from "@app/lib/resources/cached_resource_store";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
@@ -27,7 +28,6 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { terminateAllAgentLoopWorkflowsForConversation } from "@app/temporal/agent_loop/terminate";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
-import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
 import type {
   WorkspacePoolCreditState,
   WorkspaceProgrammaticCreditState,
@@ -39,10 +39,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isString, isStringArray } from "@app/types/shared/utils/general";
-import type {
-  WorkspaceSegmentationType,
-  WorkspaceSharingPolicy,
-} from "@app/types/user";
+import type { WorkspaceSegmentationType } from "@app/types/user";
 import type { WorkspaceDomain } from "@app/types/workspace";
 import type {
   Attributes,
@@ -61,29 +58,6 @@ const WORKSPACE_CACHE_KEY_VERSION = 3;
 
 export type WorkspaceConversationKillSwitchValue = {
   conversationIds: string[];
-};
-
-// We use this to avoid accidentaly inflating the cache footprint
-// Add new attributes with caution
-type CachedWorkspaceData = {
-  id: ModelId;
-  sId: string;
-  name: string;
-  description: string | null;
-  segmentation: WorkspaceSegmentationType | null;
-  ssoEnforced: boolean;
-  regionalModelsOnly: boolean;
-  workOSOrganizationId: string | null;
-  whiteListedProviders: ModelProviderIdType[] | null;
-  defaultEmbeddingProvider: EmbeddingProviderIdType | null;
-  metadata: Record<string, string | number | boolean | object> | null;
-  sharingPolicy: WorkspaceSharingPolicy;
-  conversationsRetentionDays: number | null;
-  metronomeCustomerId: string | null;
-  poolCreditState: WorkspacePoolCreditState;
-  programmaticCreditState: WorkspaceProgrammaticCreditState;
-  createdAt: number;
-  updatedAt: number;
 };
 
 type WorkspaceModelIdBatchRow = {
@@ -131,88 +105,29 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     this.blob = blob;
   }
 
-  private toCacheSnapshot(): CachedWorkspaceData {
-    return {
-      id: this.id,
-      sId: this.sId,
-      name: this.name,
-      description: this.description,
-      segmentation: this.segmentation,
-      ssoEnforced: this.ssoEnforced ?? false,
-      regionalModelsOnly: this.regionalModelsOnly,
-      workOSOrganizationId: this.workOSOrganizationId,
-      whiteListedProviders: this.whiteListedProviders,
-      defaultEmbeddingProvider: this.defaultEmbeddingProvider,
-      metadata: this.metadata,
-      sharingPolicy: this.sharingPolicy,
-      conversationsRetentionDays: this.conversationsRetentionDays,
-      metronomeCustomerId: this.metronomeCustomerId ?? null,
-      poolCreditState: this.poolCreditState,
-      programmaticCreditState: this.programmaticCreditState,
-      createdAt: this.createdAt.getTime(),
-      updatedAt: this.updatedAt.getTime(),
-    };
-  }
-
-  private static fromCacheSnapshot(
-    data: CachedWorkspaceData
-  ): WorkspaceResource {
-    const blob: Attributes<WorkspaceModel> = {
-      id: data.id,
-      sId: data.sId,
-      name: data.name,
-      description: data.description,
-      segmentation: data.segmentation,
-      ssoEnforced: data.ssoEnforced,
-      regionalModelsOnly: data.regionalModelsOnly,
-      workOSOrganizationId: data.workOSOrganizationId,
-      whiteListedProviders: data.whiteListedProviders,
-      defaultEmbeddingProvider: data.defaultEmbeddingProvider,
-      metadata: data.metadata,
-      sharingPolicy: data.sharingPolicy,
-      conversationsRetentionDays: data.conversationsRetentionDays,
-      metronomeCustomerId: data.metronomeCustomerId ?? null,
-      poolCreditState: data.poolCreditState,
-      programmaticCreditState: data.programmaticCreditState,
-      createdAt: new Date(data.createdAt),
-      updatedAt: new Date(data.updatedAt),
-    };
-    return new WorkspaceResource(WorkspaceModel, blob);
-  }
-
-  private static async fetchByIdFromDatabase(
-    workspaceId: string,
-    transaction?: Transaction
-  ): Promise<WorkspaceResource | null> {
-    const workspace = await WorkspaceModel.findOne({
-      where: { sId: workspaceId },
-      transaction,
-    });
-    return workspace
-      ? new WorkspaceResource(WorkspaceModel, workspace.get())
-      : null;
-  }
-
-  private static readonly byIdCache = defineCachedResourceLookup({
-    id: "workspace_by_sid",
-    version: WORKSPACE_CACHE_KEY_VERSION,
-    key: (workspaceId: string) => workspaceId,
-    migration: {
-      previousKey: {
-        cacheId: "_fetchByIdUncached",
-        key: (workspaceId: string) => `workspace:v2:${workspaceId}`,
-        keyPattern: "workspace:v2:*",
+  private static readonly store = defineCachedResourceStore({
+    model: WorkspaceModel,
+    materialize: (blobs) => WorkspaceResource.materialize(blobs),
+    cache: {
+      id: "workspace_by_sid",
+      version: WORKSPACE_CACHE_KEY_VERSION,
+      key: (workspaceId: string) => workspaceId,
+      loadWhere: (workspaceId) => ({ sId: workspaceId }),
+      keyOfBlob: (blob) => blob.sId,
+      migration: {
+        previousKey: {
+          cacheId: "_fetchByIdUncached",
+          key: (workspaceId: string) => `workspace:v2:${workspaceId}`,
+          keyPattern: "workspace:v2:*",
+        },
+        readFrom: "new",
+        copyToOtherKey: "after_read",
       },
-      readFrom: "new",
-      copyToOtherKey: "after_read",
     },
-    loadFromDatabase: WorkspaceResource.fetchByIdFromDatabase,
-    toSnapshot: (workspace) => workspace.toCacheSnapshot(),
-    fromSnapshot: WorkspaceResource.fromCacheSnapshot,
   });
 
   static readonly byIdCacheOperations =
-    WorkspaceResource.byIdCache.createCacheOperations({
+    WorkspaceResource.store.createCacheOperations({
       label: "Workspace (by sId)",
       inputSchema: z.object({ wId: z.string().min(1) }),
       params: [
@@ -257,12 +172,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return killSwitched.conversationIds.includes(conversationId);
   }
 
-  public static async getWhiteListedProvidersFilteredByKillSwitches(
-    whiteListedProviders: ModelProviderIdType[] | null
-  ): Promise<ModelProviderIdType[] | null> {
-    const enabledKillSwitches =
-      await KillSwitchResource.listEnabledKillSwitches();
-
+  private static filterKillSwitchedProviders(
+    whiteListedProviders: ModelProviderIdType[] | null,
+    enabledKillSwitches: KillSwitchType[]
+  ): ModelProviderIdType[] | null {
     const isAnthropicBlacklisted = enabledKillSwitches.includes(
       "global_blacklist_anthropic"
     );
@@ -279,8 +192,47 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return whiteListedProviders;
   }
 
+  public static async getWhiteListedProvidersFilteredByKillSwitches(
+    whiteListedProviders: ModelProviderIdType[] | null
+  ): Promise<ModelProviderIdType[] | null> {
+    const enabledKillSwitches =
+      await KillSwitchResource.listEnabledKillSwitches();
+    return WorkspaceResource.filterKillSwitchedProviders(
+      whiteListedProviders,
+      enabledKillSwitches
+    );
+  }
+
+  // Materialization: the single seam where fetched blobs become resources, run by every fetch
+  // path (cached or not). This is where context outside the row is folded in: provider kill
+  // switches here, so a WorkspaceResource always carries the effective whiteListedProviders while
+  // the cache keeps the raw column value. Never persist whiteListedProviders read from a
+  // materialized resource: that would make a temporary kill switch permanent.
+  // TODO(2026-08-21 flav): Move the kill-switch overlay to its consumption points (Authenticator
+  // and model gating) so workspace fetches stay pure and this materialize becomes plain
+  // construction.
+  private static async materialize(
+    blobs: Attributes<WorkspaceModel>[]
+  ): Promise<WorkspaceResource[]> {
+    if (blobs.length === 0) {
+      return [];
+    }
+    const enabledKillSwitches =
+      await KillSwitchResource.listEnabledKillSwitches();
+    return blobs.map(
+      (blob) =>
+        new WorkspaceResource(WorkspaceModel, {
+          ...blob,
+          whiteListedProviders: WorkspaceResource.filterKillSwitchedProviders(
+            blob.whiteListedProviders,
+            enabledKillSwitches
+          ),
+        })
+    );
+  }
+
   static async invalidateCache(workspaceId: string): Promise<void> {
-    await WorkspaceResource.byIdCache.invalidate(workspaceId);
+    await WorkspaceResource.store.invalidate(workspaceId);
   }
 
   protected override async update(
@@ -300,66 +252,49 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     }
 
     const result = await super.update(blob, transaction);
-    await WorkspaceResource.byIdCache.invalidate(this.sId, transaction);
+    await WorkspaceResource.store.invalidateBlob(this.blob, transaction);
     return result;
   }
 
   static async makeNew(
     blob: CreationAttributes<WorkspaceModel>
   ): Promise<WorkspaceResource> {
-    const workspace = await this.model.create(blob);
-    const workspaceResource = new this(this.model, workspace.get());
-
-    await WorkspaceResource.byIdCache.invalidate(workspaceResource.sId);
-
-    return workspaceResource;
+    return WorkspaceResource.store.create(blob);
   }
 
   static async fetchById(
     wId: string,
     transaction?: Transaction
   ): Promise<WorkspaceResource | null> {
-    const workspace = await WorkspaceResource.byIdCache.fetch(wId, transaction);
-    if (!workspace) {
-      return null;
-    }
-    const whiteListedProviders =
-      await WorkspaceResource.getWhiteListedProvidersFilteredByKillSwitches(
-        workspace.whiteListedProviders
-      );
-    return new WorkspaceResource(WorkspaceModel, {
-      ...workspace.blob,
-      whiteListedProviders,
-    });
+    return WorkspaceResource.store.fetchCached(wId, transaction);
   }
 
   static async fetchByName(name: string): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({
+    const [workspace] = await this.store.baseFetch({
       where: { name },
+      limit: 1,
     });
-    return workspace ? new this(this.model, workspace.get()) : null;
+    return workspace ?? null;
   }
 
   static async fetchByModelIds(ids: ModelId[]): Promise<WorkspaceResource[]> {
-    const workspaces = await this.model.findAll({
+    return this.store.baseFetch({
       where: {
         id: {
           [Op.in]: ids,
         },
       },
     });
-    return workspaces.map((workspace) => new this(this.model, workspace.get()));
   }
 
   static async fetchByIds(wIds: string[]): Promise<WorkspaceResource[]> {
-    const workspaces = await this.model.findAll({
+    return this.store.baseFetch({
       where: {
         sId: {
           [Op.in]: wIds,
         },
       },
     });
-    return workspaces.map((workspace) => new this(this.model, workspace.get()));
   }
 
   static async fetchModelIdsByIds(wIds: string[]): Promise<ModelId[]> {
@@ -389,8 +324,9 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
       return null;
     }
 
-    const workspace = await this.model.findOne({
+    const [workspace] = await this.store.baseFetch({
       where: { id: workspaceDomain.workspaceId },
+      limit: 1,
     });
 
     if (!workspace) {
@@ -398,7 +334,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     }
 
     return {
-      workspace: new this(this.model, workspace.get()),
+      workspace,
       domainInfo: {
         domain: workspaceDomain.domain,
         domainAutoJoinEnabled: workspaceDomain.domainAutoJoinEnabled,
@@ -428,26 +364,27 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   static async fetchByMetronomeCustomerId(
     metronomeCustomerId: string
   ): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({
+    const [workspace] = await this.store.baseFetch({
       where: { metronomeCustomerId },
+      limit: 1,
     });
-    return workspace ? new this(this.model, workspace.get()) : null;
+    return workspace ?? null;
   }
 
   static async fetchByWorkOSOrganizationId(
     workOSOrganizationId: string
   ): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({
+    const [workspace] = await this.store.baseFetch({
       where: { workOSOrganizationId },
+      limit: 1,
     });
-    return workspace ? new this(this.model, workspace.get()) : null;
+    return workspace ?? null;
   }
 
   static async listAll(order?: "ASC" | "DESC"): Promise<WorkspaceResource[]> {
-    const workspaces = await this.model.findAll({
+    return this.store.baseFetch({
       ...(order && { order: [["id", order]] }),
     });
-    return workspaces.map((workspace) => new this(this.model, workspace.get()));
   }
 
   static async listAllModelIds(order?: "ASC" | "DESC"): Promise<ModelId[]> {
@@ -513,10 +450,9 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     if (workspaceModelIds.length === 0) {
       return [];
     }
-    const workspaces = await this.model.findAll({
+    return this.store.baseFetch({
       where: { id: { [Op.in]: workspaceModelIds } },
     });
-    return workspaces.map((w) => new this(this.model, w.get()));
   }
 
   async updateSegmentation(segmentation: WorkspaceSegmentationType) {
@@ -1000,7 +936,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         where: { id: this.blob.id },
         transaction,
       });
-      await WorkspaceResource.byIdCache.invalidate(this.sId, transaction);
+      await WorkspaceResource.store.invalidateBlob(this.blob, transaction);
       return new Ok(deletedCount);
     } catch (error) {
       return new Err(normalizeError(error));

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -271,6 +271,10 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     );
   }
 
+  static async invalidateCache(workspaceId: string): Promise<void> {
+    await WorkspaceResource.store.invalidateCached(workspaceId);
+  }
+
   protected override async update(
     blob: ResourceUpdateBlob<WorkspaceModel>,
     transaction?: Transaction


### PR DESCRIPTION
## Description

A resource read from the cache must be indistinguishable from one read from the database. This PR makes that an invariant enforced by structure rather than by convention, using the workspace resource as the first consumer.

Two rules carry the invariant:
- One store: a resource declares once how its rows are fetched, cached and invalidated. The cache holds the full set of columns of the row, serialized generically from the model definition, so the cached shape can never drift from the database shape, and there is no hand written snapshot to forget a field in.
- One materialization: a single seam where a raw row becomes a resource, and the only place where context living outside the row is folded in. Every path that produces a resource goes through it: cache hit, cache miss, transaction bypass, fallback when the cache is unreachable, uncached queries, and creation. A caller can no longer build a resource that skipped it.

For the workspace, the context folded in at materialization is the provider kill switches (TBH should not even be here, but will refactor in a follow up PR). Previously they applied on a single fetch path, so the same workspace carried different provider values depending on how it had been fetched. They now apply uniformly, while the cache keeps the raw column value. In the same spirit, a coercion of the SSO enforcement flag that only happened on the cached path is removed, so the cached and uncached values agree.

Since materialization now runs on every read, the kill switch lookup gets a database fallback: an outage of the cache backend must not take workspace reads down.

## Tests

Added one asserts that a workspace served from the cache carries exactly the same attributes as one served from the database. One asserts the kill switch filter applies on a previously unfiltered fetch path. One plants a snapshot in the exact format written by the currently deployed code and asserts it still parses; it also compares the snapshot fields against the model definition, so it fails whenever the model gains or loses a column, forcing a conscious bump of the cache version, which matters because entries have no expiry.

## Risk

The cache key and version are unchanged. The generically produced snapshot was verified to contain exactly the same fields as the previous hand written one, so during a rolling deploy old and new pods read each other's entries and invalidate the same keys. The behavioral deltas are the two described above: kill switches filtering all fetch paths (only model gating and the provider pickers consume the value, and both already received the filtered one) and the SSO flag no longer coerced on the cached path (all consumers are truthiness checks). Rollback is safe since the previous code parses the same entries.

## Deploy Plan

Deploy front normally. No migration, no cache key rotation, no ordering constraint.