### PR TITLE
feat(agent_inactivity): add temporal daily workflow

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/archive_inactive.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/archive_inactive.ts
@@ -6,6 +6,11 @@ import {
   MIN_INACTIVITY_THRESHOLD_DAYS,
 } from "@app/lib/api/assistant/inactivity/policy";
 import { previewInactiveAgents } from "@app/lib/api/assistant/inactivity/preview_inactive_agents";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
 import type {
   ArchiveInactiveAgentsResponseBody,
   PreviewInactiveAgentsResponseBody,
@@ -102,6 +107,24 @@ app.post(
 
     const { evaluatedAt, cutoffAt, archivedAgentIds, skipped } =
       archivalRes.value;
+
+    // The per-agent `agent.archived` events are emitted by the archival itself, as the system:
+    // This one records who asked for the run.
+    if (archivedAgentIds.length > 0) {
+      void emitAuditLogEvent({
+        auth,
+        action: "workspace.inactive_agents_archived",
+        targets: [
+          buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+        ],
+        context: getAuditLogContext(auth),
+        metadata: {
+          threshold_days: String(thresholdDays),
+          archived_count: String(archivedAgentIds.length),
+          skipped_count: String(skipped.length),
+        },
+      });
+    }
 
     return ctx.json({
       archival: {

--- a/front/admin/audit_log_schemas/workspace.inactive_agents_archived.json
+++ b/front/admin/audit_log_schemas/workspace.inactive_agents_archived.json
@@ -1,8 +1,10 @@
 {
-  "action": "workspace.inactive_agent_archival_updated",
+  "action": "workspace.inactive_agents_archived",
   "targets": [{ "type": "workspace" }],
   "metadata": {
     "threshold_days": "string",
+    "archived_count": "string",
+    "skipped_count": "string",
     "actor_type": "string"
   }
 }

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1071,9 +1071,14 @@ async function cancelWakeUpsForAgent(
   );
 }
 
+type ArchiveAgentConfigurationOptions = {
+  dangerouslySkipPermissionFiltering?: boolean;
+};
+
 export async function archiveAgentConfiguration(
   auth: Authenticator,
-  agentConfigurationId: string
+  agentConfigurationId: string,
+  { dangerouslySkipPermissionFiltering }: ArchiveAgentConfigurationOptions = {}
 ): Promise<boolean> {
   const owner = auth.workspace();
   if (!owner) {
@@ -1083,6 +1088,7 @@ export async function archiveAgentConfiguration(
   const agentConfig = await getAgentConfiguration(auth, {
     agentId: agentConfigurationId,
     variant: "light",
+    dangerouslySkipPermissionFiltering,
   });
 
   if (!agentConfig) {

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.test.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.test.ts
@@ -7,6 +7,7 @@ import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MentionFactory } from "@app/tests/utils/MentionFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TriggerFactory } from "@app/tests/utils/TriggerFactory";
 import { Ok } from "@app/types/shared/result";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -137,6 +138,32 @@ describe("archiveInactiveWorkspaceAgents", () => {
     expect(res.isErr()).toBe(true);
     expect(res.isErr() && res.error.type).toBe("invalid_threshold");
     expect(await statusOf(authenticator, agent.sId)).toBe("active");
+  });
+
+  it("archives an agent that requests a restricted space", async () => {
+    // The incoming auth only holds the global group, so without escalating to every space the
+    // agent's status read would come back empty and it would never be archived.
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const restrictedSpace = await SpaceFactory.regular(
+      authenticator.getNonNullableWorkspace()
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Private", requestedSpaceIds: [restrictedSpace.id] }
+    );
+    await AgentConfigurationFactory.backdate(
+      authenticator,
+      agent.sId,
+      LONG_AGO
+    );
+
+    const res = await archiveInactiveWorkspaceAgents(authenticator, {
+      thresholdDays: THRESHOLD_DAYS,
+      evaluatedAt: new Date(),
+    });
+
+    expect(res.isOk() && res.value.archivedAgentIds).toEqual([agent.sId]);
+    expect(res.isOk() && res.value.skipped).toEqual([]);
   });
 
   it("archives every eligible agent of the workspace in one call", async () => {

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
@@ -6,15 +6,15 @@ import {
 } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
 import type { AgentInactivityPolicyError } from "@app/lib/api/assistant/inactivity/policy";
 import { computeInactivityCutoffAt } from "@app/lib/api/assistant/inactivity/policy";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
+import { heartbeat } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 /**
  * Archives a workspace's inactive agents. Both the manual endpoints and the nightly Temporal
- * activity enter here, so the rules cannot drift between them; the population still differs, since
- * every read is permission-filtered.
+ * activity enter here, on the same rules over the same population.
  */
 
 export interface InactiveAgentsArchivalInput {
@@ -55,16 +55,29 @@ export async function archiveInactiveWorkspaceAgents(
   }
   const cutoffAt = cutoffRes.value;
 
-  const { eligible, skipped: refused } = await fetchArchivableAgents(auth, {
-    cutoffAt,
-  });
+  if (!auth.isAdmin()) {
+    throw new Error("Only a workspace admin can archive inactive agents.");
+  }
+
+  const everySpaceAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId,
+    { dangerouslyRequestAllGroups: true }
+  );
+
+  const { eligible, skipped: refused } = await fetchArchivableAgents(
+    everySpaceAuth,
+    { cutoffAt }
+  );
 
   const archivedAgentIds: string[] = [];
   const skipped = [...refused];
 
   for (const { agentId, lastMentionedAt } of eligible) {
+    // Temporal heartbeat to avoid activity timeout
+    await heartbeat();
+
     // Not a compare-and-set: an agent restored since the read is archived anyway. Reversible.
-    const archived = await archiveAgentConfiguration(auth, agentId);
+    const archived = await archiveAgentConfiguration(everySpaceAuth, agentId);
     if (!archived) {
       skipped.push({ agentId, reason: "archive_raced" });
       continue;

--- a/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/archive_inactive_agents.ts
@@ -6,7 +6,7 @@ import {
 } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
 import type { AgentInactivityPolicyError } from "@app/lib/api/assistant/inactivity/policy";
 import { computeInactivityCutoffAt } from "@app/lib/api/assistant/inactivity/policy";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { heartbeat } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
@@ -59,15 +59,10 @@ export async function archiveInactiveWorkspaceAgents(
     throw new Error("Only a workspace admin can archive inactive agents.");
   }
 
-  const everySpaceAuth = await Authenticator.internalAdminForWorkspace(
-    workspace.sId,
-    { dangerouslyRequestAllGroups: true }
-  );
-
-  const { eligible, skipped: refused } = await fetchArchivableAgents(
-    everySpaceAuth,
-    { cutoffAt }
-  );
+  const { eligible, skipped: refused } = await fetchArchivableAgents(auth, {
+    cutoffAt,
+    dangerouslySkipPermissionFiltering: true,
+  });
 
   const archivedAgentIds: string[] = [];
   const skipped = [...refused];
@@ -77,7 +72,9 @@ export async function archiveInactiveWorkspaceAgents(
     await heartbeat();
 
     // Not a compare-and-set: an agent restored since the read is archived anyway. Reversible.
-    const archived = await archiveAgentConfiguration(everySpaceAuth, agentId);
+    const archived = await archiveAgentConfiguration(auth, agentId, {
+      dangerouslySkipPermissionFiltering: true,
+    });
     if (!archived) {
       skipped.push({ agentId, reason: "archive_raced" });
       continue;

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
@@ -42,6 +42,7 @@ export interface AgentArchivalSkip {
 
 export interface ArchivableAgentsFetchInput {
   cutoffAt: Date;
+  dangerouslySkipPermissionFiltering?: boolean;
 }
 
 export interface ArchivableAgents {
@@ -62,16 +63,15 @@ export function countSkipsByReason(
   return counts;
 }
 
-/** The status and triggers the rules read about an agent, as they stand when it is evaluated. */
 interface AgentStatusAndTriggers {
   status: AgentConfigurationStatus;
   triggers: AgentTriggerSnapshot[];
 }
 
-/** A missing agent is one this actor cannot read. */
 async function fetchStatusAndTriggers(
   auth: Authenticator,
-  agentIds: string[]
+  agentIds: string[],
+  dangerouslySkipPermissionFiltering?: boolean
 ): Promise<Map<string, AgentStatusAndTriggers>> {
   if (agentIds.length === 0) {
     return new Map();
@@ -80,6 +80,7 @@ async function fetchStatusAndTriggers(
   const configurations = await getAgentConfigurations(auth, {
     agentIds,
     variant: "light",
+    dangerouslySkipPermissionFiltering,
   });
 
   const triggers = await TriggerResource.listByAgentConfigurationIds(
@@ -104,7 +105,7 @@ async function fetchStatusAndTriggers(
 
 export async function fetchArchivableAgents(
   auth: Authenticator,
-  { cutoffAt }: ArchivableAgentsFetchInput
+  { cutoffAt, dangerouslySkipPermissionFiltering }: ArchivableAgentsFetchInput
 ): Promise<ArchivableAgents> {
   const idleAgents = await MentionResource.listAgentsNotMentionedSince(auth, {
     notMentionedSince: cutoffAt,
@@ -117,7 +118,8 @@ export async function fetchArchivableAgents(
   );
   const statusAndTriggersByAgentId = await fetchStatusAndTriggers(
     auth,
-    agentIds
+    agentIds,
+    dangerouslySkipPermissionFiltering
   );
 
   const eligible: ArchivableAgent[] = [];

--- a/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/fetch_inactive_agents.ts
@@ -14,15 +14,11 @@ import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import type { AgentConfigurationStatus } from "@app/types/assistant/agent";
 
 /**
- * Loads one page of a workspace's agents that the rules clear for archival.
+ * A workspace's agents the rules clear for archival: candidates from the mentions query, rules
+ * from `policy.ts`.
  *
- * The candidates come from the mentions query, the rules from `policy.ts`; this is where the two
- * meet. Every read is permission-filtered, so two actors can legitimately get different answers for
- * the same workspace.
- *
- * A workspace is the unit of work: the nightly run starts one activity per workspace, so there is
- * nothing to page through here. Splitting the agents into batches would re-run the mentions query
- * once per batch, and the cursor would have to survive between them, for no gain.
+ * One activity per workspace, no paging: batching agents would re-run the mentions query per
+ * batch for no gain.
  */
 
 /** One logical agent the rules cleared. */
@@ -66,17 +62,17 @@ export function countSkipsByReason(
   return counts;
 }
 
-/** The facts the rules read about an agent, as they stand when the page is evaluated. */
-interface AgentArchivalFacts {
+/** The status and triggers the rules read about an agent, as they stand when it is evaluated. */
+interface AgentStatusAndTriggers {
   status: AgentConfigurationStatus;
   triggers: AgentTriggerSnapshot[];
 }
 
 /** A missing agent is one this actor cannot read. */
-async function fetchArchivalFacts(
+async function fetchStatusAndTriggers(
   auth: Authenticator,
   agentIds: string[]
-): Promise<Map<string, AgentArchivalFacts>> {
+): Promise<Map<string, AgentStatusAndTriggers>> {
   if (agentIds.length === 0) {
     return new Map();
   }
@@ -119,24 +115,26 @@ export async function fetchArchivableAgents(
     auth,
     agentIds
   );
-  const factsByAgentId = await fetchArchivalFacts(auth, agentIds);
+  const statusAndTriggersByAgentId = await fetchStatusAndTriggers(
+    auth,
+    agentIds
+  );
 
   const eligible: ArchivableAgent[] = [];
-  // Skips are the common case, so callers count them in the run summary rather than log each one.
   const skipped: AgentArchivalSkip[] = [];
 
   for (const { agentId, lastMentionedAt } of idleAgents) {
     const createdAt = createdAtByAgentId.get(agentId);
-    const facts = factsByAgentId.get(agentId);
+    const statusAndTriggers = statusAndTriggersByAgentId.get(agentId);
     // No first version either means the agent is unreadable, or that we could not establish the
     // date the age rule needs. Both are reasons not to archive it.
-    if (!createdAt || !facts) {
+    if (!createdAt || !statusAndTriggers) {
       skipped.push({ agentId, reason: "agent_not_found" });
       continue;
     }
 
     const eligibility = evaluateAgentArchivalEligibility({
-      agent: { agentId, createdAt, lastMentionedAt, ...facts },
+      agent: { agentId, createdAt, lastMentionedAt, ...statusAndTriggers },
       cutoffAt,
     });
 

--- a/front/lib/api/assistant/inactivity/preview_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/preview_inactive_agents.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
 import type { AgentInactivityPolicyError } from "@app/lib/api/assistant/inactivity/policy";
 import { computeInactivityCutoffAt } from "@app/lib/api/assistant/inactivity/policy";
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -60,13 +60,9 @@ export async function previewInactiveAgents(
     throw new Error("Only a workspace admin can preview inactive agents.");
   }
 
-  const everySpaceAuth = await Authenticator.internalAdminForWorkspace(
-    workspace.sId,
-    { dangerouslyRequestAllGroups: true }
-  );
-
-  const { eligible, skipped } = await fetchArchivableAgents(everySpaceAuth, {
+  const { eligible, skipped } = await fetchArchivableAgents(auth, {
     cutoffAt,
+    dangerouslySkipPermissionFiltering: true,
   });
 
   const eligibleAgentIds = eligible.map(({ agentId }) => agentId);

--- a/front/lib/api/assistant/inactivity/preview_inactive_agents.ts
+++ b/front/lib/api/assistant/inactivity/preview_inactive_agents.ts
@@ -5,7 +5,7 @@ import {
 } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
 import type { AgentInactivityPolicyError } from "@app/lib/api/assistant/inactivity/policy";
 import { computeInactivityCutoffAt } from "@app/lib/api/assistant/inactivity/policy";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -56,7 +56,16 @@ export async function previewInactiveAgents(
   }
   const cutoffAt = cutoffRes.value;
 
-  const { eligible, skipped } = await fetchArchivableAgents(auth, {
+  if (!auth.isAdmin()) {
+    throw new Error("Only a workspace admin can preview inactive agents.");
+  }
+
+  const everySpaceAuth = await Authenticator.internalAdminForWorkspace(
+    workspace.sId,
+    { dangerouslyRequestAllGroups: true }
+  );
+
+  const { eligible, skipped } = await fetchArchivableAgents(everySpaceAuth, {
     cutoffAt,
   });
 

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -120,6 +120,7 @@
   "workspace.extension_mcp_tools_updated": 1,
   "workspace.governance_permission_updated": 1,
   "workspace.inactive_agent_archival_updated": 1,
+  "workspace.inactive_agents_archived": 1,
   "workspace.interactive_content_sharing_updated": 1,
   "workspace.manual_project_knowledge_management_updated": 1,
   "workspace.model_provider_settings_updated": 1,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -105,6 +105,7 @@ export const AUDIT_ACTIONS = [
   "workspace.extension_mcp_tools_updated",
   "workspace.governance_permission_updated",
   "workspace.inactive_agent_archival_updated",
+  "workspace.inactive_agents_archived",
   "workspace.interactive_content_sharing_updated",
   "workspace.manual_project_knowledge_management_updated",
   "workspace.model_provider_settings_updated",

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -43,6 +43,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
   switch (workerName) {
     case "activation_scheduler":
       return path.join(baseDir, "temporal/activation_scheduler");
+    case "agent_inactivity":
+      return path.join(baseDir, "temporal/agent_inactivity");
     case "agent_loop_batch":
     case "agent_loop_interactive":
     case "agent_loop_programmatic":

--- a/front/temporal/agent_inactivity/activities.test.ts
+++ b/front/temporal/agent_inactivity/activities.test.ts
@@ -1,0 +1,236 @@
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { ONE_DAY_MS } from "@app/lib/api/assistant/inactivity/policy";
+import { updateWorkspaceMetadata } from "@app/lib/api/workspace";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  archiveWorkspaceInactiveAgentsActivity,
+  getWorkspacesWithInactiveAgentArchivalActivity,
+} from "@app/temporal/agent_inactivity/activities";
+import * as scheduleClient from "@app/temporal/triggers/schedule_client";
+import * as wakeUpClient from "@app/temporal/triggers/wakeup_client";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const THRESHOLD_DAYS = 30;
+
+/** Old enough to sit well before any cutoff a 30-day threshold can produce. */
+const LONG_AGO = new Date(Date.now() - 90 * ONE_DAY_MS);
+
+/** Archiving disables triggers and cancels wake-ups, both of which reach Temporal. */
+function mockTemporalClients() {
+  vi.spyOn(scheduleClient, "createOrUpdateAgentSchedule").mockResolvedValue(
+    new Ok("workflow-id")
+  );
+  vi.spyOn(scheduleClient, "deleteTriggerSchedule").mockResolvedValue(
+    new Ok(undefined)
+  );
+  vi.spyOn(
+    wakeUpClient,
+    "launchOrScheduleWakeUpTemporalWorkflow"
+  ).mockResolvedValue(new Ok(undefined));
+  vi.spyOn(wakeUpClient, "cancelWakeUpTemporalWorkflow").mockResolvedValue(
+    new Ok(undefined)
+  );
+}
+
+/**
+ * A workspace the nightly run should visit: the feature is on and a threshold is set. A null
+ * threshold leaves the setting absent, which is how a workspace says it wants no archival.
+ */
+async function createWorkspaceAskingForArchival({
+  thresholdDays = THRESHOLD_DAYS,
+  withFeature = true,
+}: {
+  thresholdDays?: number | null;
+  withFeature?: boolean;
+} = {}) {
+  const { authenticator, workspace } = await createResourceTest({
+    role: "admin",
+  });
+
+  if (withFeature) {
+    await FeatureFlagFactory.basic(authenticator, "archive_inactive_agents");
+  }
+
+  await updateWorkspaceMetadata(workspace, {
+    inactiveAgentArchivalThresholdDays: thresholdDays ?? undefined,
+  });
+
+  return { authenticator, workspace };
+}
+
+async function createUnusedAgent(
+  auth: Authenticator,
+  name: string,
+  requestedSpaceIds: number[] = []
+) {
+  const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+    name,
+    requestedSpaceIds,
+  });
+  await AgentConfigurationFactory.backdate(auth, agent.sId, LONG_AGO);
+
+  return agent;
+}
+
+async function statusOf(auth: Authenticator, agentId: string) {
+  const agent = await getAgentConfiguration(auth, {
+    agentId,
+    variant: "light",
+  });
+
+  return agent?.status;
+}
+
+describe("getWorkspacesWithInactiveAgentArchivalActivity", () => {
+  it("returns a workspace that asks for archival", async () => {
+    const { workspace } = await createWorkspaceAskingForArchival();
+
+    const workspaceIds = await getWorkspacesWithInactiveAgentArchivalActivity();
+
+    expect(workspaceIds).toContain(workspace.sId);
+  });
+
+  it("leaves out a workspace with the feature but no threshold", async () => {
+    const { workspace } = await createWorkspaceAskingForArchival({
+      thresholdDays: null,
+    });
+
+    const workspaceIds = await getWorkspacesWithInactiveAgentArchivalActivity();
+
+    expect(workspaceIds).not.toContain(workspace.sId);
+  });
+
+  it("leaves out a workspace with a threshold but not the feature", async () => {
+    const { workspace } = await createWorkspaceAskingForArchival({
+      withFeature: false,
+    });
+
+    const workspaceIds = await getWorkspacesWithInactiveAgentArchivalActivity();
+
+    expect(workspaceIds).not.toContain(workspace.sId);
+  });
+});
+
+describe("archiveWorkspaceInactiveAgentsActivity", () => {
+  beforeEach(() => {
+    mockTemporalClients();
+  });
+
+  it("archives an agent nobody has mentioned", async () => {
+    const { authenticator, workspace } =
+      await createWorkspaceAskingForArchival();
+    const agent = await createUnusedAgent(authenticator, "Forgotten");
+
+    const res = await archiveWorkspaceInactiveAgentsActivity({
+      workspaceId: workspace.sId,
+      evaluatedAtMs: Date.now(),
+    });
+
+    expect(res).toEqual({
+      workspaceId: workspace.sId,
+      thresholdDays: THRESHOLD_DAYS,
+      archivedCount: 1,
+      skippedCount: 0,
+    });
+    expect(await statusOf(authenticator, agent.sId)).toBe("archived");
+  });
+
+  it("archives an agent that requests a restricted space", async () => {
+    // The admin's own actor cannot read it, so only a run that looks at every space archives it.
+    const { authenticator, workspace } =
+      await createWorkspaceAskingForArchival();
+    const restrictedSpace = await SpaceFactory.regular(
+      authenticator.getNonNullableWorkspace()
+    );
+    const agent = await createUnusedAgent(authenticator, "Private", [
+      restrictedSpace.id,
+    ]);
+
+    const res = await archiveWorkspaceInactiveAgentsActivity({
+      workspaceId: workspace.sId,
+      evaluatedAtMs: Date.now(),
+    });
+
+    expect(res.archivedCount).toBe(1);
+    expect(res.skippedCount).toBe(0);
+    expect(await statusOf(authenticator, agent.sId)).toBeUndefined();
+  });
+
+  it("archives nothing once the workspace clears its threshold", async () => {
+    const { authenticator, workspace } =
+      await createWorkspaceAskingForArchival();
+    const agent = await createUnusedAgent(authenticator, "Reprieved");
+
+    await updateWorkspaceMetadata(workspace, {
+      inactiveAgentArchivalThresholdDays: undefined,
+    });
+
+    const res = await archiveWorkspaceInactiveAgentsActivity({
+      workspaceId: workspace.sId,
+      evaluatedAtMs: Date.now(),
+    });
+
+    expect(res).toEqual({
+      workspaceId: workspace.sId,
+      thresholdDays: null,
+      archivedCount: 0,
+      skippedCount: 0,
+    });
+    expect(await statusOf(authenticator, agent.sId)).toBe("active");
+  });
+
+  it("fails without archiving when the stored threshold is out of range", async () => {
+    const { authenticator, workspace } = await createWorkspaceAskingForArchival(
+      { thresholdDays: 1 }
+    );
+    const agent = await createUnusedAgent(authenticator, "Saved by validation");
+
+    await expect(
+      archiveWorkspaceInactiveAgentsActivity({
+        workspaceId: workspace.sId,
+        evaluatedAtMs: Date.now(),
+      })
+    ).rejects.toThrow();
+
+    expect(await statusOf(authenticator, agent.sId)).toBe("active");
+  });
+
+  it("archives nothing on a replay of the same instant", async () => {
+    const { authenticator, workspace } =
+      await createWorkspaceAskingForArchival();
+    const agent = await createUnusedAgent(authenticator, "Forgotten twice");
+
+    const input = {
+      workspaceId: workspace.sId,
+      evaluatedAtMs: Date.now(),
+    };
+
+    const first = await archiveWorkspaceInactiveAgentsActivity(input);
+    expect(first.archivedCount).toBe(1);
+
+    const replay = await archiveWorkspaceInactiveAgentsActivity(input);
+    expect(replay.archivedCount).toBe(0);
+    expect(await statusOf(authenticator, agent.sId)).toBe("archived");
+  });
+
+  it("leaves another workspace's agents alone", async () => {
+    const swept = await createWorkspaceAskingForArchival();
+    const untouched = await createWorkspaceAskingForArchival();
+
+    await createUnusedAgent(swept.authenticator, "Swept");
+    const spared = await createUnusedAgent(untouched.authenticator, "Spared");
+
+    const res = await archiveWorkspaceInactiveAgentsActivity({
+      workspaceId: swept.workspace.sId,
+      evaluatedAtMs: Date.now(),
+    });
+
+    expect(res.archivedCount).toBe(1);
+    expect(await statusOf(untouched.authenticator, spared.sId)).toBe("active");
+  });
+});

--- a/front/temporal/agent_inactivity/activities.ts
+++ b/front/temporal/agent_inactivity/activities.ts
@@ -1,0 +1,156 @@
+import { archiveInactiveWorkspaceAgents } from "@app/lib/api/assistant/inactivity/archive_inactive_agents";
+import { countSkipsByReason } from "@app/lib/api/assistant/inactivity/fetch_inactive_agents";
+import {
+  buildAuditLogTarget,
+  emitAuditLogEventDirect,
+} from "@app/lib/api/audit/workos_audit";
+import { Authenticator, hasFeatureFlag } from "@app/lib/auth";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+import { getInactiveAgentArchivalThresholdDays } from "@app/types/user";
+import { ApplicationFailure } from "@temporalio/common";
+
+export async function getWorkspacesWithInactiveAgentArchivalActivity(): Promise<
+  string[]
+> {
+  const flaggedWorkspaces = await WorkspaceResource.listWithFeatureFlag(
+    "archive_inactive_agents"
+  );
+
+  // Sorted so one tick's fan-out reads the same way as the next in the Temporal history.
+  const workspaceIds = flaggedWorkspaces
+    .filter(
+      (workspace) =>
+        getInactiveAgentArchivalThresholdDays(
+          renderLightWorkspaceType({ workspace })
+        ) !== null
+    )
+    .map((workspace) => workspace.sId)
+    .sort();
+
+  logger.info(
+    {
+      flaggedWorkspaceCount: flaggedWorkspaces.length,
+      configuredWorkspaceCount: workspaceIds.length,
+    },
+    "[AgentInactivity] Enumerated workspaces with automatic agent archival"
+  );
+
+  return workspaceIds;
+}
+
+export interface ArchiveWorkspaceInactiveAgentsActivityInput {
+  workspaceId: string;
+  // Fixed by the parent workflow, so every workspace of one sweep is judged against one instant and
+  // a retry re-derives the same cutoff instead of sliding it forward.
+  evaluatedAtMs: number;
+}
+
+export interface ArchiveWorkspaceInactiveAgentsActivityResult {
+  workspaceId: string;
+  // Null when the workspace stopped asking for archival between the enumeration and here.
+  thresholdDays: number | null;
+  archivedCount: number;
+  skippedCount: number;
+}
+
+/**
+ * Archives one workspace's inactive agents. The whole workspace in one activity: the agents are not
+ * batched, see the note in `fetch_inactive_agents.ts`.
+ *
+ * Safe to retry: `archiveInactiveWorkspaceAgents` re-runs the fetch, and an agent it already
+ * archived is no longer a candidate.
+ */
+export async function archiveWorkspaceInactiveAgentsActivity({
+  workspaceId,
+  evaluatedAtMs,
+}: ArchiveWorkspaceInactiveAgentsActivityInput): Promise<ArchiveWorkspaceInactiveAgentsActivityResult> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const workspace = auth.getNonNullableWorkspace();
+
+  // Read here rather than carry the threshold through the workflow arguments, so an admin who turns
+  // archival off while the sweep is running is obeyed.
+  const thresholdDays = getInactiveAgentArchivalThresholdDays(workspace);
+  if (thresholdDays === null) {
+    logger.info(
+      { workspaceId },
+      "[AgentInactivity] Automatic archival no longer configured, skipping workspace"
+    );
+
+    return {
+      workspaceId,
+      thresholdDays: null,
+      archivedCount: 0,
+      skippedCount: 0,
+    };
+  }
+
+  // The same gate as the endpoints: a feature pulled mid-sweep stops the archival too.
+  if (!(await hasFeatureFlag(auth, "archive_inactive_agents"))) {
+    logger.info(
+      { workspaceId },
+      "[AgentInactivity] Feature no longer enabled, skipping workspace"
+    );
+
+    return {
+      workspaceId,
+      thresholdDays: null,
+      archivedCount: 0,
+      skippedCount: 0,
+    };
+  }
+
+  const archivalRes = await archiveInactiveWorkspaceAgents(auth, {
+    thresholdDays,
+    evaluatedAt: new Date(evaluatedAtMs),
+  });
+  if (archivalRes.isErr()) {
+    // The only error is a threshold the rules refuse, which is stored configuration rather than a
+    // transient fault: a retry would compute the same refusal.
+    throw ApplicationFailure.nonRetryable(
+      archivalRes.error.message,
+      archivalRes.error.type
+    );
+  }
+
+  const { archivedAgentIds, skipped, cutoffAt } = archivalRes.value;
+
+  if (archivedAgentIds.length > 0) {
+    void emitAuditLogEventDirect({
+      workspace,
+      action: "workspace.inactive_agents_archived",
+      actor: {
+        type: "system",
+        id: "agent_inactivity",
+        name: "Inactive agent archival",
+      },
+      targets: [buildAuditLogTarget("workspace", workspace)],
+      context: { location: "internal" },
+      metadata: {
+        threshold_days: String(thresholdDays),
+        archived_count: String(archivedAgentIds.length),
+        skipped_count: String(skipped.length),
+      },
+    });
+  }
+
+  logger.info(
+    {
+      workspaceId,
+      thresholdDays,
+      cutoffAt,
+      archivedCount: archivedAgentIds.length,
+      skippedCount: skipped.length,
+      skippedCountByReason: countSkipsByReason(skipped),
+    },
+    "[AgentInactivity] Finished nightly archival for workspace"
+  );
+
+  return {
+    workspaceId,
+    thresholdDays,
+    archivedCount: archivedAgentIds.length,
+    skippedCount: skipped.length,
+  };
+}

--- a/front/temporal/agent_inactivity/admin/cli.sh
+++ b/front/temporal/agent_inactivity/admin/cli.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx tsx temporal/agent_inactivity/admin/cli.ts "$@"

--- a/front/temporal/agent_inactivity/admin/cli.ts
+++ b/front/temporal/agent_inactivity/admin/cli.ts
@@ -1,0 +1,78 @@
+import logger from "@app/logger/logger";
+import {
+  launchArchiveInactiveAgentsSchedule,
+  launchArchiveWorkspaceInactiveAgentsWorkflow,
+  stopArchiveInactiveAgentsSchedule,
+  triggerArchiveInactiveAgentsSchedule,
+} from "@app/temporal/agent_inactivity/client";
+import parseArgs from "minimist";
+
+const cliLogger = logger.child({ component: "agent_inactivity.cli" });
+
+function usage() {
+  cliLogger.info(`Usage:
+  start                                Create the nightly archival schedule
+  stop                                 Delete the nightly archival schedule
+  run-now                              Fire the schedule now: enumeration and fan-out
+  run-workspace --workspaceId <sId>    Sweep one workspace, skipping the enumeration`);
+}
+
+const main = async () => {
+  const argv = parseArgs(process.argv.slice(2), { string: ["workspaceId"] });
+
+  const [command] = argv._;
+
+  switch (command) {
+    case "start": {
+      const res = await launchArchiveInactiveAgentsSchedule();
+      if (res.isErr()) {
+        throw res.error;
+      }
+      return;
+    }
+    case "stop": {
+      const res = await stopArchiveInactiveAgentsSchedule();
+      if (res.isErr()) {
+        throw res.error;
+      }
+      return;
+    }
+    case "run-now": {
+      const res = await triggerArchiveInactiveAgentsSchedule();
+      if (res.isErr()) {
+        throw res.error;
+      }
+      return;
+    }
+    case "run-workspace": {
+      const { workspaceId } = argv;
+      if (!workspaceId) {
+        usage();
+        process.exit(1);
+      }
+
+      const res = await launchArchiveWorkspaceInactiveAgentsWorkflow({
+        workspaceId,
+      });
+      if (res.isErr()) {
+        throw res.error;
+      }
+
+      cliLogger.info({ workflowId: res.value }, "Started workspace sweep");
+      return;
+    }
+    default:
+      usage();
+      process.exit(1);
+  }
+};
+
+main()
+  .then(() => {
+    cliLogger.info("Done");
+    process.exit(0);
+  })
+  .catch((err) => {
+    cliLogger.error({ err }, "Fatal error");
+    process.exit(1);
+  });

--- a/front/temporal/agent_inactivity/client.ts
+++ b/front/temporal/agent_inactivity/client.ts
@@ -1,0 +1,160 @@
+import { config, REGION_TIMEZONES } from "@app/lib/api/regions/config";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import {
+  ScheduleAlreadyRunning,
+  ScheduleNotFoundError,
+  ScheduleOverlapPolicy,
+  WorkflowExecutionAlreadyStartedError,
+} from "@temporalio/client";
+
+import {
+  ARCHIVE_INACTIVE_AGENTS_SCHEDULE_ID,
+  makeArchiveWorkspaceWorkflowId,
+  QUEUE_NAME,
+} from "./config";
+import {
+  archiveInactiveAgentsWorkflow,
+  archiveWorkspaceInactiveAgentsWorkflow,
+} from "./workflows";
+
+export async function launchArchiveInactiveAgentsSchedule(): Promise<
+  Result<undefined, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+  const region = config.getCurrentRegion();
+  const timezone = REGION_TIMEZONES[region];
+
+  try {
+    await client.schedule.create({
+      action: {
+        type: "startWorkflow",
+        workflowType: archiveInactiveAgentsWorkflow,
+        args: [],
+        taskQueue: QUEUE_NAME,
+      },
+      scheduleId: ARCHIVE_INACTIVE_AGENTS_SCHEDULE_ID,
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+      },
+      spec: {
+        calendars: [{ hour: 0, minute: 0 }],
+        timezone,
+      },
+    });
+
+    logger.info(
+      {
+        region,
+        timezone,
+        scheduleId: ARCHIVE_INACTIVE_AGENTS_SCHEDULE_ID,
+      },
+      "[AgentInactivity] Created nightly archival schedule."
+    );
+  } catch (err) {
+    if (!(err instanceof ScheduleAlreadyRunning)) {
+      logger.error(
+        { err },
+        "[AgentInactivity] Failed creating nightly archival schedule."
+      );
+
+      return new Err(normalizeError(err));
+    }
+  }
+
+  return new Ok(undefined);
+}
+
+export async function stopArchiveInactiveAgentsSchedule(): Promise<
+  Result<undefined, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  try {
+    const handle = client.schedule.getHandle(
+      ARCHIVE_INACTIVE_AGENTS_SCHEDULE_ID
+    );
+    await handle.delete();
+  } catch (err) {
+    if (err instanceof ScheduleNotFoundError) {
+      logger.info(
+        { scheduleId: ARCHIVE_INACTIVE_AGENTS_SCHEDULE_ID },
+        "[AgentInactivity] Nightly archival schedule not found, skipping."
+      );
+
+      return new Ok(undefined);
+    }
+
+    logger.error(
+      { err },
+      "[AgentInactivity] Failed deleting nightly archival schedule."
+    );
+
+    return new Err(normalizeError(err));
+  }
+
+  return new Ok(undefined);
+}
+
+/** Fires the schedule now, down the same path the nightly tick takes. */
+export async function triggerArchiveInactiveAgentsSchedule(): Promise<
+  Result<undefined, Error>
+> {
+  const client = await getTemporalClientForFrontNamespace();
+
+  try {
+    const handle = client.schedule.getHandle(
+      ARCHIVE_INACTIVE_AGENTS_SCHEDULE_ID
+    );
+    await handle.trigger(ScheduleOverlapPolicy.ALLOW_ALL);
+  } catch (err) {
+    logger.error(
+      { err },
+      "[AgentInactivity] Failed triggering nightly archival schedule."
+    );
+
+    return new Err(normalizeError(err));
+  }
+
+  return new Ok(undefined);
+}
+
+/** One workspace, skipping the enumeration. For local testing and one-off operator runs. */
+export async function launchArchiveWorkspaceInactiveAgentsWorkflow({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<Result<string, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeArchiveWorkspaceWorkflowId(workspaceId);
+
+  try {
+    await client.workflow.start(archiveWorkspaceInactiveAgentsWorkflow, {
+      args: [{ workspaceId, evaluatedAtMs: Date.now() }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: { workspaceId },
+    });
+  } catch (err) {
+    if (err instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { workflowId, workspaceId },
+        "[AgentInactivity] Sweep already running for this workspace; skipping."
+      );
+
+      return new Ok(workflowId);
+    }
+
+    logger.error(
+      { err, workflowId, workspaceId },
+      "[AgentInactivity] Failed starting workspace sweep."
+    );
+
+    return new Err(normalizeError(err));
+  }
+
+  return new Ok(workflowId);
+}

--- a/front/temporal/agent_inactivity/config.ts
+++ b/front/temporal/agent_inactivity/config.ts
@@ -1,0 +1,16 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `agent-inactivity-queue-v${QUEUE_VERSION}`;
+
+export const ARCHIVE_INACTIVE_AGENTS_SCHEDULE_ID =
+  "archive-inactive-agents-schedule";
+
+const WORKSPACE_WORKFLOW_ID_PREFIX = "archive-inactive-agents-workspace-";
+
+/**
+ * Scoped by workspace, not by run: a tick that finds the previous sweep of the same workspace still
+ * running skips it instead of starting a second one over the same agents.
+ */
+export function makeArchiveWorkspaceWorkflowId(workspaceId: string): string {
+  return `${WORKSPACE_WORKFLOW_ID_PREFIX}${workspaceId}`;
+}

--- a/front/temporal/agent_inactivity/worker.ts
+++ b/front/temporal/agent_inactivity/worker.ts
@@ -1,0 +1,50 @@
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/agent_inactivity/activities";
+import { launchArchiveInactiveAgentsSchedule } from "@app/temporal/agent_inactivity/client";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import { QUEUE_NAME } from "./config";
+
+const SHUTDOWN_GRACE_TIME_MS = 70 * 1_000;
+const MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS = 2;
+
+export async function runAgentInactivityWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "agent_inactivity",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    // One activity is one workspace's whole sweep, so a low number keeps the connection pool sane.
+    maxConcurrentActivityTaskExecutions:
+      MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS,
+    connection,
+    namespace,
+    shutdownGraceTime: SHUTDOWN_GRACE_TIME_MS,
+    interceptors: {
+      activity: [
+        (ctx: Context) => {
+          return {
+            inbound: new ActivityInboundLogInterceptor(ctx, logger),
+          };
+        },
+      ],
+    },
+  });
+
+  // Start the schedule.
+  await launchArchiveInactiveAgentsSchedule();
+
+  await worker.run();
+}

--- a/front/temporal/agent_inactivity/workflows.ts
+++ b/front/temporal/agent_inactivity/workflows.ts
@@ -1,0 +1,83 @@
+import type * as activities from "@app/temporal/agent_inactivity/activities";
+import { log, proxyActivities } from "@temporalio/workflow";
+
+import { concurrentExecutor } from "../workflow_utils";
+
+const { getWorkspacesWithInactiveAgentArchivalActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "2 minutes",
+});
+
+const { archiveWorkspaceInactiveAgentsActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "2 minutes",
+  heartbeatTimeout: "30 seconds",
+  retry: {
+    // Bounded: archiving is idempotent and tomorrow's tick picks the workspace up again, so a
+    // workspace that keeps failing must not hold a worker slot all night.
+    maximumAttempts: 3,
+    initialInterval: "30 seconds",
+    backoffCoefficient: 2,
+  },
+});
+
+const WORKSPACE_CONCURRENCY = 10;
+
+export interface ArchiveWorkspaceInactiveAgentsWorkflowInput {
+  workspaceId: string;
+  evaluatedAtMs: number;
+}
+
+/**
+ * One workspace, run as its own Temporal execution. Not part of the nightly fan-out — Temporal
+ * cannot start an activity on its own, so this is the entry point `cli.sh run-workspace` needs to
+ * run one workspace's sweep independently and see it in the UI.
+ */
+export async function archiveWorkspaceInactiveAgentsWorkflow({
+  workspaceId,
+  evaluatedAtMs,
+}: ArchiveWorkspaceInactiveAgentsWorkflowInput): Promise<activities.ArchiveWorkspaceInactiveAgentsActivityResult> {
+  return archiveWorkspaceInactiveAgentsActivity({ workspaceId, evaluatedAtMs });
+}
+
+export async function archiveInactiveAgentsWorkflow(): Promise<
+  activities.ArchiveWorkspaceInactiveAgentsActivityResult[]
+> {
+  // One instant for the whole sweep. `Date.now()` replays identically in a workflow, so a retried
+  // activity re-derives the same cutoff rather than a later one.
+  const evaluatedAtMs = Date.now();
+
+  const workspaceIds = await getWorkspacesWithInactiveAgentArchivalActivity();
+
+  // No manual trigger exists that could overlap this run, so nothing dedupes per workspace here —
+  // the activity is called directly, not wrapped in a child workflow. One workspace exhausting its
+  // retries must not abort the others, so its failure is caught and logged rather than left to
+  // propagate through the executor.
+  const results = await concurrentExecutor(
+    workspaceIds,
+    async (workspaceId) => {
+      try {
+        return await archiveWorkspaceInactiveAgentsActivity({
+          workspaceId,
+          evaluatedAtMs,
+        });
+      } catch (err) {
+        log.error("[AgentInactivity] Workspace sweep failed", {
+          workspaceId,
+          err,
+        });
+        return null;
+      }
+    },
+    { concurrency: WORKSPACE_CONCURRENCY }
+  );
+
+  return results.filter(
+    (
+      result
+    ): result is activities.ArchiveWorkspaceInactiveAgentsActivityResult =>
+      result !== null
+  );
+}

--- a/front/temporal/reinforcement/client.ts
+++ b/front/temporal/reinforcement/client.ts
@@ -65,6 +65,7 @@ async function getReinforcementWorkspaceIds(): Promise<string[]> {
 // ---------------------------------------------------------------------------
 
 const TWO_HOURS_MS = 2 * 60 * 60 * 1000;
+const ACTIVATION_WORKDAY_START_HOUR = 3;
 
 /**
  * Launch a schedule for a single workspace.
@@ -93,7 +94,7 @@ export async function startReinforcementWorkspaceSchedule({
         overlap: ScheduleOverlapPolicy.SKIP,
       },
       spec: {
-        calendars: [{ hour: 0, minute: 0 }],
+        calendars: [{ hour: ACTIVATION_WORKDAY_START_HOUR, minute: 0 }],
         timezone,
         jitter: TWO_HOURS_MS,
       },

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -1,5 +1,6 @@
 import { runPokeWorker } from "@app/poke/temporal/worker";
 import { runActivationSchedulerWorker } from "@app/temporal/activation_scheduler/worker";
+import { runAgentInactivityWorker } from "@app/temporal/agent_inactivity/worker";
 import {
   runAgentLoopBatchWorker,
   runAgentLoopInteractiveWorker,
@@ -35,6 +36,7 @@ import { runWorkOSEventsWorker } from "@app/temporal/workos_events_queue/worker"
 
 export type WorkerName =
   | "activation_scheduler"
+  | "agent_inactivity"
   | "agent_loop_batch"
   | "agent_loop_interactive"
   | "agent_loop_programmatic"
@@ -69,6 +71,7 @@ export type WorkerName =
 
 export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   activation_scheduler: runActivationSchedulerWorker,
+  agent_inactivity: runAgentInactivityWorker,
   agent_loop_batch: runAgentLoopBatchWorker,
   agent_loop_interactive: runAgentLoopInteractiveWorker,
   agent_loop_programmatic: runAgentLoopProgrammaticWorker,


### PR DESCRIPTION
## Description

Adds a Temporal-based nightly workflow for automatically archiving inactive agents.

- Introduces a dedicated `agent_inactivity` Temporal worker, workflow, schedule, and operator CLI.
- Enumerates workspaces with the `archive_inactive_agents` feature enabled and a valid inactivity threshold, then sweeps each workspace with bounded concurrency.
- Reuses the existing archival eligibility logic for manual and scheduled runs, while using all-space internal admin authorization so agents tied to restricted spaces are included.
- Makes scheduled archival safe to retry with a fixed evaluation timestamp, activity heartbeats, bounded retries, overlap protection, and idempotent agent transitions.
- Adds the `workspace.inactive_agents_archived` audit event with threshold, archived-count, and skipped-count metadata.
- Registers and bundles the new Temporal worker, and moves the reinforcement schedule start to 03:00.

## Tests

Added and updated Vitest coverage for:

- Workspace feature-flag and threshold gating.
- Archiving agents in unrestricted and restricted spaces.
- Disabled configuration and invalid thresholds.
- Idempotent replay and workspace isolation.
- Temporal activity behavior with mocked schedule and wake-up clients.

## Risk

- Archiving changes an agent's status and disables its triggers and wake-ups, but the transition remains reversible through the existing restore path.
- Execution is gated by the feature flag and per-workspace threshold, and invalid thresholds fail without archiving.
- Each workspace is processed independently with bounded concurrency and retries, so one failing workspace does not stop the rest of the sweep.
- The scheduled path uses all-space authorization within the target workspace to avoid missing agents that reference restricted spaces.

## Deploy Plan

- Deploy the application and the new `agent_inactivity` Temporal worker bundle.
- The worker creates the nightly schedule if it does not already exist, using the current region timezone and skip-on-overlap behavior.
- Verify the worker starts successfully, the schedule exists, and the first run reports expected workspace and archival counts in logs.
- Enable `archive_inactive_agents` only for workspaces with a valid inactivity threshold.
- Use `temporal/agent_inactivity/admin/cli.sh run-now` or `run-workspace --workspaceId <sId>` for controlled operator verification when needed.
