### PR TITLE
feat(sandbox): bulk egress write across Workspace and Pods

### DIFF
--- a/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
@@ -98,6 +98,16 @@ function allowedDomainsAt(path: string): string[] {
   return JSON.parse(stored).allowedDomains ?? [];
 }
 
+function requestedDomainsAt(
+  path: string
+): { domain: string; requestedAtMs: number }[] {
+  const stored = fileStorageMock.getObject(path);
+  if (stored === undefined) {
+    return [];
+  }
+  return JSON.parse(stored).requestedDomains ?? [];
+}
+
 // The GCS mock's prefix listing is override-driven; point the sandboxes/vlt_
 // prefix at the given Pods so they read back as "configured".
 function markConfigured(wId: string, pods: SpaceResource[]) {
@@ -452,6 +462,76 @@ describe("POST /api/w/:wId/sandbox/egress-policy/bulk", () => {
     expect(await response.json()).toEqual({
       results: [{ scopeId: podA.sId, success: true }],
     });
+    // A no-op remove must not create the Pod policy file — otherwise the Pod
+    // would show up as "configured" to the file-existence-based listing.
+    expect(
+      fileStorageMock.getObject(podPolicyPath(workspace.sId, podA.sId))
+    ).toBe(undefined);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("preserves a Pod's pending requests when a domain is added", async () => {
+    const { workspace, auth, podA } = await setupTest();
+
+    const seed = await writeOwnerPolicy(auth, {
+      ownerId: podA.sId,
+      policy: {
+        allowedDomains: ["api.github.com"],
+        requestedDomains: [{ domain: "api.stripe.com", requestedAtMs: 1 }],
+      },
+    });
+    if (seed.isErr()) {
+      throw seed.error;
+    }
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId],
+      operation: { operation: "add", domain: "example.com" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [{ scopeId: podA.sId, success: true }],
+    });
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([
+      "api.github.com",
+      "example.com",
+    ]);
+    // The unrelated pending request must survive the admin add.
+    expect(requestedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([
+      { domain: "api.stripe.com", requestedAtMs: 1 },
+    ]);
+  });
+
+  it("rejects writes to an archived Pod and leaves it untouched", async () => {
+    const { workspace, auth } = await setupTest();
+    const archivedPod = await SpaceFactory.project(workspace);
+    const metadata = await ProjectMetadataResource.makeNew(auth, archivedPod, {
+      description: null,
+    });
+    await metadata.archive();
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [archivedPod.sId],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [
+        {
+          scopeId: archivedPod.sId,
+          success: false,
+          errorMessage: "Pod not found.",
+        },
+      ],
+    });
+    // The archived Pod's policy file is never created.
+    expect(
+      fileStorageMock.getObject(podPolicyPath(workspace.sId, archivedPod.sId))
+    ).toBe(undefined);
     expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
@@ -1,4 +1,7 @@
-import { writeOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
+import {
+  writeOwnerPolicy,
+  writeWorkspacePolicy,
+} from "@app/lib/api/sandbox/egress_policy";
 import type { Authenticator } from "@app/lib/auth";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -11,11 +14,35 @@ import { honoApp } from "@front-api/app";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
+const { mockEmitAuditLogEvent } = vi.hoisted(() => ({
+  mockEmitAuditLogEvent: vi.fn(),
+}));
+
+vi.mock("@app/lib/api/audit/workos_audit", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/audit/workos_audit")>();
+
+  return {
+    ...actual,
+    emitAuditLogEvent: mockEmitAuditLogEvent,
+  };
+});
+
 const BulkPoliciesResponseSchema = z.object({
   policies: z.array(
     z.object({
       podId: z.string(),
       policy: z.object({ allowedDomains: z.array(z.string()) }),
+    })
+  ),
+});
+
+const BulkWriteResponseSchema = z.object({
+  results: z.array(
+    z.object({
+      scopeId: z.string(),
+      success: z.boolean(),
+      errorMessage: z.string().optional(),
     })
   ),
 });
@@ -45,6 +72,30 @@ async function setupTest({
 
 function getBulk(wId: string, query: string) {
   return honoApp.request(`/api/w/${wId}/sandbox/egress-policy/bulk?${query}`);
+}
+
+function postBulk(wId: string, body: unknown) {
+  return honoApp.request(`/api/w/${wId}/sandbox/egress-policy/bulk`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function workspacePolicyPath(wId: string) {
+  return `w/${wId}/sandbox-egress-policy.json`;
+}
+
+function podPolicyPath(wId: string, podId: string) {
+  return `w/${wId}/sandboxes/${podId}.json`;
+}
+
+function allowedDomainsAt(path: string): string[] {
+  const stored = fileStorageMock.getObject(path);
+  if (stored === undefined) {
+    return [];
+  }
+  return JSON.parse(stored).allowedDomains ?? [];
 }
 
 // The GCS mock's prefix listing is override-driven; point the sandboxes/vlt_
@@ -169,5 +220,238 @@ describe("GET /api/w/:wId/sandbox/egress-policy/bulk", () => {
     expect(await response.json()).toMatchObject({
       error: { type: "internal_server_error" },
     });
+  });
+});
+
+describe("POST /api/w/:wId/sandbox/egress-policy/bulk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fileStorageMock.setFetchFileContentNotFound(() => true);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    const { workspace, podA } = await setupTest({ role: "user" });
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "workspace_auth_error" },
+    });
+  });
+
+  it("returns 403 when sandbox_functions is disabled", async () => {
+    const { workspace, podA } = await setupTest({
+      enableSandboxFunctions: false,
+    });
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "feature_flag_not_found" },
+    });
+  });
+
+  it("returns 400 for an empty domain", async () => {
+    const { workspace, podA } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId],
+      operation: { operation: "add", domain: "" },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+  });
+
+  it("adds a domain to the workspace and every selected pod", async () => {
+    const { workspace, podA, podB } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: true,
+      podIds: [podA.sId, podB.sId],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(200);
+    const { results } = BulkWriteResponseSchema.parse(await response.json());
+    expect(results).toEqual([
+      { scopeId: "workspace", success: true },
+      { scopeId: podA.sId, success: true },
+      { scopeId: podB.sId, success: true },
+    ]);
+
+    // The GCS policy files carry the new domain.
+    expect(allowedDomainsAt(workspacePolicyPath(workspace.sId))).toEqual([
+      "api.github.com",
+    ]);
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([
+      "api.github.com",
+    ]);
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podB.sId))).toEqual([
+      "api.github.com",
+    ]);
+
+    // One audit event per changed scope: pods carry their space_id, the
+    // workspace omits it.
+    for (const pod of [podA, podB]) {
+      expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "sandbox_egress_policy.updated",
+          metadata: expect.objectContaining({
+            space_id: pod.sId,
+            allowed_domains: "api.github.com",
+          }),
+        })
+      );
+    }
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sandbox_egress_policy.updated",
+        metadata: expect.not.objectContaining({ space_id: expect.anything() }),
+      })
+    );
+  });
+
+  it("removes a domain from the workspace and every selected pod", async () => {
+    const { workspace, auth, podA, podB } = await setupTest();
+
+    const seedWorkspace = await writeWorkspacePolicy(auth, {
+      policy: { allowedDomains: ["api.github.com", "example.com"] },
+    });
+    if (seedWorkspace.isErr()) {
+      throw seedWorkspace.error;
+    }
+    for (const pod of [podA, podB]) {
+      const seed = await writeOwnerPolicy(auth, {
+        ownerId: pod.sId,
+        policy: { allowedDomains: ["api.github.com", "example.com"] },
+      });
+      if (seed.isErr()) {
+        throw seed.error;
+      }
+    }
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: true,
+      podIds: [podA.sId, podB.sId],
+      operation: { operation: "remove", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(200);
+    const { results } = BulkWriteResponseSchema.parse(await response.json());
+    expect(results).toEqual([
+      { scopeId: "workspace", success: true },
+      { scopeId: podA.sId, success: true },
+      { scopeId: podB.sId, success: true },
+    ]);
+
+    expect(allowedDomainsAt(workspacePolicyPath(workspace.sId))).toEqual([
+      "example.com",
+    ]);
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([
+      "example.com",
+    ]);
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podB.sId))).toEqual([
+      "example.com",
+    ]);
+  });
+
+  it("reports per-scope failures for unknown pods and still applies the rest", async () => {
+    const { workspace, podA } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId, "vlt_unknown"],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(200);
+    const { results } = BulkWriteResponseSchema.parse(await response.json());
+    expect(results).toEqual([
+      { scopeId: podA.sId, success: true },
+      {
+        scopeId: "vlt_unknown",
+        success: false,
+        errorMessage: "Pod not found.",
+      },
+    ]);
+
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([
+      "api.github.com",
+    ]);
+  });
+
+  it("leaves the workspace policy untouched when includeWorkspace is false", async () => {
+    const { workspace, podA } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [{ scopeId: podA.sId, success: true }],
+    });
+    // The workspace file is never written, so it stays absent.
+    expect(allowedDomainsAt(workspacePolicyPath(workspace.sId))).toEqual([]);
+  });
+
+  it("is a no-op when adding a domain already present, skipping the audit", async () => {
+    const { workspace, auth, podA } = await setupTest();
+
+    const seed = await writeOwnerPolicy(auth, {
+      ownerId: podA.sId,
+      policy: { allowedDomains: ["api.github.com"] },
+    });
+    if (seed.isErr()) {
+      throw seed.error;
+    }
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [{ scopeId: podA.sId, success: true }],
+    });
+    // Still a single entry, and no audit event for an unchanged policy.
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([
+      "api.github.com",
+    ]);
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when removing a domain that is absent", async () => {
+    const { workspace, podA } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId],
+      operation: { operation: "remove", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      results: [{ scopeId: podA.sId, success: true }],
+    });
+    expect(mockEmitAuditLogEvent).not.toHaveBeenCalled();
   });
 });

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
@@ -286,6 +286,21 @@ describe("POST /api/w/:wId/sandbox/egress-policy/bulk", () => {
     });
   });
 
