### PR TITLE
Preserve reasoning summary boundaries while streaming

### DIFF
--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.test.ts
@@ -132,6 +132,80 @@ describe("usageToTokenUsageEvent", () => {
 });
 
 describe("rawOutputToEvents", () => {
+  it("preserves blank lines between streamed reasoning summary parts", async () => {
+    const firstSummary = "**Verifying model usage by region**";
+    const secondSummary = "**Investigating workspace region data**";
+    const rawEvents: ResponseStreamEvent[] = [
+      {
+        type: "response.reasoning_summary_part.added",
+        item_id: "rs_1",
+        output_index: 0,
+        summary_index: 0,
+        sequence_number: 0,
+        part: { type: "summary_text", text: "" },
+      },
+      {
+        type: "response.reasoning_summary_text.delta",
+        item_id: "rs_1",
+        output_index: 0,
+        summary_index: 0,
+        sequence_number: 1,
+        delta: firstSummary,
+      },
+      {
+        type: "response.reasoning_summary_part.added",
+        item_id: "rs_1",
+        output_index: 0,
+        summary_index: 1,
+        sequence_number: 2,
+        part: { type: "summary_text", text: "" },
+      },
+      {
+        type: "response.reasoning_summary_text.delta",
+        item_id: "rs_1",
+        output_index: 0,
+        summary_index: 1,
+        sequence_number: 3,
+        delta: secondSummary,
+      },
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        sequence_number: 4,
+        item: {
+          type: "reasoning",
+          id: "rs_1",
+          summary: [
+            { type: "summary_text", text: firstSummary },
+            { type: "summary_text", text: secondSummary },
+          ],
+          status: "completed",
+        },
+      },
+    ];
+    const events = [];
+    for await (const event of rawOutputToEvents(
+      createAsyncGenerator(rawEvents),
+      metadata,
+      converters
+    )) {
+      events.push(event);
+    }
+
+    const streamedReasoning = events
+      .filter((event) => event.type === "reasoning_delta")
+      .map((event) => event.content.value)
+      .join("");
+    const completedReasoning = events.find(
+      (event) => event.type === "reasoning"
+    );
+
+    expect(streamedReasoning).toBe(`${firstSummary}\n\n${secondSummary}`);
+    expect(completedReasoning).toMatchObject({
+      content: { value: streamedReasoning },
+    });
+  });
+
   it("preserves interleaved reasoning and function-call item order", async () => {
     const rawEvents: ResponseStreamEvent[] = [
       {

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
@@ -529,6 +529,19 @@ export async function* rawOutputToEvents(
           ),
         ];
         break;
+      case "response.reasoning_summary_part.added":
+        // Completed reasoning items join summary parts with a blank line. Keep
+        // the streaming deltas consistent so adjacent Markdown titles do not
+        // collapse into `****` while the response is in progress.
+        if (event.summary_index > 0) {
+          outputEvents = [
+            converters.reasoningSummaryDeltaToReasoningDeltaEvent(
+              metadata,
+              "\n\n"
+            ),
+          ];
+        }
+        break;
       case "response.output_item.added":
         if (event.item.type === "function_call") {
           outputEvents = [
@@ -599,7 +612,6 @@ export async function* rawOutputToEvents(
       case "response.file_search_call.searching":
       case "response.function_call_arguments.done":
       case "response.in_progress":
-      case "response.reasoning_summary_part.added":
       case "response.reasoning_summary_part.done":
       case "response.reasoning_summary_text.done":
       case "response.reasoning_text.delta":


### PR DESCRIPTION
## Description

OpenAI concise reasoning can contain multiple summary parts. Preserve the blank-line boundary between those parts in the live delta stream so adjacent bold titles do not collapse into visible asterisks before completion.

## Tests

Added a converter regression covering two streamed reasoning summary parts and the completed item.

## Risk

Low. This only inserts the separator already used by the completed reasoning representation.

## Deploy Plan

Standard deploy.