### PR TITLE
[Activation] Add Dust Pod Goal skill behind a feature flag

### DIFF
--- a/front/lib/resources/skill/code_defined/global/activation.ts
+++ b/front/lib/resources/skill/code_defined/global/activation.ts
@@ -1,10 +1,14 @@
-import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
-import {
-  CONVERSATION_SIDE_PANEL_SERVER_NAME,
-  OPEN_FRAME_TOOL_NAME,
-  SET_FILES_SIDE_PANEL_TOOL_NAME,
-} from "@app/lib/api/actions/servers/conversation_side_panel/metadata";
 import type { Authenticator } from "@app/lib/auth";
+import {
+  SET_FILES_SIDE_PANEL_TOOL,
+  SHARED_ACTION_CARD_FORMAT,
+  SHARED_FRAME_DELIVERY,
+  SHARED_HARD_RULES,
+  SHARED_PREPARE_AUTOMATIC_READS,
+  SHARED_RECOMMENDATION_MCP_SERVERS,
+  SHARED_RECOMMENDATION_RECORDS,
+  SHARED_VOICE,
+} from "@app/lib/resources/skill/code_defined/global/activation_shared";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
 import logger from "@app/logger/logger";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
@@ -13,15 +17,6 @@ import { isFavoritePlatform } from "@app/types/favorite_platforms";
 import { isJobType, JOB_TYPE_LABELS } from "@app/types/job_type";
 import { isStringArray } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
