### PR TITLE
[pods] publishPodApp business layer

### DIFF
--- a/front/lib/api/projects/app_archive.ts
+++ b/front/lib/api/projects/app_archive.ts
@@ -6,6 +6,7 @@ import {
   listPodApps,
   POD_DATABASE_SCHEMA_FILE_SUFFIX,
   stripExtension,
+  validatePodAppFolderName,
 } from "@app/lib/api/projects/apps";
 import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
@@ -30,8 +31,6 @@ import {
   POD_APP_ARCHIVE_MANIFEST_FILE,
   PodAppManifestSchema,
 } from "@app/types/api/pod_app_archive";
-import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
-import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { SCOPED_PREFIX_POD } from "@app/types/file_system";
 import { isInteractiveContentType } from "@app/types/files";
 import {
@@ -410,29 +409,11 @@ export async function importPodApp(
   }
   const { manifest, fileBuffers } = parseResult.value;
 
-  const folderName = (name ?? manifest.name).trim();
-  if (folderName.length > MAX_POD_APP_NAME_LENGTH) {
-    return new Err(
-      new PodAppImportError(
-        "invalid_name",
-        `'${folderName}' is longer than ${MAX_POD_APP_NAME_LENGTH} characters.`
-      )
-    );
+  const nameResult = validatePodAppFolderName(name ?? manifest.name);
+  if (nameResult.isErr()) {
+    return new Err(new PodAppImportError("invalid_name", nameResult.error));
   }
-  const prefix = normalizeAppPrefix(folderName);
-  if (!prefix) {
-    return new Err(
-      new PodAppImportError(
-        "invalid_name",
-        `'${folderName}' has no letters or digits to name an app with.`
-      )
-    );
-  }
-  if (folderName.includes("/")) {
-    return new Err(
-      new PodAppImportError("invalid_name", "An app name cannot contain '/'.")
-    );
-  }
+  const { folderName, prefix } = nameResult.value;
 
   const appsResult = await listPodApps(auth, pod);
   if (appsResult.isErr()) {

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -222,7 +222,7 @@ async function resolveFramesByFolderName(
  * rather than from the sandbox, so listing apps never has to wake a sleeping pod. A database created
  * seconds ago may not be replicated yet.
  */
-async function listPodDatabaseOnDiskNames(
+export async function listPodDatabaseOnDiskNames(
   auth: Authenticator,
   pod: SpaceResource
 ): Promise<string[]> {

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -28,6 +28,7 @@ import type {
   FileSystemEntry,
   FileSystemFileEntry,
 } from "@app/types/api/file_system/types";
+import { POD_APP_MANIFEST_DB_FILE_SUFFIX } from "@app/types/api/pod_app_manifest";
 import type {
   PodApp,
   PodAppCloneSummary,
@@ -36,6 +37,7 @@ import type {
   PodAppFrame,
   PodAppFunction,
 } from "@app/types/api/pod_apps";
+import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
 import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { SCOPED_PREFIX_POD } from "@app/types/file_system";
 import { isInteractiveContentType } from "@app/types/files";
@@ -58,8 +60,12 @@ const APP_SHAPED_SUBFOLDERS = [
   APP_DATABASES_SUBFOLDER,
 ];
 
-/** Suffix of a database's schema file, e.g. `chat.db.ts` declares the `chat` database. */
-export const POD_DATABASE_SCHEMA_FILE_SUFFIX = ".db.ts";
+/**
+ * Suffix of a database's schema file, e.g. `chat.db.ts` declares the `chat` database. Aliases
+ * POD_APP_MANIFEST_DB_FILE_SUFFIX in types/api/pod_app_manifest.ts, which the manifest schema
+ * also needs and cannot import this lib module for.
+ */
+export const POD_DATABASE_SCHEMA_FILE_SUFFIX = POD_APP_MANIFEST_DB_FILE_SUFFIX;
 
 /**
  * A folder's accumulated file-system facts, before published functions and databases are joined in.
@@ -615,6 +621,34 @@ function fileEntriesOf(entries: FileSystemEntry[]): FileSystemFileEntry[] {
 }
 
 /**
+ * Validate a candidate app folder name and derive its prefix: trimmed, within the max length,
+ * free of '/', and holding at least one letter or digit for `normalizeAppPrefix` to derive a
+ * prefix from. Shared by `publishPodApp`, `clonePodApp` and `importPodApp`, which each wrap the
+ * returned `Err` string in their own error class.
+ */
+export function validatePodAppFolderName(
+  name: string
+): Result<{ folderName: string; prefix: string }, string> {
+  const folderName = name.trim();
+  if (folderName.length > MAX_POD_APP_NAME_LENGTH) {
+    return new Err(
+      `'${folderName}' is longer than ${MAX_POD_APP_NAME_LENGTH} characters.`
+    );
+  }
+  if (folderName.includes("/")) {
+    return new Err("An app name cannot contain '/'.");
+  }
+  const prefix = normalizeAppPrefix(folderName);
+  if (!prefix) {
+    return new Err(
+      `'${folderName}' has no letters or digits to name an app with.`
+    );
+  }
+
+  return new Ok({ folderName, prefix });
+}
+
+/**
  * Clone a Pod app into a new folder in the same Pod.
  *
  * What carries over: every file under the app folder, its published functions (re-published under the
@@ -641,21 +675,11 @@ export async function clonePodApp(
     );
   }
 
-  const folderName = newName.trim();
-  const newPrefix = normalizeAppPrefix(folderName);
-  if (!newPrefix) {
-    return new Err(
-      new PodAppCloneError(
-        "invalid_name",
-        `'${newName}' has no letters or digits to name an app with.`
-      )
-    );
+  const nameResult = validatePodAppFolderName(newName);
+  if (nameResult.isErr()) {
+    return new Err(new PodAppCloneError("invalid_name", nameResult.error));
   }
-  if (folderName.includes("/")) {
-    return new Err(
-      new PodAppCloneError("invalid_name", "An app name cannot contain '/'.")
-    );
-  }
+  const { folderName, prefix: newPrefix } = nameResult.value;
 
   const appsResult = await listPodApps(auth, pod);
   if (appsResult.isErr()) {

--- a/front/lib/api/projects/publish_app.test.ts
+++ b/front/lib/api/projects/publish_app.test.ts
@@ -9,6 +9,10 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { setupProjectConversation } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import {
+  MANIFEST,
+  seedAppFolder,
+} from "@app/tests/utils/pod_app_publish_test_helpers";
 import { frameContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
@@ -61,61 +65,6 @@ vi.mock("@app/lib/lock", async (importOriginal) => {
     ) => callback(),
   };
 });
-
-const MANIFEST = {
-  version: 1,
-  name: "Task List",
-  description: "Tasks.",
-  frames: [{ path: "TaskList.tsx" }],
-  functions: [
-    {
-      name: "add-task",
-      path: "src/add.ts",
-      description: "Add.",
-      executionMode: "fast",
-      defaultStake: "low",
-    },
-  ],
-  databases: [{ name: "tasks", path: "databases/tasks.db.ts" }],
-};
-
-/** Seeds the pod listing with an app folder's files and its manifest content. */
-function seedAppFolder({
-  folder,
-  relPaths,
-  manifest,
-  extraRootFolders = [],
-}: {
-  folder: string;
-  relPaths: string[];
-  manifest: unknown;
-  extraRootFolders?: { folder: string; relPaths: string[] }[];
-}) {
-  const all = [{ folder, relPaths }, ...extraRootFolders];
-  fileStorageMock.setFilesByPrefix((prefix) =>
-    all.flatMap(({ folder: f, relPaths: rps }) =>
-      rps.map((relPath) => ({
-        name: `${prefix}${f}/${relPath}`,
-        metadata: {
-          contentType: relPath.endsWith(".tsx")
-            ? "application/vnd.dust.frame"
-            : "text/plain",
-          size: "10",
-        },
-      }))
-    )
-  );
-  fileStorageMock.setFileContent((filePath) => {
-    if (filePath.endsWith(`${folder}/manifest.json`)) {
-      return JSON.stringify(manifest);
-    }
-    // Generic body for any other seeded file (e.g. a frame source read by the auto-create path).
-    const isSeeded = all.some(({ folder: f, relPaths: rps }) =>
-      rps.some((relPath) => filePath.endsWith(`${f}/${relPath}`))
-    );
-    return isSeeded ? "// seeded content" : null;
-  });
-}
 
 async function podFor(
   projectId: string,

--- a/front/lib/api/projects/publish_app.test.ts
+++ b/front/lib/api/projects/publish_app.test.ts
@@ -107,7 +107,7 @@ beforeEach(() => {
 });
 
 describe("publishPodApp", () => {
-  it("publishes databases, functions and frames from the manifest, in that order", async () => {
+  it("publishes databases, functions and the frame from the manifest, in that order", async () => {
     const { auth, projectId } = await setupProjectConversation();
     const pod = await podFor(projectId, auth);
     seedAppFolder({
@@ -132,7 +132,7 @@ describe("publishPodApp", () => {
     expect(result.value.displayName).toBe("Task List");
     expect(result.value.reconciledDatabaseNames).toEqual(["tasklist__tasks"]);
     expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
-    expect(result.value.publishedFrameNames).toEqual(["TaskList.tsx"]);
+    expect(result.value.publishedFrameName).toBe("TaskList.tsx");
     expect(vi.mocked(createPodFrameFile)).toHaveBeenCalledWith(
       auth,
       expect.objectContaining({
@@ -171,13 +171,13 @@ describe("publishPodApp", () => {
         "src/add.ts",
         "databases/tasks.db.ts",
       ],
-      manifest: { ...MANIFEST, frames: [{ path: "Notes.txt" }] },
+      manifest: { ...MANIFEST, uiEntryPoint: "Notes.txt" },
     });
 
     const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
 
     assert(result.isOk(), result.isErr() ? result.error.message : "");
-    expect(result.value.publishedFrameNames).toEqual(["Notes.txt"]);
+    expect(result.value.publishedFrameName).toBe("Notes.txt");
     expect(result.value.warnings).toEqual([]);
     expect(vi.mocked(createPodFrameFile)).toHaveBeenCalledWith(
       auth,
@@ -204,13 +204,13 @@ describe("publishPodApp", () => {
         "src/add.ts",
         "databases/tasks.db.ts",
       ],
-      manifest: { ...MANIFEST, frames: [{ path: "sub/Frame.tsx" }] },
+      manifest: { ...MANIFEST, uiEntryPoint: "sub/Frame.tsx" },
     });
 
     const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
 
     assert(result.isOk(), result.isErr() ? result.error.message : "");
-    expect(result.value.publishedFrameNames).toEqual(["sub/Frame.tsx"]);
+    expect(result.value.publishedFrameName).toBe("sub/Frame.tsx");
     expect(result.value.warnings).toEqual([]);
     expect(vi.mocked(createPodFrameFile)).toHaveBeenCalledWith(
       auth,
@@ -229,7 +229,42 @@ describe("publishPodApp", () => {
     expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
   });
 
-  it("publishes a frame-less, database-less app", async () => {
+  it("publishes a database-less app, defaulting its frame to index.tsx", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "FnsOnly",
+      relPaths: ["manifest.json", "index.tsx", "greet.ts"],
+      manifest: {
+        version: 1,
+        name: "Fns Only",
+        description: "",
+        functions: [
+          {
+            name: "greet",
+            path: "greet.ts",
+            description: "Greet.",
+            executionMode: "fast",
+          },
+        ],
+      },
+    });
+
+    const result = await publishPodApp(auth, pod, { folderName: "FnsOnly" });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.publishedFunctionSlugs).toEqual(["fnsonly__greet"]);
+    expect(result.value.publishedFrameName).toBe("index.tsx");
+    expect(result.value.warnings).toEqual([]);
+    expect(result.value.reconciledDatabaseNames).toEqual([]);
+    expect(vi.mocked(reconcileDatabaseFromPodPath)).not.toHaveBeenCalled();
+    expect(vi.mocked(publishFrame)).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({ entryRelPath: "index.tsx" })
+    );
+  });
+
+  it("fails with invalid_manifest for a functions-only app whose folder has no index.tsx", async () => {
     const { auth, projectId } = await setupProjectConversation();
     const pod = await podFor(projectId, auth);
     seedAppFolder({
@@ -252,12 +287,11 @@ describe("publishPodApp", () => {
 
     const result = await publishPodApp(auth, pod, { folderName: "FnsOnly" });
 
-    assert(result.isOk(), result.isErr() ? result.error.message : "");
-    expect(result.value.publishedFunctionSlugs).toEqual(["fnsonly__greet"]);
-    expect(result.value.publishedFrameNames).toEqual([]);
-    expect(result.value.reconciledDatabaseNames).toEqual([]);
-    expect(vi.mocked(reconcileDatabaseFromPodPath)).not.toHaveBeenCalled();
-    expect(vi.mocked(publishFrame)).not.toHaveBeenCalled();
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_manifest");
+      expect(result.error.message).toContain("index.tsx");
+    }
   });
 
   it("unpublishes a function the manifest no longer declares", async () => {
@@ -265,8 +299,8 @@ describe("publishPodApp", () => {
     const pod = await podFor(projectId, auth);
     seedAppFolder({
       folder: "TaskList",
-      relPaths: ["manifest.json", "src/add.ts"],
-      manifest: { ...MANIFEST, frames: [], databases: [] },
+      relPaths: ["manifest.json", "index.tsx", "src/add.ts"],
+      manifest: { ...MANIFEST, uiEntryPoint: undefined, databases: [] },
     });
     // Pre-publish a function the manifest does not declare.
     const { publishSandboxFunction } = await import(
@@ -298,8 +332,8 @@ describe("publishPodApp", () => {
     const pod = await podFor(projectId, auth);
     seedAppFolder({
       folder: "TaskList",
-      relPaths: ["manifest.json", "src/add.ts"],
-      manifest: { ...MANIFEST, frames: [], databases: [] },
+      relPaths: ["manifest.json", "index.tsx", "src/add.ts"],
+      manifest: { ...MANIFEST, uiEntryPoint: undefined, databases: [] },
     });
     fileStorageMock.setSubdirectoryNames(() => ["tasklist__legacy.db"]);
 
@@ -358,8 +392,8 @@ describe("publishPodApp", () => {
 
     seedAppFolder({
       folder: "TaskList",
-      relPaths: ["manifest.json"],
-      manifest: { ...MANIFEST, frames: [], databases: [] },
+      relPaths: ["manifest.json", "index.tsx"],
+      manifest: { ...MANIFEST, uiEntryPoint: undefined, databases: [] },
     });
     const missing = await publishPodApp(auth, pod, { folderName: "TaskList" });
     expect(missing.isErr() && missing.error.code === "invalid_manifest").toBe(
@@ -367,6 +401,24 @@ describe("publishPodApp", () => {
     );
     if (missing.isErr()) {
       expect(missing.error.message).toContain("src/add.ts");
+    }
+  });
+
+  it("fails with invalid_manifest when the explicit uiEntryPoint file is missing", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json", "src/add.ts", "databases/tasks.db.ts"],
+      manifest: { ...MANIFEST, uiEntryPoint: "Missing.tsx" },
+    });
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("invalid_manifest");
+      expect(result.error.message).toContain("Missing.tsx");
     }
   });
 
@@ -394,8 +446,13 @@ describe("publishPodApp", () => {
     const pod = await podFor(projectId, auth);
     seedAppFolder({
       folder: "TaskList",
-      relPaths: ["manifest.json", "src/add.ts", "databases/tasks.db.ts"],
-      manifest: { ...MANIFEST, frames: [] },
+      relPaths: [
+        "manifest.json",
+        "index.tsx",
+        "src/add.ts",
+        "databases/tasks.db.ts",
+      ],
+      manifest: { ...MANIFEST, uiEntryPoint: undefined },
     });
     vi.mocked(reconcileDatabaseFromPodPath).mockResolvedValue(
       new Err(new SandboxFunctionError("sandbox_unavailable", "Asleep."))
@@ -414,10 +471,10 @@ describe("publishPodApp", () => {
     const pod = await podFor(projectId, auth);
     seedAppFolder({
       folder: "TaskList",
-      relPaths: ["manifest.json", "src/add.ts", "src/other.ts"],
+      relPaths: ["manifest.json", "index.tsx", "src/add.ts", "src/other.ts"],
       manifest: {
         ...MANIFEST,
-        frames: [],
+        uiEntryPoint: undefined,
         databases: [],
         functions: [
           ...MANIFEST.functions,

--- a/front/lib/api/projects/publish_app.test.ts
+++ b/front/lib/api/projects/publish_app.test.ts
@@ -1,0 +1,394 @@
+import { publishPodApp } from "@app/lib/api/projects/publish_app";
+import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { SandboxFunctionError } from "@app/lib/api/sandbox_functions/errors";
+import { publishFrame } from "@app/lib/api/viz/publish_frame";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { setupProjectConversation } from "@app/tests/utils/conversation_test_factories";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { Err, Ok } from "@app/types/shared/result";
+import assert from "assert";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "@app/lib/api/sandbox_functions/build_on_sandbox",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/sandbox_functions/build_on_sandbox")
+      >();
+    return { ...actual, buildSandboxFunctionOnSandbox: vi.fn() };
+  }
+);
+
+vi.mock("@app/lib/api/sandbox_functions/dsbx_db", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/dsbx_db")
+    >();
+  return { ...actual, reconcileDatabaseFromPodPath: vi.fn() };
+});
+
+vi.mock("@app/lib/api/viz/publish_frame", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/viz/publish_frame")>();
+  return { ...actual, publishFrame: vi.fn() };
+});
+
+vi.mock("@app/lib/lock", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/lock")>();
+  return {
+    ...actual,
+    executeWithLock: async (
+      _lockName: string,
+      callback: () => Promise<unknown>
+    ) => callback(),
+  };
+});
+
+const MANIFEST = {
+  version: 1,
+  name: "Task List",
+  description: "Tasks.",
+  frames: [{ path: "TaskList.tsx" }],
+  functions: [
+    {
+      name: "add-task",
+      path: "src/add.ts",
+      description: "Add.",
+      executionMode: "fast",
+      defaultStake: "low",
+    },
+  ],
+  databases: [{ name: "tasks", path: "databases/tasks.db.ts" }],
+};
+
+/** Seeds the pod listing with an app folder's files and its manifest content. */
+function seedAppFolder({
+  folder,
+  relPaths,
+  manifest,
+  extraRootFolders = [],
+}: {
+  folder: string;
+  relPaths: string[];
+  manifest: unknown;
+  extraRootFolders?: { folder: string; relPaths: string[] }[];
+}) {
+  const all = [{ folder, relPaths }, ...extraRootFolders];
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    all.flatMap(({ folder: f, relPaths: rps }) =>
+      rps.map((relPath) => ({
+        name: `${prefix}${f}/${relPath}`,
+        metadata: {
+          contentType: relPath.endsWith(".tsx")
+            ? "application/vnd.dust.frame"
+            : "text/plain",
+          size: "10",
+        },
+      }))
+    )
+  );
+  fileStorageMock.setFileContent((filePath) =>
+    filePath.endsWith(`${folder}/manifest.json`)
+      ? JSON.stringify(manifest)
+      : null
+  );
+}
+
+async function podFor(
+  projectId: string,
+  auth: Parameters<typeof publishPodApp>[0]
+) {
+  const pod = await SpaceResource.fetchById(auth, projectId);
+  assert(pod, "pod not found");
+  return pod;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fileStorageMock.reset();
+  fileStorageMock.setFetchFileContentNotFound(() => true);
+  vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+    new Ok({
+      bundleCode: "export default {};",
+      userIdentity: "optional",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+    })
+  );
+  vi.mocked(reconcileDatabaseFromPodPath).mockResolvedValue(
+    new Ok({ database: "tasklist__tasks", created: true, statements: [] })
+  );
+  vi.mocked(publishFrame).mockResolvedValue(new Ok({ warnings: [] }));
+});
+
+describe("publishPodApp", () => {
+  it("publishes databases, functions and frames from the manifest, in that order", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: [
+        "manifest.json",
+        "TaskList.tsx",
+        "src/add.ts",
+        "databases/tasks.db.ts",
+      ],
+      manifest: MANIFEST,
+    });
+    // The real createPodFrameFile primitive (FileResource.makeNew + uploadContent +
+    // moveProjectFile) drives ensureAuthorizedFileAccessForShare's reference analysis, which
+    // reaches well past what the GCS storage mock models here and timed out. Per the brief's
+    // documented fallback, assert the frame lands in `warnings` (its path exists in the folder
+    // listing, but no FileResource is registered for it) rather than in `publishedFrameNames`.
+    // publishFrame's happy path (a real FileResource) is exercised by mocking `publishFrame`
+    // itself, as this test already does.
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.prefix).toBe("tasklist");
+    expect(result.value.displayName).toBe("Task List");
+    expect(result.value.reconciledDatabaseNames).toEqual(["tasklist__tasks"]);
+    expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
+    expect(result.value.publishedFrameNames).toEqual([]);
+    expect(result.value.warnings.join(" ")).toContain("TaskList.tsx");
+    expect(vi.mocked(publishFrame)).not.toHaveBeenCalled();
+    expect(vi.mocked(reconcileDatabaseFromPodPath)).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({
+        database: "tasks",
+        path: `pod-${projectId}/TaskList/databases/tasks.db.ts`,
+      })
+    );
+    // Databases reconcile before functions build (frames are last).
+    expect(
+      vi.mocked(reconcileDatabaseFromPodPath).mock.invocationCallOrder[0]
+    ).toBeLessThan(
+      vi.mocked(buildSandboxFunctionOnSandbox).mock.invocationCallOrder[0]
+    );
+  });
+
+  it("publishes a frame-less, database-less app", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "FnsOnly",
+      relPaths: ["manifest.json", "greet.ts"],
+      manifest: {
+        version: 1,
+        name: "Fns Only",
+        description: "",
+        functions: [
+          {
+            name: "greet",
+            path: "greet.ts",
+            description: "Greet.",
+            executionMode: "fast",
+          },
+        ],
+      },
+    });
+
+    const result = await publishPodApp(auth, pod, { folderName: "FnsOnly" });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.publishedFunctionSlugs).toEqual(["fnsonly__greet"]);
+    expect(result.value.publishedFrameNames).toEqual([]);
+    expect(result.value.reconciledDatabaseNames).toEqual([]);
+    expect(vi.mocked(reconcileDatabaseFromPodPath)).not.toHaveBeenCalled();
+    expect(vi.mocked(publishFrame)).not.toHaveBeenCalled();
+  });
+
+  it("unpublishes a function the manifest no longer declares", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json", "src/add.ts"],
+      manifest: { ...MANIFEST, frames: [], databases: [] },
+    });
+    // Pre-publish a function the manifest does not declare.
+    const { publishSandboxFunction } = await import(
+      "@app/lib/api/sandbox_functions/publish_sandbox_function"
+    );
+    const pre = await publishSandboxFunction(auth, {
+      space: pod,
+      slug: "old-fn",
+      description: "Old.",
+      path: `pod-${projectId}/TaskList/src/old.ts`,
+    });
+    assert(pre.isOk(), pre.isErr() ? pre.error.message : "");
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.unpublishedFunctionSlugs).toEqual(["tasklist__old-fn"]);
+    expect(
+      await SandboxFunctionResource.fetchBySpaceAndSlug(
+        auth,
+        pod,
+        "tasklist__old-fn"
+      )
+    ).toBeNull();
+  });
+
+  it("warns about an orphan database and never deletes it", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json", "src/add.ts"],
+      manifest: { ...MANIFEST, frames: [], databases: [] },
+    });
+    fileStorageMock.setSubdirectoryNames(() => ["tasklist__legacy.db"]);
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.warnings.join(" ")).toContain("tasklist__legacy");
+  });
+
+  it.each([
+    ["a missing folder", "Nope", "folder_not_found"],
+    ["a name with a slash", "a/b", "invalid_name"],
+  ])("fails on %s", async (_label, folderName, code) => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json", "src/add.ts"],
+      manifest: MANIFEST,
+    });
+
+    const result = await publishPodApp(auth, pod, { folderName });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe(code);
+    }
+  });
+
+  it("fails with manifest_not_found when the folder has no manifest.json", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["src/add.ts"],
+      manifest: MANIFEST,
+    });
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("manifest_not_found");
+    }
+  });
+
+  it("fails with invalid_manifest on a schema violation and on a missing referenced file", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json"],
+      manifest: { version: 2 },
+    });
+    const bad = await publishPodApp(auth, pod, { folderName: "TaskList" });
+    expect(bad.isErr() && bad.error.code === "invalid_manifest").toBe(true);
+
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json"],
+      manifest: { ...MANIFEST, frames: [], databases: [] },
+    });
+    const missing = await publishPodApp(auth, pod, { folderName: "TaskList" });
+    expect(missing.isErr() && missing.error.code === "invalid_manifest").toBe(
+      true
+    );
+    if (missing.isErr()) {
+      expect(missing.error.message).toContain("src/add.ts");
+    }
+  });
+
+  it("fails with colliding_folders when a sibling folder shares the prefix", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json", "src/add.ts"],
+      manifest: MANIFEST,
+      // "tasklist" (lowercase) is a different literal folder name that normalizes to the same
+      // prefix ("tasklist") as "TaskList" — the case-collision `normalizeAppPrefix` guards against.
+      extraRootFolders: [{ folder: "tasklist", relPaths: ["note.txt"] }],
+    });
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("colliding_folders");
+    }
+  });
+
+  it("aborts on sandbox_unavailable from the first reconcile", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json", "src/add.ts", "databases/tasks.db.ts"],
+      manifest: { ...MANIFEST, frames: [] },
+    });
+    vi.mocked(reconcileDatabaseFromPodPath).mockResolvedValue(
+      new Err(new SandboxFunctionError("sandbox_unavailable", "Asleep."))
+    );
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.code).toBe("sandbox_unavailable");
+    }
+    expect(vi.mocked(buildSandboxFunctionOnSandbox)).not.toHaveBeenCalled();
+  });
+
+  it("turns a per-item function failure into a warning and continues", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json", "src/add.ts", "src/other.ts"],
+      manifest: {
+        ...MANIFEST,
+        frames: [],
+        databases: [],
+        functions: [
+          ...MANIFEST.functions,
+          {
+            name: "other",
+            path: "src/other.ts",
+            description: "Other.",
+            executionMode: "fast",
+          },
+        ],
+      },
+    });
+    vi.mocked(buildSandboxFunctionOnSandbox)
+      .mockResolvedValueOnce(
+        new Err(new SandboxFunctionError("build_failed", "Syntax error."))
+      )
+      .mockResolvedValueOnce(
+        new Ok({
+          bundleCode: "export default {};",
+          userIdentity: "optional",
+          inputSchema: { type: "object" },
+          outputSchema: { type: "object" },
+        })
+      );
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.warnings.join(" ")).toContain("add-task");
+    expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__other"]);
+  });
+});

