### PR TITLE
[front] perf: load vendor SDKs on first use instead of at boot

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -5,91 +5,6 @@ import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
-import { default as activationRecommendationsServer } from "@app/lib/api/actions/servers/activation_recommendations";
-import { default as agentDelegationServer } from "@app/lib/api/actions/servers/agent_delegation";
-import { default as agentMemoryServer } from "@app/lib/api/actions/servers/agent_memory";
-import { default as agentRouterServer } from "@app/lib/api/actions/servers/agent_router";
-import { default as agentSidekickAgentStateServer } from "@app/lib/api/actions/servers/agent_sidekick_agent_state";
-import { default as agentSidekickContextServer } from "@app/lib/api/actions/servers/agent_sidekick_context";
-import { default as agentTemplatesServer } from "@app/lib/api/actions/servers/agent_templates";
-import { default as ashbyServer } from "@app/lib/api/actions/servers/ashby";
-import { default as askUserQuestionServer } from "@app/lib/api/actions/servers/ask_user_question";
-import { default as clariCopilotServer } from "@app/lib/api/actions/servers/clari_copilot";
-import { default as commonUtilitiesServer } from "@app/lib/api/actions/servers/common_utilities";
-import { default as confluenceServer } from "@app/lib/api/actions/servers/confluence";
-import { default as conversationFilesServer } from "@app/lib/api/actions/servers/conversation_files";
-import { default as conversationSidePanelServer } from "@app/lib/api/actions/servers/conversation_side_panel";
-import { default as dataSourcesFileSystemServer } from "@app/lib/api/actions/servers/data_sources_file_system";
-import { default as dataWarehousesServer } from "@app/lib/api/actions/servers/data_warehouses";
-import { default as databricksServer } from "@app/lib/api/actions/servers/databricks";
-import { default as exaServer } from "@app/lib/api/actions/servers/exa";
-import { default as extractDataServer } from "@app/lib/api/actions/servers/extract_data";
-import { default as fathomServer } from "@app/lib/api/actions/servers/fathom";
-import { default as fileGenerationServer } from "@app/lib/api/actions/servers/file_generation";
-import { default as filesServer } from "@app/lib/api/actions/servers/files";
-import { default as freshserviceServer } from "@app/lib/api/actions/servers/freshservice";
-import { default as frontServer } from "@app/lib/api/actions/servers/front";
-import { default as githubServer } from "@app/lib/api/actions/servers/github";
-import { default as gmailServer } from "@app/lib/api/actions/servers/gmail";
-import { default as gongServer } from "@app/lib/api/actions/servers/gong";
-import { default as calendarServer } from "@app/lib/api/actions/servers/google_calendar";
-import { default as driveServer } from "@app/lib/api/actions/servers/google_drive";
-import { default as sheetsServer } from "@app/lib/api/actions/servers/google_sheets";
-import { default as httpClientServer } from "@app/lib/api/actions/servers/http_client";
-import { default as hubspotServer } from "@app/lib/api/actions/servers/hubspot";
-import { default as imageGenerationServer } from "@app/lib/api/actions/servers/image_generation";
-import { default as includeDataServer } from "@app/lib/api/actions/servers/include_data";
-import { default as interactiveContentServer } from "@app/lib/api/actions/servers/interactive_content";
-import { default as jiraServer } from "@app/lib/api/actions/servers/jira";
-import { default as jitTestingServer } from "@app/lib/api/actions/servers/jit_testing";
-import { default as lumaServer } from "@app/lib/api/actions/servers/luma";
-import { default as microsoftDriveServer } from "@app/lib/api/actions/servers/microsoft_drive";
-import { default as microsoftExcelServer } from "@app/lib/api/actions/servers/microsoft_excel";
-import { default as microsoftTeamsServer } from "@app/lib/api/actions/servers/microsoft_teams";
-import { default as missingActionCatcherServer } from "@app/lib/api/actions/servers/missing_action_catcher";
-import { default as mondayServer } from "@app/lib/api/actions/servers/monday";
-import { default as notionServer } from "@app/lib/api/actions/servers/notion";
-import { default as openaiUsageServer } from "@app/lib/api/actions/servers/openai_usage";
-import { default as outlookCalendarServer } from "@app/lib/api/actions/servers/outlook/calendar_server";
-import { default as outlookMailServer } from "@app/lib/api/actions/servers/outlook/mail_server";
-import { default as planModeServer } from "@app/lib/api/actions/servers/plan_mode";
-import { default as podManagerServer } from "@app/lib/api/actions/servers/pod_manager";
-import { default as podTasksServer } from "@app/lib/api/actions/servers/pod_tasks";
-import { default as pokeServer } from "@app/lib/api/actions/servers/poke";
-import { default as primitiveTypesDebuggerServer } from "@app/lib/api/actions/servers/primitive_types_debugger";
-import { default as productboardServer } from "@app/lib/api/actions/servers/productboard";
-import { default as tablesQueryServerV2 } from "@app/lib/api/actions/servers/query_tables_v2";
-import { default as runAgentServer } from "@app/lib/api/actions/servers/run_agent";
-import { default as dustAppServer } from "@app/lib/api/actions/servers/run_dust_app";
-import { default as salesforceServer } from "@app/lib/api/actions/servers/salesforce";
-import { default as salesloftServer } from "@app/lib/api/actions/servers/salesloft";
-import { default as sandboxServer } from "@app/lib/api/actions/servers/sandbox";
-import { default as sandboxFunctionsServer } from "@app/lib/api/actions/servers/sandbox_functions";
-import { default as searchServer } from "@app/lib/api/actions/servers/search";
-import { default as servicenowServer } from "@app/lib/api/actions/servers/servicenow";
-import { default as shopifyServer } from "@app/lib/api/actions/servers/shopify";
-import { default as skillAuthoringServer } from "@app/lib/api/actions/servers/skill_authoring";
-import { default as skillManagementServer } from "@app/lib/api/actions/servers/skill_management";
-import { default as slabServer } from "@app/lib/api/actions/servers/slab";
-import { default as slackBotServer } from "@app/lib/api/actions/servers/slack_bot";
-import { default as slackServer } from "@app/lib/api/actions/servers/slack_personal";
-import { default as snowflakeServer } from "@app/lib/api/actions/servers/snowflake";
-import { default as soundStudio } from "@app/lib/api/actions/servers/sound_studio";
-import { default as speechGenerator } from "@app/lib/api/actions/servers/speech_generator";
-import { default as statuspageServer } from "@app/lib/api/actions/servers/statuspage";
-import { default as toolsetsServer } from "@app/lib/api/actions/servers/toolsets";
-import { default as triggersManagementServer } from "@app/lib/api/actions/servers/triggers_management";
-import { default as ukgReadyServer } from "@app/lib/api/actions/servers/ukg_ready";
-import { default as userAnalyticsServer } from "@app/lib/api/actions/servers/user_analytics";
-import { default as userMemoryServer } from "@app/lib/api/actions/servers/user_memory";
-import { default as userMentionsServer } from "@app/lib/api/actions/servers/user_mentions";
-import { default as valtownServer } from "@app/lib/api/actions/servers/val_town";
-import { default as vantaServer } from "@app/lib/api/actions/servers/vanta";
-import { default as wakeupsServer } from "@app/lib/api/actions/servers/wakeups";
-import { default as webSearchBrowseServer } from "@app/lib/api/actions/servers/web_search_browse";
-import { default as workspaceAnalyticsServer } from "@app/lib/api/actions/servers/workspace_analytics";
-import { default as workspaceManagementServer } from "@app/lib/api/actions/servers/workspace_management";
-import { default as zendeskServer } from "@app/lib/api/actions/servers/zendesk";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -117,6 +32,12 @@ function isAdvancedSearchMode(toolContext?: ToolContext) {
   );
 }
 
