### PR TITLE
[front] enh: show skill consumption analytics

### DIFF
--- a/front/components/assistant/details/tabs/AgentInsightsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentInsightsTab.tsx
@@ -4,42 +4,16 @@ import {
   ObservabilityModeSelector,
   ObservabilityPeriodSelector,
 } from "@app/components/observability/SharedObservabilityFilterSelector";
-import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
-import { ConsumptionChart } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
-import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
 import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
-import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
-import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
-import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
-import { UsageFilterSummary } from "@app/components/workspace/analytics/UsageFilterSummary";
-import type {
-  UsageFilter,
-  UsageFilterCategory,
-} from "@app/components/workspace/analytics/usageFilter";
-import {
-  addUsageFilterFromAttributionRow,
-  removeUsageFilterFromAttributionRow,
-  setUsageFilterFromAttributionRow,
-  toConsumptionScopeFilter,
-} from "@app/components/workspace/analytics/usageFilter";
+import { ScopedConsumptionAnalytics } from "@app/components/workspace/analytics/consumption/ScopedConsumptionAnalytics";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { WorkspaceType } from "@app/types/user";
-import {
-  Page,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@dust-tt/sparkle";
-import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
-import { useMemo, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 type InsightsSubTab = "analytics" | "feedback";
-
-const AGENT_ANALYTICS_HIDDEN_FILTER_CATEGORIES: readonly UsageFilterCategory[] =
-  ["agent"];
 
 interface AgentInsightsTabProps {
   owner: WorkspaceType;
@@ -55,10 +29,6 @@ export function AgentInsightsTab({
   const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
     DEFAULT_CONSUMPTION_PERIOD
   );
-  const [dimension, setDimension] = useState<ConsumptionDimension>("user");
-  const [filter, setFilter] = useState<UsageFilter>({});
-  const scopeFilter = useMemo(() => toConsumptionScopeFilter(filter), [filter]);
-  const shouldReduceMotion = useReducedMotion();
   const agentId = agentConfiguration.sId;
   const isCustomAgent = agentConfiguration.scope !== "global";
 
@@ -103,102 +73,12 @@ export function AgentInsightsTab({
           </div>
           <TabsContent value="analytics">
             <div className="pt-4">
-              <Page.Vertical align="stretch" gap="xl">
-                <div className="flex flex-col gap-1">
-                  <h3 className="text-base font-semibold text-foreground">
-                    Overview
-                  </h3>
-                  <ConsumptionOverview
-                    workspaceId={owner.sId}
-                    period={period}
-                    agentId={agentId}
-                  />
-                </div>
-
-                <ConsumptionSummary
-                  workspaceId={owner.sId}
-                  period={period}
-                  agentId={agentId}
-                />
-
-                <div className="flex flex-col gap-4">
-                  <div className="flex flex-col">
-                    <div className="flex items-center justify-between gap-4">
-                      <h3 className="text-base font-semibold text-foreground">
-                        Explore
-                      </h3>
-                      <UsageFilterPanel
-                        owner={owner}
-                        period={period}
-                        filter={filter}
-                        agentId={agentId}
-                        hiddenCategories={
-                          AGENT_ANALYTICS_HIDDEN_FILTER_CATEGORIES
-                        }
-                        onFilterChange={setFilter}
-                      />
-                    </div>
-                    <UsageFilterSummary
-                      filter={filter}
-                      onFilterChange={setFilter}
-                    />
-                  </div>
-                  <LazyMotion features={domMax}>
-                    <m.div
-                      layout={!shouldReduceMotion}
-                      transition={{
-                        duration: shouldReduceMotion ? 0 : 0.18,
-                      }}
-                      className="flex flex-col"
-                    >
-                      <ConsumptionChart
-                        workspaceId={owner.sId}
-                        period={period}
-                        dimension={dimension}
-                        filter={scopeFilter}
-                        agentId={agentId}
-                      />
-                    </m.div>
-                  </LazyMotion>
-                </div>
-
-                <ConsumptionAttributionTable
-                  workspaceId={owner.sId}
-                  period={period}
-                  filter={scopeFilter}
-                  agentId={agentId}
-                  onAddFilter={(selectedRow) => {
-                    setFilter((current) =>
-                      addUsageFilterFromAttributionRow(
-                        current,
-                        dimension,
-                        selectedRow
-                      )
-                    );
-                  }}
-                  onRemoveFilter={(selectedRow) => {
-                    setFilter((current) =>
-                      removeUsageFilterFromAttributionRow(
-                        current,
-                        dimension,
-                        selectedRow
-                      )
-                    );
-                  }}
-                  dimension={dimension}
-                  onDimensionChange={setDimension}
-                  onViewAll={(nextDimension, selectedRow) => {
-                    setFilter((current) =>
-                      setUsageFilterFromAttributionRow(
-                        current,
-                        dimension,
-                        selectedRow
-                      )
-                    );
-                    setDimension(nextDimension);
-                  }}
-                />
-              </Page.Vertical>
+              <ScopedConsumptionAnalytics
+                owner={owner}
+                period={period}
+                scope={{ type: "agent", id: agentId }}
+                defaultDimension="user"
+              />
             </div>
           </TabsContent>
           <TabsContent value="feedback">

--- a/front/components/skills/SkillDetailsBody.tsx
+++ b/front/components/skills/SkillDetailsBody.tsx
@@ -2,11 +2,13 @@ import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
+import { SkillInsightsTab } from "@app/components/skills/SkillInsightsTab";
 import {
   getSkillAvatarIcon,
   hasRelations,
   isDustProvidedSkill,
 } from "@app/lib/skill";
+import { useWorkspacePermissions } from "@app/lib/swr/permissions";
 import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import type {
   SkillRelations,
@@ -14,6 +16,7 @@ import type {
 } from "@app/types/assistant/skill_configuration";
 import type { UserType, WorkspaceType } from "@app/types/user";
 import {
+  BarChart01,
   Button,
   ContentMessage,
   ContentMessageAction,
@@ -70,15 +73,21 @@ export function SkillDetailsContent({
   owner,
   user,
 }: SkillDetailsContentProps) {
-  const [selectedTab, setSelectedTab] = useState<"info" | "editors">("info");
+  const [selectedTab, setSelectedTab] = useState<
+    "info" | "insights" | "editors"
+  >("info");
+  const { hasPermission } = useWorkspacePermissions();
 
   // The editors tab is shown to everyone (non-editors get a read-only list,
   // SkillEditorsTab hides the remove column for them), except for global
   // skills which have no editor group.
   const showEditorsTabs =
     skill.status !== "suggested" && !isDustProvidedSkill(skill);
+  const showInsightsTabs =
+    skill.status !== "suggested" &&
+    (skill.canAdministrate || hasPermission("publish", "skill"));
 
-  if (showEditorsTabs) {
+  if (showEditorsTabs || showInsightsTabs) {
     return (
       <Tabs value={selectedTab}>
         <TabsList border={false}>
@@ -88,16 +97,29 @@ export function SkillDetailsContent({
             icon={InfoCircle}
             onClick={() => setSelectedTab("info")}
           />
-          <TabsTrigger
-            value="editors"
-            label="Editors"
-            icon={Users01}
-            onClick={() => setSelectedTab("editors")}
-          />
+          {showInsightsTabs && (
+            <TabsTrigger
+              value="insights"
+              label="Insights"
+              icon={BarChart01}
+              onClick={() => setSelectedTab("insights")}
+            />
+          )}
+          {showEditorsTabs && (
+            <TabsTrigger
+              value="editors"
+              label="Editors"
+              icon={Users01}
+              onClick={() => setSelectedTab("editors")}
+            />
+          )}
         </TabsList>
         <div className="mt-4">
           <TabsContent value="info">
             <SkillInfoTab skill={skill} owner={owner} />
+          </TabsContent>
+          <TabsContent value="insights">
+            <SkillInsightsTab key={skill.sId} skill={skill} owner={owner} />
           </TabsContent>
           <TabsContent value="editors">
             {hasRelations(skill) && (

--- a/front/components/skills/SkillInsightsTab.tsx
+++ b/front/components/skills/SkillInsightsTab.tsx
@@ -1,0 +1,33 @@
+import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/consumption/ConsumptionPeriodSelector";
+import { ScopedConsumptionAnalytics } from "@app/components/workspace/analytics/consumption/ScopedConsumptionAnalytics";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { LightWorkspaceType } from "@app/types/user";
+import { useState } from "react";
+
+interface SkillInsightsTabProps {
+  owner: LightWorkspaceType;
+  skill: Pick<SkillType, "sId">;
+}
+
+export function SkillInsightsTab({ owner, skill }: SkillInsightsTabProps) {
+  const [period, setPeriod] = useState<ConsumptionPeriodSelection>(
+    DEFAULT_CONSUMPTION_PERIOD
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <h2 className="text-lg font-semibold text-foreground">Insights</h2>
+        <ConsumptionPeriodSelector period={period} onPeriodChange={setPeriod} />
+      </div>
+      <ScopedConsumptionAnalytics
+        owner={owner}
+        period={period}
+        scope={{ type: "skill", id: skill.sId }}
+        defaultDimension="agent"
+      />
+    </div>
+  );
+}

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -49,6 +49,7 @@ export interface UsageFilterPanelProps {
   filter: UsageFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   onFilterChange: (next: UsageFilter) => void;
   showMemberGroupFilter?: boolean;
   hiddenCategories?: readonly UsageFilterCategory[];
@@ -60,6 +61,7 @@ export function UsageFilterPanel({
   filter,
   personal,
   agentId,
+  skillId,
   onFilterChange,
   showMemberGroupFilter = true,
   hiddenCategories = NO_HIDDEN_USAGE_FILTER_CATEGORIES,
@@ -88,6 +90,7 @@ export function UsageFilterPanel({
     filter: state.draftScopeFilter,
     personal,
     agentId,
+    skillId,
     disabled: !state.isOpen,
   });
 

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionBreakdown.tsx
@@ -54,6 +54,7 @@ export interface ConsumptionAttributionBreakdownColumnProps {
   filter: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
   selectedRowName: string;
   onViewAll: () => void;
@@ -135,6 +136,7 @@ function WorkspaceConsumptionAttributionBreakdownColumn({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
   selectedRowName,
   onViewAll,
@@ -147,6 +149,7 @@ function WorkspaceConsumptionAttributionBreakdownColumn({
     filter,
     personal,
     agentId,
+    skillId,
     disabled,
   });
 
@@ -171,6 +174,7 @@ export interface ConsumptionAttributionBreakdownProps {
   filter?: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
   onViewAll: (
     dimension: ConsumptionDimension,
@@ -191,6 +195,7 @@ export function ConsumptionAttributionBreakdownView({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
   onViewAll,
   BreakdownColumnComponent,
@@ -221,6 +226,7 @@ export function ConsumptionAttributionBreakdownView({
           filter={selectedFilter}
           personal={personal}
           agentId={agentId}
+          skillId={skillId}
           disabled={disabled}
           selectedRowName={selectedRow.name}
           onViewAll={() => onViewAll(dimension, selectedRow)}

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionRowsTable.tsx
@@ -111,6 +111,7 @@ export interface ConsumptionAttributionRowsTableProps {
   filter?: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
   onViewAll: (
     dimension: ConsumptionDimension,
@@ -139,6 +140,7 @@ export function ConsumptionAttributionRowsTableView({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
   onViewAll,
   expandedRowId,
@@ -265,6 +267,7 @@ export function ConsumptionAttributionRowsTableView({
                           filter={filter}
                           personal={personal}
                           agentId={agentId}
+                          skillId={skillId}
                           disabled={disabled}
                           onViewAll={onViewAll}
                         />

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.test.tsx
@@ -173,6 +173,44 @@ describe("ConsumptionAttributionTable", () => {
     expect(screen.getByRole("tab", { name: "Groups" })).toBeInTheDocument();
   });
 
+  it("scopes attribution data to a skill and removes the Skills tab", () => {
+    mockUseConsumptionTop.mockReturnValue({
+      rows: [],
+      totalCredits: 0,
+      totalCount: 0,
+      hasMore: false,
+      isTopLoading: false,
+      isTopError: undefined,
+      isTopValidating: false,
+    });
+
+    render(
+      <ConsumptionAttributionTable
+        workspaceId="workspace-id"
+        period={period}
+        skillId="skill-id"
+        dimension="agent"
+        onDimensionChange={vi.fn()}
+        onAddFilter={vi.fn()}
+        onRemoveFilter={vi.fn()}
+        onViewAll={vi.fn()}
+      />
+    );
+
+    expect(mockUseConsumptionTop).toHaveBeenCalledWith(
+      expect.objectContaining({ skillId: "skill-id", dimension: "agent" })
+    );
+    expect(mockUseConsumptionExports).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("button", { name: "Download raw data" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("tab", { name: "Skills" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Agents" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Members" })).toBeInTheDocument();
+  });
+
   it("caps the available pages and fetches the selected fixed-size page", async () => {
     const rows = Array.from({ length: 1_025 }, (_, index) => ({
       id: `agent-${index + 1}`,

--- a/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionAttributionTable.tsx
@@ -441,6 +441,7 @@ export interface ConsumptionAttributionRowsProps {
   filter?: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
   onAddFilter: (row: ConsumptionTopRow) => void;
   onRemoveFilter: (row: ConsumptionTopRow) => void;
@@ -520,6 +521,7 @@ export function ConsumptionAttributionRowsView({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
   onAddFilter,
   onRemoveFilter,
@@ -618,6 +620,7 @@ export function ConsumptionAttributionRowsView({
             filter={filter}
             personal={personal}
             agentId={agentId}
+            skillId={skillId}
             disabled={disabled}
             onViewAll={onViewAll}
             expandedRowId={expandedRowId}
@@ -656,6 +659,7 @@ export function ConsumptionAttributionRowsView({
               filter={filter}
               personal={personal}
               agentId={agentId}
+              skillId={skillId}
               disabled={disabled}
               onViewAll={onViewAll}
               expandedRowId={expandedRowId}
@@ -709,6 +713,7 @@ function WorkspaceConsumptionAttributionRows(
     filter: props.filter,
     personal: props.personal,
     agentId: props.agentId,
+    skillId: props.skillId,
     sortOrder: queryState.sortOrder,
     disabled: props.disabled,
   });
@@ -737,6 +742,7 @@ export interface ConsumptionAttributionTableProps {
   filter?: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
   onAddFilter: (row: ConsumptionTopRow) => void;
   onRemoveFilter: (row: ConsumptionTopRow) => void;
@@ -761,6 +767,7 @@ export function ConsumptionAttributionTableView({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
   onAddFilter,
   onRemoveFilter,
@@ -786,7 +793,8 @@ export function ConsumptionAttributionTableView({
   const visibleDimensions = CONSUMPTION_DIMENSIONS.filter(
     (tabDimension) =>
       (!personal || (tabDimension !== "user" && tabDimension !== "group")) &&
-      (!agentId || tabDimension !== "agent")
+      (!agentId || tabDimension !== "agent") &&
+      (!skillId || tabDimension !== "skill")
   );
 
   const exportBody: ConsumptionExportBody = {
@@ -800,7 +808,7 @@ export function ConsumptionAttributionTableView({
     <div className="flex flex-col gap-3">
       <div className="flex items-center justify-between gap-4">
         <h3 className="text-base font-semibold text-foreground">Attribution</h3>
-        {showExport && !personal && !agentId && (
+        {showExport && !personal && !agentId && !skillId && (
           <ConsumptionExportPanel
             workspaceId={workspaceId}
             exportBody={exportBody}
@@ -879,6 +887,7 @@ export function ConsumptionAttributionTableView({
                     filter={filter}
                     personal={personal}
                     agentId={agentId}
+                    skillId={skillId}
                     disabled={disabled}
                     onAddFilter={onAddFilter}
                     onRemoveFilter={onRemoveFilter}

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -353,6 +353,7 @@ export interface ConsumptionChartProps {
   filter?: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
 }
 
@@ -363,6 +364,7 @@ function WorkspaceConsumptionDailyChart({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
 }: ConsumptionChartProps) {
   const { timeseries, isTimeseriesLoading, isTimeseriesError } =
@@ -375,6 +377,7 @@ function WorkspaceConsumptionDailyChart({
       filter,
       personal,
       agentId,
+      skillId,
       disabled,
     });
 
@@ -397,6 +400,7 @@ function WorkspaceConsumptionBurnUpChart({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
 }: WorkspaceConsumptionBurnUpChartProps) {
   const { overview } = useConsumptionOverview({
@@ -405,6 +409,7 @@ function WorkspaceConsumptionBurnUpChart({
     filter,
     personal,
     agentId,
+    skillId,
     disabled,
   });
   const isFiltered = Object.values(filter ?? {}).some(
@@ -427,6 +432,7 @@ function WorkspaceConsumptionBurnUpChart({
       filter,
       personal,
       agentId,
+      skillId,
       disabled,
     });
 
@@ -448,6 +454,7 @@ export function ConsumptionChart({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
 }: ConsumptionChartProps) {
   const [mode, setMode] = useState<ConsumptionTimeseriesMode>("daily");
@@ -476,6 +483,7 @@ export function ConsumptionChart({
           filter={filter}
           personal={personal}
           agentId={agentId}
+          skillId={skillId}
           disabled={disabled}
         />
       ) : (
@@ -486,6 +494,7 @@ export function ConsumptionChart({
           filter={filter}
           personal={personal}
           agentId={agentId}
+          skillId={skillId}
           disabled={disabled}
         />
       )}

--- a/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionOverview.tsx
@@ -11,6 +11,7 @@ export interface ConsumptionOverviewProps {
   showError?: boolean;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
 }
 
@@ -20,6 +21,7 @@ export function ConsumptionOverview({
   showError = false,
   personal,
   agentId,
+  skillId,
   disabled,
 }: ConsumptionOverviewProps) {
   const { overview, isOverviewLoading, isOverviewError } =
@@ -28,6 +30,7 @@ export function ConsumptionOverview({
       period: periodSelection,
       personal,
       agentId,
+      skillId,
       disabled,
     });
 
@@ -37,7 +40,7 @@ export function ConsumptionOverview({
       isOverviewLoading={isOverviewLoading}
       isOverviewError={Boolean(isOverviewError)}
       showError={showError}
-      personal={personal || agentId !== undefined}
+      personal={personal || agentId !== undefined || skillId !== undefined}
     />
   );
 }

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -34,6 +34,7 @@ export interface ConsumptionSummaryProps {
   usageLinkLabel?: string;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
 }
 
@@ -44,6 +45,7 @@ export function ConsumptionSummary({
   usageLinkLabel = "Manage in Usage",
   personal,
   agentId,
+  skillId,
   disabled,
 }: ConsumptionSummaryProps) {
   const { overview, isOverviewLoading, isOverviewError } =
@@ -52,6 +54,7 @@ export function ConsumptionSummary({
       period: periodSelection,
       personal,
       agentId,
+      skillId,
       disabled,
     });
 
@@ -62,7 +65,7 @@ export function ConsumptionSummary({
       isOverviewError={Boolean(isOverviewError)}
       usageHref={usageHref}
       usageLinkLabel={usageLinkLabel}
-      personal={personal || agentId !== undefined}
+      personal={personal || agentId !== undefined || skillId !== undefined}
     />
   );
 }

--- a/front/components/workspace/analytics/consumption/ScopedConsumptionAnalytics.tsx
+++ b/front/components/workspace/analytics/consumption/ScopedConsumptionAnalytics.tsx
@@ -1,0 +1,139 @@
+import { ConsumptionAttributionTable } from "@app/components/workspace/analytics/consumption/ConsumptionAttributionTable";
+import { ConsumptionChart } from "@app/components/workspace/analytics/consumption/ConsumptionChart";
+import { ConsumptionOverview } from "@app/components/workspace/analytics/consumption/ConsumptionOverview";
+import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
+import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
+import { UsageFilterPanel } from "@app/components/workspace/analytics/UsageFilterPanel";
+import { UsageFilterSummary } from "@app/components/workspace/analytics/UsageFilterSummary";
+import type {
+  UsageFilter,
+  UsageFilterCategory,
+} from "@app/components/workspace/analytics/usageFilter";
+import {
+  addUsageFilterFromAttributionRow,
+  removeUsageFilterFromAttributionRow,
+  setUsageFilterFromAttributionRow,
+  toConsumptionScopeFilter,
+} from "@app/components/workspace/analytics/usageFilter";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Page } from "@dust-tt/sparkle";
+import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
+import { useMemo, useState } from "react";
+
+export type ScopedConsumptionAnalyticsScope =
+  | { type: "agent"; id: string }
+  | { type: "skill"; id: string };
+
+const HIDDEN_CATEGORIES_BY_SCOPE: Record<
+  ScopedConsumptionAnalyticsScope["type"],
+  readonly UsageFilterCategory[]
+> = {
+  agent: ["agent"],
+  skill: ["skill"],
+};
+
+interface ScopedConsumptionAnalyticsProps {
+  owner: LightWorkspaceType;
+  period: ConsumptionPeriodSelection;
+  scope: ScopedConsumptionAnalyticsScope;
+  defaultDimension: ConsumptionDimension;
+}
+
+export function ScopedConsumptionAnalytics({
+  owner,
+  period,
+  scope,
+  defaultDimension,
+}: ScopedConsumptionAnalyticsProps) {
+  const [dimension, setDimension] =
+    useState<ConsumptionDimension>(defaultDimension);
+  const [filter, setFilter] = useState<UsageFilter>({});
+  const scopeFilter = useMemo(() => toConsumptionScopeFilter(filter), [filter]);
+  const shouldReduceMotion = useReducedMotion();
+  const agentId = scope.type === "agent" ? scope.id : undefined;
+  const skillId = scope.type === "skill" ? scope.id : undefined;
+
+  return (
+    <Page.Vertical align="stretch" gap="xl">
+      <div className="flex flex-col gap-1">
+        <h3 className="text-base font-semibold text-foreground">Overview</h3>
+        <ConsumptionOverview
+          workspaceId={owner.sId}
+          period={period}
+          agentId={agentId}
+          skillId={skillId}
+        />
+      </div>
+
+      <ConsumptionSummary
+        workspaceId={owner.sId}
+        period={period}
+        agentId={agentId}
+        skillId={skillId}
+      />
+
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col">
+          <div className="flex items-center justify-between gap-4">
+            <h3 className="text-base font-semibold text-foreground">Explore</h3>
+            <UsageFilterPanel
+              owner={owner}
+              period={period}
+              filter={filter}
+              agentId={agentId}
+              skillId={skillId}
+              hiddenCategories={HIDDEN_CATEGORIES_BY_SCOPE[scope.type]}
+              onFilterChange={setFilter}
+            />
+          </div>
+          <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
+        </div>
+        <LazyMotion features={domMax}>
+          <m.div
+            layout={!shouldReduceMotion}
+            transition={{
+              duration: shouldReduceMotion ? 0 : 0.18,
+            }}
+            className="flex flex-col"
+          >
+            <ConsumptionChart
+              workspaceId={owner.sId}
+              period={period}
+              dimension={dimension}
+              filter={scopeFilter}
+              agentId={agentId}
+              skillId={skillId}
+            />
+          </m.div>
+        </LazyMotion>
+      </div>
+
+      <ConsumptionAttributionTable
+        workspaceId={owner.sId}
+        period={period}
+        filter={scopeFilter}
+        agentId={agentId}
+        skillId={skillId}
+        onAddFilter={(selectedRow) => {
+          setFilter((current) =>
+            addUsageFilterFromAttributionRow(current, dimension, selectedRow)
+          );
+        }}
+        onRemoveFilter={(selectedRow) => {
+          setFilter((current) =>
+            removeUsageFilterFromAttributionRow(current, dimension, selectedRow)
+          );
+        }}
+        dimension={dimension}
+        onDimensionChange={setDimension}
+        onViewAll={(nextDimension, selectedRow) => {
+          setFilter((current) =>
+            setUsageFilterFromAttributionRow(current, dimension, selectedRow)
+          );
+          setDimension(nextDimension);
+        }}
+      />
+    </Page.Vertical>
+  );
+}

--- a/front/hooks/useConsumptionFacets.ts
+++ b/front/hooks/useConsumptionFacets.ts
@@ -52,6 +52,7 @@ export interface UseConsumptionFacetsParams {
   dimensions?: ConsumptionScopeDimension[];
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
 }
 
@@ -124,12 +125,14 @@ export function useConsumptionFacets({
   dimensions,
   personal,
   agentId,
+  skillId,
   disabled,
 }: UseConsumptionFacetsParams) {
   const url = getConsumptionAnalyticsUrl({
     workspaceId,
     personal,
     agentId,
+    skillId,
     endpoint: "facets",
   });
   const body: ConsumptionFacetsBody = {

--- a/front/hooks/useConsumptionOverview.ts
+++ b/front/hooks/useConsumptionOverview.ts
@@ -17,6 +17,7 @@ export interface UseConsumptionOverviewParams {
   filter?: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
 }
 
@@ -26,12 +27,14 @@ export function useConsumptionOverview({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
 }: UseConsumptionOverviewParams) {
   const url = getConsumptionAnalyticsUrl({
     workspaceId,
     personal,
     agentId,
+    skillId,
     endpoint: "overview",
   });
   const body: ConsumptionBody = {

--- a/front/hooks/useConsumptionQuery.test.ts
+++ b/front/hooks/useConsumptionQuery.test.ts
@@ -32,4 +32,16 @@ describe("getConsumptionAnalyticsUrl", () => {
       "/api/w/workspace-id/assistant/agent_configurations/agent-id/analytics/consumption/overview"
     );
   });
+
+  it("builds the skill-scoped consumption URL", () => {
+    expect(
+      getConsumptionAnalyticsUrl({
+        workspaceId: "workspace-id",
+        skillId: "skill-id",
+        endpoint: "overview",
+      })
+    ).toBe(
+      "/api/w/workspace-id/skills/skill-id/analytics/consumption/overview"
+    );
+  });
 });

--- a/front/hooks/useConsumptionQuery.ts
+++ b/front/hooks/useConsumptionQuery.ts
@@ -8,19 +8,23 @@ export function getConsumptionAnalyticsUrl({
   workspaceId,
   personal = false,
   agentId,
+  skillId,
   endpoint,
 }: {
   workspaceId: string;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   endpoint: string;
 }) {
   const analyticsPath =
     agentId !== undefined
       ? `assistant/agent_configurations/${agentId}/analytics`
-      : personal
-        ? "me/analytics"
-        : "analytics";
+      : skillId !== undefined
+        ? `skills/${skillId}/analytics`
+        : personal
+          ? "me/analytics"
+          : "analytics";
   return `/api/w/${workspaceId}/${analyticsPath}/consumption/${endpoint}`;
 }
 

--- a/front/hooks/useConsumptionTimeseries.ts
+++ b/front/hooks/useConsumptionTimeseries.ts
@@ -31,6 +31,7 @@ export interface UseConsumptionTimeseriesParams {
   filter?: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   disabled?: boolean;
 }
 
@@ -43,12 +44,14 @@ export function useConsumptionTimeseries({
   filter,
   personal,
   agentId,
+  skillId,
   disabled,
 }: UseConsumptionTimeseriesParams) {
   const url = getConsumptionAnalyticsUrl({
     workspaceId,
     personal,
     agentId,
+    skillId,
     endpoint: "timeseries",
   });
   const body: ConsumptionTimeseriesBody = {

--- a/front/hooks/useConsumptionTop.ts
+++ b/front/hooks/useConsumptionTop.ts
@@ -70,6 +70,7 @@ export interface UseConsumptionTopParams {
   filter?: ConsumptionScopeFilter;
   personal?: boolean;
   agentId?: string;
+  skillId?: string;
   sortOrder?: ConsumptionTopSortOrder;
   disabled?: boolean;
 }
@@ -206,6 +207,7 @@ export function useConsumptionTop({
   filter,
   personal,
   agentId,
+  skillId,
   sortOrder = "desc",
   disabled,
 }: UseConsumptionTopParams) {
@@ -213,6 +215,7 @@ export function useConsumptionTop({
     workspaceId,
     personal,
     agentId,
+    skillId,
     endpoint: CONSUMPTION_TOP_ENDPOINTS[dimension],
   });
   const body: ConsumptionTopBody = {


### PR DESCRIPTION
## Description

Skill editors need the same consumption visibility available from Agent Details, scoped to the skill they are reviewing.

This adds an Insights tab to Skill Details for skill editors and workspace skill publishers. It reuses the scoped analytics layout shared with Agent Details, defaults to the Agents breakdown, and removes the redundant Skill dimension from Explore and Attribution. Entity-scoped raw exports remain unavailable.

Stacked on #31074.

## Tests

- Added UI coverage for skill-scoped URLs and available Attribution dimensions.

## Risk

- Medium, affects Skill Details and shared consumption analytics components.

## Deploy Plan

- Deploy front.
