### PR TITLE
[front] enh: add personal conversation attribution API

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/index.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/index.ts
@@ -9,6 +9,7 @@ import overview from "./overview";
 import timeseries from "./timeseries";
 import topAgents from "./top-agents";
 import topApiKeys from "./top-api-keys";
+import topConversations from "./top-conversations";
 import topGroups from "./top-groups";
 import topModels from "./top-models";
 import topSkills from "./top-skills";
@@ -50,6 +51,7 @@ export function createPersonalConsumptionRoutes() {
   app.route("/timeseries", timeseries);
   app.route("/top-agents", topAgents);
   app.route("/top-api-keys", topApiKeys);
+  app.route("/top-conversations", topConversations);
   app.route("/top-models", topModels);
   app.route("/top-skills", topSkills);
   app.route("/top-sources", topSources);

--- a/front-api/routes/w/[wId]/analytics/consumption/top-conversations.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top-conversations.ts
@@ -1,0 +1,67 @@
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import {
+  ConsumptionBodySchema,
+  toConsumptionPeriodInput,
+} from "@app/lib/api/analytics/consumption/schema";
+import type { GetConsumptionTopConversationsResponse } from "@app/lib/api/analytics/consumption/top_conversations";
+import { fetchConsumptionTopConversations } from "@app/lib/api/analytics/consumption/top_conversations";
+import logger from "@app/logger/logger";
+import { apiError, type HandlerResult } from "@front-api/middlewares/utils";
+import { validate } from "@front-api/middlewares/validator";
+import { consumptionAnalyticsApp } from "./context";
+
+const TOP_CONVERSATIONS_LIMIT = 10;
+
+// Mounted at /api/w/:wId/me/analytics/consumption/top-conversations.
+const app = consumptionAnalyticsApp();
+
+/** @ignoreswagger */
+app.post(
+  "/",
+  validate("json", ConsumptionBodySchema),
+  async (ctx): HandlerResult<GetConsumptionTopConversationsResponse> => {
+    const auth = ctx.get("auth");
+    const userId = ctx.get("consumptionUserId");
+    if (!userId) {
+      return apiError(ctx, {
+        status_code: 404,
+        api_error: {
+          type: "invalid_request_error",
+          message:
+            "Top conversations are only available for personal analytics.",
+        },
+      });
+    }
+    const { filter, ...periodQuery } = ctx.req.valid("json");
+    const period = await resolveConsumptionPeriod(
+      auth,
+      toConsumptionPeriodInput(periodQuery)
+    );
+
+    const result = await fetchConsumptionTopConversations(auth, {
+      period,
+      limit: TOP_CONVERSATIONS_LIMIT,
+      filter: { ...filter, users: [userId] },
+    });
+    if (result.isErr()) {
+      logger.error(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          err: result.error,
+        },
+        "[ConsumptionAnalytics] Failed to retrieve top conversations."
+      );
+      return apiError(ctx, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Failed to retrieve top conversations.",
+        },
+      });
+    }
+
+    return ctx.json(result.value);
+  }
+);
+
+export default app;

--- a/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/top.test.ts
@@ -8,6 +8,10 @@ import {
   type GetConsumptionTopApiKeysResponse,
 } from "@app/lib/api/analytics/consumption/top_api_keys";
 import {
+  fetchConsumptionTopConversations,
+  type GetConsumptionTopConversationsResponse,
+} from "@app/lib/api/analytics/consumption/top_conversations";
+import {
   fetchConsumptionTopGroups,
   type GetConsumptionTopGroupsResponse,
 } from "@app/lib/api/analytics/consumption/top_groups";
@@ -64,6 +68,13 @@ vi.mock(
   async (orig) => {
     const mod = await orig();
     return { ...mod, fetchConsumptionTopModels: vi.fn() };
+  }
+);
+vi.mock(
+  import("@app/lib/api/analytics/consumption/top_conversations"),
+  async (orig) => {
+    const mod = await orig();
+    return { ...mod, fetchConsumptionTopConversations: vi.fn() };
   }
 );
 vi.mock(
@@ -152,6 +163,17 @@ const TOP_API_KEYS: GetConsumptionTopApiKeysResponse = {
       previousCredits: null,
       messageCount: 4,
       avgCreditsPerMessage: 25,
+    },
+  ],
+};
+
+const TOP_CONVERSATIONS: GetConsumptionTopConversationsResponse = {
+  period: PERIOD,
+  conversations: [
+    {
+      conversationId: "conversation1",
+      title: "Quarterly report",
+      totalCredits: 420,
     },
   ],
 };