+/**
+ * Each server is imported on demand: a static import here loads all 86 of them,
+ * and their vendor SDKs, into every front-api boot. `googleapis`, `mathjs` and
+ * the ElevenLabs SDK alone accounted for ~6,000 modules of startup work for
+ * tools that most requests never touch.
+ */
 export async function getInternalMCPServer(
   auth: Authenticator,
   {
@@ -130,179 +51,391 @@ export async function getInternalMCPServer(
 ): Promise<McpServer> {
   switch (internalMCPServerName) {
     case "github":
-      return githubServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/github")).default(
+        auth,
+        toolContext
+      );
     case "ashby":
-      return ashbyServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/ashby")).default(
+        auth,
+        toolContext
+      );
     case "clari_copilot":
-      return clariCopilotServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/clari_copilot")
+      ).default(auth, toolContext);
     case "hubspot":
-      return hubspotServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/hubspot")).default(
+        auth,
+        toolContext
+      );
     case "image_generation":
-      return imageGenerationServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/image_generation")
+      ).default(auth, toolContext);
     case "speech_generator":
-      return speechGenerator(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/speech_generator")
+      ).default(auth, toolContext);
     case "sound_studio":
-      return soundStudio(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/sound_studio")
+      ).default(auth, toolContext);
     case "file_generation":
