### PR TITLE
Implement Shopify product listing MCP tool

### DIFF
--- a/front/components/resources/resources_icon_names.ts
+++ b/front/components/resources/resources_icon_names.ts
@@ -186,6 +186,7 @@ export const INTERNAL_ALLOWED_ICONS = [
   "ActionScanIcon",
   "ActionSlideshowIcon",
   "ActionSpeakIcon",
+  "ActionStoreIcon",
   "ActionTableIcon",
   "ActionTimeIcon",
   "AdomikLogo",

--- a/front/components/resources/resources_icons.tsx
+++ b/front/components/resources/resources_icons.tsx
@@ -2,6 +2,7 @@ import type { Avatar, Icon } from "@dust-tt/sparkle";
 import {
   ActionFrame,
   ActionIcons,
+  ActionStore,
   AdomikLogo,
   AmplitudeLogo,
   Announcement01,
@@ -210,6 +211,7 @@ export const InternalActionIcons = {
   ActionScanIcon: Scan,
   ActionSlideshowIcon: PresentationChart01,
   ActionSpeakIcon: MessageSmileCircle,
+  ActionStoreIcon: ActionStore,
   ActionTableIcon: Table,
   ActionTimeIcon: Clock,
   AdomikLogo,

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2146,15 +2146,15 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
-    "export_products": {
-      "freeUsage": false,
-      "toolCostCategory": "advanced",
-    },
     "export_sales": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
     "export_top_customers_by_period": {
+      "freeUsage": false,
+      "toolCostCategory": "advanced",
+    },
+    "list_products": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
     },
@@ -3333,9 +3333,9 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
   },
   "shopify": {
     "export_customer_ltv": "never_ask",
-    "export_products": "never_ask",
     "export_sales": "never_ask",
     "export_top_customers_by_period": "never_ask",
+    "list_products": "never_ask",
   },
   "skill_authoring": {
     "create_skill": "high",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -2142,18 +2142,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
     },
   },
   "shopify": {
-    "export_customer_ltv": {
-      "freeUsage": false,
-      "toolCostCategory": "advanced",
-    },
-    "export_sales": {
-      "freeUsage": false,
-      "toolCostCategory": "advanced",
-    },
-    "export_top_customers_by_period": {
-      "freeUsage": false,
-      "toolCostCategory": "advanced",
-    },
     "list_products": {
       "freeUsage": false,
       "toolCostCategory": "advanced",
@@ -3332,9 +3320,6 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "update_incident": "low",
   },
   "shopify": {
-    "export_customer_ltv": "never_ask",
-    "export_sales": "never_ask",
-    "export_top_customers_by_period": "never_ask",
     "list_products": "never_ask",
   },
   "skill_authoring": {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1286,9 +1286,6 @@ export const INTERNAL_MCP_SERVERS = ensureUniqueToolNames({
       return !featureFlags.includes("shopify_tool");
     },
     isPreview: true,
-    // no Shopify OAuth provider yet (preview), so auth uses requiresBearerToken
-    // (we are using an access token from a client as bearer + shop domain via X-Shopify-Shop header)
-    requiresBearerToken: true,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1780,7 +1780,7 @@ const QUERIES: LabeledQuery[] = [
   // --- shopify ---
   {
     query: "list the products in my shopify store",
-    expected: "shopify.export_products",
+    expected: "shopify.list_products",
   },
 ];
 

--- a/front/lib/api/actions/servers/bm25_tool_search.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search.test.ts
@@ -1777,6 +1777,11 @@ const QUERIES: LabeledQuery[] = [
     query: "show active incidents on the status page",
     expected: "statuspage.list_incidents",
   },
+  // --- shopify ---
+  {
+    query: "list the products in my shopify store",
+    expected: "shopify.export_products",
+  },
 ];
 
 export const fullIndexWithAllServers = buildIndex(buildDocs(SERVERS));

--- a/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
+++ b/front/lib/api/actions/servers/bm25_tool_search_utils.test.ts
@@ -52,6 +52,7 @@ import {
 import { SALESFORCE_SERVER } from "@app/lib/api/actions/servers/salesforce/metadata";
 import { SALESLOFT_SERVER } from "@app/lib/api/actions/servers/salesloft/metadata";
 import { SERVICENOW_SERVER } from "@app/lib/api/actions/servers/servicenow/metadata";
+import { SHOPIFY_SERVER } from "@app/lib/api/actions/servers/shopify/metadata";
 import { SLAB_SERVER } from "@app/lib/api/actions/servers/slab/metadata";
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
 import { SLACK_PERSONAL_SERVER } from "@app/lib/api/actions/servers/slack_personal/metadata";
@@ -148,6 +149,7 @@ const SERVER_SOURCES: Array<{
   { name: "salesforce", tools: SALESFORCE_SERVER.tools },
   { name: "salesloft", tools: SALESLOFT_SERVER.tools },
   { name: "servicenow", tools: SERVICENOW_SERVER.tools },
+  { name: "shopify", tools: SHOPIFY_SERVER.tools },
   { name: "slab", tools: SLAB_SERVER.tools },
   { name: "sound_studio", tools: SOUND_STUDIO_SERVER.tools },
   { name: "speech_generator", tools: SPEECH_GENERATOR_SERVER.tools },

--- a/front/lib/api/actions/servers/shopify/client.test.ts
+++ b/front/lib/api/actions/servers/shopify/client.test.ts
@@ -132,7 +132,7 @@ describe("createShopifyClient", () => {
         token: "access-token",
         clientId: "",
         scopes: [],
-        extra: { store_domain: "not-shopify.example.com" },
+        extra: { shopify_store_domain: "not-shopify.example.com" },
       }).isErr()
     ).toBe(true);
     expect(
@@ -140,7 +140,7 @@ describe("createShopifyClient", () => {
         token: "access-token",
         clientId: "",
         scopes: [],
-        extra: { store_domain: "my-store.myshopify.com" },
+        extra: { shopify_store_domain: "my-store.myshopify.com" },
       }).isOk()
     ).toBe(true);
   });

--- a/front/lib/api/actions/servers/shopify/client.test.ts
+++ b/front/lib/api/actions/servers/shopify/client.test.ts
@@ -132,7 +132,7 @@ describe("createShopifyClient", () => {
         token: "access-token",
         clientId: "",
         scopes: [],
-        extra: { shopify_shop: "not-shopify.example.com" },
+        extra: { store_domain: "not-shopify.example.com" },
       }).isErr()
     ).toBe(true);
     expect(
@@ -140,7 +140,7 @@ describe("createShopifyClient", () => {
         token: "access-token",
         clientId: "",
         scopes: [],
-        extra: { shopify_shop: "my-store.myshopify.com" },
+        extra: { store_domain: "my-store.myshopify.com" },
       }).isOk()
     ).toBe(true);
   });