+  it("returns 400 when no scope is selected", async () => {
+    const { workspace } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { type: "invalid_request_error" },
+    });
+  });
+
   it("collapses a workspace add to the workspace alone, skipping selected pods", async () => {
     const { workspace, podA, podB } = await setupTest();
 
@@ -305,8 +320,12 @@ describe("POST /api/w/:wId/sandbox/egress-policy/bulk", () => {
       "api.github.com",
     ]);
     // The selected pod policies are left untouched.
-    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([]);
-    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podB.sId))).toEqual([]);
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual(
+      []
+    );
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podB.sId))).toEqual(
+      []
+    );
 
     // Only the workspace audit event fires (no space_id, no per-pod events).
     expect(mockEmitAuditLogEvent).toHaveBeenCalledTimes(1);

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.test.ts
@@ -286,7 +286,7 @@ describe("POST /api/w/:wId/sandbox/egress-policy/bulk", () => {
     });
   });
 
-  it("adds a domain to the workspace and every selected pod", async () => {
+  it("collapses a workspace add to the workspace alone, skipping selected pods", async () => {
     const { workspace, podA, podB } = await setupTest();
 
     const response = await postBulk(workspace.sId, {
@@ -297,42 +297,51 @@ describe("POST /api/w/:wId/sandbox/egress-policy/bulk", () => {
 
     expect(response.status).toBe(200);
     const { results } = BulkWriteResponseSchema.parse(await response.json());
-    expect(results).toEqual([
-      { scopeId: "workspace", success: true },
-      { scopeId: podA.sId, success: true },
-      { scopeId: podB.sId, success: true },
-    ]);
+    // The workspace add already covers every Pod, so the selected pods are
+    // skipped and only the workspace is written.
+    expect(results).toEqual([{ scopeId: "workspace", success: true }]);
 
-    // The GCS policy files carry the new domain.
     expect(allowedDomainsAt(workspacePolicyPath(workspace.sId))).toEqual([
       "api.github.com",
     ]);
-    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([
-      "api.github.com",
-    ]);
-    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podB.sId))).toEqual([
-      "api.github.com",
-    ]);
+    // The selected pod policies are left untouched.
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([]);
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podB.sId))).toEqual([]);
 
-    // One audit event per changed scope: pods carry their space_id, the
-    // workspace omits it.
-    for (const pod of [podA, podB]) {
-      expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: "sandbox_egress_policy.updated",
-          metadata: expect.objectContaining({
-            space_id: pod.sId,
-            allowed_domains: "api.github.com",
-          }),
-        })
-      );
-    }
+    // Only the workspace audit event fires (no space_id, no per-pod events).
+    expect(mockEmitAuditLogEvent).toHaveBeenCalledTimes(1);
     expect(mockEmitAuditLogEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         action: "sandbox_egress_policy.updated",
         metadata: expect.not.objectContaining({ space_id: expect.anything() }),
       })
     );
