### PR TITLE
[front] enh: Improve premium usage limit message

### DIFF
--- a/front-api/routes/w/[wId]/model_tiers/index.ts
+++ b/front-api/routes/w/[wId]/model_tiers/index.ts
@@ -1,5 +1,5 @@
-import { listTiers } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { GetModelTiersResponseBody } from "@app/types/api/model_tiers";
+import { listTiers } from "@app/types/assistant/models/model_tiers";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsAdmin } from "@front-api/middlewares/ensure_role";
 import type { HandlerResult } from "@front-api/middlewares/utils";

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -56,6 +56,7 @@ import { useDeleteAgentMessage } from "@app/hooks/useDeleteAgentMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useRetryMessage } from "@app/hooks/useRetryMessage";
 import { isImageProgressOutput } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { premiumModelUsageAnalyticsHref } from "@app/lib/analytics/view_params";
 import { CONTEXT_WINDOW_DOC_URL } from "@app/lib/api/assistant/errors";
 import config from "@app/lib/api/config";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
@@ -66,6 +67,7 @@ import { FILE_ID_PATTERN } from "@app/lib/files";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { getFilePreviewDirectivePaths } from "@app/lib/markdown/file_preview";
 import { extractFromString } from "@app/lib/mentions/format";
+import { LinkWrapper } from "@app/lib/platform";
 import { useUnifiedAgentConfigurations } from "@app/lib/swr/assistants";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
@@ -140,7 +142,7 @@ import { mutate } from "swr";
 interface MessageInfoChipProps {
   children: ReactNode;
   label: string;
-  title: string;
+  title?: string | null;
 }
 
 // Popover, not Tooltip: on touch there is no hover, and links inside must stay reachable.
