### PR TITLE
[sparkle] Bump Storybook to 10.5.8 and enable AI manifests + MCP

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "sparkle-storybook": {
+      "type": "http",
+      "url": "http://localhost:6006/mcp"
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,26 @@
 @CODING_RULES.md
 
 @AGENTS.local.md
+
+# Storybook MCP (Sparkle design system)
+
+When working on UI components, always use the `sparkle-storybook` MCP tools to access
+Storybook's component and documentation knowledge before answering or taking any action.
+(The server is served by the Sparkle Storybook dev server — `cd sparkle && npm run storybook`
+— and registered in `.mcp.json` at the repo root.)
+
+- **CRITICAL: Never hallucinate component properties!** Before using ANY property on a
+  component from the design system (including common-sounding ones like `shadow`, etc.), you
+  MUST use the MCP tools to check if the property is actually documented for that component.
+- Query `list-all-documentation` to get a list of all components.
+- Query `get-documentation` for that component to see all available properties and examples.
+- Only use properties that are explicitly documented or shown in example stories.
+- If a property isn't documented, do not assume properties based on naming conventions or
+  common patterns from other libraries. Check back with the user in these cases.
+- Use the `get-storybook-story-instructions` tool to fetch the latest instructions for
+  creating or updating stories. This will ensure you follow current conventions and
+  recommendations.
+- Check your work by running `run-story-tests`.
+
+Remember: A story name might not reflect the property name correctly, so always verify
+properties through documentation or example stories before using them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18088,9 +18088,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.1.tgz",
-      "integrity": "sha512-MGft/IXjJ20a9KbaSVG9bHTAAoanbucKrgEiJJRNqpim8DsXA01+XTdSk17LmiOCB203Rrq9mWgdQ6+79cc8iA==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.8.tgz",
+      "integrity": "sha512-yunl+sKa29NaUC3I4yjESwk6ED8waEgmmvIJzNAJvdhb7thFzZYYEld68RzKmOVcGBkD3snK5eZ/Xf0l4VWliQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18102,20 +18102,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.4.1"
+        "storybook": "^10.5.8"
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.1.tgz",
-      "integrity": "sha512-IYqUdjoZe4VO2LFZlKL/gwy7DsQSWCq6hX+zc1MBmZo04yycDASk1tte57n9pdlW3ajw9yYMF/+lVBi+xQjyvw==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.5.8.tgz",
+      "integrity": "sha512-NlHiMKW/UvW/uL8HXFDCEVwoH3qZeGYZ/qlWax4d7H471b/T54MBq2KcB4ZrdA785FfIH3numAJdBb5jwn00Mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "10.4.1",
+        "@storybook/csf-plugin": "10.5.8",
         "@storybook/icons": "^2.0.2",
-        "@storybook/react-dom-shim": "10.4.1",
+        "@storybook/react-dom-shim": "10.5.8",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -18126,7 +18126,7 @@
       },
       "peerDependencies": {
         "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.1"
+        "storybook": "^10.5.8"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -18134,10 +18134,34 @@
         }
       }
     },
+    "node_modules/@storybook/addon-mcp": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-mcp/-/addon-mcp-0.7.0.tgz",
+      "integrity": "sha512-f/IWGRMzWynBg5kDJ3DYvvnafuSX88kykGNFzzLOlkLVpfxEZoAmQF6AS47tw25GuH6EFIqSo6ZDBLHLVyZ/IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/mcp": "0.8.0",
+        "@tmcp/adapter-valibot": "^0.1.5",
+        "@tmcp/transport-http": "^0.8.5",
+        "picoquery": "^2.5.0",
+        "tmcp": "^1.19.4",
+        "valibot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@storybook/addon-vitest": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0",
+        "storybook": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/addon-vitest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@storybook/addon-themes": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.4.1.tgz",
-      "integrity": "sha512-nxNskZwpgptCUWyci+jiM5IrKY6xSaTpv3xzgkL6NCU+5PyCxyp0Z6jE8NDvew9jolzOC9pBhGJAW26A/jbFqg==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-10.5.8.tgz",
+      "integrity": "sha512-MYTLkN/5t02R0DJikVJUIRWnoyDqDwJprXnagUEFRT5aiO75glG7rY3uikB8n+7vXL/N9fTkgjIxER0SShkvYg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18148,13 +18172,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.4.1"
+        "storybook": "^10.5.8"
       }
     },
     "node_modules/@storybook/addon-vitest": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.4.1.tgz",