+  });
+
+  it("adds a domain to only the selected pods when the workspace is not included", async () => {
+    const { workspace, podA, podB } = await setupTest();
+
+    const response = await postBulk(workspace.sId, {
+      includeWorkspace: false,
+      podIds: [podA.sId, podB.sId],
+      operation: { operation: "add", domain: "api.github.com" },
+    });
+
+    expect(response.status).toBe(200);
+    const { results } = BulkWriteResponseSchema.parse(await response.json());
+    expect(results).toEqual([
+      { scopeId: podA.sId, success: true },
+      { scopeId: podB.sId, success: true },
+    ]);
+
+    // The workspace policy is untouched; both pods carry the new domain.
+    expect(allowedDomainsAt(workspacePolicyPath(workspace.sId))).toEqual([]);
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podA.sId))).toEqual([
+      "api.github.com",
+    ]);
+    expect(allowedDomainsAt(podPolicyPath(workspace.sId, podB.sId))).toEqual([
+      "api.github.com",
+    ]);
   });
 
   it("removes a domain from the workspace and every selected pod", async () => {

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.ts
@@ -1,23 +1,39 @@
+import { getAuditLogContext } from "@app/lib/api/audit/workos_audit";
 import {
+  bulkUpdateEgressDomain,
   listPodsWithEgressPolicy,
   parseSandboxAdminPodSelection,
   SandboxAdminPodSelectionQuerySchema,
 } from "@app/lib/api/sandbox/admin_pods";
 import { readOwnerPolicy } from "@app/lib/api/sandbox/egress_policy";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import type { GetPodEgressPoliciesBulkResponseBody } from "@app/types/api/sandbox/egress_policy";
+import type {
+  GetPodEgressPoliciesBulkResponseBody,
+  PostBulkEgressPolicyResponseBody,
+} from "@app/types/api/sandbox/egress_policy";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
+import { z } from "zod";
 
-// Mounted at /api/w/:wId/sandbox/egress-policy/bulk. Multi-pod read (GET) for
-// the central Computer admin page. The parent sub-app applies the
-// workspace-admin + Computer gates; the multi-Pod feature is gated on the
-// sandbox_functions flag. Only Pods with their own policy are surfaced.
+// Mounted at /api/w/:wId/sandbox/egress-policy/bulk. Multi-pod read (GET) and
+// add/remove write (POST) for the central Computer admin page. The parent
+// sub-app applies the workspace-admin + Computer gates; the multi-Pod feature
+// is gated on the sandbox_functions flag. Only Pods with their own policy are
+// surfaced.
 const app = workspaceApp();
 
 app.use("*", withFeatureFlag("sandbox_functions"));
+
+const PostBulkEgressPolicyBodySchema = z.object({
+  includeWorkspace: z.boolean(),
+  podIds: z.array(z.string()).max(100),
+  operation: z.discriminatedUnion("operation", [
+    z.object({ operation: z.literal("add"), domain: z.string().min(1) }),
+    z.object({ operation: z.literal("remove"), domain: z.string().min(1) }),
+  ]),
+});
 
 /** @ignoreswagger */
 app.get(
@@ -81,6 +97,25 @@ app.get(
     }
 
     return ctx.json({ policies });
+  }
+);
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", PostBulkEgressPolicyBodySchema),
+  async (ctx): HandlerResult<PostBulkEgressPolicyResponseBody> => {
+    const auth = ctx.get("auth");
+    const body = ctx.req.valid("json");
+
+    const results = await bulkUpdateEgressDomain(auth, {
+      includeWorkspace: body.includeWorkspace,
+      podIds: [...new Set(body.podIds)],
+      operation: body.operation,
+      context: getAuditLogContext(auth),
+    });
+
+    return ctx.json({ results });
   }
 );
 

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/bulk.ts
@@ -26,14 +26,21 @@ const app = workspaceApp();
 
 app.use("*", withFeatureFlag("sandbox_functions"));
 
