### PR TITLE
[front] enh: add sorting on Poke trigger view

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/triggers/search.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/search.ts
@@ -1,25 +1,24 @@
-import { AutomationTriggersBodySchema } from "@app/lib/api/analytics/automations/schema";
 import type { GetAutomationTriggersResponse } from "@app/lib/api/analytics/automations/triggers";
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
-import { fetchPokeTriggers } from "@app/lib/api/poke/triggers";
+import {
+  fetchPokeTriggers,
+  PokeTriggersSearchBodySchema,
+} from "@app/lib/api/poke/triggers";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
 // Mounted at /api/poke/workspaces/:wId/triggers/search.
 const app = pokeApp();
-const PokeAutomationTriggersBodySchema = AutomationTriggersBodySchema.omit({
-  format: true,
-});
 
 /** @ignoreswagger */
 app.post(
   "/",
-  validate("json", PokeAutomationTriggersBodySchema),
+  validate("json", PokeTriggersSearchBodySchema),
   async (ctx): HandlerResult<GetAutomationTriggersResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
+    const { limit, offset, search, filter, sortOrder, ...periodQuery } =
       ctx.req.valid("json");
     const period = await resolveConsumptionPeriod(
       auth,
@@ -32,6 +31,7 @@ app.post(
       offset,
       search,
       filter,
+      sortOrder,
     });
     if (result.isErr()) {
       return apiError(

--- a/front/components/poke/PokeColumnSortableHeader.tsx
+++ b/front/components/poke/PokeColumnSortableHeader.tsx
@@ -11,13 +11,17 @@ export function PokeColumnSortableHeader<TData>({
   column,
   label,
 }: PokeColumnSortableHeaderProps<TData>) {
+  const sorted = column.getIsSorted();
+  const nextDirection = sorted === "asc" ? "descending" : "ascending";
+
   return (
     <div className="flex items-center space-x-2">
       <p>{label}</p>
       <IconButton
+        aria-label={`Sort ${label} ${nextDirection}`}
         variant="outline"
         icon={ArrowsUpDownIcon}
-        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        onClick={() => column.toggleSorting(sorted === "asc")}
       />
     </div>
   );

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -1,3 +1,4 @@
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import { formatCredits } from "@app/lib/client/credits";
 import { clientFetch } from "@app/lib/egress/client";
@@ -74,8 +75,9 @@ export function makeColumnsForAutomationTriggers(
     },
     {
       accessorKey: "credits",
-      header: "Consumption",
-      enableSorting: false,
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Consumption" />
+      ),
       cell: ({ row }) => <ConsumptionCell trigger={row.original} />,
     },
     {

--- a/front/components/poke/triggers/table.tsx
+++ b/front/components/poke/triggers/table.tsx
@@ -11,7 +11,7 @@ import {
 } from "@app/types/assistant/triggers";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
-import type { PaginationState } from "@tanstack/react-table";
+import type { PaginationState, SortingState } from "@tanstack/react-table";
 import { useState } from "react";
 
 const TRIGGER_PAGE_SIZE = 25;
@@ -35,6 +35,9 @@ export function TriggerDataTable({ owner }: TriggerDataTableProps) {
   });
   const [search, setSearch] = useState("");
   const [selectedKinds, setSelectedKinds] = useState<TriggerKind[]>([]);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "credits", desc: true },
+  ]);
 
   const handlePeriodChange = (nextPeriod: ConsumptionPeriodSelection) => {
     setPeriod(nextPeriod);
@@ -48,6 +51,11 @@ export function TriggerDataTable({ owner }: TriggerDataTableProps) {
 
   const handleKindChange = (values: string[]) => {
     setSelectedKinds(values.filter(isValidTriggerKind));
+    setPagination((current) => ({ ...current, pageIndex: 0 }));
+  };
+
+  const handleSortingChange = (nextSorting: SortingState) => {
+    setSorting(nextSorting);
     setPagination((current) => ({ ...current, pageIndex: 0 }));
   };
 
@@ -65,6 +73,7 @@ export function TriggerDataTable({ owner }: TriggerDataTableProps) {
     offset: pagination.pageIndex * pagination.pageSize,
     search: search || undefined,
     filter: selectedKinds.length > 0 ? { kinds: selectedKinds } : undefined,
+    sortOrder: sorting[0]?.desc === false ? "asc" : "desc",
   });
 
   const onTriggerDeleted = async () => {
@@ -102,6 +111,8 @@ export function TriggerDataTable({ owner }: TriggerDataTableProps) {
             serverSideRowCount={totalCount}
             pagination={pagination}
             onPaginationChange={setPagination}
+            sorting={sorting}
+            onSortingChange={handleSortingChange}
             search={search}
             onSearchChange={handleSearchChange}
             facets={[

--- a/front/lib/api/poke/triggers.ts
+++ b/front/lib/api/poke/triggers.ts
@@ -1,4 +1,5 @@
 import type { AutomationTriggersFilter } from "@app/lib/api/analytics/automations/schema";
+import { AutomationTriggersBodySchema } from "@app/lib/api/analytics/automations/schema";
 import type {
   GetAutomationTriggersResponse,
   RankedTriggerWithResource,
@@ -8,7 +9,10 @@ import {
   fetchTriggersRanking,
 } from "@app/lib/api/analytics/automations/triggers";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import { CARDINALITY_PRECISION_THRESHOLD } from "@app/lib/api/analytics/consumption/scope";
+import {
+  CARDINALITY_PRECISION_THRESHOLD,
+  CONSUMPTION_TOP_SORT_ORDER,
+} from "@app/lib/api/analytics/consumption/scope";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -19,6 +23,17 @@ import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type { UserType } from "@app/types/user";
+import { z } from "zod";
+
+export const PokeTriggersSearchBodySchema = AutomationTriggersBodySchema.omit({
+  format: true,
+}).extend({
+  sortOrder: z.enum(CONSUMPTION_TOP_SORT_ORDER).optional().default("desc"),
+});
+
+export type PokeTriggersSearchBody = z.infer<
+  typeof PokeTriggersSearchBodySchema
+>;
 
 type TriggerConsumption = { runCount: number; credits: number };
 
@@ -53,10 +68,7 @@ function matchesFilter(
   return true;
 }
 
-/**
- * Every live workspace trigger, ranked by gross credits over the period, with
- * triggers that did not consume included at the end of the ranking.
- */
+/** Every live workspace trigger, ordered by its period consumption. */
 export async function fetchPokeTriggers(
   auth: Authenticator,
   {
@@ -65,12 +77,14 @@ export async function fetchPokeTriggers(
     offset,
     search,
     filter,
+    sortOrder,
   }: {
     period: ConsumptionPeriod;
     limit: number;
     offset: number;
     search?: string;
     filter?: AutomationTriggersFilter;
+    sortOrder: PokeTriggersSearchBody["sortOrder"];
   }
 ): Promise<Result<GetAutomationTriggersResponse, ElasticsearchError>> {
   const [liveTriggers, editors, rankingResult] = await Promise.all([
@@ -101,6 +115,7 @@ export async function fetchPokeTriggers(
       { runCount, credits },
     ])
   );
+  const sortDirection = sortOrder === "asc" ? 1 : -1;
   const ranked: RankedTriggerWithResource[] = liveTriggers
     .filter((trigger) => matchesFilter(trigger, { filter, editorModelIds }))
     .map((trigger) => ({
@@ -110,8 +125,8 @@ export async function fetchPokeTriggers(
     }))
     .sort(
       (a, b) =>
-        b.credits - a.credits ||
-        b.runCount - a.runCount ||
+        sortDirection * (a.credits - b.credits) ||
+        sortDirection * (a.runCount - b.runCount) ||
         a.trigger.name.localeCompare(b.trigger.name) ||
         a.trigger.sId.localeCompare(b.trigger.sId)
     );

--- a/front/poke/swr/triggers.ts
+++ b/front/poke/swr/triggers.ts
@@ -2,13 +2,10 @@ import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
 import type {
-  AutomationTriggersBody,
-  AutomationTriggersFilter,
-} from "@app/lib/api/analytics/automations/schema";
-import type {
   AutomationTriggerRow,
   GetAutomationTriggersResponse,
 } from "@app/lib/api/analytics/automations/triggers";
+import type { PokeTriggersSearchBody } from "@app/lib/api/poke/triggers";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetWebhookRequestsResponseBody } from "@app/types/api/poke/triggers";
 import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
@@ -22,6 +19,7 @@ export function usePokeTriggers({
   offset = 0,
   search,
   filter,
+  sortOrder,
   disabled,
 }: {
   owner: LightWorkspaceType;
@@ -29,11 +27,12 @@ export function usePokeTriggers({
   limit: number;
   offset?: number;
   search?: string;
-  filter?: AutomationTriggersFilter;
+  filter?: PokeTriggersSearchBody["filter"];
+  sortOrder: PokeTriggersSearchBody["sortOrder"];
   disabled?: boolean;
 }) {
   const url = `/api/poke/workspaces/${owner.sId}/triggers/search`;
-  const body: Omit<AutomationTriggersBody, "format"> = {
+  const body: PokeTriggersSearchBody = {
     period: period.kind,
     days:
       period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
@@ -41,10 +40,11 @@ export function usePokeTriggers({
     offset,
     search: search?.trim(),
     filter,
+    sortOrder,
   };
 
   const { data, error, mutate, isValidating } = useConsumptionQuery<
-    Omit<AutomationTriggersBody, "format">,
+    PokeTriggersSearchBody,
     GetAutomationTriggersResponse
   >({ url, body, disabled });
 


### PR DESCRIPTION
## Description

Follow up on #31010 to make Consumption sorting apply to the full Poke trigger result set, rather than only the current page.

The table sends the requested direction to the Poke endpoint. The backend joins live triggers with their consumption, sorts the complete filtered inventory, then applies pagination. This keeps never-used triggers in the ordering and adds no Elasticsearch query.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
