### PR TITLE
[front] fix: restore route tags in SQL comments

### DIFF
--- a/front-api/middlewares/request_instrumentation.test.ts
+++ b/front-api/middlewares/request_instrumentation.test.ts
@@ -1,3 +1,4 @@
+import { frontSequelize } from "@app/lib/resources/storage";
 import {
   getRequestContext,
   RequestCachedQuery,
@@ -9,6 +10,7 @@ import {
   type RequestStorageEnv,
 } from "@front-api/lib/request_context";
 import { contextStorage } from "hono/context-storage";
+import { QueryTypes } from "sequelize";
 import { describe, expect, it } from "vitest";
 
 import { requestInstrumentation } from "./request_instrumentation";
@@ -52,6 +54,35 @@ describe("requestInstrumentation", () => {
       isContextBridged: true,
       isNewRequest: true,
       value: 2,
+    });
+  });
+
+  it("injects the normalized Hono route into SQL comments", async () => {
+    const app = createHono<RequestStorageEnv>();
+
+    configureHonoRequestStorage();
+    app.use(contextStorage());
+    app.use("*", requestInstrumentation);
+    app.get("/workspaces/:workspaceId", async (c) => {
+      // biome-ignore lint/plugin/noRawSql: current_query() verifies the comment received by PostgreSQL
+      const [result] = await frontSequelize.query<{ query: string }>(
+        'SELECT current_query() AS "query"',
+        { type: QueryTypes.SELECT }
+      );
+
+      return c.json({
+        query: result.query,
+        route: getRequestContext()?.route,
+      });
+    });
+
+    const response = await app.request("/workspaces/w_123");
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      query:
+        "SELECT current_query() AS \"query\" /*route='%2Fworkspaces%2F%3AworkspaceId'*/",
+      route: "/workspaces/:workspaceId",
     });
   });
 });

--- a/front-api/middlewares/request_instrumentation.ts
+++ b/front-api/middlewares/request_instrumentation.ts
@@ -58,14 +58,13 @@ const routeConcurrencyStates = new Map<string, RouteConcurrencyState>();
 
 export const requestInstrumentation =
   createMiddleware<RequestInstrumentationEnv>(async (c, next) => {
-    // Mutable: `route` starts as the raw URL path and is updated to the matched
-    // route pattern in the finally block (routePath is only set after routing).
-    // Any unhandled rejection fired from the handler will see the updated value
-    // because routing completes before the handler (and any fire-and-forget
-    // promises it spawns) run.
+    // `-1` points at the leaf handler selected by Hono, which is known before
+    // `next()` runs. Store the normalized route early so queries executed by the
+    // handler can use it without tagging concrete resource IDs.
+    const matchedRoute = routePath(c, -1) || c.req.path;
     const reqCtx: RequestContext = {
       method: c.req.method,
-      route: c.req.path,
+      route: matchedRoute,
       url: c.req.path,
     };
     c.set("requestContext", reqCtx);
@@ -77,11 +76,7 @@ export const requestInstrumentation =
       return next();
     }
 
-    // `routePath(c)` defaults to the current middleware route (`/*` here).
-    // `-1` points at the leaf handler route selected by Hono, which is already
-    // known before `next()` runs.
-    const concurrencyRoute = routePath(c, -1) || c.req.path;
-    const concurrencyKey = `${c.req.method} ${concurrencyRoute}`;
+    const concurrencyKey = `${c.req.method} ${matchedRoute}`;
     const routeConcurrencyState = routeConcurrencyStates.get(
       concurrencyKey
     ) ?? {

--- a/front/lib/api/database.ts
+++ b/front/lib/api/database.ts
@@ -1,8 +1,7 @@
 import { queryTracker } from "@app/lib/api/query_tracker";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types/shared/utils/general";
-import { context as otelContext, trace } from "@opentelemetry/api";
-import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+import { getRequestContext } from "@app/types/shared/utils/request_context";
 import type {
   ColumnsDescription,
   Model,
@@ -283,25 +282,9 @@ export class SequelizeWithComments<
 
       const comments: Record<string, string> = {};
 
-      // Get Next.js route from OpenTelemetry span.
-      const span = trace.getSpan(otelContext.active());
-      if (span && span.isRecording()) {
-        const readableSpan = span as unknown as ReadableSpan;
-        const attrs = readableSpan.attributes;
-
-        // Case 1: getServerSideProps/getStaticProps: has explicit `next.route`.
-        if (attrs?.["next.route"]) {
-          comments.route = attrs["next.route"] as string;
-        }
-        // Case 2: API routes: extract from next.span_name.
-        else if (attrs?.["next.span_name"]) {
-          const spanName = attrs["next.span_name"] as string;
-          // Extract route from: "executing api route (pages) /api/w/[wId]/feature-flags".
-          const match = spanName.match(/executing api route \(pages\) (.+)$/);
-          if (match) {
-            comments.route = match[1];
-          }
-        }
+      const route = getRequestContext()?.route;
+      if (route) {
+        comments.route = route;
       }
 
       // Build comment string following sqlcommenter format


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR restores endpoint attribution in SQL comments used by Cloud SQL Query Insights.

After the API migration to Hono, the SQL commenter still relied on framework-specific telemetry attributes that were no longer populated. It now reads the existing request context instead.

Matched route patterns are captured before handler execution, ensuring comments contain normalized routes without concrete resource identifiers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
