### PR TITLE
[front] Switch fair-use rolling-window AWU counters to weighted microCredits

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -83,6 +83,7 @@ import {
 import { countActiveSeatsForWorkspace } from "@app/lib/api/workspace_seats";
 import { isModelAvailable } from "@app/lib/assistant";
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { extractFromString, serializeMention } from "@app/lib/mentions/format";
 import { isApiKeyCapped } from "@app/lib/metronome/api_key_block";
@@ -124,8 +125,8 @@ import { WakeUpResource } from "@app/lib/resources/wakeup_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import {
-  getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
+  getWeightedRateLimiterCount,
   rateLimiter,
 } from "@app/lib/utils/rate_limiter";
 import { withTransaction } from "@app/lib/utils/sql_utils";
@@ -3099,7 +3100,7 @@ async function isMessagesLimitReached(
 
   const user = auth.user();
   if (user && maxAwuCredits !== -1) {
-    const result = await getRateLimiterCount({
+    const result = await getWeightedRateLimiterCount({
       key: makeFairUseAwuCreditsRateLimitKeyForUser(
         owner,
         user.toJSON(),
@@ -3108,7 +3109,12 @@ async function isMessagesLimitReached(
       timeframeSeconds: getTimeframeSecondsFromLiteral(maxAwuCreditsTimeframe),
     });
 
-    if (result.isOk() && result.value >= maxAwuCredits) {
+    // The counter stores microCredits; scale the credit-denominated limit the
+    // same way before comparing.
+    if (
+      result.isOk() &&
+      result.value >= roundCreditsToMicroCredits(maxAwuCredits)
+    ) {
       return {
         isLimitReached: true,
         limitType: "plan_message_limit_exceeded",

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -82,7 +82,11 @@ export const makeFairUseAwuCreditsRateLimitKeyForUser = (
   user: UserType,
   maxAwuCreditsTimeframe: MaxAwuCreditsTimeframeType
 ) => {
-  return `workspace:${owner.id}:user:${user.id}:fair_use_awu_credit_count:${maxAwuCreditsTimeframe}`;
+  // `:v2_microcredits` marks the switch to weighted amount-carrying entries
+  // (`<microCredits>:<uuid>`, summed on read). Bumping the key prevents summing
+  // the new entries together with legacy plain-uuid rows; the short rolling
+  // window makes the pre-existing key expire quickly after cutover.
+  return `workspace:${owner.id}:user:${user.id}:fair_use_awu_credit_count:${maxAwuCreditsTimeframe}:v2_microcredits`;
 };
 
 export const PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK = 25;

--- a/front/lib/api/llm/free_usage.ts
+++ b/front/lib/api/llm/free_usage.ts
@@ -5,10 +5,11 @@ import {
   awuFromMicroUsd,
   isFreeOrigin,
 } from "@app/lib/credits/agent_message_billing";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import { isEnterpriseOrDust } from "@app/lib/plans/plan_codes";
 import {
   addRateLimiterCount,
-  getRateLimiterCount,
+  getWeightedRateLimiterCount,
 } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -32,7 +33,11 @@ const makeFreeUsageCostRateLimitKeyForUser = (
   owner: LightWorkspaceType,
   userId: number
 ) => {
-  return `workspace:${owner.id}:user:${userId}:free_usage_cost`;
+  // `:v2_microcredits` marks the switch to weighted amount-carrying entries
+  // (`<microCredits>:<uuid>`, summed on read). Bumping the key prevents summing
+  // the new entries together with legacy plain-uuid rows; the short rolling
+  // window makes the pre-existing key expire quickly after cutover.
+  return `workspace:${owner.id}:user:${userId}:free_usage_cost:v2_microcredits`;
 };
 
 // Whether an LLM call is free (unbilled). Two cases:
@@ -71,8 +76,10 @@ export async function isFreeUsageBlocked(
     return false;
   }
 
-  // Fails open on a Redis error so a transient failure never blocks usage.
-  const result = await getRateLimiterCount({
+  // Fails open on a Redis error so a transient failure never blocks usage. The
+  // counter stores microCredits, so compare against the limit scaled the same
+  // way.
+  const result = await getWeightedRateLimiterCount({
     key: makeFreeUsageCostRateLimitKeyForUser(
       auth.getNonNullableWorkspace(),
       user.id
@@ -82,7 +89,10 @@ export async function isFreeUsageBlocked(
   if (result.isErr()) {
     return false;
   }
-  return result.value >= freeUsageAwuCreditsLimitForAuth(auth);
+  return (
+    result.value >=
+    roundCreditsToMicroCredits(freeUsageAwuCreditsLimitForAuth(auth))
+  );
 }
 
 // Contribute a free call's cost (converted to AWU credits) to the user's daily

--- a/front/lib/metronome/user_block.ts
+++ b/front/lib/metronome/user_block.ts
@@ -22,12 +22,13 @@
 //
 import { makeFairUseAwuCreditsRateLimitKeyForUser } from "@app/lib/api/assistant/rate_limits";
 import { runOnRedis } from "@app/lib/api/redis";
+import { microCreditsToCredits } from "@app/lib/credits/units";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import {
-  getRateLimiterCount,
   getTimeframeSecondsFromLiteral,
+  getWeightedRateLimiterCount,
 } from "@app/lib/utils/rate_limiter";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -253,7 +254,7 @@ export async function getFairUseAwuCreditsStatus({
     };
   }
 
-  const result = await getRateLimiterCount({
+  const result = await getWeightedRateLimiterCount({
     key: makeFairUseAwuCreditsRateLimitKeyForUser(workspace, user, timeframe),
     timeframeSeconds: getTimeframeSecondsFromLiteral(timeframe),
   });
@@ -275,10 +276,12 @@ export async function getFairUseAwuCreditsStatus({
     };
   }
 
+  // The counter stores microCredits; the status stays credit-denominated (with
+  // decimals), so convert before capping against the credit limit.
   return {
     limit,
     timeframe,
-    count: Math.min(result.value, limit),
+    count: Math.min(microCreditsToCredits(result.value), limit),
   };
 }
 

--- a/front/lib/utils/rate_limiter.test.ts
+++ b/front/lib/utils/rate_limiter.test.ts
@@ -40,6 +40,7 @@ let runOnRedis: RedisModule["runOnRedis"];
 let addRateLimiterCount: RateLimiterModule["addRateLimiterCount"];
 let expireRateLimiterKey: RateLimiterModule["expireRateLimiterKey"];
 let getRateLimiterCount: RateLimiterModule["getRateLimiterCount"];
+let getWeightedRateLimiterCount: RateLimiterModule["getWeightedRateLimiterCount"];
 let rateLimiter: RateLimiterModule["rateLimiter"];
 let RATE_LIMITER_PREFIX: RateLimiterModule["RATE_LIMITER_PREFIX"];
 
@@ -229,9 +230,11 @@ describe("addRateLimiterCount", () => {
     const rateLimiterModule = await import("@app/lib/utils/rate_limiter");
 
     closeRedisClients = redisModule.closeRedisClients;
+    runOnRedis = redisModule.runOnRedis;
     addRateLimiterCount = rateLimiterModule.addRateLimiterCount;
     expireRateLimiterKey = rateLimiterModule.expireRateLimiterKey;
-    getRateLimiterCount = rateLimiterModule.getRateLimiterCount;
+    getWeightedRateLimiterCount = rateLimiterModule.getWeightedRateLimiterCount;
+    RATE_LIMITER_PREFIX = rateLimiterModule.RATE_LIMITER_PREFIX;
   });
 
   afterEach(async () => {
@@ -245,7 +248,28 @@ describe("addRateLimiterCount", () => {
     await closeRedisClients();
   });
 
-  it("records the full amount even when it overshoots what a limit-guarded write would allow", async () => {
+  it("stores a fractional credit amount as integer microCredits", async () => {
+    const key = `test:${crypto.randomUUID()}`;
+    await expireTestKey(key);
+
+    await addRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+      incrementBy: 2.5,
+      logger,
+    });
+
+    const count = await getWeightedRateLimiterCount({
+      key,
+      timeframeSeconds: 60,
+    });
+    expect(count.isOk()).toBe(true);
+    if (count.isOk()) {
+      expect(count.value).toBe(2_500_000);
+    }
+  });
+
+  it("sums the amount of multiple entries, even past what a limit-guarded write would allow", async () => {
     const key = `test:${crypto.randomUUID()}`;
     await expireTestKey(key);
 
@@ -261,38 +285,48 @@ describe("addRateLimiterCount", () => {
     await addRateLimiterCount({
       key,
       timeframeSeconds: 60,
-      incrementBy: 2,
+      incrementBy: 2.5,
       logger,
     });
 
-    const count = await getRateLimiterCount({
+    const count = await getWeightedRateLimiterCount({
       key,
       timeframeSeconds: 60,
     });
     expect(count.isOk()).toBe(true);
     if (count.isOk()) {
-      expect(count.value).toBe(11);
+      expect(count.value).toBe(11_500_000);
     }
   });
 
-  it("is counted correctly by getRateLimiterCount alongside plain rateLimiter writes", async () => {
+  it("excludes entries outside the rolling window from the sum", async () => {
     const key = `test:${crypto.randomUUID()}`;
     await expireTestKey(key);
+    const redisKey = `${RATE_LIMITER_PREFIX}:${key}`;
 
+    // A recent entry (inside a 60s window) and a stale one (2 hours old, outside
+    // it). Stale entries are written directly with an old score so the sum can
+    // be asserted deterministically.
     await addRateLimiterCount({
       key,
       timeframeSeconds: 60,
       incrementBy: 3,
       logger,
     });
+    await runOnRedis({ origin: "rate_limiter" }, async (redis) =>
+      redis.zAdd(redisKey, {
+        score: Date.now() - 2 * 60 * 60 * 1000,
+        value: `5000000:${crypto.randomUUID()}`,
+      })
+    );
 
-    const count = await getRateLimiterCount({
+    const count = await getWeightedRateLimiterCount({
       key,
       timeframeSeconds: 60,
     });
     expect(count.isOk()).toBe(true);
     if (count.isOk()) {
-      expect(count.value).toBe(3);
+      expect(count.value).toBe(3_000_000);
     }
   });
 });

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -1,4 +1,5 @@
 import { getRedisStreamClient } from "@app/lib/api/redis";
+import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type {
   MaxAwuCreditsTimeframeType,
@@ -135,12 +136,15 @@ export async function rateLimiter({
 }
 
 /**
- * Unconditionally records `incrementBy` consumption units against `key`, with no limit guard.
+ * Unconditionally records `incrementBy` AWU credits against `key`, with no limit guard.
  *
- * Unlike `rateLimiter`, which drops the write entirely when count + incrementBy would exceed the
- * limit, this always persists the entries. Use this for post-hoc recording of a cost that already
- * happened (e.g. AWU credits for a message that already ran) — enforcement must happen beforehand
- * via `getRateLimiterCount` + a limit check, not by relying on this function to gatekeep.
+ * `incrementBy` is a (possibly fractional) credit amount: it is converted to integer microCredits
+ * and stored as a single sorted-set entry carrying the amount (`<microCredits>:<uuid>`), summed on
+ * read by `getWeightedRateLimiterCount`. Unlike `rateLimiter`, which drops the write entirely when
+ * count + incrementBy would exceed the limit, this always persists the entry. Use this for post-hoc
+ * recording of a cost that already happened (e.g. AWU credits for a message that already ran) —
+ * enforcement must happen beforehand via `getWeightedRateLimiterCount` + a limit check, not by
+ * relying on this function to gatekeep.
  */
 export async function addRateLimiterCount({
   key,
@@ -153,11 +157,19 @@ export async function addRateLimiterCount({
   incrementBy: number;
   logger: LoggerInterface;
 }): Promise<void> {
-  if (!Number.isInteger(incrementBy) || incrementBy <= 0) {
-    throw new Error("incrementBy must be a positive integer.");
+  // Fail open on a non-positive/non-finite amount: recording runs on the
+  // message-finalize path (including Temporal retries), so a bad increment must
+  // never throw and break finalization — skip instead.
+  if (!Number.isFinite(incrementBy) || incrementBy <= 0) {
+    return;
   }
   if (!Number.isInteger(timeframeSeconds) || timeframeSeconds <= 0) {
     throw new Error("timeframeSeconds must be a positive integer.");
+  }
+
+  const microCredits = roundCreditsToMicroCredits(incrementBy);
+  if (microCredits <= 0) {
+    return;
   }
 
   const redisKey = makeRateLimiterKey(key);
@@ -166,16 +178,16 @@ export async function addRateLimiterCount({
   const luaScript = `
     local key = KEYS[1]
     local window_ms = tonumber(ARGV[1])
-    local increment_by = tonumber(ARGV[2])
+    local member = ARGV[2]
 
     -- Use Redis server time to avoid client clock skew
     local t = redis.call('TIME') -- { seconds, microseconds }
     local now_ms = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
 
-    -- Always record unconditionally: no limit check, no dropped writes.
-    for i = 1, increment_by do
-      redis.call('ZADD', key, now_ms, ARGV[2 + i])
-    end
+    -- Always record unconditionally: no limit check, no dropped writes. A single
+    -- entry carries the amount (microCredits prefix + uuid for uniqueness); the
+    -- reader sums the prefixes via getWeightedRateLimiterCount.
+    redis.call('ZADD', key, now_ms, member)
 
     -- Keep the key around a bit longer than the window to allow trims
     redis.call('PEXPIRE', key, window_ms + 60000)
@@ -183,10 +195,10 @@ export async function addRateLimiterCount({
 
   try {
     const redis = await getRedisStreamClient({ origin: "rate_limiter" });
-    const values = Array.from({ length: incrementBy }, () => uuidv4());
+    const member = `${microCredits}:${uuidv4()}`;
     await redis.eval(luaScript, {
       keys: [redisKey],
-      arguments: [windowMs.toString(), incrementBy.toString(), ...values],
+      arguments: [windowMs.toString(), member],
     });
   } catch (e) {
     getStatsDClient().increment("ratelimiter.error.count", 1, [
@@ -234,6 +246,51 @@ export async function getRateLimiterCount({
     const count = await redis.zCount(redisKey, trimBeforeMs, "+inf");
 
     return new Ok(count);
+  } catch (err) {
+    return new Err(normalizeError(err));
+  }
+}
+
+/**
+ * Reads the weighted total (in microCredits) of the amount-carrying entries
+ * written by `addRateLimiterCount`. Each entry is `<microCredits>:<uuid>`, so
+ * unlike `getRateLimiterCount` (which counts rows), this sums the amount prefix
+ * of every entry still inside the rolling window. Malformed members (no
+ * separator or a non-numeric prefix) are skipped.
+ */
+export async function getWeightedRateLimiterCount({
+  key,
+  timeframeSeconds,
+}: {
+  key: string;
+  timeframeSeconds: number;
+}): Promise<Result<number, Error>> {
+  if (!Number.isInteger(timeframeSeconds) || timeframeSeconds <= 0) {
+    return new Err(new Error("timeframeSeconds must be a positive integer."));
+  }
+
+  try {
+    const redis = await getRedisStreamClient({ origin: "rate_limiter" });
+    const redisKey = makeRateLimiterKey(key);
+
+    const windowMs = timeframeSeconds * 1000;
+    const trimBeforeMs = Date.now() - windowMs;
+
+    const members = await redis.zRangeByScore(redisKey, trimBeforeMs, "+inf");
+
+    let totalMicroCredits = 0;
+    for (const member of members) {
+      const separatorIndex = member.indexOf(":");
+      if (separatorIndex === -1) {
+        continue;
+      }
+      const microCredits = parseInt(member.slice(0, separatorIndex), 10);
+      if (Number.isFinite(microCredits)) {
+        totalMicroCredits += microCredits;
+      }
+    }
+
+    return new Ok(totalMicroCredits);
   } catch (err) {
     return new Err(normalizeError(err));
   }

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -255,8 +255,10 @@ export async function getRateLimiterCount({
  * Reads the weighted total (in microCredits) of the amount-carrying entries
  * written by `addRateLimiterCount`. Each entry is `<microCredits>:<uuid>`, so
  * unlike `getRateLimiterCount` (which counts rows), this sums the amount prefix
- * of every entry still inside the rolling window. Malformed members (no
- * separator or a non-numeric prefix) are skipped.
+ * of every entry still inside the rolling window. The scan + sum runs
+ * server-side in Lua so only the total crosses the wire (not every member), and
+ * the window is derived from Redis server time to match the writer. Malformed
+ * members (no separator or a non-numeric prefix) are skipped.
  */
 export async function getWeightedRateLimiterCount({
   key,
@@ -269,26 +271,40 @@ export async function getWeightedRateLimiterCount({
     return new Err(new Error("timeframeSeconds must be a positive integer."));
   }
 
+  const redisKey = makeRateLimiterKey(key);
+  const windowMs = timeframeSeconds * 1000;
+
+  const luaScript = `
+    local key = KEYS[1]
+    local window_ms = tonumber(ARGV[1])
+
+    -- Use Redis server time to avoid client clock skew (matches the writer).
+    local t = redis.call('TIME') -- { seconds, microseconds }
+    local now_ms = tonumber(t[1]) * 1000 + math.floor(tonumber(t[2]) / 1000)
+    local trim_before = now_ms - window_ms
+
+    -- Sum the '<microCredits>:<uuid>' amount prefixes of the entries still
+    -- inside the window, server-side, so only the total crosses the wire.
+    local members = redis.call('ZRANGEBYSCORE', key, trim_before, '+inf')
+    local total = 0
+    for i = 1, #members do
+      local sep = string.find(members[i], ':', 1, true)
+      if sep then
+        local amount = tonumber(string.sub(members[i], 1, sep - 1))
+        if amount then
+          total = total + amount
+        end
+      end
+    end
+    return total
+  `;
+
   try {
     const redis = await getRedisStreamClient({ origin: "rate_limiter" });
-    const redisKey = makeRateLimiterKey(key);
-
-    const windowMs = timeframeSeconds * 1000;
-    const trimBeforeMs = Date.now() - windowMs;
-
-    const members = await redis.zRangeByScore(redisKey, trimBeforeMs, "+inf");
-
-    let totalMicroCredits = 0;
-    for (const member of members) {
-      const separatorIndex = member.indexOf(":");
-      if (separatorIndex === -1) {
-        continue;
-      }
-      const microCredits = parseInt(member.slice(0, separatorIndex), 10);
-      if (Number.isFinite(microCredits)) {
-        totalMicroCredits += microCredits;
-      }
-    }
+    const totalMicroCredits = (await redis.eval(luaScript, {
+      keys: [redisKey],
+      arguments: [windowMs.toString()],
+    })) as number;
 
     return new Ok(totalMicroCredits);
   } catch (err) {


### PR DESCRIPTION
## Context

Stacked on `spend-limit-rate-cap-microcredits` (#31015), which switched the three FIXED-WINDOW spend-cap counters to store microCredits. This PR applies the same unit switch to the **fair-use / free-usage rolling-window AWU counters**.

## The problem

The rolling-window limiter (`addRateLimiterCount`) stored a value as a **count of rows** — its Lua did one `ZADD` per consumed unit, and the reader returned `zCount` (number of rows). So "5 credits" = 5 rows, and credits had to be whole integers. Naively switching the unit to microCredits would write ~1,000,000 rows per credit.

## Approach: one row per call + sum-on-read

The fair-use rolling window now stores the **amount in a single row** and **sums on read**:

- `addRateLimiterCount` treats `incrementBy` as a (possibly fractional) credit amount, converts it to integer microCredits via `roundCreditsToMicroCredits`, and writes **one** sorted-set entry `<microCredits>:<uuid>` (amount prefix + uuid for uniqueness). The window+grace `PEXPIRE` behavior is unchanged.
  - Removes the `throw` on non-integer `incrementBy` (fractional credits are now valid), replaced with a fail-open `if (!Number.isFinite(incrementBy) || incrementBy <= 0) return;` early-return. This also fixes a latent fragility where a throw here could fail the Temporal finalize activity.
- New `getWeightedRateLimiterCount({ key, timeframeSeconds })` reads via `zRangeByScore`, splits each member on the first `:`, `parseInt`s the prefix, and sums (skipping malformed members), returning the total **microCredits**.

`rateLimiter`, `getRateLimiterCount`, and every message-count / mention / premium-model key are **completely untouched** — they legitimately count rows.

## Key bump

The two AWU rolling keys are suffixed `:v2_microcredits` so the new `amount:uuid` rows can never be summed with pre-existing plain-uuid rows:
- `makeFairUseAwuCreditsRateLimitKeyForUser`
- `makeFreeUsageCostRateLimitKeyForUser`

These are short rolling windows, so the old keys expire quickly. **A user's current fair-use/free window resets once at cutover** (acceptable — there is no ES seed for rolling windows, unlike the fixed-window spend caps).

## Read sites (compare in like-units)

- `conversation.ts` fair-use gate: `getWeightedRateLimiterCount`, compares `>= roundCreditsToMicroCredits(maxAwuCredits)`.
- `free_usage.ts` free-usage gate: `getWeightedRateLimiterCount`, compares `>= roundCreditsToMicroCredits(freeUsageAwuCreditsLimitForAuth(auth))`.
- `user_block.ts` `getFairUseAwuCreditsStatus`: reads microCredits but **keeps `FairUseAwuCreditsStatus` credit-denominated (with decimals)** — converts the summed microCredits back to credits via `microCreditsToCredits` for the `count` field; `limit` stays in credits. The status semantics are identical, only the stored unit changed.

Writers (`credit_cost.ts`, `free_usage.ts`) still pass **credits** — the microCredit conversion now happens inside `addRateLimiterCount`.

## Poke

`FairUseAwuCreditsStatus` stays in credits, so no poke unit conversion is needed. The fair-use status is not surfaced in poke at all (only in the companion `FairUseCreditsUsage` widget, which already renders credits); nothing to change there.

## Tests

`rate_limiter.test.ts` (real Redis on :6479): fractional `2.5` credits → `2_500_000` microCredits; multiple adds sum; entries outside the window are excluded from the sum. The pre-existing `addRateLimiterCount` tests were migrated from `getRateLimiterCount` (row-count) to `getWeightedRateLimiterCount` (microCredit sum), since the function's storage changed. All 13 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)