-      "integrity": "sha512-ymrX9EOou1x3d21iDhjP3j3XfhOAiflhlPZWKcipULBoJCq/aZPbV68EghzovkJNuGRl9ezMYxbbKxwrMmCmGg==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-vitest/-/addon-vitest-10.5.8.tgz",
+      "integrity": "sha512-/2K6JXncyHEM8v7UfOeR0KGd7s46Q2XlfaBJUnBoGsEG6JF46la8sh43b+kIOG7JGPUqlyfA6uOMewUmG6S17w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18169,7 +18193,7 @@
         "@vitest/browser": "^3.0.0 || ^4.0.0",
         "@vitest/browser-playwright": "^4.0.0",
         "@vitest/runner": "^3.0.0 || ^4.0.0",
-        "storybook": "^10.4.1",
+        "storybook": "^10.5.8",
         "vitest": "^3.0.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
@@ -18188,13 +18212,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.1.tgz",
-      "integrity": "sha512-/oyQrXoNOqN8SW5hNnYP+I1uvgFxKxWXj/EP6NXYzc5SQwImofgru+D2+6gDhL0+Q//+Hx05DJoQO2omvUJ8bQ==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.8.tgz",
+      "integrity": "sha512-UeRnn7yT55WmBlHNOQzLrvN7vsHEvVgIukhKDO+4cMbGXN87wZkbxhx6NstpuXRH8OxGqwKS0SZNVp+SC1ftLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "10.4.1",
+        "@storybook/csf-plugin": "10.5.8",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -18202,14 +18226,14 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^10.4.1",
+        "storybook": "^10.5.8",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.1.tgz",
-      "integrity": "sha512-WdPepGBxDGOUDjYd8KxMtcf+us/2PAcnBczl77XtrnxxHNs0jWesxKkiJ9yiuGrge4BPhDeAj6rxjbBoaHxLBA==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.8.tgz",
+      "integrity": "sha512-/FHiMyOWWEXfwK/lM0WxmkP9GLzbSJJuzGtfeuNWSOVDnvAMbjavitxfHb5wSbWKIQo0XYC1EJ2Y7x91XNYP4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18222,7 +18246,7 @@
       "peerDependencies": {
         "esbuild": "*",
         "rollup": "*",
-        "storybook": "^10.4.1",
+        "storybook": "^10.5.8",
         "vite": "*",
         "webpack": "*"
       },
@@ -18259,15 +18283,28 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@storybook/mcp": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@storybook/mcp/-/mcp-0.8.0.tgz",
+      "integrity": "sha512-G+XDgoWGrE98moXqKSee8fQyMQxoIWxRAbPG8r/HQ95pKodratevDqNyOgW+t6ZigM6AAVN1WHiFc5MI+hc8sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tmcp/adapter-valibot": "^0.1.5",
+        "@tmcp/transport-http": "^0.8.5",
+        "tmcp": "^1.19.4",
+        "valibot": "1.2.0"
+      }
+    },
     "node_modules/@storybook/react": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.1.tgz",
-      "integrity": "sha512-WuYz4NaUk4gmFAMliSpCbV8w6jP5OY9juBfw1huwzu2S/k5FhnVXwmrUaL0fmf3Bq/7NgkzmBBbZr6I6LuHayQ==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.8.tgz",
+      "integrity": "sha512-6qqkmqX6imtL+0Z9Uan2tIfYivOI0FiVmWr0zpqqQR15AkJ18JfNcNTQoyjeAlCO0Kei56SWqnu2qLq52TYplg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
-        "@storybook/react-dom-shim": "10.4.1",
+        "@storybook/react-dom-shim": "10.5.8",
         "react-docgen": "^8.0.2",
         "react-docgen-typescript": "^2.2.2"
       },
@@ -18280,7 +18317,7 @@
         "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.1",
+        "storybook": "^10.5.8",
         "typescript": ">= 4.9.x"
       },
       "peerDependenciesMeta": {
@@ -18296,9 +18333,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.1.tgz",
-      "integrity": "sha512-6QFqfDNH4DMrt7yHKRfpqRopsVUc/Az+sXIdJ39IetYnHUxL3nW4NVaPc6uy/8Qi8urzUyEXL/nn7cpSIP2aPQ==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.8.tgz",
+      "integrity": "sha512-N8D13/Xny+V3kfe1KBgsAHS0nKWXLLdgOOXS9poKdYzVwVCN+CGEGBxWX0zMMtdCptqa6/57em9coPlZMoO+bg==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -18310,7 +18347,7 @@
         "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.1"
+        "storybook": "^10.5.8"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -18322,19 +18359,19 @@
       }
     },
     "node_modules/@storybook/react-vite": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.1.tgz",
