### PR TITLE
[front] refactor: keep @temporalio/worker out of the client-side temporal module

### DIFF
--- a/front/lib/temporal.ts
+++ b/front/lib/temporal.ts
@@ -6,7 +6,6 @@ import type {
 } from "@temporalio/client";
 import { Client, Connection, WorkflowNotFoundError } from "@temporalio/client";
 import { OpenTelemetryWorkflowClientInterceptor } from "@temporalio/interceptors-opentelemetry";
-import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
 
 type TemporalNamespaces = "agent" | "connectors" | "front" | "relocation";
@@ -84,26 +83,6 @@ export async function getConnectionOptions(
       },
     },
   };
-}
-
-export async function getTemporalAgentWorkerConnection(): Promise<{
-  connection: NativeConnection;
-  namespace: string | undefined;
-}> {
-  const connectionOptions = await getConnectionOptions(
-    temporalWorkspaceToEnvVar["agent"]
-  );
-  const connection = await NativeConnection.connect(connectionOptions);
-  return { connection, namespace: process.env.TEMPORAL_AGENT_NAMESPACE };
-}
-
-export async function getTemporalWorkerConnection(): Promise<{
-  connection: NativeConnection;
-  namespace: string | undefined;
-}> {
-  const connectionOptions = await getConnectionOptions();
-  const connection = await NativeConnection.connect(connectionOptions);
-  return { connection, namespace: process.env.TEMPORAL_NAMESPACE };
 }
 
 export async function getTemporalClientForAgentNamespace() {

--- a/front/lib/temporal_worker.ts
+++ b/front/lib/temporal_worker.ts
@@ -1,0 +1,25 @@
+import {
+  getConnectionOptions,
+  temporalWorkspaceToEnvVar,
+} from "@app/lib/temporal";
+import { NativeConnection } from "@temporalio/worker";
+
+export async function getTemporalAgentWorkerConnection(): Promise<{
+  connection: NativeConnection;
+  namespace: string | undefined;
+}> {
+  const connectionOptions = await getConnectionOptions(
+    temporalWorkspaceToEnvVar["agent"]
+  );
+  const connection = await NativeConnection.connect(connectionOptions);
+  return { connection, namespace: process.env.TEMPORAL_AGENT_NAMESPACE };
+}
+
+export async function getTemporalWorkerConnection(): Promise<{
+  connection: NativeConnection;
+  namespace: string | undefined;
+}> {
+  const connectionOptions = await getConnectionOptions();
+  const connection = await NativeConnection.connect(connectionOptions);
+  return { connection, namespace: process.env.TEMPORAL_NAMESPACE };
+}

--- a/front/poke/temporal/worker.ts
+++ b/front/poke/temporal/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import * as activities from "@app/poke/temporal/activities";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";

--- a/front/temporal/activation_scheduler/worker.ts
+++ b/front/temporal/activation_scheduler/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import * as activities from "@app/temporal/activation_scheduler/activities";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";

--- a/front/temporal/agent_inactivity/worker.ts
+++ b/front/temporal/agent_inactivity/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import * as activities from "@app/temporal/agent_inactivity/activities";
 import { launchArchiveInactiveAgentsSchedule } from "@app/temporal/agent_inactivity/client";

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -4,8 +4,8 @@ import {
 } from "@app/lib/api/instrumentation/init";
 import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
 import { markShuttingDownWithDelayedAbort } from "@app/lib/shutdown_signal";
-import { getTemporalAgentWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalAgentWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import {
   compactionActivity,

--- a/front/temporal/analytics_queue/worker.ts
+++ b/front/temporal/analytics_queue/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import * as activities from "@app/temporal/analytics_queue/activities";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";

--- a/front/temporal/conversation_fork_queue/worker.ts
+++ b/front/temporal/conversation_fork_queue/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/conversation_fork_queue/activities";

--- a/front/temporal/credit_alerts/worker.ts
+++ b/front/temporal/credit_alerts/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/credit_alerts/activities";

--- a/front/temporal/data_retention/worker.ts
+++ b/front/temporal/data_retention/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/data_retention/activities";

--- a/front/temporal/es_indexation/worker.ts
+++ b/front/temporal/es_indexation/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/es_indexation/activities";

--- a/front/temporal/hard_delete/worker.ts
+++ b/front/temporal/hard_delete/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/hard_delete/activities";

--- a/front/temporal/invitations/worker.ts
+++ b/front/temporal/invitations/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/invitations/activities";

--- a/front/temporal/labs/transcripts/worker.ts
+++ b/front/temporal/labs/transcripts/worker.ts
@@ -1,5 +1,5 @@
-import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/labs/transcripts/activities";

--- a/front/temporal/mentions_count_queue/worker.ts
+++ b/front/temporal/mentions_count_queue/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/mentions_count_queue/activities";

--- a/front/temporal/mentions_queue/worker.ts
+++ b/front/temporal/mentions_queue/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/mentions_queue/activities";

--- a/front/temporal/metronome_events_queue/worker.ts
+++ b/front/temporal/metronome_events_queue/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/metronome_events_queue/activities";

--- a/front/temporal/notifications_queue/worker.ts
+++ b/front/temporal/notifications_queue/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/notifications_queue/activities";

--- a/front/temporal/production_checks/worker.ts
+++ b/front/temporal/production_checks/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/production_checks/activities";

--- a/front/temporal/project_task/worker.ts
+++ b/front/temporal/project_task/worker.ts
@@ -1,9 +1,7 @@
 import { initializeOpenTelemetryInstrumentation } from "@app/lib/api/instrumentation/init";
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/project_task/activities";

--- a/front/temporal/reinforcement/worker.ts
+++ b/front/temporal/reinforcement/worker.ts
@@ -3,11 +3,9 @@ import {
   resource,
 } from "@app/lib/api/instrumentation/init";
 import { NoopSpanExporter } from "@app/lib/api/instrumentation/noop_span_exporter";
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/reinforcement/activities";

--- a/front/temporal/remote_tools/worker.ts
+++ b/front/temporal/remote_tools/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/remote_tools/activities";

--- a/front/temporal/sandbox_functions/worker.ts
+++ b/front/temporal/sandbox_functions/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import { markSandboxFunctionInvocationFailedActivity } from "@app/temporal/sandbox_functions/activities/mark_sandbox_function_invocation_failed";

--- a/front/temporal/sandbox_reaper/worker.ts
+++ b/front/temporal/sandbox_reaper/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as reaperActivities from "@app/temporal/sandbox_reaper/activities";

--- a/front/temporal/scrub_workspace/worker.ts
+++ b/front/temporal/scrub_workspace/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/scrub_workspace/activities";

--- a/front/temporal/triggers/worker.ts
+++ b/front/temporal/triggers/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalAgentWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalAgentWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";

--- a/front/temporal/triggers_garbage_collect/worker.ts
+++ b/front/temporal/triggers_garbage_collect/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalAgentWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalAgentWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import type { Context } from "@temporalio/activity";

--- a/front/temporal/upsert_queue/worker.ts
+++ b/front/temporal/upsert_queue/worker.ts
@@ -1,5 +1,5 @@
-import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/upsert_queue/activities";

--- a/front/temporal/upsert_tables/worker.ts
+++ b/front/temporal/upsert_tables/worker.ts
@@ -1,5 +1,5 @@
-import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/upsert_tables/activities";

--- a/front/temporal/usage_queue/worker.ts
+++ b/front/temporal/usage_queue/worker.ts
@@ -1,5 +1,5 @@
-import { getTemporalWorkerConnection } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/usage_queue/activities";

--- a/front/temporal/workos_events_queue/worker.ts
+++ b/front/temporal/workos_events_queue/worker.ts
@@ -1,8 +1,6 @@
-import {
-  getTemporalWorkerConnection,
-  TEMPORAL_MAXED_CACHED_WORKFLOWS,
-} from "@app/lib/temporal";
+import { TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
 import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import { getTemporalWorkerConnection } from "@app/lib/temporal_worker";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/workos_events_queue/activities";


### PR DESCRIPTION


## Description

temporalio/worker package is quite fat, or mostly its dependencies, like webpack (no it's not a _dev_ dependency 🤯), while we realistically only need temporalio/client in most case.

This pr splits our lib/temporal to avoid importing the former in front-api.


## Tests

Existing tests

## Risk

Low

## Deploy Plan

Deploy front