### PR TITLE
[front] enh: add skill-scoped consumption API

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -6155,7 +6155,7 @@
     "/api/w/{wId}/analytics/consumption/facets": {
       "post": {
         "summary": "List consumption analytics facets",
-        "description": "Lists current entities and historical indexed values present in the selected period for each consumption dimension. The workspace route requires a manager; the /me route is restricted server-side to the authenticated member; the agent route is restricted server-side to the selected agent. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.",
+        "description": "Lists current entities and historical indexed values present in the selected period for each consumption dimension. The workspace route requires a manager; the /me route is restricted server-side to the authenticated member; agent and skill routes are restricted server-side to the selected entity. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.",
         "tags": [
           "Private Analytics"
         ],
@@ -6200,7 +6200,7 @@
                   },
                   "dimensions": {
                     "type": "array",
-                    "description": "Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays. The personal route omits user and group dimensions, and the agent route omits the agent dimension.",
+                    "description": "Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays. The personal route omits user and group dimensions, the agent route omits the agent dimension, and the skill route omits the skill dimension.",
                     "items": {
                       "type": "string",
                       "enum": [

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.test.ts
@@ -3,6 +3,7 @@ import { fetchConsumptionFacets } from "@app/lib/api/analytics/consumption/facet
 import { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -126,6 +127,36 @@ describe("POST /api/w/:wId/analytics/consumption/facets", () => {
         filter: { agents: ["another-agent"], sources: ["slack"] },
         dimensions: ["user", "model"],
         requiredFilter: { agents: [agent.sId] },
+      })
+    );
+  });
+
+  it("lets editors list only facets from the selected skill", async () => {
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const skill = await SkillFactory.create(auth);
+    vi.mocked(fetchConsumptionFacets).mockResolvedValue(new Ok(RESPONSE));
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/skills/${skill.sId}/analytics/consumption/facets`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          filter: { skills: ["another-skill"], sources: ["slack"] },
+          dimensions: ["agent", "skill", "model"],
+        }),
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchConsumptionFacets).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: { skills: ["another-skill"], sources: ["slack"] },
+        dimensions: ["agent", "model"],
+        requiredFilter: { skills: [skill.sId] },
       })
     );
   });

--- a/front-api/routes/w/[wId]/analytics/consumption/facets.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/facets.ts
@@ -19,7 +19,7 @@ const app = consumptionAnalyticsApp();
  * /api/w/{wId}/analytics/consumption/facets:
  *   post:
  *     summary: List consumption analytics facets
- *     description: Lists current entities and historical indexed values present in the selected period for each consumption dimension. The workspace route requires a manager; the /me route is restricted server-side to the authenticated member; the agent route is restricted server-side to the selected agent. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.
+ *     description: Lists current entities and historical indexed values present in the selected period for each consumption dimension. The workspace route requires a manager; the /me route is restricted server-side to the authenticated member; agent and skill routes are restricted server-side to the selected entity. A facet is disabled when it has no indexed document in that period after applying every active filter except the facet's own dimension.
  *     tags:
  *       - Private Analytics
  *     parameters:
@@ -50,7 +50,7 @@ const app = consumptionAnalyticsApp();
  *                 description: Restricts which documents the facets are computed over. `automations` counts only trigger-originated runs.
  *               dimensions:
  *                 type: array
- *                 description: Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays. The personal route omits user and group dimensions, and the agent route omits the agent dimension.
+ *                 description: Dimensions to compute facets for. Defaults to every dimension. Omitted dimensions come back as empty arrays. The personal route omits user and group dimensions, the agent route omits the agent dimension, and the skill route omits the skill dimension.
  *                 items:
  *                   type: string
  *                   enum: [agent, user, api_key, group, model, tool, skill, source]

--- a/front-api/routes/w/[wId]/analytics/consumption/index.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/index.ts
@@ -1,4 +1,5 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import {
   ensureIsManager,
   ensureIsUser,
@@ -24,15 +25,22 @@ const AgentParamsSchema = z.object({
   aId: z.string(),
 });
 
+const SkillParamsSchema = z.object({
+  sId: z.string(),
+});
+
 function mountSharedConsumptionRoutes(
-  app: ReturnType<typeof consumptionAnalyticsApp>
+  app: ReturnType<typeof consumptionAnalyticsApp>,
+  { includeTopSkills = true }: { includeTopSkills?: boolean } = {}
 ) {
   app.route("/facets", facets);
   app.route("/overview", overview);
   app.route("/timeseries", timeseries);
   app.route("/top-api-keys", topApiKeys);
   app.route("/top-models", topModels);
-  app.route("/top-skills", topSkills);
+  if (includeTopSkills) {
+    app.route("/top-skills", topSkills);
+  }
   app.route("/top-sources", topSources);
   app.route("/top-tools", topTools);
 }
@@ -118,6 +126,61 @@ export function createAgentConsumptionRoutes() {
 
   mountSharedConsumptionRoutes(app);
   // The current agent is fixed by the route, so only other dimensions rank.
+  app.route("/top-groups", topGroups);
+  app.route("/top-users", topUsers);
+
+  return app;
+}
+
+export function createSkillConsumptionRoutes() {
+  const app = consumptionAnalyticsApp();
+  app.use(ensureIsUser());
+  app.use("*", validate("param", SkillParamsSchema));
+  app.use(async (ctx, next) => {
+    const auth = ctx.get("auth");
+    const sId = ctx.req.param("sId");
+    if (!sId) {
+      return apiError(ctx, {
+        status_code: 400,
+        api_error: {
+          type: "invalid_request_error",
+          message: "Missing skill ID.",
+        },
+      });
+    }
+
+    const skill = await SkillResource.fetchById(auth, sId);
+    if (!skill) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "skill_not_found",
+          message: "The skill you're trying to access was not found.",
+        },
+      });
+    }
+
+    if (
+      !skill.canAdministrate(auth) &&
+      !(await auth.hasWorkspacePermission("publish", "skill"))
+    ) {
+      return apiError(ctx, {
+        status_code: 403,
+        api_error: {
+          type: "app_auth_error",
+          message: "Only skill editors can access its consumption analytics.",
+        },
+      });
+    }
+
+    ctx.set("consumptionExcludedDimensions", ["skill"]);
+    ctx.set("consumptionRequiredFilter", { skills: [skill.sId] });
+    await next();
+  });
+
+  mountSharedConsumptionRoutes(app, { includeTopSkills: false });
+  // The current skill is fixed by the route, so only other dimensions rank.
+  app.route("/top-agents", topAgents);
   app.route("/top-groups", topGroups);
   app.route("/top-users", topUsers);
 

--- a/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
@@ -3,6 +3,7 @@ import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/ove
 import { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -74,6 +75,21 @@ function postAgentOverviewRequest(
   );
 }
 
+function postSkillOverviewRequest(
+  workspaceId: string,
+  skillId: string,
+  body: Record<string, unknown> = {}
+) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/skills/${skillId}/analytics/consumption/overview`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
 describe("POST /api/w/:wId/analytics/consumption/overview", () => {
   it("returns 403 for non-manager users", async () => {
     const { workspace } = await setupTest({ role: "user" });
@@ -137,6 +153,45 @@ describe("POST /api/w/:wId/analytics/consumption/overview", () => {
     const response = await postAgentOverviewRequest(
       ownerRequest.workspace.sId,
       agent.sId
+    );
+
+    expect(response.status).toBe(403);
+    expect(vi.mocked(fetchConsumptionOverview)).not.toHaveBeenCalled();
+  });
+
+  it("lets editors read only the selected skill's consumption", async () => {
+    vi.mocked(fetchConsumptionOverview).mockResolvedValue(new Ok(OVERVIEW));
+    const { auth, workspace } = await setupTest({ role: "user" });
+    const skill = await SkillFactory.create(auth);
+
+    const response = await postSkillOverviewRequest(workspace.sId, skill.sId, {
+      filter: { skills: ["another-skill"], sources: ["slack"] },
+    });
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchConsumptionOverview)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: { skills: [skill.sId], sources: ["slack"] },
+        includeWorkspaceContext: false,
+      })
+    );
+  });
+
+  it("refuses skill analytics to members who cannot edit the skill", async () => {
+    const ownerRequest = await setupTest({ role: "user" });
+    const skill = await SkillFactory.create(ownerRequest.auth, {
+      availability: "workspace_users",
+    });
+    await createPrivateApiMockRequest({
+      role: "user",
+      workspace: ownerRequest.workspace,
+    });
+    vi.mocked(fetchConsumptionOverview).mockClear();
+
+    const response = await postSkillOverviewRequest(
+      ownerRequest.workspace.sId,
+      skill.sId
     );
 
     expect(response.status).toBe(403);

--- a/front-api/routes/w/[wId]/analytics/consumption/timeseries.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/timeseries.test.ts
@@ -2,6 +2,7 @@ import type { GetConsumptionTimeseriesResponse } from "@app/lib/api/analytics/co
 import { fetchConsumptionTimeseries } from "@app/lib/api/analytics/consumption/timeseries";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it, vi } from "vitest";
@@ -50,6 +51,21 @@ function postAgentTimeseriesRequest(
 ) {
   return honoApp.request(
     `/api/w/${workspaceId}/assistant/agent_configurations/${agentId}/analytics/consumption/timeseries`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+function postSkillTimeseriesRequest(
+  workspaceId: string,
+  skillId: string,
+  body: Record<string, unknown> = {}
+) {
+  return honoApp.request(
+    `/api/w/${workspaceId}/skills/${skillId}/analytics/consumption/timeseries`,
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -140,6 +156,46 @@ describe("POST /api/w/:wId/analytics/consumption/timeseries", () => {
       workspace.sId,
       agent.sId,
       { breakdownBy: "agent" }
+    );
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error.type).toBe("invalid_request_error");
+    expect(vi.mocked(fetchConsumptionTimeseries)).not.toHaveBeenCalled();
+  });
+
+  it("lets editors read only the selected skill's timeseries", async () => {
+    vi.mocked(fetchConsumptionTimeseries).mockResolvedValue(new Ok(TIMESERIES));
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const skill = await SkillFactory.create(auth);
+
+    const response = await postSkillTimeseriesRequest(
+      workspace.sId,
+      skill.sId,
+      { filter: { skills: ["another-skill"], models: ["model-1"] } }
+    );
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fetchConsumptionTimeseries)).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: { skills: [skill.sId], models: ["model-1"] },
+      })
+    );
+  });
+
+  it("rejects the skill breakdown when the route already fixes the skill", async () => {
+    vi.mocked(fetchConsumptionTimeseries).mockClear();
+    const { auth, workspace } = await createPrivateApiMockRequest({
+      role: "user",
+    });
+    const skill = await SkillFactory.create(auth);
+
+    const response = await postSkillTimeseriesRequest(
+      workspace.sId,
+      skill.sId,
+      { breakdownBy: "skill" }
     );
 
     expect(response.status).toBe(400);

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -34,6 +34,7 @@ import {
 import { ElasticsearchError } from "@app/lib/api/elasticsearch";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import { Err, Ok } from "@app/types/shared/result";
 import { honoApp } from "@front-api/app";
@@ -322,6 +323,7 @@ const PERSONAL_RANKINGS = RANKINGS.filter(
   ({ path }) => path !== "top-users" && path !== "top-groups"
 );
 const AGENT_RANKINGS = RANKINGS.filter(({ path }) => path !== "top-agents");
+const SKILL_RANKINGS = RANKINGS.filter(({ path }) => path !== "top-skills");
 
 async function setupTest({
   role = "admin",
@@ -336,13 +338,16 @@ function postRankingRequest(
   path: string,
   body: Record<string, unknown> = {},
   personal = false,
-  agentId?: string
+  agentId?: string,
+  skillId?: string
 ) {
-  const analyticsPath = agentId
-    ? `assistant/agent_configurations/${agentId}/analytics`
-    : personal
-      ? "me/analytics"
-      : "analytics";
+  const analyticsPath = skillId
+    ? `skills/${skillId}/analytics`
+    : agentId
+      ? `assistant/agent_configurations/${agentId}/analytics`
+      : personal
+        ? "me/analytics"
+        : "analytics";
   return honoApp.request(`/api/w/${wId}/${analyticsPath}/consumption/${path}`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -458,6 +463,50 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
       {},
       false,
       agent.sId
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it.each(
+    SKILL_RANKINGS
+  )("$path lets editors rank only the selected skill's consumption", async ({
+    path,
+    arrangeOk,
+    lastCall,
+  }) => {
+    arrangeOk();
+    const { auth, workspace } = await setupTest({ role: "user" });
+    const skill = await SkillFactory.create(auth);
+
+    const response = await postRankingRequest(
+      workspace.sId,
+      path,
+      { filter: { skills: ["another-skill"], sources: ["slack"] } },
+      false,
+      undefined,
+      skill.sId
+    );
+
+    expect(response.status).toBe(200);
+    expect(lastCall()?.[1]).toEqual(
+      expect.objectContaining({
+        filter: { skills: [skill.sId], sources: ["slack"] },
+      })
+    );
+  });
+
+  it("does not mount the skill ranking for skill-scoped analytics", async () => {
+    const { auth, workspace } = await setupTest({ role: "user" });
+    const skill = await SkillFactory.create(auth);
+
+    const response = await postRankingRequest(
+      workspace.sId,
+      "top-skills",
+      {},
+      false,
+      undefined,
+      skill.sId
     );
 
     expect(response.status).toBe(404);

--- a/front-api/routes/w/[wId]/skills/[sId]/analytics/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/analytics/index.ts
@@ -1,0 +1,10 @@
+import { workspaceApp } from "@front-api/middlewares/ctx";
+import { createSkillConsumptionRoutes } from "@front-api/routes/w/[wId]/analytics/consumption";
+
+// Mounted under /api/w/:wId/skills/:sId/analytics.
+const app = workspaceApp();
+const consumption = createSkillConsumptionRoutes();
+
+app.route("/consumption", consumption);
+
+export default app;

--- a/front-api/routes/w/[wId]/skills/[sId]/index.ts
+++ b/front-api/routes/w/[wId]/skills/[sId]/index.ts
@@ -35,6 +35,7 @@ import uniq from "lodash/uniq";
 import uniqBy from "lodash/uniqBy";
 import { z } from "zod";
 
+import analytics from "./analytics";
 import editors from "./editors";
 import favorite from "./favorite";
 import filesRoute from "./files/[fileId]/content";
@@ -97,6 +98,7 @@ async function loadSkill(
 const app = workspaceApp();
 
 // Sub-routes for this skill.
+app.route("/analytics", analytics);
 app.route("/editors", editors);
 app.route("/favorite", favorite);
 app.route("/history", history);


### PR DESCRIPTION
## Description

Skill details need a server-owned analytics scope so editors can inspect attributed consumption without gaining access to workspace-wide data.

This adds skill-scoped consumption routes for skill editors and workspace skill publishers. The selected skill is enforced as a server-side filter across overview, timeseries, facets, and attribution rankings. The skill dimension is unavailable within that scope, while the remaining dimensions keep using the shared consumption handlers.

Skill attribution follows the existing consumption index contract: each tool row keeps its full credits for every responsible skill, so totals can overlap when several skills are attributed to the same action.

Follow-up to #31070.

## Tests

- Added route coverage for skill authorization, enforced scoping, excluded dimensions, and attribution rankings.

## Risk

- Medium, affects shared consumption analytics route plumbing.

## Deploy Plan

- Deploy front.