-      "integrity": "sha512-zY6OzaXvXqBIUyc5ySE55/LAPQiF+o9ZyhQI978WMu4mY/fL7FpQ+ZVHRUCCgz/wTXtqE9jJwd/N10HI1kD0/Q==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.8.tgz",
+      "integrity": "sha512-ioMJGi4YzueGsJBlYio+2+UhfCFB9QV5Bs1lOilkek+a4BZgKJl0D1mVSJl6k96stQBPZmLgI9/l0hLVcUL6Kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
         "@rollup/pluginutils": "^5.0.2",
-        "@storybook/builder-vite": "10.4.1",
-        "@storybook/react": "10.4.1",
+        "@storybook/builder-vite": "10.5.8",
+        "@storybook/react": "10.5.8",
         "empathic": "^2.0.0",
         "magic-string": "^0.30.0",
-        "react-docgen": "^8.0.0",
+        "react-docgen": "^8.0.2",
         "resolve": "^1.22.8",
         "tsconfig-paths": "^4.2.0"
       },
@@ -18345,8 +18382,14 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "storybook": "^10.4.1",
+        "storybook": "^10.5.8",
+        "typescript": ">= 4.9.x",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@stripe/react-stripe-js": {
@@ -20321,6 +20364,77 @@
       "peerDependencies": {
         "@tiptap/core": "^3.20.0",
         "@tiptap/pm": "^3.20.0"
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@tmcp/adapter-valibot/-/adapter-valibot-0.1.6.tgz",
+      "integrity": "sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@valibot/to-json-schema": "^1.3.0",
+        "valibot": "^1.1.0"
+      },
+      "peerDependencies": {
+        "tmcp": "^1.17.0",
+        "valibot": "^1.1.0"
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot/node_modules/@valibot/to-json-schema": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.7.1.tgz",
+      "integrity": "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "valibot": "^1.4.0"
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot/node_modules/valibot": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tmcp/session-manager": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@tmcp/session-manager/-/session-manager-0.2.2.tgz",
+      "integrity": "sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tmcp": "^1.16.3"
+      }
+    },
+    "node_modules/@tmcp/transport-http": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@tmcp/transport-http/-/transport-http-0.8.6.tgz",
+      "integrity": "sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tmcp/session-manager": "^0.2.2",
+        "esm-env": "^1.2.2"
+      },
+      "peerDependencies": {
+        "@tmcp/auth": "^0.3.3 || ^0.4.0",
+        "tmcp": "^1.18.0"
+      },
+      "peerDependenciesMeta": {
+        "@tmcp/auth": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tokenizer/inflate": {
@@ -29812,6 +29926,13 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
@@ -35449,6 +35570,13 @@
       "dependencies": {
         "foreach": "^2.0.4"
       }
+    },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
@@ -44787,6 +44915,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/picoquery": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/picoquery/-/picoquery-2.5.0.tgz",
+      "integrity": "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -52492,27 +52627,29 @@
       "license": "MIT"
     },
     "node_modules/storybook": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.1.tgz",
-      "integrity": "sha512-V1Zd2e+gBFufqAQVZ1JR8KLqALsEZ3JYSBnWwQbKa6zCfWWanR6AFMyuOkLt2gZOgGp3h2Riuz88pGNVTQSG0A==",
+      "version": "10.5.8",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.8.tgz",
+      "integrity": "sha512-rR4oFMSiWBSqI0lvsJPtcQUPj8+hzj3TkLu+Mw61Wo6YxPSb5FsLSHai0jZnuaIdKIlmu25KCfwlSQl4e1uvnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
-        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "6.9.1",
         "@testing-library/user-event": "^14.6.1",
         "@vitest/expect": "3.2.4",
         "@vitest/spy": "3.2.4",
         "@webcontainer/env": "^1.1.1",
-        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
         "open": "^10.2.0",
         "oxc-parser": "^0.127.0",
         "oxc-resolver": "^11.19.1",
         "recast": "^0.23.5",
         "semver": "^7.7.3",
         "use-sync-external-store": "^1.5.0",
-        "ws": "^8.18.0"
+        "ws": "^8.21.1"
       },
       "bin": {
         "storybook": "dist/bin/dispatcher.js"
@@ -52524,7 +52661,7 @@
       "peerDependencies": {
         "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "prettier": "^2 || ^3",
-        "vite-plus": "^0.1.15"
+        "vite-plus": "^0.1.15 || ^0.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -52565,6 +52702,28 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/storybook/node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/stream-browserify": {
@@ -53941,6 +54100,20 @@
       "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
       "license": "MIT"
     },
+    "node_modules/tmcp": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/tmcp/-/tmcp-1.20.0.tgz",
+      "integrity": "sha512-dcDximKQBGqLP/aEAVA26HcWRHhKipstg1w0fbDDJ0HcFZ6lolLU1YYmStYEn/73f534i7WrDNcjRfRYdV9CoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "json-rpc-2.0": "^1.7.1",
+        "sqids": "^0.3.0",
+        "uri-template-matcher": "^1.1.1",
+        "valibot": "^1.1.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -55287,9 +55460,9 @@
       }
     },
     "node_modules/unplugin/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -55481,6 +55654,13 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
