### PR TITLE
[front] usage tracking: make trackProgrammaticUsageActivity retryable

### DIFF
--- a/front/lib/api/programmatic_usage/tracking.test.ts
+++ b/front/lib/api/programmatic_usage/tracking.test.ts
@@ -13,6 +13,7 @@ import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { RunFactory } from "@app/tests/utils/RunFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
@@ -610,25 +611,64 @@ describe("trackProgrammaticCost", () => {
     expect(result).toEqual({ runsCostMicroUsd: 0 });
   });
 
-  it("skips consumption when the same runs were already tracked (activity retry)", async () => {
+  it("consumes credits once across a retry of the same runs", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await makeAuth(workspace);
 
+    const credit = await CreditResource.makeNew(auth, {
+      type: "payg",
+      initialAmountMicroUsd: 10_000_000,
+      consumedAmountMicroUsd: 0,
+    });
+    await credit.start(auth, {
+      startDate: new Date(Date.now() - 1000),
+      expirationDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+    });
+    const { run } = await RunFactory.createWithUsage(auth);
+
     const first = await trackProgrammaticCost(auth, {
-      dustRunIds: ["run-1", "run-2"],
+      dustRunIds: [run.dustRunId],
       userMessageOrigin: "api",
     });
-    expect(first).toEqual({ runsCostMicroUsd: 0 });
+    expect(first?.runsCostMicroUsd).toBeGreaterThan(0);
 
-    // The global redis mock does not enforce NX, so simulate the guard key
-    // already being held by the first attempt (what real redis returns).
+    const afterFirst = await CreditResource.fetchById(
+      auth,
+      credit.id.toString()
+    );
+    expect(afterFirst?.consumedAmountMicroUsd).toBeGreaterThan(0);
+
+    // Simulate the retry hitting the already-held marker (the global redis
+    // mock does not enforce NX; real redis returns null here).
     vi.mocked(runOnRedis).mockResolvedValueOnce(null);
 
     const second = await trackProgrammaticCost(auth, {
-      dustRunIds: ["run-1", "run-2"],
+      dustRunIds: [run.dustRunId],
       userMessageOrigin: "api",
     });
     expect(second).toBeUndefined();
+
+    const afterSecond = await CreditResource.fetchById(
+      auth,
+      credit.id.toString()
+    );
+    expect(afterSecond?.consumedAmountMicroUsd).toBe(
+      afterFirst?.consumedAmountMicroUsd
+    );
+  });
+
+  it("fails closed when the idempotency guard cannot be written", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await makeAuth(workspace);
+
+    vi.mocked(runOnRedis).mockRejectedValueOnce(new Error("redis down"));
+
+    await expect(
+      trackProgrammaticCost(auth, {
+        dustRunIds: ["run-1"],
+        userMessageOrigin: "api",
+      })
+    ).rejects.toThrow("redis down");
   });
 });
 

--- a/front/lib/api/programmatic_usage/tracking.test.ts
+++ b/front/lib/api/programmatic_usage/tracking.test.ts
@@ -7,6 +7,7 @@ import {
   isProgrammaticUsage,
   trackProgrammaticCost,
 } from "@app/lib/api/programmatic_usage/tracking";
+import { runOnRedis } from "@app/lib/api/redis";
 import { Authenticator } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import logger from "@app/logger/logger";
@@ -15,7 +16,7 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import type { WorkspaceType } from "@app/types/user";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 type MockCreditForConsumption = Pick<CreditResource, "type" | "expirationDate">;
 
@@ -607,6 +608,27 @@ describe("trackProgrammaticCost", () => {
     });
 
     expect(result).toEqual({ runsCostMicroUsd: 0 });
+  });
+
+  it("skips consumption when the same runs were already tracked (activity retry)", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await makeAuth(workspace);
+
+    const first = await trackProgrammaticCost(auth, {
+      dustRunIds: ["run-1", "run-2"],
+      userMessageOrigin: "api",
+    });
+    expect(first).toEqual({ runsCostMicroUsd: 0 });
+
+    // The global redis mock does not enforce NX, so simulate the guard key
+    // already being held by the first attempt (what real redis returns).
+    vi.mocked(runOnRedis).mockResolvedValueOnce(null);
+
+    const second = await trackProgrammaticCost(auth, {
+      dustRunIds: ["run-1", "run-2"],
+      userMessageOrigin: "api",
+    });
+    expect(second).toBeUndefined();
   });
 });
 

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -12,7 +12,7 @@ import {
 } from "@app/lib/api/programmatic_usage/key_cap";
 import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
-import { computeRunKey } from "@app/lib/credits/agent_message_billing";
+import { computeRunFingerprint } from "@app/lib/credits/agent_message_billing";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -24,7 +24,6 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
-import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const CREDIT_ALERT_THRESHOLD_PERCENT = 80;
 