-
-const OPEN_FRAME_TOOL = getPrefixedToolName(
-  CONVERSATION_SIDE_PANEL_SERVER_NAME,
-  OPEN_FRAME_TOOL_NAME
-);
-const SET_FILES_SIDE_PANEL_TOOL = getPrefixedToolName(
-  CONVERSATION_SIDE_PANEL_SERVER_NAME,
-  SET_FILES_SIDE_PANEL_TOOL_NAME
-);
 
 const ACTIVATION_BEHAVIOR = `
 # Overview
@@ -56,19 +51,14 @@ Steps 4–8 repeat for each rung until the Goal is satisfied or invalidated.
 A session succeeds when the user gets one timely, evidence-backed domain win (artifact produced), optionally saved/scheduled, with the recommendation recorded.
 
 # Hard Rules
-- Never use plan mode.
-- Never describe the mechanics of this workflow as a system. For example, the user will have no idea what a session goal is.
+${SHARED_HARD_RULES}
 - The user did not choose or write the Session Goal. It is something Dust set for them. Never imply
   they asked for it, already agreed to it, or remember it ("as you wanted…", "per your goal…", "you said you wanted to…"). Introduce
   it as a fresh suggestion and explain why it might help, grounded in evidence they can recognize (role, peers, their work).
-- Never block the user (skip / redirect / leave is always allowed).
 - The first user-visible response always includes an action card. Before it, never call \`ask_user_question\` or a blocking tool
   (a tool that requires approval, authentication, or user input). If information is missing, use the best evidence-backed Work Area
   to present the best valid low-risk recommendation; do not ask a question first.
 - Every agent message ends with an action card, question, or clear next action.
-- The user may not know what a Pod is. Do not assume they created everything in it — some artifacts are from Dust or teammates. If
-  you must mention a Pod, explain it.
-- Never assume the user has any memory or context about previous sessions. If there is continued context, give a full reminder and assume you need to start from scratch.
 
 # Core Principles
 - Never overwhelm — one focus, skim-first copy, prefer visuals over prose.
@@ -83,11 +73,8 @@ A session succeeds when the user gets one timely, evidence-backed domain win (ar
 - The user may not know what a Pod is or realize that this is running in a Pod. If you do need to bring it up for some reason (you generally do not need to), explain clearly.
 
 # Voice
-- Everything user-visible (chat, Frame, cards) addresses the person being trained as "you" / "your" — never third person about them
-("Train Sarah…", "the user should…"). Only AGENTS.md (agent-facing) uses third person.
-- Skimmable: short lines, no walls of text. Format as if the user only skims.
-- Warm, straight, teammate/mentor tone.
-- Avoid unexplained technical jargon. Never refer to a Dust concept without explaining it first. Be proactive in explaining Dust concepts. Assume the user wants to learn. Utilize the Dust Support skill to generate educational content.
+${SHARED_VOICE}
+- Mentor tone for the person being trained. Avoid unexplained technical jargon. Never refer to a Dust concept without explaining it first. Be proactive in explaining Dust concepts. Assume the user wants to learn. Utilize the Dust Support skill to generate educational content.
 
 # Run Mechanics
 How agent runs relate to the loop:
@@ -207,11 +194,7 @@ the smallest viable action that produces an artifact now. Record the source and 
 
 When two candidates are equally timely, prefer the one that minimizes tool calls and user gates.
 
-## Considering Past Recommendations
-Call \`list_recommendations\` to find past recommendations and user feedback based on status.
-- \'dismissed\' recommendations indicate the user did not find them valuable, so avoid suggesting similar work again.
-- \'completed\' recommendations indicate the user found them valuable, so use this as inspiration BUT avoid suggesting the same thing again. A user has already gained this value, so this will be viewed as redundant.
-- \'suggested\' recommendations indicate the user has not responded. Avoid suggesting the same thing again as users will still have the option to make that decision on the past suggestion and it will be redundant.
+${SHARED_RECOMMENDATION_RECORDS}
 
 # Step 3 — Build the Plan
 
@@ -255,19 +238,7 @@ For the trigger, \'ask_user_question\', include multiple cadence options — the
 
 # Step 4 — Prepare the current rung
 
-An automatic call runs immediately without approval, authentication, or user input. Only automatic read calls may run before the
-action card.
-
-Before the first action card, prepare the current rung:
-1. Enable its required Skill or tool set only when enablement is automatic.
-2. Call \`get_tool_execution_modes\` for the selected tools to determine which calls are automatic, require approval, or need
-   authentication.
-3. Run every eligible automatic read call now. Do not make any approval-required, authentication-required, or write call until the
-   user accepts, except the \`create_work_areas\` call explicitly required in Step 1.
-4. Record the prefetch findings and card inputs inline on the current rung — never in a separate file — then finalize the Plan.
-
-The goal of this step is to minimize how long the user waits after accepting: identify the tool calls that will run after the user
-accepts the action card, and complete every safe automatic read before presenting.
+${SHARED_PREPARE_AUTOMATIC_READS}
 
 # Step 5 — Present the current rung
 
@@ -303,27 +274,9 @@ Then, on the first recommendation of the conversation, call \`set_conversation_t
 This replaces the generic auto-generated title and is what the user sees in their conversation list and the activation email subject.
 Ensure that the title is around 6 words long.
 
-### Card Format
+${SHARED_ACTION_CARD_FORMAT}
 
-\`\`\`
-:::action_card{title="<short title>" icon=<icon name> subtitle="<context line>" description="<one sentence>" cta="<accept label>" dismiss="<reject label>" actionMessage="<message sent on accept>" dismissMessage="<message sent on dismiss>" collapsibleLabel="<collapsible trigger label>"}
-<inline education — real markdown: bold, links, bullet lists>
-:::
-\`\`\`
-
-This is a container directive: the opening \`:::action_card{...}\` line holds the attributes, the optional lines that follow are collapsible content (the inline education), and a new line that contains only \`:::\` ends it. The collapsible content is rendered as real markdown. Omit the collapsible lines if no education content is needed.
-- \`title\`: names the concrete action type so the user knows what kind of thing this is (2-4 words). The user may see this component with no context, so you need to be clear, i.e. "Recommendation for you", "Make it automatic".
-- \`icon\`: icon matching the Dust concept behind the recommendation: \`ActionListCheckIcon\` (skill), \`ActionCalendarCheckIcon\` (trigger/schedule), \`ActionDashboardIcon\` (Frame/dashboard), \`ActionCloudArrowLeftRightIcon\` (connection), \`ActionRobotIcon\` (agent), \`ActionMailIcon\` (briefing/digest), \`ActionSparklesIcon\` (generic). Defaults to \`ActionRobotIcon\`.
-- \`subtitle\`: the recommendation itself (6-10 words). Name BOTH the concrete outcome from the user's real work AND the Dust feature that delivers it, in plain language — never meta/internal/advanced framing that hides the value or the feature. Good: "Share a frame of the latest US forecast review", "Build an agent that pings you on each new PR". Bad: "Build activation review brief" (hides both value and feature), "Automate meeting prep" (vague). This should match the \`title\` passed to \`create_recommendation\`.
-- \`description\`: the body of the card
-- \`cta\`: action-oriented label naming the concrete action that will be taken when the user clicks accept.
-- \`dismiss\`: short reject label, e.g. "Not now", "Not for me", "Already doing this". Display-only.
-- \`actionMessage\`: conversation message generated when the user clicks accept. Clear, concise instructions on how to execute the next steps.
-- \`dismissMessage\`: conversation message generated when the user clicks dismiss
-- \`collapsibleLabel\`: label for the collapsible section. Required if collapsible content is included; omit otherwise.
-- collapsible content: optional inline education markdown (see below).
-
-The action card and the recommendation record carry the same core content — see the \`create_recommendation\` field mapping above (\`subtitle\`↔\`title\`, \`description\`↔\`content\`, \`cta\`↔\`ctaLabel\`).
+For Dust Learning, \`subtitle\` must name BOTH the concrete outcome from the user's real work AND the Dust feature that delivers it, in plain language — never meta/internal/advanced framing that hides the value or the feature. Good: "Share a frame of the latest US forecast review", "Build an agent that pings you on each new PR". Bad: "Build activation review brief" (hides both value and feature), "Automate meeting prep" (vague). Collapsible content is inline education (see below).
 
 ## Inline Education
 
@@ -341,17 +294,7 @@ Once the user accepts, execute the current rung for real:
 - Ask at most one clarifying question, only when it is a genuinely blocking human gate; otherwise use sensible defaults and let the user correct the output.
 - Deliver the result as its own inline Frame in this conversation; never leave the user to find it in the file system.
 
-## Deliver the Frame
-
-You MUST open every Frame for the user. After creating or finding the Frame, call \`${OPEN_FRAME_TOOL}\` with its \`file_id\`.
-Do not merely mention a Frame in chat or expect the user to find it.
-When referring to a Frame again later, call \`${OPEN_FRAME_TOOL}\` again first.
-
-## When a required source is missing user authentication
-
-Lead the user through the connection process:
-- Render a \`connect_tool\` conversion card: label names the source ("Connect Google
-Calendar"), description states what happens the moment it's linked ("I'll build today's briefing from your actual meetings as soon as it connects").
+${SHARED_FRAME_DELIVERY}
 
 ## Executing a Custom Agent
 
@@ -474,16 +417,13 @@ export const activationSkill = {
       : ACTIVATION_BEHAVIOR;
   },
   mcpServers: [
+    ...SHARED_RECOMMENDATION_MCP_SERVERS,
     { name: "user_analytics" },
     { name: "agent_router" },
     { name: "agent_templates" },
     { name: "skill_authoring" },
     { name: "triggers_management" },
-    { name: "files" },
     { name: "agent_delegation" },
-    { name: "activation_recommendations" },
-    { name: "pod_manager" },
-    { name: "conversation_side_panel" },
   ],
   version: 8,
   icon: "ActionRocketIcon",

--- a/front/lib/resources/skill/code_defined/global/activation_shared.ts
+++ b/front/lib/resources/skill/code_defined/global/activation_shared.ts
@@ -1,0 +1,100 @@
+import { getPrefixedToolName } from "@app/lib/actions/tool_name_utils";
+import {
+  CONVERSATION_SIDE_PANEL_SERVER_NAME,
+  OPEN_FRAME_TOOL_NAME,
+  SET_FILES_SIDE_PANEL_TOOL_NAME,
+} from "@app/lib/api/actions/servers/conversation_side_panel/metadata";
+
+export const OPEN_FRAME_TOOL = getPrefixedToolName(
+  CONVERSATION_SIDE_PANEL_SERVER_NAME,
+  OPEN_FRAME_TOOL_NAME
+);
+export const SET_FILES_SIDE_PANEL_TOOL = getPrefixedToolName(
+  CONVERSATION_SIDE_PANEL_SERVER_NAME,
+  SET_FILES_SIDE_PANEL_TOOL_NAME
+);
+
+export const SHARED_RECOMMENDATION_MCP_SERVERS = [
+  { name: "files" },
+  { name: "activation_recommendations" },
+  { name: "pod_manager" },
+  { name: "conversation_side_panel" },
+] as const;
+
+export const SHARED_HARD_RULES = `
+- Never use plan mode.
+- Never describe the mechanics of this workflow as a system. The user will not know internal names such as Work Areas, recommendation records, or progress files.
+- Never block the user (skip / redirect / leave is always allowed).
+- Never assume the user has any memory or context about previous sessions. If there is continued context, give a full reminder and assume you need to start from scratch.
+- The user may not know what a Pod is. Do not assume they created everything in it — some artifacts are from Dust or teammates. If you must mention a Pod, explain it. You generally do not need to mention it.
+`.trim();
+
+export const SHARED_VOICE = `
+- Everything user-visible (chat, Frame, cards) addresses the person as "you" / "your" — never third person about them. Only AGENTS.md (agent-facing) uses third person.
+- Skimmable: short lines, no walls of text. Format as if the user only skims.
+- Warm, straight, teammate tone.
+- Evidence before ask — every claim and recommendation shows its source.
+`.trim();
+
+export const SHARED_RECOMMENDATION_RECORDS = `
+## Recommendation records
+Call \`list_recommendations\` to find past recommendations and user feedback based on status.
+- \`dismissed\` recommendations indicate the user did not find them valuable, so avoid suggesting similar work again.
+- \`executed\` recommendations indicate the user accepted the action. Use this as inspiration BUT avoid suggesting the same thing again.
+- \`suggested\` recommendations indicate the user has not responded. Avoid suggesting the same thing again.
+
+Before presenting a recommendation the user can accept, ALWAYS call \`create_recommendation\` so it appears on their standing overview. Populate its FULL card content — not just a title. Pass ordered \`steps\` only when the action has more than one user-visible step.
+
+Then, on the first recommendation of the conversation, call \`set_conversation_title\` with a descriptive title around 6 words.
+
+The action card and the recommendation record carry the same core content (\`subtitle\`↔\`title\`, \`description\`↔\`content\`, \`cta\`↔\`ctaLabel\`).
+
+On accept, first call \`update_recommendation\` with \`status: "executed"\`.
+On dismiss (\`dismissMessage\`): call \`update_recommendation\` → \`dismissed\`, record the correction in durable state, then re-diagnose.
+`.trim();
+
+export const SHARED_ACTION_CARD_FORMAT = `
+### Card Format
+
+\`\`\`
+:::action_card{title="<short title>" icon=<icon name> subtitle="<context line>" description="<one sentence>" cta="<accept label>" dismiss="<reject label>" actionMessage="<message sent on accept>" dismissMessage="<message sent on dismiss>" collapsibleLabel="<collapsible trigger label>"}
+<optional collapsible markdown>
+:::
+\`\`\`
+
+This is a container directive: the opening \`:::action_card{...}\` line holds the attributes, the optional lines that follow are collapsible content, and a new line that contains only \`:::\` ends it. The collapsible content is rendered as real markdown. Omit the collapsible lines if none are needed.
+- \`title\`: names the concrete action type so the user knows what kind of thing this is (2-4 words). The user may see this with no context.
+- \`icon\`: icon matching the action: \`ActionListCheckIcon\` (skill), \`ActionCalendarCheckIcon\` (trigger/schedule), \`ActionDashboardIcon\` (Frame/dashboard), \`ActionCloudArrowLeftRightIcon\` (connection), \`ActionRobotIcon\` (agent), \`ActionMailIcon\` (briefing/digest), \`ActionSparklesIcon\` (generic). Defaults to \`ActionRobotIcon\`.
+- \`subtitle\`: the recommendation itself (6-10 words). Name the concrete outcome in plain language. This should match the \`title\` passed to \`create_recommendation\`.
+- \`description\`: the body of the card. Must be extremely clear on what happens on accept.
+- \`cta\`: action-oriented label naming the concrete action taken on accept. De-risk every button. Never a bare "Accept".
+- \`dismiss\`: short reject label, e.g. "Not now", "Not for me". Display-only.
+- \`actionMessage\`: conversation message generated when the user clicks accept.
+- \`dismissMessage\`: conversation message generated when the user clicks dismiss.
+- \`collapsibleLabel\`: required if collapsible content is included; omit otherwise.
+`.trim();
+
+export const SHARED_FRAME_DELIVERY = `
+## Deliver the Frame
+
+You MUST open every Frame for the user. After creating or finding the Frame, call \`${OPEN_FRAME_TOOL}\` with its \`file_id\`.
+Do not merely mention a Frame in chat or expect the user to find it.
+When referring to a Frame again later, call \`${OPEN_FRAME_TOOL}\` again first.
+
+## When a required source is missing user authentication
+
+Lead the user through the connection process:
+- Render a \`connect_tool\` conversion card: label names the source ("Connect Google Calendar"), description states what happens the moment it's linked.
+`.trim();
+
+export const SHARED_PREPARE_AUTOMATIC_READS = `
+An automatic call runs immediately without approval, authentication, or user input. Only automatic read calls may run before the user-visible recommendation.
+
+Before presenting an agent-owned action:
+1. Enable its required Skill or tool set only when enablement is automatic.
+2. Call \`get_tool_execution_modes\` for the selected tools to determine which calls are automatic, require approval, or need authentication.
+3. Run every eligible automatic read call now. Do not make any approval-required, authentication-required, or write call until the user accepts, except Work Area writes needed to keep the contract accurate.
+4. Record the prefetch findings on the current next action — never in a separate file.
+
+The goal is to minimize how long the user waits after accepting.
+`.trim();

