### PR TITLE
[front] Seed spend-cap counters from ES on the recorder's first touch

### DIFF
--- a/front/lib/api/credits/programmatic_usage_limit.ts
+++ b/front/lib/api/credits/programmatic_usage_limit.ts
@@ -245,12 +245,18 @@ export async function recordProgrammaticSpendLimitUsage(
     return;
   }
 
+  const redisKey =
+    makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(workspace);
+
+  // Seed from ES on the counter's first touch of the cycle (SET-if-absent), so
+  // it reflects cycle-to-date consumption even when the enforcement reader
+  // never runs (e.g. no positive programmatic cap). No-ops once live.
+  await readProgrammaticSpendLimitCountWithLazySeed(auth, { redisKey, bounds });
+
   const incrementByMicroCredits = roundCreditsToMicroCredits(incrementBy);
 
   await addFixedWindowCount({
-    key: makeProgrammaticSpendLimitAwuCreditsRateLimitKeyForWorkspace(
-      workspace
-    ),
+    key: redisKey,
     bounds,
     incrementBy: incrementByMicroCredits,
     logger,

--- a/front/lib/api/keys/spend_limit.ts
+++ b/front/lib/api/keys/spend_limit.ts
@@ -345,21 +345,29 @@ export async function backfillApiKeyCreditCapsForWorkspace(
 async function readApiKeySpendLimitCountWithLazySeed(
   auth: Authenticator,
   {
-    apiKeyName,
+    keyModelId,
     redisKey,
     bounds,
-  }: { apiKeyName: string; redisKey: string; bounds: FixedWindowBounds }
+  }: { keyModelId: number; redisKey: string; bounds: FixedWindowBounds }
 ): Promise<number | null> {
   return readFixedWindowCountWithLazySeed({
     key: redisKey,
     bounds,
     logger,
-    // The counter stores microCredits; convert the ES credit value before
-    // seeding. Preserve the null contract (ES read failed → skip seed, do not
-    // seed as 0).
+    // The ES query is keyed by the api-key name; resolve it here (only invoked
+    // on a seed miss, so no per-record fetch). The counter stores microCredits;
+    // convert the ES credit value. Preserve the null contract (ES read failed
+    // or key gone → skip seed, do not seed as 0).
     fetchSeedValue: async () => {
+      const key = await KeyResource.fetchByWorkspaceAndId({
+        workspace: auth.getNonNullableWorkspace(),
+        id: keyModelId,
+      });
+      if (!key) {
+        return null;
+      }
       const consumedAwuCredits = await getEsConsumedAwuCreditsForApiKey(auth, {
-        apiKeyName,
+        apiKeyName: key.name,
       });
       return consumedAwuCredits === null
         ? null
@@ -398,7 +406,7 @@ export async function isApiKeySpendLimitRateCapReached(
   }
 
   const count = await readApiKeySpendLimitCountWithLazySeed(auth, {
-    apiKeyName: key.name,
+    keyModelId: key.id,
     redisKey: makeApiKeySpendLimitAwuCreditsRateLimitKey(key.id),
     bounds,
   });
@@ -441,10 +449,21 @@ export async function recordApiKeySpendLimitUsage(
     return;
   }
 
+  const redisKey = makeApiKeySpendLimitAwuCreditsRateLimitKey(keyModelId);
+
+  // Seed from ES on the counter's first touch of the cycle (SET-if-absent), so
+  // it reflects cycle-to-date consumption even when the enforcement reader
+  // never runs for this key (e.g. a key with no cap set). No-ops once live.
+  await readApiKeySpendLimitCountWithLazySeed(auth, {
+    keyModelId,
+    redisKey,
+    bounds,
+  });
+
   const incrementByMicroCredits = roundCreditsToMicroCredits(incrementBy);
 
   await addFixedWindowCount({
-    key: makeApiKeySpendLimitAwuCreditsRateLimitKey(keyModelId),
+    key: redisKey,
     bounds,
     incrementBy: incrementByMicroCredits,
     logger,

--- a/front/lib/api/users/spend_limit.ts
+++ b/front/lib/api/users/spend_limit.ts
@@ -687,10 +687,21 @@ export async function recordUserSpendLimitUsage(
     return;
   }
 
+  const key = makeSpendLimitAwuCreditsRateLimitKeyForUser(
+    workspace,
+    user.toJSON()
+  );
+
+  // Seed the counter from ES on its first touch of the cycle (SET-if-absent),
+  // so it reflects cycle-to-date consumption even when the enforcement reader —
+  // the other lazy seeder — never runs for this user (e.g. a user with no
+  // effective cap). No-ops once the counter is live.
+  await readSpendLimitCountWithLazySeed(auth, { user, key, bounds, cycle });
+
   const incrementByMicroCredits = roundCreditsToMicroCredits(incrementBy);
 
   await addFixedWindowCount({
-    key: makeSpendLimitAwuCreditsRateLimitKeyForUser(workspace, user.toJSON()),
+    key,
     bounds,
     incrementBy: incrementByMicroCredits,
     logger,


### PR DESCRIPTION
The microCredits key rename made every per-user/per-API-key/programmatic
counter a fresh key at deploy. Lazy-seeding only ran from the enforcement
reader, which early-returns before seeding when there is no effective cap — but
the recorder runs on every message and creates the key via INCRBY without
seeding. So for users/keys whose first post-cutover touch was a record (no cap,
or a finalize landing before the next send-time read), the counter started at 0
and only accrued live deltas, missing cycle-to-date consumption (e.g. ES 9,499
/ RL 128 / MT 9,484).

Make each recorder seed-if-absent from ES (via the existing lazy-seed read,
SET-if-absent) before its INCRBY, so the counter is correct on first touch
regardless of whether a capped read ever runs. The ES read only fires on a seed
miss (once per key/cycle); the per-API-key path resolves the key name lazily
inside the seed miss to avoid a per-record fetch.

Repair existing drift with the resync_spend_limit_counters poke plugin.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