@@ -36,37 +35,29 @@ const CONSUMED_RUNS_GUARD_TTL_SECONDS = 24 * 60 * 60;
 const TRACKING_REDIS_ORIGIN = "programmatic_usage_tracking" as const;
 
 /**
- * Marks the given agent-loop execution (identified by its runKey) as consumed.
- * Returns false when another attempt already consumed it — the caller must then
- * skip the mutation phase so activity retries and timed-out zombie attempts
- * never consume the same runs twice. The marker is set before the mutations and
- * deliberately never released: a crash inside the mutation window leaves it
- * held, so the retry drops that execution instead of risking double
- * consumption. Do not delete the marker on failure. Fails open on Redis errors:
- * tracking must not be blocked by a Redis outage.
+ * Marks the given agent-loop execution (identified by its run fingerprint) as
+ * consumed. Returns false when another attempt already consumed it — the caller
+ * must then skip the mutation phase so activity retries and timed-out zombie
+ * attempts never consume the same runs twice. The marker is set before the
+ * mutations and deliberately never released: a crash inside the mutation window
+ * leaves it held, so the retry drops that execution instead of risking double
+ * consumption. Do not delete the marker on failure. Redis errors propagate
+ * (fail closed): without the marker we cannot guarantee at-most-once
+ * consumption, so the attempt fails and Temporal retries.
  */
 async function tryMarkRunsConsumed(
   auth: Authenticator,
-  dustRunIds: string[],
-  localLogger: Logger
+  dustRunIds: string[]
 ): Promise<boolean> {
   const workspaceId = auth.getNonNullableWorkspace().sId;
-  const guardKey = `programmatic_usage_consumed:${workspaceId}:${computeRunKey(dustRunIds)}`;
-  try {
-    const res = await runOnRedis({ origin: TRACKING_REDIS_ORIGIN }, (redis) =>
-      redis.set(guardKey, "1", {
-        NX: true,
-        EX: CONSUMED_RUNS_GUARD_TTL_SECONDS,
-      })
-    );
-    return res === "OK";
-  } catch (err) {
-    localLogger.warn(
-      { guardKey, err: normalizeError(err) },
-      "[Programmatic Usage Tracking] Failed to set idempotency guard, proceeding without."
-    );
-    return true;
-  }
+  const guardKey = `programmatic_usage_consumed:${workspaceId}:${computeRunFingerprint(dustRunIds)}`;
+  const res = await runOnRedis({ origin: TRACKING_REDIS_ORIGIN }, (redis) =>
+    redis.set(guardKey, "1", {
+      NX: true,
+      EX: CONSUMED_RUNS_GUARD_TTL_SECONDS,
+    })
+  );
+  return res === "OK";
 }
 
 type ProgrammaticUsageLimitErrorType = "credits_exhausted" | "rate_limit_error";