@@ -496,5 +518,61 @@ describe("POST /api/w/:wId/analytics/consumption/top-*", () => {
     expect(await response.json()).toMatchObject({
       error: { type: "internal_server_error" },
     });
+  });
+
+  it("returns the member's most expensive conversations", async () => {
+    vi.mocked(fetchConsumptionTopConversations).mockResolvedValue(
+      new Ok(TOP_CONVERSATIONS)
+    );
+    const { workspace, user } = await setupTest({ role: "user" });
+
+    const response = await postRankingRequest(
+      workspace.sId,
+      "top-conversations",
+      {
+        period: "days",
+        days: 7,
+        filter: { users: ["another-user"], sources: ["web"] },
+      },
+      true
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(TOP_CONVERSATIONS);
+    expect(fetchConsumptionTopConversations).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        period: { startDate: expect.any(String), endDate: expect.any(String) },
+        limit: 10,
+        filter: { users: [user.sId], sources: ["web"] },
+      }
+    );
+  });
+
+  it("does not mount top conversations on workspace analytics", async () => {
+    const { workspace } = await setupTest({ role: "admin" });
+
+    const response = await postRankingRequest(
+      workspace.sId,
+      "top-conversations"
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 500 when the conversation ranking fails", async () => {
+    vi.mocked(fetchConsumptionTopConversations).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+    const { workspace } = await setupTest({ role: "user" });
+
+    const response = await postRankingRequest(
+      workspace.sId,
+      "top-conversations",
+      {},
+      true
+    );
+
+    expect(response.status).toBe(500);
   });
 });

--- a/front/hooks/useConsumptionTopConversations.ts
+++ b/front/hooks/useConsumptionTopConversations.ts
@@ -1,0 +1,49 @@
+import {
+  getConsumptionAnalyticsUrl,
+  useConsumptionQuery,
+} from "@app/hooks/useConsumptionQuery";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import {
+  DEFAULT_CONSUMPTION_PERIOD_DAYS,
+  normalizedConsumptionFilter,
+} from "@app/lib/analytics/consumption_period";
+import type { ConsumptionBody } from "@app/lib/api/analytics/consumption/schema";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import type { GetConsumptionTopConversationsResponse } from "@app/lib/api/analytics/consumption/top_conversations";
+import { emptyArray } from "@app/lib/swr/swr";
+
+interface UseConsumptionTopConversationsParams {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  filter?: ConsumptionScopeFilter;
+  disabled?: boolean;
+}
+
+export function useConsumptionTopConversations({
+  workspaceId,
+  period,
+  filter,
+  disabled,
+}: UseConsumptionTopConversationsParams) {
+  const url = getConsumptionAnalyticsUrl({
+    workspaceId,
+    personal: true,
+    endpoint: "top-conversations",
+  });
+  const body: ConsumptionBody = {
+    period: period.kind,
+    days:
+      period.kind === "days" ? period.days : DEFAULT_CONSUMPTION_PERIOD_DAYS,
+    filter: normalizedConsumptionFilter(filter),
+  };
+  const { data, error, isLoading } = useConsumptionQuery<
+    ConsumptionBody,
+    GetConsumptionTopConversationsResponse
+  >({ url, body, disabled });
+
+  return {
+    conversations: data?.conversations ?? emptyArray(),
+    isTopConversationsLoading: !error && isLoading,
+    isTopConversationsError: error,
+  };
+}

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -36,6 +36,10 @@ export const TRIGGER_ID_FIELD = "trigger_id";
 
 export const CARDINALITY_PRECISION_THRESHOLD = 40_000;
 
+export type ConsumptionTopDimension =
+  | ConsumptionScopeDimension
+  | "conversation";
+
 export const CONSUMPTION_DIMENSION_FIELDS: Record<
   ConsumptionScopeDimension,
   string
@@ -52,6 +56,14 @@ export const CONSUMPTION_DIMENSION_FIELDS: Record<
   source: "normalized_origin",
 };
 
+export const CONSUMPTION_TOP_DIMENSION_FIELDS: Record<
+  ConsumptionTopDimension,
+  string
+> = {
+  ...CONSUMPTION_DIMENSION_FIELDS,
+  conversation: CONVERSATION_ID_FIELD,
+};
+
 export type ConsumptionTopUnit = "message" | "invocation";
 
 export const CONSUMPTION_DIMENSION_UNIT: Record<
@@ -66,6 +78,14 @@ export const CONSUMPTION_DIMENSION_UNIT: Record<
   tool: "invocation",
   skill: "invocation",
   source: "message",
