### PR TITLE
[Activation] Tighten orchestrator nudge cadence and per-run selection

### DIFF
--- a/front/lib/api/activation/nudge.test.ts
+++ b/front/lib/api/activation/nudge.test.ts
@@ -404,6 +404,53 @@ describe("isEligibleForNudge", () => {
     ).toBe(false);
   });
 
+  it("stops after two unanswered nudges by default", async () => {
+    const { authenticator, workspace, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+
+    await createNudge(authenticator, {
+      workspace,
+      pod: globalSpace,
+      nudgedAt: new Date(Date.now() - 10 * DAY_MS),
+    });
+    await createNudge(authenticator, {
+      workspace,
+      pod: globalSpace,
+      nudgedAt: new Date(Date.now() - 5 * DAY_MS),
+    });
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: globalSpace,
+        activationPod,
+        user: null,
+      })
+    ).toBe(false);
+  });
+
+  it("is still eligible after a single unanswered nudge outside the cap window", async () => {
+    const { authenticator, workspace, globalSpace } = await createResourceTest({
+      role: "admin",
+    });
+    const activationPod = await createActivationPod(authenticator, globalSpace);
+
+    await createNudge(authenticator, {
+      workspace,
+      pod: globalSpace,
+      nudgedAt: new Date(Date.now() - 5 * DAY_MS),
+    });
+
+    expect(
+      await isEligibleForNudge(authenticator, {
+        pod: globalSpace,
+        activationPod,
+        user: null,
+      })
+    ).toBe(true);
+  });
+
   it("is eligible again once the user replies after the most recent nudge", async () => {
     const { workspace, user, globalSpace } = await createResourceTest({
       role: "admin",

--- a/front/temporal/activation_scheduler/activities.ts
+++ b/front/temporal/activation_scheduler/activities.ts
@@ -7,6 +7,7 @@ import { determineEligibleActivationUsers } from "@app/lib/api/activation/orches
 import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
 import { Authenticator } from "@app/lib/auth";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -19,6 +20,7 @@ import {
   DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN,
 } from "@app/temporal/activation_scheduler/config";
 import { getNudgeSlotAtMs } from "@app/temporal/activation_scheduler/slots";
+import moment from "moment-timezone";
 
 const ACTIVATION_PODS_CONCURRENCY = 4;
 
@@ -26,6 +28,10 @@ export type EligiblePodNudge = {
   podId: string;
   targetUserId: string;
   slotAtMs: number;
+};
+
+type RankedEligiblePodNudge = EligiblePodNudge & {
+  lastNudgedAtMs: number | null;
 };
 
 /**
@@ -45,6 +51,24 @@ export async function enumerateEligiblePodsForNudgeActivity({
   userIds?: string[] | null;
   overrideChecks?: boolean;
 }): Promise<EligiblePodNudge[]> {
+  const timezone = REGION_TIMEZONES[config.getCurrentRegion()];
+  const now = new Date();
+  const dayOfWeek = moment.tz(now, timezone).day();
+
+  // Scheduled runs skip Sat/Sun in the regional timezone. Poke one-offs
+  // (`userIds` or overrideChecks) still fire immediately, including weekends.
+  if (
+    userIds == null &&
+    !overrideChecks &&
+    (dayOfWeek === 0 || dayOfWeek === 6)
+  ) {
+    logger.info(
+      { workspaceId, timezone },
+      "[ActivationScheduler] Skipping weekend run."
+    );
+    return [];
+  }
+
   // Activation conversations live in Pods, which are restricted spaces: request
   // all groups so admin auth can read/write them.
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId, {
@@ -83,10 +107,7 @@ export async function enumerateEligiblePodsForNudgeActivity({
   ]);
   const userBySId = new Map(users.map((user) => [user.sId, user]));
 
-  const timezone = REGION_TIMEZONES[config.getCurrentRegion()];
-  const now = new Date();
-
-  const eligiblePods: EligiblePodNudge[] = [];
+  const eligiblePods: RankedEligiblePodNudge[] = [];
 
   await concurrentExecutor(
     eligible,
@@ -125,9 +146,16 @@ export async function enumerateEligiblePodsForNudgeActivity({
         return;
       }
 
+      const [lastNudgedAt] =
+        await ConversationResource.listNudgeConversationTimestamps(auth, {
+          spaceModelId: pod.id,
+          limit: 1,
+        });
+
       eligiblePods.push({
         podId: pod.sId,
         targetUserId: candidate.targetUserId,
+        lastNudgedAtMs: lastNudgedAt?.getTime() ?? null,
         slotAtMs:
           userIds != null
             ? now.getTime()
@@ -143,21 +171,24 @@ export async function enumerateEligiblePodsForNudgeActivity({
     { concurrency: ACTIVATION_PODS_CONCURRENCY }
   );
 
-  const sorted = eligiblePods.sort((a, b) => a.slotAtMs - b.slotAtMs);
   if (
     !overrideChecks &&
-    sorted.length > DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN
+    eligiblePods.length > DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN
   ) {
     logger.info(
       {
         workspaceId,
-        eligibleCount: sorted.length,
+        eligibleCount: eligiblePods.length,
         cap: DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN,
       },
-      "[ActivationScheduler] Capping this run to the per-workflow user limit."
+      "[ActivationScheduler] Capping this run to the pods that have gone the longest without a nudge."
     );
   }
-  return applyActivationNudgePerRunCap(sorted, { overrideChecks });
+
+  // Cap by longest-without-a-nudge, then send in workday slot order.
+  return applyActivationNudgePerRunCap(eligiblePods, { overrideChecks }).sort(
+    (a, b) => a.slotAtMs - b.slotAtMs
+  );
 }
 
 /**

--- a/front/temporal/activation_scheduler/client.ts
+++ b/front/temporal/activation_scheduler/client.ts
@@ -40,8 +40,8 @@ const ONE_HOUR_MS = 60 * 60 * 1000;
 
 /**
  * Launch a schedule for a single workspace.
- * Fires at the start of the regional workday with a 1-hour jitter to spread
- * load.
+ * Fires at the start of the regional workday (Mon-Fri) with a 1-hour jitter
+ * to spread load.
  */
 export async function startActivationWorkspaceSchedule({
   workspaceId,
@@ -79,7 +79,13 @@ export async function startActivationWorkspaceSchedule({
         overlap: ScheduleOverlapPolicy.SKIP,
       },
       spec: {
-        calendars: [{ hour: ACTIVATION_WORKDAY_START_HOUR, minute: 0 }],
+        calendars: [
+          {
+            hour: ACTIVATION_WORKDAY_START_HOUR,
+            minute: 0,
+            dayOfWeek: ["MONDAY", "TUESDAY", "WEDNESDAY", "THURSDAY", "FRIDAY"],
+          },
+        ],
         timezone,
         jitter: ONE_HOUR_MS,
       },

--- a/front/temporal/activation_scheduler/config.test.ts
+++ b/front/temporal/activation_scheduler/config.test.ts
@@ -5,18 +5,53 @@ import {
 import { describe, expect, it } from "vitest";
 
 describe("applyActivationNudgePerRunCap", () => {
-  const items = Array.from(
-    { length: DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN + 3 },
-    (_, i) => i
-  );
+  it("keeps the pods that have gone the longest without a nudge", () => {
+    const neverNudged = Array.from(
+      { length: DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN },
+      (_, i) => ({ id: `never-${i}`, lastNudgedAtMs: null })
+    );
+    const recentlyNudged = [
+      { id: "recent-a", lastNudgedAtMs: 3_000 },
+      { id: "recent-b", lastNudgedAtMs: 2_000 },
+      { id: "oldest", lastNudgedAtMs: 1_000 },
+    ];
 
-  it("slices to the per-run cap", () => {
-    expect(
-      applyActivationNudgePerRunCap(items, { overrideChecks: false })
-    ).toEqual(items.slice(0, DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN));
+    const capped = applyActivationNudgePerRunCap(
+      [...recentlyNudged, ...neverNudged],
+      { overrideChecks: false }
+    );
+
+    expect(capped).toHaveLength(DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN);
+    expect(capped.map((item) => item.id)).toEqual(
+      neverNudged.map((item) => item.id)
+    );
+  });
+
+  it("prefers the oldest last-nudge when every pod has been nudged", () => {
+    const items = Array.from(
+      { length: DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN + 3 },
+      (_, i) => ({ id: i, lastNudgedAtMs: 10_000 - i })
+    );
+
+    const capped = applyActivationNudgePerRunCap(items, {
+      overrideChecks: false,
+    });
+
+    expect(capped.map((item) => item.id)).toEqual(
+      items
+        .slice()
+        .sort((a, b) => a.lastNudgedAtMs - b.lastNudgedAtMs)
+        .slice(0, DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN)
+        .map((item) => item.id)
+    );
   });
 
   it("does not slice when overrideChecks is set", () => {
+    const items = Array.from(
+      { length: DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN + 3 },
+      (_, i) => ({ id: i, lastNudgedAtMs: i })
+    );
+
     expect(
       applyActivationNudgePerRunCap(items, { overrideChecks: true })
     ).toEqual(items);

--- a/front/temporal/activation_scheduler/config.ts
+++ b/front/temporal/activation_scheduler/config.ts
@@ -14,18 +14,41 @@ export const DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS = 2;
 // Default number of consecutive unanswered nudges (no user message since the
 // nudge fired) after which the scheduler stops nudging a pod. Workspaces can
 // override this via the `activationNudgeMaxUnansweredCount` metadata key.
-export const DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT = 3;
+export const DEFAULT_ACTIVATION_NUDGE_MAX_UNANSWERED_COUNT = 2;
 
 // Max users a single activation workspace workflow may nudge. Applied when
 // enumerating the run; poke can skip it via overrideChecks.
 export const DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN = 100;
 
-export function applyActivationNudgePerRunCap<T>(
-  items: T[],
-  { overrideChecks }: { overrideChecks: boolean }
-): T[] {
-  if (overrideChecks) {
-    return items;
+export type ActivationNudgePerRunCapItem = {
+  lastNudgedAtMs: number | null;
+};
+
+function compareByLongestWithoutNudge(
+  a: ActivationNudgePerRunCapItem,
+  b: ActivationNudgePerRunCapItem
+): number {
+  if (a.lastNudgedAtMs === b.lastNudgedAtMs) {
+    return 0;
   }
-  return items.slice(0, DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN);
+  if (a.lastNudgedAtMs === null) {
+    return -1;
+  }
+  if (b.lastNudgedAtMs === null) {
+    return 1;
+  }
+  return a.lastNudgedAtMs - b.lastNudgedAtMs;
+}
+
+// Keeps the pods that have gone the longest without a nudge (never-nudged
+// first, then oldest last-nudge). Poke can skip the cap via overrideChecks.
+export function applyActivationNudgePerRunCap<
+  T extends ActivationNudgePerRunCapItem,
+>(items: T[], { overrideChecks }: { overrideChecks: boolean }): T[] {
+  if (overrideChecks) {
+    return [...items];
+  }
+  return [...items]
+    .sort(compareByLongestWithoutNudge)
+    .slice(0, DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN);
 }

--- a/front/temporal/activation_scheduler/config.ts
+++ b/front/temporal/activation_scheduler/config.ts
@@ -1,3 +1,5 @@
+import sortBy from "lodash/sortBy";
+
 const QUEUE_VERSION = 1;
 export const QUEUE_NAME = `activation-scheduler-queue-v${QUEUE_VERSION}`;
 
@@ -24,22 +26,6 @@ export type ActivationNudgePerRunCapItem = {
   lastNudgedAtMs: number | null;
 };
 
-function compareByLongestWithoutNudge(
-  a: ActivationNudgePerRunCapItem,
-  b: ActivationNudgePerRunCapItem
-): number {
-  if (a.lastNudgedAtMs === b.lastNudgedAtMs) {
-    return 0;
-  }
-  if (a.lastNudgedAtMs === null) {
-    return -1;
-  }
-  if (b.lastNudgedAtMs === null) {
-    return 1;
-  }
-  return a.lastNudgedAtMs - b.lastNudgedAtMs;
-}
-
 // Keeps the pods that have gone the longest without a nudge (never-nudged
 // first, then oldest last-nudge). Poke can skip the cap via overrideChecks.
 export function applyActivationNudgePerRunCap<
@@ -48,7 +34,8 @@ export function applyActivationNudgePerRunCap<
   if (overrideChecks) {
     return [...items];
   }
-  return [...items]
-    .sort(compareByLongestWithoutNudge)
-    .slice(0, DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN);
+  return sortBy(
+    items,
+    ({ lastNudgedAtMs }) => lastNudgedAtMs ?? -Infinity
+  ).slice(0, DEFAULT_ACTIVATION_NUDGE_MAX_USERS_PER_RUN);
 }


### PR DESCRIPTION
## Summary
- Stop scheduled nudges after 2 consecutive unanswered ones (down from 3); a user reply still resets the count.
- Skip weekend scheduled runs in the regional timezone, and create new workspace schedules as Mon–Fri only. Existing daily schedules are unchanged; the enumerator returns no one on Sat/Sun.
- When a workspace exceeds the 100-person per-run cap, keep the people who have gone the longest without a nudge (never-nudged first), then send in workday slot order.

## Test plan
New unit tests

## Risk
Low

## Deploy Plan
1. Deploy Front