### PR TITLE
fix: extension scroll

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -48,18 +48,31 @@ import {
   useVirtuosoLocation,
   useVirtuosoMethods,
 } from "@virtuoso.dev/message-list";
-import type { Transition } from "framer-motion";
+import type { MotionProps, Transition } from "framer-motion";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 const MAX_DISTANCE_FOR_SMOOTH_SCROLL = 2048;
 const DOUBLE_ESC_WINDOW_MS = 300;
 
-const INPUT_BAR_SWAP_TRANSFORMS = {
-  initial: "translateY(calc(var(--spacing) * 2))",
-  idle: "translateY(calc(var(--spacing) * 0))",
-  exit: "translateY(calc(var(--spacing) * -1))",
+// Offsets in px
+const INPUT_BAR_SWAP_OFFSETS_PX = {
+  initial: 8,
+  idle: 0,
+  exit: -4,
 } as const;
+
+// Framer keeps the animated transform in the style attribute once the animation
+// settles. A transform other than `none` makes this element a containing block
+// for `position: fixed` descendants, so the input bar's fixed dropdown anchor
+// would resolve its viewport coordinates against this box instead — misplacing
+// it and adding its box to the conversation scroller's scrollable overflow
+// (which un-pins the sticky input bar). Collapse the resting identity transform
+// back to `none`.
+const collapseRestingTransform: MotionProps["transformTemplate"] = (
+  { y },
+  generated
+) => (y ? generated : "none");
 
 const INPUT_BAR_SWAP_TRANSITION = {
   duration: MOTION_DURATIONS.enter,
@@ -657,22 +670,23 @@ export const AgentInputBar = ({ context }: AgentInputBarProps) => {
             initial={
               shouldReduceMotion
                 ? false
-                : { opacity: 0, transform: INPUT_BAR_SWAP_TRANSFORMS.initial }
+                : { opacity: 0, y: INPUT_BAR_SWAP_OFFSETS_PX.initial }
             }
             animate={{
               opacity: 1,
-              transform: INPUT_BAR_SWAP_TRANSFORMS.idle,
+              y: INPUT_BAR_SWAP_OFFSETS_PX.idle,
             }}
             exit={
               shouldReduceMotion
                 ? undefined
                 : {
                     opacity: 0,
-                    transform: INPUT_BAR_SWAP_TRANSFORMS.exit,
+                    y: INPUT_BAR_SWAP_OFFSETS_PX.exit,
                     transition: INPUT_BAR_SWAP_EXIT_TRANSITION,
                   }
             }
             transition={INPUT_BAR_SWAP_TRANSITION}
+            transformTemplate={collapseRestingTransform}
             className={classNames(
               "w-full",
               effectiveIsCompact && !userAnswerRequiredItem && "min-w-0 flex-1"


### PR DESCRIPTION
## Description

Fixes the conversation input bar drifting away from the bottom of the Chrome extension panel: once the last message was reached, the message list kept scrolling into empty space and the sticky input bar was carried up and out of view.

Root cause chain:

- The extension renders an invisible `position: fixed` box inside the input bar to anchor its "+" dropdown (`DropdownAnchorTrigger`), placed with viewport coordinates read from `getBoundingClientRect()`.
- #30214 wrapped the input bar content in a framer-motion `motion.div` whose `animate` target is a raw `transform` string. Framer writes that string into the style attribute and leaves it there once the animation settles, so the element permanently carried an identity `translateY`.
- Any `transform` other than `none` makes an element a containing block for `position: fixed` descendants. The anchor's viewport coordinates were therefore resolved against the input bar wrapper instead of the window, placing it well below the bottom of the conversation scroller.
- An out-of-flow box sitting below a scroller's content box extends that scroller's scrollable overflow, so the conversation gained scroll range that the message list itself did not account for.
- The input bar is `position: sticky; bottom: 0`, and a sticky element is clamped to its parent's content box. It could not follow the scroll past that box, so it was left behind and scrolled off the top.

The fix animates `y` (a motion value) instead of a raw `transform` string, and uses `transformTemplate` to emit `transform: none` whenever `y` is at rest. The enter/exit motion is unchanged — the element simply stops holding an identity transform while idle, so the anchor goes back to resolving against the window and contributes nothing to the scroller.

Before

https://github.com/user-attachments/assets/31fe1de0-d2e2-4e8c-b81a-6a2ea11963f9

After


https://github.com/user-attachments/assets/6040d26f-c09f-4326-83ae-cc701e71a9a6




## Tests

Manually.

## Risk

Low.

## Deploy Plan

Standard deployment.
