### PR TITLE
Pricing: download Metronome and ElasticSearch details usage from poke

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/credits/consumption-export.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/consumption-export.ts
@@ -1,0 +1,55 @@
+import { buildMemberConsumptionExportZip } from "@app/lib/api/credits/consumption_export";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { pokeApp } from "@front-api/middlewares/ctx";
+import { apiError } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { z } from "zod";
+
+const QuerySchema = z.object({
+  userId: z.string().min(1),
+});
+
+// Mounted at /api/poke/workspaces/:wId/credits/consumption-export.
+const app = pokeApp();
+
+/** @ignoreswagger */
+app.get("/", validate("query", QuerySchema), async (ctx) => {
+  const auth = ctx.get("auth");
+  const { userId } = ctx.req.valid("query");
+
+  const user = await UserResource.fetchById(userId);
+  if (!user) {
+    return apiError(ctx, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message:
+          "The user you're trying to export consumption for was not found.",
+      },
+    });
+  }
+
+  const result = await buildMemberConsumptionExportZip(auth, { user });
+  if (result.isErr()) {
+    return apiError(ctx, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: result.error.message,
+      },
+    });
+  }
+
+  const { zip, filename } = result.value;
+
+  // Raw Response, matching the pod app export route: the body is binary, not JSON.
+  return new Response(new Uint8Array(zip), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/zip",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+    },
+  });
+});
+
+export default app;

