### PR TITLE
feat(sandbox): pod Computer network — member read-only view + domain requests

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
@@ -152,16 +152,44 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
     ).toBeUndefined();
   });
 
-  it("rejects non-admin users with a 403", async () => {
+  it("lets a non-admin Pod member read the policy", async () => {
+    const { workspace, user } = await setupTest({ role: "user" });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    seedPolicyFile(workspace.sId, pod.sId, {
+      allowedDomains: ["api.github.com"],
+    });
+
+    const response = await getPolicy(workspace.sId, pod.sId);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      policy: { allowedDomains: ["api.github.com"] },
+      requestedDomains: [],
+    });
+  });
+
+  it("hides the Pod from a user who cannot access it", async () => {
     const { workspace } = await setupTest({ role: "user" });
+    // The user is not a member of this Pod, so it is not visible to them.
     const pod = await SpaceFactory.project(workspace);
 
     const response = await getPolicy(workspace.sId, pod.sId);
 
-    expect(response.status).toBe(403);
-    expect(await response.json()).toMatchObject({
-      error: { type: "workspace_auth_error" },
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects a non-admin Pod member's write with a 403", async () => {
+    const { workspace, user } = await setupTest({ role: "user" });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const response = await putPolicy(workspace.sId, pod.sId, {
+      allowedDomains: ["api.github.com"],
     });
+
+    expect(response.status).toBe(403);
+    expect(
+      fileStorageMock.getObject(`w/${workspace.sId}/sandboxes/${pod.sId}.json`)
+    ).toBeUndefined();
   });
 
   it("rejects workspaces without the sandbox_functions flag with a 403", async () => {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.test.ts
@@ -66,6 +66,17 @@ function dismissRequest(wId: string, spaceId: string, domain: string) {
   );
 }
 
+function requestDomain(wId: string, spaceId: string, domain: string) {
+  return honoApp.request(
+    `/api/w/${wId}/spaces/${spaceId}/sandbox/egress-policy/requests`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ domain }),
+    }
+  );
+}
+
 function seedPolicyFile(
   wId: string,
   spaceId: string,
@@ -187,6 +198,71 @@ describe("GET/PUT /api/w/:wId/spaces/:spaceId/sandbox/egress-policy", () => {
     });
 
     expect(response.status).toBe(403);
+    expect(
+      fileStorageMock.getObject(`w/${workspace.sId}/sandboxes/${pod.sId}.json`)
+    ).toBeUndefined();
+  });
+
+  it("lets a non-admin Pod member request a domain for review", async () => {
+    const { workspace, user } = await setupTest({ role: "user" });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const response = await requestDomain(
+      workspace.sId,
+      pod.sId,
+      "api.stripe.com"
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.outcome).toBe("requested");
+    // The request is recorded but never granted.
+    expect(body.policy.allowedDomains).toEqual([]);
+    expect(
+      body.policy.requestedDomains.map((r: { domain: string }) => r.domain)
+    ).toContain("api.stripe.com");
+  });
+
+  it("reports already_allowed without recording a request", async () => {
+    const { workspace, user } = await setupTest({ role: "user" });
+    const pod = await SpaceFactory.project(workspace, user.id);
+    seedPolicyFile(workspace.sId, pod.sId, {
+      allowedDomains: ["api.github.com"],
+    });
+
+    const response = await requestDomain(
+      workspace.sId,
+      pod.sId,
+      "api.github.com"
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).outcome).toBe("already_allowed");
+
+    const getResponse = await getPolicy(workspace.sId, pod.sId);
+    expect((await getResponse.json()).requestedDomains).toEqual([]);
+  });
+
+  it("hides the request route from a user who cannot access the Pod", async () => {
+    const { workspace } = await setupTest({ role: "user" });
+    const pod = await SpaceFactory.project(workspace);
+
+    const response = await requestDomain(
+      workspace.sId,
+      pod.sId,
+      "api.stripe.com"
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("rejects an invalid requested domain with a 400", async () => {
+    const { workspace, user } = await setupTest({ role: "user" });
+    const pod = await SpaceFactory.project(workspace, user.id);
+
+    const response = await requestDomain(workspace.sId, pod.sId, "127.0.0.1");
+
+    expect(response.status).toBe(400);
     expect(
       fileStorageMock.getObject(`w/${workspace.sId}/sandboxes/${pod.sId}.json`)
     ).toBeUndefined();

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
@@ -22,11 +22,10 @@ import { withSpace } from "@front-api/middlewares/with_space";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-// Mounted at /api/w/:wId/spaces/:spaceId/sandbox/egress-policy. The parent
-// sandbox sub-app applies the `sandbox_functions` gate; reads (GET) are open to
-// anyone who can read the Pod so members see it read-only, while writes (PUT,
-// requests/dismiss) additionally require a workspace admin. Each handler also
-// validates that the space is a Pod (project space).
+// Mounted at /api/w/:wId/spaces/:spaceId/sandbox/egress-policy. GET (and the
+// member request POST) are open to Pod readers; the admin writes (PUT,
+// requests/dismiss) add `ensureIsAdmin`. Each handler validates the space is a
+// Pod.
 //
 // A Pod's allowlist is its owner policy file
 // (`w/{wId}/sandboxes/{spaceSId}.json`) — the same slot conversation
@@ -149,10 +148,8 @@ app.put(
   }
 );
 
-// Any Pod member may request a domain — it only records a pending request for
-// an admin to approve or reject, never grants access. Deliberately not gated on
-// the workspace agent-request toggle: that governs the agent's on-the-fly
-// requests during a conversation, not an explicit, admin-reviewed ask here.
+// Any Pod member may request a domain; it records a pending request for admin
+// review and never grants access.
 /** @ignoreswagger */
 app.post(
   "/requests",
@@ -188,11 +185,7 @@ app.post(
       domain: parsedBody.data.domain,
     });
     if (result.isErr()) {
-      // The reachable failures are caller-actionable — an invalid domain or a
-      // full pending-request cap — so 400. requestOwnerPolicyDomain returns a
-      // flat Error, so a rare GCS write failure also lands here rather than
-      // 500; that is accepted because mapping the path to 500 would instead
-      // mislabel the common, user-actionable cap case.
+      // Caller-actionable: an invalid domain or a full pending-request cap.
       return apiError(ctx, {
         status_code: 400,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
@@ -14,15 +14,17 @@ import type {
 } from "@app/types/api/sandbox/egress_policy";
 import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { withSpace } from "@front-api/middlewares/with_space";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
 // Mounted at /api/w/:wId/spaces/:spaceId/sandbox/egress-policy. The parent
-// sandbox sub-app applies the workspace-admin and `sandbox_functions` gates;
-// each handler additionally validates that the space is a Pod (project
-// space).
+// sandbox sub-app applies the `sandbox_functions` gate; reads (GET) are open to
+// anyone who can read the Pod so members see it read-only, while writes (PUT,
+// requests/dismiss) additionally require a workspace admin. Each handler also
+// validates that the space is a Pod (project space).
 //
 // A Pod's allowlist is its owner policy file
 // (`w/{wId}/sandboxes/{spaceSId}.json`) — the same slot conversation
@@ -77,6 +79,7 @@ app.get(
 /** @ignoreswagger */
 app.put(
   "/",
+  ensureIsAdmin(),
   withSpace({ requireCanReadOrAdministrate: true }),
   async (ctx): HandlerResult<PutPodEgressPolicyResponseBody> => {
     const auth = ctx.get("auth");
@@ -147,6 +150,7 @@ app.put(
 /** @ignoreswagger */
 app.post(
   "/requests/dismiss",
+  ensureIsAdmin(),
   withSpace({ requireCanReadOrAdministrate: true }),
   async (ctx): HandlerResult<PutPodEgressPolicyResponseBody> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
@@ -188,7 +188,11 @@ app.post(
       domain: parsedBody.data.domain,
     });
     if (result.isErr()) {
-      // Invalid domain or the pending-request cap — both are caller-actionable.
+      // The reachable failures are caller-actionable — an invalid domain or a
+      // full pending-request cap — so 400. requestOwnerPolicyDomain returns a
+      // flat Error, so a rare GCS write failure also lands here rather than
+      // 500; that is accepted because mapping the path to 500 would instead
+      // mislabel the common, user-actionable cap case.
       return apiError(ctx, {
         status_code: 400,
         api_error: {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
@@ -6,10 +6,12 @@ import {
 import {
   dismissRequestedOwnerPolicyDomain,
   readOwnerPolicy,
+  requestOwnerPolicyDomain,
   writeOwnerPolicy,
 } from "@app/lib/api/sandbox/egress_policy";
 import type {
   GetPodEgressPolicyResponseBody,
+  PostPodEgressPolicyRequestResponseBody,
   PutPodEgressPolicyResponseBody,
 } from "@app/types/api/sandbox/egress_policy";
 import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
@@ -33,7 +35,7 @@ import { fromError } from "zod-validation-error";
 // activation. Mirrors the workspace egress-policy route.
 const app = workspaceApp();
 
-const DismissRequestBodySchema = z.object({
+const EgressDomainBodySchema = z.object({
   domain: z.string().min(1),
 });
 
@@ -147,6 +149,62 @@ app.put(
   }
 );
 
+// Any Pod member may request a domain — it only records a pending request for
+// an admin to approve or reject, never grants access. Deliberately not gated on
+// the workspace agent-request toggle: that governs the agent's on-the-fly
+// requests during a conversation, not an explicit, admin-reviewed ask here.
+/** @ignoreswagger */
+app.post(
+  "/requests",
+  withSpace({ requireCanReadOrAdministrate: true }),
+  async (ctx): HandlerResult<PostPodEgressPolicyRequestResponseBody> => {
+    const auth = ctx.get("auth");
+    const space = ctx.get("space");
+
+    if (!space.isProject()) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Pod egress policy is only available for project spaces.",
+        },
+      });
+    }
+
+    const body = await ctx.req.json().catch(() => null);
+    const parsedBody = EgressDomainBodySchema.safeParse(body);
+    if (!parsedBody.success) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: fromError(parsedBody.error).toString(),
+        },
+      });
+    }
+
+    const result = await requestOwnerPolicyDomain(auth, {
+      ownerId: space.sId,
+      domain: parsedBody.data.domain,
+    });
+    if (result.isErr()) {
+      // Invalid domain or the pending-request cap — both are caller-actionable.
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: result.error.message,
+        },
+      });
+    }
+
+    return ctx.json({
+      policy: result.value.policy,
+      outcome: result.value.outcome,
+    });
+  }
+);
+
 /** @ignoreswagger */
 app.post(
   "/requests/dismiss",
@@ -167,7 +225,7 @@ app.post(
     }
 
     const body = await ctx.req.json().catch(() => null);
-    const parsedBody = DismissRequestBodySchema.safeParse(body);
+    const parsedBody = EgressDomainBodySchema.safeParse(body);
     if (!parsedBody.success) {
       return apiError(ctx, {
         status_code: 400,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/egress-policy.ts
@@ -18,9 +18,9 @@ import { parseEgressPolicy } from "@app/types/sandbox/egress_policy";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
 import { z } from "zod";
-import { fromError } from "zod-validation-error";
 
 // Mounted at /api/w/:wId/spaces/:spaceId/sandbox/egress-policy. GET (and the
 // member request POST) are open to Pod readers; the admin writes (PUT,
@@ -154,6 +154,7 @@ app.put(
 app.post(
   "/requests",
   withSpace({ requireCanReadOrAdministrate: true }),
+  validate("json", EgressDomainBodySchema),
   async (ctx): HandlerResult<PostPodEgressPolicyRequestResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
@@ -168,21 +169,10 @@ app.post(
       });
     }
 
-    const body = await ctx.req.json().catch(() => null);
-    const parsedBody = EgressDomainBodySchema.safeParse(body);
-    if (!parsedBody.success) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: fromError(parsedBody.error).toString(),
-        },
-      });
-    }
-
+    const { domain } = ctx.req.valid("json");
     const result = await requestOwnerPolicyDomain(auth, {
       ownerId: space.sId,
-      domain: parsedBody.data.domain,
+      domain,
     });
     if (result.isErr()) {
       // Caller-actionable: an invalid domain or a full pending-request cap.
@@ -207,6 +197,7 @@ app.post(
   "/requests/dismiss",
   ensureIsAdmin(),
   withSpace({ requireCanReadOrAdministrate: true }),
+  validate("json", EgressDomainBodySchema),
   async (ctx): HandlerResult<PutPodEgressPolicyResponseBody> => {
     const auth = ctx.get("auth");
     const space = ctx.get("space");
@@ -221,21 +212,10 @@ app.post(
       });
     }
 
-    const body = await ctx.req.json().catch(() => null);
-    const parsedBody = EgressDomainBodySchema.safeParse(body);
-    if (!parsedBody.success) {
-      return apiError(ctx, {
-        status_code: 400,
-        api_error: {
-          type: "invalid_request_error",
-          message: fromError(parsedBody.error).toString(),
-        },
-      });
-    }
-
+    const { domain } = ctx.req.valid("json");
     const result = await dismissRequestedOwnerPolicyDomain(auth, {
       ownerId: space.sId,
-      domain: parsedBody.data.domain,
+      domain,
     });
     if (result.isErr()) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].test.ts
@@ -63,10 +63,9 @@ describe("PATCH/DELETE /api/w/:wId/spaces/:spaceId/sandbox/env-vars/:id", () => 
     vi.clearAllMocks();
   });
 
-  // The parent sandbox router no longer applies ensureIsAdmin; env-vars/index.ts
-  // re-applies it for the whole leaf. These two guard that the admin gate still
-  // covers the nested /:id routes for a Pod member (who can read the Pod but is
-  // not a workspace admin).
+  // Guard that the admin gate still covers the nested /:id routes for a Pod
+  // member (can read the Pod, not a workspace admin) after the gate moved to
+  // the env-vars leaf.
   it("rejects a non-admin DELETE", async () => {
     const { workspace, pod } = await setupTest({ role: "user" });
 

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].test.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/[id].test.ts
@@ -63,13 +63,35 @@ describe("PATCH/DELETE /api/w/:wId/spaces/:spaceId/sandbox/env-vars/:id", () => 
     vi.clearAllMocks();
   });
 
-  it("rejects non-admin requests", async () => {
+  // The parent sandbox router no longer applies ensureIsAdmin; env-vars/index.ts
+  // re-applies it for the whole leaf. These two guard that the admin gate still
+  // covers the nested /:id routes for a Pod member (who can read the Pod but is
+  // not a workspace admin).
+  it("rejects a non-admin DELETE", async () => {
     const { workspace, pod } = await setupTest({ role: "user" });
 
     const response = await deleteEnvVar(
       workspace.sId,
       pod.sId,
       "env_var_unknown"
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({
+      error: { type: "workspace_auth_error" },
+    });
+  });
+
+  it("rejects a non-admin PATCH", async () => {
+    const { workspace, pod } = await setupTest({ role: "user" });
+
+    const response = await patchEnvVar(
+      workspace.sId,
+      pod.sId,
+      "env_var_unknown",
+      {
+        allowedDomains: ["api.github.com"],
+      }
     );
 
     expect(response.status).toBe(403);

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
@@ -26,9 +26,8 @@ const PostPodSandboxEnvVarBodySchema = z.object({
 });
 
 // Mounted at /api/w/:wId/spaces/:spaceId/sandbox/env-vars. Pods are project
-// spaces: non-project spaces have no pod-scoped env vars and 404. Admin-only
-// (read and write): the parent no longer gates admin, so re-apply it here — it
-// also covers the mounted /:id.
+// spaces: non-project spaces have no pod-scoped env vars and 404. Workspace-admin
+// only (read and write); the gate on this leaf also covers the mounted /:id.
 const app = workspaceApp();
 
 app.use("*", ensureIsAdmin());

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
@@ -10,6 +10,7 @@ import type {
 } from "@app/types/api/sandbox/env_vars";
 import { SANDBOX_ENV_VAR_KINDS } from "@app/types/sandbox/env_var";
 import { workspaceApp } from "@front-api/middlewares/ctx";
+import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 import { withSpace } from "@front-api/middlewares/with_space";
@@ -26,7 +27,14 @@ const PostPodSandboxEnvVarBodySchema = z.object({
 
 // Mounted at /api/w/:wId/spaces/:spaceId/sandbox/env-vars. Pods are project
 // spaces: non-project spaces have no pod-scoped env vars and 404.
+//
+// Pod env vars stay workspace-admin only (read and write): unlike the
+// egress-policy leaf, they are not opened to Pod members. The parent sandbox
+// sub-app no longer applies the admin gate, so it is re-applied here for every
+// route, including the mounted /:id sub-app.
 const app = workspaceApp();
+
+app.use("*", ensureIsAdmin());
 
 /** @ignoreswagger */
 app.get(

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/env-vars/index.ts
@@ -26,12 +26,9 @@ const PostPodSandboxEnvVarBodySchema = z.object({
 });
 
 // Mounted at /api/w/:wId/spaces/:spaceId/sandbox/env-vars. Pods are project
-// spaces: non-project spaces have no pod-scoped env vars and 404.
-//
-// Pod env vars stay workspace-admin only (read and write): unlike the
-// egress-policy leaf, they are not opened to Pod members. The parent sandbox
-// sub-app no longer applies the admin gate, so it is re-applied here for every
-// route, including the mounted /:id sub-app.
+// spaces: non-project spaces have no pod-scoped env vars and 404. Admin-only
+// (read and write): the parent no longer gates admin, so re-apply it here — it
+// also covers the mounted /:id.
 const app = workspaceApp();
 
 app.use("*", ensureIsAdmin());

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/index.ts
@@ -5,16 +5,9 @@ import egressPolicy from "./egress-policy";
 import envVars from "./env-vars";
 
 // Mounted at /api/w/:wId/spaces/:spaceId/sandbox. Only the `sandbox_functions`
-// feature gate is applied here so every leaf below inherits it; access control
-// is decided per leaf.
-//
-// Access-control decision: the egress-policy leaf opens reads (GET) to anyone
-// who can read the Pod so members see the Pod's network settings read-only,
-// while its writes require a workspace admin. The env-vars leaf stays
-// workspace-admin only (it re-applies `ensureIsAdmin` for every route). Pod
-// membership is deliberately not consulted for edit. If the edit gate flips to
-// pod-editor, change the leaf handlers and the matching UI gate in
-// PodSettingsTab together.
+// gate is applied here; access control is per leaf — egress-policy opens GET to
+// Pod readers (writes admin-only), env-vars stays admin-only. Keep in sync with
+// the UI gate in PodSettingsTab.
 const app = workspaceApp();
 
 app.use("*", withSandboxFunctionsFeature());

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/sandbox/index.ts
@@ -1,23 +1,22 @@
 import { workspaceApp } from "@front-api/middlewares/ctx";
-import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import { withSandboxFunctionsFeature } from "@front-api/middlewares/with_sandbox_functions_feature";
 
 import egressPolicy from "./egress-policy";
 import envVars from "./env-vars";
 
-// Mounted at /api/w/:wId/spaces/:spaceId/sandbox. The workspace-admin and
-// `sandbox_functions` feature gates are applied here so every leaf below
-// inherits them.
+// Mounted at /api/w/:wId/spaces/:spaceId/sandbox. Only the `sandbox_functions`
+// feature gate is applied here so every leaf below inherits it; access control
+// is decided per leaf.
 //
-// Access-control decision (v0, deliberate): workspace-admin only, with pod
-// membership intentionally not consulted. This means a workspace admin who
-// is NOT a member of a private pod can still read and edit that pod's
-// sandbox settings through these routes (admins pass canAdministrate on
-// spaces). If this flips to pod-editor or admin-and-member, change this
-// middleware chain and the matching UI gate in PodSettingsTab together.
+// Access-control decision: the egress-policy leaf opens reads (GET) to anyone
+// who can read the Pod so members see the Pod's network settings read-only,
+// while its writes require a workspace admin. The env-vars leaf stays
+// workspace-admin only (it re-applies `ensureIsAdmin` for every route). Pod
+// membership is deliberately not consulted for edit. If the edit gate flips to
+// pod-editor, change the leaf handlers and the matching UI gate in
+// PodSettingsTab together.
 const app = workspaceApp();
 
-app.use("*", ensureIsAdmin());
 app.use("*", withSandboxFunctionsFeature());
 
 app.route("/egress-policy", egressPolicy);

--- a/front/components/pod/settings/PodNetworkSection.tsx
+++ b/front/components/pod/settings/PodNetworkSection.tsx
@@ -2,6 +2,7 @@ import { EgressDomainListEditor } from "@app/components/sandbox/EgressDomainList
 import {
   useDismissPodEgressRequest,
   usePodEgressPolicy,
+  useRequestPodEgressDomain,
   useUpdatePodEgressPolicy,
 } from "@app/lib/swr/pods";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -32,6 +33,8 @@ export function PodNetworkSection({
     useUpdatePodEgressPolicy({ owner, podId });
   const { dismissPodEgressRequest, isDismissingRequest } =
     useDismissPodEgressRequest({ owner, podId });
+  const { requestPodEgressDomain, isRequestingPodEgressDomain } =
+    useRequestPodEgressDomain({ owner, podId });
 
   if (isPodEgressPolicyLoading) {
     return <Spinner />;
@@ -57,6 +60,9 @@ export function PodNetworkSection({
       <p className="text-sm text-muted-foreground">
         This Pod's Computer can reach these domains on top of the workspace
         allowlist. Changes apply to running Computers within about a minute.
+        {!canEdit
+          ? " You can request additional domains; a workspace admin reviews each request."
+          : ""}
       </p>
 
       <EgressDomainListEditor
@@ -71,9 +77,16 @@ export function PodNetworkSection({
         }
         onRejectRequest={(domain) => dismissPodEgressRequest(domain)}
         onSave={(allowedDomains) => updatePodEgressPolicy({ allowedDomains })}
-        isUpdating={isUpdatingPodEgressPolicy || isDismissingRequest}
+        isUpdating={
+          isUpdatingPodEgressPolicy ||
+          isDismissingRequest ||
+          isRequestingPodEgressDomain
+        }
         emptyMessage="No Pod-specific domains are currently allowed."
         readOnly={!canEdit}
+        onRequestDomain={
+          canEdit ? undefined : (domain) => requestPodEgressDomain(domain)
+        }
       />
     </div>
   );

--- a/front/components/pod/settings/PodNetworkSection.tsx
+++ b/front/components/pod/settings/PodNetworkSection.tsx
@@ -10,12 +10,18 @@ import { ContentMessage, InfoCircle, Spinner } from "@dust-tt/sparkle";
 interface PodNetworkSectionProps {
   owner: LightWorkspaceType;
   podId: string;
+  // Pod members can view; only workspace admins can edit (matching the API).
+  canEdit: boolean;
 }
 
 // Pod-level sandbox egress allowlist. Merged on top of the workspace-level
-// allowlist for the Pod's Shared Computer. Workspace-admin only (matching the
-// API), gated behind the `sandbox_functions` feature at the call site.
-export function PodNetworkSection({ owner, podId }: PodNetworkSectionProps) {
+// allowlist for the Pod's Shared Computer. Visible to anyone who can open the
+// Pod settings page; editable only by workspace admins.
+export function PodNetworkSection({
+  owner,
+  podId,
+  canEdit,
+}: PodNetworkSectionProps) {
   const {
     policy,
     requestedDomains,
@@ -67,6 +73,7 @@ export function PodNetworkSection({ owner, podId }: PodNetworkSectionProps) {
         onSave={(allowedDomains) => updatePodEgressPolicy({ allowedDomains })}
         isUpdating={isUpdatingPodEgressPolicy || isDismissingRequest}
         emptyMessage="No Pod-specific domains are currently allowed."
+        readOnly={!canEdit}
       />
     </div>
   );

--- a/front/components/pod/settings/PodSettingsTab.tsx
+++ b/front/components/pod/settings/PodSettingsTab.tsx
@@ -101,12 +101,15 @@ export function PodSettingsTab({
   const { isAdmin } = useAuth();
   const hasWorkspaceDefaultAgentFeature = hasFeature("workspace_default_agent");
   const hasAdminControlledPodsFeature = hasFeature("admin_controlled_pods");
-  // The pod sandbox admin sections (network allowlist, env vars) are
-  // workspace-admin only (matching the API) and part of the Sandbox
-  // Functions surface.
-  // Mirrors the API gate (workspace-admin + sandbox_functions FF; pod
-  // membership deliberately not consulted) — change both together.
+  // The pod env vars section stays workspace-admin only (matching the API,
+  // which keeps env-vars admin-only). Mirrors that gate — change both together.
   const isPodSandboxAdminEnabled = isAdmin && hasFeature("sandbox_functions");
+  // The pod network section is visible to anyone who can open this page once
+  // the feature is on (the API opens the egress GET to Pod readers); editing
+  // stays workspace-admin only. Mirrors the egress-policy route gates — change
+  // both together.
+  const canViewPodNetwork = hasFeature("sandbox_functions");
+  const canEditPodNetwork = isPodSandboxAdminEnabled;
 
   const { podMetadata, isPodMetadataLoading } = usePodMetadata({
     workspaceId: owner.sId,
@@ -819,8 +822,12 @@ export function PodSettingsTab({
           )}
         </div>
 
-        {isPodSandboxAdminEnabled && (
-          <PodNetworkSection owner={owner} podId={pod.sId} />
+        {canViewPodNetwork && (
+          <PodNetworkSection
+            owner={owner}
+            podId={pod.sId}
+            canEdit={canEditPodNetwork}
+          />
         )}
 
         {isPodSandboxAdminEnabled && (

--- a/front/components/sandbox/EgressDomainListEditor.test.tsx
+++ b/front/components/sandbox/EgressDomainListEditor.test.tsx
@@ -1,0 +1,39 @@
+import { EgressDomainListEditor } from "@app/components/sandbox/EgressDomainListEditor";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const baseProps = {
+  allowedDomains: ["api.github.com"],
+  pendingRequests: [{ domain: "api.stripe.com" }],
+  onSave: vi.fn(async () => true),
+  onApproveRequest: vi.fn(),
+  onRejectRequest: vi.fn(),
+  isUpdating: false,
+  emptyMessage: "No domains are currently allowed.",
+};
+
+describe("EgressDomainListEditor", () => {
+  it("renders domains and pending requests but no controls when read-only", () => {
+    render(<EgressDomainListEditor {...baseProps} readOnly />);
+
+    // The allowed domain and the pending request are still visible.
+    expect(screen.getByText("api.github.com")).toBeInTheDocument();
+    expect(screen.getByText("api.stripe.com")).toBeInTheDocument();
+    expect(screen.getByText("Pending approval")).toBeInTheDocument();
+
+    // No add input and no add/remove/approve/reject controls.
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(screen.queryByLabelText("Domain")).not.toBeInTheDocument();
+  });
+
+  it("renders the mutation controls when editable", () => {
+    render(<EgressDomainListEditor {...baseProps} />);
+
+    expect(
+      screen.getByRole("button", { name: "Add domain" })
+    ).toBeInTheDocument();
+    // The Approve button's accessible name comes from its tooltip, so match the
+    // visible label text instead.
+    expect(screen.getByText("Approve")).toBeInTheDocument();
+  });
+});

--- a/front/components/sandbox/EgressDomainListEditor.test.tsx
+++ b/front/components/sandbox/EgressDomainListEditor.test.tsx
@@ -36,4 +36,25 @@ describe("EgressDomainListEditor", () => {
     // visible label text instead.
     expect(screen.getByText("Approve")).toBeInTheDocument();
   });
+
+  it("shows a request form but no admin controls in request mode", () => {
+    render(
+      <EgressDomainListEditor
+        {...baseProps}
+        readOnly
+        onRequestDomain={vi.fn(async () => true)}
+      />
+    );
+
+    // The input stays, relabelled to request, and it is the only control.
+    expect(
+      screen.getByRole("button", { name: "Request domain" })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+
+    // Domains and pending requests still render; no approve/remove controls.
+    expect(screen.getByText("api.github.com")).toBeInTheDocument();
+    expect(screen.getByText("Pending approval")).toBeInTheDocument();
+    expect(screen.queryByText("Approve")).not.toBeInTheDocument();
+  });
 });

--- a/front/components/sandbox/EgressDomainListEditor.tsx
+++ b/front/components/sandbox/EgressDomainListEditor.tsx
@@ -80,7 +80,7 @@ export function EgressDomainListEditor({
     domainInputResult?.isErr() === true || isDuplicate;
   const canAddDomain = normalizedDomain !== null && !isDuplicate && !isUpdating;
 
-  const handleAddDomain = async () => {
+  const handleSubmitDomain = async () => {
     if (!canAddDomain || normalizedDomain === null) {
       return;
     }
@@ -104,7 +104,7 @@ export function EgressDomainListEditor({
           className="flex flex-col gap-3 sm:flex-row sm:items-start"
           onSubmit={(event) => {
             event.preventDefault();
-            void handleAddDomain();
+            void handleSubmitDomain();
           }}
         >
           <div className="grow">

--- a/front/components/sandbox/EgressDomainListEditor.tsx
+++ b/front/components/sandbox/EgressDomainListEditor.tsx
@@ -20,6 +20,9 @@ interface EgressDomainListEditorProps {
   pendingRequests?: { domain: string }[];
   onApproveRequest?: (domain: string) => void;
   onRejectRequest?: (domain: string) => void;
+  // Read-only viewers (non-admin pod members) see the domains and any pending
+  // requests, but no add input and no remove/approve/reject controls.
+  readOnly?: boolean;
 }
 
 // Add/remove editor for a sandbox egress allowlist, shared by the workspace
@@ -34,6 +37,7 @@ export function EgressDomainListEditor({
   pendingRequests,
   onApproveRequest,
   onRejectRequest,
+  readOnly = false,
 }: EgressDomainListEditorProps) {
   const [domainInput, setDomainInput] = useState("");
 
@@ -74,34 +78,36 @@ export function EgressDomainListEditor({
 
   return (
     <>
-      <form
-        className="flex flex-col gap-3 sm:flex-row sm:items-start"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void handleAddDomain();
-        }}
-      >
-        <div className="grow">
-          <Input
-            label="Domain"
-            name="domain"
-            placeholder="e.g. api.openai.com or *.mistral.ai"
-            value={domainInput}
-            message={domainInputMessage}
-            messageStatus={isDomainInputInvalid ? "error" : "info"}
-            onChange={(event) => setDomainInput(event.target.value)}
-            disabled={isUpdating}
+      {!readOnly && (
+        <form
+          className="flex flex-col gap-3 sm:flex-row sm:items-start"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleAddDomain();
+          }}
+        >
+          <div className="grow">
+            <Input
+              label="Domain"
+              name="domain"
+              placeholder="e.g. api.openai.com or *.mistral.ai"
+              value={domainInput}
+              message={domainInputMessage}
+              messageStatus={isDomainInputInvalid ? "error" : "info"}
+              onChange={(event) => setDomainInput(event.target.value)}
+              disabled={isUpdating}
+            />
+          </div>
+          <Button
+            type="submit"
+            label="Add domain"
+            icon={Plus}
+            disabled={!canAddDomain}
+            isLoading={isUpdating}
+            className="mt-0 sm:mt-7"
           />
-        </div>
-        <Button
-          type="submit"
-          label="Add domain"
-          icon={Plus}
-          disabled={!canAddDomain}
-          isLoading={isUpdating}
-          className="mt-0 sm:mt-7"
-        />
-      </form>
+        </form>
+      )}
 
       {allowedDomains.length === 0 && (pendingRequests?.length ?? 0) === 0 ? (
         <ContentMessage variant="outline" size="lg">
@@ -122,24 +128,28 @@ export function EgressDomainListEditor({
                   Pending approval
                 </span>
               </div>
-              <Button
-                variant="highlight"
-                size="mini"
-                label="Approve"
-                tooltip={`Add ${request.domain} to the allowlist`}
-                disabled={isUpdating}
-                onClick={() => onApproveRequest?.(request.domain)}
-                className="shrink-0"
-              />
-              <Button
-                variant="ghost"
-                size="mini"
-                icon={XClose}
-                tooltip={`Reject ${request.domain}`}
-                disabled={isUpdating}
-                onClick={() => onRejectRequest?.(request.domain)}
-                className="shrink-0"
-              />
+              {!readOnly && (
+                <>
+                  <Button
+                    variant="highlight"
+                    size="mini"
+                    label="Approve"
+                    tooltip={`Add ${request.domain} to the allowlist`}
+                    disabled={isUpdating}
+                    onClick={() => onApproveRequest?.(request.domain)}
+                    className="shrink-0"
+                  />
+                  <Button
+                    variant="ghost"
+                    size="mini"
+                    icon={XClose}
+                    tooltip={`Reject ${request.domain}`}
+                    disabled={isUpdating}
+                    onClick={() => onRejectRequest?.(request.domain)}
+                    className="shrink-0"
+                  />
+                </>
+              )}
             </div>
           ))}
           {allowedDomains.map((domain) => (
@@ -150,17 +160,19 @@ export function EgressDomainListEditor({
               >
                 {domain}
               </pre>
-              <Button
-                variant="warning"
-                size="mini"
-                icon={Trash01}
-                tooltip={`Remove ${domain}`}
-                disabled={isUpdating}
-                onClick={() => {
-                  void handleRemoveDomain(domain);
-                }}
-                className="shrink-0"
-              />
+              {!readOnly && (
+                <Button
+                  variant="warning"
+                  size="mini"
+                  icon={Trash01}
+                  tooltip={`Remove ${domain}`}
+                  disabled={isUpdating}
+                  onClick={() => {
+                    void handleRemoveDomain(domain);
+                  }}
+                  className="shrink-0"
+                />
+              )}
             </div>
           ))}
         </div>

--- a/front/components/sandbox/EgressDomainListEditor.tsx
+++ b/front/components/sandbox/EgressDomainListEditor.tsx
@@ -21,8 +21,11 @@ interface EgressDomainListEditorProps {
   onApproveRequest?: (domain: string) => void;
   onRejectRequest?: (domain: string) => void;
   // Read-only viewers (non-admin pod members) see the domains and any pending
-  // requests, but no add input and no remove/approve/reject controls.
+  // requests, but no remove/approve/reject controls.
   readOnly?: boolean;
+  // When set (only meaningful with readOnly), the add input stays but submits a
+  // domain request for admin review instead of writing the allowlist.
+  onRequestDomain?: (domain: string) => Promise<boolean>;
 }
 
 // Add/remove editor for a sandbox egress allowlist, shared by the workspace
@@ -38,8 +41,14 @@ export function EgressDomainListEditor({
   onApproveRequest,
   onRejectRequest,
   readOnly = false,
+  onRequestDomain,
 }: EgressDomainListEditorProps) {
   const [domainInput, setDomainInput] = useState("");
+
+  // Members can't edit the allowlist, but may submit a domain request when the
+  // caller provides onRequestDomain — the input stays, everything else hides.
+  const isRequestMode = readOnly && onRequestDomain !== undefined;
+  const showDomainInput = !readOnly || isRequestMode;
 
   const hasDomainInput = domainInput.trim().length > 0;
   const domainInputResult = hasDomainInput
@@ -47,16 +56,26 @@ export function EgressDomainListEditor({
     : null;
   const normalizedDomain =
     domainInputResult?.isOk() === true ? domainInputResult.value : null;
-  const isDuplicate =
+  const isAlreadyAllowed =
     normalizedDomain !== null && allowedDomains.includes(normalizedDomain);
+  const isAlreadyPending =
+    isRequestMode &&
+    normalizedDomain !== null &&
+    (pendingRequests?.some((request) => request.domain === normalizedDomain) ??
+      false);
+  const isDuplicate = isAlreadyAllowed || isAlreadyPending;
   const domainInputMessage =
     domainInputResult?.isErr() === true
       ? domainInputResult.error.message
-      : isDuplicate
+      : isAlreadyAllowed
         ? "This domain is already allowed."
-        : normalizedDomain
-          ? `Will be saved as ${normalizedDomain}.`
-          : "Use an exact domain such as api.openai.com or a wildcard such as *.mistral.ai.";
+        : isAlreadyPending
+          ? "This domain has already been requested."
+          : normalizedDomain
+            ? isRequestMode
+              ? `Will be requested as ${normalizedDomain}.`
+              : `Will be saved as ${normalizedDomain}.`
+            : "Use an exact domain such as api.openai.com or a wildcard such as *.mistral.ai.";
   const isDomainInputInvalid =
     domainInputResult?.isErr() === true || isDuplicate;
   const canAddDomain = normalizedDomain !== null && !isDuplicate && !isUpdating;
@@ -66,7 +85,9 @@ export function EgressDomainListEditor({
       return;
     }
 
-    const success = await onSave([...allowedDomains, normalizedDomain]);
+    const success = isRequestMode
+      ? await onRequestDomain(normalizedDomain)
+      : await onSave([...allowedDomains, normalizedDomain]);
     if (success) {
       setDomainInput("");
     }
@@ -78,7 +99,7 @@ export function EgressDomainListEditor({
 
   return (
     <>
-      {!readOnly && (
+      {showDomainInput && (
         <form
           className="flex flex-col gap-3 sm:flex-row sm:items-start"
           onSubmit={(event) => {
@@ -100,7 +121,7 @@ export function EgressDomainListEditor({
           </div>
           <Button
             type="submit"
-            label="Add domain"
+            label={isRequestMode ? "Request domain" : "Add domain"}
             icon={Plus}
             disabled={!canAddDomain}
             isLoading={isUpdating}

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -1750,7 +1750,7 @@ export function useDismissPodEgressRequest({
 }
 
 // Lets a Pod member request a domain (recorded for admin review, never
-// granted). Available regardless of the workspace agent-request toggle.
+// granted).
 export function useRequestPodEgressDomain({
   owner,
   podId,

--- a/front/lib/swr/pods.ts
+++ b/front/lib/swr/pods.ts
@@ -51,6 +51,7 @@ import type {
 } from "@app/types/api/projects/tasks";
 import type {
   GetPodEgressPolicyResponseBody,
+  PostPodEgressPolicyRequestResponseBody,
   PutPodEgressPolicyResponseBody,
 } from "@app/types/api/sandbox/egress_policy";
 import type {
@@ -1746,4 +1747,87 @@ export function useDismissPodEgressRequest({
   };
 
   return { dismissPodEgressRequest, isDismissingRequest };
+}
+
+// Lets a Pod member request a domain (recorded for admin review, never
+// granted). Available regardless of the workspace agent-request toggle.
+export function useRequestPodEgressDomain({
+  owner,
+  podId,
+}: {
+  owner: LightWorkspaceType;
+  podId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const [isRequestingPodEgressDomain, setIsRequesting] = useState(false);
+  const { mutatePodEgressPolicy } = usePodEgressPolicy({
+    owner,
+    podId,
+    disabled: true,
+  });
+
+  const requestPodEgressDomain = async (domain: string): Promise<boolean> => {
+    setIsRequesting(true);
+    try {
+      const response = await clientFetch(
+        `${podEgressPolicyUrl(owner.sId, podId)}/requests`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ domain }),
+        }
+      );
+
+      if (!response.ok) {
+        const error = await getErrorFromResponse(response);
+        sendNotification({
+          type: "error",
+          title: "Failed to request domain",
+          description: error.message,
+        });
+        return false;
+      }
+
+      const data: PostPodEgressPolicyRequestResponseBody =
+        await response.json();
+      await mutatePodEgressPolicy(
+        {
+          policy: data.policy,
+          requestedDomains: (data.policy.requestedDomains ?? []).map(
+            ({ domain: d, requestedAtMs }) => ({ domain: d, requestedAtMs })
+          ),
+        },
+        false
+      );
+      sendNotification({
+        type: "success",
+        title:
+          data.outcome === "already_allowed"
+            ? "Domain already allowed"
+            : data.outcome === "already_requested"
+              ? "Domain already requested"
+              : "Domain requested",
+        description:
+          data.outcome === "requested"
+            ? "A workspace admin will review your request."
+            : `${domain} is already ${
+                data.outcome === "already_allowed"
+                  ? "allowed"
+                  : "pending review"
+              } for this Pod.`,
+      });
+      return true;
+    } catch {
+      sendNotification({
+        type: "error",
+        title: "Failed to request domain",
+        description: "An unexpected error occurred. Please try again.",
+      });
+      return false;
+    } finally {
+      setIsRequesting(false);
+    }
+  };
+
+  return { requestPodEgressDomain, isRequestingPodEgressDomain };
 }

--- a/front/types/api/sandbox/egress_policy.ts
+++ b/front/types/api/sandbox/egress_policy.ts
@@ -17,3 +17,15 @@ export type GetPodEgressPolicyResponseBody = {
 export type PutPodEgressPolicyResponseBody = {
   policy: EgressPolicy;
 };
+
+// Outcome of a member's domain request: it was recorded, or was a no-op
+// because the domain is already allowed or already pending.
+export type SandboxEgressRequestOutcome =
+  | "already_allowed"
+  | "already_requested"
+  | "requested";
+
+export type PostPodEgressPolicyRequestResponseBody = {
+  policy: EgressPolicy;
+  outcome: SandboxEgressRequestOutcome;
+};


### PR DESCRIPTION
## Why

A Pod's Computer has its own network allowlist (merged on top of the workspace baseline), but only workspace admins could see or touch it. This lets Pod **members** see what their Pod's Computer can reach, and **request** additional domains for an admin to approve — without being able to change the allowlist themselves.

## What
<img width="1176" height="749" alt="Screenshot 2026-08-24 at 4 46 23 PM" src="https://github.com/user-attachments/assets/54f46678-9457-43d9-8e1c-7af9e3506341" />

**Read-only view for members**
- Route gating on `/api/w/:wId/spaces/:spaceId/sandbox`: the parent no longer blanket-requires admin. `egress-policy` GET is open to anyone who can read the Pod; `PUT` and `requests/dismiss` additionally require a workspace admin. `env-vars` re-applies `ensureIsAdmin` for its whole leaf, so pod env vars stay workspace-admin only (read + write) — unchanged.
- `EgressDomainListEditor` gains `readOnly`; `PodNetworkSection` takes `canEdit`; `PodSettingsTab` shows the network section to any viewer with the feature, editing to admins. Env-vars section stays admin-only.

**Member domain requests**
- New route `POST …/egress-policy/requests`, gated `requireCanReadOrAdministrate` (member-accessible, **no** `ensureIsAdmin`), wrapping the existing `requestOwnerPolicyDomain`. It only records a pending request for admin review — never grants. Deliberately **not** gated on the workspace "Agent-requested domains" toggle: that governs the agent's on-the-fly requests during a conversation, not this explicit, admin-reviewed ask.
- `useRequestPodEgressDomain` hook with outcome-aware toasts (requested / already allowed / already requested).
- `EgressDomainListEditor` request mode (`readOnly` + `onRequestDomain`): keeps the input as **"Request domain"** with request-phrased copy, still hides the admin add/remove/approve/reject controls. A member's request then appears in the same pending-approval queue admins act on.

> [!WARNING]
> This removes the blanket `ensureIsAdmin` on the pod sandbox sub-app and re-asserts admin per write handler (egress PUT + dismiss; env-vars whole leaf). The request route is intentionally member-accessible but write-safe: it can only append a pending request, never grant.

## Test

`tsc` + `biome` clean. Route tests (16): member read (200) / write (403) / inaccessible Pod (404) / env-vars admin-only (403, incl. PATCH+DELETE on `/:id`); member request recorded but never granted, already-allowed no-op, inaccessible 404, invalid domain 400. Component tests (3): read-only hides all controls; editable shows them; request mode shows only "Request domain".

## Risk

Medium (access-control change). Every write path re-asserts admin; the request path can only enqueue a pending review. Safe to roll back.