### PR TITLE
[Activation] Provision Goal Pods from poke

### DIFF
--- a/front-api/routes/w/[wId]/activation-pod/index.test.ts
+++ b/front-api/routes/w/[wId]/activation-pod/index.test.ts
@@ -18,7 +18,7 @@ describe("GET /api/w/:wId/activation-pod", () => {
     expect(response.status).toBe(200);
 
     const body = await response.json();
-    expect(body).toEqual({ podId: null });
+    expect(body).toEqual({ podId: null, kind: null });
   });
 
   it("returns the pod space sId when the user has an activation pod", async () => {
@@ -40,7 +40,7 @@ describe("GET /api/w/:wId/activation-pod", () => {
     expect(response.status).toBe(200);
 
     const body = await response.json();
-    expect(body).toEqual({ podId: podSpace.sId });
+    expect(body).toEqual({ podId: podSpace.sId, kind: "learning" });
   });
 
   it("returns null when the user's activation pod is archived", async () => {
@@ -62,6 +62,6 @@ describe("GET /api/w/:wId/activation-pod", () => {
     expect(response.status).toBe(200);
 
     const body = await response.json();
-    expect(body).toEqual({ podId: null });
+    expect(body).toEqual({ podId: null, kind: null });
   });
 });

--- a/front/lib/api/actions/servers/activation_recommendations/index.ts
+++ b/front/lib/api/actions/servers/activation_recommendations/index.ts
@@ -224,8 +224,20 @@ const handlers: ToolHandlers<typeof ACTIVATION_RECOMMENDATIONS_TOOLS_METADATA> =
       ]);
     },
 