-const PostBulkEgressPolicyBodySchema = z.object({
-  includeWorkspace: z.boolean(),
-  podIds: z.array(z.string()).max(100),
-  operation: z.discriminatedUnion("operation", [
-    z.object({ operation: z.literal("add"), domain: z.string().min(1) }),
-    z.object({ operation: z.literal("remove"), domain: z.string().min(1) }),
-  ]),
-});
+const PostBulkEgressPolicyBodySchema = z
+  .object({
+    includeWorkspace: z.boolean(),
+    podIds: z.array(z.string()).max(100),
+    operation: z.discriminatedUnion("operation", [
+      z.object({ operation: z.literal("add"), domain: z.string().min(1) }),
+      z.object({ operation: z.literal("remove"), domain: z.string().min(1) }),
+    ]),
+  })
+  // A bulk write must target at least one scope: the workspace, some Pods, or
+  // both.
+  .refine((body) => body.includeWorkspace || body.podIds.length > 0, {
+    message: "Provide includeWorkspace or at least one podId.",
+    path: ["podIds"],
+  });
 
 /** @ignoreswagger */
 app.get(

--- a/front/lib/api/sandbox/admin_pods.ts
+++ b/front/lib/api/sandbox/admin_pods.ts
@@ -12,7 +12,7 @@ import {
 } from "@app/lib/api/sandbox/egress_policy";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { SANDBOX_WORKSPACE_SCOPE_ID } from "@app/types/api/sandbox/egress_policy";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import type { Result } from "@app/types/shared/result";
@@ -234,12 +234,17 @@ export async function bulkUpdateEgressDomain(
     }
   }
 
