### PR TITLE
[admin governance] use user role for internal workspace auth

### DIFF
--- a/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
+++ b/front-api/routes/v1/w/[wId]/triggers/hooks/[webhookSourceId]/[webhookSourceUrlSecret]/index.ts
@@ -124,7 +124,7 @@ app.post(
       });
     }
 
-    const auth = await Authenticator.internalBuilderForWorkspace(wId);
+    const auth = await Authenticator.internalUserForWorkspace(wId);
 
     const webhookSource = await WebhookSourceResource.fetchById(
       auth,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.test.ts
@@ -180,7 +180,7 @@ describe("computeAndStoreAgentMessageConsumptionAttribution", () => {
   it("writes attribution for a project conversation hidden from the workflow auth", async () => {
     const { workspace, conversationId, agentMessageId, agentMessageModelId } =
       await setupSettledMessageWithUsage({ restrictedConversation: true });
-    const workflowAuth = await Authenticator.internalBuilderForWorkspace(
+    const workflowAuth = await Authenticator.internalUserForWorkspace(
       workspace.sId
     );
 

--- a/front/lib/api/credits/auto_seat_upgrade.ts
+++ b/front/lib/api/credits/auto_seat_upgrade.ts
@@ -166,8 +166,8 @@ export async function maybeAutoUpgradeSeat({
   userId: string;
 }): Promise<Result<{ upgraded: boolean }, Error>> {
   // The caller's auth can't mutate seats (member, or no user at all). This only
-  // reads workspace data, we can take a builder only.
-  const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+  // reads workspace data, so a plain user auth is sufficient.
+  const auth = await Authenticator.internalUserForWorkspace(workspaceId);
 
   const config =
     await CreditUsageConfigurationResource.fetchByWorkspaceId(auth);

--- a/front/lib/api/file_system/dust_file_system.test.ts
+++ b/front/lib/api/file_system/dust_file_system.test.ts
@@ -284,7 +284,7 @@ describe("DustFileSystem.forUser", () => {
 
   it("returns Err(unauthorized) when there is no authenticated user", async () => {
     const { workspace } = await createResourceTest({});
-    const noUserAuth = await Authenticator.internalBuilderForWorkspace(
+    const noUserAuth = await Authenticator.internalUserForWorkspace(
       workspace.sId
     );
     expect(noUserAuth.user()).toBeNull();

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -1034,11 +1034,13 @@ export class Authenticator {
   }
 
   /**
-   * Creates an Authenticator for a given workspace (with role `builder`). Used for internal calls
+   * Creates an Authenticator for a given workspace (with role `user`). Used for internal calls
    * to the Dust API or other functions, when the system is calling something for the workspace.
+   * Only the workspace global group is granted; use `internalAdminForWorkspace` when broader
+   * access is required.
    * @param workspaceId string
    */
-  static async internalBuilderForWorkspace(
+  static async internalUserForWorkspace(
     workspaceId: string
   ): Promise<Authenticator> {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
@@ -1063,7 +1065,7 @@ export class Authenticator {
     return new Authenticator({
       authMethod: "internal",
       workspace,
-      role: "builder",
+      role: "user",
       groupModelIds,
       subscription,
       providersHealth,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -308,7 +308,7 @@ export class FileResource extends BaseResource<FileModel> {
       fileRes.useCase === "conversation" &&
       fileRes.useCaseMetadata?.conversationId
     ) {
-      const auth = await Authenticator.internalBuilderForWorkspace(
+      const auth = await Authenticator.internalUserForWorkspace(
         workspace.sId
       );
       const conversation = await ConversationResource.fetchById(

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -308,9 +308,7 @@ export class FileResource extends BaseResource<FileModel> {
       fileRes.useCase === "conversation" &&
       fileRes.useCaseMetadata?.conversationId
     ) {
-      const auth = await Authenticator.internalUserForWorkspace(
-        workspace.sId
-      );
+      const auth = await Authenticator.internalUserForWorkspace(workspace.sId);
       const conversation = await ConversationResource.fetchById(
         auth,
         fileRes.useCaseMetadata.conversationId,

--- a/front/lib/resources/wakeup_resource.ts
+++ b/front/lib/resources/wakeup_resource.ts
@@ -401,7 +401,7 @@ export class WakeUpResource extends BaseResource<WakeUpModel> {
     workspaceId: string;
     wakeUpId: string;
   }): Promise<Result<{ auth: Authenticator; wakeUp: WakeUpResource }, Error>> {
-    let auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+    let auth = await Authenticator.internalUserForWorkspace(workspaceId);
     const wakeUp = await WakeUpResource.fetchById(auth, wakeUpId);
 
     if (!wakeUp) {

--- a/front/migrations/20260606_backfill_frame_authorized_file_access.ts
+++ b/front/migrations/20260606_backfill_frame_authorized_file_access.ts
@@ -128,7 +128,7 @@ async function resolveAuthorAuthFromConversation(
     return null;
   }
 
-  const internalAuth = await Authenticator.internalBuilderForWorkspace(
+  const internalAuth = await Authenticator.internalUserForWorkspace(
     workspace.sId
   );
   const conversation = await ConversationResource.fetchById(
@@ -188,7 +188,7 @@ async function conversationExistsForFrame(
     return true;
   }
 
-  const auth = await Authenticator.internalBuilderForWorkspace(workspace.sId);
+  const auth = await Authenticator.internalUserForWorkspace(workspace.sId);
   const conversation = await ConversationResource.fetchById(
     auth,
     conversationId,

--- a/front/scripts/backfill_agent_message_consumption_analytics.ts
+++ b/front/scripts/backfill_agent_message_consumption_analytics.ts
@@ -310,7 +310,7 @@ makeScript(
 
     await runOnAllWorkspaces(
       async (workspace) => {
-        const auth = await Authenticator.internalBuilderForWorkspace(
+        const auth = await Authenticator.internalUserForWorkspace(
           workspace.sId
         );
 

--- a/front/scripts/backfill_frame_mount_paths.ts
+++ b/front/scripts/backfill_frame_mount_paths.ts
@@ -43,8 +43,7 @@ makeScript(
       async (workspace) => {
         const workspaceId = workspace.sId;
 
-        const auth =
-          await Authenticator.internalUserForWorkspace(workspaceId);
+        const auth = await Authenticator.internalUserForWorkspace(workspaceId);
 
         logger.info(
           { workspaceId, execute },

--- a/front/scripts/backfill_frame_mount_paths.ts
+++ b/front/scripts/backfill_frame_mount_paths.ts
@@ -44,7 +44,7 @@ makeScript(
         const workspaceId = workspace.sId;
 
         const auth =
-          await Authenticator.internalBuilderForWorkspace(workspaceId);
+          await Authenticator.internalUserForWorkspace(workspaceId);
 
         logger.info(
           { workspaceId, execute },

--- a/front/scripts/backfill_mcp_action_output_item_citations.ts
+++ b/front/scripts/backfill_mcp_action_output_item_citations.ts
@@ -57,7 +57,7 @@ makeScript(
         "[Backfill MCP output citations] Starting workspace"
       );
 
-      const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+      const auth = await Authenticator.internalUserForWorkspace(workspaceId);
 
       const actionRows = await AgentMCPActionModel.findAll({
         attributes: ["id"],

--- a/front/scripts/backfill_project_context_mount_paths.ts
+++ b/front/scripts/backfill_project_context_mount_paths.ts
@@ -39,8 +39,7 @@ makeScript(
       async (workspace) => {
         const workspaceId = workspace.sId;
 
-        const auth =
-          await Authenticator.internalUserForWorkspace(workspaceId);
+        const auth = await Authenticator.internalUserForWorkspace(workspaceId);
 
         logger.info(
           { workspaceId, execute },

--- a/front/scripts/backfill_project_context_mount_paths.ts
+++ b/front/scripts/backfill_project_context_mount_paths.ts
@@ -40,7 +40,7 @@ makeScript(
         const workspaceId = workspace.sId;
 
         const auth =
-          await Authenticator.internalBuilderForWorkspace(workspaceId);
+          await Authenticator.internalUserForWorkspace(workspaceId);
 
         logger.info(
           { workspaceId, execute },

--- a/front/scripts/dev/seed_programmatic_usage.ts
+++ b/front/scripts/dev/seed_programmatic_usage.ts
@@ -79,7 +79,7 @@ async function seedProgrammaticUsage(
     "Found workspace"
   );
 
-  const auth = await Authenticator.internalBuilderForWorkspace(wId);
+  const auth = await Authenticator.internalUserForWorkspace(wId);
 
   const usageEntries: Array<{
     document: AgentMessageAnalyticsData;

--- a/front/scripts/verify_agent_message_consumption_attribution.ts
+++ b/front/scripts/verify_agent_message_consumption_attribution.ts
@@ -193,7 +193,7 @@ makeScript(
     },
   },
   async ({ agentMessageId, execute, workspaceId }) => {
-    const auth = await Authenticator.internalBuilderForWorkspace(workspaceId);
+    const auth = await Authenticator.internalUserForWorkspace(workspaceId);
     const analyticsContext =
       await ConversationResource.fetchAgentMessageConsumptionAnalyticsContext(
         auth,

--- a/front/temporal/sandbox_reaper/activities.ts
+++ b/front/temporal/sandbox_reaper/activities.ts
@@ -82,9 +82,9 @@ type ReaperAuthMaps = {
 
 /**
  * Build workspace-scoped authenticators for each owner kind touched by the
- * batch. Conversation lifecycle calls retain builder auth. Pod lifecycle calls
- * need the workspace's project groups so their pre-sleep filesystem flush can
- * access restricted projects.
+ * batch. Conversation lifecycle calls use a plain user auth (global group
+ * only). Pod lifecycle calls need the workspace's project groups so their
+ * pre-sleep filesystem flush can access restricted projects.
  */
 async function fetchAuthMaps(
   sandboxes: SandboxResource[],
@@ -119,7 +119,7 @@ async function fetchAuthMaps(
         workspaceModelIdsByOwnerKind.conversation.has(workspace.id)
       ),
       async (workspace) => {
-        const authenticator = await Authenticator.internalBuilderForWorkspace(
+        const authenticator = await Authenticator.internalUserForWorkspace(
           workspace.sId
         );
         return [workspace.id, authenticator] as const;

--- a/front/tests/utils/TagFactory.ts
+++ b/front/tests/utils/TagFactory.ts
@@ -9,7 +9,7 @@ export class TagFactory {
       name: string;
     }
   ) {
-    const auth = await Authenticator.internalBuilderForWorkspace(workspace.sId);
+    const auth = await Authenticator.internalUserForWorkspace(workspace.sId);
     return TagResource.makeNew(auth, {
       name: params.name,
       kind: "standard",


### PR DESCRIPTION
## Description
This PR is a part of removing builder role. We create authenticator internally and we've been using either "builder" role or "admin" role. From my conversation with claude code, the role builder doesn't give any meaningful difference at every call site and it's safe to change, but I will test it on front-edge a few cases just in case.

Here is what Claude Code said: 

The difference: the two functions are identical except role: "builder" → role: "user". Same groups, same permissions. The only capability builder had over user: write access to the global space, conversations space, and open regular spaces (via the role-path ACL). Nothing else.

Does it affect callers? No. None of the 16 call sites use that capability:
- None check isBuilder() / role === "builder".
- None write into a global/conversations/open space through the role grant. Their writes are either workspace-scoped rows (tags, webhook requests, analytics, backfills, seats) or run under a separate per-user auth. Their reads use dangerouslySkipPermissionFiltering, so role is moot.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
