### PR TITLE
[playground] Fleet management prototype for Manage Agents and Manage Skills

### DIFF
--- a/sparkle/playground/src/App.tsx
+++ b/sparkle/playground/src/App.tsx
@@ -87,7 +87,16 @@ function StoryList({
 }
 
 function App() {
-  const [currentStory, setCurrentStory] = useState<string | null>(null);
+  // Read the hash during initialization, not in an effect: the "write the hash"
+  // effect below runs on the same mount pass and would otherwise clear it,
+  // breaking deep links like `?tools=salesforce#ManageAgents`.
+  const [currentStory, setCurrentStory] = useState<string | null>(() => {
+    if (typeof window === "undefined") {
+      return null;
+    }
+    const hash = window.location.hash.slice(1);
+    return hash && stories.some((s) => s.name === hash) ? hash : null;
+  });
   const [theme, setTheme] = useState<Theme>(() => {
     if (typeof window === "undefined") {
       return "light";
@@ -104,21 +113,13 @@ function App() {
     localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
-  // Read initial hash from URL
+  // Update URL hash when story changes, preserving any query string (the
+  // fleet screens keep their filters there).
   useEffect(() => {
-    const hash = window.location.hash.slice(1); // Remove the #
-    if (hash && stories.some((s) => s.name === hash)) {
-      setCurrentStory(hash);
-    }
-  }, []);
-
-  // Update URL hash when story changes
-  useEffect(() => {
-    if (currentStory) {
-      window.location.hash = currentStory;
-    } else {
-      window.location.hash = "";
-    }
+    const url = `${window.location.pathname}${window.location.search}${
+      currentStory ? `#${currentStory}` : ""
+    }`;
+    window.history.replaceState(null, "", url);
   }, [currentStory]);
 
   // Listen for hash changes (back button)

--- a/sparkle/playground/src/components/ComposerView.tsx
+++ b/sparkle/playground/src/components/ComposerView.tsx
@@ -1,0 +1,1328 @@
+import {
+  ArrowUp,
+  Attachment01,
+  Avatar,
+  BarFull,
+  BarHalf,
+  BarLow,
+  Bold01,
+  Button,
+  Check,
+  CheckDone01,
+  ChevronDown,
+  ChevronRight,
+  Chip,
+  Citation,
+  CitationClose,
+  CitationIcons,
+  CitationImage,
+  CitationTitle,
+  cn,
+  Code01,
+  Composer,
+  ComposerInput,
+  type ComposerSuggestionItem,
+  DiscoveryGlint,
+  DoubleQuotes,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+  File01,
+  Folder,
+  Globe01,
+  Heading01,
+  Icon,
+  Image01,
+  Italic01,
+  Link01,
+  List,
+  Planet,
+  Plus,
+  Robot,
+  SearchMd,
+  ShapesPlus,
+  Table,
+  Toolbar,
+  ToolbarContent,
+  ToolbarIcon,
+  Tooltip,
+  UploadCloud02,
+  VoicePicker,
+  type VoicePickerStatus,
+} from "@dust-tt/sparkle";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * Playground replica of the production conversation input bar
+ * (`front/components/assistant/conversation/input_bar`). Built entirely from
+ * Sparkle primitives with mocked data so the layout, breakpoints and dropdown
+ * behaviour can be iterated on — in particular on mobile, where the real app
+ * needs a device to reproduce. Resize the browser (or use the width presets
+ * below) to switch between the desktop and mobile layouts: the composer reads
+ * the real viewport through `md:` variants, exactly like production.
+ */
+
+// Mirrors front/components/assistant/conversation/input_bar/inputBarPillStyles.ts
+const PILL_SURFACE_CLASSNAME = cn(
+  "border-[0.5px] border-border-dark bg-background dark:bg-stone-725",
+  "shadow-[inset_2px_-2px_7px_0px_rgba(0,0,0,0.02),0px_0.5px_0.5px_0px_rgba(0,0,0,0.04)]"
+);
+const PILL_HOVER_CLASSNAME =
+  "hover:bg-primary-100 dark:hover:bg-[oklch(0.393_0.013_76.451)]";
+const PILL_CLASSNAME = cn(PILL_SURFACE_CLASSNAME, PILL_HOVER_CLASSNAME);
+
+interface MockAgent {
+  id: string;
+  name: string;
+  description: string;
+  pictureUrl?: string;
+}
+
+const MOCK_AGENTS: MockAgent[] = [
+  {
+    id: "dust",
+    name: "dust",
+    description: "Your general purpose agent. It has access to all of your...",
+    pictureUrl: "https://dust.tt/static/systemavatar/dust_avatar_full.png",
+  },
+  { id: "research", name: "Research", description: "Deep web research" },
+  { id: "code", name: "Code", description: "Write and review code" },
+  { id: "data", name: "Data", description: "Analyse spreadsheets and charts" },
+];
+
+interface MockTool {
+  id: string;
+  label: string;
+  description: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
+
+const MOCK_TOOLS: MockTool[] = [
+  {
+    id: "web-search",
+    label: "Web Search",
+    description: "Search and browse the web",
+    icon: Globe01,
+  },
+  {
+    id: "image-generation",
+    label: "Image Generation",
+    description: "Generate images from a prompt",
+    icon: Image01,
+  },
+  {
+    id: "data-analysis",
+    label: "Data Analysis",
+    description: "Run queries over your tables",
+    icon: Table,
+  },
+  {
+    id: "extract-data",
+    label: "Extract Data",
+    description: "Pull structured data out of documents",
+    icon: File01,
+  },
+];
+
+const MOCK_KNOWLEDGE_NODES = [
+  { id: "kn-1", title: "Q3 Board Deck", source: "Google Drive" },
+  { id: "kn-2", title: "Engineering Handbook", source: "Notion" },
+  { id: "kn-3", title: "Customer Feedback 2026", source: "Google Drive" },
+  { id: "kn-4", title: "Pricing Experiments", source: "Notion" },
+];
+
+const MOCK_SPACES = [
+  { id: "space-company", name: "Company Data" },
+  { id: "space-eng", name: "Engineering" },
+  { id: "space-sales", name: "Sales" },
+];
+
+// Mirrors MODEL_TIERS in front/components/model_picker/modelPickerUtils.ts.
+const MODEL_TIERS = [
+  { id: "fast", name: "Fast", description: "Quick, low cost" },
+  { id: "standard", name: "Standard", description: "Best for most" },
+  { id: "complex", name: "Complex", description: "Slower, most capable" },
+] as const;
+type ModelTierId = (typeof MODEL_TIERS)[number]["id"];
+
+const TIER_ICON: Record<
+  ModelTierId,
+  React.ComponentType<React.SVGProps<SVGSVGElement>>
+> = {
+  fast: BarLow,
+  standard: BarHalf,
+  complex: BarFull,
+};
+
+const DEFAULT_TIER_ID: ModelTierId = "standard";
+
+const MOCK_MODELS = ["Claude 5 Opus", "Claude 5 Sonnet", "GPT-5"];
+
+interface MockAttachment {
+  id: string;
+  title: string;
+  isUploading: boolean;
+  previewUrl?: string;
+  icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
+
+function revokeAttachmentPreview(attachment: MockAttachment) {
+  if (attachment.previewUrl) {
+    URL.revokeObjectURL(attachment.previewUrl);
+  }
+}
+
+/**
+ * Stand-in for `useVoiceTranscriberService`: walks through the same status
+ * machine (authorizing → recording → transcribing → idle) so the mic button
+ * renders every state the production one does.
+ */
+function useMockVoiceService(onTranscript: (text: string) => void) {
+  const [status, setStatus] = useState<VoicePickerStatus>("idle");
+  const [level, setLevel] = useState(0);
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const timersRef = useRef<number[]>([]);
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach((timer) => window.clearInterval(timer));
+    timersRef.current = [];
+  }, []);
+
+  const startRecording = useCallback(() => {
+    setStatus("authorizing_microphone");
+    const authorizeTimer = window.setTimeout(() => {
+      setStatus("recording");
+      setElapsedSeconds(0);
+      timersRef.current.push(
+        window.setInterval(() => setLevel(Math.random()), 120),
+        window.setInterval(
+          () => setElapsedSeconds((seconds) => seconds + 1),
+          1000
+        )
+      );
+    }, 400);
+    timersRef.current.push(authorizeTimer);
+  }, []);
+
+  const stopRecording = useCallback(() => {
+    clearTimers();
+    setLevel(0);
+    setStatus("transcribing");
+    const transcribeTimer = window.setTimeout(() => {
+      setStatus("idle");
+      setElapsedSeconds(0);
+      onTranscript("This is a mock voice transcription. ");
+    }, 1400);
+    timersRef.current.push(transcribeTimer);
+  }, [clearTimers, onTranscript]);
+
+  useEffect(() => clearTimers, [clearTimers]);
+
+  return { status, level, elapsedSeconds, startRecording, stopRecording };
+}
+
+/** Tracks the viewport width so the story can report which layout is live. */
+function useViewportWidth() {
+  const [width, setWidth] = useState(() =>
+    typeof window === "undefined" ? 1280 : window.innerWidth
+  );
+  useEffect(() => {
+    const onResize = () => setWidth(window.innerWidth);
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return width;
+}
+
+// Which picker the mobile layout has drilled into. Sub-menus are positioned
+// beside their parent menu, and `parent width + sub-menu width` exceeds a phone
+// viewport, so Radix flips them to the other side where they do not fit either
+// — leaving them mostly off-screen. On mobile the "+" menu therefore closes and
+// the picker reopens as a top-level dropdown anchored to the "+" button, which
+// Radix keeps inside the viewport. Mirrors InputBarPlusMenu in `front`.
+const MOBILE_PICKERS = ["capabilities", "attachments", "spaces"] as const;
+type MobilePicker = (typeof MOBILE_PICKERS)[number];
+
+interface AnchorTriggerProps {
+  anchorRef: React.RefObject<HTMLElement | null>;
+}
+
+function AnchorTrigger({ anchorRef }: AnchorTriggerProps) {
+  return (
+    <DropdownMenuTrigger asChild>
+      <div
+        ref={(el) => {
+          if (el && anchorRef.current) {
+            const rect = anchorRef.current.getBoundingClientRect();
+            el.style.position = "fixed";
+            el.style.top = `${rect.top}px`;
+            el.style.left = `${rect.left}px`;
+            el.style.width = `${rect.width}px`;
+            el.style.height = `${rect.height}px`;
+            el.style.pointerEvents = "none";
+            el.style.opacity = "0";
+          }
+        }}
+      />
+    </DropdownMenuTrigger>
+  );
+}
+
+const HIGHLIGHT_STORAGE_KEY = "dust:model-picker-highlight-dismissals";
+const REPLAY_PARAM = "replayHighlight";
+
+function isReplayRequested(): boolean {
+  return new URLSearchParams(window.location.search).has(REPLAY_PARAM);
+}
+const MAX_HIGHLIGHT_DISMISSALS = 2;
+
+function readHighlightDismissals(): number {
+  try {
+    const parsed = Number.parseInt(
+      window.localStorage.getItem(HIGHLIGHT_STORAGE_KEY) ?? "",
+      10
+    );
+    return Number.isNaN(parsed) ? 0 : parsed;
+  } catch {
+    // Storage blocked (Safari private browsing): with no way to remember the
+    // count, staying quiet beats highlighting forever.
+    return MAX_HIGHLIGHT_DISMISSALS;
+  }
+}
+
+function writeHighlightDismissals(dismissals: number): void {
+  try {
+    window.localStorage.setItem(HIGHLIGHT_STORAGE_KEY, String(dismissals));
+  } catch {
+    // Same as above: nothing to do if the write is refused.
+  }
+}
+
+interface ModelPickerHighlightProps {
+  children: React.ReactNode;
+}
+
+function ModelPickerHighlight({ children }: ModelPickerHighlightProps) {
+  const [isActive, setIsActive] = useState(
+    () =>
+      isReplayRequested() ||
+      readHighlightDismissals() < MAX_HIGHLIGHT_DISMISSALS
+  );
+  const hostRef = useRef<HTMLSpanElement>(null);
+  const hasCountedDismissalRef = useRef(false);
+
+  const dismiss = useCallback(() => {
+    if (!hasCountedDismissalRef.current && !isReplayRequested()) {
+      hasCountedDismissalRef.current = true;
+      writeHighlightDismissals(readHighlightDismissals() + 1);
+    }
+    setIsActive(false);
+  }, []);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || !isActive) {
+      return;
+    }
+    const dismissOnPrimaryButton = (event: PointerEvent) => {
+      if (event.button === 0) {
+        dismiss();
+      }
+    };
+    host.addEventListener("pointerdown", dismissOnPrimaryButton);
+    return () =>
+      host.removeEventListener("pointerdown", dismissOnPrimaryButton);
+  }, [isActive, dismiss]);
+
+  return (
+    <span ref={hostRef} className="inline-flex">
+      <DiscoveryGlint isActive={isActive}>{children}</DiscoveryGlint>
+    </span>
+  );
+}
+
+export function ComposerView() {
+  const [text, setText] = useState("");
+  const [selectedAgent, setSelectedAgent] = useState<MockAgent | null>(
+    MOCK_AGENTS[0]
+  );
+  const [selectedTools, setSelectedTools] = useState<MockTool[]>([]);
+  const [attachments, setAttachments] = useState<MockAttachment[]>([]);
+  const [messages, setMessages] = useState<{ id: string; text: string }[]>([]);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [hasSelection, setHasSelection] = useState(false);
+  const [activeFormats, setActiveFormats] = useState<Set<string>>(new Set());
+  const [agentSearch, setAgentSearch] = useState("");
+  const [toolSearch, setToolSearch] = useState("");
+  const [knowledgeSearch, setKnowledgeSearch] = useState("");
+  const [isAttachmentsOpen, setIsAttachmentsOpen] = useState(false);
+  const [isCapabilitiesSubOpen, setIsCapabilitiesSubOpen] = useState(false);
+  const [isSpacesSubOpen, setIsSpacesSubOpen] = useState(false);
+  const [isPlusMenuOpen, setIsPlusMenuOpen] = useState(false);
+  const [hasOpenedPlusMenu, setHasOpenedPlusMenu] = useState(false);
+  const [openMobilePicker, setOpenMobilePicker] = useState<MobilePicker | null>(
+    null
+  );
+  const [selectedSpaceIds, setSelectedSpaceIds] = useState<string[]>([]);
+  const [selectedTierId, setSelectedTierId] =
+    useState<ModelTierId>(DEFAULT_TIER_ID);
+  const [isMoreModelsExpanded, setIsMoreModelsExpanded] = useState(false);
+
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const nextMessageId = useRef(0);
+  const composerWrapperRef = useRef<HTMLDivElement>(null);
+  const plusButtonRef = useRef<HTMLDivElement>(null);
+  const [toolbarAnchor, setToolbarAnchor] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+
+  const viewportWidth = useViewportWidth();
+  const isMobile = viewportWidth < 768;
+
+  const openPicker = (picker: MobilePicker) => {
+    setIsPlusMenuOpen(false);
+    setOpenMobilePicker(picker);
+  };
+
+  const toggleFormat = useCallback((format: string) => {
+    setActiveFormats((prev) => {
+      const next = new Set(prev);
+      if (next.has(format)) {
+        next.delete(format);
+      } else {
+        next.add(format);
+      }
+      return next;
+    });
+  }, []);
+
+  // Visual-only: the playground input is a plain textarea (no TipTap), so the
+  // toolbar buttons toggle their own active state instead of marking up text.
+  const formatGroups = useMemo(
+    () => [
+      {
+        id: "block",
+        items: [
+          <ToolbarIcon
+            key="heading"
+            icon={Heading01}
+            size="xs"
+            active={activeFormats.has("heading")}
+            tooltip="Heading"
+            onClick={() => toggleFormat("heading")}
+          />,
+        ],
+      },
+      {
+        id: "marks",
+        items: [
+          <ToolbarIcon
+            key="bold"
+            icon={Bold01}
+            size="xs"
+            active={activeFormats.has("bold")}
+            tooltip="Bold"
+            onClick={() => toggleFormat("bold")}
+          />,
+          <ToolbarIcon
+            key="italic"
+            icon={Italic01}
+            size="xs"
+            active={activeFormats.has("italic")}
+            tooltip="Italic"
+            onClick={() => toggleFormat("italic")}
+          />,
+          <ToolbarIcon
+            key="link"
+            icon={Link01}
+            size="xs"
+            active={activeFormats.has("link")}
+            tooltip="Link"
+            onClick={() => toggleFormat("link")}
+          />,
+        ],
+      },
+      {
+        id: "lists",
+        items: [
+          <ToolbarIcon
+            key="checklist"
+            icon={CheckDone01}
+            size="xs"
+            active={activeFormats.has("checklist")}
+            tooltip="Checklist"
+            onClick={() => toggleFormat("checklist")}
+          />,
+          <ToolbarIcon
+            key="list"
+            icon={List}
+            size="xs"
+            active={activeFormats.has("list")}
+            tooltip="Bulleted list"
+            onClick={() => toggleFormat("list")}
+          />,
+        ],
+      },
+      {
+        id: "code",
+        items: [
+          <ToolbarIcon
+            key="quote"
+            icon={DoubleQuotes}
+            size="xs"
+            active={activeFormats.has("quote")}
+            tooltip="Quote"
+            onClick={() => toggleFormat("quote")}
+          />,
+          <ToolbarIcon
+            key="code"
+            icon={Code01}
+            size="xs"
+            active={activeFormats.has("code")}
+            tooltip="Code"
+            onClick={() => toggleFormat("code")}
+          />,
+        ],
+      },
+    ],
+    [activeFormats, toggleFormat]
+  );
+
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) {
+      return;
+    }
+    const updateSelection = () => {
+      const selected = el.selectionStart !== el.selectionEnd;
+      setHasSelection(selected);
+      const wrapper = composerWrapperRef.current;
+      if (selected && wrapper) {
+        const rect = wrapper.getBoundingClientRect();
+        setToolbarAnchor({ top: rect.top, left: rect.left + rect.width / 2 });
+      }
+    };
+    el.addEventListener("select", updateSelection);
+    el.addEventListener("mouseup", updateSelection);
+    el.addEventListener("keyup", updateSelection);
+    return () => {
+      el.removeEventListener("select", updateSelection);
+      el.removeEventListener("mouseup", updateSelection);
+      el.removeEventListener("keyup", updateSelection);
+    };
+  }, []);
+
+  const voice = useMockVoiceService(
+    useCallback((transcript: string) => {
+      setText((prev) => prev + transcript);
+    }, [])
+  );
+
+  // Keep the send button (and its spinner) while a submit is in flight, but let
+  // the mic own the row while recording or transcribing.
+  const showSendButton = voice.status === "idle" || isSubmitting;
+
+  const addTool = useCallback((tool: MockTool) => {
+    setSelectedTools((prev) =>
+      prev.some((t) => t.id === tool.id) ? prev : [...prev, tool]
+    );
+  }, []);
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? []);
+      const newAttachments = files.map<MockAttachment>((f, i) => ({
+        id: `${f.name}-${i}-${f.lastModified}`,
+        title: f.name,
+        isUploading: true,
+        previewUrl: f.type.startsWith("image/")
+          ? URL.createObjectURL(f)
+          : undefined,
+        icon: File01,
+      }));
+      setAttachments((prev) => [...prev, ...newAttachments]);
+      newAttachments.forEach((attachment) => {
+        window.setTimeout(() => {
+          setAttachments((prev) =>
+            prev.map((a) =>
+              a.id === attachment.id ? { ...a, isUploading: false } : a
+            )
+          );
+        }, 1200);
+      });
+      e.target.value = "";
+      setIsAttachmentsOpen(false);
+      inputRef.current?.focus();
+    },
+    []
+  );
+
+  const addKnowledgeNode = useCallback(
+    (node: (typeof MOCK_KNOWLEDGE_NODES)[number]) => {
+      setAttachments((prev) =>
+        prev.some((a) => a.id === node.id)
+          ? prev.filter((a) => a.id !== node.id)
+          : [
+              ...prev,
+              {
+                id: node.id,
+                title: node.title,
+                isUploading: false,
+                icon: Folder,
+              },
+            ]
+      );
+    },
+    []
+  );
+
+  const canSubmitEmpty = selectedAgent != null;
+  const isSubmitDisabled =
+    (!text.trim() && !canSubmitEmpty) ||
+    isSubmitting ||
+    voice.status !== "idle";
+
+  const handleSubmit = useCallback(() => {
+    if ((!text.trim() && !canSubmitEmpty) || isSubmitting) {
+      return;
+    }
+    const submittedText =
+      text.trim() || `(empty message to @${selectedAgent?.name})`;
+    const messageId = `msg-${nextMessageId.current}`;
+    nextMessageId.current += 1;
+    setIsSubmitting(true);
+    setText("");
+    attachments.forEach(revokeAttachmentPreview);
+    setAttachments([]);
+    window.setTimeout(() => {
+      setMessages((prev) => [...prev, { id: messageId, text: submittedText }]);
+      setIsSubmitting(false);
+      inputRef.current?.focus();
+    }, 900);
+  }, [text, canSubmitEmpty, isSubmitting, selectedAgent, attachments]);
+
+  const slashItems: ComposerSuggestionItem[] = [
+    {
+      id: "upload-file",
+      label: "upload-file",
+      description: "Attach a file from your computer",
+      icon: Attachment01,
+    },
+    ...MOCK_TOOLS.map((tool) => ({
+      id: tool.id,
+      label: tool.label.toLowerCase().replace(/\s/g, "-"),
+      description: tool.description,
+      icon: tool.icon,
+    })),
+  ];
+
+  const mentionItems: ComposerSuggestionItem[] = MOCK_AGENTS.map((agent) => ({
+    id: agent.id,
+    label: agent.name,
+    description: agent.description,
+    icon: Robot,
+    visual: agent.pictureUrl,
+  }));
+
+  const filteredAgents = MOCK_AGENTS.filter((a) =>
+    a.name.toLowerCase().includes(agentSearch.toLowerCase())
+  );
+  const filteredTools = MOCK_TOOLS.filter(
+    (t) =>
+      !selectedTools.some((s) => s.id === t.id) &&
+      t.label.toLowerCase().includes(toolSearch.toLowerCase())
+  );
+  const filteredKnowledgeNodes = MOCK_KNOWLEDGE_NODES.filter((n) =>
+    n.title.toLowerCase().includes(knowledgeSearch.toLowerCase())
+  );
+  const attachedIds = new Set(attachments.map((a) => a.id));
+
+  const agentPicker = (
+    <DropdownMenu onOpenChange={(open) => open && setAgentSearch("")}>
+      <DropdownMenuTrigger asChild>
+        {selectedAgent ? (
+          <button
+            type="button"
+            aria-label={`Selected agent: ${selectedAgent.name}`}
+            className={cn(
+              "box-border inline-flex h-8 items-center gap-1.5 rounded-full px-2 md:h-6",
+              "heading-xs text-primary-900",
+              PILL_CLASSNAME,
+              "cursor-pointer transition-colors duration-200"
+            )}
+          >
+            <Avatar
+              size="3xs"
+              name={selectedAgent.name}
+              visual={selectedAgent.pictureUrl}
+            />
+            <span className="grow truncate">{selectedAgent.name}</span>
+          </button>
+        ) : (
+          <Button
+            variant="ghost-secondary"
+            size="xs"
+            icon={Robot}
+            label="Agent"
+            isRounded
+            className={PILL_CLASSNAME}
+          />
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-72">
+        <DropdownMenuSearchbar
+          name="search-agents"
+          placeholder="Search agents"
+          value={agentSearch}
+          onChange={setAgentSearch}
+        />
+        <DropdownMenuSeparator />
+        {selectedAgent && (
+          <>
+            <DropdownMenuItem
+              label={`Remove @${selectedAgent.name}`}
+              onClick={() => setSelectedAgent(null)}
+            />
+            <DropdownMenuSeparator />
+          </>
+        )}
+        {filteredAgents.map((agent) => (
+          <DropdownMenuItem
+            key={agent.id}
+            label={agent.name}
+            description={agent.description}
+            onClick={() => setSelectedAgent(agent)}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const capabilitiesItems = (
+    <>
+      <DropdownMenuSearchbar
+        name="search-capabilities"
+        placeholder="Search capabilities"
+        value={toolSearch}
+        onChange={setToolSearch}
+      />
+      <DropdownMenuSeparator />
+      {filteredTools.length === 0 && (
+        <div className="px-2 py-3 text-sm text-muted-foreground">
+          {toolSearch
+            ? "No capabilities found"
+            : "No more capabilities to select"}
+        </div>
+      )}
+      {filteredTools.map((tool) => (
+        <DropdownMenuItem
+          key={tool.id}
+          icon={tool.icon}
+          label={tool.label}
+          description={tool.description}
+          onClick={() => addTool(tool)}
+        />
+      ))}
+    </>
+  );
+
+  const capabilitiesPicker = isMobile ? (
+    <DropdownMenu
+      open={openMobilePicker === "capabilities"}
+      onOpenChange={(open) => {
+        setOpenMobilePicker(open ? "capabilities" : null);
+        if (open) {
+          setToolSearch("");
+        }
+      }}
+    >
+      <AnchorTrigger anchorRef={plusButtonRef} />
+      <DropdownMenuContent
+        align="end"
+        collisionPadding={8}
+        className="w-80 max-w-[calc(100vw-1rem)]"
+      >
+        {capabilitiesItems}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ) : (
+    <DropdownMenuSub
+      open={isCapabilitiesSubOpen}
+      onOpenChange={(open) => {
+        setIsCapabilitiesSubOpen(open);
+        if (open) {
+          setToolSearch("");
+        }
+      }}
+    >
+      <DropdownMenuSubTrigger
+        label="Capabilities"
+        icon={
+          <Icon
+            size="xs"
+            visual={ShapesPlus}
+            className="text-muted-foreground"
+          />
+        }
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setIsCapabilitiesSubOpen(true);
+        }}
+      />
+      <DropdownMenuSubContent className="w-80 max-w-[calc(100vw-1rem)]">
+        {capabilitiesItems}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+
+  const knowledgeHeaders = (
+    <>
+      <DropdownMenuSearchbar
+        autoFocus
+        name="search-files"
+        placeholder="Search"
+        value={knowledgeSearch}
+        onChange={setKnowledgeSearch}
+        button={
+          <Button
+            icon={UploadCloud02}
+            label="Upload File"
+            className="ml-4"
+            onClick={() => fileInputRef.current?.click()}
+          />
+        }
+      />
+      <DropdownMenuSeparator />
+    </>
+  );
+
+  const knowledgeItems = knowledgeSearch ? (
+    filteredKnowledgeNodes.map((node) => (
+      <DropdownMenuCheckboxItem
+        key={node.id}
+        checked={attachedIds.has(node.id)}
+        icon={Folder}
+        label={node.title}
+        description={node.source}
+        onCheckedChange={() => addKnowledgeNode(node)}
+      />
+    ))
+  ) : (
+    <div className="flex h-full w-full items-center justify-center">
+      <div className="flex flex-col items-center justify-center gap-0 text-center text-base font-semibold text-primary-400">
+        <Icon visual={SearchMd} size="sm" />
+        Search knowledge
+      </div>
+    </div>
+  );
+
+  const attachmentsPicker = (
+    <>
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        style={{ display: "none" }}
+        onChange={handleFileChange}
+      />
+      {isMobile ? (
+        <DropdownMenu
+          open={openMobilePicker === "attachments"}
+          onOpenChange={(open) => {
+            setOpenMobilePicker(open ? "attachments" : null);
+            if (open) {
+              setKnowledgeSearch("");
+            }
+          }}
+        >
+          <AnchorTrigger anchorRef={plusButtonRef} />
+          <DropdownMenuContent
+            align="end"
+            collisionPadding={8}
+            className="h-80 w-80 max-w-[calc(100vw-1rem)] [&_[data-radix-scroll-area-viewport]>div]:h-full"
+            dropdownHeaders={knowledgeHeaders}
+          >
+            {knowledgeItems}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <DropdownMenuSub
+          open={isAttachmentsOpen}
+          onOpenChange={(open) => {
+            setIsAttachmentsOpen(open);
+            if (open) {
+              setKnowledgeSearch("");
+            }
+          }}
+        >
+          <DropdownMenuSubTrigger
+            label="Attach knowledge"
+            icon={
+              <Icon
+                size="xs"
+                visual={Attachment01}
+                className="text-muted-foreground"
+              />
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              setIsAttachmentsOpen(true);
+            }}
+          />
+          <DropdownMenuSubContent
+            collisionPadding={15}
+            className="h-80 w-80 xs:h-96 xs:w-96 [&_[data-radix-scroll-area-viewport]>div]:h-full"
+            dropdownHeaders={knowledgeHeaders}
+          >
+            {knowledgeItems}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      )}
+    </>
+  );
+
+  const spacesItems = (
+    <>
+      <DropdownMenuLabel>Spaces</DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      {MOCK_SPACES.map((space) => {
+        const checked = selectedSpaceIds.includes(space.id);
+        return (
+          <DropdownMenuCheckboxItem
+            key={space.id}
+            label={space.name}
+            checked={checked}
+            onCheckedChange={(nextChecked) => {
+              setSelectedSpaceIds((prev) =>
+                nextChecked
+                  ? [...prev, space.id]
+                  : prev.filter((id) => id !== space.id)
+              );
+            }}
+            onSelect={(event) => event.preventDefault()}
+          />
+        );
+      })}
+    </>
+  );
+
+  const spacesPicker = isMobile ? (
+    <DropdownMenu
+      open={openMobilePicker === "spaces"}
+      onOpenChange={(open) => setOpenMobilePicker(open ? "spaces" : null)}
+    >
+      <AnchorTrigger anchorRef={plusButtonRef} />
+      <DropdownMenuContent
+        align="end"
+        collisionPadding={8}
+        className="w-64 max-w-[calc(100vw-1rem)]"
+      >
+        {spacesItems}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ) : (
+    <DropdownMenuSub open={isSpacesSubOpen} onOpenChange={setIsSpacesSubOpen}>
+      <DropdownMenuSubTrigger
+        label={
+          selectedSpaceIds.length > 0
+            ? `${selectedSpaceIds.length} Space${selectedSpaceIds.length > 1 ? "s" : ""}`
+            : "Spaces"
+        }
+        icon={
+          <Icon size="xs" visual={Planet} className="text-muted-foreground" />
+        }
+        onClick={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          setIsSpacesSubOpen(true);
+        }}
+      />
+      <DropdownMenuSubContent className="w-64 max-w-[calc(100vw-1rem)]">
+        {spacesItems}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  );
+
+  const plusMenu = (
+    <>
+      <div ref={plusButtonRef} className="flex items-center">
+        <DropdownMenu
+          open={isPlusMenuOpen}
+          onOpenChange={(open) => {
+            setIsPlusMenuOpen(open);
+            if (open) {
+              setHasOpenedPlusMenu(true);
+            }
+          }}
+        >
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost-secondary"
+              icon={Plus}
+              size="xs"
+              isRounded
+              tooltip="More"
+              className={PILL_CLASSNAME}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            collisionPadding={8}
+            className="w-64 max-w-[calc(100vw-1rem)]"
+          >
+            {isMobile ? (
+              <>
+                <DropdownMenuItem
+                  label="Capabilities"
+                  icon={ShapesPlus}
+                  onClick={() => openPicker("capabilities")}
+                />
+                <DropdownMenuItem
+                  label="Attach knowledge"
+                  icon={Attachment01}
+                  onClick={() => openPicker("attachments")}
+                />
+                <DropdownMenuItem
+                  label="Spaces"
+                  icon={Planet}
+                  onClick={() => openPicker("spaces")}
+                />
+              </>
+            ) : (
+              <>
+                {capabilitiesPicker}
+                {attachmentsPicker}
+                {spacesPicker}
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      {isMobile && hasOpenedPlusMenu && (
+        <>
+          {capabilitiesPicker}
+          {attachmentsPicker}
+          {spacesPicker}
+        </>
+      )}
+    </>
+  );
+
+  // Mirrors front/components/model_picker/ModelPicker.tsx as the input bar
+  // renders it: `showLabel={false}`, so the trigger is an icon-only
+  // ghost-secondary button carrying the tier bars, with the tier name in a
+  // tooltip. The menu lists the three tiers with their descriptions, then a
+  // collapsed "More models" row.
+  const shownTier = MODEL_TIERS.find((tier) => tier.id === selectedTierId);
+  const modelPicker = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className="px-2"
+          variant="ghost-secondary"
+          size="xs"
+          icon={TIER_ICON[selectedTierId]}
+          tooltip={`Model picker: ${shownTier?.name}`}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-72" align="start" side="bottom">
+        {MODEL_TIERS.map((tier) => {
+          const isSelected = tier.id === selectedTierId;
+          const isDefault = tier.id === DEFAULT_TIER_ID;
+          return (
+            <DropdownMenuItem
+              key={tier.id}
+              icon={TIER_ICON[tier.id]}
+              label={`${tier.name}${isDefault ? " (Default)" : ""}`}
+              endComponent={
+                isSelected ? (
+                  <Icon
+                    visual={Check}
+                    size="sm"
+                    className="text-muted-foreground"
+                  />
+                ) : (
+                  <span className="whitespace-nowrap text-xs text-muted-foreground">
+                    {tier.description}
+                  </span>
+                )
+              }
+              onClick={() => setSelectedTierId(tier.id)}
+              onSelect={(e) => e.preventDefault()}
+            />
+          );
+        })}
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuItem
+          label="More models"
+          endComponent={
+            <Icon
+              visual={isMoreModelsExpanded ? ChevronDown : ChevronRight}
+              size="xs"
+            />
+          }
+          onClick={() => setIsMoreModelsExpanded((expanded) => !expanded)}
+          onSelect={(e) => e.preventDefault()}
+        />
+        {isMoreModelsExpanded &&
+          MOCK_MODELS.map((model) => (
+            <DropdownMenuItem
+              key={model}
+              label={model}
+              onSelect={(e) => e.preventDefault()}
+            />
+          ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  return (
+    <div className="flex min-h-screen w-full flex-col items-center bg-background px-4 py-6">
+      <div className="mb-4 flex w-full max-w-[680px] flex-wrap items-center gap-2 text-xs text-muted-foreground">
+        <span className="rounded-full bg-muted-background px-2 py-1 font-mono">
+          {viewportWidth}px · {viewportWidth < 768 ? "mobile" : "desktop"}
+        </span>
+        <span>
+          Resize the window to cross the <code>md</code> breakpoint (768px).
+        </span>
+      </div>
+
+      <h1 className="heading-3xl mb-6 text-center text-foreground">
+        What's the plan, Alexandre?
+      </h1>
+
+      <div className="flex w-full max-w-[680px] flex-col gap-4">
+        {messages.length > 0 && (
+          <div className="flex flex-col gap-2 rounded-xl bg-muted-background p-3">
+            {messages.map((message) => (
+              <div key={message.id} className="flex items-start gap-2">
+                <Avatar
+                  size="xs"
+                  name={selectedAgent?.name ?? "You"}
+                  visual={selectedAgent?.pictureUrl}
+                />
+                <p className="text-sm text-foreground">{message.text}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div ref={composerWrapperRef} className="relative w-full">
+          <Composer
+            isFocused={isFocused}
+            onContentClick={() => inputRef.current?.focus()}
+            attachments={
+              attachments.length > 0
+                ? attachments.map((attachment) => {
+                    const removeAttachment = () => {
+                      revokeAttachmentPreview(attachment);
+                      setAttachments((prev) =>
+                        prev.filter((a) => a.id !== attachment.id)
+                      );
+                    };
+                    return (
+                      <Tooltip
+                        key={attachment.id}
+                        label={attachment.title}
+                        tooltipTriggerAsChild
+                        trigger={
+                          attachment.previewUrl ? (
+                            <Citation
+                              compact
+                              isLoading={attachment.isUploading}
+                              containerClassName="h-full min-h-24"
+                            >
+                              <CitationImage
+                                imgSrc={attachment.previewUrl}
+                                title={attachment.title}
+                                isLoading={attachment.isUploading}
+                                onClose={removeAttachment}
+                              />
+                            </Citation>
+                          ) : (
+                            <Citation
+                              compact
+                              containerClassName="h-full min-h-24"
+                              className="h-full"
+                              isLoading={attachment.isUploading}
+                              loadingLabel="Uploading"
+                              action={
+                                <CitationClose onClick={removeAttachment} />
+                              }
+                            >
+                              <CitationIcons>
+                                <Icon visual={attachment.icon} size="sm" />
+                              </CitationIcons>
+                              <CitationTitle className="truncate text-ellipsis">
+                                {attachment.title}
+                              </CitationTitle>
+                            </Citation>
+                          )
+                        }
+                      />
+                    );
+                  })
+                : undefined
+            }
+            chips={
+              selectedTools.length > 0 || selectedSpaceIds.length > 0
+                ? [
+                    ...selectedTools.map((tool) => (
+                      <Chip
+                        key={tool.id}
+                        size="xs"
+                        label={tool.label}
+                        icon={tool.icon}
+                        className="bg-background text-foreground"
+                        onRemove={() =>
+                          setSelectedTools((prev) =>
+                            prev.filter((t) => t.id !== tool.id)
+                          )
+                        }
+                      />
+                    )),
+                    ...MOCK_SPACES.filter((space) =>
+                      selectedSpaceIds.includes(space.id)
+                    ).map((space) => (
+                      <Chip
+                        key={space.id}
+                        size="xs"
+                        label={space.name}
+                        icon={Planet}
+                        className="bg-background text-foreground"
+                        onRemove={() =>
+                          setSelectedSpaceIds((prev) =>
+                            prev.filter((id) => id !== space.id)
+                          )
+                        }
+                      />
+                    )),
+                  ]
+                : undefined
+            }
+            leftActions={
+              voice.status !== "recording" && (
+                <>
+                  {agentPicker}
+                  {plusMenu}
+                </>
+              )
+            }
+            rightActions={
+              <>
+                <ModelPickerHighlight>{modelPicker}</ModelPickerHighlight>
+                {/* Mic and send coexist; the mic stays a grey icon button so
+                    send remains the only highlighted action. */}
+                <VoicePicker
+                  status={voice.status}
+                  level={voice.level}
+                  elapsedSeconds={voice.elapsedSeconds}
+                  onRecordStart={voice.startRecording}
+                  onRecordStop={voice.stopRecording}
+                  size="xs"
+                  showStopLabel
+                  buttonProps={{ className: "rounded-full" }}
+                />
+                {showSendButton && (
+                  <Button
+                    variant="highlight"
+                    size="xs"
+                    aria-label="Send message"
+                    icon={ArrowUp}
+                    className="rounded-full"
+                    isLoading={isSubmitting}
+                    disabled={isSubmitDisabled}
+                    onClick={handleSubmit}
+                  />
+                )}
+              </>
+            }
+          >
+            {/* No formatting affordance on mobile: the "T" toggle used to sit
+                here, but it crowded the first row and pushed the input down.
+                Formatting stays desktop-only, via the selection toolbar below. */}
+            <ComposerInput
+              ref={inputRef}
+              value={text}
+              onChange={setText}
+              onSubmit={handleSubmit}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+              placeholder="Get work done"
+              suggestions={[
+                {
+                  trigger: "/",
+                  items: slashItems,
+                  onSelect: (item) => {
+                    if (item.id === "upload-file") {
+                      fileInputRef.current?.click();
+                      return;
+                    }
+                    const tool = MOCK_TOOLS.find((t) => t.id === item.id);
+                    if (tool) {
+                      addTool(tool);
+                    }
+                  },
+                },
+                {
+                  trigger: "@",
+                  items: mentionItems,
+                  onSelect: (item) => {
+                    const agent = MOCK_AGENTS.find((a) => a.id === item.id);
+                    if (agent) {
+                      setSelectedAgent(agent);
+                    }
+                  },
+                },
+              ]}
+            />
+          </Composer>
+
+          {/* Desktop: selecting text reveals the toolbar, mirroring the real
+              editor's BubbleMenu. Portaled to the body so it isn't clipped by
+              the composer's overflow-hidden card. */}
+          {hasSelection &&
+            toolbarAnchor &&
+            createPortal(
+              <div
+                className="fixed z-30 hidden -translate-x-1/2 -translate-y-1/2 md:block"
+                style={{ top: toolbarAnchor.top, left: toolbarAnchor.left }}
+              >
+                <Toolbar variant="inline">
+                  <ToolbarContent groups={formatGroups} />
+                </Toolbar>
+              </div>,
+              document.body
+            )}
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          <kbd>/</kbd> commands · <kbd>@</kbd> agents · <kbd>↵</kbd> send ·{" "}
+          <kbd>Shift ↵</kbd> newline · hold or click the mic to record
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/sparkle/playground/src/components/TopBannerView.tsx
+++ b/sparkle/playground/src/components/TopBannerView.tsx
@@ -1,0 +1,192 @@
+import { cn } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+// Mirrors front's StatusBanner (front/components/navigation/AppStatusBanner.tsx),
+// TopBanners and NavigationSidebar, so padding and spacing can be iterated on
+// here before touching the app.
+
+const ORANGE_VARIANT = cn(
+  "border-orange-100",
+  "bg-orange-50",
+  "text-orange-800",
+  "dark:border-info-100 dark:bg-info-50 dark:text-info-700"
+);
+
+const SKY_VARIANT = cn("border-sky-100", "bg-sky-50");
+
+interface OutageBannerProps {
+  paddingY: number;
+}
+
+function OutageBanner({ paddingY }: OutageBannerProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-0.5 border-b px-4 text-sm",
+        ORANGE_VARIANT
+      )}
+      style={{ paddingTop: `${paddingY}px`, paddingBottom: `${paddingY}px` }}
+    >
+      <div className="font-semibold">Degraded performance on conversations</div>
+      <div className="font-normal">
+        We are investigating elevated error rates on agent conversations. Some
+        messages may fail to send. Check our{" "}
+        <span className="underline">status page</span> for updates.
+      </div>
+    </div>
+  );
+}
+
+function TrialBanner() {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-4 border-b px-4 py-1",
+        SKY_VARIANT
+      )}
+    >
+      <div className="flex gap-2 text-sm">
+        <p className="font-semibold text-sky-900">
+          Heads up, your trial ends in 5 days
+        </p>
+        <p className="hidden text-sky-800 md:inline-block">
+          When your trial wraps up, your connections and team member access will
+          be removed.
+        </p>
+      </div>
+      <span className="whitespace-nowrap text-sm text-sky-900">
+        Subscribe to Dust
+      </span>
+    </div>
+  );
+}
+
+interface SliderProps {
+  label: string;
+  hint: string;
+  value: number;
+  max: number;
+  onChange: (value: number) => void;
+}
+
+function Slider({ label, hint, value, max, onChange }: SliderProps) {
+  return (
+    <label className="flex items-center gap-3 text-sm text-foreground">
+      <span className="w-64 shrink-0">
+        {label} <span className="text-muted-foreground">({hint})</span>
+      </span>
+      <input
+        type="range"
+        min={0}
+        max={max}
+        step={1}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+      <span className="w-16 shrink-0 tabular-nums text-muted-foreground">
+        {value}px
+      </span>
+    </label>
+  );
+}
+
+interface ToggleProps {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+function Toggle({ label, checked, onChange }: ToggleProps) {
+  return (
+    <label className="flex items-center gap-2 text-sm text-foreground">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      {label}
+    </label>
+  );
+}
+
+export function TopBannerView() {
+  const [bannerPaddingY, setBannerPaddingY] = useState(8);
+  const [spaceBelowBanner, setSpaceBelowBanner] = useState(4);
+  const [sidebarPaddingTop, setSidebarPaddingTop] = useState(8);
+  const [showOutage, setShowOutage] = useState(true);
+  const [showTrial, setShowTrial] = useState(false);
+
+  return (
+    <div className="flex h-dvh flex-col bg-app-background">
+      <div className="flex flex-col gap-2 border-b border-border bg-background px-4 py-3">
+        <Slider
+          label="Padding vertical de la bannière"
+          hint="StatusBanner, py-2"
+          value={bannerPaddingY}
+          max={32}
+          onChange={setBannerPaddingY}
+        />
+        <Slider
+          label="Espace sous la bannière"
+          hint="TopBanners, pb-1"
+          value={spaceBelowBanner}
+          max={32}
+          onChange={setSpaceBelowBanner}
+        />
+        <Slider
+          label="Padding haut de la sidebar"
+          hint="NavigationSidebar, pt-2"
+          value={sidebarPaddingTop}
+          max={32}
+          onChange={setSidebarPaddingTop}
+        />
+        <div className="flex gap-6 pt-1">
+          <Toggle
+            label="Bannière outage"
+            checked={showOutage}
+            onChange={setShowOutage}
+          />
+          <Toggle
+            label="Bannière trial empilée au-dessus"
+            checked={showTrial}
+            onChange={setShowTrial}
+          />
+        </div>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div
+          className="sticky top-0 z-50 flex shrink-0 flex-col bg-app-background empty:hidden"
+          style={{ paddingBottom: `${spaceBelowBanner}px` }}
+        >
+          {showTrial && <TrialBanner />}
+          {showOutage && <OutageBanner paddingY={bannerPaddingY} />}
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-row">
+          <div
+            className="flex w-80 flex-none flex-col gap-3 bg-app-background"
+            style={{ paddingTop: `${sidebarPaddingTop}px` }}
+          >
+            <div className="mx-3 flex h-8 items-center gap-2 rounded-xl bg-muted-background px-2">
+              <div className="h-4 w-12 rounded bg-border" />
+              <div className="h-4 w-4 rounded bg-border" />
+              <div className="h-4 w-4 rounded bg-border" />
+            </div>
+            <div className="mx-3 flex gap-2">
+              <div className="h-9 flex-1 rounded-xl border border-border" />
+              <div className="h-9 w-20 rounded-xl bg-highlight-500" />
+            </div>
+          </div>
+
+          <div className="my-2 mr-2 flex-1 overflow-hidden rounded-xl border border-border bg-panel-background">
+            <div className="flex flex-col gap-3 p-4">
+              <div className="h-4 w-64 rounded bg-muted-background" />
+              <div className="h-4 w-96 rounded bg-muted-background" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/sparkle/playground/src/components/manage/FleetFilterBar.tsx
+++ b/sparkle/playground/src/components/manage/FleetFilterBar.tsx
@@ -229,9 +229,9 @@ function PeopleSubMenu({
 }
 
 /**
- * All the new filter dimensions behind one button. The toolbar already carries
- * Search / Batch edit / Models / Tags / Create, so each dimension gets a
- * submenu here rather than its own button.
+ * Every filter dimension behind one button, each as a submenu. Keeps the
+ * toolbar down to Search / Filters / Create on both screens; availability is
+ * the one exception, it keeps its own control next to the tabs.
  */
 export function FleetFilterMenu({
   filters,

--- a/sparkle/playground/src/components/manage/FleetFilterBar.tsx
+++ b/sparkle/playground/src/components/manage/FleetFilterBar.tsx
@@ -17,21 +17,20 @@ import {
   DropdownMenuTrigger,
   Eye,
   FilterFunnel01,
-  Lock01,
   Tag01,
-  UserCircle,
   Users01,
+  Tool01,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 import { useState } from "react";
 
 import { FLEET_TOOLS, getToolLabel } from "../../data/fleetTools";
-import type { FleetFilters, StatusFilterValue } from "./fleetFilters";
+import type { FleetFilters } from "./fleetFilters";
 import {
   countActiveFleetFilters,
   EDITED_WITHIN_OPTIONS,
   NOT_USED_FOR_OPTIONS,
-  VISIBILITY_OPTIONS,
+  PUBLICATION_OPTIONS,
 } from "./fleetFilters";
 import { getToolIcon } from "./toolIcons";
 import { subFilter } from "./utils";
@@ -50,21 +49,17 @@ export interface FleetFilterOption {
 
 type FleetFilterListKey =
   | "editors"
-  | "lastEditors"
   | "tools"
-  | "status"
-  | "visibility"
+  | "publication"
   | "models"
   | "tags";
 
 interface FleetFilterMenuProps {
   filters: FleetFilters;
-  statusOptions: { value: StatusFilterValue; label: string }[];
   people: FleetPerson[];
-  // Agents are scoped to a workspace / space / person; skills use their own
-  // availability control, which stays where it already is.
-  showVisibility: boolean;
-  // Agents only. Empty on skills, which have neither.
+  // Agents only; skills express publication through availability, and have
+  // neither models nor tags.
+  showPublication: boolean;
   models?: FleetFilterOption[];
   tags?: FleetFilterOption[];
   onToggle: (key: FleetFilterListKey, value: string) => void;
@@ -235,17 +230,15 @@ function PeopleSubMenu({
  */
 export function FleetFilterMenu({
   filters,
-  statusOptions,
   people,
-  showVisibility,
+  showPublication,
   models,
   tags,
   onToggle,
   onUpdate,
 }: FleetFilterMenuProps) {
   const activeCount = countActiveFleetFilters(filters);
-  const selectedStatus = new Set(filters.status);
-  const selectedVisibility = new Set(filters.visibility);
+  const selectedPublication = new Set(filters.publication);
 
   return (
     <DropdownMenu>
@@ -259,44 +252,26 @@ export function FleetFilterMenu({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent className="w-60" align="end">
-        <DropdownMenuLabel label="Status" />
-        {statusOptions.map((option) => (
-          <DropdownMenuCheckboxItem
-            key={option.value}
-            label={option.label}
-            checked={selectedStatus.has(option.value)}
-            onCheckedChange={() => onToggle("status", option.value)}
-            onSelect={(event) => event.preventDefault()}
+        <DropdownMenuLabel label="Ownership" />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger label="Editors" icon={Users01} />
+          <PeopleSubMenu
+            people={people}
+            selected={filters.editors}
+            onToggle={(value) => onToggle("editors", value)}
+            placeholder="Search editors"
           />
-        ))}
+        </DropdownMenuSub>
 
         <DropdownMenuSeparator />
-
+        <DropdownMenuLabel label="Dependencies" />
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger label="Tools" icon={FilterFunnel01} />
+          <DropdownMenuSubTrigger label="Tools" icon={Tool01} />
           <ToolsSubMenu
             selected={filters.tools}
             onToggle={(value) => onToggle("tools", value)}
           />
         </DropdownMenuSub>
-
-        {showVisibility && (
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger label="Scope" icon={Lock01} />
-            <DropdownMenuSubContent className="w-52">
-              {VISIBILITY_OPTIONS.map((option) => (
-                <DropdownMenuCheckboxItem
-                  key={option.value}
-                  label={option.label}
-                  checked={selectedVisibility.has(option.value)}
-                  onCheckedChange={() => onToggle("visibility", option.value)}
-                  onSelect={(event) => event.preventDefault()}
-                />
-              ))}
-            </DropdownMenuSubContent>
-          </DropdownMenuSub>
-        )}
-
         {models && models.length > 0 && (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger label="Model" icon={CpuChip01} />
@@ -310,39 +285,18 @@ export function FleetFilterMenu({
           </DropdownMenuSub>
         )}
 
-        {tags && tags.length > 0 && (
-          <DropdownMenuSub>
-            <DropdownMenuSubTrigger label="Tags" icon={Tag01} />
-            <OptionsSubMenu
-              options={tags}
-              selected={filters.tags}
-              onToggle={(value) => onToggle("tags", value)}
-              placeholder="Search tags"
-              emptyLabel="No tags found"
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel label="Lifecycle" />
+        {showPublication &&
+          PUBLICATION_OPTIONS.map((option) => (
+            <DropdownMenuCheckboxItem
+              key={option.value}
+              label={option.label}
+              checked={selectedPublication.has(option.value)}
+              onCheckedChange={() => onToggle("publication", option.value)}
+              onSelect={(event) => event.preventDefault()}
             />
-          </DropdownMenuSub>
-        )}
-
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger label="Editors" icon={Users01} />
-          <PeopleSubMenu
-            people={people}
-            selected={filters.editors}
-            onToggle={(value) => onToggle("editors", value)}
-            placeholder="Search editors"
-          />
-        </DropdownMenuSub>
-
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger label="Last editor" icon={UserCircle} />
-          <PeopleSubMenu
-            people={people}
-            selected={filters.lastEditors}
-            onToggle={(value) => onToggle("lastEditors", value)}
-            placeholder="Search members"
-          />
-        </DropdownMenuSub>
-
+          ))}
         <DropdownMenuSub>
           <DropdownMenuSubTrigger label="Last edited" icon={ClockRewind} />
           <DropdownMenuSubContent className="w-60">
@@ -365,9 +319,8 @@ export function FleetFilterMenu({
             </DropdownMenuRadioGroup>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
-
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger label="Usage" icon={Eye} />
+          <DropdownMenuSubTrigger label="Human usage" icon={Eye} />
           <DropdownMenuSubContent className="w-64">
             <DropdownMenuRadioGroup value={filters.notUsedFor ?? ""}>
               {NOT_USED_FOR_OPTIONS.map((option) => (
@@ -388,6 +341,22 @@ export function FleetFilterMenu({
             </DropdownMenuRadioGroup>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
+
+        {tags && tags.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuSub>
+              <DropdownMenuSubTrigger label="Tags" icon={Tag01} />
+              <OptionsSubMenu
+                options={tags}
+                selected={filters.tags}
+                onToggle={(value) => onToggle("tags", value)}
+                placeholder="Search tags"
+                emptyLabel="No tags found"
+              />
+            </DropdownMenuSub>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -395,7 +364,6 @@ export function FleetFilterMenu({
 
 interface FleetFilterChipsProps {
   filters: FleetFilters;
-  statusOptions: { value: StatusFilterValue; label: string }[];
   peopleById: Map<string, string>;
   onRemove: (update: Partial<FleetFilters>) => void;
   onClear: () => void;
@@ -410,17 +378,12 @@ interface FleetFilterChipsProps {
  */
 export function FleetFilterChips({
   filters,
-  statusOptions,
   peopleById,
   onRemove,
   onClear,
   models,
   tags,
 }: FleetFilterChipsProps) {
-  const statusLabels = new Map(
-    statusOptions.map((option) => [option.value, option.label])
-  );
-
   const modelsByValue = new Map(
     (models ?? []).map((option) => [option.value, option])
   );
@@ -460,15 +423,20 @@ export function FleetFilterChips({
     );
   }
 
-  for (const status of filters.status) {
+  for (const publication of filters.publication) {
     chips.push(
       <Chip
-        key={`status-${status}`}
+        key={`publication-${publication}`}
         size="xs"
         color="primary"
-        label={statusLabels.get(status) ?? status}
+        label={
+          PUBLICATION_OPTIONS.find((o) => o.value === publication)?.label ??
+          publication
+        }
         onRemove={() =>
-          onRemove({ status: filters.status.filter((s) => s !== status) })
+          onRemove({
+            publication: filters.publication.filter((p) => p !== publication),
+          })
         }
       />
     );
@@ -489,26 +457,6 @@ export function FleetFilterChips({
     );
   }
 
-  for (const visibility of filters.visibility) {
-    chips.push(
-      <Chip
-        key={`visibility-${visibility}`}
-        size="xs"
-        color="primary"
-        icon={Lock01}
-        label={
-          VISIBILITY_OPTIONS.find((o) => o.value === visibility)?.label ??
-          visibility
-        }
-        onRemove={() =>
-          onRemove({
-            visibility: filters.visibility.filter((v) => v !== visibility),
-          })
-        }
-      />
-    );
-  }
-
   for (const editorId of filters.editors) {
     chips.push(
       <Chip
@@ -519,23 +467,6 @@ export function FleetFilterChips({
         label={peopleById.get(editorId) ?? editorId}
         onRemove={() =>
           onRemove({ editors: filters.editors.filter((e) => e !== editorId) })
-        }
-      />
-    );
-  }
-
-  for (const editorId of filters.lastEditors) {
-    chips.push(
-      <Chip
-        key={`last-editor-${editorId}`}
-        size="xs"
-        color="info"
-        icon={UserCircle}
-        label={`Last edited by ${peopleById.get(editorId) ?? editorId}`}
-        onRemove={() =>
-          onRemove({
-            lastEditors: filters.lastEditors.filter((e) => e !== editorId),
-          })
         }
       />
     );

--- a/sparkle/playground/src/components/manage/FleetFilterBar.tsx
+++ b/sparkle/playground/src/components/manage/FleetFilterBar.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Chip,
   ClockRewind,
+  CpuChip01,
   DropdownMenu,
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
@@ -17,9 +18,11 @@ import {
   Eye,
   FilterFunnel01,
   Lock01,
+  Tag01,
   UserCircle,
   Users01,
 } from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
 import { useState } from "react";
 
 import { FLEET_TOOLS, getToolLabel } from "../../data/fleetTools";
@@ -38,6 +41,22 @@ export interface FleetPerson {
   fullName: string;
 }
 
+/** A filter option; `icon` lets callers supply e.g. a model maker logo. */
+export interface FleetFilterOption {
+  value: string;
+  label: string;
+  icon?: ComponentType<{ className?: string }>;
+}
+
+type FleetFilterListKey =
+  | "editors"
+  | "lastEditors"
+  | "tools"
+  | "status"
+  | "visibility"
+  | "models"
+  | "tags";
+
 interface FleetFilterMenuProps {
   filters: FleetFilters;
   statusOptions: { value: StatusFilterValue; label: string }[];
@@ -45,11 +64,61 @@ interface FleetFilterMenuProps {
   // Agents are scoped to a workspace / space / person; skills use their own
   // availability control, which stays where it already is.
   showVisibility: boolean;
-  onToggle: (
-    key: "editors" | "lastEditors" | "tools" | "status" | "visibility",
-    value: string
-  ) => void;
+  // Agents only. Empty on skills, which have neither.
+  models?: FleetFilterOption[];
+  tags?: FleetFilterOption[];
+  onToggle: (key: FleetFilterListKey, value: string) => void;
   onUpdate: (update: Partial<FleetFilters>) => void;
+}
+
+/** Searchable multi-select submenu shared by the option-list dimensions. */
+function OptionsSubMenu({
+  options,
+  selected,
+  onToggle,
+  placeholder,
+  emptyLabel,
+}: {
+  options: FleetFilterOption[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  placeholder: string;
+  emptyLabel: string;
+}) {
+  const [search, setSearch] = useState("");
+  const searchLower = search.toLowerCase();
+  const selectedIds = new Set(selected);
+  const filtered = options.filter((option) =>
+    subFilter(searchLower, option.label.toLowerCase())
+  );
+
+  return (
+    <DropdownMenuSubContent className="w-72">
+      <DropdownMenuSearchbar
+        name="optionSearch"
+        placeholder={placeholder}
+        value={search}
+        onChange={setSearch}
+      />
+      <DropdownMenuSeparator />
+      {filtered.length === 0 && (
+        <div className="flex items-center justify-center py-4 text-sm">
+          {emptyLabel}
+        </div>
+      )}
+      {filtered.map((option) => (
+        <DropdownMenuCheckboxItem
+          key={option.value}
+          label={option.label}
+          icon={option.icon}
+          truncateText
+          checked={selectedIds.has(option.value)}
+          onCheckedChange={() => onToggle(option.value)}
+          onSelect={(event) => event.preventDefault()}
+        />
+      ))}
+    </DropdownMenuSubContent>
+  );
 }
 
 function ToolsSubMenu({
@@ -169,6 +238,8 @@ export function FleetFilterMenu({
   statusOptions,
   people,
   showVisibility,
+  models,
+  tags,
   onToggle,
   onUpdate,
 }: FleetFilterMenuProps) {
@@ -223,6 +294,32 @@ export function FleetFilterMenu({
                 />
               ))}
             </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        )}
+
+        {models && models.length > 0 && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger label="Model" icon={CpuChip01} />
+            <OptionsSubMenu
+              options={models}
+              selected={filters.models}
+              onToggle={(value) => onToggle("models", value)}
+              placeholder="Search models"
+              emptyLabel="No models found"
+            />
+          </DropdownMenuSub>
+        )}
+
+        {tags && tags.length > 0 && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger label="Tags" icon={Tag01} />
+            <OptionsSubMenu
+              options={tags}
+              selected={filters.tags}
+              onToggle={(value) => onToggle("tags", value)}
+              placeholder="Search tags"
+              emptyLabel="No tags found"
+            />
           </DropdownMenuSub>
         )}
 
@@ -302,10 +399,9 @@ interface FleetFilterChipsProps {
   peopleById: Map<string, string>;
   onRemove: (update: Partial<FleetFilters>) => void;
   onClear: () => void;
-  // Screen-specific chips (models, tags) rendered before the shared ones so
-  // the existing rows keep their order.
-  leadingChips?: React.ReactNode;
-  hasLeadingChips?: boolean;
+  // Agents only; used to resolve ids to labels and icons.
+  models?: FleetFilterOption[];
+  tags?: FleetFilterOption[];
 }
 
 /**
@@ -318,14 +414,51 @@ export function FleetFilterChips({
   peopleById,
   onRemove,
   onClear,
-  leadingChips,
-  hasLeadingChips = false,
+  models,
+  tags,
 }: FleetFilterChipsProps) {
   const statusLabels = new Map(
     statusOptions.map((option) => [option.value, option.label])
   );
 
+  const modelsByValue = new Map(
+    (models ?? []).map((option) => [option.value, option])
+  );
+  const tagsByValue = new Map(
+    (tags ?? []).map((option) => [option.value, option])
+  );
+
   const chips: React.ReactNode[] = [];
+
+  for (const modelId of filters.models) {
+    const option = modelsByValue.get(modelId);
+    chips.push(
+      <Chip
+        key={`model-${modelId}`}
+        size="xs"
+        color="primary"
+        icon={option?.icon}
+        label={option?.label ?? modelId}
+        onRemove={() =>
+          onRemove({ models: filters.models.filter((m) => m !== modelId) })
+        }
+      />
+    );
+  }
+
+  for (const tagId of filters.tags) {
+    chips.push(
+      <Chip
+        key={`tag-${tagId}`}
+        size="xs"
+        color="info"
+        label={tagsByValue.get(tagId)?.label ?? tagId}
+        onRemove={() =>
+          onRemove({ tags: filters.tags.filter((t) => t !== tagId) })
+        }
+      />
+    );
+  }
 
   for (const status of filters.status) {
     chips.push(
@@ -440,13 +573,12 @@ export function FleetFilterChips({
     );
   }
 
-  if (chips.length === 0 && !hasLeadingChips) {
+  if (chips.length === 0) {
     return null;
   }
 
   return (
     <div className="flex flex-row flex-wrap items-center gap-2">
-      {leadingChips}
       {chips}
       {chips.length > 1 && (
         <Button variant="ghost" size="xs" label="Clear all" onClick={onClear} />

--- a/sparkle/playground/src/components/manage/FleetFilterBar.tsx
+++ b/sparkle/playground/src/components/manage/FleetFilterBar.tsx
@@ -1,0 +1,456 @@
+import {
+  Button,
+  Chip,
+  ClockRewind,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+  Eye,
+  FilterFunnel01,
+  Lock01,
+  UserCircle,
+  Users01,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { FLEET_TOOLS, getToolLabel } from "../../data/fleetTools";
+import type { FleetFilters, StatusFilterValue } from "./fleetFilters";
+import {
+  countActiveFleetFilters,
+  EDITED_WITHIN_OPTIONS,
+  NOT_USED_FOR_OPTIONS,
+  VISIBILITY_OPTIONS,
+} from "./fleetFilters";
+import { getToolIcon } from "./toolIcons";
+import { subFilter } from "./utils";
+
+export interface FleetPerson {
+  sId: string;
+  fullName: string;
+}
+
+interface FleetFilterMenuProps {
+  filters: FleetFilters;
+  statusOptions: { value: StatusFilterValue; label: string }[];
+  people: FleetPerson[];
+  // Agents are scoped to a workspace / space / person; skills use their own
+  // availability control, which stays where it already is.
+  showVisibility: boolean;
+  onToggle: (
+    key: "editors" | "lastEditors" | "tools" | "status" | "visibility",
+    value: string
+  ) => void;
+  onUpdate: (update: Partial<FleetFilters>) => void;
+}
+
+function ToolsSubMenu({
+  selected,
+  onToggle,
+}: {
+  selected: string[];
+  onToggle: (value: string) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const searchLower = search.toLowerCase();
+  const selectedIds = new Set(selected);
+  const connectors = FLEET_TOOLS.filter(
+    (tool) =>
+      tool.kind === "connector" &&
+      subFilter(searchLower, tool.label.toLowerCase())
+  );
+  const capabilities = FLEET_TOOLS.filter(
+    (tool) =>
+      tool.kind === "capability" &&
+      subFilter(searchLower, tool.label.toLowerCase())
+  );
+
+  return (
+    <DropdownMenuSubContent className="w-72">
+      <DropdownMenuSearchbar
+        name="toolSearch"
+        placeholder="Search tools"
+        value={search}
+        onChange={setSearch}
+      />
+      <DropdownMenuSeparator />
+      {connectors.length === 0 && capabilities.length === 0 && (
+        <div className="flex items-center justify-center py-4 text-sm">
+          No tools found
+        </div>
+      )}
+      {connectors.length > 0 && <DropdownMenuLabel label="Connectors" />}
+      {connectors.map((tool) => (
+        <DropdownMenuCheckboxItem
+          key={tool.id}
+          label={tool.label}
+          icon={getToolIcon(tool.id)}
+          checked={selectedIds.has(tool.id)}
+          onCheckedChange={() => onToggle(tool.id)}
+          onSelect={(event) => event.preventDefault()}
+        />
+      ))}
+      {capabilities.length > 0 && <DropdownMenuLabel label="Capabilities" />}
+      {capabilities.map((tool) => (
+        <DropdownMenuCheckboxItem
+          key={tool.id}
+          label={tool.label}
+          icon={getToolIcon(tool.id)}
+          checked={selectedIds.has(tool.id)}
+          onCheckedChange={() => onToggle(tool.id)}
+          onSelect={(event) => event.preventDefault()}
+        />
+      ))}
+    </DropdownMenuSubContent>
+  );
+}
+
+function PeopleSubMenu({
+  people,
+  selected,
+  onToggle,
+  placeholder,
+}: {
+  people: FleetPerson[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  placeholder: string;
+}) {
+  const [search, setSearch] = useState("");
+  const searchLower = search.toLowerCase();
+  const selectedIds = new Set(selected);
+  const filtered = people
+    .filter((person) => subFilter(searchLower, person.fullName.toLowerCase()))
+    .slice(0, 50);
+
+  return (
+    <DropdownMenuSubContent className="w-72">
+      <DropdownMenuSearchbar
+        name="peopleSearch"
+        placeholder={placeholder}
+        value={search}
+        onChange={setSearch}
+      />
+      <DropdownMenuSeparator />
+      {filtered.length === 0 && (
+        <div className="flex items-center justify-center py-4 text-sm">
+          No members found
+        </div>
+      )}
+      {filtered.map((person) => (
+        <DropdownMenuCheckboxItem
+          key={person.sId}
+          label={person.fullName}
+          truncateText
+          checked={selectedIds.has(person.sId)}
+          onCheckedChange={() => onToggle(person.sId)}
+          onSelect={(event) => event.preventDefault()}
+        />
+      ))}
+    </DropdownMenuSubContent>
+  );
+}
+
+/**
+ * All the new filter dimensions behind one button. The toolbar already carries
+ * Search / Batch edit / Models / Tags / Create, so each dimension gets a
+ * submenu here rather than its own button.
+ */
+export function FleetFilterMenu({
+  filters,
+  statusOptions,
+  people,
+  showVisibility,
+  onToggle,
+  onUpdate,
+}: FleetFilterMenuProps) {
+  const activeCount = countActiveFleetFilters(filters);
+  const selectedStatus = new Set(filters.status);
+  const selectedVisibility = new Set(filters.visibility);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          icon={FilterFunnel01}
+          label="Filters"
+          counterValue={activeCount.toString()}
+          isCounter={activeCount > 0}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-60" align="end">
+        <DropdownMenuLabel label="Status" />
+        {statusOptions.map((option) => (
+          <DropdownMenuCheckboxItem
+            key={option.value}
+            label={option.label}
+            checked={selectedStatus.has(option.value)}
+            onCheckedChange={() => onToggle("status", option.value)}
+            onSelect={(event) => event.preventDefault()}
+          />
+        ))}
+
+        <DropdownMenuSeparator />
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger label="Tools" icon={FilterFunnel01} />
+          <ToolsSubMenu
+            selected={filters.tools}
+            onToggle={(value) => onToggle("tools", value)}
+          />
+        </DropdownMenuSub>
+
+        {showVisibility && (
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger label="Scope" icon={Lock01} />
+            <DropdownMenuSubContent className="w-52">
+              {VISIBILITY_OPTIONS.map((option) => (
+                <DropdownMenuCheckboxItem
+                  key={option.value}
+                  label={option.label}
+                  checked={selectedVisibility.has(option.value)}
+                  onCheckedChange={() => onToggle("visibility", option.value)}
+                  onSelect={(event) => event.preventDefault()}
+                />
+              ))}
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        )}
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger label="Editors" icon={Users01} />
+          <PeopleSubMenu
+            people={people}
+            selected={filters.editors}
+            onToggle={(value) => onToggle("editors", value)}
+            placeholder="Search editors"
+          />
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger label="Last editor" icon={UserCircle} />
+          <PeopleSubMenu
+            people={people}
+            selected={filters.lastEditors}
+            onToggle={(value) => onToggle("lastEditors", value)}
+            placeholder="Search members"
+          />
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger label="Last edited" icon={ClockRewind} />
+          <DropdownMenuSubContent className="w-60">
+            <DropdownMenuRadioGroup value={filters.editedWithin ?? ""}>
+              {EDITED_WITHIN_OPTIONS.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option.value}
+                  value={option.value}
+                  label={option.label}
+                  onClick={() =>
+                    onUpdate({
+                      editedWithin:
+                        filters.editedWithin === option.value
+                          ? null
+                          : option.value,
+                    })
+                  }
+                />
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger label="Usage" icon={Eye} />
+          <DropdownMenuSubContent className="w-64">
+            <DropdownMenuRadioGroup value={filters.notUsedFor ?? ""}>
+              {NOT_USED_FOR_OPTIONS.map((option) => (
+                <DropdownMenuRadioItem
+                  key={option.value}
+                  value={option.value}
+                  label={option.label}
+                  onClick={() =>
+                    onUpdate({
+                      notUsedFor:
+                        filters.notUsedFor === option.value
+                          ? null
+                          : option.value,
+                    })
+                  }
+                />
+              ))}
+            </DropdownMenuRadioGroup>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface FleetFilterChipsProps {
+  filters: FleetFilters;
+  statusOptions: { value: StatusFilterValue; label: string }[];
+  peopleById: Map<string, string>;
+  onRemove: (update: Partial<FleetFilters>) => void;
+  onClear: () => void;
+  // Screen-specific chips (models, tags) rendered before the shared ones so
+  // the existing rows keep their order.
+  leadingChips?: React.ReactNode;
+  hasLeadingChips?: boolean;
+}
+
+/**
+ * Active filters as removable chips — the row Manage Agents already uses for
+ * models and tags, extended to every dimension and reused on Manage Skills.
+ */
+export function FleetFilterChips({
+  filters,
+  statusOptions,
+  peopleById,
+  onRemove,
+  onClear,
+  leadingChips,
+  hasLeadingChips = false,
+}: FleetFilterChipsProps) {
+  const statusLabels = new Map(
+    statusOptions.map((option) => [option.value, option.label])
+  );
+
+  const chips: React.ReactNode[] = [];
+
+  for (const status of filters.status) {
+    chips.push(
+      <Chip
+        key={`status-${status}`}
+        size="xs"
+        color="primary"
+        label={statusLabels.get(status) ?? status}
+        onRemove={() =>
+          onRemove({ status: filters.status.filter((s) => s !== status) })
+        }
+      />
+    );
+  }
+
+  for (const tool of filters.tools) {
+    chips.push(
+      <Chip
+        key={`tool-${tool}`}
+        size="xs"
+        color="primary"
+        icon={getToolIcon(tool)}
+        label={getToolLabel(tool)}
+        onRemove={() =>
+          onRemove({ tools: filters.tools.filter((t) => t !== tool) })
+        }
+      />
+    );
+  }
+
+  for (const visibility of filters.visibility) {
+    chips.push(
+      <Chip
+        key={`visibility-${visibility}`}
+        size="xs"
+        color="primary"
+        icon={Lock01}
+        label={
+          VISIBILITY_OPTIONS.find((o) => o.value === visibility)?.label ??
+          visibility
+        }
+        onRemove={() =>
+          onRemove({
+            visibility: filters.visibility.filter((v) => v !== visibility),
+          })
+        }
+      />
+    );
+  }
+
+  for (const editorId of filters.editors) {
+    chips.push(
+      <Chip
+        key={`editor-${editorId}`}
+        size="xs"
+        color="info"
+        icon={Users01}
+        label={peopleById.get(editorId) ?? editorId}
+        onRemove={() =>
+          onRemove({ editors: filters.editors.filter((e) => e !== editorId) })
+        }
+      />
+    );
+  }
+
+  for (const editorId of filters.lastEditors) {
+    chips.push(
+      <Chip
+        key={`last-editor-${editorId}`}
+        size="xs"
+        color="info"
+        icon={UserCircle}
+        label={`Last edited by ${peopleById.get(editorId) ?? editorId}`}
+        onRemove={() =>
+          onRemove({
+            lastEditors: filters.lastEditors.filter((e) => e !== editorId),
+          })
+        }
+      />
+    );
+  }
+
+  if (filters.editedWithin) {
+    chips.push(
+      <Chip
+        key="edited-within"
+        size="xs"
+        color="primary"
+        icon={ClockRewind}
+        label={
+          EDITED_WITHIN_OPTIONS.find((o) => o.value === filters.editedWithin)
+            ?.label ?? ""
+        }
+        onRemove={() => onRemove({ editedWithin: null })}
+      />
+    );
+  }
+
+  if (filters.notUsedFor) {
+    chips.push(
+      <Chip
+        key="not-used-for"
+        size="xs"
+        color="warning"
+        icon={Eye}
+        label={
+          NOT_USED_FOR_OPTIONS.find((o) => o.value === filters.notUsedFor)
+            ?.label ?? ""
+        }
+        onRemove={() => onRemove({ notUsedFor: null })}
+      />
+    );
+  }
+
+  if (chips.length === 0 && !hasLeadingChips) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-row flex-wrap items-center gap-2">
+      {leadingChips}
+      {chips}
+      {chips.length > 1 && (
+        <Button variant="ghost" size="xs" label="Clear all" onClick={onClear} />
+      )}
+    </div>
+  );
+}

--- a/sparkle/playground/src/components/manage/FleetFilterBar.tsx
+++ b/sparkle/playground/src/components/manage/FleetFilterBar.tsx
@@ -17,9 +17,10 @@ import {
   DropdownMenuTrigger,
   Eye,
   FilterFunnel01,
+  Icon,
+  ShapesPlus,
   Tag01,
   Users01,
-  Tool01,
 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 import { useState } from "react";
@@ -45,6 +46,19 @@ export interface FleetFilterOption {
   value: string;
   label: string;
   icon?: ComponentType<{ className?: string }>;
+}
+
+/**
+ * Dropdown items render icons at "sm" (20px) by default, sized for a single
+ * icon carrying the whole row's meaning (Create, Models, Tags elsewhere).
+ * This menu stacks many rows of icon + label, where 20px reads heavy — so
+ * every icon here is pre-rendered at "xs" (16px) instead.
+ */
+function smallIcon(visual: ComponentType<{ className?: string }> | undefined) {
+  if (!visual) {
+    return undefined;
+  }
+  return <Icon visual={visual} size="xs" className="text-muted-foreground" />;
 }
 
 type FleetFilterListKey =
@@ -105,7 +119,7 @@ function OptionsSubMenu({
         <DropdownMenuCheckboxItem
           key={option.value}
           label={option.label}
-          icon={option.icon}
+          icon={smallIcon(option.icon)}
           truncateText
           checked={selectedIds.has(option.value)}
           onCheckedChange={() => onToggle(option.value)}
@@ -156,7 +170,7 @@ function ToolsSubMenu({
         <DropdownMenuCheckboxItem
           key={tool.id}
           label={tool.label}
-          icon={getToolIcon(tool.id)}
+          icon={smallIcon(getToolIcon(tool.id))}
           checked={selectedIds.has(tool.id)}
           onCheckedChange={() => onToggle(tool.id)}
           onSelect={(event) => event.preventDefault()}
@@ -167,7 +181,7 @@ function ToolsSubMenu({
         <DropdownMenuCheckboxItem
           key={tool.id}
           label={tool.label}
-          icon={getToolIcon(tool.id)}
+          icon={smallIcon(getToolIcon(tool.id))}
           checked={selectedIds.has(tool.id)}
           onCheckedChange={() => onToggle(tool.id)}
           onSelect={(event) => event.preventDefault()}
@@ -254,7 +268,7 @@ export function FleetFilterMenu({
       <DropdownMenuContent className="w-60" align="end">
         <DropdownMenuLabel label="Ownership" />
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger label="Editors" icon={Users01} />
+          <DropdownMenuSubTrigger label="Editors" icon={smallIcon(Users01)} />
           <PeopleSubMenu
             people={people}
             selected={filters.editors}
@@ -266,7 +280,7 @@ export function FleetFilterMenu({
         <DropdownMenuSeparator />
         <DropdownMenuLabel label="Dependencies" />
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger label="Tools" icon={Tool01} />
+          <DropdownMenuSubTrigger label="Tools" icon={smallIcon(ShapesPlus)} />
           <ToolsSubMenu
             selected={filters.tools}
             onToggle={(value) => onToggle("tools", value)}
@@ -274,7 +288,7 @@ export function FleetFilterMenu({
         </DropdownMenuSub>
         {models && models.length > 0 && (
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger label="Model" icon={CpuChip01} />
+            <DropdownMenuSubTrigger label="Model" icon={smallIcon(CpuChip01)} />
             <OptionsSubMenu
               options={models}
               selected={filters.models}
@@ -298,7 +312,10 @@ export function FleetFilterMenu({
             />
           ))}
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger label="Last edited" icon={ClockRewind} />
+          <DropdownMenuSubTrigger
+            label="Last edited"
+            icon={smallIcon(ClockRewind)}
+          />
           <DropdownMenuSubContent className="w-60">
             <DropdownMenuRadioGroup value={filters.editedWithin ?? ""}>
               {EDITED_WITHIN_OPTIONS.map((option) => (
@@ -320,7 +337,7 @@ export function FleetFilterMenu({
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger label="Human usage" icon={Eye} />
+          <DropdownMenuSubTrigger label="Human usage" icon={smallIcon(Eye)} />
           <DropdownMenuSubContent className="w-64">
             <DropdownMenuRadioGroup value={filters.notUsedFor ?? ""}>
               {NOT_USED_FOR_OPTIONS.map((option) => (
@@ -346,7 +363,7 @@ export function FleetFilterMenu({
           <>
             <DropdownMenuSeparator />
             <DropdownMenuSub>
-              <DropdownMenuSubTrigger label="Tags" icon={Tag01} />
+              <DropdownMenuSubTrigger label="Tags" icon={smallIcon(Tag01)} />
               <OptionsSubMenu
                 options={tags}
                 selected={filters.tags}

--- a/sparkle/playground/src/components/manage/ManageAgentsTable.tsx
+++ b/sparkle/playground/src/components/manage/ManageAgentsTable.tsx
@@ -127,11 +127,15 @@ const getTableColumns = ({
   isBatchEdit,
   onTagsChange,
   nowMs,
+  showSelection,
 }: {
   tags: AgentTag[];
   isBatchEdit: boolean;
   onTagsChange: (agentId: string, tags: AgentTag[]) => void;
   nowMs: number;
+  // Omitted on tabs where nothing is selectable (Default, Archived), so those
+  // lists don't carry a column of permanently disabled checkboxes.
+  showSelection: boolean;
 }) => {
   /**
    * Columns order:
@@ -148,7 +152,7 @@ const getTableColumns = ({
    */
 
   return [
-    ...(isBatchEdit
+    ...(showSelection
       ? [
           {
             header: (info: HeaderContext<RowData, boolean>) => {
@@ -199,6 +203,13 @@ const getTableColumns = ({
                 <Checkbox
                   checked={info.row.getIsSelected()}
                   disabled={!info.row.getCanSelect()}
+                  // Ticking a row must not also open the details sheet.
+                  onClick={(e) => e.stopPropagation()}
+                  onCheckedChange={(state) => {
+                    if (state !== "indeterminate") {
+                      info.row.toggleSelected(state);
+                    }
+                  }}
                 />
               </DataTable.CellContent>
             ),
@@ -497,6 +508,7 @@ interface ManageAgentsTableProps {
   agents: ManagedAgent[];
   tags: AgentTag[];
   nowMs: number;
+  showSelection: boolean;
   setDetailedAgentId: (sId: string) => void;
   onToggleAgentStatus: (agent: ManagedAgent) => void;
   onTagsChange: (agentId: string, tags: AgentTag[]) => void;
@@ -510,6 +522,7 @@ export function ManageAgentsTable({
   agents,
   tags,
   nowMs,
+  showSelection,
   setDetailedAgentId,
   onToggleAgentStatus,
   onTagsChange,
@@ -526,8 +539,15 @@ export function ManageAgentsTable({
     useState<string | null>(null);
 
   const columns = useMemo(
-    () => getTableColumns({ tags, isBatchEdit, onTagsChange, nowMs }),
-    [tags, isBatchEdit, onTagsChange, nowMs]
+    () =>
+      getTableColumns({
+        tags,
+        isBatchEdit,
+        onTagsChange,
+        nowMs,
+        showSelection,
+      }),
+    [tags, isBatchEdit, onTagsChange, nowMs, showSelection]
   );
 
   // The selection lives in the table state (and not in the rows) so that
@@ -656,8 +676,9 @@ export function ManageAgentsTable({
         setPagination={setPagination}
         getRowId={(row) => row.sId}
         enableRowSelection={
-          isBatchEdit ? (row) => row.original.canArchive : false
+          showSelection ? (row) => row.original.canArchive : false
         }
+        disableRowClickSelection={!isBatchEdit}
         rowSelection={rowSelection}
         setRowSelection={(newRowSelection) => {
           setSelection(

--- a/sparkle/playground/src/components/manage/ManageAgentsTable.tsx
+++ b/sparkle/playground/src/components/manage/ManageAgentsTable.tsx
@@ -1,0 +1,667 @@
+import type { MenuItem } from "@dust-tt/sparkle";
+import {
+  AnthropicLogo,
+  Avatar,
+  Brackets,
+  Checkbox,
+  Chip,
+  Clipboard,
+  cn,
+  DataTable,
+  DeepseekLogo,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DustLogoSquare,
+  Edit04,
+  Eye,
+  GeminiLogo,
+  GrokLogo,
+  MistralLogo,
+  OpenaiLogo,
+  SliderToggle,
+  Tooltip,
+  Trash01,
+  Users01,
+} from "@dust-tt/sparkle";
+import type {
+  CellContext,
+  HeaderContext,
+  PaginationState,
+} from "@tanstack/react-table";
+import type { ComponentType, ReactNode } from "react";
+import { useMemo, useState } from "react";
+
+import type {
+  AgentEditor,
+  AgentScope,
+  AgentTag,
+  ManagedAgent,
+  ModelMakerId,
+} from "../../data/manageAgents";
+import { AGENT_MODELS_BY_ID } from "../../data/manageAgents";
+import { TableTagSelector } from "./TableTagSelector";
+import {
+  assistantUsageMessage,
+  formatTimestampToFriendlyDate,
+  pluralize,
+} from "./utils";
+
+export const SCOPE_INFO: Record<
+  AgentScope,
+  {
+    shortLabel: string;
+    label: string;
+    color: "success" | "info" | "highlight" | "primary";
+    icon?: typeof Users01 | undefined;
+    text: string;
+  }
+> = {
+  global: {
+    shortLabel: "Default",
+    label: "Default Agent",
+    color: "primary",
+    text: "Default agents provided by Dust.",
+  },
+  hidden: {
+    shortLabel: "Not published",
+    label: "Not published",
+    color: "primary",
+    text: "Hidden agents.",
+  },
+  visible: {
+    shortLabel: "Published",
+    label: "Published",
+    color: "success",
+    text: "Visible agents.",
+  },
+};
+
+const MODEL_MAKER_LOGOS: Record<ModelMakerId, ComponentType> = {
+  anthropic: AnthropicLogo,
+  openai: OpenaiLogo,
+  google_ai_studio: GeminiLogo,
+  mistral: MistralLogo,
+  deepseek: DeepseekLogo,
+  xai: GrokLogo,
+  noop: DustLogoSquare,
+};
+
+export function getModelLogoByModelId(
+  modelId: string
+): ComponentType | undefined {
+  const model = AGENT_MODELS_BY_ID.get(modelId);
+  return model ? MODEL_MAKER_LOGOS[model.maker] : undefined;
+}
+
+type RowData = {
+  sId: string;
+  name: string;
+  description: string;
+  emoji: string;
+  backgroundColor: string;
+  editors: AgentEditor[];
+  usage: { messageCount: number; timePeriodSec: number } | undefined;
+  feedbacks: { up: number; down: number } | undefined;
+  lastUpdate: number | null;
+  scope: AgentScope;
+  model: string;
+  modelIcon: ComponentType | undefined;
+  onClick?: () => void;
+  menuItems?: MenuItem[];
+  agentTags: AgentTag[];
+  agentTagsAsString: string;
+  action?: ReactNode;
+  canArchive: boolean;
+  canEdit: boolean;
+};
+
+// Global agents (canArchive: false) cannot be edited, so we disable them in batch edit.
+function isDisabled(canArchive: boolean, isBatchEdit: boolean): boolean {
+  return !canArchive && isBatchEdit;
+}
+
+const getTableColumns = ({
+  tags,
+  isBatchEdit,
+  onTagsChange,
+}: {
+  tags: AgentTag[];
+  isBatchEdit: boolean;
+  onTagsChange: (agentId: string, tags: AgentTag[]) => void;
+}) => {
+  /**
+   * Columns order:
+   * - Select (if batch edit)
+   * - Name (always)
+   * - Model (hidden on mobile)
+   * - Access (hidden on mobile)
+   * - Editors (hidden on mobile)
+   * - Tags (always)
+   * - Usage (hidden on mobile)
+   * - Feedback (hidden on mobile)
+   * - Last Edited (hidden on mobile)
+   * - Actions (always)
+   */
+
+  return [
+    ...(isBatchEdit
+      ? [
+          {
+            header: (info: HeaderContext<RowData, boolean>) => {
+              const areAllPageRowsSelected =
+                info.table.getIsAllPageRowsSelected();
+              const hasSelection = Object.values(
+                info.table.getState().rowSelection
+              ).some((isSelected) => isSelected);
+
+              return (
+                <Checkbox
+                  checked={
+                    areAllPageRowsSelected
+                      ? true
+                      : hasSelection
+                        ? "partial"
+                        : false
+                  }
+                  disabled={
+                    !info.table
+                      .getRowModel()
+                      .rows.some((row) => row.getCanSelect())
+                  }
+                  tooltip={
+                    areAllPageRowsSelected
+                      ? "Clear selection"
+                      : "Select all on page"
+                  }
+                  onClick={(e) => {
+                    e.stopPropagation();
+                  }}
+                  onCheckedChange={(checked) => {
+                    if (checked) {
+                      info.table.toggleAllPageRowsSelected(true);
+                    } else {
+                      // Unticking clears the whole selection across pages.
+                      info.table.resetRowSelection();
+                    }
+                  }}
+                />
+              );
+            },
+            accessorKey: "select",
+            cell: (info: CellContext<RowData, boolean>) => (
+              <DataTable.CellContent
+                disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+              >
+                <Checkbox
+                  checked={info.row.getIsSelected()}
+                  disabled={!info.row.getCanSelect()}
+                />
+              </DataTable.CellContent>
+            ),
+            meta: {
+              className: "w-10",
+            },
+            enableSorting: false,
+          },
+        ]
+      : []),
+    {
+      header: "Name",
+      accessorKey: "name",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+        >
+          <div className={cn("flex flex-row items-center gap-2 py-3")}>
+            <div>
+              <Avatar
+                emoji={info.row.original.emoji}
+                backgroundColor={info.row.original.backgroundColor}
+                size="sm"
+              />
+            </div>
+            <div className="flex min-w-0 grow flex-col">
+              <div className="heading-sm overflow-hidden truncate text-foreground">
+                {`@${info.getValue()}`}
+              </div>
+              <div className="overflow-hidden truncate text-sm text-muted-foreground">
+                {info.row.original.description}
+              </div>
+            </div>
+          </div>
+        </DataTable.CellContent>
+      ),
+      meta: {
+        className: "w-32 @lg:w-full",
+      },
+    },
+    {
+      header: "Model",
+      accessorKey: "model",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+          icon={info.row.original.modelIcon}
+        >
+          {info.getValue() || "-"}
+        </DataTable.CellContent>
+      ),
+      meta: {
+        className: "hidden @sm:w-48 @sm:table-cell",
+      },
+    },
+    {
+      header: "Access",
+      accessorKey: "scope",
+      cell: (info: CellContext<RowData, AgentScope>) => (
+        <DataTable.CellContent
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+        >
+          {info.getValue() !== "hidden" && (
+            <Chip
+              size="xs"
+              label={SCOPE_INFO[info.getValue()].shortLabel}
+              color={SCOPE_INFO[info.getValue()].color}
+              icon={SCOPE_INFO[info.getValue()].icon}
+            />
+          )}
+        </DataTable.CellContent>
+      ),
+      meta: {
+        className: "hidden @sm:w-32 @sm:table-cell",
+      },
+    },
+    {
+      header: "Editors",
+      accessorKey: "editors",
+      cell: (info: CellContext<RowData, AgentEditor[]>) => {
+        const { editors } = info.row.original;
+
+        if (!editors) {
+          return (
+            <DataTable.BasicCellContent
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+              label="-"
+            />
+          );
+        }
+
+        return (
+          <DataTable.CellContent
+            avatarStack={{
+              items: editors.map((editor) => ({
+                name: editor.fullName,
+                visual: editor.image,
+                isRounded: true,
+              })),
+              nbVisibleItems: 4,
+            }}
+          />
+        );
+      },
+      meta: {
+        className: "hidden @sm:w-24 @sm:table-cell",
+      },
+    },
+    {
+      header: "Tags",
+      accessorKey: "agentTagsAsString",
+      cell: (info: CellContext<RowData, string>) => (
+        <DataTable.CellContent
+          grow
+          className={cn("flex flex-row items-center")}
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+        >
+          <div className="group flex flex-row items-center gap-1">
+            <div className="truncate text-muted-foreground">
+              <Tooltip
+                tooltipTriggerAsChild
+                label={info.getValue()}
+                trigger={<span>{info.getValue()}</span>}
+              />
+            </div>
+            {info.row.original.canEdit && (
+              <TableTagSelector
+                tags={tags}
+                agentTags={info.row.original.agentTags}
+                onChange={(newTags) =>
+                  onTagsChange(info.row.original.sId, newTags)
+                }
+              />
+            )}
+          </div>
+        </DataTable.CellContent>
+      ),
+      isFilterable: true,
+      meta: {
+        className: "w-24 xl:w-40",
+        tooltip: "Tags",
+      },
+    },
+    {
+      header: "Usage",
+      accessorFn: (row: RowData) => row.usage?.messageCount ?? 0,
+      cell: (info: CellContext<RowData, number>) => (
+        <DataTable.BasicCellContent
+          className="font-mono"
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+          tooltip={assistantUsageMessage({
+            usage: info.row.original.usage ?? null,
+          })}
+          label={info.row.original.usage?.messageCount ?? 0}
+        />
+      ),
+      meta: {
+        className: "hidden @sm:w-16 @sm:table-cell",
+        tooltip: "Messages in the last 30 days",
+      },
+    },
+    {
+      header: "Feedback",
+      accessorFn: (row: RowData) =>
+        (row.feedbacks?.down ?? 0) + (row.feedbacks?.up ?? 0),
+      cell: (info: CellContext<RowData, number>) => {
+        if (info.row.original.scope === "global") {
+          return "-";
+        }
+        const f = info.row.original.feedbacks;
+        if (f) {
+          const feedbacksCount = `${f.up + f.down} feedback${pluralize(f.up + f.down)} over the last 30 days`;
+          return (
+            <DataTable.BasicCellContent
+              className="font-mono"
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+              tooltip={feedbacksCount}
+              label={`${f.up + f.down}`}
+            />
+          );
+        }
+      },
+      meta: {
+        className: "hidden @sm:w-20 @sm:table-cell",
+        tooltip: "Active users in the last 30 days",
+      },
+    },
+    {
+      header: "Last Edited",
+      accessorKey: "lastUpdate",
+      cell: (info: CellContext<RowData, number>) => (
+        <DataTable.BasicCellContent
+          disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+          tooltip={
+            info.getValue()
+              ? formatTimestampToFriendlyDate(info.getValue(), "long")
+              : undefined
+          }
+          label={
+            info.getValue()
+              ? formatTimestampToFriendlyDate(info.getValue(), "compact")
+              : "-"
+          }
+        />
+      ),
+      meta: { className: "hidden @sm:w-32 @sm:table-cell" },
+    },
+    {
+      header: "",
+      accessorKey: "actions",
+      cell: (info: CellContext<RowData, number>) => {
+        if (info.row.original.scope === "global") {
+          return (
+            <DataTable.CellContent
+              disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+            >
+              {info.row.original.action}
+            </DataTable.CellContent>
+          );
+        }
+        return (
+          <DataTable.MoreButton
+            menuItems={info.row.original.menuItems}
+            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+          />
+        );
+      },
+      meta: {
+        className: "w-14",
+      },
+    },
+  ];
+};
+
+interface GlobalAgentActionProps {
+  agent: ManagedAgent;
+  onToggle: (agent: ManagedAgent) => void;
+  showDisabledFreeWorkspacePopup: string | null;
+  setShowDisabledFreeWorkspacePopup: (sId: string | null) => void;
+}
+
+function GlobalAgentAction({
+  agent,
+  onToggle,
+  showDisabledFreeWorkspacePopup,
+  setShowDisabledFreeWorkspacePopup,
+}: GlobalAgentActionProps) {
+  return (
+    <>
+      <SliderToggle
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle(agent);
+        }}
+        selected={agent.status === "active"}
+        disabled={agent.status === "disabled_missing_datasource"}
+      />
+      <div className="whitespace-normal" onClick={(e) => e.stopPropagation()}>
+        <Dialog
+          open={showDisabledFreeWorkspacePopup === agent.sId}
+          onOpenChange={(open) => {
+            if (!open) {
+              setShowDisabledFreeWorkspacePopup(null);
+            }
+          }}
+        >
+          <DialogContent size="md">
+            <DialogHeader hideButton={false}>
+              <DialogTitle>Free plan</DialogTitle>
+            </DialogHeader>
+            <DialogContainer>
+              {`@${agent.name} is only available on our paid plans.`}
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+                onClick: () => setShowDisabledFreeWorkspacePopup(null),
+              }}
+              rightButtonProps={{
+                label: "Check Dust plans",
+                variant: "primary",
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+    </>
+  );
+}
+
+interface ManageAgentsTableProps {
+  agents: ManagedAgent[];
+  tags: AgentTag[];
+  setDetailedAgentId: (sId: string) => void;
+  onToggleAgentStatus: (agent: ManagedAgent) => void;
+  onTagsChange: (agentId: string, tags: AgentTag[]) => void;
+  onArchiveAgent: (agent: ManagedAgent) => void;
+  isBatchEdit: boolean;
+  selection: string[];
+  setSelection: (selection: string[]) => void;
+}
+
+export function ManageAgentsTable({
+  agents,
+  tags,
+  setDetailedAgentId,
+  onToggleAgentStatus,
+  onTagsChange,
+  onArchiveAgent,
+  isBatchEdit,
+  selection,
+  setSelection,
+}: ManageAgentsTableProps) {
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 25,
+  });
+  const [showDisabledFreeWorkspacePopup, setShowDisabledFreeWorkspacePopup] =
+    useState<string | null>(null);
+
+  const columns = useMemo(
+    () => getTableColumns({ tags, isBatchEdit, onTagsChange }),
+    [tags, isBatchEdit, onTagsChange]
+  );
+
+  // The selection lives in the table state (and not in the rows) so that
+  // selecting an agent does not change the rows, which would reset pagination.
+  const rowSelection = useMemo(
+    () => Object.fromEntries(selection.map((agentId) => [agentId, true])),
+    [selection]
+  );
+
+  const rows: RowData[] = useMemo(
+    () =>
+      agents.map((agent) => {
+        const canEdit = agent.canEdit;
+        const canArchive =
+          agent.status !== "archived" && agent.scope !== "global";
+        const model = AGENT_MODELS_BY_ID.get(agent.modelId);
+
+        return {
+          sId: agent.sId,
+          name: agent.name,
+          description: agent.description,
+          emoji: agent.emoji,
+          backgroundColor: agent.backgroundColor,
+          usage: agent.usage,
+          feedbacks: agent.feedbacks,
+          editors: agent.editors,
+          lastUpdate: agent.lastUpdate,
+          scope: agent.scope,
+          model: model?.displayName ?? agent.modelId,
+          modelIcon: getModelLogoByModelId(agent.modelId),
+          agentTags: agent.tags,
+          agentTagsAsString:
+            agent.tags.length > 0
+              ? agent.tags.map((t) => t.name).join(", ")
+              : "",
+          canArchive,
+          canEdit,
+          action:
+            agent.scope === "global" ? (
+              <GlobalAgentAction
+                agent={agent}
+                onToggle={onToggleAgentStatus}
+                showDisabledFreeWorkspacePopup={showDisabledFreeWorkspacePopup}
+                setShowDisabledFreeWorkspacePopup={
+                  setShowDisabledFreeWorkspacePopup
+                }
+              />
+            ) : undefined,
+          // In batch edit, row clicks toggle the selection, which the table
+          // handles through `enableRowSelection`.
+          onClick: isBatchEdit
+            ? undefined
+            : () => {
+                setDetailedAgentId(agent.sId);
+              },
+          menuItems:
+            agent.scope !== "global" && agent.status !== "archived"
+              ? [
+                  {
+                    label: "Edit",
+                    icon: Edit04,
+                    disabled: !canEdit,
+                    onClick: (e: React.MouseEvent) => e.stopPropagation(),
+                    kind: "item" as const,
+                  },
+                  {
+                    label: "Copy agent ID",
+                    icon: Brackets,
+                    onClick: (e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      void navigator.clipboard.writeText(agent.sId);
+                    },
+                    kind: "item" as const,
+                  },
+                  {
+                    label: "More info",
+                    icon: Eye,
+                    onClick: (e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      setDetailedAgentId(agent.sId);
+                    },
+                    kind: "item" as const,
+                  },
+                  {
+                    label: "Duplicate (New)",
+                    icon: Clipboard,
+                    onClick: (e: React.MouseEvent) => e.stopPropagation(),
+                    kind: "item" as const,
+                  },
+                  {
+                    label: "Archive",
+                    icon: Trash01,
+                    disabled: !canEdit,
+                    variant: "warning" as const,
+                    onClick: (e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      onArchiveAgent(agent);
+                    },
+                    kind: "item" as const,
+                  },
+                ].filter((item) => !item.disabled)
+              : [],
+        };
+      }),
+    [
+      agents,
+      isBatchEdit,
+      onArchiveAgent,
+      onToggleAgentStatus,
+      setDetailedAgentId,
+      showDisabledFreeWorkspacePopup,
+    ]
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <DataTable
+        className="relative"
+        data={rows}
+        columns={columns}
+        pagination={pagination}
+        setPagination={setPagination}
+        getRowId={(row) => row.sId}
+        enableRowSelection={
+          isBatchEdit ? (row) => row.original.canArchive : false
+        }
+        rowSelection={rowSelection}
+        setRowSelection={(newRowSelection) => {
+          setSelection(
+            Object.keys(newRowSelection).filter(
+              (agentId) => newRowSelection[agentId]
+            )
+          );
+        }}
+      />
+    </div>
+  );
+}

--- a/sparkle/playground/src/components/manage/ManageAgentsTable.tsx
+++ b/sparkle/playground/src/components/manage/ManageAgentsTable.tsx
@@ -35,6 +35,7 @@ import type {
 import type { ComponentType, ReactNode } from "react";
 import { useMemo, useState } from "react";
 
+import type { FleetUsage } from "../../data/fleetUsage";
 import type {
   AgentEditor,
   AgentScope,
@@ -44,11 +45,8 @@ import type {
 } from "../../data/manageAgents";
 import { AGENT_MODELS_BY_ID } from "../../data/manageAgents";
 import { TableTagSelector } from "./TableTagSelector";
-import {
-  assistantUsageMessage,
-  formatTimestampToFriendlyDate,
-  pluralize,
-} from "./utils";
+import { UsageCell } from "./UsageCell";
+import { formatTimestampToFriendlyDate, pluralize } from "./utils";
 
 export const SCOPE_INFO: Record<
   AgentScope,
@@ -104,7 +102,7 @@ type RowData = {
   emoji: string;
   backgroundColor: string;
   editors: AgentEditor[];
-  usage: { messageCount: number; timePeriodSec: number } | undefined;
+  usage: FleetUsage | undefined;
   feedbacks: { up: number; down: number } | undefined;
   lastUpdate: number | null;
   scope: AgentScope;
@@ -128,10 +126,12 @@ const getTableColumns = ({
   tags,
   isBatchEdit,
   onTagsChange,
+  nowMs,
 }: {
   tags: AgentTag[];
   isBatchEdit: boolean;
   onTagsChange: (agentId: string, tags: AgentTag[]) => void;
+  nowMs: number;
 }) => {
   /**
    * Columns order:
@@ -344,20 +344,23 @@ const getTableColumns = ({
     },
     {
       header: "Usage",
-      accessorFn: (row: RowData) => row.usage?.messageCount ?? 0,
+      // Sorting on the human count: programmatic traffic must not be able to
+      // float an agent nobody actually talks to.
+      accessorFn: (row: RowData) => row.usage?.human ?? 0,
       cell: (info: CellContext<RowData, number>) => (
-        <DataTable.BasicCellContent
-          className="font-mono"
+        <DataTable.CellContent
           disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
-          tooltip={assistantUsageMessage({
-            usage: info.row.original.usage ?? null,
-          })}
-          label={info.row.original.usage?.messageCount ?? 0}
-        />
+        >
+          <UsageCell
+            usage={info.row.original.usage ?? null}
+            nowMs={nowMs}
+            disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
+          />
+        </DataTable.CellContent>
       ),
       meta: {
-        className: "hidden @sm:w-16 @sm:table-cell",
-        tooltip: "Messages in the last 30 days",
+        className: "hidden @sm:w-24 @sm:table-cell",
+        tooltip: "Human messages in the last 30 days",
       },
     },
     {
@@ -493,6 +496,7 @@ function GlobalAgentAction({
 interface ManageAgentsTableProps {
   agents: ManagedAgent[];
   tags: AgentTag[];
+  nowMs: number;
   setDetailedAgentId: (sId: string) => void;
   onToggleAgentStatus: (agent: ManagedAgent) => void;
   onTagsChange: (agentId: string, tags: AgentTag[]) => void;
@@ -505,6 +509,7 @@ interface ManageAgentsTableProps {
 export function ManageAgentsTable({
   agents,
   tags,
+  nowMs,
   setDetailedAgentId,
   onToggleAgentStatus,
   onTagsChange,
@@ -521,8 +526,8 @@ export function ManageAgentsTable({
     useState<string | null>(null);
 
   const columns = useMemo(
-    () => getTableColumns({ tags, isBatchEdit, onTagsChange }),
-    [tags, isBatchEdit, onTagsChange]
+    () => getTableColumns({ tags, isBatchEdit, onTagsChange, nowMs }),
+    [tags, isBatchEdit, onTagsChange, nowMs]
   );
 
   // The selection lives in the table state (and not in the rows) so that

--- a/sparkle/playground/src/components/manage/ManagePageLayout.tsx
+++ b/sparkle/playground/src/components/manage/ManagePageLayout.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from "react";
+
+interface ManagePageLayoutProps {
+  children: ReactNode;
+}
+
+/**
+ * Mirrors front's AppContentLayout with `contentWidth: "wide"`: a scrollable
+ * full-height column, content stretched to the viewport with the same
+ * horizontal padding.
+ */
+export function ManagePageLayout({ children }: ManagePageLayoutProps) {
+  return (
+    <div className="h-screen w-full bg-background">
+      <div className="flex h-full w-full flex-col items-center overflow-y-auto pt-8 [scrollbar-gutter:stable]">
+        <div className="flex w-full grow flex-col px-4 md:px-8">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/sparkle/playground/src/components/manage/ManageSkillsTable.tsx
+++ b/sparkle/playground/src/components/manage/ManageSkillsTable.tsx
@@ -18,6 +18,7 @@ import type {
 } from "@tanstack/react-table";
 import { useMemo, useState } from "react";
 
+import type { FleetUsage } from "../../data/fleetUsage";
 import type {
   ManagedSkill,
   SkillAvailability,
@@ -25,6 +26,7 @@ import type {
   SkillUsage,
 } from "../../data/manageSkills";
 import { SkillAvatar } from "./skillIcons";
+import { UsageCell } from "./UsageCell";
 import { UsedByButton } from "./UsedByButton";
 import { formatTimestampToFriendlyDate } from "./utils";
 
@@ -37,7 +39,7 @@ type RowData = {
   availability: SkillAvailability;
   editors: SkillEditor[] | null;
   usage: SkillUsage;
-  messageCount: number | null;
+  messageUsage: FleetUsage | null;
   updatedAt: number | null;
   createdAt: number | null;
   onClick: () => void;
@@ -161,29 +163,26 @@ const usedByColumn = (
   },
 });
 
-const usageColumn: ColumnDef<RowData, number | null> = {
+const usageColumn = (nowMs: number): ColumnDef<RowData, number> => ({
+  id: "usage",
   header: "Usage",
-  accessorKey: "messageCount",
-  cell: (info: CellContext<RowData, number | null>) => {
-    const messageCount = info.getValue();
-
-    return (
-      <DataTable.BasicCellContent
-        className="font-mono"
-        label={messageCount === null ? "-" : messageCount.toLocaleString()}
-        tooltip={
-          messageCount === null
-            ? "System skills are always active, so message usage does not apply."
-            : undefined
-        }
+  // Sorting on the human count: programmatic traffic must not be able to float
+  // a skill nobody actually reaches for.
+  accessorFn: (row: RowData) => row.messageUsage?.human ?? -1,
+  cell: (info: CellContext<RowData, number>) => (
+    <DataTable.CellContent>
+      <UsageCell
+        usage={info.row.original.messageUsage}
+        emptyTooltip="System skills are always active, so message usage does not apply."
+        nowMs={nowMs}
       />
-    );
-  },
+    </DataTable.CellContent>
+  ),
   meta: {
-    className: "hidden @sm:w-20 @sm:table-cell",
-    tooltip: "All-time messages",
+    className: "hidden @sm:w-24 @sm:table-cell",
+    tooltip: "Human messages in the last 30 days",
   },
-};
+});
 
 const lastEditedColumn = {
   header: "Last Edited",
@@ -215,10 +214,12 @@ const getTableColumns = ({
   onAgentClick,
   onUsedBySkillClick,
   enableRowSelection,
+  nowMs,
 }: {
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
   enableRowSelection: boolean;
+  nowMs: number;
 }) => {
   /**
    * Columns order:
@@ -237,7 +238,7 @@ const getTableColumns = ({
     nameColumn,
     availabilityColumn,
     usedByColumn(onAgentClick, onUsedBySkillClick),
-    usageColumn,
+    usageColumn(nowMs),
     editorsColumn,
     lastEditedColumn,
     menuColumn,
@@ -246,6 +247,7 @@ const getTableColumns = ({
 
 interface ManageSkillsTableProps {
   skills: ManagedSkill[];
+  nowMs: number;
   onSkillClick: (skill: ManagedSkill) => void;
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
@@ -257,6 +259,7 @@ interface ManageSkillsTableProps {
 
 export function ManageSkillsTable({
   skills,
+  nowMs,
   onSkillClick,
   onAgentClick,
   onUsedBySkillClick,
@@ -280,8 +283,9 @@ export function ManageSkillsTable({
         onAgentClick,
         onUsedBySkillClick,
         enableRowSelection: isSelectionEnabled,
+        nowMs,
       }),
-    [onAgentClick, onUsedBySkillClick, isSelectionEnabled]
+    [onAgentClick, onUsedBySkillClick, isSelectionEnabled, nowMs]
   );
 
   const rows: RowData[] = useMemo(
@@ -295,7 +299,7 @@ export function ManageSkillsTable({
         availability: skill.availability,
         editors: skill.relations.editors,
         usage: skill.relations.usage,
-        messageCount: skill.messageCount,
+        messageUsage: skill.messageUsage,
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
         onClick: () => {

--- a/sparkle/playground/src/components/manage/ManageSkillsTable.tsx
+++ b/sparkle/playground/src/components/manage/ManageSkillsTable.tsx
@@ -1,0 +1,369 @@
+import type { MenuItem } from "@dust-tt/sparkle";
+import {
+  Chip,
+  createSelectionColumn,
+  DataTable,
+  DustLogoSquare,
+  Edit04,
+  Eye,
+  Tooltip,
+  Trash01,
+} from "@dust-tt/sparkle";
+import type {
+  CellContext,
+  ColumnDef,
+  PaginationState,
+  Row,
+  RowSelectionState,
+} from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+
+import type {
+  ManagedSkill,
+  SkillAvailability,
+  SkillEditor,
+  SkillUsage,
+} from "../../data/manageSkills";
+import { SkillAvatar } from "./skillIcons";
+import { UsedByButton } from "./UsedByButton";
+import { formatTimestampToFriendlyDate } from "./utils";
+
+type RowData = {
+  sId: string;
+  name: string;
+  icon: string | null;
+  editedBy: number | null;
+  description: string;
+  availability: SkillAvailability;
+  editors: SkillEditor[] | null;
+  usage: SkillUsage;
+  messageCount: number | null;
+  updatedAt: number | null;
+  createdAt: number | null;
+  onClick: () => void;
+  menuItems: MenuItem[];
+};
+
+export const SKILL_AVAILABILITY_DISPLAY: Record<
+  SkillAvailability,
+  { label: string; color: "primary" | "success" | "highlight"; tooltip: string }
+> = {
+  editors: {
+    label: "Editors only",
+    color: "primary",
+    tooltip: "Only editors can find it via the input bar and agent builder",
+  },
+  workspace_users: {
+    label: "Members",
+    color: "success",
+    tooltip: "All members can find it via the input bar and agent builder",
+  },
+  users_and_agents: {
+    label: "Members and agents",
+    color: "highlight",
+    tooltip: "Available to all members and agents with Discover Skills",
+  },
+};
+
+const nameColumn = {
+  header: "Name",
+  accessorKey: "name",
+  cell: (info: CellContext<RowData, string>) => (
+    <DataTable.CellContent>
+      <div className="flex flex-row items-center gap-2 py-3">
+        <div>
+          <SkillAvatar
+            icon={info.row.original.icon}
+            isDustProvided={info.row.original.editedBy === null}
+          />
+        </div>
+        <div className="flex min-w-0 grow flex-col">
+          <div className="heading-sm overflow-hidden truncate text-foreground">
+            {info.getValue()}
+          </div>
+          <div className="overflow-hidden truncate text-sm text-muted-foreground">
+            {info.row.original.description}
+          </div>
+        </div>
+      </div>
+    </DataTable.CellContent>
+  ),
+  meta: {
+    className: "w-40 @lg:w-full",
+  },
+};
+
+const availabilityColumn = {
+  header: "Availability",
+  accessorKey: "availability",
+  cell: (info: CellContext<RowData, SkillAvailability>) => {
+    const display = SKILL_AVAILABILITY_DISPLAY[info.getValue()];
+    return (
+      <DataTable.CellContent>
+        <Tooltip
+          label={display.tooltip}
+          trigger={
+            <Chip size="xs" color={display.color} label={display.label} />
+          }
+        />
+      </DataTable.CellContent>
+    );
+  },
+  meta: {
+    className: "hidden @sm:w-40 @sm:table-cell",
+  },
+};
+
+const editorsColumn = {
+  header: "Editors",
+  accessorKey: "editors",
+  cell: (info: CellContext<RowData, SkillEditor[] | null>) => {
+    const editors = info.getValue();
+    const items = editors
+      ? editors.map((editor) => ({
+          name: editor.fullName,
+          visual: editor.image,
+          isRounded: true,
+        }))
+      : // Only Dust-managed skills should have no editors
+        [
+          {
+            name: "Dust",
+            visual: <DustLogoSquare className="h-full w-full" />,
+            isRounded: false,
+          },
+        ];
+    return <DataTable.CellContent avatarStack={{ items, nbVisibleItems: 4 }} />;
+  },
+  meta: {
+    className: "hidden @sm:w-32 @sm:table-cell",
+  },
+};
+
+const usedByColumn = (
+  onAgentClick: (agentId: string) => void,
+  onUsedBySkillClick: (skillId: string) => void
+): ColumnDef<RowData, number> => ({
+  id: "usedBy",
+  header: () => <div className="flex w-full justify-center">Used by</div>,
+  accessorFn: (row: RowData) => row.usage?.count ?? 0,
+  cell: (info: CellContext<RowData, number>) => (
+    <div className="flex h-12 w-full items-center justify-center">
+      <UsedByButton
+        usage={info.row.original.usage}
+        onAgentClick={onAgentClick}
+        onSkillClick={onUsedBySkillClick}
+      />
+    </div>
+  ),
+  meta: {
+    className: "hidden px-0 @sm:w-32 @sm:table-cell",
+  },
+});
+
+const usageColumn: ColumnDef<RowData, number | null> = {
+  header: "Usage",
+  accessorKey: "messageCount",
+  cell: (info: CellContext<RowData, number | null>) => {
+    const messageCount = info.getValue();
+
+    return (
+      <DataTable.BasicCellContent
+        className="font-mono"
+        label={messageCount === null ? "-" : messageCount.toLocaleString()}
+        tooltip={
+          messageCount === null
+            ? "System skills are always active, so message usage does not apply."
+            : undefined
+        }
+      />
+    );
+  },
+  meta: {
+    className: "hidden @sm:w-20 @sm:table-cell",
+    tooltip: "All-time messages",
+  },
+};
+
+const lastEditedColumn = {
+  header: "Last Edited",
+  accessorKey: "updatedAt",
+  cell: (info: CellContext<RowData, number | null>) => {
+    const value = info.getValue();
+    return (
+      <DataTable.BasicCellContent
+        tooltip={value ? formatTimestampToFriendlyDate(value, "long") : ""}
+        label={value ? formatTimestampToFriendlyDate(value, "compact") : ""}
+      />
+    );
+  },
+  meta: { className: "hidden @sm:w-32 @sm:table-cell" },
+};
+
+const menuColumn = {
+  header: "",
+  accessorKey: "menuItems",
+  cell: (info: CellContext<RowData, MenuItem[]>) => (
+    <DataTable.MoreButton menuItems={info.getValue()} />
+  ),
+  meta: {
+    className: "w-14",
+  },
+};
+
+const getTableColumns = ({
+  onAgentClick,
+  onUsedBySkillClick,
+  enableRowSelection,
+}: {
+  onAgentClick: (agentId: string) => void;
+  onUsedBySkillClick: (skillId: string) => void;
+  enableRowSelection: boolean;
+}) => {
+  /**
+   * Columns order:
+   * - Selection (batch edition only)
+   * - Name (always)
+   * - Access (hidden on mobile)
+   * - Used by (hidden on mobile)
+   * - Usage (hidden on mobile)
+   * - Editors (hidden on mobile)
+   * - Last Edited (hidden on mobile)
+   * - Actions (always)
+   */
+
+  return [
+    ...(enableRowSelection ? [createSelectionColumn<RowData>()] : []),
+    nameColumn,
+    availabilityColumn,
+    usedByColumn(onAgentClick, onUsedBySkillClick),
+    usageColumn,
+    editorsColumn,
+    lastEditedColumn,
+    menuColumn,
+  ];
+};
+
+interface ManageSkillsTableProps {
+  skills: ManagedSkill[];
+  onSkillClick: (skill: ManagedSkill) => void;
+  onAgentClick: (agentId: string) => void;
+  onUsedBySkillClick: (skillId: string) => void;
+  onArchiveSkill: (skill: ManagedSkill) => void;
+  canMakeSkillAutoDiscoverable?: boolean;
+  rowSelection?: RowSelectionState;
+  setRowSelection?: (selection: RowSelectionState) => void;
+}
+
+export function ManageSkillsTable({
+  skills,
+  onSkillClick,
+  onAgentClick,
+  onUsedBySkillClick,
+  onArchiveSkill,
+  canMakeSkillAutoDiscoverable = false,
+  rowSelection,
+  setRowSelection,
+}: ManageSkillsTableProps) {
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 25,
+  });
+
+  const isSelectionEnabled = rowSelection !== undefined;
+
+  // Stable columns identity: rebuilding them on every selection change makes the
+  // table re-render all rows.
+  const columns = useMemo(
+    () =>
+      getTableColumns({
+        onAgentClick,
+        onUsedBySkillClick,
+        enableRowSelection: isSelectionEnabled,
+      }),
+    [onAgentClick, onUsedBySkillClick, isSelectionEnabled]
+  );
+
+  const rows: RowData[] = useMemo(
+    () =>
+      skills.map((skill) => ({
+        sId: skill.sId,
+        name: skill.name,
+        icon: skill.icon,
+        editedBy: skill.editedBy,
+        description: skill.userFacingDescription,
+        availability: skill.availability,
+        editors: skill.relations.editors,
+        usage: skill.relations.usage,
+        messageCount: skill.messageCount,
+        updatedAt: skill.updatedAt,
+        createdAt: skill.createdAt,
+        onClick: () => {
+          // During batch edition the DataTable itself toggles the row selection
+          // on click; don't open the details panel on top of it.
+          if (isSelectionEnabled) {
+            return;
+          }
+          onSkillClick(skill);
+        },
+        menuItems:
+          skill.status !== "archived"
+            ? [
+                {
+                  label: "Edit",
+                  icon: Edit04,
+                  disabled: !skill.canAdministrate,
+                  onClick: (e: React.MouseEvent) => e.stopPropagation(),
+                  kind: "item" as const,
+                },
+                {
+                  label: "More info",
+                  icon: Eye,
+                  onClick: (e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    onSkillClick(skill);
+                  },
+                  kind: "item" as const,
+                },
+                {
+                  label: "Archive",
+                  icon: Trash01,
+                  disabled: !skill.canAdministrate,
+                  variant: "warning" as const,
+                  onClick: (e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    onArchiveSkill(skill);
+                  },
+                  kind: "item" as const,
+                },
+              ].filter((item) => !item.disabled)
+            : [],
+      })),
+    [skills, onSkillClick, onArchiveSkill, isSelectionEnabled]
+  );
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <DataTable
+      className="relative"
+      data={rows}
+      columns={columns}
+      pagination={pagination}
+      setPagination={setPagination}
+      {...(rowSelection !== undefined && setRowSelection
+        ? {
+            rowSelection,
+            setRowSelection,
+            enableRowSelection: (row: Row<RowData>) =>
+              row.original.editedBy !== null &&
+              (canMakeSkillAutoDiscoverable ||
+                row.original.availability !== "users_and_agents"),
+            getRowId: (row: RowData) => row.sId,
+          }
+        : {})}
+    />
+  );
+}

--- a/sparkle/playground/src/components/manage/ManageSkillsTable.tsx
+++ b/sparkle/playground/src/components/manage/ManageSkillsTable.tsx
@@ -1,7 +1,7 @@
 import type { MenuItem } from "@dust-tt/sparkle";
 import {
+  Checkbox,
   Chip,
-  createSelectionColumn,
   DataTable,
   DustLogoSquare,
   Edit04,
@@ -66,6 +66,65 @@ export const SKILL_AVAILABILITY_DISPLAY: Record<
     tooltip: "Available to all members and agents with Discover Skills",
   },
 };
+
+/**
+ * Local replacement for sparkle's `createSelectionColumn`: identical, but the
+ * checkbox stops the click from bubbling to the row. Sparkle's version lets it
+ * through, which used to be harmless (checkboxes only existed in batch mode,
+ * where the row click was a no-op) but now opens the details sheet on every
+ * tick. Worth pushing upstream if this graduates out of the playground.
+ */
+function createFleetSelectionColumn(): ColumnDef<RowData> {
+  return {
+    id: "select",
+    enableSorting: false,
+    enableHiding: false,
+    header: ({ table }) => (
+      <Checkbox
+        checked={
+          table.getIsAllPageRowsSelected()
+            ? true
+            : table.getIsSomeRowsSelected()
+              ? "partial"
+              : false
+        }
+        tooltip={
+          table.getIsAllPageRowsSelected()
+            ? "Clear selection"
+            : "Select all on page"
+        }
+        onClick={(e) => e.stopPropagation()}
+        onCheckedChange={(state) => {
+          if (state === "indeterminate") {
+            return;
+          }
+          if (state) {
+            table.toggleAllPageRowsSelected(true);
+          } else {
+            table.resetRowSelection();
+          }
+        }}
+      />
+    ),
+    cell: ({ row }) => (
+      <div className="flex h-full w-full items-center">
+        <Checkbox
+          checked={row.getIsSelected()}
+          disabled={!row.getCanSelect()}
+          onClick={(e) => e.stopPropagation()}
+          onCheckedChange={(state) => {
+            if (state !== "indeterminate") {
+              row.toggleSelected(state);
+            }
+          }}
+        />
+      </div>
+    ),
+    meta: {
+      className: "w-10",
+    },
+  };
+}
 
 const nameColumn = {
   header: "Name",
@@ -234,7 +293,7 @@ const getTableColumns = ({
    */
 
   return [
-    ...(enableRowSelection ? [createSelectionColumn<RowData>()] : []),
+    ...(enableRowSelection ? [createFleetSelectionColumn()] : []),
     nameColumn,
     availabilityColumn,
     usedByColumn(onAgentClick, onUsedBySkillClick),
@@ -274,6 +333,10 @@ export function ManageSkillsTable({
   });
 
   const isSelectionEnabled = rowSelection !== undefined;
+  // Batch mode is entered by ticking a row, not by a button.
+  const isBatchMode =
+    rowSelection !== undefined &&
+    Object.values(rowSelection).some((selected) => selected);
 
   // Stable columns identity: rebuilding them on every selection change makes the
   // table re-render all rows.
@@ -303,9 +366,9 @@ export function ManageSkillsTable({
         updatedAt: skill.updatedAt,
         createdAt: skill.createdAt,
         onClick: () => {
-          // During batch edition the DataTable itself toggles the row selection
-          // on click; don't open the details panel on top of it.
-          if (isSelectionEnabled) {
+          // Once a row is ticked the DataTable toggles selection on row click;
+          // don't open the details panel on top of it.
+          if (isBatchMode) {
             return;
           }
           onSkillClick(skill);
@@ -343,7 +406,7 @@ export function ManageSkillsTable({
               ].filter((item) => !item.disabled)
             : [],
       })),
-    [skills, onSkillClick, onArchiveSkill, isSelectionEnabled]
+    [skills, onSkillClick, onArchiveSkill, isBatchMode]
   );
 
   if (rows.length === 0) {
@@ -365,6 +428,7 @@ export function ManageSkillsTable({
               row.original.editedBy !== null &&
               (canMakeSkillAutoDiscoverable ||
                 row.original.availability !== "users_and_agents"),
+            disableRowClickSelection: !isBatchMode,
             getRowId: (row: RowData) => row.sId,
           }
         : {})}

--- a/sparkle/playground/src/components/manage/TableTagSelector.tsx
+++ b/sparkle/playground/src/components/manage/TableTagSelector.tsx
@@ -1,0 +1,82 @@
+import {
+  Button,
+  Check,
+  ChevronDown,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTagItem,
+  DropdownMenuTagList,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+
+import type { AgentTag } from "../../data/manageAgents";
+
+interface TableTagSelectorProps {
+  tags: AgentTag[];
+  agentTags: AgentTag[];
+  onChange: (tags: AgentTag[]) => void;
+}
+
+export function TableTagSelector({
+  tags,
+  agentTags,
+  onChange,
+}: TableTagSelectorProps) {
+  const selectedIds = new Set(agentTags.map((tag) => tag.sId));
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {agentTags.length === 0 ? (
+          <Button
+            variant="ghost"
+            size="xs"
+            label="Add tags"
+            isSelect
+            className="invisible text-muted-foreground group-hover:visible"
+          />
+        ) : (
+          <Button
+            variant="ghost"
+            icon={ChevronDown}
+            size="xmini"
+            className="invisible text-muted-foreground group-hover:visible"
+          />
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        mountPortalContainer={document.body}
+        className="w-60"
+      >
+        <DropdownMenuLabel label="Available tags" />
+        <DropdownMenuSeparator />
+        <DropdownMenuTagList>
+          {tags.length === 0 ? (
+            <div className="px-2 py-2 text-center text-sm text-muted-foreground">
+              No tags available
+            </div>
+          ) : (
+            tags.map((tag) => (
+              <DropdownMenuTagItem
+                key={tag.sId}
+                label={tag.name}
+                color="info"
+                className="m-0.5"
+                icon={selectedIds.has(tag.sId) ? Check : undefined}
+                onClick={() => {
+                  onChange(
+                    selectedIds.has(tag.sId)
+                      ? agentTags.filter((t) => t.sId !== tag.sId)
+                      : [...agentTags, tag]
+                  );
+                }}
+              />
+            ))
+          )}
+        </DropdownMenuTagList>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/sparkle/playground/src/components/manage/UsageCell.tsx
+++ b/sparkle/playground/src/components/manage/UsageCell.tsx
@@ -1,0 +1,130 @@
+import { Robot, Tooltip, Zap } from "@dust-tt/sparkle";
+
+import type { FleetUsage } from "../../data/fleetUsage";
+import { USAGE_ORIGIN_LABELS } from "../../data/fleetUsage";
+import { formatTimestampToFriendlyDate, pluralize } from "./utils";
+
+function formatCount(count: number): string {
+  return count.toLocaleString();
+}
+
+function lastUsedLabel(lastUsedAt: number | null, nowMs: number): string {
+  if (lastUsedAt === null) {
+    return "Never used";
+  }
+  const days = Math.floor((nowMs - lastUsedAt) / (24 * 60 * 60 * 1000));
+  if (days <= 0) {
+    return "Last used today";
+  }
+  if (days === 1) {
+    return "Last used yesterday";
+  }
+  if (days < 30) {
+    return `Last used ${days} days ago`;
+  }
+  return `Last used ${formatTimestampToFriendlyDate(lastUsedAt, "compactWithDay")}`;
+}
+
+function usageTooltip(usage: FleetUsage, nowMs: number): string {
+  const days = usage.timePeriodSec / (24 * 60 * 60);
+  const lines = [
+    `${formatCount(usage.human)} human message${pluralize(usage.human)} over the last ${days} days`,
+  ];
+
+  if (usage.programmatic > 0) {
+    const origins = usage.programmaticOrigins
+      .map((origin) => USAGE_ORIGIN_LABELS[origin])
+      .join(", ");
+    lines.push(
+      `Also ${formatCount(usage.programmatic)} via ${origins || "API / integrations"}`
+    );
+  }
+
+  if (usage.agentToAgent > 0) {
+    lines.push(
+      `Called ${formatCount(usage.agentToAgent)} time${pluralize(usage.agentToAgent)} by other agents — archiving it will break them`
+    );
+  }
+
+  lines.push(lastUsedLabel(usage.lastUsedAt, nowMs));
+
+  return lines.join("\n");
+}
+
+interface UsageCellProps {
+  usage: FleetUsage | null;
+  // System items are always active, so message usage does not apply to them.
+  emptyTooltip?: string;
+  nowMs: number;
+  disabled?: boolean;
+}
+
+/**
+ * One column: the human count is the number, everything automated sits behind
+ * a muted secondary indicator. Raw totals would let a single API integration
+ * make an otherwise unused agent look busy.
+ */
+export function UsageCell({
+  usage,
+  emptyTooltip,
+  nowMs,
+  disabled = false,
+}: UsageCellProps) {
+  if (!usage) {
+    return (
+      <Tooltip
+        label={emptyTooltip ?? "Usage does not apply."}
+        trigger={
+          <span className="font-mono text-sm text-muted-foreground">-</span>
+        }
+      />
+    );
+  }
+
+  const hasProgrammatic = usage.programmatic > 0;
+  const hasAgentToAgent = usage.agentToAgent > 0;
+
+  return (
+    <Tooltip
+      tooltipTriggerAsChild
+      label={
+        <span className="whitespace-pre-line">
+          {usageTooltip(usage, nowMs)}
+        </span>
+      }
+      trigger={
+        <span
+          className={
+            disabled
+              ? "flex cursor-not-allowed items-center gap-1.5 opacity-50"
+              : "flex items-center gap-1.5"
+          }
+        >
+          <span className="font-mono text-sm text-foreground tabular-nums">
+            {formatCount(usage.human)}
+          </span>
+          {(hasProgrammatic || hasAgentToAgent) && (
+            <span className="flex items-center gap-1 text-muted-foreground">
+              {hasProgrammatic && (
+                <span
+                  className="inline-flex items-center gap-0.5"
+                  aria-label={`${usage.programmatic} programmatic messages`}
+                >
+                  <Zap className="h-3.5 w-3.5 shrink-0" />
+                </span>
+              )}
+              {hasAgentToAgent && (
+                <span
+                  className="inline-flex items-center gap-0.5"
+                  aria-label={`${usage.agentToAgent} calls from other agents`}
+                >
+                  <Robot className="h-3.5 w-3.5 shrink-0" />
+                </span>
+              )}
+            </span>
+          )}
+        </span>
+      }
+    />
+  );
+}

--- a/sparkle/playground/src/components/manage/UsedByButton.tsx
+++ b/sparkle/playground/src/components/manage/UsedByButton.tsx
@@ -1,0 +1,272 @@
+import {
+  Avatar,
+  Button,
+  ChevronDown,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  PuzzlePiece01,
+  Robot,
+} from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import type { SkillUsage } from "../../data/manageSkills";
+import { SkillAvatar } from "./skillIcons";
+import { pluralize } from "./utils";
+
+type UsedByDropdownItem =
+  | {
+      kind: "agent";
+      sId: string;
+      name: string;
+      emoji: string;
+      backgroundColor: string;
+    }
+  | {
+      kind: "skill";
+      sId: string;
+      name: string;
+      emoji?: undefined;
+      backgroundColor?: undefined;
+      icon: string | null;
+    };
+
+interface UsedByButtonIconProps {
+  agentCount: number;
+  skillCount: number;
+  showChevron: boolean;
+}
+
+function UsedByButtonIcon({
+  agentCount,
+  skillCount,
+  showChevron,
+}: UsedByButtonIconProps) {
+  const hasAgents = agentCount > 0;
+  const hasSkills = skillCount > 0;
+
+  return (
+    <span className="mx-0.5 flex h-5 items-center justify-center gap-1.5 leading-none">
+      {(hasAgents || !hasSkills) && (
+        <span className="inline-flex h-5 items-center gap-1">
+          <Robot className="h-4 w-4 shrink-0" />
+          <span className="inline-flex h-5 items-center text-sm leading-none tabular-nums">
+            {agentCount}
+          </span>
+        </span>
+      )}
+      {hasSkills && (
+        <span className="inline-flex h-5 items-center gap-1">
+          <PuzzlePiece01 className="h-4 w-4 shrink-0" />
+          <span className="inline-flex h-5 items-center text-sm leading-none tabular-nums">
+            {skillCount}
+          </span>
+        </span>
+      )}
+      <ChevronDown
+        className={
+          showChevron
+            ? "-mr-px h-4 w-4 shrink-0 text-faint"
+            : "invisible -mr-px h-4 w-4 shrink-0 text-faint"
+        }
+      />
+    </span>
+  );
+}
+
+// The composite icon (robot + count + chevron) is wider than the icon-only
+// fixed width (w-6 on xs); size to content instead.
+const USED_BY_BUTTON_CLASSES =
+  "w-auto border-0 px-2 hover:bg-muted-background hover:text-foreground";
+
+interface UsedByButtonProps {
+  usage: SkillUsage | null;
+  onAgentClick: (agentId: string) => void;
+  onSkillClick: (skillId: string) => void;
+}
+
+export function UsedByButton({
+  usage,
+  onAgentClick,
+  onSkillClick,
+}: UsedByButtonProps) {
+  const [searchText, setSearchText] = useState("");
+  const [isOpen, setIsOpen] = useState(false);
+
+  const agents = usage?.agents ?? [];
+  const skills = usage?.skills ?? [];
+  const agentCount = agents.length;
+  const skillCount = skills.length;
+  const totalCount = agentCount + skillCount;
+
+  const usageLabel =
+    [
+      agentCount > 0 ? `${agentCount} agent${pluralize(agentCount)}` : null,
+      skillCount > 0 ? `${skillCount} skill${pluralize(skillCount)}` : null,
+    ]
+      .filter((label): label is string => label !== null)
+      .join(" and ") || "0 agents";
+
+  if (totalCount === 0) {
+    return (
+      <Button
+        icon={
+          <UsedByButtonIcon agentCount={0} skillCount={0} showChevron={false} />
+        }
+        variant="ghost-secondary"
+        isSelect={false}
+        size="xs"
+        className={USED_BY_BUTTON_CLASSES}
+        aria-label="Used by 0 agents"
+        disabled
+      />
+    );
+  }
+
+  const query = searchText.toLowerCase();
+  const dropdownItems: UsedByDropdownItem[] = [
+    ...agents.map((agent) => ({
+      kind: "agent" as const,
+      sId: agent.sId,
+      name: agent.name,
+      emoji: agent.emoji,
+      backgroundColor: agent.backgroundColor,
+    })),
+    ...skills.map((skill) => ({
+      kind: "skill" as const,
+      sId: skill.sId,
+      name: skill.name,
+      icon: skill.icon,
+    })),
+  ]
+    .filter(
+      (item) => query.length === 0 || item.name.toLowerCase().includes(query)
+    )
+    .sort((a, b) => {
+      const nameComparison = a.name.localeCompare(b.name, undefined, {
+        sensitivity: "base",
+      });
+      if (nameComparison !== 0) {
+        return nameComparison;
+      }
+      return a.sId.localeCompare(b.sId);
+    });
+
+  const closeMenu = () => {
+    setSearchText("");
+    setIsOpen(false);
+  };
+
+  const onFirstItemClick = () => {
+    const firstItem = dropdownItems[0];
+    if (!firstItem) {
+      return;
+    }
+    if (firstItem.kind === "agent") {
+      onAgentClick(firstItem.sId);
+    } else {
+      onSkillClick(firstItem.sId);
+    }
+    closeMenu();
+  };
+
+  return (
+    <DropdownMenu
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (open) {
+          setSearchText("");
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          icon={
+            <UsedByButtonIcon
+              agentCount={agentCount}
+              skillCount={skillCount}
+              showChevron
+            />
+          }
+          variant="ghost-secondary"
+          isSelect={false}
+          size="xs"
+          className={USED_BY_BUTTON_CLASSES}
+          aria-label={`Used by ${usageLabel}`}
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            e.stopPropagation();
+          }}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="h-96 w-72"
+        align="end"
+        onClick={(e) => e.stopPropagation()}
+        dropdownHeaders={
+          <>
+            <DropdownMenuSearchbar
+              autoFocus
+              name="search-used-by-agents"
+              placeholder={
+                skills.length > 0 ? "Search agents and skills" : "Search agents"
+              }
+              value={searchText}
+              onChange={setSearchText}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  onFirstItemClick();
+                }
+              }}
+            />
+            <DropdownMenuSeparator />
+          </>
+        }
+      >
+        {dropdownItems.map((item) =>
+          item.kind === "agent" ? (
+            <DropdownMenuItem
+              key={`assistant-picker-${item.sId}`}
+              icon={() => (
+                <Avatar
+                  size="xs"
+                  emoji={item.emoji}
+                  backgroundColor={item.backgroundColor}
+                />
+              )}
+              label={item.name}
+              truncateText
+              className="py-1"
+              onClick={(e) => {
+                e.stopPropagation();
+                onAgentClick(item.sId);
+                closeMenu();
+              }}
+            />
+          ) : (
+            <DropdownMenuItem
+              key={`skill-picker-${item.sId}`}
+              icon={() => <SkillAvatar icon={item.icon} size="xs" />}
+              label={item.name}
+              truncateText
+              className="py-1"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSkillClick(item.sId);
+                closeMenu();
+              }}
+            />
+          )
+        )}
+        {dropdownItems.length === 0 && (
+          <div className="flex items-center justify-center py-4 text-sm text-muted-foreground">
+            {skills.length > 0 ? "No matches found" : "No agents found"}
+          </div>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/sparkle/playground/src/components/manage/fleetFilters.ts
+++ b/sparkle/playground/src/components/manage/fleetFilters.ts
@@ -8,34 +8,32 @@ import { compareForFuzzySort, subFilter } from "./utils";
 // query string parsed server-side; here the same shape drives an in-memory
 // predicate so the port stays mechanical.
 
-export type StatusFilterValue =
-  | "published"
-  | "unpublished"
-  | "active"
-  | "archived";
+// Publication state — "which ones are validated". Archived is deliberately not
+// a value here: the Archived tab already is that filter, and offering both
+// produced contradictory states (status=archived returned nothing on every
+// tab, including Archived).
+export type PublicationFilterValue = "published" | "unpublished";
 
-export type VisibilityFilterValue = "workspace" | "space" | "personal";
+export type EditedWithinValue = "7d" | "30d" | "stale_180d";
 
-export type EditedWithinValue =
-  | "7d"
-  | "30d"
-  | "90d"
-  | "stale_180d"
-  | "stale_365d";
+export type NotUsedForValue = "30d" | "90d" | "never";
 
-export type NotUsedForValue = "30d" | "60d" | "90d" | "never";
-
+/**
+ * One dimension per question the fleet brief says an admin must be able to
+ * answer: who owns it (editors), what it depends on (tools), which ones are
+ * validated (publication, availability), what changed (editedWithin), where
+ * it is used (notUsedFor). Model and tags are agent-specific additions the
+ * brief calls for explicitly.
+ */
 export interface FleetFilters {
   search: string;
   editors: string[];
-  lastEditors: string[];
   tools: string[];
-  status: StatusFilterValue[];
-  visibility: VisibilityFilterValue[];
+  // Agents only; skills express the same idea through availability.
+  publication: PublicationFilterValue[];
   models: string[];
   tags: string[];
-  // Skills only: mirrors the availability dropdown that already sits next to
-  // the tabs. Kept out of `visibility` because the two vocabularies differ.
+  // Skills only: mirrors the availability dropdown next to the tabs.
   availability: string[];
   editedWithin: EditedWithinValue | null;
   notUsedFor: NotUsedForValue | null;
@@ -44,10 +42,8 @@ export interface FleetFilters {
 export const EMPTY_FLEET_FILTERS: FleetFilters = {
   search: "",
   editors: [],
-  lastEditors: [],
   tools: [],
-  status: [],
-  visibility: [],
+  publication: [],
   models: [],
   tags: [],
   availability: [],
@@ -55,15 +51,15 @@ export const EMPTY_FLEET_FILTERS: FleetFilters = {
   notUsedFor: null,
 };
 
+// Two directions only: recently touched, or gone stale. Intermediate windows
+// added options without adding answers.
 export const EDITED_WITHIN_OPTIONS: {
   value: EditedWithinValue;
   label: string;
 }[] = [
   { value: "7d", label: "Edited in the last 7 days" },
   { value: "30d", label: "Edited in the last 30 days" },
-  { value: "90d", label: "Edited in the last 90 days" },
   { value: "stale_180d", label: "Not edited in 6 months" },
-  { value: "stale_365d", label: "Not edited in a year" },
 ];
 
 export const NOT_USED_FOR_OPTIONS: {
@@ -71,35 +67,16 @@ export const NOT_USED_FOR_OPTIONS: {
   label: string;
 }[] = [
   { value: "30d", label: "No human use in 30 days" },
-  { value: "60d", label: "No human use in 60 days" },
   { value: "90d", label: "No human use in 90 days" },
   { value: "never", label: "Never used, any origin" },
 ];
 
-export const VISIBILITY_OPTIONS: {
-  value: VisibilityFilterValue;
-  label: string;
-}[] = [
-  { value: "workspace", label: "Workspace" },
-  { value: "space", label: "Space" },
-  { value: "personal", label: "Personal" },
-];
-
-export const AGENT_STATUS_OPTIONS: {
-  value: StatusFilterValue;
+export const PUBLICATION_OPTIONS: {
+  value: PublicationFilterValue;
   label: string;
 }[] = [
   { value: "published", label: "Published" },
   { value: "unpublished", label: "Not published" },
-  { value: "archived", label: "Archived" },
-];
-
-export const SKILL_STATUS_OPTIONS: {
-  value: StatusFilterValue;
-  label: string;
-}[] = [
-  { value: "active", label: "Active" },
-  { value: "archived", label: "Archived" },
 ];
 
 // ── Predicate ─────────────────────────────────────────────────────────────────
@@ -111,10 +88,9 @@ export interface FleetItemFields {
   name: string;
   editorIds: string[];
   editorNames: string[];
-  lastEditorId: string | null;
   tools: string[];
-  status: StatusFilterValue;
-  visibility: VisibilityFilterValue | null;
+  // null on skills, which use availability instead.
+  publication: PublicationFilterValue | null;
   modelId: string | null;
   tagIds: string[];
   updatedAt: number;
@@ -136,12 +112,8 @@ function matchesEditedWithin(
       return ageMs <= 7 * DAY_MS;
     case "30d":
       return ageMs <= 30 * DAY_MS;
-    case "90d":
-      return ageMs <= 90 * DAY_MS;
     case "stale_180d":
       return ageMs > 180 * DAY_MS;
-    case "stale_365d":
-      return ageMs > 365 * DAY_MS;
   }
 }
 
@@ -157,7 +129,7 @@ function matchesNotUsedFor(
   if (value === "never") {
     return totalUsage(usage) === 0 && usage.lastUsedAt === null;
   }
-  const days = value === "30d" ? 30 : value === "60d" ? 60 : 90;
+  const days = value === "30d" ? 30 : 90;
   // Deliberately reads `lastHumanUsedAt`, not `lastUsedAt`: an agent kept warm
   // only by an API integration is still one nobody talks to. The programmatic
   // and agent-to-agent indicators stay visible on the row so the dependency is
@@ -175,10 +147,8 @@ function matchesNotUsedFor(
 export function countActiveFleetFilters(filters: FleetFilters): number {
   return (
     filters.editors.length +
-    filters.lastEditors.length +
     filters.tools.length +
-    filters.status.length +
-    filters.visibility.length +
+    filters.publication.length +
     filters.models.length +
     filters.tags.length +
     (filters.editedWithin ? 1 : 0) +
@@ -198,10 +168,8 @@ export function filterFleet<T>(
   nowMs: number
 ): T[] {
   const editorIds = new Set(filters.editors);
-  const lastEditorIds = new Set(filters.lastEditors);
   const toolIds = new Set(filters.tools);
-  const statuses = new Set(filters.status);
-  const visibilities = new Set(filters.visibility);
+  const publications = new Set(filters.publication);
   const modelIds = new Set(filters.models);
   const tagIds = new Set(filters.tags);
 
@@ -217,21 +185,12 @@ export function filterFleet<T>(
     ) {
       return false;
     }
-    if (
-      lastEditorIds.size > 0 &&
-      (fields.lastEditorId === null || !lastEditorIds.has(fields.lastEditorId))
-    ) {
-      return false;
-    }
     if (toolIds.size > 0 && !fields.tools.some((tool) => toolIds.has(tool))) {
       return false;
     }
-    if (statuses.size > 0 && !statuses.has(fields.status)) {
-      return false;
-    }
     if (
-      visibilities.size > 0 &&
-      (fields.visibility === null || !visibilities.has(fields.visibility))
+      publications.size > 0 &&
+      (fields.publication === null || !publications.has(fields.publication))
     ) {
       return false;
     }
@@ -279,10 +238,8 @@ export function filterFleet<T>(
 
 const LIST_KEYS = [
   "editors",
-  "lastEditors",
   "tools",
-  "status",
-  "visibility",
+  "publication",
   "models",
   "tags",
   "availability",
@@ -330,10 +287,8 @@ export function fleetFiltersFromSearchParams(
   return {
     search: params.get("q") ?? "",
     editors: parseList(params, "editors"),
-    lastEditors: parseList(params, "lastEditors"),
     tools: parseList(params, "tools"),
-    status: parseList(params, "status") as StatusFilterValue[],
-    visibility: parseList(params, "visibility") as VisibilityFilterValue[],
+    publication: parseList(params, "publication") as PublicationFilterValue[],
     models: parseList(params, "models"),
     tags: parseList(params, "tags"),
     availability: parseList(params, "availability"),

--- a/sparkle/playground/src/components/manage/fleetFilters.ts
+++ b/sparkle/playground/src/components/manage/fleetFilters.ts
@@ -1,0 +1,425 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { totalUsage } from "../../data/fleetUsage";
+import type { FleetUsage } from "../../data/fleetUsage";
+import { compareForFuzzySort, subFilter } from "./utils";
+
+// One filter model for both fleet screens. In the product this would be a
+// query string parsed server-side; here the same shape drives an in-memory
+// predicate so the port stays mechanical.
+
+export type StatusFilterValue =
+  | "published"
+  | "unpublished"
+  | "active"
+  | "archived";
+
+export type VisibilityFilterValue = "workspace" | "space" | "personal";
+
+export type EditedWithinValue =
+  | "7d"
+  | "30d"
+  | "90d"
+  | "stale_180d"
+  | "stale_365d";
+
+export type NotUsedForValue = "30d" | "60d" | "90d" | "never";
+
+export interface FleetFilters {
+  search: string;
+  editors: string[];
+  lastEditors: string[];
+  tools: string[];
+  status: StatusFilterValue[];
+  visibility: VisibilityFilterValue[];
+  models: string[];
+  tags: string[];
+  // Skills only: mirrors the availability dropdown that already sits next to
+  // the tabs. Kept out of `visibility` because the two vocabularies differ.
+  availability: string[];
+  editedWithin: EditedWithinValue | null;
+  notUsedFor: NotUsedForValue | null;
+}
+
+export const EMPTY_FLEET_FILTERS: FleetFilters = {
+  search: "",
+  editors: [],
+  lastEditors: [],
+  tools: [],
+  status: [],
+  visibility: [],
+  models: [],
+  tags: [],
+  availability: [],
+  editedWithin: null,
+  notUsedFor: null,
+};
+
+export const EDITED_WITHIN_OPTIONS: {
+  value: EditedWithinValue;
+  label: string;
+}[] = [
+  { value: "7d", label: "Edited in the last 7 days" },
+  { value: "30d", label: "Edited in the last 30 days" },
+  { value: "90d", label: "Edited in the last 90 days" },
+  { value: "stale_180d", label: "Not edited in 6 months" },
+  { value: "stale_365d", label: "Not edited in a year" },
+];
+
+export const NOT_USED_FOR_OPTIONS: {
+  value: NotUsedForValue;
+  label: string;
+}[] = [
+  { value: "30d", label: "No human use in 30 days" },
+  { value: "60d", label: "No human use in 60 days" },
+  { value: "90d", label: "No human use in 90 days" },
+  { value: "never", label: "Never used, any origin" },
+];
+
+export const VISIBILITY_OPTIONS: {
+  value: VisibilityFilterValue;
+  label: string;
+}[] = [
+  { value: "workspace", label: "Workspace" },
+  { value: "space", label: "Space" },
+  { value: "personal", label: "Personal" },
+];
+
+export const AGENT_STATUS_OPTIONS: {
+  value: StatusFilterValue;
+  label: string;
+}[] = [
+  { value: "published", label: "Published" },
+  { value: "unpublished", label: "Not published" },
+  { value: "archived", label: "Archived" },
+];
+
+export const SKILL_STATUS_OPTIONS: {
+  value: StatusFilterValue;
+  label: string;
+}[] = [
+  { value: "active", label: "Active" },
+  { value: "archived", label: "Archived" },
+];
+
+// ── Predicate ─────────────────────────────────────────────────────────────────
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** The subset of an agent or a skill the filters actually read. */
+export interface FleetItemFields {
+  name: string;
+  editorIds: string[];
+  editorNames: string[];
+  lastEditorId: string | null;
+  tools: string[];
+  status: StatusFilterValue;
+  visibility: VisibilityFilterValue | null;
+  modelId: string | null;
+  tagIds: string[];
+  updatedAt: number;
+  usage: FleetUsage | null;
+}
+
+function searchStringFor(fields: FleetItemFields): string {
+  return [fields.name, ...fields.editorNames].join(" ").toLowerCase();
+}
+
+function matchesEditedWithin(
+  updatedAt: number,
+  value: EditedWithinValue,
+  nowMs: number
+): boolean {
+  const ageMs = nowMs - updatedAt;
+  switch (value) {
+    case "7d":
+      return ageMs <= 7 * DAY_MS;
+    case "30d":
+      return ageMs <= 30 * DAY_MS;
+    case "90d":
+      return ageMs <= 90 * DAY_MS;
+    case "stale_180d":
+      return ageMs > 180 * DAY_MS;
+    case "stale_365d":
+      return ageMs > 365 * DAY_MS;
+  }
+}
+
+function matchesNotUsedFor(
+  usage: FleetUsage | null,
+  value: NotUsedForValue,
+  nowMs: number
+): boolean {
+  // System items report no usage at all — they are never archiving candidates.
+  if (!usage) {
+    return false;
+  }
+  if (value === "never") {
+    return totalUsage(usage) === 0 && usage.lastUsedAt === null;
+  }
+  const days = value === "30d" ? 30 : value === "60d" ? 60 : 90;
+  // Deliberately reads `lastHumanUsedAt`, not `lastUsedAt`: an agent kept warm
+  // only by an API integration is still one nobody talks to. The programmatic
+  // and agent-to-agent indicators stay visible on the row so the dependency is
+  // obvious before anyone archives it.
+  return (
+    usage.lastHumanUsedAt === null ||
+    nowMs - usage.lastHumanUsedAt > days * DAY_MS
+  );
+}
+
+/**
+ * Counts what the Filters button badges. Models, tags and availability are
+ * excluded: they have their own buttons and their own chips.
+ */
+export function countActiveFleetFilters(filters: FleetFilters): number {
+  return (
+    filters.editors.length +
+    filters.lastEditors.length +
+    filters.tools.length +
+    filters.status.length +
+    filters.visibility.length +
+    (filters.editedWithin ? 1 : 0) +
+    (filters.notUsedFor ? 1 : 0)
+  );
+}
+
+/**
+ * Applies every filter dimension. Each one is a plain AND, which is what makes
+ * the dimensions combinable: "published agents using Salesforce, not used in
+ * 60 days" is just three predicates.
+ */
+export function filterFleet<T>(
+  items: T[],
+  filters: FleetFilters,
+  select: (item: T) => FleetItemFields,
+  nowMs: number
+): T[] {
+  const editorIds = new Set(filters.editors);
+  const lastEditorIds = new Set(filters.lastEditors);
+  const toolIds = new Set(filters.tools);
+  const statuses = new Set(filters.status);
+  const visibilities = new Set(filters.visibility);
+  const modelIds = new Set(filters.models);
+  const tagIds = new Set(filters.tags);
+
+  const searchLower = filters.search.trim().toLowerCase();
+  const isSearchActive = searchLower.length > 0;
+
+  const matched = items.filter((item) => {
+    const fields = select(item);
+
+    if (
+      editorIds.size > 0 &&
+      !fields.editorIds.some((id) => editorIds.has(id))
+    ) {
+      return false;
+    }
+    if (
+      lastEditorIds.size > 0 &&
+      (fields.lastEditorId === null || !lastEditorIds.has(fields.lastEditorId))
+    ) {
+      return false;
+    }
+    if (toolIds.size > 0 && !fields.tools.some((tool) => toolIds.has(tool))) {
+      return false;
+    }
+    if (statuses.size > 0 && !statuses.has(fields.status)) {
+      return false;
+    }
+    if (
+      visibilities.size > 0 &&
+      (fields.visibility === null || !visibilities.has(fields.visibility))
+    ) {
+      return false;
+    }
+    if (
+      modelIds.size > 0 &&
+      (fields.modelId === null || !modelIds.has(fields.modelId))
+    ) {
+      return false;
+    }
+    if (tagIds.size > 0 && !fields.tagIds.some((tag) => tagIds.has(tag))) {
+      return false;
+    }
+    if (
+      filters.editedWithin &&
+      !matchesEditedWithin(fields.updatedAt, filters.editedWithin, nowMs)
+    ) {
+      return false;
+    }
+    if (
+      filters.notUsedFor &&
+      !matchesNotUsedFor(fields.usage, filters.notUsedFor, nowMs)
+    ) {
+      return false;
+    }
+    if (isSearchActive && !subFilter(searchLower, searchStringFor(fields))) {
+      return false;
+    }
+    return true;
+  });
+
+  if (!isSearchActive) {
+    return matched;
+  }
+
+  return matched.sort((a, b) =>
+    compareForFuzzySort(
+      searchLower,
+      searchStringFor(select(a)),
+      searchStringFor(select(b))
+    )
+  );
+}
+
+// ── URL state ─────────────────────────────────────────────────────────────────
+
+const LIST_KEYS = [
+  "editors",
+  "lastEditors",
+  "tools",
+  "status",
+  "visibility",
+  "models",
+  "tags",
+  "availability",
+] as const;
+
+export function fleetFiltersToSearchParams(
+  filters: FleetFilters,
+  extra: Record<string, string | undefined> = {}
+): string {
+  const params = new URLSearchParams();
+  if (filters.search.trim()) {
+    params.set("q", filters.search.trim());
+  }
+  for (const key of LIST_KEYS) {
+    const values = filters[key];
+    if (values.length > 0) {
+      params.set(key, values.join(","));
+    }
+  }
+  if (filters.editedWithin) {
+    params.set("editedWithin", filters.editedWithin);
+  }
+  if (filters.notUsedFor) {
+    params.set("notUsedFor", filters.notUsedFor);
+  }
+  for (const [key, value] of Object.entries(extra)) {
+    if (value) {
+      params.set(key, value);
+    }
+  }
+  return params.toString();
+}
+
+function parseList(params: URLSearchParams, key: string): string[] {
+  const raw = params.get(key);
+  return raw ? raw.split(",").filter((value) => value.length > 0) : [];
+}
+
+export function fleetFiltersFromSearchParams(
+  params: URLSearchParams
+): FleetFilters {
+  const editedWithin = params.get("editedWithin");
+  const notUsedFor = params.get("notUsedFor");
+
+  return {
+    search: params.get("q") ?? "",
+    editors: parseList(params, "editors"),
+    lastEditors: parseList(params, "lastEditors"),
+    tools: parseList(params, "tools"),
+    status: parseList(params, "status") as StatusFilterValue[],
+    visibility: parseList(params, "visibility") as VisibilityFilterValue[],
+    models: parseList(params, "models"),
+    tags: parseList(params, "tags"),
+    availability: parseList(params, "availability"),
+    editedWithin: EDITED_WITHIN_OPTIONS.some((o) => o.value === editedWithin)
+      ? (editedWithin as EditedWithinValue)
+      : null,
+    notUsedFor: NOT_USED_FOR_OPTIONS.some((o) => o.value === notUsedFor)
+      ? (notUsedFor as NotUsedForValue)
+      : null,
+  };
+}
+
+/**
+ * Keeps the filter state in the query string so a filtered fleet view can be
+ * shared or bookmarked. Uses `replaceState` to avoid stacking one history
+ * entry per keystroke; the story name stays in the hash, untouched.
+ */
+export function useFleetFilters(
+  extra: Record<string, string | undefined> = {}
+) {
+  const [filters, setFilters] = useState<FleetFilters>(() =>
+    typeof window === "undefined"
+      ? EMPTY_FLEET_FILTERS
+      : fleetFiltersFromSearchParams(
+          new URLSearchParams(window.location.search)
+        )
+  );
+
+  const serializedExtra = JSON.stringify(extra);
+
+  useEffect(() => {
+    const query = fleetFiltersToSearchParams(
+      filters,
+      JSON.parse(serializedExtra)
+    );
+    const url = `${window.location.pathname}${query ? `?${query}` : ""}${window.location.hash}`;
+    window.history.replaceState(null, "", url);
+  }, [filters, serializedExtra]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      setFilters(
+        fleetFiltersFromSearchParams(
+          new URLSearchParams(window.location.search)
+        )
+      );
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  const updateFilters = useCallback((update: Partial<FleetFilters>) => {
+    setFilters((current) => ({ ...current, ...update }));
+  }, []);
+
+  const toggleValue = useCallback(
+    (
+      key: (typeof LIST_KEYS)[number],
+      value: string,
+      { exclusive }: { exclusive?: boolean } = {}
+    ) => {
+      setFilters((current) => {
+        // The list dimensions hold different literal unions; they are all
+        // string arrays at runtime, and the option lists are the only writers.
+        const values: string[] = current[key];
+        if (exclusive) {
+          return {
+            ...current,
+            [key]: values.includes(value) ? [] : [value],
+          };
+        }
+        return {
+          ...current,
+          [key]: values.includes(value)
+            ? values.filter((v) => v !== value)
+            : [...values, value],
+        };
+      });
+    },
+    []
+  );
+
+  const clearFilters = useCallback(() => {
+    setFilters((current) => ({
+      ...EMPTY_FLEET_FILTERS,
+      search: current.search,
+    }));
+  }, []);
+
+  return { filters, setFilters, updateFilters, toggleValue, clearFilters };
+}

--- a/sparkle/playground/src/components/manage/fleetFilters.ts
+++ b/sparkle/playground/src/components/manage/fleetFilters.ts
@@ -169,8 +169,8 @@ function matchesNotUsedFor(
 }
 
 /**
- * Counts what the Filters button badges. Models, tags and availability are
- * excluded: they have their own buttons and their own chips.
+ * Counts what the Filters button badges — every dimension the menu owns.
+ * Availability is excluded: it keeps its own control next to the tabs.
  */
 export function countActiveFleetFilters(filters: FleetFilters): number {
   return (
@@ -179,6 +179,8 @@ export function countActiveFleetFilters(filters: FleetFilters): number {
     filters.tools.length +
     filters.status.length +
     filters.visibility.length +
+    filters.models.length +
+    filters.tags.length +
     (filters.editedWithin ? 1 : 0) +
     (filters.notUsedFor ? 1 : 0)
   );

--- a/sparkle/playground/src/components/manage/skillIcons.tsx
+++ b/sparkle/playground/src/components/manage/skillIcons.tsx
@@ -1,0 +1,118 @@
+import {
+  Avatar,
+  BarChart04,
+  Calendar,
+  CreditCard01,
+  DustLogoSquare,
+  File06,
+  Flag01,
+  Globe01,
+  LayoutGrid01,
+  Lightbulb04,
+  MagicWand02,
+  Mail01,
+  MessageCircle01,
+  Monitor01,
+  PresentationChart01,
+  PuzzlePiece01,
+  Rocket01,
+  Scales01,
+  SearchLg,
+  Table,
+} from "@dust-tt/sparkle";
+import { cn } from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+import type { SkillIconKey } from "../../data/manageSkills";
+
+export const SKILL_ICON = PuzzlePiece01;
+export const SKILL_AVATAR_BACKGROUND_COLOR = "bg-highlight-50";
+export const SKILL_AVATAR_ICON_COLOR = "text-highlight";
+
+const SKILL_ICONS: Record<
+  SkillIconKey,
+  ComponentType<{ className?: string }>
+> = {
+  table: Table,
+  document: File06,
+  search: SearchLg,
+  lightbulb: Lightbulb04,
+  chat: MessageCircle01,
+  presentation: PresentationChart01,
+  card: CreditCard01,
+  chart: BarChart04,
+  mail: Mail01,
+  calendar: Calendar,
+  globe: Globe01,
+  rocket: Rocket01,
+  scales: Scales01,
+  clipboard: File06,
+  grid: LayoutGrid01,
+  wand: MagicWand02,
+  monitor: Monitor01,
+  flag: Flag01,
+};
+
+export function getSkillIcon(
+  icon: string | null
+): ComponentType<{ className?: string }> {
+  if (icon && icon in SKILL_ICONS) {
+    return SKILL_ICONS[icon as SkillIconKey];
+  }
+  return SKILL_ICON;
+}
+
+interface SkillAvatarProps {
+  icon: string | null;
+  // Dust-provided skills carry a Dust badge on the bottom-right of the avatar.
+  isDustProvided?: boolean;
+  size?: "xs" | "sm" | "md";
+  className?: string;
+}
+
+const BADGE_CLASSES: Record<
+  NonNullable<SkillAvatarProps["size"]>,
+  { badge: string; icon: string }
+> = {
+  xs: { badge: "h-3 w-3 rounded-[4px]", icon: "h-2 w-2" },
+  sm: { badge: "h-4 w-4 rounded-md", icon: "h-3 w-3" },
+  md: { badge: "h-5 w-5 rounded-md", icon: "h-4 w-4" },
+};
+
+export function SkillAvatar({
+  icon,
+  isDustProvided = false,
+  size = "sm",
+  className,
+}: SkillAvatarProps) {
+  const avatar = (
+    <Avatar
+      icon={getSkillIcon(icon)}
+      size={size}
+      backgroundColor={SKILL_AVATAR_BACKGROUND_COLOR}
+      iconColor={SKILL_AVATAR_ICON_COLOR}
+      className={className}
+    />
+  );
+
+  if (!isDustProvided) {
+    return avatar;
+  }
+
+  const badgeClasses = BADGE_CLASSES[size];
+
+  return (
+    <div className={cn("relative inline-flex overflow-visible", className)}>
+      {avatar}
+      <span
+        className={cn(
+          "pointer-events-none absolute bottom-0 right-0",
+          "flex items-center justify-center bg-background shadow-sm ring-1 ring-border",
+          badgeClasses.badge
+        )}
+      >
+        <DustLogoSquare className={badgeClasses.icon} />
+      </span>
+    </div>
+  );
+}

--- a/sparkle/playground/src/components/manage/toolIcons.tsx
+++ b/sparkle/playground/src/components/manage/toolIcons.tsx
@@ -1,0 +1,66 @@
+import {
+  ActionFrame,
+  AsanaLogo,
+  BigQueryLogo,
+  ConfluenceLogo,
+  DriveLogo,
+  FigmaLogo,
+  GcalLogo,
+  GithubLogo,
+  GmailLogo,
+  GongLogo,
+  Globe01,
+  HubspotLogo,
+  Image01,
+  IntercomLogo,
+  JiraLogo,
+  LinearLogo,
+  MondayLogo,
+  NotionLogo,
+  Robot,
+  SalesforceLogo,
+  SearchLg,
+  SlackLogo,
+  SnowflakeLogo,
+  StripeLogo,
+  Table,
+  ZendeskLogo,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+const TOOL_ICONS: Record<string, ComponentType<{ className?: string }>> = {
+  salesforce: SalesforceLogo,
+  hubspot: HubspotLogo,
+  slack: SlackLogo,
+  notion: NotionLogo,
+  google_drive: DriveLogo,
+  gmail: GmailLogo,
+  gcal: GcalLogo,
+  github: GithubLogo,
+  jira: JiraLogo,
+  linear: LinearLogo,
+  zendesk: ZendeskLogo,
+  intercom: IntercomLogo,
+  confluence: ConfluenceLogo,
+  snowflake: SnowflakeLogo,
+  bigquery: BigQueryLogo,
+  gong: GongLogo,
+  stripe: StripeLogo,
+  asana: AsanaLogo,
+  figma: FigmaLogo,
+  monday: MondayLogo,
+  web_search: Globe01,
+  browse: Globe01,
+  search: SearchLg,
+  frame: ActionFrame,
+  image_generation: Image01,
+  run_agent: Robot,
+  data_warehouse: Table,
+  extract_data: Table,
+};
+
+export function getToolIcon(
+  toolId: string
+): ComponentType<{ className?: string }> {
+  return TOOL_ICONS[toolId] ?? Table;
+}

--- a/sparkle/playground/src/components/manage/utils.ts
+++ b/sparkle/playground/src/components/manage/utils.ts
@@ -1,0 +1,136 @@
+// Ports of the front helpers the Manage screens rely on, so search, sorting
+// and date rendering behave exactly like in the product.
+
+function subFilterLastIndex(a: string, b: string) {
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      i++;
+    }
+    j++;
+  }
+  return i === a.length ? j : -1;
+}
+
+function subFilterFirstIndex(a: string, b: string) {
+  let i = a.length - 1;
+  let j = b.length - 1;
+  while (i >= 0 && j >= 0) {
+    if (a[i] === b[j]) {
+      i--;
+    }
+    j--;
+  }
+  return i === -1 ? j + 1 : -1;
+}
+
+function spreadLength(a: string, b: string) {
+  const lastIndex = subFilterLastIndex(a, b);
+  if (lastIndex === -1) {
+    return -1;
+  }
+  const firstIndex = subFilterFirstIndex(a, b.substring(0, lastIndex));
+  return lastIndex - firstIndex;
+}
+
+/** True when every character of `a` appears in `b`, in order. */
+export function subFilter(a: string, b: string) {
+  return subFilterLastIndex(a, b) > -1;
+}
+
+export function compareForFuzzySort(query: string, a: string, b: string) {
+  const normalizedQuery = query.toLowerCase();
+  const normalizedA = a.toLowerCase();
+  const normalizedB = b.toLowerCase();
+
+  if (
+    normalizedA.includes(normalizedQuery) &&
+    !normalizedB.includes(normalizedQuery)
+  ) {
+    return -1;
+  }
+  if (
+    normalizedB.includes(normalizedQuery) &&
+    !normalizedA.includes(normalizedQuery)
+  ) {
+    return 1;
+  }
+
+  const spreadA = spreadLength(normalizedQuery, normalizedA);
+  if (spreadA === -1) {
+    return 1;
+  }
+
+  const spreadB = spreadLength(normalizedQuery, normalizedB);
+  if (spreadB === -1) {
+    return -1;
+  }
+
+  if (spreadA !== spreadB) {
+    return spreadA - spreadB;
+  }
+
+  const isExactMatchA = normalizedA === normalizedQuery;
+  const isExactMatchB = normalizedB === normalizedQuery;
+  if (isExactMatchA && !isExactMatchB) {
+    return -1;
+  }
+  if (isExactMatchB && !isExactMatchA) {
+    return 1;
+  }
+
+  return 0;
+}
+
+export function formatTimestampToFriendlyDate(
+  timestamp: number,
+  version: "long" | "short" | "compact" | "compactWithDay" = "long"
+): string {
+  const date = new Date(timestamp);
+
+  switch (version) {
+    case "compact":
+      return date
+        .toLocaleDateString("en-US", { month: "short", year: "numeric" })
+        .replace(" ", ", ");
+    case "short":
+      return date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+    case "compactWithDay":
+      return date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      });
+    default:
+      return date.toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        second: "numeric",
+      });
+  }
+}
+
+export function pluralize(count: number) {
+  return count === 1 ? "" : "s";
+}
+
+export function assistantUsageMessage({
+  usage,
+}: {
+  usage: { messageCount: number; timePeriodSec: number } | null;
+}): string {
+  if (!usage) {
+    return "";
+  }
+  const days = usage.timePeriodSec / (60 * 60 * 24);
+  const nb = usage.messageCount || 0;
+  return `${nb} message${pluralize(nb)} over the last ${days} days`;
+}

--- a/sparkle/playground/src/data/fleetTools.ts
+++ b/sparkle/playground/src/data/fleetTools.ts
@@ -1,0 +1,50 @@
+// Catalog of tools / connectors an agent or a skill can be configured with.
+// In the product these are MCP server views; here the id stands in for the
+// view sId and drives both the filter and the row icons.
+
+export interface FleetTool {
+  id: string;
+  label: string;
+  // "connector" tools come from a data integration, "capability" ones are
+  // built into Dust. Only used to group the filter menu.
+  kind: "connector" | "capability";
+}
+
+export const FLEET_TOOLS: FleetTool[] = [
+  { id: "salesforce", label: "Salesforce", kind: "connector" },
+  { id: "hubspot", label: "HubSpot", kind: "connector" },
+  { id: "slack", label: "Slack", kind: "connector" },
+  { id: "notion", label: "Notion", kind: "connector" },
+  { id: "google_drive", label: "Google Drive", kind: "connector" },
+  { id: "gmail", label: "Gmail", kind: "connector" },
+  { id: "gcal", label: "Google Calendar", kind: "connector" },
+  { id: "github", label: "GitHub", kind: "connector" },
+  { id: "jira", label: "Jira", kind: "connector" },
+  { id: "linear", label: "Linear", kind: "connector" },
+  { id: "zendesk", label: "Zendesk", kind: "connector" },
+  { id: "intercom", label: "Intercom", kind: "connector" },
+  { id: "confluence", label: "Confluence", kind: "connector" },
+  { id: "snowflake", label: "Snowflake", kind: "connector" },
+  { id: "bigquery", label: "BigQuery", kind: "connector" },
+  { id: "gong", label: "Gong", kind: "connector" },
+  { id: "stripe", label: "Stripe", kind: "connector" },
+  { id: "asana", label: "Asana", kind: "connector" },
+  { id: "figma", label: "Figma", kind: "connector" },
+  { id: "monday", label: "Monday", kind: "connector" },
+  { id: "web_search", label: "Web search", kind: "capability" },
+  { id: "browse", label: "Browse", kind: "capability" },
+  { id: "search", label: "Search company data", kind: "capability" },
+  { id: "frame", label: "Create a Frame", kind: "capability" },
+  { id: "image_generation", label: "Image generation", kind: "capability" },
+  { id: "run_agent", label: "Run agent", kind: "capability" },
+  { id: "data_warehouse", label: "Query warehouse", kind: "capability" },
+  { id: "extract_data", label: "Extract data", kind: "capability" },
+];
+
+export const FLEET_TOOLS_BY_ID = new Map(
+  FLEET_TOOLS.map((tool) => [tool.id, tool])
+);
+
+export function getToolLabel(id: string): string {
+  return FLEET_TOOLS_BY_ID.get(id)?.label ?? id;
+}

--- a/sparkle/playground/src/data/fleetUsage.ts
+++ b/sparkle/playground/src/data/fleetUsage.ts
@@ -1,0 +1,215 @@
+// Usage segmentation for the fleet views.
+//
+// Mirrors front's `USAGE_ORIGINS_CLASSIFICATION`. The important nuance: being
+// automated does not make an origin programmatic. A trigger or a wake-up runs
+// on a schedule, but it runs a human's configured intent for a human audience,
+// so it counts as human usage. "Programmatic" is a billing / usage-mode call —
+// it covers API-driven and high-volume integration traffic (`api`, `zapier`,
+// `n8n`, `make`, the spreadsheet add-ins, `slack_workflow`, and the explicitly
+// programmatic variants of CLI and triggers).
+
+export type UsageOrigin =
+  | "api"
+  | "cli"
+  | "cli_programmatic"
+  | "email"
+  | "excel"
+  | "extension"
+  | "gsheet"
+  | "make"
+  | "n8n"
+  | "powerpoint"
+  | "raycast"
+  | "slack"
+  | "slack_workflow"
+  | "teams"
+  | "transcript"
+  | "triggered"
+  | "triggered_programmatic"
+  | "wakeup"
+  | "web"
+  | "zapier"
+  | "zendesk"
+  | "reinforcement";
+
+export const USAGE_ORIGINS_CLASSIFICATION: Record<
+  UsageOrigin,
+  "programmatic" | "user"
+> = {
+  api: "programmatic",
+  cli: "user",
+  cli_programmatic: "programmatic",
+  email: "user",
+  excel: "programmatic",
+  extension: "user",
+  gsheet: "programmatic",
+  make: "programmatic",
+  n8n: "programmatic",
+  powerpoint: "programmatic",
+  raycast: "user",
+  slack: "user",
+  slack_workflow: "programmatic",
+  teams: "user",
+  transcript: "user",
+  triggered: "user",
+  triggered_programmatic: "programmatic",
+  wakeup: "user",
+  web: "user",
+  zapier: "programmatic",
+  zendesk: "user",
+  reinforcement: "programmatic",
+};
+
+export const USER_USAGE_ORIGINS = (
+  Object.keys(USAGE_ORIGINS_CLASSIFICATION) as UsageOrigin[]
+).filter((origin) => USAGE_ORIGINS_CLASSIFICATION[origin] === "user");
+
+export const PROGRAMMATIC_USAGE_ORIGINS = (
+  Object.keys(USAGE_ORIGINS_CLASSIFICATION) as UsageOrigin[]
+).filter((origin) => USAGE_ORIGINS_CLASSIFICATION[origin] === "programmatic");
+
+export const USAGE_ORIGIN_LABELS: Record<UsageOrigin, string> = {
+  api: "API",
+  cli: "CLI",
+  cli_programmatic: "CLI (programmatic)",
+  email: "Email",
+  excel: "Excel add-in",
+  extension: "Browser extension",
+  gsheet: "Google Sheets add-in",
+  make: "Make",
+  n8n: "n8n",
+  powerpoint: "PowerPoint add-in",
+  raycast: "Raycast",
+  slack: "Slack",
+  slack_workflow: "Slack workflow",
+  teams: "Teams",
+  transcript: "Transcript",
+  triggered: "Trigger",
+  triggered_programmatic: "Trigger (programmatic)",
+  wakeup: "Wake-up",
+  web: "Web",
+  zapier: "Zapier",
+  zendesk: "Zendesk",
+  reinforcement: "Reinforcement",
+};
+
+export const USAGE_PERIOD_DAYS = 30;
+export const USAGE_PERIOD_SEC = USAGE_PERIOD_DAYS * 24 * 60 * 60;
+
+export interface FleetUsage {
+  // Messages in human-initiated conversations over the period. Primary metric
+  // and sort key.
+  human: number;
+  // API-driven / high-volume integration traffic over the period.
+  programmatic: number;
+  // Runs where this agent (or the agent carrying this skill) was invoked by
+  // another agent — a dependency signal, not a popularity signal.
+  agentToAgent: number;
+  // The programmatic origins that actually produced traffic, most used first.
+  programmaticOrigins: UsageOrigin[];
+  // Last use, any origin — what the tooltip shows.
+  lastUsedAt: number | null;
+  // Last human use. Separate from `lastUsedAt` on purpose: an agent driven
+  // only by an API integration is "not used by anyone" for triage even though
+  // it was hit five minutes ago.
+  lastHumanUsedAt: number | null;
+  timePeriodSec: number;
+}
+
+export const EMPTY_FLEET_USAGE: FleetUsage = {
+  human: 0,
+  programmatic: 0,
+  agentToAgent: 0,
+  programmaticOrigins: [],
+  lastUsedAt: null,
+  lastHumanUsedAt: null,
+  timePeriodSec: USAGE_PERIOD_SEC,
+};
+
+export function hasSecondaryUsage(usage: FleetUsage): boolean {
+  return usage.programmatic > 0 || usage.agentToAgent > 0;
+}
+
+/** Total across every origin — used for "never used" checks, never displayed. */
+export function totalUsage(usage: FleetUsage): number {
+  return usage.human + usage.programmatic + usage.agentToAgent;
+}
+
+/**
+ * Builds a coherent usage record around a known human count. Deliberately
+ * generates cases where programmatic traffic dwarfs human traffic, and cases
+ * where an item looks unused but is called by other agents — those are the two
+ * situations the segmentation exists to surface.
+ */
+export function makeFleetUsage(
+  random: () => number,
+  {
+    human,
+    nowMs,
+    // Items that are structurally API-facing (integrations, data extraction)
+    // get programmatic traffic far more often.
+    programmaticBias = 0,
+    // Items called as sub-agents / through skills.
+    dependencyBias = 0,
+  }: {
+    human: number;
+    nowMs: number;
+    programmaticBias?: number;
+    dependencyBias?: number;
+  }
+): FleetUsage {
+  const hasProgrammatic = random() < 0.22 + programmaticBias;
+  const programmatic = hasProgrammatic
+    ? Math.max(1, Math.floor(random() * 3200))
+    : 0;
+
+  const programmaticOrigins: UsageOrigin[] = [];
+  if (hasProgrammatic) {
+    const candidates = [...PROGRAMMATIC_USAGE_ORIGINS];
+    const count = 1 + Math.floor(random() * 2);
+    while (programmaticOrigins.length < count && candidates.length > 0) {
+      const [origin] = candidates.splice(
+        Math.floor(random() * candidates.length),
+        1
+      );
+      programmaticOrigins.push(origin);
+    }
+  }
+
+  const agentToAgent =
+    random() < 0.18 + dependencyBias
+      ? Math.max(1, Math.floor(random() * 900))
+      : 0;
+
+  const dayMs = 24 * 60 * 60 * 1000;
+
+  const lastHumanUsedAt =
+    human > 0
+      ? // Inside the window, weighted towards recent.
+        nowMs - Math.floor(random() ** 2 * USAGE_PERIOD_DAYS * dayMs)
+      : // No human message in the window: either never talked to, or last
+        // talked to somewhere between a month and a year and a half ago.
+        random() < 0.35
+        ? null
+        : nowMs - Math.floor((USAGE_PERIOD_DAYS + random() * 500) * dayMs);
+
+  const lastAutomatedUsedAt =
+    programmatic > 0 || agentToAgent > 0
+      ? nowMs - Math.floor(random() ** 2 * USAGE_PERIOD_DAYS * dayMs)
+      : null;
+
+  const lastUsedAt =
+    lastHumanUsedAt === null && lastAutomatedUsedAt === null
+      ? null
+      : Math.max(lastHumanUsedAt ?? 0, lastAutomatedUsedAt ?? 0);
+
+  return {
+    human,
+    programmatic,
+    agentToAgent,
+    programmaticOrigins,
+    lastUsedAt,
+    lastHumanUsedAt,
+    timePeriodSec: USAGE_PERIOD_SEC,
+  };
+}

--- a/sparkle/playground/src/data/index.ts
+++ b/sparkle/playground/src/data/index.ts
@@ -5,6 +5,8 @@ export * from "./types";
 export * from "./agentBuilder";
 export * from "./agents";
 export * from "./conversations";
+export * from "./manageAgents";
+export * from "./manageSkills";
 export * from "./myPod";
 export * from "./spaces";
 export * from "./spaceMembers";

--- a/sparkle/playground/src/data/manageAgents.ts
+++ b/sparkle/playground/src/data/manageAgents.ts
@@ -8,11 +8,6 @@ import { mockUsers } from "./users";
 
 export type AgentScope = "global" | "visible" | "hidden";
 
-// Where the agent is reachable from. `workspace` agents are visible to
-// everyone, `space` agents are scoped to one space/pod, `personal` ones only
-// to their editors.
-export type AgentVisibility = "workspace" | "space" | "personal";
-
 export type AgentStatus =
   | "active"
   | "archived"
@@ -56,11 +51,7 @@ export interface ManagedAgent {
   status: AgentStatus;
   modelId: string;
   editors: AgentEditor[];
-  // Author of the current version — what "Last Edited" refers to.
-  lastEditedBy: AgentEditor | null;
   tags: AgentTag[];
-  visibility: AgentVisibility;
-  spaceName: string | null;
   // MCP server view ids, see `fleetTools.ts`.
   tools: string[];
   usage: FleetUsage;
@@ -70,15 +61,6 @@ export interface ManagedAgent {
 }
 
 export const AGENT_USAGE_PERIOD_SEC = 30 * 24 * 60 * 60;
-
-export const AGENT_SPACES = [
-  "Company",
-  "Engineering",
-  "GTM",
-  "Finance",
-  "People",
-  "Support",
-];
 
 // ── Models ────────────────────────────────────────────────────────────────────
 
@@ -257,8 +239,6 @@ type CuratedAgent = {
   modelId?: string;
   tags?: string[];
   tools?: string[];
-  visibility?: AgentVisibility;
-  spaceName?: string;
   usage: number;
   feedbacks?: { up: number; down: number };
   lastUpdate: string;
@@ -882,7 +862,7 @@ function pickEditors(random: () => number, count: number): AgentEditor[] {
   return editors;
 }
 
-// ── Tools & visibility ────────────────────────────────────────────────────────
+// ── Tools ─────────────────────────────────────────────────────────────────────
 
 const TOOL_IDS = FLEET_TOOLS.map((tool) => tool.id);
 const FLEET_TOOLS_IDS = new Set(TOOL_IDS);
@@ -917,14 +897,6 @@ function pickTools(random: () => number): string[] {
     }
   }
   return tools;
-}
-
-function pickVisibility(random: () => number): AgentVisibility {
-  const roll = random();
-  if (roll < 0.62) {
-    return "workspace";
-  }
-  return roll < 0.9 ? "space" : "personal";
 }
 
 const NOW_MS = new Date("2026-08-10T10:00:00Z").getTime();
@@ -1133,7 +1105,6 @@ function buildCustomAgents(): ManagedAgent[] {
   for (const [index, curated] of CURATED_AGENTS.entries()) {
     const editors = pickEditors(random, 1 + Math.floor(random() * 3));
     const tools = curated.tools ?? pickTools(random);
-    const visibility = curated.visibility ?? pickVisibility(random);
     agents.push({
       sId: `agent_curated_${index}`,
       name: curated.name,
@@ -1144,13 +1115,7 @@ function buildCustomAgents(): ManagedAgent[] {
       status: "active",
       modelId: curated.modelId ?? "claude-sonnet-4-6",
       editors,
-      lastEditedBy: editors[0],
       tags: tagsFor(curated.tags ?? []),
-      visibility,
-      spaceName:
-        visibility === "space"
-          ? (curated.spaceName ?? pick(random, AGENT_SPACES))
-          : null,
       tools,
       usage: makeFleetUsage(random, {
         human: curated.usage,
@@ -1189,7 +1154,6 @@ function buildCustomAgents(): ManagedAgent[] {
       messageCount > 50 ? Math.floor(random() * 14) : Math.floor(random() * 2);
     const editors = pickEditors(random, 1 + Math.floor(random() * 4));
     const tools = pickTools(random);
-    const visibility = pickVisibility(random);
 
     agents.push({
       sId: `agent_gen_${index}`,
@@ -1202,15 +1166,12 @@ function buildCustomAgents(): ManagedAgent[] {
       status: "active",
       modelId: pickModelId(random),
       editors,
-      lastEditedBy: pick(random, editors),
       tags:
         random() < 0.45
           ? tagsFor([pick(random, AGENT_TAGS).name]).concat(
               random() < 0.2 ? tagsFor([pick(random, AGENT_TAGS).name]) : []
             )
           : [],
-      visibility,
-      spaceName: visibility === "space" ? pick(random, AGENT_SPACES) : null,
       tools,
       usage: makeFleetUsage(random, {
         human: messageCount,
@@ -1270,10 +1231,7 @@ function buildGlobalAgents(): ManagedAgent[] {
     status: index % 9 === 5 ? "disabled_by_admin" : "active",
     modelId: globalAgent.modelId,
     editors: [],
-    lastEditedBy: null,
     tags: [],
-    visibility: "workspace",
-    spaceName: null,
     tools: [],
     usage: makeFleetUsage(random, {
       human: Math.floor(random() * 1400),
@@ -1298,10 +1256,7 @@ function buildGlobalAgents(): ManagedAgent[] {
       status: random() < 0.25 ? "disabled_missing_datasource" : "active",
       modelId: "claude-sonnet-4-6",
       editors: [],
-      lastEditedBy: null,
       tags: [],
-      visibility: "workspace",
-      spaceName: null,
       tools: [connector].filter((tool) => FLEET_TOOLS_IDS.has(tool)),
       usage: makeFleetUsage(random, {
         human: Math.floor(random() * 300),
@@ -1335,10 +1290,7 @@ function buildArchivedAgents(): ManagedAgent[] {
       status: "archived",
       modelId: pickModelId(random),
       editors,
-      lastEditedBy: editors[0],
       tags: random() < 0.3 ? tagsFor([pick(random, AGENT_TAGS).name]) : [],
-      visibility: pickVisibility(random),
-      spaceName: null,
       tools: pickTools(random),
       usage: makeFleetUsage(random, {
         human: Math.floor(random() * 40),

--- a/sparkle/playground/src/data/manageAgents.ts
+++ b/sparkle/playground/src/data/manageAgents.ts
@@ -1,9 +1,17 @@
+import { FLEET_TOOLS } from "./fleetTools";
+import type { FleetUsage } from "./fleetUsage";
+import { makeFleetUsage } from "./fleetUsage";
 import { mockUsers } from "./users";
 
 // Mirrors `LightAgentConfigurationType` from front, reduced to what the
 // Manage Agents table actually renders.
 
 export type AgentScope = "global" | "visible" | "hidden";
+
+// Where the agent is reachable from. `workspace` agents are visible to
+// everyone, `space` agents are scoped to one space/pod, `personal` ones only
+// to their editors.
+export type AgentVisibility = "workspace" | "space" | "personal";
 
 export type AgentStatus =
   | "active"
@@ -48,14 +56,29 @@ export interface ManagedAgent {
   status: AgentStatus;
   modelId: string;
   editors: AgentEditor[];
+  // Author of the current version — what "Last Edited" refers to.
+  lastEditedBy: AgentEditor | null;
   tags: AgentTag[];
-  usage: { messageCount: number; timePeriodSec: number };
+  visibility: AgentVisibility;
+  spaceName: string | null;
+  // MCP server view ids, see `fleetTools.ts`.
+  tools: string[];
+  usage: FleetUsage;
   feedbacks: { up: number; down: number };
   lastUpdate: number;
   canEdit: boolean;
 }
 
 export const AGENT_USAGE_PERIOD_SEC = 30 * 24 * 60 * 60;
+
+export const AGENT_SPACES = [
+  "Company",
+  "Engineering",
+  "GTM",
+  "Finance",
+  "People",
+  "Support",
+];
 
 // ── Models ────────────────────────────────────────────────────────────────────
 
@@ -233,6 +256,9 @@ type CuratedAgent = {
   backgroundColor: string;
   modelId?: string;
   tags?: string[];
+  tools?: string[];
+  visibility?: AgentVisibility;
+  spaceName?: string;
   usage: number;
   feedbacks?: { up: number; down: number };
   lastUpdate: string;
@@ -243,6 +269,7 @@ type CuratedAgent = {
 const CURATED_AGENTS: CuratedAgent[] = [
   {
     name: "AccountExecutive-Scorecard-Generator",
+    tools: ["extract_data", "search"],
     description:
       "Recruiter Screen Scorecard Assistant: evaluate candidates against criteria, produce structured scorecard assessments for Ashby.",
     emoji: "🤖",
@@ -253,6 +280,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "AccountPenetrationEngine",
+    tools: ["salesforce", "web_search", "extract_data"],
     description:
       "Account Penetration Engine: autonomous data extraction and analysis agent for strategic insights.",
     emoji: "🛰",
@@ -263,6 +291,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "AccountPenetrationRenderer",
+    tools: ["frame", "run_agent"],
     description:
       "Account Penetration Renderer: a template population agent that inserts JSON data into a Dust Frame template for rendering.",
     emoji: "🎨",
@@ -273,6 +302,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Accounts_Receivable_Analyst",
+    tools: ["stripe", "gmail", "search"],
     description:
       "Fetches overdue invoices, groups by client, creates Gmail drafts with payment links for Finance to review and send.",
     emoji: "📮",
@@ -283,6 +313,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "AccountSnapshot",
+    tools: ["salesforce", "gong", "web_search", "search"],
     description:
       "Specialized assistant creating detailed B2B account briefings for sales meeting preparation.",
     emoji: "🍀",
@@ -293,6 +324,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Action_Recap",
+    tools: ["slack", "search"],
     description:
       "A CFO-focused agent that screens meeting notes to track action items and blockers, sending a structured Slack DM recap.",
     emoji: "🦊",
@@ -303,6 +335,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "add_event_to_Gcalendar",
+    tools: ["gcal", "gmail"],
     description:
       "Assistant specialized in analyzing emails to create Google Calendar events automatically.",
     emoji: "📅",
@@ -312,6 +345,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "add_event_to_Notion_calendar",
+    tools: ["notion", "gcal"],
     description: "create new events in go/events",
     emoji: "📅",
     backgroundColor: "bg-green-200",
@@ -320,6 +354,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "AdminGovernanceExpert",
+    tools: ["notion", "search"],
     description:
       "An expert agent for the Admin Governance initiative, assisting with admin roles, permissions, and documentation.",
     emoji: "🔮",
@@ -330,6 +365,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "agenda_cleaner",
+    tools: ["gcal"],
     description:
       "Google Calendar assistant: cleans event titles, adds 'Task:' prefix, and changes color to pink.",
     emoji: "🧹",
@@ -339,6 +375,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Agent_Auditor",
+    tools: ["search", "run_agent"],
     description:
       "Expert AI agent auditor for enterprise workspace deployments.",
     emoji: "🔍",
@@ -350,6 +387,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "AI-digest-news",
+    tools: ["web_search", "browse"],
     description:
       "Generative AI industry monitor: research assistant tracking latest developments in AI companies, products, and research.",
     emoji: "🐼",
@@ -359,6 +397,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "AID-Scorecard",
+    tools: ["extract_data", "search"],
     description:
       "Recruiter Screen Scorecard Assistant: evaluate candidates against criteria, produce structured scorecard assessments for Ashby.",
     emoji: "🤖",
@@ -369,6 +408,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "AmbraEA",
+    tools: ["gcal", "gmail", "slack"],
     description:
       "Expert executive assistant AI for the Chief of Staff, managing daily workflow with precision.",
     emoji: "🧭",
@@ -378,6 +418,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Amelie_call_",
+    tools: ["gmail", "gong"],
     description: "follow-up emails after customer calls with key info.",
     emoji: "📞",
     backgroundColor: "bg-blue-100",
@@ -387,6 +428,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Analytics_Copilot",
+    tools: ["snowflake", "bigquery", "data_warehouse", "frame"],
     description:
       "Answers product analytics questions over the warehouse and returns charts with the SQL it ran.",
     emoji: "📊",
@@ -399,6 +441,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Assistant_Onboarding",
+    tools: ["notion", "gcal", "search"],
     description:
       "Walks new hires through their first two weeks, surfacing the right docs, tools and people at the right time.",
     emoji: "🚀",
@@ -410,6 +453,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Bug_Triage",
+    tools: ["github", "linear", "search"],
     description:
       "Reads incoming Sentry issues and GitHub reports, deduplicates them and proposes a severity and an owner.",
     emoji: "🐛",
@@ -421,6 +465,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Churn_Signal_Watcher",
+    tools: ["salesforce", "data_warehouse", "slack"],
     description:
       "Monitors usage drops across accounts and drafts a save play for the CSM with the supporting evidence.",
     emoji: "📉",
@@ -431,6 +476,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Contract_Reviewer",
+    tools: ["google_drive", "notion", "extract_data"],
     description:
       "Reviews inbound MSAs and DPAs against our playbook and flags the clauses that need Legal.",
     emoji: "⚖️",
@@ -443,6 +489,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "daily_standup_digest",
+    tools: ["github", "linear", "slack"],
     description:
       "Compiles yesterday's merged PRs, incidents and Linear updates into one Slack digest.",
     emoji: "☀️",
@@ -454,6 +501,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Deal_Desk",
+    tools: ["salesforce", "search", "data_warehouse"],
     description:
       "Answers pricing, discounting and approval questions using the current commercial policy.",
     emoji: "💼",
@@ -465,6 +513,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Design_Critique",
+    tools: ["figma", "browse"],
     description:
       "Gives structured feedback on a Figma frame: hierarchy, spacing, contrast and copy.",
     emoji: "🎨",
@@ -475,6 +524,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Docs_Gardener",
+    tools: ["notion", "search"],
     description:
       "Finds stale internal documentation, proposes edits and opens the corresponding Notion tasks.",
     emoji: "🪴",
@@ -485,6 +535,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Enterprise_RFP",
+    tools: ["salesforce", "notion", "search"],
     description:
       "Drafts answers to security and procurement questionnaires from our approved answer library.",
     emoji: "📋",
@@ -497,6 +548,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Expense_Checker",
+    tools: ["google_drive", "extract_data"],
     description:
       "Checks submitted expenses against the travel policy and flags the ones that need a manager review.",
     emoji: "🧾",
@@ -507,6 +559,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Incident_Commander",
+    tools: ["github", "slack", "linear"],
     description:
       "Runs the incident checklist, keeps the status page updated and drafts the post-mortem skeleton.",
     emoji: "🚨",
@@ -519,6 +572,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Interview_Debrief",
+    tools: ["notion", "search"],
     description:
       "Turns raw interview notes into a structured debrief with evidence for each competency.",
     emoji: "🗣",
@@ -529,6 +583,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Knowledge_Search",
+    tools: ["search", "notion", "google_drive", "slack", "confluence"],
     description:
       "Searches every connected source at once and answers with citations you can open.",
     emoji: "🔎",
@@ -540,6 +595,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Localization_Buddy",
+    tools: ["notion", "google_drive"],
     description:
       "Translates product copy and keeps the glossary consistent across locales.",
     emoji: "🌍",
@@ -551,6 +607,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "meeting_notes_to_crm",
+    tools: ["hubspot", "gong", "search"],
     description:
       "Extracts next steps, MEDDIC fields and risks from a call transcript and writes them back to HubSpot.",
     emoji: "📝",
@@ -562,6 +619,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Onboarding_Buddy",
+    tools: ["notion", "search"],
     description:
       "Answers the questions new joiners are afraid to ask, from payroll to the coffee machine.",
     emoji: "🐣",
@@ -573,6 +631,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "PR_Reviewer",
+    tools: ["github", "linear", "search"],
     description:
       "Reviews a pull request against our coding rules and comments only on what actually matters.",
     emoji: "🧑‍💻",
@@ -585,6 +644,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Pricing_Analyst",
+    tools: ["data_warehouse", "salesforce"],
     description:
       "Models the revenue impact of a pricing change and explains the assumptions behind it.",
     emoji: "💰",
@@ -596,6 +656,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Release_Notes_Writer",
+    tools: ["github", "notion"],
     description:
       "Turns merged PRs into customer-facing release notes in our tone of voice.",
     emoji: "📣",
@@ -607,6 +668,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Security_Questionnaire",
+    tools: ["notion", "google_drive", "search"],
     description:
       "Answers vendor security reviews using the trust center and escalates anything unanswered.",
     emoji: "🛡",
@@ -617,6 +679,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Slack_Summarizer",
+    tools: ["slack", "search"],
     description:
       "Summarizes a busy channel or a long thread into the three things you actually need to know.",
     emoji: "💬",
@@ -629,6 +692,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Support_Triage",
+    tools: ["zendesk", "intercom", "search"],
     description:
       "Classifies inbound Zendesk tickets, drafts a first reply and routes the hard ones to a human.",
     emoji: "🎧",
@@ -640,6 +704,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "weekly_business_review",
+    tools: ["data_warehouse", "snowflake", "frame", "salesforce"],
     description:
       "Assembles the weekly metrics pack and writes the narrative around the numbers.",
     emoji: "📈",
@@ -652,6 +717,7 @@ const CURATED_AGENTS: CuratedAgent[] = [
   },
   {
     name: "Zendesk_Macro_Writer",
+    tools: ["zendesk", "search"],
     description:
       "Proposes new macros based on the tickets that keep coming back.",
     emoji: "🧰",
@@ -814,6 +880,51 @@ function pickEditors(random: () => number, count: number): AgentEditor[] {
     }
   }
   return editors;
+}
+
+// ── Tools & visibility ────────────────────────────────────────────────────────
+
+const TOOL_IDS = FLEET_TOOLS.map((tool) => tool.id);
+const FLEET_TOOLS_IDS = new Set(TOOL_IDS);
+
+// Tools that make an agent a natural API/integration target — those are the
+// ones whose raw message counts are the most misleading.
+const API_FACING_TOOLS = new Set([
+  "salesforce",
+  "hubspot",
+  "zendesk",
+  "intercom",
+  "stripe",
+  "snowflake",
+  "bigquery",
+  "data_warehouse",
+  "extract_data",
+]);
+
+function programmaticBiasForTools(tools: string[]): number {
+  return tools.some((tool) => API_FACING_TOOLS.has(tool)) ? 0.32 : 0;
+}
+
+function pickTools(random: () => number): string[] {
+  const count = Math.floor(random() * 5);
+  const tools: string[] = [];
+  const used = new Set<string>();
+  while (tools.length < count) {
+    const tool = pick(random, TOOL_IDS);
+    if (!used.has(tool)) {
+      used.add(tool);
+      tools.push(tool);
+    }
+  }
+  return tools;
+}
+
+function pickVisibility(random: () => number): AgentVisibility {
+  const roll = random();
+  if (roll < 0.62) {
+    return "workspace";
+  }
+  return roll < 0.9 ? "space" : "personal";
 }
 
 const NOW_MS = new Date("2026-08-10T10:00:00Z").getTime();
@@ -1020,6 +1131,9 @@ function buildCustomAgents(): ManagedAgent[] {
   const agents: ManagedAgent[] = [];
 
   for (const [index, curated] of CURATED_AGENTS.entries()) {
+    const editors = pickEditors(random, 1 + Math.floor(random() * 3));
+    const tools = curated.tools ?? pickTools(random);
+    const visibility = curated.visibility ?? pickVisibility(random);
     agents.push({
       sId: `agent_curated_${index}`,
       name: curated.name,
@@ -1029,12 +1143,21 @@ function buildCustomAgents(): ManagedAgent[] {
       scope: curated.scope ?? "visible",
       status: "active",
       modelId: curated.modelId ?? "claude-sonnet-4-6",
-      editors: pickEditors(random, 1 + Math.floor(random() * 3)),
+      editors,
+      lastEditedBy: editors[0],
       tags: tagsFor(curated.tags ?? []),
-      usage: {
-        messageCount: curated.usage,
-        timePeriodSec: AGENT_USAGE_PERIOD_SEC,
-      },
+      visibility,
+      spaceName:
+        visibility === "space"
+          ? (curated.spaceName ?? pick(random, AGENT_SPACES))
+          : null,
+      tools,
+      usage: makeFleetUsage(random, {
+        human: curated.usage,
+        nowMs: NOW_MS,
+        programmaticBias: programmaticBiasForTools(tools),
+        dependencyBias: tools.includes("run_agent") ? 0.3 : 0,
+      }),
       feedbacks: curated.feedbacks ?? { up: 0, down: 0 },
       lastUpdate: new Date(`${curated.lastUpdate}T09:12:00Z`).getTime(),
       canEdit: curated.canEdit ?? false,
@@ -1064,6 +1187,9 @@ function buildCustomAgents(): ManagedAgent[] {
           : Math.floor(random() * 900);
     const feedbackCount =
       messageCount > 50 ? Math.floor(random() * 14) : Math.floor(random() * 2);
+    const editors = pickEditors(random, 1 + Math.floor(random() * 4));
+    const tools = pickTools(random);
+    const visibility = pickVisibility(random);
 
     agents.push({
       sId: `agent_gen_${index}`,
@@ -1075,14 +1201,23 @@ function buildCustomAgents(): ManagedAgent[] {
       scope: random() < 0.12 ? "hidden" : "visible",
       status: "active",
       modelId: pickModelId(random),
-      editors: pickEditors(random, 1 + Math.floor(random() * 4)),
+      editors,
+      lastEditedBy: pick(random, editors),
       tags:
         random() < 0.45
           ? tagsFor([pick(random, AGENT_TAGS).name]).concat(
               random() < 0.2 ? tagsFor([pick(random, AGENT_TAGS).name]) : []
             )
           : [],
-      usage: { messageCount, timePeriodSec: AGENT_USAGE_PERIOD_SEC },
+      visibility,
+      spaceName: visibility === "space" ? pick(random, AGENT_SPACES) : null,
+      tools,
+      usage: makeFleetUsage(random, {
+        human: messageCount,
+        nowMs: NOW_MS,
+        programmaticBias: programmaticBiasForTools(tools),
+        dependencyBias: tools.includes("run_agent") ? 0.3 : 0,
+      }),
       feedbacks: {
         up: Math.ceil(feedbackCount * 0.75),
         down: Math.floor(feedbackCount * 0.25),
@@ -1135,11 +1270,18 @@ function buildGlobalAgents(): ManagedAgent[] {
     status: index % 9 === 5 ? "disabled_by_admin" : "active",
     modelId: globalAgent.modelId,
     editors: [],
+    lastEditedBy: null,
     tags: [],
-    usage: {
-      messageCount: Math.floor(random() * 1400),
-      timePeriodSec: AGENT_USAGE_PERIOD_SEC,
-    },
+    visibility: "workspace",
+    spaceName: null,
+    tools: [],
+    usage: makeFleetUsage(random, {
+      human: Math.floor(random() * 1400),
+      nowMs: NOW_MS,
+      // Default agents are the ones people wire into scripts and integrations.
+      programmaticBias: 0.25,
+      dependencyBias: 0.1,
+    }),
     feedbacks: { up: 0, down: 0 },
     lastUpdate: NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS),
     canEdit: false,
@@ -1156,11 +1298,16 @@ function buildGlobalAgents(): ManagedAgent[] {
       status: random() < 0.25 ? "disabled_missing_datasource" : "active",
       modelId: "claude-sonnet-4-6",
       editors: [],
+      lastEditedBy: null,
       tags: [],
-      usage: {
-        messageCount: Math.floor(random() * 300),
-        timePeriodSec: AGENT_USAGE_PERIOD_SEC,
-      },
+      visibility: "workspace",
+      spaceName: null,
+      tools: [connector].filter((tool) => FLEET_TOOLS_IDS.has(tool)),
+      usage: makeFleetUsage(random, {
+        human: Math.floor(random() * 300),
+        nowMs: NOW_MS,
+        programmaticBias: 0.2,
+      }),
       feedbacks: { up: 0, down: 0 },
       lastUpdate: NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS),
       canEdit: false,
@@ -1177,6 +1324,7 @@ function buildArchivedAgents(): ManagedAgent[] {
   for (let index = 0; index < TOTAL_ARCHIVED_AGENTS; index++) {
     const domain = pick(random, NAME_DOMAINS);
     const role = pick(random, NAME_ROLES);
+    const editors = pickEditors(random, 1 + Math.floor(random() * 2));
     agents.push({
       sId: `agent_archived_${index}`,
       name: styleName(domain, role, pick(random, [...NAME_STYLES])),
@@ -1186,12 +1334,16 @@ function buildArchivedAgents(): ManagedAgent[] {
       scope: "visible",
       status: "archived",
       modelId: pickModelId(random),
-      editors: pickEditors(random, 1 + Math.floor(random() * 2)),
+      editors,
+      lastEditedBy: editors[0],
       tags: random() < 0.3 ? tagsFor([pick(random, AGENT_TAGS).name]) : [],
-      usage: {
-        messageCount: Math.floor(random() * 40),
-        timePeriodSec: AGENT_USAGE_PERIOD_SEC,
-      },
+      visibility: pickVisibility(random),
+      spaceName: null,
+      tools: pickTools(random),
+      usage: makeFleetUsage(random, {
+        human: Math.floor(random() * 40),
+        nowMs: NOW_MS,
+      }),
       feedbacks: { up: 0, down: 0 },
       lastUpdate: NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS),
       canEdit: true,

--- a/sparkle/playground/src/data/manageAgents.ts
+++ b/sparkle/playground/src/data/manageAgents.ts
@@ -1,0 +1,1209 @@
+import { mockUsers } from "./users";
+
+// Mirrors `LightAgentConfigurationType` from front, reduced to what the
+// Manage Agents table actually renders.
+
+export type AgentScope = "global" | "visible" | "hidden";
+
+export type AgentStatus =
+  | "active"
+  | "archived"
+  | "disabled_by_admin"
+  | "disabled_missing_datasource";
+
+export type ModelMakerId =
+  | "anthropic"
+  | "openai"
+  | "google_ai_studio"
+  | "mistral"
+  | "deepseek"
+  | "xai"
+  | "noop";
+
+export interface AgentTag {
+  sId: string;
+  name: string;
+  kind: "standard" | "protected";
+}
+
+export interface AgentEditor {
+  sId: string;
+  fullName: string;
+  image?: string;
+}
+
+export interface AgentModel {
+  modelId: string;
+  displayName: string;
+  maker: ModelMakerId;
+}
+
+export interface ManagedAgent {
+  sId: string;
+  name: string;
+  description: string;
+  emoji: string;
+  backgroundColor: string;
+  scope: AgentScope;
+  status: AgentStatus;
+  modelId: string;
+  editors: AgentEditor[];
+  tags: AgentTag[];
+  usage: { messageCount: number; timePeriodSec: number };
+  feedbacks: { up: number; down: number };
+  lastUpdate: number;
+  canEdit: boolean;
+}
+
+export const AGENT_USAGE_PERIOD_SEC = 30 * 24 * 60 * 60;
+
+// ── Models ────────────────────────────────────────────────────────────────────
+
+export const AGENT_MODELS: AgentModel[] = [
+  {
+    modelId: "claude-sonnet-4-6",
+    displayName: "Claude Sonnet 4.6",
+    maker: "anthropic",
+  },
+  {
+    modelId: "claude-opus-4-6",
+    displayName: "Claude Opus 4.6",
+    maker: "anthropic",
+  },
+  {
+    modelId: "claude-opus-4-7",
+    displayName: "Claude Opus 4.7",
+    maker: "anthropic",
+  },
+  {
+    modelId: "claude-haiku-4-5",
+    displayName: "Claude Haiku 4.5",
+    maker: "anthropic",
+  },
+  { modelId: "gpt-5-2", displayName: "GPT-5.2", maker: "openai" },
+  { modelId: "gpt-5-2-mini", displayName: "GPT-5.2 mini", maker: "openai" },
+  { modelId: "o4", displayName: "o4", maker: "openai" },
+  {
+    modelId: "gemini-3-pro",
+    displayName: "Gemini 3 Pro",
+    maker: "google_ai_studio",
+  },
+  {
+    modelId: "gemini-3-flash",
+    displayName: "Gemini 3 Flash",
+    maker: "google_ai_studio",
+  },
+  {
+    modelId: "mistral-large-3",
+    displayName: "Mistral Large 3",
+    maker: "mistral",
+  },
+  { modelId: "deepseek-v4", displayName: "DeepSeek V4", maker: "deepseek" },
+  { modelId: "grok-5", displayName: "Grok 5", maker: "xai" },
+  { modelId: "auto", displayName: "Dust Auto", maker: "noop" },
+];
+
+export const AGENT_MODELS_BY_ID = new Map(
+  AGENT_MODELS.map((model) => [model.modelId, model])
+);
+
+// The distribution is deliberately lopsided: real workspaces overwhelmingly
+// sit on one or two models.
+const MODEL_WEIGHTS: { modelId: string; weight: number }[] = [
+  { modelId: "claude-sonnet-4-6", weight: 62 },
+  { modelId: "claude-opus-4-6", weight: 12 },
+  { modelId: "claude-opus-4-7", weight: 6 },
+  { modelId: "claude-haiku-4-5", weight: 3 },
+  { modelId: "gpt-5-2", weight: 6 },
+  { modelId: "gpt-5-2-mini", weight: 2 },
+  { modelId: "o4", weight: 1 },
+  { modelId: "gemini-3-pro", weight: 3 },
+  { modelId: "gemini-3-flash", weight: 1 },
+  { modelId: "mistral-large-3", weight: 2 },
+  { modelId: "deepseek-v4", weight: 1 },
+  { modelId: "grok-5", weight: 1 },
+];
+
+// ── Tags ──────────────────────────────────────────────────────────────────────
+
+export const AGENT_TAGS: AgentTag[] = [
+  { sId: "tag_gtm", name: "GTM", kind: "standard" },
+  { sId: "tag_marketing", name: "Marketing", kind: "standard" },
+  { sId: "tag_talent", name: "Talent", kind: "standard" },
+  { sId: "tag_engineering", name: "Engineering", kind: "standard" },
+  { sId: "tag_product", name: "Product", kind: "standard" },
+  { sId: "tag_finance", name: "Finance", kind: "standard" },
+  { sId: "tag_support", name: "Support", kind: "standard" },
+  { sId: "tag_legal", name: "Legal", kind: "standard" },
+  { sId: "tag_data", name: "Data", kind: "standard" },
+  { sId: "tag_ops", name: "Ops", kind: "standard" },
+  { sId: "tag_people", name: "People", kind: "standard" },
+  { sId: "tag_security", name: "Security", kind: "standard" },
+  { sId: "tag_company", name: "Company", kind: "protected" },
+];
+
+const TAGS_BY_NAME = new Map(AGENT_TAGS.map((tag) => [tag.name, tag]));
+
+function tagsFor(names: string[]): AgentTag[] {
+  return names.flatMap((name) => {
+    const tag = TAGS_BY_NAME.get(name);
+    return tag ? [tag] : [];
+  });
+}
+
+// ── Deterministic pseudo-randomness ───────────────────────────────────────────
+
+function createRandom(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296;
+    return state / 4294967296;
+  };
+}
+
+// ── Editors ───────────────────────────────────────────────────────────────────
+
+const EDITOR_POOL: AgentEditor[] = mockUsers.map((user) => ({
+  sId: user.id,
+  fullName: user.fullName,
+  image: user.portrait,
+}));
+
+export const CURRENT_USER: AgentEditor = EDITOR_POOL[0];
+
+// ── Avatars ───────────────────────────────────────────────────────────────────
+
+const AVATAR_EMOJIS = [
+  "🤖",
+  "🎯",
+  "📊",
+  "🧠",
+  "🔍",
+  "📝",
+  "⚡️",
+  "🧪",
+  "📮",
+  "🗂",
+  "🛰",
+  "🧭",
+  "💡",
+  "🪄",
+  "📈",
+  "🧰",
+  "🛠",
+  "🔮",
+  "🧵",
+  "🚀",
+  "🦉",
+  "🐙",
+  "🦊",
+  "🐝",
+  "🍀",
+  "🌊",
+  "🔥",
+  "🎨",
+  "🎙",
+  "📅",
+];
+
+const AVATAR_BACKGROUNDS = [
+  "bg-blue-100",
+  "bg-blue-200",
+  "bg-green-100",
+  "bg-green-200",
+  "bg-golden-100",
+  "bg-golden-200",
+  "bg-rose-100",
+  "bg-rose-200",
+  "bg-violet-100",
+  "bg-violet-200",
+  "bg-lime-100",
+  "bg-pink-100",
+  "bg-red-100",
+  "bg-highlight-100",
+  "bg-primary-200",
+];
+
+// ── Curated agents (verbatim shapes from a real workspace) ────────────────────
+
+type CuratedAgent = {
+  name: string;
+  description: string;
+  emoji: string;
+  backgroundColor: string;
+  modelId?: string;
+  tags?: string[];
+  usage: number;
+  feedbacks?: { up: number; down: number };
+  lastUpdate: string;
+  scope?: AgentScope;
+  canEdit?: boolean;
+};
+
+const CURATED_AGENTS: CuratedAgent[] = [
+  {
+    name: "AccountExecutive-Scorecard-Generator",
+    description:
+      "Recruiter Screen Scorecard Assistant: evaluate candidates against criteria, produce structured scorecard assessments for Ashby.",
+    emoji: "🤖",
+    backgroundColor: "bg-blue-100",
+    tags: ["Talent"],
+    usage: 4,
+    lastUpdate: "2026-07-18",
+  },
+  {
+    name: "AccountPenetrationEngine",
+    description:
+      "Account Penetration Engine: autonomous data extraction and analysis agent for strategic insights.",
+    emoji: "🛰",
+    backgroundColor: "bg-lime-100",
+    modelId: "claude-opus-4-6",
+    usage: 0,
+    lastUpdate: "2026-03-04",
+  },
+  {
+    name: "AccountPenetrationRenderer",
+    description:
+      "Account Penetration Renderer: a template population agent that inserts JSON data into a Dust Frame template for rendering.",
+    emoji: "🎨",
+    backgroundColor: "bg-green-200",
+    modelId: "claude-opus-4-6",
+    usage: 0,
+    lastUpdate: "2026-03-04",
+  },
+  {
+    name: "Accounts_Receivable_Analyst",
+    description:
+      "Fetches overdue invoices, groups by client, creates Gmail drafts with payment links for Finance to review and send.",
+    emoji: "📮",
+    backgroundColor: "bg-rose-100",
+    tags: ["Finance"],
+    usage: 2,
+    lastUpdate: "2026-07-02",
+  },
+  {
+    name: "AccountSnapshot",
+    description:
+      "Specialized assistant creating detailed B2B account briefings for sales meeting preparation.",
+    emoji: "🍀",
+    backgroundColor: "bg-golden-100",
+    tags: ["GTM"],
+    usage: 7,
+    lastUpdate: "2025-06-21",
+  },
+  {
+    name: "Action_Recap",
+    description:
+      "A CFO-focused agent that screens meeting notes to track action items and blockers, sending a structured Slack DM recap.",
+    emoji: "🦊",
+    backgroundColor: "bg-golden-200",
+    tags: ["Finance"],
+    usage: 4,
+    lastUpdate: "2026-06-11",
+  },
+  {
+    name: "add_event_to_Gcalendar",
+    description:
+      "Assistant specialized in analyzing emails to create Google Calendar events automatically.",
+    emoji: "📅",
+    backgroundColor: "bg-green-200",
+    usage: 2,
+    lastUpdate: "2026-02-09",
+  },
+  {
+    name: "add_event_to_Notion_calendar",
+    description: "create new events in go/events",
+    emoji: "📅",
+    backgroundColor: "bg-green-200",
+    usage: 1,
+    lastUpdate: "2026-08-03",
+  },
+  {
+    name: "AdminGovernanceExpert",
+    description:
+      "An expert agent for the Admin Governance initiative, assisting with admin roles, permissions, and documentation.",
+    emoji: "🔮",
+    backgroundColor: "bg-blue-200",
+    tags: ["Ops", "Security"],
+    usage: 8,
+    lastUpdate: "2026-07-24",
+  },
+  {
+    name: "agenda_cleaner",
+    description:
+      "Google Calendar assistant: cleans event titles, adds 'Task:' prefix, and changes color to pink.",
+    emoji: "🧹",
+    backgroundColor: "bg-blue-100",
+    usage: 31,
+    lastUpdate: "2026-07-29",
+  },
+  {
+    name: "Agent_Auditor",
+    description:
+      "Expert AI agent auditor for enterprise workspace deployments.",
+    emoji: "🔍",
+    backgroundColor: "bg-blue-100",
+    modelId: "claude-opus-4-7",
+    usage: 25,
+    feedbacks: { up: 3, down: 0 },
+    lastUpdate: "2026-06-30",
+  },
+  {
+    name: "AI-digest-news",
+    description:
+      "Generative AI industry monitor: research assistant tracking latest developments in AI companies, products, and research.",
+    emoji: "🐼",
+    backgroundColor: "bg-primary-200",
+    usage: 5,
+    lastUpdate: "2025-12-15",
+  },
+  {
+    name: "AID-Scorecard",
+    description:
+      "Recruiter Screen Scorecard Assistant: evaluate candidates against criteria, produce structured scorecard assessments for Ashby.",
+    emoji: "🤖",
+    backgroundColor: "bg-blue-100",
+    tags: ["Talent"],
+    usage: 0,
+    lastUpdate: "2026-07-18",
+  },
+  {
+    name: "AmbraEA",
+    description:
+      "Expert executive assistant AI for the Chief of Staff, managing daily workflow with precision.",
+    emoji: "🧭",
+    backgroundColor: "bg-blue-100",
+    usage: 0,
+    lastUpdate: "2026-04-14",
+  },
+  {
+    name: "Amelie_call_",
+    description: "follow-up emails after customer calls with key info.",
+    emoji: "📞",
+    backgroundColor: "bg-blue-100",
+    tags: ["Marketing"],
+    usage: 13,
+    lastUpdate: "2026-03-26",
+  },
+  {
+    name: "Analytics_Copilot",
+    description:
+      "Answers product analytics questions over the warehouse and returns charts with the SQL it ran.",
+    emoji: "📊",
+    backgroundColor: "bg-violet-100",
+    modelId: "claude-opus-4-6",
+    tags: ["Data", "Product"],
+    usage: 214,
+    feedbacks: { up: 11, down: 2 },
+    lastUpdate: "2026-08-05",
+  },
+  {
+    name: "Assistant_Onboarding",
+    description:
+      "Walks new hires through their first two weeks, surfacing the right docs, tools and people at the right time.",
+    emoji: "🚀",
+    backgroundColor: "bg-green-100",
+    tags: ["People"],
+    usage: 87,
+    feedbacks: { up: 6, down: 1 },
+    lastUpdate: "2026-07-11",
+  },
+  {
+    name: "Bug_Triage",
+    description:
+      "Reads incoming Sentry issues and GitHub reports, deduplicates them and proposes a severity and an owner.",
+    emoji: "🐛",
+    backgroundColor: "bg-red-100",
+    tags: ["Engineering"],
+    usage: 156,
+    feedbacks: { up: 9, down: 3 },
+    lastUpdate: "2026-08-07",
+  },
+  {
+    name: "Churn_Signal_Watcher",
+    description:
+      "Monitors usage drops across accounts and drafts a save play for the CSM with the supporting evidence.",
+    emoji: "📉",
+    backgroundColor: "bg-rose-200",
+    tags: ["GTM", "Support"],
+    usage: 42,
+    lastUpdate: "2026-06-02",
+  },
+  {
+    name: "Contract_Reviewer",
+    description:
+      "Reviews inbound MSAs and DPAs against our playbook and flags the clauses that need Legal.",
+    emoji: "⚖️",
+    backgroundColor: "bg-golden-100",
+    modelId: "claude-opus-4-7",
+    tags: ["Legal"],
+    usage: 63,
+    feedbacks: { up: 4, down: 0 },
+    lastUpdate: "2026-07-31",
+  },
+  {
+    name: "daily_standup_digest",
+    description:
+      "Compiles yesterday's merged PRs, incidents and Linear updates into one Slack digest.",
+    emoji: "☀️",
+    backgroundColor: "bg-golden-200",
+    tags: ["Engineering"],
+    usage: 311,
+    feedbacks: { up: 18, down: 1 },
+    lastUpdate: "2026-08-08",
+  },
+  {
+    name: "Deal_Desk",
+    description:
+      "Answers pricing, discounting and approval questions using the current commercial policy.",
+    emoji: "💼",
+    backgroundColor: "bg-blue-200",
+    tags: ["GTM", "Finance"],
+    usage: 128,
+    feedbacks: { up: 7, down: 2 },
+    lastUpdate: "2026-05-19",
+  },
+  {
+    name: "Design_Critique",
+    description:
+      "Gives structured feedback on a Figma frame: hierarchy, spacing, contrast and copy.",
+    emoji: "🎨",
+    backgroundColor: "bg-violet-200",
+    tags: ["Product"],
+    usage: 24,
+    lastUpdate: "2026-04-28",
+  },
+  {
+    name: "Docs_Gardener",
+    description:
+      "Finds stale internal documentation, proposes edits and opens the corresponding Notion tasks.",
+    emoji: "🪴",
+    backgroundColor: "bg-lime-100",
+    tags: ["Ops"],
+    usage: 19,
+    lastUpdate: "2026-02-24",
+  },
+  {
+    name: "Enterprise_RFP",
+    description:
+      "Drafts answers to security and procurement questionnaires from our approved answer library.",
+    emoji: "📋",
+    backgroundColor: "bg-blue-100",
+    modelId: "gpt-5-2",
+    tags: ["GTM", "Security"],
+    usage: 71,
+    feedbacks: { up: 5, down: 1 },
+    lastUpdate: "2026-07-06",
+  },
+  {
+    name: "Expense_Checker",
+    description:
+      "Checks submitted expenses against the travel policy and flags the ones that need a manager review.",
+    emoji: "🧾",
+    backgroundColor: "bg-green-100",
+    tags: ["Finance"],
+    usage: 33,
+    lastUpdate: "2026-01-16",
+  },
+  {
+    name: "Incident_Commander",
+    description:
+      "Runs the incident checklist, keeps the status page updated and drafts the post-mortem skeleton.",
+    emoji: "🚨",
+    backgroundColor: "bg-red-100",
+    modelId: "claude-opus-4-7",
+    tags: ["Engineering", "Ops"],
+    usage: 47,
+    feedbacks: { up: 8, down: 0 },
+    lastUpdate: "2026-08-01",
+  },
+  {
+    name: "Interview_Debrief",
+    description:
+      "Turns raw interview notes into a structured debrief with evidence for each competency.",
+    emoji: "🗣",
+    backgroundColor: "bg-pink-100",
+    tags: ["Talent"],
+    usage: 58,
+    lastUpdate: "2026-06-17",
+  },
+  {
+    name: "Knowledge_Search",
+    description:
+      "Searches every connected source at once and answers with citations you can open.",
+    emoji: "🔎",
+    backgroundColor: "bg-blue-200",
+    tags: ["Company"],
+    usage: 903,
+    feedbacks: { up: 41, down: 6 },
+    lastUpdate: "2026-08-09",
+  },
+  {
+    name: "Localization_Buddy",
+    description:
+      "Translates product copy and keeps the glossary consistent across locales.",
+    emoji: "🌍",
+    backgroundColor: "bg-green-200",
+    modelId: "gemini-3-pro",
+    tags: ["Product", "Marketing"],
+    usage: 66,
+    lastUpdate: "2026-03-12",
+  },
+  {
+    name: "meeting_notes_to_crm",
+    description:
+      "Extracts next steps, MEDDIC fields and risks from a call transcript and writes them back to HubSpot.",
+    emoji: "📝",
+    backgroundColor: "bg-golden-100",
+    tags: ["GTM"],
+    usage: 187,
+    feedbacks: { up: 12, down: 4 },
+    lastUpdate: "2026-07-22",
+  },
+  {
+    name: "Onboarding_Buddy",
+    description:
+      "Answers the questions new joiners are afraid to ask, from payroll to the coffee machine.",
+    emoji: "🐣",
+    backgroundColor: "bg-golden-200",
+    tags: ["People"],
+    usage: 145,
+    feedbacks: { up: 10, down: 0 },
+    lastUpdate: "2026-05-05",
+  },
+  {
+    name: "PR_Reviewer",
+    description:
+      "Reviews a pull request against our coding rules and comments only on what actually matters.",
+    emoji: "🧑‍💻",
+    backgroundColor: "bg-violet-100",
+    modelId: "claude-opus-4-7",
+    tags: ["Engineering"],
+    usage: 421,
+    feedbacks: { up: 27, down: 5 },
+    lastUpdate: "2026-08-06",
+  },
+  {
+    name: "Pricing_Analyst",
+    description:
+      "Models the revenue impact of a pricing change and explains the assumptions behind it.",
+    emoji: "💰",
+    backgroundColor: "bg-lime-100",
+    modelId: "claude-opus-4-6",
+    tags: ["Finance", "Product"],
+    usage: 29,
+    lastUpdate: "2026-04-02",
+  },
+  {
+    name: "Release_Notes_Writer",
+    description:
+      "Turns merged PRs into customer-facing release notes in our tone of voice.",
+    emoji: "📣",
+    backgroundColor: "bg-blue-100",
+    tags: ["Product", "Marketing"],
+    usage: 94,
+    feedbacks: { up: 6, down: 1 },
+    lastUpdate: "2026-07-14",
+  },
+  {
+    name: "Security_Questionnaire",
+    description:
+      "Answers vendor security reviews using the trust center and escalates anything unanswered.",
+    emoji: "🛡",
+    backgroundColor: "bg-red-100",
+    tags: ["Security", "Legal"],
+    usage: 38,
+    lastUpdate: "2026-06-25",
+  },
+  {
+    name: "Slack_Summarizer",
+    description:
+      "Summarizes a busy channel or a long thread into the three things you actually need to know.",
+    emoji: "💬",
+    backgroundColor: "bg-green-100",
+    modelId: "claude-haiku-4-5",
+    tags: ["Company"],
+    usage: 652,
+    feedbacks: { up: 33, down: 8 },
+    lastUpdate: "2026-08-04",
+  },
+  {
+    name: "Support_Triage",
+    description:
+      "Classifies inbound Zendesk tickets, drafts a first reply and routes the hard ones to a human.",
+    emoji: "🎧",
+    backgroundColor: "bg-blue-200",
+    tags: ["Support"],
+    usage: 388,
+    feedbacks: { up: 21, down: 9 },
+    lastUpdate: "2026-08-02",
+  },
+  {
+    name: "weekly_business_review",
+    description:
+      "Assembles the weekly metrics pack and writes the narrative around the numbers.",
+    emoji: "📈",
+    backgroundColor: "bg-violet-200",
+    modelId: "claude-opus-4-6",
+    tags: ["Data", "Company"],
+    usage: 76,
+    feedbacks: { up: 5, down: 0 },
+    lastUpdate: "2026-08-10",
+  },
+  {
+    name: "Zendesk_Macro_Writer",
+    description:
+      "Proposes new macros based on the tickets that keep coming back.",
+    emoji: "🧰",
+    backgroundColor: "bg-golden-100",
+    tags: ["Support"],
+    usage: 11,
+    lastUpdate: "2026-01-29",
+  },
+];
+
+// ── Generated agents ──────────────────────────────────────────────────────────
+
+const NAME_DOMAINS = [
+  "Account",
+  "Analytics",
+  "Billing",
+  "Campaign",
+  "Candidate",
+  "Changelog",
+  "Compliance",
+  "Content",
+  "Customer",
+  "Dashboard",
+  "Data",
+  "Demo",
+  "Doc",
+  "Email",
+  "Escalation",
+  "Feedback",
+  "Forecast",
+  "Growth",
+  "Hiring",
+  "Incident",
+  "Insight",
+  "Invoice",
+  "Lead",
+  "Legal",
+  "Meeting",
+  "Metrics",
+  "Onboarding",
+  "Outbound",
+  "Partner",
+  "Payroll",
+  "Pipeline",
+  "Playbook",
+  "Podcast",
+  "Pricing",
+  "Product",
+  "Prospect",
+  "Quality",
+  "Recruiting",
+  "Release",
+  "Renewal",
+  "Report",
+  "Research",
+  "Revenue",
+  "Roadmap",
+  "Runbook",
+  "Sales",
+  "Security",
+  "Sprint",
+  "Support",
+  "Survey",
+  "Ticket",
+  "Training",
+  "Usage",
+  "Vendor",
+  "Webinar",
+];
+
+const NAME_ROLES = [
+  "Agent",
+  "Analyst",
+  "Assistant",
+  "Auditor",
+  "Bot",
+  "Builder",
+  "Checker",
+  "Coach",
+  "Copilot",
+  "Digest",
+  "Drafter",
+  "Expert",
+  "Extractor",
+  "Finder",
+  "Generator",
+  "Helper",
+  "Monitor",
+  "Navigator",
+  "Reviewer",
+  "Scout",
+  "Summarizer",
+  "Tracker",
+  "Triage",
+  "Writer",
+];
+
+const DESCRIPTION_TEMPLATES = [
+  (domain: string, role: string) =>
+    `${domain} ${role.toLowerCase()}: pulls the relevant context from connected sources and returns a structured answer.`,
+  (domain: string) =>
+    `Drafts ${domain.toLowerCase()} updates for the team and posts them to the right Slack channel.`,
+  (domain: string) =>
+    `Answers ${domain.toLowerCase()} questions using our internal documentation, with citations.`,
+  (domain: string) =>
+    `Watches ${domain.toLowerCase()} data and flags anything that looks off before it becomes a problem.`,
+  (domain: string, role: string) =>
+    `Turns raw ${domain.toLowerCase()} notes into a clean ${role.toLowerCase()} output ready to share.`,
+  (domain: string) =>
+    `Runs the weekly ${domain.toLowerCase()} review and highlights what changed since last week.`,
+  (domain: string) =>
+    `Extracts ${domain.toLowerCase()} fields from documents and writes them back to the source of truth.`,
+  (domain: string) =>
+    `Helps the team move faster on ${domain.toLowerCase()} by removing the copy-paste work.`,
+];
+
+const NAME_STYLES = ["pascal", "snake", "kebab", "spaced"] as const;
+
+function styleName(
+  domain: string,
+  role: string,
+  style: (typeof NAME_STYLES)[number]
+): string {
+  switch (style) {
+    case "pascal":
+      return `${domain}${role}`;
+    case "snake":
+      return `${domain.toLowerCase()}_${role.toLowerCase()}`;
+    case "kebab":
+      return `${domain}-${role}`;
+    default:
+      return `${domain}_${role}`;
+  }
+}
+
+function pick<T>(random: () => number, items: T[]): T {
+  return items[Math.floor(random() * items.length)];
+}
+
+function pickModelId(random: () => number): string {
+  const total = MODEL_WEIGHTS.reduce((sum, m) => sum + m.weight, 0);
+  let threshold = random() * total;
+  for (const entry of MODEL_WEIGHTS) {
+    threshold -= entry.weight;
+    if (threshold <= 0) {
+      return entry.modelId;
+    }
+  }
+  return MODEL_WEIGHTS[0].modelId;
+}
+
+function pickEditors(random: () => number, count: number): AgentEditor[] {
+  const editors: AgentEditor[] = [];
+  const used = new Set<string>();
+  while (editors.length < count) {
+    const editor = pick(random, EDITOR_POOL);
+    if (!used.has(editor.sId)) {
+      used.add(editor.sId);
+      editors.push(editor);
+    }
+  }
+  return editors;
+}
+
+const NOW_MS = new Date("2026-08-10T10:00:00Z").getTime();
+const FOURTEEN_MONTHS_MS = 425 * 24 * 60 * 60 * 1000;
+
+// ── Global (Dust-provided) agents ─────────────────────────────────────────────
+
+const GLOBAL_AGENTS: {
+  name: string;
+  description: string;
+  modelId: string;
+  emoji: string;
+  backgroundColor: string;
+}[] = [
+  {
+    name: "dust",
+    description:
+      "An agent with context on your company data. Use it to search across every connected source.",
+    modelId: "auto",
+    emoji: "🐦‍⬛",
+    backgroundColor: "bg-primary-200",
+  },
+  {
+    name: "claude-sonnet-4-6",
+    description: "Anthropic's Claude Sonnet 4.6 model.",
+    modelId: "claude-sonnet-4-6",
+    emoji: "🧠",
+    backgroundColor: "bg-golden-100",
+  },
+  {
+    name: "claude-opus-4-6",
+    description: "Anthropic's Claude Opus 4.6 model.",
+    modelId: "claude-opus-4-6",
+    emoji: "🧠",
+    backgroundColor: "bg-golden-200",
+  },
+  {
+    name: "claude-opus-4-7",
+    description: "Anthropic's most capable model.",
+    modelId: "claude-opus-4-7",
+    emoji: "🧠",
+    backgroundColor: "bg-golden-200",
+  },
+  {
+    name: "claude-haiku-4-5",
+    description: "Anthropic's fastest model.",
+    modelId: "claude-haiku-4-5",
+    emoji: "🍃",
+    backgroundColor: "bg-lime-100",
+  },
+  {
+    name: "gpt-5-2",
+    description: "OpenAI's GPT-5.2 model.",
+    modelId: "gpt-5-2",
+    emoji: "🌀",
+    backgroundColor: "bg-green-100",
+  },
+  {
+    name: "gpt-5-2-mini",
+    description: "OpenAI's smaller, faster GPT-5.2 model.",
+    modelId: "gpt-5-2-mini",
+    emoji: "🌀",
+    backgroundColor: "bg-green-200",
+  },
+  {
+    name: "o4",
+    description: "OpenAI's reasoning model.",
+    modelId: "o4",
+    emoji: "🧮",
+    backgroundColor: "bg-green-100",
+  },
+  {
+    name: "gemini-3-pro",
+    description: "Google's Gemini 3 Pro model.",
+    modelId: "gemini-3-pro",
+    emoji: "♊️",
+    backgroundColor: "bg-blue-100",
+  },
+  {
+    name: "gemini-3-flash",
+    description: "Google's fast Gemini 3 Flash model.",
+    modelId: "gemini-3-flash",
+    emoji: "⚡️",
+    backgroundColor: "bg-blue-200",
+  },
+  {
+    name: "mistral-large-3",
+    description: "Mistral's large model.",
+    modelId: "mistral-large-3",
+    emoji: "🇪🇺",
+    backgroundColor: "bg-golden-100",
+  },
+  {
+    name: "deepseek-v4",
+    description: "DeepSeek's V4 model.",
+    modelId: "deepseek-v4",
+    emoji: "🐋",
+    backgroundColor: "bg-blue-100",
+  },
+  {
+    name: "grok-5",
+    description: "xAI's Grok 5 model.",
+    modelId: "grok-5",
+    emoji: "🛸",
+    backgroundColor: "bg-primary-200",
+  },
+  {
+    name: "help",
+    description: "Help on how to use Dust.",
+    modelId: "claude-sonnet-4-6",
+    emoji: "🙋",
+    backgroundColor: "bg-blue-100",
+  },
+  {
+    name: "notion",
+    description: "An agent with context on your Notion Data.",
+    modelId: "claude-sonnet-4-6",
+    emoji: "📓",
+    backgroundColor: "bg-primary-200",
+  },
+  {
+    name: "slack",
+    description: "An agent with context on your Slack Data.",
+    modelId: "claude-sonnet-4-6",
+    emoji: "💬",
+    backgroundColor: "bg-violet-100",
+  },
+  {
+    name: "googledrive",
+    description: "An agent with context on your Google Drive Data.",
+    modelId: "claude-sonnet-4-6",
+    emoji: "📁",
+    backgroundColor: "bg-golden-100",
+  },
+  {
+    name: "github",
+    description: "An agent with context on your GitHub Data.",
+    modelId: "claude-sonnet-4-6",
+    emoji: "🐙",
+    backgroundColor: "bg-primary-200",
+  },
+  {
+    name: "intercom",
+    description: "An agent with context on your Intercom Data.",
+    modelId: "claude-sonnet-4-6",
+    emoji: "💠",
+    backgroundColor: "bg-blue-200",
+  },
+  {
+    name: "confluence",
+    description: "An agent with context on your Confluence Data.",
+    modelId: "claude-sonnet-4-6",
+    emoji: "🌐",
+    backgroundColor: "bg-blue-100",
+  },
+];
+
+const GLOBAL_CONNECTOR_FILLERS = [
+  "salesforce",
+  "hubspot",
+  "zendesk",
+  "jira",
+  "linear",
+  "gong",
+  "snowflake",
+  "bigquery",
+  "microsoft",
+  "sharepoint",
+  "onedrive",
+  "outlook",
+  "gmail",
+  "gcal",
+  "asana",
+  "monday",
+  "figma",
+  "gitlab",
+  "sentry",
+  "datadog",
+  "pagerduty",
+  "stripe",
+  "netsuite",
+  "workday",
+  "greenhouse",
+  "ashby",
+  "lever",
+  "notiondb",
+  "airtable",
+  "dropbox",
+  "box",
+  "webcrawler",
+  "websearch",
+  "browse",
+  "image",
+];
+
+// ── Assembly ──────────────────────────────────────────────────────────────────
+
+const TOTAL_CUSTOM_AGENTS = 382;
+const TOTAL_EDITABLE_BY_ME = 42;
+const TOTAL_ARCHIVED_AGENTS = 14;
+
+function buildCustomAgents(): ManagedAgent[] {
+  const random = createRandom(20260810);
+  const agents: ManagedAgent[] = [];
+
+  for (const [index, curated] of CURATED_AGENTS.entries()) {
+    agents.push({
+      sId: `agent_curated_${index}`,
+      name: curated.name,
+      description: curated.description,
+      emoji: curated.emoji,
+      backgroundColor: curated.backgroundColor,
+      scope: curated.scope ?? "visible",
+      status: "active",
+      modelId: curated.modelId ?? "claude-sonnet-4-6",
+      editors: pickEditors(random, 1 + Math.floor(random() * 3)),
+      tags: tagsFor(curated.tags ?? []),
+      usage: {
+        messageCount: curated.usage,
+        timePeriodSec: AGENT_USAGE_PERIOD_SEC,
+      },
+      feedbacks: curated.feedbacks ?? { up: 0, down: 0 },
+      lastUpdate: new Date(`${curated.lastUpdate}T09:12:00Z`).getTime(),
+      canEdit: curated.canEdit ?? false,
+    });
+  }
+
+  let index = 0;
+  while (agents.length < TOTAL_CUSTOM_AGENTS) {
+    const domain = pick(random, NAME_DOMAINS);
+    const role = pick(random, NAME_ROLES);
+    const style = pick(random, [...NAME_STYLES]);
+    const name = styleName(domain, role, style);
+
+    if (agents.some((agent) => agent.name === name)) {
+      index += 1;
+      continue;
+    }
+
+    const template = pick(random, DESCRIPTION_TEMPLATES);
+    // Long tail: most agents are barely used, a few carry the workspace.
+    const usageRoll = random();
+    const messageCount =
+      usageRoll < 0.45
+        ? Math.floor(random() * 5)
+        : usageRoll < 0.85
+          ? Math.floor(random() * 60)
+          : Math.floor(random() * 900);
+    const feedbackCount =
+      messageCount > 50 ? Math.floor(random() * 14) : Math.floor(random() * 2);
+
+    agents.push({
+      sId: `agent_gen_${index}`,
+      name,
+      description: template(domain, role),
+      emoji: pick(random, AVATAR_EMOJIS),
+      backgroundColor: pick(random, AVATAR_BACKGROUNDS),
+      // A minority of agents never got published.
+      scope: random() < 0.12 ? "hidden" : "visible",
+      status: "active",
+      modelId: pickModelId(random),
+      editors: pickEditors(random, 1 + Math.floor(random() * 4)),
+      tags:
+        random() < 0.45
+          ? tagsFor([pick(random, AGENT_TAGS).name]).concat(
+              random() < 0.2 ? tagsFor([pick(random, AGENT_TAGS).name]) : []
+            )
+          : [],
+      usage: { messageCount, timePeriodSec: AGENT_USAGE_PERIOD_SEC },
+      feedbacks: {
+        up: Math.ceil(feedbackCount * 0.75),
+        down: Math.floor(feedbackCount * 0.25),
+      },
+      lastUpdate: NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS),
+      canEdit: false,
+    });
+    index += 1;
+  }
+
+  // Deduplicate tags introduced by the double-tag roll above.
+  for (const agent of agents) {
+    const seen = new Set<string>();
+    agent.tags = agent.tags.filter((tag) => {
+      if (seen.has(tag.sId)) {
+        return false;
+      }
+      seen.add(tag.sId);
+      return true;
+    });
+  }
+
+  // The current user edits a fixed slice of the workspace.
+  const editableRandom = createRandom(4242);
+  const editableIndexes = new Set<number>();
+  while (editableIndexes.size < TOTAL_EDITABLE_BY_ME) {
+    editableIndexes.add(Math.floor(editableRandom() * agents.length));
+  }
+  for (const editableIndex of editableIndexes) {
+    const agent = agents[editableIndex];
+    agent.canEdit = true;
+    if (!agent.editors.some((editor) => editor.sId === CURRENT_USER.sId)) {
+      agent.editors = [CURRENT_USER, ...agent.editors].slice(0, 4);
+    }
+  }
+
+  return agents;
+}
+
+function buildGlobalAgents(): ManagedAgent[] {
+  const random = createRandom(777);
+  const agents: ManagedAgent[] = GLOBAL_AGENTS.map((globalAgent, index) => ({
+    sId: `agent_global_${globalAgent.name}`,
+    name: globalAgent.name,
+    description: globalAgent.description,
+    emoji: globalAgent.emoji,
+    backgroundColor: globalAgent.backgroundColor,
+    scope: "global",
+    // `helper` can never be disabled, everything else can.
+    status: index % 9 === 5 ? "disabled_by_admin" : "active",
+    modelId: globalAgent.modelId,
+    editors: [],
+    tags: [],
+    usage: {
+      messageCount: Math.floor(random() * 1400),
+      timePeriodSec: AGENT_USAGE_PERIOD_SEC,
+    },
+    feedbacks: { up: 0, down: 0 },
+    lastUpdate: NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS),
+    canEdit: false,
+  }));
+
+  for (const connector of GLOBAL_CONNECTOR_FILLERS) {
+    agents.push({
+      sId: `agent_global_${connector}`,
+      name: connector,
+      description: `An agent with context on your ${connector} data.`,
+      emoji: pick(random, AVATAR_EMOJIS),
+      backgroundColor: pick(random, AVATAR_BACKGROUNDS),
+      scope: "global",
+      status: random() < 0.25 ? "disabled_missing_datasource" : "active",
+      modelId: "claude-sonnet-4-6",
+      editors: [],
+      tags: [],
+      usage: {
+        messageCount: Math.floor(random() * 300),
+        timePeriodSec: AGENT_USAGE_PERIOD_SEC,
+      },
+      feedbacks: { up: 0, down: 0 },
+      lastUpdate: NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS),
+      canEdit: false,
+    });
+  }
+
+  return agents;
+}
+
+function buildArchivedAgents(): ManagedAgent[] {
+  const random = createRandom(1312);
+  const agents: ManagedAgent[] = [];
+
+  for (let index = 0; index < TOTAL_ARCHIVED_AGENTS; index++) {
+    const domain = pick(random, NAME_DOMAINS);
+    const role = pick(random, NAME_ROLES);
+    agents.push({
+      sId: `agent_archived_${index}`,
+      name: styleName(domain, role, pick(random, [...NAME_STYLES])),
+      description: pick(random, DESCRIPTION_TEMPLATES)(domain, role),
+      emoji: pick(random, AVATAR_EMOJIS),
+      backgroundColor: pick(random, AVATAR_BACKGROUNDS),
+      scope: "visible",
+      status: "archived",
+      modelId: pickModelId(random),
+      editors: pickEditors(random, 1 + Math.floor(random() * 2)),
+      tags: random() < 0.3 ? tagsFor([pick(random, AGENT_TAGS).name]) : [],
+      usage: {
+        messageCount: Math.floor(random() * 40),
+        timePeriodSec: AGENT_USAGE_PERIOD_SEC,
+      },
+      feedbacks: { up: 0, down: 0 },
+      lastUpdate: NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS),
+      canEdit: true,
+    });
+  }
+
+  return agents;
+}
+
+export const mockManagedAgents: ManagedAgent[] = [
+  ...buildCustomAgents(),
+  ...buildGlobalAgents(),
+];
+
+export const mockArchivedAgents: ManagedAgent[] = buildArchivedAgents();

--- a/sparkle/playground/src/data/manageSkills.ts
+++ b/sparkle/playground/src/data/manageSkills.ts
@@ -1,0 +1,767 @@
+import { mockUsers } from "./users";
+
+// Mirrors `SkillWithoutInstructionsAndToolsWithRelationsType` from front,
+// reduced to what the Manage Skills table actually renders.
+
+export type SkillAvailability =
+  | "editors"
+  | "workspace_users"
+  | "users_and_agents";
+
+export const SKILL_AVAILABILITIES: SkillAvailability[] = [
+  "editors",
+  "workspace_users",
+  "users_and_agents",
+];
+
+export type SkillStatus = "active" | "archived" | "suggested";
+
+export interface SkillEditor {
+  sId: string;
+  fullName: string;
+  image?: string;
+}
+
+export interface SkillUsageAgent {
+  sId: string;
+  name: string;
+  emoji: string;
+  backgroundColor: string;
+}
+
+export interface SkillUsageSkill {
+  sId: string;
+  name: string;
+  icon: string | null;
+}
+
+export interface SkillUsage {
+  count: number;
+  agents: SkillUsageAgent[];
+  skills: SkillUsageSkill[];
+}
+
+export interface ManagedSkill {
+  sId: string;
+  name: string;
+  userFacingDescription: string;
+  icon: string | null;
+  // `null` marks a Dust-provided skill (no human editor), which is what the
+  // Dust badge on the avatar keys off.
+  editedBy: number | null;
+  availability: SkillAvailability;
+  status: SkillStatus;
+  isFavorite: boolean;
+  canAdministrate: boolean;
+  messageCount: number | null;
+  updatedAt: number;
+  createdAt: number;
+  relations: {
+    editors: SkillEditor[] | null;
+    usage: SkillUsage;
+  };
+}
+
+// Icon keys resolved to components in `skillIcons.tsx`.
+export const SKILL_ICON_KEYS = [
+  "table",
+  "document",
+  "search",
+  "lightbulb",
+  "chat",
+  "presentation",
+  "card",
+  "chart",
+  "mail",
+  "calendar",
+  "globe",
+  "rocket",
+  "scales",
+  "clipboard",
+  "grid",
+  "wand",
+  "monitor",
+  "flag",
+] as const;
+
+export type SkillIconKey = (typeof SKILL_ICON_KEYS)[number];
+
+// ── Deterministic pseudo-randomness ───────────────────────────────────────────
+
+function createRandom(seed: number) {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) % 4294967296;
+    return state / 4294967296;
+  };
+}
+
+function pick<T>(random: () => number, items: readonly T[]): T {
+  return items[Math.floor(random() * items.length)];
+}
+
+const EDITOR_POOL: SkillEditor[] = mockUsers.map((user) => ({
+  sId: user.id,
+  fullName: user.fullName,
+  image: user.portrait,
+}));
+
+export const CURRENT_SKILL_USER: SkillEditor = EDITOR_POOL[0];
+
+// The signed-in user is never picked at random, so the "Editable by me" tab
+// only counts the skills we explicitly assign to them.
+const RANDOM_EDITOR_POOL = EDITOR_POOL.slice(1);
+
+function pickEditors(random: () => number, count: number): SkillEditor[] {
+  const editors: SkillEditor[] = [];
+  const used = new Set<string>();
+  while (editors.length < count) {
+    const editor = pick(random, RANDOM_EDITOR_POOL);
+    if (!used.has(editor.sId)) {
+      used.add(editor.sId);
+      editors.push(editor);
+    }
+  }
+  return editors;
+}
+
+const NOW_MS = new Date("2026-08-10T10:00:00Z").getTime();
+const FOURTEEN_MONTHS_MS = 425 * 24 * 60 * 60 * 1000;
+
+// ── Agent and skill names used by the "Used by" dropdown ──────────────────────
+
+const USING_AGENTS: { name: string; emoji: string; backgroundColor: string }[] =
+  [
+    { name: "AccountSnapshot", emoji: "🍀", backgroundColor: "bg-golden-100" },
+    {
+      name: "Analytics_Copilot",
+      emoji: "📊",
+      backgroundColor: "bg-violet-100",
+    },
+    { name: "Bug_Triage", emoji: "🐛", backgroundColor: "bg-red-100" },
+    { name: "Content_Writer", emoji: "📝", backgroundColor: "bg-blue-100" },
+    { name: "Deal_Desk", emoji: "💼", backgroundColor: "bg-blue-200" },
+    { name: "Enterprise_RFP", emoji: "📋", backgroundColor: "bg-blue-100" },
+    { name: "Knowledge_Search", emoji: "🔎", backgroundColor: "bg-blue-200" },
+    {
+      name: "meeting_notes_to_crm",
+      emoji: "📝",
+      backgroundColor: "bg-golden-100",
+    },
+    { name: "PR_Reviewer", emoji: "🧑‍💻", backgroundColor: "bg-violet-100" },
+    {
+      name: "Release_Notes_Writer",
+      emoji: "📣",
+      backgroundColor: "bg-blue-100",
+    },
+    { name: "Support_Triage", emoji: "🎧", backgroundColor: "bg-blue-200" },
+    {
+      name: "weekly_business_review",
+      emoji: "📈",
+      backgroundColor: "bg-violet-200",
+    },
+  ];
+
+// ── Curated skills (verbatim shapes from a real workspace) ────────────────────
+
+type CuratedSkill = {
+  name: string;
+  description: string;
+  icon: SkillIconKey;
+  availability: SkillAvailability;
+  agents?: number;
+  skills?: number;
+  usage: number | null;
+  editors: number;
+  updatedAt: string;
+  isDustProvided?: boolean;
+  isFavorite?: boolean;
+};
+
+const CURATED_SKILLS: CuratedSkill[] = [
+  {
+    name: "[Agent Optimization] Create Frame",
+    description:
+      "Classifies a Dust user's builder profile into one of six types and generates personalized Wrapped card copy for the Agent Optimizer frame. Enable after the Agent Optimization skills return data.",
+    icon: "table",
+    availability: "workspace_users",
+    skills: 1,
+    usage: 120,
+    editors: 1,
+    updatedAt: "2026-08-04",
+  },
+  {
+    name: "[Agent Optimization] Get Details",
+    description:
+      "Retrieves full metadata of a Dust agent, including config, usage, and active triggers.",
+    icon: "search",
+    availability: "workspace_users",
+    skills: 1,
+    usage: 101,
+    editors: 1,
+    updatedAt: "2026-08-04",
+  },
+  {
+    name: "[Agent Optimization] Get recommendation",
+    description:
+      "Audit a Dust agent's configuration and produce actionable optimization recommendations on model choice, instructions quality, architecture, capabilities, and knowledge — covering both quality and cost efficiency.",
+    icon: "lightbulb",
+    availability: "workspace_users",
+    skills: 1,
+    usage: 57,
+    editors: 1,
+    updatedAt: "2026-07-22",
+  },
+  {
+    name: "[Agent Optimization] Master Skill",
+    description: "Master Skill for Agent Optimization Pipeline",
+    icon: "search",
+    availability: "workspace_users",
+    usage: 69,
+    editors: 4,
+    updatedAt: "2026-08-04",
+  },
+  {
+    name: "[Area Lead] Team Weekly Presentation",
+    description:
+      "Builds a branded weekly presentation frame for your area using the team template.",
+    icon: "presentation",
+    availability: "workspace_users",
+    agents: 4,
+    usage: 505,
+    editors: 2,
+    updatedAt: "2026-06-18",
+  },
+  {
+    name: "[Comms] Panel Prep",
+    description:
+      "Create a panel prep document ahead of a conference where a public speaker representing the company is participating",
+    icon: "chat",
+    availability: "workspace_users",
+    usage: 3,
+    editors: 1,
+    updatedAt: "2026-07-09",
+  },
+  {
+    name: "[Community] Workshop Facilitator",
+    description:
+      "Helps plan and run technical workshops for engineer audiences at customer sites.",
+    icon: "chat",
+    availability: "workspace_users",
+    usage: 4,
+    editors: 1,
+    updatedAt: "2026-06-25",
+  },
+  {
+    name: "[Content] AI-generated detector",
+    description:
+      "Rates written content on how human or AI-generated it reads, with flagged quotes and fix recommendations.",
+    icon: "search",
+    availability: "users_and_agents",
+    agents: 4,
+    usage: 411,
+    editors: 2,
+    updatedAt: "2026-07-30",
+  },
+  {
+    name: "[Content] Dust style guide",
+    description:
+      "Apply Dust's writing style and tone of voice standards to any external content — blogs, web copy, white papers, emails, and more.",
+    icon: "document",
+    availability: "users_and_agents",
+    agents: 4,
+    usage: 1873,
+    editors: 3,
+    updatedAt: "2026-08-07",
+    isFavorite: true,
+  },
+  {
+    name: "[Content] Review blog or customer story",
+    description:
+      "Reviews blog posts and customer stories from the perspective of a skeptical B2B buyer. Checks length, title, opening, structure, AI signal patterns, language, formatting, credibility, and factual accuracy. Returns a scorecard plus prioritized fixes.",
+    icon: "document",
+    availability: "users_and_agents",
+    agents: 1,
+    usage: 43,
+    editors: 1,
+    updatedAt: "2026-08-01",
+  },
+  {
+    name: "[Content] Technical blog post",
+    description:
+      "Reviews technical engineering blog drafts with prioritized, quoted feedback through six credibility lenses.",
+    icon: "search",
+    availability: "users_and_agents",
+    usage: 5,
+    editors: 1,
+    updatedAt: "2026-07-15",
+  },
+  {
+    name: "[CS] Business Review",
+    description:
+      "Generates an interactive Business Review Frame for a customer. Covers 6 tabs: Review Objectives, Adoption & Metrics, ROI Analysis, Governance, Action Plan, and Product Roadmap.",
+    icon: "presentation",
+    availability: "users_and_agents",
+    usage: 134,
+    editors: 1,
+    updatedAt: "2026-08-05",
+  },
+  {
+    name: "[CS] Customer Handoff",
+    description:
+      "Extracts and documents key account information from sales calls, demos, and discovery notes to produce a structured Customer Success handoff in Notion, then adds a HubSpot note and prompts for intro emails.",
+    icon: "document",
+    availability: "users_and_agents",
+    skills: 1,
+    usage: 56,
+    editors: 1,
+    updatedAt: "2026-07-28",
+  },
+  {
+    name: "[CS] Handoff Readiness Check",
+    description:
+      "Run before any Sales-to-CS handoff to verify all Pre-Sales signal is captured. Flags missing inputs, blocks premature handovers, and drafts AE/SE follow-ups for gaps.",
+    icon: "card",
+    availability: "workspace_users",
+    usage: 3,
+    editors: 2,
+    updatedAt: "2026-07-03",
+  },
+  {
+    name: "[CS] Kick-off",
+    description:
+      "Prepares the customer kick-off: agenda, success criteria, stakeholder map and the follow-up recap.",
+    icon: "rocket",
+    availability: "users_and_agents",
+    skills: 1,
+    usage: 157,
+    editors: 1,
+    updatedAt: "2026-07-21",
+  },
+  {
+    name: "[Data] Warehouse query",
+    description:
+      "Writes and runs SQL against the warehouse, then explains the result and the assumptions behind it.",
+    icon: "table",
+    availability: "users_and_agents",
+    agents: 7,
+    usage: 2410,
+    editors: 2,
+    updatedAt: "2026-08-09",
+    isFavorite: true,
+  },
+  {
+    name: "[Finance] Invoice extraction",
+    description:
+      "Extracts amounts, dates and payment terms from PDF invoices into a normalized structure.",
+    icon: "card",
+    availability: "workspace_users",
+    agents: 2,
+    usage: 318,
+    editors: 1,
+    updatedAt: "2026-06-30",
+  },
+  {
+    name: "[GTM] Account research",
+    description:
+      "Builds a one-page account brief from public sources, the CRM and past conversations.",
+    icon: "globe",
+    availability: "users_and_agents",
+    agents: 9,
+    skills: 2,
+    usage: 1642,
+    editors: 3,
+    updatedAt: "2026-08-08",
+  },
+  {
+    name: "[Legal] Clause playbook",
+    description:
+      "Compares a contract clause to our standard position and suggests the fallback language.",
+    icon: "scales",
+    availability: "editors",
+    usage: 27,
+    editors: 2,
+    updatedAt: "2026-05-14",
+  },
+  {
+    name: "[People] Interview scorecard",
+    description:
+      "Turns interview notes into a structured scorecard with evidence per competency.",
+    icon: "clipboard",
+    availability: "workspace_users",
+    agents: 3,
+    usage: 209,
+    editors: 2,
+    updatedAt: "2026-07-17",
+  },
+  {
+    name: "Search company knowledge",
+    description:
+      "Searches every connected data source and returns the passages that answer the question, with citations.",
+    icon: "search",
+    availability: "users_and_agents",
+    agents: 12,
+    skills: 4,
+    usage: null,
+    editors: 0,
+    updatedAt: "2026-08-10",
+    isDustProvided: true,
+  },
+  {
+    name: "Browse the web",
+    description:
+      "Opens a URL and extracts its readable content so an agent can reason over it.",
+    icon: "globe",
+    availability: "users_and_agents",
+    agents: 15,
+    usage: null,
+    editors: 0,
+    updatedAt: "2026-08-10",
+    isDustProvided: true,
+  },
+  {
+    name: "Create a Frame",
+    description:
+      "Builds an interactive frame — dashboards, reports, mini-apps — from data an agent already has.",
+    icon: "grid",
+    availability: "users_and_agents",
+    agents: 8,
+    skills: 3,
+    usage: null,
+    editors: 0,
+    updatedAt: "2026-08-10",
+    isDustProvided: true,
+  },
+  {
+    name: "Run agent",
+    description:
+      "Delegates a sub-task to another agent and returns its answer.",
+    icon: "wand",
+    availability: "users_and_agents",
+    agents: 6,
+    skills: 5,
+    usage: null,
+    editors: 0,
+    updatedAt: "2026-08-10",
+    isDustProvided: true,
+  },
+];
+
+// ── Generated skills ──────────────────────────────────────────────────────────
+
+const SKILL_AREAS = [
+  "Analytics",
+  "Brand",
+  "Comms",
+  "Community",
+  "Content",
+  "CS",
+  "Data",
+  "Design",
+  "Eng",
+  "Finance",
+  "GTM",
+  "Growth",
+  "Legal",
+  "Marketing",
+  "Ops",
+  "People",
+  "Partnerships",
+  "Product",
+  "RevOps",
+  "Sales",
+  "Security",
+  "Support",
+  "Talent",
+];
+
+const SKILL_SUBJECTS = [
+  "Account brief",
+  "Battlecard lookup",
+  "Bug reproduction",
+  "Campaign brief",
+  "Changelog draft",
+  "Churn analysis",
+  "Competitive scan",
+  "Compliance check",
+  "Customer quote finder",
+  "Deal review",
+  "Doc summarizer",
+  "Email draft",
+  "Escalation summary",
+  "Feedback digest",
+  "Forecast rollup",
+  "Headcount plan",
+  "Incident timeline",
+  "Interview debrief",
+  "Invoice lookup",
+  "KPI snapshot",
+  "Lead enrichment",
+  "Meeting recap",
+  "Metrics pack",
+  "Onboarding checklist",
+  "Persona research",
+  "Pipeline hygiene",
+  "Pricing simulation",
+  "Product brief",
+  "Prospect list",
+  "Quarterly review",
+  "Release checklist",
+  "Renewal risk",
+  "Roadmap update",
+  "Runbook lookup",
+  "Sales objection",
+  "SEO audit",
+  "Slack digest",
+  "Survey analysis",
+  "Ticket clustering",
+  "Training plan",
+  "Usage report",
+  "Vendor review",
+  "Webinar recap",
+];
+
+const SKILL_DESCRIPTION_TEMPLATES = [
+  (subject: string) =>
+    `Produces a ${subject.toLowerCase()} from the connected sources, formatted so it can be pasted straight into the doc.`,
+  (subject: string) =>
+    `Runs the ${subject.toLowerCase()} workflow end to end and returns the result with the sources it used.`,
+  (subject: string) =>
+    `Standardizes how we do ${subject.toLowerCase()} so every agent produces the same shape of output.`,
+  (subject: string) =>
+    `Collects the inputs needed for a ${subject.toLowerCase()}, flags what's missing, and drafts the rest.`,
+  (subject: string) =>
+    `Reusable instructions and tools for ${subject.toLowerCase()}, maintained by the owning team.`,
+];
+
+const AVAILABILITY_WEIGHTS: {
+  availability: SkillAvailability;
+  weight: number;
+}[] = [
+  { availability: "workspace_users", weight: 52 },
+  { availability: "users_and_agents", weight: 34 },
+  { availability: "editors", weight: 14 },
+];
+
+function pickAvailability(random: () => number): SkillAvailability {
+  const total = AVAILABILITY_WEIGHTS.reduce((sum, a) => sum + a.weight, 0);
+  let threshold = random() * total;
+  for (const entry of AVAILABILITY_WEIGHTS) {
+    threshold -= entry.weight;
+    if (threshold <= 0) {
+      return entry.availability;
+    }
+  }
+  return "workspace_users";
+}
+
+const TOTAL_ACTIVE_SKILLS = 543;
+const TOTAL_EDITABLE_BY_ME = 1;
+const TOTAL_ARCHIVED_SKILLS = 23;
+const TOTAL_SUGGESTED_SKILLS = 3;
+
+function buildUsage(
+  random: () => number,
+  agentCount: number,
+  skillCount: number,
+  allSkillNames: string[]
+): SkillUsage {
+  const agents: SkillUsageAgent[] = [];
+  for (let index = 0; index < agentCount; index++) {
+    const agent = pick(random, USING_AGENTS);
+    agents.push({
+      sId: `agent_use_${index}_${Math.floor(random() * 100000)}`,
+      name: agent.name,
+      emoji: agent.emoji,
+      backgroundColor: agent.backgroundColor,
+    });
+  }
+  const skills: SkillUsageSkill[] = [];
+  for (let index = 0; index < skillCount; index++) {
+    skills.push({
+      sId: `skill_use_${index}_${Math.floor(random() * 100000)}`,
+      name: pick(random, allSkillNames),
+      icon: pick(random, SKILL_ICON_KEYS),
+    });
+  }
+  return { count: agentCount + skillCount, agents, skills };
+}
+
+function buildActiveSkills(): ManagedSkill[] {
+  const random = createRandom(20260811);
+  const skills: ManagedSkill[] = [];
+  const curatedNames = CURATED_SKILLS.map((skill) => skill.name);
+
+  for (const [index, curated] of CURATED_SKILLS.entries()) {
+    const isDustProvided = curated.isDustProvided ?? false;
+    skills.push({
+      sId: `skill_curated_${index}`,
+      name: curated.name,
+      userFacingDescription: curated.description,
+      icon: curated.icon,
+      editedBy: isDustProvided ? null : 1,
+      availability: curated.availability,
+      status: "active",
+      isFavorite: curated.isFavorite ?? false,
+      canAdministrate: !isDustProvided,
+      messageCount: curated.usage,
+      updatedAt: new Date(`${curated.updatedAt}T14:32:00Z`).getTime(),
+      createdAt: new Date(`${curated.updatedAt}T14:32:00Z`).getTime() - 6e9,
+      relations: {
+        editors: isDustProvided
+          ? null
+          : pickEditors(random, Math.max(curated.editors, 1)),
+        usage: buildUsage(
+          random,
+          curated.agents ?? 0,
+          curated.skills ?? 0,
+          curatedNames
+        ),
+      },
+    });
+  }
+
+  let index = 0;
+  while (skills.length < TOTAL_ACTIVE_SKILLS) {
+    const area = pick(random, SKILL_AREAS);
+    const subject = pick(random, SKILL_SUBJECTS);
+    const name = `[${area}] ${subject}`;
+
+    if (skills.some((skill) => skill.name === name)) {
+      index += 1;
+      continue;
+    }
+
+    const usageRoll = random();
+    const messageCount =
+      usageRoll < 0.4
+        ? Math.floor(random() * 10)
+        : usageRoll < 0.85
+          ? Math.floor(random() * 200)
+          : Math.floor(random() * 2500);
+
+    const updatedAt = NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS);
+
+    skills.push({
+      sId: `skill_gen_${index}`,
+      name,
+      userFacingDescription: pick(random, SKILL_DESCRIPTION_TEMPLATES)(subject),
+      icon: pick(random, SKILL_ICON_KEYS),
+      editedBy: 1,
+      availability: pickAvailability(random),
+      status: "active",
+      isFavorite: false,
+      canAdministrate: random() < 0.35,
+      messageCount,
+      updatedAt,
+      createdAt: updatedAt - Math.floor(random() * 1e10),
+      relations: {
+        editors: pickEditors(random, 1 + Math.floor(random() * 4)),
+        usage: buildUsage(
+          random,
+          random() < 0.55 ? Math.floor(random() * 8) : 0,
+          random() < 0.2 ? 1 + Math.floor(random() * 3) : 0,
+          curatedNames
+        ),
+      },
+    });
+    index += 1;
+  }
+
+  // The current user only edits a handful of skills.
+  const editable = skills.filter((skill) => skill.editedBy !== null);
+  for (let i = 0; i < TOTAL_EDITABLE_BY_ME; i++) {
+    const skill = editable[i * 37];
+    skill.relations.editors = [
+      CURRENT_SKILL_USER,
+      ...(skill.relations.editors ?? []),
+    ].slice(0, 4);
+    skill.canAdministrate = true;
+  }
+
+  return skills;
+}
+
+function buildArchivedSkills(): ManagedSkill[] {
+  const random = createRandom(99);
+  const skills: ManagedSkill[] = [];
+
+  for (let index = 0; index < TOTAL_ARCHIVED_SKILLS; index++) {
+    const area = pick(random, SKILL_AREAS);
+    const subject = pick(random, SKILL_SUBJECTS);
+    const updatedAt = NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS);
+    skills.push({
+      sId: `skill_archived_${index}`,
+      name: `[${area}] ${subject}`,
+      userFacingDescription: pick(random, SKILL_DESCRIPTION_TEMPLATES)(subject),
+      icon: pick(random, SKILL_ICON_KEYS),
+      editedBy: 1,
+      availability: pickAvailability(random),
+      status: "archived",
+      isFavorite: false,
+      canAdministrate: true,
+      messageCount: Math.floor(random() * 80),
+      updatedAt,
+      createdAt: updatedAt - 5e9,
+      relations: {
+        editors: pickEditors(random, 1 + Math.floor(random() * 2)),
+        usage: { count: 0, agents: [], skills: [] },
+      },
+    });
+  }
+
+  return skills;
+}
+
+function buildSuggestedSkills(): ManagedSkill[] {
+  const random = createRandom(555);
+  const suggestions: {
+    name: string;
+    description: string;
+    icon: SkillIconKey;
+  }[] = [
+    {
+      name: "[Support] Ticket clustering",
+      description:
+        "Groups the last 30 days of tickets into themes and ranks them by volume and sentiment.",
+      icon: "chart",
+    },
+    {
+      name: "[Marketing] SEO audit",
+      description:
+        "Audits a page for structure, internal links and keyword coverage, then lists the fixes in order.",
+      icon: "globe",
+    },
+    {
+      name: "[Eng] Runbook lookup",
+      description:
+        "Finds the right runbook for an alert and walks through the steps with the current context.",
+      icon: "monitor",
+    },
+  ];
+
+  return suggestions
+    .slice(0, TOTAL_SUGGESTED_SKILLS)
+    .map((suggestion, index) => ({
+      sId: `skill_suggested_${index}`,
+      name: suggestion.name,
+      userFacingDescription: suggestion.description,
+      icon: suggestion.icon,
+      editedBy: 1,
+      availability: "workspace_users" as const,
+      status: "suggested" as const,
+      isFavorite: false,
+      canAdministrate: true,
+      messageCount: 0,
+      updatedAt: NOW_MS - Math.floor(random() * 1e9),
+      createdAt: NOW_MS - Math.floor(random() * 1e10),
+      relations: {
+        editors: null,
+        usage: { count: 0, agents: [], skills: [] },
+      },
+    }));
+}
+
+export const mockActiveSkills: ManagedSkill[] = buildActiveSkills();
+export const mockArchivedSkills: ManagedSkill[] = buildArchivedSkills();
+export const mockSuggestedSkills: ManagedSkill[] = buildSuggestedSkills();

--- a/sparkle/playground/src/data/manageSkills.ts
+++ b/sparkle/playground/src/data/manageSkills.ts
@@ -1,3 +1,6 @@
+import { FLEET_TOOLS } from "./fleetTools";
+import type { FleetUsage } from "./fleetUsage";
+import { EMPTY_FLEET_USAGE, makeFleetUsage } from "./fleetUsage";
 import { mockUsers } from "./users";
 
 // Mirrors `SkillWithoutInstructionsAndToolsWithRelationsType` from front,
@@ -53,7 +56,12 @@ export interface ManagedSkill {
   status: SkillStatus;
   isFavorite: boolean;
   canAdministrate: boolean;
-  messageCount: number | null;
+  // Segmented over the last 30 days, like agents. `null` for system skills,
+  // which are always active so message usage does not apply.
+  messageUsage: FleetUsage | null;
+  // MCP server view ids, see `fleetTools.ts`.
+  tools: string[];
+  lastEditedBy: SkillEditor | null;
   updatedAt: number;
   createdAt: number;
   relations: {
@@ -128,6 +136,41 @@ function pickEditors(random: () => number, count: number): SkillEditor[] {
 const NOW_MS = new Date("2026-08-10T10:00:00Z").getTime();
 const FOURTEEN_MONTHS_MS = 425 * 24 * 60 * 60 * 1000;
 
+// ── Tools ─────────────────────────────────────────────────────────────────────
+
+const TOOL_IDS = FLEET_TOOLS.map((tool) => tool.id);
+
+// Tools that make a skill a natural API/integration target.
+const API_FACING_TOOLS = new Set([
+  "salesforce",
+  "hubspot",
+  "zendesk",
+  "intercom",
+  "stripe",
+  "snowflake",
+  "bigquery",
+  "data_warehouse",
+  "extract_data",
+]);
+
+function programmaticBiasForTools(tools: string[]): number {
+  return tools.some((tool) => API_FACING_TOOLS.has(tool)) ? 0.32 : 0;
+}
+
+function pickTools(random: () => number): string[] {
+  const count = 1 + Math.floor(random() * 3);
+  const tools: string[] = [];
+  const used = new Set<string>();
+  while (tools.length < count) {
+    const tool = pick(random, TOOL_IDS);
+    if (!used.has(tool)) {
+      used.add(tool);
+      tools.push(tool);
+    }
+  }
+  return tools;
+}
+
 // ── Agent and skill names used by the "Used by" dropdown ──────────────────────
 
 const USING_AGENTS: { name: string; emoji: string; backgroundColor: string }[] =
@@ -171,6 +214,7 @@ type CuratedSkill = {
   availability: SkillAvailability;
   agents?: number;
   skills?: number;
+  tools?: string[];
   usage: number | null;
   editors: number;
   updatedAt: string;
@@ -181,6 +225,7 @@ type CuratedSkill = {
 const CURATED_SKILLS: CuratedSkill[] = [
   {
     name: "[Agent Optimization] Create Frame",
+    tools: ["frame", "run_agent"],
     description:
       "Classifies a Dust user's builder profile into one of six types and generates personalized Wrapped card copy for the Agent Optimizer frame. Enable after the Agent Optimization skills return data.",
     icon: "table",
@@ -192,6 +237,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Agent Optimization] Get Details",
+    tools: ["search", "run_agent"],
     description:
       "Retrieves full metadata of a Dust agent, including config, usage, and active triggers.",
     icon: "search",
@@ -203,6 +249,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Agent Optimization] Get recommendation",
+    tools: ["search"],
     description:
       "Audit a Dust agent's configuration and produce actionable optimization recommendations on model choice, instructions quality, architecture, capabilities, and knowledge — covering both quality and cost efficiency.",
     icon: "lightbulb",
@@ -214,6 +261,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Agent Optimization] Master Skill",
+    tools: ["run_agent", "search"],
     description: "Master Skill for Agent Optimization Pipeline",
     icon: "search",
     availability: "workspace_users",
@@ -223,6 +271,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Area Lead] Team Weekly Presentation",
+    tools: ["frame", "google_drive", "data_warehouse"],
     description:
       "Builds a branded weekly presentation frame for your area using the team template.",
     icon: "presentation",
@@ -234,6 +283,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Comms] Panel Prep",
+    tools: ["web_search", "browse", "notion"],
     description:
       "Create a panel prep document ahead of a conference where a public speaker representing the company is participating",
     icon: "chat",
@@ -244,6 +294,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Community] Workshop Facilitator",
+    tools: ["notion", "gcal"],
     description:
       "Helps plan and run technical workshops for engineer audiences at customer sites.",
     icon: "chat",
@@ -254,6 +305,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Content] AI-generated detector",
+    tools: ["search"],
     description:
       "Rates written content on how human or AI-generated it reads, with flagged quotes and fix recommendations.",
     icon: "search",
@@ -265,6 +317,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Content] Dust style guide",
+    tools: ["notion", "search"],
     description:
       "Apply Dust's writing style and tone of voice standards to any external content — blogs, web copy, white papers, emails, and more.",
     icon: "document",
@@ -277,6 +330,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Content] Review blog or customer story",
+    tools: ["browse", "search"],
     description:
       "Reviews blog posts and customer stories from the perspective of a skeptical B2B buyer. Checks length, title, opening, structure, AI signal patterns, language, formatting, credibility, and factual accuracy. Returns a scorecard plus prioritized fixes.",
     icon: "document",
@@ -288,6 +342,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Content] Technical blog post",
+    tools: ["github", "search"],
     description:
       "Reviews technical engineering blog drafts with prioritized, quoted feedback through six credibility lenses.",
     icon: "search",
@@ -298,6 +353,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[CS] Business Review",
+    tools: ["frame", "salesforce", "data_warehouse"],
     description:
       "Generates an interactive Business Review Frame for a customer. Covers 6 tabs: Review Objectives, Adoption & Metrics, ROI Analysis, Governance, Action Plan, and Product Roadmap.",
     icon: "presentation",
@@ -308,6 +364,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[CS] Customer Handoff",
+    tools: ["notion", "hubspot", "gong"],
     description:
       "Extracts and documents key account information from sales calls, demos, and discovery notes to produce a structured Customer Success handoff in Notion, then adds a HubSpot note and prompts for intro emails.",
     icon: "document",
@@ -319,6 +376,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[CS] Handoff Readiness Check",
+    tools: ["salesforce", "gong"],
     description:
       "Run before any Sales-to-CS handoff to verify all Pre-Sales signal is captured. Flags missing inputs, blocks premature handovers, and drafts AE/SE follow-ups for gaps.",
     icon: "card",
@@ -329,6 +387,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[CS] Kick-off",
+    tools: ["notion", "gcal", "hubspot"],
     description:
       "Prepares the customer kick-off: agenda, success criteria, stakeholder map and the follow-up recap.",
     icon: "rocket",
@@ -340,6 +399,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Data] Warehouse query",
+    tools: ["snowflake", "bigquery", "data_warehouse"],
     description:
       "Writes and runs SQL against the warehouse, then explains the result and the assumptions behind it.",
     icon: "table",
@@ -352,6 +412,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Finance] Invoice extraction",
+    tools: ["extract_data", "stripe", "google_drive"],
     description:
       "Extracts amounts, dates and payment terms from PDF invoices into a normalized structure.",
     icon: "card",
@@ -363,6 +424,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[GTM] Account research",
+    tools: ["salesforce", "web_search", "browse", "gong"],
     description:
       "Builds a one-page account brief from public sources, the CRM and past conversations.",
     icon: "globe",
@@ -375,6 +437,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[Legal] Clause playbook",
+    tools: ["google_drive", "extract_data"],
     description:
       "Compares a contract clause to our standard position and suggests the fallback language.",
     icon: "scales",
@@ -385,6 +448,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "[People] Interview scorecard",
+    tools: ["notion", "extract_data"],
     description:
       "Turns interview notes into a structured scorecard with evidence per competency.",
     icon: "clipboard",
@@ -396,6 +460,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "Search company knowledge",
+    tools: ["search"],
     description:
       "Searches every connected data source and returns the passages that answer the question, with citations.",
     icon: "search",
@@ -409,6 +474,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "Browse the web",
+    tools: ["browse", "web_search"],
     description:
       "Opens a URL and extracts its readable content so an agent can reason over it.",
     icon: "globe",
@@ -421,6 +487,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "Create a Frame",
+    tools: ["frame"],
     description:
       "Builds an interactive frame — dashboards, reports, mini-apps — from data an agent already has.",
     icon: "grid",
@@ -434,6 +501,7 @@ const CURATED_SKILLS: CuratedSkill[] = [
   },
   {
     name: "Run agent",
+    tools: ["run_agent"],
     description:
       "Delegates a sub-task to another agent and returns its answer.",
     icon: "wand",
@@ -594,6 +662,10 @@ function buildActiveSkills(): ManagedSkill[] {
 
   for (const [index, curated] of CURATED_SKILLS.entries()) {
     const isDustProvided = curated.isDustProvided ?? false;
+    const editors = isDustProvided
+      ? null
+      : pickEditors(random, Math.max(curated.editors, 1));
+    const tools = curated.tools ?? pickTools(random);
     skills.push({
       sId: `skill_curated_${index}`,
       name: curated.name,
@@ -604,13 +676,22 @@ function buildActiveSkills(): ManagedSkill[] {
       status: "active",
       isFavorite: curated.isFavorite ?? false,
       canAdministrate: !isDustProvided,
-      messageCount: curated.usage,
+      messageUsage:
+        curated.usage === null
+          ? null
+          : makeFleetUsage(random, {
+              human: curated.usage,
+              nowMs: NOW_MS,
+              programmaticBias: programmaticBiasForTools(tools),
+              // A skill attached to agents is a dependency by construction.
+              dependencyBias: (curated.agents ?? 0) > 0 ? 0.4 : 0,
+            }),
+      tools,
+      lastEditedBy: editors?.[0] ?? null,
       updatedAt: new Date(`${curated.updatedAt}T14:32:00Z`).getTime(),
       createdAt: new Date(`${curated.updatedAt}T14:32:00Z`).getTime() - 6e9,
       relations: {
-        editors: isDustProvided
-          ? null
-          : pickEditors(random, Math.max(curated.editors, 1)),
+        editors,
         usage: buildUsage(
           random,
           curated.agents ?? 0,
@@ -641,6 +722,9 @@ function buildActiveSkills(): ManagedSkill[] {
           : Math.floor(random() * 2500);
 
     const updatedAt = NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS);
+    const editors = pickEditors(random, 1 + Math.floor(random() * 4));
+    const tools = pickTools(random);
+    const agentCount = random() < 0.55 ? Math.floor(random() * 8) : 0;
 
     skills.push({
       sId: `skill_gen_${index}`,
@@ -652,14 +736,21 @@ function buildActiveSkills(): ManagedSkill[] {
       status: "active",
       isFavorite: false,
       canAdministrate: random() < 0.35,
-      messageCount,
+      messageUsage: makeFleetUsage(random, {
+        human: messageCount,
+        nowMs: NOW_MS,
+        programmaticBias: programmaticBiasForTools(tools),
+        dependencyBias: agentCount > 0 ? 0.4 : 0,
+      }),
+      tools,
+      lastEditedBy: editors[0],
       updatedAt,
       createdAt: updatedAt - Math.floor(random() * 1e10),
       relations: {
-        editors: pickEditors(random, 1 + Math.floor(random() * 4)),
+        editors,
         usage: buildUsage(
           random,
-          random() < 0.55 ? Math.floor(random() * 8) : 0,
+          agentCount,
           random() < 0.2 ? 1 + Math.floor(random() * 3) : 0,
           curatedNames
         ),
@@ -690,6 +781,7 @@ function buildArchivedSkills(): ManagedSkill[] {
     const area = pick(random, SKILL_AREAS);
     const subject = pick(random, SKILL_SUBJECTS);
     const updatedAt = NOW_MS - Math.floor(random() * FOURTEEN_MONTHS_MS);
+    const editors = pickEditors(random, 1 + Math.floor(random() * 2));
     skills.push({
       sId: `skill_archived_${index}`,
       name: `[${area}] ${subject}`,
@@ -700,11 +792,16 @@ function buildArchivedSkills(): ManagedSkill[] {
       status: "archived",
       isFavorite: false,
       canAdministrate: true,
-      messageCount: Math.floor(random() * 80),
+      messageUsage: makeFleetUsage(random, {
+        human: Math.floor(random() * 80),
+        nowMs: NOW_MS,
+      }),
+      tools: pickTools(random),
+      lastEditedBy: editors[0],
       updatedAt,
       createdAt: updatedAt - 5e9,
       relations: {
-        editors: pickEditors(random, 1 + Math.floor(random() * 2)),
+        editors,
         usage: { count: 0, agents: [], skills: [] },
       },
     });
@@ -752,7 +849,9 @@ function buildSuggestedSkills(): ManagedSkill[] {
       status: "suggested" as const,
       isFavorite: false,
       canAdministrate: true,
-      messageCount: 0,
+      messageUsage: EMPTY_FLEET_USAGE,
+      tools: pickTools(random),
+      lastEditedBy: null,
       updatedAt: NOW_MS - Math.floor(random() * 1e9),
       createdAt: NOW_MS - Math.floor(random() * 1e10),
       relations: {

--- a/sparkle/playground/src/data/manageSkills.ts
+++ b/sparkle/playground/src/data/manageSkills.ts
@@ -61,7 +61,6 @@ export interface ManagedSkill {
   messageUsage: FleetUsage | null;
   // MCP server view ids, see `fleetTools.ts`.
   tools: string[];
-  lastEditedBy: SkillEditor | null;
   updatedAt: number;
   createdAt: number;
   relations: {
@@ -687,7 +686,6 @@ function buildActiveSkills(): ManagedSkill[] {
               dependencyBias: (curated.agents ?? 0) > 0 ? 0.4 : 0,
             }),
       tools,
-      lastEditedBy: editors?.[0] ?? null,
       updatedAt: new Date(`${curated.updatedAt}T14:32:00Z`).getTime(),
       createdAt: new Date(`${curated.updatedAt}T14:32:00Z`).getTime() - 6e9,
       relations: {
@@ -743,7 +741,6 @@ function buildActiveSkills(): ManagedSkill[] {
         dependencyBias: agentCount > 0 ? 0.4 : 0,
       }),
       tools,
-      lastEditedBy: editors[0],
       updatedAt,
       createdAt: updatedAt - Math.floor(random() * 1e10),
       relations: {
@@ -797,7 +794,6 @@ function buildArchivedSkills(): ManagedSkill[] {
         nowMs: NOW_MS,
       }),
       tools: pickTools(random),
-      lastEditedBy: editors[0],
       updatedAt,
       createdAt: updatedAt - 5e9,
       relations: {
@@ -851,7 +847,6 @@ function buildSuggestedSkills(): ManagedSkill[] {
       canAdministrate: true,
       messageUsage: EMPTY_FLEET_USAGE,
       tools: pickTools(random),
-      lastEditedBy: null,
       updatedAt: NOW_MS - Math.floor(random() * 1e9),
       createdAt: NOW_MS - Math.floor(random() * 1e10),
       relations: {

--- a/sparkle/playground/src/stories/InputBar.tsx
+++ b/sparkle/playground/src/stories/InputBar.tsx
@@ -1,0 +1,5 @@
+import { ComposerView } from "../components/ComposerView";
+
+export default function InputBar() {
+  return <ComposerView />;
+}

--- a/sparkle/playground/src/stories/ManageAgents.tsx
+++ b/sparkle/playground/src/stories/ManageAgents.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Chip,
   CpuChip01,
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -29,6 +28,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import type { FleetFilterOption } from "../components/manage/FleetFilterBar";
 import {
   FleetFilterChips,
   FleetFilterMenu,
@@ -69,181 +69,7 @@ const AGENT_MANAGER_TABS = [
 
 type AssistantManagerTabsType = (typeof AGENT_MANAGER_TABS)[number]["id"];
 
-type AgentModelFilterType = { modelId: string; displayName: string };
-
-const tagsSorter = (a: AgentTag, b: AgentTag) => {
-  if (a.kind !== b.kind) {
-    return a.kind.localeCompare(b.kind);
-  }
-  return a.name.localeCompare(b.name);
-};
-
-const getAgentSearchString = (agent: ManagedAgent) =>
-  agent.name.toLowerCase() +
-  " " +
-  agent.editors
-    .map((editor) => editor.fullName)
-    .join(" ")
-    .toLowerCase();
-
 // ── Filter menus ──────────────────────────────────────────────────────────────
-
-interface ModelsFilterMenuProps {
-  models: AgentModelFilterType[];
-  selectedModels: AgentModelFilterType[];
-  setSelectedModels: (models: AgentModelFilterType[]) => void;
-}
-
-function ModelsFilterMenu({
-  models,
-  selectedModels,
-  setSelectedModels,
-}: ModelsFilterMenuProps) {
-  const [isDropdownOpen, setDropdownOpen] = useState(false);
-  const [modelSearch, setModelSearch] = useState("");
-
-  const selectedModelIds = new Set(selectedModels.map((m) => m.modelId));
-
-  const searchLower = modelSearch.toLowerCase();
-  const filteredModels = models
-    .filter((m) => subFilter(searchLower, m.displayName.toLowerCase()))
-    .sort((a, b) => {
-      if (modelSearch) {
-        return compareForFuzzySort(searchLower, a.displayName, b.displayName);
-      }
-      return a.displayName.localeCompare(b.displayName);
-    });
-
-  return (
-    <DropdownMenu
-      open={isDropdownOpen}
-      onOpenChange={(open) => {
-        setDropdownOpen(open);
-        if (!open) {
-          setModelSearch("");
-        }
-      }}
-    >
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          icon={CpuChip01}
-          label="Models"
-          counterValue={selectedModels.length.toString()}
-          isCounter={selectedModels.length > 0}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        className="w-96"
-        dropdownHeaders={
-          <DropdownMenuSearchbar
-            name="modelSearch"
-            placeholder="Search models"
-            value={modelSearch}
-            onChange={setModelSearch}
-          />
-        }
-      >
-        {filteredModels.length === 0 && (
-          <div className="flex items-center justify-center py-4 text-sm">
-            No models found
-          </div>
-        )}
-        {filteredModels.map((model) => (
-          <DropdownMenuCheckboxItem
-            key={model.modelId}
-            label={model.displayName}
-            icon={getModelLogoByModelId(model.modelId)}
-            truncateText
-            checked={selectedModelIds.has(model.modelId)}
-            onCheckedChange={() => {
-              setSelectedModels(
-                selectedModelIds.has(model.modelId)
-                  ? selectedModels.filter((m) => m.modelId !== model.modelId)
-                  : [...selectedModels, model]
-              );
-            }}
-            // Keep the menu open so several models can be toggled in a row.
-            onSelect={(event) => event.preventDefault()}
-          />
-        ))}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-interface TagsFilterMenuProps {
-  tags: AgentTag[];
-  selectedTags: AgentTag[];
-  setSelectedTags: (tags: AgentTag[]) => void;
-}
-
-function TagsFilterMenu({
-  tags,
-  selectedTags,
-  setSelectedTags,
-}: TagsFilterMenuProps) {
-  const [isDropdownOpen, setDropdownOpen] = useState(false);
-  const [tagSearch, setTagSearch] = useState("");
-
-  const filteredTags = tags
-    .filter((t) => subFilter(tagSearch, t.name.toLowerCase()))
-    .sort((a, b) => {
-      if (tagSearch) {
-        return compareForFuzzySort(
-          tagSearch,
-          a.name.toLowerCase(),
-          b.name.toLowerCase()
-        );
-      }
-      return tagsSorter(a, b);
-    });
-
-  return (
-    <DropdownMenu open={isDropdownOpen} onOpenChange={setDropdownOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          icon={Tag01}
-          label="Tags"
-          counterValue={selectedTags.length.toString()}
-          isCounter={selectedTags.length > 0}
-        />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        className="w-96"
-        dropdownHeaders={
-          <DropdownMenuSearchbar
-            name="tagSearch"
-            placeholder="Search tags"
-            value={tagSearch}
-            onChange={setTagSearch}
-            button={<Button variant="primary" label="Manage tags" />}
-          />
-        }
-      >
-        {filteredTags.length === 0 && (
-          <div className="flex items-center justify-center py-4 text-sm">
-            No tags found
-          </div>
-        )}
-        <DropdownMenuTagList>
-          {filteredTags
-            .filter((tag) => !selectedTags.includes(tag))
-            .map((tag) => (
-              <DropdownMenuTagItem
-                key={tag.sId}
-                label={tag.name}
-                color="info"
-                className="m-0.5"
-                onClick={() => setSelectedTags([...selectedTags, tag])}
-              />
-            ))}
-        </DropdownMenuTagList>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
 
 function CreateDropdown() {
   return (
@@ -269,6 +95,14 @@ function CreateDropdown() {
     </DropdownMenu>
   );
 }
+
+// Protected tags sort after standard ones, as in the product.
+const tagsSorter = (a: AgentTag, b: AgentTag) => {
+  if (a.kind !== b.kind) {
+    return a.kind.localeCompare(b.kind);
+  }
+  return a.name.localeCompare(b.name);
+};
 
 // ── Batch edit bar ────────────────────────────────────────────────────────────
 
@@ -421,26 +255,6 @@ export default function ManageAgents() {
   const assistantSearch = filters.search;
   const setAssistantSearch = (search: string) => updateFilters({ search });
 
-  const selectedTags = useMemo(
-    () => AGENT_TAGS.filter((tag) => filters.tags.includes(tag.sId)),
-    [filters.tags]
-  );
-  const selectedModels = useMemo<AgentModelFilterType[]>(
-    () =>
-      filters.models.map((modelId) => ({
-        modelId,
-        displayName: AGENT_MODELS_BY_ID.get(modelId)?.displayName ?? modelId,
-      })),
-    [filters.models]
-  );
-
-  // The two pre-existing menus keep their own shapes; they just write into the
-  // shared filter state so every dimension composes.
-  const setSelectedTags = (tags: AgentTag[]) =>
-    updateFilters({ tags: tags.map((tag) => tag.sId) });
-  const setSelectedModels = (models: AgentModelFilterType[]) =>
-    updateFilters({ models: models.map((model) => model.modelId) });
-
   const isSearchActive = assistantSearch.trim() !== "";
   const isFilterActive =
     isSearchActive ||
@@ -482,15 +296,21 @@ export default function ManageAgents() {
     );
   }, [agents]);
 
-  const uniqueModels = useMemo(() => {
-    const models = agents.map((a) => ({
-      modelId: a.modelId,
-      displayName: AGENT_MODELS_BY_ID.get(a.modelId)?.displayName ?? a.modelId,
+  const modelOptions = useMemo<FleetFilterOption[]>(() => {
+    const options = agents.map((a) => ({
+      value: a.modelId,
+      label: AGENT_MODELS_BY_ID.get(a.modelId)?.displayName ?? a.modelId,
+      icon: getModelLogoByModelId(a.modelId),
     }));
     return Array.from(
-      new Map(models.map((model) => [model.modelId, model])).values()
-    ).sort((a, b) => a.displayName.localeCompare(b.displayName));
+      new Map(options.map((option) => [option.value, option])).values()
+    ).sort((a, b) => a.label.localeCompare(b.label));
   }, [agents]);
+
+  const tagOptions = useMemo<FleetFilterOption[]>(
+    () => uniqueTags.map((tag) => ({ value: tag.sId, label: tag.name })),
+    [uniqueTags]
+  );
 
   // Everyone who edits something in the fleet — the option list for the
   // Editors and Last editor filters.
@@ -586,21 +406,13 @@ export default function ManageAgents() {
               onChange={setAssistantSearch}
             />
             <div className="flex gap-2">
-              <ModelsFilterMenu
-                models={uniqueModels}
-                selectedModels={selectedModels}
-                setSelectedModels={setSelectedModels}
-              />
-              <TagsFilterMenu
-                tags={uniqueTags}
-                selectedTags={selectedTags}
-                setSelectedTags={setSelectedTags}
-              />
               <FleetFilterMenu
                 filters={filters}
                 statusOptions={AGENT_STATUS_OPTIONS}
                 people={people}
                 showVisibility
+                models={modelOptions}
+                tags={tagOptions}
                 onToggle={toggleValue}
                 onUpdate={updateFilters}
               />
@@ -613,40 +425,8 @@ export default function ManageAgents() {
             peopleById={peopleById}
             onRemove={updateFilters}
             onClear={clearFilters}
-            hasLeadingChips={
-              selectedModels.length > 0 || selectedTags.length > 0
-            }
-            leadingChips={
-              <>
-                {selectedModels.map((model) => (
-                  <Chip
-                    key={model.modelId}
-                    label={model.displayName}
-                    size="xs"
-                    color="primary"
-                    icon={getModelLogoByModelId(model.modelId)}
-                    onRemove={() =>
-                      setSelectedModels(
-                        selectedModels.filter(
-                          (m) => m.modelId !== model.modelId
-                        )
-                      )
-                    }
-                  />
-                ))}
-                {selectedTags.map((tag) => (
-                  <Chip
-                    key={tag.sId}
-                    label={tag.name}
-                    size="xs"
-                    color="info"
-                    onRemove={() =>
-                      setSelectedTags(selectedTags.filter((t) => t !== tag))
-                    }
-                  />
-                ))}
-              </>
-            }
+            models={modelOptions}
+            tags={tagOptions}
           />
           {isFilterActive && (
             <div className="text-sm text-muted-foreground">

--- a/sparkle/playground/src/stories/ManageAgents.tsx
+++ b/sparkle/playground/src/stories/ManageAgents.tsx
@@ -31,6 +31,16 @@ import {
 } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import {
+  FleetFilterChips,
+  FleetFilterMenu,
+} from "../components/manage/FleetFilterBar";
+import type { FleetItemFields } from "../components/manage/fleetFilters";
+import {
+  AGENT_STATUS_OPTIONS,
+  filterFleet,
+  useFleetFilters,
+} from "../components/manage/fleetFilters";
 import { ManageAgentsTable } from "../components/manage/ManageAgentsTable";
 import { getModelLogoByModelId } from "../components/manage/ManageAgentsTable";
 import { ManagePageLayout } from "../components/manage/ManagePageLayout";
@@ -365,20 +375,43 @@ function AgentEditBar({
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
+// The mock fleet is generated around a fixed "today" so relative filters
+// ("not used in 60 days") stay stable across renders.
+const NOW_MS = new Date("2026-08-10T10:00:00Z").getTime();
+
+function agentFilterFields(agent: ManagedAgent): FleetItemFields {
+  return {
+    name: agent.name,
+    editorIds: agent.editors.map((editor) => editor.sId),
+    editorNames: agent.editors.map((editor) => editor.fullName),
+    lastEditorId: agent.lastEditedBy?.sId ?? null,
+    tools: agent.tools,
+    status:
+      agent.status === "archived"
+        ? "archived"
+        : agent.scope === "hidden"
+          ? "unpublished"
+          : "published",
+    visibility: agent.visibility,
+    modelId: agent.modelId,
+    tagIds: agent.tags.map((tag) => tag.sId),
+    updatedAt: agent.lastUpdate,
+    usage: agent.usage,
+  };
+}
+
 export default function ManageAgents() {
   const [agents, setAgents] = useState<ManagedAgent[]>(mockManagedAgents);
   const [archivedAgents] = useState<ManagedAgent[]>(mockArchivedAgents);
-  const [assistantSearch, setAssistantSearch] = useState("");
   const [selectedTab, setSelectedTab] =
     useState<AssistantManagerTabsType>("all_custom");
-  const [selectedTags, setSelectedTags] = useState<AgentTag[]>([]);
-  const [selectedModels, setSelectedModels] = useState<AgentModelFilterType[]>(
-    []
-  );
   const [isBatchEdit, setIsBatchEdit] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
   const [detailedAgentId, setDetailedAgentId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  const { filters, updateFilters, toggleValue, clearFilters } =
+    useFleetFilters();
 
   // The real page renders a spinner while the agent configurations load.
   useEffect(() => {
@@ -386,66 +419,62 @@ export default function ManageAgents() {
     return () => window.clearTimeout(timeout);
   }, []);
 
+  const assistantSearch = filters.search;
+  const setAssistantSearch = (search: string) => updateFilters({ search });
+
+  const selectedTags = useMemo(
+    () => AGENT_TAGS.filter((tag) => filters.tags.includes(tag.sId)),
+    [filters.tags]
+  );
+  const selectedModels = useMemo<AgentModelFilterType[]>(
+    () =>
+      filters.models.map((modelId) => ({
+        modelId,
+        displayName: AGENT_MODELS_BY_ID.get(modelId)?.displayName ?? modelId,
+      })),
+    [filters.models]
+  );
+
+  // The two pre-existing menus keep their own shapes; they just write into the
+  // shared filter state so every dimension composes.
+  const setSelectedTags = (tags: AgentTag[]) =>
+    updateFilters({ tags: tags.map((tag) => tag.sId) });
+  const setSelectedModels = (models: AgentModelFilterType[]) =>
+    updateFilters({ models: models.map((model) => model.modelId) });
+
   const isSearchActive = assistantSearch.trim() !== "";
   const isFilterActive =
-    isSearchActive || selectedTags.length > 0 || selectedModels.length > 0;
+    isSearchActive ||
+    filters.tags.length > 0 ||
+    filters.models.length > 0 ||
+    filters.tools.length > 0 ||
+    filters.status.length > 0 ||
+    filters.visibility.length > 0 ||
+    filters.editors.length > 0 ||
+    filters.lastEditors.length > 0 ||
+    filters.editedWithin !== null ||
+    filters.notUsedFor !== null;
 
   const selectedAgents = agents.filter((a) => selection.includes(a.sId));
 
   const agentsByTab = useMemo(() => {
-    const selectedTagIds = new Set(selectedTags.map((tag) => tag.sId));
-    const selectedModelIds = new Set(
-      selectedModels.map((model) => model.modelId)
-    );
-    const allAgents = agents
-      .filter((a) => {
-        if (
-          selectedTagIds.size > 0 &&
-          !a.tags.some((t) => selectedTagIds.has(t.sId))
-        ) {
-          return false;
-        }
-        if (selectedModelIds.size > 0 && !selectedModelIds.has(a.modelId)) {
-          return false;
-        }
-        return true;
-      })
-      .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+    // Every dimension is a plain AND over the same list, which is what makes
+    // "published agents using Salesforce, not used in 60 days" expressible.
+    const byName = (list: ManagedAgent[]) =>
+      [...list].sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+      );
 
-    const searchLower = assistantSearch.toLowerCase();
-    const filteredList = (list: ManagedAgent[]) => {
-      if (!isSearchActive) {
-        return list;
-      }
-      return list
-        .filter((a) => subFilter(searchLower, getAgentSearchString(a)))
-        .sort((a, b) =>
-          compareForFuzzySort(
-            searchLower,
-            getAgentSearchString(a),
-            getAgentSearchString(b)
-          )
-        );
-    };
+    const filteredList = (list: ManagedAgent[]) =>
+      filterFleet(byName(list), filters, agentFilterFields, NOW_MS);
 
     return {
-      all_custom: filteredList(allAgents.filter((a) => a.scope !== "global")),
-      editable_by_me: filteredList(allAgents.filter((a) => a.canEdit)),
-      global: filteredList(allAgents.filter((a) => a.scope === "global")),
-      archived: filteredList(
-        [...archivedAgents].sort((a, b) =>
-          a.name.toLowerCase().localeCompare(b.name.toLowerCase())
-        )
-      ),
+      all_custom: filteredList(agents.filter((a) => a.scope !== "global")),
+      editable_by_me: filteredList(agents.filter((a) => a.canEdit)),
+      global: filteredList(agents.filter((a) => a.scope === "global")),
+      archived: filteredList(archivedAgents),
     };
-  }, [
-    agents,
-    archivedAgents,
-    selectedTags,
-    selectedModels,
-    assistantSearch,
-    isSearchActive,
-  ]);
+  }, [agents, archivedAgents, filters]);
 
   const uniqueTags = useMemo(() => {
     const tags = agents.flatMap((a) => a.tags);
@@ -463,6 +492,25 @@ export default function ManageAgents() {
       new Map(models.map((model) => [model.modelId, model])).values()
     ).sort((a, b) => a.displayName.localeCompare(b.displayName));
   }, [agents]);
+
+  // Everyone who edits something in the fleet — the option list for the
+  // Editors and Last editor filters.
+  const people = useMemo(() => {
+    const byId = new Map<string, { sId: string; fullName: string }>();
+    for (const agent of [...agents, ...archivedAgents]) {
+      for (const editor of agent.editors) {
+        byId.set(editor.sId, { sId: editor.sId, fullName: editor.fullName });
+      }
+    }
+    return Array.from(byId.values()).sort((a, b) =>
+      a.fullName.localeCompare(b.fullName)
+    );
+  }, [agents, archivedAgents]);
+
+  const peopleById = useMemo(
+    () => new Map(people.map((person) => [person.sId, person.fullName])),
+    [people]
+  );
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 
@@ -551,37 +599,64 @@ export default function ManageAgents() {
                   selectedTags={selectedTags}
                   setSelectedTags={setSelectedTags}
                 />
+                <FleetFilterMenu
+                  filters={filters}
+                  statusOptions={AGENT_STATUS_OPTIONS}
+                  people={people}
+                  showVisibility
+                  onToggle={toggleValue}
+                  onUpdate={updateFilters}
+                />
                 <CreateDropdown />
               </div>
             )}
           </div>
-          {(selectedModels.length > 0 || selectedTags.length > 0) && (
-            <div className="flex flex-row flex-wrap gap-2">
-              {selectedModels.map((model) => (
-                <Chip
-                  key={model.modelId}
-                  label={model.displayName}
-                  size="xs"
-                  color="primary"
-                  icon={getModelLogoByModelId(model.modelId)}
-                  onRemove={() =>
-                    setSelectedModels(
-                      selectedModels.filter((m) => m.modelId !== model.modelId)
-                    )
-                  }
-                />
-              ))}
-              {selectedTags.map((tag) => (
-                <Chip
-                  key={tag.sId}
-                  label={tag.name}
-                  size="xs"
-                  color="info"
-                  onRemove={() =>
-                    setSelectedTags(selectedTags.filter((t) => t !== tag))
-                  }
-                />
-              ))}
+          <FleetFilterChips
+            filters={filters}
+            statusOptions={AGENT_STATUS_OPTIONS}
+            peopleById={peopleById}
+            onRemove={updateFilters}
+            onClear={clearFilters}
+            hasLeadingChips={
+              selectedModels.length > 0 || selectedTags.length > 0
+            }
+            leadingChips={
+              <>
+                {selectedModels.map((model) => (
+                  <Chip
+                    key={model.modelId}
+                    label={model.displayName}
+                    size="xs"
+                    color="primary"
+                    icon={getModelLogoByModelId(model.modelId)}
+                    onRemove={() =>
+                      setSelectedModels(
+                        selectedModels.filter(
+                          (m) => m.modelId !== model.modelId
+                        )
+                      )
+                    }
+                  />
+                ))}
+                {selectedTags.map((tag) => (
+                  <Chip
+                    key={tag.sId}
+                    label={tag.name}
+                    size="xs"
+                    color="info"
+                    onRemove={() =>
+                      setSelectedTags(selectedTags.filter((t) => t !== tag))
+                    }
+                  />
+                ))}
+              </>
+            }
+          />
+          {isFilterActive && (
+            <div className="text-sm text-muted-foreground">
+              {activeAgents.length} agent
+              {activeAgents.length === 1 ? "" : "s"} match
+              {activeAgents.length === 1 ? "es" : ""} the current filters.
             </div>
           )}
           <div className="flex flex-col pt-3">
@@ -630,6 +705,7 @@ export default function ManageAgents() {
                 setSelection={setSelection}
                 agents={activeAgents}
                 tags={AGENT_TAGS}
+                nowMs={NOW_MS}
                 setDetailedAgentId={setDetailedAgentId}
                 onToggleAgentStatus={handleToggleAgentStatus}
                 onTagsChange={(agentId, tags) => updateAgent(agentId, { tags })}

--- a/sparkle/playground/src/stories/ManageAgents.tsx
+++ b/sparkle/playground/src/stories/ManageAgents.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Chip,
-  ContactsRobot,
   CpuChip01,
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -570,7 +569,7 @@ export default function ManageAgents() {
   return (
     <ManagePageLayout>
       <div className="flex w-full flex-col gap-8 pb-4">
-        <Page.Header title="Manage Agents" icon={ContactsRobot} />
+        <Page.Header title="Manage Agents" noTopPadding />
         <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">
             <SearchInput

--- a/sparkle/playground/src/stories/ManageAgents.tsx
+++ b/sparkle/playground/src/stories/ManageAgents.tsx
@@ -35,7 +35,6 @@ import {
 } from "../components/manage/FleetFilterBar";
 import type { FleetItemFields } from "../components/manage/fleetFilters";
 import {
-  AGENT_STATUS_OPTIONS,
   filterFleet,
   useFleetFilters,
 } from "../components/manage/fleetFilters";
@@ -216,15 +215,10 @@ function agentFilterFields(agent: ManagedAgent): FleetItemFields {
     name: agent.name,
     editorIds: agent.editors.map((editor) => editor.sId),
     editorNames: agent.editors.map((editor) => editor.fullName),
-    lastEditorId: agent.lastEditedBy?.sId ?? null,
     tools: agent.tools,
-    status:
-      agent.status === "archived"
-        ? "archived"
-        : agent.scope === "hidden"
-          ? "unpublished"
-          : "published",
-    visibility: agent.visibility,
+    // Independent of archived-ness: the Archived tab owns that dimension, so
+    // an archived agent still has a publication state to filter on.
+    publication: agent.scope === "hidden" ? "unpublished" : "published",
     modelId: agent.modelId,
     tagIds: agent.tags.map((tag) => tag.sId),
     updatedAt: agent.lastUpdate,
@@ -261,10 +255,8 @@ export default function ManageAgents() {
     filters.tags.length > 0 ||
     filters.models.length > 0 ||
     filters.tools.length > 0 ||
-    filters.status.length > 0 ||
-    filters.visibility.length > 0 ||
+    filters.publication.length > 0 ||
     filters.editors.length > 0 ||
-    filters.lastEditors.length > 0 ||
     filters.editedWithin !== null ||
     filters.notUsedFor !== null;
 
@@ -396,21 +388,22 @@ export default function ManageAgents() {
       <div className="flex w-full flex-col gap-8 pb-4">
         <Page.Header title="Manage Agents" noTopPadding />
         <Page.Vertical gap="md" align="stretch">
-          <div className="flex flex-row gap-2">
+          <div className="flex flex-row items-center gap-2">
+            {/* Bounded, not full-width: a fleet is filtered far more often than
+                it is keyword-searched, so the input should not dominate. */}
             <SearchInput
               ref={searchBarRef}
-              className="flex-grow"
+              className="w-full max-w-md"
               name="search"
               placeholder="Search (Name, Editors)"
               value={assistantSearch}
               onChange={setAssistantSearch}
             />
-            <div className="flex gap-2">
+            <div className="ml-auto flex gap-2">
               <FleetFilterMenu
                 filters={filters}
-                statusOptions={AGENT_STATUS_OPTIONS}
                 people={people}
-                showVisibility
+                showPublication
                 models={modelOptions}
                 tags={tagOptions}
                 onToggle={toggleValue}
@@ -421,7 +414,6 @@ export default function ManageAgents() {
           </div>
           <FleetFilterChips
             filters={filters}
-            statusOptions={AGENT_STATUS_OPTIONS}
             peopleById={peopleById}
             onRemove={updateFilters}
             onClear={clearFilters}

--- a/sparkle/playground/src/stories/ManageAgents.tsx
+++ b/sparkle/playground/src/stories/ManageAgents.tsx
@@ -15,7 +15,6 @@ import {
   EmptyCTA,
   File02,
   FolderOpen,
-  ListSelect,
   MagicWand02,
   Page,
   Plus,
@@ -404,8 +403,9 @@ export default function ManageAgents() {
   const [archivedAgents] = useState<ManagedAgent[]>(mockArchivedAgents);
   const [selectedTab, setSelectedTab] =
     useState<AssistantManagerTabsType>("all_custom");
-  const [isBatchEdit, setIsBatchEdit] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
+  // Rows always carry a checkbox; ticking one is what opens batch mode.
+  const isBatchEdit = selection.length > 0;
   const [detailedAgentId, setDetailedAgentId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
@@ -565,6 +565,11 @@ export default function ManageAgents() {
   };
 
   const activeAgents = agentsByTab[selectedTab];
+  // Default agents and archived ones can't be batch-edited, so those tabs get
+  // no checkbox column at all.
+  const showSelection = activeAgents.some(
+    (agent) => agent.status !== "archived" && agent.scope !== "global"
+  );
 
   return (
     <ManagePageLayout>
@@ -580,35 +585,27 @@ export default function ManageAgents() {
               value={assistantSearch}
               onChange={setAssistantSearch}
             />
-            {!isBatchEdit && (
-              <div className="flex gap-2">
-                <Button
-                  variant="outline"
-                  icon={ListSelect}
-                  label="Batch edit"
-                  onClick={() => setIsBatchEdit(true)}
-                />
-                <ModelsFilterMenu
-                  models={uniqueModels}
-                  selectedModels={selectedModels}
-                  setSelectedModels={setSelectedModels}
-                />
-                <TagsFilterMenu
-                  tags={uniqueTags}
-                  selectedTags={selectedTags}
-                  setSelectedTags={setSelectedTags}
-                />
-                <FleetFilterMenu
-                  filters={filters}
-                  statusOptions={AGENT_STATUS_OPTIONS}
-                  people={people}
-                  showVisibility
-                  onToggle={toggleValue}
-                  onUpdate={updateFilters}
-                />
-                <CreateDropdown />
-              </div>
-            )}
+            <div className="flex gap-2">
+              <ModelsFilterMenu
+                models={uniqueModels}
+                selectedModels={selectedModels}
+                setSelectedModels={setSelectedModels}
+              />
+              <TagsFilterMenu
+                tags={uniqueTags}
+                selectedTags={selectedTags}
+                setSelectedTags={setSelectedTags}
+              />
+              <FleetFilterMenu
+                filters={filters}
+                statusOptions={AGENT_STATUS_OPTIONS}
+                people={people}
+                showVisibility
+                onToggle={toggleValue}
+                onUpdate={updateFilters}
+              />
+              <CreateDropdown />
+            </div>
           </div>
           <FleetFilterChips
             filters={filters}
@@ -661,10 +658,7 @@ export default function ManageAgents() {
           <div className="flex flex-col pt-3">
             {isBatchEdit ? (
               <AgentEditBar
-                onClose={() => {
-                  setIsBatchEdit(false);
-                  setSelection([]);
-                }}
+                onClose={() => setSelection([])}
                 selectedAgents={selectedAgents}
                 tags={AGENT_TAGS}
                 onToggleTag={handleBatchToggleTag}
@@ -705,6 +699,7 @@ export default function ManageAgents() {
                 agents={activeAgents}
                 tags={AGENT_TAGS}
                 nowMs={NOW_MS}
+                showSelection={showSelection}
                 setDetailedAgentId={setDetailedAgentId}
                 onToggleAgentStatus={handleToggleAgentStatus}
                 onTagsChange={(agentId, tags) => updateAgent(agentId, { tags })}

--- a/sparkle/playground/src/stories/ManageAgents.tsx
+++ b/sparkle/playground/src/stories/ManageAgents.tsx
@@ -1,0 +1,685 @@
+import {
+  Button,
+  Chip,
+  ContactsRobot,
+  CpuChip01,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSearchbar,
+  DropdownMenuSeparator,
+  DropdownMenuTagItem,
+  DropdownMenuTagList,
+  DropdownMenuTrigger,
+  EmptyCTA,
+  File02,
+  FolderOpen,
+  ListSelect,
+  MagicWand02,
+  Page,
+  Plus,
+  PuzzlePiece01,
+  SearchInput,
+  Spinner,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Tag01,
+  XClose,
+} from "@dust-tt/sparkle";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { ManageAgentsTable } from "../components/manage/ManageAgentsTable";
+import { getModelLogoByModelId } from "../components/manage/ManageAgentsTable";
+import { ManagePageLayout } from "../components/manage/ManagePageLayout";
+import { compareForFuzzySort, subFilter } from "../components/manage/utils";
+import type { AgentTag, ManagedAgent } from "../data/manageAgents";
+import {
+  AGENT_MODELS_BY_ID,
+  AGENT_TAGS,
+  mockArchivedAgents,
+  mockManagedAgents,
+} from "../data/manageAgents";
+
+const AGENT_MANAGER_TABS = [
+  // default shown tab = earliest in this list with non-empty agents
+  { id: "all_custom", label: "All", description: "All custom agents." },
+  {
+    id: "editable_by_me",
+    label: "Editable by me",
+    description: "Edited or created by you.",
+  },
+  {
+    id: "global",
+    label: "Default",
+    description: "Default agents provided by Dust.",
+  },
+  { id: "archived", label: "Archived", description: "Archived agents." },
+] as const;
+
+type AssistantManagerTabsType = (typeof AGENT_MANAGER_TABS)[number]["id"];
+
+type AgentModelFilterType = { modelId: string; displayName: string };
+
+const tagsSorter = (a: AgentTag, b: AgentTag) => {
+  if (a.kind !== b.kind) {
+    return a.kind.localeCompare(b.kind);
+  }
+  return a.name.localeCompare(b.name);
+};
+
+const getAgentSearchString = (agent: ManagedAgent) =>
+  agent.name.toLowerCase() +
+  " " +
+  agent.editors
+    .map((editor) => editor.fullName)
+    .join(" ")
+    .toLowerCase();
+
+// ── Filter menus ──────────────────────────────────────────────────────────────
+
+interface ModelsFilterMenuProps {
+  models: AgentModelFilterType[];
+  selectedModels: AgentModelFilterType[];
+  setSelectedModels: (models: AgentModelFilterType[]) => void;
+}
+
+function ModelsFilterMenu({
+  models,
+  selectedModels,
+  setSelectedModels,
+}: ModelsFilterMenuProps) {
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const [modelSearch, setModelSearch] = useState("");
+
+  const selectedModelIds = new Set(selectedModels.map((m) => m.modelId));
+
+  const searchLower = modelSearch.toLowerCase();
+  const filteredModels = models
+    .filter((m) => subFilter(searchLower, m.displayName.toLowerCase()))
+    .sort((a, b) => {
+      if (modelSearch) {
+        return compareForFuzzySort(searchLower, a.displayName, b.displayName);
+      }
+      return a.displayName.localeCompare(b.displayName);
+    });
+
+  return (
+    <DropdownMenu
+      open={isDropdownOpen}
+      onOpenChange={(open) => {
+        setDropdownOpen(open);
+        if (!open) {
+          setModelSearch("");
+        }
+      }}
+    >
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          icon={CpuChip01}
+          label="Models"
+          counterValue={selectedModels.length.toString()}
+          isCounter={selectedModels.length > 0}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-96"
+        dropdownHeaders={
+          <DropdownMenuSearchbar
+            name="modelSearch"
+            placeholder="Search models"
+            value={modelSearch}
+            onChange={setModelSearch}
+          />
+        }
+      >
+        {filteredModels.length === 0 && (
+          <div className="flex items-center justify-center py-4 text-sm">
+            No models found
+          </div>
+        )}
+        {filteredModels.map((model) => (
+          <DropdownMenuCheckboxItem
+            key={model.modelId}
+            label={model.displayName}
+            icon={getModelLogoByModelId(model.modelId)}
+            truncateText
+            checked={selectedModelIds.has(model.modelId)}
+            onCheckedChange={() => {
+              setSelectedModels(
+                selectedModelIds.has(model.modelId)
+                  ? selectedModels.filter((m) => m.modelId !== model.modelId)
+                  : [...selectedModels, model]
+              );
+            }}
+            // Keep the menu open so several models can be toggled in a row.
+            onSelect={(event) => event.preventDefault()}
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface TagsFilterMenuProps {
+  tags: AgentTag[];
+  selectedTags: AgentTag[];
+  setSelectedTags: (tags: AgentTag[]) => void;
+}
+
+function TagsFilterMenu({
+  tags,
+  selectedTags,
+  setSelectedTags,
+}: TagsFilterMenuProps) {
+  const [isDropdownOpen, setDropdownOpen] = useState(false);
+  const [tagSearch, setTagSearch] = useState("");
+
+  const filteredTags = tags
+    .filter((t) => subFilter(tagSearch, t.name.toLowerCase()))
+    .sort((a, b) => {
+      if (tagSearch) {
+        return compareForFuzzySort(
+          tagSearch,
+          a.name.toLowerCase(),
+          b.name.toLowerCase()
+        );
+      }
+      return tagsSorter(a, b);
+    });
+
+  return (
+    <DropdownMenu open={isDropdownOpen} onOpenChange={setDropdownOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          icon={Tag01}
+          label="Tags"
+          counterValue={selectedTags.length.toString()}
+          isCounter={selectedTags.length > 0}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        className="w-96"
+        dropdownHeaders={
+          <DropdownMenuSearchbar
+            name="tagSearch"
+            placeholder="Search tags"
+            value={tagSearch}
+            onChange={setTagSearch}
+            button={<Button variant="primary" label="Manage tags" />}
+          />
+        }
+      >
+        {filteredTags.length === 0 && (
+          <div className="flex items-center justify-center py-4 text-sm">
+            No tags found
+          </div>
+        )}
+        <DropdownMenuTagList>
+          {filteredTags
+            .filter((tag) => !selectedTags.includes(tag))
+            .map((tag) => (
+              <DropdownMenuTagItem
+                key={tag.sId}
+                label={tag.name}
+                color="info"
+                className="m-0.5"
+                onClick={() => setSelectedTags([...selectedTags, tag])}
+              />
+            ))}
+        </DropdownMenuTagList>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function CreateDropdown() {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="primary"
+          icon={Plus}
+          label="Create"
+          size="sm"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuLabel label="Agents" />
+        <DropdownMenuItem label="agent from scratch" icon={File02} />
+        <DropdownMenuItem label="agent from template" icon={MagicWand02} />
+        <DropdownMenuItem label="agent from YAML" icon={FolderOpen} />
+        <DropdownMenuLabel label="Skills" />
+        <DropdownMenuItem label="skill from scratch" icon={PuzzlePiece01} />
+        <DropdownMenuItem label="skill from existing" icon={FolderOpen} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+// ── Batch edit bar ────────────────────────────────────────────────────────────
+
+interface AgentEditBarProps {
+  onClose: () => void;
+  selectedAgents: ManagedAgent[];
+  tags: AgentTag[];
+  onToggleTag: (tag: AgentTag) => void;
+}
+
+function AgentEditBar({
+  onClose,
+  selectedAgents,
+  tags,
+  onToggleTag,
+}: AgentEditBarProps) {
+  const [tagSearch, setTagSearch] = useState("");
+
+  const filteredTags = tags
+    .filter((t) => subFilter(tagSearch, t.name.toLowerCase()))
+    .sort((a, b) => {
+      if (tagSearch) {
+        return compareForFuzzySort(
+          tagSearch,
+          a.name.toLowerCase(),
+          b.name.toLowerCase()
+        );
+      }
+      return tagsSorter(a, b);
+    });
+
+  const isEmptySelection = selectedAgents.length === 0;
+
+  return (
+    <div className="border-1 mb-2 flex flex-row items-center gap-2 rounded-xl bg-muted-background p-2">
+      <Button
+        size="xs"
+        variant="outline"
+        label="Close edition"
+        icon={XClose}
+        onClick={onClose}
+      />
+      <div className="flex-1" />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            size="xs"
+            variant="outline"
+            isSelect
+            icon={Tag01}
+            label="Tag selection"
+            disabled={isEmptySelection}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          className="w-60"
+          dropdownHeaders={
+            <>
+              <DropdownMenuSearchbar
+                name="tagSearch"
+                placeholder="Search tags"
+                value={tagSearch}
+                onChange={setTagSearch}
+              />
+              <DropdownMenuSeparator />
+            </>
+          }
+        >
+          <DropdownMenuTagList>
+            {filteredTags.map((tag) => (
+              <DropdownMenuTagItem
+                key={tag.sId}
+                label={tag.name}
+                color="info"
+                onClick={() => onToggleTag(tag)}
+              />
+            ))}
+          </DropdownMenuTagList>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <Button
+        size="xs"
+        variant="outline"
+        label="Set model"
+        disabled={isEmptySelection}
+      />
+      <Button
+        size="xs"
+        variant="outline"
+        label="Unpublish"
+        disabled={isEmptySelection}
+      />
+      <Button
+        size="xs"
+        variant="warning"
+        label="Archive"
+        disabled={isEmptySelection}
+      />
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function ManageAgents() {
+  const [agents, setAgents] = useState<ManagedAgent[]>(mockManagedAgents);
+  const [archivedAgents] = useState<ManagedAgent[]>(mockArchivedAgents);
+  const [assistantSearch, setAssistantSearch] = useState("");
+  const [selectedTab, setSelectedTab] =
+    useState<AssistantManagerTabsType>("all_custom");
+  const [selectedTags, setSelectedTags] = useState<AgentTag[]>([]);
+  const [selectedModels, setSelectedModels] = useState<AgentModelFilterType[]>(
+    []
+  );
+  const [isBatchEdit, setIsBatchEdit] = useState(false);
+  const [selection, setSelection] = useState<string[]>([]);
+  const [detailedAgentId, setDetailedAgentId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // The real page renders a spinner while the agent configurations load.
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setIsLoading(false), 350);
+    return () => window.clearTimeout(timeout);
+  }, []);
+
+  const isSearchActive = assistantSearch.trim() !== "";
+  const isFilterActive =
+    isSearchActive || selectedTags.length > 0 || selectedModels.length > 0;
+
+  const selectedAgents = agents.filter((a) => selection.includes(a.sId));
+
+  const agentsByTab = useMemo(() => {
+    const selectedTagIds = new Set(selectedTags.map((tag) => tag.sId));
+    const selectedModelIds = new Set(
+      selectedModels.map((model) => model.modelId)
+    );
+    const allAgents = agents
+      .filter((a) => {
+        if (
+          selectedTagIds.size > 0 &&
+          !a.tags.some((t) => selectedTagIds.has(t.sId))
+        ) {
+          return false;
+        }
+        if (selectedModelIds.size > 0 && !selectedModelIds.has(a.modelId)) {
+          return false;
+        }
+        return true;
+      })
+      .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+
+    const searchLower = assistantSearch.toLowerCase();
+    const filteredList = (list: ManagedAgent[]) => {
+      if (!isSearchActive) {
+        return list;
+      }
+      return list
+        .filter((a) => subFilter(searchLower, getAgentSearchString(a)))
+        .sort((a, b) =>
+          compareForFuzzySort(
+            searchLower,
+            getAgentSearchString(a),
+            getAgentSearchString(b)
+          )
+        );
+    };
+
+    return {
+      all_custom: filteredList(allAgents.filter((a) => a.scope !== "global")),
+      editable_by_me: filteredList(allAgents.filter((a) => a.canEdit)),
+      global: filteredList(allAgents.filter((a) => a.scope === "global")),
+      archived: filteredList(
+        [...archivedAgents].sort((a, b) =>
+          a.name.toLowerCase().localeCompare(b.name.toLowerCase())
+        )
+      ),
+    };
+  }, [
+    agents,
+    archivedAgents,
+    selectedTags,
+    selectedModels,
+    assistantSearch,
+    isSearchActive,
+  ]);
+
+  const uniqueTags = useMemo(() => {
+    const tags = agents.flatMap((a) => a.tags);
+    return Array.from(new Map(tags.map((tag) => [tag.sId, tag])).values()).sort(
+      (a, b) => a.name.localeCompare(b.name)
+    );
+  }, [agents]);
+
+  const uniqueModels = useMemo(() => {
+    const models = agents.map((a) => ({
+      modelId: a.modelId,
+      displayName: AGENT_MODELS_BY_ID.get(a.modelId)?.displayName ?? a.modelId,
+    }));
+    return Array.from(
+      new Map(models.map((model) => [model.modelId, model])).values()
+    ).sort((a, b) => a.displayName.localeCompare(b.displayName));
+  }, [agents]);
+
+  const searchBarRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    searchBarRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.key === "/") {
+        event.preventDefault();
+        searchBarRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  }, []);
+
+  const updateAgent = (sId: string, update: Partial<ManagedAgent>) => {
+    setAgents((current) =>
+      current.map((agent) =>
+        agent.sId === sId ? { ...agent, ...update } : agent
+      )
+    );
+  };
+
+  const handleToggleAgentStatus = (agent: ManagedAgent) => {
+    updateAgent(agent.sId, {
+      status:
+        agent.status === "disabled_by_admin" ? "active" : "disabled_by_admin",
+    });
+  };
+
+  const handleBatchToggleTag = (tag: AgentTag) => {
+    const allHaveTag = selectedAgents.every((agent) =>
+      agent.tags.some((t) => t.sId === tag.sId)
+    );
+    setAgents((current) =>
+      current.map((agent) => {
+        if (!selection.includes(agent.sId)) {
+          return agent;
+        }
+        const hasTag = agent.tags.some((t) => t.sId === tag.sId);
+        if (allHaveTag) {
+          return {
+            ...agent,
+            tags: agent.tags.filter((t) => t.sId !== tag.sId),
+          };
+        }
+        return hasTag ? agent : { ...agent, tags: [...agent.tags, tag] };
+      })
+    );
+  };
+
+  const activeAgents = agentsByTab[selectedTab];
+
+  return (
+    <ManagePageLayout>
+      <div className="flex w-full flex-col gap-8 pb-4">
+        <Page.Header title="Manage Agents" icon={ContactsRobot} />
+        <Page.Vertical gap="md" align="stretch">
+          <div className="flex flex-row gap-2">
+            <SearchInput
+              ref={searchBarRef}
+              className="flex-grow"
+              name="search"
+              placeholder="Search (Name, Editors)"
+              value={assistantSearch}
+              onChange={setAssistantSearch}
+            />
+            {!isBatchEdit && (
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  icon={ListSelect}
+                  label="Batch edit"
+                  onClick={() => setIsBatchEdit(true)}
+                />
+                <ModelsFilterMenu
+                  models={uniqueModels}
+                  selectedModels={selectedModels}
+                  setSelectedModels={setSelectedModels}
+                />
+                <TagsFilterMenu
+                  tags={uniqueTags}
+                  selectedTags={selectedTags}
+                  setSelectedTags={setSelectedTags}
+                />
+                <CreateDropdown />
+              </div>
+            )}
+          </div>
+          {(selectedModels.length > 0 || selectedTags.length > 0) && (
+            <div className="flex flex-row flex-wrap gap-2">
+              {selectedModels.map((model) => (
+                <Chip
+                  key={model.modelId}
+                  label={model.displayName}
+                  size="xs"
+                  color="primary"
+                  icon={getModelLogoByModelId(model.modelId)}
+                  onRemove={() =>
+                    setSelectedModels(
+                      selectedModels.filter((m) => m.modelId !== model.modelId)
+                    )
+                  }
+                />
+              ))}
+              {selectedTags.map((tag) => (
+                <Chip
+                  key={tag.sId}
+                  label={tag.name}
+                  size="xs"
+                  color="info"
+                  onRemove={() =>
+                    setSelectedTags(selectedTags.filter((t) => t !== tag))
+                  }
+                />
+              ))}
+            </div>
+          )}
+          <div className="flex flex-col pt-3">
+            {isBatchEdit ? (
+              <AgentEditBar
+                onClose={() => {
+                  setIsBatchEdit(false);
+                  setSelection([]);
+                }}
+                selectedAgents={selectedAgents}
+                tags={AGENT_TAGS}
+                onToggleTag={handleBatchToggleTag}
+              />
+            ) : (
+              <Tabs value={selectedTab}>
+                <TabsList>
+                  {AGENT_MANAGER_TABS.map((tab) => (
+                    <TabsTrigger
+                      key={tab.id}
+                      value={tab.id}
+                      label={tab.label}
+                      onClick={() => setSelectedTab(tab.id)}
+                      tooltip={tab.description}
+                      isCounter={tab.id !== "archived"}
+                      counterValue={`${agentsByTab[tab.id].length}`}
+                    />
+                  ))}
+                </TabsList>
+              </Tabs>
+            )}
+            {isLoading ? (
+              <div className="mt-8 flex justify-center">
+                <Spinner size="lg" />
+              </div>
+            ) : isFilterActive && activeAgents.length === 0 ? (
+              <div className="pt-2">
+                <EmptyCTA
+                  message="No agent matches your search or filters."
+                  action={null}
+                />
+              </div>
+            ) : (
+              <ManageAgentsTable
+                isBatchEdit={isBatchEdit}
+                selection={selection}
+                setSelection={setSelection}
+                agents={activeAgents}
+                tags={AGENT_TAGS}
+                setDetailedAgentId={setDetailedAgentId}
+                onToggleAgentStatus={handleToggleAgentStatus}
+                onTagsChange={(agentId, tags) => updateAgent(agentId, { tags })}
+                onArchiveAgent={(agent) =>
+                  setAgents((current) =>
+                    current.filter((a) => a.sId !== agent.sId)
+                  )
+                }
+              />
+            )}
+          </div>
+        </Page.Vertical>
+      </div>
+      {detailedAgentId && (
+        <AgentDetailsPlaceholder
+          agent={agents.find((a) => a.sId === detailedAgentId) ?? null}
+          onClose={() => setDetailedAgentId(null)}
+        />
+      )}
+    </ManagePageLayout>
+  );
+}
+
+// The details sheet is out of scope for this playground; a minimal panel keeps
+// the row click meaningful.
+function AgentDetailsPlaceholder({
+  agent,
+  onClose,
+}: {
+  agent: ManagedAgent | null;
+  onClose: () => void;
+}) {
+  if (!agent) {
+    return null;
+  }
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end bg-black/20"
+      onClick={onClose}
+    >
+      <div
+        className="flex h-full w-96 flex-col gap-3 bg-background p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span className="heading-lg text-foreground">@{agent.name}</span>
+          <Button size="xs" variant="ghost" icon={XClose} onClick={onClose} />
+        </div>
+        <p className="text-sm text-muted-foreground">{agent.description}</p>
+      </div>
+    </div>
+  );
+}

--- a/sparkle/playground/src/stories/ManageSkills.tsx
+++ b/sparkle/playground/src/stories/ManageSkills.tsx
@@ -606,8 +606,8 @@ export default function ManageSkills() {
       <div className="flex w-full flex-col gap-8 pb-4">
         <Page.Header
           title="Manage Skills"
-          icon={PuzzlePiece01}
           description="Reusable packages of instructions and tools that agents can share."
+          noTopPadding
         />
         <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">

--- a/sparkle/playground/src/stories/ManageSkills.tsx
+++ b/sparkle/playground/src/stories/ManageSkills.tsx
@@ -33,6 +33,16 @@ import {
 import type { RowSelectionState } from "@tanstack/react-table";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import {
+  FleetFilterChips,
+  FleetFilterMenu,
+} from "../components/manage/FleetFilterBar";
+import type { FleetItemFields } from "../components/manage/fleetFilters";
+import {
+  filterFleet,
+  SKILL_STATUS_OPTIONS,
+  useFleetFilters,
+} from "../components/manage/fleetFilters";
 import { ManagePageLayout } from "../components/manage/ManagePageLayout";
 import { ManageSkillsTable } from "../components/manage/ManageSkillsTable";
 import { SKILL_AVAILABILITY_DISPLAY } from "../components/manage/ManageSkillsTable";
@@ -316,6 +326,30 @@ function SkillsBatchEditBar({
 
 // ── Page ──────────────────────────────────────────────────────────────────────
 
+// The mock fleet is generated around a fixed "today" so relative filters
+// ("not used in 60 days") stay stable across renders.
+const NOW_MS = new Date("2026-08-10T10:00:00Z").getTime();
+
+function skillFilterFields(skill: ManagedSkill): FleetItemFields {
+  return {
+    name: skill.name,
+    editorIds: (skill.relations.editors ?? []).map((editor) => editor.sId),
+    editorNames: (skill.relations.editors ?? []).map(
+      (editor) => editor.fullName
+    ),
+    lastEditorId: skill.lastEditedBy?.sId ?? null,
+    tools: skill.tools,
+    status: skill.status === "archived" ? "archived" : "active",
+    // Skills express their scope through availability, which keeps its own
+    // control next to the tabs.
+    visibility: null,
+    modelId: null,
+    tagIds: [],
+    updatedAt: skill.updatedAt,
+    usage: skill.messageUsage,
+  };
+}
+
 export default function ManageSkills() {
   const [activeSkills, setActiveSkills] =
     useState<ManagedSkill[]>(mockActiveSkills);
@@ -325,9 +359,6 @@ export default function ManageSkills() {
     useState<ManagedSkill[]>(mockSuggestedSkills);
 
   const [selectedTab, setSelectedTab] = useState<SkillManagerTabType>("active");
-  const [skillSearch, setSkillSearch] = useState("");
-  const [availabilityFilter, setAvailabilityFilter] =
-    useState<AvailabilityFilter>("all");
   const [bypassEditorVisibility, setBypassEditorVisibility] = useState(false);
   const [isBatchEditing, setIsBatchEditing] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
@@ -335,6 +366,18 @@ export default function ManageSkills() {
     useState<BatchAvailabilityAction | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<ManagedSkill | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+
+  // The availability dropdown keeps its own query param, exactly as it does
+  // today; the rest of the dimensions live in the shared filter state.
+  const { filters, updateFilters, toggleValue, clearFilters } =
+    useFleetFilters();
+  const availabilityFilter = (filters.availability[0] ??
+    "all") as AvailabilityFilter;
+  const setAvailabilityFilter = (value: AvailabilityFilter) =>
+    updateFilters({ availability: value === "all" ? [] : [value] });
+
+  const skillSearch = filters.search;
+  const setSkillSearch = (search: string) => updateFilters({ search });
 
   // The real page renders a spinner while the skills load.
   useEffect(() => {
@@ -345,7 +388,15 @@ export default function ManageSkills() {
   const canMakeSkillAutoDiscoverable = true;
 
   const isSearchActive = skillSearch.trim() !== "";
-  const isFilterActive = isSearchActive || availabilityFilter !== "all";
+  const isFilterActive =
+    isSearchActive ||
+    availabilityFilter !== "all" ||
+    filters.tools.length > 0 ||
+    filters.status.length > 0 ||
+    filters.editors.length > 0 ||
+    filters.lastEditors.length > 0 ||
+    filters.editedWithin !== null ||
+    filters.notUsedFor !== null;
 
   // Switching tabs resets the availability filter to avoid carrying it across
   // lists.
@@ -368,10 +419,28 @@ export default function ManageSkills() {
     [archivedSkills]
   );
 
+  // Everyone who edits something in the fleet — the option list for the
+  // Editors and Last editor filters.
+  const people = useMemo(() => {
+    const byId = new Map<string, { sId: string; fullName: string }>();
+    for (const skill of [...activeSkills, ...archivedSkills]) {
+      for (const editor of skill.relations.editors ?? []) {
+        byId.set(editor.sId, { sId: editor.sId, fullName: editor.fullName });
+      }
+    }
+    return Array.from(byId.values()).sort((a, b) =>
+      a.fullName.localeCompare(b.fullName)
+    );
+  }, [activeSkills, archivedSkills]);
+
+  const peopleById = useMemo(
+    () => new Map(people.map((person) => [person.sId, person.fullName])),
+    [people]
+  );
+
   const skillsByTab = useMemo<
     Record<SkillManagerTabType, ManagedSkill[]>
   >(() => {
-    const searchLower = skillSearch.toLowerCase();
     const editableByMeSkills = sortedActiveSkills.filter((s) =>
       s.relations.editors?.some((e) => e.sId === "1")
     );
@@ -379,34 +448,27 @@ export default function ManageSkills() {
       activeSkills.filter((s) => s.isFavorite)
     );
 
+    // Availability keeps its dedicated control; every other dimension goes
+    // through the shared predicate so they all combine.
+    const filteredList = (list: ManagedSkill[]) =>
+      filterFleet(
+        filterByAvailability(list, availabilityFilter),
+        filters,
+        skillFilterFields,
+        NOW_MS
+      );
+
     return {
-      active: filterBySearch(
-        filterByAvailability(sortedActiveSkills, availabilityFilter),
-        searchLower,
-        isSearchActive
-      ),
-      editable_by_me: filterBySearch(
-        filterByAvailability(editableByMeSkills, availabilityFilter),
-        searchLower,
-        isSearchActive
-      ),
-      favorites: filterBySearch(
-        filterByAvailability(favoriteSkills, availabilityFilter),
-        searchLower,
-        isSearchActive
-      ),
-      archived: filterBySearch(
-        filterByAvailability(sortedArchivedSkills, availabilityFilter),
-        searchLower,
-        isSearchActive
-      ),
+      active: filteredList(sortedActiveSkills),
+      editable_by_me: filteredList(editableByMeSkills),
+      favorites: filteredList(favoriteSkills),
+      archived: filteredList(sortedArchivedSkills),
     };
   }, [
     sortedActiveSkills,
     sortedArchivedSkills,
     activeSkills,
-    skillSearch,
-    isSearchActive,
+    filters,
     availabilityFilter,
   ]);
 
@@ -565,6 +627,14 @@ export default function ManageSkills() {
                 onClick={() => setIsBatchEditing(true)}
               />
             )}
+            <FleetFilterMenu
+              filters={filters}
+              statusOptions={SKILL_STATUS_OPTIONS}
+              people={people}
+              showVisibility={false}
+              onToggle={toggleValue}
+              onUpdate={updateFilters}
+            />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button label="Create skill" icon={Plus} isSelect />
@@ -575,6 +645,21 @@ export default function ManageSkills() {
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
+          <FleetFilterChips
+            filters={filters}
+            statusOptions={SKILL_STATUS_OPTIONS}
+            peopleById={peopleById}
+            onRemove={updateFilters}
+            onClear={clearFilters}
+          />
+          {isFilterActive && (
+            <div className="text-sm text-muted-foreground">
+              {skillsByTab[selectedTab].length} skill
+              {skillsByTab[selectedTab].length === 1 ? "" : "s"} match
+              {skillsByTab[selectedTab].length === 1 ? "es" : ""} the current
+              filters.
+            </div>
+          )}
           {isBatchEditionAvailable && isBatchEditing && (
             <SkillsBatchEditBar
               selectedSkills={selectedSkills}
@@ -649,7 +734,7 @@ export default function ManageSkills() {
             ) : (
               <>
                 {selectedTab === "active" &&
-                  availabilityFilter === "all" &&
+                  !isFilterActive &&
                   suggestedSkills.length > 0 && (
                     <SuggestedSkillsSection
                       skills={sortSkillsByName(suggestedSkills)}
@@ -666,6 +751,7 @@ export default function ManageSkills() {
                 ) : (
                   <ManageSkillsTable
                     skills={skillsByTab[selectedTab]}
+                    nowMs={NOW_MS}
                     onSkillClick={handleSkillClick}
                     onAgentClick={handleAgentClick}
                     onUsedBySkillClick={handleUsedBySkillClick}

--- a/sparkle/playground/src/stories/ManageSkills.tsx
+++ b/sparkle/playground/src/stories/ManageSkills.tsx
@@ -17,7 +17,6 @@ import {
   EmptyCTAButton,
   FolderOpen,
   InfoCircle,
-  ListSelect,
   Page,
   Plus,
   PuzzlePiece01,
@@ -360,7 +359,6 @@ export default function ManageSkills() {
 
   const [selectedTab, setSelectedTab] = useState<SkillManagerTabType>("active");
   const [bypassEditorVisibility, setBypassEditorVisibility] = useState(false);
-  const [isBatchEditing, setIsBatchEditing] = useState(false);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [pendingBatchAction, setPendingBatchAction] =
     useState<BatchAvailabilityAction | null>(null);
@@ -485,7 +483,6 @@ export default function ManageSkills() {
   );
 
   const closeBatchEdition = () => {
-    setIsBatchEditing(false);
     setRowSelection({});
   };
 
@@ -541,7 +538,9 @@ export default function ManageSkills() {
     return () => window.removeEventListener("keydown", handleKeyPress);
   }, []);
 
+  // Archived skills have nothing to batch-edit, so they keep no checkboxes.
   const isBatchEditionAvailable = selectedTab !== "archived";
+  const isBatchEditing = selectedSkillIds.length > 0;
   const isActiveTabEmpty = skillsByTab[selectedTab].length === 0;
 
   const renderEmptyTabState = () => {
@@ -619,14 +618,6 @@ export default function ManageSkills() {
               value={skillSearch}
               onChange={setSkillSearch}
             />
-            {isBatchEditionAvailable && !isBatchEditing && (
-              <Button
-                variant="outline"
-                label="Batch edit"
-                icon={ListSelect}
-                onClick={() => setIsBatchEditing(true)}
-              />
-            )}
             <FleetFilterMenu
               filters={filters}
               statusOptions={SKILL_STATUS_OPTIONS}
@@ -757,7 +748,7 @@ export default function ManageSkills() {
                     onUsedBySkillClick={handleUsedBySkillClick}
                     onArchiveSkill={handleArchiveSkill}
                     canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
-                    {...(isBatchEditionAvailable && isBatchEditing
+                    {...(isBatchEditionAvailable
                       ? { rowSelection, setRowSelection }
                       : {})}
                   />

--- a/sparkle/playground/src/stories/ManageSkills.tsx
+++ b/sparkle/playground/src/stories/ManageSkills.tsx
@@ -1,0 +1,728 @@
+import {
+  Button,
+  Card,
+  CardActionButton,
+  Checkbox,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  EmptyCTA,
+  EmptyCTAButton,
+  FolderOpen,
+  InfoCircle,
+  ListSelect,
+  Page,
+  Plus,
+  PuzzlePiece01,
+  SearchInput,
+  Spinner,
+  Stars02,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  Tooltip,
+  XClose,
+} from "@dust-tt/sparkle";
+import type { RowSelectionState } from "@tanstack/react-table";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { ManagePageLayout } from "../components/manage/ManagePageLayout";
+import { ManageSkillsTable } from "../components/manage/ManageSkillsTable";
+import { SKILL_AVAILABILITY_DISPLAY } from "../components/manage/ManageSkillsTable";
+import { SkillAvatar } from "../components/manage/skillIcons";
+import {
+  compareForFuzzySort,
+  pluralize,
+  subFilter,
+} from "../components/manage/utils";
+import type { ManagedSkill, SkillAvailability } from "../data/manageSkills";
+import {
+  mockActiveSkills,
+  mockArchivedSkills,
+  mockSuggestedSkills,
+  SKILL_AVAILABILITIES,
+} from "../data/manageSkills";
+
+// ── Tabs and filters ──────────────────────────────────────────────────────────
+
+type SkillManagerTabType =
+  | "active"
+  | "editable_by_me"
+  | "favorites"
+  | "archived";
+
+const SKILL_MANAGER_TABS: {
+  id: SkillManagerTabType;
+  label: string;
+  description: string;
+}[] = [
+  { id: "active", label: "All", description: "All active skills" },
+  {
+    id: "editable_by_me",
+    label: "Editable by me",
+    description: "Skills you can edit",
+  },
+  { id: "favorites", label: "Favorites", description: "Skills you favorited" },
+  { id: "archived", label: "Archived", description: "Archived skills" },
+];
+
+type AvailabilityFilter = SkillAvailability | "all";
+
+const AVAILABILITY_FILTER_OPTIONS: {
+  value: AvailabilityFilter;
+  label: string;
+}[] = [
+  { value: "all", label: "All availabilities" },
+  ...SKILL_AVAILABILITIES.map((availability) => ({
+    value: availability,
+    label: SKILL_AVAILABILITY_DISPLAY[availability].label,
+  })),
+];
+
+function getAvailabilityFilterLabel(filter: AvailabilityFilter): string {
+  return (
+    AVAILABILITY_FILTER_OPTIONS.find((o) => o.value === filter)?.label ??
+    "All availabilities"
+  );
+}
+
+function getSkillSearchString(skill: ManagedSkill): string {
+  const editorNames = skill.relations.editors?.map((e) => e.fullName) ?? [];
+  return [skill.name].concat(editorNames).join(" ").toLowerCase();
+}
+
+function sortSkillsByName(skills: ManagedSkill[]) {
+  return [...skills].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function filterByAvailability(
+  skills: ManagedSkill[],
+  availabilityFilter: AvailabilityFilter
+) {
+  return availabilityFilter === "all"
+    ? skills
+    : skills.filter((s) => s.availability === availabilityFilter);
+}
+
+function filterBySearch(
+  skills: ManagedSkill[],
+  searchLower: string,
+  isSearchActive: boolean
+) {
+  if (!isSearchActive) {
+    return skills;
+  }
+  return skills
+    .filter((s) => subFilter(searchLower, getSkillSearchString(s)))
+    .sort((a, b) =>
+      compareForFuzzySort(
+        searchLower,
+        getSkillSearchString(a),
+        getSkillSearchString(b)
+      )
+    );
+}
+
+// ── Suggested skills ──────────────────────────────────────────────────────────
+
+interface SuggestedSkillsSectionProps {
+  skills: ManagedSkill[];
+  onSkillClick: (skill: ManagedSkill) => void;
+  onDismiss: (skill: ManagedSkill) => void;
+}
+
+function SuggestedSkillsSection({
+  skills,
+  onSkillClick,
+  onDismiss,
+}: SuggestedSkillsSectionProps) {
+  if (skills.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-6 flex flex-col gap-3 pb-6">
+      <h4 className="heading-sm flex items-center gap-1.5 text-foreground">
+        Suggested skills
+        <Stars02 className="h-4 w-4" />
+      </h4>
+      <div className="flex gap-2 overflow-x-auto">
+        {skills.map((skill) => (
+          <div key={skill.sId} className="max-w-80 flex-shrink-0">
+            <Card
+              variant="primary"
+              onClick={() => onSkillClick(skill)}
+              action={
+                <CardActionButton
+                  size="icon"
+                  icon={XClose}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDismiss(skill);
+                  }}
+                />
+              }
+            >
+              <div className="flex h-full w-full flex-col justify-between gap-3">
+                <div className="flex flex-col">
+                  <div className="mb-2 flex items-center gap-2">
+                    <SkillAvatar icon={skill.icon} size="sm" />
+                    <span className="truncate text-sm font-medium">
+                      {skill.name}
+                    </span>
+                  </div>
+                  <p className="line-clamp-2 text-sm text-muted-foreground">
+                    {skill.userFacingDescription}
+                  </p>
+                </div>
+                <div>
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    icon={Plus}
+                    label="Add skill"
+                    onClick={(e) => e.stopPropagation()}
+                  />
+                </div>
+              </div>
+            </Card>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Batch edition ─────────────────────────────────────────────────────────────
+
+type BatchAvailabilityAction = {
+  label: string;
+  description?: string;
+  availability: SkillAvailability;
+  getDialogTitle: (count: number) => string;
+  dialogDescription: (count: number) => string;
+};
+
+const BATCH_AVAILABILITY_ACTIONS: BatchAvailabilityAction[] = [
+  {
+    label: "Editors only",
+    availability: "editors",
+    getDialogTitle: (count) =>
+      `Make ${count} skill${pluralize(count)} editors only`,
+    dialogDescription: (count) => {
+      const pronoun = count === 1 ? "it" : "them";
+      const subject = count === 1 ? "The skill remains" : "The skills remain";
+      return `Only editors can find ${pronoun} via the input bar and agent builder. ${subject} available through agents and skills that use ${pronoun}.`;
+    },
+  },
+  {
+    label: "Members",
+    availability: "workspace_users",
+    getDialogTitle: (count) =>
+      `Make ${count} skill${pluralize(count)} available to all members`,
+    dialogDescription: (count) => {
+      const pronoun = count === 1 ? "it" : "them";
+      return `All members can find ${pronoun} via the input bar and agent builder.`;
+    },
+  },
+  {
+    label: "Members and agents",
+    description: "Available to all members and agents with Discover Skills",
+    availability: "users_and_agents",
+    getDialogTitle: () => "This affects your entire workspace",
+    dialogDescription: (count) => {
+      const pronoun = count === 1 ? "it" : "them";
+      return `All members can find ${pronoun} via the input bar and agent builder. Agents with Discover Skills, including Dust, can use ${pronoun} automatically.`;
+    },
+  },
+];
+
+interface SkillsBatchEditBarProps {
+  selectedSkills: ManagedSkill[];
+  canMakeSkillAutoDiscoverable: boolean;
+  onClose: () => void;
+  onSelectAction: (action: BatchAvailabilityAction) => void;
+  onArchive: () => void;
+}
+
+function SkillsBatchEditBar({
+  selectedSkills,
+  canMakeSkillAutoDiscoverable,
+  onClose,
+  onSelectAction,
+  onArchive,
+}: SkillsBatchEditBarProps) {
+  const selectedCount = selectedSkills.length;
+
+  return (
+    <div className="flex flex-row items-center justify-between gap-2 rounded-xl bg-muted-background px-2 py-2 dark:bg-muted-background-night">
+      <Button
+        variant="outline"
+        size="xs"
+        icon={XClose}
+        label="Close edition"
+        onClick={onClose}
+      />
+      <div className="flex flex-row items-center gap-2">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="outline"
+              size="xs"
+              label="Set availability"
+              isSelect
+              disabled={selectedCount === 0}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {BATCH_AVAILABILITY_ACTIONS.map((action) => {
+              const isActionDisabled =
+                action.availability === "users_and_agents" &&
+                !canMakeSkillAutoDiscoverable;
+              return (
+                <DropdownMenuItem
+                  key={action.availability}
+                  label={action.label}
+                  description={
+                    isActionDisabled
+                      ? "You don’t have permission to make skills auto-discoverable"
+                      : action.description
+                  }
+                  disabled={isActionDisabled}
+                  onClick={() => onSelectAction(action)}
+                />
+              );
+            })}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button
+          variant="warning"
+          size="xs"
+          label="Archive"
+          disabled={selectedCount === 0}
+          onClick={onArchive}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ── Page ──────────────────────────────────────────────────────────────────────
+
+export default function ManageSkills() {
+  const [activeSkills, setActiveSkills] =
+    useState<ManagedSkill[]>(mockActiveSkills);
+  const [archivedSkills, setArchivedSkills] =
+    useState<ManagedSkill[]>(mockArchivedSkills);
+  const [suggestedSkills, setSuggestedSkills] =
+    useState<ManagedSkill[]>(mockSuggestedSkills);
+
+  const [selectedTab, setSelectedTab] = useState<SkillManagerTabType>("active");
+  const [skillSearch, setSkillSearch] = useState("");
+  const [availabilityFilter, setAvailabilityFilter] =
+    useState<AvailabilityFilter>("all");
+  const [bypassEditorVisibility, setBypassEditorVisibility] = useState(false);
+  const [isBatchEditing, setIsBatchEditing] = useState(false);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [pendingBatchAction, setPendingBatchAction] =
+    useState<BatchAvailabilityAction | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<ManagedSkill | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // The real page renders a spinner while the skills load.
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setIsLoading(false), 350);
+    return () => window.clearTimeout(timeout);
+  }, []);
+
+  const canMakeSkillAutoDiscoverable = true;
+
+  const isSearchActive = skillSearch.trim() !== "";
+  const isFilterActive = isSearchActive || availabilityFilter !== "all";
+
+  // Switching tabs resets the availability filter to avoid carrying it across
+  // lists.
+  const handleTabChange = (tabId: SkillManagerTabType) => {
+    setSelectedTab(tabId);
+    setAvailabilityFilter("all");
+  };
+
+  const handleShowHiddenChange = (checked: boolean) => {
+    setBypassEditorVisibility(checked);
+    setAvailabilityFilter(checked ? "editors" : "all");
+  };
+
+  const sortedActiveSkills = useMemo(
+    () => sortSkillsByName(activeSkills),
+    [activeSkills]
+  );
+  const sortedArchivedSkills = useMemo(
+    () => sortSkillsByName(archivedSkills),
+    [archivedSkills]
+  );
+
+  const skillsByTab = useMemo<
+    Record<SkillManagerTabType, ManagedSkill[]>
+  >(() => {
+    const searchLower = skillSearch.toLowerCase();
+    const editableByMeSkills = sortedActiveSkills.filter((s) =>
+      s.relations.editors?.some((e) => e.sId === "1")
+    );
+    const favoriteSkills = sortSkillsByName(
+      activeSkills.filter((s) => s.isFavorite)
+    );
+
+    return {
+      active: filterBySearch(
+        filterByAvailability(sortedActiveSkills, availabilityFilter),
+        searchLower,
+        isSearchActive
+      ),
+      editable_by_me: filterBySearch(
+        filterByAvailability(editableByMeSkills, availabilityFilter),
+        searchLower,
+        isSearchActive
+      ),
+      favorites: filterBySearch(
+        filterByAvailability(favoriteSkills, availabilityFilter),
+        searchLower,
+        isSearchActive
+      ),
+      archived: filterBySearch(
+        filterByAvailability(sortedArchivedSkills, availabilityFilter),
+        searchLower,
+        isSearchActive
+      ),
+    };
+  }, [
+    sortedActiveSkills,
+    sortedArchivedSkills,
+    activeSkills,
+    skillSearch,
+    isSearchActive,
+    availabilityFilter,
+  ]);
+
+  const selectedSkillIds = useMemo(
+    () =>
+      Object.entries(rowSelection)
+        .filter(([, selected]) => selected)
+        .map(([sId]) => sId),
+    [rowSelection]
+  );
+  const selectedSkills = useMemo(
+    () => activeSkills.filter((skill) => rowSelection[skill.sId]),
+    [activeSkills, rowSelection]
+  );
+
+  const closeBatchEdition = () => {
+    setIsBatchEditing(false);
+    setRowSelection({});
+  };
+
+  const handleBatchAvailability = (availability: SkillAvailability) => {
+    setActiveSkills((current) =>
+      current.map((skill) =>
+        selectedSkillIds.includes(skill.sId)
+          ? { ...skill, availability }
+          : skill
+      )
+    );
+    setRowSelection({});
+  };
+
+  const handleArchiveSkill = useCallback((skill: ManagedSkill) => {
+    setActiveSkills((current) => current.filter((s) => s.sId !== skill.sId));
+    setArchivedSkills((current) => [
+      ...current,
+      { ...skill, status: "archived" },
+    ]);
+  }, []);
+
+  const handleSkillClick = useCallback((skill: ManagedSkill) => {
+    setSelectedSkill(skill);
+  }, []);
+
+  const handleAgentClick = useCallback(() => {}, []);
+
+  const handleUsedBySkillClick = useCallback(
+    (skillId: string) => {
+      const skill = activeSkills.find((s) => s.sId === skillId);
+      if (skill) {
+        setSelectedSkill(skill);
+      }
+    },
+    [activeSkills]
+  );
+
+  const searchBarRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    searchBarRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event.key === "/") {
+        event.preventDefault();
+        searchBarRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", handleKeyPress);
+    return () => window.removeEventListener("keydown", handleKeyPress);
+  }, []);
+
+  const isBatchEditionAvailable = selectedTab !== "archived";
+  const isActiveTabEmpty = skillsByTab[selectedTab].length === 0;
+
+  const renderEmptyTabState = () => {
+    if (isFilterActive) {
+      return (
+        <EmptyCTA
+          message="No skill matches your search or filters."
+          action={null}
+        />
+      );
+    }
+    // Nothing to create into from the archived tab.
+    if (selectedTab === "archived") {
+      return null;
+    }
+    return (
+      <EmptyCTA
+        action={
+          <EmptyCTAButton
+            label="Create a skill"
+            icon={Plus}
+            variant="primary"
+          />
+        }
+      />
+    );
+  };
+
+  return (
+    <ManagePageLayout>
+      {pendingBatchAction && (
+        <Dialog
+          open
+          onOpenChange={(open) => {
+            if (!open) {
+              setPendingBatchAction(null);
+            }
+          }}
+        >
+          <DialogContent size="md" isAlertDialog>
+            <DialogHeader hideButton>
+              <DialogTitle>
+                {pendingBatchAction.getDialogTitle(selectedSkillIds.length)}
+              </DialogTitle>
+            </DialogHeader>
+            <DialogContainer className="text-sm">
+              {pendingBatchAction.dialogDescription(selectedSkillIds.length)}
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{ label: "Cancel", variant: "outline" }}
+              rightButtonProps={{
+                label: "Update",
+                onClick: () => {
+                  handleBatchAvailability(pendingBatchAction.availability);
+                  setPendingBatchAction(null);
+                },
+              }}
+            />
+          </DialogContent>
+        </Dialog>
+      )}
+      <div className="flex w-full flex-col gap-8 pb-4">
+        <Page.Header
+          title="Manage Skills"
+          icon={PuzzlePiece01}
+          description="Reusable packages of instructions and tools that agents can share."
+        />
+        <Page.Vertical gap="md" align="stretch">
+          <div className="flex flex-row gap-2">
+            <SearchInput
+              ref={searchBarRef}
+              className="flex-grow"
+              name="search"
+              placeholder="Search (Name, Editors)"
+              value={skillSearch}
+              onChange={setSkillSearch}
+            />
+            {isBatchEditionAvailable && !isBatchEditing && (
+              <Button
+                variant="outline"
+                label="Batch edit"
+                icon={ListSelect}
+                onClick={() => setIsBatchEditing(true)}
+              />
+            )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button label="Create skill" icon={Plus} isSelect />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem label="From scratch" icon={PuzzlePiece01} />
+                <DropdownMenuItem label="From existing" icon={FolderOpen} />
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          {isBatchEditionAvailable && isBatchEditing && (
+            <SkillsBatchEditBar
+              selectedSkills={selectedSkills}
+              canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
+              onClose={closeBatchEdition}
+              onSelectAction={setPendingBatchAction}
+              onArchive={() => {
+                selectedSkills.forEach(handleArchiveSkill);
+                closeBatchEdition();
+              }}
+            />
+          )}
+          <div className="flex flex-col pt-3">
+            <Tabs value={selectedTab}>
+              <TabsList>
+                {SKILL_MANAGER_TABS.map((tab) => (
+                  <TabsTrigger
+                    key={tab.id}
+                    value={tab.id}
+                    label={tab.label}
+                    onClick={() => handleTabChange(tab.id)}
+                    tooltip={tab.description}
+                    isCounter={tab.id !== "archived"}
+                    counterValue={`${skillsByTab[tab.id].length}`}
+                  />
+                ))}
+                <div className="ml-auto flex flex-row items-center gap-3 self-center text-sm text-muted-foreground">
+                  <span className="flex gap-1">
+                    <label className="flex cursor-pointer flex-row items-center gap-2 whitespace-nowrap">
+                      <Checkbox
+                        checked={bypassEditorVisibility}
+                        onCheckedChange={(checked) =>
+                          handleShowHiddenChange(checked === true)
+                        }
+                      />
+                      Show hidden skills
+                    </label>
+                    <Tooltip
+                      label="Shows skills you can access as an admin, even if you’re not an editor"
+                      trigger={
+                        <InfoCircle className="h-4 w-4 text-muted-foreground" />
+                      }
+                    />
+                  </span>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        isSelect
+                        className="w-44 justify-between"
+                        label={getAvailabilityFilterLabel(availabilityFilter)}
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="w-48">
+                      {AVAILABILITY_FILTER_OPTIONS.map((option) => (
+                        <DropdownMenuItem
+                          key={option.value}
+                          label={option.label}
+                          onClick={() => setAvailabilityFilter(option.value)}
+                        />
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+              </TabsList>
+            </Tabs>
+            {isLoading ? (
+              <div className="mt-8 flex justify-center">
+                <Spinner size="lg" />
+              </div>
+            ) : (
+              <>
+                {selectedTab === "active" &&
+                  availabilityFilter === "all" &&
+                  suggestedSkills.length > 0 && (
+                    <SuggestedSkillsSection
+                      skills={sortSkillsByName(suggestedSkills)}
+                      onSkillClick={handleSkillClick}
+                      onDismiss={(skill) =>
+                        setSuggestedSkills((current) =>
+                          current.filter((s) => s.sId !== skill.sId)
+                        )
+                      }
+                    />
+                  )}
+                {isActiveTabEmpty ? (
+                  <div className="pt-2">{renderEmptyTabState()}</div>
+                ) : (
+                  <ManageSkillsTable
+                    skills={skillsByTab[selectedTab]}
+                    onSkillClick={handleSkillClick}
+                    onAgentClick={handleAgentClick}
+                    onUsedBySkillClick={handleUsedBySkillClick}
+                    onArchiveSkill={handleArchiveSkill}
+                    canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
+                    {...(isBatchEditionAvailable && isBatchEditing
+                      ? { rowSelection, setRowSelection }
+                      : {})}
+                  />
+                )}
+              </>
+            )}
+          </div>
+        </Page.Vertical>
+      </div>
+      {selectedSkill && (
+        <SkillDetailsPlaceholder
+          skill={selectedSkill}
+          onClose={() => setSelectedSkill(null)}
+        />
+      )}
+    </ManagePageLayout>
+  );
+}
+
+// The details sheet is out of scope for this playground; a minimal panel keeps
+// the row click meaningful.
+function SkillDetailsPlaceholder({
+  skill,
+  onClose,
+}: {
+  skill: ManagedSkill;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex justify-end bg-black/20"
+      onClick={onClose}
+    >
+      <div
+        className="flex h-full w-96 flex-col gap-3 bg-background p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2">
+            <SkillAvatar
+              icon={skill.icon}
+              isDustProvided={skill.editedBy === null}
+            />
+            <span className="heading-lg text-foreground">{skill.name}</span>
+          </div>
+          <Button size="xs" variant="ghost" icon={XClose} onClick={onClose} />
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {skill.userFacingDescription}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/sparkle/playground/src/stories/ManageSkills.tsx
+++ b/sparkle/playground/src/stories/ManageSkills.tsx
@@ -39,7 +39,6 @@ import {
 import type { FleetItemFields } from "../components/manage/fleetFilters";
 import {
   filterFleet,
-  SKILL_STATUS_OPTIONS,
   useFleetFilters,
 } from "../components/manage/fleetFilters";
 import { ManagePageLayout } from "../components/manage/ManagePageLayout";
@@ -336,12 +335,10 @@ function skillFilterFields(skill: ManagedSkill): FleetItemFields {
     editorNames: (skill.relations.editors ?? []).map(
       (editor) => editor.fullName
     ),
-    lastEditorId: skill.lastEditedBy?.sId ?? null,
     tools: skill.tools,
-    status: skill.status === "archived" ? "archived" : "active",
-    // Skills express their scope through availability, which keeps its own
-    // control next to the tabs.
-    visibility: null,
+    // Skills express publication through availability, which keeps its own
+    // control next to the tabs; status is already the Archived tab.
+    publication: null,
     modelId: null,
     tagIds: [],
     updatedAt: skill.updatedAt,
@@ -390,9 +387,7 @@ export default function ManageSkills() {
     isSearchActive ||
     availabilityFilter !== "all" ||
     filters.tools.length > 0 ||
-    filters.status.length > 0 ||
     filters.editors.length > 0 ||
-    filters.lastEditors.length > 0 ||
     filters.editedWithin !== null ||
     filters.notUsedFor !== null;
 
@@ -609,36 +604,38 @@ export default function ManageSkills() {
           noTopPadding
         />
         <Page.Vertical gap="md" align="stretch">
-          <div className="flex flex-row gap-2">
+          <div className="flex flex-row items-center gap-2">
+            {/* Bounded, not full-width: a fleet is filtered far more often than
+                it is keyword-searched, so the input should not dominate. */}
             <SearchInput
               ref={searchBarRef}
-              className="flex-grow"
+              className="w-full max-w-md"
               name="search"
               placeholder="Search (Name, Editors)"
               value={skillSearch}
               onChange={setSkillSearch}
             />
-            <FleetFilterMenu
-              filters={filters}
-              statusOptions={SKILL_STATUS_OPTIONS}
-              people={people}
-              showVisibility={false}
-              onToggle={toggleValue}
-              onUpdate={updateFilters}
-            />
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button label="Create skill" icon={Plus} isSelect />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuItem label="From scratch" icon={PuzzlePiece01} />
-                <DropdownMenuItem label="From existing" icon={FolderOpen} />
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <div className="ml-auto flex gap-2">
+              <FleetFilterMenu
+                filters={filters}
+                people={people}
+                showPublication={false}
+                onToggle={toggleValue}
+                onUpdate={updateFilters}
+              />
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button label="Create skill" icon={Plus} isSelect />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent>
+                  <DropdownMenuItem label="From scratch" icon={PuzzlePiece01} />
+                  <DropdownMenuItem label="From existing" icon={FolderOpen} />
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </div>
           <FleetFilterChips
             filters={filters}
-            statusOptions={SKILL_STATUS_OPTIONS}
             peopleById={peopleById}
             onRemove={updateFilters}
             onClear={clearFilters}

--- a/sparkle/playground/src/stories/SidebarScrollBlur.tsx
+++ b/sparkle/playground/src/stories/SidebarScrollBlur.tsx
@@ -1,0 +1,411 @@
+import {
+  Button,
+  cn,
+  Counter,
+  Lightbulb04,
+  MessagePlusCircle,
+  NavigationList,
+  NavigationListItem,
+  Robot,
+  ScrollArea,
+  SearchInput,
+} from "@dust-tt/sparkle";
+import { useEffect, useRef, useState } from "react";
+
+// Replica of front/components/assistant/conversation/SidebarMenu.tsx so the
+// top-of-scroll blur can be tuned in isolation.
+//
+// "Single" is one backdrop-filter layer faded out by a mask — cheap, but the
+// blur radius is constant so the eye catches where it stops.
+// "Progressive" stacks N layers, each blurring more and masked to a shorter
+// band, so the radius itself ramps up towards the header. That's the effect
+// used by macOS/iOS (and what the Claude Code sidebar looks like).
+
+const CONVERSATIONS = [
+  "Outage banner sticky positioning",
+  "Playground Manage Agent Skills",
+  "Dark mode ContentMessage fix",
+  "Sidebar scroll behaviour",
+  "Agent builder model tooltips",
+  "User memory skill instructions",
+  "Swagger annotations lint",
+  "Temporal worker retries",
+  "Elasticsearch reindex plan",
+  "Audit log schema sync",
+  "Pod conversation summary",
+  "Infinite scroll root margin",
+  "Zendesk custom fields",
+  "Notion connector backfill",
+  "Slack thread ingestion",
+  "Webhook source rotation",
+  "Sandbox egress policy",
+  "Frame view regressions",
+  "Citation hover states",
+  "Table virtualization",
+];
+
+type Mode = "shadow" | "single" | "progressive";
+
+const SHADOWS = ["shadow", "shadow-md", "shadow-lg", "shadow-xl"] as const;
+
+interface OverlayConfig {
+  mode: Mode;
+  heightPx: number;
+  blurPx: number;
+  layers: number;
+  tintPct: number;
+  paddingPx: number;
+  shadow: string;
+}
+
+/**
+ * Layers for the progressive mode. Each one blurs twice as much as the
+ * previous and is masked to a band half as tall, so blur ramps up towards the
+ * top with no single visible edge.
+ */
+function progressiveLayers(count: number, blurPx: number) {
+  return Array.from({ length: count }, (_, i) => {
+    const stop = 100 / 2 ** i;
+    return {
+      key: i,
+      blur: blurPx * 2 ** i,
+      maskStop: stop,
+    };
+  });
+}
+
+function ScrollBlurOverlay({
+  config,
+  isVisible,
+}: {
+  config: OverlayConfig;
+  isVisible: boolean;
+}) {
+  const { mode, heightPx, blurPx, layers, tintPct } = config;
+
+  const tint =
+    tintPct > 0
+      ? `color-mix(in oklab, var(--color-app-background) ${tintPct}%, transparent)`
+      : undefined;
+
+  const common = cn(
+    "pointer-events-none absolute inset-x-0 top-0",
+    "transition-opacity duration-200",
+    isVisible ? "opacity-100" : "opacity-0"
+  );
+
+  if (mode === "single") {
+    return (
+      <div
+        className={common}
+        style={{
+          height: `${heightPx}px`,
+          backdropFilter: `blur(${blurPx}px)`,
+          WebkitBackdropFilter: `blur(${blurPx}px)`,
+          backgroundColor: tint,
+          maskImage: "linear-gradient(to bottom, black 0%, transparent 100%)",
+          WebkitMaskImage:
+            "linear-gradient(to bottom, black 0%, transparent 100%)",
+        }}
+      />
+    );
+  }
+
+  return (
+    <>
+      {tint && (
+        <div
+          className={common}
+          style={{
+            height: `${heightPx}px`,
+            backgroundColor: tint,
+            maskImage: "linear-gradient(to bottom, black 0%, transparent 100%)",
+            WebkitMaskImage:
+              "linear-gradient(to bottom, black 0%, transparent 100%)",
+          }}
+        />
+      )}
+      {progressiveLayers(layers, blurPx).map(({ key, blur, maskStop }) => {
+        const mask = `linear-gradient(to bottom, black 0%, black ${maskStop / 2}%, transparent ${maskStop}%)`;
+        return (
+          <div
+            key={key}
+            className={common}
+            style={{
+              height: `${heightPx}px`,
+              backdropFilter: `blur(${blur}px)`,
+              WebkitBackdropFilter: `blur(${blur}px)`,
+              maskImage: mask,
+              WebkitMaskImage: mask,
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}
+
+function Sidebar({ config }: { config: OverlayConfig }) {
+  const [scrollViewport, setScrollViewport] = useState<HTMLDivElement | null>(
+    null
+  );
+  const [isScrolled, setIsScrolled] = useState(false);
+  const scrollTopSentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const sentinel = scrollTopSentinelRef.current;
+    if (
+      !scrollViewport ||
+      !sentinel ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setIsScrolled(!entry.isIntersecting),
+      { root: scrollViewport }
+    );
+    observer.observe(sentinel);
+
+    return () => observer.disconnect();
+  }, [scrollViewport]);
+
+  return (
+    <div className="flex h-full w-[320px] flex-col border-r border-border bg-app-background">
+      <div className="z-50 flex justify-end gap-2 p-sidebar-side-spacing">
+        <div className="flex-1">
+          <SearchInput
+            name="search"
+            placeholder="Search"
+            value=""
+            onChange={() => {}}
+          />
+        </div>
+        <Button
+          label="New"
+          icon={MessagePlusCircle}
+          variant="highlight"
+          className="shrink-0"
+        />
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ScrollArea
+          viewportRef={setScrollViewport}
+          className="dd-privacy-mask h-full w-full"
+        >
+          <div ref={scrollTopSentinelRef} className="h-px" aria-hidden />
+          <div className="sticky top-0 z-30 h-0" aria-hidden>
+            {config.mode === "shadow" ? (
+              <div
+                className={cn(
+                  "pointer-events-none absolute inset-x-0 top-0 h-px",
+                  "bg-app-background transition-opacity duration-200",
+                  config.shadow,
+                  isScrolled ? "opacity-100" : "opacity-0"
+                )}
+              />
+            ) : (
+              <ScrollBlurOverlay config={config} isVisible={isScrolled} />
+            )}
+          </div>
+
+          <div
+            className="flex flex-col gap-4"
+            style={{ paddingTop: `${config.paddingPx}px` }}
+          >
+            <NavigationList className="mx-sidebar-side-spacing pt-1">
+              <NavigationListItem
+                label="For you"
+                icon={Lightbulb04}
+                suffix={<Counter value={1} size="xs" variant="highlight" />}
+              />
+              <NavigationListItem icon={Robot} label="Agents" />
+              <NavigationListItem icon={Robot} label="Skills" />
+            </NavigationList>
+
+            <NavigationList className="mx-sidebar-side-spacing">
+              {CONVERSATIONS.map((title) => (
+                <NavigationListItem key={title} label={title} />
+              ))}
+            </NavigationList>
+          </div>
+        </ScrollArea>
+      </div>
+    </div>
+  );
+}
+
+interface SliderRowProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  unit: string;
+  onChange: (value: number) => void;
+}
+
+function SliderRow({
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  unit,
+  onChange,
+}: SliderRowProps) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="copy-sm text-muted-foreground">
+        {label}: {value}
+        {unit}
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </label>
+  );
+}
+
+export default function SidebarScrollBlur() {
+  const [mode, setMode] = useState<Mode>("shadow");
+  const [heightPx, setHeightPx] = useState(40);
+  const [blurPx, setBlurPx] = useState(1);
+  const [layers, setLayers] = useState(4);
+  const [tintPct, setTintPct] = useState(0);
+  const [paddingPx, setPaddingPx] = useState(0);
+  const [shadow, setShadow] = useState<string>("shadow-md");
+
+  const config = { mode, heightPx, blurPx, layers, tintPct, paddingPx, shadow };
+
+  const snippet =
+    mode === "shadow"
+      ? `pointer-events-none absolute inset-x-0 top-0 h-px bg-app-background ${shadow} transition-opacity duration-200`
+      : mode === "single"
+        ? [
+            "pointer-events-none absolute inset-x-0 top-0",
+            `h-[${heightPx}px] backdrop-blur-[${blurPx}px]`,
+            tintPct > 0 ? `bg-app-background/${tintPct}` : null,
+            "[mask-image:linear-gradient(to_bottom,black_0%,transparent_100%)]",
+            "transition-opacity duration-200",
+          ]
+            .filter(Boolean)
+            .join(" ")
+        : progressiveLayers(layers, blurPx)
+            .map(
+              ({ blur, maskStop }) =>
+                `blur ${blur}px · mask black→${maskStop / 2}%→transparent ${maskStop}%`
+            )
+            .join("\n");
+
+  return (
+    <div className="flex h-screen bg-background">
+      <Sidebar config={config} />
+
+      <div className="flex w-[420px] flex-col gap-4 p-6">
+        <h2 className="heading-lg text-foreground">Top-scroll blur</h2>
+        <p className="copy-sm text-muted-foreground">
+          Scroll the sidebar to reveal the overlay.
+        </p>
+
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            label="Shadow"
+            variant={mode === "shadow" ? "primary" : "outline"}
+            onClick={() => setMode("shadow")}
+          />
+          <Button
+            size="sm"
+            label="Progressive"
+            variant={mode === "progressive" ? "primary" : "outline"}
+            onClick={() => setMode("progressive")}
+          />
+          <Button
+            size="sm"
+            label="Single layer"
+            variant={mode === "single" ? "primary" : "outline"}
+            onClick={() => setMode("single")}
+          />
+        </div>
+
+        {mode === "shadow" && (
+          <div className="flex flex-wrap gap-2">
+            {SHADOWS.map((s) => (
+              <Button
+                key={s}
+                size="xs"
+                label={s}
+                variant={shadow === s ? "primary" : "outline"}
+                onClick={() => setShadow(s)}
+              />
+            ))}
+          </div>
+        )}
+
+        <SliderRow
+          label="Padding above content"
+          value={paddingPx}
+          min={0}
+          max={64}
+          step={4}
+          unit="px"
+          onChange={setPaddingPx}
+        />
+        <SliderRow
+          label="Band height"
+          value={heightPx}
+          min={8}
+          max={120}
+          step={4}
+          unit="px"
+          onChange={setHeightPx}
+        />
+        <SliderRow
+          label={mode === "single" ? "Blur" : "Base blur (doubles per layer)"}
+          value={blurPx}
+          min={0.5}
+          max={8}
+          step={0.5}
+          unit="px"
+          onChange={setBlurPx}
+        />
+        {mode === "progressive" && (
+          <SliderRow
+            label="Layers"
+            value={layers}
+            min={1}
+            max={6}
+            unit=""
+            onChange={setLayers}
+          />
+        )}
+        <SliderRow
+          label="Background tint"
+          value={tintPct}
+          min={0}
+          max={100}
+          step={5}
+          unit="%"
+          onChange={setTintPct}
+        />
+
+        <div className="mt-4 rounded-xl border border-border bg-muted-background p-3">
+          <p className="copy-xs mb-2 text-muted-foreground">
+            {mode === "single" ? "className" : "layers (top → bottom)"}
+          </p>
+          <code className="copy-xs block whitespace-pre-wrap break-all text-foreground">
+            {snippet}
+          </code>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/sparkle/playground/src/stories/TopBanner.tsx
+++ b/sparkle/playground/src/stories/TopBanner.tsx
@@ -1,0 +1,5 @@
+import { TopBannerView } from "../components/TopBannerView";
+
+export default function TopBanner() {
+  return <TopBannerView />;
+}


### PR DESCRIPTION
Front-end prototype, in `sparkle/playground` only — **no backend, nothing wired to real data.** Two standalone stories, `#ManageAgents` and `#ManageSkills`, exploring how admins could reason about a large fleet of agents and skills.

## Why

Today both screens only search by name and editors. As workspaces grow past a few hundred agents/skills, admins can't answer basic questions: which ones are actually used, which ones touch a given connector, which are stale enough to archive — and which look unused but are depended upon.

## What's in it

**Faithful baseline first.** Both screens reproduce the real ones on Sparkle components: same layout, columns, tabs and counters, batch edit, empty states, pagination, responsive breakpoints, dark mode. Populated with deterministic mock data (382 custom agents + 55 default + 14 archived; 543 skills + 23 archived + 3 suggested), seeded so renders are stable.

**Combinable filters.** One `Filters` button with a counter, each dimension a submenu: tools/connectors, status, scope, model, tags, editors, last editor, last edited, usage. Every dimension is a plain AND in a single `filterFleet` predicate shared by both screens, so `"published agents using Salesforce, not used in 60 days"` is just three predicates. Active filters render as removable chips with `Clear all`.

**Shareable URLs.** Filter state lives in the query string:

- `?status=published&tools=salesforce&notUsedFor=60d#ManageAgents`
- `?editedWithin=stale_180d&notUsedFor=90d#ManageSkills` — the archiving-candidate view

**Segmented usage column.** One sortable column: human messages over 30 days is the number *and* the sort key, so API traffic can't float an agent nobody talks to. Programmatic and agent-to-agent traffic are muted secondary indicators, with the full breakdown and last use in the tooltip:

> 0 human messages over the last 30 days
> Also 1,549 via Slack workflow, PowerPoint add-in
> Called 841 times by other agents — archiving it will break them
> Last used today

Origin classification mirrors front's `USAGE_ORIGINS_CLASSIFICATION` verbatim: **automated is not the same as programmatic** — triggers and wake-ups count as human usage since they run a human's configured intent; only API-driven and high-volume integration origins are programmatic. The "not used" filter reads a separate `lastHumanUsedAt`, so an agent kept warm by an integration still surfaces as one nobody talks to, with its dependency visible on the row.

**Batch mode by selection.** Every selectable row carries a checkbox; ticking one enters batch mode, so there's no `Batch edit` button. Row click stays the details sheet while nothing is selected and toggles selection once batch mode is on. Tabs with nothing selectable (default agents, archived) get no checkbox column rather than a column of disabled ones.

## Deliberate deviations from the current UI

- **Models and Tags moved into the `Filters` menu.** They had their own toolbar buttons; leaving them out gave three filter controls side by side. Toolbar is now Search / Filters / Create on both screens.
- **Chips row added to Manage Skills** (Manage Agents already had one for models/tags).
- **Agents gained a mock `visibility`** (workspace / space / personal) to give the Scope filter something to bite on. Filter only, no new column.
- **`Page.Header` icon dropped** to follow main.
- Suggested skills are hidden while a filter is active.

## Notes for reviewers

- Filtering is client-side over mocks, but isolated in a pure `filterFleet(items, filters, select, now)` — the port to a server-side query is mechanical. Doing it for real needs an ES aggregation for the usage dimensions plus SQL for the config ones; happy to write that plan up separately.
- Skills usage moved from an unsegmented all-time count to 30-day human, to match agents.
- Two things worth upstreaming if this graduates: sparkle's `createSelectionColumn` lets the checkbox click bubble to the row (replaced locally here), and the playground router dropped the hash on first load, which broke deep links (fixed in `App.tsx`).

Out of scope by design: merging the two screens, batch actions, lifecycle/approval flow, semantic search. Details sheets are minimal placeholders.
