### PR TITLE
feat(automations): workspace pool card, no name sorting

### DIFF
--- a/front/components/workspace/analytics/automations/AutomationsOverview.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsOverview.tsx
@@ -27,6 +27,7 @@ export function AutomationsOverview({
 
   const { automationCredits, workspaceTotalCredits, triggers } = overview;
   const disabledCount = triggers.total - triggers.enabled;
+  const memberPoolCount = triggers.total - triggers.workspacePool;
 
   return (
     <div className="flex items-stretch gap-6">
@@ -43,6 +44,11 @@ export function AutomationsOverview({
         label="Triggers enabled"
         value={`${triggers.enabled.toLocaleString()} / ${triggers.total.toLocaleString()}`}
         hint={disabledCount > 0 ? `${disabledCount} disabled` : null}
+      />
+      <SummaryCard
+        label="Workspace pool"
+        value={`${triggers.workspacePool.toLocaleString()} / ${triggers.total.toLocaleString()}`}
+        hint={memberPoolCount > 0 ? `${memberPoolCount} on member pool` : null}
       />
     </div>
   );

--- a/front/components/workspace/analytics/automations/AutomationsTriggersRowsTable.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsTriggersRowsTable.tsx
@@ -182,7 +182,9 @@ export function AutomationsTriggersRowsTable<T extends TriggerRowData>({
                   className={cn(
                     "flex items-center space-x-1 whitespace-nowrap",
                     header.column.columnDef.meta?.headerAlign === "right" &&
-                      "justify-end"
+                      "justify-end",
+                    header.column.columnDef.meta?.headerAlign === "center" &&
+                      "justify-center"
                   )}
                 >
                   {flexRender(

--- a/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
+++ b/front/components/workspace/analytics/automations/automationsTriggerColumns.tsx
@@ -83,6 +83,7 @@ export function nameColumn<T extends TriggerRowData>(): ColumnDef<T> {
     id: "name",
     accessorKey: "name",
     header: "Name",
+    enableSorting: false,
     meta: { className: "truncate", headerAlign: "left" },
     cell: (info) => (
       <DataTable.CellContent className="w-full justify-start text-left">
@@ -156,7 +157,7 @@ export function typeColumn<T extends TriggerRowData>(): ColumnDef<T> {
     id: "type",
     header: "Type",
     enableSorting: false,
-    meta: { className: "w-8" },
+    meta: { className: "w-8", headerAlign: "center" },
     cell: (info) => (
       <DataTable.CellContent className="w-full justify-center">
         <TypeCell trigger={info.row.original} />

--- a/front/lib/api/analytics/automations/overview.ts
+++ b/front/lib/api/analytics/automations/overview.ts
@@ -21,6 +21,7 @@ export type AutomationsOverview = {
   triggers: {
     enabled: number;
     total: number;
+    workspacePool: number;
   };
 };
 

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -331,15 +331,23 @@ export class TriggerResource extends BaseResource<TriggerModel> {
   ): Promise<{ enabled: number; total: number; workspacePool: number }> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    const [enabled, total, workspacePool] = await Promise.all([
-      this.model.count({ where: { workspaceId, status: "enabled" } }),
-      this.model.count({ where: { workspaceId } }),
-      this.model.count({
-        where: { workspaceId, executionMode: "workspace_pool" },
-      }),
-    ]);
+    const triggers = await this.model.findAll({
+      attributes: ["status", "executionMode"],
+      where: { workspaceId },
+    });
 
-    return { enabled, total, workspacePool };
+    let enabled = 0;
+    let workspacePool = 0;
+    for (const trigger of triggers) {
+      if (trigger.status === "enabled") {
+        enabled++;
+      }
+      if (trigger.executionMode === "workspace_pool") {
+        workspacePool++;
+      }
+    }
+
+    return { enabled, total: triggers.length, workspacePool };
   }
 
   static listByWorkspaceAndKinds(

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -328,15 +328,18 @@ export class TriggerResource extends BaseResource<TriggerModel> {
 
   static async countForWorkspace(
     auth: Authenticator
-  ): Promise<{ enabled: number; total: number }> {
+  ): Promise<{ enabled: number; total: number; workspacePool: number }> {
     const workspaceId = auth.getNonNullableWorkspace().id;
 
-    const [enabled, total] = await Promise.all([
+    const [enabled, total, workspacePool] = await Promise.all([
       this.model.count({ where: { workspaceId, status: "enabled" } }),
       this.model.count({ where: { workspaceId } }),
+      this.model.count({
+        where: { workspaceId, executionMode: "workspace_pool" },
+      }),
     ]);
 
-    return { enabled, total };
+    return { enabled, total, workspacePool };
   }
 
   static listByWorkspaceAndKinds(


### PR DESCRIPTION
## Description

Adds a third card to the automations overview with the number of triggers running on the workspace pool, out of the workspace total, plus a hint for the ones left on member pools. Reading that number previously meant paging through the table.

Also drops sorting on the Name column, and centers the Type header over its icon (the automations table's local header renderer ignored `headerAlign: "center"`).

<img width="1380" height="1506" alt="Capture d’écran 2026-08-24 à 14 29 21" src="https://github.com/user-attachments/assets/6f14d4b7-3f86-4bdb-a4ae-9650ebf2fd82" />


## Tests

Manual: overview cards on the automations analytics page, with triggers moved between pools; checked the Name header is no longer clickable and the Type header lines up with the icons.

## Risk

Low, one extra `count` query on the triggers table for the overview endpoint and cosmetic table changes.

## Deploy Plan

Deploy front.