### PR TITLE
feat: release trigger pool use, and adjust phrasing

### DIFF
--- a/front-api/routes/w/[wId]/governance-permissions.test.ts
+++ b/front-api/routes/w/[wId]/governance-permissions.test.ts
@@ -51,7 +51,7 @@ describe("GET /api/w/:wId/governance-permissions", () => {
     const { governancePermissions }: GetGovernancePermissionsResponseBody =
       await response.json();
 
-    // Admin sees every domain: agent/skill/frame plus the admin-only billing/identity.
+    // Admin sees every domain: agent/skill/frame/trigger plus the admin-only billing/identity.
     expect(governancePermissions).toEqual({
       "create:agent": adminsOnly("create", "agent"),
       "publish:agent": adminsOnly("publish", "agent"),
@@ -60,6 +60,7 @@ describe("GET /api/w/:wId/governance-permissions", () => {
       "make_discoverable:skill": adminsOnly("make_discoverable", "skill"),
       "invite:frame": adminsOnly("invite", "frame"),
       "publish:frame": adminsOnly("publish", "frame"),
+      "use_workspace_pool:trigger": adminsOnly("use_workspace_pool", "trigger"),
       "admin:billing": adminsOnly("admin", "billing"),
       "admin:security": adminsOnly("admin", "security"),
     });
@@ -77,7 +78,7 @@ describe("GET /api/w/:wId/governance-permissions", () => {
     const { governancePermissions }: GetGovernancePermissionsResponseBody =
       await response.json();
 
-    // Manager sees agent/skill/frame but never the admin-only billing/identity.
+    // Manager sees agent/skill/frame/trigger but never the admin-only billing/identity.
     expect(governancePermissions).toEqual({
       "create:agent": adminsOnly("create", "agent"),
       "publish:agent": adminsOnly("publish", "agent"),
@@ -86,6 +87,7 @@ describe("GET /api/w/:wId/governance-permissions", () => {
       "make_discoverable:skill": adminsOnly("make_discoverable", "skill"),
       "invite:frame": adminsOnly("invite", "frame"),
       "publish:frame": adminsOnly("publish", "frame"),
+      "use_workspace_pool:trigger": adminsOnly("use_workspace_pool", "trigger"),
     });
   });
 

--- a/front-api/routes/w/[wId]/triggers/[tId]/execution_mode.test.ts
+++ b/front-api/routes/w/[wId]/triggers/[tId]/execution_mode.test.ts
@@ -2,7 +2,6 @@ import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
@@ -52,7 +51,6 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const trigger = await TriggerFactory.webhook(auth, {
       agentConfigurationId: agent.sId,
@@ -76,7 +74,6 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     await grantWorkspacePoolToEverybody(workspace);
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const trigger = await TriggerFactory.webhook(auth, {
@@ -102,7 +99,6 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const trigger = await TriggerFactory.webhook(auth, {
       agentConfigurationId: agent.sId,
@@ -118,15 +114,10 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
   });
 
   it("rejects a member who is neither manager nor editor", async () => {
-    const { workspace, user } = await createPrivateApiMockRequest({
+    const { workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
       role: "user",
     });
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     await grantWorkspacePoolToEverybody(workspace);
     const editorAuth = await createOtherEditorAuth(workspace);
     const agent = await AgentConfigurationFactory.createTestAgent(editorAuth);
@@ -166,16 +157,10 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
   });
 
   it("returns 404 for an unknown trigger", async () => {
-    const { workspace, user } = await createPrivateApiMockRequest({
+    const { workspace } = await createPrivateApiMockRequest({
       method: "PATCH",
       role: "admin",
     });
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
-
     const response = await patchExecutionMode(workspace, "unknown", {
       executionMode: "workspace_pool",
     });
@@ -192,7 +177,6 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const trigger = await TriggerFactory.webhook(auth, {
       agentConfigurationId: agent.sId,

--- a/front-api/routes/w/[wId]/triggers/[tId]/execution_mode.test.ts
+++ b/front-api/routes/w/[wId]/triggers/[tId]/execution_mode.test.ts
@@ -135,27 +135,6 @@ describe("PATCH /api/w/:wId/triggers/:tId/execution_mode", () => {
     expect(updated?.executionMode).toBe("workspace_pool");
   });
 
-  it("returns 404 when the feature flag is off", async () => {
-    const { workspace, user } = await createPrivateApiMockRequest({
-      method: "PATCH",
-      role: "admin",
-    });
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-    const agent = await AgentConfigurationFactory.createTestAgent(auth);
-    const trigger = await TriggerFactory.webhook(auth, {
-      agentConfigurationId: agent.sId,
-    });
-
-    const response = await patchExecutionMode(workspace, trigger.sId, {
-      executionMode: "workspace_pool",
-    });
-
-    expect(response.status).toBe(404);
-  });
-
   it("returns 404 for an unknown trigger", async () => {
     const { workspace } = await createPrivateApiMockRequest({
       method: "PATCH",

--- a/front-api/routes/w/[wId]/triggers/[tId]/execution_mode.ts
+++ b/front-api/routes/w/[wId]/triggers/[tId]/execution_mode.ts
@@ -1,4 +1,3 @@
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   TriggerExecutionModeForbiddenError,
   TriggerResource,
@@ -26,17 +25,6 @@ app.patch(
     const auth = ctx.get("auth");
     const { tId } = ctx.req.valid("param");
     const { executionMode } = ctx.req.valid("json");
-
-    const featureFlags = await getFeatureFlags(auth);
-    if (!featureFlags.includes("trigger_pool_choice")) {
-      return apiError(ctx, {
-        status_code: 404,
-        api_error: {
-          type: "feature_flag_not_found",
-          message: "The trigger pool choice feature is not enabled.",
-        },
-      });
-    }
 
     const trigger = await TriggerResource.fetchById(auth, tId);
     if (!trigger) {

--- a/front-api/routes/w/[wId]/triggers/bulk-execution-mode.test.ts
+++ b/front-api/routes/w/[wId]/triggers/bulk-execution-mode.test.ts
@@ -2,7 +2,6 @@ import { Authenticator } from "@app/lib/auth";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
@@ -11,11 +10,9 @@ import { describe, expect, it } from "vitest";
 
 async function setupTest({
   role = "admin",
-  withFeatureFlag = true,
   withWorkspacePoolGrant = true,
 }: {
   role?: MembershipRoleType;
-  withFeatureFlag?: boolean;
   withWorkspacePoolGrant?: boolean;
 }) {
   const { workspace, user } = await createPrivateApiMockRequest({
@@ -29,9 +26,6 @@ async function setupTest({
   const adminAuth = await Authenticator.internalAdminForWorkspace(
     workspace.sId
   );
-  if (withFeatureFlag) {
-    await FeatureFlagFactory.basic(adminAuth, "trigger_pool_choice");
-  }
   if (withWorkspacePoolGrant) {
     await GroupPermissionResource.setForEverybody(adminAuth, {
       grantType: "use_workspace_pool",
@@ -53,17 +47,6 @@ function postBulkExecutionMode(wId: string, body: Record<string, unknown>) {
 describe("POST /api/w/:wId/triggers/bulk-execution-mode", () => {
   it("returns 403 for regular users", async () => {
     const { workspace } = await setupTest({ role: "user" });
-
-    const response = await postBulkExecutionMode(workspace.sId, {
-      selection: { mode: "ids", triggerIds: ["trg1"] },
-      executionMode: "workspace_pool",
-    });
-
-    expect(response.status).toBe(403);
-  });
-
-  it("returns 403 without the trigger_pool_choice feature flag", async () => {
-    const { workspace } = await setupTest({ withFeatureFlag: false });
 
     const response = await postBulkExecutionMode(workspace.sId, {
       selection: { mode: "ids", triggerIds: ["trg1"] },

--- a/front-api/routes/w/[wId]/triggers/bulk-execution-mode.ts
+++ b/front-api/routes/w/[wId]/triggers/bulk-execution-mode.ts
@@ -11,7 +11,6 @@ import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
-import { withFeatureFlag } from "@front-api/middlewares/with_feature_flag";
 import { z } from "zod";
 
 const BodySchema = z.object({
@@ -28,7 +27,6 @@ const app = workspaceApp();
 app.post(
   "/",
   ensureIsManager(),
-  withFeatureFlag("trigger_pool_choice"),
   validate("json", BodySchema),
   async (ctx): HandlerResult<BulkTriggerExecutionModeResponseBody> => {
     const auth = ctx.get("auth");

--- a/front-api/routes/w/[wId]/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/triggers/index.test.ts
@@ -514,30 +514,6 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
     expect(response.status).toBe(403);
   });
 
-  it("ignores the requested pool when the feature flag is off", async () => {
-    const { workspace, user } = await createPrivateApiMockRequest({
-      method: "POST",
-      role: "admin",
-    });
-    const auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-    const agent = await AgentConfigurationFactory.createTestAgent(auth);
-
-    const body = scheduleTriggerBody(null);
-    const response = await postTriggers(workspace, agent.sId, {
-      triggers: [{ ...body.triggers[0], executionMode: "workspace_pool" }],
-    });
-
-    expect(response.status).toBe(204);
-    const triggers = await TriggerResource.listByAgentConfigurationId(
-      auth,
-      agent.sId
-    );
-    expect(triggers[0].executionMode).toBe("user_pool");
-  });
-
   it("moves an existing trigger to the workspace pool on update", async () => {
     const { workspace, user } = await createPrivateApiMockRequest({
       method: "PATCH",

--- a/front-api/routes/w/[wId]/triggers/index.test.ts
+++ b/front-api/routes/w/[wId]/triggers/index.test.ts
@@ -2,7 +2,6 @@ import { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
@@ -481,7 +480,6 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
 
     const body = scheduleTriggerBody(null);
@@ -506,7 +504,6 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
 
     const body = scheduleTriggerBody(null);
@@ -550,7 +547,6 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const trigger = await createScheduleTrigger(workspace, agent.sId, null);
 
@@ -579,7 +575,6 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const trigger = await createScheduleTrigger(workspace, agent.sId, null);
 
@@ -608,7 +603,6 @@ describe("POST/PATCH /api/w/:wId/triggers (executionMode)", () => {
       user.sId,
       workspace.sId
     );
-    await FeatureFlagFactory.basic(auth, "trigger_pool_choice");
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
     const trigger = await TriggerFactory.schedule(auth, {
       agentConfigurationId: agent.sId,

--- a/front-api/routes/w/[wId]/triggers/index.ts
+++ b/front-api/routes/w/[wId]/triggers/index.ts
@@ -1,5 +1,4 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { getFeatureFlags } from "@app/lib/auth";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import {
   resolveTriggerSpaceId,
@@ -9,9 +8,7 @@ import {
 import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { GetTriggersResponseBody } from "@app/types/api/assistant/configuration/triggers";
-import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
 import { TriggerSchema } from "@app/types/assistant/triggers";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { apiError } from "@front-api/middlewares/utils";
@@ -35,17 +32,6 @@ const PatchTriggersRequestBodySchema = z.object({
 const PostTriggersRequestBodySchema = z.object({
   triggers: z.array(TriggerSchema),
 });
-
-function requestedExecutionMode(
-  trigger: z.infer<typeof TriggerSchema>,
-  featureFlags: WhitelistableFeature[]
-): TriggerExecutionMode | undefined {
-  if (!featureFlags.includes("trigger_pool_choice")) {
-    return undefined;
-  }
-
-  return trigger.executionMode;
-}
 
 function isWebhookTriggerData(trigger: {
   kind: string;
@@ -213,7 +199,6 @@ app.patch(
 
     const { triggers } = ctx.req.valid("json");
     const workspace = auth.getNonNullableWorkspace();
-    const featureFlags = await getFeatureFlags(auth);
 
     for (const triggerData of triggers) {
       const triggerToUpdate = userTriggers.find(
@@ -270,10 +255,7 @@ app.patch(
         ? getResourceIdFromSId(validatedTrigger.webhookSourceViewId)
         : null;
 
-      const executionMode = requestedExecutionMode(
-        validatedTrigger,
-        featureFlags
-      );
+      const executionMode = validatedTrigger.executionMode;
       const spaceIdRes = await resolveTriggerSpaceId(
         auth,
         validatedTrigger.spaceId
@@ -387,7 +369,6 @@ app.post(
 
     const { triggers } = ctx.req.valid("json");
     const workspace = auth.getNonNullableWorkspace();
-    const featureFlags = await getFeatureFlags(auth);
 
     for (const triggerData of triggers) {
       const triggerValidation = TriggerSchema.safeParse({
@@ -412,8 +393,7 @@ app.post(
         ? validatedTrigger.executionPerDayLimitOverride
         : null;
 
-      const executionMode =
-        requestedExecutionMode(validatedTrigger, featureFlags) ?? "user_pool";
+      const executionMode = validatedTrigger.executionMode ?? "user_pool";
 
       const spaceIdRes = await resolveTriggerSpaceId(
         auth,

--- a/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
+++ b/front/components/agent_builder/triggers/TriggerPoolSelector.tsx
@@ -1,5 +1,4 @@
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type { TriggerExecutionMode } from "@app/types/assistant/triggers";
 import {
@@ -29,13 +28,8 @@ export function TriggerPoolSelector({
 }: TriggerPoolSelectorProps) {
   const { control } = useFormContext<TriggerViewsSheetFormValues>();
   const { field } = useController({ control, name });
-  const { hasFeature } = useFeatureFlags();
+
   const { hasPermission } = useWorkspacePermissions();
-
-  if (!hasFeature("trigger_pool_choice")) {
-    return null;
-  }
-
   const canSetPool = hasPermission("use_workspace_pool", "trigger");
 
   return (

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -5,7 +5,8 @@ import { TriggerPoolSelector } from "@app/components/agent_builder/triggers/Trig
 import { TriggerStatusToggle } from "@app/components/agent_builder/triggers/TriggerStatusToggle";
 import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/triggers/triggerViewsSheetFormSchema";
 import { WebhookEditionFilters } from "@app/components/agent_builder/triggers/webhook/WebhookEditionFilters";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { isCreditPricedPlan } from "@app/types/plan";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
 import type {
@@ -14,7 +15,6 @@ import type {
 } from "@app/types/triggers/webhooks_source_preset";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
-  AlertCircle,
   Button,
   Checkbox,
   ContentMessage,
@@ -60,6 +60,30 @@ function WebhookEditionNameInput({ isEditor }: WebhookEditionNameInputProps) {
   );
 }
 
+function getQuotaDescription({
+  isCreditPooled,
+  executionMode,
+}: {
+  isCreditPooled: boolean;
+  executionMode: "user_pool" | "workspace_pool";
+}) {
+  if (isCreditPooled) {
+    switch (executionMode) {
+      case "user_pool":
+        return "personal credit pool.";
+      case "workspace_pool":
+        return "workspace's credit pool.";
+    }
+  } else {
+    switch (executionMode) {
+      case "user_pool":
+        return "personal fair use limits.";
+      case "workspace_pool":
+        return "workspace's programmatic usage.";
+    }
+  }
+}
+
 interface WebhookEditionExecutionLimitProps {
   isEditor: boolean;
 }
@@ -68,7 +92,7 @@ function WebhookEditionExecutionLimit({
   isEditor,
 }: WebhookEditionExecutionLimitProps) {
   const { control } = useFormContext<TriggerViewsSheetFormValues>();
-  const { hasFeature } = useFeatureFlags();
+  const { subscription } = useAuth();
   const {
     field: limitField,
     fieldState: { error },
@@ -80,47 +104,19 @@ function WebhookEditionExecutionLimit({
     field: { value: executionMode },
   } = useController({ control, name: "webhook.executionMode" });
 
-  const quotaName =
-    executionMode === "user_pool" ? "fair use" : "programmatic usage";
-
-  if (!hasFeature("trigger_pool_choice")) {
-    return (
-      <div className="flex flex-col space-y-1">
-        <Label htmlFor="execution-limit">Rate limits</Label>
-        <p>Limits are set on a 24-hour window. </p>
-        <ContentMessage
-          variant="info"
-          size="lg"
-          icon={AlertCircle}
-          title={`Up to ${limitField.value} requests per day`}
-        >
-          This trigger can send a limited number of messages per day. This
-          prevents a single trigger from using up your workspace's message fair
-          use quota. This trigger is currently running on your workspace's{" "}
-          {quotaName} quota.
-          <br /> (
-          <LinkWrapper
-            href="https://docs.dust.tt/docs/rate-limiting#/"
-            target="_blank"
-            rel="noreferrer"
-            className="underline"
-          >
-            Learn more
-          </LinkWrapper>
-          )
-        </ContentMessage>
-      </div>
-    );
-  }
-
   return (
     <div className="flex flex-col space-y-1">
       <Label htmlFor="execution-limit">Rate limits</Label>
       <p className="text-sm text-muted-foreground">
-        Maximum number of runs over a 24-hour window, on top of your workspace's{" "}
-        {quotaName} quota. (
+        Maximum number of runs over a 24-hour window. This will count towards
+        your{" "}
+        {getQuotaDescription({
+          isCreditPooled: isCreditPricedPlan(subscription.plan),
+          executionMode,
+        })}{" "}
+        (
         <LinkWrapper
-          href="https://docs.dust.tt/docs/rate-limiting#/"
+          href="https://docs.dust.tt/docs/user-documentation/agents/triggers/credits-usage"
           target="_blank"
           rel="noreferrer"
           className="underline"

--- a/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
+++ b/front/components/agent_builder/triggers/webhook/WebhookEditionSheet.tsx
@@ -7,6 +7,7 @@ import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/
 import { WebhookEditionFilters } from "@app/components/agent_builder/triggers/webhook/WebhookEditionFilters";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { isCreditPricedPlan } from "@app/types/plan";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
 import type {
@@ -73,6 +74,8 @@ function getQuotaDescription({
         return "personal credit pool.";
       case "workspace_pool":
         return "workspace's credit pool.";
+      default:
+        return assertNever(executionMode);
     }
   } else {
     switch (executionMode) {
@@ -80,6 +83,8 @@ function getQuotaDescription({
         return "personal fair use limits.";
       case "workspace_pool":
         return "workspace's programmatic usage.";
+      default:
+        return assertNever(executionMode);
     }
   }
 }

--- a/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersTable.tsx
@@ -28,7 +28,6 @@ import type {
 } from "@app/lib/api/analytics/automations/schema";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import type { BulkTriggerSelection } from "@app/lib/api/triggers/bulk_selection";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import {
   useBulkUpdateTriggerExecutionMode,
   useUpdateTriggerExecutionMode,
@@ -194,11 +193,9 @@ function rowSelectionColumn(): ColumnDef<TriggerRowData> {
 
 function buildColumns({
   expandedRowId,
-  showPoolColumn,
   showSelectionColumn,
 }: {
   expandedRowId: string | null;
-  showPoolColumn: boolean;
   showSelectionColumn: boolean;
 }): ColumnDef<TriggerRowData>[] {
   return [
@@ -218,21 +215,17 @@ function buildColumns({
     agentColumn(),
     typeColumn(),
     creditsColumn(),
-    ...(showPoolColumn
-      ? [
-          {
-            id: "pool",
-            header: "Pool",
-            enableSorting: false,
-            meta: { className: "w-28" },
-            cell: (info) => (
-              <DataTable.CellContent className="w-full justify-start">
-                <PoolCell row={info.row.original} />
-              </DataTable.CellContent>
-            ),
-          } satisfies ColumnDef<TriggerRowData>,
-        ]
-      : []),
+    {
+      id: "pool",
+      header: "Pool",
+      enableSorting: false,
+      meta: { className: "w-28" },
+      cell: (info) => (
+        <DataTable.CellContent className="w-full justify-start">
+          <PoolCell row={info.row.original} />
+        </DataTable.CellContent>
+      ),
+    },
     {
       id: "status",
       header: "Enabled",
@@ -314,11 +307,8 @@ export function AutomationsTriggersTable({
     workspaceId,
   });
 
-  const { hasFeature } = useFeatureFlags();
-  const showPoolColumn = hasFeature("trigger_pool_choice");
   const { hasPermission } = useWorkspacePermissions();
-  const canBulkSetPool =
-    showPoolColumn && hasPermission("use_workspace_pool", "trigger");
+  const canBulkSetPool = hasPermission("use_workspace_pool", "trigger");
 
   const triggersQuery: AutomationTriggersQuery = useMemo(
     () => ({
@@ -595,7 +585,6 @@ export function AutomationsTriggersTable({
         workspaceId={workspaceId}
         period={period}
         expandedRowId={expandedRowId}
-        showPoolColumn={showPoolColumn}
         showSelectionColumn={canBulkSetPool}
         rowSelection={selection.rowSelection}
         onRowSelectionChange={selection.onRowSelectionChange}
@@ -623,7 +612,6 @@ interface TriggersTableBodyProps {
   workspaceId: string;
   period: ConsumptionPeriodSelection;
   expandedRowId: string | null;
-  showPoolColumn: boolean;
   showSelectionColumn: boolean;
   rowSelection: RowSelectionState;
   onRowSelectionChange: (selection: RowSelectionState) => void;
@@ -642,14 +630,13 @@ function TriggersTableBody({
   workspaceId,
   period,
   expandedRowId,
-  showPoolColumn,
   showSelectionColumn,
   rowSelection,
   onRowSelectionChange,
 }: TriggersTableBodyProps) {
   const columns = useMemo(
-    () => buildColumns({ expandedRowId, showPoolColumn, showSelectionColumn }),
-    [expandedRowId, showPoolColumn, showSelectionColumn]
+    () => buildColumns({ expandedRowId, showSelectionColumn }),
+    [expandedRowId, showSelectionColumn]
   );
 
   const firstRowIndex = pagination.pageIndex * pagination.pageSize;

--- a/front/lib/api/permissions/governance.ts
+++ b/front/lib/api/permissions/governance.ts
@@ -4,7 +4,6 @@ import {
   getAuditLogContext,
 } from "@app/lib/api/audit/workos_audit";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { CapabilityState } from "@app/lib/resources/group_permission_resource";
 import { GroupPermissionResource } from "@app/lib/resources/group_permission_resource";
@@ -20,7 +19,6 @@ import {
   GOVERNANCE_CAPABILITIES,
 } from "@app/types/group_permissions";
 import { isManageableGroupKind } from "@app/types/groups";
-import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -42,10 +40,7 @@ const ADMIN_CAPABILITIES: CapabilitySpec[] = [
 
 // The capabilities the caller's role is allowed to see and manage. Admins get everything; business
 // admins get every domain except billing/identity; no other role manages any governance capability.
-function capabilitiesForRole(
-  auth: Authenticator,
-  featureFlags: WhitelistableFeature[]
-): CapabilitySpec[] {
+function capabilitiesForRole(auth: Authenticator): CapabilitySpec[] {
   const role = auth.role();
   switch (role) {
     case "admin":
@@ -81,7 +76,7 @@ function toConfiguration(
 export async function getWorkspaceGovernancePermissions(
   auth: Authenticator
 ): Promise<GovernancePermissionsByKey> {
-  const capabilities = capabilitiesForRole(auth, await getFeatureFlags(auth));
+  const capabilities = capabilitiesForRole(auth);
 
   const stateByKey = await GroupPermissionResource.getCapabilitiesState(
     auth,
@@ -117,7 +112,7 @@ export async function setWorkspaceGovernancePermission(
 > {
   const capability: CapabilitySpec = { grantType, resourceType };
 
-  const canManage = capabilitiesForRole(auth, await getFeatureFlags(auth)).some(
+  const canManage = capabilitiesForRole(auth).some(
     (c) => c.grantType === grantType && c.resourceType === resourceType
   );
   if (!canManage) {

--- a/front/lib/api/permissions/governance.ts
+++ b/front/lib/api/permissions/governance.ts
@@ -31,6 +31,7 @@ const MANAGER_CAPABILITIES: CapabilitySpec[] = [
   ...GOVERNANCE_CAPABILITIES.agent,
   ...GOVERNANCE_CAPABILITIES.skill,
   ...GOVERNANCE_CAPABILITIES.frame,
+  ...GOVERNANCE_CAPABILITIES.trigger,
 ];
 
 // Capabilities every admin can manage.
@@ -45,16 +46,12 @@ function capabilitiesForRole(
   auth: Authenticator,
   featureFlags: WhitelistableFeature[]
 ): CapabilitySpec[] {
-  const flagged = featureFlags.includes("trigger_pool_choice")
-    ? GOVERNANCE_CAPABILITIES.trigger
-    : [];
-
   const role = auth.role();
   switch (role) {
     case "admin":
-      return [...ADMIN_CAPABILITIES, ...flagged];
+      return ADMIN_CAPABILITIES;
     case "manager":
-      return [...MANAGER_CAPABILITIES, ...flagged];
+      return MANAGER_CAPABILITIES;
     case "builder":
     case "user":
     case "none":

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -371,11 +371,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Allow editing tool inputs before approving a tool call in the tool validation UI.",
     stage: "dust_only",
   },
-  trigger_pool_choice: {
-    description:
-      "Let trigger editors pick the credit pool (workspace or member) a trigger runs on, and let admins govern who may pick the workspace pool.",
-    stage: "dust_only",
-  },
   skip_free_usage_rate_limit: {
     description:
       "Skip the per-user daily free-usage cost cap enforced at the LLM call site. Escape hatch to unstick legitimate workspaces that legitimately exceed the free-usage limit.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -820,7 +820,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "enforce_premium_model_message_limit"
   | "editable_tool_inputs"
   | "skip_free_usage_rate_limit"
-  | "trigger_pool_choice"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR releases the trigger pool choice feature. Admins can now determine who can pick from the workspace's allowance to run their triggers, and who can not. Users are presented a "Credits" dropdown in the Trigger builder, and still have a Rate limiting option for webhooks as before.

This also adds a "Pool" column in the Automations page, and allow admins to bulk swap the pool allowance for credits. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Already tested by unit tests + hand tests.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, revert is a rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Write the new docs page before this goes out.
Deploy front.