### PR TITLE
[front] enh: tag SQL queries with Temporal activities

### DIFF
--- a/front/lib/api/database.test.ts
+++ b/front/lib/api/database.test.ts
@@ -1,0 +1,23 @@
+import { frontSequelize } from "@app/lib/resources/storage";
+import { runWithTemporalActivityContext } from "@app/lib/temporal_activity_context";
+import { QueryTypes } from "sequelize";
+import { describe, expect, it } from "vitest";
+
+describe("SequelizeWithComments", () => {
+  it("injects the Temporal activity name into SQL comments", async () => {
+    const [result] = await runWithTemporalActivityContext(
+      "testActivity",
+      () => {
+        // biome-ignore lint/plugin/noRawSql: current_query() verifies the comment received by PostgreSQL
+        return frontSequelize.query<{ query: string }>(
+          'SELECT current_query() AS "query"',
+          { type: QueryTypes.SELECT }
+        );
+      }
+    );
+
+    expect(result.query).toBe(
+      "SELECT current_query() AS \"query\" /*activity='testActivity'*/"
+    );
+  });
+});

--- a/front/lib/api/database.ts
+++ b/front/lib/api/database.ts
@@ -1,4 +1,5 @@
 import { queryTracker } from "@app/lib/api/query_tracker";
+import { getTemporalActivityContext } from "@app/lib/temporal_activity_context";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types/shared/utils/general";
 import { getRequestContext } from "@app/types/shared/utils/request_context";
@@ -281,6 +282,11 @@ export class SequelizeWithComments<
       }
 
       const comments: Record<string, string> = {};
+
+      const activityName = getTemporalActivityContext()?.activityName;
+      if (activityName) {
+        comments.activity = activityName;
+      }
 
       const route = getRequestContext()?.route;
       if (route) {

--- a/front/lib/temporal_activity_context.ts
+++ b/front/lib/temporal_activity_context.ts
@@ -1,0 +1,21 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+type TemporalActivityContext = {
+  activityName: string;
+};
+
+const temporalActivityContext =
+  new AsyncLocalStorage<TemporalActivityContext>();
+
+export function runWithTemporalActivityContext<T>(
+  activityName: string,
+  fn: () => T
+): T {
+  return temporalActivityContext.run({ activityName }, fn);
+}
+
+export function getTemporalActivityContext():
+  | TemporalActivityContext
+  | undefined {
+  return temporalActivityContext.getStore();
+}

--- a/front/lib/temporal_monitoring.ts
+++ b/front/lib/temporal_monitoring.ts
@@ -1,4 +1,5 @@
 import { queryTracker } from "@app/lib/api/query_tracker";
+import { runWithTemporalActivityContext } from "@app/lib/temporal_activity_context";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import type logger from "@app/logger/logger";
 import type { Logger } from "@app/logger/logger";
@@ -63,27 +64,31 @@ export class ActivityInboundLogInterceptor
 
     try {
       this.logger.info("Activity started.");
-      return await queryTracker.run(queryTrackerStore, () =>
-        tracer.trace(
-          `${this.context.info.workflowType}-${this.context.info.activityType}`,
-          {
-            resource: this.context.info.activityType,
-            type: "temporal-activity",
-          },
-          async (span) => {
-            span?.setTag("attempt", this.context.info.attempt);
-            span?.setTag(
-              "workflow_id",
-              this.context.info.workflowExecution.workflowId
-            );
-            span?.setTag(
-              "workflow_run_id",
-              this.context.info.workflowExecution.runId
-            );
+      return await runWithTemporalActivityContext(
+        this.context.info.activityType,
+        () =>
+          queryTracker.run(queryTrackerStore, () =>
+            tracer.trace(
+              `${this.context.info.workflowType}-${this.context.info.activityType}`,
+              {
+                resource: this.context.info.activityType,
+                type: "temporal-activity",
+              },
+              async (span) => {
+                span?.setTag("attempt", this.context.info.attempt);
+                span?.setTag(
+                  "workflow_id",
+                  this.context.info.workflowExecution.workflowId
+                );
+                span?.setTag(
+                  "workflow_run_id",
+                  this.context.info.workflowExecution.runId
+                );
 
-            return next(input);
-          }
-        )
+                return next(input);
+              }
+            )
+          )
       );
     } catch (err: unknown) {
       error = err;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In the same path as https://github.com/dust-tt/dust/pull/31025. This PR adds background activity attribution to SQL comments used by database query observability.

The shared activity interceptor now propagates the static activity type through async context. Database queries executed within that context receive an activity tag.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
