### PR TITLE
[front] enh: add credit usage Learn more button

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -89,6 +89,7 @@ export function UserMenu({
   const [toolsOpen, setToolsOpen] = useState(false);
   const [automationsOpen, setAutomationsOpen] = useState(false);
   const [analyticsOpen, setAnalyticsOpen] = useState(false);
+  const [userMenuOpen, setUserMenuOpen] = useState(false);
 
   const sendNotification = useSendNotification();
   const devMode = useDevMode();
@@ -265,7 +266,7 @@ export function UserMenu({
           />
         </DialogContent>
       </Dialog>
-      <DropdownMenu>
+      <DropdownMenu open={userMenuOpen} onOpenChange={setUserMenuOpen}>
         <DropdownMenuTrigger className="hover:bg-hover data-[state=open]:bg-selected rounded-xl p-2 m-2">
           <div className="group flex cursor-pointer items-center justify-between gap-2">
             <span className="sr-only">Open user menu</span>
@@ -312,7 +313,14 @@ export function UserMenu({
         >
           {creditUsageState && (
             <>
-              <CreditUsage state={creditUsageState} variant="profile_menu" />
+              <CreditUsage
+                state={creditUsageState}
+                variant="profile_menu"
+                onLearnMore={() => {
+                  setUserMenuOpen(false);
+                  setAnalyticsOpen(true);
+                }}
+              />
               <Separator className="my-1" />
             </>
           )}

--- a/front/components/app/CreditUsage.test.tsx
+++ b/front/components/app/CreditUsage.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import type { CreditUsageState } from "./CreditUsage";
 import { CreditUsage } from "./CreditUsage";
 
@@ -20,6 +20,22 @@ describe("CreditUsage", () => {
     expect(
       screen.getByRole("progressbar", { name: "Credits used" })
     ).toHaveAttribute("aria-valuenow", "80");
+  });
+
+  it("renders the profile menu learn more action", () => {
+    const onLearnMore = vi.fn();
+
+    render(
+      <CreditUsage
+        state={ON_TARGET_STATE}
+        variant="profile_menu"
+        onLearnMore={onLearnMore}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Learn more" }));
+
+    expect(onLearnMore).toHaveBeenCalledOnce();
   });
 
   it("renders the companion presentation and clamps displayed usage", () => {

--- a/front/components/app/CreditUsage.tsx
+++ b/front/components/app/CreditUsage.tsx
@@ -28,11 +28,7 @@ interface CreditUsageProps {
   onLearnMore?: () => void;
 }
 
-export function CreditUsage({
-  state,
-  variant,
-  onLearnMore,
-}: CreditUsageProps) {
+export function CreditUsage({ state, variant, onLearnMore }: CreditUsageProps) {
   const resetUnit = state.resetInDays === 1 ? "day" : "days";
   const companionStatusLabel =
     variant === "companion" && state.target !== "on_target"

--- a/front/components/app/CreditUsage.tsx
+++ b/front/components/app/CreditUsage.tsx
@@ -1,6 +1,7 @@
 import type { CreditUsageCardVariant } from "@app/components/app/CreditUsageCard";
 import { CreditUsageCard } from "@app/components/app/CreditUsageCard";
 import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
+import { Button } from "@dust-tt/sparkle";
 
 export interface CreditUsageState {
   usedPercentage: number;
@@ -24,14 +25,21 @@ const COMPANION_STATUS_LABELS: Record<
 interface CreditUsageProps {
   state: CreditUsageState;
   variant: CreditUsageCardVariant;
+  onLearnMore?: () => void;
 }
 
-export function CreditUsage({ state, variant }: CreditUsageProps) {
+export function CreditUsage({
+  state,
+  variant,
+  onLearnMore,
+}: CreditUsageProps) {
   const resetUnit = state.resetInDays === 1 ? "day" : "days";
   const companionStatusLabel =
     variant === "companion" && state.target !== "on_target"
       ? COMPANION_STATUS_LABELS[state.target]
       : null;
+  const statusLabel = companionStatusLabel ? `${companionStatusLabel} · ` : "";
+  const resetLabel = `${statusLabel}${RESET_LABEL_PREFIX[variant]} in ${state.resetInDays} ${resetUnit}`;
 
   return (
     <CreditUsageCard
@@ -40,8 +48,20 @@ export function CreditUsage({ state, variant }: CreditUsageProps) {
       tone={state.target}
       variant={variant}
     >
-      {companionStatusLabel ? `${companionStatusLabel} · ` : null}
-      {RESET_LABEL_PREFIX[variant]} in {state.resetInDays} {resetUnit}
+      {onLearnMore ? (
+        <div className="flex flex-col gap-2">
+          <span>{resetLabel}</span>
+          <Button
+            label="Learn more"
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={onLearnMore}
+          />
+        </div>
+      ) : (
+        resetLabel
+      )}
     </CreditUsageCard>
   );
 }


### PR DESCRIPTION
## Description

Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=13286-61788&t=ctfIu9QC56KoJgfM-11).

Credit usage in the user menu currently shows reset timing. This PR adds a path to the personal analytics view from there, for the user to quickly find explanations on the credits.

This PR adds a full-width `Learn more` button. Clicking on this button opens the personal analytics popover.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
