### PR TITLE
[pods] publish_app MCP tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2108,6 +2108,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "publish_app": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "unpublish": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -3321,6 +3325,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "inspect_invocations": "never_ask",
     "list": "never_ask",
     "publish": "low",
+    "publish_app": "low",
     "unpublish": "high",
   },
   "search": {

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -276,6 +276,32 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
     toolCostCategory: "basic",
     freeUsage: true,
   },
+  {
+    name: "publish_app",
+    description:
+      "Publish a pod app in one call from the manifest.json at the root of its folder: " +
+      "reconcile its databases, publish its functions and Frames, and unpublish functions " +
+      "the manifest no longer declares. Prefer this over the individual publish and " +
+      "db_reconcile tools once the app has a manifest; use those to iterate on a single " +
+      "function or database.",
+    schema: {
+      folder: z
+        .string()
+        .min(1)
+        .describe(
+          "The app folder name at the pod root (e.g. `TaskList`). Its manifest.json declares " +
+            "the app's name, description, frames, functions and databases, each with a " +
+            "folder-relative source path."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Publishing pod app...",
+      done: "Published pod app",
+    },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
 ] as const;
 
 export const SANDBOX_FUNCTIONS_SERVER = {

--- a/front/lib/api/actions/servers/sandbox_functions/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/metadata.ts
@@ -280,18 +280,18 @@ export const SANDBOX_FUNCTIONS_TOOLS_METADATA = [
     name: "publish_app",
     description:
       "Publish a pod app in one call from the manifest.json at the root of its folder: " +
-      "reconcile its databases, publish its functions and Frames, and unpublish functions " +
-      "the manifest no longer declares. Prefer this over the individual publish and " +
-      "db_reconcile tools once the app has a manifest; use those to iterate on a single " +
-      "function or database.",
+      "reconcile its databases, publish its functions and its UI entry point (frame), and " +
+      "unpublish functions the manifest no longer declares. Prefer this over the individual " +
+      "publish and db_reconcile tools once the app has a manifest; use those to iterate on a " +
+      "single function or database.",
     schema: {
       folder: z
         .string()
         .min(1)
         .describe(
           "The app folder name at the pod root (e.g. `TaskList`). Its manifest.json declares " +
-            "the app's name, description, frames, functions and databases, each with a " +
-            "folder-relative source path."
+            "the app's name, description, uiEntryPoint (defaulting to index.tsx), functions " +
+            "and databases, each with a folder-relative source path."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/index.ts
@@ -9,12 +9,14 @@ import { getHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools
 import { inspectInvocationsHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/inspect_invocations";
 import { listHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/list";
 import { publishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish";
+import { publishAppHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish_app";
 import { unpublishHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/unpublish";
 
 const HANDLERS = {
   list: listHandler,
   get: getHandler,
   publish: publishHandler,
+  publish_app: publishAppHandler,
   unpublish: unpublishHandler,
   call: callHandler,
   inspect_invocations: inspectInvocationsHandler,

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.test.ts
@@ -1,0 +1,210 @@
+import { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
+import { publishAppHandler } from "@app/lib/api/actions/servers/sandbox_functions/tools/publish_app";
+import { buildSandboxFunctionOnSandbox } from "@app/lib/api/sandbox_functions/build_on_sandbox";
+import { reconcileDatabaseFromPodPath } from "@app/lib/api/sandbox_functions/dsbx_db";
+import { publishFrame } from "@app/lib/api/viz/publish_frame";
+import {
+  makeExtra,
+  setupProjectConversation,
+} from "@app/tests/utils/conversation_test_factories";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(
+  "@app/lib/api/sandbox_functions/build_on_sandbox",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("@app/lib/api/sandbox_functions/build_on_sandbox")
+      >();
+    return { ...actual, buildSandboxFunctionOnSandbox: vi.fn() };
+  }
+);
+
+vi.mock("@app/lib/api/sandbox_functions/dsbx_db", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@app/lib/api/sandbox_functions/dsbx_db")
+    >();
+  return { ...actual, reconcileDatabaseFromPodPath: vi.fn() };
+});
+
+vi.mock("@app/lib/api/viz/publish_frame", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@app/lib/api/viz/publish_frame")>();
+  return { ...actual, publishFrame: vi.fn() };
+});
+
+vi.mock("@app/lib/lock", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/lock")>();
+  return {
+    ...actual,
+    executeWithLock: async (
+      _lockName: string,
+      callback: () => Promise<unknown>
+    ) => callback(),
+  };
+});
+
+const MANIFEST = {
+  version: 1,
+  name: "Task List",
+  description: "Tasks.",
+  frames: [{ path: "TaskList.tsx" }],
+  functions: [
+    {
+      name: "add-task",
+      path: "src/add.ts",
+      description: "Add.",
+      executionMode: "fast",
+      defaultStake: "low",
+    },
+  ],
+  databases: [{ name: "tasks", path: "databases/tasks.db.ts" }],
+};
+
+/** Seeds the pod listing with an app folder's files and its manifest content. */
+function seedAppFolder({
+  folder,
+  relPaths,
+  manifest,
+  extraRootFolders = [],
+}: {
+  folder: string;
+  relPaths: string[];
+  manifest: unknown;
+  extraRootFolders?: { folder: string; relPaths: string[] }[];
+}) {
+  const all = [{ folder, relPaths }, ...extraRootFolders];
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    all.flatMap(({ folder: f, relPaths: rps }) =>
+      rps.map((relPath) => ({
+        name: `${prefix}${f}/${relPath}`,
+        metadata: {
+          contentType: relPath.endsWith(".tsx")
+            ? "application/vnd.dust.frame"
+            : "text/plain",
+          size: "10",
+        },
+      }))
+    )
+  );
+  fileStorageMock.setFileContent((filePath) =>
+    filePath.endsWith(`${folder}/manifest.json`)
+      ? JSON.stringify(manifest)
+      : null
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fileStorageMock.reset();
+  fileStorageMock.setFetchFileContentNotFound(() => true);
+  vi.mocked(buildSandboxFunctionOnSandbox).mockResolvedValue(
+    new Ok({
+      bundleCode: "export default {};",
+      userIdentity: "optional",
+      inputSchema: { type: "object" },
+      outputSchema: { type: "object" },
+    })
+  );
+  vi.mocked(reconcileDatabaseFromPodPath).mockResolvedValue(
+    new Ok({ database: "tasklist__tasks", created: true, statements: [] })
+  );
+  vi.mocked(publishFrame).mockResolvedValue(new Ok({ warnings: [] }));
+});
+
+describe("publishAppHandler", () => {
+  it("publishes the app and reports the summary", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["manifest.json", "src/add.ts", "databases/tasks.db.ts"],
+      manifest: { ...MANIFEST, frames: [] },
+    });
+
+    const result = await publishAppHandler(
+      { folder: "TaskList" },
+      makeExtra(auth, conversation)
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const [block] = result.value;
+    if (block?.type !== "text") {
+      throw new Error("Expected a text block.");
+    }
+    expect(block.text).toContain('Published app "TaskList" (prefix: tasklist)');
+    expect(block.text).toContain("tasklist__add-task");
+    expect(block.text).toContain("tasklist__tasks");
+  });
+
+  it("publishes a manifest-declared frame that has a real FileResource", async () => {
+    const { auth, conversation, projectId } = await setupProjectConversation();
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: [
+        "manifest.json",
+        "TaskList.tsx",
+        "src/add.ts",
+        "databases/tasks.db.ts",
+      ],
+      manifest: MANIFEST,
+    });
+    const workspaceId = auth.getNonNullableWorkspace().sId;
+    await FileFactory.create(auth, auth.user(), {
+      contentType: "application/vnd.dust.frame",
+      fileName: "TaskList.tsx",
+      fileSize: 10,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: projectId },
+      mountFilePath: `w/${workspaceId}/pods/${projectId}/files/TaskList/TaskList.tsx`,
+    });
+
+    const result = await publishAppHandler(
+      { folder: "TaskList" },
+      makeExtra(auth, conversation)
+    );
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+    const [block] = result.value;
+    if (block?.type !== "text") {
+      throw new Error("Expected a text block.");
+    }
+    expect(block.text).toContain("Frames published: TaskList.tsx");
+  });
+
+  it("tells the model to write a manifest when the folder has none", async () => {
+    const { auth, conversation } = await setupProjectConversation();
+    seedAppFolder({
+      folder: "TaskList",
+      relPaths: ["src/add.ts"],
+      manifest: MANIFEST,
+    });
+
+    const result = await publishAppHandler(
+      { folder: "TaskList" },
+      makeExtra(auth, conversation)
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("manifest.json");
+    }
+  });
+
+  it("declares a folder-only schema", () => {
+    const metadata = SANDBOX_FUNCTIONS_TOOLS_METADATA.find(
+      (tool) => tool.name === "publish_app"
+    );
+    expect(metadata).toBeDefined();
+    expect(metadata?.schema.folder.safeParse("TaskList").success).toBe(true);
+    expect(metadata?.schema.folder.safeParse("").success).toBe(false);
+  });
+});

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.test.ts
@@ -72,31 +72,6 @@ beforeEach(() => {
 
 describe("publishAppHandler", () => {
   it("publishes the app and reports the summary", async () => {
-    const { auth, conversation } = await setupProjectConversation();
-    seedAppFolder({
-      folder: "TaskList",
-      relPaths: ["manifest.json", "src/add.ts", "databases/tasks.db.ts"],
-      manifest: { ...MANIFEST, frames: [] },
-    });
-
-    const result = await publishAppHandler(
-      { folder: "TaskList" },
-      makeExtra(auth, conversation)
-    );
-
-    if (result.isErr()) {
-      throw result.error;
-    }
-    const [block] = result.value;
-    if (block?.type !== "text") {
-      throw new Error("Expected a text block.");
-    }
-    expect(block.text).toContain('Published app "TaskList" (prefix: tasklist)');
-    expect(block.text).toContain("tasklist__add-task");
-    expect(block.text).toContain("tasklist__tasks");
-  });
-
-  it("publishes a manifest-declared frame that has a real FileResource", async () => {
     const { auth, conversation, projectId } = await setupProjectConversation();
     seedAppFolder({
       folder: "TaskList",
@@ -108,6 +83,9 @@ describe("publishAppHandler", () => {
       ],
       manifest: MANIFEST,
     });
+    // Pre-register the frame's FileResource so publishAppHandler doesn't have to auto-create it
+    // through the real (unmocked here) createPodFrameFile, which times out under the GCS storage
+    // mock — see the dedicated auto-create coverage in publish_app.test.ts.
     const workspaceId = auth.getNonNullableWorkspace().sId;
     await FileFactory.create(auth, auth.user(), {
       contentType: "application/vnd.dust.frame",
@@ -131,7 +109,10 @@ describe("publishAppHandler", () => {
     if (block?.type !== "text") {
       throw new Error("Expected a text block.");
     }
-    expect(block.text).toContain("Frames published: TaskList.tsx");
+    expect(block.text).toContain('Published app "TaskList" (prefix: tasklist)');
+    expect(block.text).toContain("tasklist__add-task");
+    expect(block.text).toContain("tasklist__tasks");
+    expect(block.text).toContain("Frame published: TaskList.tsx");
   });
 
   it("tells the model to write a manifest when the folder has none", async () => {

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.test.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.test.ts
@@ -9,6 +9,10 @@ import {
 } from "@app/tests/utils/conversation_test_factories";
 import { FileFactory } from "@app/tests/utils/FileFactory";
 import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import {
+  MANIFEST,
+  seedAppFolder,
+} from "@app/tests/utils/pod_app_publish_test_helpers";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -47,56 +51,6 @@ vi.mock("@app/lib/lock", async (importOriginal) => {
     ) => callback(),
   };
 });
-
-const MANIFEST = {
-  version: 1,
-  name: "Task List",
-  description: "Tasks.",
-  frames: [{ path: "TaskList.tsx" }],
-  functions: [
-    {
-      name: "add-task",
-      path: "src/add.ts",
-      description: "Add.",
-      executionMode: "fast",
-      defaultStake: "low",
-    },
-  ],
-  databases: [{ name: "tasks", path: "databases/tasks.db.ts" }],
-};
-
-/** Seeds the pod listing with an app folder's files and its manifest content. */
-function seedAppFolder({
-  folder,
-  relPaths,
-  manifest,
-  extraRootFolders = [],
-}: {
-  folder: string;
-  relPaths: string[];
-  manifest: unknown;
-  extraRootFolders?: { folder: string; relPaths: string[] }[];
-}) {
-  const all = [{ folder, relPaths }, ...extraRootFolders];
-  fileStorageMock.setFilesByPrefix((prefix) =>
-    all.flatMap(({ folder: f, relPaths: rps }) =>
-      rps.map((relPath) => ({
-        name: `${prefix}${f}/${relPath}`,
-        metadata: {
-          contentType: relPath.endsWith(".tsx")
-            ? "application/vnd.dust.frame"
-            : "text/plain",
-          size: "10",
-        },
-      }))
-    )
-  );
-  fileStorageMock.setFileContent((filePath) =>
-    filePath.endsWith(`${folder}/manifest.json`)
-      ? JSON.stringify(manifest)
-      : null
-  );
-}
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.ts
@@ -1,0 +1,78 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolHandlerExtra,
+  ToolHandlerResult,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getWritablePodContext } from "@app/lib/api/actions/servers/pod_manager/helpers";
+import type { PodAppPublishError } from "@app/lib/api/projects/publish_app";
+import { publishPodApp } from "@app/lib/api/projects/publish_app";
+import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export async function publishAppHandler(
+  { folder }: { folder: string },
+  { auth, runContext }: ToolHandlerExtra
+): Promise<ToolHandlerResult> {
+  const podResult = await getWritablePodContext(auth, {
+    toolContext: { runContext },
+  });
+  if (podResult.isErr()) {
+    return new Err(podResult.error);
+  }
+
+  const result = await publishPodApp(auth, podResult.value.pod, {
+    folderName: folder,
+  });
+  if (result.isErr()) {
+    return new Err(toMCPError(result.error));
+  }
+
+  const summary = result.value;
+  const lines = [
+    `Published app "${summary.name}" (prefix: ${summary.prefix}).`,
+  ];
+  if (summary.reconciledDatabaseNames.length > 0) {
+    lines.push(
+      `Databases reconciled: ${summary.reconciledDatabaseNames.join(", ")}.`
+    );
+  }
+  if (summary.publishedFunctionSlugs.length > 0) {
+    lines.push(
+      `Functions published: ${summary.publishedFunctionSlugs.join(", ")}.`
+    );
+  }
+  if (summary.publishedFrameNames.length > 0) {
+    lines.push(`Frames published: ${summary.publishedFrameNames.join(", ")}.`);
+  }
+  if (summary.unpublishedFunctionSlugs.length > 0) {
+    lines.push(
+      "Functions unpublished (no longer in the manifest): " +
+        `${summary.unpublishedFunctionSlugs.join(", ")}.`
+    );
+  }
+  if (summary.warnings.length > 0) {
+    lines.push(
+      `Warnings:\n${summary.warnings.map((warning) => `- ${warning}`).join("\n")}`
+    );
+  }
+
+  return new Ok([{ type: "text", text: lines.join("\n") }]);
+}
+
+function toMCPError(error: PodAppPublishError): MCPError {
+  switch (error.code) {
+    // The model controls the folder and the manifest, so surface the detail to let it fix.
+    case "not_a_pod":
+    case "invalid_name":
+    case "folder_not_found":
+    case "manifest_not_found":
+    case "invalid_manifest":
+    case "colliding_folders":
+      return new MCPError(error.message, { tracked: false });
+    case "sandbox_unavailable":
+    case "internal":
+      return new MCPError(error.message);
+    default:
+      return assertNever(error.code);
+  }
+}

--- a/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.ts
+++ b/front/lib/api/actions/servers/sandbox_functions/tools/publish_app.ts
@@ -41,8 +41,8 @@ export async function publishAppHandler(
       `Functions published: ${summary.publishedFunctionSlugs.join(", ")}.`
     );
   }
-  if (summary.publishedFrameNames.length > 0) {
-    lines.push(`Frames published: ${summary.publishedFrameNames.join(", ")}.`);
+  if (summary.publishedFrameName !== null) {
+    lines.push(`Frame published: ${summary.publishedFrameName}.`);
   }
   if (summary.unpublishedFunctionSlugs.length > 0) {
     lines.push(


### PR DESCRIPTION
Third PR of the manifest-publish stack. Exposes publishPodApp as a publish_app tool on the sandbox_functions server: single folder argument, pod resolved from the conversation context like every other publish tool. Individual publish/db_reconcile/publish_interactive_content_file tools are untouched and remain the granular path.