### PR TITLE
[front-api] Report created conversations as read for their creator

### DIFF
--- a/front-api/routes/w/[wId]/assistant/conversations/index.test.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.test.ts
@@ -134,6 +134,50 @@ describe("POST /api/w/:wId/assistant/conversations", () => {
     ).toBe(true);
   });
 
+  it("returns the created conversation as read for its creator", async () => {
+    const { workspace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "admin",
+    });
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: null,
+          visibility: "unlisted",
+          spaceId: null,
+          message: null,
+          contentFragments: [],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+
+    const responseData = await response.json();
+    // The sidebar prepends this conversation to its list: reporting it unread would flash
+    // it in the inbox while the creator is on it.
+    expect(responseData.conversation.unread).toBe(false);
+    expect(responseData.conversation.lastReadMs).not.toBeNull();
+
+    // Also assert the persisted read record, not just the response: the list endpoint must
+    // agree, otherwise the next sidebar refresh would flash the conversation as unread.
+    const listResponse = await honoApp.request(
+      `/api/w/${workspace.sId}/assistant/conversations`,
+      { method: "GET" }
+    );
+    expect(listResponse.status).toBe(200);
+    const listData = await listResponse.json();
+    const created = listData.conversations.find(
+      (c: { sId: string }) => c.sId === responseData.conversation.sId
+    );
+    expect(created).toBeDefined();
+    expect(created.unread).toBe(false);
+  });
+
   it("requires the database filesystem flag for a standalone conversation", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "POST",

--- a/front-api/routes/w/[wId]/assistant/conversations/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/index.ts
@@ -367,11 +367,21 @@ app.post(
     }
 
     if (newConversation.depth === 0) {
+      const lastReadAt = new Date();
       await ConversationResource.upsertParticipation(auth, {
         conversation: newConversation,
         action: "subscribed",
         user: user.toJSON(),
+        lastReadAt,
       });
+
+      // The serialization above predates the read-record write: reflect it so the sidebar
+      // does not flash the freshly created conversation as unread for its creator.
+      newConversation = {
+        ...newConversation,
+        unread: false,
+        lastReadMs: lastReadAt.getTime(),
+      };
     }
 
     const newContentFragments: ContentFragmentType[] = [];


### PR DESCRIPTION
## Description

Creating a conversation flashed it in the sidebar inbox while the creator was on it: the POST response serialized `unread: true` because `toJSON()` runs before `upsertParticipation` writes the creator's read record, and the client prepends that response into the sidebar list. The DB was already correct; only the response lied. Reflect the read record in the response.

Trigger-created conversations are unaffected (different code path, must stay born unread).

Companion of #30985 (both are needed): measured with a MutationObserver, the flash is ~2s before, ~0.4s with #30985 alone, none with both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
