### PR TITLE
feat(automations): filter triggers by credit pool

### DIFF
--- a/front/components/workspace/analytics/automations/AutomationsFilterOptionIcon.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterOptionIcon.tsx
@@ -28,6 +28,7 @@ export function AutomationsFilterOptionIcon({
         />
       );
     case "type":
+    case "pool":
       return null;
     default:
       assertNeverAndIgnore(option.category);

--- a/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
+++ b/front/components/workspace/analytics/automations/AutomationsFilterPanel.tsx
@@ -1,4 +1,5 @@
 import { AutomationsFilterOptionIcon } from "@app/components/workspace/analytics/automations/AutomationsFilterOptionIcon";
+import { POOL_OPTIONS } from "@app/components/workspace/analytics/automations/trigger_pool_options";
 import type {
   AutomationsFilter,
   AutomationsFilterCategory,
@@ -41,6 +42,15 @@ const TYPE_OPTIONS: AutomationsFilterOption[] = [
   { id: "schedule", name: "Schedule", disabled: false, category: "type" },
   { id: "webhook", name: "Webhook", disabled: false, category: "type" },
 ];
+
+const POOL_FILTER_OPTIONS: AutomationsFilterOption[] = POOL_OPTIONS.map(
+  ({ value, label }) => ({
+    id: value,
+    name: label,
+    disabled: false,
+    category: "pool",
+  })
+);
 
 interface AutomationsFilterPanelProps {
   owner: LightWorkspaceType;
@@ -120,11 +130,13 @@ export function AutomationsFilterPanel({
         category: "member",
       })),
       type: TYPE_OPTIONS,
+      pool: POOL_FILTER_OPTIONS,
     }),
     [agentOptions, facetOptions]
   );
 
-  const isFacetBackedCategory = activeCategory !== "type";
+  const isFacetBackedCategory =
+    activeCategory !== "type" && activeCategory !== "pool";
   const isOptionsLoading = isFacetBackedCategory && isFacetsLoading;
 
   const activeOptions = categoryOptions[activeCategory];

--- a/front/components/workspace/analytics/automationsFilter.test.ts
+++ b/front/components/workspace/analytics/automationsFilter.test.ts
@@ -37,18 +37,32 @@ describe("toAutomationsTriggersFilter", () => {
           },
           { id: "webhook", name: "Webhook", category: "type", disabled: false },
         ],
+        pool: [
+          {
+            id: "workspace_pool",
+            name: "Workspace",
+            category: "pool",
+            disabled: false,
+          },
+        ],
       })
     ).toEqual({
       agentIds: ["agent-1"],
       editorIds: ["member-1"],
       kinds: ["schedule", "webhook"],
+      executionModes: ["workspace_pool"],
     });
   });
 
   it("omits empty selections", () => {
     expect(toAutomationsTriggersFilter({})).toEqual({});
     expect(
-      toAutomationsTriggersFilter({ agent: [], member: [], type: [] })
+      toAutomationsTriggersFilter({
+        agent: [],
+        member: [],
+        type: [],
+        pool: [],
+      })
     ).toEqual({});
   });
 
@@ -73,6 +87,27 @@ describe("toAutomationsTriggersFilter", () => {
     ).toEqual({ kinds: ["schedule"] });
   });
 