--- a/front-api/routes/poke/workspaces/[wId]/credits/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/credits/index.ts
@@ -4,6 +4,7 @@ import { pokeApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
 import awuPoolSummary from "./awu-pool-summary";
+import consumptionExport from "./consumption-export";
 import membersUsage from "./members-usage";
 import topUps from "./top-ups";
 
@@ -35,6 +36,7 @@ app.get("/", async (ctx): HandlerResult<PokeListCreditsResponseBody> => {
 });
 
 app.route("/awu-pool-summary", awuPoolSummary);
+app.route("/consumption-export", consumptionExport);
 app.route("/members-usage", membersUsage);
 app.route("/top-ups", topUps);
 

--- a/front/components/poke/credits/MemberConsumptionExportButton.tsx
+++ b/front/components/poke/credits/MemberConsumptionExportButton.tsx
@@ -1,0 +1,33 @@
+import { useDownloadCsv } from "@app/hooks/useDownloadCsv";
+import type { WorkspaceType } from "@app/types/user";
+import { Button, Download01 } from "@dust-tt/sparkle";
+
+interface MemberConsumptionExportButtonProps {
+  owner: WorkspaceType;
+  userId: string;
+}
+
+// Downloads a ZIP with one CSV per itemizable consumption source
+// (Elasticsearch and Metronome), each listing the rows behind the total shown in
+// the "Consumed (ES / RL / MT)" column for the current billing cycle. The RL
+// counter has no file: Redis holds a single counter, with nothing to itemize.
+export function MemberConsumptionExportButton({
+  owner,
+  userId,
+}: MemberConsumptionExportButtonProps) {
+  const { isDownloading, handleDownload } = useDownloadCsv({
+    url: `/api/poke/workspaces/${owner.sId}/credits/consumption-export?userId=${userId}`,
+    filename: `dust_consumption_${owner.sId}_${userId}.zip`,
+  });
+
+  return (
+    <Button
+      icon={Download01}
+      variant="ghost"
+      size="xs"
+      tooltip="Download ES / MT consumption details (ZIP)"
+      onClick={handleDownload}
+      isLoading={isDownloading}
+    />
+  );
+}

--- a/front/components/poke/credits/PokeMembersUsageTable.tsx
+++ b/front/components/poke/credits/PokeMembersUsageTable.tsx
@@ -1,6 +1,7 @@
 import { AlertChip } from "@app/components/poke/credits/AlertChip";
 import { CreditStateLogsLink } from "@app/components/poke/credits/CreditStateLogsLink";
 import { GrantFreeCreditsButton } from "@app/components/poke/credits/GrantFreeCreditsButton";
+import { MemberConsumptionExportButton } from "@app/components/poke/credits/MemberConsumptionExportButton";
 import { ReconcileCreditStateButton } from "@app/components/poke/credits/ReconcileCreditStateButton";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
@@ -243,25 +244,29 @@ function makeColumns({
           consumedAwuCredits,
           rateLimiterSpendAwuCredits,
           metronomeConsumedAwuCredits,
+          sId,
         } = row.original;
         if (!showCreditColumns) {
           return <span>{formatCreditsPrecise(consumedAwuCredits)}</span>;
         }
         return (
-          <div className="flex flex-col text-xs">
-            <span>ES {formatCreditsPrecise(consumedAwuCredits)}</span>
-            <span className="text-muted-foreground">
-              RL{" "}
-              {rateLimiterSpendAwuCredits !== null
-                ? formatCreditsPrecise(rateLimiterSpendAwuCredits)
-                : "-"}
-            </span>
-            <span className="text-muted-foreground">
-              MT{" "}
-              {metronomeConsumedAwuCredits !== null
-                ? formatCreditsPrecise(metronomeConsumedAwuCredits)
-                : "-"}
-            </span>
+          <div className="flex items-center gap-1">
+            <div className="flex flex-col text-xs">
+              <span>ES {formatCreditsPrecise(consumedAwuCredits)}</span>
+              <span className="text-muted-foreground">
+                RL{" "}
+                {rateLimiterSpendAwuCredits !== null
+                  ? formatCreditsPrecise(rateLimiterSpendAwuCredits)
+                  : "-"}
+              </span>
+              <span className="text-muted-foreground">
+                MT{" "}
+                {metronomeConsumedAwuCredits !== null
+                  ? formatCreditsPrecise(metronomeConsumedAwuCredits)
+                  : "-"}
+              </span>
+            </div>
+            <MemberConsumptionExportButton owner={owner} userId={sId} />
           </div>
         );
       },

--- a/front/lib/api/credits/consumption_export.test.ts
+++ b/front/lib/api/credits/consumption_export.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment node: adm-zip requires Node builtins (Buffer, zlib)
+import { buildMemberConsumptionExportZip } from "@app/lib/api/credits/consumption_export";
+import type { ElasticsearchBaseDocument } from "@app/lib/api/elasticsearch";
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import { fetchPerUserAwuUsageRows } from "@app/lib/metronome/per_user_usage";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import AdmZip from "adm-zip";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Both consumption sources are external (Elasticsearch, Metronome); stub each
+// read and keep the rest — membership resolution, row shaping, CSV and ZIP
+// assembly — real.
+vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/elasticsearch")>();
+  return { ...actual, searchAnalytics: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/contracts", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/metronome/contracts")>();
+  return { ...actual, getCachedMetronomeCurrentBillingPeriod: vi.fn() };
+});
+
+vi.mock("@app/lib/metronome/per_user_usage", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/metronome/per_user_usage")>();
+  return { ...actual, fetchPerUserAwuUsageRows: vi.fn() };
+});
+
+const CYCLE_START = new Date("2026-08-01T00:00:00.000Z");
+const CYCLE_END = new Date("2026-09-01T00:00:00.000Z");
+
+function mockEsDocuments(documents: ElasticsearchBaseDocument[]) {
+  vi.mocked(searchAnalytics).mockResolvedValue(
+    new Ok({
+      took: 1,
+      timed_out: false,
+      _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+      hits: {
+        total: { value: documents.length, relation: "eq" },
+        hits: documents.map((doc, i) => ({
+          _index: "analytics",
+          _id: String(i),
+          _source: doc,
+          sort: [i],
+        })),
+      },
+    })
+  );
+}
+
+function makeEsDocument({
+  messageId,
+  billableAwu,
+}: {
+  messageId: string;
+  billableAwu: number;
+}) {
+  return {
+    workspace_id: "workspace_id",
+    message_id: messageId,
+    conversation_id: "conv_1",
+    agent_id: "agent_1",
+    agent_version: "3",
+    model: { provider_id: "anthropic", model_id: "claude-opus-5" },
+    status: "succeeded",
+    is_free_seat: false,
+    context_origin: "web",
+    timestamp: "2026-08-02T10:00:00.000Z",
+    cost: {
+      full_awu: billableAwu,
+      llm_awu: billableAwu,
+      tool_awu: 0,
+      billable_awu: billableAwu,
+    },
+  };
+}
+
+function readCsv(zip: Buffer, entryName: string): string[] {
+  return new AdmZip(zip)
+    .getEntry(entryName)!
+    .getData()
+    .toString("utf-8")
+    .trim()
+    .split("\n");
+}
+
+async function setup() {
+  const workspace = await WorkspaceFactory.creditPriced();
+  const user = await UserFactory.basic();
+  await MembershipFactory.associate(workspace, user, { role: "user" });
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  return { auth, user, workspace };
+}
+
+describe("buildMemberConsumptionExportZip", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedMetronomeCurrentBillingPeriod).mockResolvedValue(
+      new Ok({ cycleStart: CYCLE_START, cycleEnd: CYCLE_END })
+    );
+    mockEsDocuments([]);
+    vi.mocked(fetchPerUserAwuUsageRows).mockResolvedValue(new Ok([]));
+  });
+
+  it("writes one CSV per source, each row dated by its consumption event", async () => {
+    const { auth, user } = await setup();
+
+    mockEsDocuments([
+      makeEsDocument({ messageId: "msg_1", billableAwu: 12 }),
+      makeEsDocument({ messageId: "msg_2", billableAwu: 30 }),
+    ]);
+    vi.mocked(fetchPerUserAwuUsageRows).mockResolvedValue(
+      new Ok([
+        {
+          userId: user.sId,
+          metric: "llm_provider_cost_awu",
+          usageType: "user",
+          toolCategory: null,
+          startingOn: "2026-08-02T00:00:00.000Z",
+          endingBefore: "2026-08-03T00:00:00.000Z",
+          value: 40,
+          awuWeight: 1,
+          awuCredits: 40,
+        },
+      ])
+    );
+
+    const result = await buildMemberConsumptionExportZip(auth, { user });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const { zip } = result.value;
+    const esLines = readCsv(zip, "elasticsearch.csv");
+    const metronomeLines = readCsv(zip, "metronome.csv");
+
+    // Header + one row per message / per usage bucket.
+    expect(esLines).toHaveLength(3);
+    expect(metronomeLines).toHaveLength(2);
+    // Both files carry the shared columns, then their own dating: the message
+    // timestamp for ES, the bucket bounds for Metronome.
+    expect(esLines[0]).toContain("awuCredits,date,messageId");
+    expect(esLines[1]).toContain("12,2026-08-02T10:00:00.000Z,msg_1");
+    expect(metronomeLines[0]).toContain("awuCredits,startDate,endDate");
+    expect(metronomeLines[1]).toContain(
+      "40,2026-08-02T00:00:00.000Z,2026-08-03T00:00:00.000Z"
+    );
+
+    // Hourly windows: the finest per-user breakdown Metronome exposes, so a
+    // reporting gap can be located in time.
+    expect(fetchPerUserAwuUsageRows).toHaveBeenCalledWith(
+      expect.objectContaining({ hourly: true })
+    );
+
+    // No file for the rate limiter: Redis has nothing to itemize.
+    expect(new AdmZip(zip).getEntries().map((e) => e.entryName)).toEqual([
+      "elasticsearch.csv",
+      "metronome.csv",
+    ]);
+  });
+
+  it("still exports Elasticsearch rows when the Metronome read comes back empty", async () => {
+    const { auth, user } = await setup();
+
+    mockEsDocuments([makeEsDocument({ messageId: "msg_1", billableAwu: 7 })]);
+    vi.mocked(fetchPerUserAwuUsageRows).mockResolvedValue(
+      new Ok([]) // No usage reported for the user.
+    );
+
+    const result = await buildMemberConsumptionExportZip(auth, { user });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    // Header-only file for the source with nothing to report.
+    expect(readCsv(result.value.zip, "elasticsearch.csv")).toHaveLength(2);
+    expect(readCsv(result.value.zip, "metronome.csv")).toHaveLength(1);
+  });
+
+  it("fails when the workspace has no current billing period", async () => {
+    const { auth, user } = await setup();
+    vi.mocked(getCachedMetronomeCurrentBillingPeriod).mockResolvedValue(
+      new Ok(null)
+    );
+
+    const result = await buildMemberConsumptionExportZip(auth, { user });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/credits/consumption_export.ts
+++ b/front/lib/api/credits/consumption_export.ts
@@ -1,0 +1,366 @@
+import {
+  roundToTwoDecimals,
+  rowsToCsv,
+} from "@app/lib/api/analytics/csv_utils";
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import type { BillingCycle } from "@app/lib/client/subscription";
+import { toFreeMetronomeUserId } from "@app/lib/metronome/constants";
+import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
+import type { PerUserAwuUsageRow } from "@app/lib/metronome/per_user_usage";
+import { fetchPerUserAwuUsageRows } from "@app/lib/metronome/per_user_usage";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import type { AgentMessageAnalyticsData } from "@app/types/assistant/analytics";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { estypes } from "@elastic/elasticsearch";
+import AdmZip from "adm-zip";
+
+// The two itemizable counters compared in the members table's
+// "Consumed (ES / RL / MT)" column. Each file in the export details one of them.
+// The RL figure has no file: Redis only holds a single counter for the cycle,
+// with no per-event trace to list.
+type ConsumptionSource = "elasticsearch" | "metronome";
+
+const ES_EXPORT_PAGE_SIZE = 1_000;
+
+// Every row of both files starts with these columns, so the two can be
+// concatenated or diffed side by side. `awuCredits` is the row's contribution
+// to that source's total. When the consumption happened is source-specific: ES
+// rows carry the message `date`, Metronome rows the `startDate`/`endDate` of
+// their usage bucket.
+type SharedExportRow = {
+  source: ConsumptionSource;
+  workspaceId: string;
+  userId: string;
+  userEmail: string;
+  cycleStart: string;
+  cycleEnd: string;
+  awuCredits: number;
+};
+
+const SHARED_HEADERS = [
+  "source",
+  "workspaceId",
+  "userId",
+  "userEmail",
+  "cycleStart",
+  "cycleEnd",
+  "awuCredits",
+] as const;
+
+// One row per indexed agent message: the granular documents whose
+// `cost.billable_awu` the members table sums into the ES figure.
+type EsExportRow = SharedExportRow & {
+  // When the message was indexed, i.e. when the consumption happened.
+  date: string;
+  messageId: string;
+  conversationId: string;
+  agentId: string;
+  agentVersion: string;
+  modelProviderId: string;
+  modelId: string;
+  status: string;
+  isFreeSeat: string;
+  contextOrigin: string;
+  fullAwu: number;
+  llmAwu: number;
+  toolAwu: number;
+};
+
+const ES_HEADERS = [
+  ...SHARED_HEADERS,
+  "date",
+  "messageId",
+  "conversationId",
+  "agentId",
+  "agentVersion",
+  "modelProviderId",
+  "modelId",
+  "status",
+  "isFreeSeat",
+  "contextOrigin",
+  "fullAwu",
+  "llmAwu",
+  "toolAwu",
+] as const;
+
+// One row per Metronome usage bucket (metric × hour × usage type × tool
+// category), the finest per-user breakdown the usage API exposes: Metronome
+// does not let us list the underlying ingested events back, and the dimensions
+// that would identify them (agent, model, origin, api key) are not compounded
+// with `user_id` on the billable metrics. Hourly windows are what make a gap
+// locatable in time.
+type MetronomeExportRow = SharedExportRow & {
+  // Bounds of the hourly usage bucket the row aggregates.
+  startDate: string;
+  endDate: string;
+  metronomeUserId: string;
+  metric: string;
+  usageType: string;
+  toolCategory: string;
+  rawValue: number;
+  awuWeight: number;
+};
+
+const METRONOME_HEADERS = [
+  ...SHARED_HEADERS,
+  "startDate",
+  "endDate",
+  "metronomeUserId",
+  "metric",
+  "usageType",
+  "toolCategory",
+  "rawValue",
+  "awuWeight",
+] as const;
+
+type SharedRowContext = {
+  workspaceId: string;
+  userId: string;
+  userEmail: string;
+  cycleStart: string;
+  cycleEnd: string;
+};
+
+/**
+ * Every analytics document that contributes to the user's ES consumption for
+ * the cycle. Mirrors the filter of `fetchConsumedAwuCreditsByUserId` (same
+ * workspace/user/timestamp scope and the same free/paid seat split), so the
+ * summed `cost.billable_awu` of these documents is the figure the members table
+ * shows as "ES".
+ */
+async function fetchEsConsumptionDocuments({
+  workspaceId,
+  userId,
+  isFreeSeat,
+  cycle,
+}: {
+  workspaceId: string;
+  userId: string;
+  isFreeSeat: boolean;
+  cycle: BillingCycle;
+}): Promise<Result<AgentMessageAnalyticsData[], Error>> {
+  const seatSplitClause: estypes.QueryDslQueryContainer = isFreeSeat
+    ? { term: { is_free_seat: true } }
+    : // `must_not is_free_seat=true` (rather than `is_free_seat=false`) so
+      // documents indexed before the field existed count as paid.
+      { bool: { must_not: [{ term: { is_free_seat: true } }] } };
+
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        { term: { workspace_id: workspaceId } },
+        { term: { user_id: userId } },
+        seatSplitClause,
+        {
+          range: {
+            timestamp: {
+              gte: cycle.cycleStart.toISOString(),
+              lte: cycle.cycleEnd.toISOString(),
+            },
+          },
+        },
+      ],
+    },
+  };
+
+  const documents: AgentMessageAnalyticsData[] = [];
+  let searchAfter: estypes.SortResults | undefined;
+  let hitCount: number;
+
+  do {
+    const result = await searchAnalytics<AgentMessageAnalyticsData>(query, {
+      size: ES_EXPORT_PAGE_SIZE,
+      sort: [{ timestamp: "asc" }, { message_id: "asc" }],
+      search_after: searchAfter,
+    });
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    const { hits } = result.value.hits;
+    for (const hit of hits) {
+      if (hit._source) {
+        documents.push(hit._source);
+      }
+    }
+
+    hitCount = hits.length;
+    searchAfter = hits[hits.length - 1]?.sort;
+  } while (hitCount === ES_EXPORT_PAGE_SIZE);
+
+  return new Ok(documents);
+}
+
+function toEsExportRow(
+  shared: SharedRowContext,
+  doc: AgentMessageAnalyticsData
+): EsExportRow {
+  return {
+    ...shared,
+    source: "elasticsearch",
+    date: doc.timestamp,
+    awuCredits: roundToTwoDecimals(doc.cost.billable_awu),
+    messageId: doc.message_id,
+    conversationId: doc.conversation_id,
+    agentId: doc.agent_id,
+    agentVersion: doc.agent_version,
+    modelProviderId: doc.model?.provider_id ?? "",
+    modelId: doc.model?.model_id ?? "",
+    status: doc.status,
+    isFreeSeat: String(doc.is_free_seat),
+    contextOrigin: doc.context_origin ?? "",
+    fullAwu: roundToTwoDecimals(doc.cost.full_awu),
+    llmAwu: roundToTwoDecimals(doc.cost.llm_awu),
+    toolAwu: roundToTwoDecimals(doc.cost.tool_awu),
+  };
+}
+
+function toMetronomeExportRow(
+  shared: SharedRowContext,
+  metronomeUserId: string,
+  row: PerUserAwuUsageRow
+): MetronomeExportRow {
+  return {
+    ...shared,
+    source: "metronome",
+    startDate: row.startingOn,
+    endDate: row.endingBefore,
+    awuCredits: roundToTwoDecimals(row.awuCredits),
+    metronomeUserId,
+    metric: row.metric,
+    usageType: row.usageType,
+    toolCategory: row.toolCategory ?? "",
+    rawValue: roundToTwoDecimals(row.value),
+    awuWeight: row.awuWeight,
+  };
+}
+
+async function fetchMetronomeExportRows({
+  auth,
+  shared,
+  metronomeUserId,
+}: {
+  auth: Authenticator;
+  shared: SharedRowContext;
+  metronomeUserId: string;
+}): Promise<MetronomeExportRow[]> {
+  const workspace = auth.getNonNullableWorkspace();
+  if (!workspace.metronomeCustomerId) {
+    return [];
+  }
+
+  const rowsResult = await fetchPerUserAwuUsageRows({
+    workspaceId: workspace.sId,
+    metronomeCustomerId: workspace.metronomeCustomerId,
+    userIds: [metronomeUserId],
+    hourly: true,
+  });
+  if (rowsResult.isErr()) {
+    logger.warn(
+      {
+        err: rowsResult.error,
+        workspaceId: workspace.sId,
+        userId: shared.userId,
+      },
+      "[ConsumptionExport] Failed to read Metronome usage rows"
+    );
+    return [];
+  }
+
+  return rowsResult.value.map((row) =>
+    toMetronomeExportRow(shared, metronomeUserId, row)
+  );
+}
+
+/**
+ * A ZIP holding the rows behind the consumption figures the poke members table
+ * compares for one member over the current billing cycle: the Elasticsearch
+ * analytics documents and the Metronome usage buckets, in two CSVs sharing a
+ * leading set of columns (see `SHARED_HEADERS`). The RL figure has no file — see
+ * `ConsumptionSource`.
+ *
+ * A source that can't be read (no Metronome customer, a Metronome failure)
+ * contributes a header-only file rather than failing the whole export.
+ */
+export async function buildMemberConsumptionExportZip(
+  auth: Authenticator,
+  { user }: { user: UserResource }
+): Promise<Result<{ zip: Buffer; filename: string }, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const periodResult = await getCachedMetronomeCurrentBillingPeriod(
+    workspace.sId
+  );
+  if (periodResult.isErr()) {
+    return new Err(periodResult.error);
+  }
+  const cycle = periodResult.value;
+  if (!cycle) {
+    return new Err(
+      new Error(
+        "No current billing period for this workspace; nothing to export."
+      )
+    );
+  }
+
+  const membership =
+    await MembershipResource.getActiveMembershipOfUserInWorkspace({
+      user,
+      workspace,
+    });
+  if (!membership) {
+    return new Err(new Error("User is not an active member of the workspace."));
+  }
+
+  const isFreeSeat = membership.seatType === "free";
+  // Metronome splits free-seat usage under a prefixed user id; Elasticsearch
+  // keys on the plain sId for everyone.
+  const metronomeUserId = isFreeSeat
+    ? toFreeMetronomeUserId(user.sId)
+    : user.sId;
+
+  const shared: SharedRowContext = {
+    workspaceId: workspace.sId,
+    userId: user.sId,
+    userEmail: user.email ?? "",
+    cycleStart: cycle.cycleStart.toISOString(),
+    cycleEnd: cycle.cycleEnd.toISOString(),
+  };
+
+  const [esDocumentsResult, metronomeRows] = await Promise.all([
+    fetchEsConsumptionDocuments({
+      workspaceId: workspace.sId,
+      userId: user.sId,
+      isFreeSeat,
+      cycle,
+    }),
+    fetchMetronomeExportRows({ auth, shared, metronomeUserId }),
+  ]);
+  if (esDocumentsResult.isErr()) {
+    return new Err(normalizeError(esDocumentsResult.error));
+  }
+
+  const esRows = esDocumentsResult.value.map((doc) =>
+    toEsExportRow(shared, doc)
+  );
+
+  const zip = new AdmZip();
+  zip.addFile(
+    "elasticsearch.csv",
+    Buffer.from(rowsToCsv(ES_HEADERS, esRows), "utf-8")
+  );
+  zip.addFile(
+    "metronome.csv",
+    Buffer.from(rowsToCsv(METRONOME_HEADERS, metronomeRows), "utf-8")
+  );
+
+  return new Ok({
+    zip: zip.toBuffer(),
+    filename: `dust_consumption_${workspace.sId}_${user.sId}.zip`,
+  });
+}

