### PR TITLE
[front] enh: replace the Usage tab with personal analytics

### DIFF
--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -1,3 +1,4 @@
+import { PersonalUsageCard } from "@app/components/credits/PersonalUsageCard";
 import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
 import { ConsumptionChart } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
 import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
@@ -31,11 +32,13 @@ import { useMemo, useState } from "react";
 interface UserAnalyticsPopoverProps {
   open: boolean;
   owner: WorkspaceType;
+  onClose: () => void;
 }
 
 export function UserAnalyticsPopover({
   open,
   owner,
+  onClose,
 }: UserAnalyticsPopoverProps) {
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
@@ -80,6 +83,12 @@ export function UserAnalyticsPopover({
 
       <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8 pt-1 sm:px-6">
         <Page.Vertical align="stretch" gap="xl">
+          <PersonalUsageCard
+            owner={owner}
+            visible={open}
+            onManagerNavigate={onClose}
+          />
+
           <ConsumptionSummary
             workspaceId={owner.sId}
             period={period}
@@ -128,6 +137,7 @@ export function UserAnalyticsPopover({
             filter={scopeFilter}
             personal
             disabled={!open}
+            onConversationNavigate={onClose}
             onAddFilter={(selectedRow) => {
               setFilter((current) =>
                 addUsageFilterFromAttributionRow(

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -263,6 +263,7 @@ export function UserMenu({
             key={owner.sId}
             open={analyticsOpen}
             owner={owner}
+            onClose={() => setAnalyticsOpen(false)}
           />
         </DialogContent>
       </Dialog>

--- a/front/components/UserSettingsPopover.tsx
+++ b/front/components/UserSettingsPopover.tsx
@@ -1,4 +1,3 @@
-import { UsageUpgradeButton } from "@app/components/credits/UsageUpgradeButton";
 import { MarkdownEditor } from "@app/components/editor/MarkdownEditor";
 import {
   NotificationPreferences,
@@ -11,37 +10,24 @@ import {
 } from "@app/components/me/SoundNotificationPreferences";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { MyAwuUsageFromAnalyticsChart } from "@app/components/workspace/AwuUsageFromAnalyticsChart";
-import { CreditsCell } from "@app/components/workspace/analytics/creditsTableCells";
-import { AwuUsageBar } from "@app/components/workspace/MembersUsageTable";
 import { useFileUploaderService } from "@app/hooks/useFileUploaderService";
 import { useIsMac } from "@app/hooks/useKeyboardShortcutLabel";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { isSubmitMessageKey } from "@app/lib/keymaps";
-import { useAppRouter } from "@app/lib/platform";
 import { useActivationPod } from "@app/lib/swr/activation";
-import {
-  useMyTopConversations,
-  useMyUsage,
-  useSeatPlan,
-} from "@app/lib/swr/credits";
-import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import {
   usePatchUser,
   usePendingInvitations,
   useUser,
   useUserMemory,
-  useWorkspaceUsageStatus,
 } from "@app/lib/swr/user";
 import { useAuthContext } from "@app/lib/swr/workspaces";
-import { getConversationRoute } from "@app/lib/utils/router";
 import {
   MAX_USER_MEMORY_CHARS,
   MAX_USER_MEMORY_CONTENT_LENGTH,
 } from "@app/types/api/me/memory";
 import type { PendingInvitationOption } from "@app/types/membership_invitation";
-import { isCreditPricedPlan } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 import {
   ANONYMOUS_USER_IMAGE_URL,
@@ -49,7 +35,6 @@ import {
 } from "@app/types/user";
 import {
   Avatar,
-  BarChart01,
   Bell01,
   Brain,
   Button,
@@ -71,21 +56,17 @@ import {
   NavigationList,
   NavigationListItem,
   Page,
-  Separator,
   Settings01,
   SliderToggle,
   Spinner,
-  Stars02,
   Sun,
   Tabs,
   TabsList,
   TabsTrigger,
-  Tooltip,
   User01,
   XClose,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ExternalLinkIcon } from "lucide-react";
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useController, useForm } from "react-hook-form";
@@ -93,7 +74,6 @@ import { z } from "zod";
 
 type SettingsSection =
   | "personal"
-  | "usage"
   | "customization"
   | "notifications"
   | "memory"
@@ -137,230 +117,6 @@ function SectionContent({
         </div>
       )}
     </div>
-  );
-}
-
-// ─── Usage ────────────────────────────────────────────────────────────────────
-
-function ordinalDay(day: number): string {
-  const suffix =
-    day >= 11 && day <= 13
-      ? "th"
-      : day % 10 === 1
-        ? "st"
-        : day % 10 === 2
-          ? "nd"
-          : day % 10 === 3
-            ? "rd"
-            : "th";
-  return `${day}${suffix}`;
-}
-
-interface MyTopConversationsSectionProps {
-  owner: WorkspaceType;
-  onClose: () => void;
-  visible: boolean;
-}
-
-// Conversations ranked by the user's own credit consumption over the last 30
-// days. Hidden when there is no consumption to show.
-function MyTopConversationsSection({
-  owner,
-  onClose,
-  visible,
-}: MyTopConversationsSectionProps) {
-  const router = useAppRouter();
-  const { topConversations, isTopConversationsLoading } = useMyTopConversations(
-    {
-      workspaceId: owner.sId,
-      disabled: !visible,
-    }
-  );
-
-  if (!isTopConversationsLoading && topConversations.length === 0) {
-    return null;
-  }
-
-  return (
-    <section className="flex flex-col gap-2">
-      <div className="flex items-center gap-1.5">
-        <span className="text-sm font-semibold text-foreground">
-          Most expensive recent conversations
-        </span>
-        <Tooltip
-          label="Conversations with your highest credit consumption over the last 30 days. Costs only reflect your own messages, not the whole conversation's cost."
-          trigger={<InfoCircle className="h-4 w-4 text-muted-foreground" />}
-        />
-      </div>
-      {isTopConversationsLoading ? (
-        <div className="flex justify-center py-2">
-          <Spinner size="sm" />
-        </div>
-      ) : (
-        <NavigationList>
-          {topConversations.map((conversation) => (
-            <NavigationListItem
-              key={conversation.conversationId}
-              label={conversation.title ?? "Untitled conversation"}
-              onClick={() => {
-                onClose();
-                void router.push(
-                  getConversationRoute(owner.sId, conversation.conversationId)
-                );
-              }}
-              suffix={<CreditsCell credits={conversation.totalCredits} />}
-            />
-          ))}
-        </NavigationList>
-      )}
-    </section>
-  );
-}
-
-interface UsageSectionProps {
-  owner: WorkspaceType;
-  onClose: () => void;
-  // The popover stays mounted while closed (animated exit), so gate fetches on
-  // visibility to avoid polling the analytics endpoint from a hidden dialog.
-  visible: boolean;
-}
-
-function UsageSection({ owner, onClose, visible }: UsageSectionProps) {
-  const { isManager, subscription } = useAuth();
-  const { hasPermission } = useWorkspacePermissions();
-  const canAccessBilling = hasPermission("admin", "billing");
-
-  const isCreditBased = isCreditPricedPlan(subscription.plan);
-
-  const { myUsage, nextCreditResetAt, isMyUsageLoading } = useMyUsage({
-    workspaceId: owner.sId,
-    disabled: !isCreditBased || !visible,
-  });
-  const { seatPlans } = useSeatPlan({
-    workspaceId: owner.sId,
-    disabled: !isCreditBased || !visible,
-  });
-
-  const { hasPendingUpgradeRequest, requireReason } = useWorkspaceUsageStatus({
-    owner,
-    disabled: isManager || !isCreditBased || !visible,
-  });
-
-  const seatName =
-    (myUsage?.seatType ? seatPlans[myUsage.seatType]?.name : null) ??
-    subscription.plan.name;
-
-  const isLoading = isMyUsageLoading;
-
-  const hasPersonalUsage =
-    (myUsage?.spendLimitAwuCredits ?? myUsage?.memberUsageLimit ?? null) !==
-    null;
-
-  return (
-    <SectionContent
-      title="Usage"
-      description="Manage the usage of your Dust workspace"
-    >
-      {isCreditBased && (
-        <section className="flex flex-col gap-2 rounded-lg bg-muted-background p-4">
-          <div className="flex items-center justify-between">
-            <span className="flex items-center gap-2">
-              <span className="flex h-6 w-6 items-center justify-center rounded-lg bg-highlight-100 outline outline-1 outline-highlight-500/20">
-                <Stars02 className="h-3 w-3 text-highlight-500" />
-              </span>
-              <span className="text-base font-semibold text-foreground">
-                {seatName}
-              </span>
-            </span>
-            <UsageUpgradeButton
-              owner={owner}
-              hasPendingUpgradeRequest={hasPendingUpgradeRequest}
-              variant="button"
-              isManager={isManager}
-              requireReason={requireReason}
-              onManagerNavigate={onClose}
-            />
-          </div>
-          <Separator />
-          {isLoading ? (
-            <div className="flex justify-center py-2">
-              <Spinner size="sm" />
-            </div>
-          ) : (
-            <div className="flex flex-col gap-3">
-              {hasPersonalUsage ? (
-                <>
-                  <div className="flex flex-col gap-0.5">
-                    <span className="text-sm font-medium text-foreground">
-                      Your Credits
-                    </span>
-                    {nextCreditResetAt &&
-                      myUsage?.seatType !== "free" &&
-                      (() => {
-                        const d = new Date(nextCreditResetAt);
-                        const month = d.toLocaleDateString("en-US", {
-                          month: "long",
-                          timeZone: "UTC",
-                        });
-                        return (
-                          <span className="text-xs text-muted-foreground">
-                            Resets on {month} {ordinalDay(d.getUTCDate())}
-                          </span>
-                        );
-                      })()}
-                  </div>
-                  <AwuUsageBar
-                    consumed={myUsage?.consumedAwuCredits ?? 0}
-                    consumedFromAllowance={
-                      myUsage?.consumedFromAllowanceAwuCredits ?? 0
-                    }
-                    consumedFromPool={myUsage?.consumedFromPoolAwuCredits ?? 0}
-                    memberUsageLimit={myUsage?.memberUsageLimit ?? null}
-                    seatBalanceAwu={myUsage?.seatBalanceAwu ?? null}
-                    effectiveLimit={myUsage?.spendLimitAwuCredits ?? 0}
-                    spendLimitSource={myUsage?.spendLimitSource ?? "none"}
-                    seatType={myUsage?.seatType ?? null}
-                    isTotalAllowedUsagePending={false}
-                  />
-                </>
-              ) : null}
-            </div>
-          )}
-        </section>
-      )}
-
-      <MyAwuUsageFromAnalyticsChart
-        workspaceId={owner.sId}
-        disabled={!visible}
-      />
-
-      <MyTopConversationsSection
-        owner={owner}
-        onClose={onClose}
-        visible={visible}
-      />
-
-      {canAccessBilling && (
-        <section className="flex items-center justify-between border-b border-border dark:border-border-dark pb-4">
-          <div className="flex flex-col gap-0.5">
-            <span className="text-sm font-semibold text-foreground">
-              Invoices
-            </span>
-            <span className="text-sm text-muted-foreground">
-              Access and download your invoices
-            </span>
-          </div>
-          <Button
-            variant="outline"
-            size="xs"
-            label="Billing"
-            icon={ExternalLinkIcon}
-            href={`/w/${owner.sId}/${isCreditBased ? "billing" : "subscription"}`}
-            target="_blank"
-          />
-        </section>
-      )}
-    </SectionContent>
   );
 }
 
@@ -909,7 +665,6 @@ const NAV_ITEMS: Array<{
   label: string;
 }> = [
   { section: "personal", icon: User01, label: "Personal Information" },
-  { section: "usage", icon: BarChart01, label: "Usage" },
   { section: "customization", icon: Settings01, label: "Customization" },
   { section: "memory", icon: Brain, label: "Memory" },
   { section: "notifications", icon: Bell01, label: "Notifications" },
@@ -1020,13 +775,6 @@ export function UserSettingsPopover({
           <div className="flex flex-1 flex-col overflow-hidden">
             {activeSection === "personal" && (
               <PersonalInfoSection owner={owner} />
-            )}
-            {activeSection === "usage" && (
-              <UsageSection
-                owner={owner}
-                onClose={() => onOpenChange(false)}
-                visible={open}
-              />
             )}
             {activeSection === "customization" && <CustomizationSection />}
             {activeSection === "notifications" && (

--- a/front/components/credits/PersonalUsageCard.tsx
+++ b/front/components/credits/PersonalUsageCard.tsx
@@ -1,0 +1,115 @@
+import { UsageUpgradeButton } from "@app/components/credits/UsageUpgradeButton";
+import { AwuUsageBar } from "@app/components/workspace/MembersUsageTable";
+import { useAuth } from "@app/lib/auth/AuthContext";
+import { useMyUsage, useSeatPlan } from "@app/lib/swr/credits";
+import { useWorkspaceUsageStatus } from "@app/lib/swr/user";
+import { isCreditPricedPlan } from "@app/types/plan";
+import { ordinalDay } from "@app/types/shared/utils/date_utils";
+import type { WorkspaceType } from "@app/types/user";
+import { Separator, Spinner, Stars02 } from "@dust-tt/sparkle";
+
+interface PersonalUsageCardProps {
+  owner: WorkspaceType;
+  visible: boolean;
+  onManagerNavigate?: () => void;
+}
+
+export function PersonalUsageCard({
+  owner,
+  visible,
+  onManagerNavigate,
+}: PersonalUsageCardProps) {
+  const { isManager, subscription } = useAuth();
+  const isCreditBased = isCreditPricedPlan(subscription.plan);
+  const { myUsage, nextCreditResetAt, isMyUsageLoading } = useMyUsage({
+    workspaceId: owner.sId,
+    disabled: !isCreditBased || !visible,
+  });
+  const { seatPlans } = useSeatPlan({
+    workspaceId: owner.sId,
+    disabled: !isCreditBased || !visible,
+  });
+  const { hasPendingUpgradeRequest, requireReason } = useWorkspaceUsageStatus({
+    owner,
+    disabled: isManager || !isCreditBased || !visible,
+  });
+
+  if (!isCreditBased) {
+    return null;
+  }
+
+  const seatName =
+    (myUsage?.seatType ? seatPlans[myUsage.seatType]?.name : null) ??
+    subscription.plan.name;
+  const hasPersonalUsage =
+    (myUsage?.spendLimitAwuCredits ?? myUsage?.memberUsageLimit ?? null) !==
+    null;
+
+  return (
+    <section className="flex flex-col gap-2 rounded-lg bg-muted-background p-4">
+      <div className="flex items-center justify-between">
+        <span className="flex items-center gap-2">
+          <span className="flex h-6 w-6 items-center justify-center rounded-lg bg-highlight-100 outline outline-1 outline-highlight-500/20">
+            <Stars02 className="h-3 w-3 text-highlight-500" />
+          </span>
+          <span className="text-base font-semibold text-foreground">
+            {seatName}
+          </span>
+        </span>
+        <UsageUpgradeButton
+          owner={owner}
+          hasPendingUpgradeRequest={hasPendingUpgradeRequest}
+          variant="button"
+          isManager={isManager}
+          requireReason={requireReason}
+          onManagerNavigate={onManagerNavigate}
+        />
+      </div>
+      <Separator />
+      {isMyUsageLoading ? (
+        <div className="flex justify-center py-2">
+          <Spinner size="sm" />
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {hasPersonalUsage ? (
+            <>
+              <div className="flex flex-col gap-0.5">
+                <span className="text-sm font-medium text-foreground">
+                  Your Credits
+                </span>
+                {nextCreditResetAt &&
+                  myUsage?.seatType !== "free" &&
+                  (() => {
+                    const resetAt = new Date(nextCreditResetAt);
+                    const month = resetAt.toLocaleDateString("en-US", {
+                      month: "long",
+                      timeZone: "UTC",
+                    });
+                    return (
+                      <span className="text-xs text-muted-foreground">
+                        Resets on {month} {ordinalDay(resetAt.getUTCDate())}
+                      </span>
+                    );
+                  })()}
+              </div>
+              <AwuUsageBar
+                consumed={myUsage?.consumedAwuCredits ?? 0}
+                consumedFromAllowance={
+                  myUsage?.consumedFromAllowanceAwuCredits ?? 0
+                }
+                consumedFromPool={myUsage?.consumedFromPoolAwuCredits ?? 0}
+                memberUsageLimit={myUsage?.memberUsageLimit ?? null}
+                seatBalanceAwu={myUsage?.seatBalanceAwu ?? null}
+                effectiveLimit={myUsage?.spendLimitAwuCredits ?? 0}
+                spendLimitSource={myUsage?.spendLimitSource ?? "none"}
+                seatType={myUsage?.seatType ?? null}
+                isTotalAllowedUsagePending={false}
+              />
+            </>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -56,6 +56,15 @@ vi.mock(
   })
 );
 
+vi.mock(
+  "@app/components/workspace/analytics/consumption/ConsumptionConversationAttribution",
+  () => ({
+    ConsumptionConversationAttribution: () => (
+      <div>Conversation attribution</div>
+    ),
+  })
+);
+
 const period = { kind: "days", days: 30 } as const;
 
 function ControlledAttributionTable({
@@ -127,6 +136,9 @@ describe("ConsumptionAttributionTable", () => {
       screen.queryByRole("button", { name: "Download raw data" })
     ).not.toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Agents" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Conversations" })).toHaveClass(
+      "ml-auto"
+    );
     expect(
       screen.queryByRole("tab", { name: "Members" })
     ).not.toBeInTheDocument();
@@ -169,6 +181,58 @@ describe("ConsumptionAttributionTable", () => {
     expect(mockUseConsumptionTop).toHaveBeenLastCalledWith(
       expect.objectContaining({ dimension: "agent", personal: true })
     );
+  });
+
+  it("shows conversations only in personal attribution without changing the chart dimension", () => {
+    const onDimensionChange = vi.fn();
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [],
+      totalCredits: 0,
+      totalCount: 0,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    });
+
+    const { rerender } = render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        personal
+        dimension="agent"
+        onDimensionChange={onDimensionChange}
+        onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    const conversationsTab = screen.getByRole("tab", {
+      name: "Conversations",
+    });
+    fireEvent.pointerDown(conversationsTab);
+    fireEvent.mouseDown(conversationsTab, { button: 0, ctrlKey: false });
+
+    expect(onDimensionChange).not.toHaveBeenCalled();
+    expect(screen.getByText("Conversation attribution")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search…")).not.toBeInTheDocument();
+
+    rerender(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        dimension="agent"
+        onDimensionChange={onDimensionChange}
+        onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.queryByRole("tab", { name: "Conversations" })
+    ).not.toBeInTheDocument();
   });
 
   it("caps the available pages and fetches the selected fixed-size page", async () => {

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -5,6 +5,7 @@ import {
   isInternalAllowedIcon,
 } from "@app/components/resources/resources_icons";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { ConsumptionConversationAttribution } from "@app/components/workspace/analytics/consumption/ConsumptionConversationAttribution";
 import { ConsumptionExportPanel } from "@app/components/workspace/analytics/consumption/ConsumptionExportPanel";
 import {
   AvatarNameCell,
@@ -72,13 +73,17 @@ import type {
   ConsumptionAttributionRowsTableProps,
 } from "./ConsumptionAttributionRowsTable";
 import { ConsumptionAttributionRowsTable } from "./ConsumptionAttributionRowsTable";
-import type { ConsumptionDimension } from "./consumptionDimensions";
+import type {
+  ConsumptionAttributionDimension,
+  ConsumptionDimension,
+} from "./consumptionDimensions";
 import {
+  CONSUMPTION_ATTRIBUTION_DIMENSIONS,
   CONSUMPTION_DIMENSION_CONFIG,
-  CONSUMPTION_DIMENSIONS,
+  consumptionAttributionDimensionLabel,
   DEFAULT_CONSUMPTION_DIMENSION,
   getConsumptionAttributionDimensions,
-  isConsumptionDimension,
+  isConsumptionAttributionDimension,
 } from "./consumptionDimensions";
 
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
@@ -96,7 +101,7 @@ const ATTRIBUTION_SERVER_SORTABLE_COLUMN_IDS = new Set([
 type AttributionTransitionDirection = -1 | 0 | 1;
 
 interface AttributionTransition {
-  target: ConsumptionDimension | null;
+  target: ConsumptionAttributionDimension | null;
   direction: AttributionTransitionDirection;
 }
 
@@ -124,11 +129,12 @@ const ATTRIBUTION_BODY_VARIANTS: Variants = {
 };
 
 function getAttributionTransitionDirection(
-  currentDimension: ConsumptionDimension,
-  nextDimension: ConsumptionDimension
+  currentDimension: ConsumptionAttributionDimension,
+  nextDimension: ConsumptionAttributionDimension
 ): AttributionTransitionDirection {
-  const currentIndex = CONSUMPTION_DIMENSIONS.indexOf(currentDimension);
-  const nextIndex = CONSUMPTION_DIMENSIONS.indexOf(nextDimension);
+  const currentIndex =
+    CONSUMPTION_ATTRIBUTION_DIMENSIONS.indexOf(currentDimension);
+  const nextIndex = CONSUMPTION_ATTRIBUTION_DIMENSIONS.indexOf(nextDimension);
 
   if (currentIndex === nextIndex) {
     return 0;
@@ -744,6 +750,7 @@ export interface ConsumptionAttributionTableProps {
     selectedRow: ConsumptionTopRow
   ) => void;
   showExport?: boolean;
+  onConversationNavigate?: () => void;
 }
 
 interface ConsumptionAttributionTableViewProps
@@ -763,23 +770,28 @@ export function ConsumptionAttributionTableView({
   onDimensionChange,
   onViewAll,
   showExport = true,
+  onConversationNavigate,
   AttributionRowsComponent,
 }: ConsumptionAttributionTableViewProps) {
   const { inputValue, debouncedValue, setValue } = useDebounce("", {
     delay: SEARCH_DEBOUNCE_DELAY_MS,
   });
-  const pendingPointerDimension = useRef<ConsumptionDimension | null>(null);
-  const [transition, setTransition] = useState<AttributionTransition>({
-    target: null,
-    direction: 0,
-  });
+  const [isConversationSelected, setIsConversationSelected] = useState(false);
   const activeDimension =
     personal && (dimension === "user" || dimension === "group")
       ? DEFAULT_CONSUMPTION_DIMENSION
       : dimension;
+  const attributionDimension: ConsumptionAttributionDimension =
+    personal && isConversationSelected ? "conversation" : activeDimension;
+  const pendingPointerDimension =
+    useRef<ConsumptionAttributionDimension | null>(null);
+  const [transition, setTransition] = useState<AttributionTransition>({
+    target: null,
+    direction: 0,
+  });
   const shouldReduceMotion = useReducedMotion();
   const effectiveTransitionDirection =
-    shouldReduceMotion || transition.target !== activeDimension
+    shouldReduceMotion || transition.target !== attributionDimension
       ? 0
       : transition.direction;
   const visibleDimensions = getConsumptionAttributionDimensions({ personal });
@@ -805,21 +817,26 @@ export function ConsumptionAttributionTableView({
       <div className="rounded-lg border border-border bg-panel-background p-4">
         <div className="flex flex-col gap-3">
           <Tabs
-            value={activeDimension}
+            value={attributionDimension}
             onValueChange={(value) => {
-              if (isConsumptionDimension(value)) {
+              if (isConsumptionAttributionDimension(value)) {
                 setTransition({
                   target: value,
                   direction:
                     pendingPointerDimension.current === value
                       ? getAttributionTransitionDirection(
-                          activeDimension,
+                          attributionDimension,
                           value
                         )
                       : 0,
                 });
                 pendingPointerDimension.current = null;
-                onDimensionChange(value);
+                if (value === "conversation") {
+                  setIsConversationSelected(true);
+                } else {
+                  setIsConversationSelected(false);
+                  onDimensionChange(value);
+                }
               }
             }}
           >
@@ -828,7 +845,10 @@ export function ConsumptionAttributionTableView({
                 <TabsTrigger
                   key={tabDimension}
                   value={tabDimension}
-                  label={CONSUMPTION_DIMENSION_CONFIG[tabDimension].label}
+                  label={consumptionAttributionDimensionLabel(tabDimension)}
+                  className={
+                    tabDimension === "conversation" ? "ml-auto" : undefined
+                  }
                   onPointerDown={() => {
                     pendingPointerDimension.current = tabDimension;
                   }}
@@ -842,13 +862,15 @@ export function ConsumptionAttributionTableView({
               ))}
             </TabsList>
           </Tabs>
-          <SearchInput
-            name="consumption-attribution-search"
-            placeholder="Search…"
-            value={inputValue}
-            onChange={setValue}
-            className="w-full"
-          />
+          {attributionDimension !== "conversation" && (
+            <SearchInput
+              name="consumption-attribution-search"
+              placeholder="Search…"
+              value={inputValue}
+              onChange={setValue}
+              className="w-full"
+            />
+          )}
           <LazyMotion features={domMax}>
             <div className="relative overflow-hidden">
               <AnimatePresence
@@ -857,31 +879,40 @@ export function ConsumptionAttributionTableView({
                 custom={effectiveTransitionDirection}
               >
                 <m.div
-                  key={activeDimension}
+                  key={attributionDimension}
                   custom={effectiveTransitionDirection}
                   variants={ATTRIBUTION_BODY_VARIANTS}
                   initial="initial"
                   animate="animate"
                   exit="exit"
                 >
-                  {/* Reset table state whenever its dataset or local search changes. */}
-                  <AttributionRowsComponent
-                    key={JSON.stringify({
-                      period,
-                      filter,
-                      search: debouncedValue,
-                    })}
-                    workspaceId={workspaceId}
-                    dimension={activeDimension}
-                    period={period}
-                    filter={filter}
-                    personal={personal}
-                    disabled={disabled}
-                    onAddFilter={onAddFilter}
-                    onRemoveFilter={onRemoveFilter}
-                    search={debouncedValue}
-                    onViewAll={onViewAll}
-                  />
+                  {attributionDimension === "conversation" ? (
+                    <ConsumptionConversationAttribution
+                      workspaceId={workspaceId}
+                      period={period}
+                      filter={filter}
+                      disabled={disabled}
+                      onNavigate={onConversationNavigate}
+                    />
+                  ) : (
+                    <AttributionRowsComponent
+                      key={JSON.stringify({
+                        period,
+                        filter,
+                        search: debouncedValue,
+                      })}
+                      workspaceId={workspaceId}
+                      dimension={attributionDimension}
+                      period={period}
+                      filter={filter}
+                      personal={personal}
+                      disabled={disabled}
+                      onAddFilter={onAddFilter}
+                      onRemoveFilter={onRemoveFilter}
+                      search={debouncedValue}
+                      onViewAll={onViewAll}
+                    />
+                  )}
                 </m.div>
               </AnimatePresence>
             </div>

--- a/front/components/workspace/analytics/consumption/ConsumptionConversationAttribution.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionConversationAttribution.test.tsx
@@ -1,0 +1,68 @@
+import { ConsumptionConversationAttribution } from "@app/components/workspace/analytics/consumption/ConsumptionConversationAttribution";
+import { getConversationRoute } from "@app/lib/utils/router";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPush, mockUseConsumptionTopConversations } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockUseConsumptionTopConversations: vi.fn(),
+}));
+
+vi.mock("@app/hooks/useConsumptionTopConversations", () => ({
+  useConsumptionTopConversations: mockUseConsumptionTopConversations,
+}));
+
+vi.mock("@app/lib/platform", () => ({
+  useAppRouter: () => ({ push: mockPush }),
+}));
+
+describe("ConsumptionConversationAttribution", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockUseConsumptionTopConversations.mockReturnValue({
+      conversations: [
+        {
+          conversationId: "conversation-id",
+          title: "Quarterly report",
+          totalCredits: 42,
+        },
+      ],
+      isTopConversationsLoading: false,
+      isTopConversationsError: undefined,
+    });
+  });
+
+  it("renders labeled columns and opens the selected conversation", () => {
+    const onNavigate = vi.fn();
+
+    render(
+      <ConsumptionConversationAttribution
+        workspaceId="workspace-id"
+        period={{ kind: "days", days: 30 }}
+        onNavigate={onNavigate}
+      />
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: "Conversation" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Total Credits" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Quarterly report")).toHaveClass("text-sm");
+
+    fireEvent.click(screen.getByText("Quarterly report"));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(mockPush).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Quarterly report" })
+    );
+
+    expect(onNavigate).toHaveBeenCalledOnce();
+    expect(mockPush).toHaveBeenCalledWith(
+      getConversationRoute("workspace-id", "conversation-id")
+    );
+  });
+});

--- a/front/components/workspace/analytics/consumption/ConsumptionConversationAttribution.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionConversationAttribution.tsx
@@ -1,0 +1,130 @@
+import { CreditsCell } from "@app/components/workspace/analytics/creditsTableCells";
+import { useConsumptionTopConversations } from "@app/hooks/useConsumptionTopConversations";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type { ConsumptionTopConversationRow } from "@app/lib/api/analytics/consumption/top_conversations";
+import { useAppRouter } from "@app/lib/platform";
+import { getConversationRoute } from "@app/lib/utils/router";
+import { ArrowRight, Button, DataTable, Spinner } from "@dust-tt/sparkle";
+import type { ColumnDef } from "@tanstack/react-table";
+
+type ConversationAttributionRow = ConsumptionTopConversationRow & {
+  onOpen: () => void;
+  // DataTable requires rows to share one of its interaction props. Navigation
+  // stays scoped to the explicit action cell.
+  onClick?: never;
+};
+
+const CONVERSATION_COLUMNS: ColumnDef<ConversationAttributionRow>[] = [
+  {
+    id: "conversation",
+    header: "Conversation",
+    cell: ({ row }) => (
+      <DataTable.CellContent className="w-full justify-start text-left">
+        <span className="truncate text-sm">
+          {row.original.title || "Untitled conversation"}
+        </span>
+      </DataTable.CellContent>
+    ),
+    enableSorting: false,
+  },
+  {
+    id: "totalCredits",
+    header: "Total Credits",
+    cell: ({ row }) => <CreditsCell credits={row.original.totalCredits} />,
+    enableSorting: false,
+    meta: {
+      className: "w-32 text-right",
+      headerAlign: "right",
+    },
+  },
+  {
+    id: "open",
+    header: "",
+    enableSorting: false,
+    meta: { className: "w-12 p-0", headerAlign: "right" },
+    cell: ({ row }) => {
+      const title = row.original.title || "Untitled conversation";
+      return (
+        <Button
+          icon={ArrowRight}
+          variant="ghost-secondary"
+          size="xs"
+          className="h-12 w-full rounded-none"
+          tooltip="Open conversation"
+          aria-label={`Open ${title}`}
+          onClick={row.original.onOpen}
+        />
+      );
+    },
+  },
+];
+
+export interface ConsumptionConversationAttributionProps {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+  disabled?: boolean;
+  onNavigate?: () => void;
+}
+
+export function ConsumptionConversationAttribution({
+  workspaceId,
+  period,
+  filter,
+  disabled,
+  onNavigate,
+}: ConsumptionConversationAttributionProps) {
+  const router = useAppRouter();
+  const { conversations, isTopConversationsLoading, isTopConversationsError } =
+    useConsumptionTopConversations({
+      workspaceId,
+      period,
+      filter,
+      disabled,
+    });
+
+  if (isTopConversationsError) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        Failed to load attribution.
+      </div>
+    );
+  }
+
+  if (isTopConversationsLoading) {
+    return (
+      <div className="flex justify-center py-2">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground">
+        No consumption over this period.
+      </div>
+    );
+  }
+
+  const rows: ConversationAttributionRow[] = conversations.map(
+    (conversation) => ({
+      ...conversation,
+      onOpen: () => {
+        onNavigate?.();
+        void router.push(
+          getConversationRoute(workspaceId, conversation.conversationId)
+        );
+      },
+    })
+  );
+
+  return (
+    <DataTable<ConversationAttributionRow>
+      data={rows}
+      columns={CONVERSATION_COLUMNS}
+      getRowId={(row) => row.conversationId}
+    />
+  );
+}

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
@@ -36,12 +36,12 @@ describe("consumption dimension URL state", () => {
     );
     expect(getConsumptionAttributionDimensions({ personal: true })).toEqual([
       "agent",
-      "conversation",
       "model",
       "tool",
       "skill",
       "source",
       "api_key",
+      "conversation",
     ]);
   });
 

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.test.ts
@@ -1,4 +1,5 @@
 import {
+  CONSUMPTION_ATTRIBUTION_DIMENSIONS,
   CONSUMPTION_DIMENSION_CONFIG,
   CONSUMPTION_DIMENSIONS,
   consumptionDimensionFromQueryParam,
@@ -10,6 +11,7 @@ describe("consumption dimension URL state", () => {
   it("reads valid dimensions and falls back to agents", () => {
     expect(consumptionDimensionFromQueryParam("user")).toBe("user");
     expect(consumptionDimensionFromQueryParam("api_key")).toBe("api_key");
+    expect(consumptionDimensionFromQueryParam("conversation")).toBe("agent");
     expect(consumptionDimensionFromQueryParam("invalid")).toBe("agent");
     expect(consumptionDimensionFromQueryParam(undefined)).toBe("agent");
   });
@@ -34,11 +36,27 @@ describe("consumption dimension URL state", () => {
     );
     expect(getConsumptionAttributionDimensions({ personal: true })).toEqual([
       "agent",
+      "conversation",
       "model",
       "tool",
       "skill",
       "source",
       "api_key",
     ]);
+  });
+
+  it("adds conversations only to attribution tabs", () => {
+    expect(CONSUMPTION_ATTRIBUTION_DIMENSIONS).toEqual([
+      "agent",
+      "user",
+      "group",
+      "model",
+      "tool",
+      "skill",
+      "source",
+      "api_key",
+      "conversation",
+    ]);
+    expect(CONSUMPTION_DIMENSIONS).not.toContain("conversation");
   });
 });

--- a/front/components/workspace/analytics/consumption/consumptionDimensions.ts
+++ b/front/components/workspace/analytics/consumption/consumptionDimensions.ts
@@ -16,16 +16,36 @@ export const CONSUMPTION_DIMENSIONS: ConsumptionDimension[] = [
   "api_key",
 ];
 
-const PERSONAL_CONSUMPTION_DIMENSIONS = CONSUMPTION_DIMENSIONS.filter(
-  (dimension) => dimension !== "user" && dimension !== "group"
-);
+export type ConsumptionAttributionDimension =
+  | ConsumptionDimension
+  | "conversation";
+
+export const CONSUMPTION_ATTRIBUTION_DIMENSIONS: ConsumptionAttributionDimension[] =
+  [
+    "agent",
+    "user",
+    "group",
+    "model",
+    "tool",
+    "skill",
+    "source",
+    "api_key",
+    "conversation",
+  ];
+
+const PERSONAL_CONSUMPTION_ATTRIBUTION_DIMENSIONS =
+  CONSUMPTION_ATTRIBUTION_DIMENSIONS.filter(
+    (dimension) => dimension !== "user" && dimension !== "group"
+  );
 
 export function getConsumptionAttributionDimensions({
   personal,
 }: {
   personal?: boolean;
-}): readonly ConsumptionDimension[] {
-  return personal ? PERSONAL_CONSUMPTION_DIMENSIONS : CONSUMPTION_DIMENSIONS;
+}): readonly ConsumptionAttributionDimension[] {
+  return personal
+    ? PERSONAL_CONSUMPTION_ATTRIBUTION_DIMENSIONS
+    : CONSUMPTION_DIMENSIONS;
 }
 
 interface ConsumptionDimensionConfig {
@@ -96,6 +116,20 @@ export function isConsumptionDimension(
   value: string
 ): value is ConsumptionDimension {
   return CONSUMPTION_DIMENSIONS.some((dimension) => dimension === value);
+}
+
+export function isConsumptionAttributionDimension(
+  value: string
+): value is ConsumptionAttributionDimension {
+  return value === "conversation" || isConsumptionDimension(value);
+}
+
+export function consumptionAttributionDimensionLabel(
+  dimension: ConsumptionAttributionDimension
+): string {
+  return dimension === "conversation"
+    ? "Conversations"
+    : CONSUMPTION_DIMENSION_CONFIG[dimension].label;
 }
 
 export function consumptionDimensionFromQueryParam(

--- a/front/types/shared/utils/date_utils.test.ts
+++ b/front/types/shared/utils/date_utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { ordinalDay } from "./date_utils";
+
+describe("ordinalDay", () => {
+  it.each([
+    [1, "1st"],
+    [2, "2nd"],
+    [3, "3rd"],
+    [4, "4th"],
+    [11, "11th"],
+    [12, "12th"],
+    [13, "13th"],
+    [21, "21st"],
+    [22, "22nd"],
+    [23, "23rd"],
+    [31, "31st"],
+  ])("formats %i as %s", (day, expected) => {
+    expect(ordinalDay(day)).toBe(expected);
+  });
+});

--- a/front/types/shared/utils/date_utils.ts
+++ b/front/types/shared/utils/date_utils.ts
@@ -8,6 +8,21 @@ export function dateToHumanReadable(date: Date) {
   return format(date, "MMM d, yyyy 'at' h:mm a");
 }
 
+export function ordinalDay(day: number): string {
+  const suffix =
+    day >= 11 && day <= 13
+      ? "th"
+      : day % 10 === 1
+        ? "st"
+        : day % 10 === 2
+          ? "nd"
+          : day % 10 === 3
+            ? "rd"
+            : "th";
+
+  return `${day}${suffix}`;
+}
+
 export function getTime(date: number): string {
   return format(new Date(date), "HH:mm");
 }


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/31079/changes.
Part of https://github.com/dust-tt/tasks/issues/10166.

The personal Analytics popover now replaces the separate Usage tab in user settings. It moves two existing surfaces into the popover:

The current seat and credit allowance, together with the existing `UsageUpgradeButton`.

<img width="940" height="713" alt="image" src="https://github.com/user-attachments/assets/d6b6443a-83b1-4cf9-8e1b-a752b0736239" />

The top most expensive conversations view, exposed as a dedicated attribution tab with an explicit open-conversation action.

<img width="947" height="718" alt="image" src="https://github.com/user-attachments/assets/11f3aacf-6bd3-4e70-90d7-45119a9236ac" />

The personal conversations API and hook live in #31079; this PR contains only the UI integration.

## Tests

- Added focused coverage for dimension availability, conversation attribution rendering, and ordinal-day formatting.

## Risk

- Low. Limited to personal analytics and user settings navigation.

## Deploy Plan

- Deploy front.