### PR TITLE
chore: remove the browser_extension_mcp_tools feature flag

### DIFF
--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -1,4 +1,3 @@
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import logger from "@app/logger/logger";
 import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { normalizeError } from "@extension/shared/lib/utils";
@@ -20,7 +19,6 @@ export function useMcpServer() {
 
   const { workspace } = useExtensionAuth();
   const workspaceId = workspace?.sId;
-  const { hasFeature } = useFeatureFlags();
 
   const disconnectServer = useCallback(async () => {
     if (platform.mcp) {
@@ -45,10 +43,7 @@ export function useMcpServer() {
       return;
     }
 
-    if (
-      hasFeature("browser_extension_mcp_tools") &&
-      workspace?.metadata?.disableExtensionMcpTools === true
-    ) {
+    if (workspace?.metadata?.disableExtensionMcpTools === true) {
       setIsSupported(false);
       return;
     }
@@ -116,7 +111,7 @@ export function useMcpServer() {
       setIsConnected(false);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- workspace object excluded; workspaceId triggers re-runs.
-  }, [platform.mcp, workspaceId, hasFeature]);
+  }, [platform.mcp, workspaceId]);
 
   return {
     server,

--- a/front/components/workspace/ExtensionMcpToolsSection.tsx
+++ b/front/components/workspace/ExtensionMcpToolsSection.tsx
@@ -1,13 +1,11 @@
 import { GovernanceSettingRowLayout } from "@app/components/pages/workspace/governance/GovernanceSettingRowLayout";
 import { useExtensionMcpToolsToggle } from "@app/hooks/useExtensionMcpToolsToggle";
-import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import type { LightWorkspaceType } from "@app/types/user";
 import { SliderToggle } from "@dust-tt/sparkle";
 
 const LABEL = "Browser Extension Tools";
 const DESCRIPTION =
-  "Whether the Dust browser extension can use MCP tools such as " +
-  "listing and reading browser tabs.";
+  "Whether the Dust browser extension is allowed to list and read browser tabs.";
 
 interface ExtensionMcpToolsSectionProps {
   owner: LightWorkspaceType;
@@ -18,11 +16,6 @@ export function ExtensionMcpToolsSection({
 }: ExtensionMcpToolsSectionProps) {
   const { isEnabled, isChanging, doToggleExtensionMcpTools } =
     useExtensionMcpToolsToggle({ owner });
-  const { hasFeature } = useFeatureFlags();
-
-  if (!hasFeature("browser_extension_mcp_tools")) {
-    return null;
-  }
 
   return (
     <GovernanceSettingRowLayout

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -281,11 +281,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Dummy feature flag used for testing feature flag behavior",
     stage: "dust_only",
   },
-  browser_extension_mcp_tools: {
-    description:
-      "Show the browser extension MCP tools toggle in workspace access settings",
-    stage: "dust_only",
-  },
   sensitivity_labels: {
     description:
       "Enable Microsoft sensitivity labels for data classification on connectors and MCP servers",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -806,7 +806,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "collapsible_messages"
   | "conversation_consumption_details"
   | "use_dust_keys"
-  | "browser_extension_mcp_tools"
   | "sensitivity_labels"
   | "use_vertex_for_supported_models"
   | "live_speech_to_text"


### PR DESCRIPTION
## Description

This drops the `browser_extension_mcp_tools` feature flag.

The flag only hid a finished feature. The setting it gated, `disableExtensionMcpTools`, already lives in workspace metadata and renders through `GovernanceSettingRowLayout` in the Features section, exactly like `PrivateConversationUrlsToggle` and its other neighbours, none of which are flagged.

Also reworded the row description, which was leaking "MCP tools" at admins: it now reads "Whether the Dust browser extension is allowed to list and read browser tabs."

## Tests

Toggled the row off and on in the governance page and checked the extension stops registering its MCP server when disabled, and picks it back up when re-enabled.

## Risk

Low.

## Deploy Plan

Deploy front, then release the extension.