--- a/front/lib/metronome/per_user_usage.test.ts
+++ b/front/lib/metronome/per_user_usage.test.ts
@@ -1,4 +1,7 @@
-import { buildUsageQuerySegments } from "@app/lib/metronome/per_user_usage";
+import {
+  buildHourlyUsageQuerySegment,
+  buildUsageQuerySegments,
+} from "@app/lib/metronome/per_user_usage";
 import { describe, expect, it } from "vitest";
 
 describe("buildUsageQuerySegments", () => {
@@ -148,5 +151,32 @@ describe("buildUsageQuerySegments", () => {
     for (let i = 1; i < segments.length; i++) {
       expect(segments[i].startingOn).toBe(segments[i - 1].endingBefore);
     }
+  });
+});
+
+describe("buildHourlyUsageQuerySegment", () => {
+  it("covers the whole range with one midnight-aligned HOUR segment", () => {
+    expect(
+      buildHourlyUsageQuerySegment({
+        cycleStart: new Date("2026-06-15T15:00:00.000Z"),
+        requestEnd: new Date("2026-06-18T09:30:00.000Z"),
+      })
+    ).toEqual([
+      {
+        startingOn: "2026-06-15T00:00:00.000Z",
+        endingBefore: "2026-06-19T00:00:00.000Z",
+        windowSize: "HOUR",
+      },
+    ]);
+  });
+
+  it("returns no segment when requestEnd does not come after cycleStart", () => {
+    const sameInstant = new Date("2026-06-15T12:00:00.000Z");
+    expect(
+      buildHourlyUsageQuerySegment({
+        cycleStart: sameInstant,
+        requestEnd: sameInstant,
+      })
+    ).toEqual([]);
   });
 });

