### PR TITLE
Fix Poke feature flag search

### DIFF
--- a/front/components/poke/plugins/EnumSelect.test.tsx
+++ b/front/components/poke/plugins/EnumSelect.test.tsx
@@ -1,0 +1,75 @@
+import { EnumSelect } from "@app/components/poke/plugins/EnumSelect";
+import {
+  PokeForm,
+  PokeFormField,
+  PokeFormItem,
+} from "@app/components/poke/shadcn/ui/form";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+Element.prototype.scrollIntoView = vi.fn();
+
+const OPTIONS = [
+  {
+    label: "[On demand] models_picker",
+    value: "models_picker",
+  },
+  {
+    label: "[Dust only] xai_feature",
+    value: "xai_feature",
+  },
+] as const;
+
+function TestEnumSelect() {
+  const form = useForm({
+    defaultValues: { features: [] as string[] },
+  });
+
+  return (
+    <PokeForm {...form}>
+      <PokeFormField
+        control={form.control}
+        name="features"
+        render={({ field }) => (
+          <PokeFormItem>
+            <EnumSelect
+              label="Feature Flags"
+              multiple
+              onValuesChange={field.onChange}
+              options={OPTIONS}
+              values={field.value}
+            />
+          </PokeFormItem>
+        )}
+      />
+    </PokeForm>
+  );
+}
+
+describe("EnumSelect", () => {
+  it("filters feature flags using space-separated terms", async () => {
+    const user = userEvent.setup();
+    render(<TestEnumSelect />);
+
+    await user.click(screen.getByRole("combobox"));
+    await user.type(
+      screen.getByPlaceholderText("Feature Flags"),
+      "models picker"
+    );
+
+    expect(screen.getByText("[On demand] models_picker")).toBeVisible();
+    expect(
+      screen.queryByText("[Dust only] xai_feature")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -98,6 +98,7 @@ export function EnumSelect({
                 return (
                   <PokeCommandItem
                     value={option.label}
+                    keywords={[option.value.replaceAll("_", " ")]}
                     key={option.value}
                     onSelect={() => {
                       onValuesChange([option.value]);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Current search of FF in poke is really bad, you get plenty of noise despite exact match. The search is currently handed over to `cmkd` which runs a very permissive search. This PR fixes it by indexing human-readable versions of flag names. Searches containing spaces, such as “models picker,” now correctly match underscore-separated values like `models_picker`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
