### PR TITLE
[pods] Manifest-aware app listing

### DIFF
--- a/front/components/pod/apps/PodAppTile.tsx
+++ b/front/components/pod/apps/PodAppTile.tsx
@@ -5,13 +5,16 @@ import {
 } from "@app/components/resources/resources_icons";
 import type { PodApp, PodAppFrame } from "@app/types/api/pod_apps";
 import {
+  AlertCircle,
   Card,
   CardActionButton,
   Chip,
   Download01,
   Edit04,
   GitBranch01,
+  Icon,
   Spinner,
+  Tooltip,
   Trash01,
 } from "@dust-tt/sparkle";
 import { useCallback, useState } from "react";
@@ -139,7 +142,7 @@ export function PodAppTile({
         <div className="flex min-w-0 flex-col gap-1">
           <div className="flex min-w-0 items-center gap-2">
             <span className="truncate heading-base text-foreground dark:text-foreground-night">
-              {app.name}
+              {app.displayName ?? app.name}
             </span>
             {isDraft && !isDeleting && (
               <Chip
@@ -149,7 +152,23 @@ export function PodAppTile({
                 className="shrink-0"
               />
             )}
+            {app.manifestError && (
+              <Tooltip
+                label={app.manifestError}
+                tooltipTriggerAsChild
+                trigger={
+                  <span className="flex shrink-0 items-center text-warning">
+                    <Icon visual={AlertCircle} size="xs" />
+                  </span>
+                }
+              />
+            )}
           </div>
+          {app.description && (
+            <span className="line-clamp-2 copy-sm text-muted-foreground dark:text-muted-foreground-night">
+              {app.description}
+            </span>
+          )}
           {isDeleting && (
             <span className="copy-xs text-muted-foreground dark:text-muted-foreground-night">
               Deleting…

--- a/front/lib/api/projects/apps.test.ts
+++ b/front/lib/api/projects/apps.test.ts
@@ -130,4 +130,72 @@ describe("listPodApps with manifests", () => {
     expect(result.value[0].displayName).toBeNull();
     expect(result.value[0].manifestError).toBeNull();
   });
+
+  it("lists a manifest-declared frame nested in a subfolder", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    assert(pod);
+    const manifest = { ...MANIFEST, frames: [{ path: "ui/Dashboard.tsx" }] };
+    // The entry's storage content type is "text/plain", not a Frame MIME type, to prove that a
+    // manifest-declared frame is listed regardless of the storage object's guessed content type.
+    fileStorageMock.setFilesByPrefix((prefix) => [
+      {
+        name: `${prefix}Dash/manifest.json`,
+        metadata: { contentType: "text/plain", size: "10" },
+      },
+      {
+        name: `${prefix}Dash/ui/Dashboard.tsx`,
+        metadata: { contentType: "text/plain", size: "10" },
+      },
+      {
+        name: `${prefix}Dash/src/add.ts`,
+        metadata: { contentType: "text/plain", size: "10" },
+      },
+    ]);
+    fileStorageMock.setFileContent((filePath) =>
+      filePath.endsWith("Dash/manifest.json") ? JSON.stringify(manifest) : null
+    );
+
+    const result = await listPodApps(auth, pod);
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value).toHaveLength(1);
+    const frame = result.value[0].frames.find((f) =>
+      f.path.endsWith("ui/Dashboard.tsx")
+    );
+    expect(frame).toBeDefined();
+    expect(frame?.fileName).toBe("Dashboard.tsx");
+  });
+
+  it("still lists a top-level frame the manifest does not declare (union semantics)", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    assert(pod);
+    const manifest = { ...MANIFEST, frames: [] };
+    fileStorageMock.setFilesByPrefix((prefix) => [
+      {
+        name: `${prefix}Board/manifest.json`,
+        metadata: { contentType: "text/plain", size: "10" },
+      },
+      {
+        name: `${prefix}Board/Board.tsx`,
+        metadata: { contentType: "application/vnd.dust.frame", size: "10" },
+      },
+      {
+        name: `${prefix}Board/src/add.ts`,
+        metadata: { contentType: "text/plain", size: "10" },
+      },
+    ]);
+    fileStorageMock.setFileContent((filePath) =>
+      filePath.endsWith("Board/manifest.json") ? JSON.stringify(manifest) : null
+    );
+
+    const result = await listPodApps(auth, pod);
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].frames.map((f) => f.fileName)).toContain(
+      "Board.tsx"
+    );
+  });
 });

