### PR TITLE
[Activation] Show the Goal overview only to Pod editors

### DIFF
--- a/front-api/routes/w/[wId]/activation-pod/index.ts
+++ b/front-api/routes/w/[wId]/activation-pod/index.ts
@@ -9,8 +9,9 @@ const app = workspaceApp();
 /** @ignoreswagger */
 app.get("/", async (ctx): HandlerResult<GetActivationPodResponseBody> => {
   const auth = ctx.get("auth");
+  const podId = ctx.req.query("podId");
 
-  const podInfo = await getActivationPodInfo(auth);
+  const podInfo = await getActivationPodInfo(auth, { podId });
 
   return ctx.json(podInfo);
 });

--- a/front/components/activation/WorkAreaSection.tsx
+++ b/front/components/activation/WorkAreaSection.tsx
@@ -34,6 +34,7 @@ interface WorkAreaSectionProps {
   copy: WorkAreaSectionCopy;
   actions: readonly WorkAreaSectionAction[];
   disabled?: boolean;
+  skillTag?: string;
 }
 
 export function WorkAreaSection({
@@ -44,6 +45,7 @@ export function WorkAreaSection({
   copy,
   actions,
   disabled,
+  skillTag,
 }: WorkAreaSectionProps) {
   const router = useAppRouter();
   const sendNotification = useSendNotification();
@@ -94,7 +96,7 @@ export function WorkAreaSection({
         : [];
       const res = await createConversationWithMessage({
         messageData: {
-          input: message,
+          input: skillTag ? `${skillTag}\n\n${message}` : message,
           mentions,
           contentFragments: { uploaded: [], contentNodes: [] },
         },
@@ -118,6 +120,7 @@ export function WorkAreaSection({
       owner.sId,
       router,
       sendNotification,
+      skillTag,
     ]
   );
 

--- a/front/components/pages/pod/PodPage.tsx
+++ b/front/components/pages/pod/PodPage.tsx
@@ -14,6 +14,7 @@ import {
   useFeatureFlags,
   useWorkspace,
 } from "@app/lib/auth/AuthContext";
+import { useActivationPod } from "@app/lib/swr/activation";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
@@ -68,6 +69,8 @@ export function PodPage() {
   const { user } = useAuth();
   const { hasFeature } = useFeatureFlags();
   const podId = useActivePodId();
+  const { podKind } = useActivationPod({ workspaceId: owner.sId, podId });
+  const isGoalPod = podKind === "goal";
   const hasFrameTabs = hasFeature("pod_frame_tabs");
   // Pod Apps sit on top of Pod Functions, so both flags are required.
   const hasApps =
@@ -86,7 +89,6 @@ export function PodPage() {
     spaceId: podId,
     includeAllMembers: true,
   });
-
   const { value: podUiPreferences, setValue: setPodUiPreferences } =
     useScopedPodUiPreferences({
       scope: "podUi",
@@ -251,6 +253,7 @@ export function PodPage() {
 
         <PodPageContent
           podInfo={podInfo}
+          isGoalPod={isGoalPod}
           onTabChange={handleTabChange}
           podUiPreferences={podUiPreferences}
           setPodUiPreferences={setPodUiPreferences}

--- a/front/components/pod/GoalPodOverview.tsx
+++ b/front/components/pod/GoalPodOverview.tsx
@@ -1,0 +1,195 @@
+import { ActivationSurface } from "@app/components/activation/ActivationSurface";
+import { JustAskComposer } from "@app/components/activation/JustAskComposer";
+import { RecentConversations } from "@app/components/activation/RecentConversations";
+import type { RecommendationSectionCopy } from "@app/components/activation/RecommendationSection";
+import { RecommendationSection } from "@app/components/activation/RecommendationSection";
+import type { WorkAreaSectionCopy } from "@app/components/activation/WorkAreaSection";
+import { WorkAreaSection } from "@app/components/activation/WorkAreaSection";
+import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useAppRouter } from "@app/lib/platform";
+import { serializeSkillTag } from "@app/lib/skills/format";
+import { usePodMetadata } from "@app/lib/swr/pods";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { UserType, WorkspaceType } from "@app/types/user";
+import { resolveDefaultAgentId } from "@app/types/user";
+import { Button } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+const GOAL_SKILL_TAG = serializeSkillTag({
+  id: "dust_pod_goal",
+  name: "Dust Pod Goal",
+  icon: "ActionFlagIcon",
+});
+
+function withGoalSkill(message: string): string {
+  return `${GOAL_SKILL_TAG}\n\n${message}`;
+}
+
+const GOAL_WORK_AREA_COPY: WorkAreaSectionCopy = {
+  title: "What we're after",
+  description:
+    "The job this Pod keeps in view. Recommendations below are based on this.",
+  emptyState: "Nothing to chase yet.",
+  actionDescription:
+    "Choose an option below to refine it. The Pod will update this and reconsider the next move.",
+  runningBanner: "An agent is reviewing the job this Pod is working on.",
+};
+
+const GOAL_WORK_AREA_ACTIONS = [
+  {
+    label: "Scan sources for progress",
+    message:
+      "Review the job this Pod is working on against the latest evidence in its connected sources.\n\n" +
+      "1. Read the current work areas; that is the job this Pod is working on.\n" +
+      "2. Scan connected sources for progress, changes, blockers, and stale assumptions.\n" +
+      "3. Update the work areas and let me correct them if needed.\n" +
+      "4. Once that job is settled, pick one bounded next action only if it materially advances it, then decide whether Dust or a human should own it.",
+  },
+  {
+    label: "Help me sharpen this",
+    message:
+      "Help me refine the job this Pod is working on.\n\n" +
+      "1. Read the current work areas; that is the job this Pod is working on.\n" +
+      "2. Ask focused questions about the work, constraints, progress, and blockers.\n" +
+      "3. Update the work areas based on my answers and let me correct them if needed.\n" +
+      "4. Once that job is settled, pick one bounded next action only if it materially advances it, then decide whether Dust or a human should own it.",
+  },
+] as const;
+
+const GOAL_RECOMMENDATION_COPY: RecommendationSectionCopy = {
+  title: "What should happen next?",
+  description: "This changes as the Pod gathers evidence and makes progress.",
+  emptyState: "No evidence-backed action is warranted right now.",
+  generateLabel: "Check what matters now",
+  runningBanner: "An agent is checking what should happen next?",
+};
+
+const GOAL_QUICK_PROMPTS = [
+  {
+    label: "What should happen next",
+    message:
+      "Review the job this Pod is working on against the latest available evidence. Diagnose the current constraint, pick one bounded next action, decide whether Dust or a human should own it, and present that move only if it would materially advance the job now.",
+  },
+  {
+    label: "Where are we blocked?",
+    message:
+      "Review the job this Pod is working on and the current evidence. Identify the most important blocker, if there is one.",
+  },
+  {
+    label: "What evidence are we missing?",
+    message:
+      "Review the job this Pod is working on and tell me what missing evidence would most improve our next decision.",
+  },
+] as const;
+
+interface GoalPodOverviewProps {
+  owner: WorkspaceType;
+  user: UserType | null;
+  podId: string;
+}
+
+export function GoalPodOverview({ owner, user, podId }: GoalPodOverviewProps) {
+  const router = useAppRouter();
+  const sendNotification = useSendNotification();
+  const { hasFeature } = useFeatureFlags();
+  const { podMetadata } = usePodMetadata({
+    workspaceId: owner.sId,
+    podId,
+  });
+  const defaultAgentId = resolveDefaultAgentId({
+    owner,
+    podDefaultAgentId: podMetadata?.defaultAgentId,
+    hasWorkspaceDefaultAgentFeature: hasFeature("workspace_default_agent"),
+  });
+  const createConversationWithMessage = useCreateConversationWithMessage({
+    owner,
+    user,
+  });
+  const [isChecking, setIsChecking] = useState(false);
+
+  const startConversation = async (input: string) => {
+    setIsChecking(true);
+    const result = await createConversationWithMessage({
+      messageData: {
+        input: withGoalSkill(input),
+        mentions: defaultAgentId ? [{ configurationId: defaultAgentId }] : [],
+        contentFragments: { uploaded: [], contentNodes: [] },
+      },
+      spaceId: podId,
+    });
+    setIsChecking(false);
+
+    if (result.isErr()) {
+      sendNotification({
+        type: "error",
+        title: "Couldn't start the review",
+        description: result.error.message,
+      });
+      return;
+    }
+    await router.push(getConversationRoute(owner.sId, result.value.sId));
+  };
+
+  return (
+    <div className="h-full overflow-y-auto bg-background">
+      <ActivationSurface
+        highlightedTitle="This Pod has a job to do"
+        description={
+          <>
+            It keeps that job in view and nudges the next useful move when the
+            evidence is there.
+          </>
+        }
+      >
+        <WorkAreaSection
+          owner={owner}
+          user={user}
+          podId={podId}
+          defaultAgentId={defaultAgentId}
+          copy={GOAL_WORK_AREA_COPY}
+          actions={GOAL_WORK_AREA_ACTIONS}
+          skillTag={GOAL_SKILL_TAG}
+        />
+        <RecommendationSection
+          owner={owner}
+          podId={podId}
+          copy={GOAL_RECOMMENDATION_COPY}
+          isGenerating={isChecking}
+          onGenerate={() => void startConversation("Check what matters now")}
+        />
+        <div className="mt-12">
+          <h2 className="text-base font-semibold leading-6 tracking-tight text-foreground">
+            Or just ask
+          </h2>
+          <p className="mt-1 text-sm leading-5 tracking-tight text-muted-foreground">
+            Ask about progress, blockers, evidence, or the next decision.
+          </p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {GOAL_QUICK_PROMPTS.map((prompt) => (
+              <Button
+                key={prompt.label}
+                variant="outline"
+                size="sm"
+                isRounded
+                label={prompt.label}
+                disabled={isChecking}
+                onClick={() => void startConversation(prompt.message)}
+              />
+            ))}
+          </div>
+          <div className="mt-4">
+            <JustAskComposer
+              owner={owner}
+              user={user}
+              podId={podId}
+              defaultAgentId={defaultAgentId}
+            />
+          </div>
+        </div>
+        <RecentConversations owner={owner} podId={podId} />
+      </ActivationSurface>
+    </div>
+  );
+}

--- a/front/components/pod/PodPageContent.tsx
+++ b/front/components/pod/PodPageContent.tsx
@@ -4,6 +4,7 @@ import { PodAppsTab } from "@app/components/pod/apps/PodAppsTab";
 import { PodConnectedDataTab } from "@app/components/pod/connected_data/PodConnectedDataTab";
 import { PodConversationsTab } from "@app/components/pod/conversation/PodConversationsTab";
 import { PodFilesTab } from "@app/components/pod/files/PodFilesTab";
+import { GoalPodOverview } from "@app/components/pod/GoalPodOverview";
 import { PodFrameTabContent } from "@app/components/pod/PodFrameTabContent";
 import { PodSettingsTab } from "@app/components/pod/settings/PodSettingsTab";
 import { PodTasksTab } from "@app/components/pod/tasks/PodTasksTab";
@@ -33,6 +34,7 @@ type PodInfo = NonNullable<ReturnType<typeof useSpaceInfo>["spaceInfo"]>;
 
 interface PodPageContentProps {
   podInfo: PodInfo;
+  isGoalPod?: boolean;
   onTabChange: (tab: PodTab) => void;
   podUiPreferences: PodUiScopedPreferences;
   setPodUiPreferences: (value: PodUiScopedPreferences) => void;
@@ -44,6 +46,7 @@ interface PodPageContentProps {
 
 export function PodPageContent({
   podInfo,
+  isGoalPod = false,
   onTabChange,
   podUiPreferences,
   setPodUiPreferences,
@@ -191,25 +194,29 @@ export function PodPageContent({
   return (
     <>
       <NavTabPillContent value="conversations">
-        <PodConversationsTab
-          owner={owner}
-          user={user}
-          conversations={conversations}
-          isConversationsLoading={isConversationsLoading}
-          hasMore={hasMore}
-          loadMore={loadMore}
-          isLoadingMore={isLoadingMore}
-          podInfo={podInfo}
-          isPodEmpty={isPodEmpty}
-          conversationFilter={conversationFilter}
-          onConversationFilterChange={handleConversationFilterChange}
-          hideTriggeredConversations={hideTriggeredConversations}
-          onHideTriggeredConversationsChange={
-            handleHideTriggeredConversationsChange
-          }
-          onSubmit={handleConversationCreation}
-          onNavigateToTasks={() => onTabChange("tasks")}
-        />
+        {isGoalPod && podInfo.isEditor ? (
+          <GoalPodOverview owner={owner} user={user} podId={podInfo.sId} />
+        ) : (
+          <PodConversationsTab
+            owner={owner}
+            user={user}
+            conversations={conversations}
+            isConversationsLoading={isConversationsLoading}
+            hasMore={hasMore}
+            loadMore={loadMore}
+            isLoadingMore={isLoadingMore}
+            podInfo={podInfo}
+            isPodEmpty={isPodEmpty}
+            conversationFilter={conversationFilter}
+            onConversationFilterChange={handleConversationFilterChange}
+            hideTriggeredConversations={hideTriggeredConversations}
+            onHideTriggeredConversationsChange={
+              handleHideTriggeredConversationsChange
+            }
+            onSubmit={handleConversationCreation}
+            onNavigateToTasks={() => onTabChange("tasks")}
+          />
+        )}
       </NavTabPillContent>
       <NavTabPillContent value="tasks">
         <PodTasksTab

--- a/front/lib/api/activation/pods.ts
+++ b/front/lib/api/activation/pods.ts
@@ -9,23 +9,6 @@ export type ActivationPodWithSpace = {
   activationPod: ActivationPodResource;
 };
 
-export async function canAdministrateActivationPod(
-  auth: Authenticator,
-  activationPodModelId: ModelId
-): Promise<boolean> {
-  const [activationPod] = await ActivationPodResource.fetchByModelIds(auth, [
-    activationPodModelId,
-  ]);
-  if (!activationPod) {
-    return false;
-  }
-
-  const [pod] = await SpaceResource.fetchByModelIds(auth, [
-    activationPod.spaceId,
-  ]);
-  return pod?.canAdministrate(auth) ?? false;
-}
-
 // Maps each user to one Activation Pod of the given kind. Defaults to the
 // Learning Space, matching GET /activation-pod with no podId.
 export async function listActivationPodsByUser(

--- a/front/lib/api/activation/pods.ts
+++ b/front/lib/api/activation/pods.ts
@@ -9,6 +9,23 @@ export type ActivationPodWithSpace = {
   activationPod: ActivationPodResource;
 };
 
+export async function canAdministrateActivationPod(
+  auth: Authenticator,
+  activationPodModelId: ModelId
+): Promise<boolean> {
+  const [activationPod] = await ActivationPodResource.fetchByModelIds(auth, [
+    activationPodModelId,
+  ]);
+  if (!activationPod) {
+    return false;
+  }
+
+  const [pod] = await SpaceResource.fetchByModelIds(auth, [
+    activationPod.spaceId,
+  ]);
+  return pod?.canAdministrate(auth) ?? false;
+}
+
 // Maps each user to one Activation Pod of the given kind. Defaults to the
 // Learning Space, matching GET /activation-pod with no podId.
 export async function listActivationPodsByUser(

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -1,3 +1,4 @@
+import { canAdministrateActivationPod } from "@app/lib/api/activation/pods";
 import type { Authenticator } from "@app/lib/auth";
 import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import type { ActivationRecommendationStatus } from "@app/lib/models/activation/activation_recommendation";
@@ -32,8 +33,21 @@ export interface GetActivationPodResponseBody {
 }
 
 export async function getActivationPodInfo(
-  auth: Authenticator
+  auth: Authenticator,
+  { podId }: { podId?: string } = {}
 ): Promise<GetActivationPodResponseBody> {
+  if (podId) {
+    const space = await SpaceResource.fetchById(auth, podId);
+    if (!space) {
+      return { podId: null, kind: null };
+    }
+    const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
+    return {
+      podId: activationPod ? space.sId : null,
+      kind: activationPod?.kind ?? null,
+    };
+  }
+
   const allPods = await ActivationPodResource.listByUser(auth);
   const learningPod = allPods.find((p) => p.kind === "learning") ?? null;
   if (!learningPod) {
@@ -63,12 +77,18 @@ export async function listActivationRecommendationsForUser(
   }: { podId?: string; status?: ActivationRecommendationStatus } = {}
 ): Promise<ActivationRecommendationForUserType[]> {
   let spaceModelId: number | undefined;
+  let activationPodModelId: number | undefined;
   if (podId !== undefined) {
     const space = await SpaceResource.fetchById(auth, podId);
     if (!space) {
       return [];
     }
     spaceModelId = space.id;
+    const activationPod = await ActivationPodResource.fetchBySpace(auth, space);
+    if (!activationPod) {
+      return [];
+    }
+    activationPodModelId = activationPod.id;
   }
 
   const recs = await ActivationRecommendationResource.listByUserAndStatus(
@@ -78,6 +98,7 @@ export async function listActivationRecommendationsForUser(
       limit: status === "executed" ? EXECUTED_LIMIT : SUGGESTED_LIMIT,
       sinceDaysAgo: NEXT_STEPS_WINDOW_DAYS,
       spaceModelId,
+      activationPodModelId,
     }
   );
 
@@ -109,11 +130,14 @@ export async function updateActivationRecommendationForUser(
     auth,
     recommendationId
   );
-  // fetchById only scopes to the workspace, so also enforce ownership: a
-  // recommendation may only be updated by the user it belongs to. Return
-  // "not_found" rather than a distinct error so we don't leak the existence of
-  // another user's recommendation.
-  if (!rec || rec.userId !== auth.getNonNullableUser().id) {
+  if (!rec) {
+    return "not_found";
+  }
+  const canUpdate =
+    rec.activationPodId !== null
+      ? await canAdministrateActivationPod(auth, rec.activationPodId)
+      : rec.userId === auth.getNonNullableUser().id;
+  if (!canUpdate) {
     return "not_found";
   }
 

--- a/front/lib/api/activation/recommendations.ts
+++ b/front/lib/api/activation/recommendations.ts
@@ -1,4 +1,3 @@
-import { canAdministrateActivationPod } from "@app/lib/api/activation/pods";
 import type { Authenticator } from "@app/lib/auth";
 import type { ActivationPodKind } from "@app/lib/models/activation/activation_pod";
 import type { ActivationRecommendationStatus } from "@app/lib/models/activation/activation_recommendation";
@@ -133,10 +132,16 @@ export async function updateActivationRecommendationForUser(
   if (!rec) {
     return "not_found";
   }
-  const canUpdate =
-    rec.activationPodId !== null
-      ? await canAdministrateActivationPod(auth, rec.activationPodId)
-      : rec.userId === auth.getNonNullableUser().id;
+
+  const [activationPod] = rec.activationPodId
+    ? await ActivationPodResource.fetchByModelIds(auth, [rec.activationPodId])
+    : [];
+  const [space] = activationPod
+    ? await SpaceResource.fetchByModelIds(auth, [activationPod.spaceId])
+    : [];
+  const canUpdate = rec.activationPodId
+    ? Boolean(space?.canAdministrate(auth))
+    : rec.userId === auth.getNonNullableUser().id;
   if (!canUpdate) {
     return "not_found";
   }

--- a/front/lib/resources/activation_recommendation_resource.ts
+++ b/front/lib/resources/activation_recommendation_resource.ts
@@ -183,11 +183,13 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
       limit = 5,
       sinceDaysAgo,
       spaceModelId,
+      activationPodModelId,
     }: {
       status: ActivationRecommendationStatus;
       limit?: number;
       sinceDaysAgo?: number;
       spaceModelId?: ModelId;
+      activationPodModelId?: ModelId;
     }
   ): Promise<
     {
@@ -195,12 +197,12 @@ export class ActivationRecommendationResource extends BaseResource<ActivationRec
       conversationSId: string | null;
     }[]
   > {
-    const user = auth.getNonNullableUser();
-
     const where: WhereOptions<ActivationRecommendationModel> = {
-      userId: user.id,
       workspaceId: auth.getNonNullableWorkspace().id,
       status,
+      ...(activationPodModelId !== undefined
+        ? { activationPodId: activationPodModelId }
+        : { userId: auth.getNonNullableUser().id }),
     };
 
     if (sinceDaysAgo !== undefined) {

--- a/front/lib/swr/activation.ts
+++ b/front/lib/swr/activation.ts
@@ -56,24 +56,31 @@ export function useActivationRecommendations({
   };
 }
 
+// The current user's activation pod, optionally scoped to a specific pod sId.
 export function useActivationPod({
   workspaceId,
+  podId,
   disabled,
 }: {
   workspaceId: string;
+  podId?: string | null;
   disabled?: boolean;
 }) {
   const { fetcher } = useFetcher();
   const podFetcher: Fetcher<GetActivationPodResponseBody> = fetcher;
 
-  const { data, error, isLoading } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/activation-pod`,
-    podFetcher,
-    { disabled, revalidateOnFocus: false }
-  );
+  const url = podId
+    ? `/api/w/${workspaceId}/activation-pod?podId=${podId}`
+    : `/api/w/${workspaceId}/activation-pod`;
+
+  const { data, error, isLoading } = useSWRWithDefaults(url, podFetcher, {
+    disabled,
+    revalidateOnFocus: false,
+  });
 
   return {
     activationPodId: data?.podId ?? null,
+    podKind: data?.kind ?? null,
     isActivationPodLoading: disabled ? false : isLoading,
     isActivationPodError: !!error,
   };


### PR DESCRIPTION
## Summary
- Goal Pod editors get `GoalPodOverview` on the Conversations tab (same For You composition, Goal copy). Non-editors still see the normal Conversations list.
- `GET /activation-pod?podId=` returns that Pod's `kind` so the page can branch
- Rec dismiss is authorized via pod editors, matching other Pod edits.

## Testing
<img width="1518" height="872" alt="Screenshot 2026-08-24 at 3 48 22 PM" src="https://github.com/user-attachments/assets/f07a5ae3-4583-4f4f-8c71-1891c7af9e23" />

## Risk
Low, not customer facing

## Deploy
1. Deploy front