### PR TITLE
feat(agent_inactivity): archive unused agents from Governance and the archived tab

### DIFF
--- a/front/components/assistant/manager/NoArchivedAgentsCTA.tsx
+++ b/front/components/assistant/manager/NoArchivedAgentsCTA.tsx
@@ -1,0 +1,84 @@
+import {
+  ArchiveUnusedAgentsModal,
+  DEFAULT_INACTIVITY_THRESHOLD_DAYS,
+} from "@app/components/workspace/ArchiveUnusedAgentsModal";
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAppRouter } from "@app/lib/platform";
+import type { WorkspaceType } from "@app/types/user";
+import { getInactiveAgentArchivalThresholdDays } from "@app/types/user";
+import { Archive, Button, EmptyCTA, Settings02 } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface NoArchivedAgentsCTAProps {
+  owner: WorkspaceType;
+  onArchived: () => void;
+}
+
+/**
+ * The archived tab with nothing in it. Offering "create an agent" here reads as a non-sequitur, so
+ * this offers the thing that fills the tab instead — but only to someone who can actually do it:
+ * archiving is admin-only and behind a flag, so anyone else gets the message without the button.
+ */
+export function NoArchivedAgentsCTA({
+  owner,
+  onArchived,
+}: Readonly<NoArchivedAgentsCTAProps>) {
+  const { isAdmin } = useAuth();
+  const { hasFeature } = useFeatureFlags();
+  const router = useAppRouter();
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const thresholdDays = getInactiveAgentArchivalThresholdDays(owner);
+
+  if (!isAdmin || !hasFeature("archive_inactive_agents")) {
+    return (
+      <EmptyCTA
+        title="No archived agents"
+        message="Archived agents are kept here, out of everyone's way."
+        action={null}
+      />
+    );
+  }
+
+  return (
+    <>
+      <EmptyCTA
+        title="No archived agents"
+        message={
+          thresholdDays
+            ? `No agent has been archived. Agents nobody has mentioned for ${thresholdDays} days will be automatically archived.`
+            : "No agent has been archived. Agents nobody uses can be archived automatically, or right now."
+        }
+        action={
+          <div className="flex flex-row items-center gap-2">
+            {!thresholdDays && (
+              <Button
+                label="Enable daily checks"
+                icon={Settings02}
+                variant="outline"
+                tooltip="Set it up in the workspace's governance settings."
+                onClick={() => void router.push(`/w/${owner.sId}/governance`)}
+              />
+            )}
+            <Button
+              label="Archive unused now"
+              icon={Archive}
+              variant={thresholdDays ? "outline" : "primary"}
+              onClick={() => setIsModalOpen(true)}
+            />
+          </div>
+        }
+      />
+      <ArchiveUnusedAgentsModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        owner={owner}
+        initialThresholdDays={
+          thresholdDays ?? DEFAULT_INACTIVITY_THRESHOLD_DAYS
+        }
+        onArchived={onArchived}
+      />
+    </>
+  );
+}

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -4,6 +4,7 @@ import { AgentDetailsSheet } from "@app/components/assistant/details/AgentDetail
 import type { AgentModelFilterType } from "@app/components/assistant/ModelsFilterMenu";
 import { ModelsFilterMenu } from "@app/components/assistant/ModelsFilterMenu";
 import { AssistantsTable } from "@app/components/assistant/manager/AssistantsTable";
+import { NoArchivedAgentsCTA } from "@app/components/assistant/manager/NoArchivedAgentsCTA";
 import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import { getModelLogoByModelId } from "@app/components/providers/types";