-      return fileGenerationServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/file_generation")
+      ).default(auth, toolContext);
     case "interactive_content":
-      return interactiveContentServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/interactive_content")
+      ).default(auth, toolContext);
     case "query_tables_v2":
-      return tablesQueryServerV2(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/query_tables_v2")
+      ).default(auth, toolContext);
     case "primitive_types_debugger":
-      return primitiveTypesDebuggerServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/primitive_types_debugger")
+      ).default(auth, toolContext);
     case "jit_testing":
-      return jitTestingServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/jit_testing")).default(
+        auth,
+        toolContext
+      );
     case "common_utilities":
-      return commonUtilitiesServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/common_utilities")
+      ).default(auth, toolContext);
     case "web_search_&_browse":
-      return webSearchBrowseServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/web_search_browse")
+      ).default(auth, toolContext);
     case "search":
       // If we are in advanced search mode, we use the data_sources_file_system server instead.
       if (isAdvancedSearchMode(toolContext)) {
-        return dataSourcesFileSystemServer(auth, toolContext);
+        return (
+          await import("@app/lib/api/actions/servers/data_sources_file_system")
+        ).default(auth, toolContext);
       }
-      return searchServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/search")).default(
+        auth,
+        toolContext
+      );
     case "missing_action_catcher":
-      return missingActionCatcherServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/missing_action_catcher")
+      ).default(auth, toolContext);
     case "notion":
-      return notionServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/notion")).default(
+        auth,
+        toolContext
+      );
     case "openai_usage":
-      return openaiUsageServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/openai_usage")
+      ).default(auth, toolContext);
     case "include_data":
-      return includeDataServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/include_data")
+      ).default(auth, toolContext);
     case "run_agent":
-      return runAgentServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/run_agent")).default(
+        auth,
+        toolContext
+      );
     case "agent_delegation":
-      return agentDelegationServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/agent_delegation")
+      ).default(auth, toolContext);
     case "run_dust_app":
-      return dustAppServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/run_dust_app")
+      ).default(auth, toolContext);
     case "agent_router":
-      return agentRouterServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/agent_router")
+      ).default(auth, toolContext);
     case "extract_data":
-      return extractDataServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/extract_data")
+      ).default(auth, toolContext);
     case "salesforce":
-      return salesforceServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/salesforce")).default(
+        auth,
+        toolContext
+      );
     case "salesloft":
-      return salesloftServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/salesloft")).default(
+        auth,
+        toolContext
+      );
     case "slab":
-      return slabServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/slab")).default(
+        auth,
+        toolContext
+      );
     case "snowflake":
-      return snowflakeServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/snowflake")).default(
+        auth,
+        toolContext
+      );
     case "gmail":
-      return gmailServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/gmail")).default(
+        auth,
+        toolContext
+      );
     case "gong":
-      return gongServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/gong")).default(
+        auth,
+        toolContext
+      );
     case "google_calendar":
