### PR TITLE
fix(archived_agents): let admins find archived agents on spaces they can't read

### DIFF
--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -387,7 +387,7 @@ export function ManageAgentsPage() {
                     counterValue={`${agentsByTab[tab.id].length}`}
                   />
                 ))}
-                {canShowHiddenAgents && (
+                {canShowHiddenAgents && activeTab === "all_custom" && (
                   <span className="ml-auto flex gap-1 self-center text-sm text-muted-foreground">
                     <label className="flex cursor-pointer flex-row items-center gap-2 whitespace-nowrap">
                       <Checkbox

--- a/front/lib/api/assistant/configuration/views.test.ts
+++ b/front/lib/api/assistant/configuration/views.test.ts
@@ -1,3 +1,4 @@
+import { archiveAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -130,5 +131,66 @@ describe("getAgentConfigurationsForView, 'analytics' view", () => {
     expect(await listAgentIdsForAnalytics(memberAuth)).toEqual(
       listedForMember.map((agent) => agent.sId)
     );
+  });
+});
+
+describe("getAgentConfigurationsForView, 'archived' view", () => {
+  async function listAgentIdsForArchived(auth: Authenticator) {
+    const agents = await getAgentConfigurationsForView({
+      auth,
+      agentsGetView: "archived",
+      variant: "light",
+    });
+    return agents.map((agent) => agent.sId);
+  }
+
+  it("lets an admin find an archived agent built on a space they are not a member of", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const space = await SpaceFactory.regular(
+      editorAuth.getNonNullableWorkspace()
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Restricted archived agent",
+      scope: "visible",
+      requestedSpaceIds: [space.id],
+    });
+    // Archiving reads the agent first: an actor scoped to editorAuth's own groups cannot see an
+    // agent on a space it never joined, so the archive itself needs every-space visibility.
+    const everySpaceAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId,
+      { dangerouslyRequestAllGroups: true }
+    );
+    expect(await archiveAgentConfiguration(everySpaceAuth, agent.sId)).toBe(
+      true
+    );
+
+    const adminAuth = await authenticatorForNewMember(workspace, "admin");
+
+    expect(await listAgentIdsForArchived(adminAuth)).toContain(agent.sId);
+  });
+
+  it("still hides an archived agent on an unreadable space from a plain member", async () => {
+    const { workspace, authenticator: editorAuth } = await createResourceTest({
+      role: "user",
+    });
+    const space = await SpaceFactory.regular(
+      editorAuth.getNonNullableWorkspace()
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Restricted archived agent",
+      scope: "visible",
+      requestedSpaceIds: [space.id],
+    });
+    const everySpaceAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId,
+      { dangerouslyRequestAllGroups: true }
+    );
+    await archiveAgentConfiguration(everySpaceAuth, agent.sId);
+
+    const memberAuth = await authenticatorForNewMember(workspace, "user");
+
+    expect(await listAgentIdsForArchived(memberAuth)).not.toContain(agent.sId);
   });
 });

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -353,10 +353,12 @@ async function fetchWorkspaceAgentConfigurationsForView(
   // Analytics counts credits for agents built on spaces a manager cannot read,
   // so the manager analytics view has to list them as well. The unrestricted manage view does the
   // same for admins, and is gated on the role by its caller.
+  // Archived is unrestricted for admins too, matching its documented admin/superuser-only contract.
   const skipPermissionFiltering =
     dangerouslySkipPermissionFiltering ||
     (agentsGetView === "analytics" && auth.isManager()) ||
-    agentsGetView === "manage_unrestricted";
+    agentsGetView === "manage_unrestricted" ||
+    (agentsGetView === "archived" && auth.isAdmin());
 
   const allowedAgentModels = skipPermissionFiltering
     ? agentModels


### PR DESCRIPTION
## Description

The "Show hidden agents" admin bypass for the manage view skips space permission filtering entirely, so an admin can see any active agent regardless of space membership. The archived view had no equivalent: once an agent the admin could only see through that bypass gets archived, it drops out of "All" (no longer active) and out of "Archived" too (`filterAgentsByRequestedSpaces` still runs), becoming invisible in the UI even to admins.

Extends the same skip to the `archived` view for admins, matching its documented contract ("all agents that are archived", admin/superuser only, no partial view). Also hides the "Show hidden agents" toggle outside the All tab, since it never affected any other tab's fetch and Archived has no togglable restricted state to begin with.

Found while testing the archive-inactive-agents feature: an agent living in a restricted space, once auto-archived, became unreachable from any admin UI.

## Tests

- New regression test: an admin can find an archived agent built on a space they are not a member of (`front/lib/api/assistant/configuration/views.test.ts`) — fails without the fix (verified by reverting `views.ts` locally), passes with it.
- New test: a plain member still cannot see it (space filtering still applies to non-admins).
- `npx tsgo --noEmit` clean, `biome check` clean, `views.test.ts` 9/9 passing.

## Risk

Low. The bypass is additive (`|| (agentsGetView === "archived" && auth.isAdmin())`) and gated on `auth.isAdmin()`, so non-admin behavior is unchanged. Safe to roll back by reverting.

## Deploy Plan

Standard deploy, no migration or feature flag involved.