### PR TITLE
[admin governance] migrate builder role to user

### DIFF
--- a/front/migrations/20260824_migrate_builder_role_to_user.ts
+++ b/front/migrations/20260824_migrate_builder_role_to_user.ts
@@ -1,0 +1,104 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const DEFAULT_BATCH_SIZE = 1_000;
+const DEFAULT_BATCH_DELAY_MS = 100;
+
+const SELECT_SQL = `
+  SELECT id
+  FROM memberships
+  WHERE id > :lastId
+    AND role = 'builder'
+  ORDER BY id ASC
+  LIMIT :batchSize
+`;
+
+const UPDATE_SQL = `
+  UPDATE memberships
+  SET role = 'user'
+  WHERE id IN (:ids)
+    AND role = 'builder'
+`;
+
+const COUNT_SQL = `SELECT COUNT(*) AS count FROM memberships WHERE role = 'builder'`;
+
+function wait(durationMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, durationMs));
+}
+
+makeScript(
+  {
+    batchSize: {
+      type: "number",
+      default: DEFAULT_BATCH_SIZE,
+      describe: "Maximum number of rows updated per transaction",
+    },
+    batchDelayMs: {
+      type: "number",
+      default: DEFAULT_BATCH_DELAY_MS,
+      describe: "Delay between update batches in milliseconds",
+    },
+  },
+  async ({ execute, batchSize, batchDelayMs }, logger) => {
+    if (!Number.isInteger(batchSize) || batchSize <= 0) {
+      throw new Error("batchSize must be a positive integer");
+    }
+    if (!Number.isInteger(batchDelayMs) || batchDelayMs < 0) {
+      throw new Error("batchDelayMs must be a non-negative integer");
+    }
+
+    if (!execute) {
+      const [{ count }] = await frontSequelize.query<{ count: string }>(
+        COUNT_SQL,
+        { type: QueryTypes.SELECT }
+      );
+      logger.info(
+        { wouldUpdate: Number(count), batchSize, batchDelayMs },
+        "Dry run: would migrate membership role builder -> user"
+      );
+      return;
+    }
+
+    let batch = 0;
+    let lastId = 0;
+    let totalUpdated = 0;
+
+    for (;;) {
+      // Keyset pagination prevents each batch from rescanning rows already processed.
+      const rows = await frontSequelize.query<{ id: number }>(SELECT_SQL, {
+        replacements: { lastId, batchSize },
+        type: QueryTypes.SELECT,
+      });
+
+      if (rows.length === 0) {
+        break;
+      }
+
+      lastId = rows[rows.length - 1].id;
+      // Keep each batch in its own autocommit transaction so row locks are released before the
+      // pause. Raw SQL also leaves the row's updatedAt untouched.
+      const [, updated] = await frontSequelize.query(UPDATE_SQL, {
+        replacements: { ids: rows.map(({ id }) => id) },
+        type: QueryTypes.UPDATE,
+      });
+
+      batch += 1;
+      totalUpdated += updated;
+      logger.info(
+        { batch, batchSize: rows.length, lastId, updated, totalUpdated },
+        "Migrated membership role builder -> user batch"
+      );
+
+      if (batchDelayMs > 0) {
+        await wait(batchDelayMs);
+      }
+    }
+
+    logger.info(
+      { batches: batch, lastId, totalUpdated },
+      "Completed membership role builder -> user migration"
+    );
+  }
+);


### PR DESCRIPTION
## Description
This PR is to migrate memberships role `builder` to `user`. We already communicated with users about deprecating builder role (via email) and already show role "User" in UI. We have 12,880 builder users in US and 9,792 in EU. We need to sync with WorkOS after (they also save roles in their db, and we need to trigger a sync or something iiuc). I will clean up the code to remove builder check once both are done. 

Builders will lose "write" access in global/conversations and open space:
https://github.com/dust-tt/dust/blob/151f01fba5bc9c76e0346c4a4a43f8f65887afe7/front/lib/resources/space_resource.ts#L1905-L1913

And they need to be manager if they want to have "write" access. 

There is another one in group space member resource but I heard this will be removed and safe to ignore:

https://github.com/dust-tt/dust/blob/22f9dddad92e57de18a9e9b04ad84c863c013012/front/lib/resources/group_space_member_resource.ts#L177-L193

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