+};
+
+export const CONSUMPTION_TOP_DIMENSION_UNIT: Record<
+  ConsumptionTopDimension,
+  ConsumptionTopUnit
+> = {
+  ...CONSUMPTION_DIMENSION_UNIT,
+  conversation: "message",
 };
 
 export const CONSUMPTION_METRICS = ["credit_micro"] as const;

--- a/front/lib/api/analytics/consumption/top.test.ts
+++ b/front/lib/api/analytics/consumption/top.test.ts
@@ -3,6 +3,7 @@ import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/label
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { fetchConsumptionTopAgents } from "@app/lib/api/analytics/consumption/top_agents";
 import { fetchConsumptionTopApiKeys } from "@app/lib/api/analytics/consumption/top_api_keys";
+import { fetchConsumptionTopConversations } from "@app/lib/api/analytics/consumption/top_conversations";
 import { fetchConsumptionTopGroups } from "@app/lib/api/analytics/consumption/top_groups";
 import { fetchConsumptionTopModels } from "@app/lib/api/analytics/consumption/top_models";
 import { fetchConsumptionTopSkills } from "@app/lib/api/analytics/consumption/top_skills";
@@ -14,6 +15,7 @@ import {
   searchConsumptionAnalytics,
 } from "@app/lib/api/elasticsearch";
 import { Authenticator } from "@app/lib/auth";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Err, Ok } from "@app/types/shared/result";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -614,6 +616,56 @@ describe("consumption top rankings", () => {
     expect(lastSearchCall()[1]?.aggregations?.by_group?.terms).toMatchObject({
       field: "normalized_origin",
     });
+  });
+
+  it("ranks deleted conversations from the consumption index", async () => {
+    const { auth } = await setup();
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "unused",
+      messagesCreatedAt: [],
+      visibility: "deleted",
+    });
+    mockAggs({
+      buckets: [
+        {
+          key: conversation.sId,
+          doc_count: 4,
+          credit_micro: { value: 6_000_000 },
+          messages: { value: 2 },
+        },
+      ],
+      totalMicro: 6_000_000,
+    });
+
+    const result = await fetchConsumptionTopConversations(auth, {
+      period: PERIOD,
+      limit: 10,
+      filter: { users: ["user1"] },
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.conversations).toEqual([
+      {
+        conversationId: conversation.sId,
+        title: "Test Conversation",
+        totalCredits: 6,
+      },
+    ]);
+
+    const [query, options] = rankingSearchCall();
+    expect(query.bool?.filter).toContainEqual({
+      term: { "user.id": "user1" },
+    });
+    expect(options?.aggregations?.by_group?.terms).toMatchObject({
+      field: "conversation_id",
+      order: { credit_micro: "desc" },
+    });
+    expect(
+      options?.aggregations?.by_group?.aggs?.messages?.cardinality?.field
+    ).toBe("agent_message_id");
   });
 
   it("narrows the scope with the requested filter", async () => {

--- a/front/lib/api/analytics/consumption/top.ts
+++ b/front/lib/api/analytics/consumption/top.ts
@@ -5,6 +5,7 @@ import { previousConsumptionPeriod } from "@app/lib/api/analytics/consumption/pe
 import type {
   ConsumptionScopeDimension,
   ConsumptionScopeFilter,
+  ConsumptionTopDimension,
   ConsumptionTopSortOrder,
   ConsumptionTopUnit,
 } from "@app/lib/api/analytics/consumption/scope";
@@ -13,7 +14,8 @@ import {
   buildConsumptionScopeQuery,
   CARDINALITY_PRECISION_THRESHOLD,
   CONSUMPTION_DIMENSION_FIELDS,
-  CONSUMPTION_DIMENSION_UNIT,
+  CONSUMPTION_TOP_DIMENSION_FIELDS,
+  CONSUMPTION_TOP_DIMENSION_UNIT,
   CREDIT_MICRO_FIELD,
 } from "@app/lib/api/analytics/consumption/scope";
 import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
@@ -145,10 +147,14 @@ async function resolveConsumptionTopSearchFilter(
     dimension,
     search,
   }: {
-    dimension: ConsumptionScopeDimension;
+    dimension: ConsumptionTopDimension;
     search?: string;
   }
 ): Promise<estypes.QueryDslQueryContainer | null> {
+  if (dimension === "conversation") {
+    return null;
+  }
+
   const normalizedSearch = search?.trim().toLowerCase();
   if (!normalizedSearch) {
     return null;
@@ -174,14 +180,14 @@ function buildConsumptionTopAggregations({
   searchFilter,
   sortOrder,
 }: {
-  dimension: ConsumptionScopeDimension;
+  dimension: ConsumptionTopDimension;
   bucketCount: number;
   excludedKeys: string[];
   searchFilter: estypes.QueryDslQueryContainer | null;
   sortOrder: ConsumptionTopSortOrder;
 }): Record<string, estypes.AggregationsAggregationContainer> {
-  const unit = CONSUMPTION_DIMENSION_UNIT[dimension];
-  const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
+  const unit = CONSUMPTION_TOP_DIMENSION_UNIT[dimension];
+  const dimensionField = CONSUMPTION_TOP_DIMENSION_FIELDS[dimension];
 
   const rankingAggregations = {
     by_group: {
@@ -231,7 +237,7 @@ async function fetchConsumptionPreviousCredits(
     filter,
     keys,
   }: {
-    dimension: ConsumptionScopeDimension;
+    dimension: ConsumptionTopDimension;
     previousPeriod: ConsumptionPeriod;
     filter?: ConsumptionScopeFilter;
     keys: string[];
@@ -254,7 +260,7 @@ async function fetchConsumptionPreviousCredits(
       aggregations: {
         by_group: {
           terms: {
-            field: CONSUMPTION_DIMENSION_FIELDS[dimension],
+            field: CONSUMPTION_TOP_DIMENSION_FIELDS[dimension],
             include: keys,
             size: keys.length,
           },
@@ -298,7 +304,7 @@ export async function fetchConsumptionTopGroups(
     filter,
     sortOrder = "desc",
   }: {
-    dimension: ConsumptionScopeDimension;
+    dimension: ConsumptionTopDimension;
     period: ConsumptionPeriod;
     limit: number;
     offset?: number;
@@ -358,7 +364,10 @@ export async function fetchConsumptionTopGroups(
       ...buckets.map((bucket) => ({
         key: String(bucket.key),
         credits: microCreditsToCredits(bucket[CREDIT_AGG]?.value ?? 0),
-        count: countFromBucket(bucket, CONSUMPTION_DIMENSION_UNIT[dimension]),
+        count: countFromBucket(
+          bucket,
+          CONSUMPTION_TOP_DIMENSION_UNIT[dimension]
+        ),
       }))
     );
     totalCredits = microCreditsToCredits(

--- a/front/lib/api/analytics/consumption/top_conversations.ts
+++ b/front/lib/api/analytics/consumption/top_conversations.ts
@@ -1,0 +1,80 @@
+import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
+import { fetchConsumptionTopGroups } from "@app/lib/api/analytics/consumption/top";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { getConversationDisplayTitle } from "@app/types/assistant/conversation";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+export type ConsumptionTopConversationRow = {
+  conversationId: string;
+  title: string;
+  totalCredits: number;
+};
+
+export type ConsumptionTopConversations = {
+  period: ConsumptionPeriod;
+  conversations: ConsumptionTopConversationRow[];
+};
+
+export type GetConsumptionTopConversationsResponse =
+  ConsumptionTopConversations;
+
+export async function fetchConsumptionTopConversations(
+  auth: Authenticator,
+  {
+    period,
+    limit,
+    filter,
+  }: {
+    period: ConsumptionPeriod;
+    limit: number;
+    filter?: ConsumptionScopeFilter;
+  }
+): Promise<Result<ConsumptionTopConversations, ElasticsearchError>> {
+  const result = await fetchConsumptionTopGroups(auth, {
+    dimension: "conversation",
+    period,
+    limit,
+    filter,
+  });
+  if (result.isErr()) {
+    return result;
+  }
+
+  const conversations = await ConversationResource.fetchByIds(
+    auth,
+    result.value.groups.map((group) => group.key),
+    { includeDeleted: true }
+  );
+  const conversationMetadataById = new Map(
+    conversations.map((conversation) => [
+      conversation.sId,
+      {
+        conversationId: conversation.sId,
+        title: getConversationDisplayTitle({
+          created: conversation.createdAt.getTime(),
+          forkingData: conversation.forkingData,
+          title: conversation.title,
+        }),
+      },
+    ])
+  );
+
+  return new Ok({
+    period,
+    conversations: result.value.groups.flatMap((group) => {
+      const conversation = conversationMetadataById.get(group.key);
+      return conversation
+        ? [
+            {
+              ...conversation,
+              totalCredits: group.credits,
+            },
+          ]
+        : [];
+    }),
+  });
+}


### PR DESCRIPTION
## Description

This PR is the first of 2 PRs to deprecate the Usage tab in the user menu popover and migrating what needs to be migrated to the new Analytics menu.

Personal analytics need a view for the top most expensive conversations.

This PR adds the backend for it + the hook.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
