### PR TITLE
[connectors] slack: throttle conversations.list and bound GC retries

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -460,6 +460,9 @@ async function _getTypedChannelsUncached(
   let nextCursor: string | undefined = undefined;
   let nbCalls = 0;
   do {
+    // Throttled pagination can run long; heartbeat so a cancelled or timed-out
+    // activity stops instead of keeping consuming the rate-limit budget.
+    await heartbeat();
     reportSlackUsage({
       connectorId,
       method: "conversations.list",

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -3,11 +3,13 @@ import {
   getSlackChannelSourceUrl,
   slackChannelInternalIdFromSlackChannelId,
 } from "@connectors/connectors/slack/lib/utils";
+import { RATE_LIMITS } from "@connectors/connectors/slack/ratelimits";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
 import { ProviderWorkflowError } from "@connectors/lib/error";
 import { SlackChannelModel } from "@connectors/lib/models/slack";
 import { heartbeat } from "@connectors/lib/temporal";
+import { throttleWithRedis } from "@connectors/lib/throttle";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
@@ -463,15 +465,26 @@ async function _getTypedChannelsUncached(
       method: "conversations.list",
       useCase: "batch_sync",
     });
-    const c = await slackClient.conversations.list({
-      types,
-      // despite the limit being 1000, slack may return fewer channels
-      // we observed ~50 channels per call at times see https://github.com/dust-tt/tasks/issues/1655
-      limit: 999,
-      cursor: nextCursor,
-      exclude_archived: true,
-    });
+    const c = await throttleWithRedis(
+      RATE_LIMITS["conversations.list"],
+      `${connectorId}-conversations-list`,
+      { canBeIgnored: false },
+      () =>
+        slackClient.conversations.list({
+          types,
+          // despite the limit being 1000, slack may return fewer channels
+          // we observed ~50 channels per call at times see https://github.com/dust-tt/tasks/issues/1655
+          limit: 999,
+          cursor: nextCursor,
+          exclude_archived: true,
+        }),
+      { source: "getChannels" }
+    );
     nbCalls++;
+
+    if (!c) {
+      throw new Error("Throttled conversations.list returned no response");
+    }
 
     logger.info(
       {

--- a/connectors/src/connectors/slack/ratelimits.ts
+++ b/connectors/src/connectors/slack/ratelimits.ts
@@ -4,6 +4,11 @@
 import type { RateLimit } from "@connectors/lib/throttle";
 
 export const RATE_LIMITS = {
+  // Tier 2 methods (20/min) - apply conservative limit to avoid bursts
+  "conversations.list": {
+    limit: 15,
+    windowInMs: 60 * 1000,
+  },
   // Tier 3 methods (50/min) - apply conservative limit to avoid bursts
   "chat.update": {
     limit: 50,

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -41,6 +41,7 @@ function getSlackActivities() {
   // throttled to respect Slack rate limits.
   const { getChannelsToGarbageCollect } = proxyActivities<typeof activities>({
     startToCloseTimeout: "30 minutes",
+    heartbeatTimeout: "10 minutes",
     retry: {
       maximumAttempts: 25,
     },

--- a/connectors/src/connectors/slack/temporal/workflows.ts
+++ b/connectors/src/connectors/slack/temporal/workflows.ts
@@ -29,10 +29,21 @@ function getSlackActivities() {
     saveSuccessSyncActivity,
     syncChannelMetadata,
     reportInitialSyncProgressActivity,
-    getChannelsToGarbageCollect,
     deleteChannelsFromConnectorDb,
   } = proxyActivities<typeof activities>({
     startToCloseTimeout: "10 minutes",
+  });
+
+  // Bounded on purpose: listing all channels can hit Slack rate limits, and an
+  // unbounded retry would keep the garbage collector workflow stuck (and eating
+  // the connector's Slack budget) forever. Better to fail; the workflow is
+  // relaunched after each sync. Timeout is large because pagination is
+  // throttled to respect Slack rate limits.
+  const { getChannelsToGarbageCollect } = proxyActivities<typeof activities>({
+    startToCloseTimeout: "30 minutes",
+    retry: {
+      maximumAttempts: 25,
+    },
   });
 
   const { attemptChannelJoinActivity } = proxyActivities<typeof activities>({


### PR DESCRIPTION
The slack garbage collector workflow can get stuck retrying forever on a Slack rate limit (seen on `slack-GarbageCollector-10850`: 440+ attempts, one every 30s for hours). `getChannelsToGarbageCollect` paginates `conversations.list` with no throttling, hits the Tier 2 limit (~20/min) before finishing, and each retry restarts pagination from page 1, so it never completes.

- Throttle `conversations.list` through `throttleWithRedis` (15/min), same pattern as the other Slack methods.
- Bound `getChannelsToGarbageCollect` to 25 attempts so the workflow fails instead of spinning forever (it is relaunched after each sync), and raise its start-to-close timeout to 30 minutes since pagination is now throttled.

The stuck production workflow needs to be terminated manually after deploy.