### PR TITLE
[front] Make getProgrammaticUsageFilterClause strictly mirror isProgrammaticUsage

### DIFF
--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -100,16 +100,17 @@ export type UsageAggregations = {
 };
 
 /**
- * Query-side mirror of isProgrammaticUsage: API-key requests, messages with no
- * context origin, or a listed programmatic origin. Single source of truth for
- * splitting analytics docs into programmatic vs user.
+ * Query-side mirror of `isProgrammaticUsageFromContext`: API-key requests OR a
+ * listed programmatic origin. Kept strictly equivalent to the runtime predicate
+ * (which classifies a missing origin as `"web"` → user), so ES/analytics and the
+ * recording path (Metronome + rate-limiter) split docs identically. Single
+ * source of truth for programmatic vs user.
  */
 export function getProgrammaticUsageFilterClause(): estypes.QueryDslQueryContainer {
   return {
     bool: {
       should: [
         { term: { auth_method: "api_key" } },
-        { bool: { must_not: { exists: { field: "context_origin" } } } },
         { terms: { context_origin: PROGRAMMATIC_USAGE_ORIGINS } },
       ],
       minimum_should_match: 1,


### PR DESCRIPTION
## Description

The ES clause had an extra `must_not exists context_origin` should-clause that
classified messages with no context origin as programmatic. The runtime
predicate isProgrammaticUsageFromContext has no such rule (a missing origin is
coerced to "web" → user), so ES/analytics drifted from the recording path
(Metronome + rate-limiter) which use isProgrammaticUsage. Drop the clause so
both are strictly equivalent: programmatic iff auth_method=api_key OR a
programmatic context_origin.

Note: this relies on the analytics doc's auth_method being populated for API
calls (it is, and the api_key should-clause already depends on it); the removed
clause was a defensive heuristic for docs lacking it.

## Tests

## Risk

low, update only ES Query

## Deploy plan 

front deploy