### PR TITLE
[front] use consumption ES index for agents export

### DIFF
--- a/front-api/routes/w/[wId]/analytics/agents-export.ts
+++ b/front-api/routes/w/[wId]/analytics/agents-export.ts
@@ -4,8 +4,9 @@ import {
   fetchAgentExportRows,
   toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
-import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
 import { apiError } from "@front-api/middlewares/utils";
@@ -24,11 +25,12 @@ app.get("/", ensureIsManager(), validate("query", QuerySchema), async (ctx) => {
   const auth = ctx.get("auth");
 
   const { days } = ctx.req.valid("query");
-  const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    days,
+  const period = await resolveConsumptionPeriod(auth, { kind: "days", days });
+  const baseQuery = buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
   });
 
   const result = await fetchAgentExportRows(baseQuery, auth, true);

--- a/front/lib/api/analytics/agents_export.test.ts
+++ b/front/lib/api/analytics/agents_export.test.ts
@@ -5,7 +5,7 @@ import {
   toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -20,7 +20,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
   const actual =
     await importActual<typeof import("@app/lib/api/elasticsearch")>();
-  return { ...actual, searchAnalytics: vi.fn() };
+  return { ...actual, searchConsumptionAnalytics: vi.fn() };
 });
 
 // The export reads from the read replica; in tests there is no replica so point