@@ -164,7 +166,7 @@ function MessageInfoChip({ children, label, title }: MessageInfoChipProps) {
         align="start"
         className="flex w-[min(24rem,calc(100vw-1.5rem))] flex-col gap-2"
       >
-        <div className="font-semibold">{title}</div>
+        { title && <div className="font-semibold">{title}</div> }
         <div className="flex flex-col gap-2 text-justify text-sm text-muted-foreground">
           {children}
         </div>
@@ -174,20 +176,29 @@ function MessageInfoChip({ children, label, title }: MessageInfoChipProps) {
 }
 
 interface PremiumDowngradeChipProps {
-  modelName: string | null;
+  workspaceId: string;
+  userId: string;
 }
 
-function PremiumDowngradeChip({ modelName }: PremiumDowngradeChipProps) {
+function PremiumDowngradeChip({
+  workspaceId,
+  userId,
+}: PremiumDowngradeChipProps) {
   return (
-    <MessageInfoChip
-      label="Premium limit reached"
-      title={modelName ? `Ran on ${modelName}` : "Ran on a Standard model"}
-    >
+    <MessageInfoChip label="Auto-switched to Standard">
       <p>
-        You have reached your limit of premium messages for the current 7 day
-        window.
+        You have reached your Premium model limit for the current 7-day window,
+        so Dust ran this message on a Standard model instead.
       </p>
-      <p>Credit-based plans have no such limit.</p>
+      <p>
+        <LinkWrapper
+          href={premiumModelUsageAnalyticsHref(workspaceId, userId)}
+          className="underline hover:text-foreground"
+        >
+          View your Premium model usage in Analytics
+        </LinkWrapper>
+        .
+      </p>
     </MessageInfoChip>
   );
 }
@@ -1029,9 +1040,6 @@ export function AgentMessage({
 
   const isFairUseDowngrade =
     agentMessage.modelResolutionMethod === "fair_use_downgrade";
-  const downgradedModelName = agentMessage.resolvedModel
-    ? (getSupportedModelConfig(agentMessage.resolvedModel)?.displayName ?? null)
-    : null;
 
   const renderName = useCallback(
     () => (
@@ -1159,7 +1167,10 @@ export function AgentMessage({
             timestamp={timestamp}
             infoChip={
               isFairUseDowngrade ? (
-                <PremiumDowngradeChip modelName={downgradedModelName} />
+                <PremiumDowngradeChip
+                  workspaceId={owner.sId}
+                  userId={user.sId}
+                />
               ) : agentMessage.prunedContext ? (
                 <PrunedContextChip />
               ) : undefined

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -26,12 +26,12 @@ import {
 } from "@app/components/model_picker/modelPickerUtils";
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import { getTierForModel } from "@app/lib/api/assistant/token_pricing/tiers";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { useModels } from "@app/lib/swr/models";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type {
   ModelConfigurationType,

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -5,7 +5,6 @@ import {
   getTierLockReason,
   isPremiumModel,
 } from "@app/components/model_picker/modelPickerUtils";
-import { getTierForModel } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import {
   CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG,
@@ -21,6 +20,7 @@ import {
   AUTO_MODEL_ID,
 } from "@app/types/assistant/models/auto";
 import { GEMINI_2_5_PRO_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import { O1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 import type { ModelIdType } from "@app/types/assistant/models/types";
 import { describe, expect, it } from "vitest";

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -1,7 +1,3 @@
-import {
-  getTierForModel,
-  STATIC_MODEL_SUPPORTED_REASONING_EFFORTS,
-} from "@app/lib/api/assistant/token_pricing/tiers";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import type {
   EnabledModelConfigurationType,
@@ -15,6 +11,10 @@ import {
   AUTO_MODEL_ID,
   isModelStreamId,
 } from "@app/types/assistant/models/auto";
+import {
+  getTierForModel,
+  STATIC_MODEL_SUPPORTED_REASONING_EFFORTS,
+} from "@app/types/assistant/models/model_tiers";
 import { isStaticModelId } from "@app/types/assistant/models/models";
 import type {
   ModelConfigurationType,

--- a/front/components/pages/workspace/UsagePage.tsx
+++ b/front/components/pages/workspace/UsagePage.tsx
@@ -31,7 +31,6 @@ import {
   DEFAULT_CONSUMPTION_PERIOD,
   formatConsumptionDate,
 } from "@app/lib/analytics/consumption_period";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import {
   useAuth,
@@ -86,6 +85,7 @@ import {
   usePerSeatPricing,
   useWorkspaceSeatAvailability,
 } from "@app/lib/swr/workspaces";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import type {
   MembershipSeatType,

--- a/front/components/workspace/GroupModelTierPickerDropdown.tsx
+++ b/front/components/workspace/GroupModelTierPickerDropdown.tsx
@@ -1,5 +1,4 @@
 import { ModelTierPickerDropdown } from "@app/components/workspace/ModelTierPickerDropdown";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import {
   getGroupModelTierOptions,
   NO_GROUP_MODEL_TIER,
@@ -8,6 +7,7 @@ import {
   useGroupAllowedModelTierMutations,
   useGroupAllowedModelTiers,
 } from "@app/lib/swr/model_tiers";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import type { LightWorkspaceType } from "@app/types/user";
 
 interface GroupModelTierPickerDropdownProps {

--- a/front/components/workspace/MembersUsageTable.tsx
+++ b/front/components/workspace/MembersUsageTable.tsx
@@ -10,7 +10,6 @@ import {
   MUTED_BAR_CLASSES,
   OVERAGE_BAR_CLASSES,
 } from "@app/components/workspace/seat_styles";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { MemberUsageType } from "@app/lib/api/credits/members_usage";
 import { formatCredits } from "@app/lib/client/credits";
 import type { UserModelTierSelection } from "@app/lib/client/model_tier_options";
@@ -27,6 +26,7 @@ import {
 import type { ModelsTierDefinition } from "@app/lib/model_tiers/allowed_tiers";
 import { getMaxTierName } from "@app/lib/model_tiers/tier_order";
 import type { EffectiveSpendLimitSource } from "@app/lib/spend_limits/effective";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import type { MembershipSeatType } from "@app/types/memberships";
 import {
   isPaidSeatType,

--- a/front/components/workspace/ModelTiersInfoModal.tsx
+++ b/front/components/workspace/ModelTiersInfoModal.tsx
@@ -1,6 +1,6 @@
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { ModelTierExplainerTier } from "@app/lib/client/model_tiers_explainer";
 import { getModelTierExplainer } from "@app/lib/client/model_tiers_explainer";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import {
   Button,
   ChevronDown,

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -25,8 +25,8 @@ import type { ConsumptionFacetOptions } from "@app/hooks/useConsumptionFacets";
 import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import { useGroups } from "@app/lib/swr/groups";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { LightWorkspaceType } from "@app/types/user";
 import {

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -1,4 +1,3 @@
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type {
   ConsumptionScopeDimension,
   ConsumptionScopeFilter,
@@ -9,6 +8,7 @@ import {
 } from "@app/types/api/analytics/consumption";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import { AGENT_CONFIGURATION_SCOPES } from "@app/types/assistant/agent";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import type { ConnectorProvider } from "@app/types/data_source";
 import { isConnectorProvider } from "@app/types/data_source";

--- a/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
+++ b/front/components/workspace/analytics/usageFilterPanel/UsageFilterModelComplexityControls.tsx
@@ -3,11 +3,11 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { FilterAvailabilityStatus } from "@app/components/workspace/analytics/filterPanel/FilterAvailabilityStatus";
 import type { UsageFilterModelOption } from "@app/components/workspace/analytics/usageFilter";
 import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import {
   getModelsTierDisplayName,
   MODELS_TIER_NAMES,
-} from "@app/lib/api/assistant/token_pricing/tiers";
+} from "@app/types/assistant/models/model_tiers";
 import {
   getModelMakerDisplayName,
   MODEL_MAKER_IDS,

--- a/front/components/workspace/usage/ModelTiersSettingsCard.tsx
+++ b/front/components/workspace/usage/ModelTiersSettingsCard.tsx
@@ -1,13 +1,13 @@
 import { ModelTierPickerDropdown } from "@app/components/workspace/ModelTierPickerDropdown";
 import { ModelTiersInfoButton } from "@app/components/workspace/ModelTiersInfoModal";
 import { usePublishedAgentsRestrictedModelsToggle } from "@app/hooks/usePublishedAgentsRestrictedModelsToggle";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getWorkspaceModelTierOptions } from "@app/lib/client/model_tier_options";
 import { DEFAULT_MAX_MODEL_TIER } from "@app/lib/model_tiers/tier_order";
 import {
   useWorkspaceAllowedModelTierMutations,
   useWorkspaceAllowedModelTiers,
 } from "@app/lib/swr/model_tiers";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Page, SettingsList, SliderToggle } from "@dust-tt/sparkle";
 

--- a/front/lib/analytics/view_params.test.ts
+++ b/front/lib/analytics/view_params.test.ts
@@ -8,6 +8,7 @@ import {
   analyticsViewUrlQuery,
   DEFAULT_ANALYTICS_VIEW_STATE,
   MAX_ANALYTICS_URL_LENGTH,
+  premiumModelUsageAnalyticsHref,
   readAnalyticsView,
 } from "@app/lib/analytics/view_params";
 import {
@@ -221,5 +222,18 @@ describe("analyticsConsumptionHref", () => {
         filter: { source: ["x".repeat(MAX_ANALYTICS_URL_LENGTH)] },
       })
     ).toBe(`/w/${WORKSPACE_ID}/analytics/consumption`);
+  });
+});
+
+describe("premiumModelUsageAnalyticsHref", () => {
+  it("links to the user's Premium model usage for the limit window", () => {
+    const href = premiumModelUsageAnalyticsHref(WORKSPACE_ID, "user-1");
+    const url = new URL(href, "https://dust.tt");
+
+    expect(url.pathname).toBe(`/w/${WORKSPACE_ID}/analytics/consumption`);
+    expect(url.searchParams.get("p")).toBe("7");
+    expect(url.searchParams.getAll("u")).toEqual(["user-1"]);
+    expect(url.searchParams.getAll("m").length).toBeGreaterThan(0);
+    expect(url.searchParams.getAll("m")).not.toContain("auto_complex");
   });
 });

--- a/front/lib/analytics/view_params.ts
+++ b/front/lib/analytics/view_params.ts
@@ -8,11 +8,14 @@ import {
   CONSUMPTION_PERIOD_DAY_OPTIONS,
   DEFAULT_CONSUMPTION_PERIOD,
 } from "@app/lib/analytics/consumption_period";
+import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import type { ConsumptionScopeDimension } from "@app/types/api/analytics/consumption";
 import {
   CONSUMPTION_FILTER_MAX_VALUES_PER_DIMENSION,
   CONSUMPTION_SCOPE_DIMENSIONS,
 } from "@app/types/api/analytics/consumption";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type AnalyticsViewState = {
@@ -194,4 +197,30 @@ export function analyticsConsumptionHref(
   const query = analyticsViewUrlQuery(path, {}, view);
 
   return urlWithQuery(path, query);
+}
+
+export function premiumModelUsageAnalyticsHref(
+  workspaceId: string,
+  userId: string
+): string {
+  const premiumModelIds = [
+    ...new Set(
+      getSupportedModelConfigs()
+        .filter(
+          (model) =>
+            !isModelStreamId(model.modelId) &&
+            getTierForModel(model.modelId, model.defaultReasoningEffort) ===
+              "premium"
+        )
+        .map((model) => model.modelId)
+    ),
+  ];
+
+  return analyticsConsumptionHref(workspaceId, {
+    period: { kind: "days", days: 7 },
+    filter: {
+      user: [userId],
+      model: premiumModelIds,
+    },
+  });
 }

--- a/front/lib/api/analytics/consumption/facet_catalog.ts
+++ b/front/lib/api/analytics/consumption/facet_catalog.ts
@@ -5,8 +5,6 @@ import {
 import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
 import { SOURCE_ORIGIN_LABELS } from "@app/lib/api/analytics/source_labels";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
-import { getTierForModel } from "@app/lib/api/assistant/token_pricing/tiers";
 import { getMembers } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
 import { getModelsForAuth } from "@app/lib/model_tiers/enabled_models";
@@ -19,6 +17,8 @@ import tracer from "@app/logger/tracer";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import { isHiddenHelperSubAgentId } from "@app/types/assistant/assistant";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -17,7 +17,6 @@ import {
   CONSUMPTION_SCOPE_DIMENSIONS,
   TRIGGER_ID_FIELD,
 } from "@app/lib/api/analytics/consumption/scope";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import {
   bucketsToArray,
@@ -27,6 +26,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import tracer from "@app/logger/tracer";
 import type { AgentConfigurationScope } from "@app/types/assistant/agent";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/api/assistant/premium_model_limit.ts
+++ b/front/lib/api/assistant/premium_model_limit.ts
@@ -4,7 +4,6 @@ import {
   PREMIUM_MODEL_MESSAGE_RATE_LIMIT_PER_USER_PER_WEEK,
   PREMIUM_MODEL_MESSAGE_RATE_LIMIT_WINDOW_SECONDS,
 } from "@app/lib/api/assistant/rate_limits";
-import { getTierForModel } from "@app/lib/api/assistant/token_pricing/tiers";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage/tracking";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -21,6 +20,7 @@ import {
   AUTO_FAST_MODEL_ID,
   AUTO_MODEL_ID,
 } from "@app/types/assistant/models/auto";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import type { ResolvedRequestedModel } from "@app/types/assistant/models/types";
 import type { APIErrorWithContentfulStatusCode } from "@app/types/error";
 import { isCreditPricedPlan } from "@app/types/plan";

--- a/front/lib/client/model_tier_options.ts
+++ b/front/lib/client/model_tier_options.ts
@@ -1,8 +1,8 @@
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import {
   isModelsTierName,
   MODELS_TIER_NAMES,
-} from "@app/lib/api/assistant/token_pricing/tiers";
+} from "@app/types/assistant/models/model_tiers";
 import { formatMaxTierDescription } from "../model_tiers/tier_order";
 import { formatModelTiersSummary } from "./model_tiers";
 

--- a/front/lib/client/model_tiers.ts
+++ b/front/lib/client/model_tiers.ts
@@ -1,8 +1,8 @@
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
-import { getModelsTierDisplayName } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { ModelsTierDefinition } from "@app/lib/model_tiers/allowed_tiers";
 import { resolveAllowedModelTiers } from "@app/lib/model_tiers/resolve_allowed";
 import { expandTiersUpTo } from "@app/lib/model_tiers/tier_order";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import { getModelsTierDisplayName } from "@app/types/assistant/models/model_tiers";
 
 type ResolvedModelTiersForUser = ReturnType<typeof resolveAllowedModelTiers>;
 

--- a/front/lib/client/model_tiers_explainer.ts
+++ b/front/lib/client/model_tiers_explainer.ts
@@ -1,12 +1,12 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/model_configs";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import { getTierIndex } from "@app/lib/model_tiers/tier_order";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import {
   getModelsTierDisplayName,
   MODELS_TIERS,
   STATIC_MODEL_TIERS,
-} from "@app/lib/api/assistant/token_pricing/tiers";
-import { getTierIndex } from "@app/lib/model_tiers/tier_order";
-import { isModelStreamId } from "@app/types/assistant/models/auto";
+} from "@app/types/assistant/models/model_tiers";
 import { isStaticModelId } from "@app/types/assistant/models/models";
 import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types";

--- a/front/lib/model_tiers/access.ts
+++ b/front/lib/model_tiers/access.ts
@@ -1,4 +1,3 @@
-import { getTierForModel } from "@app/lib/api/assistant/token_pricing/tiers";
 import type { Authenticator } from "@app/lib/auth";
 import { resolveAllowedTierNames } from "@app/lib/model_tiers/allowed_tiers";
 import type {
@@ -6,6 +5,7 @@ import type {
   GenericErrorContent,
 } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import type {
   ModelConfigurationType,
   ModelResolutionMethodType,

--- a/front/lib/model_tiers/allowed_tiers.test.ts
+++ b/front/lib/model_tiers/allowed_tiers.test.ts
@@ -1,4 +1,3 @@
-import { MODELS_TIER_NAMES } from "@app/lib/api/assistant/token_pricing/tiers";
 import { Authenticator } from "@app/lib/auth";
 import {
   clearGroupMaxAllowedTier,
@@ -19,6 +18,7 @@ import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { MODELS_TIER_NAMES } from "@app/types/assistant/models/model_tiers";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("allowed model tiers permissions", () => {

--- a/front/lib/model_tiers/allowed_tiers.ts
+++ b/front/lib/model_tiers/allowed_tiers.ts
@@ -1,9 +1,3 @@
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
-import {
-  getTier,
-  MODELS_TIER_NAMES,
-  MODELS_TIERS,
-} from "@app/lib/api/assistant/token_pricing/tiers";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { isModelTierOverrideGroupKind } from "@app/lib/model_tiers/group_kinds";
@@ -23,6 +17,12 @@ import type {
   GroupAllowedModelTiersType,
   UserAllowedModelTiersType,
 } from "@app/types/api/model_tiers";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import {
+  getTier,
+  MODELS_TIER_NAMES,
+  MODELS_TIERS,
+} from "@app/types/assistant/models/model_tiers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -32,15 +32,14 @@ import type { Transaction } from "sequelize";
 import { Op } from "sequelize";
 
 export type {
-  ModelsTierDefinition,
-  ModelsTierName,
-  ModelTierSelection,
-} from "@app/lib/api/assistant/token_pricing/tiers";
-
-export type {
   ModelTierResolutionSource,
   ResolvedAllowedModelTiers,
 } from "@app/lib/model_tiers/resolve_allowed";
+export type {
+  ModelsTierDefinition,
+  ModelsTierName,
+  ModelTierSelection,
+} from "@app/types/assistant/models/model_tiers";
 
 const MODELS_TIER_GRANT_TYPE = "use" as const;
 const MODELS_TIER_RESOURCE_TYPE = "models_tier" as const;

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -1,9 +1,4 @@
 import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preferences";
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
-import {
-  getTierForModel,
-  STATIC_MODEL_TIERS,
-} from "@app/lib/api/assistant/token_pricing/tiers";
 import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -22,6 +17,11 @@ import {
   AUTO_MODEL_ID,
   MODEL_STREAMS,
 } from "@app/types/assistant/models/auto";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import {
+  getTierForModel,
+  STATIC_MODEL_TIERS,
+} from "@app/types/assistant/models/model_tiers";
 import { ORDERED_REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import type {
   ModelConfigurationType,

--- a/front/lib/model_tiers/resolve_allowed.ts
+++ b/front/lib/model_tiers/resolve_allowed.ts
@@ -1,8 +1,8 @@
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
 import {
   expandTiersUpTo,
   getMaxTierName,
 } from "@app/lib/model_tiers/tier_order";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 
 export type ModelTierResolutionSource = "workspace" | "groups" | "user";
 

--- a/front/lib/model_tiers/tier_order.ts
+++ b/front/lib/model_tiers/tier_order.ts
@@ -1,8 +1,8 @@
-import type { ModelsTierName } from "@app/lib/api/assistant/token_pricing/tiers";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
 import {
   getModelsTierDisplayName,
   MODELS_TIER_NAMES,
-} from "@app/lib/api/assistant/token_pricing/tiers";
+} from "@app/types/assistant/models/model_tiers";
 
 export const DEFAULT_MAX_MODEL_TIER: ModelsTierName = "premium";
 

--- a/front/types/api/model_tiers.ts
+++ b/front/types/api/model_tiers.ts
@@ -1,4 +1,4 @@
-import { MODELS_TIER_NAMES } from "@app/lib/api/assistant/token_pricing/tiers";
+import { MODELS_TIER_NAMES } from "@app/types/assistant/models/model_tiers";
 import { z } from "zod";
 
 const ModelsTierNameSchema = z.enum(MODELS_TIER_NAMES);

--- a/front/types/assistant/models/model_tiers.test.ts
+++ b/front/types/assistant/models/model_tiers.test.ts
@@ -4,7 +4,7 @@ import {
   MODELS_TIERS,
   STATIC_MODEL_SUPPORTED_REASONING_EFFORTS,
   STATIC_MODEL_TIERS,
-} from "@app/lib/api/assistant/token_pricing/tiers";
+} from "@app/types/assistant/models/model_tiers";
 import {
   CLAUDE_FABLE_5_MODEL_ID,
   CLAUDE_OPUS_4_8_MODEL_ID,
@@ -25,7 +25,7 @@ import { getAvailableReasoningEfforts } from "@app/types/assistant/models/types"
 import { GROK_4_6_MODEL_ID } from "@app/types/assistant/models/xai";
 import { describe, expect, it } from "vitest";
 
-describe("token_pricing/tiers", () => {
+describe("model_tiers", () => {
   it("lists tier definitions without selections", () => {
     expect(MODELS_TIERS.map((tier) => tier.id)).toEqual([1, 2, 3]);
     expect(MODELS_TIERS.every((tier) => tier.description.length > 0)).toBe(

--- a/front/types/assistant/models/model_tiers.ts
+++ b/front/types/assistant/models/model_tiers.ts
@@ -1,4 +1,4 @@
-import { STATIC_MODEL_SUPPORTED_REASONING_EFFORTS } from "@app/lib/api/assistant/token_pricing/static_model_reasoning_efforts";
+import { STATIC_MODEL_SUPPORTED_REASONING_EFFORTS } from "@app/types/assistant/models/static_model_reasoning_efforts";
 import type { StaticModelIdType } from "@app/types/assistant/models/models";
 import { isStaticModelId } from "@app/types/assistant/models/models";
 import type {

--- a/front/types/assistant/models/static_model_reasoning_efforts.ts
+++ b/front/types/assistant/models/static_model_reasoning_efforts.ts
@@ -2,7 +2,7 @@ import type { StaticModelIdType } from "@app/types/assistant/models/models";
 import type { ReasoningEffortSupport } from "@app/types/assistant/models/types";
 
 // Supported reasoning efforts per static model, mirroring SUPPORTED_MODEL_CONFIGS.
-// Kept in sync via tiers.test.ts; literals must stay as const for per-model tier typing.
+// Kept in sync via model_tiers.test.ts; literals must stay as const for per-model tier typing.
 export const STATIC_MODEL_SUPPORTED_REASONING_EFFORTS = {
   "gpt-3.5-turbo": {
     none: true,


### PR DESCRIPTION
## Description

polish a bit the premium messages limit "warning" tooltip in the conversation

side 🚗 : moved `import { getTierForModel } from "@app/lib/api/assistant/token_pricing/tiers";` to a non lib/api folder - we were importing lib/api from frontend 🤯 


## Tests

Tested locally

## Risk

Low

## Deploy Plan

Deploy front