@@ -162,9 +153,13 @@ export async function decreaseProgrammaticCredits(
   {
     amountMicroUsd,
     userMessageOrigin,
+    // Callers holding the idempotency marker prefetch credits BEFORE setting
+    // it, so a read failure retries instead of dropping the execution.
+    prefetchedActiveCredits,
   }: {
     amountMicroUsd: number;
     userMessageOrigin: UserMessageOrigin;
+    prefetchedActiveCredits?: CreditResource[];
   },
   parentLogger?: Logger
 ): Promise<{
@@ -174,7 +169,8 @@ export async function decreaseProgrammaticCredits(
 }> {
   const localLogger = parentLogger ?? logger;
   const workspace = auth.getNonNullableWorkspace();
-  const activeCredits = await CreditResource.listActive(auth);
+  const activeCredits =
+    prefetchedActiveCredits ?? (await CreditResource.listActive(auth));
 
   const sortedCredits = [...activeCredits].sort(compareCreditsForConsumption);
 
@@ -368,14 +364,14 @@ export async function trackProgrammaticCost(
     runsCostMicroUsd * (1 + DUST_MARKUP_PERCENT / 100)
   );
 
+  // Prefetch the credits before setting the marker: reads are safe to retry,
+  // and once the marker is held a failure drops the execution.
+  const prefetchedActiveCredits = await CreditResource.listActive(auth);
+
   // Everything above is read-only and safe to retry; everything below mutates
   // (credit ledger, redis counters). Guard the mutation phase so an activity
   // retry after a partial failure never consumes the same runs twice.
-  const isFirstConsumption = await tryMarkRunsConsumed(
-    auth,
-    dustRunIds,
-    localLogger
-  );
+  const isFirstConsumption = await tryMarkRunsConsumed(auth, dustRunIds);
   if (!isFirstConsumption) {
     localLogger.warn(
       { dustRunIds },
@@ -390,6 +386,7 @@ export async function trackProgrammaticCost(
       {
         amountMicroUsd: costWithMarkupMicroUsd,
         userMessageOrigin,
+        prefetchedActiveCredits,
       },
       localLogger
     );

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -10,7 +10,9 @@ import {
   hasKeyReachedUsageCap,
   incrementRedisKeyUsageMicroUsd,
 } from "@app/lib/api/programmatic_usage/key_cap";
+import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
+import { computeRunKey } from "@app/lib/credits/agent_message_billing";
 import { CreditResource } from "@app/lib/resources/credit_resource";
 import { RunResource } from "@app/lib/resources/run_resource";
 import { getStatsDClient } from "@app/lib/utils/statsd";
@@ -22,8 +24,50 @@ import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const CREDIT_ALERT_THRESHOLD_PERCENT = 80;
+
+// TTL on the per-execution idempotency marker guarding credit consumption.
+// Activity retries span minutes; 24 hours comfortably covers late zombie
+// attempts without accumulating keys forever.
+const CONSUMED_RUNS_GUARD_TTL_SECONDS = 24 * 60 * 60;
+
+const TRACKING_REDIS_ORIGIN = "programmatic_usage_tracking" as const;
+
+/**
+ * Marks the given agent-loop execution (identified by its runKey) as consumed.
+ * Returns false when another attempt already consumed it — the caller must then
+ * skip the mutation phase so activity retries and timed-out zombie attempts
+ * never consume the same runs twice. The marker is set before the mutations and
+ * deliberately never released: a crash inside the mutation window leaves it
+ * held, so the retry drops that execution instead of risking double
+ * consumption. Do not delete the marker on failure. Fails open on Redis errors:
+ * tracking must not be blocked by a Redis outage.
+ */
+async function tryMarkRunsConsumed(
+  auth: Authenticator,
+  dustRunIds: string[],
+  localLogger: Logger
+): Promise<boolean> {
+  const workspaceId = auth.getNonNullableWorkspace().sId;
+  const guardKey = `programmatic_usage_consumed:${workspaceId}:${computeRunKey(dustRunIds)}`;
+  try {
+    const res = await runOnRedis({ origin: TRACKING_REDIS_ORIGIN }, (redis) =>
+      redis.set(guardKey, "1", {
+        NX: true,
+        EX: CONSUMED_RUNS_GUARD_TTL_SECONDS,
+      })
+    );
+    return res === "OK";
+  } catch (err) {
+    localLogger.warn(
+      { guardKey, err: normalizeError(err) },
+      "[Programmatic Usage Tracking] Failed to set idempotency guard, proceeding without."
+    );
+    return true;
+  }
+}
 
 type ProgrammaticUsageLimitErrorType = "credits_exhausted" | "rate_limit_error";
 
@@ -323,6 +367,23 @@ export async function trackProgrammaticCost(
   const costWithMarkupMicroUsd = Math.ceil(
     runsCostMicroUsd * (1 + DUST_MARKUP_PERCENT / 100)
   );
+
+  // Everything above is read-only and safe to retry; everything below mutates
+  // (credit ledger, redis counters). Guard the mutation phase so an activity
+  // retry after a partial failure never consumes the same runs twice.
+  const isFirstConsumption = await tryMarkRunsConsumed(
+    auth,
+    dustRunIds,
+    localLogger
+  );
+  if (!isFirstConsumption) {
+    localLogger.warn(
+      { dustRunIds },
+      "[Programmatic Usage Tracking] Runs already consumed by a previous attempt. Skipping."
+    );
+    return;
+  }
+
   const { totalConsumedMicroUsd, totalInitialMicroUsd, activeCredits } =
     await decreaseProgrammaticCredits(
       auth,

--- a/front/lib/api/programmatic_usage/tracking.ts
+++ b/front/lib/api/programmatic_usage/tracking.ts
@@ -44,6 +44,12 @@ const TRACKING_REDIS_ORIGIN = "programmatic_usage_tracking" as const;
  * consumption. Do not delete the marker on failure. Redis errors propagate
  * (fail closed): without the marker we cannot guarantee at-most-once
  * consumption, so the attempt fails and Temporal retries.
+ *
+ * Known limit: the marker is only as durable as Redis. If Redis loses it
+ * (eviction, failover) between a post-consumption crash and its retry, that
+ * one execution can be counted twice. Accepted trade-off: closing it needs a
+ * ledger-transactional marker (new table), which is not worth it for a
+ * cents-level tail risk.
  */
 async function tryMarkRunsConsumed(
   auth: Authenticator,

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -62,6 +62,7 @@ export type RedisUsageTagsType =
   | "email_context"
   | "otp_challenge"
   | "force_reload_commits"
+  | "programmatic_usage_tracking"
   | "group_permissions_cache"
   | "key_usage_tracking"
   | "lock"

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -106,14 +106,20 @@ export function isFreeOrigin(origin: UserMessageOrigin | null): boolean {
   return origin !== null && FREE_ORIGINS.has(origin);
 }
 
+// Full-length fingerprint of one agent-loop execution, for callers that need
+// collision resistance (e.g. idempotency keys): the truncated run key below
+// only has 32 bits of entropy.
+export function computeRunFingerprint(dustRunIds: string[]): string {
+  return createHash("sha256")
+    .update([...dustRunIds].sort().join(","))
+    .digest("hex");
+}
+
 // A run key identifies one agent-loop execution. Retries with the same run IDs
 // deduplicate in Metronome, while interrupt/resume executions receive distinct
 // keys and are consequently rounded and billed independently.
 export function computeRunKey(dustRunIds: string[]): string {
-  return createHash("sha256")
-    .update([...dustRunIds].sort().join(","))
-    .digest("hex")
-    .slice(0, 8);
+  return computeRunFingerprint(dustRunIds).slice(0, 8);
 }
 
 // Convert provider cost in micro-USD to credits, rounding up exactly as the

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -22,8 +22,11 @@ const { recordUsageActivity } = proxyActivities<typeof activities>({
 // guarded by a per-execution idempotency marker (see trackProgrammaticCost), so
 // a retry after a partial failure or a timed-out zombie attempt never consumes
 // the same runs twice. Retries mostly cover transient DB pool exhaustion.
+// scheduleToCloseTimeout bounds the whole retry lifetime well under the
+// marker's 24h TTL, so a stale retry can never run after the marker expired.
 const { trackProgrammaticUsageActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
+  scheduleToCloseTimeout: "1 hour",
   retry: {
     initialInterval: "10s",
     backoffCoefficient: 2,

--- a/front/temporal/usage_queue/workflows.ts
+++ b/front/temporal/usage_queue/workflows.ts
@@ -18,10 +18,17 @@ const { recordUsageActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "10 minutes",
 });
 
+// Retries are safe: the mutation phase (credit consumption, redis counters) is
+// guarded by a per-execution idempotency marker (see trackProgrammaticCost), so
+// a retry after a partial failure or a timed-out zombie attempt never consumes
+// the same runs twice. Retries mostly cover transient DB pool exhaustion.
 const { trackProgrammaticUsageActivity } = proxyActivities<typeof activities>({
   startToCloseTimeout: "5 minutes",
   retry: {
-    maximumAttempts: 1,
+    initialInterval: "10s",
+    backoffCoefficient: 2,
+    maximumInterval: "2 minutes",
+    maximumAttempts: 5,
   },
 });
 


### PR DESCRIPTION
I landed here because I was trying to reduce Failed workflow. 
[See in temporal for EU](https://cloud.temporal.io/namespaces/eu-dust-front-prod.gmnlm/workflows?query=%60ExecutionStatus%60%3D%22Failed%22+AND+%60WorkflowType%60%3D%22trackProgrammaticUsageWorkflow%22)
[See in temporal for US](https://cloud.temporal.io/namespaces/dust-front-prod.gmnlm/workflows?query=%60ExecutionStatus%60%3D%22Failed%22+AND+%60WorkflowType%60%3D%22trackProgrammaticUsageWorkflow%22)

`trackProgrammaticUsageWorkflow` fails permanently on any transient error (`maximumAttempts: 1`): DB pool acquire timeouts and 5-minute StartToClose timeouts in prod, and the programmatic cost of those executions is never tracked. The single attempt existed because the activity mutates the credit ledger, so a blind retry could double-consume. 

- Guard the mutation phase with a redis `SET NX` marker keyed on workspaceId + the full sha256 fingerprint of the sorted dustRunIds (the same identity Metronome dedups retries with, untruncated for collision resistance). A retry or a timed-out zombie attempt that finds the marker skips consumption. Fails closed on redis errors: without the marker we cannot guarantee at-most-once consumption, so the attempt fails and Temporal retries.
- Active credits are prefetched before the marker is set, so the pool-timeout reads this PR recovers from stay retryable; only the millisecond ledger writes sit inside the marked window.
- Allow 5 attempts with backoff on the activity, bounded by a 1-hour `scheduleToCloseTimeout` so no retry can outlive the marker's 24h TTL.

Known limit: the marker is only as durable as redis. Double-counting one execution requires a post-consumption crash AND redis losing that fresh key within the 1-hour retry window; the blast radius is one message's cost on the internal ledger. Closing it would need a ledger-transactional marker table, deliberately not worth it. On the other side, a crash inside the ledger-write window drops that execution's tracking, same as today's failure mode but with a far smaller window. Safe to rollback; stale guard keys expire after 24h.