### PR TITLE
[front] Add disable_fair_use_awu_limit workspace feature flag

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -3099,7 +3099,13 @@ async function isMessagesLimitReached(
   } = plan.limits.assistant;
 
   const user = auth.user();
-  if (user && maxAwuCredits !== -1) {
+  const featureFlags = await getFeatureFlags(auth);
+  // Escape hatch: the per-user fair-use AWU cap can be disabled per workspace.
+  if (
+    user &&
+    maxAwuCredits !== -1 &&
+    !featureFlags.includes("disable_fair_use_awu_limit")
+  ) {
     const result = await getWeightedRateLimiterCount({
       key: makeFairUseAwuCreditsRateLimitKeyForUser(
         owner,

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -303,11 +303,17 @@ export async function computeAndStoreAgentMessageCredits(
   const user = auth.user();
   const plan = auth.plan();
   const assistantLimits = plan?.limits.assistant;
+
+  // Feature flags gate the fair-use recording and the spend-cap backups below;
+  // fetch once when there is a delta to record.
+  const featureFlags = recordedCostDelta > 0 ? await getFeatureFlags(auth) : [];
+
   if (
     user &&
     assistantLimits &&
     recordedCostDelta > 0 &&
-    assistantLimits.maxAwuCredits !== -1
+    assistantLimits.maxAwuCredits !== -1 &&
+    !featureFlags.includes("disable_fair_use_awu_limit")
   ) {
     // The limit guard lives in isMessagesLimitReached (pre-message), which reads
     // the count via getRateLimiterCount and blocks the next message once the
@@ -329,7 +335,6 @@ export async function computeAndStoreAgentMessageCredits(
   // Record against the spend-cap backups (Redis fixed-window counters over the
   // contract billing cycle).
   if (recordedCostDelta > 0) {
-    const featureFlags = await getFeatureFlags(auth);
     if (featureFlags.includes("enforce_user_spend_limit_rate_cap")) {
       // Per-user cap.
       if (user) {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -371,6 +371,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Skip the per-user daily free-usage cost cap enforced at the LLM call site. Escape hatch to unstick legitimate workspaces that legitimately exceed the free-usage limit.",
     stage: "on_demand",
   },
+  disable_fair_use_awu_limit: {
+    description:
+      "Disable the per-user fair-use AWU credit limit on this workspace: skip both the pre-message enforcement (read) and the usage recording (write). Escape hatch for workspaces that should not be subject to the fair-use cap.",
+    stage: "on_demand",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -819,6 +819,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "enforce_premium_model_message_limit"
   | "editable_tool_inputs"
   | "skip_free_usage_rate_limit"
+  | "disable_fair_use_awu_limit"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION
## Descriptions

Escape hatch to exempt a workspace from the per-user fair-use AWU credit limit,
covering both sides:
- Read (enforcement): the pre-message fair-use gate in isMessagesLimitReached
  skips the counter check when the flag is set.
- Write (recording): finalizeAgentMessageCost skips recording usage into the
  fair-use rolling counter when the flag is set.

The recording path now fetches feature flags once and reuses them for both the
fair-use gate and the existing spend-cap backup gate. On-demand stage, toggled
per workspace from poke like skip_free_usage_rate_limit.

## Tests

## Risks

low

## Deploy Plan

deploy front
