### PR TITLE
Pricing: show cap per key in poke usage tab

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/api-keys-usage.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/api-keys-usage.ts
@@ -1,0 +1,18 @@
+import type { GetApiKeysUsageResponseBody } from "@app/lib/api/credits/api_keys_usage";
+import { getApiKeysUsage } from "@app/lib/api/credits/api_keys_usage";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import type { HandlerResult } from "@front-api/middlewares/utils";
+
+export type { GetApiKeysUsageResponseBody };
+
+// Mounted at /api/poke/workspaces/:wId/credits/api-keys-usage.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get("/", async (ctx): HandlerResult<GetApiKeysUsageResponseBody> => {
+  const auth = ctx.get("auth");
+
+  return ctx.json(await getApiKeysUsage(auth));
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -3,6 +3,7 @@ import type { PokeListCreditsResponseBody } from "@app/types/api/poke/credits";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
+import apiKeysUsage from "./api-keys-usage";
 import awuPoolSummary from "./awu-pool-summary";
 import membersUsage from "./members-usage";
 import topUps from "./top-ups";
@@ -34,6 +35,7 @@ app.get("/", async (ctx): HandlerResult<PokeListCreditsResponseBody> => {
   });
 });
 
+app.route("/api-keys-usage", apiKeysUsage);
 app.route("/awu-pool-summary", awuPoolSummary);
 app.route("/members-usage", membersUsage);
 app.route("/top-ups", topUps);