-    list_recommendations: async (_params, { auth }) => {
-      const recs = await ActivationRecommendationResource.fetchByUser(auth);
+    list_recommendations: async (_params, { auth, runContext }) => {
+      const podSpaceId = isAgentLoopRunContext(runContext)
+        ? runContext.conversation.spaceId
+        : null;
+      const pod = podSpaceId
+        ? await SpaceResource.fetchById(auth, podSpaceId)
+        : null;
+      const activationPod = pod
+        ? await ActivationPodResource.fetchBySpace(auth, pod)
+        : null;
+
+      const recs = await ActivationRecommendationResource.fetchByUser(auth, {
+        activationPodModelId: activationPod?.id,
+      });
 
       if (recs.length === 0) {
         return new Ok([

--- a/front/lib/api/activation/nudge.ts
+++ b/front/lib/api/activation/nudge.ts
@@ -7,11 +7,15 @@ import { isNonCreditPricedUserSpendLimitReached } from "@app/lib/api/users/spend
 import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { serializeMention } from "@app/lib/mentions/format";
 import { isUserBlocked } from "@app/lib/metronome/user_block";
+import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import type { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { activationSkill } from "@app/lib/resources/skill/code_defined/global/activation";
+import { jobSkill } from "@app/lib/resources/skill/code_defined/global/job";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { serializeSkillTag } from "@app/lib/skills/format";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import {
   DEFAULT_ACTIVATION_NUDGE_FREQUENCY_CAP_DAYS,
@@ -23,10 +27,29 @@ import { ACTIVATION_NUDGE_ORIGIN } from "@app/types/assistant/conversation";
 import { isCreditPricedPlan } from "@app/types/plan";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
 import isNumber from "lodash/isNumber";
 
-const ACTIVATION_NUDGE_PROMPT = "Run the Dust Learning workflow.";
+function nudgeSkillForKind(kind: ActivationPodKind) {
+  switch (kind) {
+    case "learning":
+      return activationSkill;
+    case "goal":
+      return jobSkill;
+    default:
+      assertNever(kind);
+  }
+}
+
+function nudgePromptForKind(kind: ActivationPodKind): string {
+  const skill = nudgeSkillForKind(kind);
+  return serializeSkillTag({
+    id: skill.sId,
+    name: skill.name,
+    icon: skill.icon,
+  });
+}
 
 // A resource type that the activation nudge should drive the user toward
 export type ActivationNudgePushedResourceType = "skill" | "agent";
@@ -192,7 +215,13 @@ export async function isEligibleForNudge(
 // and never surface it.
 function buildActivationNudgeContent(
   agentConfiguration: AgentConfigurationType,
-  context: ActivationNudgeContext | undefined
+  {
+    kind,
+    context,
+  }: {
+    kind: ActivationPodKind;
+    context: ActivationNudgeContext | undefined;
+  }
 ): string {
   const contextLines = removeNulls([
     context?.sessionGoal ? `Session goal: ${context.sessionGoal}` : null,
@@ -206,7 +235,7 @@ function buildActivationNudgeContent(
   ]);
 
   const content =
-    serializeMention(agentConfiguration) + `\n\n${ACTIVATION_NUDGE_PROMPT}`;
+    serializeMention(agentConfiguration) + `\n\n${nudgePromptForKind(kind)}`;
   if (contextLines.length === 0) {
     return content;
   }
@@ -280,7 +309,10 @@ export async function postActivationNudge(
 
   const messageRes = await postUserMessage(userAuth, {
     conversationResource: conversation,
-    content: buildActivationNudgeContent(agentConfiguration, context),
+    content: buildActivationNudgeContent(agentConfiguration, {
+      kind: activationPod.kind,
+      context,
+    }),
     mentions: [{ configurationId: agentConfiguration.sId }],
     context: {
       timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",

--- a/front/lib/api/activation/pods.test.ts
+++ b/front/lib/api/activation/pods.test.ts
@@ -36,4 +36,33 @@ describe("listActivationPodsByUser", () => {
 
     expect(byUser.get(user.id)?.pod.sId).toBe(pod.sId);
   });
+
+  it("selects Learning Spaces by explicit kind", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+    const activationSpace = await SpaceFactory.project(workspace, user.id);
+    const goalSpace = await SpaceFactory.project(workspace, user.id);
+    await ProjectMetadataResource.makeNew(authenticator, activationSpace, {
+      description: "A normal project description",
+    });
+    await ProjectMetadataResource.makeNew(authenticator, goalSpace, {
+      description: null,
+    });
+    await ActivationPodResource.makeNew(authenticator, {
+      pod: activationSpace,
+      user,
+    });
+    await ActivationPodResource.makeNew(authenticator, {
+      pod: goalSpace,
+      user,
+      kind: "goal",
+    });
+
+    const activationPods = await listActivationPodsByUser(authenticator, {
+      kind: "learning",
+    });
+
+    expect(activationPods.get(user.id)?.pod.sId).toBe(activationSpace.sId);
+  });
 });

--- a/front/lib/api/activation/pods.ts
+++ b/front/lib/api/activation/pods.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -8,14 +9,17 @@ export type ActivationPodWithSpace = {
   activationPod: ActivationPodResource;
 };
 
-// Maps each user who owns an Activation Pod to that pod. Used to decide, per
-// target user, whether to provision a fresh pod or nudge an existing one.
+// Maps each user to one Activation Pod of the given kind. Defaults to the
+// Learning Space, matching GET /activation-pod with no podId.
 export async function listActivationPodsByUser(
-  auth: Authenticator
+  auth: Authenticator,
+  { kind = "learning" }: { kind?: ActivationPodKind } = {}
 ): Promise<Map<ModelId, ActivationPodWithSpace>> {
   const byUser = new Map<ModelId, ActivationPodWithSpace>();
 
-  const activationPods = await ActivationPodResource.listForWorkspace(auth);
+  const activationPods = await ActivationPodResource.listForWorkspace(auth, {
+    kind,
+  });
   if (activationPods.length === 0) {
     return byUser;
   }

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import type { ActivationRecommendationStatus } from "@app/lib/models/activation/activation_recommendation";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { ActivationRecommendationResource } from "@app/lib/resources/activation_recommendation_resource";
@@ -27,21 +28,26 @@ export interface GetActivationRecommendationsResponseBody {
 
 export interface GetActivationPodResponseBody {
   podId: string | null;
+  kind: ActivationPodKind | null;
 }
 
 export async function getActivationPodInfo(
   auth: Authenticator
 ): Promise<GetActivationPodResponseBody> {
-  const activationPod = await ActivationPodResource.fetchByUser(auth);
-  if (!activationPod) {
-    return { podId: null };
+  const allPods = await ActivationPodResource.listByUser(auth);
+  const learningPod = allPods.find((p) => p.kind === "learning") ?? null;
+  if (!learningPod) {
+    return { podId: null, kind: null };
   }
-
+  const [pod] = await SpaceResource.fetchByModelIds(auth, [
+    learningPod.spaceId,
+  ]);
+  if (!pod) {
+    return { podId: null, kind: null };
+  }
   return {
-    podId: SpaceResource.modelIdToSId({
-      id: activationPod.spaceId,
-      workspaceId: activationPod.workspaceId,
-    }),
+    podId: pod.sId,
+    kind: "learning",
   };
 }
 

--- a/front/lib/api/poke/plugins/spaces/activation_management.test.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.test.ts
@@ -221,8 +221,8 @@ describe("activationManagementPlugin.execute", () => {
     expect(mockStartActivationWorkspaceWorkflow).not.toHaveBeenCalled();
   });
 
-  it("provisions a fresh Goal Pod and bootstraps its first recommendation", async () => {
-    const { adminAuth, editor } = await makeWorkspaceWithEditor();
+  it("provisions a fresh Goal Pod and queues it into Temporal", async () => {
+    const { workspace, adminAuth, editor } = await makeWorkspaceWithEditor();
     const goal = "Beat the quarterly revenue plan";
 
     const result = await activationManagementPlugin.execute(adminAuth, null, {
@@ -241,16 +241,21 @@ describe("activationManagementPlugin.execute", () => {
       expect.objectContaining({ kind: "goal" })
     );
     expect(ActivationWorkAreaResource.makeNew).not.toHaveBeenCalled();
-    expect(mockStartActivationWorkspaceWorkflow).not.toHaveBeenCalled();
-
-    const nudgeArgs = mockPostActivationNudge.mock.calls[0]?.[1];
-    expect(nudgeArgs?.context.workAreas).toBe(goal);
-    expect(nudgeArgs?.context.sessionGoal).toContain("job contract");
-    expect(nudgeArgs?.context.activationPlaybook).toContain("Decide ownership");
+    expect(mockPostActivationNudge).not.toHaveBeenCalled();
+    expect(mockStartActivationWorkspaceWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: workspace.sId,
+        userIds: [editor.sId],
+        context: expect.objectContaining({
+          workAreas: goal,
+          sessionGoal: expect.stringContaining("job contract"),
+        }),
+      })
+    );
   });
 
-  it("reuses an existing Goal Pod and nudges it when Force recreate is off", async () => {
-    const { adminAuth, editor } = await makeWorkspaceWithEditor();
+  it("reuses an existing Goal Pod and queues it when Force recreate is off", async () => {
+    const { workspace, adminAuth, editor } = await makeWorkspaceWithEditor();
     const existingPod = await SpaceFactory.project(
       adminAuth.getNonNullableWorkspace(),
       editor.id,
@@ -276,11 +281,11 @@ describe("activationManagementPlugin.execute", () => {
 
     expect(result.isOk()).toBe(true);
     expect(ActivationPodResource.makeNew).not.toHaveBeenCalled();
-    expect(mockStartActivationWorkspaceWorkflow).not.toHaveBeenCalled();
-    expect(mockPostActivationNudge).toHaveBeenCalledWith(
-      expect.anything(),
+    expect(mockPostActivationNudge).not.toHaveBeenCalled();
+    expect(mockStartActivationWorkspaceWorkflow).toHaveBeenCalledWith(
       expect.objectContaining({
-        pod: existingPod,
+        workspaceId: workspace.sId,
+        userIds: [editor.sId],
         context: expect.objectContaining({
           workAreas: goalPluginArgs.goal,
         }),

--- a/front/lib/api/poke/plugins/spaces/activation_management.test.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.test.ts
@@ -1,9 +1,11 @@
 import { activationManagementPlugin } from "@app/lib/api/poke/plugins/spaces/activation_management";
 import { Authenticator } from "@app/lib/auth";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
+import { ActivationWorkAreaResource } from "@app/lib/resources/activation_work_area_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
@@ -11,16 +13,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   mockListActivationPodsByUser,
+  mockPostActivationNudge,
   mockStartActivationWorkspaceSchedule,
   mockStartActivationWorkspaceWorkflow,
 } = vi.hoisted(() => ({
   mockListActivationPodsByUser: vi.fn(),
+  mockPostActivationNudge: vi.fn(),
   mockStartActivationWorkspaceSchedule: vi.fn(),
   mockStartActivationWorkspaceWorkflow: vi.fn(),
 }));
 
 vi.mock("@app/lib/api/activation/pods", () => ({
   listActivationPodsByUser: mockListActivationPodsByUser,
+}));
+
+vi.mock("@app/lib/api/activation/nudge", () => ({
+  postActivationNudge: mockPostActivationNudge,
 }));
 
 vi.mock("@app/temporal/activation_scheduler/client", () => ({
@@ -30,11 +38,13 @@ vi.mock("@app/temporal/activation_scheduler/client", () => ({
 
 beforeEach(async () => {
   mockListActivationPodsByUser.mockReset();
+  mockPostActivationNudge.mockReset();
   mockStartActivationWorkspaceSchedule.mockReset();
   mockStartActivationWorkspaceWorkflow.mockReset();
 
   // No user has a pod yet, so every target is provisioned fresh.
   mockListActivationPodsByUser.mockResolvedValue(new Map());
+  mockPostActivationNudge.mockResolvedValue(new Ok(undefined));
   mockStartActivationWorkspaceSchedule.mockResolvedValue(new Ok(undefined));
   mockStartActivationWorkspaceWorkflow.mockResolvedValue(
     new Ok("activation-workspace-test-manual-1")
@@ -42,8 +52,11 @@ beforeEach(async () => {
 
   // The canonical ActivationPod row is orthogonal to the schedule lifecycle
   // under test. Stub it out.
-  vi.spyOn(ActivationPodResource, "makeNew").mockResolvedValue(
-    {} as ActivationPodResource
+  vi.spyOn(ActivationPodResource, "makeNew").mockResolvedValue({
+    id: 123,
+  } as ActivationPodResource);
+  vi.spyOn(ActivationWorkAreaResource, "makeNew").mockResolvedValue(
+    {} as ActivationWorkAreaResource
   );
 
   // Pod creation kicks off a real (external) dust_project connector; stub it
@@ -81,6 +94,8 @@ async function makeWorkspaceWithEditor({
 }
 
 const pluginArgs = {
+  podType: ["learning"] as string[],
+  goal: "",
   groupId: [] as string[],
   sessionGoal: "",
   pushedResource: [] as string[],
@@ -92,6 +107,13 @@ const pluginArgs = {
   pctNotActivated: 0,
   forceRecreate: false,
   overrideChecks: false,
+};
+
+const goalPluginArgs = {
+  ...pluginArgs,
+  podType: ["goal"],
+  goal: "Beat the quarterly revenue plan",
+  guidance: ["none"],
 };
 
 describe("activationManagementPlugin.execute", () => {
@@ -197,5 +219,72 @@ describe("activationManagementPlugin.execute", () => {
       expect(result.error.message).toContain("temporal unavailable");
     }
     expect(mockStartActivationWorkspaceWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("provisions a fresh Goal Pod and bootstraps its first recommendation", async () => {
+    const { adminAuth, editor } = await makeWorkspaceWithEditor();
+    const goal = "Beat the quarterly revenue plan";
+
+    const result = await activationManagementPlugin.execute(adminAuth, null, {
+      ...goalPluginArgs,
+      goal,
+      targetUserIds: [editor.sId],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(mockListActivationPodsByUser).toHaveBeenCalledWith(
+      expect.anything(),
+      { kind: "goal" }
+    );
+    expect(ActivationPodResource.makeNew).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ kind: "goal" })
+    );
+    expect(ActivationWorkAreaResource.makeNew).not.toHaveBeenCalled();
+    expect(mockStartActivationWorkspaceWorkflow).not.toHaveBeenCalled();
+
+    const nudgeArgs = mockPostActivationNudge.mock.calls[0]?.[1];
+    expect(nudgeArgs?.context.workAreas).toBe(goal);
+    expect(nudgeArgs?.context.sessionGoal).toContain("job contract");
+    expect(nudgeArgs?.context.activationPlaybook).toContain("Decide ownership");
+  });
+
+  it("reuses an existing Goal Pod and nudges it when Force recreate is off", async () => {
+    const { adminAuth, editor } = await makeWorkspaceWithEditor();
+    const existingPod = await SpaceFactory.project(
+      adminAuth.getNonNullableWorkspace(),
+      editor.id,
+      { name: "Existing Goal Pod" }
+    );
+    mockListActivationPodsByUser.mockResolvedValue(
+      new Map([
+        [
+          editor.id,
+          {
+            pod: existingPod,
+            activationPod: { id: 99 } as ActivationPodResource,
+          },
+        ],
+      ])
+    );
+    vi.mocked(ActivationPodResource.makeNew).mockClear();
+
+    const result = await activationManagementPlugin.execute(adminAuth, null, {
+      ...goalPluginArgs,
+      targetUserIds: [editor.sId],
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(ActivationPodResource.makeNew).not.toHaveBeenCalled();
+    expect(mockStartActivationWorkspaceWorkflow).not.toHaveBeenCalled();
+    expect(mockPostActivationNudge).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        pod: existingPod,
+        context: expect.objectContaining({
+          workAreas: goalPluginArgs.goal,
+        }),
+      })
+    );
   });
 });

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -634,31 +634,30 @@ export const activationManagementPlugin = createPlugin({
     }
     const pushed = resolvedPushedResource.value;
 
-    const context: ActivationNudgeContext = isGoalPod
-      ? {
-          sessionGoal: GOAL_POD_BOOTSTRAP_SESSION_GOAL,
-          pushedResourceType: null,
-          pushedResourceName: null,
-          workAreas: declaredIntent,
-          activationPlaybook: GOAL_POD_BOOTSTRAP_PLAYBOOK,
-        }
-      : useGuidance
-        ? {
-            sessionGoal: sessionGoal?.trim() ? sessionGoal.trim() : null,
-            pushedResourceType: pushed?.type ?? null,
-            pushedResourceName: pushed?.name ?? null,
-            workAreas: workAreas?.trim() ? workAreas.trim() : null,
-            activationPlaybook: activationPlaybook?.trim()
-              ? activationPlaybook.trim()
-              : null,
-          }
-        : {
-            sessionGoal: null,
-            pushedResourceType: null,
-            pushedResourceName: null,
-            workAreas: null,
-            activationPlaybook: null,
-          };
+    let context: ActivationNudgeContext = {
+      sessionGoal: null,
+      pushedResourceType: null,
+      pushedResourceName: null,
+      workAreas: null,
+      activationPlaybook: null,
+    };
+    if (isGoalPod) {
+      context = {
+        sessionGoal: GOAL_POD_BOOTSTRAP_SESSION_GOAL,
+        pushedResourceType: null,
+        pushedResourceName: null,
+        workAreas: declaredIntent,
+        activationPlaybook: GOAL_POD_BOOTSTRAP_PLAYBOOK,
+      };
+    } else if (useGuidance) {
+      context = {
+        sessionGoal: sessionGoal?.trim() || null,
+        pushedResourceType: pushed?.type ?? null,
+        pushedResourceName: pushed?.name ?? null,
+        workAreas: workAreas?.trim() || null,
+        activationPlaybook: activationPlaybook?.trim() || null,
+      };
+    }
 
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId,

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -3,7 +3,6 @@ import type {
   ActivationNudgeContext,
   ActivationNudgePushedResourceType,
 } from "@app/lib/api/activation/nudge";
-import { postActivationNudge } from "@app/lib/api/activation/nudge";
 import { listActivationPodsByUser } from "@app/lib/api/activation/pods";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
@@ -273,7 +272,7 @@ async function provisionTrainingPod(
 type TargetOutcome = {
   name: string;
   userId: string;
-  status: "provisioned" | "recreated" | "queued" | "nudged" | "failed";
+  status: "provisioned" | "recreated" | "queued" | "failed";
   podLink?: string;
   message?: string;
 };
@@ -682,35 +681,8 @@ export const activationManagementPlugin = createPlugin({
       const existing = existingPodsByUser.get(user.id);
 
       // Reuse path: the user already has a Pod of this kind and we're not
-      // recreating it. Learning Spaces are queued into the shared Temporal
-      // workflow. Goal Pods are nudged immediately — they skip the Learning
-      // eligibility gates.
+      // recreating it — queue them for the shared Temporal workflow.
       if (existing && !forceRecreate) {
-        if (isGoalPod) {
-          const nudgeResult = await postActivationNudge(adminAuth, {
-            pod: existing.pod,
-            activationPod: existing.activationPod,
-            context,
-          });
-          if (nudgeResult.isErr()) {
-            outcomes.push({
-              name,
-              userId: user.sId,
-              status: "failed",
-              message: `reused existing Goal Pod but failed to nudge: ${nudgeResult.error.message}`,
-              podLink: podLink(existing.pod),
-            });
-            continue;
-          }
-          outcomes.push({
-            name,
-            userId: user.sId,
-            status: "nudged",
-            podLink: podLink(existing.pod),
-          });
-          continue;
-        }
-
         outcomes.push({
           name,
           userId: user.sId,
@@ -758,24 +730,7 @@ export const activationManagementPlugin = createPlugin({
         continue;
       }
 
-      const { pod, activationPod } = provisionResult.value;
-      if (isGoalPod) {
-        const nudgeResult = await postActivationNudge(adminAuth, {
-          pod,
-          activationPod,
-          context,
-        });
-        if (nudgeResult.isErr()) {
-          outcomes.push({
-            name,
-            userId: user.sId,
-            status: "failed",
-            message: `${recreated ? "recreated" : "provisioned"} but failed to nudge: ${nudgeResult.error.message}`,
-            podLink: podLink(pod),
-          });
-          continue;
-        }
-      }
+      const { pod } = provisionResult.value;
 
       outcomes.push({
         name,
@@ -788,13 +743,8 @@ export const activationManagementPlugin = createPlugin({
     const provisioned = outcomes.filter((o) => o.status === "provisioned");
     const recreated = outcomes.filter((o) => o.status === "recreated");
     const queued = outcomes.filter((o) => o.status === "queued");
-    const nudged = outcomes.filter((o) => o.status === "nudged");
     const failed = outcomes.filter((o) => o.status === "failed");
-    // Goal Pods are nudged inline above. Learning Spaces go through Temporal
-    // so the same eligibility gates as the daily scheduler apply.
-    const toNudge = isGoalPod
-      ? []
-      : outcomes.filter((o) => o.status !== "failed");
+    const toNudge = outcomes.filter((o) => o.status !== "failed");
 
     let workflowId: string | null = null;
     if (toNudge.length > 0) {
@@ -823,7 +773,6 @@ export const activationManagementPlugin = createPlugin({
         provisionedCount: provisioned.length,
         recreatedCount: recreated.length,
         queuedCount: queued.length,
-        nudgedCount: nudged.length,
         failedCount: failed.length,
         forceRecreate: Boolean(forceRecreate),
         overrideChecks: Boolean(overrideChecks),

--- a/front/lib/api/poke/plugins/spaces/activation_management.ts
+++ b/front/lib/api/poke/plugins/spaces/activation_management.ts
@@ -3,6 +3,7 @@ import type {
   ActivationNudgeContext,
   ActivationNudgePushedResourceType,
 } from "@app/lib/api/activation/nudge";
+import { postActivationNudge } from "@app/lib/api/activation/nudge";
 import { listActivationPodsByUser } from "@app/lib/api/activation/pods";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
@@ -12,6 +13,7 @@ import {
   softDeleteSpaceAndLaunchScrubWorkflow,
 } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
+import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import { ActivationPodResource } from "@app/lib/resources/activation_pod_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
@@ -32,10 +34,17 @@ import { removeNulls } from "@app/types/shared/utils/general";
 import { createHash } from "crypto";
 
 const LEARNING_SPACE_NAME_SUFFIX = "'s Learning Space";
+const GOAL_POD_NAME_SUFFIX = "'s Goal Pod";
 
 const activationManagementLogger = logger.child({
   activity: "activation-management",
 });
+
+const GOAL_POD_BOOTSTRAP_SESSION_GOAL =
+  "Establish the job contract and the first evidence-backed next move, or confirm that none is warranted yet.";
+
+const GOAL_POD_BOOTSTRAP_PLAYBOOK =
+  "This is a newly provisioned Pod. Work areas in the opening block are raw input, not a work area — do not store them verbatim. Interpret them, then decide: durable job contract(s) become Work Areas; operating context (formula, sources, authority, how to judge progress) goes in AGENTS.md; a Skill only if that is the actual highest-value next action after diagnosis, not as a dump of the intent. Time horizons (now / this quarter / this year) may inform diagnosis; they are not separate Work Areas. Diagnose from connected sources. Select one bounded next action only if evidence supports it. Decide ownership (Dust vs human) after selecting the action, then present accordingly. Do not produce a full plan.";
 
 // A skill or agent the nudge should drive the user toward. Encoded in the
 // picker as "skill:<sId>" / "agent:<sId>" so one control can offer both.
@@ -71,7 +80,8 @@ function parsePushedResource(
 // run, the colliding pods fall back to the owner's email for disambiguation.
 function learningSpaceNameForCreator(
   creator: UserResource,
-  otherUsers: UserResource[]
+  otherUsers: UserResource[],
+  kind: ActivationPodKind
 ): string {
   const creatorFullName = creator.fullName();
   const hasNameCollision = otherUsers.some(
@@ -79,7 +89,9 @@ function learningSpaceNameForCreator(
   );
 
   const label = hasNameCollision ? creator.email : creatorFullName;
-  return `${label}${LEARNING_SPACE_NAME_SUFFIX}`;
+  const suffix =
+    kind === "goal" ? GOAL_POD_NAME_SUFFIX : LEARNING_SPACE_NAME_SUFFIX;
+  return `${label}${suffix}`;
 }
 
 function cohortBucket(workspaceSId: string, userId: string): number {
@@ -96,7 +108,12 @@ async function selectCohortUserSIds(
   {
     pctActivated,
     pctNotActivated,
-  }: { pctActivated: number; pctNotActivated: number }
+    kind = "learning",
+  }: {
+    pctActivated: number;
+    pctNotActivated: number;
+    kind?: ActivationPodKind;
+  }
 ): Promise<Result<string[], Error>> {
   const workspace = auth.getNonNullableWorkspace();
 
@@ -107,7 +124,7 @@ async function selectCohortUserSIds(
     memberships.map((membership) => membership.userId)
   );
 
-  const podsByUser = await listActivationPodsByUser(auth);
+  const podsByUser = await listActivationPodsByUser(auth, { kind });
   const cohort = members.filter((member) => !podsByUser.has(member.id));
   if (cohort.length === 0) {
     return new Ok([]);
@@ -196,15 +213,17 @@ async function provisionTrainingPod(
   {
     creator,
     otherUsers,
+    kind,
   }: {
     creator: UserResource;
     otherUsers: UserResource[];
+    kind: ActivationPodKind;
   }
 ): Promise<
   Result<{ pod: SpaceResource; activationPod: ActivationPodResource }, Error>
 > {
   const workspace = auth.getNonNullableWorkspace();
-  const podName = learningSpaceNameForCreator(creator, otherUsers);
+  const podName = learningSpaceNameForCreator(creator, otherUsers, kind);
 
   const creatorAuth = await Authenticator.fromUserIdAndWorkspaceId(
     creator.sId,
@@ -222,7 +241,9 @@ async function provisionTrainingPod(
   }
   const pod = createResult.value;
 
-  await pinActivationSkill(auth, pod);
+  if (kind === "learning") {
+    await pinActivationSkill(auth, pod);
+  }
 
   // Record the canonical ActivationPod row now that the pod's owner is known.
   // `isEligibleForNudge` and the activation scheduler rely on this row to find
@@ -230,6 +251,7 @@ async function provisionTrainingPod(
   const activationPod = await ActivationPodResource.makeNew(auth, {
     pod,
     user: creator,
+    kind,
   });
 
   // Ensure the workspace has a running Activation schedule now that it has a
@@ -251,7 +273,7 @@ async function provisionTrainingPod(
 type TargetOutcome = {
   name: string;
   userId: string;
-  status: "provisioned" | "recreated" | "queued" | "failed";
+  status: "provisioned" | "recreated" | "queued" | "nudged" | "failed";
   podLink?: string;
   message?: string;
 };
@@ -274,10 +296,29 @@ export const activationManagementPlugin = createPlugin({
       "Work Areas for the first conversation. Check 'Force " +
       "recreate' to delete and rebuild an existing Pod from scratch. " +
       "Use 'Who to target' to pick specific users, a group, or a deterministic " +
-      "percentage cohort of active members who don't have a Pod yet.",
+      "percentage cohort of active members who don't have a Pod yet. " +
+      "Choose [Experimental] Goal Pod to keep a job moving instead of training someone on Dust.",
     resourceTypes: ["workspaces"],
     warning: "Large groups can take several minutes.",
     args: {
+      podType: {
+        type: "enum",
+        label: "Pod type",
+        description:
+          "A Learning Space helps someone get going on Dust. A Goal Pod keeps a job moving.",
+        values: [
+          { label: "Learning Space", value: "learning", checked: true },
+          { label: "[Experimental] Goal Pod", value: "goal" },
+        ],
+        multiple: false,
+      },
+      goal: {
+        type: "text",
+        label: "What should this Pod keep working on?",
+        description:
+          "Intent for the first conversation to interpret. Not stored as a work area as-is.",
+        dependsOn: { field: "podType", value: "goal" },
+      },
       targetingMode: {
         type: "enum",
         label: "Who to target",
@@ -353,6 +394,7 @@ export const activationManagementPlugin = createPlugin({
           { label: "Provide curated guidance", value: "curated" },
         ],
         multiple: false,
+        dependsOn: { field: "podType", value: "learning" },
       },
       sessionGoal: {
         type: "text",
@@ -461,6 +503,8 @@ export const activationManagementPlugin = createPlugin({
     auth,
     _resource,
     {
+      podType,
+      goal,
       targetingMode,
       targetUserIds,
       groupId,
@@ -476,6 +520,16 @@ export const activationManagementPlugin = createPlugin({
     }
   ) => {
     const workspace = auth.getNonNullableWorkspace();
+    const kind = podType?.[0] === "goal" ? "goal" : "learning";
+    const isGoalPod = kind === "goal";
+    const declaredIntent = goal?.trim() || null;
+
+    if (isGoalPod && !declaredIntent) {
+      return new Err(new Error("Say what this Pod should keep working on."));
+    }
+    if (declaredIntent && declaredIntent.length > 512) {
+      return new Err(new Error("Keep that under 512 characters."));
+    }
 
     if (auth.plan()?.isByok && !overrideChecks) {
       return new Err(
@@ -501,6 +555,7 @@ export const activationManagementPlugin = createPlugin({
       const cohortResult = await selectCohortUserSIds(auth, {
         pctActivated: pctActivatedValue,
         pctNotActivated: pctNotActivatedValue,
+        kind,
       });
       if (cohortResult.isErr()) {
         return cohortResult;
@@ -565,10 +620,12 @@ export const activationManagementPlugin = createPlugin({
       );
     }
 
-    // The curated fields only apply when the operator opts into providing
-    // guidance; otherwise the nudge runs with no injected context and the agent
-    // researches the user on its own.
-    const useGuidance = guidance?.[0] === "curated";
+    // The curated fields only apply to Learning Spaces when the operator opts
+    // into providing guidance; otherwise the nudge runs with no injected
+    // context and the agent researches the user on its own. Goal Pods always
+    // use the bootstrap playbook, and send declared intent on `workAreas` —
+    // the Goal skill interprets that as raw input, not a work area as-is.
+    const useGuidance = !isGoalPod && guidance?.[0] === "curated";
 
     const resolvedPushedResource = useGuidance
       ? await resolvePushedResource(auth, pushedResource?.[0])
@@ -578,31 +635,40 @@ export const activationManagementPlugin = createPlugin({
     }
     const pushed = resolvedPushedResource.value;
 
-    const context: ActivationNudgeContext = useGuidance
+    const context: ActivationNudgeContext = isGoalPod
       ? {
-          sessionGoal: sessionGoal?.trim() ? sessionGoal.trim() : null,
-          pushedResourceType: pushed?.type ?? null,
-          pushedResourceName: pushed?.name ?? null,
-          workAreas: workAreas?.trim() ? workAreas.trim() : null,
-          activationPlaybook: activationPlaybook?.trim()
-            ? activationPlaybook.trim()
-            : null,
-        }
-      : {
-          sessionGoal: null,
+          sessionGoal: GOAL_POD_BOOTSTRAP_SESSION_GOAL,
           pushedResourceType: null,
           pushedResourceName: null,
-          workAreas: null,
-          activationPlaybook: null,
-        };
+          workAreas: declaredIntent,
+          activationPlaybook: GOAL_POD_BOOTSTRAP_PLAYBOOK,
+        }
+      : useGuidance
+        ? {
+            sessionGoal: sessionGoal?.trim() ? sessionGoal.trim() : null,
+            pushedResourceType: pushed?.type ?? null,
+            pushedResourceName: pushed?.name ?? null,
+            workAreas: workAreas?.trim() ? workAreas.trim() : null,
+            activationPlaybook: activationPlaybook?.trim()
+              ? activationPlaybook.trim()
+              : null,
+          }
+        : {
+            sessionGoal: null,
+            pushedResourceType: null,
+            pushedResourceName: null,
+            workAreas: null,
+            activationPlaybook: null,
+          };
 
     const adminAuth = await Authenticator.internalAdminForWorkspace(
       workspace.sId,
       { dangerouslyRequestAllGroups: true }
     );
 
-    // Decide per user whether to provision or nudge based on existing pods.
-    const existingPodsByUser = await listActivationPodsByUser(adminAuth);
+    const existingPodsByUser = await listActivationPodsByUser(adminAuth, {
+      kind,
+    });
 
     const podLink = (space: SpaceResource) =>
       `/poke/${workspace.sId}/spaces/${space.sId}`;
@@ -615,9 +681,36 @@ export const activationManagementPlugin = createPlugin({
 
       const existing = existingPodsByUser.get(user.id);
 
-      // Reuse path: the user already has a Pod and we're not recreating it —
-      // queue them for the shared Temporal workflow.
+      // Reuse path: the user already has a Pod of this kind and we're not
+      // recreating it. Learning Spaces are queued into the shared Temporal
+      // workflow. Goal Pods are nudged immediately — they skip the Learning
+      // eligibility gates.
       if (existing && !forceRecreate) {
+        if (isGoalPod) {
+          const nudgeResult = await postActivationNudge(adminAuth, {
+            pod: existing.pod,
+            activationPod: existing.activationPod,
+            context,
+          });
+          if (nudgeResult.isErr()) {
+            outcomes.push({
+              name,
+              userId: user.sId,
+              status: "failed",
+              message: `reused existing Goal Pod but failed to nudge: ${nudgeResult.error.message}`,
+              podLink: podLink(existing.pod),
+            });
+            continue;
+          }
+          outcomes.push({
+            name,
+            userId: user.sId,
+            status: "nudged",
+            podLink: podLink(existing.pod),
+          });
+          continue;
+        }
+
         outcomes.push({
           name,
           userId: user.sId,
@@ -650,9 +743,10 @@ export const activationManagementPlugin = createPlugin({
       }
 
       const otherUsers = users.filter((u) => u.sId !== user.sId);
-      const provisionResult = await provisionTrainingPod(auth, {
+      const provisionResult = await provisionTrainingPod(adminAuth, {
         creator: user,
         otherUsers,
+        kind,
       });
       if (provisionResult.isErr()) {
         outcomes.push({
@@ -664,7 +758,25 @@ export const activationManagementPlugin = createPlugin({
         continue;
       }
 
-      const { pod } = provisionResult.value;
+      const { pod, activationPod } = provisionResult.value;
+      if (isGoalPod) {
+        const nudgeResult = await postActivationNudge(adminAuth, {
+          pod,
+          activationPod,
+          context,
+        });
+        if (nudgeResult.isErr()) {
+          outcomes.push({
+            name,
+            userId: user.sId,
+            status: "failed",
+            message: `${recreated ? "recreated" : "provisioned"} but failed to nudge: ${nudgeResult.error.message}`,
+            podLink: podLink(pod),
+          });
+          continue;
+        }
+      }
+
       outcomes.push({
         name,
         userId: user.sId,
@@ -676,8 +788,13 @@ export const activationManagementPlugin = createPlugin({
     const provisioned = outcomes.filter((o) => o.status === "provisioned");
     const recreated = outcomes.filter((o) => o.status === "recreated");
     const queued = outcomes.filter((o) => o.status === "queued");
+    const nudged = outcomes.filter((o) => o.status === "nudged");
     const failed = outcomes.filter((o) => o.status === "failed");
-    const toNudge = outcomes.filter((o) => o.status !== "failed");
+    // Goal Pods are nudged inline above. Learning Spaces go through Temporal
+    // so the same eligibility gates as the daily scheduler apply.
+    const toNudge = isGoalPod
+      ? []
+      : outcomes.filter((o) => o.status !== "failed");
 
     let workflowId: string | null = null;
     if (toNudge.length > 0) {
@@ -701,10 +818,12 @@ export const activationManagementPlugin = createPlugin({
       {
         action: "activation_management",
         workspaceId: workspace.sId,
+        kind,
         targetCount: users.length,
         provisionedCount: provisioned.length,
         recreatedCount: recreated.length,
         queuedCount: queued.length,
+        nudgedCount: nudged.length,
         failedCount: failed.length,
         forceRecreate: Boolean(forceRecreate),
         overrideChecks: Boolean(overrideChecks),
@@ -716,12 +835,16 @@ export const activationManagementPlugin = createPlugin({
     );
 
     const lines: string[] = [];
-    const focus = removeNulls([
-      context.sessionGoal ? `session goal "${context.sessionGoal}"` : null,
-      context.pushedResourceName
-        ? `pushing the "${context.pushedResourceName}" ${context.pushedResourceType}`
-        : null,
-    ]);
+    const focus = isGoalPod
+      ? removeNulls([
+          declaredIntent ? `declared intent "${declaredIntent}"` : null,
+        ])
+      : removeNulls([
+          context.sessionGoal ? `session goal "${context.sessionGoal}"` : null,
+          context.pushedResourceName
+            ? `pushing the "${context.pushedResourceName}" ${context.pushedResourceType}`
+            : null,
+        ]);
     lines.push(
       `Processed ${users.length} user(s)` +
         (focus.length > 0 ? ` — ${focus.join(", ")}.` : ".")
@@ -741,7 +864,7 @@ export const activationManagementPlugin = createPlugin({
       }
     }
 
-    if (failed.length > 0 && toNudge.length === 0) {
+    if (failed.length > 0 && failed.length === outcomes.length) {
       return new Err(new Error(lines.join("\n")));
     }
 

--- a/front/lib/resources/activation_pod_resource.test.ts
+++ b/front/lib/resources/activation_pod_resource.test.ts
@@ -34,6 +34,31 @@ describe("ActivationPodResource", () => {
     projectSpace = await SpaceFactory.project(workspace);
   });
 
+  describe("kind", () => {
+    it("defaults to learning", async () => {
+      const user = await UserFactory.basic();
+
+      const pod = await makeActivationPod(auth, projectSpace, user);
+
+      expect(pod.kind).toBe("learning");
+    });
+
+    it("stores goal Pods explicitly", async () => {
+      const user = await UserFactory.basic();
+      await ProjectMetadataResource.makeNew(auth, projectSpace, {
+        description: null,
+      });
+
+      const pod = await ActivationPodResource.makeNew(auth, {
+        pod: projectSpace,
+        user,
+        kind: "goal",
+      });
+
+      expect(pod.kind).toBe("goal");
+    });
+  });
+
   describe("listWorkspaceModelIdsWithActivationPods", () => {
     it("returns the workspace of an activation pod", async () => {
       const user = await UserFactory.basic();

--- a/front/lib/resources/activation_pod_resource.ts
+++ b/front/lib/resources/activation_pod_resource.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import { ActivationPodModel } from "@app/lib/models/activation/activation_pod";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
@@ -52,15 +53,18 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     {
       pod,
       user,
+      kind = "learning",
     }: {
       pod: SpaceResource;
       user: UserResource;
+      kind?: ActivationPodKind;
     }
   ): Promise<ActivationPodResource> {
     const model = await this.model.create({
       workspaceId: auth.getNonNullableWorkspace().id,
       spaceId: pod.id,
       userId: user.id,
+      kind,
     });
 
     return new this(this.model, model.get());
@@ -169,13 +173,16 @@ export class ActivationPodResource extends BaseResource<ActivationPodModel> {
     return activationPods.map((pod) => new this(this.model, pod.get()));
   }
 
-  // Lists every live Activation Pod in the calling workspace.
+  // Lists live Activation Pods in the calling workspace. Pass `kind` to
+  // restrict to Learning Spaces or Goal Pods.
   static async listForWorkspace(
-    auth: Authenticator
+    auth: Authenticator,
+    { kind }: { kind?: ActivationPodKind } = {}
   ): Promise<ActivationPodResource[]> {
     const activationPods = await this.model.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
+        ...(kind ? { kind } : {}),
       },
       include: this.unarchivedQuery.include,
     });

--- a/front/lib/resources/activation_recommendation_resource.test.ts
+++ b/front/lib/resources/activation_recommendation_resource.test.ts
@@ -98,6 +98,26 @@ describe("ActivationRecommendationResource", () => {
       expect(recs.length).toBeGreaterThanOrEqual(2);
     });
 
+    it("can isolate recommendations to one activation pod", async () => {
+      const { authenticator, globalSpace, systemSpace } =
+        await createResourceTest({ role: "admin" });
+      const activationPod = await makeActivationPod(authenticator, globalSpace);
+      const goalPod = await makeActivationPod(authenticator, systemSpace);
+      const activationRec = await makeRec(authenticator, {
+        activationPodId: activationPod.id,
+      });
+      await makeRec(authenticator, {
+        activationPodId: goalPod.id,
+      });
+
+      const recs = await ActivationRecommendationResource.fetchByUser(
+        authenticator,
+        { activationPodModelId: activationPod.id }
+      );
+
+      expect(recs.map((rec) => rec.sId)).toEqual([activationRec.sId]);
+    });
+
     it("does not return recommendations from another user in the same workspace", async () => {
       const { workspace, authenticator } = await createResourceTest({
         role: "user",

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -140,13 +140,19 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
 
   static async fetchByUser(
     auth: Authenticator,
-    { limit = 100 }: { limit?: number } = {}
+    {
+      limit = 100,
+      activationPodModelId,
+    }: { limit?: number; activationPodModelId?: number } = {}
   ): Promise<ActivationRecommendationResource[]> {
     const user = auth.getNonNullableUser();
     const recs = await this.model.findAll({
       where: {
         userId: user.id,
         workspaceId: auth.getNonNullableWorkspace().id,
+        ...(activationPodModelId
+          ? { activationPodId: activationPodModelId }
+          : {}),
       },
       order: [["createdAt", "DESC"]],
       limit,


### PR DESCRIPTION
## Summary
- Activation Management poke can provision a Goal Pod
- Goal nudges tag Dust Pod Goal and run immediately
- Reusing poke tool for learning space

## Test plan
<img width="810" height="783" alt="Screenshot 2026-08-24 at 3 57 05 PM" src="https://github.com/user-attachments/assets/08a6a696-50bd-4f2d-a2dd-c98448a50d4e" />

## Risk
Low, poke only


## Deploy
1. Deploy front