### PR TITLE
fix(triggers): assert workspacePool in countForWorkspace tests

### DIFF
--- a/front-api/routes/w/[wId]/analytics/automations/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/automations/overview.test.ts
@@ -25,6 +25,7 @@ const OVERVIEW: GetAutomationsOverviewResponse = {
   triggers: {
     enabled: 142,
     total: 152,
+    workspacePool: 12,
   },
 };
 

--- a/front/lib/resources/trigger_resource.test.ts
+++ b/front/lib/resources/trigger_resource.test.ts
@@ -451,6 +451,7 @@ describe("TriggerResource", () => {
       expect(await TriggerResource.countForWorkspace(authenticator)).toEqual({
         enabled: 2,
         total: 4,
+        workspacePool: 0,
       });
 
       mockCreateOrUpdateWorkflow.mockRestore();
@@ -462,6 +463,7 @@ describe("TriggerResource", () => {
       expect(await TriggerResource.countForWorkspace(authenticator)).toEqual({
         enabled: 0,
         total: 0,
+        workspacePool: 0,
       });
     });
   });


### PR DESCRIPTION
## Description

`countForWorkspace` started returning `workspacePool` in #31037 but the tests still asserted only `enabled` and `total`, so both cases failed on the extra key.

## Tests

`npm test -- lib/resources/trigger_resource.test.ts -t countForWorkspace` passes.

## Risk

None, test-only.

## Deploy Plan

Deploy front.