### PR TITLE
feat: move triggers when merging user identities

### DIFF
--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -15,6 +15,7 @@ import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_
 import { FileModel } from "@app/lib/resources/storage/models/files";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { guessFirstAndLastNameFromFullName } from "@app/lib/user";
 import logger from "@app/logger/logger";
@@ -354,6 +355,16 @@ export async function mergeUserIdentities({
 
   // Migrate authorship of keys from the secondary user to the primary user.
   await KeyModel.update(userIdValues, userIdOptions);
+
+  // Migrate trigger editorship from the secondary user to the primary user. Must run before the
+  // revocation below, which deletes every trigger still owned by the secondary user.
+  const triggerTransferResult = await TriggerResource.transferEditor(auth, {
+    fromUser: secondaryUser,
+    toUser: primaryUser,
+  });
+  if (triggerTransferResult.isErr()) {
+    return new Err(triggerTransferResult.error);
+  }
 
   if (
     primaryUser.email === secondaryUser.email &&

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -544,4 +544,109 @@ describe("TriggerResource", () => {
       expect(reloaded?.executionMode).toBe("workspace_pool");
     });
   });
+
+  describe("transferEditor", () => {
+    it("moves the triggers and re-registers enabled schedules for the new editor", async () => {
+      const mockCreateOrUpdateWorkflow = vi
+        .spyOn(temporalClient, "createOrUpdateAgentSchedule")
+        .mockResolvedValue(new Ok("workflow-id"));
+
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+
+      const primaryUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, primaryUser, {
+        role: "user",
+      });
+      const secondaryUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, secondaryUser, {
+        role: "user",
+      });
+      const secondaryAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        secondaryUser.sId,
+        workspace.sId
+      );
+
+      const enabledTrigger = await TriggerFactory.schedule(secondaryAuth, {
+        agentConfigurationId: agentConfig.sId,
+        status: "enabled",
+        configuration: { cron: "0 9 * * 1", timezone: "UTC" },
+      });
+      const disabledTrigger = await TriggerFactory.schedule(secondaryAuth, {
+        agentConfigurationId: agentConfig.sId,
+        configuration: { cron: "0 10 * * 1", timezone: "UTC" },
+      });
+      mockCreateOrUpdateWorkflow.mockClear();
+
+      const result = await TriggerResource.transferEditor(authenticator, {
+        fromUser: secondaryUser,
+        toUser: primaryUser,
+      });
+
+      expect(result.isOk()).toBe(true);
+      for (const trigger of [enabledTrigger, disabledTrigger]) {
+        const reloaded = await TriggerResource.fetchById(
+          authenticator,
+          trigger.sId
+        );
+        expect(reloaded?.editor).toBe(primaryUser.id);
+      }
+
+      // Only the enabled schedule has a live Temporal schedule to re-point, and it must be
+      // re-registered as the new editor: the schedule bakes the editor's sId into its args.
+      expect(mockCreateOrUpdateWorkflow).toHaveBeenCalledTimes(1);
+      const [{ auth: scheduleAuth, trigger: scheduledTrigger }] =
+        mockCreateOrUpdateWorkflow.mock.calls[0];
+      expect(scheduleAuth.getNonNullableUser().id).toBe(primaryUser.id);
+      expect(scheduledTrigger.sId).toBe(enabledTrigger.sId);
+      // The resource must carry the new editor too: `createOrUpdateAgentSchedule` silently skips
+      // triggers whose `editor` does not match the caller.
+      expect(scheduledTrigger.editor).toBe(primaryUser.id);
+    });
+
+    it("leaves the other members' triggers untouched", async () => {
+      vi.spyOn(temporalClient, "createOrUpdateAgentSchedule").mockResolvedValue(
+        new Ok("workflow-id")
+      );
+
+      const { workspace, authenticator } = await createResourceTest({
+        role: "admin",
+      });
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Test Agent" }
+      );
+
+      const adminTrigger = await TriggerFactory.schedule(authenticator, {
+        agentConfigurationId: agentConfig.sId,
+        configuration: { cron: "0 11 * * 1", timezone: "UTC" },
+      });
+
+      const primaryUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, primaryUser, {
+        role: "user",
+      });
+      const secondaryUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, secondaryUser, {
+        role: "user",
+      });
+
+      const result = await TriggerResource.transferEditor(authenticator, {
+        fromUser: secondaryUser,
+        toUser: primaryUser,
+      });
+
+      expect(result.isOk()).toBe(true);
+      const reloaded = await TriggerResource.fetchById(
+        authenticator,
+        adminTrigger.sId
+      );
+      expect(reloaded?.editor).toBe(authenticator.getNonNullableUser().id);
+    });
+  });
 });

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -726,6 +726,100 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return new Ok(undefined);
   }
 