-      return calendarServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/google_calendar")
+      ).default(auth, toolContext);
     case "google_drive":
-      return driveServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/google_drive")
+      ).default(auth, toolContext);
     case "google_sheets":
-      return sheetsServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/google_sheets")
+      ).default(auth, toolContext);
     case "data_sources_file_system":
-      return dataSourcesFileSystemServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/data_sources_file_system")
+      ).default(auth, toolContext);
     case "conversation_files":
-      return conversationFilesServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/conversation_files")
+      ).default(auth, toolContext);
     case "conversation_side_panel":
-      return conversationSidePanelServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/conversation_side_panel")
+      ).default(auth, toolContext);
     case "files":
-      return filesServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/files")).default(
+        auth,
+        toolContext
+      );
     case "databricks":
-      return databricksServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/databricks")).default(
+        auth,
+        toolContext
+      );
     case "servicenow":
-      return servicenowServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/servicenow")).default(
+        auth,
+        toolContext
+      );
     case "shopify":
-      return shopifyServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/shopify")).default(
+        auth,
+        toolContext
+      );
     case "jira":
-      return jiraServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/jira")).default(
+        auth,
+        toolContext
+      );
     case "luma":
-      return lumaServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/luma")).default(
+        auth,
+        toolContext
+      );
     case "microsoft_drive":
-      return microsoftDriveServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/microsoft_drive")
+      ).default(auth, toolContext);
     case "microsoft_excel":
-      return microsoftExcelServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/microsoft_excel")
+      ).default(auth, toolContext);
     case "microsoft_teams":
-      return microsoftTeamsServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/microsoft_teams")
+      ).default(auth, toolContext);
     case "monday":
-      return mondayServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/monday")).default(
+        auth,
+        toolContext
+      );
     case "slack":
-      return slackServer(auth, mcpServerId, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/slack_personal")
+      ).default(auth, mcpServerId, toolContext);
     case "slack_bot":
-      return slackBotServer(auth, mcpServerId, toolContext);
+      return (await import("@app/lib/api/actions/servers/slack_bot")).default(
+        auth,
+        mcpServerId,
+        toolContext
+      );
     case "agent_memory":
-      return agentMemoryServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/agent_memory")
+      ).default(auth, toolContext);
     case "confluence":
-      return confluenceServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/confluence")).default(
+        auth,
+        toolContext
+      );
     case "outlook":
-      return outlookMailServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/outlook/mail_server")
+      ).default(auth, toolContext);
     case "outlook_calendar":
-      return outlookCalendarServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/outlook/calendar_server")
+      ).default(auth, toolContext);
     case "agent_sidekick_agent_state":
-      return agentSidekickAgentStateServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/agent_sidekick_agent_state")
+      ).default(auth, toolContext);
     case "agent_sidekick_context":
-      return agentSidekickContextServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/agent_sidekick_context")
+      ).default(auth, toolContext);
     case "agent_templates":
-      return agentTemplatesServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/agent_templates")
+      ).default(auth, toolContext);
     case "exa_people_and_company":
-      return exaServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/exa")).default(
+        auth,
+        toolContext
+      );
     case "fathom":
-      return fathomServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/fathom")).default(
+        auth,
+        toolContext
+      );
     case "freshservice":
-      return freshserviceServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/freshservice")
+      ).default(auth, toolContext);
     case "data_warehouses":
-      return dataWarehousesServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/data_warehouses")
+      ).default(auth, toolContext);
     case "toolsets":
-      return toolsetsServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/toolsets")).default(
+        auth,
+        toolContext
+      );
     case "val_town":
-      return valtownServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/val_town")).default(
+        auth,
+        toolContext
+      );
     case "vanta":
-      return vantaServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/vanta")).default(
+        auth,
+        toolContext
+      );
     case "http_client":
-      return httpClientServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/http_client")).default(
+        auth,
+        toolContext
+      );
     case "front":
-      return frontServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/front")).default(
+        auth,
+        toolContext
+      );
     case "zendesk":
