### PR TITLE
[front] fix: hide consumption in usage page

### DIFF
--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -473,7 +473,8 @@ export function UsagePage() {
     workspaceId: owner.sId,
   });
 
-  const showConsumptionAnalytics = isWorkspaceAdmin;
+  // TODO(2026-08-24): add back logic to show consumption here.
+  const showConsumptionAnalytics = false;
 
   const {
     overview: consumptionOverview,


### PR DESCRIPTION
## Description

Context in [thread](https://dust4ai.slack.com/archives/C0BJ3T5SA0L/p1787583252449789)
This PR removes the consumption-based overview for the Usage page (admin tab).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
