### PR TITLE
[pods] Manifest-first publishing guidance

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -26,6 +26,8 @@ import {
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
+import type { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
+import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 
 const FILES_EDIT_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
@@ -47,6 +49,12 @@ const FILES_MOVE_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
   FILES_MOVE_ACTION_NAME
 );
+function sandboxFunctionsToolName(
+  name: (typeof SANDBOX_FUNCTIONS_TOOLS_METADATA)[number]["name"]
+): string {
+  return getPrefixedToolName(SANDBOX_FUNCTIONS_SERVER_NAME, name);
+}
+const PUBLISH_APP_TOOL = sandboxFunctionsToolName("publish_app");
 
 const UPDATING_SECTION_LEGACY = `\
 ### Updating Existing Files:
@@ -161,6 +169,8 @@ ${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
 \`\`\`
 
 From then on, edit the source at its Pod path and publish it again. Anything the Frame imports relatively must live under its folder, which is the bundling root.
+
+If the app has a \`manifest.json\` declaring this Frame among its \`frames\`, \`${PUBLISH_APP_TOOL}\` publishes it there along with the app's functions and databases in one call; use \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` directly, as above, when publishing just this one Frame.
 
 #### Changing An Existing Pod Frame
 

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -167,7 +167,7 @@ ${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
 
 From then on, edit the source at its Pod path and publish it again. Anything the Frame imports relatively must live under its folder, which is the bundling root.
 
-If the app has a \`manifest.json\` declaring this Frame among its \`frames\`, \`${PUBLISH_APP_TOOL}\` publishes it there along with the app's functions and databases in one call; use \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` directly, as above, when publishing just this one Frame.
+If the app has a \`manifest.json\`, this Frame is the app's UI entry point (its \`uiEntryPoint\`, or \`index.tsx\` by default when the manifest omits it), so \`${PUBLISH_APP_TOOL}\` publishes it there along with the app's functions and databases in one call; use \`${PUBLISH_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` directly, as above, when publishing just this one Frame.
 
 #### Changing An Existing Pod Frame
 

--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -26,7 +26,6 @@ import {
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/api/actions/servers/interactive_content/metadata";
-import type { SANDBOX_FUNCTIONS_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 import { SANDBOX_FUNCTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/sandbox_functions/metadata";
 
 const FILES_EDIT_TOOL = getPrefixedToolName(
@@ -49,12 +48,10 @@ const FILES_MOVE_TOOL = getPrefixedToolName(
   FILES_SERVER_NAME,
   FILES_MOVE_ACTION_NAME
 );
-function sandboxFunctionsToolName(
-  name: (typeof SANDBOX_FUNCTIONS_TOOLS_METADATA)[number]["name"]
-): string {
-  return getPrefixedToolName(SANDBOX_FUNCTIONS_SERVER_NAME, name);
-}
-const PUBLISH_APP_TOOL = sandboxFunctionsToolName("publish_app");
+const PUBLISH_APP_TOOL = getPrefixedToolName(
+  SANDBOX_FUNCTIONS_SERVER_NAME,
+  "publish_app"
+);
 
 const UPDATING_SECTION_LEGACY = `\
 ### Updating Existing Files:

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -89,8 +89,9 @@ Pod file system rather than splitting it between the conversation and the Pod ro
 Write the \`manifest.json\` declaring the app's \`name\`, \`description\`, and the \`frames\` /
 \`functions\` / \`databases\` it publishes, each entry pointing at a folder-relative \`path\` — the
 \`functions/\` and \`databases/\` folders above are convention, not a requirement, so what matters is
-the manifest's paths, not where a source happens to sit. Publishing the app, described in full
-under "Publishing, discovering, and invoking" below, always reads this manifest.
+the manifest's paths, not where a source happens to sit. Publish the whole app in one call with
+\`${toolName("publish_app")}\`, passing just the folder name — see "Publishing, discovering, and
+invoking" below for what that call does and when to re-run it.
 
 \`\`\`json
 // MyApp/manifest.json

--- a/front/lib/resources/skill/code_defined/global/pod_functions.ts
+++ b/front/lib/resources/skill/code_defined/global/pod_functions.ts
@@ -74,8 +74,8 @@ Pod file system rather than splitting it between the conversation and the Pod ro
 \`\`\`
 /files/pod-<podId>/
   MyApp/
-    manifest.json      declares the app: name, description, frames, functions, databases
-    MyApp.tsx          the Frame's source; its directory is the Frame's bundling root
+    manifest.json      declares the app: name, description, functions, databases
+    index.tsx          the Frame's source; its directory is the Frame's bundling root
     functions/
       list-notes.ts    one file per function, named after the function; the app folder
                        above becomes the published slug's prefix (myapp__list-notes)
@@ -86,7 +86,10 @@ Pod file system rather than splitting it between the conversation and the Pod ro
       notes.db.ts      one shared drizzle schema file per database
 \`\`\`
 
-Write the \`manifest.json\` declaring the app's \`name\`, \`description\`, and the \`frames\` /
+Every app has exactly one UI entry point: \`index.tsx\` at the folder root by default, or a
+different folder-relative path set explicitly with the manifest's \`uiEntryPoint\`. A
+"functions-only" app still ships a minimal Frame at its entry point — there is no such thing as an
+app with no UI. Write the \`manifest.json\` declaring the app's \`name\`, \`description\`, and the
 \`functions\` / \`databases\` it publishes, each entry pointing at a folder-relative \`path\` — the
 \`functions/\` and \`databases/\` folders above are convention, not a requirement, so what matters is
 the manifest's paths, not where a source happens to sit. Publish the whole app in one call with
@@ -99,7 +102,6 @@ invoking" below for what that call does and when to re-run it.
   "version": 1,
   "name": "MyApp",
   "description": "A shared notes app.",
-  "frames": [{ "path": "MyApp.tsx" }],
   "functions": [
     {
       "name": "list-notes",
@@ -124,7 +126,8 @@ it publishes. If the app's Frame does not exist yet, or still sits in the conver
 skill covers creating it and moving it into the app folder with \`${FILES_MOVE_TOOL}\` before
 \`${PUBLISH_FRAME_TOOL}\`; \`${CREATE_FRAME_TOOL}\` always creates it in the conversation first.
 
-Functions that no Frame calls still get an app folder, named after what they do together.
+Functions that no Frame calls still get an app folder, named after what they do together, and
+still need a minimal Frame at \`index.tsx\` — every app has one.
 
 **Copying an app folder still needs a publish of its own.** The manifest.json, databases and
 published slugs all follow the new folder, but nothing is live until you publish the copy — see


### PR DESCRIPTION
Last PR of the manifest-publish stack. Prose only: the pod_functions skill, the interactive_content instructions and the publish/db_reconcile tool descriptions now teach writing a manifest.json and calling publish_app, with the individual tools kept as the granular path.