### PR TITLE
[front] refactor: query agent triggers through the Poke trigger endpoint

### DIFF
--- a/front-api/routes/poke/workspaces/[wId]/triggers/search.ts
+++ b/front-api/routes/poke/workspaces/[wId]/triggers/search.ts
@@ -1,38 +1,22 @@
-import { AutomationTriggersBodySchema } from "@app/lib/api/analytics/automations/schema";
-import type { GetAutomationTriggersResponse } from "@app/lib/api/analytics/automations/triggers";
-import { fetchAutomationTriggers } from "@app/lib/api/analytics/automations/triggers";
-import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
+import {
+  PokeTriggerSearchBodySchema,
+  type PokeTriggerSearchResponse,
+  searchPokeTriggers,
+} from "@app/lib/api/poke/triggers";
 import { pokeApp } from "@front-api/middlewares/ctx";
 import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
 
 // Mounted at /api/poke/workspaces/:wId/triggers/search.
 const app = pokeApp();
-const PokeAutomationTriggersBodySchema = AutomationTriggersBodySchema.omit({
-  format: true,
-});
 
 /** @ignoreswagger */
 app.post(
   "/",
-  validate("json", PokeAutomationTriggersBodySchema),
-  async (ctx): HandlerResult<GetAutomationTriggersResponse> => {
+  validate("json", PokeTriggerSearchBodySchema),
+  async (ctx): HandlerResult<PokeTriggerSearchResponse> => {
     const auth = ctx.get("auth");
-    const { limit, offset, search, filter, ...periodQuery } =
-      ctx.req.valid("json");
-    const period = await resolveConsumptionPeriod(
-      auth,
-      toConsumptionPeriodInput(periodQuery)
-    );
-
-    const result = await fetchAutomationTriggers(auth, {
-      period,
-      limit,
-      offset,
-      search,
-      filter,
-    });
+    const result = await searchPokeTriggers(auth, ctx.req.valid("json"));
     if (result.isErr()) {
       return apiError(
         ctx,

--- a/front/components/poke/PokeColumnSortableHeader.tsx
+++ b/front/components/poke/PokeColumnSortableHeader.tsx
@@ -11,13 +11,17 @@ export function PokeColumnSortableHeader<TData>({
   column,
   label,
 }: PokeColumnSortableHeaderProps<TData>) {
+  const sorted = column.getIsSorted();
+  const nextDirection = sorted === "asc" ? "descending" : "ascending";
+
   return (
     <div className="flex items-center space-x-2">
       <p>{label}</p>
       <IconButton
+        aria-label={`Sort ${label} ${nextDirection}`}
         variant="outline"
         icon={ArrowsUpDownIcon}
-        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+        onClick={() => column.toggleSorting(sorted === "asc")}
       />
     </div>
   );

--- a/front/components/poke/shadcn/ui/data_table.tsx
+++ b/front/components/poke/shadcn/ui/data_table.tsx
@@ -50,10 +50,11 @@ interface DataTableProps<TData, TValue> {
   facets?: Facet[];
   pageSize?: number;
   // Server-side (manual) mode. When `serverSideRowCount` is provided,
-  // pagination and sorting are controlled by the caller and applied
-  // server-side (the `data` prop is the current page only). Otherwise the
-  // table paginates/sorts/filters the full `data` set client-side as before.
+  // pagination is controlled by the caller and applied server-side (the
+  // `data` prop is the current page only). Sorting is server-side by default.
   serverSideRowCount?: number;
+  // Keep pagination server-side while sorting the current page locally.
+  sortCurrentPage?: boolean;
   pagination?: PaginationState;
   onPaginationChange?: (pagination: PaginationState) => void;
   sorting?: SortingState;
@@ -91,6 +92,7 @@ export function PokeDataTable<TData, TValue>({
   isValidating,
   pageSize = 10,
   serverSideRowCount,
+  sortCurrentPage = false,
   pagination,
   onPaginationChange,
   sorting,
@@ -104,13 +106,14 @@ export function PokeDataTable<TData, TValue>({
   getRowClassName,
 }: DataTableProps<TData, TValue>) {
   const isServerSide = serverSideRowCount !== undefined;
+  const isSortingLocally = !isServerSide || sortCurrentPage;
   const isServerSearch = onSearchChange !== undefined;
 
   const [internalSorting, setInternalSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
-  const resolvedSorting = isServerSide ? (sorting ?? []) : internalSorting;
+  const resolvedSorting = isSortingLocally ? internalSorting : (sorting ?? []);
 
   const selectionColumn: ColumnDef<TData, TValue> = {
     id: "select",
@@ -156,17 +159,16 @@ export function PokeDataTable<TData, TValue>({
     onColumnFiltersChange: setColumnFilters,
     globalFilterFn: "includesString", // built-in filter function
     manualPagination: isServerSide,
-    manualSorting: isServerSide,
-    ...(isServerSide
-      ? { rowCount: serverSideRowCount }
-      : { getSortedRowModel: getSortedRowModel() }),
-    onSortingChange: isServerSide
-      ? (updater: Updater<SortingState>) => {
+    manualSorting: !isSortingLocally,
+    ...(isServerSide ? { rowCount: serverSideRowCount } : {}),
+    ...(isSortingLocally ? { getSortedRowModel: getSortedRowModel() } : {}),
+    onSortingChange: isSortingLocally
+      ? setInternalSorting
+      : (updater: Updater<SortingState>) => {
           const next =
             typeof updater === "function" ? updater(resolvedSorting) : updater;
           onSortingChange?.(next);
-        }
-      : setInternalSorting,
+        },
     ...(isServerSide
       ? {
           onPaginationChange: (updater: Updater<PaginationState>) => {

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -1,17 +1,12 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
-import type { TriggerWithProviderType } from "@app/lib/api/poke/triggers";
 import { formatCredits } from "@app/lib/client/credits";
 import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
-import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
-import type { TriggerType } from "@app/types/assistant/triggers";
+import type { PokeAgentTriggerRow } from "@app/types/api/poke/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Chip, IconButton, LinkWrapper, Trash01 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
-
-type TriggerDisplayType = TriggerWithProviderType;
 
 function ConsumptionCell({ trigger }: { trigger: AutomationTriggerRow }) {
   const { credits, runCount } = trigger;
@@ -41,29 +36,22 @@ function ConsumptionCell({ trigger }: { trigger: AutomationTriggerRow }) {
 
 export function makeColumnsForTriggers(
   owner: LightWorkspaceType,
-  agentConfigurations: LightAgentConfigurationType[],
   onTriggerDeleted: () => Promise<void>
-): ColumnDef<TriggerDisplayType>[] {
-  const agentConfigMap = new Map(
-    agentConfigurations.map((agent) => [agent.sId, agent])
-  );
-
+): ColumnDef<PokeAgentTriggerRow>[] {
   return [
     {
-      accessorKey: "sId",
+      accessorKey: "triggerId",
       cell: ({ row }) => {
         const trigger = row.original;
-        const agent = agentConfigMap.get(trigger.agentConfigurationId);
-
-        if (!agent) {
-          return trigger.sId;
+        if (!trigger.agent.isAvailable) {
+          return trigger.triggerId;
         }
 
         return (
           <LinkWrapper
-            href={`/poke/${owner.sId}/assistants/${agent.sId}/triggers/${trigger.sId}`}
+            href={`/poke/${owner.sId}/assistants/${trigger.agent.agentId}/triggers/${trigger.triggerId}`}
           >
-            {trigger.sId}
+            {trigger.triggerId}
           </LinkWrapper>
         );
       },
@@ -82,10 +70,7 @@ export function makeColumnsForTriggers(
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Agent name" />
       ),
-      accessorFn: (row) => {
-        const agent = agentConfigMap.get(row.agentConfigurationId);
-        return agent?.name ?? row.agentConfigurationId;
-      },
+      accessorFn: (row) => row.agent.name,
     },
     {
       accessorKey: "kind",
@@ -111,7 +96,13 @@ export function makeColumnsForTriggers(
       },
     },
     {
-      accessorKey: "provider",
+      id: "provider",
+      accessorFn: (trigger) => {
+        if (trigger.kind === "webhook") {
+          return trigger.provider ?? "Custom";
+        }
+        return "-";
+      },
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Provider" />
       ),
@@ -127,28 +118,10 @@ export function makeColumnsForTriggers(
       },
     },
     {
-      accessorKey: "configuration",
+      accessorKey: "configurationSummary",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Configuration" />
       ),
-      cell: ({ row }) => {
-        const trigger = row.original;
-        if (trigger.kind === "schedule") {
-          return `${describeScheduleConfig(trigger.configuration)} (${trigger.configuration.timezone})`;
-        }
-        // Webhook: show event + filter summary
-        const parts: string[] = [];
-        if (trigger.configuration.event) {
-          parts.push(trigger.configuration.event);
-        }
-        if (trigger.configuration.filter) {
-          parts.push("+ filter");
-        }
-        if (trigger.configuration.includePayload) {
-          parts.push("w/ payload");
-        }
-        return parts.length > 0 ? parts.join(" ") : "All events";
-      },
     },
     {
       accessorKey: "status",
@@ -158,21 +131,13 @@ export function makeColumnsForTriggers(
     },
     {
       id: "editorEmail",
-      accessorFn: (row) => {
-        if (row.editorUser) {
-          return row.editorUser.email;
-        }
-        return row.editor?.toString() ?? "";
-      },
+      accessorFn: (row) => row.editor?.email ?? row.editor?.name ?? "",
       header: ({ column }) => (
         <PokeColumnSortableHeader column={column} label="Editor" />
       ),
       cell: ({ row }) => {
         const trigger = row.original;
-        if (trigger.editorUser) {
-          return `${trigger.editorUser.email}`;
-        }
-        return trigger.editor?.toString() ?? "-";
+        return trigger.editor?.email ?? trigger.editor?.name ?? "-";
       },
     },
     {
@@ -192,6 +157,7 @@ export function makeColumnsForTriggers(
 
         return (
           <IconButton
+            aria-label={`Delete trigger ${trigger.name}`}
             icon={Trash01}
             size="xs"
             variant="outline"
@@ -276,7 +242,7 @@ export function makeColumnsForAutomationTriggers(
           onClick={async () => {
             await deleteTrigger(owner, onTriggerDeleted, {
               name: row.original.name,
-              sId: row.original.triggerId,
+              triggerId: row.original.triggerId,
             });
           }}
         />
@@ -288,7 +254,7 @@ export function makeColumnsForAutomationTriggers(
 async function deleteTrigger(
   owner: LightWorkspaceType,
   onTriggerDeleted: () => Promise<void>,
-  trigger: Pick<TriggerType, "name" | "sId">
+  trigger: { name: string; triggerId: string }
 ) {
   if (
     !window.confirm(
@@ -300,7 +266,7 @@ async function deleteTrigger(
 
   try {
     const r = await clientFetch(
-      `/api/poke/workspaces/${owner.sId}/triggers?tId=${trigger.sId}`,
+      `/api/poke/workspaces/${owner.sId}/triggers?tId=${trigger.triggerId}`,
       {
         method: "DELETE",
         headers: {

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -247,8 +247,9 @@ export function makeColumnsForAutomationTriggers(
     },
     {
       accessorKey: "credits",
-      header: "Consumption",
-      enableSorting: false,
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Consumption" />
+      ),
       cell: ({ row }) => <ConsumptionCell trigger={row.original} />,
     },
     {

--- a/front/components/poke/triggers/table.tsx
+++ b/front/components/poke/triggers/table.tsx
@@ -1,4 +1,3 @@
-import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
 import {
   makeColumnsForAutomationTriggers,
@@ -7,17 +6,15 @@ import {
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
-import { usePokeAgentConfigurations } from "@app/poke/swr/agent_configurations";
-import {
-  usePokeAutomationTriggers,
-  usePokeTriggers,
-} from "@app/poke/swr/triggers";
+import { usePokeTriggers } from "@app/poke/swr/triggers";
 import type { TriggerKind } from "@app/types/assistant/triggers";
 import { isValidTriggerKind } from "@app/types/assistant/triggers";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import { WEBHOOK_PROVIDERS } from "@app/types/triggers/webhooks";
 import type { LightWorkspaceType } from "@app/types/user";
+import { Button, Spinner } from "@dust-tt/sparkle";
 import type { PaginationState } from "@tanstack/react-table";
+import type { ReactNode } from "react";
 import { useState } from "react";
 
 const TRIGGER_PAGE_SIZE = 25;
@@ -56,10 +53,9 @@ export function TriggerDataTable({ owner, agentId }: TriggerDataTableProps) {
   });
   const [search, setSearch] = useState("");
   const [selectedKinds, setSelectedKinds] = useState<TriggerKind[]>([]);
-  const { data: agentConfigurations } = usePokeAgentConfigurations({
-    owner,
-    disabled: agentId === undefined,
-  });
+  const [loadedAgentId, setLoadedAgentId] = useState<string | null>(null);
+  const shouldLoadAgentTriggers =
+    agentId !== undefined && loadedAgentId === agentId;
 
   const handlePeriodChange = (nextPeriod: ConsumptionPeriodSelection) => {
     setPeriod(nextPeriod);
@@ -76,103 +72,111 @@ export function TriggerDataTable({ owner, agentId }: TriggerDataTableProps) {
     setPagination((current) => ({ ...current, pageIndex: 0 }));
   };
 
-  const {
-    triggers,
-    totalCount,
-    isTriggersLoading,
-    isTriggersValidating,
-    isTriggersError,
-    mutateTriggers,
-  } = usePokeAutomationTriggers({
-    owner,
-    period,
-    limit: pagination.pageSize,
-    offset: pagination.pageIndex * pagination.pageSize,
-    search: search || undefined,
-    filter: selectedKinds.length > 0 ? { kinds: selectedKinds } : undefined,
-    disabled: agentId !== undefined,
-  });
-
-  if (agentId !== undefined) {
-    return (
-      <PokeDataTableConditionalFetch
-        header="Triggers"
-        owner={owner}
-        useSWRHook={usePokeTriggers}
-      >
-        {(agentTriggers, mutateAgentTriggers) => {
-          const filteredTriggers = agentTriggers.filter(
-            (trigger) => trigger.agentConfigurationId === agentId
-          );
-          const onAgentTriggerDeleted = async () => {
-            await mutateAgentTriggers();
-          };
-
-          return (
-            <PokeDataTable
-              columns={makeColumnsForTriggers(
-                owner,
-                agentConfigurations,
-                onAgentTriggerDeleted
-              )}
-              data={filteredTriggers}
-              facets={TRIGGER_PROVIDER_FACETS}
-            />
-          );
-        }}
-      </PokeDataTableConditionalFetch>
-    );
-  }
+  const triggerData = usePokeTriggers(
+    agentId !== undefined
+      ? {
+          scope: "agent",
+          owner,
+          agentId,
+          disabled: !shouldLoadAgentTriggers,
+        }
+      : {
+          scope: "workspace",
+          owner,
+          period,
+          limit: pagination.pageSize,
+          offset: pagination.pageIndex * pagination.pageSize,
+          search: search || undefined,
+          filter:
+            selectedKinds.length > 0 ? { kinds: selectedKinds } : undefined,
+        }
+  );
 
   const onTriggerDeleted = async () => {
-    if (triggers.length === 1 && pagination.pageIndex > 0) {
+    if (
+      triggerData.scope === "workspace" &&
+      triggerData.triggers.length === 1 &&
+      pagination.pageIndex > 0
+    ) {
       setPagination((current) => ({
         ...current,
         pageIndex: Math.max(0, current.pageIndex - 1),
       }));
       return;
     }
-    await mutateTriggers();
+    await triggerData.mutateTriggers();
   };
+
+  let content: ReactNode;
+
+  if (triggerData.scope === "agent" && !shouldLoadAgentTriggers) {
+    content = (
+      <div className="flex justify-center">
+        <Button
+          label="Load Data"
+          variant="outline"
+          onClick={() => setLoadedAgentId(triggerData.agentId)}
+        />
+      </div>
+    );
+  } else if (triggerData.isTriggersError) {
+    content = (
+      <div className="flex h-32 items-center justify-center">
+        <p>Error loading data.</p>
+      </div>
+    );
+  } else if (triggerData.scope === "agent") {
+    content = triggerData.isTriggersLoading ? (
+      <div className="flex h-32 items-center justify-center">
+        <Spinner />
+      </div>
+    ) : (
+      <PokeDataTable
+        columns={makeColumnsForTriggers(owner, onTriggerDeleted)}
+        data={triggerData.triggers}
+        facets={TRIGGER_PROVIDER_FACETS}
+      />
+    );
+  } else {
+    content = (
+      <PokeDataTable
+        columns={makeColumnsForAutomationTriggers(owner, onTriggerDeleted)}
+        data={triggerData.triggers}
+        getRowId={(trigger) => trigger.triggerId}
+        isLoading={triggerData.isTriggersLoading}
+        isValidating={triggerData.isTriggersValidating}
+        serverSideRowCount={triggerData.totalCount}
+        sortCurrentPage
+        pagination={pagination}
+        onPaginationChange={setPagination}
+        search={search}
+        onSearchChange={handleSearchChange}
+        facets={[
+          {
+            columnId: "kind",
+            title: "Kind",
+            options: TRIGGER_KIND_OPTIONS,
+            selectedValues: selectedKinds,
+            onSelectedValuesChange: handleKindChange,
+          },
+        ]}
+      />
+    );
+  }
 
   return (
     <div className="my-4 flex min-h-24 flex-col rounded-lg border bg-background">
       <div className="flex justify-between gap-3 rounded-t-lg border-b border-separator bg-background p-4">
         <h2 className="text-md font-bold">Triggers</h2>
-        <ConsumptionPeriodSelector
-          period={period}
-          onPeriodChange={handlePeriodChange}
-        />
-      </div>
-      <div className="flex flex-grow flex-col justify-center p-4">
-        {isTriggersError ? (
-          <div className="flex h-32 items-center justify-center">
-            <p>Error loading data.</p>
-          </div>
-        ) : (
-          <PokeDataTable
-            columns={makeColumnsForAutomationTriggers(owner, onTriggerDeleted)}
-            data={triggers}
-            getRowId={(trigger) => trigger.triggerId}
-            isLoading={isTriggersLoading}
-            isValidating={isTriggersValidating}
-            serverSideRowCount={totalCount}
-            sortCurrentPage
-            pagination={pagination}
-            onPaginationChange={setPagination}
-            search={search}
-            onSearchChange={handleSearchChange}
-            facets={[
-              {
-                columnId: "kind",
-                title: "Kind",
-                options: TRIGGER_KIND_OPTIONS,
-                selectedValues: selectedKinds,
-                onSelectedValuesChange: handleKindChange,
-              },
-            ]}
+        {triggerData.scope === "workspace" && (
+          <ConsumptionPeriodSelector
+            period={period}
+            onPeriodChange={handlePeriodChange}
           />
         )}
+      </div>
+      <div className="flex flex-grow flex-col justify-center p-4">
+        {content}
       </div>
     </div>
   );

--- a/front/components/poke/triggers/table.tsx
+++ b/front/components/poke/triggers/table.tsx
@@ -157,6 +157,7 @@ export function TriggerDataTable({ owner, agentId }: TriggerDataTableProps) {
             isLoading={isTriggersLoading}
             isValidating={isTriggersValidating}
             serverSideRowCount={totalCount}
+            sortCurrentPage
             pagination={pagination}
             onPaginationChange={setPagination}
             search={search}

--- a/front/lib/api/poke/triggers.ts
+++ b/front/lib/api/poke/triggers.ts
@@ -1,13 +1,146 @@
+import { AutomationTriggersBodySchema } from "@app/lib/api/analytics/automations/schema";
+import type { GetAutomationTriggersResponse } from "@app/lib/api/analytics/automations/triggers";
+import { fetchAutomationTriggers } from "@app/lib/api/analytics/automations/triggers";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { toConsumptionPeriodInput } from "@app/lib/api/analytics/consumption/schema";
+import { resolveAnalyticsAgentLabels } from "@app/lib/api/assistant/observability/agent_labels";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
 import type { TriggerWithProviderAndEditor } from "@app/lib/triggers/admin/list_with_metadata";
+import type { PokeAgentTriggerRow } from "@app/types/api/poke/triggers";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import { removeNulls } from "@app/types/shared/utils/general";
 import type { UserType } from "@app/types/user";
+import { z } from "zod";
 
 export type TriggerWithProviderType = TriggerWithProviderAndEditor;
 
 export type PokeListTriggers = {
   triggers: TriggerWithProviderType[];
 };
+
+const PokeAgentTriggerSearchBodySchema = z.object({
+  scope: z.literal("agent"),
+  agentId: z.string().min(1),
+});
+
+const PokeWorkspaceTriggerSearchBodySchema = AutomationTriggersBodySchema.omit({
+  format: true,
+}).extend({
+  scope: z.literal("workspace"),
+});
+
+export const PokeTriggerSearchBodySchema = z.discriminatedUnion("scope", [
+  PokeAgentTriggerSearchBodySchema,
+  PokeWorkspaceTriggerSearchBodySchema,
+]);
+
+export type PokeTriggerSearchBody = z.infer<typeof PokeTriggerSearchBodySchema>;
+
+export type PokeTriggerSearchResponse =
+  | {
+      scope: "agent";
+      agentId: string;
+      triggers: PokeAgentTriggerRow[];
+    }
+  | ({ scope: "workspace" } & GetAutomationTriggersResponse);
+
+async function listPokeAgentTriggers(
+  auth: Authenticator,
+  agentId: string
+): Promise<PokeAgentTriggerRow[]> {
+  const triggers = await TriggerResource.listByAgentConfigurationId(
+    auth,
+    agentId
+  );
+  if (triggers.length === 0) {
+    return [];
+  }
+
+  const editorModelIds = [
+    ...new Set(triggers.map((trigger) => trigger.editor)),
+  ];
+  const webhookSourceViewModelIds = [
+    ...new Set(
+      removeNulls(triggers.map((trigger) => trigger.webhookSourceViewId))
+    ),
+  ];
+
+  const [agentLabels, editors, webhookSourceViews] = await Promise.all([
+    resolveAnalyticsAgentLabels(auth, [agentId]),
+    UserResource.fetchByModelIds(editorModelIds),
+    webhookSourceViewModelIds.length > 0
+      ? WebhookSourcesViewResource.fetchByModelIds(
+          auth,
+          webhookSourceViewModelIds
+        )
+      : Promise.resolve([]),
+  ]);
+  const editorsByModelId = new Map(
+    editors.map((editor) => [editor.id, editor])
+  );
+  const webhookSourceViewsByModelId = new Map(
+    webhookSourceViews.map((view) => [view.id, view])
+  );
+
+  return triggers.map((trigger) => {
+    const agentLabel = agentLabels.get(trigger.agentConfigurationId);
+    const webhookSourceView = trigger.webhookSourceViewId
+      ? webhookSourceViewsByModelId.get(trigger.webhookSourceViewId)
+      : undefined;
+
+    return trigger.toPokeListJSON({
+      agentName: agentLabel?.name ?? trigger.agentConfigurationId,
+      agentIsAvailable: agentLabel !== undefined,
+      editor: editorsByModelId.get(trigger.editor) ?? null,
+      provider: webhookSourceView?.webhookSource.provider ?? null,
+    });
+  });
+}
+
+export async function searchPokeTriggers(
+  auth: Authenticator,
+  body: PokeTriggerSearchBody
+): Promise<Result<PokeTriggerSearchResponse, ElasticsearchError>> {
+  switch (body.scope) {
+    case "agent": {
+      const triggers = await listPokeAgentTriggers(auth, body.agentId);
+      return new Ok({
+        scope: "agent",
+        agentId: body.agentId,
+        triggers,
+      });
+    }
+    case "workspace": {
+      const { limit, offset, search, filter } = body;
+      const period = await resolveConsumptionPeriod(
+        auth,
+        toConsumptionPeriodInput(body)
+      );
+      const result = await fetchAutomationTriggers(auth, {
+        period,
+        limit,
+        offset,
+        search,
+        filter,
+      });
+      if (result.isErr()) {
+        return result;
+      }
+
+      return new Ok({ scope: "workspace", ...result.value });
+    }
+    default:
+      return assertNever(body);
+  }
+}
 
 export type PokeGetTriggerExecutionStats = {
   statusBreakdown: Record<string, number>;

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -17,11 +17,13 @@ import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { describeScheduleConfig } from "@app/lib/utils/schedule_description";
 import logger from "@app/logger/logger";
 import {
   createOrUpdateAgentSchedule,
   deleteTriggerSchedule,
 } from "@app/temporal/triggers/schedule_client";
+import type { PokeAgentTriggerRow } from "@app/types/api/poke/triggers";
 import type {
   BulkTriggerUpdateOutcome,
   ScheduleConfig,
@@ -31,12 +33,16 @@ import type {
   TriggerType,
   WebhookConfig,
 } from "@app/types/assistant/triggers";
-import { getTriggerStatusOwner } from "@app/types/assistant/triggers";
+import {
+  getTriggerStatusOwner,
+  isScheduleTrigger,
+} from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { WebhookProvider } from "@app/types/triggers/webhooks";
 import type { UserType } from "@app/types/user";
 import assert from "assert";
 import type {
@@ -1349,6 +1355,64 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       id,
       workspaceId,
     });
+  }
+
+  private getPokeConfigurationSummary(): string {
+    const trigger = this.toJSON();
+    if (isScheduleTrigger(trigger)) {
+      return `${describeScheduleConfig(trigger.configuration)} (${trigger.configuration.timezone})`;
+    }
+
+    const { configuration } = trigger;
+    const parts: string[] = [];
+    if (configuration.event) {
+      parts.push(configuration.event);
+    }
+    if (configuration.filter) {
+      parts.push("+ filter");
+    }
+    if (configuration.includePayload) {
+      parts.push("w/ payload");
+    }
+    return parts.length > 0 ? parts.join(" ") : "All events";
+  }
+
+  toPokeListJSON({
+    agentName,
+    agentIsAvailable,
+    editor,
+    provider,
+  }: {
+    agentName: string;
+    agentIsAvailable: boolean;
+    editor: UserResource | null;
+    provider: WebhookProvider | null;
+  }): PokeAgentTriggerRow {
+    return {
+      triggerId: this.sId,
+      name: this.name,
+      agent: {
+        agentId: this.agentConfigurationId,
+        name: agentName,
+        isAvailable: agentIsAvailable,
+      },
+      kind: this.kind,
+      origin: this.origin,
+      provider: this.kind === "webhook" ? provider : null,
+      configurationSummary: this.getPokeConfigurationSummary(),
+      status: this.status,
+      editor: editor
+        ? {
+            name:
+              editor.fullName() ||
+              editor.username ||
+              editor.email ||
+              "Unknown user",
+            email: editor.email ?? null,
+          }
+        : null,
+      createdAt: this.createdAt.getTime(),
+    };
   }
 
   toJSON(): TriggerType {

--- a/front/poke/swr/triggers.ts
+++ b/front/poke/swr/triggers.ts
@@ -1,18 +1,17 @@
 import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD_DAYS } from "@app/lib/analytics/consumption_period";
+import type { AutomationTriggersFilter } from "@app/lib/api/analytics/automations/schema";
+import type { AutomationTriggerRow } from "@app/lib/api/analytics/automations/triggers";
 import type {
-  AutomationTriggersBody,
-  AutomationTriggersFilter,
-} from "@app/lib/api/analytics/automations/schema";
-import type {
-  AutomationTriggerRow,
-  GetAutomationTriggersResponse,
-} from "@app/lib/api/analytics/automations/triggers";
-import type { PokeListTriggers } from "@app/lib/api/poke/triggers";
+  PokeTriggerSearchBody,
+  PokeTriggerSearchResponse,
+} from "@app/lib/api/poke/triggers";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
-import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
-import type { PokeGetWebhookRequestsResponseBody } from "@app/types/api/poke/triggers";
+import type {
+  PokeAgentTriggerRow,
+  PokeGetWebhookRequestsResponseBody,
+} from "@app/types/api/poke/triggers";
 import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
@@ -20,63 +19,75 @@ import type { Fetcher } from "swr";
 const pokeTriggersUrl = (workspaceId: string) =>
   `/api/poke/workspaces/${workspaceId}/triggers`;
 
-export function usePokeTriggers({
-  disabled,
-  owner,
-}: PokeConditionalFetchProps) {
-  const { fetcher } = useFetcher();
-  const triggersFetcher: Fetcher<PokeListTriggers> = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
-    pokeTriggersUrl(owner.sId),
-    triggersFetcher,
-    { disabled }
-  );
+type UsePokeTriggersProps =
+  | {
+      scope: "agent";
+      owner: LightWorkspaceType;
+      agentId: string;
+      disabled?: boolean;
+    }
+  | {
+      scope: "workspace";
+      owner: LightWorkspaceType;
+      period: ConsumptionPeriodSelection;
+      limit: number;
+      offset?: number;
+      search?: string;
+      filter?: AutomationTriggersFilter;
+      disabled?: boolean;
+    };
 
-  return {
-    data: data?.triggers ?? [],
-    isLoading: !disabled && !error && !data,
-    isError: error,
-    mutate,
-  };
-}
-
-export function usePokeAutomationTriggers({
-  owner,
-  period,
-  limit,
-  offset = 0,
-  search,
-  filter,
-  disabled,
-}: {
-  owner: LightWorkspaceType;
-  period: ConsumptionPeriodSelection;
-  limit: number;
-  offset?: number;
-  search?: string;
-  filter?: AutomationTriggersFilter;
-  disabled?: boolean;
-}) {
+export function usePokeTriggers(props: UsePokeTriggersProps) {
+  const { owner, disabled } = props;
   const url = `${pokeTriggersUrl(owner.sId)}/search`;
-  const body: Omit<AutomationTriggersBody, "format"> = {
-    period: period.kind,
-    days:
-      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
-    limit,
-    offset,
-    search: search?.trim(),
-    filter,
-  };
+  const body: PokeTriggerSearchBody =
+    props.scope === "agent"
+      ? {
+          scope: "agent",
+          agentId: props.agentId,
+        }
+      : {
+          scope: "workspace",
+          period: props.period.kind,
+          days:
+            props.period.kind === "days"
+              ? props.period.days
+              : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+          limit: props.limit,
+          offset: props.offset ?? 0,
+          search: props.search?.trim(),
+          filter: props.filter,
+        };
 
   const { data, error, mutate, isValidating } = useConsumptionQuery<
-    Omit<AutomationTriggersBody, "format">,
-    GetAutomationTriggersResponse
+    PokeTriggerSearchBody,
+    PokeTriggerSearchResponse
   >({ url, body, disabled });
 
+  if (props.scope === "agent") {
+    const response =
+      data?.scope === "agent" && data.agentId === props.agentId
+        ? data
+        : undefined;
+
+    return {
+      scope: "agent" as const,
+      agentId: props.agentId,
+      triggers: response?.triggers ?? emptyArray<PokeAgentTriggerRow>(),
+      isTriggersLoading: !disabled && !error && !response,
+      isTriggersValidating: !disabled && !error && isValidating,
+      isTriggersError: error,
+      mutateTriggers: mutate,
+    };
+  }
+
+  const response = data?.scope === "workspace" ? data : undefined;
+
   return {
-    triggers: data?.triggers ?? emptyArray<AutomationTriggerRow>(),
-    totalCount: data?.totalCount ?? 0,
-    isTriggersLoading: !disabled && !error && !data,
+    scope: "workspace" as const,
+    triggers: response?.triggers ?? emptyArray<AutomationTriggerRow>(),
+    totalCount: response?.totalCount ?? 0,
+    isTriggersLoading: !disabled && !error && !response,
     isTriggersValidating: !disabled && !error && isValidating,
     isTriggersError: error,
     mutateTriggers: mutate,

--- a/front/types/api/poke/triggers.ts
+++ b/front/types/api/poke/triggers.ts
@@ -1,4 +1,30 @@
-import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
+import type {
+  TriggerKind,
+  TriggerOrigin,
+  TriggerStatus,
+  WebhookRequestTriggerStatus,
+} from "@app/types/assistant/triggers";
+import type { WebhookProvider } from "@app/types/triggers/webhooks";
+
+export type PokeAgentTriggerRow = {
+  triggerId: string;
+  name: string;
+  agent: {
+    agentId: string;
+    name: string;
+    isAvailable: boolean;
+  };
+  kind: TriggerKind;
+  origin: TriggerOrigin;
+  provider: WebhookProvider | null;
+  configurationSummary: string;
+  status: TriggerStatus;
+  editor: {
+    name: string;
+    email: string | null;
+  } | null;
+  createdAt: number;
+};
 
 export interface PokeGetWebhookRequestsResponseBody {
   requests: {


### PR DESCRIPTION
## Description

Follow up on #31010 and #31030 to move the agent trigger table onto the same Poke trigger query used by the workspace table.

The endpoint now accepts an agent or workspace scope. Agent requests query only that agent’s triggers and return a Poke-safe row shape, while workspace pagination, filtering, consumption ranking, and current-page sorting remain unchanged. The existing GET endpoint remains available for compatibility.

## Tests

- Front and front-api typechecks.
- Scoped Biome checks.
- Swagger annotation lint.

## Risk

Low. Poke-only.

## Deploy Plan

Deploy front.