### PR TITLE
[front] Store microCredits in fixed-window spend-cap counters

### DIFF
--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -4,7 +4,7 @@ import { GrantFreeCreditsButton } from "@app/components/poke/credits/GrantFreeCr
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
-import { formatCredits } from "@app/lib/client/credits";
+import { formatCredits, formatCreditsPrecise } from "@app/lib/client/credits";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getMetronomeAlertUrl } from "@app/lib/metronome/urls";
 import { usePokeMembersUsage } from "@app/poke/swr/credits";
@@ -237,17 +237,17 @@ function makeColumns({
         } = row.original;
         return (
           <div className="flex flex-col text-xs">
-            <span>ES {formatCredits(consumedAwuCredits)}</span>
+            <span>ES {formatCreditsPrecise(consumedAwuCredits)}</span>
             <span className="text-muted-foreground">
               RL{" "}
               {rateLimiterSpendAwuCredits !== null
-                ? formatCredits(rateLimiterSpendAwuCredits)
+                ? formatCreditsPrecise(rateLimiterSpendAwuCredits)
                 : "-"}
             </span>
             <span className="text-muted-foreground">
               MT{" "}
               {metronomeConsumedAwuCredits !== null
-                ? formatCredits(metronomeConsumedAwuCredits)
+                ? formatCreditsPrecise(metronomeConsumedAwuCredits)
                 : "-"}
             </span>
           </div>

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -10,7 +10,7 @@ import type {
   PokeProgrammaticAlerts,
   PokeStripeSubscriptionWire,
 } from "@app/lib/api/poke/workspace_info";
-import { formatCredits } from "@app/lib/client/credits";
+import { formatCredits, formatCreditsPrecise } from "@app/lib/client/credits";
 import type { DefaultMetronomeAlerts } from "@app/lib/metronome/alerts/default_alerts";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { usePokeAwuPoolSummary } from "@app/poke/swr/credits";
@@ -54,7 +54,7 @@ interface SpendCountersInlineProps {
 }
 
 const formatCreditsOrDash = (value: number | null): string =>
-  value !== null ? formatCredits(value) : "—";
+  value !== null ? formatCreditsPrecise(value) : "—";
 
 // The three spend figures for a cap dimension shown together to spot
 // divergence: ES = Elasticsearch-derived, RL = Redis rate-limiter counter (the

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -103,7 +103,7 @@ export const makeSpendLimitAwuCreditsRateLimitKeyForUser = (
   owner: LightWorkspaceType,
   user: UserType
 ) => {
-  return `workspace:${owner.id}:user:${user.id}:spend_limit_awu_credit_count`;
+  return `workspace:${owner.id}:user:${user.id}:spend_limit_awu_microcredit_count`;
 };
 
 // Fixed-window bounds for the per-user spend cap over a Metronome contract
@@ -127,7 +127,7 @@ export const makeSpendLimitCycleWindowBounds = (
 // Metronome contract billing cycle via `makeSpendLimitCycleWindowBounds`, like
 // the per-user key above.
 export const makeApiKeySpendLimitAwuCreditsRateLimitKey = (keyId: number) => {
-  return `api_key:${keyId}:spend_limit_awu_credit_count`;
+  return `api_key:${keyId}:spend_limit_awu_microcredit_count`;
 };
 
 // Fixed-window counter backing the workspace programmatic monthly spend cap
@@ -136,7 +136,7 @@ export const makeApiKeySpendLimitAwuCreditsRateLimitKey = (keyId: number) => {
 export const makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace = (
   owner: LightWorkspaceType
 ) => {
-  return `workspace:${owner.id}:programmatic_spend_limit_awu_credit_count`;
+  return `workspace:${owner.id}:programmatic_spend_limit_awu_microcredit_count`;
 };
 
 export const makeProgrammaticUsageRateLimitKeyForWorkspace = (

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -9,6 +9,10 @@ import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
 import { getProgrammaticUsageFilterClause } from "@app/lib/api/programmatic_usage/common";
 import type { Authenticator } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
+import {
+  microCreditsToCredits,
+  roundCreditsToMicroCredits,
+} from "@app/lib/credits/units";
 import { listPerUserCreditBalanceAlertsForWorkspace } from "@app/lib/metronome/alerts/per_user_credit_balance";
 import type {
   MetronomeCapAlertIds,
@@ -1081,7 +1085,7 @@ export async function resyncSpendLimitCountersFromEsUsage(
           user.toJSON()
         ),
         bounds,
-        value: Math.max(0, Math.round(consumed)),
+        value: Math.max(0, roundCreditsToMicroCredits(consumed)),
         logger,
       });
       return setResult.isOk();
@@ -1139,7 +1143,7 @@ export async function resyncApiKeySpendLimitCountersFromEsUsage(
       const setResult = await setFixedWindowCount({
         key: makeApiKeySpendLimitAwuCreditsRateLimitKey(key.id),
         bounds,
-        value: Math.max(0, Math.round(consumed)),
+        value: Math.max(0, roundCreditsToMicroCredits(consumed)),
         logger,
       });
       return setResult.isOk();
@@ -1195,7 +1199,7 @@ export async function resyncProgrammaticSpendLimitCounterFromEsUsage(
       workspace
     ),
     bounds,
-    value: Math.max(0, Math.round(consumed)),
+    value: Math.max(0, roundCreditsToMicroCredits(consumed)),
     logger,
   });
   return new Ok({ programmaticCounterSeeded: setResult.isOk() });
@@ -1875,7 +1879,12 @@ export async function getMembersUsage({
             ),
             bounds,
           });
-          return [u.sId, result.isOk() ? result.value : 0] as const;
+          // The counter stores microCredits; convert back to credits so it
+          // lines up with the ES/MT figures (all in credits).
+          return [
+            u.sId,
+            result.isOk() ? microCreditsToCredits(result.value) : 0,
+          ] as const;
         },
         { concurrency: 8 }
       );