--- a/front/lib/metronome/per_user_usage.ts
+++ b/front/lib/metronome/per_user_usage.ts
@@ -15,6 +15,7 @@ import {
   isToolCostCategory,
   TOOL_COST_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/metronome/events";
+import type { MetronomeUsageWithGroupsResponse } from "@app/lib/metronome/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -84,6 +85,31 @@ export function buildUsageQuerySegments({
     });
   }
   return segments;
+}
+
+/**
+ * The whole `[cycleStart, requestEnd)` range as a single midnight-aligned
+ * HOUR-granularity segment. Coarser day segments hide when within a day usage
+ * stopped being reported, so exports that hunt for gaps query hours throughout
+ * — at the cost of ~24x more buckets than `buildUsageQuerySegments`.
+ */
+export function buildHourlyUsageQuerySegment({
+  cycleStart,
+  requestEnd,
+}: {
+  cycleStart: Date;
+  requestEnd: Date;
+}): UsageQuerySegment[] {
+  if (requestEnd.getTime() <= cycleStart.getTime()) {
+    return [];
+  }
+  return [
+    {
+      startingOn: floorToMidnightUTC(cycleStart).toISOString(),
+      endingBefore: ceilToMidnightUTC(requestEnd).toISOString(),
+      windowSize: "HOUR",
+    },
+  ];
 }
 
 function flattenUsageResults<T>(
@@ -173,8 +199,70 @@ export async function fetchPerUserAwuUsage({
   // an unfiltered query is capped and omits users. Empty → empty result.
   userIds: string[];
 }): Promise<Result<Map<string, number>, Error>> {
+  const rowsResult = await fetchPerUserAwuUsageRows({
+    workspaceId,
+    metronomeCustomerId,
+    userIds,
+  });
+  if (rowsResult.isErr()) {
+    return rowsResult;
+  }
+
+  const perUser = new Map<string, number>();
+  for (const row of rowsResult.value) {
+    perUser.set(row.userId, (perUser.get(row.userId) ?? 0) + row.awuCredits);
+  }
+  return new Ok(perUser);
+}
+
+// One Metronome usage bucket contributing to a user's AWU consumption: a
+// (metric, time window, usage type, tool category) group and the AWU credits it
+// accounts for. Buckets that don't count towards billed AWU (free usage, or
+// windows outside the billing cycle) are never emitted, so summing `awuCredits`
+// reproduces `fetchPerUserAwuUsage` exactly.
+export type PerUserAwuUsageRow = {
+  userId: string;
+  metric: "llm_provider_cost_awu" | "tool_invocations";
+  usageType: string;
+  toolCategory: string | null;
+  startingOn: string;
+  endingBefore: string;
+  // The raw metric value: AWU spend for the AI-usage metric, an invocation
+  // count for the tool metric.
+  value: number;
+  // Price applied to `value` to get `awuCredits` (1 for AI usage, the
+  // per-category weight for tools).
+  awuWeight: number;
+  awuCredits: number;
+};
+
+/**
+ * The individual Metronome usage buckets behind `fetchPerUserAwuUsage`, kept as
+ * rows instead of a per-user total. Same query, same filtering — see that
+ * function's doc for the query shape and why free/out-of-cycle buckets are
+ * dropped in code.
+ *
+ * `hourly` forces HOUR windows over the whole period instead of the cheaper
+ * day-granularity segmentation, so gaps can be located within a day. It is the
+ * finest breakdown available per user: `agent_id`, `model_id`, `origin` and
+ * `api_key_name` are only declared as standalone group keys on the billable
+ * metrics (see `setup_new_pricing.ts`), never compounded with `user_id`, and
+ * Metronome rejects partial compound keys — so they cannot be scoped to one
+ * user.
+ */
+export async function fetchPerUserAwuUsageRows({
+  workspaceId,
+  metronomeCustomerId,
+  userIds,
+  hourly = false,
+}: {
+  workspaceId: string;
+  metronomeCustomerId: string;
+  userIds: string[];
+  hourly?: boolean;
+}): Promise<Result<PerUserAwuUsageRow[], Error>> {
   if (userIds.length === 0) {
-    return new Ok(new Map());
+    return new Ok([]);
   }
   const periodResult =
     await getCachedMetronomeCurrentBillingPeriod(workspaceId);
@@ -182,7 +270,7 @@ export async function fetchPerUserAwuUsage({
     return new Err(periodResult.error);
   }
   if (!periodResult.value) {
-    return new Ok(new Map());
+    return new Ok([]);
   }
   const { cycleStart, cycleEnd } = periodResult.value;
   const cycleEndMs = cycleEnd.getTime();
@@ -191,9 +279,11 @@ export async function fetchPerUserAwuUsage({
   // The usage endpoint requires midnight-aligned bounds; buckets outside
   // [cycleStart, cycleEnd) are trimmed below regardless of segment.
   const requestEnd = new Date(Math.min(cycleEndMs, Date.now()));
-  const segments = buildUsageQuerySegments({ cycleStart, requestEnd });
+  const segments = hourly
+    ? buildHourlyUsageQuerySegment({ cycleStart, requestEnd })
+    : buildUsageQuerySegments({ cycleStart, requestEnd });
   if (segments.length === 0) {
-    return new Ok(new Map());
+    return new Ok([]);
   }
 
   const [aiResult, toolResult] = await Promise.all([
@@ -219,21 +309,34 @@ export async function fetchPerUserAwuUsage({
     return new Err(toolResult.error);
   }
 
-  const perUser = new Map<string, number>();
+  const isBilledBucket = (entry: MetronomeUsageWithGroupsResponse): boolean => {
+    const startMs = new Date(entry.startingOn).getTime();
+    return (
+      entry.group?.[USAGE_TYPE_GROUP_KEY] !== USAGE_TYPE_FREE &&
+      startMs >= cycleStartMs &&
+      startMs < cycleEndMs
+    );
+  };
+
+  const rows: PerUserAwuUsageRow[] = [];
 
   // AI usage: the value is already AWU spend (cost_awu, priced 1:1).
   for (const entry of aiResult.value) {
     const userId = entry.group?.["user_id"];
-    if (
-      !userId ||
-      entry.value === null ||
-      entry.group?.[USAGE_TYPE_GROUP_KEY] === USAGE_TYPE_FREE ||
-      new Date(entry.startingOn).getTime() < cycleStartMs ||
-      new Date(entry.startingOn).getTime() >= cycleEndMs
-    ) {
+    if (!userId || entry.value === null || !isBilledBucket(entry)) {
       continue;
     }
-    perUser.set(userId, (perUser.get(userId) ?? 0) + entry.value);
+    rows.push({
+      userId,
+      metric: "llm_provider_cost_awu",
+      usageType: entry.group?.[USAGE_TYPE_GROUP_KEY] ?? "",
+      toolCategory: null,
+      startingOn: entry.startingOn,
+      endingBefore: entry.endingBefore,
+      value: entry.value,
+      awuWeight: 1,
+      awuCredits: entry.value,
+    });
   }
 
   // Tool usage: the value is an invocation count — weight it by the
@@ -244,19 +347,27 @@ export async function fetchPerUserAwuUsage({
     if (
       !userId ||
       entry.value === null ||
-      entry.group?.[USAGE_TYPE_GROUP_KEY] === USAGE_TYPE_FREE ||
-      new Date(entry.startingOn).getTime() < cycleStartMs ||
-      new Date(entry.startingOn).getTime() >= cycleEndMs ||
+      !isBilledBucket(entry) ||
       !category ||
       !isToolCostCategory(category)
     ) {
       continue;
     }
-    const awuSpent = entry.value * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
-    perUser.set(userId, (perUser.get(userId) ?? 0) + awuSpent);
+    const awuWeight = TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
+    rows.push({
+      userId,
+      metric: "tool_invocations",
+      usageType: entry.group?.[USAGE_TYPE_GROUP_KEY] ?? "",
+      toolCategory: category,
+      startingOn: entry.startingOn,
+      endingBefore: entry.endingBefore,
+      value: entry.value,
+      awuWeight,
+      awuCredits: entry.value * awuWeight,
+    });
   }
 
-  return new Ok(perUser);
+  return new Ok(rows);
 }
 
 const PER_USER_AWU_USAGE_CACHE_TTL_MS = 60 * 1000;


### PR DESCRIPTION
## Description

Allow to download data from both ES and MT from poke, for a given user:

<img width="1288" height="268" alt="image" src="https://github.com/user-attachments/assets/8918bc37-49e9-43ef-bc51-dbae93f927f8" />

It downlaods a zip with 2 CSVs:
 - one for ES containing the data per operations:
```csv
source,workspaceId,userId,userEmail,cycleStart,cycleEnd,awuCredits,date,messageId,conversationId,agentId,agentVersion,modelProviderId,modelId,status,isFreeSeat,contextOrigin,fullAwu,llmAwu,toolAwu
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,2,2026-08-24T09:20:05.996Z,zYzk4ph6Km,rg27hnDVMz,dust,0,anthropic,claude-sonnet-4-6,succeeded,false,web,2,2,0
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,1,2026-08-24T09:20:15.891Z,vxEyJIcFyL,7TBvEhEljI,analyst,0,openai,gpt-5.6-luna,succeeded,false,web,1,1,0
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,10,2026-08-24T09:20:22.576Z,3lmZYxpBkU,C78S495VSD,dust,0,anthropic,claude-sonnet-4-6,succeeded,false,web,10,8,2
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,15,2026-08-24T09:20:39.441Z,F0TriG1yQ7,gSbaSRKCko,dust,0,anthropic,claude-sonnet-4-6,succeeded,false,web,15,12,3
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,2,2026-08-24T09:20:49.200Z,MxfjoIINFp,4VlBCQ4xOo,claude-4.5-haiku,0,anthropic,claude-haiku-4-5-20251001,succeeded,false,web,2,2,0
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,10,2026-08-24T09:20:53.851Z,DrrVNe0HqT,bMomSHtXi4,dust-task,0,openai,gpt-5.6-luna,succeeded,false,web,10,4,6
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,2,2026-08-24T09:21:52.435Z,XJ3RH3VxZu,rg27hnDVMz,dust,0,anthropic,claude-sonnet-4-6,succeeded,false,web,2,2,0
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,1,2026-08-24T09:21:55.557Z,QDGGxlLiNY,rg27hnDVMz,dust,0,anthropic,claude-sonnet-4-6,succeeded,false,web,1,1,0
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,4,2026-08-24T12:09:55.545Z,pKuJDJqavf,RCHWQshWEo,dust,0,anthropic,claude-sonnet-4-6,gracefully_stopped,false,web,4,3,1
elasticsearch,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,22,2026-08-24T12:10:10.660Z,dU7n3fHS4x,RCHWQshWEo,dust,0,anthropic,claude-sonnet-4-6,succeeded,false,web,22,21,1
```
<img width="2618" height="576" alt="image" src="https://github.com/user-attachments/assets/e173d739-a977-4d0b-a2cd-11bf31963e51" />

 - one file for metronome, containing one row per hour for each metric/usage type/tool category
```csv
source,workspaceId,userId,userEmail,cycleStart,cycleEnd,awuCredits,startDate,endDate,metronomeUserId,metric,usageType,toolCategory,rawValue,awuWeight
metronome,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,32,2026-08-24T09:00:00+00:00,2026-08-24T10:00:00+00:00,ETDa5wLhO3,llm_provider_cost_awu,user,,32,1
metronome,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,24,2026-08-24T12:00:00+00:00,2026-08-24T13:00:00+00:00,ETDa5wLhO3,llm_provider_cost_awu,user,,24,1
metronome,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,3,2026-08-24T09:00:00+00:00,2026-08-24T10:00:00+00:00,ETDa5wLhO3,tool_invocations,user,advanced,1,3
metronome,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,8,2026-08-24T09:00:00+00:00,2026-08-24T10:00:00+00:00,ETDa5wLhO3,tool_invocations,user,basic,8,1
metronome,DevWkSpace,ETDa5wLhO3,fabien@dust.tt,2026-08-24T09:00:00.000Z,2026-09-24T09:00:00.000Z,2,2026-08-24T12:00:00+00:00,2026-08-24T13:00:00+00:00,ETDa5wLhO3,tool_invocations,user,basic,2,1
```

<img width="2086" height="340" alt="image" src="https://github.com/user-attachments/assets/6fbbec8c-4b0d-4266-8931-4d2cbc9dd6b2" />

Sadly we cannot get more granularity from metronome API, this can be used to pinpoint an hour with the discrepancy

We also canot get the detailed consumption in Redis as we only store a number


## Tests

tested locally

## Risk

low, only poke

## Deploy Plan

deploy front
