### PR TITLE
fix(mcp): enforce feature flag when resolving internal MCP server views

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -29,6 +29,8 @@ app.get(
         "lastError",
         "sharedSecret",
       ],
+      // Poke admin surface: surface a restricted server's view too.
+      includeRestricted: true,
     });
     if (!mcpServerView) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
+++ b/front-api/routes/w/[wId]/mcp/[serverId]/index.ts
@@ -50,9 +50,12 @@ app.get(
     const { serverType, id } = getServerTypeAndIdFromSId(serverId);
     switch (serverType) {
       case "internal": {
+        // Admin management surface: surface an installed-but-restricted server
+        // so it can be inspected and removed even with its flag off.
         const server = await InternalMCPServerInMemoryResource.fetchById(
           auth,
-          serverId
+          serverId,
+          { includeRestricted: true }
         );
 
         if (!server) {
@@ -136,7 +139,8 @@ app.patch(
 
     const internalServer = await InternalMCPServerInMemoryResource.fetchById(
       auth,
-      serverId
+      serverId,
+      { includeRestricted: true }
     );
     if (!internalServer) {
       return apiError(ctx, {
@@ -164,7 +168,9 @@ app.delete(
     const server =
       serverType === "remote"
         ? await RemoteMCPServerResource.fetchById(auth, serverId)
-        : await InternalMCPServerInMemoryResource.fetchById(auth, serverId);
+        : await InternalMCPServerInMemoryResource.fetchById(auth, serverId, {
+            includeRestricted: true,
+          });
 
     if (!server) {
       return apiError(ctx, {

--- a/front-api/routes/w/[wId]/me/approvals.ts
+++ b/front-api/routes/w/[wId]/me/approvals.ts
@@ -39,9 +39,12 @@ app.get("/", async (ctx): HandlerResult<GetUserApprovalsResponseBody> => {
       const { serverType } = getServerTypeAndIdFromSId(validation.mcpServerId);
 
       if (serverType === "internal") {
+        // Display-only: resolve the server name even if its flag is now off so
+        // an existing approval still shows a meaningful label.
         const server = await InternalMCPServerInMemoryResource.fetchById(
           auth,
-          validation.mcpServerId
+          validation.mcpServerId,
+          { includeRestricted: true }
         );
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         serverName = server?.toJSON().name || "Unknown Internal Server";

--- a/front/lib/api/poke/mcp_diagnostics.ts
+++ b/front/lib/api/poke/mcp_diagnostics.ts
@@ -821,9 +821,11 @@ async function resolveServerContext(
 
   let serverViewResource: MCPServerViewResource | null = null;
   if (serverViewId) {
+    // Poke admin diagnostics: surface a restricted server's view too.
     serverViewResource = await MCPServerViewResource.fetchById(
       auth,
-      serverViewId
+      serverViewId,
+      { includeRestricted: true }
     );
     if (!serverViewResource) {
       return {

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -311,15 +311,25 @@ export class InternalMCPServerInMemoryResource {
     return new Ok(1);
   }
 
-  static async fetchById(auth: Authenticator, id: string) {
-    const results = await this.fetchByIds(auth, [id]);
+  static async fetchById(
+    auth: Authenticator,
+    id: string,
+    { includeRestricted = false }: { includeRestricted?: boolean } = {}
+  ) {
+    const results = await this.fetchByIds(auth, [id], { includeRestricted });
 
     return results[0] ?? null;
   }
 
+  // `includeRestricted` opts into surfacing servers gated behind a feature flag
+  // the workspace does not have. It defaults to `false` so a leftover or
+  // force-created view for a restricted server cannot be resolved into runnable
+  // tools (agent loop, skill/action resolution). Only admin management surfaces
+  // that must display an installed-but-restricted server pass `true`.
   static async fetchByIds(
     auth: Authenticator,
-    ids: string[]
+    ids: string[],
+    { includeRestricted = false }: { includeRestricted?: boolean } = {}
   ): Promise<InternalMCPServerInMemoryResource[]> {
     if (ids.length === 0) {
       return [];
@@ -371,16 +381,21 @@ export class InternalMCPServerInMemoryResource {
       })
     );
 
-    // Filter out the names of the servers that are not enabled (e.g. gated behind a feature flag that is not enabled).
+    // Drop servers gated behind a feature flag the workspace does not have
+    // (e.g. a leftover or force-created view for a restricted server), unless
+    // the caller explicitly opts into surfacing them for admin management.
     const enabledServerNames = await this.computeEnabledServerNames(
       auth,
       resolvedIds.map(({ name }) => name)
     );
+    const permittedIds = includeRestricted
+      ? resolvedIds
+      : resolvedIds.filter(({ name }) => enabledServerNames.has(name));
 
     // Fetch the credentials (API keys, headers) for MCP servers that have some.
     const decryptedCredentials = await this.fetchDecryptedCredentialsByIds(
       auth,
-      resolvedIds.map(({ id }) => id)
+      permittedIds.map(({ id }) => id)
     );
     const credentialsById = new Map(
       decryptedCredentials.map((credential) => [
@@ -392,14 +407,14 @@ export class InternalMCPServerInMemoryResource {
       ])
     );
 
-    return resolvedIds.map(({ id, name }) => {
-      if (!enabledServerNames.has(name)) {
+    return permittedIds.map(({ id, name }) => {
+      if (includeRestricted && !enabledServerNames.has(name)) {
         logger.info(
           {
             workspaceId: auth.getNonNullableWorkspace().sId,
             serverName: name,
           },
-          "Initializing restricted internal MCP server from existing view"
+          "Surfacing restricted internal MCP server for admin management"
         );
       }
 

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -942,4 +942,79 @@ describe("MCPServerViewResource", () => {
       expect(json.toolsMetadata).toEqual([]);
     });
   });
+
+  describe("feature-flag enforcement", () => {
+    it("drops views for restricted internal servers unless includeRestricted is set", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+      const globalSpace =
+        await SpaceResource.fetchWorkspaceGlobalSpace(adminAuth);
+
+      // Gate primitive_types_debugger behind a flag, and grant it so the server
+      // and its views can be created — simulating a workspace that had the flag.
+      const originalConfig = INTERNAL_MCP_SERVERS["primitive_types_debugger"];
+      Object.defineProperty(INTERNAL_MCP_SERVERS, "primitive_types_debugger", {
+        value: {
+          ...originalConfig,
+          availability: "auto",
+          isRestricted: ({
+            featureFlags,
+          }: {
+            plan: PlanType;
+            featureFlags: WhitelistableFeature[];
+          }) => !featureFlags.includes("dev_mcp_actions"),
+        },
+        writable: true,
+        configurable: true,
+      });
+      await FeatureFlagFactory.basic(adminAuth, "dev_mcp_actions");
+
+      const internalServer = await InternalMCPServerInMemoryResource.makeNew(
+        adminAuth,
+        { name: "primitive_types_debugger", useCase: null }
+      );
+      const view = await MCPServerViewFactory.create(
+        workspace,
+        internalServer.id,
+        globalSpace
+      );
+
+      // The flag is turned off: the view now resolves to a restricted server.
+      Object.defineProperty(INTERNAL_MCP_SERVERS, "primitive_types_debugger", {
+        value: {
+          ...originalConfig,
+          availability: "auto",
+          isRestricted: () => true,
+        },
+        writable: true,
+        configurable: true,
+      });
+
+      // Default: the restricted view is not resolved into a runnable tool.
+      expect(
+        await MCPServerViewResource.fetchById(adminAuth, view.sId)
+      ).toBeNull();
+      expect(
+        await MCPServerViewResource.fetchByIds(adminAuth, [view.sId])
+      ).toEqual([]);
+
+      // Opt-in: admin surfaces can still surface it for management.
+      const surfaced = await MCPServerViewResource.fetchById(
+        adminAuth,
+        view.sId,
+        { includeRestricted: true }
+      );
+      expect(surfaced).not.toBeNull();
+      expect(surfaced!.sId).toBe(view.sId);
+
+      Object.defineProperty(INTERNAL_MCP_SERVERS, "primitive_types_debugger", {
+        value: originalConfig,
+        writable: true,
+        configurable: true,
+      });
+    });
+  });
 });

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -219,9 +219,12 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       }
       resource.remoteMCPServer = remoteServer;
     } else if (blob.internalMCPServerId) {
+      // Creation is gated upstream (createInternalMCPServer); resolve the server
+      // even when restricted so an admin-installed view can still be built.
       const internalServer = await InternalMCPServerInMemoryResource.fetchById(
         auth,
-        blob.internalMCPServerId
+        blob.internalMCPServerId,
+        { includeRestricted: true }
       );
       if (!internalServer) {
         throw new DustError(
@@ -467,11 +470,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       includeMetadata = true,
       includeHeavyAttributes,
       isRestrictedToSkills,
+      includeRestricted = false,
       transaction,
     }: {
       includeMetadata?: boolean;
       includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
       isRestrictedToSkills?: boolean;
+      // Surface views whose internal server is gated behind a feature flag the
+      // workspace does not have. Defaults to `false` so restricted servers are
+      // not resolved into runnable tools; only admin management surfaces opt in.
+      includeRestricted?: boolean;
       transaction?: Transaction;
     } = {}
   ) {
@@ -514,7 +522,8 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
       const internalServers =
         await InternalMCPServerInMemoryResource.fetchByIds(
           auth,
-          removeNulls(views.map((v) => v.internalMCPServerId))
+          removeNulls(views.map((v) => v.internalMCPServerId)),
+          { includeRestricted }
         );
       const internalServerMap = new Map(internalServers.map((s) => [s.id, s]));
 
@@ -624,6 +633,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     options?: ResourceFindOptions<MCPServerViewModel> & {
       includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
       isRestrictedToSkills?: boolean;
+      includeRestricted?: boolean;
     }
   ): Promise<MCPServerViewResource | null> {
     const [mcpServerView] = await this.fetchByIds(auth, [id], options);
@@ -637,11 +647,16 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
     options?: ResourceFindOptions<MCPServerViewModel> & {
       includeHeavyAttributes?: readonly RemoteMCPServerHeavyAttributeType[];
       isRestrictedToSkills?: boolean;
+      includeRestricted?: boolean;
     }
   ): Promise<MCPServerViewResource[]> {
     const viewModelIds = removeNulls(ids.map((id) => getResourceIdFromSId(id)));
-    const { includeHeavyAttributes, isRestrictedToSkills, ...findOptions } =
-      options ?? {};
+    const {
+      includeHeavyAttributes,
+      isRestrictedToSkills,
+      includeRestricted,
+      ...findOptions
+    } = options ?? {};
 
     const views = await this.baseFetch(
       auth,
@@ -654,7 +669,7 @@ export class MCPServerViewResource extends ResourceWithSpace<MCPServerViewModel>
           },
         },
       },
-      { includeHeavyAttributes, isRestrictedToSkills }
+      { includeHeavyAttributes, isRestrictedToSkills, includeRestricted }
     );
 
     return views ?? [];


### PR DESCRIPTION
## Problem

Feature-flag gating on internal MCP servers (`isRestricted` in `constants.ts`) is enforced only at the **listing** and **view-provisioning** layers, never at the seam that resolves a view by id and turns it into runnable tools. `InternalMCPServerInMemoryResource.fetchByIds` computed the enabled set but only **logged** when a server was restricted — it returned the server anyway.

As a result, a leftover or force-created `MCPServerView` for a flag-gated server could be referenced by a custom Skill (`POST /skills` only checks the view exists) or an agent action config, and its tools listed and executed **with the flag off**. Concretely: a workspace without `sandbox_functions` could still publish Pod Functions. The class generalizes to any flag-gated internal server whose tools don't self-check the flag.

## Fix

Make the resolve-by-id seam enforce by default, with an explicit opt-in for admin surfaces:

- `InternalMCPServerInMemoryResource.fetchByIds` / `fetchById` now take `{ includeRestricted = false }` and **drop** restricted servers instead of logging-and-returning.
- Threaded through `MCPServerViewResource.baseFetch` (default `false`) and exposed on the public `fetchById` / `fetchByIds`.
- Admin/management surfaces opt in with `includeRestricted: true`: the server management route (GET/PATCH/DELETE), approvals name display, poke diagnostics + view-details, and view creation (`makeNew`, gated upstream).

This closes both entry paths at once — skill creation and agent action config validation reject restricted views, and run-time skill/agent tool resolution no longer surfaces their tools. The `includeDeleted` branch of `baseFetch` short-circuits before internal-server resolution, so **workspace scrubbing is unaffected**. `listByWorkspace` (the builder "your tools" listing) is a separate method and left untouched.

## Verification

- `tsgo --noEmit` clean on `front` and `front-api`.
- `mcp_server_view_resource.test.ts`: 20/20, including a new regression test asserting a restricted server's view is dropped by default and surfaced only with `includeRestricted`.
- Against real leftover `sandbox_functions` views in a flag-off workspace: default `fetchByIds` returns **0** (was 2); `includeRestricted: true` returns both.

## Scope / follow-ups

This is the highest-leverage fix of the three identified. Not included here (separate follow-ups):

- Reject restricted servers in `createInternalMCPServer` (closes the admin force-install vector).
- A flag check inside `publishSandboxFunction` itself (defense in depth at the single publish choke point).

A few poke internals (`poke/temporal/activities.ts`, `lib/poke/search.ts`, `lib/api/poke/utils.ts`) are intentionally left secure-by-default; they handle a null fetch gracefully, so the only effect is reduced visibility of a restricted leftover in those spots.