### PR TITLE
[front] perf: Fetch render actions without the tool-execution join

### DIFF
--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -70,10 +70,12 @@ AgentStepContentToolExecutionModel.init(
         concurrently: true,
         name: "agent_step_content_tool_executions_agent_mcp_action_id",
       },
+      // Covering index: rendering resolves a conversation's step contents to their actions and
+      // reads nothing else off this table, so the scan stays out of the heap.
       {
-        fields: ["stepContentId"],
+        fields: ["stepContentId", "workspaceId", "agentMCPActionId"],
         concurrently: true,
-        name: "agent_step_content_tool_executions_step_content_id",
+        name: "agent_sc_te_step_content_workspace_action",
       },
       {
         fields: ["workspaceId", "conversationId", "agentMessageId"],

--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -75,10 +75,11 @@ AgentStepContentToolExecutionModel.init(
         concurrently: true,
         name: "agent_step_content_tool_executions_step_content_id",
       },
-      // Covering index: rendering resolves a conversation's step contents to their actions and
-      // reads nothing else off this table, so the scan stays out of the heap.
+      // In the database this index carries INCLUDE ("agentMCPActionId"), which Sequelize cannot
+      // express: rendering resolves step contents to their actions and reads nothing else off this
+      // table, so the scan stays out of the heap. Keep the INCLUDE when regenerating migrations.
       {
-        fields: ["workspaceId", "stepContentId", "agentMCPActionId"],
+        fields: ["workspaceId", "stepContentId"],
         concurrently: true,
         name: "agent_sc_te_workspace_step_content_action",
       },

--- a/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
+++ b/front/lib/models/agent/actions/agent_step_content_tool_execution.ts
@@ -70,12 +70,17 @@ AgentStepContentToolExecutionModel.init(
         concurrently: true,
         name: "agent_step_content_tool_executions_agent_mcp_action_id",
       },
+      {
+        fields: ["stepContentId"],
+        concurrently: true,
+        name: "agent_step_content_tool_executions_step_content_id",
+      },
       // Covering index: rendering resolves a conversation's step contents to their actions and
       // reads nothing else off this table, so the scan stays out of the heap.
       {
-        fields: ["stepContentId", "workspaceId", "agentMCPActionId"],
+        fields: ["workspaceId", "stepContentId", "agentMCPActionId"],
         concurrently: true,
-        name: "agent_sc_te_step_content_workspace_action",
+        name: "agent_sc_te_workspace_step_content_action",
       },
       {
         fields: ["workspaceId", "conversationId", "agentMessageId"],

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -15,6 +15,7 @@ import {
   warmGcsContentCache,
 } from "@app/lib/resources/agent_mcp_action/output_storage";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -31,6 +32,7 @@ import type {
   ConversationType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { WorkspaceType } from "@app/types/user";
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
@@ -1274,5 +1276,141 @@ describe("listGeneratedFilesForConversation", () => {
       });
 
     expect(result).toEqual([]);
+  });
+});
+
+describe("fetchByStepContents", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+  });
+
+  async function createAgentMessage(rank: number): Promise<ModelId> {
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: `Test Agent ${rank}`,
+    });
+
+    const userMessageRow = await ConversationFactory.createUserMessageWithRank({
+      auth,
+      workspace,
+      conversationId: conversation.id,
+      rank,
+      content: "Test message",
+    });
+
+    const agentMessageRow =
+      await ConversationFactory.createAgentMessageWithRank({
+        workspace,
+        conversationId: conversation.id,
+        rank: rank + 1,
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        parentId: userMessageRow.id,
+      });
+
+    return agentMessageRow.agentMessageId!;
+  }
+
+  function createAction(agentMessageModelId: ModelId, step: number) {
+    return AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId,
+      status: "succeeded",
+      step,
+    });
+  }
+
+  it("should return the actions of every given agent message", async () => {
+    const firstAgentMessageId = await createAgentMessage(0);
+    const secondAgentMessageId = await createAgentMessage(2);
+
+    const { action: firstAction } = await createAction(firstAgentMessageId, 1);
+    const { action: secondAction } = await createAction(
+      secondAgentMessageId,
+      1
+    );
+
+    const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+      auth,
+      { agentMessageIds: [firstAgentMessageId, secondAgentMessageId] }
+    );
+
+    const actions = await AgentMCPActionResource.fetchByStepContents(auth, {
+      stepContents,
+    });
+
+    expect(actions.map((a) => a.id).sort()).toEqual(
+      [firstAction.id, secondAction.id].sort()
+    );
+  });
+
+  it("should only return the actions of the given step contents", async () => {
+    const agentMessageId = await createAgentMessage(0);
+    const { action: firstAction } = await createAction(agentMessageId, 1);
+    await createAction(agentMessageId, 2);
+
+    const actions = await AgentMCPActionResource.fetchByStepContents(auth, {
+      stepContents: [firstAction.stepContent],
+    });
+
+    expect(actions.map((a) => a.id)).toEqual([firstAction.id]);
+  });
+
+  it("should return no action when no step content is a function call", async () => {
+    const agentMessageId = await createAgentMessage(0);
+    await createAction(agentMessageId, 1);
+
+    const textContent = await AgentStepContentResource.createNewVersion({
+      workspaceId: workspace.id,
+      agentMessageId,
+      step: 1,
+      index: 42,
+      type: "text_content",
+      value: { type: "text_content", value: "Some text" },
+    });
+
+    const actions = await AgentMCPActionResource.fetchByStepContents(auth, {
+      stepContents: [textContent],
+    });
+
+    expect(actions).toEqual([]);
+  });
+
+  it("should exclude sandbox child actions sharing their parent step content", async () => {
+    const agentMessageId = await createAgentMessage(0);
+    const { action: parentAction } = await createAction(agentMessageId, 1);
+
+    await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessageId,
+      status: "succeeded",
+      step: 1,
+      parentAction,
+      sandboxChildActionInfo: { parentActionId: parentAction.sId },
+    });
+
+    const stepContents = await AgentStepContentResource.fetchByAgentMessages(
+      auth,
+      { agentMessageIds: [agentMessageId] }
+    );
+
+    const actions = await AgentMCPActionResource.fetchByStepContents(auth, {
+      stepContents,
+    });
+
+    expect(actions.map((a) => a.id)).toEqual([parentAction.id]);
   });
 });

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -662,58 +662,88 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       stepContents: AgentStepContentResource[];
     }
   ): Promise<AgentMCPActionResource[]> {
-    if (stepContents.length === 0) {
+    const functionCallStepContents = stepContents.filter(
+      (
+        content
+      ): content is AgentStepContentResource & {
+        value: AgentFunctionCallContentType;
+      } => content.isFunctionCallContent()
+    );
+    if (functionCallStepContents.length === 0) {
       return [];
     }
 
     const workspaceId = auth.getNonNullableWorkspace().id;
+    const agentMessageIds = [
+      ...new Set(
+        functionCallStepContents.map((content) => content.agentMessageId)
+      ),
+    ];
 
-    const agentStepContentToolExecutions =
-      await AgentStepContentToolExecutionModel.findAll({
-        where: {
-          workspaceId,
-          stepContentId: { [Op.in]: stepContents.map((content) => content.id) },
-        },
-        include: [
-          {
-            model: AgentMCPActionModel,
-            as: "agentMCPAction",
-            required: true,
-          },
-        ],
-      });
-
-    const stepContentsMap = new Map(stepContents.map((s) => [s.id, s]));
-
-    // Sandbox-child actions share their parent's stepContent and must not
-    // surface as separate executions in the conversation timeline.
-    const visibleExecutions = agentStepContentToolExecutions.filter(
-      (row) =>
-        !isSandboxChildActionInfo(
-          row.agentMCPAction.stepContext.sandboxChildActionInfo
-        )
-    );
-
-    return visibleExecutions.map((row) => {
-      const a = row.agentMCPAction;
-      const stepContent = stepContentsMap.get(row.stepContentId);
-
-      // Each action must have a function call step content.
-      assert(stepContent, "Step content not found.");
-      assert(
-        stepContent.isFunctionCallContent(),
-        "Step content is not a function call."
-      );
-
-      const internalMCPServerName = a.toolConfiguration.toolServerId
-        ? getInternalMCPServerNameFromSId(a.toolConfiguration.toolServerId)
-        : null;
-
-      return new this(this.model, a.get(), stepContent, {
-        internalMCPServerName,
-        mcpServerId: a.toolConfiguration.toolServerId,
-      });
+    const toolExecutions = await AgentStepContentToolExecutionModel.findAll({
+      attributes: ["agentMCPActionId", "stepContentId"],
+      where: {
+        workspaceId,
+        agentMessageId: { [Op.in]: agentMessageIds },
+      },
     });
+
+    const stepContentsMap = new Map(
+      functionCallStepContents.map((content) => [content.id, content])
+    );
+    const actionIdsByStepContentId = new Map<ModelId, ModelId[]>();
+    for (const toolExecution of toolExecutions) {
+      if (!stepContentsMap.has(toolExecution.stepContentId)) {
+        continue;
+      }
+      const actionIds =
+        actionIdsByStepContentId.get(toolExecution.stepContentId) ?? [];
+      actionIds.push(toolExecution.agentMCPActionId);
+      actionIdsByStepContentId.set(toolExecution.stepContentId, actionIds);
+    }
+    if (actionIdsByStepContentId.size === 0) {
+      return [];
+    }
+
+    const actions = await AgentMCPActionModel.findAll({
+      where: {
+        workspaceId,
+        agentMessageId: { [Op.in]: agentMessageIds },
+      },
+    });
+    const actionsById = new Map(actions.map((action) => [action.id, action]));
+
+    const resources: AgentMCPActionResource[] = [];
+    for (const stepContent of functionCallStepContents) {
+      const actionIds = actionIdsByStepContentId.get(stepContent.id) ?? [];
+      for (const actionId of actionIds) {
+        const action = actionsById.get(actionId);
+        assert(action, "Action not found.");
+
+        // Sandbox-child actions share their parent's stepContent and must not
+        // surface as separate executions in the conversation timeline.
+        if (
+          isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
+        ) {
+          continue;
+        }
+
+        const internalMCPServerName = action.toolConfiguration.toolServerId
+          ? getInternalMCPServerNameFromSId(
+              action.toolConfiguration.toolServerId
+            )
+          : null;
+
+        resources.push(
+          new this(this.model, action.get(), stepContent, {
+            internalMCPServerName,
+            mcpServerId: action.toolConfiguration.toolServerId,
+          })
+        );
+      }
+    }
+
+    return resources;
   }
 
   static async listModelIdsByAgentMessageIds(

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -674,73 +674,59 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }
 
     const workspaceId = auth.getNonNullableWorkspace().id;
-    const agentMessageIds = [
-      ...new Set(
-        functionCallStepContents.map((content) => content.agentMessageId)
-      ),
-    ];
 
     const toolExecutions = await AgentStepContentToolExecutionModel.findAll({
-      attributes: ["agentMCPActionId", "stepContentId"],
+      attributes: ["stepContentId", "agentMCPActionId"],
       where: {
         workspaceId,
-        agentMessageId: { [Op.in]: agentMessageIds },
+        stepContentId: {
+          [Op.in]: functionCallStepContents.map((content) => content.id),
+        },
       },
     });
-
-    const stepContentsMap = new Map(
-      functionCallStepContents.map((content) => [content.id, content])
-    );
-    const actionIdsByStepContentId = new Map<ModelId, ModelId[]>();
-    for (const toolExecution of toolExecutions) {
-      if (!stepContentsMap.has(toolExecution.stepContentId)) {
-        continue;
-      }
-      const actionIds =
-        actionIdsByStepContentId.get(toolExecution.stepContentId) ?? [];
-      actionIds.push(toolExecution.agentMCPActionId);
-      actionIdsByStepContentId.set(toolExecution.stepContentId, actionIds);
-    }
-    if (actionIdsByStepContentId.size === 0) {
+    if (toolExecutions.length === 0) {
       return [];
     }
 
     const actions = await AgentMCPActionModel.findAll({
       where: {
         workspaceId,
-        agentMessageId: { [Op.in]: agentMessageIds },
+        id: {
+          [Op.in]: toolExecutions.map(
+            (toolExecution) => toolExecution.agentMCPActionId
+          ),
+        },
       },
     });
     const actionsById = new Map(actions.map((action) => [action.id, action]));
+    const stepContentsMap = new Map(
+      functionCallStepContents.map((content) => [content.id, content])
+    );
 
     const resources: AgentMCPActionResource[] = [];
-    for (const stepContent of functionCallStepContents) {
-      const actionIds = actionIdsByStepContentId.get(stepContent.id) ?? [];
-      for (const actionId of actionIds) {
-        const action = actionsById.get(actionId);
-        assert(action, "Action not found.");
+    for (const toolExecution of toolExecutions) {
+      const action = actionsById.get(toolExecution.agentMCPActionId);
+      assert(action, "Action not found.");
 
-        // Sandbox-child actions share their parent's stepContent and must not
-        // surface as separate executions in the conversation timeline.
-        if (
-          isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)
-        ) {
-          continue;
-        }
-
-        const internalMCPServerName = action.toolConfiguration.toolServerId
-          ? getInternalMCPServerNameFromSId(
-              action.toolConfiguration.toolServerId
-            )
-          : null;
-
-        resources.push(
-          new this(this.model, action.get(), stepContent, {
-            internalMCPServerName,
-            mcpServerId: action.toolConfiguration.toolServerId,
-          })
-        );
+      // Sandbox-child actions share their parent's stepContent and must not
+      // surface as separate executions in the conversation timeline.
+      if (isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo)) {
+        continue;
       }
+
+      const stepContent = stepContentsMap.get(toolExecution.stepContentId);
+      assert(stepContent, "Step content not found.");
+
+      const internalMCPServerName = action.toolConfiguration.toolServerId
+        ? getInternalMCPServerNameFromSId(action.toolConfiguration.toolServerId)
+        : null;
+
+      resources.push(
+        new this(this.model, action.get(), stepContent, {
+          internalMCPServerName,
+          mcpServerId: action.toolConfiguration.toolServerId,
+        })
+      );
     }
 
     return resources;

--- a/front/migrations/pre-deploy/20260824122407_add_covering_step_content_index_on_tool_executions.sql
+++ b/front/migrations/pre-deploy/20260824122407_add_covering_step_content_index_on_tool_executions.sql
@@ -4,4 +4,4 @@ Statement 0
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY agent_sc_te_workspace_step_content_action ON public.agent_step_content_tool_executions USING btree ("workspaceId", "stepContentId", "agentMCPActionId");
+CREATE INDEX CONCURRENTLY agent_sc_te_workspace_step_content_action ON public.agent_step_content_tool_executions USING btree ("workspaceId", "stepContentId") INCLUDE ("agentMCPActionId");

--- a/front/migrations/pre-deploy/20260824122407_add_covering_step_content_index_on_tool_executions.sql
+++ b/front/migrations/pre-deploy/20260824122407_add_covering_step_content_index_on_tool_executions.sql
@@ -4,14 +4,4 @@ Statement 0
 */
 SET SESSION statement_timeout = 1200000;
 SET SESSION lock_timeout = 3000;
-CREATE INDEX CONCURRENTLY agent_sc_te_step_content_workspace_action ON public.agent_step_content_tool_executions USING btree ("stepContentId", "workspaceId", "agentMCPActionId");
-
-/*
-Statement 1
-  - Superseded by the index above, which leads on the same column: it serves the same lookups and
-    the stepContentId foreign key check.
-  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
-*/
-SET SESSION statement_timeout = 1200000;
-SET SESSION lock_timeout = 3000;
-DROP INDEX CONCURRENTLY "public"."agent_step_content_tool_executions_step_content_id";
+CREATE INDEX CONCURRENTLY agent_sc_te_workspace_step_content_action ON public.agent_step_content_tool_executions USING btree ("workspaceId", "stepContentId", "agentMCPActionId");

--- a/front/migrations/pre-deploy/20260824122407_add_covering_step_content_index_on_tool_executions.sql
+++ b/front/migrations/pre-deploy/20260824122407_add_covering_step_content_index_on_tool_executions.sql
@@ -1,0 +1,17 @@
+/*
+Statement 0
+  - INDEX_BUILD: This might affect database performance. Concurrent index builds require a non-trivial amount of CPU, potentially affecting database performance. They also can take a while but do not lock out writes.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY agent_sc_te_step_content_workspace_action ON public.agent_step_content_tool_executions USING btree ("stepContentId", "workspaceId", "agentMCPActionId");
+
+/*
+Statement 1
+  - Superseded by the index above, which leads on the same column: it serves the same lookups and
+    the stepContentId foreign key check.
+  - INDEX_DROPPED: Dropping this index means queries that use this index might perform worse because they will no longer will be able to leverage it.
+*/
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."agent_step_content_tool_executions_step_content_id";


### PR DESCRIPTION
## Description

https://app.pganalyze.com/databases/-642267629/queries/13265983126

Mcp action resource has always been a hot point in our data-model, especially the fetchByStepContents used in batch render message.

Currently, in this fetchByStepContents, we join mcp action with step tool execution resource to fetch all mcp action given a set of steps.

1. We do not filter steps passed down, and only function tool call steps can yield an mcp action row.
2. This join can be split into 2 queries provided the set of actions to fetch in two queries is much smaller than the set scanned during the join

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
