### PR TITLE
[front] perf: migrate v1 analytics export tables to consumption ES index

### DIFF
--- a/front-api/routes/v1/w/[wId]/analytics/export.test.ts
+++ b/front-api/routes/v1/w/[wId]/analytics/export.test.ts
@@ -5,7 +5,7 @@ import { ENSURE_IS_ADMIN_ERROR_MESSAGE } from "@front-api/middlewares/ensure_rol
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/assistant/observability/messages_metrics", async () => ({
-  fetchMessageMetrics: vi.fn(
+  fetchConsumptionUsageMetrics: vi.fn(
     async () =>
       new Ok([
         {
@@ -21,7 +21,7 @@ vi.mock("@app/lib/api/assistant/observability/messages_metrics", async () => ({
 vi.mock(
   "@app/lib/api/assistant/observability/active_users_metrics",
   async () => ({
-    fetchActiveUsersMetrics: vi.fn(
+    fetchConsumptionActiveUsersMetrics: vi.fn(
       async () =>
         new Ok([
           {
@@ -43,7 +43,7 @@ vi.mock(
     ...(await importOriginal<
       typeof import("@app/lib/api/assistant/observability/context_origin")
     >()),
-    fetchContextOriginDailyBreakdown: vi.fn(
+    fetchConsumptionContextOriginDailyBreakdown: vi.fn(
       async () =>
         new Ok([{ date: "2024-06-01", origin: "web", messageCount: 10 }])
     ),
@@ -52,7 +52,7 @@ vi.mock(
 
 vi.mock("@app/lib/api/analytics/agents_export", async () => ({
   AGENT_EXPORT_HEADERS: ["agentId", "name", "messages"],
-  fetchAgentExportRows: vi.fn(
+  fetchConsumptionAgentExportRows: vi.fn(
     async () =>
       new Ok([{ agentId: "agent-123", name: "TestAgent", messages: 5 }])
   ),
@@ -61,7 +61,7 @@ vi.mock("@app/lib/api/analytics/agents_export", async () => ({
 
 vi.mock("@app/lib/api/analytics/users_export", async () => ({
   USER_EXPORT_HEADERS: ["userName", "messageCount"],
-  fetchUserExportRows: vi.fn(
+  fetchConsumptionUserExportRows: vi.fn(
     async () => new Ok([{ userName: "Alice", messageCount: 7 }])
   ),
 }));
@@ -96,8 +96,7 @@ vi.mock("@app/lib/api/assistant/observability/skill_usage", async () => ({
 }));
 
 vi.mock("@app/lib/api/assistant/observability/tool_usage", async () => ({
-  fetchAvailableTools: vi.fn(async () => new Ok([])),
-  fetchToolUsageMetrics: vi.fn(async () => new Ok([])),
+  fetchConsumptionToolUsageExport: vi.fn(async () => new Ok([])),
 }));
 
 vi.mock("@app/lib/api/analytics/messages_export", async () => ({

--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -1,5 +1,17 @@
+import {
+  AGENT_MESSAGE_ID_FIELD,
+  buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
+  CONVERSATION_ID_FIELD,
+  metricSubAgg,
+  metricValue,
+} from "@app/lib/api/analytics/consumption/scope";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  searchAnalytics,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
@@ -18,6 +30,26 @@ type TopAgentExportBucket = {
 
 type TopAgentsExportAggs = {
   by_agent?: estypes.AggregationsMultiBucketAggregateBase<TopAgentExportBucket>;
+};
+
+type ConsumptionTopAgentExportBucket = {
+  key: string;
+  doc_count: number;
+  unique_messages?: estypes.AggregationsCardinalityAggregate;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+  unique_conversations?: estypes.AggregationsCardinalityAggregate;
+  metric?: estypes.AggregationsSumAggregate;
+};
+
+type ConsumptionTopAgentsExportAggs = {
+  by_agent?: estypes.AggregationsMultiBucketAggregateBase<ConsumptionTopAgentExportBucket>;
+};
+
+type AgentEsMetrics = {
+  messages: number;
+  distinctUsersReached: number;
+  distinctConversations: number;
+  credits: number;
 };
 
 interface AgentMetadataRow {
@@ -83,7 +115,6 @@ export async function fetchAgentExportRows(
   auth: Authenticator,
   includeHiddenAgents: boolean
 ): Promise<Result<AgentExportRow[], Error>> {
-  const owner = auth.getNonNullableWorkspace();
   const esResult = await searchAnalytics<never, TopAgentsExportAggs>(
     {
       bool: {
@@ -118,7 +149,7 @@ export async function fetchAgentExportRows(
     esResult.value.aggregations?.by_agent?.buckets
   );
 
-  const esMetrics = new Map(
+  const esMetrics = new Map<string, AgentEsMetrics>(
     buckets.map((b) => [
       String(b.key),
       {
@@ -130,6 +161,99 @@ export async function fetchAgentExportRows(
     ])
   );
 
+  const rows = await assembleAgentExportRows(
+    auth,
+    esMetrics,
+    buckets.map((b) => String(b.key)),
+    includeHiddenAgents
+  );
+
+  return new Ok(rows);
+}
+
+// Consumption-index counterpart of `fetchAgentExportRows`, scoped to the
+// `agents` export table. `agent.id` (not `agent.attributed_id`) is used so
+// sub-agent runs are not rolled up into the parent agent's numbers, and
+// "messages" becomes a distinct count since the index carries multiple
+// documents per agent message.
+export async function fetchConsumptionAgentExportRows(
+  auth: Authenticator,
+  startDate: string,
+  endDate: string,
+  includeHiddenAgents: boolean
+): Promise<Result<AgentExportRow[], Error>> {
+  const query = buildConsumptionScopeQuery({ auth, startDate, endDate });
+
+  const esResult = await searchConsumptionAnalytics<
+    never,
+    ConsumptionTopAgentsExportAggs
+  >(query, {
+    aggregations: {
+      by_agent: {
+        terms: { field: "agent.id", size: 10000 },
+        aggs: {
+          unique_messages: {
+            cardinality: {
+              field: AGENT_MESSAGE_ID_FIELD,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+          unique_users: {
+            cardinality: {
+              field: "user.id",
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+          unique_conversations: {
+            cardinality: {
+              field: CONVERSATION_ID_FIELD,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+          ...metricSubAgg("credit_micro"),
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (esResult.isErr()) {
+    return new Err(new Error(esResult.error.message));
+  }
+
+  const buckets = bucketsToArray<ConsumptionTopAgentExportBucket>(
+    esResult.value.aggregations?.by_agent?.buckets
+  );
+
+  const esMetrics = new Map<string, AgentEsMetrics>(
+    buckets.map((b) => [
+      String(b.key),
+      {
+        messages: Math.round(b.unique_messages?.value ?? 0),
+        distinctUsersReached: Math.round(b.unique_users?.value ?? 0),
+        distinctConversations: Math.round(b.unique_conversations?.value ?? 0),
+        credits: Math.round(metricValue("credit_micro", b.metric)),
+      },
+    ])
+  );
+
+  const rows = await assembleAgentExportRows(
+    auth,
+    esMetrics,
+    buckets.map((b) => String(b.key)),
+    includeHiddenAgents
+  );
+
+  return new Ok(rows);
+}
+
+async function assembleAgentExportRows(
+  auth: Authenticator,
+  esMetrics: Map<string, AgentEsMetrics>,
+  allAgentIdsFromEs: string[],
+  includeHiddenAgents: boolean
+): Promise<AgentExportRow[]> {
+  const owner = auth.getNonNullableWorkspace();
   const scopeFilter = (alias: string) =>
     includeHiddenAgents ? "" : `AND ${alias}."scope" != 'hidden'`;
 
@@ -205,9 +329,7 @@ export async function fetchAgentExportRows(
     };
   });
 
-  const globalAgentIds = buckets
-    .map((b) => String(b.key))
-    .filter(isGlobalAgentId);
+  const globalAgentIds = allAgentIdsFromEs.filter(isGlobalAgentId);
   if (globalAgentIds.length > 0) {
     const globalAgents = await getAgentConfigurations(auth, {
       agentIds: globalAgentIds,
@@ -235,5 +357,5 @@ export async function fetchAgentExportRows(
 
   rows.sort((a, b) => b.messages - a.messages);
 
-  return new Ok(rows);
+  return rows;
 }

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -1,7 +1,7 @@
 import type { AgentExportRow } from "@app/lib/api/analytics/agents_export";
 import {
   AGENT_EXPORT_HEADERS,
-  fetchAgentExportRows,
+  fetchConsumptionAgentExportRows,
   toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
@@ -22,20 +22,17 @@ import {
 } from "@app/lib/api/analytics/skills_export";
 import type { UserExportRow } from "@app/lib/api/analytics/users_export";
 import {
-  fetchUserExportRows,
+  fetchConsumptionUserExportRows,
   USER_EXPORT_HEADERS,
 } from "@app/lib/api/analytics/users_export";
-import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
-import { fetchContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
-import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
+import { fetchConsumptionActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { fetchConsumptionContextOriginDailyBreakdown } from "@app/lib/api/assistant/observability/context_origin";
+import { fetchConsumptionUsageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
   fetchAvailableSkills,
   fetchSkillUsageMetrics,
 } from "@app/lib/api/assistant/observability/skill_usage";
-import {
-  fetchAvailableTools,
-  fetchToolUsageMetrics,
-} from "@app/lib/api/assistant/observability/tool_usage";
+import { fetchConsumptionToolUsageExport } from "@app/lib/api/assistant/observability/tool_usage";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -45,6 +42,14 @@ import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
 import moment from "moment-timezone";
+
+// `buildConsumptionScopeQuery`'s `completed_at` filter is a half-open
+// [start, end) range, while this endpoint's `endDate` is an inclusive
+// calendar day. Advance it by one day so the range still covers the whole
+// requested last day.
+function toExclusiveEndDate(endDate: string): string {
+  return moment.utc(endDate).add(1, "day").format("YYYY-MM-DD");
+}
 
 type AnalyticsExportTable =
   | "usage_metrics"
@@ -197,27 +202,26 @@ export async function exportTable({
 }): Promise<Result<ExportTableData, Error>> {
   switch (table) {
     case "usage_metrics":
-      return exportUsageMetrics({ startDate, endDate, timezone, owner });
+      return exportUsageMetrics({ auth, startDate, endDate, timezone });
     case "active_users":
-      return exportActiveUsers({ startDate, endDate, timezone, owner });
+      return exportActiveUsers({ auth, startDate, endDate, timezone });
     case "source":
-      return exportSource({ startDate, endDate, timezone, owner });
+      return exportSource({ auth, startDate, endDate, timezone });
     case "agents":
       return exportAgents({
         auth,
         startDate,
         endDate,
-        owner,
         includeHiddenAgents,
       });
     case "users":
-      return exportUsers({ startDate, endDate, timezone, owner });
+      return exportUsers({ auth, startDate, endDate, timezone, owner });
     case "skills":
-      return exportSkills({ auth, startDate, endDate, timezone, owner });
+      return exportSkills({ auth, startDate, endDate, timezone });
     case "skill_usage":
       return exportSkillUsage({ startDate, endDate, timezone, owner });
     case "tool_usage":
-      return exportToolUsage({ startDate, endDate, timezone, owner });
+      return exportToolUsage({ auth, startDate, endDate, timezone });
     case "messages":
       return exportMessages({ auth, startDate, endDate, timezone, owner });
     case "feedback":
@@ -255,26 +259,20 @@ export function stringifyExportTableAsCsv(data: ExportTableData): string {
 }
 
 async function exportUsageMetrics({
+  auth,
   startDate,
   endDate,
   timezone,
-  owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
-  owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const result = await fetchConsumptionUsageMetrics(
+    auth,
     startDate,
-    endDate,
-  });
-
-  const result = await fetchMessageMetrics(
-    baseQuery,
-    "day",
-    ["conversations", "activeUsers"] as const,
+    toExclusiveEndDate(endDate),
     timezone
   );
 
@@ -299,18 +297,18 @@ async function exportUsageMetrics({
 }
 
 async function exportActiveUsers({
+  auth,
   startDate,
   endDate,
   timezone,
-  owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
-  owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const result = await fetchActiveUsersMetrics(
-    owner,
+  const result = await fetchConsumptionActiveUsersMetrics(
+    auth,
     startDate,
     endDate,
     timezone
@@ -339,23 +337,22 @@ async function exportActiveUsers({
 }
 
 async function exportSource({
+  auth,
   startDate,
   endDate,
   timezone,
-  owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
-  owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const result = await fetchConsumptionContextOriginDailyBreakdown(
+    auth,
     startDate,
-    endDate,
-  });
-
-  const result = await fetchContextOriginDailyBreakdown(baseQuery, timezone);
+    toExclusiveEndDate(endDate),
+    timezone
+  );
 
   if (result.isErr()) {
     return new Err(
@@ -384,24 +381,17 @@ async function exportAgents({
   auth,
   startDate,
   endDate,
-  owner,
   includeHiddenAgents,
 }: {
   auth: Authenticator;
   startDate: string;
   endDate: string;
-  owner: WorkspaceType;
   includeHiddenAgents: boolean;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    startDate,
-    endDate,
-  });
-
-  const result = await fetchAgentExportRows(
-    baseQuery,
+  const result = await fetchConsumptionAgentExportRows(
     auth,
+    startDate,
+    toExclusiveEndDate(endDate),
     includeHiddenAgents
   );
 
@@ -419,30 +409,26 @@ async function exportAgents({
 }
 
 async function exportUsers({
+  auth,
   startDate,
   endDate,
   timezone,
   owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
   owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    startDate,
-    endDate,
-  });
-
-  // `startDate` / `endDate` are plain YYYY-MM-DD days. Elasticsearch rounds a
-  // date-only `lte` up to the end of that day, but the membership SQL filters
-  // compare against instants, so the bounds have to be widened to the full day
-  // in the requested timezone. Without this, memberships that started earlier
-  // today (or ended later today) are dropped from the export.
-  const result = await fetchUserExportRows({
-    baseQuery,
-    owner,
+  // `startDate` / `endDate` are plain YYYY-MM-DD days. The membership SQL
+  // filters compare against instants, so the bounds have to be widened to the
+  // full day in the requested timezone. Without this, memberships that
+  // started earlier today (or ended later today) are dropped from the export.
+  const result = await fetchConsumptionUserExportRows({
+    auth,
+    esStartDate: startDate,
+    esEndDate: toExclusiveEndDate(endDate),
     startDate: moment.tz(startDate, timezone).startOf("day").toDate(),
     endDate: moment.tz(endDate, timezone).endOf("day").toDate(),
     timezone,
@@ -466,21 +452,18 @@ async function exportSkills({
   startDate,
   endDate,
   timezone,
-  owner,
 }: {
   auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
-  owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const result = await fetchSkillExportRows(
+    auth,
     startDate,
-    endDate,
-  });
-
-  const result = await fetchSkillExportRows(auth, baseQuery, timezone);
+    toExclusiveEndDate(endDate),
+    timezone
+  );
 
   if (result.isErr()) {
     return new Err(
@@ -560,55 +543,30 @@ async function exportSkillUsage({
 }
 
 async function exportToolUsage({
+  auth,
   startDate,
   endDate,
   timezone,
-  owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
-  owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const result = await fetchConsumptionToolUsageExport(
+    auth,
     startDate,
-    endDate,
-  });
+    toExclusiveEndDate(endDate),
+    timezone
+  );
 
-  const toolsResult = await fetchAvailableTools(baseQuery);
-  if (toolsResult.isErr()) {
+  if (result.isErr()) {
     return new Err(
-      new Error(
-        `Failed to retrieve available tools: ${toolsResult.error.message}`
-      )
+      new Error(`Failed to retrieve tool usage: ${result.error.message}`)
     );
   }
 
-  const nestedRows = await concurrentExecutor(
-    toolsResult.value,
-    async (item) => {
-      const usageResult = await fetchToolUsageMetrics(
-        baseQuery,
-        item.serverName,
-        timezone
-      );
-      if (usageResult.isErr()) {
-        throw new Error(
-          `Failed to retrieve tool usage for ${item.serverName}: ${usageResult.error.message}`
-        );
-      }
-      return usageResult.value.map<ToolUsageRow>((point) => ({
-        date: point.date,
-        toolName: item.serverName,
-        executions: point.executionCount,
-        uniqueUsers: point.uniqueUsers,
-      }));
-    },
-    { concurrency: 8 }
-  );
-
-  const rows = nestedRows.flat().sort((a, b) => {
+  const rows = [...result.value].sort((a, b) => {
     const dateCompare = a.date.localeCompare(b.date);
     if (dateCompare !== 0) {
       return dateCompare;

--- a/front/lib/api/analytics/skills_export.ts
+++ b/front/lib/api/analytics/skills_export.ts
@@ -1,3 +1,4 @@
+import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
 import { fetchUsedSkills } from "@app/lib/api/assistant/observability/skill_usage";
 import { formatDateFromMillis } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
@@ -7,7 +8,6 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type { estypes } from "@elastic/elasticsearch";
 
 export const SKILL_EXPORT_HEADERS = [
   "skillId",
@@ -25,7 +25,8 @@ export type SkillExportRow = Record<
 
 export async function fetchSkillExportRows(
   auth: Authenticator,
-  baseQuery: estypes.QueryDslQueryContainer,
+  startDate: string,
+  endDate: string,
   timezone: string
 ): Promise<Result<SkillExportRow[], Error>> {
   const activeCustomSkills = await SkillResource.listByWorkspace(auth, {
@@ -36,7 +37,14 @@ export async function fetchSkillExportRows(
     withFileAttachments: false,
   });
 
-  const usedSkillsResult = await fetchUsedSkills(baseQuery);
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate,
+    endDate,
+    extraFilters: [{ term: { consumption_type: "tool" } }],
+  });
+
+  const usedSkillsResult = await fetchUsedSkills(query);
   if (usedSkillsResult.isErr()) {
     return new Err(usedSkillsResult.error);
   }

--- a/front/lib/api/analytics/users_export.ts
+++ b/front/lib/api/analytics/users_export.ts
@@ -1,4 +1,17 @@
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  AGENT_MESSAGE_ID_FIELD,
+  buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
+  COMPLETED_AT_FIELD,
+  metricSubAgg,
+  metricValue,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
+  bucketsToArray,
+  searchAnalytics,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { getUserGroupMemberships } from "@app/lib/workspace_usage";
@@ -19,6 +32,26 @@ type TopUserExportBucket = {
 
 type TopUsersExportAggs = {
   by_user?: estypes.AggregationsMultiBucketAggregateBase<TopUserExportBucket>;
+};
+
+type ConsumptionTopUserExportBucket = {
+  key: string;
+  doc_count: number;
+  unique_messages?: estypes.AggregationsCardinalityAggregate;
+  last_message?: estypes.AggregationsMaxAggregate;
+  active_days?: estypes.AggregationsDateHistogramAggregate;
+  metric?: estypes.AggregationsSumAggregate;
+};
+
+type ConsumptionTopUsersExportAggs = {
+  by_user?: estypes.AggregationsMultiBucketAggregateBase<ConsumptionTopUserExportBucket>;
+};
+
+type UserEsMetrics = {
+  messageCount: number;
+  lastMessageSent: string;
+  activeDaysCount: number;
+  credits: number;
 };
 
 // `revoked` when the membership has ended, `unregistered` when the user never
@@ -124,6 +157,125 @@ export async function fetchUserExportRows({
     })
   );
 
+  const rows = await assembleUserExportRows({
+    esMetrics,
+    owner,
+    startDate,
+    endDate,
+    timezone,
+  });
+
+  return new Ok(rows);
+}
+
+// Consumption-index counterpart of `fetchUserExportRows`, scoped to the
+// `users` export table. "messageCount" becomes a distinct count since the
+// index carries multiple documents per agent message.
+export async function fetchConsumptionUserExportRows({
+  auth,
+  esStartDate,
+  esEndDate,
+  startDate,
+  endDate,
+  timezone,
+}: {
+  auth: Authenticator;
+  esStartDate: string;
+  esEndDate: string;
+  startDate: Date;
+  endDate: Date;
+  timezone: string;
+}): Promise<Result<UserExportRow[], Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate: esStartDate,
+    endDate: esEndDate,
+  });
+
+  const esResult = await searchConsumptionAnalytics<
+    never,
+    ConsumptionTopUsersExportAggs
+  >(query, {
+    aggregations: {
+      by_user: {
+        terms: { field: "user.id", size: 10000 },
+        aggs: {
+          unique_messages: {
+            cardinality: {
+              field: AGENT_MESSAGE_ID_FIELD,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+          last_message: { max: { field: COMPLETED_AT_FIELD } },
+          active_days: {
+            date_histogram: {
+              field: COMPLETED_AT_FIELD,
+              calendar_interval: "day",
+              min_doc_count: 1,
+              time_zone: timezone,
+            },
+          },
+          ...metricSubAgg("credit_micro"),
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (esResult.isErr()) {
+    return new Err(new Error(esResult.error.message));
+  }
+
+  const buckets = bucketsToArray<ConsumptionTopUserExportBucket>(
+    esResult.value.aggregations?.by_user?.buckets
+  );
+
+  const esMetrics = new Map<string, UserEsMetrics>(
+    buckets.map((b) => {
+      const lastMessageMs = b.last_message?.value;
+      const activeDaysBuckets = b.active_days?.buckets;
+      return [
+        String(b.key),
+        {
+          messageCount: Math.round(b.unique_messages?.value ?? 0),
+          lastMessageSent:
+            typeof lastMessageMs === "number"
+              ? moment(lastMessageMs).tz(timezone).format("YYYY-MM-DD")
+              : "",
+          activeDaysCount: Array.isArray(activeDaysBuckets)
+            ? activeDaysBuckets.filter((d) => d.doc_count > 0).length
+            : 0,
+          credits: Math.round(metricValue("credit_micro", b.metric)),
+        },
+      ] as const;
+    })
+  );
+
+  const rows = await assembleUserExportRows({
+    esMetrics,
+    owner,
+    startDate,
+    endDate,
+    timezone,
+  });
+
+  return new Ok(rows);
+}
+
+async function assembleUserExportRows({
+  esMetrics,
+  owner,
+  startDate,
+  endDate,
+  timezone,
+}: {
+  esMetrics: Map<string, UserEsMetrics>;
+  owner: WorkspaceType;
+  startDate: Date;
+  endDate: Date;
+  timezone: string;
+}): Promise<UserExportRow[]> {
   // TODO(BACK5): Migrate to MembershipResource when it supports custom date range filters.
   const memberships = await MembershipModel.findAll({
     where: {
@@ -178,7 +330,7 @@ export async function fetchUserExportRows({
 
   rows.sort((a, b) => b.messageCount - a.messageCount);
 
-  return new Ok(rows);
+  return rows;
 }
 
 function getUserExportStatus({

--- a/front/lib/api/assistant/observability/active_users_metrics.ts
+++ b/front/lib/api/assistant/observability/active_users_metrics.ts
@@ -1,7 +1,9 @@
 import {
   formatDateFromMillis,
   searchAnalytics,
+  searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -177,6 +179,154 @@ export async function fetchActiveUsersMetrics(
   });
 
   // Calculate rolling windows for each day in the requested range
+  const points: ActiveUsersMetricsPoint[] = [];
+
+  for (const timestamp of requestedTimestamps) {
+    const dau = usersByDay.get(timestamp)?.size ?? 0;
+    const wau = computeRollingActiveUsers(
+      usersByDay,
+      timestamp,
+      WAU_WINDOW_DAYS
+    );
+    const mau = computeRollingActiveUsers(
+      usersByDay,
+      timestamp,
+      MAU_WINDOW_DAYS
+    );
+
+    points.push({
+      timestamp,
+      date: formatDateFromMillis(timestamp, timezone),
+      dau,
+      wau,
+      mau,
+      memberCount: memberCountsByDay.get(timestamp) ?? 0,
+    });
+  }
+
+  return new Ok(points);
+}
+
+interface ConsumptionCompositeKey {
+  day: number;
+  user: string;
+}
+
+interface ConsumptionUserDayBucket {
+  key: ConsumptionCompositeKey;
+  doc_count: number;
+}
+
+interface ConsumptionActiveUsersAggs {
+  by_user_day?: {
+    after_key?: ConsumptionCompositeKey;
+    buckets: ConsumptionUserDayBucket[];
+  };
+}
+
+// Consumption-index counterpart of `fetchActiveUsersMetrics`, scoped to the
+// `active_users` export table. Programmatic runs simply have no `user.id` on
+// the consumption index (rather than the old index's "unknown" sentinel), and
+// a terms aggregation already skips documents missing the aggregated field,
+// so no equivalent must_not filter is needed here.
+export async function fetchConsumptionActiveUsersMetrics(
+  auth: Authenticator,
+  startDate: string,
+  endDate: string,
+  timezone: string = "UTC"
+): Promise<Result<ActiveUsersMetricsPoint[], Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const workspaceId = workspace.sId;
+
+  const extendedStart = moment
+    .tz(startDate, timezone)
+    .subtract(MAU_WINDOW_DAYS - 1, "days")
+    .format("YYYY-MM-DD");
+  const rangeFilter: estypes.QueryDslQueryContainer = {
+    range: { completed_at: { gte: extendedStart, lte: endDate } },
+  };
+  const cutoffTimestamp = moment
+    .tz(startDate, timezone)
+    .startOf("day")
+    .valueOf();
+
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [{ term: { workspace_id: workspaceId } }, rangeFilter],
+    },
+  };
+
+  const usersByDay = new Map<number, Set<string>>();
+  let afterKey: ConsumptionCompositeKey | undefined;
+  let buckets: ConsumptionUserDayBucket[];
+
+  do {
+    const result = await searchConsumptionAnalytics<
+      never,
+      ConsumptionActiveUsersAggs
+    >(query, {
+      aggregations: {
+        by_user_day: {
+          composite: {
+            size: COMPOSITE_AGG_SIZE,
+            sources: [
+              {
+                day: {
+                  date_histogram: {
+                    field: "completed_at",
+                    calendar_interval: "day",
+                    time_zone: timezone,
+                  },
+                },
+              },
+              { user: { terms: { field: "user.id" } } },
+            ],
+            ...(afterKey ? { after: afterKey } : {}),
+          },
+        },
+      },
+      size: 0,
+    });
+
+    if (result.isErr()) {
+      const status =
+        result.error.statusCode !== undefined
+          ? `, HTTP ${result.error.statusCode}`
+          : "";
+
+      return new Err(
+        new Error(
+          `Elasticsearch query failed (${result.error.type}${status}): ${result.error.message}`,
+          { cause: result.error }
+        )
+      );
+    }
+
+    const aggregation = result.value.aggregations?.by_user_day;
+    buckets = aggregation?.buckets ?? [];
+    for (const bucket of buckets) {
+      const users = usersByDay.get(bucket.key.day);
+      if (users) {
+        users.add(bucket.key.user);
+      } else {
+        usersByDay.set(bucket.key.day, new Set([bucket.key.user]));
+      }
+    }
+
+    afterKey = aggregation?.after_key;
+  } while (afterKey !== undefined && buckets.length > 0);
+
+  const sortedTimestamps = [...usersByDay.keys()].sort((a, b) => a - b);
+
+  const requestedTimestamps = sortedTimestamps.filter(
+    (ts) => ts >= cutoffTimestamp
+  );
+
+  const memberCountsByDay = await MembershipResource.countActiveMembersPerDay({
+    workspace,
+    timestampsMs: requestedTimestamps,
+  });
+
   const points: ActiveUsersMetricsPoint[] = [];
 
   for (const timestamp of requestedTimestamps) {

--- a/front/lib/api/assistant/observability/context_origin.ts
+++ b/front/lib/api/assistant/observability/context_origin.ts
@@ -1,9 +1,17 @@
+import {
+  AGENT_MESSAGE_ID_FIELD,
+  buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
+  COMPLETED_AT_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
 import { sourceLabelForOrigin } from "@app/lib/api/analytics/source_labels";
 import {
   bucketsToArray,
   formatDateFromMillis,
   searchAnalytics,
+  searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -194,6 +202,95 @@ export async function fetchContextOriginDailyBreakdown(
         date,
         origin: String(originBucket.key),
         messageCount: originBucket.doc_count ?? 0,
+      });
+    }
+  }
+
+  return new Ok(points);
+}
+
+type ConsumptionOriginSubBucket = {
+  key: string;
+  doc_count: number;
+  unique_messages?: estypes.AggregationsCardinalityAggregate;
+};
+
+type ConsumptionDailyOriginDateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  by_origin: estypes.AggregationsMultiBucketAggregateBase<ConsumptionOriginSubBucket>;
+};
+
+type ConsumptionDailyOriginAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<ConsumptionDailyOriginDateBucket>;
+};
+
+// Consumption-index counterpart of `fetchContextOriginDailyBreakdown`, scoped
+// to the `source` export table. A message can now have several documents
+// (one per LLM run-usage, one per tool call) under the same origin, so
+// messageCount has to be a distinct count rather than a raw document count.
+export async function fetchConsumptionContextOriginDailyBreakdown(
+  auth: Authenticator,
+  startDate: string,
+  endDate: string,
+  timezone: string = "UTC"
+): Promise<Result<ContextOriginDailyPoint[], Error>> {
+  const query = buildConsumptionScopeQuery({ auth, startDate, endDate });
+
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_date: {
+      date_histogram: {
+        field: COMPLETED_AT_FIELD,
+        calendar_interval: "day",
+        time_zone: timezone,
+      },
+      aggs: {
+        by_origin: {
+          terms: {
+            field: "context_origin",
+            size: 20,
+            missing: UNKNOWN_CONTEXT_ORIGIN,
+          },
+          aggs: {
+            unique_messages: {
+              cardinality: {
+                field: AGENT_MESSAGE_ID_FIELD,
+                precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchConsumptionAnalytics<
+    never,
+    ConsumptionDailyOriginAggs
+  >(query, { aggregations: aggs, size: 0 });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const dateBuckets = bucketsToArray<ConsumptionDailyOriginDateBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  const points: ContextOriginDailyPoint[] = [];
+
+  for (const dateBucket of dateBuckets) {
+    const date = formatDateFromMillis(dateBucket.key, timezone);
+    const originBuckets = bucketsToArray<ConsumptionOriginSubBucket>(
+      dateBucket.by_origin?.buckets
+    );
+
+    for (const originBucket of originBuckets) {
+      points.push({
+        date,
+        origin: String(originBucket.key),
+        messageCount: Math.round(originBucket.unique_messages?.value ?? 0),
       });
     }
   }

--- a/front/lib/api/assistant/observability/messages_metrics.ts
+++ b/front/lib/api/assistant/observability/messages_metrics.ts
@@ -1,4 +1,16 @@
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  AGENT_MESSAGE_ID_FIELD,
+  buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
+  COMPLETED_AT_FIELD,
+  CONVERSATION_ID_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
+  bucketsToArray,
+  searchAnalytics,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import type { estypes } from "@elastic/elasticsearch";
@@ -237,3 +249,87 @@ export type GetWorkspaceUsageMetricsResponse = {
     "timestamp" | "count" | "conversations" | "activeUsers"
   >[];
 };
+
+export type ConsumptionUsageMetricsPoint = {
+  timestamp: number;
+  count: number;
+  conversations: number;
+  activeUsers: number;
+};
+
+type ConsumptionUsageMetricsBucket = {
+  key: number;
+  unique_messages?: estypes.AggregationsCardinalityAggregate;
+  unique_conversations?: estypes.AggregationsCardinalityAggregate;
+  active_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+type ConsumptionUsageMetricsAggs = {
+  by_interval?: estypes.AggregationsMultiBucketAggregateBase<ConsumptionUsageMetricsBucket>;
+};
+
+// Consumption-index counterpart of `fetchMessageMetrics`, scoped to the
+// `usage_metrics` export table. The consumption index carries one document per
+// LLM run-usage or tool call, so "messages" has to be a distinct count rather
+// than a raw document count.
+export async function fetchConsumptionUsageMetrics(
+  auth: Authenticator,
+  startDate: string,
+  endDate: string,
+  timezone: string = "UTC"
+): Promise<Result<ConsumptionUsageMetricsPoint[], Error>> {
+  const query = buildConsumptionScopeQuery({ auth, startDate, endDate });
+
+  const result = await searchConsumptionAnalytics<
+    never,
+    ConsumptionUsageMetricsAggs
+  >(query, {
+    aggregations: {
+      by_interval: {
+        date_histogram: {
+          field: COMPLETED_AT_FIELD,
+          calendar_interval: "day",
+          time_zone: timezone,
+        },
+        aggs: {
+          unique_messages: {
+            cardinality: {
+              field: AGENT_MESSAGE_ID_FIELD,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+          unique_conversations: {
+            cardinality: {
+              field: CONVERSATION_ID_FIELD,
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+          active_users: {
+            cardinality: {
+              field: "user.id",
+              precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+            },
+          },
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const buckets = bucketsToArray<ConsumptionUsageMetricsBucket>(
+    result.value.aggregations?.by_interval?.buckets
+  );
+
+  return new Ok(
+    buckets.map((bucket) => ({
+      timestamp: bucket.key,
+      count: Math.round(bucket.unique_messages?.value ?? 0),
+      conversations: Math.round(bucket.unique_conversations?.value ?? 0),
+      activeUsers: Math.round(bucket.active_users?.value ?? 0),
+    }))
+  );
+}

--- a/front/lib/api/assistant/observability/skill_usage.ts
+++ b/front/lib/api/assistant/observability/skill_usage.ts
@@ -2,6 +2,7 @@ import {
   bucketsToArray,
   formatDateFromMillis,
   searchAnalytics,
+  searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -265,25 +266,30 @@ export async function fetchAvailableSkillsBySkillId(
   );
 }
 
+type ConsumptionSkillIdListAggs = {
+  by_skill_id: estypes.AggregationsMultiBucketAggregateBase<SkillBucket>;
+};
+
+// Consumption-index counterpart of the old `fetchUsedSkills`, scoped to the
+// `skills` export table. `tool.attributed_skill_ids` is a flat field on this
+// index, so no nested aggregation is needed.
 export async function fetchUsedSkills(
-  baseQuery: estypes.QueryDslQueryContainer
+  query: estypes.QueryDslQueryContainer
 ): Promise<Result<string[], Error>> {
   const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
-    skills_nested: {
-      nested: { path: "skills_used" },
-      aggs: {
-        by_skill_id: {
-          terms: {
-            field: "skills_used.skill_id",
-            size: 1000,
-            order: { _count: "desc" },
-          },
-        },
+    by_skill_id: {
+      terms: {
+        field: "tool.attributed_skill_ids",
+        size: 1000,
+        order: { _count: "desc" },
       },
     },
   };
 
-  const result = await searchAnalytics<never, SkillIdListAggs>(baseQuery, {
+  const result = await searchConsumptionAnalytics<
+    never,
+    ConsumptionSkillIdListAggs
+  >(query, {
     aggregations: aggs,
     size: 0,
   });
@@ -293,7 +299,7 @@ export async function fetchUsedSkills(
   }
 
   const skillIdBuckets = bucketsToArray<SkillBucket>(
-    result.value.aggregations?.skills_nested?.by_skill_id?.buckets
+    result.value.aggregations?.by_skill_id?.buckets
   );
 
   return new Ok(skillIdBuckets.map((bucket) => bucket.key));

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -1,7 +1,12 @@
 import {
+  buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
   bucketsToArray,
   formatDateFromMillis,
   searchAnalytics,
+  searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
@@ -225,6 +230,105 @@ export async function fetchAvailableTools(
   }));
 
   return new Ok(tools);
+}
+
+export type ToolUsageExportRow = {
+  date: string;
+  toolName: string;
+  executions: number;
+  uniqueUsers: number;
+};
+
+type ConsumptionToolUsageServerBucket = {
+  key: string;
+  doc_count: number;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+};
+
+type ConsumptionToolUsageDateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  by_server: estypes.AggregationsMultiBucketAggregateBase<ConsumptionToolUsageServerBucket>;
+};
+
+type ConsumptionToolUsageAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<ConsumptionToolUsageDateBucket>;
+};
+
+// Consumption-index counterpart of the old `fetchAvailableTools` +
+// `fetchToolUsageMetrics` fan-out, scoped to the `tool_usage` export table.
+// The index already carries one flat document per tool invocation, so a
+// single query discovers both which tools ran and their daily metrics —
+// unlike the old per-server nested-agg fan-out, `doc_count` is already a
+// correct invocation count here and does not need to become a cardinality.
+export async function fetchConsumptionToolUsageExport(
+  auth: Authenticator,
+  startDate: string,
+  endDate: string,
+  timezone: string = "UTC"
+): Promise<Result<ToolUsageExportRow[], Error>> {
+  const query = buildConsumptionScopeQuery({
+    auth,
+    startDate,
+    endDate,
+    extraFilters: [{ term: { consumption_type: "tool" } }],
+  });
+
+  const result = await searchConsumptionAnalytics<
+    never,
+    ConsumptionToolUsageAggs
+  >(query, {
+    aggregations: {
+      by_date: {
+        date_histogram: {
+          field: "completed_at",
+          calendar_interval: "day",
+          time_zone: timezone,
+        },
+        aggs: {
+          by_server: {
+            terms: { field: "tool.server_name", size: 100 },
+            aggs: {
+              unique_users: {
+                cardinality: {
+                  field: "user.id",
+                  precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const dateBuckets = bucketsToArray<ConsumptionToolUsageDateBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  const rows: ToolUsageExportRow[] = [];
+  for (const dateBucket of dateBuckets) {
+    const date = formatDateFromMillis(dateBucket.key, timezone);
+    const serverBuckets = bucketsToArray<ConsumptionToolUsageServerBucket>(
+      dateBucket.by_server?.buckets
+    );
+    for (const serverBucket of serverBuckets) {
+      rows.push({
+        date,
+        toolName: String(serverBucket.key),
+        executions: serverBucket.doc_count ?? 0,
+        uniqueUsers: Math.round(serverBucket.unique_users?.value ?? 0),
+      });
+    }
+  }
+
+  return new Ok(rows);
 }
 
 export async function resolveServerDisplayNames(


### PR DESCRIPTION
## Summary
- Migrate 7 tables of `GET /api/v1/w/{wId}/analytics/export` (`usage_metrics`, `active_users`, `source`, `agents`, `users`, `skills`, `tool_usage`) from the legacy message-level ES index (`front.agent_message_analytics`) to the newer per-consumption-unit index (`front.agent_message_consumption_analytics`), keeping the external response shape (columns/CSV/JSON structure) unchanged.
- `tool_usage` also drops its per-tool-server N+1 query fan-out (`concurrentExecutor` loop) in favor of a single aggregation, since the consumption index is already one flat document per tool invocation.
- Left `GET /api/v1/w/{wId}/usage` (deprecated), and the `messages`, `feedback`, and `skill_usage` export tables untouched — their required fields (message ancestry, feedback data, message-level skill mentions) don't exist in the consumption index without a real semantic change.
- Existing dashboard-facing fetchers used by private `front-api/routes/w/[wId]/analytics/*` routes were left untouched; new sibling `fetchConsumption*` functions were added instead, since those fetchers take a generic ES query and swapping their index in place would have silently broken the dashboards.

## Notes on value drift (shape-identical, but underlying numbers can shift slightly)
- Message/user/conversation counts move from exact `doc_count` to `cardinality(...)` aggregations (approximate above ~40k distinct values).
- Day bucketing shifts from message-creation time to message-completion time (`completed_at`).
- Free/non-billed usage (e.g. `agent_sidekick` origin) is not indexed in the consumption index, so it disappears from these exports.
- Credits move from AWU-rounded integers to `credit_micro`-derived values (minor rounding differences).

## Test plan
- [ ] `npx tsgo --noEmit` clean on touched files (no new errors vs. baseline)
- [ ] Biome clean on touched files
- [ ] `context_origin.test.ts` passes (6/6) against the refactored path
- [ ] Full `vitest` run blocked repo-wide by an unrelated pre-existing missing `@novu/framework` dependency — verify in CI
- [ ] Manually verify `GET /api/v1/w/{wId}/analytics/export?table=tool_usage` (and the other 6 tables) against a workspace with recent consumption data, comparing against pre-change output for a known date range