+  /**
+   * Transfers editorship of every trigger owned by `fromUser` to `toUser`, in
+   * the current workspace. Used by the user identity merge: without this the
+   * triggers stay on the merged-away identity, become unmanageable by the
+   * surviving one, and are deleted outright if the secondary user is revoked
+   * (see `revokeAndTrackMembership`).
+   *
+   * Schedule triggers bake the editor's sId into the Temporal schedule's
+   * workflow args, so the schedule is re-upserted with the new editor's auth;
+   * webhook triggers resolve their editor at fire time and need nothing extra.
+   */
+  static async transferEditor(
+    auth: Authenticator,
+    {
+      fromUser,
+      toUser,
+    }: {
+      fromUser: UserResource;
+      toUser: UserResource;
+    }
+  ): Promise<Result<undefined, Error>> {
+    assert(
+      auth.isAdmin(),
+      "Trigger editorship can only be transferred by admins."
+    );
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    const [, updatedRows] = await this.model.update(
+      { editor: toUser.id },
+      {
+        where: {
+          workspaceId: workspace.id,
+          editor: fromUser.id,
+        },
+        returning: true,
+      }
+    );
+    if (updatedRows.length === 0) {
+      return new Ok(undefined);
+    }
+
+    const transferred = updatedRows.map(
+      (row) => new this(this.model, row.get())
+    );
+
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        fromUserId: fromUser.sId,
+        toUserId: toUser.sId,
+        triggerIds: transferred.map((trigger) => trigger.sId),
+      },
+      "Transferred trigger editorship between users"
+    );
+
+    const toUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      toUser.sId,
+      workspace.sId
+    );
+
+    // Only enabled triggers have a live schedule; disabling removes it, so re-upserting a
+    // disabled one would resurrect it.
+    const enabled = transferred.filter(
+      (trigger) => trigger.status === "enabled"
+    );
+    const results = await concurrentExecutor(
+      enabled,
+      async (trigger) => ({
+        sId: trigger.sId,
+        result: await trigger.upsertTemporalWorkflow(toUserAuth),
+      }),
+      { concurrency: 4 }
+    );
+
+    // The rows already point at the new editor, so a retry of the transfer finds nothing to do
+    // and will not fix these schedules: they keep firing as the old editor until someone pauses
+    // and unpauses them (`enable` re-upserts with the current editor's auth).
+    const staleTriggerIds = results
+      .filter(({ result }) => result.isErr())
+      .map(({ sId }) => sId);
+    if (staleTriggerIds.length > 0) {
+      return new Err(
+        new Error(
+          `Trigger editorship moved to ${toUser.sId}, but ${staleTriggerIds.length} schedule(s) ` +
+            `still run as ${fromUser.sId} and must be paused then unpaused to be re-registered: ` +
+            staleTriggerIds.join(", ")
+        )
+      );
+    }
+
+    return new Ok(undefined);
+  }
+
   static async deleteAllForUser(
     auth: Authenticator,
     user: UserResource | UserType

--- a/front/scripts/merge_mapped_identities.ts
+++ b/front/scripts/merge_mapped_identities.ts
@@ -2,7 +2,6 @@ import { userIdentityMergePlugin } from "@app/lib/api/poke/plugins/workspaces/us
 import { getMembers } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
-import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { promises as fs } from "fs";
@@ -121,7 +120,6 @@ function buildPairs(
   memberById: Map<string, Member>,
   primaryByEmail: Map<string, Member>,
   duplicateEmails: Set<string>,
-  triggerCountByEditor: Map<number, number>,
   ssoUserIds: Set<string>,
   activeAdminCount: number
 ) {
@@ -132,9 +130,6 @@ function buildPairs(
   for (const record of records) {
     const oldUser = memberById.get(record.oldUserId);
     const primaryUser = primaryByEmail.get(record.primaryEmail);
-    const triggerCount = oldUser
-      ? triggerCountByEditor.get(oldUser.id)
-      : undefined;
     const oldMembership = oldUser?.workspaces[0];
     const primaryMembership = primaryUser?.workspaces[0];
     let reason: string | null = null;
@@ -170,8 +165,6 @@ function buildPairs(
       activeAdminCount < MIN_ADMINS_FOR_REVOCATION
     ) {
       reason = "Old user is the workspace's last active admin.";
-    } else if (triggerCount && triggerCount > 0) {
-      reason = "Old user owns triggers that revocation would delete.";
     }
 
     if (reason) {
@@ -211,23 +204,12 @@ async function preflight(auth: Authenticator, records: MergeRecord[]) {
       .filter((primaryUser) => primaryUser.workOSUserId)
       .map((primaryUser) => primaryUser.sId)
   );
-  // Fetch once for the workspace so trigger checks do not add one query per mapping.
-  const triggers = await TriggerResource.listByWorkspace(auth);
-  const triggerCountByEditor = new Map<number, number>();
-  for (const trigger of triggers) {
-    const triggerCount = triggerCountByEditor.get(trigger.editor);
-    triggerCountByEditor.set(
-      trigger.editor,
-      triggerCount ? triggerCount + 1 : 1
-    );
-  }
 
   const { pairs, blocked } = buildPairs(
     records,
     memberById,
     primaryByEmail,
     duplicateEmails,
-    triggerCountByEditor,
     ssoUserIds,
     activeAdminCount
   );


### PR DESCRIPTION
## Description

This PR moves trigger ownership to the surviving user when merging user identities.

## Tests

Added tests for transferring enabled and disabled triggers and preserving other members’ triggers.

## Risks

A failed schedule re-registration can leave the trigger ownership updated while the Temporal schedule still references the previous editor.

## Deploy Plan

Standard deployment.