@@ -35,7 +35,7 @@ vi.mock("@app/lib/resources/storage", async (importActual) => {
 });
 
 function mockEmptyEsMetrics() {
-  vi.mocked(searchAnalytics).mockResolvedValue(
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
     new Ok({
       took: 1,
       timed_out: false,

--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -1,6 +1,17 @@
+import {
+  AGENT_MESSAGE_ID_FIELD,
+  CARDINALITY_PRECISION_THRESHOLD,
+  CONSUMPTION_DIMENSION_FIELDS,
+  CONVERSATION_ID_FIELD,
+  CREDIT_MICRO_FIELD,
+} from "@app/lib/api/analytics/consumption/scope";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
 import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type { Result } from "@app/types/shared/result";
@@ -11,9 +22,10 @@ import { QueryTypes } from "sequelize";
 type TopAgentExportBucket = {
   key: string;
   doc_count: number;
+  unique_messages?: estypes.AggregationsCardinalityAggregate;
   unique_users?: estypes.AggregationsCardinalityAggregate;
   unique_conversations?: estypes.AggregationsCardinalityAggregate;
-  credits?: estypes.AggregationsSumAggregate;
+  credit_micro?: estypes.AggregationsSumAggregate;
 };
 
 type TopAgentsExportAggs = {
@@ -84,7 +96,7 @@ export async function fetchAgentExportRows(
   includeHiddenAgents: boolean
 ): Promise<Result<AgentExportRow[], Error>> {
   const owner = auth.getNonNullableWorkspace();
-  const esResult = await searchAnalytics<never, TopAgentsExportAggs>(
+  const esResult = await searchConsumptionAnalytics<never, TopAgentsExportAggs>(
     {
       bool: {
         filter: [baseQuery],
@@ -93,16 +105,30 @@ export async function fetchAgentExportRows(
     {
       aggregations: {
         by_agent: {
-          terms: { field: "agent_id", size: 10000 },
+          terms: { field: CONSUMPTION_DIMENSION_FIELDS.agent, size: 10000 },
           aggs: {
-            unique_users: { cardinality: { field: "user_id" } },
-            unique_conversations: {
-              cardinality: { field: "conversation_id" },
+            // Consumption documents are split per LLM step and per tool call,
+            // so a message contributes several documents to the same agent
+            // bucket: dedupe by agent_message_id to count distinct messages.
+            unique_messages: {
+              cardinality: {
+                field: AGENT_MESSAGE_ID_FIELD,
+                precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+              },
             },
-            // Billed credits per execution via `cost.billable_awu` (0 for the
-            // non-billable errored-terminal part), so no status filter is needed;
-            // the count metrics above stay inclusive of all activity.
-            credits: { sum: { field: "cost.billable_awu" } },
+            unique_users: {
+              cardinality: {
+                field: CONSUMPTION_DIMENSION_FIELDS.user,
+                precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+              },
+            },
+            unique_conversations: {
+              cardinality: {
+                field: CONVERSATION_ID_FIELD,
+                precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+              },
+            },
+            credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
           },
         },
       },
@@ -122,10 +148,10 @@ export async function fetchAgentExportRows(
     buckets.map((b) => [
       String(b.key),
       {
-        messages: b.doc_count,
+        messages: Math.round(b.unique_messages?.value ?? 0),
         distinctUsersReached: Math.round(b.unique_users?.value ?? 0),
         distinctConversations: Math.round(b.unique_conversations?.value ?? 0),
-        credits: Math.round(b.credits?.value ?? 0),
+        credits: Math.round(microCreditsToCredits(b.credit_micro?.value ?? 0)),
       },
     ])
   );

--- a/front/lib/api/analytics/export_tables.test.ts
+++ b/front/lib/api/analytics/export_tables.test.ts
@@ -1,0 +1,117 @@
+import { exportTable } from "@app/lib/api/analytics/export_tables";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Keep `bucketsToArray` (and everything else) real; only stub the
+// Elasticsearch query so the test does not depend on a live cluster.
+vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/api/elasticsearch")>();
+  return { ...actual, searchConsumptionAnalytics: vi.fn() };
+});
+
+// The export reads from the read replica; in tests there is no replica so
+// point it at the primary test connection.
+vi.mock("@app/lib/resources/storage", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@app/lib/resources/storage")>();
+  return {
+    ...actual,
+    getFrontReplicaDbConnection: () => actual.frontSequelize,
+  };
+});
+
+describe("exportTable agents", () => {
+  beforeEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("queries the consumption index with a half-open completed_at range and returns its aggregated metrics", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const agent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Agent" }
+    );
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" }, hits: [] },
+        aggregations: {
+          by_agent: {
+            buckets: [
+              {
+                key: agent.sId,
+                doc_count: 5,
+                unique_messages: { value: 3 },
+                unique_users: { value: 2 },
+                unique_conversations: { value: 1 },
+                credit_micro: { value: 2_000_000 },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const result = await exportTable({
+      auth: authenticator,
+      table: "agents",
+      startDate: "2024-01-01",
+      endDate: "2024-01-31",
+      timezone: "UTC",
+      owner: workspace,
+      includeHiddenAgents: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    if (result.value.table !== "agents") {
+      throw new Error(`Expected "agents" table, got "${result.value.table}"`);
+    }
+
+    // Regression: exportAgents used to build its query with the legacy,
+    // timestamp-based buildAgentAnalyticsBaseQuery, which the consumption
+    // index does not have a `timestamp` field for — every agent row silently
+    // came back with zero metrics. It must now query the consumption index
+    // with a half-open [startDate, endDate) `completed_at` range, bumping the
+    // inclusive `endDate` calendar day up by one day.
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          {
+            bool: {
+              filter: [
+                { term: { workspace_id: workspace.sId } },
+                {
+                  range: {
+                    completed_at: { gte: "2024-01-01", lt: "2024-02-01" },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const row = result.value.rows.find((r) => r.agentId === agent.sId);
+    expect(row).toBeDefined();
+    expect(row!.messages).toBe(3);
+    expect(row!.distinctUsersReached).toBe(2);
+    expect(row!.distinctConversations).toBe(1);
+    expect(row!.credits).toBe(2);
+  });
+});

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -4,6 +4,7 @@ import {
   fetchAgentExportRows,
   toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
+import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import type { FeedbackExportRow } from "@app/lib/api/analytics/feedback_export";
 import {
@@ -207,7 +208,6 @@ export async function exportTable({
         auth,
         startDate,
         endDate,
-        owner,
         includeHiddenAgents,
       });
     case "users":
@@ -384,19 +384,26 @@ async function exportAgents({
   auth,
   startDate,
   endDate,
-  owner,
   includeHiddenAgents,
 }: {
   auth: Authenticator;
   startDate: string;
   endDate: string;
-  owner: WorkspaceType;
   includeHiddenAgents: boolean;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  // The consumption index's completed_at range is half-open ([startDate,
+  // endDate)), while startDate/endDate here are inclusive calendar days
+  // ("YYYY-MM-DD"); bump the upper bound to the start of the following day so
+  // the whole endDate day is included.
+  const exclusiveEndDate = moment
+    .utc(endDate)
+    .add(1, "day")
+    .format("YYYY-MM-DD");
+
+  const baseQuery = buildConsumptionScopeQuery({
+    auth,
     startDate,
-    endDate,
+    endDate: exclusiveEndDate,
   });
 
   const result = await fetchAgentExportRows(


### PR DESCRIPTION
## Description

The agents table in the analytics export panel still read from the old, message-level Elasticsearch index, while the rest of the consumption dashboard (top agents, timeseries, etc.) already reads from the newer consumption index. This moves the agents export over too, for both places it's produced: the dedicated agents-export endpoint and the `agents` table of the combined export endpoint.

Because the consumption index stores data at a finer grain (per LLM step / tool call rather than per message), the metrics are now computed with distinct-count aggregations instead of raw document counts, mirroring how the rest of the consumption dashboard already does it.

The CSV output and what the user sees is unchanged — only the underlying data source and computation method changed.

## Tests

- Updated the existing agents-export test to the new data source.
- Added a regression test for the combined export endpoint's `agents` table, covering a bug caught in review where its date range excluded the last day of the period.
- Confirmed the neighboring export-endpoint test suite (which doesn't touch Elasticsearch directly) still passes.

## Risk

Low - The other tables in the same export panel still read from the old index, so the panel now sources different tables from different indices. Not expected to cause visible discrepancies, but worth knowing if reconciling numbers across CSVs.

## Deploy Plan

- Deploy front
