### PR TITLE
Merge agent message `runIds` and `duration` updates into one statement

### DIFF
--- a/front/temporal/agent_loop/activities/common.test.ts
+++ b/front/temporal/agent_loop/activities/common.test.ts
@@ -792,7 +792,7 @@ describe("updateAgentMessageDBAndMemory", () => {
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
         update: {
-          type: "modelInteractionDurationMs",
+          type: "usageMetadata",
           modelInteractionDurationMs: 100,
         },
       });
@@ -842,7 +842,7 @@ describe("updateAgentMessageDBAndMemory", () => {
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
         update: {
-          type: "modelInteractionDurationMs",
+          type: "usageMetadata",
           modelInteractionDurationMs: 75,
         },
       });
@@ -885,7 +885,7 @@ describe("updateAgentMessageDBAndMemory", () => {
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
         update: {
-          type: "modelInteractionDurationMs",
+          type: "usageMetadata",
           modelInteractionDurationMs: 99.7,
         },
       });
@@ -939,7 +939,7 @@ describe("updateAgentMessageDBAndMemory", () => {
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
         update: {
-          type: "runIds",
+          type: "usageMetadata",
           runIds: ["run1", "run2"],
         },
       });
@@ -988,7 +988,7 @@ describe("updateAgentMessageDBAndMemory", () => {
       await updateAgentMessageDBAndMemory(auth, {
         agentMessage,
         update: {
-          type: "runIds",
+          type: "usageMetadata",
           runIds: ["run2", "run3"],
         },
       });
@@ -1004,6 +1004,54 @@ describe("updateAgentMessageDBAndMemory", () => {
         expect.arrayContaining(["run1", "run2", "run3"])
       );
       expect(dbMessage?.runIds?.length).toBe(3);
+    });
+
+    it("should update runIds and modelInteractionDurationMs together in a single call", async () => {
+      // Arrange: Create agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: agentConfig.sId,
+        messagesCreatedAt: [],
+      });
+      const { agentMessage } = await ConversationFactory.createAgentMessage(
+        auth,
+        {
+          workspace,
+          conversation,
+          agentConfig,
+        }
+      );
+
+      // Act: Update both fields at once
+      await updateAgentMessageDBAndMemory(auth, {
+        agentMessage,
+        update: {
+          type: "usageMetadata",
+          runIds: ["run1", "run2"],
+          modelInteractionDurationMs: 100,
+        },
+      });
+
+      // Assert: Both fields should be updated in database
+      const dbMessage = await AgentMessageModel.findOne({
+        where: {
+          id: agentMessage.agentMessageId,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(dbMessage?.runIds).toEqual(
+        expect.arrayContaining(["run1", "run2"])
+      );
+      expect(dbMessage?.runIds?.length).toBe(2);
+      expect(dbMessage?.modelInteractionDurationMs).toBe(100);
+
+      // Assert: In-memory object should be updated
+      expect(agentMessage.modelInteractionDurationMs).toBe(100);
     });
   });
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -73,12 +73,9 @@ export async function updateAgentMessageDBAndMemory(
         agentMessage: AgentMessageType;
         update:
           | {
-              type: "runIds";
-              runIds: string[];
-            }
-          | {
-              type: "modelInteractionDurationMs";
-              modelInteractionDurationMs: number;
+              type: "usageMetadata";
+              runIds?: string[];
+              modelInteractionDurationMs?: number;
             }
           | {
               type: "prunedContext";
@@ -132,43 +129,44 @@ export async function updateAgentMessageDBAndMemory(
   // Non-terminal metadata updates — no lock needed.
   const { update } = args;
   switch (update.type) {
-    case "modelInteractionDurationMs":
+    case "usageMetadata":
       {
-        const roundedModelInteractionDurationMs = Math.round(
-          update.modelInteractionDurationMs
-        );
-        // Note: we update the modelInteractionDurationMs directly in the database using a function to ensure
-        // an atomic update.
-        await AgentMessageModel.update(
-          {
-            modelInteractionDurationMs: literal(
-              `COALESCE("modelInteractionDurationMs", 0) + ${roundedModelInteractionDurationMs}`
-            ),
-          },
-          { where }
-        );
+        const roundedModelInteractionDurationMs =
+          update.modelInteractionDurationMs !== undefined
+            ? Math.round(update.modelInteractionDurationMs)
+            : null;
 
-        agentMessage.modelInteractionDurationMs =
-          (agentMessage.modelInteractionDurationMs ?? 0) +
-          roundedModelInteractionDurationMs;
-      }
-      break;
+        // Note: both fields are updated directly in the database using functions to ensure
+        // atomic updates, and in a single statement to avoid one commit per field.
+        const values = {
+          ...(roundedModelInteractionDurationMs !== null
+            ? {
+                modelInteractionDurationMs: literal(
+                  `COALESCE("modelInteractionDurationMs", 0) + ${roundedModelInteractionDurationMs}`
+                ),
+              }
+            : {}),
+          ...(update.runIds && update.runIds.length > 0
+            ? {
+                runIds: fn(
+                  "ARRAY",
+                  literal(
+                    `SELECT DISTINCT unnest(COALESCE("runIds", '{}') || ARRAY['${update.runIds.join("','")}']::text[])`
+                  )
+                ),
+              }
+            : {}),
+        };
 
-    case "runIds":
-      {
-        // Note: we update the runIds directly in the database using a function to ensure
-        // an atomic update.
-        await AgentMessageModel.update(
-          {
-            runIds: fn(
-              "ARRAY",
-              literal(
-                `SELECT DISTINCT unnest(COALESCE("runIds", '{}') || ARRAY['${update.runIds.join("','")}']::text[])`
-              )
-            ),
-          },
-          { where }
-        );
+        if (Object.keys(values).length > 0) {
+          await AgentMessageModel.update(values, { where });
+        }
+
+        if (roundedModelInteractionDurationMs !== null) {
+          agentMessage.modelInteractionDurationMs =
+            (agentMessage.modelInteractionDurationMs ?? 0) +
+            roundedModelInteractionDurationMs;
+        }
       }
       break;
 
@@ -233,25 +231,19 @@ export async function processEventForDatabase(
     modelInteractionDurationMs?: number;
   }
 ): Promise<boolean> {
-  // If we have a model interaction duration, store it.
-  if (modelInteractionDurationMs) {
+  // Store the model interaction duration and merge runIds from events that include them, in a
+  // single update. This ensures runIds are persisted incrementally as events are published.
+  const eventRunIds =
+    "runIds" in event && event.runIds && event.runIds.length > 0
+      ? event.runIds
+      : undefined;
+  if (modelInteractionDurationMs || eventRunIds) {
     await updateAgentMessageDBAndMemory(auth, {
       agentMessage,
       update: {
-        type: "modelInteractionDurationMs",
-        modelInteractionDurationMs,
-      },
-    });
-  }
-
-  // Merge runIds from events that include them. This ensures runIds are persisted
-  // incrementally as events are published.
-  if ("runIds" in event && event.runIds && event.runIds.length > 0) {
-    await updateAgentMessageDBAndMemory(auth, {
-      agentMessage,
-      update: {
-        type: "runIds",
-        runIds: event.runIds,
+        type: "usageMetadata",
+        modelInteractionDurationMs: modelInteractionDurationMs || undefined,
+        runIds: eventRunIds,
       },
     });
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
While investigating CPU saturation on the front database we found that the agent loop persists usage metadata carried by events through two back-to-back updates to the same agent message row, one for the model interaction duration and one for the run ids.

This merges the two update variants of the helper into a single one that accepts both fields optionally and builds one update statement covering whichever fields are present, so an event carrying both now costs a single commit instead of two. Behavior is otherwise unchanged: the duration is still accumulated atomically in the database, run ids are still merged and deduplicated server side, and falsy or empty values are still skipped exactly as before.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
