### PR TITLE
[front] Triggers: do not fail agentTriggerWorkflow on non-retryable trigger states

### DIFF
--- a/front/temporal/triggers/activities.test.ts
+++ b/front/temporal/triggers/activities.test.ts
@@ -1,14 +1,51 @@
 import { createConversation } from "@app/lib/api/assistant/conversation";
 import { WakeUpModel } from "@app/lib/resources/storage/models/wakeup";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import {
   expireWakeUpActivity,
+  runTriggeredAgentsActivity,
   runWakeUpActivity,
 } from "@app/temporal/triggers/activities";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
 const MISSING_WAKE_UP_MODEL_ID = 9_000_000_000;
+const MISSING_TRIGGER_MODEL_ID = 9_000_000_000;
+
+describe("runTriggeredAgentsActivity", () => {
+  it("skips missing triggers without failing the activity", async () => {
+    const { user, workspace } = await createResourceTest({ role: "builder" });
+    const triggerId = TriggerResource.modelIdToSId({
+      id: MISSING_TRIGGER_MODEL_ID,
+      workspaceId: workspace.id,
+    });
+
+    await expect(
+      runTriggeredAgentsActivity({
+        userId: user.sId,
+        workspaceId: workspace.sId,
+        triggerId,
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips missing users without failing the activity", async () => {
+    const { workspace } = await createResourceTest({ role: "builder" });
+    const triggerId = TriggerResource.modelIdToSId({
+      id: MISSING_TRIGGER_MODEL_ID,
+      workspaceId: workspace.id,
+    });
+
+    await expect(
+      runTriggeredAgentsActivity({
+        userId: "usr_missing",
+        workspaceId: workspace.sId,
+        triggerId,
+      })
+    ).resolves.toBeUndefined();
+  });
+});
 
 describe("wake-up activities", () => {
   it("skips terminal wake-ups without failing the activity", async () => {

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -205,6 +205,10 @@ export async function runTriggeredAgentsActivity({
 
   const triggerResource = await TriggerResource.fetchById(auth, triggerId);
   if (!triggerResource) {
+    logger.info(
+      { triggerId, workspaceId },
+      "Skipping trigger run: trigger not found."
+    );
     throw new TriggerNonRetryableError(
       `Trigger with ID ${triggerId} not found.`
     );

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -34,8 +34,6 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
-class TriggerNonRetryableError extends Error {}
-
 async function createConversationForAgentConfiguration({
   auth,
   agentConfiguration,
@@ -191,16 +189,15 @@ export async function runTriggeredAgentsActivity({
     workspaceId
   );
 
-  if (!auth.workspace() || !auth.user()) {
-    throw new TriggerNonRetryableError(
-      "Invalid authentication. Missing workspaceId or userId."
+  // Expected terminal states (workspace, user, trigger or agent gone by the
+  // time the schedule or webhook fires): there is nothing left to run, so the
+  // activity logs and returns instead of failing the workflow.
+  if (!auth.workspace() || !auth.user() || !auth.isUser()) {
+    logger.info(
+      { triggerId, userId, workspaceId },
+      "Skipping trigger run: workspace or user no longer available."
     );
-  }
-
-  if (!auth.isUser()) {
-    throw new TriggerNonRetryableError(
-      "Invalid authentication. Missing user permissions."
-    );
+    return;
   }
 
   const triggerResource = await TriggerResource.fetchById(auth, triggerId);
@@ -209,9 +206,7 @@ export async function runTriggeredAgentsActivity({
       { triggerId, workspaceId },
       "Skipping trigger run: trigger not found."
     );
-    throw new TriggerNonRetryableError(
-      `Trigger with ID ${triggerId} not found.`
-    );
+    return;
   }
 
   const trigger = triggerResource.toJSON();
@@ -231,9 +226,7 @@ export async function runTriggeredAgentsActivity({
       "Disabling trigger: agent configuration not found."
     );
     await triggerResource.disable(auth);
-    throw new TriggerNonRetryableError(
-      `Agent configuration with ID ${trigger.agentConfigurationId} not found in workspace ${auth.getNonNullableWorkspace().id}.`
-    );
+    return;
   }
 
   void emitAuditLogEvent({

--- a/front/temporal/triggers/activities.ts
+++ b/front/temporal/triggers/activities.ts
@@ -192,10 +192,18 @@ export async function runTriggeredAgentsActivity({
   // Expected terminal states (workspace, user, trigger or agent gone by the
   // time the schedule or webhook fires): there is nothing left to run, so the
   // activity logs and returns instead of failing the workflow.
-  if (!auth.workspace() || !auth.user() || !auth.isUser()) {
+  if (!auth.workspace() || !auth.user()) {
     logger.info(
       { triggerId, userId, workspaceId },
-      "Skipping trigger run: workspace or user no longer available."
+      "Invalid authentication. Missing workspaceId or userId."
+    );
+    return;
+  }
+
+  if (!auth.isUser()) {
+    logger.info(
+      { triggerId, userId, workspaceId },
+      "Invalid authentication. Missing user permissions."
     );
     return;
   }
@@ -204,7 +212,7 @@ export async function runTriggeredAgentsActivity({
   if (!triggerResource) {
     logger.info(
       { triggerId, workspaceId },
-      "Skipping trigger run: trigger not found."
+      `Trigger with ID ${triggerId} not found.`
     );
     return;
   }

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -22,17 +22,6 @@ const { expireWakeUpActivity, runWakeUpActivity } = proxyActivities<
   },
 });
 
-function isActivityFailureOf(
-  error: unknown,
-  activityType: string
-): error is ActivityFailure {
-  if (!(error instanceof ActivityFailure)) {
-    return false;
-  }
-
-  return error.activityType === activityType;
-}
-
 export async function agentTriggerWorkflow({
   userId,
   workspaceId,
@@ -44,25 +33,20 @@ export async function agentTriggerWorkflow({
   triggerId: string;
   webhookRequestId?: number;
 }) {
-  try {
-    await runTriggeredAgentsActivity({
-      userId,
-      workspaceId,
-      triggerId,
-      webhookRequestId,
-    });
-  } catch (error) {
-    // Older workers threw TriggerNonRetryableError for expected terminal states
-    // (trigger, user or agent gone before the run); newer ones log and return.
-    if (
-      isActivityFailureOf(error, "runTriggeredAgentsActivity") &&
-      error.retryState === RetryState.NON_RETRYABLE_FAILURE
-    ) {
-      return;
-    }
+  await runTriggeredAgentsActivity({
+    userId,
+    workspaceId,
+    triggerId,
+    webhookRequestId,
+  });
+}
 
-    throw error;
+function isRunWakeUpActivityFailure(error: unknown): error is ActivityFailure {
+  if (!(error instanceof ActivityFailure)) {
+    return false;
   }
+
+  return error.activityType === "runWakeUpActivity";
 }
 
 function isWakeUpActivityRetryExhausted(error: ActivityFailure): boolean {
@@ -82,7 +66,7 @@ export async function wakeUpWorkflow({
   try {
     await runWakeUpActivity({ workspaceId, wakeUpId });
   } catch (error) {
-    if (isActivityFailureOf(error, "runWakeUpActivity")) {
+    if (isRunWakeUpActivityFailure(error)) {
       // Older workers used WakeUpNonRetryableError for expected stale wake-up states.
       if (error.retryState === RetryState.NON_RETRYABLE_FAILURE) {
         return;

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -52,9 +52,8 @@ export async function agentTriggerWorkflow({
       webhookRequestId,
     });
   } catch (error) {
-    // TriggerNonRetryableError marks expected terminal states (trigger deleted
-    // before the run, user or agent gone): there is nothing left to run, so the
-    // workflow completes instead of failing.
+    // Older workers threw TriggerNonRetryableError for expected terminal states
+    // (trigger, user or agent gone before the run); newer ones log and return.
     if (
       isActivityFailureOf(error, "runTriggeredAgentsActivity") &&
       error.retryState === RetryState.NON_RETRYABLE_FAILURE

--- a/front/temporal/triggers/workflows.ts
+++ b/front/temporal/triggers/workflows.ts
@@ -22,6 +22,17 @@ const { expireWakeUpActivity, runWakeUpActivity } = proxyActivities<
   },
 });
 
+function isActivityFailureOf(
+  error: unknown,
+  activityType: string
+): error is ActivityFailure {
+  if (!(error instanceof ActivityFailure)) {
+    return false;
+  }
+
+  return error.activityType === activityType;
+}
+
 export async function agentTriggerWorkflow({
   userId,
   workspaceId,
@@ -33,20 +44,26 @@ export async function agentTriggerWorkflow({
   triggerId: string;
   webhookRequestId?: number;
 }) {
-  await runTriggeredAgentsActivity({
-    userId,
-    workspaceId,
-    triggerId,
-    webhookRequestId,
-  });
-}
+  try {
+    await runTriggeredAgentsActivity({
+      userId,
+      workspaceId,
+      triggerId,
+      webhookRequestId,
+    });
+  } catch (error) {
+    // TriggerNonRetryableError marks expected terminal states (trigger deleted
+    // before the run, user or agent gone): there is nothing left to run, so the
+    // workflow completes instead of failing.
+    if (
+      isActivityFailureOf(error, "runTriggeredAgentsActivity") &&
+      error.retryState === RetryState.NON_RETRYABLE_FAILURE
+    ) {
+      return;
+    }
 
-function isRunWakeUpActivityFailure(error: unknown): error is ActivityFailure {
-  if (!(error instanceof ActivityFailure)) {
-    return false;
+    throw error;
   }
-
-  return error.activityType === "runWakeUpActivity";
 }
 
 function isWakeUpActivityRetryExhausted(error: ActivityFailure): boolean {
@@ -66,7 +83,7 @@ export async function wakeUpWorkflow({
   try {
     await runWakeUpActivity({ workspaceId, wakeUpId });
   } catch (error) {
-    if (isRunWakeUpActivityFailure(error)) {
+    if (isActivityFailureOf(error, "runWakeUpActivity")) {
       // Older workers used WakeUpNonRetryableError for expected stale wake-up states.
       if (error.retryState === RetryState.NON_RETRYABLE_FAILURE) {
         return;


### PR DESCRIPTION
## Description

Some `agentTriggerWorkflow` fail with `Trigger with ID trg_... not found.` when a trigger is deleted between the schedule/webhook firing and the activity running. Same for a user or agent configuration gone by then. These are expected terminal states: there is nothing left to run, and `TriggerNonRetryableError` correctly prevented retries, but the workflow then failed.

Fix: the activity logs and returns for these states instead of throwing, like `runWakeUpActivity` in the same file and like the activity's own conversation-error path already do. `TriggerNonRetryableError` is removed; the workflow is untouched. The `nonRetryableErrorTypes` retry config stays (string-matched) so old workers throwing during the rolling deploy still do not retry; their workflows fail like today for those few minutes.

## Tests

Activity tests: missing trigger and missing user both resolve without throwing.

## Risk

Worst case, a trigger run is silently skipped for a state we misclassified as terminal (the skip is logged). Safe to rollback.

## Deploy Plan

- [ ] Deploy front