--- a/front/lib/api/actions/servers/shopify/client.test.ts
+++ b/front/lib/api/actions/servers/shopify/client.test.ts
@@ -45,7 +45,7 @@ function pageResponse(
   );
 }
 
-describe("ShopifyClient.exportProducts", () => {
+describe("ShopifyClient.listProducts", () => {
   beforeEach(() => {
     mocks.untrustedFetch.mockReset();
   });
@@ -66,7 +66,7 @@ describe("ShopifyClient.exportProducts", () => {
       );
     const client = new ShopifyClient("access-token", "my-store.myshopify.com");
 
-    const result = await client.exportProducts({
+    const result = await client.listProducts({
       status: "ACTIVE",
       vendor: "O'Reilly",
       searchQuery: "tag:sale",
@@ -113,7 +113,7 @@ describe("ShopifyClient.exportProducts", () => {
     );
     const client = new ShopifyClient("access-token", "my-store.myshopify.com");
 
-    const result = await client.exportProducts({ limit: 10 });
+    const result = await client.listProducts({ limit: 10 });
 
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {

--- a/front/lib/api/actions/servers/shopify/client.test.ts
+++ b/front/lib/api/actions/servers/shopify/client.test.ts
@@ -1,0 +1,147 @@
+import {
+  createShopifyClient,
+  ShopifyClient,
+} from "@app/lib/api/actions/servers/shopify/client";
+import type { ShopifyProduct } from "@app/lib/api/actions/servers/shopify/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  untrustedFetch: vi.fn(),
+}));
+
+vi.mock("@app/lib/egress/server", () => ({
+  untrustedFetch: mocks.untrustedFetch,
+}));
+
+function product(id: number): ShopifyProduct {
+  return {
+    id: `gid://shopify/Product/${id}`,
+    title: `Product ${id}`,
+    handle: `product-${id}`,
+    status: "ACTIVE",
+    vendor: "Dust",
+    productType: "Software",
+    totalInventory: id,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-02T00:00:00Z",
+    priceRangeV2: {
+      minVariantPrice: { amount: "10.00", currencyCode: "USD" },
+      maxVariantPrice: { amount: "20.00", currencyCode: "USD" },
+    },
+  };
+}
+
+function pageResponse(
+  products: ShopifyProduct[],
+  { hasNextPage, endCursor }: { hasNextPage: boolean; endCursor: string | null }
+) {
+  return new Response(
+    JSON.stringify({
+      data: {
+        products: { nodes: products, pageInfo: { hasNextPage, endCursor } },
+      },
+    }),
+    { status: 200 }
+  );
+}
+
+describe("ShopifyClient.exportProducts", () => {
+  beforeEach(() => {
+    mocks.untrustedFetch.mockReset();
+  });
+
+  it("paginates products up to the requested limit and sends filters as variables", async () => {
+    mocks.untrustedFetch
+      .mockResolvedValueOnce(
+        pageResponse([product(1), product(2)], {
+          hasNextPage: true,
+          endCursor: "cursor-2",
+        })
+      )
+      .mockResolvedValueOnce(
+        pageResponse([product(3)], {
+          hasNextPage: false,
+          endCursor: null,
+        })
+      );
+    const client = new ShopifyClient("access-token", "my-store.myshopify.com");
+
+    const result = await client.exportProducts({
+      status: "ACTIVE",
+      vendor: "O'Reilly",
+      searchQuery: "tag:sale",
+      limit: 3,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      return;
+    }
+    expect(result.value.products).toHaveLength(3);
+    expect(result.value.truncated).toBe(false);
+    expect(mocks.untrustedFetch).toHaveBeenCalledTimes(2);
+
+    const [firstUrl, firstInit] = mocks.untrustedFetch.mock.calls[0];
+    expect(firstUrl).toBe(
+      "https://my-store.myshopify.com/admin/api/2026-07/graphql.json"
+    );
+    const firstBody = JSON.parse(firstInit.body as string);
+    expect(firstBody.variables).toEqual({
+      first: 3,
+      after: null,
+      query: "status:active vendor:'O\\'Reilly' tag:sale",
+    });
+
+    const secondBody = JSON.parse(
+      mocks.untrustedFetch.mock.calls[1][1].body as string
+    );
+    expect(secondBody.variables).toMatchObject({
+      first: 1,
+      after: "cursor-2",
+    });
+  });
+
+  it("surfaces GraphQL errors returned with no data", async () => {
+    mocks.untrustedFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          data: null,
+          errors: [{ message: "Access denied for products field." }],
+        }),
+        { status: 200 }
+      )
+    );
+    const client = new ShopifyClient("access-token", "my-store.myshopify.com");
+
+    const result = await client.exportProducts({ limit: 10 });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain(
+        "Access denied for products field"
+      );
+    }
+  });
+});
+
+describe("createShopifyClient", () => {
+  it("requires the OAuth token and store metadata", () => {
+    expect(createShopifyClient().isErr()).toBe(true);
+    expect(
+      createShopifyClient({
+        token: "access-token",
+        clientId: "",
+        scopes: [],
+        extra: { shopify_shop: "not-shopify.example.com" },
+      }).isErr()
+    ).toBe(true);
+    expect(
+      createShopifyClient({
+        token: "access-token",
+        clientId: "",
+        scopes: [],
+        extra: { shopify_shop: "my-store.myshopify.com" },
+      }).isOk()
+    ).toBe(true);
+  });
+});

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -225,7 +225,9 @@ export function createShopifyClient(
     return new Err(new MCPError("No Shopify access token found."));
   }
 
-  const storeDomain = normalizeShopifyStoreDomain(authInfo.extra?.store_domain);
+  const storeDomain = normalizeShopifyStoreDomain(
+    authInfo.extra?.shopify_store_domain
+  );
   if (!storeDomain) {
     return new Err(
       new MCPError(

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -225,7 +225,7 @@ export function createShopifyClient(
     return new Err(new MCPError("No Shopify access token found."));
   }
 
-  const shop = normalizeShopifyShopDomain(authInfo.extra?.shopify_shop);
+  const shop = normalizeShopifyShopDomain(authInfo.extra?.store_domain);
   if (!shop) {
     return new Err(
       new MCPError(

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -7,7 +7,7 @@ import type {
 import { ProductNodeSchema } from "@app/lib/api/actions/servers/shopify/types";
 import { untrustedFetch } from "@app/lib/egress/server";
 import logger from "@app/logger/logger";
-import { normalizeShopifyShopDomain } from "@app/types/oauth/lib";
+import { normalizeShopifyStoreDomain } from "@app/types/oauth/lib";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -62,7 +62,7 @@ function quoteSearchValue(value: string): string {
 export class ShopifyClient {
   constructor(
     private readonly accessToken: string,
-    private readonly shop: string
+    private readonly storeDomain: string
   ) {}
 
   private async fetchProductsPage({
@@ -83,7 +83,7 @@ export class ShopifyClient {
       MCPError
     >
   > {
-    const url = `https://${this.shop}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
+    const url = `https://${this.storeDomain}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
     let response: Awaited<ReturnType<typeof untrustedFetch>>;
     try {
       response = await untrustedFetch(url, {
@@ -225,8 +225,8 @@ export function createShopifyClient(
     return new Err(new MCPError("No Shopify access token found."));
   }
 
-  const shop = normalizeShopifyShopDomain(authInfo.extra?.store_domain);
-  if (!shop) {
+  const storeDomain = normalizeShopifyStoreDomain(authInfo.extra?.store_domain);
+  if (!storeDomain) {
     return new Err(
       new MCPError(
         "Shopify store domain not found. Reconnect the Shopify tool with a valid myshopify.com domain."
@@ -234,5 +234,5 @@ export function createShopifyClient(
     );
   }
 
-  return new Ok(new ShopifyClient(authInfo.token, shop));
+  return new Ok(new ShopifyClient(authInfo.token, storeDomain));
 }

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -1,0 +1,238 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
+import type {
+  ProductExportResult,
+  ShopifyProduct,
+} from "@app/lib/api/actions/servers/shopify/types";
+import { ProductNodeSchema } from "@app/lib/api/actions/servers/shopify/types";
+import { untrustedFetch } from "@app/lib/egress/server";
+import logger from "@app/logger/logger";
+import { normalizeShopifyShopDomain } from "@app/types/oauth/lib";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { z } from "zod";
+
+const SHOPIFY_API_VERSION = "2026-07";
+const PAGE_SIZE = 250;
+
+const PRODUCTS_QUERY = `
+  query ListProducts($first: Int!, $after: String, $query: String) {
+    products(first: $first, after: $after, query: $query) {
+      nodes {
+        id
+        title
+        handle
+        status
+        vendor
+        productType
+        totalInventory
+        createdAt
+        updatedAt
+        priceRangeV2 {
+          minVariantPrice { amount currencyCode }
+          maxVariantPrice { amount currencyCode }
+        }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+`;
+
+const ProductsDataSchema = z.object({
+  products: z.object({
+    nodes: z.array(ProductNodeSchema),
+    pageInfo: z.object({
+      hasNextPage: z.boolean(),
+      endCursor: z.string().nullable(),
+    }),
+  }),
+});
+
+const ProductsResponseSchema = z.object({
+  data: ProductsDataSchema.nullish(),
+  errors: z.array(z.object({ message: z.string() })).optional(),
+});
+
+function quoteSearchValue(value: string): string {
+  return `'${value.replace(/\\/g, "\\\\").replace(/'/g, "\\'")}'`;
+}
+
+export class ShopifyClient {
+  constructor(
+    private readonly accessToken: string,
+    private readonly shop: string
+  ) {}
+
+  private async fetchProductsPage({
+    first,
+    after,
+    query,
+  }: {
+    first: number;
+    after: string | null;
+    query: string | null;
+  }): Promise<
+    Result<
+      {
+        products: ShopifyProduct[];
+        hasNextPage: boolean;
+        endCursor: string | null;
+      },
+      MCPError
+    >
+  > {
+    const url = `https://${this.shop}/admin/api/${SHOPIFY_API_VERSION}/graphql.json`;
+    let response: Awaited<ReturnType<typeof untrustedFetch>>;
+    try {
+      response = await untrustedFetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Shopify-Access-Token": this.accessToken,
+        },
+        body: JSON.stringify({
+          query: PRODUCTS_QUERY,
+          variables: { first, after, query },
+        }),
+      });
+    } catch (error) {
+      return new Err(
+        new MCPError(
+          `Failed to reach the Shopify API: ${normalizeError(error).message}`
+        )
+      );
+    }
+
+    if (!response.ok) {
+      const body = await response.text();
+      if (response.status === 401 || response.status === 403) {
+        return new Err(
+          new MCPError(
+            "Shopify authentication failed. Reconnect the Shopify tool and ensure the app has the read_products scope.",
+            { tracked: false }
+          )
+        );
+      }
+      return new Err(
+        new MCPError(
+          `Shopify API error: ${response.status} ${response.statusText} - ${body.slice(0, 200)}`,
+          { tracked: false }
+        )
+      );
+    }
+
+    let payload: unknown;
+    try {
+      payload = JSON.parse(await response.text());
+    } catch (error) {
+      return new Err(
+        new MCPError(
+          `Invalid JSON from the Shopify API: ${normalizeError(error).message}`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const parsed = ProductsResponseSchema.safeParse(payload);
+    if (!parsed.success) {
+      logger.error(
+        { error: parsed.error.message },
+        "[Shopify MCP Server] Product response validation failed"
+      );
+      return new Err(
+        new MCPError(`Invalid Shopify response format: ${parsed.error.message}`)
+      );
+    }
+
+    const { data, errors } = parsed.data;
+    if (!data) {
+      return new Err(
+        new MCPError(
+          `Shopify GraphQL error: ${errors?.map((error) => error.message).join("; ") ?? "Shopify returned no data."}`,
+          { tracked: false }
+        )
+      );
+    }
+    if (errors?.length) {
+      logger.warn(
+        { errors: errors.map((error) => error.message) },
+        "[Shopify MCP Server] Partial product response"
+      );
+    }
+
+    return new Ok({
+      products: data.products.nodes,
+      hasNextPage: data.products.pageInfo.hasNextPage,
+      endCursor: data.products.pageInfo.endCursor,
+    });
+  }
+
+  async exportProducts({
+    status,
+    vendor,
+    searchQuery,
+    limit,
+  }: {
+    status?: "ACTIVE" | "DRAFT" | "ARCHIVED" | "UNLISTED";
+    vendor?: string;
+    searchQuery?: string;
+    limit: number;
+  }): Promise<Result<ProductExportResult, MCPError>> {
+    const cap = Math.min(limit, MAX_EXPORT_ITEMS);
+    const filters: string[] = [];
+    if (status) {
+      filters.push(`status:${status.toLowerCase()}`);
+    }
+    if (vendor) {
+      filters.push(`vendor:${quoteSearchValue(vendor)}`);
+    }
+    if (searchQuery) {
+      filters.push(searchQuery);
+    }
+
+    const products: ShopifyProduct[] = [];
+    let cursor: string | null = null;
+    while (products.length < cap) {
+      const page = await this.fetchProductsPage({
+        first: Math.min(PAGE_SIZE, cap - products.length),
+        after: cursor,
+        query: filters.length > 0 ? filters.join(" ") : null,
+      });
+      if (page.isErr()) {
+        return page;
+      }
+
+      products.push(...page.value.products);
+      if (!page.value.hasNextPage || !page.value.endCursor) {
+        return new Ok({ products: products.slice(0, cap), truncated: false });
+      }
+      cursor = page.value.endCursor;
+    }
+
+    return new Ok({
+      products: products.slice(0, cap),
+      truncated: cap === MAX_EXPORT_ITEMS,
+    });
+  }
+}
+
+export function createShopifyClient(
+  authInfo?: AuthInfo
+): Result<ShopifyClient, MCPError> {
+  if (!authInfo?.token) {
+    return new Err(new MCPError("No Shopify access token found."));
+  }
+
+  const shop = normalizeShopifyShopDomain(authInfo.extra?.shopify_shop);
+  if (!shop) {
+    return new Err(
+      new MCPError(
+        "Shopify store domain not found. Reconnect the Shopify tool with a valid myshopify.com domain."
+      )
+    );
+  }
+
+  return new Ok(new ShopifyClient(authInfo.token, shop));
+}

--- a/front/lib/api/actions/servers/shopify/client.ts
+++ b/front/lib/api/actions/servers/shopify/client.ts
@@ -1,7 +1,7 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
 import type {
-  ProductExportResult,
+  ProductListResult,
   ShopifyProduct,
 } from "@app/lib/api/actions/servers/shopify/types";
 import { ProductNodeSchema } from "@app/lib/api/actions/servers/shopify/types";
@@ -169,7 +169,7 @@ export class ShopifyClient {
     });
   }
 
-  async exportProducts({
+  async listProducts({
     status,
     vendor,
     searchQuery,
@@ -179,7 +179,7 @@ export class ShopifyClient {
     vendor?: string;
     searchQuery?: string;
     limit: number;
-  }): Promise<Result<ProductExportResult, MCPError>> {
+  }): Promise<Result<ProductListResult, MCPError>> {
     const cap = Math.min(limit, MAX_EXPORT_ITEMS);
     const filters: string[] = [];
     if (status) {

--- a/front/lib/api/actions/servers/shopify/helpers.ts
+++ b/front/lib/api/actions/servers/shopify/helpers.ts
@@ -1,3 +1,2 @@
-// Hard cap on exported records to keep responses and API usage bounded. The
-// export helpers that enforce it land in a follow-up PR.
+// Hard cap on exported records to keep responses and API usage bounded.
 export const MAX_EXPORT_ITEMS = 1_000;

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -141,8 +141,7 @@ export const SHOPIFY_SERVER = {
       supported_use_cases: ["platform_actions"] as const,
     },
     icon: "ActionTableIcon",
-    documentationUrl:
-      "https://shopify.dev/docs/api/admin-graphql/latest/queries/products",
+    documentationUrl: null,
   },
   tools: SHOPIFY_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -43,12 +43,13 @@ export const SHOPIFY_SERVER = {
   serverInfo: {
     name: SHOPIFY_SERVER_NAME,
     version: "1.0.0",
-    description: "List the product catalog from a Shopify store.",
+    description:
+      "Access catalog, customers and orders data from a Shopify store.",
     authorization: {
       provider: "shopify" as const,
       supported_use_cases: ["platform_actions"] as const,
     },
-    icon: "ActionTableIcon",
+    icon: "ActionStoreIcon",
     documentationUrl: null,
   },
   tools: SHOPIFY_TOOLS_METADATA,

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -14,9 +14,9 @@ const limitSchema = (noun: string) =>
 
 export const SHOPIFY_TOOLS_METADATA = [
   {
-    name: "export_products",
+    name: "list_products",
     description:
-      "Export the Shopify product catalog with title, status, vendor, type, inventory, and price range.",
+      "List the Shopify product catalog with title, status, vendor, type, inventory, and price range.",
     schema: {
       status: z
         .enum(["ACTIVE", "DRAFT", "ARCHIVED", "UNLISTED"])
@@ -31,8 +31,8 @@ export const SHOPIFY_TOOLS_METADATA = [
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Exporting Shopify products",
-      done: "Export Shopify products",
+      running: "Listing Shopify products",
+      done: "List Shopify products",
     },
     toolCostCategory: "advanced",
     freeUsage: false,

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -37,105 +37,13 @@ export const SHOPIFY_TOOLS_METADATA = [
     toolCostCategory: "advanced",
     freeUsage: false,
   },
-  {
-    name: "export_customer_ltv",
-    description:
-      "Export customer lifetime value: total amount spent and order count per customer, identified by ID.",
-    schema: {
-      sortByAmountSpent: z
-        .boolean()
-        .optional()
-        .describe(
-          "Rank customers by lifetime amount spent, highest first (default: true). Exact for up to 1000 customers; use minAmountSpentDollars to narrow beyond that."
-        ),
-      minAmountSpentDollars: z
-        .number()
-        .nonnegative()
-        .optional()
-        .describe(
-          "Keep only customers whose lifetime spend is at least this amount, in store currency."
-        ),
-      limit: limitSchema("customers"),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Exporting Shopify customer LTV",
-      done: "Export Shopify customer LTV",
-    },
-    toolCostCategory: "advanced",
-    freeUsage: false,
-  },
-  {
-    name: "export_sales",
-    description:
-      "Export Shopify orders for a date range, with totals, taxes, and payment and fulfillment status. Without the read_all_orders scope, only the last 60 days are available.",
-    schema: {
-      startDate: z
-        .string()
-        .optional()
-        .describe("ISO 8601 lower bound for order creation date (inclusive)."),
-      endDate: z
-        .string()
-        .optional()
-        .describe("ISO 8601 upper bound for order creation date (inclusive)."),
-      financialStatus: z
-        .enum([
-          "PAID",
-          "PENDING",
-          "AUTHORIZED",
-          "PARTIALLY_PAID",
-          "PARTIALLY_REFUNDED",
-          "REFUNDED",
-          "VOIDED",
-          "EXPIRED",
-        ])
-        .optional()
-        .describe("Filter by payment status."),
-      fulfillmentStatus: z
-        .enum(["UNFULFILLED", "FULFILLED", "PARTIAL", "SCHEDULED", "ON_HOLD"])
-        .optional()
-        .describe("Filter by fulfillment status."),
-      limit: limitSchema("orders"),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Exporting Shopify sales",
-      done: "Export Shopify sales",
-    },
-    toolCostCategory: "advanced",
-    freeUsage: false,
-  },
-  {
-    name: "export_top_customers_by_period",
-    description:
-      "Rank the top customers by total spend over a date range, aggregated from their orders. Without the read_all_orders scope, only the last 60 days are available.",
-    schema: {
-      startDate: z
-        .string()
-        .optional()
-        .describe("ISO 8601 lower bound for order creation date (inclusive)."),
-      endDate: z
-        .string()
-        .optional()
-        .describe("ISO 8601 upper bound for order creation date (inclusive)."),
-      limit: limitSchema("customers"),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Ranking Shopify top customers",
-      done: "Rank Shopify top customers",
-    },
-    toolCostCategory: "advanced",
-    freeUsage: false,
-  },
 ] as const;
 
 export const SHOPIFY_SERVER = {
   serverInfo: {
     name: SHOPIFY_SERVER_NAME,
     version: "1.0.0",
-    description:
-      "Export product catalog, customer lifetime value, and sales data from a Shopify store.",
+    description: "List the product catalog from a Shopify store.",
     authorization: {
       provider: "shopify" as const,
       supported_use_cases: ["platform_actions"] as const,

--- a/front/lib/api/actions/servers/shopify/metadata.ts
+++ b/front/lib/api/actions/servers/shopify/metadata.ts
@@ -19,7 +19,7 @@ export const SHOPIFY_TOOLS_METADATA = [
       "Export the Shopify product catalog with title, status, vendor, type, inventory, and price range.",
     schema: {
       status: z
-        .enum(["ACTIVE", "DRAFT", "ARCHIVED"])
+        .enum(["ACTIVE", "DRAFT", "ARCHIVED", "UNLISTED"])
         .optional()
         .describe("Filter by product status."),
       vendor: z.string().optional().describe("Filter by exact vendor name."),
@@ -136,12 +136,13 @@ export const SHOPIFY_SERVER = {
     version: "1.0.0",
     description:
       "Export product catalog, customer lifetime value, and sales data from a Shopify store.",
-    // Pilot (phase 1) uses a merchant-provided token injected via authInfo; no
-    // Dust OAuth provider yet. Phase 2 will set
-    // `authorization: { provider: "shopify", supported_use_cases: [...] }`.
-    authorization: null,
+    authorization: {
+      provider: "shopify" as const,
+      supported_use_cases: ["platform_actions"] as const,
+    },
     icon: "ActionTableIcon",
-    documentationUrl: null,
+    documentationUrl:
+      "https://shopify.dev/docs/api/admin-graphql/latest/queries/products",
   },
   tools: SHOPIFY_TOOLS_METADATA,
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/shopify/rendering.ts
+++ b/front/lib/api/actions/servers/shopify/rendering.ts
@@ -1,14 +1,14 @@
 import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
-import type { ProductExportResult } from "@app/lib/api/actions/servers/shopify/types";
+import type { ProductListResult } from "@app/lib/api/actions/servers/shopify/types";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
-export function renderProductExport({
+export function renderProductList({
   products,
   truncated,
-}: ProductExportResult): CallToolResult["content"] {
+}: ProductListResult): CallToolResult["content"] {
   const summary = truncated
-    ? `Exported ${products.length} products (truncated at the ${MAX_EXPORT_ITEMS}-product cap).`
-    : `Exported ${products.length} products.`;
+    ? `Listed ${products.length} products (truncated at the ${MAX_EXPORT_ITEMS}-product cap).`
+    : `Listed ${products.length} products.`;
   return [
     { type: "text", text: summary },
     { type: "text", text: JSON.stringify(products, null, 2) },

--- a/front/lib/api/actions/servers/shopify/rendering.ts
+++ b/front/lib/api/actions/servers/shopify/rendering.ts
@@ -1,0 +1,16 @@
+import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
+import type { ProductExportResult } from "@app/lib/api/actions/servers/shopify/types";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export function renderProductExport({
+  products,
+  truncated,
+}: ProductExportResult): CallToolResult["content"] {
+  const summary = truncated
+    ? `Exported ${products.length} products (truncated at the ${MAX_EXPORT_ITEMS}-product cap).`
+    : `Exported ${products.length} products.`;
+  return [
+    { type: "text", text: summary },
+    { type: "text", text: JSON.stringify(products, null, 2) },
+  ];
+}

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -1,16 +1,37 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createShopifyClient } from "@app/lib/api/actions/servers/shopify/client";
+import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
 import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
-import { Err } from "@app/types/shared/result";
+import { renderProductExport } from "@app/lib/api/actions/servers/shopify/rendering";
+import { Err, Ok } from "@app/types/shared/result";
 
-// Tool contracts are registered here; the implementations land in a follow-up
-// PR. Until then every handler returns a not-implemented error.
+// The remaining export contracts stay registered for the preview but return a
+// clear error until their implementations land.
 const notImplemented = () =>
   Promise.resolve(new Err(new MCPError("Shopify tool not yet implemented.")));
 
 const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
-  export_products: notImplemented,
+  export_products: async (
+    { status, vendor, searchQuery, limit },
+    { authInfo }
+  ) => {
+    const client = createShopifyClient(authInfo);
+    if (client.isErr()) {
+      return client;
+    }
+    const products = await client.value.exportProducts({
+      status,
+      vendor,
+      searchQuery,
+      limit: limit ?? MAX_EXPORT_ITEMS,
+    });
+    if (products.isErr()) {
+      return products;
+    }
+    return new Ok(renderProductExport(products.value));
+  },
   export_customer_ltv: notImplemented,
   export_sales: notImplemented,
   export_top_customers_by_period: notImplemented,

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -4,7 +4,7 @@ import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definitio
 import { createShopifyClient } from "@app/lib/api/actions/servers/shopify/client";
 import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
 import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
-import { renderProductExport } from "@app/lib/api/actions/servers/shopify/rendering";
+import { renderProductList } from "@app/lib/api/actions/servers/shopify/rendering";
 import { Err, Ok } from "@app/types/shared/result";
 
 // The remaining export contracts stay registered for the preview but return a
@@ -13,7 +13,7 @@ const notImplemented = () =>
   Promise.resolve(new Err(new MCPError("Shopify tool not yet implemented.")));
 
 const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
-  export_products: async (
+  list_products: async (
     { status, vendor, searchQuery, limit },
     { authInfo }
   ) => {
@@ -21,7 +21,7 @@ const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
     if (client.isErr()) {
       return client;
     }
-    const products = await client.value.exportProducts({
+    const products = await client.value.listProducts({
       status,
       vendor,
       searchQuery,
@@ -30,7 +30,7 @@ const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
     if (products.isErr()) {
       return products;
     }
-    return new Ok(renderProductExport(products.value));
+    return new Ok(renderProductList(products.value));
   },
   export_customer_ltv: notImplemented,
   export_sales: notImplemented,

--- a/front/lib/api/actions/servers/shopify/tools/index.ts
+++ b/front/lib/api/actions/servers/shopify/tools/index.ts
@@ -1,16 +1,10 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createShopifyClient } from "@app/lib/api/actions/servers/shopify/client";
 import { MAX_EXPORT_ITEMS } from "@app/lib/api/actions/servers/shopify/helpers";
 import { SHOPIFY_TOOLS_METADATA } from "@app/lib/api/actions/servers/shopify/metadata";
 import { renderProductList } from "@app/lib/api/actions/servers/shopify/rendering";
-import { Err, Ok } from "@app/types/shared/result";
-
-// The remaining export contracts stay registered for the preview but return a
-// clear error until their implementations land.
-const notImplemented = () =>
-  Promise.resolve(new Err(new MCPError("Shopify tool not yet implemented.")));
+import { Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
   list_products: async (
@@ -32,9 +26,6 @@ const handlers: ToolHandlers<typeof SHOPIFY_TOOLS_METADATA> = {
     }
     return new Ok(renderProductList(products.value));
   },
-  export_customer_ltv: notImplemented,
-  export_sales: notImplemented,
-  export_top_customers_by_period: notImplemented,
 };
 
 export const TOOLS = buildTools(SHOPIFY_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/shopify/types.ts
+++ b/front/lib/api/actions/servers/shopify/types.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+const MoneySchema = z.object({
+  amount: z.string(),
+  currencyCode: z.string(),
+});
+
+export const ProductNodeSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  handle: z.string(),
+  status: z.enum(["ACTIVE", "DRAFT", "ARCHIVED", "UNLISTED"]),
+  vendor: z.string(),
+  productType: z.string(),
+  totalInventory: z.number(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  priceRangeV2: z.object({
+    minVariantPrice: MoneySchema,
+    maxVariantPrice: MoneySchema,
+  }),
+});
+
+export type ShopifyProduct = z.infer<typeof ProductNodeSchema>;
+
+export interface ProductExportResult {
+  products: ShopifyProduct[];
+  truncated: boolean;
+}

--- a/front/lib/api/actions/servers/shopify/types.ts
+++ b/front/lib/api/actions/servers/shopify/types.ts
@@ -23,7 +23,7 @@ export const ProductNodeSchema = z.object({
 
 export type ShopifyProduct = z.infer<typeof ProductNodeSchema>;
 
-export interface ProductExportResult {
+export interface ProductListResult {
   products: ShopifyProduct[];
   truncated: boolean;
 }

--- a/sdks/js/src/mcp_icon_types.ts
+++ b/sdks/js/src/mcp_icon_types.ts
@@ -19,6 +19,7 @@ export const MCPInternalActionIconSchema = z.enum([
   "ActionRobotIcon",
   "ActionScanIcon",
   "ActionSpeakIcon",
+  "ActionStoreIcon",
   "ActionTableIcon",
   "ActionTimeIcon",
   "AdomikLogo",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3405,6 +3405,7 @@ const InternalAllowedIconSchema = FlexibleEnumSchema<
   | "ActionRobotIcon"
   | "ActionScanIcon"
   | "ActionSpeakIcon"
+  | "ActionStoreIcon"
   | "ActionTableIcon"
   | "ActionTimeIcon"
   | "AdomikLogo"


### PR DESCRIPTION
## Description

- Wire the preview Shopify MCP server to shared workspace OAuth connections provided by #31091.
- Implement the product catalog listing tool through the Shopify Admin GraphQL API with filtering, pagination, response validation, and a 1,000-product cap.
- Keep the integration behind the `shopify_tool` feature flag.

<img width="1422" height="1251" alt="Screenshot 2026-08-26 at 14 17 42" src="https://github.com/user-attachments/assets/c2581b88-d8e7-4563-912d-848ce1d8c0c2" />

## Tests

- Shopify client and BM25 retrieval tests passed.
- MCP metadata snapshot tests passed.
- Front TypeScript typecheck passed.
- Biome passed on all touched files.

## Risk

Low.

## Deploy Plan

- Deploy `front`