### PR TITLE
Cap MCP server tool credits per agent message

### DIFF
--- a/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/attribution_builder.ts
@@ -17,8 +17,9 @@ import assert from "assert";
 // context-window safety padding from tool footprints and uses o200k for GPT-5 provider accounting.
 // Version 6 excludes enabled-skill tool definitions when provider-side tool search keeps those
 // non-eager tools deferred, while continuing to attribute the enabled skill's instructions.
+// Version 7 records post-cap MCP server calls with zero direct credits.
 // Each version remains a separate, self-consistent set of rows.
-export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 6;
+export const AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION = 7;
 
 export type RunUsageForAttribution = Pick<
   RunUsageType,

--- a/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
+++ b/front/lib/api/assistant/agent_message_consumption_attribution/store.ts
@@ -1,4 +1,5 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { getToolNameFromFunctionCallName } from "@app/lib/actions/tool_display_labels";
 import { isSandboxChildActionInfo } from "@app/lib/actions/types";
 import { buildLatestMessageConsumptionAllocation } from "@app/lib/api/assistant/agent_message_consumption_attribution/allocation";
 import {
@@ -8,8 +9,8 @@ import {
 } from "@app/lib/api/assistant/agent_message_consumption_attribution/attribution_builder";
 import { measureToolCallFootprints } from "@app/lib/api/assistant/agent_message_consumption_attribution/tool_footprint";
 import type { Authenticator } from "@app/lib/auth";
+import { buildAgentMessageBillingPlan } from "@app/lib/credits/agent_message_billing";
 import { roundCreditsToMicroCredits } from "@app/lib/credits/units";
-import { toolAwuFromAction } from "@app/lib/metronome/events";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type {
   CompletedAgentMessageConsumptionItem,
@@ -22,10 +23,7 @@ import { RunResource } from "@app/lib/resources/run_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
-import type {
-  AgentMessageStatus,
-  UserMessageOrigin,
-} from "@app/types/assistant/conversation";
+import type { AgentMessageStatus } from "@app/types/assistant/conversation";
 import {
   AGENT_MESSAGE_STATUSES_TO_TRACK,
   isTerminalAgentMessageStatus,
@@ -186,15 +184,15 @@ async function buildRunUsageConsumptionEvidence(
   auth: Authenticator,
   {
     enrichedActionByModelId,
+    directCreditAmountMicroByActionModelId,
     includeToolResultFootprints,
     runActions,
-    triggeringUserMessageOrigin,
     usage,
   }: {
     enrichedActionByModelId: ReadonlyMap<ModelId, AgentMCPActionWithOutputType>;
+    directCreditAmountMicroByActionModelId: ReadonlyMap<ModelId, number>;
     includeToolResultFootprints: boolean;
     runActions: AgentMCPActionResource[];
-    triggeringUserMessageOrigin: UserMessageOrigin | null;
     usage: RunUsageWithRunKeyType;
   }
 ): Promise<{
@@ -248,9 +246,8 @@ async function buildRunUsageConsumptionEvidence(
   // is the same tool call across both. From here each call carries its own data through the builder,
   // so nothing downstream re-derives the position.
   const measuredToolCalls = modelVisibleRunActionPairs.map(
-    ({ action, enrichedAction }, index) => ({
+    ({ action }, index) => ({
       action,
-      enrichedAction,
       footprint: footprints[index],
     })
   );
@@ -294,7 +291,7 @@ async function buildRunUsageConsumptionEvidence(
   }
 
   for (const toolCall of toolCalls) {
-    const { action, enrichedAction, footprint } = toolCall.tool;
+    const { action, footprint } = toolCall.tool;
 
     // A blocked action carries no result and no charge yet, and billing does not charge it. Record
     // only the emitted call output as a pending row. The rest lands once the action is final.
@@ -311,15 +308,12 @@ async function buildRunUsageConsumptionEvidence(
 
     // Zero for a denied call, which billing does not charge. Its emitted output tokens stay
     // attributed here.
-    const directCreditAmountMicro = roundCreditsToMicroCredits(
-      toolAwuFromAction(
-        {
-          toolName: enrichedAction.toolName,
-          internalMCPServerName: enrichedAction.internalMCPServerName,
-          status: action.status,
-        },
-        triggeringUserMessageOrigin
-      )
+    const directCreditAmountMicro = directCreditAmountMicroByActionModelId.get(
+      action.id
+    );
+    assert(
+      directCreditAmountMicro !== undefined,
+      "A completed action must have a canonical billing line"
     );
     const toolAttribution = buildToolAttribution({
       usage,
@@ -354,20 +348,12 @@ async function buildRunUsageConsumptionEvidence(
       continue;
     }
 
-    const enrichedAction = enrichedActionByModelId.get(action.id);
-    assert(
-      enrichedAction,
-      "A completed sandbox child action must have an enriched counterpart"
+    const directCreditAmountMicro = directCreditAmountMicroByActionModelId.get(
+      action.id
     );
-    const directCreditAmountMicro = roundCreditsToMicroCredits(
-      toolAwuFromAction(
-        {
-          toolName: enrichedAction.toolName,
-          internalMCPServerName: enrichedAction.internalMCPServerName,
-          status: action.status,
-        },
-        triggeringUserMessageOrigin
-      )
+    assert(
+      directCreditAmountMicro !== undefined,
+      "A completed sandbox child action must have a canonical billing line"
     );
 
     records.push({
@@ -561,6 +547,26 @@ async function computeAndStoreAgentMessageConsumptionAttributionComputation(
       item.attributionVersion === AGENT_MESSAGE_CONSUMPTION_ATTRIBUTION_VERSION
   );
 
+  const toolBillingPlan = buildAgentMessageBillingPlan({
+    actions: actions.map((actionResource) => ({
+      actionResource,
+      internalMCPServerName: actionResource.metadata.internalMCPServerName,
+      mcpServerId: actionResource.metadata.mcpServerId ?? null,
+      status: actionResource.status,
+      toolName: getToolNameFromFunctionCallName(
+        actionResource.functionCallName
+      ),
+    })),
+    contextOrigin: triggeringUserMessageOrigin,
+    runUsages: [],
+  });
+  const directCreditAmountMicroByActionModelId = new Map(
+    toolBillingPlan.tools.map(({ action, billedCredits }) => [
+      action.actionResource.id,
+      roundCreditsToMicroCredits(billedCredits),
+    ])
+  );
+
   const dustRunIdByRunModelId = new Map(
     runs.map((run) => [run.id, run.dustRunId])
   );
@@ -593,6 +599,7 @@ async function computeAndStoreAgentMessageConsumptionAttributionComputation(
   );
   const actionsToEnrich = actions.filter(
     (action) =>
+      !isSandboxChildActionInfo(action.stepContext.sandboxChildActionInfo) &&
       action.stepContent.dustRunId !== null &&
       dustRunIdsToProcess.has(action.stepContent.dustRunId)
   );
@@ -618,11 +625,11 @@ async function computeAndStoreAgentMessageConsumptionAttributionComputation(
     const runActions = (dustRunId && actionsByDustRunId.get(dustRunId)) || [];
     const usageEvidence = await buildRunUsageConsumptionEvidence(auth, {
       enrichedActionByModelId,
+      directCreditAmountMicroByActionModelId,
       includeToolResultFootprints: !unconsumedToolResultRunUsageModelIds.has(
         usage.runUsageModelId
       ),
       runActions,
-      triggeringUserMessageOrigin,
       usage,
     });
     records.push(...usageEvidence.records);

--- a/front/lib/api/assistant/credit_cost.ts
+++ b/front/lib/api/assistant/credit_cost.ts
@@ -37,6 +37,7 @@ import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "@app/types/assistant/conversati
 interface CreditActionMinimalInput {
   toolName: string;
   internalMCPServerName: InternalMCPServerNameType | null;
+  mcpServerId?: string | null;
   status: ToolExecutionStatus;
 }
 
@@ -280,6 +281,7 @@ export async function computeAndStoreAgentMessageCredits(
     actions: actions.map((action) => ({
       toolName: getToolNameFromFunctionCallName(action.functionCallName),
       internalMCPServerName: action.metadata.internalMCPServerName,
+      mcpServerId: action.metadata.mcpServerId ?? null,
       status: action.status,
     })),
     contextOrigin: triggeringUserMessageOrigin,

--- a/front/lib/credits/agent_message_billing.test.ts
+++ b/front/lib/credits/agent_message_billing.test.ts
@@ -214,4 +214,52 @@ describe("buildAgentMessageBillingPlan", () => {
       }),
     ]);
   });
+
+  it("makes subsequent calls free after one MCP server reaches 20 credits", () => {
+    const cappedServerActions = Array.from({ length: 8 }, () => ({
+      toolName: "custom_tool",
+      mcpServerId: "capped_server",
+      internalMCPServerName: null,
+      status: "succeeded" as const,
+    }));
+    const plan = buildAgentMessageBillingPlan({
+      actions: [
+        ...cappedServerActions,
+        {
+          toolName: "custom_tool",
+          mcpServerId: "other_server",
+          internalMCPServerName: null,
+          status: "succeeded",
+        },
+      ],
+      contextOrigin: "web",
+      runUsages: [],
+    });
+
+    expect(plan.tools.map(({ billedCredits }) => billedCredits)).toEqual([
+      3, 3, 3, 3, 3, 3, 3, 0, 3,
+    ]);
+    expect(plan.tools[7]?.billingDisposition).toBe("free_mcp_server_cap");
+    expect(plan.totals.toolBilledCredits).toBe(24);
+  });
+
+  it("makes the call after an exact 20-credit total free", () => {
+    const plan = buildAgentMessageBillingPlan({
+      actions: Array.from({ length: 21 }, () => ({
+        toolName: "websearch",
+        mcpServerId: "basic_server",
+        internalMCPServerName: "web_search_&_browse" as const,
+        status: "succeeded" as const,
+      })),
+      contextOrigin: "web",
+      runUsages: [],
+    });
+
+    expect(plan.tools[19]?.billedCredits).toBe(1);
+    expect(plan.tools[20]).toMatchObject({
+      billedCredits: 0,
+      billingDisposition: "free_mcp_server_cap",
+    });
+    expect(plan.totals.toolBilledCredits).toBe(20);
+  });
 });

--- a/front/lib/credits/agent_message_billing.ts
+++ b/front/lib/credits/agent_message_billing.ts
@@ -37,12 +37,20 @@ export const TOOL_COST_CATEGORY_AWU_WEIGHTS: Record<ToolCostCategory, number> =
     advanced: 3,
   };
 
+// Once one MCP server has accrued this many billed tool credits within an
+// agent message, its subsequent tool calls are metered but free. The action
+// that reaches (or crosses) the cap remains fully billed.
+export const MCP_SERVER_AGENT_MESSAGE_TOOL_AWU_CAP = 20;
+
 export type AgentMessageBillingRunUsage = RunUsageType & {
   runKey: string | null;
 };
 
 export type AgentMessageBillingAction = {
   internalMCPServerName: InternalMCPServerNameType | null;
+  // Old actions may not carry their server id. Internal servers still have a
+  // stable name fallback. Unidentified external actions are left uncapped.
+  mcpServerId?: string | null;
   status: ToolExecutionStatus;
   toolName: string;
 };
@@ -52,6 +60,7 @@ export type AgentMessageLlmBillingDisposition = "billed" | "free_origin";
 
 export type AgentMessageToolBillingDisposition =
   | AgentMessageLlmBillingDisposition
+  | "free_mcp_server_cap"
   | "free_tool"
   | "unbillable_status";
 
@@ -146,6 +155,16 @@ export function getToolBillingInfo(
     toolCostCategory: tool.toolCostCategory,
     freeUsage: tool.freeUsage,
   };
+}
+
+function getMCPServerBillingKey(
+  action: AgentMessageBillingAction
+): string | null {
+  if (action.internalMCPServerName !== null) {
+    return `internal:${action.internalMCPServerName}`;
+  }
+
+  return action.mcpServerId ? `external:${action.mcpServerId}` : null;
 }
 
 // Split a rounded billing line across its raw usage rows with the largest
@@ -244,7 +263,8 @@ function resolveToolBillingDisposition({
  *
  * LLM provider cost is grouped and rounded once per (execution, provider,
  * model), then those groups are summed for the message. Tool actions are priced
- * independently at their category's fixed rate.
+ * independently at their category's fixed rate. Actions must be provided in
+ * chronological order so the per-MCP-server message cap is deterministic.
  *
  * `ratedCredits` is the price before free-origin/tool waivers;
  * `billedCredits` is the authoritative charge after those rules. Callers should
@@ -342,17 +362,33 @@ export function buildAgentMessageBillingPlan<
     }
   );
 
+  const billedToolCreditsByMCPServer = new Map<string, number>();
   const tools = actions.map((action) => {
     const { toolCostCategory, freeUsage } = getToolBillingInfo(
       action.internalMCPServerName,
       action.toolName
     );
-    const billingDisposition = resolveToolBillingDisposition({
+    let billingDisposition = resolveToolBillingDisposition({
       freeUsage,
       isMessageFree,
       status: action.status,
     });
     const ratedCredits = TOOL_COST_CATEGORY_AWU_WEIGHTS[toolCostCategory];
+
+    const mcpServerBillingKey = getMCPServerBillingKey(action);
+    if (billingDisposition === "billed" && mcpServerBillingKey !== null) {
+      const billedCreditsForServer =
+        billedToolCreditsByMCPServer.get(mcpServerBillingKey) ?? 0;
+      if (billedCreditsForServer >= MCP_SERVER_AGENT_MESSAGE_TOOL_AWU_CAP) {
+        billingDisposition = "free_mcp_server_cap";
+      } else {
+        billedToolCreditsByMCPServer.set(
+          mcpServerBillingKey,
+          billedCreditsForServer + ratedCredits
+        );
+      }
+    }
+
     const billedCredits = billingDisposition === "billed" ? ratedCredits : 0;
 
     return {

--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -84,6 +84,7 @@ describe("Metronome billing event adapters", () => {
           internalMCPServerName: "web_search_&_browse",
           status: "succeeded",
           executionDurationMs: 10,
+          shouldEmit: true,
         },
         {
           toolName: "websearch",
@@ -91,6 +92,7 @@ describe("Metronome billing event adapters", () => {
           internalMCPServerName: "web_search_&_browse",
           status: "succeeded",
           executionDurationMs: 20,
+          shouldEmit: true,
         },
       ],
     });
@@ -114,10 +116,66 @@ describe("Metronome billing event adapters", () => {
           internalMCPServerName: null,
           status: "denied",
           executionDurationMs: null,
+          shouldEmit: true,
         },
       ],
     });
 
     expect(events).toEqual([]);
+  });
+
+  it("splits paid and post-cap calls to the same tool", () => {
+    const events = buildToolUseEvents({
+      ...commonEventInput,
+      actions: Array.from({ length: 8 }, () => ({
+        toolName: "custom_tool",
+        mcpServerId: "mcp_server",
+        internalMCPServerName: null,
+        status: "succeeded" as const,
+        executionDurationMs: 10,
+        shouldEmit: true,
+      })),
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events.map(({ properties }) => properties)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ count: 7, usage_type: "user" }),
+        expect.objectContaining({ count: 1, usage_type: "free" }),
+      ])
+    );
+    expect(
+      new Set(events.map(({ transaction_id }) => transaction_id)).size
+    ).toBe(2);
+  });
+
+  it("applies prior execution spend without re-emitting prior actions", () => {
+    const events = buildToolUseEvents({
+      ...commonEventInput,
+      actions: [
+        ...Array.from({ length: 7 }, () => ({
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "succeeded" as const,
+          executionDurationMs: 10,
+          shouldEmit: false,
+        })),
+        {
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "succeeded",
+          executionDurationMs: 10,
+          shouldEmit: true,
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({
+      count: 1,
+      usage_type: "free",
+    });
   });
 });

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -74,10 +74,13 @@ export function getUsageType(
   return isProgrammaticUsage ? USAGE_TYPE_PROGRAMMATIC : USAGE_TYPE_USER;
 }
 
-function getToolUsageType(
-  baseUsageType: UsageType,
-  isFreeUsage: boolean
-): UsageType {
+function getToolUsageType({
+  baseUsageType,
+  isFreeUsage,
+}: {
+  baseUsageType: UsageType;
+  isFreeUsage: boolean;
+}): UsageType {
   return isFreeUsage ? USAGE_TYPE_FREE : baseUsageType;
 }
 
@@ -351,10 +354,10 @@ export function buildToolUseEvents({
 
   return [...groups.values()].map(({ billingLine, count, totalDurationMs }) => {
     const { action, billingDisposition, toolCostCategory } = billingLine;
-    const effectiveUsageType = getToolUsageType(
-      usageType,
-      billingDisposition !== "billed"
-    );
+    const effectiveUsageType = getToolUsageType({
+      baseUsageType: usageType,
+      isFreeUsage: billingDisposition !== "billed",
+    });
     const transactionIdDispositionSuffix =
       billingDisposition === "free_mcp_server_cap"
         ? `-${billingDisposition}`

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -76,9 +76,9 @@ export function getUsageType(
 
 function getToolUsageType(
   baseUsageType: UsageType,
-  isFreeTool: boolean
+  isFreeUsage: boolean
 ): UsageType {
-  return isFreeTool ? USAGE_TYPE_FREE : baseUsageType;
+  return isFreeUsage ? USAGE_TYPE_FREE : baseUsageType;
 }
 
 // Intelligence (AI compute) credits for a *single execution's* run usages.
@@ -257,12 +257,16 @@ interface ToolAction {
   internalMCPServerName: InternalMCPServerNameType | null;
   status: ToolExecutionStatus;
   executionDurationMs: number | null;
+  // The billing plan needs every chronological action in the message to apply
+  // the per-server cap, while each execution emits only its own actions.
+  shouldEmit: boolean;
 }
 
 /**
  * Build aggregated Metronome tool_use events for an agent message.
- * Actions are grouped by (toolName, internalMCPServerName, mcpServerId, status)
- * — one event per group with `count` and `total_execution_duration_ms`.
+ * Actions are grouped by (toolName, internalMCPServerName, mcpServerId, status,
+ * billingDisposition). Each group produces one event with `count` and
+ * `total_execution_duration_ms`.
  *
  * transaction_id pattern: tool-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{toolHash}
  * toolHash is a 12-char SHA-256 of toolName|mcpServerId|status to keep under 128 chars.
@@ -310,7 +314,9 @@ export function buildToolUseEvents({
     runUsages: [],
   });
 
-  // Group actions by (toolName, internalMCPServerName, mcpServerId, status).
+  // Group actions by (toolName, internalMCPServerName, mcpServerId, status,
+  // billingDisposition). The disposition split is required when one execution
+  // contains both paid and post-cap calls to the same tool.
   const groups = new Map<
     string,
     {
@@ -320,13 +326,16 @@ export function buildToolUseEvents({
     }
   >();
   for (const billingLine of billingPlan.tools) {
+    if (!billingLine.action.shouldEmit) {
+      continue;
+    }
     // Metronome prices every emitted tool event. Actions that never reached the
     // tool must therefore be omitted rather than represented as zero-cost.
     if (billingLine.billingDisposition === "unbillable_status") {
       continue;
     }
     const { action } = billingLine;
-    const key = `${action.toolName}|${action.internalMCPServerName ?? ""}|${action.mcpServerId ?? ""}|${action.status}`;
+    const key = `${action.toolName}|${action.internalMCPServerName ?? ""}|${action.mcpServerId ?? ""}|${action.status}|${billingLine.billingDisposition}`;
     const existing = groups.get(key);
     if (existing) {
       existing.count++;
@@ -344,11 +353,15 @@ export function buildToolUseEvents({
     const { action, billingDisposition, toolCostCategory } = billingLine;
     const effectiveUsageType = getToolUsageType(
       usageType,
-      billingDisposition === "free_tool"
+      billingDisposition !== "billed"
     );
+    const transactionIdDispositionSuffix =
+      billingDisposition === "free_mcp_server_cap"
+        ? `-${billingDisposition}`
+        : "";
     return {
       transaction_id: truncateTransactionId(
-        `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}`
+        `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}${transactionIdDispositionSuffix}`
       ),
       customer_id: getMetronomeIngestAlias(workspaceId),
       event_type: "tool_use_v3",

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -757,6 +757,9 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   ): Promise<AgentMCPActionResource[]> {
     return this.baseFetch(auth, {
       where: { agentMessageId: { [Op.in]: agentMessageIds } },
+      // Billing policies are applied chronologically. Model ids preserve action
+      // creation order and provide a deterministic tie-break for parallel calls.
+      order: [["id", "ASC"]],
     });
   }
 

--- a/front/temporal/analytics_queue/activities/agent_analytics.ts
+++ b/front/temporal/analytics_queue/activities/agent_analytics.ts
@@ -245,6 +245,7 @@ export async function storeAgentAnalytics(
       return {
         actionResource,
         internalMCPServerName: action.internalMCPServerName,
+        mcpServerId: action.mcpServerId,
         status: action.status,
         toolName: getToolNameFromFunctionCallName(
           actionResource.functionCallName

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -358,30 +358,25 @@ export async function emitMetronomeUsageEventsActivity(
   });
   const runUsages = await RunResource.listRunUsagesForRuns(auth, { runs });
 
-  // Get MCP actions, filtered to this execution's steps if startStep is available. The event
-  // adapter applies the canonical billing-status gate before producing Metronome events.
+  // Get every MCP action for the message so the canonical billing plan can
+  // apply message-level policies across interrupt/resume executions. The event
+  // adapter only emits the actions belonging to this execution.
   const allMcpActions = await AgentMCPActionResource.listByAgentMessageIds(
     auth,
     [agentMessage.id]
   );
-  const mcpActions = allMcpActions.filter((a) => {
+  const toolActions = allMcpActions.map((a) => {
     const json = a.toJSON();
-    if (
-      agentLoopArgs.startStep !== undefined &&
-      json.step < agentLoopArgs.startStep
-    ) {
-      return false;
-    }
-    return true;
-  });
-  const toolActions = mcpActions.map((a) => {
-    const json = a.toJSON();
+
     return {
       toolName: json.toolName,
       mcpServerId: json.mcpServerId,
       internalMCPServerName: json.internalMCPServerName,
       status: json.status,
       executionDurationMs: json.executionDurationMs,
+      shouldEmit:
+        agentLoopArgs.startStep === undefined ||
+        json.step >= agentLoopArgs.startStep,
     };
   });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR caps tool billing at 20 credits per MCP server for one agent message.

After a server reaches 20 billed tool credits, later calls to that same server in the same agent message are free.

This is a temporary solution. It lets us ship the cap without changing the current billing source of truth or the Metronome configuration.

## Exact billing behavior

- The cap is tracked separately for each MCP server.
- The cap resets for every agent message.
- LLM usage is unchanged.
- Tool execution is unchanged. Calls still run normally.
- Basic tools cost 1 credit.
- Advanced tools cost 3 credits.
- The call that reaches or crosses 20 credits is fully billed.
- Only later calls are free.
- Free tools and calls with an unbillable status do not count toward the cap.
- Calls without an identifiable external MCP server remain uncapped.

Examples:

- 20 basic calls cost 20 credits. The 21st call is free.
- 7 advanced calls cost 21 credits. The 8th call is free.
- Reaching the cap on server A does not make calls to server B free.

## Message resumes

An agent message can be interrupted and resumed several times.

When emitting usage for a resumed execution, we load all actions from the agent message. Calls from previous executions count toward the server cap. We still emit only the actions that belong to the current execution. Previous actions are not emitted again. Actions are ordered by their database ID so the result is stable for retries and parallel calls.

## Metronome changes

Metronome currently bills tool usage from `tool_use_v3` events using:
- count
- tool_category
- usage_type

Post-cap calls are emitted with `usage_type=free`. The existing free rate makes their billed amount zero. This does not require a new metric, product, or rate.

One execution can contain both paid and post-cap calls to the same tool. For example, it can contain 7 paid calls and 1 free call.

These calls cannot stay in one event because one event has only one `usage_type`. We therefore split the local event group by billing disposition.

The paid event keeps its existing transaction ID.

The post-cap free event receives a `-free_mcp_server_cap` suffix. It needs a different transaction ID because Metronome deduplicates events by transaction ID. Without the suffix, Metronome would drop either the paid event or the
free event.

This does not rewrite events already ingested before deployment. The cap applies correctly to newly emitted usage after deployment.

## Other billing records

The same billing calculation is used for:

- The `costCredits` stored on the agent message
- Metronome events
- Agent analytics
- Per-tool analytics
- Consumption attribution

Post-cap calls keep their rated cost for debugging, but their billed cost is zero.

The consumption attribution version is bumped so capped calls are stored with zero direct tool credits.

## Why this is temporary

The goal is to ship the protection quickly without making a large billing change.

When we change the billing source of truth, this rule should move there. The temporary event handling and attribution handling can then be removed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