-      return zendeskServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/zendesk")).default(
+        auth,
+        toolContext
+      );
     case "workspace_analytics":
-      return workspaceAnalyticsServer(auth, toolContext);
-    case "workspace_management":
-      return workspaceManagementServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/workspace_analytics")
+      ).default(auth, toolContext);
     case "skill_management":
-      return skillManagementServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/skill_management")
+      ).default(auth, toolContext);
     case "skill_authoring":
-      return skillAuthoringServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/skill_authoring")
+      ).default(auth, toolContext);
     case "triggers_management":
-      return triggersManagementServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/triggers_management")
+      ).default(auth, toolContext);
     case "productboard":
-      return productboardServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/productboard")
+      ).default(auth, toolContext);
     case "pod_manager":
-      return podManagerServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/pod_manager")).default(
+        auth,
+        toolContext
+      );
     case "pod_tasks":
-      return podTasksServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/pod_tasks")).default(
+        auth,
+        toolContext
+      );
     case "poke":
-      return pokeServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/poke")).default(
+        auth,
+        toolContext
+      );
     case "ask_user_question":
-      return askUserQuestionServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/ask_user_question")
+      ).default(auth, toolContext);
     case "ukg_ready":
-      return ukgReadyServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/ukg_ready")).default(
+        auth,
+        toolContext
+      );
     case "user_mentions":
-      return userMentionsServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/user_mentions")
+      ).default(auth, toolContext);
     case "statuspage":
-      return statuspageServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/statuspage")).default(
+        auth,
+        toolContext
+      );
     case "sandbox":
-      return sandboxServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/sandbox")).default(
+        auth,
+        toolContext
+      );
     case "sandbox_functions":
-      return sandboxFunctionsServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/sandbox_functions")
+      ).default(auth, toolContext);
     case "wakeups":
-      return wakeupsServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/wakeups")).default(
+        auth,
+        toolContext
+      );
     case "plan_mode":
-      return planModeServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/plan_mode")).default(
+        auth,
+        toolContext
+      );
     case "user_analytics":
-      return userAnalyticsServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/user_analytics")
+      ).default(auth, toolContext);
+    case "workspace_management":
+      return (
+        await import("@app/lib/api/actions/servers/workspace_management")
+      ).default(auth, toolContext);
     case "user_memory":
-      return userMemoryServer(auth, toolContext);
+      return (await import("@app/lib/api/actions/servers/user_memory")).default(
+        auth,
+        toolContext
+      );
     case "activation_recommendations":
