### PR TITLE
Admin governance: clean space_resource.spaceRoleGrants read permissions

### DIFF
--- a/front-api/routes/v1/w/[wId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front-api/routes/v1/w/[wId]/data_sources/[dsId]/tables/csv.test.ts
@@ -1,7 +1,6 @@
 import { internalFetch } from "@app/lib/api/internal_fetch";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
-import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
@@ -104,14 +103,12 @@ function postCsv(
 
 describe("POST /api/v1/w/:wId/data_sources/:dsId/tables/csv (legacy endpoint)", () => {
   it("successfully upserts a CSV received as file", async () => {
-    const { auth, workspace, globalGroup, key } =
-      await createPublicApiMockRequest({
-        systemKey: true,
-        method: "POST",
-      });
+    const { auth, workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "POST",
+    });
 
     const space = await SpaceFactory.global(workspace);
-    await GroupSpaceFactory.associate(space, globalGroup);
     const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     const file = await FileFactory.csv(auth, null, {
@@ -180,14 +177,12 @@ describe("POST /api/v1/w/:wId/data_sources/:dsId/tables/csv (legacy endpoint)", 
   });
 
   it("errors if the file provided has the wrong use-case", async () => {
-    const { auth, workspace, globalGroup, key } =
-      await createPublicApiMockRequest({
-        systemKey: true,
-        method: "POST",
-      });
+    const { auth, workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "POST",
+    });
 
     const space = await SpaceFactory.global(workspace);
-    await GroupSpaceFactory.associate(space, globalGroup);
     const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     const file = await FileFactory.csv(auth, null, {

--- a/front-api/routes/v1/w/[wId]/data_sources/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/data_sources/index.test.ts
@@ -1,5 +1,4 @@
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { expectArrayOfObjectsWithSpecificLength } from "@app/tests/utils/utils";
@@ -22,10 +21,9 @@ describe("GET /api/v1/w/:wId/data_sources (legacy endpoint)", () => {
   });
 
   it("returns data sources for the global space", async () => {
-    const { workspace, globalGroup, key } = await createPublicApiMockRequest();
+    const { workspace, key } = await createPublicApiMockRequest();
 
     const space = await SpaceFactory.global(workspace);
-    await GroupSpaceFactory.associate(space, globalGroup);
 
     // Create test data source views to the space
     await DataSourceViewFactory.folder(workspace, space);

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/csv.test.ts
@@ -1,7 +1,6 @@
 import { internalFetch } from "@app/lib/api/internal_fetch";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { FileFactory } from "@app/tests/utils/FileFactory";
-import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { honoApp } from "@front-api/app";
@@ -105,14 +104,12 @@ function postCsv(
 
 describe("POST /api/v1/w/:wId/spaces/:spaceId/data_sources/:dsId/tables/csv", () => {
   it("successfully upserts a CSV received as file", async () => {
-    const { auth, workspace, globalGroup, key } =
-      await createPublicApiMockRequest({
-        systemKey: true,
-        method: "POST",
-      });
+    const { auth, workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "POST",
+    });
 
     const space = await SpaceFactory.global(workspace);
-    await GroupSpaceFactory.associate(space, globalGroup);
     const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     const file = await FileFactory.csv(auth, null, {
@@ -180,14 +177,12 @@ describe("POST /api/v1/w/:wId/spaces/:spaceId/data_sources/:dsId/tables/csv", ()
   });
 
   it("errors if the file provided has the wrong use-case", async () => {
-    const { auth, workspace, globalGroup, key } =
-      await createPublicApiMockRequest({
-        systemKey: true,
-        method: "POST",
-      });
+    const { auth, workspace, key } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "POST",
+    });
 
     const space = await SpaceFactory.global(workspace);
-    await GroupSpaceFactory.associate(space, globalGroup);
     const dataSourceView = await DataSourceViewFactory.folder(workspace, space);
 
     const file = await FileFactory.csv(auth, null, {

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/index.test.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/data_sources/index.test.ts
@@ -1,5 +1,4 @@
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { expectArrayOfObjectsWithSpecificLength } from "@app/tests/utils/utils";
@@ -21,10 +20,9 @@ function getDataSources(
 
 describe("GET /api/v1/w/:wId/spaces/:spaceId/data_sources", () => {
   it("returns an empty list when no data sources exist", async () => {
-    const { workspace, globalGroup, key } = await createPublicApiMockRequest();
+    const { workspace, key } = await createPublicApiMockRequest();
 
     const space = await SpaceFactory.global(workspace);
-    await GroupSpaceFactory.associate(space, globalGroup);
 
     const response = await getDataSources(workspace, space.sId, key);
 
@@ -33,10 +31,9 @@ describe("GET /api/v1/w/:wId/spaces/:spaceId/data_sources", () => {
   });
 
   it("returns accessible data sources for the space", async () => {
-    const { workspace, globalGroup, key } = await createPublicApiMockRequest();
+    const { workspace, key } = await createPublicApiMockRequest();
 
     const space = await SpaceFactory.global(workspace);
-    await GroupSpaceFactory.associate(space, globalGroup);
 
     // Create test data source views to the space
     await DataSourceViewFactory.folder(workspace, space);

--- a/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.test.ts
@@ -736,6 +736,11 @@ describe("PATCH /api/w/:wId/skills/:sId", () => {
 
     const openSpace = await SpaceFactory.regular(workspace);
     await GroupSpaceFactory.associate(openSpace, globalGroup);
+    // An open space confers read through the global group's `reader` grant, and an Authenticator
+    // resolves its grants once, at construction. `requestUserAuth` predates the space, so refresh
+    // it before reading a skill that requests it — `SkillResource` drops skills whose spaces it
+    // cannot read.
+    await requestUserAuth.refresh();
 
     const response = await patchSkill(workspace, skill.sId, {
       name: skill.name,

--- a/front-api/routes/w/[wId]/skills/index.test.ts
+++ b/front-api/routes/w/[wId]/skills/index.test.ts
@@ -1324,6 +1324,10 @@ describe("POST /api/w/:wId/skills", () => {
 
     const openSpace = await SpaceFactory.regular(workspace);
     await GroupSpaceFactory.associate(openSpace, globalGroup);
+    // An open space confers read through the global group's `reader` grant, and an Authenticator
+    // resolves its grants once, at construction. `auth` predates the space, so refresh it before
+    // reading a skill that requests it — `SkillResource` drops skills whose spaces it cannot read.
+    await auth.refresh();
 
     const response = await postSkill(workspace, {
       name: "Skill With Additional Space",

--- a/front/lib/actions/mcp_internal_actions/tools/utils.test.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.test.ts
@@ -240,9 +240,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should return core search args when data source configuration belongs to the workspace", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -297,9 +296,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should carry over tagsIn filter from AgentDataSourceConfigurationModel", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -338,9 +336,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should carry over tagsNotIn filter from AgentDataSourceConfigurationModel", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -378,9 +375,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should carry over both tagsIn and tagsNotIn filters from AgentDataSourceConfigurationModel", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -421,9 +417,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should carry over tags with auto mode from AgentDataSourceConfigurationModel", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -459,9 +454,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should carry over parentsIn filter from AgentDataSourceConfigurationModel", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -499,9 +493,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should carry over parentsNotIn filter from AgentDataSourceConfigurationModel", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -539,9 +532,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should carry over both parentsIn and parentsNotIn filters from AgentDataSourceConfigurationModel", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -581,9 +573,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should carry over both tags and parents filters from AgentDataSourceConfigurationModel", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder = await DataSourceViewFactory.folder(workspace, space);
 
       const dataSourceConfig = await AgentDataSourceConfigurationModel.create({
@@ -676,9 +667,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should handle multiple datasources with no filters", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder1 = await DataSourceViewFactory.folder(workspace, space);
       const folder2 = await DataSourceViewFactory.folder(workspace, space);
 
@@ -754,9 +744,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should handle multiple datasources with different tag filters", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder1 = await DataSourceViewFactory.folder(workspace, space);
       const folder2 = await DataSourceViewFactory.folder(workspace, space);
 
@@ -827,9 +816,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should handle multiple datasources with different parent filters", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder1 = await DataSourceViewFactory.folder(workspace, space);
       const folder2 = await DataSourceViewFactory.folder(workspace, space);
 
@@ -901,9 +889,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should handle multiple datasources with mixed configurations", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder1 = await DataSourceViewFactory.folder(workspace, space);
       const folder2 = await DataSourceViewFactory.folder(workspace, space);
       const folder3 = await DataSourceViewFactory.folder(workspace, space);
@@ -1056,9 +1043,8 @@ describe("MCP Internal Actions Server Utils", () => {
 
     it("should handle multiple datasources and return them in the correct order", async () => {
       const workspace = await WorkspaceFactory.basic();
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-
       const space = await SpaceFactory.global(workspace);
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
       const folder1 = await DataSourceViewFactory.folder(workspace, space);
       const folder2 = await DataSourceViewFactory.folder(workspace, space);
       const folder3 = await DataSourceViewFactory.folder(workspace, space);

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -19,6 +19,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import type { UserResource } from "@app/lib/resources/user_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
@@ -37,6 +38,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 describe("createAgentMessages", () => {
   let workspace: WorkspaceType;
+  let user: UserResource;
   let auth: Authenticator;
   let conversation: ConversationType;
 
@@ -44,6 +46,7 @@ describe("createAgentMessages", () => {
     // Create workspace, user, spaces, and groups using the helper
     const setup = await createResourceTest({});
     workspace = setup.workspace;
+    user = setup.user;
     auth = setup.authenticator;
 
     // Create a conversation using the factory
@@ -956,7 +959,15 @@ describe("createAgentMessages", () => {
       const openSpaceModelId = getResourceIdFromSId(refreshedOpenSpace!.sId);
       expect(openSpaceModelId).not.toBeNull();
 
-      const openConversation = await ConversationFactory.create(auth, {
+      // Rebuilt now that the space is open: an open space confers read through the global group's
+      // `reader` grant, and an Authenticator resolves its grants once, at construction. `auth` was
+      // built before the space existed, so it does not carry that grant.
+      const openSpaceAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const openConversation = await ConversationFactory.create(openSpaceAuth, {
         agentConfigurationId: "test-agent",
         messagesCreatedAt: [],
         visibility: "unlisted",
@@ -974,7 +985,7 @@ describe("createAgentMessages", () => {
       expect(canAccess).toBe("allowed");
 
       const { userMessage } = await ConversationFactory.createUserMessage({
-        auth,
+        auth: openSpaceAuth,
         workspace,
         conversation: openConversation,
         content: `Hello @${mentionedUser.username}`,
@@ -987,7 +998,7 @@ describe("createAgentMessages", () => {
         },
       ];
 
-      const result = await resolveAndCreateUserMentions(auth, {
+      const result = await resolveAndCreateUserMentions(openSpaceAuth, {
         mentions,
         message: userMessage,
         conversation: openConversation,

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -863,7 +863,6 @@ describe("DustFileSystem.forAgentLoop", () => {
       await MembershipFactory.associate(workspace, regularUser, {
         role: "user",
       });
-      const userSessionAuth = await sessionAuthForUser(regularUser, workspace);
 
       const openProjectRes = await createSpaceAndGroup(adminAuth, {
         name: `open pod ${Date.now()}`,
@@ -882,6 +881,9 @@ describe("DustFileSystem.forAgentLoop", () => {
         user.sId,
         workspace.sId
       );
+      // Built after the pod exists: an open pod confers read through the global group's `reader`
+      // grant, and an Authenticator resolves its grants once, at construction.
+      const userSessionAuth = await sessionAuthForUser(regularUser, workspace);
 
       const openProject = await SpaceResource.fetchById(
         refreshedAdminAuth,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1928,36 +1928,23 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return [{ role: "admin", permissions: ["admin", "write"] }];
     }
 
-    // Global Workspace space and Conversations space.
-    if (this.isGlobal() || this.isConversations()) {
+    // Global Workspace space, Conversations space and open regular spaces. Read is not granted by
+    // role: all three attach the workspace global group with a `reader` grant, and every workspace
+    // member belongs to that group, so `group_permissions` already confers read on everyone. Write
+    // is the only thing the role still grants here, and the only remaining difference with a
+    // restricted regular space.
+    if (this.isGlobal() || this.isConversations() || this.isRegularAndOpen()) {
       return [
-        { role: "admin", permissions: ["admin", "read", "write"] },
+        { role: "admin", permissions: ["admin", "write"] },
         // TODO(governance): remove once manager is available for everyone
-        { role: "builder", permissions: ["read", "write"] },
-        { role: "manager", permissions: ["read", "write"] },
+        { role: "builder", permissions: ["write"] },
+        { role: "manager", permissions: ["write"] },
       ];
     }
 
-    // Open space.
-    if (this.isRegularAndOpen()) {
-      return [
-        { role: "admin", permissions: ["admin", "read", "write"] },
-        // TODO(governance): remove once manager is available for everyone
-        { role: "builder", permissions: ["read", "write"] },
-        { role: "manager", permissions: ["read", "write"] },
-        { role: "user", permissions: ["read"] },
-      ];
-    }
-
-    if (this.isProject()) {
-      return [
-        { role: "admin", permissions: ["admin"] },
-        { role: "manager", permissions: this.isOpen() ? ["read"] : [] }, // Non-restricted projects are visible to all users
-        { role: "user", permissions: this.isOpen() ? ["read"] : [] }, // Non-restricted projects are visible to all users
-      ];
-    }
-
-    // Restricted regular space.
+    // Projects and restricted regular spaces: the role only confers administration. Read and write
+    // come from the space's grants — including on an open project, where the global group's
+    // `reader` grant makes it visible to every workspace member.
     return [{ role: "admin", permissions: ["admin"] }];
   }
 

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -40,6 +40,13 @@ export class SpaceFactory {
   }
 
   static async global(workspace: WorkspaceType, globalGroup?: GroupResource) {
+    // Production always attaches the workspace global group (see
+    // `SpaceResource.makeDefaultsForWorkspace`), and that group's `reader` grant is what confers
+    // read on the global space. Default to it so a factory-built global space is readable the same
+    // way. `GroupFactory.defaults` reuses the workspace's existing groups.
+    const group =
+      globalGroup ?? (await GroupFactory.defaults(workspace)).globalGroup;
+
     return SpaceResource.makeNew(
       await this.internalAuth(workspace),
       {
@@ -47,7 +54,7 @@ export class SpaceFactory {
         kind: "global",
         workspaceId: workspace.id,
       },
-      { members: removeNulls([globalGroup]) } // TODO: Add groups
+      { members: [group] }
     );
   }
 


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/10189

Remove the "read" permissions from the `space_resource.spaceRoleGrants` when the global group already has the read permission: every user of the workspace already has the read permissions from the global group membership. 
This changes the following spaces:
 - global
 - conversations
 - open regular
 - projects

updated some tests, with 2 categories:
 - stop associating the global group as reader on global space, it's done automatically by the factory
 - refresh auth after granting a read permission on a space.

## Tests

all front tests pass

## Risk

non destructive: can be reverted if needed 

## Deploy Plan

deploy front
