### PR TITLE
Move consumption exports to the tmp-workloads bucket

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -1,6 +1,6 @@
+import { buildConsumptionExportGcsPrefix } from "@app/temporal/analytics_queue/activities/consumption_export";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
-import { buildConsumptionExportGcsPrefix } from "@app/temporal/analytics_queue/activities/consumption_export";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/export-raw.test.ts
@@ -1,5 +1,6 @@
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { buildConsumptionExportGcsPrefix } from "@app/temporal/analytics_queue/activities/consumption_export";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -82,7 +83,7 @@ describe("POST /api/w/:wId/analytics/consumption/export-raw/status", () => {
 
   it("lists past exports for the workspace, newest first", async () => {
     const { workspace } = await setupTest();
-    const prefix = `w/${workspace.sId}/consumption_exports/`;
+    const prefix = buildConsumptionExportGcsPrefix(workspace.sId);
     fileStorageMock.setFilesByPrefix((requestedPrefix) => {
       if (requestedPrefix !== prefix) {
         return null;

--- a/front/lib/api/analytics/consumption/export_jobs.ts
+++ b/front/lib/api/analytics/consumption/export_jobs.ts
@@ -1,7 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { getTmpWorkloadsBucket } from "@app/lib/file_storage";
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import {
   buildConsumptionExportCacheKey,
@@ -37,7 +37,7 @@ export async function listConsumptionExports(
   auth: Authenticator
 ): Promise<ConsumptionExportListItem[]> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const bucket = getPrivateUploadBucket();
+  const bucket = getTmpWorkloadsBucket();
 
   const { files } = await bucket.getAllFilesByPrefix({
     prefix: buildConsumptionExportGcsPrefix(workspaceId),
@@ -64,7 +64,7 @@ export async function getConsumptionExportDownloadUrl(
   }
 
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const bucket = getPrivateUploadBucket();
+  const bucket = getTmpWorkloadsBucket();
   const path = `${buildConsumptionExportGcsPrefix(workspaceId)}${fileName}`;
 
   const downloadUrl = await bucket.getSignedUrl(path, {
@@ -106,7 +106,7 @@ export async function getConsumptionExportStatus(
 
   const [isGenerating, [isReady]] = await Promise.all([
     isConsumptionExportRunning(client.workflow.getHandle(workflowId)),
-    getPrivateUploadBucket()
+    getTmpWorkloadsBucket()
       .file(buildConsumptionExportGcsPath(workspaceId, exportId))
       .exists(),
   ]);

--- a/front/lib/file_storage/config.ts
+++ b/front/lib/file_storage/config.ts
@@ -13,6 +13,9 @@ const config = {
   getGcsUpsertQueueBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_UPSERT_QUEUE_BUCKET");
   },
+  getGcsTmpWorkloadsBucket: (): string => {
+    return EnvironmentConfig.getEnvVariable("DUST_TMP_WORKLOADS_BUCKET");
+  },
   getDustDataSourcesBucket: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_DATA_SOURCES_BUCKET");
   },

--- a/front/lib/file_storage/index.ts
+++ b/front/lib/file_storage/index.ts
@@ -598,6 +598,9 @@ export const getPublicUploadBucket = (options?: FileStorageOptions) =>
 export const getUpsertQueueBucket = (options?: FileStorageOptions) =>
   getBucketInstance(config.getGcsUpsertQueueBucket(), options);
 
+export const getTmpWorkloadsBucket = (options?: FileStorageOptions) =>
+  getBucketInstance(config.getGcsTmpWorkloadsBucket(), options);
+
 export const getDustDataSourcesBucket = (options?: FileStorageOptions) =>
   getBucketInstance(config.getDustDataSourcesBucket(), options);
 

--- a/front/temporal/analytics_queue/activities/consumption_export.test.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.test.ts
@@ -4,7 +4,7 @@ import {
   ElasticsearchError,
   searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { getTmpWorkloadsBucket } from "@app/lib/file_storage";
 import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/consumption-export-ready";
 import {
   buildConsumptionExportBucketPartsGcsPrefix,
@@ -339,7 +339,7 @@ describe("finalizeConsumptionExportActivity", () => {
       .map((call) => call.filePath);
     expect(writtenTmpPaths.length).toBeGreaterThan(0); // sanity: parts were written
     for (const path of writtenTmpPaths) {
-      const [content] = await getPrivateUploadBucket().file(path).download();
+      const [content] = await getTmpWorkloadsBucket().file(path).download();
       expect(content.toString()).toBe("");
     }
   });

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -18,8 +18,10 @@ import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/c
 import logger from "@app/logger/logger";
 import { createHash } from "crypto";
 
+// Kept as a top-level prefix (not nested under `w/{workspaceId}/`) so a single GCS
+// lifecycle matches_prefix rule can target every workspace's exports for expiry.
 export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
-  return `w/${workspaceId}/consumption_exports/`;
+  return `consumption_exports/${workspaceId}/`;
 }
 
 export function buildConsumptionExportGcsPath(
@@ -35,7 +37,7 @@ export function buildConsumptionExportBucketPartsGcsPrefix(
   workspaceId: string,
   exportId: string
 ): string {
-  return `w/${workspaceId}/consumption_exports_tmp/${exportId}/`;
+  return `consumption_exports_tmp/${workspaceId}/${exportId}/`;
 }
 
 function buildConsumptionExportBucketPartGcsPath(

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -18,12 +18,10 @@ import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/c
 import logger from "@app/logger/logger";
 import { createHash } from "crypto";
 
-// Exports live in the shared tmp-workloads bucket (not private-uploads), which already
-// deletes everything after 7 days: reusing that bucket-wide TTL instead of adding a new
-// one. Namespaced under a top-level prefix to avoid colliding with other workloads
-// (connectors, etc.) that write into the same bucket.
+// Written to the shared tmp-workloads bucket rather than private-uploads, reusing its
+// existing 7-day TTL instead of adding a new one.
 export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
-  return `consumption_exports/${workspaceId}/`;
+  return `w/${workspaceId}/consumption_exports/`;
 }
 
 export function buildConsumptionExportGcsPath(
@@ -39,7 +37,7 @@ export function buildConsumptionExportBucketPartsGcsPrefix(
   workspaceId: string,
   exportId: string
 ): string {
-  return `consumption_exports_tmp/${workspaceId}/${exportId}/`;
+  return `w/${workspaceId}/consumption_exports_tmp/${exportId}/`;
 }
 
 function buildConsumptionExportBucketPartGcsPath(

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -18,8 +18,6 @@ import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/c
 import logger from "@app/logger/logger";
 import { createHash } from "crypto";
 
-// Written to the shared tmp-workloads bucket rather than private-uploads, reusing its
-// existing 7-day TTL instead of adding a new one.
 export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
   return `w/${workspaceId}/consumption_exports/`;
 }

--- a/front/temporal/analytics_queue/activities/consumption_export.ts
+++ b/front/temporal/analytics_queue/activities/consumption_export.ts
@@ -12,14 +12,16 @@ import { Authenticator } from "@app/lib/auth";
 import type { FileStorage } from "@app/lib/file_storage";
 import {
   GCS_COMPOSE_MAX_SOURCES,
-  getPrivateUploadBucket,
+  getTmpWorkloadsBucket,
 } from "@app/lib/file_storage";
 import { notifyConsumptionExportReady } from "@app/lib/notifications/workflows/consumption-export-ready";
 import logger from "@app/logger/logger";
 import { createHash } from "crypto";
 
-// Kept as a top-level prefix (not nested under `w/{workspaceId}/`) so a single GCS
-// lifecycle matches_prefix rule can target every workspace's exports for expiry.
+// Exports live in the shared tmp-workloads bucket (not private-uploads), which already
+// deletes everything after 7 days: reusing that bucket-wide TTL instead of adding a new
+// one. Namespaced under a top-level prefix to avoid colliding with other workloads
+// (connectors, etc.) that write into the same bucket.
 export function buildConsumptionExportGcsPrefix(workspaceId: string): string {
   return `consumption_exports/${workspaceId}/`;
 }
@@ -137,7 +139,7 @@ export async function runConsumptionExportBucketActivity(
     bucketIndex
   );
 
-  await getPrivateUploadBucket()
+  await getTmpWorkloadsBucket()
     .file(gcsPath)
     .save(Buffer.from(result.value, "utf-8"), {
       contentType: "text/csv",
@@ -188,7 +190,7 @@ export async function finalizeConsumptionExportActivity(
 ): Promise<void> {
   const auth = await Authenticator.fromJSON(authType);
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const bucket = getPrivateUploadBucket();
+  const bucket = getTmpWorkloadsBucket();
 
   const tmpPrefix = buildConsumptionExportBucketPartsGcsPrefix(
     workspaceId,

--- a/front/temporal/analytics_queue/client.ts
+++ b/front/temporal/analytics_queue/client.ts
@@ -1,7 +1,7 @@
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
-import { getPrivateUploadBucket } from "@app/lib/file_storage";
+import { getTmpWorkloadsBucket } from "@app/lib/file_storage";
 import {
   AgentMessageModel,
   MessageModel,
@@ -247,7 +247,7 @@ export async function launchConsumptionExportWorkflow(
 
   // Checked here rather than inside the workflow so a cache hit returns immediately,
   // without paying for a Temporal round-trip.
-  const [cached] = await getPrivateUploadBucket().file(gcsPath).exists();
+  const [cached] = await getTmpWorkloadsBucket().file(gcsPath).exists();
   if (cached) {
     return new Ok({ status: "cached", gcsPath });
   }

--- a/front/tests/utils/mocks/file_storage.ts
+++ b/front/tests/utils/mocks/file_storage.ts
@@ -247,6 +247,7 @@ class FileStorageMock {
       getPrivateUploadBucket: vi.fn(createStorage),
       getPublicUploadBucket: vi.fn(createStorage),
       getUpsertQueueBucket: vi.fn(createStorage),
+      getTmpWorkloadsBucket: vi.fn(createStorage),
       getDustDataSourcesBucket: vi.fn(createStorage),
       getWebhookRequestsBucket: vi.fn(createStorage),
       getLLMTracesBucket: vi.fn(createStorage),


### PR DESCRIPTION
## Description

Moves consumption exports (#30557) from `private-uploads` to the existing `tmp-workloads` bucket, which already deletes everything after 7 days. No infra change needed (dust-tt/dust-infra#983 closed).

- Adds `getGcsTmpWorkloadsBucket()` / `getTmpWorkloadsBucket()`, following the existing per-bucket helper pattern.
- Keeps the top-level `consumption_exports/{workspaceId}/...` prefix to avoid colliding with other workloads writing into the same shared bucket.

## Tests

Existing unit tests updated to use the new bucket helper; all pass.

## Risk

Low. Old exports under the previous `private-uploads` path become unreachable but harmless. Export retention drops from the originally-planned 15 days to `tmp-workloads`' 7-day TTL.

## Deploy plan

**Needs a `DUST_TMP_WORKLOADS_BUCKET` secret added for `front`** before deploy (GSM, created out-of-band like the other bucket-name vars). No new IAM needed — `front` already has project-level `storage.objectUser`.