-  const spaces = await SpaceResource.fetchByIds(auth, podIds);
-  const spacesById = new Map(spaces.map((space) => [space.sId, space]));
+  // Validate against the same live, non-archived project Pods the read path
+  // surfaces, so an archived Pod's id can't be used to mutate its policy.
+  const livePods = await listNonArchivedProjectSpacesAsAdmin(auth);
+  if (livePods.isErr()) {
+    // Admin-gated by the route; a failure here is a should-never-happen.
+    throw livePods.error;
+  }
+  const livePodIds = new Set(livePods.value.map((pod) => pod.sId));
 
   for (const podId of podIds) {
-    const pod = spacesById.get(podId);
-    if (!pod || !pod.isProject()) {
+    if (!livePodIds.has(podId)) {
       results.push({
         scopeId: podId,
         success: false,

--- a/front/lib/api/sandbox/admin_pods.ts
+++ b/front/lib/api/sandbox/admin_pods.ts
@@ -228,6 +228,13 @@ export async function bulkUpdateEgressDomain(
     }
   }
 
+  // A workspace add already covers every Pod, so writing to the selected Pods
+  // is redundant. Remove still targets each Pod below (a Pod can hold its own
+  // copy a workspace remove would not clear).
+  if (operation.operation === "add" && includeWorkspace) {
+    return results;
+  }
+
   // Validate against the same live, non-archived project Pods the read path
   // surfaces, so an archived Pod's id can't be used to mutate its policy.
   const livePods = await listNonArchivedProjectSpacesAsAdmin(auth);

--- a/front/lib/api/sandbox/admin_pods.ts
+++ b/front/lib/api/sandbox/admin_pods.ts
@@ -1,7 +1,20 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+} from "@app/lib/api/audit/workos_audit";
 import { listNonArchivedProjectSpacesAsAdmin } from "@app/lib/api/projects/list";
-import { listPodIdsWithEgressPolicy } from "@app/lib/api/sandbox/egress_policy";
+import {
+  addOwnerPolicyDomain,
+  addWorkspacePolicyDomain,
+  listPodIdsWithEgressPolicy,
+  removeOwnerPolicyDomain,
+  removeWorkspacePolicyDomain,
+} from "@app/lib/api/sandbox/egress_policy";
+import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { SANDBOX_WORKSPACE_SCOPE_ID } from "@app/types/api/sandbox/egress_policy";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { z } from "zod";
@@ -71,4 +84,176 @@ export async function listPodsWithEgressPolicy(
       .filter((pod) => configured.has(pod.sId))
       .sort((a, b) => a.name.localeCompare(b.name))
   );
+}
+
+// One egress-domain add/remove applied across the workspace policy and/or a
+// set of pod policies for the central Computer admin page. scopeId is
+// "workspace" for the workspace scope or a pod sId.
+export type BulkEgressOperation =
+  | { operation: "add"; domain: string }
+  | { operation: "remove"; domain: string };
+
+export type ScopeMutationResult = {
+  scopeId: string;
+  success: boolean;
+  errorMessage?: string;
+};
+
+// Emits the same sandbox_egress_policy.updated event as the single-pod PUT
+// route. space_id carries the pod sId for pods and is omitted for the
+// workspace scope (same convention as sandbox_env_var.* events).
+function emitEgressPolicyAudit(
+  auth: Authenticator,
+  {
+    podId,
+    policy,
+    context,
+  }: { podId: string | null; policy: EgressPolicy; context?: AuditLogContext }
+): void {
+  const workspace = auth.getNonNullableWorkspace();
+  void emitAuditLogEvent({
+    auth,
+    action: "sandbox_egress_policy.updated",
+    targets: [
+      buildAuditLogTarget("workspace", workspace),
+      {
+        type: "sandbox_egress_policy",
+        id: podId ?? workspace.sId,
+        name: podId ? "Pod sandbox egress policy" : "Sandbox egress policy",
+      },
+    ],
+    context,
+    metadata: {
+      allowed_domain_count: String(policy.allowedDomains.length),
+      allowed_domains: policy.allowedDomains.join(","),
+      ...(podId ? { space_id: podId } : {}),
+    },
+  });
+}
+
+// Applies one egress-domain add/remove to each selected scope independently,
+// reusing the same per-scope helpers (and audit event) the single-scope routes
+// use. Sequential on purpose — the route schema bounds podIds at 100 and
+// parallel writes would only pressure the connection pool and GCS.
+export async function bulkUpdateEgressDomain(
+  auth: Authenticator,
+  {
+    includeWorkspace,
+    podIds,
+    operation,
+    context,
+  }: {
+    includeWorkspace: boolean;
+    podIds: string[];
+    operation: BulkEgressOperation;
+    context?: AuditLogContext;
+  }
+): Promise<ScopeMutationResult[]> {
+  const { domain } = operation;
+
+  // Normalize both scopes' distinct add/remove return shapes into a single
+  // { policy, changed } outcome so callers audit uniformly.
+  async function applyWorkspace(): Promise<
+    Result<{ policy: EgressPolicy; changed: boolean }, Error>
+  > {
+    if (operation.operation === "add") {
+      const r = await addWorkspacePolicyDomain(auth, { domain });
+      if (r.isErr()) {
+        return r;
+      }
+      return new Ok({
+        policy: r.value.policy,
+        changed: r.value.addedDomain !== null,
+      });
+    }
+    const r = await removeWorkspacePolicyDomain(auth, { domain });
+    if (r.isErr()) {
+      return r;
+    }
+    return new Ok({
+      policy: r.value.policy,
+      changed: r.value.removedDomain !== null,
+    });
+  }
+
+  async function applyPod(
+    ownerId: string
+  ): Promise<Result<{ policy: EgressPolicy; changed: boolean }, Error>> {
+    if (operation.operation === "add") {
+      const r = await addOwnerPolicyDomain(auth, { ownerId, domain });
+      if (r.isErr()) {
+        return r;
+      }
+      return new Ok({
+        policy: r.value.policy,
+        changed: r.value.addedDomain !== null,
+      });
+    }
+    const r = await removeOwnerPolicyDomain(auth, { ownerId, domain });
+    if (r.isErr()) {
+      return r;
+    }
+    return new Ok({
+      policy: r.value.policy,
+      changed: r.value.removedDomain !== null,
+    });
+  }
+
+  const results: ScopeMutationResult[] = [];
+
+  if (includeWorkspace) {
+    const result = await applyWorkspace();
+    if (result.isErr()) {
+      results.push({
+        scopeId: SANDBOX_WORKSPACE_SCOPE_ID,
+        success: false,
+        errorMessage: result.error.message,
+      });
+    } else {
+      results.push({ scopeId: SANDBOX_WORKSPACE_SCOPE_ID, success: true });
+      if (result.value.changed) {
+        emitEgressPolicyAudit(auth, {
+          podId: null,
+          policy: result.value.policy,
+          context,
+        });
+      }
+    }
+  }
+
+  const spaces = await SpaceResource.fetchByIds(auth, podIds);
+  const spacesById = new Map(spaces.map((space) => [space.sId, space]));
+
+  for (const podId of podIds) {
+    const pod = spacesById.get(podId);
+    if (!pod || !pod.isProject()) {
+      results.push({
+        scopeId: podId,
+        success: false,
+        errorMessage: "Pod not found.",
+      });
+      continue;
+    }
+
+    const result = await applyPod(podId);
+    if (result.isErr()) {
+      results.push({
+        scopeId: podId,
+        success: false,
+        errorMessage: result.error.message,
+      });
+      continue;
+    }
+
+    results.push({ scopeId: podId, success: true });
+    if (result.value.changed) {
+      emitEgressPolicyAudit(auth, {
+        podId,
+        policy: result.value.policy,
+        context,
+      });
+    }
+  }
+
+  return results;
 }

--- a/front/lib/api/sandbox/admin_pods.ts
+++ b/front/lib/api/sandbox/admin_pods.ts
@@ -17,6 +17,7 @@ import { SANDBOX_WORKSPACE_SCOPE_ID } from "@app/types/api/sandbox/egress_policy
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { z } from "zod";
 
 // Pod selection for the central Computer admin page's multi-pod reads.
@@ -156,47 +157,59 @@ export async function bulkUpdateEgressDomain(
   async function applyWorkspace(): Promise<
     Result<{ policy: EgressPolicy; changed: boolean }, Error>
   > {
-    if (operation.operation === "add") {
-      const r = await addWorkspacePolicyDomain(auth, { domain });
-      if (r.isErr()) {
-        return r;
+    switch (operation.operation) {
+      case "add": {
+        const r = await addWorkspacePolicyDomain(auth, { domain });
+        if (r.isErr()) {
+          return r;
+        }
+        return new Ok({
+          policy: r.value.policy,
+          changed: r.value.addedDomain !== null,
+        });
       }
-      return new Ok({
-        policy: r.value.policy,
-        changed: r.value.addedDomain !== null,
-      });
+      case "remove": {
+        const r = await removeWorkspacePolicyDomain(auth, { domain });
+        if (r.isErr()) {
+          return r;
+        }
+        return new Ok({
+          policy: r.value.policy,
+          changed: r.value.removedDomain !== null,
+        });
+      }
+      default:
+        return assertNever(operation);
     }
-    const r = await removeWorkspacePolicyDomain(auth, { domain });
-    if (r.isErr()) {
-      return r;
-    }
-    return new Ok({
-      policy: r.value.policy,
-      changed: r.value.removedDomain !== null,
-    });
   }
 
   async function applyPod(
     ownerId: string
   ): Promise<Result<{ policy: EgressPolicy; changed: boolean }, Error>> {
-    if (operation.operation === "add") {
-      const r = await addOwnerPolicyDomain(auth, { ownerId, domain });
-      if (r.isErr()) {
-        return r;
+    switch (operation.operation) {
+      case "add": {
+        const r = await addOwnerPolicyDomain(auth, { ownerId, domain });
+        if (r.isErr()) {
+          return r;
+        }
+        return new Ok({
+          policy: r.value.policy,
+          changed: r.value.addedDomain !== null,
+        });
       }
-      return new Ok({
-        policy: r.value.policy,
-        changed: r.value.addedDomain !== null,
-      });
+      case "remove": {
+        const r = await removeOwnerPolicyDomain(auth, { ownerId, domain });
+        if (r.isErr()) {
+          return r;
+        }
+        return new Ok({
+          policy: r.value.policy,
+          changed: r.value.removedDomain !== null,
+        });
+      }
+      default:
+        return assertNever(operation);
     }
-    const r = await removeOwnerPolicyDomain(auth, { ownerId, domain });
-    if (r.isErr()) {
-      return r;
-    }
-    return new Ok({
-      policy: r.value.policy,
-      changed: r.value.removedDomain !== null,
-    });
   }
 
   const results: ScopeMutationResult[] = [];

--- a/front/lib/api/sandbox/admin_pods.ts
+++ b/front/lib/api/sandbox/admin_pods.ts
@@ -13,6 +13,7 @@ import {
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { ScopeMutationResult } from "@app/types/api/sandbox/egress_policy";
 import { SANDBOX_WORKSPACE_SCOPE_ID } from "@app/types/api/sandbox/egress_policy";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 import type { Result } from "@app/types/shared/result";
@@ -94,12 +95,6 @@ export type BulkEgressOperation =
   | { operation: "add"; domain: string }
   | { operation: "remove"; domain: string };
 
-export type ScopeMutationResult = {
-  scopeId: string;
-  success: boolean;
-  errorMessage?: string;
-};
-
 // Emits the same sandbox_egress_policy.updated event as the single-pod PUT
 // route. space_id carries the pod sId for pods and is omitted for the
 // workspace scope (same convention as sandbox_env_var.* events).
@@ -132,10 +127,9 @@ function emitEgressPolicyAudit(
   });
 }
 
-// Applies one egress-domain add/remove to each selected scope independently,
-// reusing the same per-scope helpers (and audit event) the single-scope routes
-// use. Sequential on purpose — the route schema bounds podIds at 100 and
-// parallel writes would only pressure the connection pool and GCS.
+// Applies one egress-domain add/remove to each selected scope, reusing the
+// per-scope helpers and audit event the single-scope routes use. Sequential;
+// the route schema caps podIds at 100.
 export async function bulkUpdateEgressDomain(
   auth: Authenticator,
   {
@@ -153,7 +147,7 @@ export async function bulkUpdateEgressDomain(
   const { domain } = operation;
 
   // Normalize both scopes' distinct add/remove return shapes into a single
-  // { policy, changed } outcome so callers audit uniformly.
+  // { policy, changed } outcome.
   async function applyWorkspace(): Promise<
     Result<{ policy: EgressPolicy; changed: boolean }, Error>
   > {

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -260,13 +260,11 @@ export async function addOwnerPolicyDomain(
     parsedDomain.value
   );
   const addedDomain = alreadyAllowed ? null : parsedDomain.value;
-  const policy: EgressPolicy = {
-    allowedDomains: alreadyAllowed
-      ? currentPolicy.value.allowedDomains
-      : [...currentPolicy.value.allowedDomains, parsedDomain.value],
-  };
+  const allowedDomains = alreadyAllowed
+    ? currentPolicy.value.allowedDomains
+    : [...currentPolicy.value.allowedDomains, parsedDomain.value];
 
-  if (policy.allowedDomains.length > SANDBOX_POLICY_MAX_DOMAINS) {
+  if (allowedDomains.length > SANDBOX_POLICY_MAX_DOMAINS) {
     return new Err(
       new Error(
         `Sandbox egress policy cannot exceed ${SANDBOX_POLICY_MAX_DOMAINS} domains.`
@@ -274,20 +272,18 @@ export async function addOwnerPolicyDomain(
     );
   }
 
-  try {
-    // Last-writer-wins is acceptable here because sandbox policy updates are user-approved and rare.
-    await getPolicyBucket().uploadRawContentToBucket({
-      content: JSON.stringify(policy),
-      contentType: "application/json",
-      filePath: getOwnerPolicyPath(auth, ownerId),
-    });
-
-    await invalidateOwnerPolicyCache(auth, ownerId);
-
-    return new Ok({ policy, addedDomain });
-  } catch (error) {
-    return new Err(normalizeError(error));
+  // Write through writeOwnerPolicy so the file's pending requestedDomains are
+  // preserved (and a now-allowed request is resolved) rather than overwritten
+  // with an allowlist-only policy.
+  const written = await writeOwnerPolicy(auth, {
+    ownerId,
+    policy: { allowedDomains },
+  });
+  if (written.isErr()) {
+    return written;
   }
+
+  return new Ok({ policy: written.value, addedDomain });
 }
 
 // Workspace-scoped counterpart of addOwnerPolicyDomain: exact-domain append
@@ -352,10 +348,13 @@ export async function removeOwnerPolicyDomain(
     return new Err(currentPolicy.error);
   }
 
-  const wasPresent = currentPolicy.value.allowedDomains.includes(
-    parsedDomain.value
-  );
-  const removedDomain = wasPresent ? parsedDomain.value : null;
+  // Skip the write entirely when the domain is absent so a no-op remove never
+  // creates an owner policy file — which would make an unconfigured Pod look
+  // configured to listPodIdsWithEgressPolicy (file-existence based).
+  if (!currentPolicy.value.allowedDomains.includes(parsedDomain.value)) {
+    return new Ok({ policy: currentPolicy.value, removedDomain: null });
+  }
+
   const allowedDomains = currentPolicy.value.allowedDomains.filter(
     (allowed) => allowed !== parsedDomain.value
   );
@@ -368,7 +367,7 @@ export async function removeOwnerPolicyDomain(
     return new Err(written.error);
   }
 
-  return new Ok({ policy: written.value, removedDomain });
+  return new Ok({ policy: written.value, removedDomain: parsedDomain.value });
 }
 
 // Workspace-scoped counterpart of removeOwnerPolicyDomain.
@@ -388,10 +387,12 @@ export async function removeWorkspacePolicyDomain(
     return new Err(currentPolicy.error);
   }
 
-  const wasPresent = currentPolicy.value.allowedDomains.includes(
-    parsedDomain.value
-  );
-  const removedDomain = wasPresent ? parsedDomain.value : null;
+  // Skip the write when the domain is absent (no-op remove), mirroring
+  // removeOwnerPolicyDomain.
+  if (!currentPolicy.value.allowedDomains.includes(parsedDomain.value)) {
+    return new Ok({ policy: currentPolicy.value, removedDomain: null });
+  }
+
   const allowedDomains = currentPolicy.value.allowedDomains.filter(
     (allowed) => allowed !== parsedDomain.value
   );
@@ -403,7 +404,7 @@ export async function removeWorkspacePolicyDomain(
     return new Err(written.error);
   }
 
-  return new Ok({ policy: written.value, removedDomain });
+  return new Ok({ policy: written.value, removedDomain: parsedDomain.value });
 }
 
 // Caps the pending-request section: the proxy re-reads this file on every

--- a/front/lib/api/sandbox/egress_policy.ts
+++ b/front/lib/api/sandbox/egress_policy.ts
@@ -290,6 +290,122 @@ export async function addOwnerPolicyDomain(
   }
 }
 
+// Workspace-scoped counterpart of addOwnerPolicyDomain: exact-domain append
+// with the same dedupe and cap, but on the workspace policy file.
+export async function addWorkspacePolicyDomain(
+  auth: Authenticator,
+  { domain }: { domain: string }
+): Promise<
+  Result<{ policy: EgressPolicy; addedDomain: string | null }, Error>
+> {
+  const parsedDomain = parseExactEgressDomain(domain);
+  if (parsedDomain.isErr()) {
+    return new Err(parsedDomain.error);
+  }
+
+  const currentPolicy = await readWorkspacePolicy(auth);
+  if (currentPolicy.isErr()) {
+    return new Err(currentPolicy.error);
+  }
+
+  const alreadyAllowed = currentPolicy.value.allowedDomains.includes(
+    parsedDomain.value
+  );
+  const addedDomain = alreadyAllowed ? null : parsedDomain.value;
+  const allowedDomains = alreadyAllowed
+    ? currentPolicy.value.allowedDomains
+    : [...currentPolicy.value.allowedDomains, parsedDomain.value];
+
+  if (allowedDomains.length > SANDBOX_POLICY_MAX_DOMAINS) {
+    return new Err(
+      new Error(
+        `Sandbox egress policy cannot exceed ${SANDBOX_POLICY_MAX_DOMAINS} domains.`
+      )
+    );
+  }
+
+  const written = await writeWorkspacePolicy(auth, {
+    policy: { allowedDomains },
+  });
+  if (written.isErr()) {
+    return new Err(written.error);
+  }
+
+  return new Ok({ policy: written.value, addedDomain });
+}
+
+// Removes an exact domain from a pod's allowlist. No cap check (removal only
+// shrinks the list); removedDomain is null when the domain was not present.
+export async function removeOwnerPolicyDomain(
+  auth: Authenticator,
+  { ownerId, domain }: { ownerId: string; domain: string }
+): Promise<
+  Result<{ policy: EgressPolicy; removedDomain: string | null }, Error>
+> {
+  const parsedDomain = parseExactEgressDomain(domain);
+  if (parsedDomain.isErr()) {
+    return new Err(parsedDomain.error);
+  }
+
+  const currentPolicy = await readOwnerPolicy(auth, ownerId);
+  if (currentPolicy.isErr()) {
+    return new Err(currentPolicy.error);
+  }
+
+  const wasPresent = currentPolicy.value.allowedDomains.includes(
+    parsedDomain.value
+  );
+  const removedDomain = wasPresent ? parsedDomain.value : null;
+  const allowedDomains = currentPolicy.value.allowedDomains.filter(
+    (allowed) => allowed !== parsedDomain.value
+  );
+
+  const written = await writeOwnerPolicy(auth, {
+    ownerId,
+    policy: { allowedDomains },
+  });
+  if (written.isErr()) {
+    return new Err(written.error);
+  }
+
+  return new Ok({ policy: written.value, removedDomain });
+}
+
+// Workspace-scoped counterpart of removeOwnerPolicyDomain.
+export async function removeWorkspacePolicyDomain(
+  auth: Authenticator,
+  { domain }: { domain: string }
+): Promise<
+  Result<{ policy: EgressPolicy; removedDomain: string | null }, Error>
+> {
+  const parsedDomain = parseExactEgressDomain(domain);
+  if (parsedDomain.isErr()) {
+    return new Err(parsedDomain.error);
+  }
+
+  const currentPolicy = await readWorkspacePolicy(auth);
+  if (currentPolicy.isErr()) {
+    return new Err(currentPolicy.error);
+  }
+
+  const wasPresent = currentPolicy.value.allowedDomains.includes(
+    parsedDomain.value
+  );
+  const removedDomain = wasPresent ? parsedDomain.value : null;
+  const allowedDomains = currentPolicy.value.allowedDomains.filter(
+    (allowed) => allowed !== parsedDomain.value
+  );
+
+  const written = await writeWorkspacePolicy(auth, {
+    policy: { allowedDomains },
+  });
+  if (written.isErr()) {
+    return new Err(written.error);
+  }
+
+  return new Ok({ policy: written.value, removedDomain });
+}
+
 // Caps the pending-request section: the proxy re-reads this file on every
 // cache miss, so an agent must not be able to grow it unboundedly.
 const SANDBOX_POLICY_MAX_REQUESTED_DOMAINS = 50;

--- a/front/types/api/sandbox/egress_policy.ts
+++ b/front/types/api/sandbox/egress_policy.ts
@@ -1,9 +1,16 @@
-import type { ScopeMutationResult } from "@app/lib/api/sandbox/admin_pods";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
 
 // The scopeId the bulk egress write reports for the workspace baseline; pods
 // use their sId. Shared so the client can map a result back to the Workspace.
 export const SANDBOX_WORKSPACE_SCOPE_ID = "workspace";
+
+// Per-scope outcome of a bulk egress write. scopeId is
+// SANDBOX_WORKSPACE_SCOPE_ID for the workspace scope or a pod sId.
+export type ScopeMutationResult = {
+  scopeId: string;
+  success: boolean;
+  errorMessage?: string;
+};
 
 export type GetWorkspaceEgressPolicyResponseBody = {
   policy: EgressPolicy;

--- a/front/types/api/sandbox/egress_policy.ts
+++ b/front/types/api/sandbox/egress_policy.ts
@@ -1,4 +1,9 @@
+import type { ScopeMutationResult } from "@app/lib/api/sandbox/admin_pods";
 import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+
+// The scopeId the bulk egress write reports for the workspace baseline; pods
+// use their sId. Shared so the client can map a result back to the Workspace.
+export const SANDBOX_WORKSPACE_SCOPE_ID = "workspace";
 
 export type GetWorkspaceEgressPolicyResponseBody = {
   policy: EgressPolicy;
@@ -37,4 +42,8 @@ export type GetEgressPolicyPodsResponseBody = {
 
 export type GetPodEgressPoliciesBulkResponseBody = {
   policies: { podId: string; policy: EgressPolicy }[];
+};
+
+export type PostBulkEgressPolicyResponseBody = {
+  results: ScopeMutationResult[];
 };


### PR DESCRIPTION
## Problem

PR 2 of the Computer admin stack. PR 1 added the multi-Pod egress **read**; this adds the **write** — applying a single domain add/remove across the Workspace baseline and/or selected Pods in one call.
## What this PR does

- **`addWorkspacePolicyDomain` / `removeWorkspacePolicyDomain` / `removeOwnerPolicyDomain`** — the workspace-scoped and removal counterparts of the existing `addOwnerPolicyDomain` (same exact-domain parse, dedupe, and 100-domain cap).
- **`bulkUpdateEgressDomain`** applies one `{ add | remove, domain }` across the selected scopes (Workspace when included, plus each Pod), preserving every scope's other domains, returning a per-scope `{ scopeId, success, errorMessage? }`, and emitting `sandbox_egress_policy.updated` **only for scopes that actually changed**.
- **`POST /w/:wId/sandbox/egress-policy/bulk`** wires it up.

## Semantics

It's *"add/remove domain X across these scopes,"* not *"set these Pods' policy to P."* Each Pod is validated as a live project space (unknown ids come back as a per-scope `Pod not found`, they don't sink the batch). The body caps `podIds` at 100.

## Gating

Same as the read: workspace-admin + Computer (parent sub-app) + `sandbox_functions` on the route.

## Risk

Additive write endpoint behind admin + feature-flag gates. Worst case a bulk write misbehaves for admins with the flag on; per-scope isolation keeps one Pod's failure from affecting others. Safe to roll back.

## Tests

Add/remove across Workspace + Pods (files + audit), per-scope failure for unknown Pods, workspace-only (Pod files untouched), and no-op idempotency (adding a present domain / removing an absent one skips the audit). Response bodies parsed with zod (no `as`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)