--- a/front/lib/api/projects/apps.test.ts
+++ b/front/lib/api/projects/apps.test.ts
@@ -1,0 +1,114 @@
+import { listPodApps } from "@app/lib/api/projects/apps";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { setupProjectConversation } from "@app/tests/utils/conversation_test_factories";
+import { fileStorageMock } from "@app/tests/utils/mocks/file_storage";
+import assert from "assert";
+import { beforeEach, describe, expect, it } from "vitest";
+
+const MANIFEST = {
+  version: 1,
+  name: "Task List",
+  description: "Track and manage team tasks.",
+  functions: [
+    {
+      name: "add-task",
+      path: "src/add.ts",
+      description: "Add.",
+      executionMode: "fast",
+    },
+  ],
+};
+
+function seedFolders(
+  folders: { folder: string; relPaths: string[] }[],
+  manifestByFolder: Record<string, unknown>
+) {
+  fileStorageMock.setFilesByPrefix((prefix) =>
+    folders.flatMap(({ folder, relPaths }) =>
+      relPaths.map((relPath) => ({
+        name: `${prefix}${folder}/${relPath}`,
+        metadata: { contentType: "text/plain", size: "10" },
+      }))
+    )
+  );
+  fileStorageMock.setFileContent((filePath) => {
+    for (const [folder, manifest] of Object.entries(manifestByFolder)) {
+      if (filePath.endsWith(`${folder}/manifest.json`)) {
+        return JSON.stringify(manifest);
+      }
+    }
+    return null;
+  });
+}
+
+beforeEach(() => {
+  fileStorageMock.reset();
+  fileStorageMock.setFetchFileContentNotFound(() => true);
+});
+
+describe("listPodApps with manifests", () => {
+  it("lists a folder holding only a manifest and sources as an app, with its metadata", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    assert(pod);
+    // No functions/ or databases/ subfolder, no frame: only the manifest makes this an app.
+    seedFolders(
+      [{ folder: "TaskList", relPaths: ["manifest.json", "src/add.ts"] }],
+      { TaskList: MANIFEST }
+    );
+
+    const result = await listPodApps(auth, pod);
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0]).toMatchObject({
+      prefix: "tasklist",
+      name: "TaskList",
+      displayName: "Task List",
+      description: "Track and manage team tasks.",
+      manifestError: null,
+    });
+  });
+
+  it("keeps listing a folder whose manifest is malformed, with a manifestError", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    assert(pod);
+    seedFolders(
+      [
+        {
+          folder: "Broken",
+          relPaths: ["manifest.json", "functions/x.ts"],
+        },
+      ],
+      { Broken: { version: 99 } }
+    );
+
+    const result = await listPodApps(auth, pod);
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].displayName).toBeNull();
+    expect(result.value[0].manifestError).not.toBeNull();
+  });
+
+  it("leaves manifest-less folders on the legacy heuristic", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    assert(pod);
+    seedFolders(
+      [
+        { folder: "Legacy", relPaths: ["functions/greet.ts"] },
+        { folder: "NotAnApp", relPaths: ["notes.txt"] },
+      ],
+      {}
+    );
+
+    const result = await listPodApps(auth, pod);
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value.map((app) => app.prefix)).toEqual(["legacy"]);
+    expect(result.value[0].displayName).toBeNull();
+    expect(result.value[0].manifestError).toBeNull();
+  });
+});