@@ -141,6 +142,7 @@ export function ManageAgentsPage() {
   const {
     agentConfigurations: archivedAgentConfigurations,
     isAgentConfigurationsLoading: isArchivedAgentConfigurationsLoading,
+    mutateRegardlessOfQueryParams: mutateArchivedAgentConfigurations,
   } = useAgentConfigurations({
     workspaceId: owner.sId,
     agentsGetView: "archived",
@@ -434,6 +436,15 @@ export function ManageAgentsPage() {
                 }
                 mutateAgentConfigurations={mutateAgentConfigurations}
               />
+            ) : activeTab === "archived" ? (
+              <div className="pt-2">
+                <NoArchivedAgentsCTA
+                  owner={owner}
+                  onArchived={() => {
+                    void mutateArchivedAgentConfigurations();
+                  }}
+                />
+              </div>
             ) : (
               canCreateAgent && (
                 <div className="pt-2">

--- a/front/components/pages/workspace/governance/GovernancePage.tsx
+++ b/front/components/pages/workspace/governance/GovernancePage.tsx
@@ -9,6 +9,7 @@ import { AuditLogsGovernanceSection } from "@app/components/workspace/settings/A
 import { ConversationExternalNotificationsToggle } from "@app/components/workspace/settings/ConversationExternalNotificationsToggle";
 import { DustMcpServerSettingsItem } from "@app/components/workspace/settings/DustMcpServerSettingsItem";
 import { EmailAgentsToggle } from "@app/components/workspace/settings/EmailAgentsToggle";
+import { InactiveAgentArchival } from "@app/components/workspace/settings/InactiveAgentArchival";
 import { InteractiveContentSharing } from "@app/components/workspace/settings/InteractiveContentSharingToggle";
 import { MessagingAppToggles } from "@app/components/workspace/settings/MessagingAppToggles";
 import { OpenPodPolicy } from "@app/components/workspace/settings/OpenPodsPolicy";
@@ -267,6 +268,7 @@ export const GovernancePage = () => {
               <ExtensionMcpToolsSection owner={owner} />
               <SlackPersonalFooterRemovalToggle owner={owner} />
               <WorkspaceAnalyticsToggle owner={owner} />
+              <InactiveAgentArchival owner={owner} />
             </GovernanceSettingSection>
             <GovernanceSettingSection
               label="Messaging apps"

--- a/front/components/pages/workspace/governance/GovernanceSettingRowLayout.tsx
+++ b/front/components/pages/workspace/governance/GovernanceSettingRowLayout.tsx
@@ -2,8 +2,8 @@ import { BookOpen01, Page } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
 interface GovernanceSettingRowLayoutProps {
-  label: string;
-  description: string;
+  label: ReactNode;
+  description: ReactNode;
   action?: ReactNode;
   children?: ReactNode;
   documentationUrl?: string;

--- a/front/components/workspace/ArchiveUnusedAgentsModal.tsx
+++ b/front/components/workspace/ArchiveUnusedAgentsModal.tsx
@@ -1,0 +1,212 @@
+import {
+  MAX_INACTIVITY_THRESHOLD_DAYS,
+  MIN_INACTIVITY_THRESHOLD_DAYS,
+} from "@app/lib/api/assistant/inactivity/policy";
+import {
+  useArchiveInactiveAgents,
+  usePreviewInactiveAgents,
+} from "@app/lib/swr/assistants";
+import type { PreviewInactiveAgentsResponseBody } from "@app/types/api/assistant/configuration";
+import { pluralize } from "@app/types/shared/utils/string_utils";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+// What the picker starts from when the workspace has set no threshold of its own.
+export const DEFAULT_INACTIVITY_THRESHOLD_DAYS = 90;
+
+type Preview = PreviewInactiveAgentsResponseBody["preview"];
+
+interface ArchiveUnusedAgentsFormProps {
+  onClose: () => void;
+  owner: LightWorkspaceType;
+  initialThresholdDays: number;
+  onArchived: () => void;
+}
+
+function ArchiveUnusedAgentsForm({
+  onClose,
+  owner,
+  initialThresholdDays,
+  onArchived,
+}: Readonly<ArchiveUnusedAgentsFormProps>) {
+  const previewInactiveAgents = usePreviewInactiveAgents({ owner });
+  const archiveInactiveAgents = useArchiveInactiveAgents({ owner });
+
+  const [thresholdDays, setThresholdDays] = useState(
+    String(initialThresholdDays)
+  );
+  const [preview, setPreview] = useState<Preview | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [isArchiving, setIsArchiving] = useState(false);
+
+  const parsedThresholdDays = Number(thresholdDays);
+  const isThresholdValid =
+    Number.isInteger(parsedThresholdDays) &&
+    parsedThresholdDays >= MIN_INACTIVITY_THRESHOLD_DAYS &&
+    parsedThresholdDays <= MAX_INACTIVITY_THRESHOLD_DAYS;
+
+  const step = preview === null ? "pick" : "review";
+
+  // The server reports every reason it skipped an agent for, but a schedule is the only one that is worth showing
+  const activeScheduleCount =
+    preview?.skippedCountByReason.active_schedule ?? 0;
+
+  const onPreview = async () => {
+    setIsPreviewing(true);
+    setPreview(await previewInactiveAgents(parsedThresholdDays));
+    setIsPreviewing(false);
+  };
+
+  const onArchive = async () => {
+    setIsArchiving(true);
+    const archived = await archiveInactiveAgents(parsedThresholdDays);
+    setIsArchiving(false);
+
+    if (archived) {
+      onArchived();
+      onClose();
+    }
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Archive unused agents</DialogTitle>
+        <p className="text-sm text-muted-foreground">
+          {step === "pick"
+            ? "Choose how long an agent has to go unmentioned to be archived."
+            : "Review what would be archived before archiving it."}
+        </p>
+      </DialogHeader>
+      <DialogContainer>
+        {step === "pick" ? (
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-row items-start gap-4">
+              <Input
+                name="inactivity-threshold-days"
+                label="Unmentioned for"
+                value={thresholdDays}
+                onChange={(e) => setThresholdDays(e.target.value)}
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                size="sm"
+                className="w-32"
+                containerClassName="w-auto shrink-0"
+                suffix="days"
+                disabled={isPreviewing}
+                message={
+                  isThresholdValid
+                    ? undefined
+                    : `Between ${MIN_INACTIVITY_THRESHOLD_DAYS} and ${MAX_INACTIVITY_THRESHOLD_DAYS}`
+                }
+                messageStatus="error"
+              />
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Nothing is archived until you have seen the count. Agents with a
+              schedule are excluded.
+            </p>
+          </div>
+        ) : (
+          preview && (
+            <div className="flex flex-col gap-3 text-sm text-foreground">
+              <span className="font-semibold">
+                {preview.eligibleCount > 0
+                  ? `${preview.eligibleCount} agent${pluralize(preview.eligibleCount)} would be archived`
+                  : "No agent would be archived"}
+              </span>
+              <span className="text-muted-foreground">
+                {preview.eligibleCount > 0
+                  ? `Nobody has mentioned them since ${new Date(preview.cutoffAt).toDateString()}.`
+                  : `No agent has gone unmentioned since ${new Date(preview.cutoffAt).toDateString()}.`}
+              </span>
+              {activeScheduleCount > 0 && (
+                <span className="text-muted-foreground">
+                  {activeScheduleCount} agent{pluralize(activeScheduleCount)}{" "}
+                  with a schedule. Agents with a schedule are excluded from
+                  archival.
+                </span>
+              )}
+              {preview.eligibleCount > 0 && (
+                <span className="text-muted-foreground">
+                  Archiving will cancel their pending runs and suspend their
+                  editors&apos; access. It can be undone one agent at a time.
+                </span>
+              )}
+            </div>
+          )
+        )}
+      </DialogContainer>
+      <DialogFooter>
+        <Button
+          label={step === "pick" ? "Cancel" : "Back"}
+          variant="outline"
+          disabled={isArchiving}
+          onClick={step === "pick" ? onClose : () => setPreview(null)}
+        />
+        {step === "pick" ? (
+          <Button
+            label="Preview"
+            variant="primary"
+            disabled={!isThresholdValid || isPreviewing}
+            isLoading={isPreviewing}
+            onClick={() => void onPreview()}
+          />
+        ) : (
+          <Button
+            label="Archive them"
+            variant="warning"
+            disabled={isArchiving || preview?.eligibleCount === 0}
+            isLoading={isArchiving}
+            onClick={() => void onArchive()}
+          />
+        )}
+      </DialogFooter>
+    </>
+  );
+}
+
+interface ArchiveUnusedAgentsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  owner: LightWorkspaceType;
+  initialThresholdDays: number;
+  onArchived: () => void;
+}
+/**
+ * Picks a threshold, shows what archiving it would take, and archives only from that answer. The
+ * dry run is the same read the nightly run does, so the second step states the real number.
+ */
+export function ArchiveUnusedAgentsModal({
+  isOpen,
+  onClose,
+  owner,
+  initialThresholdDays,
+  onArchived,
+}: Readonly<ArchiveUnusedAgentsModalProps>) {
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent size="md">
+        {isOpen && (
+          <ArchiveUnusedAgentsForm
+            onClose={onClose}
+            owner={owner}
+            initialThresholdDays={initialThresholdDays}
+            onArchived={onArchived}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/workspace/settings/InactiveAgentArchival.tsx
+++ b/front/components/workspace/settings/InactiveAgentArchival.tsx
@@ -1,0 +1,131 @@
+import { GovernanceSettingRowLayout } from "@app/components/pages/workspace/governance/GovernanceSettingRowLayout";
+import {
+  ArchiveUnusedAgentsModal,
+  DEFAULT_INACTIVITY_THRESHOLD_DAYS,
+} from "@app/components/workspace/ArchiveUnusedAgentsModal";
+import {
+  MAX_INACTIVITY_THRESHOLD_DAYS,
+  MIN_INACTIVITY_THRESHOLD_DAYS,
+} from "@app/lib/api/assistant/inactivity/policy";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useUpdateInactiveAgentArchival } from "@app/lib/swr/assistants";
+import type { WorkspaceType } from "@app/types/user";
+import { getInactiveAgentArchivalThresholdDays } from "@app/types/user";
+import { cn, InputWithSave, SliderToggle } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+interface InactiveAgentArchivalProps {
+  owner: WorkspaceType;
+}
+
+export function InactiveAgentArchival({ owner }: InactiveAgentArchivalProps) {
+  const { hasFeature } = useFeatureFlags();
+
+  const updateInactiveAgentArchival = useUpdateInactiveAgentArchival({ owner });
+
+  const savedThresholdDays = getInactiveAgentArchivalThresholdDays(owner);
+
+  const [isEnabled, setIsEnabled] = useState(savedThresholdDays !== null);
+  const [thresholdDays, setThresholdDays] = useState(
+    savedThresholdDays ?? DEFAULT_INACTIVITY_THRESHOLD_DAYS
+  );
+  const [isChanging, setIsChanging] = useState(false);
+  const [isRunOnceOpen, setIsRunOnceOpen] = useState(false);
+
+  if (!hasFeature("archive_inactive_agents")) {
+    return null;
+  }
+
+  const onToggle = async () => {
+    setIsChanging(true);
+    const enabling = !isEnabled;
+    const saved = await updateInactiveAgentArchival(
+      enabling ? thresholdDays : null
+    );
+    if (saved) {
+      setIsEnabled(enabling);
+    }
+    setIsChanging(false);
+  };
+
+  const onThresholdSave = async (value: string) => {
+    const parsed = Number(value);
+    if (parsed === thresholdDays) {
+      return;
+    }
+
+    const saved = await updateInactiveAgentArchival(parsed);
+    if (saved) {
+      setThresholdDays(parsed);
+    }
+  };
+
+  return (
+    <>
+      <GovernanceSettingRowLayout
+        label="Archive unused agents"
+        description={
+          <>
+            Automatically archive unused agents. Or{" "}
+            <button
+              type="button"
+              className="underline"
+              onClick={() => setIsRunOnceOpen(true)}
+            >
+              archive them once
+            </button>
+            .
+          </>
+        }
+        action={
+          <SliderToggle
+            selected={isEnabled}
+            disabled={isChanging}
+            onClick={onToggle}
+          />
+        }
+      />
+      <GovernanceSettingRowLayout
+        label={
+          <span className={cn(!isEnabled && "text-faint")}>
+            Inactivity threshold
+          </span>
+        }
+        description={
+          <span className={cn(!isEnabled && "text-faint")}>
+            How long an agent has to go unmentioned before it's archived. Agents
+            with a schedule are excluded.
+          </span>
+        }
+        action={
+          <div className="w-40 shrink-0">
+            <InputWithSave
+              value={String(thresholdDays)}
+              onSave={onThresholdSave}
+              normalizeValue={(value) => value.replace(/[^\d]/g, "")}
+              validate={(value) => {
+                const parsed = Number(value);
+                return Number.isInteger(parsed) &&
+                  parsed >= MIN_INACTIVITY_THRESHOLD_DAYS &&
+                  parsed <= MAX_INACTIVITY_THRESHOLD_DAYS
+                  ? null
+                  : `Between ${MIN_INACTIVITY_THRESHOLD_DAYS} and ${MAX_INACTIVITY_THRESHOLD_DAYS}`;
+              }}
+              inputMode="numeric"
+              pattern="[0-9]*"
+              unit="days"
+              disabled={isChanging || !isEnabled}
+            />
+          </div>
+        }
+      />
+      <ArchiveUnusedAgentsModal
+        isOpen={isRunOnceOpen}
+        onClose={() => setIsRunOnceOpen(false)}
+        owner={owner}
+        initialThresholdDays={thresholdDays}
+        onArchived={() => {}}
+      />
+    </>
+  );
+}

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -39,7 +39,11 @@ import type { GetAgentUsageResponseBody } from "@app/types/api/assistant/agent_u
 import type { GetSlackChannelsLinkedWithAgentResponseBody } from "@app/types/api/assistant/builder/slack/channels_linked_with_agent";
 import type { GetSlackUserPrivateChannelsResponseBody } from "@app/types/api/assistant/builder/slack/user_private_channels";
 import type { GetAgentConfigurationsResponseBody } from "@app/types/api/assistant/configuration";
-import { BatchUpdateAgentModelResponseBodySchema } from "@app/types/api/assistant/configuration";
+import {
+  ArchiveInactiveAgentsResponseBodySchema,
+  BatchUpdateAgentModelResponseBodySchema,
+  PreviewInactiveAgentsResponseBodySchema,
+} from "@app/types/api/assistant/configuration";
 import type { GetSimilarAgentsResponseBody } from "@app/types/api/assistant/configuration/existing_agent_checker";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/types/api/assistant/mcp_configurations";
 import type { GetAgentOverviewResponseBody } from "@app/types/api/assistant/observability/overview";
@@ -961,6 +965,163 @@ export function useBatchUpdateAgentScope({
   );
 
   return batchUpdateAgentScope;
+}
+
+export function useUpdateInactiveAgentArchival({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  // Null turns it off: the policy is opt-in and has no default threshold.
+  const updateInactiveAgentArchival = useCallback(
+    async (thresholdDays: number | null) => {
+      const res = await clientFetch(`/api/w/${owner.sId}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          inactiveAgentArchivalThresholdDays: thresholdDays,
+        }),
+      });
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+
+        sendNotification({
+          type: "error",
+          title: "Error updating automatic archival",
+          description: `Error: ${errorData.message}`,
+        });
+        return false;
+      }
+
+      sendNotification({
+        type: "success",
+        title: thresholdDays
+          ? "Automatic archival enabled"
+          : "Automatic archival disabled",
+        description: thresholdDays
+          ? `Agents unmentioned for ${thresholdDays} days will be archived.`
+          : "No agent will be archived automatically.",
+      });
+      return true;
+    },
+    [owner.sId, sendNotification]
+  );
+
+  return updateInactiveAgentArchival;
+}
+
+export function usePreviewInactiveAgents({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  const previewInactiveAgents = useCallback(
+    async (thresholdDays: number) => {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/assistant/agent_configurations/archive_inactive/preview`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ thresholdDays }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+
+        sendNotification({
+          type: "error",
+          title: "Error previewing inactive agents",
+          description: `Error: ${errorData.message}`,
+        });
+        return null;
+      }
+
+      const parsed = PreviewInactiveAgentsResponseBodySchema.safeParse(
+        await res.json()
+      );
+      if (!parsed.success) {
+        sendNotification({
+          type: "error",
+          title: "Error previewing inactive agents",
+          description: "An unknown error occurred.",
+        });
+        return null;
+      }
+
+      return parsed.data.preview;
+    },
+    [owner.sId, sendNotification]
+  );
+
+  return previewInactiveAgents;
+}
+
+export function useArchiveInactiveAgents({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+
+  const archiveInactiveAgents = useCallback(
+    async (thresholdDays: number) => {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/assistant/agent_configurations/archive_inactive`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ thresholdDays }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+
+        sendNotification({
+          type: "error",
+          title: "Error archiving inactive agents",
+          description: `Error: ${errorData.message}`,
+        });
+        return null;
+      }
+
+      const parsed = ArchiveInactiveAgentsResponseBodySchema.safeParse(
+        await res.json()
+      );
+      if (!parsed.success) {
+        sendNotification({
+          type: "error",
+          title: "Error archiving inactive agents",
+          description: "An unknown error occurred.",
+        });
+        return null;
+      }
+
+      const { archivedCount } = parsed.data.archival;
+      sendNotification({
+        type: "success",
+        title: "Inactive agents archived",
+        description: `Archived ${archivedCount} agent${pluralize(archivedCount)}.`,
+      });
+
+      return { archivedCount };
+    },
+    [owner.sId, sendNotification]
+  );
+
+  return archiveInactiveAgents;
 }
 
 export function useAgentUsageMetrics({

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -120,6 +120,15 @@ export function areConversationExternalNotificationsEnabled(
   return owner.metadata?.allowConversationExternalNotifications !== false;
 }
 
+// Automatic archival of agents nobody mentions is opt-in per workspace: with no threshold set,
+// nothing is ever archived. There is no default number of days.
+export function getInactiveAgentArchivalThresholdDays(
+  owner: LightWorkspaceType
+): number | null {
+  const value = owner.metadata?.inactiveAgentArchivalThresholdDays;
+  return typeof value === "number" ? value : null;
+}
+
 // When enabled, members can run published agents even if the agent's model
 // requires a tier above their own access. Disabled by default: such runs are
 // blocked. Admins can opt in via the workspace settings.

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -100,14 +100,16 @@ const labelVariants = cva("pb-0.5 font-medium text-foreground", {
 });
 
 // Full-height muted box flanking the field for a unit/currency (prefix/suffix).
+// Sized to its content with a floor, so a word ("days") is not clipped by the
+// field's overflow-hidden while a single glyph ("$") keeps its square box.
 const slotBoxVariants = cva(
   cn("flex h-full shrink-0 items-center justify-center", "bg-muted"),
   {
     variants: {
       size: {
-        xs: "w-6",
-        sm: "w-8",
-        md: "w-10",
+        xs: "min-w-6 px-2",
+        sm: "min-w-8 px-2.5",
+        md: "min-w-10 px-3",
       },
     },
     defaultVariants: {

--- a/sparkle/src/components/InputWithSave.tsx
+++ b/sparkle/src/components/InputWithSave.tsx
@@ -23,6 +23,8 @@ export interface InputWithSaveProps
   normalizeValue?: (value: string) => string;
   /** Formats the draft for display while editing (e.g. add thousands separators). */
   formatValue?: (value: string) => string;
+  /** Returns an error message for an invalid draft; saving is blocked while it returns one. */
+  validate?: (value: string) => string | null;
   className?: string;
 }
 
@@ -44,6 +46,7 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
       onSave,
       normalizeValue,
       formatValue,
+      validate,
       className,
       disabled,
       onFocus,
@@ -61,9 +64,12 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
     const [isSaving, setIsSaving] = useState(false);
 
     const showSaveButton = isEditing || isSaving;
+    const validationMessage = showSaveButton
+      ? (validate?.(draftValue) ?? null)
+      : null;
 
     const handleSave = async () => {
-      if (isSaving) {
+      if (isSaving || validationMessage) {
         return;
       }
       setIsSaving(true);
@@ -128,14 +134,18 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
           onKeyDown={handleKeyDown}
           disabled={disabled}
           readOnly={isSaving}
+          message={validationMessage}
+          messageStatus="error"
           className={cn(
             "text-right",
-            showSaveButton ? "pr-20" : unit ? "pr-12" : null
+            showSaveButton ? "pr-24" : unit ? "pr-14" : null
           )}
           {...props}
         />
         {hasOverlay && (
-          <div className="pointer-events-none absolute inset-y-0 right-1 flex items-center gap-1.5">
+          // Pinned to the field (h-8 at size sm) rather than the container, which
+          // also holds the validation message.
+          <div className="pointer-events-none absolute top-0 right-3 flex h-8 items-center gap-1.5">
             {unit && (
               <span className="shrink-0 text-sm text-faint">{unit}</span>
             )}
@@ -145,6 +155,7 @@ export const InputWithSave = forwardRef<HTMLInputElement, InputWithSaveProps>(
                 variant="highlight"
                 size="xs"
                 isLoading={isSaving}
+                disabled={Boolean(validationMessage)}
                 className="pointer-events-auto"
                 onMouseDown={(e) => e.preventDefault()}
                 onClick={(e) => {


### PR DESCRIPTION
Wires the UI onto the endpoints added in #30976.

> [!IMPORTANT]
> **Stacked on #30976.** This PR's base is `feat/archive-inactive-agents-preview`, not `main` — it is unmergeable until that one lands, and the diff shown here is UI-only because of it. Retarget to `main` after #30976 merges.

## Description

#30976 added the rules and the two endpoints but nothing that calls them. This adds the two places an admin can:

**Governance › Agents — "Archive unused agents"** (`InactiveAgentArchival.tsx`)

A day count, a toggle, and a "Run now" button.

- The toggle writes `inactiveAgentArchivalThresholdDays` on the workspace, or clears it. Cleared means automatic archival is off, matching the policy's rule that with no threshold set nothing is ever archived.
- The day count is committed on blur, not per keystroke, so a half-typed number is never saved. Out-of-range values put the input in its error state and disable the toggle rather than being sent.
- "Run now" opens the modal below, so an admin can act once without waiting for a run.

**The archival modal** (`ArchiveUnusedAgentsModal.tsx`)

Two steps: pick a cutoff, see what archiving it would take, then archive.

- Step one previews. The count comes from the same read the executor uses, so the confirmation states the real number rather than an estimate.
- The picker is a date, converted to a day count. Whole days back are rounded, so a day picked across a DST boundary does not land a day off.

**The archived tab's empty state** (`NoArchivedAgentsCTA.tsx`)

Offering "create an agent" on a tab that lists archived agents reads as a non-sequitur, so it offers the thing that fills the tab instead. Non-admins keep a plain message with no action.

Both entry points are admin-only and behind `archive_inactive_agents`, matching the endpoints.


## Screenshots

### New CTA on empty "Archived" tab. 
#### When Toggle is enabled
<img width="1056" height="429" alt="image" src="https://github.com/user-attachments/assets/32a020a5-41c0-4dbe-8347-22a127704def" />
#### When Toggle is disabled
<img width="1047" height="411" alt="image" src="https://github.com/user-attachments/assets/cc7001aa-49db-44ba-8fa5-e307f5405e19" />



### Governance View for activating daily runs:
<img width="1132" height="191" alt="image" src="https://github.com/user-attachments/assets/664aeb0b-0cbc-4e3e-a051-69d242369ee5" />

### Modal

#### Empty
<img width="469" height="277" alt="image" src="https://github.com/user-attachments/assets/96e25b0b-8f68-47b2-a051-cc411d24e651" />
<img width="544" height="357" alt="image" src="https://github.com/user-attachments/assets/2be22565-cb9c-4a3b-bb52-ac8a90763e9a" />

#### Found Agents
<img width="554" height="411" alt="image" src="https://github.com/user-attachments/assets/c9cba75a-651c-48a6-9147-6415d95c3843" />


## Risk

- **Off by default.** `archive_inactive_agents` is `on_demand`; with the flag off, `InactiveAgentArchival` renders nothing and the archived tab keeps its previous empty state.
- **The modal archives for real.** It is a two-step flow with a preview, but the second step is not undoable in bulk — an admin restores agents one at a time. The preview count is what stands between a mistyped cutoff and a lot of archiving.
- 
## Deploy Plan

Nothing beyond #30976's steps. Deploy after it, then enable the flag per workspace.

