### PR TITLE
[front] fix: carry seat consumption when origin fully consumed

### DIFF
--- a/front/lib/metronome/seats.test.ts
+++ b/front/lib/metronome/seats.test.ts
@@ -1012,13 +1012,62 @@ describe("computeSeatCreditTransfers", () => {
     ).toEqual([]);
   });
 
-  it("is idempotent: skips an already-emptied origin credit", () => {
-    // After a prior transfer the old credit is at 0 → nothing to carry over.
+  it("carries the full allocation when the origin was fully consumed (remaining 0)", () => {
+    // 8000/8000 spent on pro → the whole allocation must carry over so max ends
+    // at 8000/40000 (remaining 32000), NOT a fresh 40000 on top of the 8000
+    // already spent (which would let the user spend 48000). A zero balance is a
+    // fully-consumed origin, not a signal to skip.
+    const transfers = computeSeatCreditTransfers({
+      metronomeSeatByUser: new Map([["u1", "pro"]]),
+      desiredSeatByUser: new Map([["u1", "max"]]),
+      balanceByUser: new Map([["u1", 0]]),
+      allocationBySeatType: ALLOCATIONS,
+    });
+    expect(transfers).toEqual([
+      {
+        userSId: "u1",
+        oldSeatType: "pro",
+        newSeatType: "max",
+        oldCreditName: PRO_SEAT_CREDIT_NAME,
+        newCreditName: MAX_SEAT_CREDIT_NAME,
+        remaining: 0,
+        consumed: 8000,
+      },
+    ]);
+  });
+
+  it("carries an overdrawn origin (negative remaining)", () => {
+    // Overspent pro by 500 (remaining -500) → consumed is 8500, so max ends at
+    // 40000 − 8500 = 31500.
+    const transfers = computeSeatCreditTransfers({
+      metronomeSeatByUser: new Map([["u1", "pro"]]),
+      desiredSeatByUser: new Map([["u1", "max"]]),
+      balanceByUser: new Map([["u1", -500]]),
+      allocationBySeatType: ALLOCATIONS,
+    });
+    expect(transfers).toEqual([
+      {
+        userSId: "u1",
+        oldSeatType: "pro",
+        newSeatType: "max",
+        oldCreditName: PRO_SEAT_CREDIT_NAME,
+        newCreditName: MAX_SEAT_CREDIT_NAME,
+        remaining: -500,
+        consumed: 8500,
+      },
+    ]);
+  });
+
+  it("skips a user with no balance reading (undefined): consumption can't be derived", () => {
+    // Idempotency lives in seat reassignment + the absolute destination
+    // reconcile, so a genuinely already-transferred move is caught by the
+    // seat-match check above — not by the balance. An undefined balance is the
+    // only case we skip here, because we cannot compute `consumed`.
     expect(
       computeSeatCreditTransfers({
         metronomeSeatByUser: new Map([["u1", "pro"]]),
         desiredSeatByUser: new Map([["u1", "max"]]),
-        balanceByUser: new Map([["u1", 0]]),
+        balanceByUser: new Map(),
         allocationBySeatType: ALLOCATIONS,
       })
     ).toEqual([]);

--- a/front/lib/metronome/seats.ts
+++ b/front/lib/metronome/seats.ts
@@ -918,14 +918,21 @@ type SeatCreditTransfer = {
  * immediate moves between two recurring-credit seats (e.g. `pro` → `max`).
  *
  * A transfer is needed when a user is still assigned to one allowance seat in
- * Metronome but the DB has already moved them to a different allowance seat,
- * and the old seat credit still has a positive balance. The caller then empties
- * the old credit (by `remaining`) and debits the new one (by `consumed`), so
- * the move carries usage over instead of resetting it — e.g. 2000/8000 used on
- * `pro` becomes 2000/40000 used on `max` (remaining 6000 → 38000).
+ * Metronome but the DB has already moved them to a different allowance seat.
+ * The caller then empties the old credit's unused balance (`remaining`, when
+ * positive) and reconciles the new one to `allocation − consumed`, so the move
+ * carries usage over instead of resetting it — e.g. 2000/8000 used on `pro`
+ * becomes 2000/40000 used on `max` (remaining 6000 → 38000). This holds even
+ * when the origin is fully consumed: 8000/8000 on `pro` becomes 8000/40000 on
+ * `max` (remaining 0 → 32000), NOT a fresh 40000 on top of the 8000 already
+ * spent (which would let the user spend 48000).
  *
- * Keying the trigger on "old credit still has a balance" makes the whole thing
- * idempotent: once the old credit is emptied, a re-run finds nothing to do.
+ * Idempotency does NOT come from the origin balance — it comes from two other
+ * places: once the sync reassigns the user to the new seat,
+ * `metronomeSeatByUser` matches `desiredSeatByUser` and no transfer is
+ * detected; and the destination adjustment reconciles to an absolute target
+ * (`allocation − consumed`), so re-running before the reassignment propagates
+ * converges to the same balance rather than double-debiting.
  *
  * Also covers same-allowance moves between billing frequencies (e.g. `max` →
  * `max_yearly`): they share a credit name but are distinct recurring credits,
@@ -964,9 +971,12 @@ export function computeSeatCreditTransfers({
       continue;
     }
     const remaining = balanceByUser.get(userSId);
-    // No balance left → nothing to carry over (fresh seat, or already
-    // transferred on a prior run).
-    if (remaining === undefined || remaining <= 0) {
+    // No balance reading for this user → we can't derive how much was consumed,
+    // so skip rather than guess. A zero or negative (overdrawn) balance is NOT
+    // skipped: a fully-consumed origin is exactly when the consumed amount must
+    // be carried onto the new seat — otherwise the new seat keeps its full fresh
+    // allowance on top of what was already spent.
+    if (remaining === undefined) {
       continue;
     }
     const allocation = allocationBySeatType.get(oldSeatType);
@@ -1057,7 +1067,10 @@ async function resolveSeatAdjustmentTimestamp({
  * Detect users who moved between two recurring-credit seats (Metronome still
  * has them on the old seat, the DB on the new one) and empty their old seat
  * credit. Returns the transfers whose old credit was successfully emptied, so
- * the caller can credit the new seat once it's been assigned.
+ * the caller can credit the new seat once it's been assigned. Origins with no
+ * unused balance (fully consumed or overdrawn) are returned without an
+ * adjustment — there is nothing to reclaim, but their consumed amount is still
+ * carried onto the new seat.
  *
  * Runs BEFORE seat reconciliation while the old seat is still assigned: a
  * manual ledger entry requires the seat to be active at the adjustment
@@ -1159,6 +1172,14 @@ async function emptyOriginSeatCreditsForTransfers({
   const emptied: SeatCreditTransfer[] = [];
   for (const t of transfers) {
     await heartbeat();
+    // A fully-consumed (or overdrawn) origin has no unused balance to reclaim,
+    // so there is nothing to empty — but the consumed amount must still be
+    // carried onto the new seat. Keep it in the returned transfers and skip the
+    // origin adjustment.
+    if (t.remaining <= 0) {
+      emptied.push(t);
+      continue;
+    }
     const recurringCreditId = recurringCreditIdBySeatType.get(t.oldSeatType);
     if (!recurringCreditId) {
       logger.warn(


### PR DESCRIPTION
## Problem

A user who **fully spent their origin seat allowance** before upgrading between two recurring-credit seats (e.g. `pro` → `max`) ended up able to spend **both** allowances — e.g. 8000 (pro) + 40000 (max) = **48000 credits**.

The carry-over logic in `computeSeatCreditTransfers` (`front/lib/metronome/seats.ts`) bailed on a zero or negative origin balance:

```ts
if (remaining === undefined || remaining <= 0) {
  continue; // no transfer recorded
}
```

That guard conflated a **fully-consumed origin** (`remaining === 0`, the exact case where the consumed amount must be carried) with "nothing to do". So the transfer was skipped, the origin was never emptied, and the new `max` seat kept its fresh **40000** on top of the 8000 already spent.

This was confirmed on a real contract's worker logs: the seat-sync ran (`Current seat state fetched`, `Updating seat-based subscription assignments`) with **no** `No seat-type transfer candidates` line (so a candidate existed) and **no** `Emptying origin seat credit for transfer` / `carryConsumptionToNewSeatCredits done` lines — i.e. the transfer was computed to empty by the `remaining <= 0` guard.

## Fix

- `computeSeatCreditTransfers` now only skips when the balance reading is **missing** (`undefined`) — we can't derive `consumed` then. A zero or negative (overdrawn) balance produces a transfer with `consumed = allocation − remaining`.
- `emptyOriginSeatCreditsForTransfers` skips just the origin-emptying adjustment when there is no unused balance to reclaim (`remaining <= 0`), but still carries the consumed amount onto the new seat.
- Idempotency is unchanged in effect: it comes from the seat reassignment (once Metronome matches the DB, no transfer is detected) and the destination's absolute reconcile to `allocation − consumed` — not from the origin balance.

## Tests

- Corrected the misleading `remaining === 0` test (it encoded the bug) to assert full carry-over: `pro`(8000/8000) → `max` ends at remaining 32000.
- Added coverage for an overdrawn origin (negative remaining) and for the `undefined`-balance skip.
- All 66 tests in `seats.test.ts` pass; `tsgo --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)