### PR TITLE
fix: reject creation of restricted internal MCP servers

### DIFF
--- a/front/lib/api/mcp/servers.ts
+++ b/front/lib/api/mcp/servers.ts
@@ -280,6 +280,15 @@ export async function createInternalMCPServer(
     return new Err(new Error("Invalid internal MCP server name"));
   }
 
+  const isRestricted =
+    await InternalMCPServerInMemoryResource.isRestrictedForWorkspace(
+      auth,
+      name
+    );
+  if (isRestricted) {
+    return new Err(new Error("This tool is not available for this workspace."));
+  }
+
   if (viewName !== undefined) {
     const trimmed = viewName.trim();
     if (trimmed.length === 0 || trimmed.length > MAX_NAME_LENGTH) {

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -109,6 +109,17 @@ export class InternalMCPServerInMemoryResource {
     );
   }
 
+  static async isRestrictedForWorkspace(
+    auth: Authenticator,
+    name: InternalMCPServerNameType
+  ): Promise<boolean> {
+    const enabledServerNames = await this.computeEnabledServerNames(auth, [
+      name,
+    ]);
+
+    return !enabledServerNames.has(name);
+  }
+
   static async makeNew(
     auth: Authenticator,
     {


### PR DESCRIPTION
## Description

`createInternalMCPServer` checks that the posted name is a known internal server and stops there. It never evaluates `isRestricted`, so any workspace admin can install a flag-gated or plan-gated server by posting its name to `/api/w/:wId/mcp`. The only thing that normally keeps those servers out of reach is the "add a tool" dialog in the space administration, which filters on `isRestricted` as it renders. It's just a display filter, not an auth check.

This moves the check onto the create path. `isRestrictedForWorkspace` now gate the input to the actual accessible list of servers to the workspace (feature flags, deep dive, workspace analytics, plan).

## Tests

None

## Risk

Workspaces already running a restricted server are unaffected, since this only touches creation.

## Deploy Plan

Deploy front.