--- a/front/components/poke/credits/PokeApiKeysUsageTable.tsx
+++ b/front/components/poke/credits/PokeApiKeysUsageTable.tsx
@@ -1,0 +1,193 @@
+import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import type { ApiKeyUsageType } from "@app/lib/api/credits/api_keys_usage";
+import { formatCredits, formatCreditsPrecise } from "@app/lib/client/credits";
+import { usePokeApiKeysUsage } from "@app/poke/swr/credits";
+import type { ApiKeyCreditState } from "@app/types/key";
+import type { WorkspaceType } from "@app/types/user";
+import {
+  AlertCircle,
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  ContentMessage,
+} from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+
+const API_KEY_CREDIT_STATE_CHIP_COLOR: Record<
+  ApiKeyCreditState,
+  "success" | "warning"
+> = {
+  on_pool: "success",
+  capped: "warning",
+};
+
+interface PokeApiKeysUsageTableProps {
+  owner: WorkspaceType;
+}
+
+function makeColumns({
+  owner,
+  onReconciled,
+}: {
+  owner: WorkspaceType;
+  onReconciled: () => void;
+}): ColumnDef<ApiKeyUsageType>[] {
+  return [
+    {
+      accessorKey: "name",
+      header: "API key",
+      cell: ({ row }) => {
+        const { name, isActive } = row.original;
+        return (
+          <span className="inline-flex items-center gap-2">
+            <span className="font-medium">{name}</span>
+            {!isActive && <Chip size="xs" color="warning" label="revoked" />}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: "consumedAwuCredits",
+      // ES = Elasticsearch, RL = Redis rate-limiter counter, MT = Metronome.
+      // The three should agree; divergence points at a counter/metric issue.
+      // ES and MT are aggregated on `api_key_name` (like the cap itself), so
+      // keys sharing a name show the same figure; RL is per key.
+      header: "Consumed (ES / RL / MT)",
+      cell: ({ row }) => {
+        const {
+          consumedAwuCredits,
+          rateLimiterSpendAwuCredits,
+          metronomeConsumedAwuCredits,
+        } = row.original;
+        return (
+          <div className="flex flex-col text-xs">
+            <span>ES {formatCreditsPrecise(consumedAwuCredits)}</span>
+            <span className="text-muted-foreground">
+              RL{" "}
+              {rateLimiterSpendAwuCredits !== null
+                ? formatCreditsPrecise(rateLimiterSpendAwuCredits)
+                : "-"}
+            </span>
+            <span className="text-muted-foreground">
+              MT{" "}
+              {metronomeConsumedAwuCredits !== null
+                ? formatCreditsPrecise(metronomeConsumedAwuCredits)
+                : "-"}
+            </span>
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "monthlyCapAwuCredits",
+      header: "Key cap",
+      cell: ({ row }) => {
+        const { monthlyCapAwuCredits } = row.original;
+        return (
+          <span>
+            {monthlyCapAwuCredits !== null
+              ? formatCredits(monthlyCapAwuCredits)
+              : "—"}
+          </span>
+        );
+      },
+    },
+    {
+      accessorKey: "creditState",
+      header: "Credit state",
+      cell: ({ row }) => {
+        const { creditState } = row.original;
+        return (
+          <Chip
+            size="xs"
+            color={API_KEY_CREDIT_STATE_CHIP_COLOR[creditState]}
+            label={creditState}
+          />
+        );
+      },
+    },
+    {
+      id: "actions",
+      header: () => null,
+      enableSorting: false,
+      cell: ({ row }) => (
+        <div className="flex items-center justify-end">
+          <ReconcileCreditStateButton
+            owner={owner}
+            target="api_key"
+            keyName={row.original.name}
+            onReconciled={onReconciled}
+          />
+        </div>
+      ),
+    },
+  ];
+}
+
+interface PokeApiKeysUsageTableContentProps {
+  isOpen: boolean;
+  owner: WorkspaceType;
+}
+
+function PokeApiKeysUsageTableContent({
+  isOpen,
+  owner,
+}: PokeApiKeysUsageTableContentProps) {
+  const {
+    apiKeys,
+    isApiKeysUsageLoading,
+    isApiKeysUsageError,
+    mutateApiKeysUsage,
+  } = usePokeApiKeysUsage({ owner, disabled: !isOpen });
+
+  const columns = useMemo(
+    () =>
+      makeColumns({
+        owner,
+        onReconciled: () => void mutateApiKeysUsage(),
+      }),
+    [owner, mutateApiKeysUsage]
+  );
+
+  if (isApiKeysUsageError) {
+    return (
+      <ContentMessage
+        title="Failed to load API keys usage"
+        icon={AlertCircle}
+        variant="warning"
+      >
+        Could not load per-API-key consumption and cap data for this workspace.
+      </ContentMessage>
+    );
+  }
+
+  return (
+    <PokeDataTable
+      columns={columns}
+      data={apiKeys}
+      defaultFilterColumn="name"
+      isLoading={isApiKeysUsageLoading}
+    />
+  );
+}
+
+// Collapsed by default: each expansion fans out to Elasticsearch, Metronome and
+// one Redis read per key, which is wasted work on a workspace with many keys
+// nobody is looking at. The hook is disabled until the section is opened.
+export function PokeApiKeysUsageTable({ owner }: PokeApiKeysUsageTableProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-border p-4">
+      <Collapsible defaultOpen={false} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger label="API keys credit states" />
+        <CollapsibleContent>
+          <PokeApiKeysUsageTableContent isOpen={isOpen} owner={owner} />
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/front/components/poke/credits/PokeUsageTab.tsx
+++ b/front/components/poke/credits/PokeUsageTab.tsx
@@ -1,6 +1,7 @@
 import { PokeWorkspaceUsageChart } from "@app/components/poke/analytics/PokeWorkspaceUsageChart";
 import { AlertChip } from "@app/components/poke/credits/AlertChip";
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
+import { PokeApiKeysUsageTable } from "@app/components/poke/credits/PokeApiKeysUsageTable";
 import { PokeAwuUsageFromAnalyticsChart } from "@app/components/poke/credits/PokeAwuUsageFromAnalyticsChart";
 import { PokeMembersUsageTable } from "@app/components/poke/credits/PokeMembersUsageTable";
 import { PokeTopUpsHistoryTable } from "@app/components/poke/credits/PokeTopUpsHistoryTable";
@@ -402,6 +403,7 @@ export function PokeUsageTab({
         owner={owner}
         isCreditBased={hasMetronomeBillingUsage}
       />
+      <PokeApiKeysUsageTable owner={owner} />
       {billingCycleStartDay && (
         <PokeAwuUsageFromAnalyticsChart
           owner={owner}

--- a/front/components/poke/credits/ReconcileCreditStateButton.tsx
+++ b/front/components/poke/credits/ReconcileCreditStateButton.tsx
@@ -7,6 +7,51 @@ import { useState } from "react";
 
 const RECONCILE_CREDIT_STATE_PLUGIN_ID = "reconcile-credit-state";
 
+interface ReconcileSummary {
+  corrected: boolean;
+  description: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function summarizeStateTransition(
+  report: Record<string, unknown>
+): ReconcileSummary {
+  const corrected = report.corrected === true;
+  const previousState = String(report.previousState ?? "?");
+  const newState = String(report.newState ?? "?");
+  return {
+    corrected,
+    description: corrected
+      ? `${previousState} → ${newState}`
+      : `State: ${newState}`,
+  };
+}
+
+// The plugin reports as untyped JSON, in one of two shapes: the pool /
+// programmatic / user targets return a flat previous/new state, while
+// `api_key` returns a `keys` array (key names aren't unique, so reconciling a
+// name covers every active key sharing it).
+function summarizeReconcileReport(value: unknown): ReconcileSummary {
+  if (!isRecord(value)) {
+    return { corrected: false, description: "State: ?" };
+  }
+  const { keys } = value;
+  if (!Array.isArray(keys)) {
+    return summarizeStateTransition(value);
+  }
+  const summaries = keys.filter(isRecord).map(summarizeStateTransition);
+  if (summaries.length === 0) {
+    return { corrected: false, description: "No active key with this name." };
+  }
+  return {
+    corrected: summaries.some((summary) => summary.corrected),
+    description: summaries.map((summary) => summary.description).join(" · "),
+  };
+}
+
 interface ReconcileCreditStateButtonProps {
   owner: WorkspaceType;
   target: ReconcileCreditStateTarget;
@@ -61,20 +106,16 @@ export function ReconcileCreditStateButton({
       return;
     }
 
-    const value =
-      result.value.display === "json" ? result.value.value : undefined;
-    const corrected = value?.corrected === true;
-    const previousState = String(value?.previousState ?? "?");
-    const newState = String(value?.newState ?? "?");
+    const { corrected, description } = summarizeReconcileReport(
+      result.value.display === "json" ? result.value.value : undefined
+    );
 
     sendNotification({
       type: "success",
       title: corrected
         ? `Reconciled ${target} state`
         : `${target} state already in sync`,
-      description: corrected
-        ? `${previousState} → ${newState}`
-        : `State: ${newState}`,
+      description,
     });
     onReconciled?.();
   };

--- a/front/lib/api/credits/api_keys_usage.ts
+++ b/front/lib/api/credits/api_keys_usage.ts
@@ -1,0 +1,154 @@
+import { makeApiKeySpendLimitAwuCreditsRateLimitKey } from "@app/lib/api/assistant/rate_limits";
+import { fetchConsumedAwuCreditsByApiKeyName } from "@app/lib/api/credits/members_usage";
+import type { Authenticator } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
+import { fetchPerApiKeyAwuUsage } from "@app/lib/metronome/per_api_key_usage";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import { resolveSpendLimitCycleBounds } from "@app/lib/spend_limits/cycle";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { getFixedWindowCount } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import type { ApiKeyCreditState } from "@app/types/key";
+import type { LightWorkspaceType } from "@app/types/user";
+
+export type ApiKeyUsageType = {
+  name: string;
+  isActive: boolean;
+  creditState: ApiKeyCreditState;
+  // Elasticsearch-derived AWU consumption for the current billing cycle, summed
+  // on `api_key_name`. Caps are per-name (Metronome aggregates spend by name),
+  // so keys sharing a name report the same figure.
+  consumedAwuCredits: number;
+  // AWU credits recorded in the Redis fixed-window spend-cap counter for the
+  // current billing cycle — the value enforcement reads. Unlike the two other
+  // figures this one is per key, not per name. Null when the billing period
+  // can't be resolved.
+  rateLimiterSpendAwuCredits: number | null;
+  // Metronome-side per-API-key AWU consumption for the current billing cycle
+  // (the value reconcile and the cap alert read). Null when Metronome isn't
+  // configured or the read failed.
+  metronomeConsumedAwuCredits: number | null;
+  monthlyCapAwuCredits: number | null;
+};
+
+export type GetApiKeysUsageResponseBody = {
+  keys: ApiKeyUsageType[];
+};
+
+/**
+ * Metronome-side consumption per API key name for the current billing period.
+ * Resilient: degrades to an empty map when Metronome isn't configured or the
+ * read fails, so the table still renders the ES and rate-limiter figures.
+ */
+async function fetchMetronomeUsageByApiKeyName({
+  workspace,
+  keyNames,
+}: {
+  workspace: LightWorkspaceType;
+  keyNames: string[];
+}): Promise<Map<string, number>> {
+  const { metronomeCustomerId } = workspace;
+  if (!metronomeCustomerId || keyNames.length === 0) {
+    return new Map();
+  }
+  const result = await fetchPerApiKeyAwuUsage({
+    workspaceId: workspace.sId,
+    metronomeCustomerId,
+    keyNames,
+  });
+  if (result.isErr()) {
+    logger.warn(
+      { err: result.error, workspaceId: workspace.sId },
+      "[ApiKeysUsage] Failed to read per-API-key usage from Metronome, degrading to empty map"
+    );
+    return new Map();
+  }
+  return result.value;
+}
+
+/**
+ * The Redis fixed-window spend-cap counter of each key, keyed by key model id.
+ * Empty when the contract billing period can't be resolved (the counter is
+ * bucketed on it).
+ */
+async function fetchRateLimiterSpendByKeyId({
+  workspace,
+  keys,
+}: {
+  workspace: LightWorkspaceType;
+  keys: KeyResource[];
+}): Promise<Map<number, number>> {
+  const bounds = await resolveSpendLimitCycleBounds(workspace);
+  if (!bounds) {
+    return new Map();
+  }
+  // Redis reads (not database queries), one per non-system key of the workspace.
+  const entries = await concurrentExecutor(
+    keys,
+    async (key) => {
+      const result = await getFixedWindowCount({
+        key: makeApiKeySpendLimitAwuCreditsRateLimitKey(key.id),
+        bounds,
+      });
+      // The counter stores microCredits; convert back to credits so it lines
+      // up with the ES/MT figures (all in credits).
+      return [
+        key.id,
+        result.isOk() ? microCreditsToCredits(result.value) : 0,
+      ] as const;
+    },
+    { concurrency: 8 }
+  );
+  return new Map(entries);
+}
+
+/**
+ * Per-API-key credit consumption for the workspace's current billing cycle, as
+ * measured by the three independent counters (Elasticsearch, the Redis
+ * rate-limiter enforcement reads, and Metronome), alongside each key's cap and
+ * credit state. Poke-only: it exists to spot divergence between the three,
+ * which points at a counter or metric issue.
+ */
+export async function getApiKeysUsage(
+  auth: Authenticator
+): Promise<GetApiKeysUsageResponseBody> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const keys = await KeyResource.listNonSystemKeysByWorkspace(workspace);
+  if (keys.length === 0) {
+    return { keys: [] };
+  }
+  // Both the ES aggregation and the Metronome query are scoped by name, and
+  // several keys can share one.
+  const keyNames = [...new Set(keys.map((key) => key.name))];
+
+  const [consumedByName, metronomeConsumedByName, rateLimiterSpendByKeyId] =
+    await Promise.all([
+      fetchConsumedAwuCreditsByApiKeyName({
+        workspace,
+        apiKeyNames: keyNames,
+      }),
+      fetchMetronomeUsageByApiKeyName({ workspace, keyNames }),
+      fetchRateLimiterSpendByKeyId({ workspace, keys }),
+    ]);
+
+  const apiKeys = keys.map((key) => ({
+    name: key.name,
+    isActive: key.isActive,
+    creditState: key.creditState,
+    consumedAwuCredits: consumedByName.get(key.name) ?? 0,
+    rateLimiterSpendAwuCredits: rateLimiterSpendByKeyId.get(key.id) ?? null,
+    metronomeConsumedAwuCredits: metronomeConsumedByName.get(key.name) ?? null,
+    monthlyCapAwuCredits: key.monthlyCapAwuCredits,
+  }));
+
+  // Biggest spenders first — the reason to open this table — then by name for a
+  // stable order among the keys with no usage this cycle.
+  return {
+    keys: apiKeys.sort(
+      (a, b) =>
+        b.consumedAwuCredits - a.consumedAwuCredits ||
+        a.name.localeCompare(b.name)
+    ),
+  };
+}

--- a/front/lib/api/credits/members_usage.ts
+++ b/front/lib/api/credits/members_usage.ts
@@ -439,9 +439,10 @@ type ApiKeyConsumedCreditsAggs = {
  * Elasticsearch-derived AWU consumption for the current billing cycle, summed
  * per `api_key_name` — the same dimension the Metronome per-API-key cap alert
  * aggregates spend on. Used to lazily seed / resync the per-API-key spend-cap
- * counter. Returns an empty map on no usage or an analytics read failure.
+ * counter, and to populate the poke API-keys usage table. Returns an empty map
+ * on no usage or an analytics read failure.
  */
-async function fetchConsumedAwuCreditsByApiKeyName({
+export async function fetchConsumedAwuCreditsByApiKeyName({
   workspace,
   apiKeyNames,
   cycle,

--- a/front/poke/swr/credits.ts
+++ b/front/poke/swr/credits.ts
@@ -6,6 +6,7 @@ import type {
   GetWorkspaceProgrammaticCostResponse,
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
+import type { GetApiKeysUsageResponseBody } from "@app/lib/api/credits/api_keys_usage";
 import type { GetMembersUsageResponseBody } from "@app/lib/api/credits/members_usage";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
@@ -250,5 +251,28 @@ export function usePokeMembersUsage({
     isMembersUsageError: error,
     isMembersUsageValidating: isValidating,
     mutateMembersUsage: mutate,
+  };
+}
+
+export function usePokeApiKeysUsage({
+  disabled,
+  owner,
+}: PokeConditionalFetchProps) {
+  const { fetcher } = useFetcher();
+  const fetcherFn: Fetcher<GetApiKeysUsageResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    disabled
+      ? null
+      : `/api/poke/workspaces/${owner.sId}/credits/api-keys-usage`,
+    fetcherFn,
+    { revalidateOnFocus: false }
+  );
+
+  return {
+    apiKeys: data?.keys ?? emptyArray(),
+    isApiKeysUsageLoading: !error && !data && !disabled,
+    isApiKeysUsageError: error,
+    mutateApiKeysUsage: mutate,
   };
 }


### PR DESCRIPTION
## Description

Add a table to show the consumption per key in the usage tab on poke
Lazy loaded when opened for not loading it uselessly

<img width="3242" height="624" alt="image" src="https://github.com/user-attachments/assets/313550fc-32a6-4918-a17b-2d5e99ef8198" />


## Tests

tested locally

## Risk

low

## Deploy Plan

deploy front