### PR TITLE
[front] Agent loop: stop failing workflows on tool activity heartbeat timeouts

### DIFF
--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -5,6 +5,7 @@ import {
 } from "@app/lib/api/assistant/email/email_reply";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import {
   launchAgentMessageAnalytics,
   launchAgentMessageConsumptionAttribution,
@@ -175,6 +176,20 @@ export async function finalizeErroredAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs,
   error: { message: string; name: string }
 ): Promise<void> {
+  // Keep the failure cause queryable in Datadog: swallowed infrastructure timeouts no longer
+  // emit a "Workflow failed" log, and this activity is the only remaining place that sees why
+  // the run errored.
+  logger.warn(
+    {
+      conversationId: agentLoopArgs.conversationId,
+      agentMessageId: agentLoopArgs.agentMessageId,
+      workspaceId: authType.workspaceId,
+      workflowErrorName: error.name,
+      workflowErrorMessage: error.message,
+    },
+    "Agent loop finalized as errored"
+  );
+
   await notifyWorkflowError(authType, agentLoopArgs, error);
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -174,21 +174,35 @@ export async function finalizeCreditStoppedAgentLoopActivity(
 export async function finalizeErroredAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs,
-  error: { message: string; name: string }
+  error: {
+    message: string;
+    name: string;
+    // The fields below are absent for workflows started before they were added.
+    swallowed?: boolean;
+    activityType?: string;
+    retryState?: string;
+    timeoutType?: string;
+  }
 ): Promise<void> {
-  // Keep the failure cause queryable in Datadog: swallowed infrastructure timeouts no longer
-  // emit a "Workflow failed" log, and this activity is the only remaining place that sees why
-  // the run errored.
-  logger.warn(
-    {
-      conversationId: agentLoopArgs.conversationId,
-      agentMessageId: agentLoopArgs.agentMessageId,
-      workspaceId: authType.workspaceId,
-      workflowErrorName: error.name,
-      workflowErrorMessage: error.message,
-    },
-    "Agent loop finalized as errored"
-  );
+  // Keep the failure cause queryable in Datadog: swallowed infrastructure timeouts do not emit
+  // a "Workflow failed" log, and this activity is the only remaining place that sees why the
+  // run errored. Rethrown failures keep the SDK's "Workflow failed" log, so they are not logged
+  // twice here.
+  if (error.swallowed) {
+    logger.warn(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+        workspaceId: authType.workspaceId,
+        workflowErrorName: error.name,
+        workflowErrorMessage: error.message,
+        activityType: error.activityType,
+        retryState: error.retryState,
+        timeoutType: error.timeoutType,
+      },
+      "Agent loop finalized as errored"
+    );
+  }
 
   await notifyWorkflowError(authType, agentLoopArgs, error);
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -128,7 +128,6 @@ async function _runToolActivity(
     runIds?: string[];
   }
 ): Promise<ToolExecutionResult> {
-
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
   const { auth, runAgentDataRes, action } = await withPeriodicHeartbeat(

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -17,7 +17,10 @@ import { getShutdownSignal } from "@app/lib/shutdown_signal";
 import { withPeriodicHeartbeat } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
-import { TOOL_SETUP_HEARTBEAT_INTERVAL_MS } from "@app/temporal/agent_loop/config";
+import {
+  TOOL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
+  TOOL_SETUP_HEARTBEAT_INTERVAL_MS,
+} from "@app/temporal/agent_loop/config";
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type {
@@ -91,6 +94,28 @@ function extractDataSourceIds(
 
 export async function runToolActivity(
   authType: AuthenticatorType,
+  params: {
+    actionId: ModelId;
+    runAgentArgs: AgentLoopArgsWithTiming;
+    step: number;
+    runIds?: string[];
+  }
+): Promise<ToolExecutionResult> {
+  // Several phases of a tool run (action state transitions, MCP server connection, event
+  // publication) sit outside the MCP call's own heartbeat loop and can stall past the heartbeat
+  // timeout under DB or network contention. Tools with the no_retry policy get a single attempt,
+  // so one missed heartbeat window fails the whole run: heartbeat immediately and periodically
+  // for the whole activity, same pattern as runModelAndCreateActionsActivity.
+  heartbeat();
+
+  return withPeriodicHeartbeat(() => _runToolActivity(authType, params), {
+    intervalMs: TOOL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
+    heartbeatFn: () => heartbeat(),
+  });
+}
+
+async function _runToolActivity(
+  authType: AuthenticatorType,
   {
     actionId,
     runAgentArgs,
@@ -103,10 +128,6 @@ export async function runToolActivity(
     runIds?: string[];
   }
 ): Promise<ToolExecutionResult> {
-  // The setup phase below is DB-bound and can stall past the heartbeat timeout under
-  // connection-pool contention. Tool activities are not retried, so a missed first heartbeat
-  // kills the whole run: heartbeat immediately and periodically until setup completes.
-  heartbeat();
 
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -130,6 +130,8 @@ async function _runToolActivity(
 ): Promise<ToolExecutionResult> {
   const deferredEvents: ToolExecutionResult["deferredEvents"] = [];
 
+  // The activity-lifetime wrapper above already covers liveness: this inner wrapper is kept for
+  // its log, each firing meaning the DB-bound setup phase is stalling (DB pool contention).
   const { auth, runAgentDataRes, action } = await withPeriodicHeartbeat(
     async () => {
       const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -98,17 +98,22 @@ export const RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS = 1 * 60 * 1000;
 export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 export const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 
+// The worker's maxHeartbeatThrottleInterval: the SDK sends at most one heartbeat to the server
+// per interval, so a faster app-side cadence buys nothing. The activity cadences below derive
+// from it so the values cannot drift apart.
+export const HEARTBEAT_THROTTLE_INTERVAL_MS = 20 * 1000;
+
 // Heartbeat cadence for the whole model activity. Its setup phase (agent data loading, MCP
 // tools listing, conversation rendering) can stall past the heartbeat timeout, e.g. a hung MCP
-// server's tools/list call times out after 60s, exactly the heartbeat timeout. Aligned with the
-// worker's maxHeartbeatThrottleInterval.
-export const MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS = 20 * 1000;
+// server's tools/list call times out after 60s, exactly the heartbeat timeout.
+export const MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS =
+  HEARTBEAT_THROTTLE_INTERVAL_MS;
 
 // Heartbeat cadence for the whole tool activity. Phases outside the MCP call loop (action state
 // transitions, input handling, MCP server connection, event publication) are DB/network-bound and
-// can stall past the heartbeat timeout under contention. Aligned with the worker's
-// maxHeartbeatThrottleInterval.
-export const TOOL_ACTIVITY_HEARTBEAT_INTERVAL_MS = 20 * 1000;
+// can stall past the heartbeat timeout under contention.
+export const TOOL_ACTIVITY_HEARTBEAT_INTERVAL_MS =
+  HEARTBEAT_THROTTLE_INTERVAL_MS;
 
 // Heartbeat cadence while tool result processing runs (file handling can take minutes): fire
 // comfortably within the heartbeat timeout.
@@ -120,5 +125,5 @@ export const TOOL_RESULT_PROCESSING_HEARTBEAT_INTERVAL_MS =
 // Heartbeat cadence while the tool activity's DB-bound setup (auth + conversation + action
 // fetches) runs. Setup normally completes in well under a second, so a firing means the fetch
 // phase is stalling (DB contention): the log emitted alongside each firing is monitored in
-// Datadog. Aligned with the worker's maxHeartbeatThrottleInterval.
-export const TOOL_SETUP_HEARTBEAT_INTERVAL_MS = 20 * 1000;
+// Datadog.
+export const TOOL_SETUP_HEARTBEAT_INTERVAL_MS = HEARTBEAT_THROTTLE_INTERVAL_MS;

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -104,6 +104,12 @@ export const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 // worker's maxHeartbeatThrottleInterval.
 export const MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS = 20 * 1000;
 
+// Heartbeat cadence for the whole tool activity. Phases outside the MCP call loop (action state
+// transitions, input handling, MCP server connection, event publication) are DB/network-bound and
+// can stall past the heartbeat timeout under contention. Aligned with the worker's
+// maxHeartbeatThrottleInterval.
+export const TOOL_ACTIVITY_HEARTBEAT_INTERVAL_MS = 20 * 1000;
+
 // Heartbeat cadence while tool result processing runs (file handling can take minutes): fire
 // comfortably within the heartbeat timeout.
 const TOOL_RESULT_PROCESSING_HEARTBEAT_TIMEOUT_MARGIN_MS = 5 * 1000;

--- a/front/temporal/agent_loop/lib/wait_for_all_promises.test.ts
+++ b/front/temporal/agent_loop/lib/wait_for_all_promises.test.ts
@@ -1,6 +1,17 @@
+import {
+  ActivityFailure,
+  ApplicationFailure,
+  RetryState,
+  TimeoutFailure,
+  TimeoutType,
+} from "@temporalio/common";
 import { describe, expect, it } from "vitest";
 
 import { waitForAllPromises } from "./wait_for_all_promises";
+import {
+  isTerminalRunToolTimeout,
+  RUN_TOOL_ACTIVITY_NAME,
+} from "./workflow_failures";
 
 describe("waitForAllPromises", () => {
   it("preserves result order after every promise succeeds", async () => {
@@ -30,5 +41,55 @@ describe("waitForAllPromises", () => {
 
     resolveRemainingActivity?.();
     await expect(result).rejects.toBe(activityFailure);
+  });
+
+  it("propagates the preferred rejection over an earlier one", async () => {
+    const first = new Error("first");
+    const preferred = new Error("preferred");
+
+    await expect(
+      waitForAllPromises([Promise.reject(first), Promise.reject(preferred)], {
+        preferRejection: (reason) => reason === preferred,
+      })
+    ).rejects.toBe(preferred);
+  });
+
+  it("falls back to the first rejection when none is preferred", async () => {
+    const first = new Error("first");
+    const second = new Error("second");
+
+    await expect(
+      waitForAllPromises([Promise.reject(first), Promise.reject(second)], {
+        preferRejection: () => false,
+      })
+    ).rejects.toBe(first);
+  });
+
+  it("lets a sibling application failure win over a swallowable tool timeout", async () => {
+    // Regression: the agent loop must not swallow a real tool failure because a swallowable
+    // infrastructure timeout on a sibling tool rejected first.
+    const toolTimeout = new ActivityFailure(
+      "Activity task timed out",
+      RUN_TOOL_ACTIVITY_NAME,
+      "activity-id-1",
+      RetryState.MAXIMUM_ATTEMPTS_REACHED,
+      "worker-id",
+      new TimeoutFailure("activity timed out", undefined, TimeoutType.HEARTBEAT)
+    );
+    const applicationFailure = new ActivityFailure(
+      "Activity task failed",
+      RUN_TOOL_ACTIVITY_NAME,
+      "activity-id-2",
+      RetryState.MAXIMUM_ATTEMPTS_REACHED,
+      "worker-id",
+      ApplicationFailure.create({ message: "tool blew up" })
+    );
+
+    await expect(
+      waitForAllPromises(
+        [Promise.reject(toolTimeout), Promise.reject(applicationFailure)],
+        { preferRejection: (reason) => !isTerminalRunToolTimeout(reason) }
+      )
+    ).rejects.toBe(applicationFailure);
   });
 });

--- a/front/temporal/agent_loop/lib/wait_for_all_promises.ts
+++ b/front/temporal/agent_loop/lib/wait_for_all_promises.ts
@@ -2,24 +2,36 @@
  * Wait for every promise to settle, then preserve Promise.all's success and failure contract.
  * This prevents one cancelled activity from letting a workflow finalize while sibling activities
  * are still completing.
+ *
+ * When several promises reject, the first rejection in input order is thrown. `preferRejection`
+ * overrides that order: the first rejection matching the predicate wins, so a swallowable
+ * infrastructure timeout cannot mask a sibling's real failure.
  */
 export async function waitForAllPromises<T>(
-  promises: readonly Promise<T>[]
+  promises: readonly Promise<T>[],
+  { preferRejection }: { preferRejection?: (reason: unknown) => boolean } = {}
 ): Promise<T[]> {
   const results = await Promise.allSettled(promises);
   const values: T[] = [];
   let firstRejection: PromiseRejectedResult | undefined;
+  let firstPreferredRejection: PromiseRejectedResult | undefined;
 
   for (const result of results) {
     if (result.status === "fulfilled") {
       values.push(result.value);
-    } else if (!firstRejection) {
+      continue;
+    }
+    if (!firstRejection) {
       firstRejection = result;
+    }
+    if (!firstPreferredRejection && preferRejection?.(result.reason)) {
+      firstPreferredRejection = result;
     }
   }
 
-  if (firstRejection) {
-    throw firstRejection.reason;
+  const rejection = firstPreferredRejection ?? firstRejection;
+  if (rejection) {
+    throw rejection.reason;
   }
 
   return values;

--- a/front/temporal/agent_loop/lib/workflow_failures.test.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.test.ts
@@ -2,6 +2,7 @@ import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
 import type { ProtoFailure } from "@temporalio/common";
 import {
   ActivityFailure,
+  ApplicationFailure,
   RetryState,
   TimeoutFailure,
   TimeoutType,
@@ -12,7 +13,9 @@ import { makeRunModelLLMError } from "./run_model_errors";
 import {
   isRunModelLLMUnresponsiveError,
   isTerminalRunModelTimeout,
+  isTerminalRunToolTimeout,
   RUN_MODEL_ACTIVITY_NAME,
+  RUN_TOOL_ACTIVITY_NAME,
 } from "./workflow_failures";
 
 const LLM_TIMEOUT_MESSAGE =
@@ -62,9 +65,12 @@ function makeActivityFailure({
   );
 }
 
+// Mirrors the expression in agentLoopWorkflow's catch block.
 function shouldSwallowWorkflowFailure(error: unknown): boolean {
   return (
-    isTerminalRunModelTimeout(error) && isRunModelLLMUnresponsiveError(error)
+    (isTerminalRunModelTimeout(error) &&
+      isRunModelLLMUnresponsiveError(error)) ||
+    isTerminalRunToolTimeout(error)
   );
 }
 
@@ -115,12 +121,61 @@ describe("workflow failure predicates", () => {
       retryState: RetryState.IN_PROGRESS,
     });
     const unrelatedActivityFailure = makeActivityFailure({
-      activityType: "runToolActivity",
+      activityType: "checkCreditsActivity",
     });
 
     expect(isTerminalRunModelTimeout(nonTerminalFailure)).toBe(false);
     expect(shouldSwallowWorkflowFailure(nonTerminalFailure)).toBe(false);
     expect(isTerminalRunModelTimeout(unrelatedActivityFailure)).toBe(false);
     expect(shouldSwallowWorkflowFailure(unrelatedActivityFailure)).toBe(false);
+  });
+
+  it("matches terminal tool heartbeat timeouts, the single-attempt no_retry case included", () => {
+    // A no_retry tool activity has maximumAttempts 1: its first heartbeat timeout is terminal
+    // with MAXIMUM_ATTEMPTS_REACHED.
+    const failure = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+    });
+
+    expect(isTerminalRunToolTimeout(failure)).toBe(true);
+    expect(shouldSwallowWorkflowFailure(failure)).toBe(true);
+  });
+
+  it("matches terminal tool StartToClose timeouts", () => {
+    const failure = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+      retryState: RetryState.TIMEOUT,
+      timeoutType: TimeoutType.START_TO_CLOSE,
+    });
+
+    expect(isTerminalRunToolTimeout(failure)).toBe(true);
+    expect(shouldSwallowWorkflowFailure(failure)).toBe(true);
+  });
+
+  it("ignores non-terminal tool timeouts and non-timeout tool failures", () => {
+    const nonTerminalFailure = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+      retryState: RetryState.IN_PROGRESS,
+    });
+    // A tool throwing an application error (not a timeout) must still fail the workflow.
+    const applicationFailure = new ActivityFailure(
+      "Activity task failed",
+      RUN_TOOL_ACTIVITY_NAME,
+      "activity-id",
+      RetryState.MAXIMUM_ATTEMPTS_REACHED,
+      "worker-id",
+      ApplicationFailure.create({ message: "tool blew up" })
+    );
+
+    expect(isTerminalRunToolTimeout(nonTerminalFailure)).toBe(false);
+    expect(shouldSwallowWorkflowFailure(nonTerminalFailure)).toBe(false);
+    expect(isTerminalRunToolTimeout(applicationFailure)).toBe(false);
+    expect(shouldSwallowWorkflowFailure(applicationFailure)).toBe(false);
   });
 });

--- a/front/temporal/agent_loop/lib/workflow_failures.test.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.test.ts
@@ -11,7 +11,9 @@ import { describe, expect, it } from "vitest";
 
 import { makeRunModelLLMError } from "./run_model_errors";
 import {
+  getWorkflowFailureDetails,
   isRunModelLLMUnresponsiveError,
+  isSwallowableWorkflowFailure,
   isTerminalRunModelTimeout,
   isTerminalRunToolTimeout,
   RUN_MODEL_ACTIVITY_NAME,
@@ -65,13 +67,9 @@ function makeActivityFailure({
   );
 }
 
-// Mirrors the expression in agentLoopWorkflow's catch block.
+// The production decision, with the tool-timeout patch active as it is for new executions.
 function shouldSwallowWorkflowFailure(error: unknown): boolean {
-  return (
-    (isTerminalRunModelTimeout(error) &&
-      isRunModelLLMUnresponsiveError(error)) ||
-    isTerminalRunToolTimeout(error)
-  );
+  return isSwallowableWorkflowFailure(error, { swallowToolTimeouts: true });
 }
 
 describe("workflow failure predicates", () => {
@@ -177,5 +175,43 @@ describe("workflow failure predicates", () => {
     expect(shouldSwallowWorkflowFailure(nonTerminalFailure)).toBe(false);
     expect(isTerminalRunToolTimeout(applicationFailure)).toBe(false);
     expect(shouldSwallowWorkflowFailure(applicationFailure)).toBe(false);
+  });
+
+  it("keeps the legacy throw for tool timeouts when the patch is inactive", () => {
+    // Replays of histories that predate the "swallow-terminal-tool-timeouts" patch.
+    const toolTimeout = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+    });
+    const modelTimeout = makeActivityFailure();
+
+    expect(
+      isSwallowableWorkflowFailure(toolTimeout, { swallowToolTimeouts: false })
+    ).toBe(false);
+    // The model swallow predates the patch and is not affected by it.
+    expect(
+      isSwallowableWorkflowFailure(modelTimeout, { swallowToolTimeouts: false })
+    ).toBe(true);
+  });
+});
+
+describe("getWorkflowFailureDetails", () => {
+  it("extracts the activity type, retry state and timeout type", () => {
+    const failure = makeActivityFailure({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      llmErrorType: null,
+      llmErrorMessage: null,
+    });
+
+    expect(getWorkflowFailureDetails(failure)).toEqual({
+      activityType: RUN_TOOL_ACTIVITY_NAME,
+      retryState: "MAXIMUM_ATTEMPTS_REACHED",
+      timeoutType: "HEARTBEAT",
+    });
+  });
+
+  it("returns no details for non-activity failures", () => {
+    expect(getWorkflowFailureDetails(new Error("boom"))).toEqual({});
   });
 });

--- a/front/temporal/agent_loop/lib/workflow_failures.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.ts
@@ -57,6 +57,51 @@ export function isTerminalRunToolTimeout(
   return isTerminalActivityTimeout(error, RUN_TOOL_ACTIVITY_NAME);
 }
 
+// Decides whether agentLoopWorkflow completes instead of failing after an error: the message is
+// finalized as errored either way, so swallowing only removes the FAILED status. Model timeouts
+// are swallowed when the failure chain proves the blocked work was an LLM provider timeout. Tool
+// activity timeouts are infrastructure failures (pod killed without drain, heartbeat starvation),
+// not tool errors (tools report those as events): swallowToolTimeouts carries the workflow's
+// patched() state so replays of histories predating the patch keep the legacy throw. Anything
+// else fails the workflow.
+export function isSwallowableWorkflowFailure(
+  error: unknown,
+  { swallowToolTimeouts }: { swallowToolTimeouts: boolean }
+): boolean {
+  if (
+    isTerminalRunModelTimeout(error) &&
+    isRunModelLLMUnresponsiveError(error)
+  ) {
+    return true;
+  }
+
+  return swallowToolTimeouts && isTerminalRunToolTimeout(error);
+}
+
+// Structured failure fields for the finalize activity's log: which activity failed, how its retry
+// policy ended and which timeout fired. Enum values are stringified since they cross the
+// workflow to activity payload boundary.
+export function getWorkflowFailureDetails(error: unknown): {
+  activityType?: string;
+  retryState?: string;
+  timeoutType?: string;
+} {
+  if (!(error instanceof ActivityFailure)) {
+    return {};
+  }
+
+  return {
+    activityType: error.activityType,
+    ...(error.retryState !== undefined
+      ? { retryState: RetryState[error.retryState] }
+      : {}),
+    ...(error.cause instanceof TimeoutFailure &&
+    error.cause.timeoutType !== undefined
+      ? { timeoutType: TimeoutType[error.cause.timeoutType] }
+      : {}),
+  };
+}
+
 export function isRunModelLLMUnresponsiveError(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;

--- a/front/temporal/agent_loop/lib/workflow_failures.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.ts
@@ -11,14 +11,7 @@ import {
 import { isRunModelLLMUnresponsiveFailureType } from "./run_model_errors";
 
 export const RUN_MODEL_ACTIVITY_NAME = "runModelAndCreateActionsActivity";
-
-function isRunModelActivityFailure(error: unknown): error is ActivityFailure {
-  if (!(error instanceof ActivityFailure)) {
-    return false;
-  }
-
-  return error.activityType === RUN_MODEL_ACTIVITY_NAME;
-}
+export const RUN_TOOL_ACTIVITY_NAME = "runToolActivity";
 
 function isTerminalRetryState(retryState: RetryState): boolean {
   return (
@@ -27,10 +20,14 @@ function isTerminalRetryState(retryState: RetryState): boolean {
   );
 }
 
-export function isTerminalRunModelTimeout(
-  error: unknown
+function isTerminalActivityTimeout(
+  error: unknown,
+  activityName: string
 ): error is ActivityFailure {
-  if (!isRunModelActivityFailure(error)) {
+  if (
+    !(error instanceof ActivityFailure) ||
+    error.activityType !== activityName
+  ) {
     return false;
   }
 
@@ -46,6 +43,18 @@ export function isTerminalRunModelTimeout(
     error.cause.timeoutType === TimeoutType.START_TO_CLOSE ||
     error.cause.timeoutType === TimeoutType.HEARTBEAT
   );
+}
+
+export function isTerminalRunModelTimeout(
+  error: unknown
+): error is ActivityFailure {
+  return isTerminalActivityTimeout(error, RUN_MODEL_ACTIVITY_NAME);
+}
+
+export function isTerminalRunToolTimeout(
+  error: unknown
+): error is ActivityFailure {
+  return isTerminalActivityTimeout(error, RUN_TOOL_ACTIVITY_NAME);
 }
 
 export function isRunModelLLMUnresponsiveError(error: unknown): boolean {

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -27,6 +27,7 @@ import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activ
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import {
   BATCH_QUEUE_NAME,
+  HEARTBEAT_THROTTLE_INTERVAL_MS,
   INTERACTIVE_QUEUE_NAME,
   PROGRAMMATIC_QUEUE_NAME,
   SCHEDULES_QUEUE_NAME,
@@ -123,7 +124,7 @@ async function runAgentLoopWorkerForQueue({
     shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
     // This also bounds the time until an activity may receive a cancellation signal.
     // See https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling
-    maxHeartbeatThrottleInterval: "20 seconds",
+    maxHeartbeatThrottleInterval: HEARTBEAT_THROTTLE_INTERVAL_MS,
     maxConcurrentActivityTaskExecutions:
       MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS,
     interceptors: {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -22,6 +22,7 @@ import { waitForAllPromises } from "@app/temporal/agent_loop/lib/wait_for_all_pr
 import {
   isRunModelLLMUnresponsiveError,
   isTerminalRunModelTimeout,
+  isTerminalRunToolTimeout,
 } from "@app/temporal/agent_loop/lib/workflow_failures";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import {
@@ -407,10 +408,14 @@ export async function agentLoopWorkflow({
   } catch (err) {
     const workflowError = err instanceof Error ? err : new Error(String(err));
     // The activity publishes user-facing model errors when our code regains control. We swallow
-    // only terminal Temporal timeouts whose failure chain proves the blocked work was an LLM
-    // provider timeout, so unrelated infrastructure timeouts still surface as workflow failures.
+    // terminal Temporal timeouts in two cases, the message being finalized as errored below
+    // either way: model timeouts whose failure chain proves the blocked work was an LLM provider
+    // timeout, and tool activity timeouts, which are infrastructure failures (pod killed without
+    // drain, heartbeat starvation), not tool errors: tools report their own failures as events.
+    // Other failures still surface as workflow failures.
     const shouldSwallowWorkflowFailure =
-      isTerminalRunModelTimeout(err) && isRunModelLLMUnresponsiveError(err);
+      (isTerminalRunModelTimeout(err) && isRunModelLLMUnresponsiveError(err)) ||
+      isTerminalRunToolTimeout(err);
 
     // Notify error in a non-cancellable scope to ensure it runs even if the workflow is canceled.
     // Pass this execution's runIds and startStep to finalize so tracking

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -20,8 +20,8 @@ import {
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { waitForAllPromises } from "@app/temporal/agent_loop/lib/wait_for_all_promises";
 import {
-  isRunModelLLMUnresponsiveError,
-  isTerminalRunModelTimeout,
+  getWorkflowFailureDetails,
+  isSwallowableWorkflowFailure,
   isTerminalRunToolTimeout,
 } from "@app/temporal/agent_loop/lib/workflow_failures";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
@@ -407,15 +407,16 @@ export async function agentLoopWorkflow({
     });
   } catch (err) {
     const workflowError = err instanceof Error ? err : new Error(String(err));
-    // The activity publishes user-facing model errors when our code regains control. We swallow
-    // terminal Temporal timeouts in two cases, the message being finalized as errored below
-    // either way: model timeouts whose failure chain proves the blocked work was an LLM provider
-    // timeout, and tool activity timeouts, which are infrastructure failures (pod killed without
-    // drain, heartbeat starvation), not tool errors: tools report their own failures as events.
-    // Other failures still surface as workflow failures.
-    const shouldSwallowWorkflowFailure =
-      (isTerminalRunModelTimeout(err) && isRunModelLLMUnresponsiveError(err)) ||
-      isTerminalRunToolTimeout(err);
+    // The message is finalized as errored below either way: swallowing only removes the FAILED
+    // workflow status (see isSwallowableWorkflowFailure). Swallowing a tool timeout turns the
+    // terminal command from fail into complete, so it is gated on a patch marker: replays of
+    // histories that predate the patch keep the legacy throw. The patch is only consulted (and
+    // its marker only recorded) when the error actually is a terminal tool timeout.
+    const shouldSwallowWorkflowFailure = isSwallowableWorkflowFailure(err, {
+      swallowToolTimeouts:
+        isTerminalRunToolTimeout(err) &&
+        patched("swallow-terminal-tool-timeouts"),
+    });
 
     // Notify error in a non-cancellable scope to ensure it runs even if the workflow is canceled.
     // Pass this execution's runIds and startStep to finalize so tracking
@@ -446,6 +447,8 @@ export async function agentLoopWorkflow({
         // before passing to the activity.
         message: workflowError.message,
         name: workflowError.name,
+        swallowed: shouldSwallowWorkflowFailure,
+        ...getWorkflowFailureDetails(err),
       })
     );
 
@@ -537,8 +540,13 @@ async function executeStepIteration({
           runIds: [...(runIds ?? []), ...(runId ? [runId] : [])],
         })
   );
-  const toolResults: ToolExecutionResult[] =
-    await waitForAllPromises(toolActivityPromises);
+  const toolResults: ToolExecutionResult[] = await waitForAllPromises(
+    toolActivityPromises,
+    {
+      // A swallowable infrastructure timeout must not mask a sibling tool's real failure.
+      preferRejection: (reason) => !isTerminalRunToolTimeout(reason),
+    }
+  );
 
   // Collect all deferred events from tool executions.
   const allDeferredEvents = toolResults.flatMap(


### PR DESCRIPTION
## Description

87% of agentLoopWorkflow FAILED runs over the last 7 days (823/944) are `runToolActivity` heartbeat timeouts ([Datadog](https://app.datadoghq.eu/logs?query=service%3Afront-agent-loop-worker%20%22Workflow%20failed%22%20%40workflowType%3AagentLoopWorkflow)). Tools with the default `no_retry` policy run with `maximumAttempts: 1`, so a single 60s heartbeat gap kills the whole run. Two causes observed in production:

- Un-heartbeated stretch: action state transitions, MCP server connection and event publication sit outside the MCP call's heartbeat loop. Traced a tool stuck ~2min pre-connect, timed out by the server, that then completed successfully into the void.
- Hard pod kills (no drain): pods dying mid-work at load peaks; every in-flight tool activity heartbeat-times-out 60s later.

Two changes:

- `runToolActivity` now heartbeats for its whole lifetime (same wrapper pattern as `runModelAndCreateActionsActivity`), so a live-but-stalled pod is never timed out.
- The workflow swallows terminal tool activity timeouts the way it already swallows LLM-unresponsive model timeouts: the message is finalized as errored for the user either way, and the FAILED status was only Temporal noise. Tool application errors still fail the workflow.

Observability: swallowed timeouts no longer emit a "Workflow failed" log, so `finalizeErroredAgentLoopActivity` now logs the error cause ("Agent loop finalized as errored") to keep dead-pod heartbeat timeouts queryable and alertable in Datadog.

Follow-ups (separate PRs): retry-policy classification for read-only remote MCP tools (needs plumbing in `remote_servers.ts`), hard-kill investigation (OOM/evictions) on agent-loop pods.

## Tests

Unit tests cover the production swallow decision (`isSwallowableWorkflowFailure`, patched and unpatched), `isTerminalRunToolTimeout`, `getWorkflowFailureDetails`, and a mixed-failure regression on `waitForAllPromises` (a sibling application failure wins over a swallowable timeout). `workflows.test.ts` and `finalize.test.ts` green. `tsgo --noEmit` clean on touched files.

## Risk

Swallowing a tool timeout changes the workflow's terminal command (complete instead of fail), so it is gated behind `patched("swallow-terminal-tool-timeouts")`: replays of histories that predate the patch keep the legacy throw. Standard patch caveat applies to rollback: workflows that recorded the marker must complete before rolling back to a build without the patch. Parallel tools propagate a sibling's real failure in preference to a swallowable timeout, so application errors cannot be masked.

## Deploy Plan

- Deploy front.
- Watch `service:front-agent-loop-worker "Workflow failed" @workflowType:agentLoopWorkflow`: heartbeat-timeout failures should drop to ~zero.

