### PR TITLE
[front] Surface per-user fair-use AWU usage in Poke members table

### DIFF
--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -160,6 +160,10 @@ function FreeSeatBalanceBadges({
 
 interface PokeMembersUsageTableProps {
   owner: WorkspaceType;
+  // Credit-priced workspaces (Metronome contract). Gates the credit-only
+  // columns (user cap, seat balance/allowance, credit state), which are
+  // meaningless for non-credit workspaces.
+  isCreditBased: boolean;
 }
 
 function makeColumns({
@@ -168,14 +172,18 @@ function makeColumns({
   orderColumn,
   orderDirection,
   onToggleSort,
+  showFairUse,
+  showCreditColumns,
 }: {
   owner: WorkspaceType;
   onReconciled: () => void;
   orderColumn: OrderColumn;
   orderDirection: SortDirection;
   onToggleSort: (column: OrderColumn) => void;
+  showFairUse: boolean;
+  showCreditColumns: boolean;
 }): ColumnDef<MemberUsageType>[] {
-  return [
+  const columns: ColumnDef<MemberUsageType>[] = [
     {
       accessorKey: "name",
       enableSorting: false,
@@ -402,9 +410,30 @@ function makeColumns({
       ),
     },
   ];
+
+  return columns.filter((col) => {
+    const key =
+      "accessorKey" in col && typeof col.accessorKey === "string"
+        ? col.accessorKey
+        : (col.id ?? "");
+    if (key === "fairUse") {
+      return showFairUse;
+    }
+    if (
+      key === "spendLimitAwuCredits" ||
+      key === "memberUsageLimit" ||
+      key === "creditState"
+    ) {
+      return showCreditColumns;
+    }
+    return true;
+  });
 }
 
-export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
+export function PokeMembersUsageTable({
+  owner,
+  isCreditBased,
+}: PokeMembersUsageTableProps) {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: DEFAULT_PAGE_SIZE,
@@ -480,6 +509,10 @@ export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
     []
   );
 
+  // The fair-use limit is plan-level, so it's uniform across members: show the
+  // column when any member carries a fair-use limit (i.e. the plan has one).
+  const showFairUse = members.some((m) => Boolean(m.fairUse));
+
   const columns = useMemo(
     () =>
       makeColumns({
@@ -488,8 +521,18 @@ export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
         orderColumn,
         orderDirection,
         onToggleSort: toggleSort,
+        showFairUse,
+        showCreditColumns: isCreditBased,
       }),
-    [owner, mutateMembersUsage, orderColumn, orderDirection, toggleSort]
+    [
+      owner,
+      mutateMembersUsage,
+      orderColumn,
+      orderDirection,
+      toggleSort,
+      showFairUse,
+      isCreditBased,
+    ]
   );
 
   if (isMembersUsageError) {
@@ -517,12 +560,14 @@ export function PokeMembersUsageTable({ owner }: PokeMembersUsageTableProps) {
           options={MEMBERSHIP_SEAT_TYPES}
           onChange={handleSeatTypeFilterChange}
         />
-        <EnumFilterDropdown
-          label="Credit state"
-          value={creditStateFilter}
-          options={USER_CREDIT_STATES}
-          onChange={handleCreditStateFilterChange}
-        />
+        {isCreditBased && (
+          <EnumFilterDropdown
+            label="Credit state"
+            value={creditStateFilter}
+            options={USER_CREDIT_STATES}
+            onChange={handleCreditStateFilterChange}
+          />
+        )}
       </div>
       <PokeDataTable
         columns={columns}

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -255,6 +255,26 @@ function makeColumns({
       },
     },
     {
+      id: "fairUse",
+      // Per-user fair-use AWU usage (used / limit, credits). Applies to
+      // non-credit-based plans (free/trial); "—" when the plan carries no
+      // fair-use limit.
+      header: "Fair-use",
+      enableSorting: false,
+      cell: ({ row }) => {
+        const { fairUse } = row.original;
+        if (!fairUse) {
+          return <span>—</span>;
+        }
+        return (
+          <span>
+            {formatCreditsPrecise(fairUse.usedCredits)} /{" "}
+            {formatCreditsPrecise(fairUse.limitCredits)}
+          </span>
+        );
+      },
+    },
+    {
       accessorKey: "spendLimitAwuCredits",
       header: "User cap",
       enableSorting: false,

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -226,10 +226,11 @@ function makeColumns({
       accessorKey: "consumedAwuCredits",
       // ES = Elasticsearch, RL = Redis rate-limiter counter, MT = Metronome.
       // The three should agree; divergence points at a counter/metric issue.
+      // Non-credit workspaces have no RL/MT counters, so only ES is shown.
       // Sorting is driven by the ES figure (see resolveMembersUsagePageUsers).
       header: () => (
         <SortableHeader
-          label="Consumed (ES / RL / MT)"
+          label={showCreditColumns ? "Consumed (ES / RL / MT)" : "Consumed"}
           column="consumedAwuCredits"
           activeColumn={orderColumn}
           direction={orderDirection}
@@ -243,6 +244,9 @@ function makeColumns({
           rateLimiterSpendAwuCredits,
           metronomeConsumedAwuCredits,
         } = row.original;
+        if (!showCreditColumns) {
+          return <span>{formatCreditsPrecise(consumedAwuCredits)}</span>;
+        }
         return (
           <div className="flex flex-col text-xs">
             <span>ES {formatCreditsPrecise(consumedAwuCredits)}</span>
@@ -400,12 +404,14 @@ function makeColumns({
               onGranted={onReconciled}
             />
           )}
-          <ReconcileCreditStateButton
-            owner={owner}
-            target="user"
-            userId={row.original.sId}
-            onReconciled={onReconciled}
-          />
+          {showCreditColumns && (
+            <ReconcileCreditStateButton
+              owner={owner}
+              target="user"
+              userId={row.original.sId}
+              onReconciled={onReconciled}
+            />
+          )}
         </div>
       ),
     },

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -360,7 +360,10 @@ export function PokeUsageTab({
     return (
       <div className="flex flex-col gap-4">
         <PokeWorkspaceUsageChart workspaceId={owner.sId} period={30} />
-        <PokeMembersUsageTable owner={owner} />
+        <PokeMembersUsageTable
+          owner={owner}
+          isCreditBased={hasMetronomeBillingUsage}
+        />
       </div>
     );
   }
@@ -395,7 +398,10 @@ export function PokeUsageTab({
       <PokeDefaultAlertsCard defaultAlerts={defaultAlerts} />
       <PokeCreditPoolCard owner={owner} />
       <PokeTopUpsHistoryTable owner={owner} />
-      <PokeMembersUsageTable owner={owner} />
+      <PokeMembersUsageTable
+        owner={owner}
+        isCreditBased={hasMetronomeBillingUsage}
+      />
       {billingCycleStartDay && (
         <PokeAwuUsageFromAnalyticsChart
           owner={owner}

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -353,7 +353,16 @@ export function PokeUsageTab({
   defaultAlerts,
 }: PokeUsageTabProps) {
   if (!hasMetronomeBillingUsage) {
-    return <PokeWorkspaceUsageChart workspaceId={owner.sId} period={30} />;
+    // Non-credit-based workspaces (no Metronome contract) have no credit
+    // diagnostics, but fair-use AWU limits still apply to them (free/trial), so
+    // the members table — which surfaces per-user fair-use usage — is shown
+    // alongside the activity chart.
+    return (
+      <div className="flex flex-col gap-4">
+        <PokeWorkspaceUsageChart workspaceId={owner.sId} period={30} />
+        <PokeMembersUsageTable owner={owner} />
+      </div>
+    );
   }
 
   const billingCycleStartDay = stripeSubscription?.current_period_start

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -1642,6 +1642,7 @@ async function resolveMembersUsagePageUsers({
         workspace,
         userIds: allUsers.map((u) => u.sId),
         freeSeatUserIds,
+        cycle: spendLimitCycleOverrideForAuth(auth),
       });
       for (const u of allUsers) {
         sortKeyByUserId.set(u.sId, creditsByUserId.get(u.sId) ?? 0);
@@ -1789,6 +1790,10 @@ export async function getMembersUsage({
       workspace,
       userIds: users.map((u) => u.sId),
       freeSeatUserIds,
+      // Non-credit workspaces have no Metronome billing period to anchor the
+      // window on; fall back to the UTC calendar month (same window the spend
+      // caps use) so consumed (ES) reflects real usage instead of 0.
+      cycle: spendLimitCycleOverrideForAuth(auth),
     }),
     fetchSeatDataForMembersTable({
       metronomeCustomerId: metronomeCustomerId ?? null,

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -39,7 +39,10 @@ import { getSeatAllowancesByNormalizedSeatType } from "@app/lib/metronome/seat_t
 import type { SeatData } from "@app/lib/metronome/seats";
 import { getCachedSeatDataByUserId } from "@app/lib/metronome/seats";
 import type { BillingFrequency } from "@app/lib/metronome/types";
-import { isUserAwuWarned } from "@app/lib/metronome/user_block";
+import {
+  getFairUseAwuCreditsStatus,
+  isUserAwuWarned,
+} from "@app/lib/metronome/user_block";
 import { CreditUsageConfigurationResource } from "@app/lib/resources/credit_usage_configuration_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
@@ -72,6 +75,7 @@ import {
   toBaseSeatType,
   USER_CREDIT_STATES,
 } from "@app/types/memberships";
+import type { MaxAwuCreditsTimeframeType } from "@app/types/plan";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -152,6 +156,17 @@ export type MemberUsageType = {
   // Whether the user has consumed ≥ 80% of their effective limit. Driven by
   // the nearLimit Redis flag (see user_block.ts). Poke-only.
   nearLimit: boolean;
+  // Per-user fair-use AWU credit usage (credits, with decimals) backed by the
+  // microCredit rate-limit counter. Applies to non-credit-based plans
+  // (free/trial) where a fair-use limit is set. Null when the plan carries no
+  // fair-use limit (limit === -1) or when not requested. Poke-only.
+  fairUse?: MemberFairUseUsage | null;
+};
+
+export type MemberFairUseUsage = {
+  usedCredits: number;
+  limitCredits: number;
+  timeframe: MaxAwuCreditsTimeframeType;
 };
 
 export type GetMembersUsageResponseBody = {
@@ -1913,6 +1928,41 @@ export async function getMembersUsage({
     }
   }
 
+  // Bulk-fetch each user's fair-use AWU credit usage (poke-only). This is a
+  // bounded page (≤ 150) of Redis reads, so batch with `concurrentExecutor`.
+  // Fair-use limits apply to non-credit-based plans (free/trial), so this is
+  // resolved regardless of the workspace's credit-based status. Null when the
+  // plan carries no fair-use limit.
+  const fairUseByUserId = new Map<string, MemberFairUseUsage | null>();
+  if (includeAlertLinks) {
+    const plan = auth.plan();
+    const entries = await concurrentExecutor(
+      users,
+      async (u) =>
+        [
+          u.sId,
+          await getFairUseAwuCreditsStatus({
+            workspace,
+            user: u.toJSON(),
+            plan,
+          }),
+        ] as const,
+      { concurrency: 8 }
+    );
+    for (const [sId, status] of entries) {
+      fairUseByUserId.set(
+        sId,
+        status.limit === -1
+          ? null
+          : {
+              usedCredits: status.count,
+              limitCredits: status.limit,
+              timeframe: status.timeframe,
+            }
+      );
+    }
+  }
+
   const membersUsage: MemberUsageType[] = users.flatMap((u) => {
     const membership = membershipByUserId.get(u.id);
     if (!membership) {
@@ -2059,6 +2109,7 @@ export async function getMembersUsage({
         freeCreditEmptyAlert: freeCreditAlerts?.empty ?? null,
         creditState: membership.creditState,
         nearLimit: nearLimitByUserId.get(userId) ?? false,
+        fairUse: fairUseByUserId.get(userId) ?? null,
       },
     ];
   });


### PR DESCRIPTION
## Description

Surfaces **per-user fair-use AWU credit usage** (used / limit, with decimals) in the Poke usage tab's members table.

Fair-use limits apply to **non-credit-based** workspaces (free/trial, where `maxAwuCredits !== -1`), so this display is **not** gated behind credit-based / new-pricing conditions — it now renders for those workspaces too.


<img width="1742" height="293" alt="Screenshot 2026-08-24 at 13 14 55" src="https://github.com/user-attachments/assets/cb851ee1-c600-4ba9-b046-81d73359030a" />

Stacked on `fair-use-rate-cap-microcredits`, reusing its `getFairUseAwuCreditsStatus` (credit-denominated, microCredit-backed) and `formatCreditsPrecise`.

## Changes

- **`front/lib/api/credits/members_usage.ts`**: append optional `fairUse` field to `MemberUsageType` (append-only per BACK12; `null` when the plan carries no fair-use limit, i.e. `limit === -1`). Populated per member via `concurrentExecutor` (bounded page ≤ 150 of Redis reads, poke-only via `includeAlertLinks`). Maps `count`→`usedCredits`, `limit`→`limitCredits`, plus `timeframe`.
- **`front/components/poke/credits/PokeMembersUsageTable.tsx`**: new "Fair-use" column rendering `usedCredits / limitCredits` via `formatCreditsPrecise`, "—" when there is no limit.
- **`front/components/poke/credits/PokeUsageTab.tsx`**: ungate — when `hasMetronomeBillingUsage` is false (non-credit workspaces, no Metronome contract), the members table is now shown alongside the activity chart so fair-use is visible. Credit-only cards remain gated to credit workspaces.

## Tests

locally 

## Risks

low, poke only 

## Deploy Plan

deploy front