--- a/front/lib/api/projects/apps.test.ts
+++ b/front/lib/api/projects/apps.test.ts
@@ -135,7 +135,7 @@ describe("listPodApps with manifests", () => {
     const { auth, projectId } = await setupProjectConversation();
     const pod = await SpaceResource.fetchById(auth, projectId);
     assert(pod);
-    const manifest = { ...MANIFEST, frames: [{ path: "ui/Dashboard.tsx" }] };
+    const manifest = { ...MANIFEST, uiEntryPoint: "ui/Dashboard.tsx" };
     // The entry's storage content type is "text/plain", not a Frame MIME type, to prove that a
     // manifest-declared frame is listed regardless of the storage object's guessed content type.
     fileStorageMock.setFilesByPrefix((prefix) => [
@@ -171,7 +171,7 @@ describe("listPodApps with manifests", () => {
     const { auth, projectId } = await setupProjectConversation();
     const pod = await SpaceResource.fetchById(auth, projectId);
     assert(pod);
-    const manifest = { ...MANIFEST, frames: [] };
+    const manifest = { ...MANIFEST };
     fileStorageMock.setFilesByPrefix((prefix) => [
       {
         name: `${prefix}Board/manifest.json`,
@@ -196,6 +196,42 @@ describe("listPodApps with manifests", () => {
     expect(result.value).toHaveLength(1);
     expect(result.value[0].frames.map((f) => f.fileName)).toContain(
       "Board.tsx"
+    );
+  });
+
+  it("lists the defaulted index.tsx entry point when uiEntryPoint is omitted", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    assert(pod);
+    // No uiEntryPoint declared, but an index.tsx sits at the folder root: it resolves to the
+    // default entry point and must be listed, even though its storage MIME type is not a Frame's
+    // (the manifest-declared path is authoritative, same as an explicit uiEntryPoint).
+    fileStorageMock.setFilesByPrefix((prefix) => [
+      {
+        name: `${prefix}Dashboard/manifest.json`,
+        metadata: { contentType: "text/plain", size: "10" },
+      },
+      {
+        name: `${prefix}Dashboard/index.tsx`,
+        metadata: { contentType: "text/plain", size: "10" },
+      },
+      {
+        name: `${prefix}Dashboard/src/add.ts`,
+        metadata: { contentType: "text/plain", size: "10" },
+      },
+    ]);
+    fileStorageMock.setFileContent((filePath) =>
+      filePath.endsWith("Dashboard/manifest.json")
+        ? JSON.stringify(MANIFEST)
+        : null
+    );
+
+    const result = await listPodApps(auth, pod);
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].frames.map((f) => f.fileName)).toContain(
+      "index.tsx"
     );
   });
 });

--- a/front/lib/api/projects/apps.test.ts
+++ b/front/lib/api/projects/apps.test.ts
@@ -92,6 +92,25 @@ describe("listPodApps with manifests", () => {
     expect(result.value[0].manifestError).not.toBeNull();
   });
 
+  it("lists a folder holding ONLY a malformed manifest, with a manifestError", async () => {
+    const { auth, projectId } = await setupProjectConversation();
+    const pod = await SpaceResource.fetchById(auth, projectId);
+    assert(pod);
+    // No functions/ or databases/ subfolder, no frame: the malformed manifest alone must still
+    // make this an app, via the manifestPath disjunct rather than the legacy heuristic.
+    seedFolders([{ folder: "Broken", relPaths: ["manifest.json"] }], {
+      Broken: { version: 99 },
+    });
+
+    const result = await listPodApps(auth, pod);
+
+    assert(result.isOk(), result.isErr() ? result.error.message : "");
+    expect(result.value).toHaveLength(1);
+    expect(result.value[0].prefix).toEqual("broken");
+    expect(result.value[0].displayName).toBeNull();
+    expect(result.value[0].manifestError).not.toBeNull();
+  });
+
   it("leaves manifest-less folders on the legacy heuristic", async () => {
     const { auth, projectId } = await setupProjectConversation();
     const pod = await SpaceResource.fetchById(auth, projectId);

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -28,7 +28,11 @@ import type {
   FileSystemEntry,
   FileSystemFileEntry,
 } from "@app/types/api/file_system/types";
-import { POD_APP_MANIFEST_DB_FILE_SUFFIX } from "@app/types/api/pod_app_manifest";
+import {
+  POD_APP_MANIFEST_DB_FILE_SUFFIX,
+  POD_APP_MANIFEST_FILE,
+  PodAppPublishManifestSchema,
+} from "@app/types/api/pod_app_manifest";
 import type {
   PodApp,
   PodAppCloneSummary,
@@ -44,6 +48,8 @@ import { isInteractiveContentType } from "@app/types/files";
 import { getPodStateBasePath } from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import { fromError } from "zod-validation-error";
 
 /** A litestream replica directory is named after the database file it replicates. */
 const POD_DATABASE_FILE_SUFFIX = ".db";
@@ -76,6 +82,8 @@ type AppFolder = {
   fileCount: number;
   frameEntries: FileSystemFileEntry[];
   hasAppShapedSubfolder: boolean;
+  /** Canonical path of the folder's `manifest.json`, or null when the folder has none. */
+  manifestPath: string | null;
 };
 
 /** Drop the last extension from a file name, e.g. `add-task.ts` -> `add-task`. */
@@ -122,6 +130,7 @@ function collectAppFolders(
       fileCount: 0,
       frameEntries: [],
       hasAppShapedSubfolder: false,
+      manifestPath: null,
     };
     folders.set(name, folder);
 
@@ -154,6 +163,10 @@ function collectAppFolders(
 
     const folder = folderFor(segments[0]);
     folder.fileCount += 1;
+
+    if (segments.length === 2 && segments[1] === POD_APP_MANIFEST_FILE) {
+      folder.manifestPath = entry.path;
+    }
 
     // A file inside an app subfolder implies that subfolder, whether or not GCS holds a placeholder
     // object for it.
@@ -316,6 +329,61 @@ function groupFunctionsByAppPrefix(
   return byPrefix;
 }
 
+type AppManifestReadResult =
+  | { manifest: { name: string; description: string }; error: null }
+  | { manifest: null; error: string };
+
+/**
+ * Read and validate each folder's manifest.json for listing purposes. One small GCS read per
+ * manifest-bearing folder; a pod holds few apps, so no batching. A malformed manifest never hides
+ * the folder — the error is reported on the app instead.
+ */
+async function readAppManifests(
+  dustFs: DustFileSystem,
+  folders: AppFolder[]
+): Promise<Map<string, AppManifestReadResult>> {
+  const results = new Map<string, AppManifestReadResult>();
+  for (const folder of folders) {
+    if (!folder.manifestPath) {
+      continue;
+    }
+    const bufferResult = await dustFs.readBuffer(folder.manifestPath);
+    if (bufferResult.isErr() || bufferResult.value === null) {
+      results.set(folder.name, {
+        manifest: null,
+        error: "manifest.json could not be read.",
+      });
+      continue;
+    }
+    let json: unknown;
+    try {
+      json = JSON.parse(bufferResult.value.toString("utf-8"));
+    } catch (err) {
+      results.set(folder.name, {
+        manifest: null,
+        error: `manifest.json is not valid JSON: ${normalizeError(err).message}`,
+      });
+      continue;
+    }
+    const validation = PodAppPublishManifestSchema.safeParse(json);
+    if (!validation.success) {
+      results.set(folder.name, {
+        manifest: null,
+        error: fromError(validation.error).toString(),
+      });
+      continue;
+    }
+    results.set(folder.name, {
+      manifest: {
+        name: validation.data.name,
+        description: validation.data.description,
+      },
+      error: null,
+    });
+  }
+  return results;
+}
+
 /**
  * List a Pod's apps.
  *
@@ -372,6 +440,7 @@ export async function listPodApps(
     folders,
     pinnedFramePaths
   );
+  const manifestsByFolderName = await readAppManifests(dustFs, folders);
 
   // Several folder names can normalize onto one prefix (`Task List` and `Task-List` both give
   // `task-list`), and such folders genuinely share published slugs and databases. Group by prefix so
@@ -407,6 +476,7 @@ export async function listPodApps(
     );
 
     const isApp =
+      prefixFolders.some((folder) => folder.manifestPath !== null) ||
       prefixFolders.some((folder) => folder.hasAppShapedSubfolder) ||
       frames.length > 0 ||
       functions.length > 0 ||
@@ -416,10 +486,16 @@ export async function listPodApps(
     }
 
     const [primaryFolder] = prefixFolders;
+    const manifestRead = primaryFolder
+      ? manifestsByFolderName.get(primaryFolder.name)
+      : undefined;
     apps.push({
       prefix,
       // With no folder left, the prefix is the only name the app still has.
       name: primaryFolder?.name ?? prefix,
+      displayName: manifestRead?.manifest?.name ?? null,
+      description: manifestRead?.manifest?.description ?? null,
+      manifestError: manifestRead?.error ?? null,
       folderPath: primaryFolder?.path ?? null,
       frames,
       functions,

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -29,6 +29,7 @@ import type {
   FileSystemFileEntry,
 } from "@app/types/api/file_system/types";
 import {
+  POD_APP_DEFAULT_UI_ENTRY_POINT,
   POD_APP_MANIFEST_DB_FILE_SUFFIX,
   POD_APP_MANIFEST_FILE,
   parsePodAppManifest,
@@ -175,8 +176,8 @@ function collectAppFolders(
     // Positional heuristic, applied to every folder: a Frame at the top of the app folder is taken
     // to be the app's own Frame, while anything deeper is assumed to be a detail of how the app is
     // laid out (e.g. an imported .tsx helper module). For manifest-less folders this is the only
-    // signal; for manifest-bearing folders it is the base case that manifest-declared frames (which
-    // may live at any depth) are UNIONED with later, from the manifest read (see
+    // signal; for manifest-bearing folders it is the base case that the manifest's declared UI
+    // entry point (which may live at any depth) is UNIONED with later, from the manifest read (see
     // `withDeclaredFrameEntries`).
     if (segments.length === 2 && isInteractiveContentType(entry.contentType)) {
       folder.frameEntries.push(entry);
@@ -336,8 +337,13 @@ type AppManifestReadResult =
       manifest: {
         name: string;
         description: string;
-        /** Folder-relative paths the manifest declares as frames, at any depth. */
-        framePaths: string[];
+        /**
+         * Folder-relative path to the app's UI entry point, resolved from the manifest: the
+         * explicit `uiEntryPoint`, or `POD_APP_DEFAULT_UI_ENTRY_POINT` when omitted. Listing is
+         * tolerant of this file not existing — unlike publish, that is not an error here, it just
+         * means `withDeclaredFrameEntries` has nothing to add for this folder.
+         */
+        entryPointPath: string;
       };
       error: null;
     }
@@ -374,7 +380,8 @@ async function readAppManifests(
       manifest: {
         name: parseResult.value.name,
         description: parseResult.value.description,
-        framePaths: parseResult.value.frames.map((frame) => frame.path),
+        entryPointPath:
+          parseResult.value.uiEntryPoint ?? POD_APP_DEFAULT_UI_ENTRY_POINT,
       },
       error: null,
     });
@@ -383,11 +390,12 @@ async function readAppManifests(
 }
 
 /**
- * Augment each valid-manifest folder's Frame entries with the file entries matching its
- * manifest's declared frame paths, at any depth. The manifest declaration is authoritative
- * regardless of the entry's storage content type (see `publishPodApp`'s auto-create path for why
- * that MIME type is untrusted). Entries already present (matched by path — the legacy top-level
- * heuristic can find the same file) are not duplicated.
+ * Augment each valid-manifest folder's Frame entries with the file entry matching its manifest's
+ * resolved UI entry point (at any depth). The manifest declaration is authoritative regardless of
+ * the entry's storage content type (see `publishPodApp`'s auto-create path for why that MIME type
+ * is untrusted). An entry already present (matched by path — the legacy top-level heuristic can
+ * find the same file) is not duplicated. A defaulted entry point that has no matching file is
+ * normal here — listing reflects reality; only publish enforces that every app has a frame.
  *
  * Returns a new array rather than mutating `folders`, whose `frameEntries` are otherwise only
  * ever appended to inside `collectAppFolders`.
@@ -406,19 +414,16 @@ function withDeclaredFrameEntries(
     const existingPaths = new Set(
       folder.frameEntries.map((entry) => entry.path)
     );
-    const declaredEntries = manifestRead.manifest.framePaths.flatMap(
-      (framePath) => {
-        const entry = fileEntryByPath.get(`${folder.path}/${framePath}`);
-        return entry && !existingPaths.has(entry.path) ? [entry] : [];
-      }
+    const entry = fileEntryByPath.get(
+      `${folder.path}/${manifestRead.manifest.entryPointPath}`
     );
-    if (declaredEntries.length === 0) {
+    if (!entry || existingPaths.has(entry.path)) {
       return folder;
     }
 
     return {
       ...folder,
-      frameEntries: [...folder.frameEntries, ...declaredEntries],
+      frameEntries: [...folder.frameEntries, entry],
     };
   });
 }

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -172,8 +172,12 @@ function collectAppFolders(
       folder.hasAppShapedSubfolder = true;
     }
 
-    // Only a Frame at the top of the app folder is the app's own Frame; anything deeper is a detail
-    // of how the app is laid out.
+    // Positional heuristic, applied to every folder: a Frame at the top of the app folder is taken
+    // to be the app's own Frame, while anything deeper is assumed to be a detail of how the app is
+    // laid out (e.g. an imported .tsx helper module). For manifest-less folders this is the only
+    // signal; for manifest-bearing folders it is the base case that manifest-declared frames (which
+    // may live at any depth) are UNIONED with later, from the manifest read (see
+    // `withDeclaredFrameEntries`).
     if (segments.length === 2 && isInteractiveContentType(entry.contentType)) {
       folder.frameEntries.push(entry);
     }
@@ -328,7 +332,15 @@ function groupFunctionsByAppPrefix(
 }
 
 type AppManifestReadResult =
-  | { manifest: { name: string; description: string }; error: null }
+  | {
+      manifest: {
+        name: string;
+        description: string;
+        /** Folder-relative paths the manifest declares as frames, at any depth. */
+        framePaths: string[];
+      };
+      error: null;
+    }
   | { manifest: null; error: string };
 
 /**
@@ -362,11 +374,53 @@ async function readAppManifests(
       manifest: {
         name: parseResult.value.name,
         description: parseResult.value.description,
+        framePaths: parseResult.value.frames.map((frame) => frame.path),
       },
       error: null,
     });
   }
   return results;
+}
+
+/**
+ * Augment each valid-manifest folder's Frame entries with the file entries matching its
+ * manifest's declared frame paths, at any depth. The manifest declaration is authoritative
+ * regardless of the entry's storage content type (see `publishPodApp`'s auto-create path for why
+ * that MIME type is untrusted). Entries already present (matched by path — the legacy top-level
+ * heuristic can find the same file) are not duplicated.
+ *
+ * Returns a new array rather than mutating `folders`, whose `frameEntries` are otherwise only
+ * ever appended to inside `collectAppFolders`.
+ */
+function withDeclaredFrameEntries(
+  folders: AppFolder[],
+  manifestsByFolderName: Map<string, AppManifestReadResult>,
+  fileEntryByPath: Map<string, FileSystemFileEntry>
+): AppFolder[] {
+  return folders.map((folder) => {
+    const manifestRead = manifestsByFolderName.get(folder.name);
+    if (!manifestRead?.manifest) {
+      return folder;
+    }
+
+    const existingPaths = new Set(
+      folder.frameEntries.map((entry) => entry.path)
+    );
+    const declaredEntries = manifestRead.manifest.framePaths.flatMap(
+      (framePath) => {
+        const entry = fileEntryByPath.get(`${folder.path}/${framePath}`);
+        return entry && !existingPaths.has(entry.path) ? [entry] : [];
+      }
+    );
+    if (declaredEntries.length === 0) {
+      return folder;
+    }
+
+    return {
+      ...folder,
+      frameEntries: [...folder.frameEntries, ...declaredEntries],
+    };
+  });
 }
 
 /**
@@ -419,10 +473,27 @@ export async function listPodApps(
   const folders = Array.from(
     collectAppFolders(listResult.value, podRoot).values()
   );
-  const [framesByFolderName, manifestsByFolderName] = await Promise.all([
-    resolveFramesByFolderName(auth, dustFs, folders, pinnedFramePaths),
-    readAppManifests(dustFs, folders),
-  ]);
+
+  // Sequential, not Promise.all: frame resolution depends on the manifest read below, since a
+  // manifest's declared frame paths augment each folder's frameEntries before they are resolved
+  // to FileResources.
+  const manifestsByFolderName = await readAppManifests(dustFs, folders);
+  const fileEntryByPath = new Map(
+    listResult.value.flatMap((entry) =>
+      entry.isDirectory ? [] : [[entry.path, entry] as const]
+    )
+  );
+  const foldersWithDeclaredFrames = withDeclaredFrameEntries(
+    folders,
+    manifestsByFolderName,
+    fileEntryByPath
+  );
+  const framesByFolderName = await resolveFramesByFolderName(
+    auth,
+    dustFs,
+    foldersWithDeclaredFrames,
+    pinnedFramePaths
+  );
 
   // Several folder names can normalize onto one prefix (`Task List` and `Task-List` both give
   // `task-list`), and such folders genuinely share published slugs and databases. Group by prefix so

--- a/front/lib/api/projects/apps.ts
+++ b/front/lib/api/projects/apps.ts
@@ -31,7 +31,7 @@ import type {
 import {
   POD_APP_MANIFEST_DB_FILE_SUFFIX,
   POD_APP_MANIFEST_FILE,
-  PodAppPublishManifestSchema,
+  parsePodAppManifest,
 } from "@app/types/api/pod_app_manifest";
 import type {
   PodApp,
@@ -48,8 +48,6 @@ import { isInteractiveContentType } from "@app/types/files";
 import { getPodStateBasePath } from "@app/types/mount_path";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { fromError } from "zod-validation-error";
 
 /** A litestream replica directory is named after the database file it replicates. */
 const POD_DATABASE_FILE_SUFFIX = ".db";
@@ -355,28 +353,15 @@ async function readAppManifests(
       });
       continue;
     }
-    let json: unknown;
-    try {
-      json = JSON.parse(bufferResult.value.toString("utf-8"));
-    } catch (err) {
-      results.set(folder.name, {
-        manifest: null,
-        error: `manifest.json is not valid JSON: ${normalizeError(err).message}`,
-      });
-      continue;
-    }
-    const validation = PodAppPublishManifestSchema.safeParse(json);
-    if (!validation.success) {
-      results.set(folder.name, {
-        manifest: null,
-        error: fromError(validation.error).toString(),
-      });
+    const parseResult = parsePodAppManifest(bufferResult.value);
+    if (parseResult.isErr()) {
+      results.set(folder.name, { manifest: null, error: parseResult.error });
       continue;
     }
     results.set(folder.name, {
       manifest: {
-        name: validation.data.name,
-        description: validation.data.description,
+        name: parseResult.value.name,
+        description: parseResult.value.description,
       },
       error: null,
     });
@@ -434,13 +419,10 @@ export async function listPodApps(
   const folders = Array.from(
     collectAppFolders(listResult.value, podRoot).values()
   );
-  const framesByFolderName = await resolveFramesByFolderName(
-    auth,
-    dustFs,
-    folders,
-    pinnedFramePaths
-  );
-  const manifestsByFolderName = await readAppManifests(dustFs, folders);
+  const [framesByFolderName, manifestsByFolderName] = await Promise.all([
+    resolveFramesByFolderName(auth, dustFs, folders, pinnedFramePaths),
+    readAppManifests(dustFs, folders),
+  ]);
 
   // Several folder names can normalize onto one prefix (`Task List` and `Task-List` both give
   // `task-list`), and such folders genuinely share published slugs and databases. Group by prefix so

--- a/front/types/api/pod_apps.ts
+++ b/front/types/api/pod_apps.ts
@@ -53,6 +53,12 @@ export type PodApp = {
   prefix: string;
   /** The folder name as authored (`TaskList`), falling back to the prefix if the folder is gone. */
   name: string;
+  /** The manifest's display name, or null when the folder has no (valid) manifest. */
+  displayName: string | null;
+  /** The manifest's description, or null when the folder has no (valid) manifest. */
+  description: string | null;
+  /** Why the folder's manifest.json could not be used, or null when absent or valid. */
+  manifestError: string | null;
   /** Canonical scoped path of the app folder, or null when only published artifacts remain. */
   folderPath: string | null;
   frames: PodAppFrame[];


### PR DESCRIPTION
Fifth PR of the manifest-publish stack. A pod-root folder containing a manifest.json now lists as an app regardless of the legacy functions//databases/ heuristic, and the listing carries the manifest's display name and description (PodApp gains displayName/description/manifestError, all nullable — backward compatible). A malformed manifest never hides the app: it still lists with a manifestError the tile surfaces as a warning tooltip. The Apps tab tile shows the display name and description.