--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -7,6 +7,7 @@ import { getEsConsumedProgrammaticAwuCredits } from "@app/lib/api/credits/member
 import { reconcileProgrammatic } from "@app/lib/api/metronome/reconcile_credit_state";
 import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import {
   clearMetronomeProgrammaticCapAlerts,
   upsertMetronomeProgrammaticCapAlerts,
@@ -157,7 +158,18 @@ async function readProgrammaticSpendLimitCountWithLazySeed(
     key: redisKey,
     bounds,
     logger,
-    fetchSeedValue: () => getEsConsumedProgrammaticAwuCredits(auth, {}),
+    // The counter stores microCredits; convert the ES credit value before
+    // seeding. Preserve the null contract (ES read failed → skip seed, do not
+    // seed as 0).
+    fetchSeedValue: async () => {
+      const consumedAwuCredits = await getEsConsumedProgrammaticAwuCredits(
+        auth,
+        {}
+      );
+      return consumedAwuCredits === null
+        ? null
+        : roundCreditsToMicroCredits(consumedAwuCredits);
+    },
   });
 }
 
@@ -203,7 +215,9 @@ export async function isProgrammaticSpendLimitRateCapReached(
     return false;
   }
 
-  return count >= threshold;
+  // The counter stores microCredits; scale the credit threshold up so the
+  // comparison stays integer-on-integer.
+  return count >= roundCreditsToMicroCredits(threshold);
 }
 
 /**
@@ -217,22 +231,10 @@ export async function recordProgrammaticSpendLimitUsage(
   auth: Authenticator,
   { incrementBy }: { incrementBy: number }
 ): Promise<void> {
-  // Only whole positive credits are recordable (the counter is an integer
-  // INCRBY); skip anything else rather than letting it reach the counter. A
-  // non-integer should never happen (credits are integer end-to-end), so log
-  // it loudly; a non-positive delta is a normal no-op (e.g. a retry with no
-  // new usage) and stays silent.
-  if (!Number.isInteger(incrementBy)) {
-    logger.error(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        incrementBy,
-      },
-      "[ProgrammaticSpendLimitRateCap] Non-integer credit delta; skipping counter update."
-    );
-    return;
-  }
-  if (incrementBy <= 0) {
+  // Credits may be fractional; the counter stores microCredits (integer
+  // INCRBY), so convert before recording. A non-positive or non-finite delta is
+  // a normal no-op (e.g. a retry with no new usage) and stays silent.
+  if (!Number.isFinite(incrementBy) || incrementBy <= 0) {
     return;
   }
 
@@ -243,12 +245,14 @@ export async function recordProgrammaticSpendLimitUsage(
     return;
   }
 
+  const incrementByMicroCredits = roundCreditsToMicroCredits(incrementBy);
+
   await addFixedWindowCount({
     key: makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(
       workspace
     ),
     bounds,
-    incrementBy,
+    incrementBy: incrementByMicroCredits,
     logger,
   });
 }

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -5,6 +5,7 @@ import {
   reconcileWorkspaceApiKeyCreditStates,
 } from "@app/lib/api/metronome/reconcile_credit_state";
 import type { Authenticator } from "@app/lib/auth";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import {
   clearMetronomeApiKeyCapAlert,
   upsertMetronomeApiKeyCapAlert,
@@ -353,8 +354,17 @@ async function readApiKeySpendLimitCountWithLazySeed(
     key: redisKey,
     bounds,
     logger,
-    fetchSeedValue: () =>
-      getEsConsumedAwuCreditsForApiKey(auth, { apiKeyName }),
+    // The counter stores microCredits; convert the ES credit value before
+    // seeding. Preserve the null contract (ES read failed → skip seed, do not
+    // seed as 0).
+    fetchSeedValue: async () => {
+      const consumedAwuCredits = await getEsConsumedAwuCreditsForApiKey(auth, {
+        apiKeyName,
+      });
+      return consumedAwuCredits === null
+        ? null
+        : roundCreditsToMicroCredits(consumedAwuCredits);
+    },
   });
 }
 
@@ -400,7 +410,9 @@ export async function isApiKeySpendLimitRateCapReached(
     return false;
   }
 
-  return count >= threshold;
+  // The counter stores microCredits; scale the credit threshold up so the
+  // comparison stays integer-on-integer.
+  return count >= roundCreditsToMicroCredits(threshold);
 }
 
 /**
@@ -415,23 +427,10 @@ export async function recordApiKeySpendLimitUsage(
   auth: Authenticator,
   { keyModelId, incrementBy }: { keyModelId: number; incrementBy: number }
 ): Promise<void> {
-  // Only whole positive credits are recordable (the counter is an integer
-  // INCRBY); skip anything else rather than letting it reach the counter. A
-  // non-integer should never happen (credits are integer end-to-end), so log
-  // it loudly; a non-positive delta is a normal no-op (e.g. a retry with no
-  // new usage) and stays silent.
-  if (!Number.isInteger(incrementBy)) {
-    logger.error(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        keyModelId,
-        incrementBy,
-      },
-      "[ApiKeySpendLimitRateCap] Non-integer credit delta; skipping counter update."
-    );
-    return;
-  }
-  if (incrementBy <= 0) {
+  // Credits may be fractional; the counter stores microCredits (integer
+  // INCRBY), so convert before recording. A non-positive or non-finite delta is
+  // a normal no-op (e.g. a retry with no new usage) and stays silent.
+  if (!Number.isFinite(incrementBy) || incrementBy <= 0) {
     return;
   }
 
@@ -442,10 +441,12 @@ export async function recordApiKeySpendLimitUsage(
     return;
   }
 
+  const incrementByMicroCredits = roundCreditsToMicroCredits(incrementBy);
+
   await addFixedWindowCount({
     key: makeApiKeySpendLimitAwuCreditsRateLimitKey(keyModelId),
     bounds,
-    incrementBy,
+    incrementBy: incrementByMicroCredits,
     logger,
   });
 }

--- a/front/lib/api/poke/workspace_info.ts
+++ b/front/lib/api/poke/workspace_info.ts
@@ -8,6 +8,7 @@ import { isMetronomeBillingEnabled } from "@app/lib/api/subscription";
 import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { hasFeatureFlag } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
 import type { DefaultMetronomeAlerts } from "@app/lib/metronome/alerts/default_alerts";
 import type { MetronomeAlertRef } from "@app/lib/metronome/alerts/types";
 import { getCachedWorkspaceMetronomeAlerts } from "@app/lib/metronome/alerts/workspace_alerts";
@@ -163,8 +164,10 @@ export async function getPokeWorkspaceInfo(
       key: makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(owner),
       bounds: spendLimitBounds,
     });
+    // The counter stores microCredits; convert back to credits so RL lines up
+    // with the ES/MT figures (all in credits).
     programmaticSpendLimitRateCapCount = countResult.isOk()
-      ? countResult.value
+      ? microCreditsToCredits(countResult.value)
       : null;
   }
   const programmaticEsConsumedAwuCredits = spendLimitBounds

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -17,6 +17,7 @@ import type { AuditLogContext } from "@app/lib/api/workos/organization";
 import { getNonCreditPricedDefaultUserSpendLimit } from "@app/lib/api/workspace/default_user_spend_limit";
 import type { Authenticator } from "@app/lib/auth";
 import type { BillingCycle } from "@app/lib/client/subscription";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import {
   clearMetronomePerUserCapAlert,
   clearMetronomePerUserWarningAlert,
@@ -531,7 +532,18 @@ async function readSpendLimitCountWithLazySeed(
     key,
     bounds,
     logger,
-    fetchSeedValue: () => getEsConsumedAwuCreditsForUser(auth, { user, cycle }),
+    // The counter stores microCredits; convert the ES credit value before
+    // seeding. Preserve the null contract (ES read failed → skip seed, do not
+    // seed as 0).
+    fetchSeedValue: async () => {
+      const consumedAwuCredits = await getEsConsumedAwuCreditsForUser(auth, {
+        user,
+        cycle,
+      });
+      return consumedAwuCredits === null
+        ? null
+        : roundCreditsToMicroCredits(consumedAwuCredits);
+    },
   });
 }
 
@@ -571,7 +583,9 @@ async function isSpendCapCounterReached(
     return false;
   }
 
-  return count >= thresholdAwuCredits;
+  // The counter stores microCredits; scale the credit threshold up so the
+  // comparison stays integer-on-integer.
+  return count >= roundCreditsToMicroCredits(thresholdAwuCredits);
 }
 
 /**
@@ -657,23 +671,10 @@ export async function recordUserSpendLimitUsage(
     cycle,
   }: { user: UserResource; incrementBy: number; cycle?: BillingCycle }
 ): Promise<void> {
-  // Only whole positive credits are recordable (the counter is an integer
-  // INCRBY); skip anything else rather than letting it reach the counter. A
-  // non-integer should never happen (credits are integer end-to-end), so log
-  // it loudly; a non-positive delta is a normal no-op (e.g. a retry with no
-  // new usage) and stays silent.
-  if (!Number.isInteger(incrementBy)) {
-    logger.error(
-      {
-        workspaceId: auth.getNonNullableWorkspace().sId,
-        userId: user.sId,
-        incrementBy,
-      },
-      "[SpendLimitRateCap] Non-integer credit delta; skipping counter update."
-    );
-    return;
-  }
-  if (incrementBy <= 0) {
+  // Credits may be fractional; the counter stores microCredits (integer
+  // INCRBY), so convert before recording. A non-positive or non-finite delta is
+  // a normal no-op (e.g. a retry with no new usage) and stays silent.
+  if (!Number.isFinite(incrementBy) || incrementBy <= 0) {
     return;
   }
 
@@ -686,10 +687,12 @@ export async function recordUserSpendLimitUsage(
     return;
   }
 
+  const incrementByMicroCredits = roundCreditsToMicroCredits(incrementBy);
+
   await addFixedWindowCount({
     key: makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
     bounds,
-    incrementBy,
+    incrementBy: incrementByMicroCredits,
     logger,
   });
 }

--- a/front/lib/client/credits.ts
+++ b/front/lib/client/credits.ts
@@ -9,6 +9,14 @@ export function formatCredits(credits: number): string {
   return credits.toLocaleString("en-US", { maximumFractionDigits: 1 });
 }
 
+// Format AWU credits with full fractional precision (up to 6 decimals,
+// trailing zeros trimmed). Used by Poke debugging views that surface
+// microcredit-derived figures (e.g. the rate-limiter counter), where an
+// integer-rounded display would hide fractional-credit divergence.
+export function formatCreditsPrecise(credits: number): string {
+  return credits.toLocaleString("en-US", { maximumFractionDigits: 6 });
+}
+
 export function formatCreditValue(credits: number): string {
   return `${formatCredits(credits)} credit${pluralize(credits)}`;
 }

--- a/front/lib/utils/rate_limiter.test.ts
+++ b/front/lib/utils/rate_limiter.test.ts
@@ -1,4 +1,8 @@
 import {
+  microCreditsToCredits,
+  roundCreditsToMicroCredits,
+} from "@app/lib/credits/units";
+import {
   afterAll,
   afterEach,
   beforeAll,
@@ -369,5 +373,54 @@ describe("fixed-window counter", () => {
     const countB = await getFixedWindowCount({ key, bounds: windowB });
     expect(countA.isOk() && countA.value).toBe(4);
     expect(countB.isOk() && countB.value).toBe(7);
+  });
+
+  // Mirrors the spend-cap recorder/enforcer: the counter stores microCredits
+  // (credits × 1e6) so it survives a switch to fractional credits. Recording a
+  // fractional 2.5-credit delta must land as 2_500_000 microCredits, and
+  // enforcement blocks once the counter reaches the cap scaled up the same way
+  // (cap × 1e6).
+  it("stores fractional credits as integer microCredits and enforces caps at the microCredit scale", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    const bounds = boundsFor("microcredits");
+    fixedWindowKeysToExpire.add(`${key}:${bounds.label}`);
+
+    const capCredits = 5;
+
+    // First fractional delta: 2.5 credits recorded as microCredits.
+    await addFixedWindowCount({
+      key,
+      bounds,
+      incrementBy: roundCreditsToMicroCredits(2.5),
+      logger,
+    });
+
+    const afterFirst = await getFixedWindowCount({ key, bounds });
+    expect(afterFirst.isOk() && afterFirst.value).toBe(2_500_000);
+    // 2.5 < 5 credits: enforcement does not block yet.
+    expect(
+      afterFirst.isOk() &&
+        afterFirst.value >= roundCreditsToMicroCredits(capCredits)
+    ).toBe(false);
+
+    // Second fractional delta brings the total to exactly the cap.
+    await addFixedWindowCount({
+      key,
+      bounds,
+      incrementBy: roundCreditsToMicroCredits(2.5),
+      logger,
+    });
+
+    const afterSecond = await getFixedWindowCount({ key, bounds });
+    expect(afterSecond.isOk() && afterSecond.value).toBe(5_000_000);
+    // Reached cap × 1e6: enforcement blocks.
+    expect(
+      afterSecond.isOk() &&
+        afterSecond.value >= roundCreditsToMicroCredits(capCredits)
+    ).toBe(true);
+    // The poke read converts the counter back to whole credits.
+    expect(afterSecond.isOk() && microCreditsToCredits(afterSecond.value)).toBe(
+      5
+    );
   });
 });


### PR DESCRIPTION
## What

Store **microCredits** (credits × 1,000,000, integer) in the three **fixed-window** spend-cap Redis counters — **per-user**, **per-API-key**, and **programmatic** — instead of whole credits, so the counters survive an upcoming switch to fractional credits. This mirrors `AgentMessageConsumptionItemModel`, which already stores microCredits. Reuses the helpers in `front/lib/credits/units.ts` (`roundCreditsToMicroCredits` / `microCreditsToCredits`).

## Changes

- **Key rename:** the three spend-limit key builders now emit `...:spend_limit_awu_microcredit_count` / `...:programmatic_spend_limit_awu_microcredit_count` so old credit-scale counters aren't mixed with the new microcredit values after deploy. Old keys expire; **the counters reseed from Elasticsearch (in microCredits) on the first read after deploy** via the existing lazy seed.
- **Write boundaries:** recorders (`recordUserSpendLimitUsage`, `recordApiKeySpendLimitUsage`, `recordProgrammaticSpendLimitUsage`) now accept **fractional** credits — the old non-integer error log is removed (fractional is now valid), the guard is `!Number.isFinite || <= 0` — and convert via `roundCreditsToMicroCredits` before the INCRBY.
- **Lazy seed / resync:** `fetchSeedValue` and the `setFixedWindowCount` resyncs convert the ES credit value to microCredits, preserving the `null` "ES read failed → skip seed" contract (never seeded as 0).
- **Read boundaries:** enforcement scales the credit cap up to microCredits (`count >= roundCreditsToMicroCredits(cap)`) for an integer-on-integer comparison; the two Poke reads convert microCredits back to credits so ES/RL/MT stay in the same unit.
- **Poke display:** added `formatCreditsPrecise` (up to 6 decimals, trailing zeros trimmed) and used it for the ES/RL/MT figures so a microcredit-derived fractional value (e.g. `826.5`) renders correctly instead of being integer-rounded. The shared `formatCredits` is untouched.

## Out of scope / follow-ups

- The **fair-use rolling limiter** (`addRateLimiterCount` / `makeFairUseAwuCreditsRateLimitKeyForUser`) is intentionally **excluded**: its Lua does one `ZADD` per unit in a loop, so multiplying by 1e6 would write a million entries.
- The **workspace usage cap (#30655)** is not on `main` yet; it will need the **same microCredits treatment** when it lands.

## Tests

- Added a runnable Redis-backed test in `rate_limiter.test.ts` proving a fractional `2.5`-credit delta is recorded as `2_500_000` microCredits and that enforcement blocks once the counter reaches `cap × 1_000_000`.
- `units.test.ts` already covers the conversion helpers.
- The DB-backed spend-limit integration tests could not run in this environment due to a pre-existing missing `@novu/framework` dependency (unrelated to this change); the Redis/units-level tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)