### PR TITLE
Open frames at two-thirds panel width

### DIFF
--- a/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContainer.tsx
@@ -1,6 +1,9 @@
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
-import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
+import {
+  DEFAULT_RIGHT_PANEL_SIZE,
+  getDefaultRightPanelSize,
+} from "@app/components/assistant/conversation/constant";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useLockDocumentScroll } from "@app/hooks/useLockDocumentScroll";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
@@ -51,7 +54,12 @@ export default function ConversationSidePanelContainer({
       return;
     }
 
-    panelRef.current?.expand(DEFAULT_RIGHT_PANEL_SIZE);
+    const defaultSize = getDefaultRightPanelSize(currentPanel);
+    if (panelRef.current.isCollapsed()) {
+      panelRef.current.expand(defaultSize);
+    } else {
+      panelRef.current.resize(defaultSize);
+    }
   }, [currentPanel, isMobile]);
 
   if (isMobile) {

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -1,4 +1,4 @@
-import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
+import { getDefaultRightPanelSize } from "@app/components/assistant/conversation/constant";
 import type { AgentMessageWithStreaming } from "@app/components/assistant/conversation/types";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useHashParam } from "@app/hooks/useHashParams";
@@ -215,7 +215,7 @@ export function ConversationSidePanelProvider({
 
       // Re-expand imperatively: the container's expand effect only fires when `currentPanel`
       // changes, so a close→reopen race (same value) wouldn't re-run it. No-op on mobile.
-      panelRef.current?.expand(DEFAULT_RIGHT_PANEL_SIZE);
+      panelRef.current?.expand(getDefaultRightPanelSize(params.type));
     },
     [setCurrentPanel, setData, data, closePanel, currentPanel]
   );

--- a/front/components/assistant/conversation/constant.test.ts
+++ b/front/components/assistant/conversation/constant.test.ts
@@ -1,0 +1,25 @@
+import {
+  DEFAULT_FRAME_PANEL_SIZE,
+  DEFAULT_RIGHT_PANEL_SIZE,
+  getDefaultRightPanelSize,
+} from "@app/components/assistant/conversation/constant";
+import {
+  AGENT_ACTIONS_SIDE_PANEL_TYPE,
+  INTERACTIVE_CONTENT_SIDE_PANEL_TYPE,
+} from "@app/types/conversation_side_panel";
+import { describe, expect, it } from "vitest";
+
+describe("getDefaultRightPanelSize", () => {
+  it("opens Frames at two-thirds width", () => {
+    expect(DEFAULT_FRAME_PANEL_SIZE).toBeCloseTo((2 / 3) * 100);
+    expect(getDefaultRightPanelSize(INTERACTIVE_CONTENT_SIDE_PANEL_TYPE)).toBe(
+      DEFAULT_FRAME_PANEL_SIZE
+    );
+  });
+
+  it("keeps other side panels at their existing width", () => {
+    expect(getDefaultRightPanelSize(AGENT_ACTIONS_SIDE_PANEL_TYPE)).toBe(
+      DEFAULT_RIGHT_PANEL_SIZE
+    );
+  });
+});

--- a/front/components/assistant/conversation/constant.ts
+++ b/front/components/assistant/conversation/constant.ts
@@ -1,1 +1,13 @@
+import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
+import { INTERACTIVE_CONTENT_SIDE_PANEL_TYPE } from "@app/types/conversation_side_panel";
+
 export const DEFAULT_RIGHT_PANEL_SIZE = 40;
+export const DEFAULT_FRAME_PANEL_SIZE = (2 / 3) * 100;
+
+export function getDefaultRightPanelSize(
+  panelType: ConversationSidePanelType
+): number {
+  return panelType === INTERACTIVE_CONTENT_SIDE_PANEL_TYPE
+    ? DEFAULT_FRAME_PANEL_SIZE
+    : DEFAULT_RIGHT_PANEL_SIZE;
+}

--- a/front/components/assistant/conversation/constant.ts
+++ b/front/components/assistant/conversation/constant.ts
@@ -7,7 +7,10 @@ export const DEFAULT_FRAME_PANEL_SIZE = (2 / 3) * 100;
 export function getDefaultRightPanelSize(
   panelType: ConversationSidePanelType
 ): number {
-  return panelType === INTERACTIVE_CONTENT_SIDE_PANEL_TYPE
-    ? DEFAULT_FRAME_PANEL_SIZE
-    : DEFAULT_RIGHT_PANEL_SIZE;
+  switch (panelType) {
+    case INTERACTIVE_CONTENT_SIDE_PANEL_TYPE:
+      return DEFAULT_FRAME_PANEL_SIZE;
+    default:
+      return DEFAULT_RIGHT_PANEL_SIZE;
+  }
 }

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -1,7 +1,7 @@
 import { AuthenticatedVisualizationActionIframe } from "@app/components/assistant/conversation/actions/AuthenticatedVisualizationActionIframe";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
 import { ConversationSidePanelHeader } from "@app/components/assistant/conversation/ConversationSidePanelHeader";
-import { DEFAULT_RIGHT_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
+import { DEFAULT_FRAME_PANEL_SIZE } from "@app/components/assistant/conversation/constant";
 import { CenteredState } from "@app/components/assistant/conversation/interactive_content/CenteredState";
 import { ExportContentDropdown } from "@app/components/assistant/conversation/interactive_content/ExportContentDropdown";
 import { ShareFrameSheet } from "@app/components/assistant/conversation/interactive_content/frame/ShareFrameSheet";
@@ -72,7 +72,7 @@ export function FrameRenderer({
     useDesktopNavigation();
   const [isLoading, setIsLoading] = useState(false);
   const isNavBarPrevOpenRef = useRef(isNavigationBarOpen);
-  const prevPanelSizeRef = useRef(DEFAULT_RIGHT_PANEL_SIZE);
+  const prevPanelSizeRef = useRef(DEFAULT_FRAME_PANEL_SIZE);
 
   const { spaceInfo: projectInfo, isSpaceInfoLoading } = useSpaceInfo({
     workspaceId: owner.sId,
@@ -201,7 +201,7 @@ export function FrameRenderer({
   const restoreLayout = useCallback(() => {
     if (panel) {
       setIsNavigationBarOpen(isNavBarPrevOpenRef.current ?? true);
-      panel.resize(prevPanelSizeRef.current ?? DEFAULT_RIGHT_PANEL_SIZE);
+      panel.resize(prevPanelSizeRef.current ?? DEFAULT_FRAME_PANEL_SIZE);
     }
   }, [panel, setIsNavigationBarOpen]);
 

--- a/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions_v2.ts
@@ -1,7 +1,7 @@
 export const INTERACTIVE_CONTENT_AUTHORING_PROSE_V2 = `\
 ### Rendering Context
 
-Frames render inside a resizable iframe in the conversation side panel. The default panel is often about 40% of the browser width, and inline frames are capped at 600px high before the user expands them. Make the top 600px useful: clear title, primary visual or metric, and the first meaningful controls or status.
+Frames render inside a resizable iframe in the conversation side panel. The default panel is two-thirds of the browser width, and inline frames are capped at 600px high before the user expands them. Make the top 600px useful: clear title, primary visual or metric, and the first meaningful controls or status.
 
 Before declaring a frame done, mentally check both the default panel width and fullscreen. Look for clipped content, collapsed charts, colorless bulk surfaces, stale template data, and whether the top 600px is useful.
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See thread [here](https://dust4ai.slack.com/archives/C09C8L42C8M/p1787575833920679).

This PR ensures frames open 2/3 of the view.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