+  it("drops pool ids that are not valid execution modes", () => {
+    expect(
+      toAutomationsTriggersFilter({
+        pool: [
+          {
+            id: "user_pool",
+            name: "Member",
+            category: "pool",
+            disabled: false,
+          },
+          {
+            id: "not-a-pool",
+            name: "Unknown",
+            category: "pool",
+            disabled: false,
+          },
+        ],
+      })
+    ).toEqual({ executionModes: ["user_pool"] });
+  });
+
   it("only maps the selected categories, leaving the others out", () => {
     expect(toAutomationsTriggersFilter({ agent: [agentOption] })).toEqual({
       agentIds: ["agent-1"],
@@ -93,7 +128,7 @@ describe("toAutomationsScopeFilter", () => {
     });
   });
 
-  it("drops the type category, which is not a consumption dimension", () => {
+  it("drops the type and pool categories, which are not consumption dimensions", () => {
     expect(
       toAutomationsScopeFilter({
         type: [
@@ -101,6 +136,14 @@ describe("toAutomationsScopeFilter", () => {
             id: "schedule",
             name: "Schedule",
             category: "type",
+            disabled: false,
+          },
+        ],
+        pool: [
+          {
+            id: "workspace_pool",
+            name: "Workspace",
+            category: "pool",
             disabled: false,
           },
         ],

--- a/front/components/workspace/analytics/automationsFilter.ts
+++ b/front/components/workspace/analytics/automationsFilter.ts
@@ -7,12 +7,17 @@ import {
   getFilterSummaries,
 } from "@app/components/workspace/analytics/filterPanel/filterState";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
-import type { TriggerKind } from "@app/types/assistant/triggers";
+import type {
+  TriggerExecutionMode,
+  TriggerKind,
+} from "@app/types/assistant/triggers";
+import { isTriggerExecutionMode } from "@app/types/assistant/triggers";
 
 export const AUTOMATIONS_FILTER_CATEGORIES = [
   "agent",
   "member",
   "type",
+  "pool",
 ] as const;
 
 export type AutomationsFilterCategory =
@@ -31,6 +36,7 @@ export const AUTOMATIONS_FILTER_CATEGORY_LABEL: Record<
   agent: "Agents",
   member: "Members",
   type: "Type",
+  pool: "Pool",
 };
 
 export const AUTOMATIONS_FILTER_CATEGORY_SINGULAR_LABEL: Record<
@@ -40,6 +46,7 @@ export const AUTOMATIONS_FILTER_CATEGORY_SINGULAR_LABEL: Record<
   agent: "Agent",
   member: "Member",
   type: "Type",
+  pool: "Pool",
 };
 
 export interface AutomationsFilterOption extends FilterOptionBase {
@@ -74,10 +81,12 @@ export type AutomationsTriggersFilter = {
   agentIds?: string[];
   editorIds?: string[];
   kinds?: TriggerKind[];
+  executionModes?: TriggerExecutionMode[];
 };
 
-// Availability counts ignore the type filter: trigger kinds are not a
-// consumption dimension, so they cannot be expressed as a scope filter.
+// Availability counts ignore the type and pool filters: trigger kinds and
+// execution modes are not consumption dimensions, so they cannot be expressed
+// as a scope filter.
 export function toAutomationsScopeFilter(
   filter: AutomationsFilter
 ): ConsumptionScopeFilter {
@@ -106,11 +115,15 @@ export function toAutomationsTriggersFilter(
   const agentIds = filter.agent?.map((option) => option.id);
   const editorIds = filter.member?.map((option) => option.id);
   const kinds = filter.type?.map((option) => option.id).filter(isTriggerKind);
+  const executionModes = filter.pool
+    ?.map((option) => option.id)
+    .filter(isTriggerExecutionMode);
 
   return {
     ...(agentIds && agentIds.length > 0 ? { agentIds } : {}),
     ...(editorIds && editorIds.length > 0 ? { editorIds } : {}),
     ...(kinds && kinds.length > 0 ? { kinds } : {}),
+    ...(executionModes && executionModes.length > 0 ? { executionModes } : {}),
   };
 }
 

--- a/front/lib/api/analytics/automations/schema.ts
+++ b/front/lib/api/analytics/automations/schema.ts
@@ -1,4 +1,5 @@
 import { ConsumptionPeriodSchema } from "@app/lib/api/analytics/consumption/schema";
+import { TRIGGER_EXECUTION_MODES } from "@app/types/assistant/triggers";
 import { z } from "zod";
 
 export const DEFAULT_AUTOMATION_TRIGGERS_LIMIT = 25;
@@ -13,6 +14,7 @@ export const AutomationTriggersFilterSchema = z.object({
   agentIds: z.array(z.string()).optional(),
   editorIds: z.array(z.string()).optional(),
   kinds: z.array(z.enum(["schedule", "webhook"])).optional(),
+  executionModes: z.array(z.enum(TRIGGER_EXECUTION_MODES)).optional(),
 });
 
 export type AutomationTriggersFilter = z.infer<

--- a/front/lib/api/analytics/automations/triggers.ts
+++ b/front/lib/api/analytics/automations/triggers.ts
@@ -113,19 +113,29 @@ export function median(values: number[]): number {
 }
 
 /**
- * Trigger kind isn't indexed in the consumption Elasticsearch documents, so
- * a kind filter is resolved to a concrete set of trigger ids up front and
- * applied as a terms filter on TRIGGER_ID_FIELD. Returns null when no kind
- * filter is requested (no restriction).
+ * Neither trigger kind nor execution mode is indexed in the consumption
+ * Elasticsearch documents, so those filters are resolved to a concrete set of
+ * trigger ids up front and applied as a terms filter on TRIGGER_ID_FIELD.
+ * Returns null when neither filter is requested (no restriction).
  */
-async function resolveTriggerIdsForKindFilter(
+async function resolveTriggerIdsForTriggerAttributeFilters(
   auth: Authenticator,
-  kinds: TriggerKind[] | undefined
+  {
+    kinds,
+    executionModes,
+  }: {
+    kinds: TriggerKind[] | undefined;
+    executionModes: TriggerExecutionMode[] | undefined;
+  }
 ): Promise<string[] | null> {
-  if (!kinds || kinds.length === 0) {
+  if (!kinds?.length && !executionModes?.length) {
     return null;
   }
-  const triggers = await TriggerResource.listByWorkspaceAndKinds(auth, kinds);
+  const triggers =
+    await TriggerResource.listByWorkspaceAndKindsAndExecutionModes(auth, {
+      kinds,
+      executionModes,
+    });
   return triggers.map((trigger) => trigger.sId);
 }
 
@@ -194,10 +204,11 @@ export async function fetchTriggersRanking(
     scopeFilter.users = filter.editorIds;
   }
 
-  const triggerIdsForKindFilter = await resolveTriggerIdsForKindFilter(
-    auth,
-    filter?.kinds
-  );
+  const triggerIdsForAttributeFilters =
+    await resolveTriggerIdsForTriggerAttributeFilters(auth, {
+      kinds: filter?.kinds,
+      executionModes: filter?.executionModes,
+    });
   const triggerIdsForSearch = await resolveTriggerIdsForSearch(auth, search);
 
   const query = buildConsumptionScopeQuery({
@@ -206,8 +217,8 @@ export async function fetchTriggersRanking(
     endDate: period.endDate,
     filter: scopeFilter,
     extraFilters:
-      triggerIdsForKindFilter !== null
-        ? [{ terms: { [TRIGGER_ID_FIELD]: triggerIdsForKindFilter } }]
+      triggerIdsForAttributeFilters !== null
+        ? [{ terms: { [TRIGGER_ID_FIELD]: triggerIdsForAttributeFilters } }]
         : [],
   });
 

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -350,12 +350,20 @@ export class TriggerResource extends BaseResource<TriggerModel> {
     return { enabled, total: triggers.length, workspacePool };
   }
 
-  static listByWorkspaceAndKinds(
+  static listByWorkspaceAndKindsAndExecutionModes(
     auth: Authenticator,
-    kinds: TriggerKind[]
+    {
+      kinds,
+      executionModes,
+    }: { kinds?: TriggerKind[]; executionModes?: TriggerExecutionMode[] }
   ): Promise<TriggerResource[]> {
     return this.baseFetch(auth, {
-      where: { kind: { [Op.in]: kinds } },
+      where: {
+        ...(kinds?.length ? { kind: { [Op.in]: kinds } } : {}),
+        ...(executionModes?.length
+          ? { executionMode: { [Op.in]: executionModes } }
+          : {}),
+      },
     });
   }
 


### PR DESCRIPTION
## Description

The automations admin table shows which credit pool each trigger charges, but there was no way to narrow it down to one. This adds a Pool filter category (Workspace / Member) next to Type, using the same option list the pool column dropdown already uses. Execution mode isn't indexed in the consumption documents, so like the kind filter it resolves to a set of trigger ids first and is applied as a terms filter on the ranking query. The /me automations table keeps its two categories.

## Tests

Extended the filter mapping unit tests (pool selection maps to `executionModes`, invalid ids are dropped, pool stays out of the scope filter). Checked the panel manually: filtering on Workspace or Member narrows the table, combining Pool with Type intersects, and the count badge and summary chips pick the category up.

<img width="1380" height="1506" alt="Capture d’écran 2026-08-24 à 17 34 29" src="https://github.com/user-attachments/assets/f19caba6-c394-4486-8a11-18b871f6b6e9" />
<img width="1380" height="1506" alt="Capture d’écran 2026-08-24 à 17 34 19" src="https://github.com/user-attachments/assets/f9f170f0-22e0-4b60-8337-f5639373c6c5" />


## Risk

Low. The new filter field is optional everywhere; an unset pool filter goes down the exact same query path as before. `listByWorkspaceAndKinds` was generalized to also take execution modes and had a single caller.

## Deploy Plan

Deploy front.