### PR TITLE
feat(sandbox): workspace toggle for agent-requested Computer domains

### DIFF
--- a/front-api/routes/w/[wId]/sandbox/egress-policy/pods.test.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/pods.test.ts
@@ -73,7 +73,7 @@ describe("GET /api/w/:wId/sandbox/egress-policy/pods", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({
-      pods: [{ sId: podA.sId, name: podA.name }],
+      pods: [{ sId: podA.sId, name: podA.name, isRestricted: true }],
     });
   });
 

--- a/front-api/routes/w/[wId]/sandbox/egress-policy/pods.ts
+++ b/front-api/routes/w/[wId]/sandbox/egress-policy/pods.ts
@@ -28,7 +28,11 @@ app.get("/", async (ctx): HandlerResult<GetEgressPolicyPodsResponseBody> => {
   }
 
   return ctx.json({
-    pods: pods.value.map((pod) => ({ sId: pod.sId, name: pod.name })),
+    pods: pods.value.map((pod) => ({
+      sId: pod.sId,
+      name: pod.name,
+      isRestricted: pod.isProjectAndRestricted(),
+    })),
   });
 });
 

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,13 +1,74 @@
 import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
-import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
+import { MultiPodNetworkSection } from "@app/components/sandbox/MultiPodNetworkSection";
+import type { SandboxScopeSelection } from "@app/components/sandbox/SandboxScopeSelector";
+import { SandboxScopeSelector } from "@app/components/sandbox/SandboxScopeSelector";
+import { useComputerAdminAccess } from "@app/hooks/useComputerAdminAccess";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useEgressPolicyPods } from "@app/lib/swr/sandbox";
 import { ContentMessage, InfoCircle, Page } from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
 
 export function SandboxPage() {
-  const { isAdmin } = useAuth();
-  const { featureFlags } = useFeatureFlags();
-  const hasSandboxAdmin = isComputerFeatureEnabled(featureFlags);
+  const owner = useWorkspace();
+  const { isAdmin, isComputerEnabled, canAdministratePods } =
+    useComputerAdminAccess();
+  const [selection, setSelection] = useState<SandboxScopeSelection>({
+    includeWorkspace: true,
+    podIds: [],
+  });
+
+  // Only Pods with their own policy are offered; a brand-new Pod is configured
+  // from its own settings page, then appears here.
+  const { pods, isEgressPolicyPodsLoading } = useEgressPolicyPods({
+    owner,
+    disabled: !canAdministratePods,
+  });
+
+  const selectedPods = useMemo(() => {
+    const set = new Set(selection.podIds);
+    return pods.filter((pod) => set.has(pod.sId));
+  }, [selection.podIds, pods]);
+
+  const scopeCount = (selection.includeWorkspace ? 1 : 0) + selectedPods.length;
+
+  // Workspace-only leaves this null so the multi-pod read is skipped and only
+  // the workspace baseline is shown.
+  const podSelection =
+    selectedPods.length > 0
+      ? { kind: "pods" as const, podIds: selectedPods.map((pod) => pod.sId) }
+      : null;
+
+  // Network is scope-aware (Workspace and/or Pods), so the scope selector lives
+  // with it. Environment variables stay workspace-scoped.
+  const renderNetwork = () => (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <div className="heading-xl text-foreground">Network</div>
+        <div className="shrink-0">
+          <SandboxScopeSelector
+            pods={pods}
+            selection={selection}
+            onChange={setSelection}
+            isLoading={isEgressPolicyPodsLoading}
+          />
+        </div>
+      </div>
+      {scopeCount === 0 ? (
+        <ContentMessage variant="info" icon={InfoCircle} size="lg">
+          Select the Workspace or one or more Pods to view and edit network
+          access.
+        </ContentMessage>
+      ) : (
+        <MultiPodNetworkSection
+          owner={owner}
+          includeWorkspace={selection.includeWorkspace}
+          selection={podSelection}
+          selectedPods={selectedPods}
+        />
+      )}
+    </div>
+  );
 
   const renderBody = () => {
     if (!isAdmin) {
@@ -17,8 +78,7 @@ export function SandboxPage() {
         </ContentMessage>
       );
     }
-
-    if (!hasSandboxAdmin) {
+    if (!isComputerEnabled) {
       return (
         <ContentMessage variant="info" icon={InfoCircle} size="lg">
           Computer administration is not enabled for this workspace.
@@ -28,7 +88,7 @@ export function SandboxPage() {
 
     return (
       <>
-        <NetworkSection />
+        {canAdministratePods ? renderNetwork() : <NetworkSection />}
         <EnvironmentSection />
       </>
     );
@@ -38,7 +98,7 @@ export function SandboxPage() {
     <Page.Vertical gap="xl" align="stretch">
       <Page.Header
         title="Computer"
-        description="Configure workspace-level network access and environment variables for the Computer."
+        description="Configure workspace and Pod network access and environment variables for the Computer."
       />
       {renderBody()}
     </Page.Vertical>

--- a/front/components/pages/workspace/developers/SandboxPage.tsx
+++ b/front/components/pages/workspace/developers/SandboxPage.tsx
@@ -1,5 +1,6 @@
 import { EnvironmentSection } from "@app/components/pages/workspace/developers/sections/EnvironmentSection";
 import { NetworkSection } from "@app/components/pages/workspace/developers/sections/NetworkSection";
+import { AgentRequestedDomainsSetting } from "@app/components/sandbox/AgentRequestedDomainsSetting";
 import { MultiPodNetworkSection } from "@app/components/sandbox/MultiPodNetworkSection";
 import type { SandboxScopeSelection } from "@app/components/sandbox/SandboxScopeSelector";
 import { SandboxScopeSelector } from "@app/components/sandbox/SandboxScopeSelector";
@@ -88,6 +89,7 @@ export function SandboxPage() {
 
     return (
       <>
+        <AgentRequestedDomainsSetting />
         {canAdministratePods ? renderNetwork() : <NetworkSection />}
         <EnvironmentSection />
       </>

--- a/front/components/sandbox/AgentRequestedDomainsSetting.tsx
+++ b/front/components/sandbox/AgentRequestedDomainsSetting.tsx
@@ -1,0 +1,104 @@
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useUpdateWorkspaceSandboxAgentEgressRequests } from "@app/lib/swr/sandbox";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  SliderToggle,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+// Workspace-wide toggle for whether agents can request additional domains
+// during a conversation (add_egress_domain). Shown on its own so it stays
+// visible regardless of the scope being viewed on the Computer admin page.
+export function AgentRequestedDomainsSetting() {
+  const owner = useWorkspace();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const {
+    allowAgentEgressRequests,
+    updateWorkspaceSandboxAgentEgressRequests,
+    isUpdatingWorkspaceSandboxAgentEgressRequests,
+  } = useUpdateWorkspaceSandboxAgentEgressRequests({ owner });
+
+  const handleToggle = async () => {
+    if (allowAgentEgressRequests) {
+      await updateWorkspaceSandboxAgentEgressRequests(false);
+      return;
+    }
+    setIsDialogOpen(true);
+  };
+
+  const handleConfirmEnable = async () => {
+    const success = await updateWorkspaceSandboxAgentEgressRequests(true);
+    if (success) {
+      setIsDialogOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsDialogOpen(false);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              Allow agents to request additional domains?
+            </DialogTitle>
+          </DialogHeader>
+          <DialogContainer>
+            When enabled, any agent running in the Computer can ask the user to
+            allow additional domains during the conversation. Each request is
+            approval-gated, but a non-admin user in this workspace can grant
+            network access to a domain you have not pre-approved. Domains added
+            this way last only for the current Computer.
+          </DialogContainer>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              onClick: () => setIsDialogOpen(false),
+            }}
+            rightButtonProps={{
+              label: "Enable",
+              onClick: () => {
+                void handleConfirmEnable();
+              },
+              isLoading: isUpdatingWorkspaceSandboxAgentEgressRequests,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <div className="flex items-center justify-between gap-4 border-y border-border py-4">
+        <div className="flex min-w-0 flex-col">
+          <div className="heading-xl text-foreground">
+            Agent-requested domains
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Applies to every Computer in this workspace, across all Pods. Allow
+            agents to ask for additional domains, one approval per domain,
+            during the conversation. When disabled, agents cannot request new
+            domains and rely only on the allowed domains configured per scope
+            below.
+          </div>
+        </div>
+        <SliderToggle
+          selected={allowAgentEgressRequests}
+          onClick={() => {
+            void handleToggle();
+          }}
+          disabled={isUpdatingWorkspaceSandboxAgentEgressRequests}
+        />
+      </div>
+    </>
+  );
+}

--- a/front/components/sandbox/MultiPodNetworkSection.tsx
+++ b/front/components/sandbox/MultiPodNetworkSection.tsx
@@ -1,0 +1,515 @@
+import { Pill } from "@app/components/sandbox/Pill";
+import { podIcon } from "@app/components/sandbox/pod_icon";
+import type { SandboxPodSelection } from "@app/lib/swr/sandbox";
+import {
+  useBulkPodEgressPolicies,
+  useBulkUpdateEgressDomain,
+  useDismissPodEgressRequestByPod,
+  useDismissWorkspaceEgressRequest,
+  useWorkspaceEgressPolicy,
+} from "@app/lib/swr/sandbox";
+import type { SandboxAdminPod } from "@app/types/api/sandbox/egress_policy";
+import { normalizeEgressPolicyDomain } from "@app/types/sandbox/egress_policy";
+import type { LightWorkspaceType } from "@app/types/user";
+import {
+  Building04,
+  Button,
+  ContentMessage,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  InfoCircle,
+  Input,
+  Page,
+  Plus,
+  Spinner,
+  Trash01,
+  XClose,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+interface MultiPodNetworkSectionProps {
+  owner: LightWorkspaceType;
+  // null when no Pods are selected (workspace-only): the pod policies aren't
+  // read and only the workspace baseline is shown.
+  selection: SandboxPodSelection | null;
+  // The pods `selection` resolves to, for names and counts.
+  selectedPods: SandboxAdminPod[];
+  // When true, the workspace baseline is one of the scopes being edited.
+  includeWorkspace: boolean;
+}
+
+// One editable domain across the selected scopes. `inWorkspace` means the
+// workspace baseline allows it (so every Pod inherits it); `ownedByPods` are
+// the selected Pods whose own policy file lists it.
+type DomainRow = {
+  domain: string;
+  inWorkspace: boolean;
+  ownedByPods: SandboxAdminPod[];
+  // Scopes this row can actually be removed from with the current selection:
+  // the workspace (only when it's in the selection) plus any owning Pod. Zero
+  // means the row is inherited-only here and removal must happen at the
+  // workspace.
+  removableScopeCount: number;
+};
+
+// One agent-requested domain awaiting review, tied to the single scope it was
+// requested on — approve/reject act only on that origin.
+type PendingRequest = {
+  key: string;
+  domain: string;
+  scopeName: string;
+} & ({ scopeKind: "workspace" } | { scopeKind: "pod"; pod: SandboxAdminPod });
+
+// Bulk egress editor across the selected scopes (optionally the workspace
+// baseline, plus each selected Pod). Adding writes the domain to every selected
+// scope; removing a row clears it from the scopes that own it. Workspace
+// domains are inherited by every Pod, so they render with a neutral pill and
+// can only be removed when the workspace itself is selected.
+export function MultiPodNetworkSection({
+  owner,
+  selection,
+  selectedPods,
+  includeWorkspace,
+}: MultiPodNetworkSectionProps) {
+  const {
+    podPolicies,
+    isPodPoliciesLoading,
+    isPodPoliciesError,
+    mutatePodPolicies,
+  } = useBulkPodEgressPolicies({ owner, selection });
+  // Always read the workspace policy: even when it is not an editing scope, its
+  // domains are inherited by every Pod and shown as such.
+  const {
+    policy: workspacePolicy,
+    requestedDomains: workspaceRequestedDomains,
+    isWorkspaceEgressPolicyLoading,
+    isWorkspaceEgressPolicyError,
+    mutateWorkspaceEgressPolicy,
+  } = useWorkspaceEgressPolicy({ owner });
+  const { bulkUpdateEgressDomain, isBulkUpdatingEgressDomain } =
+    useBulkUpdateEgressDomain({ owner });
+  const { dismissWorkspaceEgressRequest, isDismissingRequest } =
+    useDismissWorkspaceEgressRequest({ owner });
+  const { dismissPodEgressRequest, isDismissingPodEgressRequest } =
+    useDismissPodEgressRequestByPod({ owner });
+
+  const [domainInput, setDomainInput] = useState("");
+  const [removeTarget, setRemoveTarget] = useState<DomainRow | null>(null);
+
+  const workspaceDomains = useMemo(
+    () => new Set(workspacePolicy.allowedDomains),
+    [workspacePolicy]
+  );
+  const podOwnById = useMemo(
+    () =>
+      new Map(
+        podPolicies.map(({ podId, policy }) => [
+          podId,
+          new Set(policy.allowedDomains),
+        ])
+      ),
+    [podPolicies]
+  );
+  const podPolicyById = useMemo(
+    () => new Map(podPolicies.map(({ podId, policy }) => [podId, policy])),
+    [podPolicies]
+  );
+
+  // Agent-requested domains awaiting review, one row per originating scope
+  // (the workspace when selected, plus each selected Pod). A request already
+  // covered by that scope's allowlist is dropped.
+  const pendingRequests: PendingRequest[] = useMemo(() => {
+    const rows: PendingRequest[] = [];
+    if (includeWorkspace) {
+      for (const request of workspaceRequestedDomains) {
+        if (!workspaceDomains.has(request.domain)) {
+          rows.push({
+            key: `workspace:${request.domain}`,
+            domain: request.domain,
+            scopeName: "Workspace",
+            scopeKind: "workspace",
+          });
+        }
+      }
+    }
+    for (const pod of selectedPods) {
+      const owned = podOwnById.get(pod.sId);
+      for (const request of podPolicyById.get(pod.sId)?.requestedDomains ??
+        []) {
+        if (!owned?.has(request.domain)) {
+          rows.push({
+            key: `${pod.sId}:${request.domain}`,
+            domain: request.domain,
+            scopeName: pod.name,
+            scopeKind: "pod",
+            pod,
+          });
+        }
+      }
+    }
+    return rows.sort(
+      (a, b) =>
+        a.domain.localeCompare(b.domain) ||
+        a.scopeName.localeCompare(b.scopeName)
+    );
+  }, [
+    includeWorkspace,
+    workspaceRequestedDomains,
+    workspaceDomains,
+    selectedPods,
+    podOwnById,
+    podPolicyById,
+  ]);
+
+  const isRequestBusy =
+    isBulkUpdatingEgressDomain ||
+    isDismissingRequest ||
+    isDismissingPodEgressRequest;
+
+  const domainRows: DomainRow[] = useMemo(() => {
+    const domains = new Set<string>(workspaceDomains);
+    for (const { policy } of podPolicies) {
+      for (const domain of policy.allowedDomains) {
+        domains.add(domain);
+      }
+    }
+    return [...domains]
+      .map((domain) => {
+        const inWorkspace = workspaceDomains.has(domain);
+        const ownedByPods = selectedPods.filter((pod) =>
+          podOwnById.get(pod.sId)?.has(domain)
+        );
+        return {
+          domain,
+          inWorkspace,
+          ownedByPods,
+          removableScopeCount:
+            (includeWorkspace && inWorkspace ? 1 : 0) + ownedByPods.length,
+        };
+      })
+      .sort((a, b) => a.domain.localeCompare(b.domain));
+  }, [
+    workspaceDomains,
+    podPolicies,
+    podOwnById,
+    selectedPods,
+    includeWorkspace,
+  ]);
+
+  const hasDomainInput = domainInput.trim().length > 0;
+  const domainInputResult = hasDomainInput
+    ? normalizeEgressPolicyDomain(domainInput)
+    : null;
+  const normalizedDomain =
+    domainInputResult?.isOk() === true ? domainInputResult.value : null;
+  // Adding writes to the workspace when it is selected (every Pod inherits the
+  // baseline, so there is no need to also write each Pod's file); otherwise it
+  // writes each selected Pod. Duplicate means the write target already allows
+  // it.
+  const isDuplicate =
+    normalizedDomain !== null &&
+    (includeWorkspace
+      ? workspaceDomains.has(normalizedDomain)
+      : selectedPods.every((pod) =>
+          podOwnById.get(pod.sId)?.has(normalizedDomain)
+        ));
+  const addTargetLabel = includeWorkspace
+    ? "the Workspace, inherited by all Pods,"
+    : `the ${selectedPods.length} selected ${
+        selectedPods.length === 1 ? "Pod" : "Pods"
+      }`;
+  const domainInputMessage =
+    domainInputResult?.isErr() === true
+      ? domainInputResult.error.message
+      : isDuplicate
+        ? includeWorkspace
+          ? "This domain is already allowed workspace-wide."
+          : "This domain is already allowed in every selected Pod."
+        : normalizedDomain
+          ? `Will be added to ${addTargetLabel} as ${normalizedDomain}.`
+          : "Use an exact domain such as api.openai.com or a wildcard such as *.mistral.ai.";
+  const isDomainInputInvalid =
+    domainInputResult?.isErr() === true || isDuplicate;
+  const canAddDomain =
+    normalizedDomain !== null && !isDuplicate && !isBulkUpdatingEgressDomain;
+
+  const revalidate = async () => {
+    await Promise.all([mutatePodPolicies(), mutateWorkspaceEgressPolicy()]);
+  };
+
+  const handleAddDomain = async () => {
+    if (!canAddDomain || normalizedDomain === null) {
+      return;
+    }
+    const success = await bulkUpdateEgressDomain({
+      includeWorkspace,
+      // A workspace-wide add is inherited by every Pod, so skip writing each
+      // Pod's own file; a Pod-only selection writes the selected Pods.
+      pods: includeWorkspace ? [] : selectedPods,
+      operation: "add",
+      domain: normalizedDomain,
+    });
+    if (success) {
+      setDomainInput("");
+      await revalidate();
+    }
+  };
+
+  const handleRemoveDomain = async (domain: string) => {
+    const success = await bulkUpdateEgressDomain({
+      includeWorkspace,
+      pods: selectedPods,
+      operation: "remove",
+      domain,
+    });
+    if (success) {
+      await revalidate();
+    }
+  };
+
+  // Approving adds the domain to the request's own scope (which then covers it
+  // for that scope); the pending row drops once the allowlist includes it.
+  const handleApproveRequest = async (request: PendingRequest) => {
+    const success = await bulkUpdateEgressDomain({
+      includeWorkspace: request.scopeKind === "workspace",
+      pods: request.scopeKind === "pod" ? [request.pod] : [],
+      operation: "add",
+      domain: request.domain,
+    });
+    if (success) {
+      await revalidate();
+    }
+  };
+
+  const handleRejectRequest = async (request: PendingRequest) => {
+    const success =
+      request.scopeKind === "workspace"
+        ? await dismissWorkspaceEgressRequest(request.domain)
+        : await dismissPodEgressRequest(request.pod.sId, request.domain);
+    if (success) {
+      await revalidate();
+    }
+  };
+
+  // Removing a Workspace domain drops the baseline every Pod and running
+  // Computer inherits, so confirm those; a Pod-only removal is scoped and goes
+  // straight through.
+  const requestRemoveDomain = (row: DomainRow) => {
+    if (includeWorkspace && row.inWorkspace) {
+      setRemoveTarget(row);
+      return;
+    }
+    void handleRemoveDomain(row.domain);
+  };
+
+  const handleConfirmRemove = async () => {
+    if (!removeTarget) {
+      return;
+    }
+    const domain = removeTarget.domain;
+    setRemoveTarget(null);
+    await handleRemoveDomain(domain);
+  };
+
+  const renderRows = () => {
+    if (isPodPoliciesLoading || isWorkspaceEgressPolicyLoading) {
+      return <Spinner />;
+    }
+    if (isPodPoliciesError || isWorkspaceEgressPolicyError) {
+      return (
+        <ContentMessage
+          variant="warning"
+          icon={InfoCircle}
+          size="lg"
+          title="Failed to load"
+        >
+          The Pod network settings could not be loaded.
+        </ContentMessage>
+      );
+    }
+    if (domainRows.length === 0 && pendingRequests.length === 0) {
+      return (
+        <ContentMessage variant="outline" size="lg">
+          No domains are currently allowed in the selected scopes.
+        </ContentMessage>
+      );
+    }
+
+    return (
+      <div className="flex w-full flex-col divide-y divide-separator">
+        {pendingRequests.map((request) => (
+          <div key={request.key} className="flex items-center gap-3 py-3">
+            <div
+              title={request.domain}
+              className="flex min-w-0 grow items-center gap-2 overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2"
+            >
+              <span className="font-mono text-sm text-foreground">
+                {request.domain}
+              </span>
+              <Pill color="golden" label="Pending approval" />
+              {request.scopeKind === "workspace" ? (
+                <Pill color="blue" label="Workspace" icon={Building04} />
+              ) : (
+                <Pill
+                  color="blue"
+                  label={request.pod.name}
+                  icon={podIcon(request.pod)}
+                />
+              )}
+            </div>
+            <Button
+              variant="highlight"
+              size="mini"
+              label="Approve"
+              tooltip={`Add ${request.domain} to ${request.scopeName}`}
+              disabled={isRequestBusy}
+              onClick={() => {
+                void handleApproveRequest(request);
+              }}
+              className="shrink-0"
+            />
+            <Button
+              variant="ghost"
+              size="mini"
+              icon={XClose}
+              tooltip={`Reject ${request.domain} for ${request.scopeName}`}
+              disabled={isRequestBusy}
+              onClick={() => {
+                void handleRejectRequest(request);
+              }}
+              className="shrink-0"
+            />
+          </div>
+        ))}
+        {domainRows.map((row) => (
+          <div key={row.domain} className="flex items-center gap-3 py-3">
+            <div
+              title={row.domain}
+              className="flex min-w-0 grow items-center gap-2 overflow-x-auto whitespace-nowrap rounded bg-muted-background p-2"
+            >
+              <span className="font-mono text-sm text-foreground">
+                {row.domain}
+              </span>
+              {row.inWorkspace ? (
+                <Pill color="blue" label="Workspace" icon={Building04} />
+              ) : null}
+              {row.ownedByPods.map((pod) => (
+                <Pill
+                  key={pod.sId}
+                  color="blue"
+                  label={pod.name}
+                  icon={podIcon(pod)}
+                />
+              ))}
+            </div>
+            <Button
+              variant="warning"
+              size="mini"
+              icon={Trash01}
+              tooltip={
+                row.removableScopeCount === 0
+                  ? "Inherited from the Workspace — select the Workspace to remove it."
+                  : `Remove ${row.domain}`
+              }
+              disabled={
+                row.removableScopeCount === 0 || isBulkUpdatingEgressDomain
+              }
+              onClick={() => requestRemoveDomain(row)}
+              className="shrink-0"
+            />
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <>
+      <Dialog
+        open={removeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setRemoveTarget(null);
+          }
+        }}
+      >
+        <DialogContent size="md" isAlertDialog>
+          <DialogHeader hideButton>
+            <DialogTitle>Remove Workspace domain</DialogTitle>
+            <DialogDescription>
+              {removeTarget?.domain} is a Workspace domain, inherited by every
+              Pod and running Computer. Removing it here drops it from the
+              Workspace
+              {removeTarget && removeTarget.ownedByPods.length > 0
+                ? ` and ${removeTarget.ownedByPods
+                    .map((pod) => pod.name)
+                    .join(", ")}`
+                : ""}
+              . This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              disabled: isBulkUpdatingEgressDomain,
+            }}
+            rightButtonProps={{
+              label: "Remove",
+              variant: "warning",
+              disabled: isBulkUpdatingEgressDomain,
+              onClick: (event: React.MouseEvent) => {
+                event.preventDefault();
+                void handleConfirmRemove();
+              },
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      <Page.Vertical align="stretch" gap="lg">
+        <div className="flex flex-col gap-1">
+          <div className="heading-base text-foreground">Allowed domains</div>
+          <div className="text-sm text-muted-foreground">
+            Domains allowed across the selected scopes. Adding writes to the
+            Workspace when it is selected (inherited by all Pods), otherwise to
+            each selected Pod.
+          </div>
+        </div>
+        <form
+          className="flex flex-col gap-3 sm:flex-row sm:items-start"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleAddDomain();
+          }}
+        >
+          <div className="grow">
+            <Input
+              label="Domain"
+              name="domain"
+              placeholder="e.g. api.openai.com or *.mistral.ai"
+              value={domainInput}
+              message={domainInputMessage}
+              messageStatus={isDomainInputInvalid ? "error" : "info"}
+              onChange={(event) => setDomainInput(event.target.value)}
+              disabled={isBulkUpdatingEgressDomain}
+            />
+          </div>
+          <Button
+            type="submit"
+            label="Add domain"
+            icon={Plus}
+            disabled={!canAddDomain}
+            isLoading={isBulkUpdatingEgressDomain}
+            className="mt-0 sm:mt-7"
+          />
+        </form>
+        {renderRows()}
+      </Page.Vertical>
+    </>
+  );
+}

--- a/front/components/sandbox/Pill.tsx
+++ b/front/components/sandbox/Pill.tsx
@@ -1,0 +1,28 @@
+import type { ComponentType, SVGProps } from "react";
+
+type PillColor = "blue" | "golden" | "neutral";
+
+// Small rounded status pill, shared by the egress request rows and the
+// Computer admin comparison views.
+const PILL_CLASSES: Record<PillColor, string> = {
+  blue: "bg-blue-100 text-blue-800",
+  golden: "bg-golden-100 text-golden-800",
+  neutral: "bg-primary-100 text-primary-700",
+};
+
+interface PillProps {
+  color: PillColor;
+  label: string;
+  icon?: ComponentType<SVGProps<SVGSVGElement>>;
+}
+
+export function Pill({ color, label, icon: Icon }: PillProps) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${PILL_CLASSES[color]}`}
+    >
+      {Icon ? <Icon className="h-3 w-3" /> : null}
+      {label}
+    </span>
+  );
+}

--- a/front/components/sandbox/SandboxScopeSelector.tsx
+++ b/front/components/sandbox/SandboxScopeSelector.tsx
@@ -1,0 +1,187 @@
+import { podIcon } from "@app/components/sandbox/pod_icon";
+import type { SandboxAdminPod } from "@app/types/api/sandbox/egress_policy";
+import {
+  Building04,
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+// The scopes edited together on the central Computer admin page: the workspace
+// baseline and/or any Pods. Every selected scope is a write target.
+export type SandboxScopeSelection = {
+  includeWorkspace: boolean;
+  podIds: string[];
+};
+
+function labelForSelection(
+  selection: SandboxScopeSelection,
+  pods: SandboxAdminPod[]
+): string {
+  const allPodsSelected =
+    pods.length > 0 && selection.podIds.length === pods.length;
+  if (selection.includeWorkspace && allPodsSelected) {
+    return "All scopes";
+  }
+
+  const parts: string[] = [];
+  if (selection.includeWorkspace) {
+    parts.push("Workspace");
+  }
+  if (selection.podIds.length === 1) {
+    const pod = pods.find((candidate) => candidate.sId === selection.podIds[0]);
+    parts.push(pod?.name ?? "1 Pod");
+  } else if (selection.podIds.length > 1) {
+    parts.push(
+      allPodsSelected ? "all Pods" : `${selection.podIds.length} Pods`
+    );
+  }
+  return parts.length === 0 ? "Select scope" : parts.join(" + ");
+}
+
+interface SandboxScopeSelectorProps {
+  pods: SandboxAdminPod[];
+  selection: SandboxScopeSelection;
+  onChange: (selection: SandboxScopeSelection) => void;
+  isLoading: boolean;
+  disabled?: boolean;
+}
+
+export function SandboxScopeSelector({
+  pods,
+  selection,
+  onChange,
+  isLoading,
+  disabled = false,
+}: SandboxScopeSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchText, setSearchText] = useState("");
+
+  const selectedPodIds = useMemo(
+    () => new Set(selection.podIds),
+    [selection.podIds]
+  );
+
+  const filteredPods = useMemo(() => {
+    const query = searchText.trim().toLowerCase();
+    return query
+      ? pods.filter((pod) => pod.name.toLowerCase().includes(query))
+      : pods;
+  }, [searchText, pods]);
+
+  const allPodsSelected =
+    pods.length > 0 && selection.podIds.length === pods.length;
+
+  const togglePod = (podId: string, checked: boolean) => {
+    onChange({
+      ...selection,
+      podIds: checked
+        ? [...selection.podIds, podId]
+        : selection.podIds.filter((id) => id !== podId),
+    });
+  };
+
+  return (
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (open) {
+          setSearchText("");
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          label={labelForSelection(selection, pods)}
+          isSelect
+          disabled={disabled}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-80 max-w-[calc(100vw-1rem)]"
+        align="start"
+        collisionPadding={8}
+      >
+        <DropdownMenuCheckboxItem
+          label="Workspace"
+          icon={Building04}
+          checked={selection.includeWorkspace}
+          onCheckedChange={(checked) =>
+            onChange({ ...selection, includeWorkspace: checked === true })
+          }
+          onSelect={(event) => {
+            event.preventDefault();
+          }}
+        />
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel label="Pods" />
+        <DropdownMenuSearchbar
+          autoFocus
+          name="search-pods"
+          placeholder="Search Pods"
+          value={searchText}
+          onChange={setSearchText}
+          disabled={isLoading}
+        />
+        <DropdownMenuItem
+          label={allPodsSelected ? "Clear all" : "Select all"}
+          disabled={pods.length === 0}
+          onClick={() =>
+            onChange({
+              ...selection,
+              podIds: allPodsSelected ? [] : pods.map((pod) => pod.sId),
+            })
+          }
+          onSelect={(event) => {
+            event.preventDefault();
+          }}
+        />
+        {isLoading ? (
+          <DropdownMenuItem
+            label="Loading"
+            disabled
+            endComponent={<Spinner size="xs" />}
+          />
+        ) : pods.length === 0 ? (
+          <DropdownMenuItem label="No Pods with their own policy" disabled />
+        ) : filteredPods.length === 0 ? (
+          <DropdownMenuItem label="No matching Pods" disabled />
+        ) : (
+          filteredPods.map((pod) => (
+            <DropdownMenuCheckboxItem
+              key={pod.sId}
+              label={pod.name}
+              icon={podIcon(pod)}
+              checked={selectedPodIds.has(pod.sId)}
+              onCheckedChange={(checked) =>
+                togglePod(pod.sId, checked === true)
+              }
+              onSelect={(event) => {
+                event.preventDefault();
+              }}
+            />
+          ))
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          label="Reset"
+          disabled={selection.includeWorkspace && selection.podIds.length === 0}
+          onClick={() => onChange({ includeWorkspace: true, podIds: [] })}
+          onSelect={(event) => {
+            event.preventDefault();
+          }}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/front/components/sandbox/pod_icon.ts
+++ b/front/components/sandbox/pod_icon.ts
@@ -1,0 +1,8 @@
+import type { SandboxAdminPod } from "@app/types/api/sandbox/egress_policy";
+import { Cube01, CubeOutline } from "@dust-tt/sparkle";
+
+// Central Computer admin Pods are always project spaces, so the icon is just
+// open vs restricted (mirrors getSpaceIcon's project branch).
+export function podIcon(pod: SandboxAdminPod) {
+  return pod.isRestricted ? CubeOutline : Cube01;
+}

--- a/front/hooks/useComputerAdminAccess.ts
+++ b/front/hooks/useComputerAdminAccess.ts
@@ -1,0 +1,24 @@
+import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
+
+// The single client-side capability check for administrating Computer
+// settings. Mirrors the API gates (`ensureIsAdmin` + the Computer feature on
+// the sandbox sub-apps); pod membership is deliberately not consulted. Change
+// both together.
+export function useComputerAdminAccess() {
+  const { isAdmin } = useAuth();
+  const { featureFlags } = useFeatureFlags();
+  const isComputerEnabled = isComputerFeatureEnabled(featureFlags);
+  const canAdministrateComputer = isAdmin && isComputerEnabled;
+  const hasSandboxFunctions = featureFlags.includes("sandbox_functions");
+  // The multi-Pod scope selector and Pod editing on the Computer admin page
+  // ride the Pod Functions flag, on top of Computer admin access.
+  const canAdministratePods = canAdministrateComputer && hasSandboxFunctions;
+
+  return {
+    isAdmin,
+    isComputerEnabled,
+    canAdministrateComputer,
+    canAdministratePods,
+  };
+}

--- a/front/lib/swr/sandbox.ts
+++ b/front/lib/swr/sandbox.ts
@@ -8,9 +8,14 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type {
+  GetEgressPolicyPodsResponseBody,
+  GetPodEgressPoliciesBulkResponseBody,
   GetWorkspaceEgressPolicyResponseBody,
+  PostBulkEgressPolicyResponseBody,
   PutWorkspaceEgressPolicyResponseBody,
+  SandboxAdminPod,
 } from "@app/types/api/sandbox/egress_policy";
+import { SANDBOX_WORKSPACE_SCOPE_ID } from "@app/types/api/sandbox/egress_policy";
 import type {
   GetSandboxEnvVarsResponseBody,
   PostSandboxEnvVarsResponseBody,
@@ -28,6 +33,40 @@ import type { Fetcher } from "swr";
 
 function workspaceEgressPolicyUrl(workspaceId: string) {
   return `/api/w/${workspaceId}/sandbox/egress-policy`;
+}
+
+// The Pods a central-admin bulk egress read/write targets: every configured
+// Pod ("all-pods") or an explicit set.
+export type SandboxPodSelection =
+  | { kind: "all-pods" }
+  | { kind: "pods"; podIds: string[] };
+
+// Sorted so the same selection always produces the same SWR key.
+function podSelectionQuery(selection: SandboxPodSelection): string {
+  return selection.kind === "all-pods"
+    ? "scope=all-pods"
+    : `podIds=${[...selection.podIds].sort().map(encodeURIComponent).join(",")}`;
+}
+
+function scopeNameById(pods: { sId: string; name: string }[]) {
+  return new Map<string, string>([
+    [SANDBOX_WORKSPACE_SCOPE_ID, "Workspace"],
+    ...pods.map((pod) => [pod.sId, pod.name] as const),
+  ]);
+}
+
+function describeScopeFailures(
+  failures: { scopeId: string; errorMessage?: string }[],
+  nameByScopeId: Map<string, string>
+): string {
+  return failures
+    .map(
+      (failure) =>
+        `${nameByScopeId.get(failure.scopeId) ?? failure.scopeId}: ${
+          failure.errorMessage ?? "unknown error"
+        }`
+    )
+    .join(" — ");
 }
 
 // Workspace-scoped env vars live under /sandbox/env-vars; pod-scoped ones
@@ -66,6 +105,217 @@ export function useWorkspaceEgressPolicy({
     isWorkspaceEgressPolicyLoading: disabled ? false : isLoading,
     isWorkspaceEgressPolicyError: !!error,
     mutateWorkspaceEgressPolicy: mutate,
+  };
+}
+
+// The Pods that have their own egress policy — the options for the central
+// Computer admin scope selector.
+export function useEgressPolicyPods({
+  owner,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const podsFetcher: Fetcher<GetEgressPolicyPodsResponseBody> = fetcher;
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    `${workspaceEgressPolicyUrl(owner.sId)}/pods`,
+    podsFetcher,
+    { disabled }
+  );
+
+  return {
+    pods: data?.pods ?? emptyArray<SandboxAdminPod>(),
+    isEgressPolicyPodsLoading: disabled ? false : isLoading,
+    isEgressPolicyPodsError: !!error,
+    mutateEgressPolicyPods: mutate,
+  };
+}
+
+// Reads the egress policies of the selected Pods in one request. null selection
+// (workspace-only) skips the read; only the workspace baseline is then shown.
+export function useBulkPodEgressPolicies({
+  owner,
+  selection,
+  disabled = false,
+}: {
+  owner: LightWorkspaceType;
+  selection: SandboxPodSelection | null;
+  disabled?: boolean;
+}) {
+  const { fetcher } = useFetcher();
+  const policiesFetcher: Fetcher<GetPodEgressPoliciesBulkResponseBody> =
+    fetcher;
+  const url = selection
+    ? `${workspaceEgressPolicyUrl(owner.sId)}/bulk?${podSelectionQuery(selection)}`
+    : null;
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
+    url,
+    policiesFetcher,
+    { disabled }
+  );
+
+  return {
+    podPolicies: data?.policies ?? emptyArray(),
+    isPodPoliciesLoading: disabled || !selection ? false : isLoading,
+    isPodPoliciesError: !!error,
+    mutatePodPolicies: mutate,
+  };
+}
+
+// Adds or removes one egress domain across the selected scopes (optionally the
+// workspace baseline, plus each Pod) in a single request. Reports partial
+// failures per scope; the caller revalidates the affected reads on success.
+export function useBulkUpdateEgressDomain({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  const bulkUpdateEgressDomain = async ({
+    includeWorkspace,
+    pods,
+    operation,
+    domain,
+  }: {
+    includeWorkspace: boolean;
+    pods: { sId: string; name: string }[];
+    operation: "add" | "remove";
+    domain: string;
+  }): Promise<boolean> => {
+    setIsUpdating(true);
+    const failureTitle =
+      operation === "add" ? "Failed to add domain" : "Failed to remove domain";
+    try {
+      const response = await clientFetch(
+        `${workspaceEgressPolicyUrl(owner.sId)}/bulk`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            includeWorkspace,
+            podIds: pods.map((pod) => pod.sId),
+            operation: { operation, domain },
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: failureTitle,
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PostBulkEgressPolicyResponseBody = await response.json();
+      const scopeLabel = (count: number) =>
+        count === 1 ? "1 scope" : `${count} scopes`;
+      const verb = operation === "add" ? "added to" : "removed from";
+
+      const failures = data.results.filter((result) => !result.success);
+      if (failures.length > 0) {
+        const okCount = data.results.length - failures.length;
+        sendNotification({
+          type: "error",
+          title:
+            operation === "add"
+              ? "Domain partially added"
+              : "Domain partially removed",
+          description: `${domain} was ${verb} ${okCount} of ${scopeLabel(
+            data.results.length
+          )}. Failed: ${describeScopeFailures(failures, scopeNameById(pods))}`,
+        });
+        return false;
+      }
+
+      // A workspace add applies to every Pod, so spell that out rather than
+      // reporting the single workspace scope.
+      const workspaceAddCoversPods = operation === "add" && includeWorkspace;
+      sendNotification({
+        type: "success",
+        title: operation === "add" ? "Domain added" : "Domain removed",
+        description: workspaceAddCoversPods
+          ? `${domain} was added to the workspace, which applies to all Pods. Computer egress policy changes will be applied by the proxy cache shortly.`
+          : `${domain} was ${verb} ${scopeLabel(
+              data.results.length
+            )}. Computer egress policy changes will be applied by the proxy cache shortly.`,
+      });
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: failureTitle,
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return {
+    bulkUpdateEgressDomain,
+    isBulkUpdatingEgressDomain: isUpdating,
+  };
+}
+
+// Rejects one agent-requested domain on a specific Pod (its originating scope).
+// Parameterized by podId so the multi-scope view can reject across Pods without
+// a hook bound per Pod; the caller revalidates the bulk read on success.
+export function useDismissPodEgressRequestByPod({
+  owner,
+}: {
+  owner: LightWorkspaceType;
+}) {
+  const sendNotification = useSendNotification();
+  const [isDismissing, setIsDismissing] = useState(false);
+
+  const dismissPodEgressRequest = async (
+    podId: string,
+    domain: string
+  ): Promise<boolean> => {
+    setIsDismissing(true);
+    try {
+      const response = await clientFetch(
+        `/api/w/${owner.sId}/spaces/${podId}/sandbox/egress-policy/requests/dismiss`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ domain }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to reject domain request",
+          description: error.message,
+        });
+        return false;
+      }
+      return true;
+    } catch (error) {
+      sendNotification({
+        type: "error",
+        title: "Failed to reject domain request",
+        description: normalizeError(error).message,
+      });
+      return false;
+    } finally {
+      setIsDismissing(false);
+    }
+  };
+
+  return {
+    dismissPodEgressRequest,
+    isDismissingPodEgressRequest: isDismissing,
   };
 }
 

--- a/front/types/api/sandbox/egress_policy.ts
+++ b/front/types/api/sandbox/egress_policy.ts
@@ -42,9 +42,17 @@ export type PostPodEgressPolicyRequestResponseBody = {
   outcome: SandboxEgressRequestOutcome;
 };
 
+// A Pod offered by the central Computer admin scope selector: identity, display
+// name, and whether it is restricted (drives the open/restricted Pod icon).
+export type SandboxAdminPod = {
+  sId: string;
+  name: string;
+  isRestricted: boolean;
+};
+
 // The Pods that have their own egress policy, for the admin scope selector.
 export type GetEgressPolicyPodsResponseBody = {
-  pods: { sId: string; name: string }[];
+  pods: SandboxAdminPod[];
 };
 
 export type GetPodEgressPoliciesBulkResponseBody = {


### PR DESCRIPTION
## Why

Agents running in the Computer can request additional egress domains mid-conversation (`add_egress_domain`), but there's no admin control over whether that's allowed. This adds a workspace-wide toggle to the Computer admin page.

Part of the central Computer admin stack:
- PR1 `30986` — list configured Pods + bulk egress read
- PR2 `30995` — bulk egress write
- PR-A `30996` — scope-aware multi-Pod network view + editing
- PR-B (this PR) — agent-requested-domains toggle
- Follow-up — Pod-member read-only view

## What

`AgentRequestedDomainsSetting`: a workspace-wide `SliderToggle` for `add_egress_domain`. Enabling is confirmation-gated (it lets non-admin users grant per-conversation network access to un-pre-approved domains). Rendered above the Network section so it stays visible regardless of the scope being viewed. Uses the existing `useUpdateWorkspaceSandboxAgentEgressRequests` hook — no new backend.

## Test

`tsc` + `biome` clean. Manual: toggle on (confirm dialog) / off, verify the workspace setting persists.

## Risk

Low. One workspace toggle over an existing endpoint; safe to roll back.