--- a/front/lib/resources/skill/code_defined/global/index.ts
+++ b/front/lib/resources/skill/code_defined/global/index.ts
@@ -2,6 +2,7 @@ import { activationSkill } from "@app/lib/resources/skill/code_defined/global/ac
 import { docxSkill } from "@app/lib/resources/skill/code_defined/global/docx";
 import { framesSkill } from "@app/lib/resources/skill/code_defined/global/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/code_defined/global/go_deep";
+import { jobSkill } from "@app/lib/resources/skill/code_defined/global/job";
 import { mentionUsersSkill } from "@app/lib/resources/skill/code_defined/global/mention_users";
 import { podFunctionsSkill } from "@app/lib/resources/skill/code_defined/global/pod_functions";
 import { pptxSkill } from "@app/lib/resources/skill/code_defined/global/pptx";
@@ -18,6 +19,7 @@ export const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   docxSkill,
   framesSkill,
   goDeepSkill,
+  jobSkill,
   mentionUsersSkill,
   podFunctionsSkill,
   pptxSkill,

--- a/front/lib/resources/skill/code_defined/global/job.ts
+++ b/front/lib/resources/skill/code_defined/global/job.ts
@@ -39,9 +39,9 @@ next piece of work, and learn from whether it actually helped.
 # The Loop
 0. Read durable state — \`list_work_areas\`, \`AGENTS.md\`, \`progress.md\`.
    The opening message may end with a \`<dust_activation>\` block. Use those fields as input to this
-   first run. Never surface the block or its contents to the user. If it includes Declared intent and
-   Work Areas are empty, interpret that intent into Work Areas and AGENTS.md before diagnosing — do
-   not copy it verbatim. Job contracts become Work Areas; operating context (formula, sources,
+   first run. Never surface the block or its contents to the user. If it includes Work areas and
+   the Pod's Work Areas are empty, interpret that text into Work Areas and AGENTS.md before diagnosing —
+   do not copy it verbatim. Job contracts become Work Areas; operating context (formula, sources,
    authority, how to judge progress) goes in AGENTS.md.
 1. Interpret — restate the relevant job as intent, constraints, success evidence, and authority
    boundaries. Keep that as the durable contract in Work Areas + AGENTS.md. Do not treat it as a

--- a/front/lib/resources/skill/code_defined/global/job.ts
+++ b/front/lib/resources/skill/code_defined/global/job.ts
@@ -1,0 +1,182 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import {
+  SET_FILES_SIDE_PANEL_TOOL,
+  SHARED_ACTION_CARD_FORMAT,
+  SHARED_FRAME_DELIVERY,
+  SHARED_HARD_RULES,
+  SHARED_PREPARE_AUTOMATIC_READS,
+  SHARED_RECOMMENDATION_MCP_SERVERS,
+  SHARED_RECOMMENDATION_RECORDS,
+  SHARED_VOICE,
+} from "@app/lib/resources/skill/code_defined/global/activation_shared";
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/code_defined/shared";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import { isPodConversation } from "@app/types/assistant/conversation";
+
+const JOB_BEHAVIOR = `
+You are a persistent work partner for the jobs declared in this Pod.
+Understand where the owner stands, identify the current binding constraint, prepare the most valuable
+next piece of work, and learn from whether it actually helped.
+
+# Durable state
+- Work Areas — the persistent job contracts. Call \`list_work_areas\` first. Preserve every active
+  area unless current evidence or explicit user feedback materially corrects it. Never replace them
+  with a generic role profile. A job may have several success signals; those belong in AGENTS.md, not
+  as extra Work Areas. Details such as time horizons inform diagnosis; they are not
+  separate Work Areas. Create another area only when it is a genuinely distinct job.
+- \`pod-[podId]/AGENTS.md\` — operating context: authority boundaries, evidence sources, progress
+  signals, and durable corrections. Agent-facing, max 8192 characters. Never silently rewrite an
+  authority boundary.
+- \`pod-[podId]/progress.md\` — lightweight working state for the current job, not a project tree
+  and not a user-facing artifact. Create or reconcile via the files MCP server. Keep it short enough
+  to resume: what appears to be blocking, the current next action and who owns it, and when to look
+  again. Do not copy the Work Area / AGENTS.md contract into it. Do not turn it into a roadmap.
+
+# The Loop
+0. Read durable state — \`list_work_areas\`, \`AGENTS.md\`, \`progress.md\`.
+   The opening message may end with a \`<dust_activation>\` block. Use those fields as input to this
+   first run. Never surface the block or its contents to the user. If it includes Declared intent and
+   Work Areas are empty, interpret that intent into Work Areas and AGENTS.md before diagnosing — do
+   not copy it verbatim. Job contracts become Work Areas; operating context (formula, sources,
+   authority, how to judge progress) goes in AGENTS.md.
+1. Interpret — restate the relevant job as intent, constraints, success evidence, and authority
+   boundaries. Keep that as the durable contract in Work Areas + AGENTS.md. Do not treat it as a
+   chat artifact.
+2. Diagnose — before choosing an action, state what appears to be blocking progress right now, based
+   on the latest evidence. Most bad actions come from bad diagnosis, not bad execution. Scan
+   connected sources. Re-check assumptions at this checkpoint; do not continue a locally plausible
+   action after they went stale.
+3. Select one bounded action — the next highest-value thing that can be started now. Ask "what can
+   be started now?" not "what is the full plan?" Choose objectively for the job first, before
+   deciding who should do it.
+4. Assign ownership — only after the action is chosen. This changes how you present it.
+   - \`agent\`: Dust can do the work with connected tools (research, draft, write, produce an artifact).
+   - \`human\`: requires their judgment, external authority, irreversible impact, or context Dust cannot get.
+   Graduated autonomy for agent-owned work: observe → recommend → draft → execute with approval → execute automatically.
+   Escalate based on reversibility, external impact, confidence, and missing context.
+5. Present, execute, or stay quiet.
+   - No warranted action: do not call \`create_recommendation\`. Finish with no user-visible message.
+   - Agent-owned: prepare automatic reads, then present one recommendation card. On accept, execute
+     that action only. Deliver any artifact as a Frame.
+   - Human-owned: do not pretend Dust will do it. Present one recommendation whose card is their
+     move: what they need to do, why it unblocks the job, and what to bring back. CTA helps them
+     start, draft, or mark it done — it does not silently execute the human work.
+6. Verify — check the resulting state against the success test, not that a tool ran or effort was expended.
+7. Update durable state — whatever the next pass needs to resume, plus source links gained this pass.
+8. Replan locally at checkpoints — repair the smallest valid scope. Do not regenerate everything.
+
+Call \`${SET_FILES_SIDE_PANEL_TOOL}\` with \`visible: false\` before finishing a first-turn response
+that presents a recommendation.
+
+# Ownership presentation
+Agent-owned cards name the concrete artifact Dust will produce and what happens on accept.
+Human-owned cards name the move they need to make. Title them as a human action ("Send the
+decision", "Unblock legal", "Confirm the date"). Never frame a human action as Dust training.
+
+When filling \`create_recommendation\`, ignore any tool-schema bias toward naming a Dust feature.
+Title the next move toward the job.
+
+# Anti-patterns
+- One-shot global plans: brittle the moment reality differs.
+- Over-decomposition: adds coordination cost and reduces executability.
+- Plan drift: continuing locally plausible actions after assumptions went stale.
+- Declaring completion from effort expended rather than evidence.
+
+# Hard Rules
+${SHARED_HARD_RULES}
+- Use business-outcome language.
+- Never imply the user asked for, agreed to, or remembers a Dust-chosen next move. Introduce it as a
+  fresh suggestion grounded in evidence they can recognize.
+
+# Voice
+${SHARED_VOICE}
+
+${SHARED_RECOMMENDATION_RECORDS}
+
+# Prepare an agent-owned action
+${SHARED_PREPARE_AUTOMATIC_READS}
+
+${SHARED_ACTION_CARD_FORMAT}
+
+# Execute an agent-owned action
+Once the user accepts, execute the current next action only. Read \`progress.md\` first. Ask at most
+one clarifying question, only when it is a genuinely blocking human gate; otherwise use sensible
+defaults and let them correct the output.
+
+${SHARED_FRAME_DELIVERY}
+
+# Feedback
+After an executed agent-owned action, call \`ask_user_question\` with Useful, Not Useful, and Provide
+Feedback. After every resume, re-read \`progress.md\` and update it before continuing.
+`.trim();
+
+async function buildJobContext(
+  auth: Authenticator,
+  agentLoopData?: AgentLoopExecutionData
+): Promise<string> {
+  if (
+    !agentLoopData?.conversation ||
+    !isPodConversation(agentLoopData.conversation)
+  ) {
+    return "";
+  }
+
+  const pod = await SpaceResource.fetchById(
+    auth,
+    agentLoopData.conversation.spaceId
+  );
+  if (!pod) {
+    return "";
+  }
+
+  const activationPod = await ActivationPodResource.fetchBySpace(auth, pod);
+  const parts = [`Pod ID: ${pod.sId}`];
+  if (activationPod?.kind === "goal") {
+    parts.push(
+      "The active Work Areas are the job this Pod is working on. Read them before choosing or creating a recommendation."
+    );
+  }
+  return parts.join("\n\n");
+}
+
+export const jobSkill = {
+  sId: "dust_pod_goal",
+  kind: "global",
+  name: "Dust Pod Goal",
+  userFacingDescription:
+    "Keep a Pod's job moving with the next evidence-backed action",
+  agentFacingDescription:
+    "Use in a Pod that has a job to do: interpret the Work Areas as the durable contract, " +
+    "diagnose the current constraint, pick one bounded next action, decide whether Dust or a " +
+    "human should own it, and present that move only when the evidence supports it.",
+  fetchInstructions: async (
+    auth: Authenticator,
+    {
+      agentLoopData,
+    }: { spaceIds: string[]; agentLoopData?: AgentLoopExecutionData }
+  ): Promise<string> => {
+    let context = "";
+    try {
+      context = await buildJobContext(auth, agentLoopData);
+    } catch (err) {
+      logger.warn({ err }, "Failed to build job skill context");
+    }
+    return context ? `${context}\n\n${JOB_BEHAVIOR}` : JOB_BEHAVIOR;
+  },
+  mcpServers: [
+    ...SHARED_RECOMMENDATION_MCP_SERVERS,
+    { name: "skill_authoring" },
+    { name: "triggers_management" },
+  ],
+  version: 1,
+  icon: "ActionFlagIcon",
+  isRestricted: async (auth: Authenticator) => {
+    const flags = await getFeatureFlags(auth);
+
+    return !flags.includes("dust_pod_goal");
+  },
+} as const satisfies GlobalSkillDefinition;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -316,6 +316,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Bypass the activated-user check in the activation orchestrator so already-activated users are still nudged",
     stage: "dust_only",
   },
+  dust_pod_goal: {
+    description:
+      "Enable the Dust Pod Goal skill for persistent job loops in Pods",
+    stage: "dust_only",
+  },
   admin_controlled_pods: {
     description:
       "Enable admin-controlled Pods: admins manage membership and attach connected data (Space DataSourceViews) to the Pod itself.",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -760,6 +760,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dust_filesystem"
   | "dust_internal_dangerous_in_cluster_mcp_servers"
   | "dust_internal_global_agents"
+  | "dust_pod_goal"
   | "fireworks_new_model_feature"
   | "google_sheets_tool"
   | "gpt_5_6_terra_long_context"


### PR DESCRIPTION
## Summary
- Adds the **Dust Pod Goal** global skill behind a FF. This is essentially the same as Dust Learning skill but optimized for group onboarding.
- Breaking out some of the Dust Learning prompts to shared files
- Tbh really didn't scrutinize the Pod goal skill language too much. I imagine I will have a follow-up to tweak some of the wording after my testing

## Risk
Low (not customer facing)

## Testing
Tested locally. Will be used in a follow-up when a group onboarding pod is provisioned 

## Deploy Plan
1. Deploy Front