+    },
+    "node_modules/uri-template-matcher": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/uri-template-matcher/-/uri-template-matcher-1.1.2.tgz",
+      "integrity": "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/url": {
       "version": "0.11.4",
@@ -55755,6 +55935,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/validator": {
@@ -58058,12 +58253,13 @@
       },
       "devDependencies": {
         "@radix-ui/react-focus-scope": "^1.0.3",
-        "@storybook/addon-a11y": "10.4.1",
-        "@storybook/addon-docs": "10.4.1",
-        "@storybook/addon-themes": "10.4.1",
-        "@storybook/addon-vitest": "10.4.1",
-        "@storybook/react": "10.4.1",
-        "@storybook/react-vite": "10.4.1",
+        "@storybook/addon-a11y": "10.5.8",
+        "@storybook/addon-docs": "10.5.8",
+        "@storybook/addon-mcp": "0.7.0",
+        "@storybook/addon-themes": "10.5.8",
+        "@storybook/addon-vitest": "10.5.8",
+        "@storybook/react": "10.5.8",
+        "@storybook/react-vite": "10.5.8",
         "@svgr/cli": "^8.0.1",
         "@tailwindcss/cli": "^4.3.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -58083,7 +58279,7 @@
         "playwright": "1.57.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "storybook": "10.4.1",
+        "storybook": "10.5.8",
         "storybook-addon-tag-badges": "^3.1.0",
         "tailwindcss": "^4.3.0",
         "tsc-alias": "^1.8.10",

--- a/sparkle/.storybook/main.ts
+++ b/sparkle/.storybook/main.ts
@@ -17,6 +17,10 @@ const config: StorybookConfig = {
     "@storybook/addon-docs",
     "@storybook/addon-a11y",
     "@storybook/addon-vitest",
+    // Generates AI manifests (/manifests/components.json, /manifests/docs.json)
+    // and serves the MCP endpoint at /mcp. Stories tagged "!manifest" are
+    // excluded from the manifests.
+    "@storybook/addon-mcp",
     "storybook-addon-tag-badges",
   ],
 

--- a/sparkle/AGENTS.md
+++ b/sparkle/AGENTS.md
@@ -23,9 +23,26 @@ Stories must live in `src/stories/`, not next to components: `package.json` `fil
 
 - `npm run storybook` — dev server on :6006. A static build is deployed as the prod instance.
 - `npm run build-storybook` — static build; also the cheapest way to catch story compile errors.
-- Addons: themes, docs, a11y, vitest, tag-badges. Suite packages are pinned to one exact
+- Addons: themes, docs, a11y, vitest, mcp, tag-badges. Suite packages are pinned to one exact
   version (no `^`) because Storybook addons peer-lock to the exact core version; bump them all
   together, and only to versions older than the repo `.npmrc` `min-release-age` cooldown.
+
+# AI manifests & MCP
+
+`@storybook/addon-mcp` generates AI-consumable manifests and serves an MCP endpoint:
+
+- Manifests: `/manifests/components.json` and `/manifests/docs.json` (dev server and static
+  build); debugger UI at `/manifests/components.html`.
+- MCP endpoint: `http://localhost:6006/mcp` (dev server only). Register it in an agent with
+  `npx mcp-add --type http --url "http://localhost:6006/mcp" --scope project`.
+- Curation is tag-driven: stories or files tagged `"!manifest"` are excluded (asset catalogs,
+  token tables, design-review galleries, interaction tests, deprecated components). The
+  `"deprecated"` tag renders a sidebar badge. Keep meta `tags: [...]` on one line — the a11y
+  sync script parses it textually.
+- Story conventions that feed the manifest: JSDoc with `@summary` on every story export,
+  intent-bearing story names, args-driven CSF3 (a `render` must spread its args), `fn()` from
+  `storybook/test` for callbacks, component-level JSDoc in `src/components/` (picked up by
+  react-docgen-typescript). `src/stories/Button.stories.tsx` is the model file.
 
 # Story tests
 

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -17,9 +17,7 @@
   },
   "watch": {
     "build": {
-      "patterns": [
-        "src"
-      ],
+      "patterns": ["src"],
       "extensions": "ts,tsx,css",
       "ignore": ""
     }
@@ -50,15 +48,8 @@
     "./styles/tailwind.css": "./src/styles/tailwind.css",
     "./styles/theme.css": "./src/styles/theme.css"
   },