--- a/front/lib/api/projects/publish_app.test.ts
+++ b/front/lib/api/projects/publish_app.test.ts
@@ -193,7 +193,7 @@ describe("publishPodApp", () => {
     expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
   });
 
-  it("warns instead of auto-creating a frame declared in a subfolder", async () => {
+  it("auto-creates a declared frame in a subfolder", async () => {
     const { auth, projectId } = await setupProjectConversation();
     const pod = await podFor(projectId, auth);
     seedAppFolder({
@@ -210,11 +210,20 @@ describe("publishPodApp", () => {
     const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
 
     assert(result.isOk(), result.isErr() ? result.error.message : "");
-    expect(result.value.publishedFrameNames).toEqual([]);
-    expect(result.value.warnings.join(" ")).toContain("sub/Frame.tsx");
-    expect(result.value.warnings.join(" ")).toContain("subfolder");
-    expect(vi.mocked(createPodFrameFile)).not.toHaveBeenCalled();
-    expect(vi.mocked(publishFrame)).not.toHaveBeenCalled();
+    expect(result.value.publishedFrameNames).toEqual(["sub/Frame.tsx"]);
+    expect(result.value.warnings).toEqual([]);
+    expect(vi.mocked(createPodFrameFile)).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({
+        folderName: "TaskList",
+        fileName: "sub/Frame.tsx",
+        contentType: frameContentType,
+      })
+    );
+    expect(vi.mocked(publishFrame)).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({ entryRelPath: "sub/Frame.tsx" })
+    );
     // The rest of the publish still went through.
     expect(result.value.reconciledDatabaseNames).toEqual(["tasklist__tasks"]);
     expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);

--- a/front/lib/api/projects/publish_app.test.ts
+++ b/front/lib/api/projects/publish_app.test.ts
@@ -9,6 +9,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { setupProjectConversation } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { frameContentType } from "@app/types/files";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -188,7 +189,7 @@ describe("publishPodApp", () => {
       expect.objectContaining({
         folderName: "TaskList",
         fileName: "TaskList.tsx",
-        contentType: "application/vnd.dust.frame",
+        contentType: frameContentType,
       })
     );
     expect(vi.mocked(publishFrame)).toHaveBeenCalled();
@@ -207,12 +208,14 @@ describe("publishPodApp", () => {
     );
   });
 
-  it("warns instead of auto-creating a frame whose source is not interactive content", async () => {
+  it("auto-creates a declared frame even when storage guessed a non-frame content type", async () => {
     const { auth, projectId } = await setupProjectConversation();
     const pod = await podFor(projectId, auth);
     seedAppFolder({
       folder: "TaskList",
-      // "Notes.txt" does not end in ".tsx", so seedAppFolder's listing marks it "text/plain".
+      // "Notes.txt" does not end in ".tsx", so seedAppFolder's listing marks it "text/plain" —
+      // mirroring gcsfuse's extension-based guess for a sandbox-authored file. The manifest
+      // declaring it as a frame must still be trusted over that guessed storage MIME type.
       relPaths: [
         "manifest.json",
         "Notes.txt",
@@ -225,9 +228,42 @@ describe("publishPodApp", () => {
     const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
 
     assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.publishedFrameNames).toEqual(["Notes.txt"]);
+    expect(result.value.warnings).toEqual([]);
+    expect(vi.mocked(createPodFrameFile)).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({
+        folderName: "TaskList",
+        fileName: "Notes.txt",
+        contentType: frameContentType,
+      })
+    );
+    expect(vi.mocked(publishFrame)).toHaveBeenCalled();
+    // The rest of the publish still went through.
+    expect(result.value.reconciledDatabaseNames).toEqual(["tasklist__tasks"]);
+    expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
+  });
+
+  it("warns instead of auto-creating a frame declared in a subfolder", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: [
+        "manifest.json",
+        "sub/Frame.tsx",
+        "src/add.ts",
+        "databases/tasks.db.ts",
+      ],
+      manifest: { ...MANIFEST, frames: [{ path: "sub/Frame.tsx" }] },
+    });
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
     expect(result.value.publishedFrameNames).toEqual([]);
-    expect(result.value.warnings.join(" ")).toContain("Notes.txt");
-    expect(result.value.warnings.join(" ")).toContain("text/plain");
+    expect(result.value.warnings.join(" ")).toContain("sub/Frame.tsx");
+    expect(result.value.warnings.join(" ")).toContain("subfolder");
     expect(vi.mocked(createPodFrameFile)).not.toHaveBeenCalled();
     expect(vi.mocked(publishFrame)).not.toHaveBeenCalled();
     // The rest of the publish still went through.

--- a/front/lib/api/projects/publish_app.test.ts
+++ b/front/lib/api/projects/publish_app.test.ts
@@ -1,3 +1,4 @@
+import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import { publishPodApp } from "@app/lib/api/projects/publish_app";
 import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
 import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
@@ -6,6 +7,7 @@ import { publishFrame } from "@app/lib/api/viz/publish_frame";
 import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { setupProjectConversation } from "@app/tests/utils/conversation_test_factories";
+import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
 import { Err, Ok } from "@app/types/shared/result";
 import assert from "assert";
@@ -34,6 +36,18 @@ vi.mock("@app/lib/api/viz/publish_frame", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("@app/lib/api/viz/publish_frame")>();
   return { ...actual, publishFrame: vi.fn() };
+});
+
+// The real `createPodFrameFile` (FileResource.makeNew + uploadContent + moveProjectFile) drives
+// `ensureAuthorizedFileAccessForShare`'s reference analysis, which reaches well past what the GCS
+// storage mock models here and times out. These tests verify `publishPodApp`'s branching around
+// it, not the primitive itself.
+vi.mock("@app/lib/api/projects/pod_frame_file", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/projects/pod_frame_file")
+    >();
+  return { ...actual, createPodFrameFile: vi.fn() };
 });
 
 vi.mock("@app/lib/lock", async (importOriginal) => {
@@ -90,11 +104,16 @@ function seedAppFolder({
       }))
     )
   );
-  fileStorageMock.setFileContent((filePath) =>
-    filePath.endsWith(`${folder}/manifest.json`)
-      ? JSON.stringify(manifest)
-      : null
-  );
+  fileStorageMock.setFileContent((filePath) => {
+    if (filePath.endsWith(`${folder}/manifest.json`)) {
+      return JSON.stringify(manifest);
+    }
+    // Generic body for any other seeded file (e.g. a frame source read by the auto-create path).
+    const isSeeded = all.some(({ folder: f, relPaths: rps }) =>
+      rps.some((relPath) => filePath.endsWith(`${f}/${relPath}`))
+    );
+    return isSeeded ? "// seeded content" : null;
+  });
 }
 
 async function podFor(
@@ -122,6 +141,19 @@ beforeEach(() => {
     new Ok({ database: "tasklist__tasks", created: true, statements: [] })
   );
   vi.mocked(publishFrame).mockResolvedValue(new Ok({ warnings: [] }));
+  vi.mocked(createPodFrameFile).mockImplementation(
+    async (auth, { space, fileName, contentType }) => {
+      const file = await FileFactory.create(auth, auth.user(), {
+        contentType,
+        fileName,
+        fileSize: 10,
+        status: "ready",
+        useCase: "project_context",
+        useCaseMetadata: { spaceId: space.sId },
+      });
+      return new Ok(file);
+    }
+  );
 });
 
 describe("publishPodApp", () => {
@@ -138,13 +170,10 @@ describe("publishPodApp", () => {
       ],
       manifest: MANIFEST,
     });
-    // The real createPodFrameFile primitive (FileResource.makeNew + uploadContent +
-    // moveProjectFile) drives ensureAuthorizedFileAccessForShare's reference analysis, which
-    // reaches well past what the GCS storage mock models here and timed out. Per the brief's
-    // documented fallback, assert the frame lands in `warnings` (its path exists in the folder
-    // listing, but no FileResource is registered for it) rather than in `publishedFrameNames`.
-    // publishFrame's happy path (a real FileResource) is exercised by mocking `publishFrame`
-    // itself, as this test already does.
+    // The frame's source exists in the folder listing as a Frame-typed object, but has no
+    // FileResource (e.g. lost by a folder copy). `publishPodApp` must recreate it via
+    // `createPodFrameFile` (mocked above; the real primitive times out under the GCS storage
+    // mock) rather than warning it away.
 
     const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
 
@@ -153,9 +182,16 @@ describe("publishPodApp", () => {
     expect(result.value.displayName).toBe("Task List");
     expect(result.value.reconciledDatabaseNames).toEqual(["tasklist__tasks"]);
     expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
-    expect(result.value.publishedFrameNames).toEqual([]);
-    expect(result.value.warnings.join(" ")).toContain("TaskList.tsx");
-    expect(vi.mocked(publishFrame)).not.toHaveBeenCalled();
+    expect(result.value.publishedFrameNames).toEqual(["TaskList.tsx"]);
+    expect(vi.mocked(createPodFrameFile)).toHaveBeenCalledWith(
+      auth,
+      expect.objectContaining({
+        folderName: "TaskList",
+        fileName: "TaskList.tsx",
+        contentType: "application/vnd.dust.frame",
+      })
+    );
+    expect(vi.mocked(publishFrame)).toHaveBeenCalled();
     expect(vi.mocked(reconcileDatabaseFromPodPath)).toHaveBeenCalledWith(
       auth,
       expect.objectContaining({
@@ -169,6 +205,34 @@ describe("publishPodApp", () => {
     ).toBeLessThan(
       vi.mocked(buildSandboxFunctionOnSandbox).mock.invocationCallOrder[0]
     );
+  });
+
+  it("warns instead of auto-creating a frame whose source is not interactive content", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await podFor(projectId, auth);
+    seedAppFolder({
+      folder: "TaskList",
+      // "Notes.txt" does not end in ".tsx", so seedAppFolder's listing marks it "text/plain".
+      relPaths: [
+        "manifest.json",
+        "Notes.txt",
+        "src/add.ts",
+        "databases/tasks.db.ts",
+      ],
+      manifest: { ...MANIFEST, frames: [{ path: "Notes.txt" }] },
+    });
+
+    const result = await publishPodApp(auth, pod, { folderName: "TaskList" });
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.publishedFrameNames).toEqual([]);
+    expect(result.value.warnings.join(" ")).toContain("Notes.txt");
+    expect(result.value.warnings.join(" ")).toContain("text/plain");
+    expect(vi.mocked(createPodFrameFile)).not.toHaveBeenCalled();
+    expect(vi.mocked(publishFrame)).not.toHaveBeenCalled();
+    // The rest of the publish still went through.
+    expect(result.value.reconciledDatabaseNames).toEqual(["tasklist__tasks"]);
+    expect(result.value.publishedFunctionSlugs).toEqual(["tasklist__add-task"]);
   });
 
   it("publishes a frame-less, database-less app", async () => {

--- a/front/lib/api/projects/publish_app.ts
+++ b/front/lib/api/projects/publish_app.ts
@@ -264,17 +264,7 @@ export async function publishPodApp(
 
       // No FileResource: the manifest declares a frame that exists only as a bare storage
       // object (e.g. copied into the pod, or written directly inside the sandbox, both of which
-      // lose the FileResource). Recreate it in place the same way `importPodApp` does, so the
-      // manifest-first flow self-heals. Works at any depth: the manifest's declared frame path is
-      // authoritative for entry points regardless of nesting.
-      //
-      // The manifest declaring the path as a frame is trusted over the listing's storage MIME
-      // type: files written inside the sandbox get their GCS Content-Type guessed from the
-      // extension by gcsfuse, and `.tsx` guesses to `application/x-tiled-tsx` (a Tiled tileset),
-      // not a Frame type — so that guess can never pass an interactive-content check. The
-      // manifest is the authoritative statement that the path is a frame; `publishFrame`'s
-      // bundler performs the real validation (TS/JSX parse etc.) and rejects non-frame sources
-      // with a meaningful error.
+      // lose the FileResource). Recreate it in place so the manifest-first flow self-heals.
       if (!file) {
         const sourceResult = await dustFs.readBuffer(frame.scopedPath);
         if (sourceResult.isErr() || sourceResult.value === null) {

--- a/front/lib/api/projects/publish_app.ts
+++ b/front/lib/api/projects/publish_app.ts
@@ -1,0 +1,329 @@
+import { DustFileSystem } from "@app/lib/api/file_system";
+import { listPodDatabaseOnDiskNames } from "@app/lib/api/projects/apps";
+import { buildPodAppPublishPlan } from "@app/lib/api/projects/publish_app_plan";
+import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
+import { unpublishSandboxFunction } from "@app/lib/api/sandbox_functions/unpublish_sandbox_function";
+import { createMountFrameSourceReader } from "@app/lib/api/viz/build_frame_bundle";
+import { publishFrame } from "@app/lib/api/viz/publish_frame";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SandboxFunctionResource } from "@app/lib/resources/sandbox_function_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { PodAppPublishSummary } from "@app/types/api/pod_app_manifest";
+import {
+  POD_APP_MANIFEST_FILE,
+  PodAppPublishManifestSchema,
+} from "@app/types/api/pod_app_manifest";
+import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
+import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
+import { SCOPED_PREFIX_POD } from "@app/types/file_system";
+import { isInteractiveContentType } from "@app/types/files";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { fromError } from "zod-validation-error";
+
+export type PodAppPublishErrorCode =
+  | "not_a_pod"
+  | "invalid_name"
+  | "folder_not_found"
+  | "manifest_not_found"
+  | "invalid_manifest"
+  | "colliding_folders"
+  | "sandbox_unavailable"
+  | "internal";
+
+export class PodAppPublishError extends Error {
+  constructor(
+    readonly code: PodAppPublishErrorCode,
+    message: string
+  ) {
+    super(message);
+    this.name = "PodAppPublishError";
+  }
+}
+
+/**
+ * Publish a Pod app from the `manifest.json` at the root of its folder: reconcile its databases,
+ * publish its functions, publish its frames, then unpublish the functions the manifest no longer
+ * declares.
+ *
+ * **The step order is the design.** Databases go first so functions can rely on them; frames go
+ * last because `publishFrame` validates their function references against what was just published;
+ * cleanup runs after everything the manifest wants exists, so a rename (drop `old`, add `new`)
+ * never leaves a window where neither is callable.
+ *
+ * The manifest is the source of truth for functions (declarative), conservative for databases
+ * (never dropped — an undeclared database with this app's prefix is only warned about), and
+ * publish-only for frames (no unpublish-frame operation exists).
+ *
+ * Failure model mirrors `importPodApp`: per-item failures land in `warnings` rather than aborting —
+ * a partially published app is visible and fixable. Only an invalid manifest, a prefix collision,
+ * and sandbox unavailability abort.
+ */
+export async function publishPodApp(
+  auth: Authenticator,
+  pod: SpaceResource,
+  { folderName }: { folderName: string }
+): Promise<Result<PodAppPublishSummary, PodAppPublishError>> {
+  if (!pod.isProject()) {
+    return new Err(
+      new PodAppPublishError("not_a_pod", "Apps only exist on Pod spaces.")
+    );
+  }
+
+  const trimmed = folderName.trim();
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > MAX_POD_APP_NAME_LENGTH ||
+    trimmed.includes("/")
+  ) {
+    return new Err(
+      new PodAppPublishError(
+        "invalid_name",
+        `Invalid app folder name '${folderName}'.`
+      )
+    );
+  }
+  const prefix = normalizeAppPrefix(trimmed);
+  if (!prefix) {
+    return new Err(
+      new PodAppPublishError(
+        "invalid_name",
+        `'${trimmed}' has no letters or digits to derive an app prefix from.`
+      )
+    );
+  }
+
+  const fsResult = await DustFileSystem.forPod(auth, pod);
+  if (fsResult.isErr()) {
+    return new Err(
+      new PodAppPublishError("internal", "Failed to initialise file system.")
+    );
+  }
+  const dustFs = fsResult.value;
+  const podRoot = `${SCOPED_PREFIX_POD}${pod.sId}`;
+  const folderPath = `${podRoot}/${trimmed}`;
+
+  // One recursive root listing serves three needs: the folder's own files, its existence, and
+  // prefix collisions with sibling folders (which would silently cross-wire slugs and databases,
+  // so they abort — same rule as export).
+  const listResult = await dustFs.list(podRoot);
+  if (listResult.isErr()) {
+    return new Err(
+      new PodAppPublishError("internal", listResult.error.message)
+    );
+  }
+  const folderRelPaths = new Set<string>();
+  const collidingFolderNames = new Set<string>();
+  for (const entry of listResult.value) {
+    if (entry.isDirectory || !entry.path.startsWith(`${podRoot}/`)) {
+      continue;
+    }
+    const segments = entry.path
+      .slice(podRoot.length + 1)
+      .split("/")
+      .filter((segment) => segment.length > 0);
+    if (segments.length < 2) {
+      continue;
+    }
+    const [head, ...rest] = segments;
+    if (head === trimmed) {
+      folderRelPaths.add(rest.join("/"));
+    } else if (normalizeAppPrefix(head) === prefix) {
+      collidingFolderNames.add(head);
+    }
+  }
+  if (collidingFolderNames.size > 0) {
+    return new Err(
+      new PodAppPublishError(
+        "colliding_folders",
+        `Folders ${[trimmed, ...collidingFolderNames].join(", ")} all resolve to '${prefix}'. ` +
+          "Rename all but one before publishing."
+      )
+    );
+  }
+  if (folderRelPaths.size === 0) {
+    return new Err(
+      new PodAppPublishError(
+        "folder_not_found",
+        `No folder '${trimmed}' at the pod root.`
+      )
+    );
+  }
+  if (!folderRelPaths.has(POD_APP_MANIFEST_FILE)) {
+    return new Err(
+      new PodAppPublishError(
+        "manifest_not_found",
+        `Folder '${trimmed}' has no ${POD_APP_MANIFEST_FILE}. Write one at the folder root, then retry.`
+      )
+    );
+  }
+
+  const manifestResult = await dustFs.readBuffer(
+    `${folderPath}/${POD_APP_MANIFEST_FILE}`
+  );
+  if (manifestResult.isErr() || manifestResult.value === null) {
+    return new Err(
+      new PodAppPublishError(
+        "manifest_not_found",
+        `Could not read '${trimmed}/${POD_APP_MANIFEST_FILE}'.`
+      )
+    );
+  }
+  let manifestJson: unknown;
+  try {
+    manifestJson = JSON.parse(manifestResult.value.toString("utf-8"));
+  } catch (err) {
+    return new Err(
+      new PodAppPublishError(
+        "invalid_manifest",
+        `${POD_APP_MANIFEST_FILE} is not valid JSON: ${normalizeError(err).message}`
+      )
+    );
+  }
+  const validation = PodAppPublishManifestSchema.safeParse(manifestJson);
+  if (!validation.success) {
+    return new Err(
+      new PodAppPublishError(
+        "invalid_manifest",
+        fromError(validation.error).toString()
+      )
+    );
+  }
+  const manifest = validation.data;
+
+  const [sandboxFunctions, databaseOnDiskNames] = await Promise.all([
+    SandboxFunctionResource.listBySpace(auth, pod),
+    listPodDatabaseOnDiskNames(auth, pod),
+  ]);
+
+  const planResult = buildPodAppPublishPlan({
+    manifest,
+    folderPath,
+    folderRelPaths,
+    prefix,
+    publishedFunctionSlugs: sandboxFunctions.map((fn) => fn.slug),
+    databaseOnDiskNames,
+  });
+  if (planResult.isErr()) {
+    return new Err(
+      new PodAppPublishError("invalid_manifest", planResult.error.message)
+    );
+  }
+  const plan = planResult.value;
+  const warnings = [...plan.warnings];
+
+  // 1. Databases first, so functions can rely on them.
+  const reconciledDatabaseNames: string[] = [];
+  for (const database of plan.databasesToReconcile) {
+    const result = await reconcileDatabaseFromPodPath(auth, {
+      space: pod,
+      database: database.name,
+      path: database.scopedPath,
+    });
+    if (result.isErr()) {
+      if (result.error.code === "sandbox_unavailable") {
+        return new Err(
+          new PodAppPublishError("sandbox_unavailable", result.error.message)
+        );
+      }
+      warnings.push(`Database ${database.name}: ${result.error.message}`);
+      continue;
+    }
+    reconciledDatabaseNames.push(result.value.database);
+  }
+
+  // 2. Functions. The scoped path's first segment is the app folder, which is what prefixes the
+  // published slug (deriveSandboxFunctionSlug) — so arbitrary paths inside the folder are fine.
+  const publishedFunctionSlugs: string[] = [];
+  for (const fn of plan.functionsToPublish) {
+    const result = await publishSandboxFunction(auth, {
+      space: pod,
+      slug: fn.name,
+      description: fn.description,
+      path: fn.scopedPath,
+      executionMode: fn.executionMode,
+      defaultStake: fn.defaultStake,
+    });
+    if (result.isErr()) {
+      if (result.error.code === "sandbox_unavailable") {
+        return new Err(
+          new PodAppPublishError("sandbox_unavailable", result.error.message)
+        );
+      }
+      warnings.push(`Function ${fn.name}: ${result.error.message}`);
+      continue;
+    }
+    publishedFunctionSlugs.push(result.value.sandboxFunction.slug);
+  }
+
+  // 3. Frames last: publishFrame validates their function references against what step 2 just
+  // published. Resolved in one batched query rather than per frame.
+  const publishedFrameNames: string[] = [];
+  if (plan.framesToPublish.length > 0) {
+    const mountPathByRelPath = new Map<string, string>();
+    for (const frame of plan.framesToPublish) {
+      const mountPath = dustFs.toMountFilePath(frame.scopedPath);
+      if (mountPath) {
+        mountPathByRelPath.set(frame.relPath, mountPath);
+      }
+    }
+    const files = await FileResource.fetchByMountFilePaths(
+      auth,
+      Array.from(mountPathByRelPath.values())
+    );
+    const fileByMountPath = new Map(
+      files.flatMap((file) =>
+        file.mountFilePath ? [[file.mountFilePath, file] as const] : []
+      )
+    );
+
+    for (const frame of plan.framesToPublish) {
+      const mountPath = mountPathByRelPath.get(frame.relPath);
+      const file = mountPath ? fileByMountPath.get(mountPath) : undefined;
+      if (!file || !isInteractiveContentType(file.contentType)) {
+        warnings.push(
+          `Frame ${frame.relPath}: not a Frame file (create it as interactive content, then retry).`
+        );
+        continue;
+      }
+      const result = await publishFrame(auth, {
+        file,
+        reader: createMountFrameSourceReader(dustFs, folderPath),
+        entryRelPath: frame.relPath,
+        rootScopedPath: folderPath,
+      });
+      if (result.isErr()) {
+        warnings.push(`Frame ${frame.relPath}: ${result.error.message}`);
+        continue;
+      }
+      publishedFrameNames.push(frame.relPath);
+    }
+  }
+
+  // 4. Declarative cleanup: functions with this app's prefix that the manifest dropped. Runs last
+  // so a rename never leaves a window where neither the old nor the new name is callable.
+  const unpublishedFunctionSlugs: string[] = [];
+  for (const slug of plan.functionSlugsToUnpublish) {
+    const result = await unpublishSandboxFunction(auth, { space: pod, slug });
+    // Already gone is fine — republishing after a partial failure must be safe.
+    if (result.isErr() && result.error.code !== "not_found") {
+      warnings.push(`Unpublish ${slug}: ${result.error.message}`);
+      continue;
+    }
+    unpublishedFunctionSlugs.push(slug);
+  }
+
+  return new Ok({
+    prefix,
+    name: trimmed,
+    displayName: manifest.name,
+    reconciledDatabaseNames,
+    publishedFunctionSlugs,
+    publishedFrameNames,
+    unpublishedFunctionSlugs,
+    warnings,
+  });
+}

--- a/front/lib/api/projects/publish_app.ts
+++ b/front/lib/api/projects/publish_app.ts
@@ -47,17 +47,19 @@ export class PodAppPublishError extends Error {
 
 /**
  * Publish a Pod app from the `manifest.json` at the root of its folder: reconcile its databases,
- * publish its functions, publish its frames, then unpublish the functions the manifest no longer
- * declares.
+ * publish its functions, publish its UI entry point as a frame, then unpublish the functions the
+ * manifest no longer declares. Every app has exactly one frame to publish (an explicit
+ * `uiEntryPoint` or the defaulted `index.tsx`) — an app with no UI entry point at all fails
+ * upstream in `buildPodAppPublishPlan` with `invalid_manifest`.
  *
- * **The step order is the design.** Databases go first so functions can rely on them; frames go
- * last because `publishFrame` validates their function references against what was just published;
- * cleanup runs after everything the manifest wants exists, so a rename (drop `old`, add `new`)
- * never leaves a window where neither is callable.
+ * **The step order is the design.** Databases go first so functions can rely on them; the frame
+ * goes last because `publishFrame` validates its function references against what was just
+ * published; cleanup runs after everything the manifest wants exists, so a rename (drop `old`, add
+ * `new`) never leaves a window where neither is callable.
  *
  * The manifest is the source of truth for functions (declarative), conservative for databases
  * (never dropped — an undeclared database with this app's prefix is only warned about), and
- * publish-only for frames (no unpublish-frame operation exists).
+ * publish-only for the frame (no unpublish-frame operation exists).
  *
  * Failure model mirrors `importPodApp`: per-item failures land in `warnings` rather than aborting —
  * a partially published app is visible and fixable. Only an invalid manifest, a prefix collision,
@@ -229,48 +231,32 @@ export async function publishPodApp(
     publishedFunctionSlugs.push(result.value.sandboxFunction.slug);
   }
 
-  // 3. Frames last: publishFrame validates their function references against what step 2 just
-  // published. Resolved in one batched query rather than per frame.
-  const publishedFrameNames: string[] = [];
-  if (plan.framesToPublish.length > 0) {
-    const mountPathByRelPath = new Map<string, string>();
-    for (const frame of plan.framesToPublish) {
-      const mountPath = dustFs.toMountFilePath(frame.scopedPath);
-      if (mountPath) {
-        mountPathByRelPath.set(frame.relPath, mountPath);
-      }
-    }
-    const files = await FileResource.fetchByMountFilePaths(
-      auth,
-      Array.from(mountPathByRelPath.values())
+  // 3. The frame last: publishFrame validates its function references against what step 2 just
+  // published. Resolved through the same batched-fetch API, with a one-element array. Every app
+  // has a frame to publish (buildPodAppPublishPlan guarantees `frameToPublish`); a failure here
+  // still only becomes a warning, leaving `publishedFrameName` null.
+  let publishedFrameName: string | null = null;
+  const frame = plan.frameToPublish;
+  const mountPath = dustFs.toMountFilePath(frame.scopedPath);
+  const files = mountPath
+    ? await FileResource.fetchByMountFilePaths(auth, [mountPath])
+    : [];
+  let file = files[0];
+
+  if (file && !isInteractiveContentType(file.contentType)) {
+    warnings.push(
+      `Frame ${frame.relPath}: its FileResource content type is '${file.contentType}', ` +
+        "not a Frame. Create it as interactive content, then retry."
     );
-    const fileByMountPath = new Map(
-      files.flatMap((file) =>
-        file.mountFilePath ? [[file.mountFilePath, file] as const] : []
-      )
-    );
-
-    for (const frame of plan.framesToPublish) {
-      const mountPath = mountPathByRelPath.get(frame.relPath);
-      let file = mountPath ? fileByMountPath.get(mountPath) : undefined;
-
-      if (file && !isInteractiveContentType(file.contentType)) {
-        warnings.push(
-          `Frame ${frame.relPath}: its FileResource content type is '${file.contentType}', ` +
-            "not a Frame. Create it as interactive content, then retry."
-        );
-        continue;
-      }
-
-      // No FileResource: the manifest declares a frame that exists only as a bare storage
-      // object (e.g. copied into the pod, or written directly inside the sandbox, both of which
-      // lose the FileResource). Recreate it in place so the manifest-first flow self-heals.
-      if (!file) {
-        const sourceResult = await dustFs.readBuffer(frame.scopedPath);
-        if (sourceResult.isErr() || sourceResult.value === null) {
-          warnings.push(`Frame ${frame.relPath}: could not read its source.`);
-          continue;
-        }
+  } else {
+    // No FileResource: the manifest declares a frame that exists only as a bare storage
+    // object (e.g. copied into the pod, or written directly inside the sandbox, both of which
+    // lose the FileResource). Recreate it in place so the manifest-first flow self-heals.
+    if (!file) {
+      const sourceResult = await dustFs.readBuffer(frame.scopedPath);
+      if (sourceResult.isErr() || sourceResult.value === null) {
+        warnings.push(`Frame ${frame.relPath}: could not read its source.`);
+      } else {
         const createResult = await createPodFrameFile(auth, {
           space: pod,
           folderName: trimmed,
@@ -282,11 +268,13 @@ export async function publishPodApp(
           warnings.push(
             `Frame ${frame.relPath}: ${createResult.error.message}`
           );
-          continue;
+        } else {
+          file = createResult.value;
         }
-        file = createResult.value;
       }
+    }
 
+    if (file) {
       const result = await publishFrame(auth, {
         file,
         reader: createMountFrameSourceReader(dustFs, folderPath),
@@ -295,9 +283,9 @@ export async function publishPodApp(
       });
       if (result.isErr()) {
         warnings.push(`Frame ${frame.relPath}: ${result.error.message}`);
-        continue;
+      } else {
+        publishedFrameName = frame.relPath;
       }
-      publishedFrameNames.push(frame.relPath);
     }
   }
 
@@ -320,7 +308,7 @@ export async function publishPodApp(
     displayName: manifest.name,
     reconciledDatabaseNames,
     publishedFunctionSlugs,
-    publishedFrameNames,
+    publishedFrameName,
     unpublishedFunctionSlugs,
     warnings,
   });

--- a/front/lib/api/projects/publish_app.ts
+++ b/front/lib/api/projects/publish_app.ts
@@ -265,7 +265,8 @@ export async function publishPodApp(
       // No FileResource: the manifest declares a frame that exists only as a bare storage
       // object (e.g. copied into the pod, or written directly inside the sandbox, both of which
       // lose the FileResource). Recreate it in place the same way `importPodApp` does, so the
-      // manifest-first flow self-heals.
+      // manifest-first flow self-heals. Works at any depth: the manifest's declared frame path is
+      // authoritative for entry points regardless of nesting.
       //
       // The manifest declaring the path as a frame is trusted over the listing's storage MIME
       // type: files written inside the sandbox get their GCS Content-Type guessed from the
@@ -275,16 +276,6 @@ export async function publishPodApp(
       // bundler performs the real validation (TS/JSX parse etc.) and rejects non-frame sources
       // with a meaningful error.
       if (!file) {
-        // A Frame recreated deeper than the app folder's top level would be invisible to listing,
-        // delete, export and clone: `collectAppFolders` in apps.ts only recognizes a Frame at the
-        // TOP of the app folder (`segments.length === 2`) as the app's own Frame.
-        if (frame.relPath.includes("/")) {
-          warnings.push(
-            `Frame ${frame.relPath}: cannot auto-create a Frame in a subfolder; create it ` +
-              "as interactive content, then retry."
-          );
-          continue;
-        }
         const sourceResult = await dustFs.readBuffer(frame.scopedPath);
         if (sourceResult.isErr() || sourceResult.value === null) {
           warnings.push(`Frame ${frame.relPath}: could not read its source.`);

--- a/front/lib/api/projects/publish_app.ts
+++ b/front/lib/api/projects/publish_app.ts
@@ -1,5 +1,8 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
-import { listPodDatabaseOnDiskNames } from "@app/lib/api/projects/apps";
+import {
+  listPodDatabaseOnDiskNames,
+  validatePodAppFolderName,
+} from "@app/lib/api/projects/apps";
 import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import { buildPodAppPublishPlan } from "@app/lib/api/projects/publish_app_plan";
 import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
@@ -14,16 +17,13 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { PodAppPublishSummary } from "@app/types/api/pod_app_manifest";
 import {
   POD_APP_MANIFEST_FILE,
-  PodAppPublishManifestSchema,
+  parsePodAppManifest,
 } from "@app/types/api/pod_app_manifest";
-import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
 import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { SCOPED_PREFIX_POD } from "@app/types/file_system";
 import { frameContentType, isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { fromError } from "zod-validation-error";
 
 export type PodAppPublishErrorCode =
   | "not_a_pod"
@@ -74,28 +74,11 @@ export async function publishPodApp(
     );
   }
 
-  const trimmed = folderName.trim();
-  if (
-    trimmed.length === 0 ||
-    trimmed.length > MAX_POD_APP_NAME_LENGTH ||
-    trimmed.includes("/")
-  ) {
-    return new Err(
-      new PodAppPublishError(
-        "invalid_name",
-        `Invalid app folder name '${folderName}'.`
-      )
-    );
+  const nameResult = validatePodAppFolderName(folderName);
+  if (nameResult.isErr()) {
+    return new Err(new PodAppPublishError("invalid_name", nameResult.error));
   }
-  const prefix = normalizeAppPrefix(trimmed);
-  if (!prefix) {
-    return new Err(
-      new PodAppPublishError(
-        "invalid_name",
-        `'${trimmed}' has no letters or digits to derive an app prefix from.`
-      )
-    );
-  }
+  const { folderName: trimmed, prefix } = nameResult.value;
 
   const fsResult = await DustFileSystem.forPod(auth, pod);
   if (fsResult.isErr()) {
@@ -173,27 +156,13 @@ export async function publishPodApp(
       )
     );
   }
-  let manifestJson: unknown;
-  try {
-    manifestJson = JSON.parse(manifestResult.value.toString("utf-8"));
-  } catch (err) {
+  const manifestParseResult = parsePodAppManifest(manifestResult.value);
+  if (manifestParseResult.isErr()) {
     return new Err(
-      new PodAppPublishError(
-        "invalid_manifest",
-        `${POD_APP_MANIFEST_FILE} is not valid JSON: ${normalizeError(err).message}`
-      )
+      new PodAppPublishError("invalid_manifest", manifestParseResult.error)
     );
   }
-  const validation = PodAppPublishManifestSchema.safeParse(manifestJson);
-  if (!validation.success) {
-    return new Err(
-      new PodAppPublishError(
-        "invalid_manifest",
-        fromError(validation.error).toString()
-      )
-    );
-  }
-  const manifest = validation.data;
+  const manifest = manifestParseResult.value;
 
   const [sandboxFunctions, databaseOnDiskNames] = await Promise.all([
     SandboxFunctionResource.listBySpace(auth, pod),
@@ -306,6 +275,9 @@ export async function publishPodApp(
       // bundler performs the real validation (TS/JSX parse etc.) and rejects non-frame sources
       // with a meaningful error.
       if (!file) {
+        // A Frame recreated deeper than the app folder's top level would be invisible to listing,
+        // delete, export and clone: `collectAppFolders` in apps.ts only recognizes a Frame at the
+        // TOP of the app folder (`segments.length === 2`) as the app's own Frame.
         if (frame.relPath.includes("/")) {
           warnings.push(
             `Frame ${frame.relPath}: cannot auto-create a Frame in a subfolder; create it ` +

--- a/front/lib/api/projects/publish_app.ts
+++ b/front/lib/api/projects/publish_app.ts
@@ -1,5 +1,6 @@
 import { DustFileSystem } from "@app/lib/api/file_system";
 import { listPodDatabaseOnDiskNames } from "@app/lib/api/projects/apps";
+import { createPodFrameFile } from "@app/lib/api/projects/pod_frame_file";
 import { buildPodAppPublishPlan } from "@app/lib/api/projects/publish_app_plan";
 import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
 import { publishSandboxFunction } from "@app/lib/api/sandbox_functions/publish_sandbox_function";
@@ -116,6 +117,10 @@ export async function publishPodApp(
     );
   }
   const folderRelPaths = new Set<string>();
+  // Content type as reported by the listing, keyed by folder-relative path. Lets the frame step
+  // tell "no FileResource, but a Frame-typed object exists" apart from "not a Frame at all"
+  // without a second listing call.
+  const contentTypeByRelPath = new Map<string, string>();
   const collidingFolderNames = new Set<string>();
   for (const entry of listResult.value) {
     if (entry.isDirectory || !entry.path.startsWith(`${podRoot}/`)) {
@@ -130,7 +135,9 @@ export async function publishPodApp(
     }
     const [head, ...rest] = segments;
     if (head === trimmed) {
-      folderRelPaths.add(rest.join("/"));
+      const relPath = rest.join("/");
+      folderRelPaths.add(relPath);
+      contentTypeByRelPath.set(relPath, entry.contentType);
     } else if (normalizeAppPrefix(head) === prefix) {
       collidingFolderNames.add(head);
     }
@@ -282,13 +289,61 @@ export async function publishPodApp(
 
     for (const frame of plan.framesToPublish) {
       const mountPath = mountPathByRelPath.get(frame.relPath);
-      const file = mountPath ? fileByMountPath.get(mountPath) : undefined;
-      if (!file || !isInteractiveContentType(file.contentType)) {
+      let file = mountPath ? fileByMountPath.get(mountPath) : undefined;
+
+      if (file && !isInteractiveContentType(file.contentType)) {
         warnings.push(
-          `Frame ${frame.relPath}: not a Frame file (create it as interactive content, then retry).`
+          `Frame ${frame.relPath}: its FileResource content type is '${file.contentType}', ` +
+            "not a Frame. Create it as interactive content, then retry."
         );
         continue;
       }
+
+      // No FileResource: the manifest declares a frame that exists only as a bare storage
+      // object (e.g. copied into the pod, which loses the FileResource). Recreate it in place
+      // the same way `importPodApp` does, so the manifest-first flow self-heals.
+      if (!file) {
+        const contentType = contentTypeByRelPath.get(frame.relPath);
+        if (
+          contentType === undefined ||
+          !isInteractiveContentType(contentType)
+        ) {
+          warnings.push(
+            contentType === undefined
+              ? `Frame ${frame.relPath}: not a Frame file (create it as interactive content, then retry).`
+              : `Frame ${frame.relPath}: its content type is '${contentType}', not a Frame. ` +
+                  "Create it as interactive content, then retry."
+          );
+          continue;
+        }
+        if (frame.relPath.includes("/")) {
+          warnings.push(
+            `Frame ${frame.relPath}: cannot auto-create a Frame in a subfolder; create it ` +
+              "as interactive content, then retry."
+          );
+          continue;
+        }
+        const sourceResult = await dustFs.readBuffer(frame.scopedPath);
+        if (sourceResult.isErr() || sourceResult.value === null) {
+          warnings.push(`Frame ${frame.relPath}: could not read its source.`);
+          continue;
+        }
+        const createResult = await createPodFrameFile(auth, {
+          space: pod,
+          folderName: trimmed,
+          fileName: frame.relPath,
+          contentType,
+          content: sourceResult.value.toString("utf-8"),
+        });
+        if (createResult.isErr()) {
+          warnings.push(
+            `Frame ${frame.relPath}: ${createResult.error.message}`
+          );
+          continue;
+        }
+        file = createResult.value;
+      }
+
       const result = await publishFrame(auth, {
         file,
         reader: createMountFrameSourceReader(dustFs, folderPath),

--- a/front/lib/api/projects/publish_app.ts
+++ b/front/lib/api/projects/publish_app.ts
@@ -19,7 +19,7 @@ import {
 import { MAX_POD_APP_NAME_LENGTH } from "@app/types/api/pod_apps";
 import { normalizeAppPrefix } from "@app/types/api/pod_function_reference";
 import { SCOPED_PREFIX_POD } from "@app/types/file_system";
-import { isInteractiveContentType } from "@app/types/files";
+import { frameContentType, isInteractiveContentType } from "@app/types/files";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -117,10 +117,6 @@ export async function publishPodApp(
     );
   }
   const folderRelPaths = new Set<string>();
-  // Content type as reported by the listing, keyed by folder-relative path. Lets the frame step
-  // tell "no FileResource, but a Frame-typed object exists" apart from "not a Frame at all"
-  // without a second listing call.
-  const contentTypeByRelPath = new Map<string, string>();
   const collidingFolderNames = new Set<string>();
   for (const entry of listResult.value) {
     if (entry.isDirectory || !entry.path.startsWith(`${podRoot}/`)) {
@@ -135,9 +131,7 @@ export async function publishPodApp(
     }
     const [head, ...rest] = segments;
     if (head === trimmed) {
-      const relPath = rest.join("/");
-      folderRelPaths.add(relPath);
-      contentTypeByRelPath.set(relPath, entry.contentType);
+      folderRelPaths.add(rest.join("/"));
     } else if (normalizeAppPrefix(head) === prefix) {
       collidingFolderNames.add(head);
     }
@@ -300,22 +294,18 @@ export async function publishPodApp(
       }
 
       // No FileResource: the manifest declares a frame that exists only as a bare storage
-      // object (e.g. copied into the pod, which loses the FileResource). Recreate it in place
-      // the same way `importPodApp` does, so the manifest-first flow self-heals.
+      // object (e.g. copied into the pod, or written directly inside the sandbox, both of which
+      // lose the FileResource). Recreate it in place the same way `importPodApp` does, so the
+      // manifest-first flow self-heals.
+      //
+      // The manifest declaring the path as a frame is trusted over the listing's storage MIME
+      // type: files written inside the sandbox get their GCS Content-Type guessed from the
+      // extension by gcsfuse, and `.tsx` guesses to `application/x-tiled-tsx` (a Tiled tileset),
+      // not a Frame type — so that guess can never pass an interactive-content check. The
+      // manifest is the authoritative statement that the path is a frame; `publishFrame`'s
+      // bundler performs the real validation (TS/JSX parse etc.) and rejects non-frame sources
+      // with a meaningful error.
       if (!file) {
-        const contentType = contentTypeByRelPath.get(frame.relPath);
-        if (
-          contentType === undefined ||
-          !isInteractiveContentType(contentType)
-        ) {
-          warnings.push(
-            contentType === undefined
-              ? `Frame ${frame.relPath}: not a Frame file (create it as interactive content, then retry).`
-              : `Frame ${frame.relPath}: its content type is '${contentType}', not a Frame. ` +
-                  "Create it as interactive content, then retry."
-          );
-          continue;
-        }
         if (frame.relPath.includes("/")) {
           warnings.push(
             `Frame ${frame.relPath}: cannot auto-create a Frame in a subfolder; create it ` +
@@ -332,7 +322,7 @@ export async function publishPodApp(
           space: pod,
           folderName: trimmed,
           fileName: frame.relPath,
-          contentType,
+          contentType: frameContentType,
           content: sourceResult.value.toString("utf-8"),
         });
         if (createResult.isErr()) {

--- a/front/lib/api/projects/publish_app_plan.test.ts
+++ b/front/lib/api/projects/publish_app_plan.test.ts
@@ -1,0 +1,122 @@
+import { buildPodAppPublishPlan } from "@app/lib/api/projects/publish_app_plan";
+import type { PodAppPublishManifest } from "@app/types/api/pod_app_manifest";
+import { describe, expect, it } from "vitest";
+
+const FOLDER_PATH = "pod-vlt_abc/TaskList";
+
+const MANIFEST: PodAppPublishManifest = {
+  version: 1,
+  name: "Task List",
+  description: "Tasks.",
+  frames: [{ path: "TaskList.tsx" }],
+  functions: [
+    {
+      name: "add-task",
+      path: "src/add.ts",
+      description: "Add.",
+      executionMode: "fast",
+      defaultStake: "low",
+    },
+  ],
+  databases: [{ name: "tasks", path: "databases/tasks.db.ts" }],
+};
+
+const ALL_REL_PATHS = new Set([
+  "manifest.json",
+  "TaskList.tsx",
+  "src/add.ts",
+  "databases/tasks.db.ts",
+]);
+
+describe("buildPodAppPublishPlan", () => {
+  it("maps manifest entries onto scoped paths", () => {
+    const result = buildPodAppPublishPlan({
+      manifest: MANIFEST,
+      folderPath: FOLDER_PATH,
+      folderRelPaths: ALL_REL_PATHS,
+      prefix: "tasklist",
+      publishedFunctionSlugs: [],
+      databaseOnDiskNames: [],
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.functionsToPublish).toEqual([
+      {
+        name: "add-task",
+        scopedPath: `${FOLDER_PATH}/src/add.ts`,
+        description: "Add.",
+        executionMode: "fast",
+        defaultStake: "low",
+      },
+    ]);
+    expect(result.value.databasesToReconcile).toEqual([
+      { name: "tasks", scopedPath: `${FOLDER_PATH}/databases/tasks.db.ts` },
+    ]);
+    expect(result.value.framesToPublish).toEqual([
+      { relPath: "TaskList.tsx", scopedPath: `${FOLDER_PATH}/TaskList.tsx` },
+    ]);
+    expect(result.value.functionSlugsToUnpublish).toEqual([]);
+    expect(result.value.warnings).toEqual([]);
+  });
+
+  it("rejects a manifest referencing files absent from the folder", () => {
+    const result = buildPodAppPublishPlan({
+      manifest: MANIFEST,
+      folderPath: FOLDER_PATH,
+      folderRelPaths: new Set(["manifest.json"]),
+      prefix: "tasklist",
+      publishedFunctionSlugs: [],
+      databaseOnDiskNames: [],
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("TaskList.tsx");
+      expect(result.error.message).toContain("src/add.ts");
+    }
+  });
+
+  it("plans unpublish for this app's functions the manifest dropped, and only this app's", () => {
+    const result = buildPodAppPublishPlan({
+      manifest: MANIFEST,
+      folderPath: FOLDER_PATH,
+      folderRelPaths: ALL_REL_PATHS,
+      prefix: "tasklist",
+      publishedFunctionSlugs: [
+        "tasklist__add-task", // still declared -> kept
+        "tasklist__old-fn", // dropped -> unpublish
+        "otherapp__old-fn", // another app -> untouched
+        "bare-root-fn", // no prefix -> untouched
+      ],
+      databaseOnDiskNames: [],
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.functionSlugsToUnpublish).toEqual([
+        "tasklist__old-fn",
+      ]);
+    }
+  });
+
+  it("warns about this app's orphan databases without planning any deletion", () => {
+    const result = buildPodAppPublishPlan({
+      manifest: MANIFEST,
+      folderPath: FOLDER_PATH,
+      folderRelPaths: ALL_REL_PATHS,
+      prefix: "tasklist",
+      publishedFunctionSlugs: [],
+      databaseOnDiskNames: [
+        "tasklist__tasks", // declared -> no warning
+        "tasklist__legacy", // undeclared -> warning
+        "otherapp__data", // another app -> untouched
+        "bare", // no prefix -> untouched
+      ],
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.warnings).toHaveLength(1);
+      expect(result.value.warnings[0]).toContain("tasklist__legacy");
+    }
+  });
+});

--- a/front/lib/api/projects/publish_app_plan.test.ts
+++ b/front/lib/api/projects/publish_app_plan.test.ts
@@ -8,7 +8,7 @@ const MANIFEST: PodAppPublishManifest = {
   version: 1,
   name: "Task List",
   description: "Tasks.",
-  frames: [{ path: "TaskList.tsx" }],
+  uiEntryPoint: "TaskList.tsx",
   functions: [
     {
       name: "add-task",
@@ -54,11 +54,88 @@ describe("buildPodAppPublishPlan", () => {
     expect(result.value.databasesToReconcile).toEqual([
       { name: "tasks", scopedPath: `${FOLDER_PATH}/databases/tasks.db.ts` },
     ]);
-    expect(result.value.framesToPublish).toEqual([
-      { relPath: "TaskList.tsx", scopedPath: `${FOLDER_PATH}/TaskList.tsx` },
-    ]);
+    expect(result.value.frameToPublish).toEqual({
+      relPath: "TaskList.tsx",
+      scopedPath: `${FOLDER_PATH}/TaskList.tsx`,
+    });
     expect(result.value.functionSlugsToUnpublish).toEqual([]);
     expect(result.value.warnings).toEqual([]);
+  });
+
+  it("defaults the frame to index.tsx when uiEntryPoint is omitted and it exists", () => {
+    const manifest: PodAppPublishManifest = {
+      ...MANIFEST,
+      uiEntryPoint: undefined,
+    };
+    const result = buildPodAppPublishPlan({
+      manifest,
+      folderPath: FOLDER_PATH,
+      folderRelPaths: new Set([
+        "manifest.json",
+        "index.tsx",
+        "src/add.ts",
+        "databases/tasks.db.ts",
+      ]),
+      prefix: "tasklist",
+      publishedFunctionSlugs: [],
+      databaseOnDiskNames: [],
+    });
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.frameToPublish).toEqual({
+        relPath: "index.tsx",
+        scopedPath: `${FOLDER_PATH}/index.tsx`,
+      });
+    }
+  });
+
+  it("rejects a manifest with no uiEntryPoint and no index.tsx in the folder", () => {
+    const manifest: PodAppPublishManifest = {
+      ...MANIFEST,
+      uiEntryPoint: undefined,
+    };
+    const result = buildPodAppPublishPlan({
+      manifest,
+      folderPath: FOLDER_PATH,
+      folderRelPaths: new Set([
+        "manifest.json",
+        "src/add.ts",
+        "databases/tasks.db.ts",
+      ]),
+      prefix: "tasklist",
+      publishedFunctionSlugs: [],
+      databaseOnDiskNames: [],
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("index.tsx");
+      expect(result.error.message).toContain(
+        "every app needs a UI entry point"
+      );
+    }
+  });
+
+  it("rejects an explicit uiEntryPoint that is absent from the folder", () => {
+    const manifest: PodAppPublishManifest = {
+      ...MANIFEST,
+      uiEntryPoint: "Missing.tsx",
+    };
+    const result = buildPodAppPublishPlan({
+      manifest,
+      folderPath: FOLDER_PATH,
+      folderRelPaths: new Set([
+        "manifest.json",
+        "src/add.ts",
+        "databases/tasks.db.ts",
+      ]),
+      prefix: "tasklist",
+      publishedFunctionSlugs: [],
+      databaseOnDiskNames: [],
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Missing.tsx");
+    }
   });
 
   it("rejects a manifest referencing files absent from the folder", () => {

--- a/front/lib/api/projects/publish_app_plan.ts
+++ b/front/lib/api/projects/publish_app_plan.ts
@@ -1,0 +1,111 @@
+import {
+  appPrefixFromPodDatabaseName,
+  podDatabaseNameWithoutAppPrefix,
+} from "@app/lib/api/sandbox_functions/db_naming";
+import {
+  appPrefixFromSlug,
+  sandboxFunctionNameFromSlug,
+} from "@app/lib/api/sandbox_functions/slug";
+import type { PodAppPublishManifest } from "@app/types/api/pod_app_manifest";
+import type {
+  SandboxFunctionExecutionMode,
+  SandboxFunctionStake,
+} from "@app/types/api/sandbox_functions";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type PodAppPublishPlan = {
+  databasesToReconcile: { name: string; scopedPath: string }[];
+  functionsToPublish: {
+    name: string;
+    scopedPath: string;
+    description: string;
+    executionMode: SandboxFunctionExecutionMode;
+    defaultStake?: SandboxFunctionStake;
+  }[];
+  framesToPublish: { relPath: string; scopedPath: string }[];
+  functionSlugsToUnpublish: string[];
+  warnings: string[];
+};
+
+/**
+ * Turn a parsed manifest into an executable publish plan, given the current published state.
+ *
+ * Pure: every input is data, so the declarative-diff rules live here where they are unit-testable
+ * without a sandbox. The manifest is the source of truth for FUNCTIONS — a published function
+ * carrying this app's prefix that the manifest no longer declares is planned for unpublish.
+ * Databases are conservative: an on-disk database with this app's prefix that the manifest does not
+ * declare only produces a warning, never a deletion. Frames are publish-only (there is no
+ * unpublish-frame operation), so nothing is planned for a frame the manifest dropped.
+ */
+export function buildPodAppPublishPlan({
+  manifest,
+  folderPath,
+  folderRelPaths,
+  prefix,
+  publishedFunctionSlugs,
+  databaseOnDiskNames,
+}: {
+  manifest: PodAppPublishManifest;
+  folderPath: string;
+  folderRelPaths: Set<string>;
+  prefix: string;
+  publishedFunctionSlugs: string[];
+  databaseOnDiskNames: string[];
+}): Result<PodAppPublishPlan, Error> {
+  const missing = [
+    ...manifest.frames.map((frame) => frame.path),
+    ...manifest.functions.map((fn) => fn.path),
+    ...manifest.databases.map((db) => db.path),
+  ].filter((path) => !folderRelPaths.has(path));
+  if (missing.length > 0) {
+    return new Err(
+      new Error(
+        `Manifest references files missing from the app folder: ${missing.join(", ")}.`
+      )
+    );
+  }
+
+  const declaredFunctionNames = new Set(
+    manifest.functions.map((fn) => fn.name)
+  );
+  const functionSlugsToUnpublish = publishedFunctionSlugs.filter(
+    (slug) =>
+      appPrefixFromSlug(slug) === prefix &&
+      !declaredFunctionNames.has(sandboxFunctionNameFromSlug(slug))
+  );
+
+  const declaredDatabaseNames = new Set(
+    manifest.databases.map((db) => db.name)
+  );
+  const warnings = databaseOnDiskNames
+    .filter(
+      (onDiskName) =>
+        appPrefixFromPodDatabaseName(onDiskName) === prefix &&
+        !declaredDatabaseNames.has(podDatabaseNameWithoutAppPrefix(onDiskName))
+    )
+    .map(
+      (onDiskName) =>
+        `Database '${onDiskName}' exists but is not declared in the manifest; it was left untouched.`
+    );
+
+  return new Ok({
+    databasesToReconcile: manifest.databases.map((db) => ({
+      name: db.name,
+      scopedPath: `${folderPath}/${db.path}`,
+    })),
+    functionsToPublish: manifest.functions.map((fn) => ({
+      name: fn.name,
+      scopedPath: `${folderPath}/${fn.path}`,
+      description: fn.description,
+      executionMode: fn.executionMode,
+      ...(fn.defaultStake ? { defaultStake: fn.defaultStake } : {}),
+    })),
+    framesToPublish: manifest.frames.map((frame) => ({
+      relPath: frame.path,
+      scopedPath: `${folderPath}/${frame.path}`,
+    })),
+    functionSlugsToUnpublish,
+    warnings,
+  });
+}

--- a/front/lib/api/projects/publish_app_plan.ts
+++ b/front/lib/api/projects/publish_app_plan.ts
@@ -7,6 +7,7 @@ import {
   sandboxFunctionNameFromSlug,
 } from "@app/lib/api/sandbox_functions/slug";
 import type { PodAppPublishManifest } from "@app/types/api/pod_app_manifest";
+import { POD_APP_DEFAULT_UI_ENTRY_POINT } from "@app/types/api/pod_app_manifest";
 import type {
   SandboxFunctionExecutionMode,
   SandboxFunctionStake,
@@ -23,7 +24,7 @@ export type PodAppPublishPlan = {
     executionMode: SandboxFunctionExecutionMode;
     defaultStake?: SandboxFunctionStake;
   }[];
-  framesToPublish: { relPath: string; scopedPath: string }[];
+  frameToPublish: { relPath: string; scopedPath: string };
   functionSlugsToUnpublish: string[];
   warnings: string[];
 };
@@ -35,8 +36,14 @@ export type PodAppPublishPlan = {
  * without a sandbox. The manifest is the source of truth for FUNCTIONS — a published function
  * carrying this app's prefix that the manifest no longer declares is planned for unpublish.
  * Databases are conservative: an on-disk database with this app's prefix that the manifest does not
- * declare only produces a warning, never a deletion. Frames are publish-only (there is no
- * unpublish-frame operation), so nothing is planned for a frame the manifest dropped.
+ * declare only produces a warning, never a deletion. The frame is publish-only (there is no
+ * unpublish-frame operation).
+ *
+ * Every app has exactly one UI entry point, so `frameToPublish` is always populated: an explicit
+ * `uiEntryPoint` must exist in the folder (else it's added to the missing-files error below); an
+ * omitted one defaults to `POD_APP_DEFAULT_UI_ENTRY_POINT`, and if that default file is absent too
+ * this returns a dedicated, more helpful error rather than the generic missing-files one — there is
+ * no such thing as a UI-less app.
  */
 export function buildPodAppPublishPlan({
   manifest,
@@ -53,8 +60,23 @@ export function buildPodAppPublishPlan({
   publishedFunctionSlugs: string[];
   databaseOnDiskNames: string[];
 }): Result<PodAppPublishPlan, Error> {
+  // Every app needs a frame. An omitted `uiEntryPoint` defaults to
+  // `POD_APP_DEFAULT_UI_ENTRY_POINT`; if that default file is also absent, there is no declared
+  // path to name, so this gets its own message rather than folding into the missing-files list
+  // below.
+  const uiEntryPoint = manifest.uiEntryPoint ?? POD_APP_DEFAULT_UI_ENTRY_POINT;
+  if (!manifest.uiEntryPoint && !folderRelPaths.has(uiEntryPoint)) {
+    return new Err(
+      new Error(
+        `No uiEntryPoint declared and no ${POD_APP_DEFAULT_UI_ENTRY_POINT} in the folder — ` +
+          "every app needs a UI entry point."
+      )
+    );
+  }
+
+  // An explicit `uiEntryPoint` must exist in the folder, like any other declared path.
   const missing = [
-    ...manifest.frames.map((frame) => frame.path),
+    ...(manifest.uiEntryPoint ? [manifest.uiEntryPoint] : []),
     ...manifest.functions.map((fn) => fn.path),
     ...manifest.databases.map((db) => db.path),
   ].filter((path) => !folderRelPaths.has(path));
@@ -101,10 +123,13 @@ export function buildPodAppPublishPlan({
       executionMode: fn.executionMode,
       ...(fn.defaultStake ? { defaultStake: fn.defaultStake } : {}),
     })),
-    framesToPublish: manifest.frames.map((frame) => ({
-      relPath: frame.path,
-      scopedPath: `${folderPath}/${frame.path}`,
-    })),
+    // Guaranteed to exist in the folder at this point: the checks above returned early otherwise,
+    // whether `uiEntryPoint` was explicit (covered by the missing-files check) or defaulted
+    // (covered by the dedicated check above it).
+    frameToPublish: {
+      relPath: uiEntryPoint,
+      scopedPath: `${folderPath}/${uiEntryPoint}`,
+    },
     functionSlugsToUnpublish,
     warnings,
   });

--- a/front/tests/utils/pod_app_publish_test_helpers.ts
+++ b/front/tests/utils/pod_app_publish_test_helpers.ts
@@ -14,7 +14,7 @@ export const MANIFEST = {
   version: 1,
   name: "Task List",
   description: "Tasks.",
-  frames: [{ path: "TaskList.tsx" }],
+  uiEntryPoint: "TaskList.tsx",
   functions: [
     {
       name: "add-task",

--- a/front/tests/utils/pod_app_publish_test_helpers.ts
+++ b/front/tests/utils/pod_app_publish_test_helpers.ts
@@ -1,0 +1,66 @@
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+
+/**
+ * Shared fixtures for `publishPodApp` tests (`lib/api/projects/publish_app.test.ts` and
+ * `lib/api/actions/servers/sandbox_functions/tools/publish_app.test.ts`), which both exercise the
+ * same publish pipeline through two different entry points.
+ *
+ * The `vi.mock` blocks stay local to each test file: hoisting only reaches the top of the file
+ * `vi.mock` is written in, so registering them here would run too late relative to each test
+ * file's own (earlier) imports of the mocked modules.
+ */
+
+export const MANIFEST = {
+  version: 1,
+  name: "Task List",
+  description: "Tasks.",
+  frames: [{ path: "TaskList.tsx" }],
+  functions: [
+    {
+      name: "add-task",
+      path: "src/add.ts",
+      description: "Add.",
+      executionMode: "fast",
+      defaultStake: "low",
+    },
+  ],
+  databases: [{ name: "tasks", path: "databases/tasks.db.ts" }],
+};
+
+/** Seeds the pod listing with an app folder's files and its manifest content. */
+export function seedAppFolder({
+  folder,
+  relPaths,
+  manifest,
+  extraRootFolders = [],
+}: {
+  folder: string;
+  relPaths: string[];
+  manifest: unknown;
+  extraRootFolders?: { folder: string; relPaths: string[] }[];
+}) {
+  const all = [{ folder, relPaths }, ...extraRootFolders];
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    all.flatMap(({ folder: f, relPaths: rps }) =>
+      rps.map((relPath) => ({
+        name: `${prefix}${f}/${relPath}`,
+        metadata: {
+          contentType: relPath.endsWith(".tsx")
+            ? "application/vnd.dust.frame"
+            : "text/plain",
+          size: "10",
+        },
+      }))
+    )
+  );
+  fileStorageMock.setFileContent((filePath) => {
+    if (filePath.endsWith(`${folder}/manifest.json`)) {
+      return JSON.stringify(manifest);
+    }
+    // Generic body for any other seeded file (e.g. a frame source read by the auto-create path).
+    const isSeeded = all.some(({ folder: f, relPaths: rps }) =>
+      rps.some((relPath) => filePath.endsWith(`${f}/${relPath}`))
+    );
+    return isSeeded ? "// seeded content" : null;
+  });
+}


### PR DESCRIPTION
Second PR of the manifest-publish stack. Adds publishPodApp, which publishes a whole app from its manifest.json: databases reconciled first, then functions, then frames (whose reference validation needs the functions in place), then declarative cleanup — functions carrying the app's prefix that the manifest dropped are unpublished; undeclared databases only produce warnings, never deletions. Per-item failures land in warnings like importPodApp; only invalid manifest, prefix collision and sandbox unavailability abort. The pure plan-builder (declarative diff + path validation) is split into publish_app_plan.ts and unit-tested without mocks. Nothing calls this yet — the MCP tool lands in the next PR.