-      return activationRecommendationsServer(auth, toolContext);
+      return (
+        await import("@app/lib/api/actions/servers/activation_recommendations")
+      ).default(auth, toolContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/api/elasticsearch.ts
+++ b/front/lib/api/elasticsearch.ts
@@ -2,8 +2,24 @@ import config from "@app/lib/api/config";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import type { estypes } from "@elastic/elasticsearch";
-import { Client, errors as esErrors } from "@elastic/elasticsearch";
+import type {
+  Client,
+  errors as esErrors,
+  estypes,
+} from "@elastic/elasticsearch";
+
+// The client and its transport are 542 modules and nothing needs them until a
+// query runs, so the SDK is resolved on first use instead of at boot. The
+// callers below are a mix of sync and async, hence a require rather than a
+// dynamic import.
+let elasticsearch: typeof import("@elastic/elasticsearch") | undefined;
+
+function getElasticsearch(): typeof import("@elastic/elasticsearch") {
+  elasticsearch ??=
+    require("@elastic/elasticsearch") as typeof import("@elastic/elasticsearch");
+  return elasticsearch;
+}
+
 import moment from "moment-timezone";
 
 let esClient: Client | null = null;
@@ -76,14 +92,15 @@ function extractErrorReason(err: esErrors.ResponseError): string {
 }
 
 function toElasticsearchError(err: unknown): ElasticsearchError {
-  if (err instanceof esErrors.ResponseError) {
+  const { errors } = getElasticsearch();
+  if (err instanceof errors.ResponseError) {
     const statusCode = err.statusCode ?? undefined;
     const reason = extractErrorReason(err);
     return new ElasticsearchError("query_error", reason, statusCode, {
       cause: err,
     });
   }
-  if (err instanceof esErrors.ConnectionError) {
+  if (err instanceof errors.ConnectionError) {
     return new ElasticsearchError(
       "connection_error",
       "Failed to connect to Elasticsearch",
@@ -115,7 +132,7 @@ export async function getClient(): Promise<Client> {
   }
 
   const { url, username, password } = config.getElasticsearchConfig();
-  esClient = new Client({
+  esClient = new (getElasticsearch().Client)({
     node: url,
     auth: { username, password },
     tls: { rejectUnauthorized: false },

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -32,7 +32,6 @@ import type {
   ConnectionOptions,
   SnowflakeError,
 } from "snowflake-sdk";
-import snowflake from "snowflake-sdk";
 
 /**
  * Snowflake OAuth provider for MCP server integration.
@@ -375,7 +374,9 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
     warehouse: string,
     connectionId: string
   ): Promise<Result<void, Error>> {
-    // Configure SDK to suppress verbose logging
+    // Loaded here rather than at module scope: the SDK is 884 modules (it pulls
+    // the AWS, Azure and GCS storage clients) and only this check needs it.
+    const snowflake = (await import("snowflake-sdk")).default;
     snowflake.configure({ logLevel: "OFF" });
 
     const logCtx = {

--- a/front/lib/editor/instructions_block_conflict.ts
+++ b/front/lib/editor/instructions_block_conflict.ts
@@ -1,5 +1,15 @@
 import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
-import { JSDOM } from "jsdom";
+import type { JSDOM as JSDOMConstructor } from "jsdom";
+
+// jsdom is 622 modules and 4.9 MB, and only the three helpers below need it.
+// These are synchronous (their callers are too), so it is resolved on first use
+// with a require rather than a dynamic import.
+let jsdomConstructor: typeof JSDOMConstructor | undefined;
+
+function getJSDOM(): typeof JSDOMConstructor {
+  jsdomConstructor ??= (require("jsdom") as typeof import("jsdom")).JSDOM;
+  return jsdomConstructor;
+}
 
 function getDescendantBlockIdsFromDoc(
   doc: Document,
@@ -27,7 +37,7 @@ export function getDescendantBlockIds(
   instructionsHtml: string,
   targetBlockId: string
 ): Set<string> {
-  const dom = new JSDOM(instructionsHtml);
+  const dom = new (getJSDOM())(instructionsHtml);
   return getDescendantBlockIdsFromDoc(dom.window.document, targetBlockId);
 }
 
@@ -35,7 +45,7 @@ export function getDescendantBlockIds(
  * Returns every `data-block-id` present anywhere in serialized instructions HTML.
  */
 export function getAllBlockIds(instructionsHtml: string): Set<string> {
-  const doc = new JSDOM(instructionsHtml).window.document;
+  const doc = new (getJSDOM())(instructionsHtml).window.document;
   const blockIds = new Set<string>();
   doc.querySelectorAll("[data-block-id]").forEach((element) => {
     const id = element.getAttribute("data-block-id");
@@ -55,7 +65,7 @@ export function buildDescendantMap(
   instructionsHtml: string,
   blockIds: Iterable<string>
 ): Map<string, Set<string>> {
-  const dom = new JSDOM(instructionsHtml);
+  const dom = new (getJSDOM())(instructionsHtml);
   const doc = dom.window.document;
   const map = new Map<string, Set<string>>();
   for (const blockId of blockIds) {


### PR DESCRIPTION


## Description

Our MCP internal servers are one of the biggest source of heavy node_modules imports (we use 3P sdks, which are more or less responsible in terms of supply chain).

And it's not critical for front-api's start to have them imported right away (or temporal workers, for that matter).

Deferring is one solution to this, although it raises some risks, especially if we end-up seeing agents adopting this pattern more broadly. This could be a reason NOT to do it


## Tests

Tested in front-edge (to of the stack).

## Risk

Low

## Deploy Plan

Deploy front