-  "files": [
-    "dist/",
-    "src/",
-    "!src/stories/"
-  ],
-  "sideEffects": [
-    "src/index_with_tw_base.ts",
-    "*.css"
-  ],
+  "files": ["dist/", "src/", "!src/stories/"],
+  "sideEffects": ["src/index_with_tw_base.ts", "*.css"],
   "devDependencies": {
     "@radix-ui/react-focus-scope": "^1.0.3",
     "@storybook/addon-a11y": "10.5.8",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -17,7 +17,9 @@
   },
   "watch": {
     "build": {
-      "patterns": ["src"],
+      "patterns": [
+        "src"
+      ],
       "extensions": "ts,tsx,css",
       "ignore": ""
     }
@@ -48,29 +50,36 @@
     "./styles/tailwind.css": "./src/styles/tailwind.css",
     "./styles/theme.css": "./src/styles/theme.css"
   },
-  "files": ["dist/", "src/", "!src/stories/"],
-  "sideEffects": ["src/index_with_tw_base.ts", "*.css"],
+  "files": [
+    "dist/",
+    "src/",
+    "!src/stories/"
+  ],
+  "sideEffects": [
+    "src/index_with_tw_base.ts",
+    "*.css"
+  ],
   "devDependencies": {
     "@radix-ui/react-focus-scope": "^1.0.3",
-    "@storybook/addon-a11y": "10.4.1",
-    "@storybook/addon-docs": "10.4.1",
-    "@storybook/addon-themes": "10.4.1",
-    "@storybook/addon-vitest": "10.4.1",
-    "@storybook/react": "10.4.1",
-    "@storybook/react-vite": "10.4.1",
+    "@storybook/addon-a11y": "10.5.8",
+    "@storybook/addon-docs": "10.5.8",
+    "@storybook/addon-mcp": "0.7.0",
+    "@storybook/addon-themes": "10.5.8",
+    "@storybook/addon-vitest": "10.5.8",
+    "@storybook/react": "10.5.8",
+    "@storybook/react-vite": "10.5.8",
     "@svgr/cli": "^8.0.1",
-    "@vitest/browser": "4.0.18",
-    "@vitest/browser-playwright": "4.0.18",
-    "@vitest/coverage-v8": "4.0.18",
+    "@tailwindcss/cli": "^4.3.0",
     "@tailwindcss/forms": "^0.5.9",
+    "@tailwindcss/postcss": "^4.3.0",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@types/uuid": "^9.0.6",
     "@typescript/native-preview": "^7.0.0-dev.20260224.1",
-    "@tailwindcss/cli": "^4.3.0",
-    "@tailwindcss/postcss": "^4.3.0",
-
+    "@vitest/browser": "4.0.18",
+    "@vitest/browser-playwright": "4.0.18",
+    "@vitest/coverage-v8": "4.0.18",
     "copyfiles": "^2.4.1",
     "esbuild": "^0.27.3",
     "esbuild-plugin-postcss2": "^0.1.2",
@@ -78,7 +87,7 @@
     "playwright": "1.57.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "storybook": "10.4.1",
+    "storybook": "10.5.8",
     "storybook-addon-tag-badges": "^3.1.0",
     "tailwindcss": "^4.3.0",
     "tsc-alias": "^1.8.10",


### PR DESCRIPTION
## Description

Bumps the Storybook suite from 10.4.1 to 10.5.8 across all `@storybook/*` packages in the `sparkle` package, and adds `@storybook/addon-mcp` (0.7.0). The MCP addon generates component and docs manifests (`/manifests/components.json`, `/manifests/docs.json`) covering 94 components (with `!manifest`-tagged stories, catalogs, token tables, and deprecated components correctly excluded) and exposes an MCP endpoint at `/mcp` on the dev server. The manifest/MCP setup and story conventions are documented in `sparkle/AGENTS.md`.

## Tests

Verified on 10.5.8: `tsc` clean, 438/438 story tests pass (vitest browser mode), `build-storybook` succeeds, `a11y:sync` stable (no tag changes), MCP `initialize` handshake responds.

## Risk

Minor risk from the Storybook minor version bump (10.4.1 → 10.5.8); limited to the `sparkle` dev toolchain with no runtime impact.

## Deploy Plan

Deploy sparkle.