### PR TITLE
feat(sandbox): multi-Pod network editor on the Computer admin page

### DIFF
--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,14 +1,79 @@
 import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
 import { AgentRequestedDomainsSetting } from "@app/components/sandbox/AgentRequestedDomainsSetting";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
+import { MultiPodNetworkSection } from "@app/components/sandbox/MultiPodNetworkSection";
+import type { SandboxScopeSelection } from "@app/components/sandbox/SandboxScopeSelector";
+import { SandboxScopeSelector } from "@app/components/sandbox/SandboxScopeSelector";
+import { useComputerAdminAccess } from "@app/hooks/useComputerAdminAccess";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useEgressPolicyPods } from "@app/lib/swr/sandbox";
 import { ContentMessage, InfoCircle, Page } from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
 
 export function SandboxPage() {
-  const { isAdmin } = useAuth();
-  const { featureFlags } = useFeatureFlags();
-  const hasSandboxAdmin = isComputerFeatureEnabled(featureFlags);
+  const owner = useWorkspace();
+  const { isAdmin, isComputerEnabled, canAdministratePodNetwork } =
+    useComputerAdminAccess();
+  const [selection, setSelection] = useState<SandboxScopeSelection>({
+    includeWorkspace: true,
+    podIds: [],
+  });
+
+  // Only Pods with their own policy are offered; a brand-new Pod is configured
+  // from its own settings page, then appears here.
+  const { pods, isEgressPolicyPodsLoading, isEgressPolicyPodsError } =
+    useEgressPolicyPods({
+      owner,
+      disabled: !canAdministratePodNetwork,
+    });
+
+  const selectedPods = useMemo(() => {
+    const set = new Set(selection.podIds);
+    return pods.filter((pod) => set.has(pod.sId));
+  }, [selection.podIds, pods]);
+
+  const scopeCount = (selection.includeWorkspace ? 1 : 0) + selectedPods.length;
+
+  // Workspace-only leaves this null so the multi-pod read is skipped and only
+  // the workspace baseline is shown.
+  const podSelection =
+    selectedPods.length > 0
+      ? { kind: "pods" as const, podIds: selectedPods.map((pod) => pod.sId) }
+      : null;
+
+  // Network is scope-aware (Workspace and/or Pods), so the scope selector lives
+  // with it. Environment variables stay workspace-scoped.
+  const renderNetwork = () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="heading-xl text-foreground">Network</div>
+        <div className="shrink-0">
+          <SandboxScopeSelector
+            pods={pods}
+            selection={selection}
+            onChange={setSelection}
+            isLoading={isEgressPolicyPodsLoading}
+            isError={isEgressPolicyPodsError}
+          />
+        </div>
+      </div>
+      {scopeCount === 0 ? (
+        <ContentMessage
+          variant="info"
+          icon={InfoCircle}
+          size="lg"
+          title="Select the Workspace or one or more Pods to view and edit network access."
+        />
+      ) : (
+        <MultiPodNetworkSection
+          owner={owner}
+          includeWorkspace={selection.includeWorkspace}
+          selection={podSelection}
+          selectedPods={selectedPods}
+        />
+      )}
+    </div>
+  );
 
   const renderBody = () => {
     if (!isAdmin) {
@@ -18,8 +83,7 @@ export function SandboxPage() {
         </ContentMessage>
       );
     }
-
-    if (!hasSandboxAdmin) {
+    if (!isComputerEnabled) {
       return (
         <ContentMessage variant="info" icon={InfoCircle} size="lg">
           Computer administration is not enabled for this workspace.
@@ -30,7 +94,7 @@ export function SandboxPage() {
     return (
       <>
         <AgentRequestedDomainsSetting />
-        <NetworkSection />
+        {canAdministratePodNetwork ? renderNetwork() : <NetworkSection />}
         <EnvironmentSection />
       </>
     );
@@ -40,7 +104,7 @@ export function SandboxPage() {
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
         title="Computer"
-        description="Configure workspace-level network access and environment variables for the Computer."
+        description="Configure workspace and Pod network access and environment variables for the Computer."
       />
       {renderBody()}
     </Page.Vertical>

--- a/front/components/sandbox/MultiPodNetworkSection.test.tsx
+++ b/front/components/sandbox/MultiPodNetworkSection.test.tsx
@@ -1,0 +1,200 @@
+import {
+  buildDomainRows,
+  buildPendingRequests,
+  MultiPodNetworkSection,
+} from "@app/components/sandbox/MultiPodNetworkSection";
+import type { SandboxAdminPod } from "@app/types/api/sandbox/egress_policy";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import type { LightWorkspaceType } from "@app/types/user";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { bulkUpdateMock, mutatePodPoliciesMock, mutateWorkspaceMock } =
+  vi.hoisted(() => ({
+    bulkUpdateMock: vi.fn(),
+    mutatePodPoliciesMock: vi.fn(),
+    mutateWorkspaceMock: vi.fn(),
+  }));
+
+vi.mock("@app/lib/swr/sandbox", () => ({
+  useBulkPodEgressPolicies: () => ({
+    podPolicies: [],
+    isPodPoliciesLoading: false,
+    isPodPoliciesError: false,
+    mutatePodPolicies: mutatePodPoliciesMock,
+  }),
+  useWorkspaceEgressPolicy: () => ({
+    policy: { allowedDomains: [] },
+    requestedDomains: [],
+    isWorkspaceEgressPolicyLoading: false,
+    isWorkspaceEgressPolicyError: false,
+    mutateWorkspaceEgressPolicy: mutateWorkspaceMock,
+  }),
+  useBulkUpdateEgressDomain: () => ({
+    bulkUpdateEgressDomain: bulkUpdateMock,
+    isBulkUpdatingEgressDomain: false,
+  }),
+  useDismissWorkspaceEgressRequest: () => ({
+    dismissWorkspaceEgressRequest: vi.fn(),
+    isDismissingRequest: false,
+  }),
+  useDismissPodEgressRequestByPod: () => ({
+    dismissPodEgressRequest: vi.fn(),
+    isDismissingPodEgressRequest: false,
+  }),
+}));
+
+const podA: SandboxAdminPod = {
+  sId: "vlt_a",
+  name: "Alpha",
+  isRestricted: false,
+};
+const podB: SandboxAdminPod = {
+  sId: "vlt_b",
+  name: "Beta",
+  isRestricted: true,
+};
+
+function policy(
+  allowedDomains: string[],
+  requestedDomains: { domain: string; requestedAtMs: number }[] = []
+): EgressPolicy {
+  return { allowedDomains, requestedDomains };
+}
+
+describe("buildDomainRows", () => {
+  it("unions workspace and Pod domains, sorted", () => {
+    const rows = buildDomainRows({
+      workspaceAllowedDomains: ["b.com"],
+      podPolicies: [{ podId: podA.sId, policy: policy(["a.com"]) }],
+      selectedPods: [podA],
+      includeWorkspace: true,
+    });
+
+    expect(rows.map((row) => row.domain)).toEqual(["a.com", "b.com"]);
+  });
+
+  it("marks a workspace domain as inherited and removable only at the workspace", () => {
+    const [row] = buildDomainRows({
+      workspaceAllowedDomains: ["shared.com"],
+      podPolicies: [{ podId: podA.sId, policy: policy([]) }],
+      selectedPods: [podA],
+      includeWorkspace: true,
+    });
+
+    expect(row.inWorkspace).toBe(true);
+    expect(row.ownedByPods).toEqual([]);
+    expect(row.removableScopeCount).toBe(1);
+  });
+
+  it("cannot remove an inherited-only domain when the workspace is not selected", () => {
+    const [row] = buildDomainRows({
+      workspaceAllowedDomains: ["shared.com"],
+      podPolicies: [{ podId: podA.sId, policy: policy([]) }],
+      selectedPods: [podA],
+      includeWorkspace: false,
+    });
+
+    expect(row.inWorkspace).toBe(true);
+    expect(row.removableScopeCount).toBe(0);
+  });
+
+  it("counts the workspace plus each owning Pod as removable", () => {
+    const [row] = buildDomainRows({
+      workspaceAllowedDomains: ["shared.com"],
+      podPolicies: [
+        { podId: podA.sId, policy: policy(["shared.com"]) },
+        { podId: podB.sId, policy: policy(["shared.com"]) },
+      ],
+      selectedPods: [podA, podB],
+      includeWorkspace: true,
+    });
+
+    expect(row.ownedByPods.map((pod) => pod.sId)).toEqual([podA.sId, podB.sId]);
+    expect(row.removableScopeCount).toBe(3);
+  });
+});
+
+describe("buildPendingRequests", () => {
+  it("keeps workspace requests not yet allowed and drops covered ones", () => {
+    const rows = buildPendingRequests({
+      workspaceRequestedDomains: [
+        { domain: "new.com" },
+        { domain: "already.com" },
+      ],
+      workspaceAllowedDomains: ["already.com"],
+      podPolicies: [],
+      selectedPods: [],
+      includeWorkspace: true,
+    });
+
+    expect(rows.map((row) => row.domain)).toEqual(["new.com"]);
+    expect(rows[0].scopeKind).toBe("workspace");
+  });
+
+  it("skips workspace requests when the workspace is not selected", () => {
+    const rows = buildPendingRequests({
+      workspaceRequestedDomains: [{ domain: "new.com" }],
+      workspaceAllowedDomains: [],
+      podPolicies: [],
+      selectedPods: [],
+      includeWorkspace: false,
+    });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("surfaces a Pod request tied to its originating Pod", () => {
+    const rows = buildPendingRequests({
+      workspaceRequestedDomains: [],
+      workspaceAllowedDomains: [],
+      podPolicies: [
+        {
+          podId: podA.sId,
+          policy: policy([], [{ domain: "pod.com", requestedAtMs: 1 }]),
+        },
+      ],
+      selectedPods: [podA],
+      includeWorkspace: false,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      domain: "pod.com",
+      scopeKind: "pod",
+      scopeName: "Alpha",
+    });
+  });
+});
+
+describe("MultiPodNetworkSection mutation flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("revalidates after a partial-failure add so changed scopes are not left stale", async () => {
+    // A bulk write can return 200 with mixed results (the hook then returns
+    // false), but some scopes may have changed — so the reads must still
+    // revalidate, not only on full success.
+    bulkUpdateMock.mockResolvedValue(false);
+
+    render(
+      <MultiPodNetworkSection
+        owner={{ sId: "wId" } as LightWorkspaceType}
+        includeWorkspace
+        selection={null}
+        selectedPods={[]}
+      />
+    );
+
+    await userEvent.type(screen.getByRole("textbox"), "api.openai.com");
+    await userEvent.click(screen.getByRole("button", { name: "Add domain" }));
+
+    expect(bulkUpdateMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mutatePodPoliciesMock).toHaveBeenCalled();
+      expect(mutateWorkspaceMock).toHaveBeenCalled();
+    });
+  });
+});

--- a/front/components/sandbox/MultiPodNetworkSection.tsx
+++ b/front/components/sandbox/MultiPodNetworkSection.tsx
@@ -1,0 +1,535 @@
+import { DomainBadge } from "@app/components/sandbox/DomainBadge";
+import { DomainInputForm } from "@app/components/sandbox/DomainInputForm";
+import { podIcon } from "@app/components/sandbox/pod_icon";
+import type { SandboxPodSelection } from "@app/lib/swr/sandbox";
+import {
+  useBulkPodEgressPolicies,
+  useBulkUpdateEgressDomain,
+  useDismissPodEgressRequestByPod,
+  useDismissWorkspaceEgressRequest,
+  useWorkspaceEgressPolicy,
+} from "@app/lib/swr/sandbox";
+import type { SandboxAdminPod } from "@app/types/api/sandbox/egress_policy";
+import type { EgressPolicy } from "@app/types/sandbox/egress_policy";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Building04,
+  Button,
+  Chip,
+  ContentMessage,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  InfoCircle,
+  Page,
+  Spinner,
+  Trash01,
+  XClose,
+} from "@dust-tt/sparkle";
+import type { MouseEvent } from "react";
+import { useMemo, useState } from "react";
+
+interface MultiPodNetworkSectionProps {
+  owner: LightWorkspaceType;
+  // null when no Pods are selected (workspace-only): the pod policies aren't
+  // read and only the workspace baseline is shown.
+  selection: SandboxPodSelection | null;
+  // The pods `selection` resolves to, for names and counts.
+  selectedPods: SandboxAdminPod[];
+  // When true, the workspace baseline is one of the scopes being edited.
+  includeWorkspace: boolean;
+}
+
+// One editable domain across the selected scopes. `inWorkspace` means the
+// workspace baseline allows it (so every Pod inherits it); `ownedByPods` are
+// the selected Pods whose own policy file lists it.
+export type DomainRow = {
+  domain: string;
+  inWorkspace: boolean;
+  ownedByPods: SandboxAdminPod[];
+  // Scopes this row can actually be removed from with the current selection:
+  // the workspace (only when it's in the selection) plus any owning Pod. Zero
+  // means the row is inherited-only here and removal must happen at the
+  // workspace.
+  removableScopeCount: number;
+};
+
+// One agent-requested domain awaiting review, tied to the single scope it was
+// requested on — approve/reject act only on that origin.
+export type PendingRequest = {
+  key: string;
+  domain: string;
+  scopeName: string;
+} & ({ scopeKind: "workspace" } | { scopeKind: "pod"; pod: SandboxAdminPod });
+
+// Union of allowed domains across the workspace baseline and the selected Pods,
+// sorted, each row tagging the owning scopes and how many of the current
+// selection it can be removed from.
+export function buildDomainRows({
+  workspaceAllowedDomains,
+  podPolicies,
+  selectedPods,
+  includeWorkspace,
+}: {
+  workspaceAllowedDomains: string[];
+  podPolicies: { podId: string; policy: EgressPolicy }[];
+  selectedPods: SandboxAdminPod[];
+  includeWorkspace: boolean;
+}): DomainRow[] {
+  const workspaceDomains = new Set(workspaceAllowedDomains);
+  const podOwnById = new Map(
+    podPolicies.map(({ podId, policy }) => [
+      podId,
+      new Set(policy.allowedDomains),
+    ])
+  );
+
+  const domains = new Set<string>(workspaceDomains);
+  for (const { policy } of podPolicies) {
+    for (const domain of policy.allowedDomains) {
+      domains.add(domain);
+    }
+  }
+
+  return [...domains]
+    .map((domain) => {
+      const inWorkspace = workspaceDomains.has(domain);
+      const ownedByPods = selectedPods.filter((pod) =>
+        podOwnById.get(pod.sId)?.has(domain)
+      );
+      return {
+        domain,
+        inWorkspace,
+        ownedByPods,
+        removableScopeCount:
+          (includeWorkspace && inWorkspace ? 1 : 0) + ownedByPods.length,
+      };
+    })
+    .sort((a, b) => a.domain.localeCompare(b.domain));
+}
+
+// Agent-requested domains awaiting review, one row per originating scope (the
+// workspace when selected, plus each selected Pod). A request already covered
+// by that scope's allowlist is dropped.
+export function buildPendingRequests({
+  workspaceRequestedDomains,
+  workspaceAllowedDomains,
+  podPolicies,
+  selectedPods,
+  includeWorkspace,
+}: {
+  workspaceRequestedDomains: { domain: string }[];
+  workspaceAllowedDomains: string[];
+  podPolicies: { podId: string; policy: EgressPolicy }[];
+  selectedPods: SandboxAdminPod[];
+  includeWorkspace: boolean;
+}): PendingRequest[] {
+  const workspaceDomains = new Set(workspaceAllowedDomains);
+  const podOwnById = new Map(
+    podPolicies.map(({ podId, policy }) => [
+      podId,
+      new Set(policy.allowedDomains),
+    ])
+  );
+  const podPolicyById = new Map(
+    podPolicies.map(({ podId, policy }) => [podId, policy])
+  );
+
+  const rows: PendingRequest[] = [];
+  if (includeWorkspace) {
+    for (const request of workspaceRequestedDomains) {
+      if (!workspaceDomains.has(request.domain)) {
+        rows.push({
+          key: `workspace:${request.domain}`,
+          domain: request.domain,
+          scopeName: "Workspace",
+          scopeKind: "workspace",
+        });
+      }
+    }
+  }
+  for (const pod of selectedPods) {
+    const owned = podOwnById.get(pod.sId);
+    for (const request of podPolicyById.get(pod.sId)?.requestedDomains ?? []) {
+      if (!owned?.has(request.domain)) {
+        rows.push({
+          key: `${pod.sId}:${request.domain}`,
+          domain: request.domain,
+          scopeName: pod.name,
+          scopeKind: "pod",
+          pod,
+        });
+      }
+    }
+  }
+  return rows.sort(
+    (a, b) =>
+      a.domain.localeCompare(b.domain) || a.scopeName.localeCompare(b.scopeName)
+  );
+}
+
+// Bulk egress editor across the selected scopes (optionally the workspace
+// baseline, plus each selected Pod). Adding writes the domain to every selected
+// scope; removing a row clears it from the scopes that own it. Workspace
+// domains are inherited by every Pod, so they carry a Workspace badge and can
+// only be removed when the workspace itself is selected.
+export function MultiPodNetworkSection({
+  owner,
+  selection,
+  selectedPods,
+  includeWorkspace,
+}: MultiPodNetworkSectionProps) {
+  const {
+    podPolicies,
+    isPodPoliciesLoading,
+    isPodPoliciesError,
+    mutatePodPolicies,
+  } = useBulkPodEgressPolicies({ owner, selection });
+  // Always read the workspace policy: even when it is not an editing scope, its
+  // domains are inherited by every Pod and shown as such.
+  const {
+    policy: workspacePolicy,
+    requestedDomains: workspaceRequestedDomains,
+    isWorkspaceEgressPolicyLoading,
+    isWorkspaceEgressPolicyError,
+    mutateWorkspaceEgressPolicy,
+  } = useWorkspaceEgressPolicy({ owner });
+  const { bulkUpdateEgressDomain, isBulkUpdatingEgressDomain } =
+    useBulkUpdateEgressDomain({ owner });
+  const { dismissWorkspaceEgressRequest, isDismissingRequest } =
+    useDismissWorkspaceEgressRequest({ owner });
+  const { dismissPodEgressRequest, isDismissingPodEgressRequest } =
+    useDismissPodEgressRequestByPod({ owner });
+
+  const [removeTarget, setRemoveTarget] = useState<DomainRow | null>(null);
+
+  const workspaceDomains = useMemo(
+    () => new Set(workspacePolicy.allowedDomains),
+    [workspacePolicy]
+  );
+  const podOwnById = useMemo(
+    () =>
+      new Map(
+        podPolicies.map(({ podId, policy }) => [
+          podId,
+          new Set(policy.allowedDomains),
+        ])
+      ),
+    [podPolicies]
+  );
+  const pendingRequests = useMemo(
+    () =>
+      buildPendingRequests({
+        workspaceRequestedDomains,
+        workspaceAllowedDomains: workspacePolicy.allowedDomains,
+        podPolicies,
+        selectedPods,
+        includeWorkspace,
+      }),
+    [
+      workspaceRequestedDomains,
+      workspacePolicy,
+      podPolicies,
+      selectedPods,
+      includeWorkspace,
+    ]
+  );
+
+  const isRequestBusy =
+    isBulkUpdatingEgressDomain ||
+    isDismissingRequest ||
+    isDismissingPodEgressRequest;
+
+  const domainRows = useMemo(
+    () =>
+      buildDomainRows({
+        workspaceAllowedDomains: workspacePolicy.allowedDomains,
+        podPolicies,
+        selectedPods,
+        includeWorkspace,
+      }),
+    [workspacePolicy, podPolicies, selectedPods, includeWorkspace]
+  );
+
+  // Adding writes to the workspace when it is selected (every Pod inherits the
+  // baseline); otherwise it writes each selected Pod.
+  const isDuplicate = (domain: string) =>
+    includeWorkspace
+      ? workspaceDomains.has(domain)
+      : selectedPods.every((pod) => podOwnById.get(pod.sId)?.has(domain));
+  const addTargetLabel = includeWorkspace
+    ? "the Workspace, inherited by all Pods,"
+    : `the ${selectedPods.length} selected ${
+        selectedPods.length === 1 ? "Pod" : "Pods"
+      }`;
+
+  // Refresh the affected reads after every mutation attempt: a bulk write can
+  // return a partial success (some scopes changed, others failed), so gating
+  // revalidation on full success would leave the changed scopes stale.
+  const revalidate = async () => {
+    await Promise.all([mutatePodPolicies(), mutateWorkspaceEgressPolicy()]);
+  };
+
+  const handleAddDomain = async (domain: string): Promise<boolean> => {
+    const success = await bulkUpdateEgressDomain({
+      includeWorkspace,
+      pods: includeWorkspace ? [] : selectedPods,
+      operation: "add",
+      domain,
+    });
+    await revalidate();
+    return success;
+  };
+
+  const handleRemoveDomain = async (domain: string) => {
+    await bulkUpdateEgressDomain({
+      includeWorkspace,
+      pods: selectedPods,
+      operation: "remove",
+      domain,
+    });
+    await revalidate();
+  };
+
+  // Approving adds the domain to the request's own scope (which then covers it
+  // for that scope); the pending row drops once the allowlist includes it.
+  const handleApproveRequest = async (request: PendingRequest) => {
+    await bulkUpdateEgressDomain({
+      includeWorkspace: request.scopeKind === "workspace",
+      pods: request.scopeKind === "pod" ? [request.pod] : [],
+      operation: "add",
+      domain: request.domain,
+    });
+    await revalidate();
+  };
+
+  const handleRejectRequest = async (request: PendingRequest) => {
+    if (request.scopeKind === "workspace") {
+      await dismissWorkspaceEgressRequest(request.domain);
+    } else {
+      await dismissPodEgressRequest(request.pod.sId, request.domain);
+    }
+    await revalidate();
+  };
+
+  // Removing a Workspace domain drops the baseline every Pod and running
+  // Computer inherits, so confirm those; a Pod-only removal is scoped and goes
+  // straight through.
+  const requestRemoveDomain = (row: DomainRow) => {
+    if (includeWorkspace && row.inWorkspace) {
+      setRemoveTarget(row);
+      return;
+    }
+    void handleRemoveDomain(row.domain);
+  };
+
+  const handleConfirmRemove = async () => {
+    if (!removeTarget) {
+      return;
+    }
+    const domain = removeTarget.domain;
+    setRemoveTarget(null);
+    await handleRemoveDomain(domain);
+  };
+
+  // Scope badges only disambiguate once Pods are in the mix. In the
+  // Workspace-only view every row is a workspace domain, so the badges would be
+  // redundant on every line — hide them to keep that default view clean.
+  const showScopeBadges = selectedPods.length > 0;
+
+  // Hide the add form until both reads resolve: duplicate detection falls back
+  // to an empty policy while loading/errored, so the form would let you submit
+  // without seeing the current state. `isLoading` is initial-only, so this does
+  // not flicker on post-write revalidation.
+  const readsReady =
+    !isPodPoliciesLoading &&
+    !isWorkspaceEgressPolicyLoading &&
+    !isPodPoliciesError &&
+    !isWorkspaceEgressPolicyError;
+
+  const renderRows = () => {
+    if (isPodPoliciesLoading || isWorkspaceEgressPolicyLoading) {
+      return <Spinner />;
+    }
+    if (isPodPoliciesError || isWorkspaceEgressPolicyError) {
+      return (
+        <ContentMessage
+          variant="warning"
+          icon={InfoCircle}
+          size="lg"
+          title="Failed to load"
+        >
+          Network settings could not be loaded.
+        </ContentMessage>
+      );
+    }
+    if (domainRows.length === 0 && pendingRequests.length === 0) {
+      return (
+        <ContentMessage variant="outline" size="lg">
+          No domains are currently allowed in the selected scopes.
+        </ContentMessage>
+      );
+    }
+
+    return (
+      <div className="flex w-full flex-col divide-y divide-separator">
+        {pendingRequests.map((request) => (
+          <div key={request.key} className="flex items-center gap-3 py-3">
+            <DomainBadge domain={request.domain}>
+              <Chip size="xs" color="warning" label="Pending approval" />
+              {showScopeBadges ? (
+                request.scopeKind === "workspace" ? (
+                  <Chip
+                    size="xs"
+                    color="info"
+                    label="Workspace"
+                    icon={Building04}
+                  />
+                ) : (
+                  <Chip
+                    size="xs"
+                    color="info"
+                    label={request.pod.name}
+                    icon={podIcon(request.pod)}
+                  />
+                )
+              ) : null}
+            </DomainBadge>
+            <Button
+              variant="highlight"
+              size="mini"
+              label="Approve"
+              tooltip={`Add ${request.domain} to ${request.scopeName}`}
+              disabled={isRequestBusy}
+              onClick={() => {
+                void handleApproveRequest(request);
+              }}
+              className="shrink-0"
+            />
+            <Button
+              variant="ghost"
+              size="mini"
+              icon={XClose}
+              tooltip={`Reject ${request.domain} for ${request.scopeName}`}
+              disabled={isRequestBusy}
+              onClick={() => {
+                void handleRejectRequest(request);
+              }}
+              className="shrink-0"
+            />
+          </div>
+        ))}
+        {domainRows.map((row) => (
+          <div key={row.domain} className="flex items-center gap-3 py-3">
+            <DomainBadge domain={row.domain}>
+              {showScopeBadges && row.inWorkspace ? (
+                <Chip
+                  size="xs"
+                  color="info"
+                  label="Workspace"
+                  icon={Building04}
+                />
+              ) : null}
+              {row.ownedByPods.map((pod) => (
+                <Chip
+                  key={pod.sId}
+                  size="xs"
+                  color="info"
+                  label={pod.name}
+                  icon={podIcon(pod)}
+                />
+              ))}
+            </DomainBadge>
+            <Button
+              variant="warning"
+              size="mini"
+              icon={Trash01}
+              tooltip={
+                row.removableScopeCount === 0
+                  ? "Inherited from the Workspace — select the Workspace to remove it."
+                  : `Remove ${row.domain}`
+              }
+              disabled={row.removableScopeCount === 0 || isRequestBusy}
+              onClick={() => requestRemoveDomain(row)}
+              className="shrink-0"
+            />
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <Dialog
+        open={removeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRemoveTarget(null);
+          }
+        }}
+      >
+        <DialogContent size="md" isAlertDialog>
+          <DialogHeader hideButton>
+            <DialogTitle>Remove Workspace domain</DialogTitle>
+            <DialogDescription>
+              {removeTarget?.domain} is a Workspace domain, inherited by every
+              Pod and running Computer. Removing it here drops it from the
+              Workspace
+              {removeTarget && removeTarget.ownedByPods.length > 0
+                ? ` and ${removeTarget.ownedByPods
+                    .map((pod) => pod.name)
+                    .join(", ")}`
+                : ""}
+              . This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              disabled: isRequestBusy,
+            }}
+            rightButtonProps={{
+              label: "Remove",
+              variant: "warning",
+              disabled: isRequestBusy,
+              onClick: (event: MouseEvent) => {
+                event.preventDefault();
+                void handleConfirmRemove();
+              },
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Page.Vertical align="stretch" gap="lg">
+        <Page.SectionHeader
+          title="Allowed domains"
+          description="Domains allowed across the selected scopes. Adding writes to the Workspace when it is selected (inherited by all Pods), otherwise to each selected Pod."
+        />
+        {readsReady ? (
+          <DomainInputForm
+            isUpdating={isRequestBusy}
+            submitLabel="Add domain"
+            duplicateMessage={(domain) =>
+              isDuplicate(domain)
+                ? includeWorkspace
+                  ? "This domain is already allowed workspace-wide."
+                  : "This domain is already allowed in every selected Pod."
+                : null
+            }
+            validMessage={(domain) =>
+              `Will be added to ${addTargetLabel} as ${domain}.`
+            }
+            onSubmit={handleAddDomain}
+          />
+        ) : null}
+        {renderRows()}
+      </Page.Vertical>
+    </>
+  );
+}


### PR DESCRIPTION
## Description

Final of the 3-PR split — the multi-Pod network **editor** + its page integration. Stacks on `31287` (scope selector + access) → `31285` (shared UI + toggle), over the merged `31233` (data hooks). Screenshot of the assembled Network section below.

- **`MultiPodNetworkSection`** — the union of allowed domains across the selected scopes (each badged with the scope(s) that own it) plus pending agent-requested domains; add/remove + approve/reject, with a confirm on workspace-domain removal since every Pod inherits it. Row/pending derivations are pure `buildDomainRows` / `buildPendingRequests` (unit-tested), incl. a render test for revalidation after a partial-failure write.
- **`SandboxPage`** wires the scope selector + editor into the Network section, gated on `canAdministratePodNetwork`.

**Gating (this PR).** `SandboxPage` renders the scope selector + editor only for flagged admins (`canAdministratePodNetwork`) and disables the Pod fetch otherwise; unflagged workspaces fall back to the workspace-only `NetworkSection`, so no Pod concepts are exposed. (The `/egress-policy/pods` + `/bulk` routes are already `withFeatureFlag("sandbox_functions")` from `31233`/`30995`, so direct API calls are rejected too.)

<!-- TODO: attach a screenshot of the Network section — scope selector, scope-badged domain rows, and the agent-requested-domains toggle. -->
<img width="895" height="503" alt="Screenshot 2026-08-27 at 2 03 23 PM" src="https://github.com/user-attachments/assets/be64dbc5-b533-4bc8-b6ba-a99ecb091550" />

## Tests

`tsc` clean. Unit tests for the `buildDomainRows` / `buildPendingRequests` derivations (workspace-inheritance + removal counts, pending-request scoping) and a `MultiPodNetworkSection` render test that a partial-failure write still revalidates. Manual: select Workspace + Pods, add/remove a domain, approve/reject an agent request, confirm a workspace-domain removal.

## Risk

Low. New UI behind the `sandbox_functions` flag; the write paths reuse the already-merged `31233`/`30995` bulk endpoints and existing dismiss routes. Worst case is a UI regression on the Computer admin Network section — safe to roll back.

## Deploy Plan

Standard front deploy. No migration. Merge after `31287`.
