### PR TITLE
[front] Fix consumption export retention copy to 7 days

### DIFF
--- a/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionExportPanel.tsx
@@ -120,7 +120,7 @@ export function ConsumptionExportPanel({
             Raw data exports
           </span>
           <span className="text-xs text-muted-foreground">
-            Exports are kept for a maximum of 15 days.
+            Exports are kept for a maximum of 7 days.
           </span>
           {isConsumptionExportsLoading ? (
             <div className="flex justify-center py-4">


### PR DESCRIPTION
## Summary
- Corrects the displayed retention period for raw data exports from 15 days to 7 days.

## Test plan
- [ ] Visually confirm the copy on the workspace analytics consumption export panel.