### PR TITLE
Add cursor cloud agent env.

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,99 @@
+# syntax=docker/dockerfile:1.4
+# Dust Cloud Agent dev image — system toolchain and infra binaries only.
+# Application source is checked out by Cursor at runtime; deps are built in `install`.
+#
+# Layer cache: keep this file stable — any ENV/RUN edit above the apt layer invalidates
+# all downstream steps (apt, rust, temporal, …). Shell/terminal defaults live in
+# .cursor/scripts/env.defaults.sh and .cursor/bashrc (bind-mounted at runtime).
+FROM node:24.16.0-bookworm
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LEFTHOOK_EXCLUDE=front-lint-test-filenames,front-typecheck,front-circular,front-docs-check,connectors-lint-test-filenames,connectors-typecheck,lint-staged \
+    OP_ENVIRONMENT_ID=r6iqd3y67zqlbsxnotrj6bm25q \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH="/usr/local/cargo/bin:/root/.temporalio/bin:/opt/qdrant:${PATH}"
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+  && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+    | gpg --dearmor -o /usr/share/keyrings/postgresql-keyring.gpg \
+  && echo "deb [signed-by=/usr/share/keyrings/postgresql-keyring.gpg] http://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+    > /etc/apt/sources.list.d/pgdg.list \
+  && apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    sudo \
+    python3 \
+    postgresql-16 \
+    postgresql-client-16 \
+    redis-server \
+    build-essential \
+    cmake \
+    pkg-config \
+    libssl-dev \
+    procps \
+    lsof \
+    netcat-openbsd \
+    unzip \
+    less \
+    vim-tiny \
+    bash-completion \
+    tmux \
+  && rm -rf /var/lib/apt/lists/*
+
+# Rust (core-api, oauth) + dev process runners (bacon, mprocs)
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain 1.94.1 \
+  && cargo install bacon mprocs
+
+# Temporal dev server
+RUN curl -sSf https://temporal.download/cli.sh | sh \
+  && install -m 0755 /root/.temporalio/bin/temporal /usr/local/bin/temporal \
+  && temporal --version
+
+# Qdrant
+RUN mkdir -p /opt/qdrant \
+  && curl -fsSL https://github.com/qdrant/qdrant/releases/download/v1.18.3/qdrant-x86_64-unknown-linux-gnu.tar.gz \
+    | tar -xz -C /opt/qdrant --strip-components=1
+
+# Elasticsearch 8.x + ICU plugin
+ARG ES_VERSION=8.11.3
+RUN curl -fsSL "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz" \
+    | tar -xz -C /opt \
+  && mv "/opt/elasticsearch-${ES_VERSION}" /opt/es \
+  && /opt/es/bin/elasticsearch-plugin install --batch analysis-icu \
+  && groupadd -r elasticsearch \
+  && useradd -r -g elasticsearch -d /opt/es -s /usr/sbin/nologin elasticsearch \
+  && mkdir -p /opt/es/data /opt/es/logs \
+  && chown -R elasticsearch:elasticsearch /opt/es
+
+# 1Password CLI beta — `op run --environment` requires >= 2.33.0-beta.02 (stable apt pkg lacks it)
+ARG OP_CLI_VERSION=2.39.1-beta.01
+RUN curl -sSfLo /tmp/op.zip \
+      "https://cache.agilebits.com/dist/1P/op2/pkg/v${OP_CLI_VERSION}/op_linux_amd64_v${OP_CLI_VERSION}.zip" \
+  && unzip -q /tmp/op.zip -d /usr/local/bin \
+  && rm /tmp/op.zip \
+  && op --version
+
+# Postgres dev user (databases are created at agent start by init-databases.sh)
+RUN service postgresql start \
+  && sudo -u postgres psql -v ON_ERROR_STOP=1 -c "DO \$\$ BEGIN CREATE USER dev WITH PASSWORD 'dev' SUPERUSER; EXCEPTION WHEN duplicate_object THEN NULL; END \$\$;" \
+  && sudo -u postgres psql -c "ALTER USER dev WITH SUPERUSER;" \
+  && service postgresql stop
+
+RUN mkdir -p /tmp/dust-infra /opt/temporal /root/.config/mprocs \
+  && printf '%s\n' \
+    '# Source repo-local shell config when /workspace is mounted.' \
+    'if [ -f /workspace/.cursor/bashrc ]; then' \
+    '  # shellcheck disable=SC1091' \
+    '  source /workspace/.cursor/bashrc' \
+    'fi' \
+    > /root/.bashrc
+
+WORKDIR /workspace

--- a/.cursor/bashrc
+++ b/.cursor/bashrc
@@ -1,0 +1,40 @@
+# Interactive shell defaults for the Dust dev container.
+
+case $- in
+  *i*) ;;
+  *) return ;;
+esac
+
+export SHELL=/bin/bash
+export LANG="${LANG:-C.UTF-8}"
+export LC_ALL="${LC_ALL:-C.UTF-8}"
+export TERM="${TERM:-xterm-256color}"
+export COLORTERM="${COLORTERM:-truecolor}"
+
+shopt -s checkwinsize histappend globstar 2>/dev/null || true
+
+HISTCONTROL=ignoreboth:erasedups
+HISTSIZE=10000
+HISTFILESIZE=20000
+
+if [ -x /usr/bin/dircolors ]; then
+  eval "$(dircolors -b)"
+  alias ls='ls --color=auto'
+  alias grep='grep --color=auto'
+fi
+
+alias ll='ls -alF'
+alias la='ls -A'
+alias l='ls -CF'
+
+# Repo helper when /workspace is mounted.
+if [ -d /workspace/.git ]; then
+  alias cdust='cd /workspace'
+fi
+
+if [ -f /etc/bash_completion ]; then
+  # shellcheck disable=SC1091
+  source /etc/bash_completion
+fi
+
+PS1='\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '

--- a/.cursor/config/mprocs.yaml
+++ b/.cursor/config/mprocs.yaml
@@ -1,0 +1,6 @@
+# Global mprocs defaults for the Dust dev container (~/.config/mprocs/mprocs.yaml).
+# Process definitions stay in tools/mprocs.yaml.
+
+scrollback: 20000
+mouse_scroll_speed: 3
+proc_list_width: 28

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,23 @@
+{
+  "name": "dust-tt/dust",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "install": "bash .cursor/scripts/install.sh",
+  "start": "bash .cursor/scripts/start-infra.sh",
+  "terminals": [
+    {
+      "name": "mprocs",
+      "command": "bash .cursor/scripts/start-mprocs.sh",
+      "description": "Dev stack via mprocs: npm install, sdks-js/sparkle watches, bacon Rust reload, all services"
+    }
+  ],
+  "ports": [
+    { "name": "front-api", "port": 3000 },
+    { "name": "front-spa", "port": 3011 },
+    { "name": "core-api", "port": 3001 },
+    { "name": "viz", "port": 3007 },
+    { "name": "temporal", "port": 7233 }
+  ]
+}

--- a/.cursor/scripts/common.sh
+++ b/.cursor/scripts/common.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Shared helpers for Dust Cloud Agent dev scripts.
+
+DUST_REPO_ROOT="${DUST_REPO_ROOT:-$(
+  cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd
+)}"
+export DUST_REPO_ROOT
+
+DUST_INFRA_LOG_DIR="${DUST_INFRA_LOG_DIR:-/tmp/dust-infra}"
+mkdir -p "$DUST_INFRA_LOG_DIR"
+
+log() {
+  echo "[${DUST_DEV_SCRIPT_NAME:-cursor-dev}] $*"
+}
+
+install_cursor_runtime_config() {
+  if [ -f "${DUST_REPO_ROOT}/.cursor/config/mprocs.yaml" ]; then
+    mkdir -p "${HOME}/.config/mprocs"
+    cp "${DUST_REPO_ROOT}/.cursor/config/mprocs.yaml" "${HOME}/.config/mprocs/mprocs.yaml"
+  fi
+}
+
+ensure_node_path() {
+  if command -v node >/dev/null 2>&1; then
+    return 0
+  fi
+  log "node not found on PATH"
+  return 1
+}
+
+resolve_temporal_bin() {
+  if command -v temporal >/dev/null 2>&1; then
+    command -v temporal
+    return 0
+  fi
+  for candidate in /usr/local/bin/temporal /root/.temporalio/bin/temporal; do
+    if [ -x "$candidate" ]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  log "temporal CLI not found (rebuild .cursor/Dockerfile or install to /usr/local/bin)"
+  return 1
+}
+
+# Migrations and seed scripts import @dust-tt/client (main: sdks/js/dist/index.js).
+ensure_workspace_deps() {
+  ensure_node_path
+  cd "$DUST_REPO_ROOT"
+
+  if [ ! -f node_modules/@dust-tt/client/package.json ]; then
+    log "Installing npm workspaces (required before migrations)..."
+    npm install
+  fi
+
+  if [ ! -f sdks/js/dist/index.js ]; then
+    log "Building @dust-tt/client (sdks/js)..."
+    npm -w @dust-tt/client run build
+  fi
+}
+
+write_gcp_service_account_file() {
+  if [ -n "${GCP_SERVICE_ACCOUNT:-}" ]; then
+    printf '%s' "$GCP_SERVICE_ACCOUNT" >"${SERVICE_ACCOUNT:-/tmp/dust-dev-sa.json}"
+    export SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-/tmp/dust-dev-sa.json}"
+  fi
+}
+
+# op run --environment requires 1Password CLI >= 2.33.0-beta.02 (Environments feature).
+op_cli_supports_environments() {
+  local current="${1:-$(op --version 2>/dev/null | head -1 | tr -d '[:space:]')}"
+  local minimum="2.33.0-beta.02"
+
+  if [ -z "$current" ]; then
+    return 1
+  fi
+
+  # sort -V: if minimum sorts first, current is >= minimum.
+  [ "$(printf '%s\n' "$minimum" "$current" | sort -V | head -1)" = "$minimum" ]
+}
+
+require_op_credentials() {
+  if [ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]; then
+    log "OP_SERVICE_ACCOUNT_TOKEN is not set (add it as a Cursor runtime secret)"
+    return 1
+  fi
+  if [ -z "${OP_ENVIRONMENT_ID:-}" ]; then
+    log "OP_ENVIRONMENT_ID is not set"
+    return 1
+  fi
+  if ! op_cli_supports_environments; then
+    log "op CLI is too old ($(op --version 2>/dev/null || echo unknown)); need >= 2.33.0-beta.02 with op run --environment (rebuild .cursor/Dockerfile)"
+    return 1
+  fi
+  return 0
+}
+
+# Load 1Password Environment vars into the current shell.
+# Do not wrap interactive TUIs (mprocs) in `op run` — it masks stdout/stderr and breaks ANSI control sequences.
+load_op_environment() {
+  local env_file
+
+  require_op_credentials || return 1
+
+  env_file="$(mktemp /tmp/dust-op-env.XXXXXX)"
+  if ! op environment read "$OP_ENVIRONMENT_ID" >"$env_file"; then
+    rm -f "$env_file"
+    log "Failed to read 1Password environment $OP_ENVIRONMENT_ID"
+    return 1
+  fi
+
+  set -a
+  # shellcheck disable=SC1090
+  source "$env_file"
+  set +a
+  rm -f "$env_file"
+  return 0
+}
+
+# Host-injected secrets override 1Password Environment values when set.
+export_local_dev_infra() {
+  export POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+  export POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+  export REDIS_HOST="${REDIS_HOST:-localhost}"
+  export REDIS_PORT="${REDIS_PORT:-6379}"
+
+  export FRONT_DATABASE_URI="postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_front"
+  export FRONT_DATABASE_READ_REPLICA_URI="$FRONT_DATABASE_URI"
+  export CORE_DATABASE_URI="postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_api"
+  export CORE_DATABASE_READ_REPLICA_URI="$CORE_DATABASE_URI"
+  export CONNECTORS_DATABASE_URI="postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_connectors"
+  export CONNECTORS_DATABASE_READ_REPLICA_URI="$CONNECTORS_DATABASE_URI"
+  export OAUTH_DATABASE_URI="postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_oauth"
+
+  export REDIS_URI="redis://${REDIS_HOST}:${REDIS_PORT}"
+  export REDIS_CACHE_URI="$REDIS_URI"
+  export ELASTICSEARCH_URL="http://${ELASTICSEARCH_HOST:-localhost}:${ELASTICSEARCH_PORT:-9200}"
+  export ELASTICSEARCH_USERNAME="${ELASTICSEARCH_USERNAME:-elastic}"
+  export ELASTICSEARCH_PASSWORD="${ELASTICSEARCH_PASSWORD:-}"
+  export TEMPORAL_ADDRESS="${DUST_LOCAL_TEMPORAL_ADDRESS:-127.0.0.1:7233}"
+
+  export CORE_API="http://localhost:3001"
+  export DUST_FRONT_API="http://localhost:3000"
+  export DUST_FRONT_INTERNAL_API="http://localhost:3000"
+  export DUST_INTERNAL_API_URL="http://localhost:3000"
+  export DUST_CLIENT_FACING_URL="http://localhost:3000"
+  export DUST_PUBLIC_URL="http://localhost:3000"
+  export DUST_AUTH_REDIRECT_BASE_URL="http://localhost:3000"
+  export NEXT_PUBLIC_DUST_API_URL="http://localhost:3000"
+  export NEXT_PUBLIC_DUST_APP_URL="http://localhost:3011"
+  export NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL="http://localhost:3000"
+}
+
+export_op_runtime_secrets() {
+  export DUST_REPO_ROOT="$DUST_REPO_ROOT"
+  export SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-}"
+  export GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT:-}"
+  export DEV_WORKOS_USER_EMAIL="${DEV_WORKOS_USER_EMAIL:-}"
+  export DEV_WORKOS_USER_PASSWORD="${DEV_WORKOS_USER_PASSWORD:-}"
+  export DEV_WORKOS_USER_ID="${DEV_WORKOS_USER_ID:-}"
+  # Local Cursor dev always uses in-container infra. 1Password envs often point at cloud
+  # Postgres/Temporal/staging NODE_ENV which breaks init_plans, workers, and seed SQL.
+  export NODE_ENV="development"
+  export_local_dev_infra
+}

--- a/.cursor/scripts/docker-run.sh
+++ b/.cursor/scripts/docker-run.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Run the Dust dev container locally with isolated Linux-native deps.
+#
+# Binds the repo for live edits but overlays node_modules and core/target so
+# container npm install / cargo builds do not touch your Mac copies (lefthook,
+# esbuild, etc.).
+#
+# Default: gitignored host dirs under .cursor/docker-volumes/ (not in the image).
+# Alternative: DUST_DEV_VOLUME_MODE=docker for opaque Docker named volumes.
+#
+# Usage (from repo root):
+#   bash .cursor/scripts/docker-run.sh              # start container (if needed), then shell
+#   bash .cursor/scripts/docker-run.sh --terminal   # shell into the running container only
+#   bash .cursor/scripts/docker-run.sh --build      # rebuild image, then start + shell
+#   bash .cursor/scripts/docker-run.sh --reset-volumes --build
+#   bash .cursor/scripts/docker-run.sh bash .cursor/scripts/start-infra.sh
+#
+# Pass host secrets through the environment before running, e.g.:
+#   export OP_SERVICE_ACCOUNT_TOKEN=...
+#   export DEV_WORKOS_USER_EMAIL=... DEV_WORKOS_USER_ID=... DEV_WORKOS_USER_PASSWORD=...
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+IMAGE_NAME="${DUST_DEV_IMAGE:-dust-dev}"
+CONTAINER_NAME="${DUST_DEV_CONTAINER:-dust-dev}"
+PLATFORM="${DUST_DEV_PLATFORM:-linux/amd64}"
+VOLUME_MODE="${DUST_DEV_VOLUME_MODE:-host}"
+VOLUME_PREFIX="${DUST_DEV_VOLUME_PREFIX:-dust-dev}"
+HOST_VOLUME_ROOT="${DUST_DEV_HOST_VOLUME_ROOT:-$REPO_ROOT/.cursor/docker-volumes}"
+NODE_MODULES_VOLUME="${VOLUME_PREFIX}-node-modules"
+CARGO_TARGET_VOLUME="${VOLUME_PREFIX}-cargo-target"
+
+BUILD=0
+RESET_VOLUMES=0
+TERMINAL=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --build)
+      BUILD=1
+      shift
+      ;;
+    --reset-volumes)
+      RESET_VOLUMES=1
+      shift
+      ;;
+    --terminal)
+      TERMINAL=1
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+collect_env_args() {
+  ENV_ARGS=()
+  for var in \
+    OP_SERVICE_ACCOUNT_TOKEN \
+    GCP_SERVICE_ACCOUNT \
+    DEV_WORKOS_USER_EMAIL \
+    DEV_WORKOS_USER_ID \
+    DEV_WORKOS_USER_PASSWORD; do
+    if [ -n "${!var:-}" ]; then
+      ENV_ARGS+=(-e "$var")
+    fi
+  done
+}
+
+exec_interactive() {
+  local -a cmd=("$@")
+  exec docker exec -it \
+    -e TERM="${TERM:-xterm-256color}" \
+    -e COLORTERM="${COLORTERM:-truecolor}" \
+    -e SHELL=/bin/bash \
+    -e LANG=C.UTF-8 \
+    -e LC_ALL=C.UTF-8 \
+    "${ENV_ARGS[@]}" \
+    "$CONTAINER_NAME" \
+    "${cmd[@]}"
+}
+
+if [ "$TERMINAL" = 1 ]; then
+  if [ "$#" -gt 0 ]; then
+    echo "--terminal opens an interactive shell; omit the command." >&2
+    exit 1
+  fi
+  if ! docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+    echo "Container ${CONTAINER_NAME} is not running." >&2
+    echo "Start it with: bash .cursor/scripts/docker-run.sh" >&2
+    exit 1
+  fi
+  if [ "$(docker container inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" != "true" ]; then
+    echo "Container ${CONTAINER_NAME} exists but is not running." >&2
+    echo "Start it with: bash .cursor/scripts/docker-run.sh" >&2
+    exit 1
+  fi
+  collect_env_args
+  exec_interactive bash -l
+fi
+
+if [ "$BUILD" = 1 ] || ! docker image inspect "$IMAGE_NAME" >/dev/null 2>&1; then
+  echo "Building ${IMAGE_NAME} from .cursor/Dockerfile..."
+  docker build --platform "$PLATFORM" -f "$REPO_ROOT/.cursor/Dockerfile" -t "$IMAGE_NAME" "$REPO_ROOT"
+fi
+
+if [ "$BUILD" = 1 ] && docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+  echo "Removing container ${CONTAINER_NAME} to use rebuilt image..."
+  docker rm -f "$CONTAINER_NAME" >/dev/null
+fi
+
+if [ "$RESET_VOLUMES" = 1 ] && docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+  echo "Removing container ${CONTAINER_NAME} before resetting volumes..."
+  docker rm -f "$CONTAINER_NAME" >/dev/null
+fi
+
+VOLUME_ARGS=()
+case "$VOLUME_MODE" in
+  host)
+    NODE_MODULES_MOUNT="$HOST_VOLUME_ROOT/node_modules"
+    CARGO_TARGET_MOUNT="$HOST_VOLUME_ROOT/core-target"
+    if [ "$RESET_VOLUMES" = 1 ]; then
+      echo "Resetting host dev volumes under ${HOST_VOLUME_ROOT}..."
+      rm -rf "$NODE_MODULES_MOUNT" "$CARGO_TARGET_MOUNT"
+    fi
+    mkdir -p "$NODE_MODULES_MOUNT" "$CARGO_TARGET_MOUNT"
+    VOLUME_ARGS+=(
+      -v "$NODE_MODULES_MOUNT:/workspace/node_modules"
+      -v "$CARGO_TARGET_MOUNT:/workspace/core/target"
+    )
+    echo "Using host-isolated deps: ${NODE_MODULES_MOUNT}"
+    ;;
+  docker)
+    if [ "$RESET_VOLUMES" = 1 ]; then
+      echo "Removing Docker volumes ${NODE_MODULES_VOLUME} and ${CARGO_TARGET_VOLUME}..."
+      docker volume rm "$NODE_MODULES_VOLUME" "$CARGO_TARGET_VOLUME" >/dev/null 2>&1 || true
+    fi
+    docker volume create "$NODE_MODULES_VOLUME" >/dev/null
+    docker volume create "$CARGO_TARGET_VOLUME" >/dev/null
+    VOLUME_ARGS+=(
+      -v "$NODE_MODULES_VOLUME:/workspace/node_modules"
+      -v "$CARGO_TARGET_VOLUME:/workspace/core/target"
+    )
+    echo "Using Docker volumes: ${NODE_MODULES_VOLUME}, ${CARGO_TARGET_VOLUME}"
+    ;;
+  *)
+    echo "Unknown DUST_DEV_VOLUME_MODE=${VOLUME_MODE} (expected host or docker)" >&2
+    exit 1
+    ;;
+esac
+
+collect_env_args
+
+if [ "$#" -eq 0 ]; then
+  set -- bash -l
+fi
+
+if docker container inspect "$CONTAINER_NAME" >/dev/null 2>&1; then
+  if [ "$(docker container inspect -f '{{.State.Running}}' "$CONTAINER_NAME")" != "true" ]; then
+    echo "Starting existing container ${CONTAINER_NAME}..."
+    docker start "$CONTAINER_NAME" >/dev/null
+  fi
+else
+  echo "Starting dev container ${CONTAINER_NAME}..."
+  docker run -d --init --platform "$PLATFORM" \
+    --name "$CONTAINER_NAME" \
+    -e TERM="${TERM:-xterm-256color}" \
+    -e COLORTERM="${COLORTERM:-truecolor}" \
+    -e SHELL=/bin/bash \
+    -e LANG=C.UTF-8 \
+    -e LC_ALL=C.UTF-8 \
+    -p 3000:3000 \
+    -p 3011:3011 \
+    -p 3001:3001 \
+    -p 3007:3007 \
+    -p 7233:7233 \
+    -v "$REPO_ROOT:/workspace" \
+    "${VOLUME_ARGS[@]}" \
+    "${ENV_ARGS[@]}" \
+    "$IMAGE_NAME" \
+    sleep infinity >/dev/null
+fi
+
+exec_interactive "$@"

--- a/.cursor/scripts/ensure-temporal.sh
+++ b/.cursor/scripts/ensure-temporal.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Start the local Temporal dev server if needed and wait until gRPC port 7233 is open.
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=ensure-temporal
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+# Always probe/start the in-container dev server — never a cloud TEMPORAL_ADDRESS from 1Password.
+LOCAL_TEMPORAL_ADDRESS="${DUST_LOCAL_TEMPORAL_ADDRESS:-127.0.0.1:7233}"
+TEMPORAL_HOST="${LOCAL_TEMPORAL_ADDRESS}"
+TEMPORAL_HOST_ONLY="${TEMPORAL_HOST%%:*}"
+TEMPORAL_PORT="${TEMPORAL_HOST##*:}"
+
+TEMPORAL_BIN="$(resolve_temporal_bin)" || exit 1
+
+temporal_port_open() {
+  if command -v nc >/dev/null 2>&1; then
+    nc -z "$TEMPORAL_HOST_ONLY" "$TEMPORAL_PORT" 2>/dev/null
+    return $?
+  fi
+  (echo >/dev/tcp/"$TEMPORAL_HOST_ONLY"/"$TEMPORAL_PORT") 2>/dev/null
+}
+
+start_temporal_dev_server() {
+  mkdir -p /opt/temporal "${DUST_INFRA_LOG_DIR}"
+  log "Starting Temporal dev server on ${LOCAL_TEMPORAL_ADDRESS} (${TEMPORAL_BIN})..."
+  nohup "$TEMPORAL_BIN" server start-dev \
+    --ip 0.0.0.0 \
+    --port "${TEMPORAL_PORT}" \
+    --db-filename /opt/temporal/dev.db \
+    >>"${DUST_INFRA_LOG_DIR}/temporal.log" 2>&1 &
+}
+
+wait_for_temporal() {
+  local attempt=0
+  local max_attempts=90
+
+  until temporal_port_open; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -gt "$max_attempts" ]; then
+      log "Temporal did not become ready on ${LOCAL_TEMPORAL_ADDRESS}"
+      if [ -f "${DUST_INFRA_LOG_DIR}/temporal.log" ]; then
+        tail -40 "${DUST_INFRA_LOG_DIR}/temporal.log"
+      fi
+      return 1
+    fi
+    if [ "$attempt" -eq 1 ] || [ $((attempt % 15)) -eq 0 ]; then
+      log "Waiting for Temporal on ${LOCAL_TEMPORAL_ADDRESS} (${attempt}s)..."
+    fi
+    sleep 1
+  done
+  log "Temporal is ready on ${LOCAL_TEMPORAL_ADDRESS}"
+}
+
+ensure_temporal_namespaces() {
+  local ns
+  for ns in \
+    "${TEMPORAL_NAMESPACE:-}" \
+    "${TEMPORAL_AGENT_NAMESPACE:-}" \
+    "${TEMPORAL_CONNECTORS_NAMESPACE:-}" \
+    "${TEMPORAL_RELOCATION_NAMESPACE:-}"; do
+    [ -z "$ns" ] && continue
+    [ "$ns" = "default" ] && continue
+    "$TEMPORAL_BIN" operator namespace describe --address "$LOCAL_TEMPORAL_ADDRESS" "$ns" >/dev/null 2>&1 \
+      || "$TEMPORAL_BIN" operator namespace create --address "$LOCAL_TEMPORAL_ADDRESS" "$ns" \
+      || log "Could not ensure Temporal namespace: $ns"
+  done
+}
+
+create_temporal_search_attribute() {
+  local namespace="$1"
+  local name="$2"
+  local attr_type="$3"
+  local err=""
+
+  err=$("$TEMPORAL_BIN" operator search-attribute create \
+    --address "$LOCAL_TEMPORAL_ADDRESS" \
+    --namespace "$namespace" \
+    --name "$name" \
+    --type "$attr_type" 2>&1) || {
+    if echo "$err" | grep -qi 'already exists'; then
+      return 0
+    fi
+    log "Could not create Temporal search attribute ${name} on ${namespace}: ${err}"
+    return 1
+  }
+}
+
+ensure_temporal_search_attributes() {
+  local ns namespaces=()
+  local seen=" default "
+
+  namespaces+=("default")
+  for ns in \
+    "${TEMPORAL_NAMESPACE:-}" \
+    "${TEMPORAL_AGENT_NAMESPACE:-}" \
+    "${TEMPORAL_CONNECTORS_NAMESPACE:-}" \
+    "${TEMPORAL_RELOCATION_NAMESPACE:-}"; do
+    [ -z "$ns" ] && continue
+    case "$seen" in
+      *" ${ns} "*) continue ;;
+    esac
+    seen="${seen}${ns} "
+    namespaces+=("$ns")
+  done
+
+  log "Ensuring Temporal search attributes (connectorId, conversationId, workspaceId)..."
+  for ns in "${namespaces[@]}"; do
+    create_temporal_search_attribute "$ns" connectorId Int
+    create_temporal_search_attribute "$ns" conversationId Text
+    create_temporal_search_attribute "$ns" workspaceId Text
+  done
+  log "Temporal search attributes ready"
+}
+
+if temporal_port_open; then
+  log "Temporal already listening on ${LOCAL_TEMPORAL_ADDRESS}"
+elif pgrep -f 'temporal server start-dev' >/dev/null 2>&1; then
+  log "Temporal process running; waiting for port ${LOCAL_TEMPORAL_ADDRESS}..."
+  wait_for_temporal
+else
+  start_temporal_dev_server
+  wait_for_temporal
+fi
+
+ensure_temporal_namespaces
+ensure_temporal_search_attributes

--- a/.cursor/scripts/env.defaults.sh
+++ b/.cursor/scripts/env.defaults.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Non-secret defaults for localhost services inside the Cloud Agent container.
+
+export POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+export POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+export REDIS_HOST="${REDIS_HOST:-localhost}"
+export REDIS_PORT="${REDIS_PORT:-6379}"
+export ELASTICSEARCH_HOST="${ELASTICSEARCH_HOST:-localhost}"
+export ELASTICSEARCH_PORT="${ELASTICSEARCH_PORT:-9200}"
+export QDRANT_HTTP_HOST="${QDRANT_HTTP_HOST:-localhost}"
+export QDRANT_HTTP_PORT="${QDRANT_HTTP_PORT:-6333}"
+export QDRANT_GRPC_PORT="${QDRANT_GRPC_PORT:-6334}"
+export TEMPORAL_ADDRESS="${TEMPORAL_ADDRESS:-127.0.0.1:7233}"
+# In-container Temporal dev server (always gRPC 7233). Cloud TEMPORAL_ADDRESS from 1Password
+# must not be used for local lifecycle checks — workers connect to 127.0.0.1:7233 in development.
+export DUST_LOCAL_TEMPORAL_ADDRESS="${DUST_LOCAL_TEMPORAL_ADDRESS:-127.0.0.1:7233}"
+
+# Temporal CLI is installed to /usr/local/bin in the dev image; also check the installer path.
+for _temporal_dir in /usr/local/bin /root/.temporalio/bin; do
+  if [ -x "${_temporal_dir}/temporal" ]; then
+    export PATH="${_temporal_dir}:${PATH}"
+    break
+  fi
+done
+unset _temporal_dir
+
+export FRONT_DATABASE_URI="${FRONT_DATABASE_URI:-postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_front}"
+export FRONT_DATABASE_READ_REPLICA_URI="${FRONT_DATABASE_READ_REPLICA_URI:-$FRONT_DATABASE_URI}"
+export CORE_DATABASE_URI="${CORE_DATABASE_URI:-postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_api}"
+export CORE_DATABASE_READ_REPLICA_URI="${CORE_DATABASE_READ_REPLICA_URI:-$CORE_DATABASE_URI}"
+export CONNECTORS_DATABASE_URI="${CONNECTORS_DATABASE_URI:-postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_connectors}"
+export CONNECTORS_DATABASE_READ_REPLICA_URI="${CONNECTORS_DATABASE_READ_REPLICA_URI:-$CONNECTORS_DATABASE_URI}"
+export OAUTH_DATABASE_URI="${OAUTH_DATABASE_URI:-postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/dust_oauth}"
+
+export REDIS_URI="${REDIS_URI:-redis://${REDIS_HOST}:${REDIS_PORT}}"
+export REDIS_CACHE_URI="${REDIS_CACHE_URI:-$REDIS_URI}"
+export ELASTICSEARCH_URL="${ELASTICSEARCH_URL:-http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}}"
+export QDRANT_CLUSTER_0_URL="${QDRANT_CLUSTER_0_URL:-http://${QDRANT_HTTP_HOST}:${QDRANT_GRPC_PORT}}"
+export QDRANT_USE_SHARDING="${QDRANT_USE_SHARDING:-false}"
+
+export CORE_API="${CORE_API:-http://localhost:3001}"
+export CORE_PORT="${CORE_PORT:-3001}"
+export DUST_FRONT_API="${DUST_FRONT_API:-http://localhost:3000}"
+export DUST_FRONT_INTERNAL_API="${DUST_FRONT_INTERNAL_API:-http://localhost:3000}"
+export DUST_INTERNAL_API_URL="${DUST_INTERNAL_API_URL:-http://localhost:3000}"
+export DUST_CLIENT_FACING_URL="${DUST_CLIENT_FACING_URL:-http://localhost:3000}"
+export DUST_PUBLIC_URL="${DUST_PUBLIC_URL:-http://localhost:3000}"
+export DUST_AUTH_REDIRECT_BASE_URL="${DUST_AUTH_REDIRECT_BASE_URL:-http://localhost:3000}"
+export NEXT_PUBLIC_DUST_API_URL="${NEXT_PUBLIC_DUST_API_URL:-http://localhost:3000}"
+export NEXT_PUBLIC_DUST_APP_URL="${NEXT_PUBLIC_DUST_APP_URL:-http://localhost:3011}"
+export NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL="${NEXT_PUBLIC_DUST_STATIC_WEBSITE_URL:-http://localhost:3000}"
+
+export NODE_ENV="${NODE_ENV:-development}"
+
+# front-api/esbuild.dev.ts binds the dev proxy to $HOSTNAME. Docker sets HOSTNAME to the
+# container id, so health checks against localhost:3000 never reach front-api.
+export HOSTNAME="${DUST_DEV_BIND_HOST:-0.0.0.0}"
+
+export SHELL="${SHELL:-/bin/bash}"
+export LANG="${LANG:-C.UTF-8}"
+export LC_ALL="${LC_ALL:-C.UTF-8}"
+export TERM="${TERM:-xterm-256color}"
+export COLORTERM="${COLORTERM:-truecolor}"
+export FORCE_COLOR="${FORCE_COLOR:-1}"
+export CLICOLOR="${CLICOLOR:-1}"
+export CLICOLOR_FORCE="${CLICOLOR_FORCE:-1}"
+export CARGO_TERM_COLOR="${CARGO_TERM_COLOR:-always}"

--- a/.cursor/scripts/init-databases.sh
+++ b/.cursor/scripts/init-databases.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=init-databases
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+admin_uri="postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/postgres"
+
+log "Waiting for Postgres at ${POSTGRES_HOST}:${POSTGRES_PORT}..."
+for _ in $(seq 1 60); do
+  if PGPASSWORD=dev psql "$admin_uri" -tc "select 1" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+for db in dust_api dust_databases_store dust_front dust_front_test dust_connectors dust_connectors_test dust_oauth; do
+  if ! PGPASSWORD=dev psql "$admin_uri" -tc "SELECT 1 FROM pg_database WHERE datname='$db'" | grep -q 1; then
+    log "Creating database $db"
+    PGPASSWORD=dev createdb -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U dev "$db"
+  fi
+done
+
+log "Waiting for Elasticsearch at ${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}..."
+for _ in $(seq 1 90); do
+  if curl -sf "http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}" >/dev/null 2>&1; then
+    log "Elasticsearch is ready"
+    exit 0
+  fi
+  sleep 1
+done
+
+log "Elasticsearch did not become ready in time"
+exit 1

--- a/.cursor/scripts/init-elasticsearch-indices.sh
+++ b/.cursor/scripts/init-elasticsearch-indices.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Idempotent local Elasticsearch index bootstrap (mirrors dust-hive initAllElasticsearch).
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=init-elasticsearch
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+export_local_dev_infra
+export NODE_ENV=development
+# Core/front index scripts use NODE_ENV=development => region "local".
+export ELASTICSEARCH_USERNAME="${ELASTICSEARCH_USERNAME:-elastic}"
+export ELASTICSEARCH_PASSWORD="${ELASTICSEARCH_PASSWORD:-}"
+
+ensure_node_path
+ensure_workspace_deps
+
+wait_for_elasticsearch() {
+  log "Waiting for Elasticsearch at ${ELASTICSEARCH_URL}..."
+  for _ in $(seq 1 90); do
+    if curl -sf "${ELASTICSEARCH_URL}" >/dev/null 2>&1; then
+      log "Elasticsearch is ready"
+      return 0
+    fi
+    sleep 1
+  done
+  log "Elasticsearch did not become ready in time"
+  return 1
+}
+
+output_already_exists() {
+  grep -qi 'already exists' <<<"$1"
+}
+
+create_core_index() {
+  local index_name="$1"
+  local index_version="$2"
+  local output=""
+
+  log "Ensuring core.${index_name}_${index_version}..."
+  output=$(
+    cd "${DUST_REPO_ROOT}/core"
+    cargo run --bin elasticsearch_create_index -- \
+      --index-name "$index_name" \
+      --index-version "$index_version" \
+      --skip-confirmation 2>&1
+  ) || {
+    if output_already_exists "$output"; then
+      log "core.${index_name}_${index_version} already exists"
+      return 0
+    fi
+    log "Failed to create core.${index_name}_${index_version}:"
+    echo "$output"
+    return 1
+  }
+}
+
+create_front_index() {
+  local index_name="$1"
+  local index_version="$2"
+  local output=""
+
+  log "Ensuring front.${index_name}_${index_version}..."
+  output=$(
+    cd "${DUST_REPO_ROOT}/front"
+    export PATH="${DUST_REPO_ROOT}/node_modules/.bin:${PATH}"
+    npx tsx ./scripts/create_elasticsearch_index.ts \
+      --index-name "$index_name" \
+      --index-version "$index_version" \
+      --skip-confirmation 2>&1
+  ) || {
+    if output_already_exists "$output"; then
+      log "front.${index_name}_${index_version} already exists"
+      return 0
+    fi
+    log "Failed to create front.${index_name}_${index_version}:"
+    echo "$output"
+    return 1
+  }
+}
+
+wait_for_elasticsearch
+
+# Keep in sync with x/henry/dust-hive/src/lib/init.ts (initElasticsearchRust / initElasticsearchTS).
+create_core_index data_sources_nodes 4
+create_core_index data_sources 1
+
+create_front_index agent_document_outputs 1
+create_front_index agent_message_analytics 2
+create_front_index agent_message_consumption_analytics 1
+create_front_index user_search 1
+
+log "Elasticsearch indices ready"

--- a/.cursor/scripts/install.sh
+++ b/.cursor/scripts/install.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Cursor Cloud Agent install phase — runs once at image build / snapshot time.
+# Must finish before start-infra (migrations, ES init) or start-mprocs need node_modules.
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=install
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+export CI=true
+export LEFTHOOK_EXCLUDE="${LEFTHOOK_EXCLUDE:-front-lint-test-filenames,front-typecheck,front-circular,front-docs-check,connectors-lint-test-filenames,connectors-typecheck,lint-staged}"
+export OP_ENVIRONMENT_ID="${OP_ENVIRONMENT_ID:-r6iqd3y67zqlbsxnotrj6bm25q}"
+
+ensure_node_path
+cd "$DUST_REPO_ROOT"
+
+log "Running npm install..."
+npm install
+
+log "Installing lefthook git hooks..."
+npx lefthook install -f
+
+log "Install complete"

--- a/.cursor/scripts/seed-dev-user.sh
+++ b/.cursor/scripts/seed-dev-user.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Idempotent dev-user seed, mirroring dust-hive's dust_hive_seed.sql flow.
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=seed-dev-user
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+SEED_LOG="${DUST_INFRA_LOG_DIR}/seed-dev-user.log"
+touch "$SEED_LOG"
+log() {
+  echo "[seed-dev-user] $*" | tee -a "$SEED_LOG"
+}
+
+on_seed_error() {
+  local exit_code=$?
+  log "Seed failed (exit ${exit_code}). Full log: ${SEED_LOG}"
+  for extra_log in init-plans.log upgrade-workspace.log; do
+    if [ -s "${DUST_INFRA_LOG_DIR}/${extra_log}" ]; then
+      log "--- tail ${extra_log} ---"
+      tail -20 "${DUST_INFRA_LOG_DIR}/${extra_log}" | tee -a "$SEED_LOG"
+    fi
+  done
+  exit "$exit_code"
+}
+trap on_seed_error ERR
+
+log "Starting dev user seed..."
+export_local_dev_infra
+ensure_node_path
+ensure_workspace_deps
+
+for secret in DEV_WORKOS_USER_ID DEV_WORKOS_USER_EMAIL DEV_WORKOS_USER_PASSWORD; do
+  eval "val=\${$secret:-}"
+  if [ -n "$val" ]; then
+    log "$secret is set"
+  else
+    log "$secret is not set"
+  fi
+done
+
+if [ -z "${DEV_WORKOS_USER_ID:-}" ]; then
+  log "DEV_WORKOS_USER_ID not set; skipping seed"
+  exit 0
+fi
+
+if [ -z "${DEV_WORKOS_USER_EMAIL:-}" ]; then
+  log "DEV_WORKOS_USER_EMAIL not set; skipping full dust-hive seed"
+  exit 0
+fi
+
+SQL_FILE="${DUST_REPO_ROOT}/front/lib/dev/dust_hive_seed.sql"
+STATE_FILE="/tmp/dust-dev-seed.json"
+WORKSPACE_ID="DevWkSpace"
+
+escape_sql() {
+  local value="$1"
+  if [ -z "$value" ]; then
+    printf 'NULL'
+  else
+    printf "'%s'" "${value//\'/\'\'}"
+  fi
+}
+
+generate_sid() {
+  # Avoid `tr | head -c N` — with pipefail, head closing the pipe makes tr SIGPIPE (exit 141).
+  python3 -c "import random,string; print(''.join(random.choices(string.ascii_letters+string.digits,k=10)))"
+}
+
+run_init_plans() {
+  local plans_ready
+  plans_ready=$(
+    PGPASSWORD=dev psql "$FRONT_DATABASE_URI" -tAc \
+      "SELECT 1 FROM plans WHERE code = 'FREE_UPGRADED_PLAN' LIMIT 1" \
+      2>/dev/null | tr -d '[:space:]' || true
+  )
+  if [ "$plans_ready" = "1" ]; then
+    log "FREE_UPGRADED_PLAN already present; skipping init_plans"
+    return 0
+  fi
+
+  log "Ensuring subscription plans exist (init_plans.sh)..."
+  log "Using FRONT_DATABASE_URI=${FRONT_DATABASE_URI}"
+  (
+    cd "${DUST_REPO_ROOT}/front"
+    export FRONT_DATABASE_URI NODE_ENV=development
+    export PATH="${DUST_REPO_ROOT}/node_modules/.bin:${PATH}"
+    ./admin/init_plans.sh
+  ) >"${DUST_INFRA_LOG_DIR}/init-plans.log" 2>&1 || {
+    log "init_plans failed; see ${DUST_INFRA_LOG_DIR}/init-plans.log"
+    tail -40 "${DUST_INFRA_LOG_DIR}/init-plans.log" | tee -a "$SEED_LOG"
+    return 1
+  }
+  log "init_plans succeeded"
+}
+
+ensure_dev_super_user() {
+  PGPASSWORD=dev psql "$FRONT_DATABASE_URI" -q -c \
+    "UPDATE users SET \"isDustSuperUser\" = true, \"updatedAt\" = NOW()
+     WHERE \"workOSUserId\" = $(escape_sql "$DEV_WORKOS_USER_ID")" \
+    >/dev/null 2>&1 || true
+}
+
+ensure_free_upgraded_subscription() {
+  local workspace_sid="${1:-$WORKSPACE_ID}"
+  log "Ensuring workspace $workspace_sid is on FREE_UPGRADED_PLAN..."
+  (
+    cd "${DUST_REPO_ROOT}/front"
+    export PATH="${DUST_REPO_ROOT}/node_modules/.bin:${PATH}"
+    NODE_ENV=development npx tsx admin/cli.ts workspace upgrade --wId "$workspace_sid"
+  ) >"${DUST_INFRA_LOG_DIR}/upgrade-workspace.log" 2>&1 || {
+    if grep -q "already subscribed" "${DUST_INFRA_LOG_DIR}/upgrade-workspace.log"; then
+      log "Workspace already on FREE_UPGRADED_PLAN"
+      return 0
+    fi
+    log "Workspace upgrade failed; see ${DUST_INFRA_LOG_DIR}/upgrade-workspace.log"
+    tail -30 "${DUST_INFRA_LOG_DIR}/upgrade-workspace.log"
+    return 1
+  }
+}
+
+find_user_workspace_sid() {
+  PGPASSWORD=dev psql "$FRONT_DATABASE_URI" -tAc \
+    "SELECT w.\"sId\" FROM users u
+     JOIN memberships m ON m.\"userId\" = u.id AND m.\"endAt\" IS NULL
+     JOIN workspaces w ON w.id = m.\"workspaceId\"
+     WHERE u.\"workOSUserId\" = $(escape_sql "$DEV_WORKOS_USER_ID")
+       AND w.\"sId\" <> $(escape_sql "$WORKSPACE_ID")
+     ORDER BY CASE WHEN m.role = 'admin' THEN 0 ELSE 1 END, m.\"createdAt\" ASC
+     LIMIT 1" \
+    2>/dev/null | tr -d '[:space:]'
+}
+
+dev_workspace_ready=$(
+  PGPASSWORD=dev psql "$FRONT_DATABASE_URI" -tAc \
+    "SELECT 1 FROM users u
+     JOIN memberships m ON m.\"userId\" = u.id AND m.\"endAt\" IS NULL
+     JOIN workspaces w ON w.id = m.\"workspaceId\" AND w.\"sId\" = $(escape_sql "$WORKSPACE_ID")
+     JOIN subscriptions s ON s.\"workspaceId\" = w.id AND s.status = 'active'
+     JOIN plans p ON p.id = s.\"planId\" AND p.code = 'FREE_UPGRADED_PLAN'
+     WHERE u.\"workOSUserId\" = $(escape_sql "$DEV_WORKOS_USER_ID")
+     LIMIT 1" \
+    2>/dev/null | tr -d '[:space:]' || true
+)
+if [ "$dev_workspace_ready" = "1" ]; then
+  log "Dev workspace $WORKSPACE_ID is ready (FREE_UPGRADED_PLAN + membership)"
+  trap - ERR
+  exit 0
+fi
+
+run_init_plans
+
+dev_workspace_exists=$(
+  PGPASSWORD=dev psql "$FRONT_DATABASE_URI" -tAc \
+    "SELECT 1 FROM workspaces WHERE \"sId\" = $(escape_sql "$WORKSPACE_ID") LIMIT 1" \
+    2>/dev/null | tr -d '[:space:]' || true
+)
+if [ "$dev_workspace_exists" = "1" ]; then
+  log "Workspace $WORKSPACE_ID exists but is not fully ready; repairing subscription"
+  ensure_dev_super_user
+  ensure_free_upgraded_subscription "$WORKSPACE_ID"
+  log "Subscription repair succeeded for workspace $WORKSPACE_ID"
+  trap - ERR
+  exit 0
+fi
+
+existing_user_sid=$(
+  PGPASSWORD=dev psql "$FRONT_DATABASE_URI" -tAc \
+    "SELECT \"sId\" FROM users WHERE \"workOSUserId\" = $(escape_sql "$DEV_WORKOS_USER_ID") LIMIT 1" \
+    2>/dev/null | tr -d '[:space:]' || true
+)
+if [ -n "$existing_user_sid" ]; then
+  login_workspace_sid="$(find_user_workspace_sid)"
+  if [ -n "$login_workspace_sid" ]; then
+    log "User exists from login (sId=$existing_user_sid, workspace=$login_workspace_sid); creating $WORKSPACE_ID"
+  else
+    log "User exists from login (sId=$existing_user_sid); creating $WORKSPACE_ID"
+  fi
+fi
+
+if [ ! -f "$SQL_FILE" ]; then
+  log "Missing seed SQL at $SQL_FILE"
+  exit 1
+fi
+
+if [ -n "$existing_user_sid" ]; then
+  user_id="$existing_user_sid"
+elif [ -f "$STATE_FILE" ]; then
+  user_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["userId"])' "$STATE_FILE")
+else
+  user_id=$(generate_sid)
+fi
+
+if [ -f "$STATE_FILE" ]; then
+  subscription_id=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["subscriptionId"])' "$STATE_FILE")
+else
+  subscription_id=$(generate_sid)
+fi
+printf '{"userId":"%s","subscriptionId":"%s"}\n' "$user_id" "$subscription_id" >"$STATE_FILE"
+
+email="${DEV_WORKOS_USER_EMAIL,,}"
+username="${email%%@*}"
+first_name="${username%%+*}"
+first_name="${first_name%%.*}"
+first_name="${first_name:-Dev}"
+display_name="$first_name"
+workspace_name="${first_name}'s Dev Workspace"
+
+log "Seeding dev user $email into workspace $WORKSPACE_ID..."
+
+final_sql=$(
+  sed \
+    -e "s/:userId/$(escape_sql "$user_id")/g" \
+    -e "s/:workspaceId/$(escape_sql "$WORKSPACE_ID")/g" \
+    -e "s/:subscriptionId/$(escape_sql "$subscription_id")/g" \
+    -e "s/:email/$(escape_sql "$email")/g" \
+    -e "s/:username/$(escape_sql "$username")/g" \
+    -e "s/:name/$(escape_sql "$display_name")/g" \
+    -e "s/:firstName/$(escape_sql "$first_name")/g" \
+    -e "s/:lastName/NULL/g" \
+    -e "s/:workspaceName/$(escape_sql "$workspace_name")/g" \
+    -e "s/:workOSUserId/$(escape_sql "$DEV_WORKOS_USER_ID")/g" \
+    -e "s/:providerId/NULL/g" \
+    -e "s/:provider/NULL/g" \
+    -e "s/:imageUrl/NULL/g" \
+    -e "s/'org_01KEF5MMN72N50JA89BDD5TQ4T'/NULL/g" \
+    "$SQL_FILE"
+)
+
+seed_output=$(PGPASSWORD=dev psql "$FRONT_DATABASE_URI" -c "$final_sql" 2>&1) || {
+  log "Seed SQL failed:"
+  echo "$seed_output" | tee -a "$SEED_LOG"
+  exit 1
+}
+echo "$seed_output" >>"$SEED_LOG"
+
+if ! grep -qE '[[:space:]]+[0-9]+[[:space:]]+\|[[:space:]]+[0-9]+[[:space:]]+\|[[:space:]]+[0-9]+' <<<"$seed_output"; then
+  log "Seed SQL ran but subscription row is missing; repairing via upgrade..."
+  ensure_dev_super_user
+  ensure_free_upgraded_subscription "$WORKSPACE_ID"
+  log "Subscription repair succeeded for workspace $WORKSPACE_ID"
+  trap - ERR
+  exit 0
+fi
+
+ensure_dev_super_user
+log "Seed succeeded for workspace $WORKSPACE_ID"
+trap - ERR
+exit 0

--- a/.cursor/scripts/setup-dev-db.sh
+++ b/.cursor/scripts/setup-dev-db.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# One-time / idempotent DB bootstrap: migrations only.
+# Dev-user seed runs from start-mprocs.sh where Cursor runtime secrets (DEV_WORKOS_*) are set.
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=setup-dev-db
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+ensure_workspace_deps
+
+core_schema_ready=$(
+  PGPASSWORD=dev psql "$CORE_DATABASE_URI" -tAc \
+    "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='sqlite_workers' LIMIT 1" \
+    2>/dev/null | tr -d '[:space:]'
+)
+
+if [ "$core_schema_ready" != "1" ]; then
+  log "Initializing core + oauth databases (cargo run --bin init_db)..."
+  (
+    cd "${DUST_REPO_ROOT}/core"
+    cargo run --bin init_db
+  ) >"${DUST_INFRA_LOG_DIR}/core-init-db.log" 2>&1 || {
+    log "Core init_db failed; see ${DUST_INFRA_LOG_DIR}/core-init-db.log"
+    tail -30 "${DUST_INFRA_LOG_DIR}/core-init-db.log"
+    exit 1
+  }
+else
+  log "Core schema already present; skipping init_db"
+fi
+
+schema_ready=$(
+  PGPASSWORD=dev psql "$FRONT_DATABASE_URI" -tAc \
+    "SELECT 1 FROM information_schema.tables WHERE table_schema='public' AND table_name='users' LIMIT 1" \
+    2>/dev/null | tr -d '[:space:]'
+)
+
+if [ "$schema_ready" = "1" ]; then
+  log "Front schema already present; skipping migrations"
+else
+  log "Applying front migrations..."
+  (
+    cd "${DUST_REPO_ROOT}/front"
+    npm run migration:apply
+  ) >"${DUST_INFRA_LOG_DIR}/front-migration.log" 2>&1 || {
+    log "Front migration failed; see ${DUST_INFRA_LOG_DIR}/front-migration.log"
+    tail -30 "${DUST_INFRA_LOG_DIR}/front-migration.log"
+    exit 1
+  }
+
+  log "Applying connectors migrations..."
+  (
+    cd "${DUST_REPO_ROOT}/connectors"
+    npm run migration:apply
+  ) >"${DUST_INFRA_LOG_DIR}/connectors-migration.log" 2>&1 || {
+    log "Connectors migration failed; see ${DUST_INFRA_LOG_DIR}/connectors-migration.log"
+    tail -30 "${DUST_INFRA_LOG_DIR}/connectors-migration.log"
+    exit 1
+  }
+fi
+
+log "Database setup complete"

--- a/.cursor/scripts/start-infra.sh
+++ b/.cursor/scripts/start-infra.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Start infra services and bootstrap databases (migrations). Dev-user seed runs in start-mprocs.
+set +e
+
+DUST_DEV_SCRIPT_NAME=start-infra
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+install_cursor_runtime_config
+rm -f "${DUST_INFRA_LOG_DIR}/infra.ready"
+
+ensure_node_path
+ensure_workspace_deps
+
+start_bg() {
+  local name="$1"
+  shift
+  log "Starting $name..."
+  "$@" >"${DUST_INFRA_LOG_DIR}/${name}.log" 2>&1 &
+}
+
+# --- Postgres ---
+if ! pgrep -x postgres >/dev/null 2>&1; then
+  pg_version="$(ls /etc/postgresql 2>/dev/null | sort -rn | head -1)"
+  if [ -z "$pg_version" ]; then
+    log "Postgres not installed"
+    exit 1
+  fi
+  start_bg postgres sudo pg_ctlcluster "$pg_version" main start
+  sleep 2
+fi
+
+# --- Redis ---
+if ! redis-cli ping >/dev/null 2>&1; then
+  log "Starting redis..."
+  sudo redis-server /etc/redis/redis.conf --daemonize yes
+fi
+
+# --- Qdrant ---
+if ! pgrep -x qdrant >/dev/null 2>&1; then
+  start_bg qdrant bash -lc "cd /opt/qdrant && ./qdrant"
+fi
+
+# --- Elasticsearch ---
+if ! curl -sf "http://${ELASTICSEARCH_HOST}:${ELASTICSEARCH_PORT}" >/dev/null 2>&1; then
+  if ! id elasticsearch >/dev/null 2>&1; then
+    groupadd -r elasticsearch 2>/dev/null || true
+    useradd -r -g elasticsearch -d /opt/es -s /usr/sbin/nologin elasticsearch 2>/dev/null || true
+  fi
+  mkdir -p /opt/es/data /opt/es/logs
+  chown -R elasticsearch:elasticsearch /opt/es
+  start_bg elasticsearch sudo -u elasticsearch bash -lc \
+    'ES_JAVA_OPTS="-Xms512m -Xmx512m" /opt/es/bin/elasticsearch -d -p /tmp/es.pid -E discovery.type=single-node -E xpack.security.enabled=false -E bootstrap.memory_lock=false -E path.data=/opt/es/data -E path.logs=/opt/es/logs'
+fi
+
+# --- Temporal dev server ---
+bash "$(dirname "$0")/ensure-temporal.sh" \
+  >"${DUST_INFRA_LOG_DIR}/ensure-temporal.log" 2>&1 || {
+  log "Temporal setup failed; see ${DUST_INFRA_LOG_DIR}/ensure-temporal.log"
+  tail -30 "${DUST_INFRA_LOG_DIR}/ensure-temporal.log"
+  exit 1
+}
+
+log "Initializing databases..."
+bash "$(dirname "$0")/init-databases.sh" || exit 1
+
+log "Ensuring Elasticsearch indices..."
+bash "$(dirname "$0")/init-elasticsearch-indices.sh" \
+  >"${DUST_INFRA_LOG_DIR}/init-elasticsearch.log" 2>&1 || {
+  log "Elasticsearch index init failed; see ${DUST_INFRA_LOG_DIR}/init-elasticsearch.log"
+  tail -40 "${DUST_INFRA_LOG_DIR}/init-elasticsearch.log"
+  exit 1
+}
+
+if require_op_credentials; then
+  log "Running DB migrations via op run..."
+  bash "$(dirname "$0")/with-op-run.sh" bash "$(dirname "$0")/setup-dev-db.sh" \
+    >"${DUST_INFRA_LOG_DIR}/setup-dev-db.log" 2>&1 || {
+    log "setup-dev-db failed; see ${DUST_INFRA_LOG_DIR}/setup-dev-db.log"
+    tail -30 "${DUST_INFRA_LOG_DIR}/setup-dev-db.log"
+    exit 1
+  }
+
+  log "Ensuring Temporal namespaces exist..."
+  bash "$(dirname "$0")/with-op-run.sh" bash "$(dirname "$0")/ensure-temporal.sh" \
+    >"${DUST_INFRA_LOG_DIR}/temporal-namespaces.log" 2>&1 || true
+else
+  log "Skipping op-backed DB setup (OP_SERVICE_ACCOUNT_TOKEN missing)"
+  bash "$(dirname "$0")/setup-dev-db.sh" >"${DUST_INFRA_LOG_DIR}/setup-dev-db.log" 2>&1 || {
+    log "setup-dev-db failed; see ${DUST_INFRA_LOG_DIR}/setup-dev-db.log"
+    tail -30 "${DUST_INFRA_LOG_DIR}/setup-dev-db.log"
+    exit 1
+  }
+fi
+
+log "Infra ready. App services run in Cursor terminals."
+log "Infra logs: ${DUST_INFRA_LOG_DIR}/"
+date -u +%Y-%m-%dT%H:%M:%SZ >"${DUST_INFRA_LOG_DIR}/infra.ready"

--- a/.cursor/scripts/start-mprocs-inner.sh
+++ b/.cursor/scripts/start-mprocs-inner.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Container entrypoint for tools/mprocs.yaml — deps, watches, and services.
+# npm install + bacon rebuilds happen here, not in Cursor install/start.
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=start-mprocs
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+ensure_node_path
+install_cursor_runtime_config
+
+cd "$DUST_REPO_ROOT"
+
+# Force dependents to wait for a fresh sdks-js build (same as tools/start-mprocs.sh).
+rm -rf sdks/js/dist
+
+log "Running npm install (incremental; re-run this terminal to pick up lockfile changes)..."
+npm install
+
+export DUST_USE_START_MPROCS=1
+
+log "Starting mprocs (select a process and press r to restart; q to quit)"
+cd "${DUST_REPO_ROOT}/tools"
+exec env \
+  SHELL=/bin/bash \
+  TERM="${TERM}" \
+  COLORTERM="${COLORTERM}" \
+  LANG="${LANG}" \
+  LC_ALL="${LC_ALL}" \
+  mprocs --config mprocs.yaml

--- a/.cursor/scripts/start-mprocs.sh
+++ b/.cursor/scripts/start-mprocs.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Launch mprocs with 1Password + host runtime secrets.
+# Secrets are loaded into this shell first — mprocs must not run under `op run`
+# (op masks stdout/stderr and corrupts the TUI).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=.cursor/scripts/common.sh
+source "${SCRIPT_DIR}/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "${SCRIPT_DIR}/env.defaults.sh"
+
+if ! command -v mprocs >/dev/null 2>&1; then
+  echo "mprocs not found; rebuild the .cursor/Dockerfile image" >&2
+  exit 1
+fi
+
+if ! command -v bacon >/dev/null 2>&1; then
+  echo "bacon not found; rebuild the .cursor/Dockerfile image" >&2
+  exit 1
+fi
+
+write_gcp_service_account_file
+load_op_environment || log "1Password env not loaded; using defaults + host secrets only"
+export_op_runtime_secrets
+
+bash "${SCRIPT_DIR}/wait-for-infra.sh" || {
+  log "Infra is not ready; fix start-infra first (see ${DUST_INFRA_LOG_DIR}/)"
+  exit 1
+}
+
+bash "${SCRIPT_DIR}/ensure-temporal.sh" || {
+  log "Temporal is required for front-workers and connectors; see ${DUST_INFRA_LOG_DIR}/temporal.log"
+  exit 1
+}
+
+print_seed_failure_logs() {
+  for log_file in seed-dev-user.log init-plans.log upgrade-workspace.log; do
+    if [ -s "${DUST_INFRA_LOG_DIR}/${log_file}" ]; then
+      log "--- ${log_file} ---"
+      tail -40 "${DUST_INFRA_LOG_DIR}/${log_file}"
+    fi
+  done
+}
+
+# DEV_WORKOS_* are Cursor runtime secrets — only guaranteed in this terminal, not start-infra.
+if [ -n "${DEV_WORKOS_USER_ID:-}" ] && [ -n "${DEV_WORKOS_USER_EMAIL:-}" ]; then
+  bash "${SCRIPT_DIR}/seed-dev-user.sh" || {
+    log "Dev user seed failed"
+    print_seed_failure_logs
+    exit 1
+  }
+else
+  log "DEV_WORKOS_USER_ID/EMAIL not set — skipping seed (add Cursor runtime secrets, then restart mprocs)"
+fi
+
+exec bash "${SCRIPT_DIR}/start-mprocs-inner.sh"

--- a/.cursor/scripts/wait-for-infra.sh
+++ b/.cursor/scripts/wait-for-infra.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Block until start-infra.sh finishes (Cursor runs start + terminals in parallel).
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=wait-for-infra
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+READY_FILE="${DUST_INFRA_LOG_DIR}/infra.ready"
+MAX_WAIT_SECONDS="${DUST_INFRA_WAIT_SECONDS:-900}"
+POLL_INTERVAL="${DUST_INFRA_WAIT_POLL:-2}"
+
+if [ -f "$READY_FILE" ]; then
+  log "Infra already ready"
+  exit 0
+fi
+
+log "Waiting for start-infra to finish (up to ${MAX_WAIT_SECONDS}s)..."
+log "Ready marker: ${READY_FILE}"
+
+attempt=0
+max_attempts=$((MAX_WAIT_SECONDS / POLL_INTERVAL))
+while [ "$attempt" -lt "$max_attempts" ]; do
+  if [ -f "$READY_FILE" ]; then
+    log "Infra is ready"
+    exit 0
+  fi
+
+  attempt=$((attempt + 1))
+  if [ "$attempt" -eq 1 ] || [ $((attempt % 15)) -eq 0 ]; then
+    log "Still waiting for infra (${attempt}/${max_attempts})..."
+    if [ -s "${DUST_INFRA_LOG_DIR}/setup-dev-db.log" ]; then
+      tail -1 "${DUST_INFRA_LOG_DIR}/setup-dev-db.log" 2>/dev/null || true
+    fi
+  fi
+  sleep "$POLL_INTERVAL"
+done
+
+log "Timed out waiting for infra. Check the start-infra output and ${DUST_INFRA_LOG_DIR}/"
+if [ -f "${DUST_INFRA_LOG_DIR}/init-elasticsearch.log" ]; then
+  tail -20 "${DUST_INFRA_LOG_DIR}/init-elasticsearch.log"
+fi
+if [ -f "${DUST_INFRA_LOG_DIR}/setup-dev-db.log" ]; then
+  tail -20 "${DUST_INFRA_LOG_DIR}/setup-dev-db.log"
+fi
+exit 1

--- a/.cursor/scripts/with-op-run.sh
+++ b/.cursor/scripts/with-op-run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Run a command with 1Password environment secrets plus host-injected runtime secrets.
+set -euo pipefail
+
+DUST_DEV_SCRIPT_NAME=with-op-run
+# shellcheck source=.cursor/scripts/common.sh
+source "$(dirname "$0")/common.sh"
+# shellcheck source=.cursor/scripts/env.defaults.sh
+source "$(dirname "$0")/env.defaults.sh"
+
+require_op_credentials
+
+write_gcp_service_account_file
+export_local_dev_infra
+
+exec op run --no-masking --environment "$OP_ENVIRONMENT_ID" -- env \
+  DUST_REPO_ROOT="$DUST_REPO_ROOT" \
+  SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-}" \
+  GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT:-}" \
+  DEV_WORKOS_USER_EMAIL="${DEV_WORKOS_USER_EMAIL:-}" \
+  DEV_WORKOS_USER_PASSWORD="${DEV_WORKOS_USER_PASSWORD:-}" \
+  DEV_WORKOS_USER_ID="${DEV_WORKOS_USER_ID:-}" \
+  NODE_ENV="development" \
+  FRONT_DATABASE_URI="$FRONT_DATABASE_URI" \
+  FRONT_DATABASE_READ_REPLICA_URI="$FRONT_DATABASE_READ_REPLICA_URI" \
+  CORE_DATABASE_URI="$CORE_DATABASE_URI" \
+  CORE_DATABASE_READ_REPLICA_URI="$CORE_DATABASE_READ_REPLICA_URI" \
+  CONNECTORS_DATABASE_URI="$CONNECTORS_DATABASE_URI" \
+  CONNECTORS_DATABASE_READ_REPLICA_URI="$CONNECTORS_DATABASE_READ_REPLICA_URI" \
+  OAUTH_DATABASE_URI="$OAUTH_DATABASE_URI" \
+  REDIS_URI="$REDIS_URI" \
+  REDIS_CACHE_URI="$REDIS_CACHE_URI" \
+  TEMPORAL_ADDRESS="$TEMPORAL_ADDRESS" \
+  ELASTICSEARCH_URL="$ELASTICSEARCH_URL" \
+  ELASTICSEARCH_USERNAME="$ELASTICSEARCH_USERNAME" \
+  ELASTICSEARCH_PASSWORD="$ELASTICSEARCH_PASSWORD" \
+  DUST_FRONT_API="$DUST_FRONT_API" \
+  DUST_AUTH_REDIRECT_BASE_URL="$DUST_AUTH_REDIRECT_BASE_URL" \
+  "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ process-compose*.log
 **/.npm-cache
 AGENTS.local.md
 CLAUDE.local.md
+.cursor/docker-volumes/
 node_modules
 thoughts/*
 .superpowers/

--- a/tools/check-start-mprocs.sh
+++ b/tools/check-start-mprocs.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Guard: mprocs must be launched via start-mprocs.sh (prep + DUST_USE_START_MPROCS).
+set -euo pipefail
+
+if [ -z "${DUST_USE_START_MPROCS:-}" ]; then
+  echo ""
+  echo "ERROR: Run the start-mprocs wrapper instead of invoking mprocs directly:"
+  echo "       tools/start-mprocs.sh           (local Mac)"
+  echo "       .cursor/scripts/start-mprocs.sh (Docker / Cursor)"
+  echo "       Wrappers set up deps and export DUST_USE_START_MPROCS."
+  echo ""
+  exit 1
+fi
+
+echo "OK"

--- a/tools/mprocs.yaml
+++ b/tools/mprocs.yaml
@@ -9,16 +9,10 @@
 
 procs:
   _check-start-script:
-    shell: |
-      if [ -z "$DUST_USE_START_MPROCS" ]; then
-        echo ""
-        echo "ERROR: Run tools/start-mprocs.sh instead of invoking mprocs directly."
-        echo "       It sets up nvm, clears stale build artifacts, and installs dependencies."
-        echo ""
-        exit 1
-      fi
-      echo "OK"
+    cwd: "<CONFIG_DIR>/.."
+    cmd: ["bash", "tools/check-start-mprocs.sh"]
     autostart: true
+    autorestart: false
 
   docker-infra:
     cwd: "<CONFIG_DIR>/.."
@@ -70,18 +64,13 @@ procs:
     cwd: "<CONFIG_DIR>/.."
     env:
       READY_FILE: "sdks/js/dist/client.esm.js.map"
-    shell: |
-      echo "Waiting for sdks-js to compile..."
-      echo "Expecting file: $READY_FILE"
-      while [ ! -f "$READY_FILE" ]; do sleep 1; done
-      echo "sdks-js ready. Starting migrations."
-      npm -w front run migration:apply
-      npm -w connectors run migration:apply
+    shell: "bash tools/run-migrations.sh"
 
   front-api-hono:
     cwd: "<CONFIG_DIR>/../front-api"
     env:
       NODE_ENV: "development"
+      HOSTNAME: "0.0.0.0"
       # Guard: throw if anything tries to load `next` at runtime.
       NODE_OPTIONS: "--require=./forbid-next.cjs"
       READY_FILE: "../sdks/js/dist/client.esm.js.map"
@@ -93,18 +82,15 @@ procs:
       npm run dev
 
   front-workers:
-    cwd: "<CONFIG_DIR>/../front"
-    shell: |
-      echo "Waiting for front to be ready..."
-      until curl -sf http://localhost:3000/api/healthz; do sleep 1; done
-      echo "front ready. Starting front-workers."
-      ./admin/dev_worker.sh
+    cwd: "<CONFIG_DIR>/.."
+    shell: "bash tools/wait-for-front-api.sh"
 
   connectors:
     cwd: "<CONFIG_DIR>/../connectors"
     env:
       READY_FILE: "../sdks/js/dist/client.esm.js.map"
     shell: |
+      bash ../tools/wait-for-temporal.sh
       echo "Waiting for sdks-js to compile..."
       while [ ! -f "$READY_FILE" ]; do sleep 1; done
       echo "sdks-js ready. Starting connectors."

--- a/tools/run-migrations.sh
+++ b/tools/run-migrations.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# One-shot front + connectors migrations for mprocs. Must exit when finished.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# run-migrate.cjs falls back to `tsx` when dist/migrate.js is missing; npm scripts
+# add node_modules/.bin to PATH, but this script runs node directly.
+export PATH="${ROOT}/node_modules/.bin:${PATH}"
+
+READY_FILE="${READY_FILE:-sdks/js/dist/client.esm.js.map}"
+if [[ "$READY_FILE" != /* ]]; then
+  READY_FILE="${ROOT}/${READY_FILE}"
+fi
+
+echo "Waiting for sdks-js to compile..."
+echo "Expecting file: $READY_FILE"
+while [ ! -f "$READY_FILE" ]; do
+  sleep 1
+done
+echo "sdks-js ready. Starting migrations."
+
+apply_workspace_migrations() {
+  local workspace="$1"
+  echo "Applying ${workspace} migrations..."
+  (
+    cd "${ROOT}/${workspace}"
+    node ../scripts/db/run-migrate.cjs --command pre-deploy --execute
+    node ../scripts/db/run-migrate.cjs --command post-deploy --execute
+  )
+}
+
+apply_workspace_migrations front
+apply_workspace_migrations connectors
+
+echo "Migrations complete."

--- a/tools/start-mprocs.sh
+++ b/tools/start-mprocs.sh
@@ -3,14 +3,18 @@
 # Where the script is defined, absolute path
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 
+
+# Skip the Docker daemon check when already running inside a container.
+if [ ! -f /.dockerenv ]; then
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker is not running. Please start Docker Desktop/Orb Stack and try again."
+    exit 1
+  fi
+fi
+
 # Source and install the correct node version using nvm.
 # If DUST_NODE_VERSION is set (e.g. via `source scripts/try-node24.sh`), use that version
 # instead of the .nvmrc default.
-if ! docker info >/dev/null 2>&1; then
-  echo "Docker is not running. Please start Docker Desktop/Orb Stack and try again."
-  exit 1
-fi
-
 source ~/.nvm/nvm.sh
 if [ -n "${DUST_NODE_VERSION:-}" ]; then
   nvm install "$DUST_NODE_VERSION"

--- a/tools/wait-for-front-api.sh
+++ b/tools/wait-for-front-api.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Wait for front-api (Hono dev proxy) then start Temporal workers.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HEALTH_URL="${DUST_FRONT_API:-http://127.0.0.1:3000}/api/healthz"
+
+bash "${ROOT}/tools/wait-for-temporal.sh"
+
+echo "Waiting for front-api at ${HEALTH_URL}..."
+attempt=0
+until curl -sf "$HEALTH_URL" >/dev/null; do
+  attempt=$((attempt + 1))
+  if [ "$attempt" -eq 30 ] || [ $((attempt % 30)) -eq 0 ]; then
+    echo "Still waiting for front-api (${attempt}s)... check the front-api-hono proc"
+  fi
+  sleep 1
+done
+
+echo "front-api ready. Starting front-workers."
+cd "${ROOT}/front"
+exec ./admin/dev_worker.sh

--- a/tools/wait-for-temporal.sh
+++ b/tools/wait-for-temporal.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Ensure the local Temporal dev server is up before starting workers or connectors.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "${ROOT}/.cursor/scripts/ensure-temporal.sh"


### PR DESCRIPTION
## Description

Repo-managed Cloud Agent development environment. `.cursor/Dockerfile` provides the Linux toolchain and local Postgres, Redis, Qdrant, Elasticsearch, and Temporal services; `.cursor/environment.json` and `.cursor/scripts/` now bootstrap infrastructure, databases, Elasticsearch indices, 1Password-backed secrets, and the development user. `tools/mprocs.yaml` starts the application stack with `NODE_ENV=development`, readiness gates, migrations, and memory-safe Temporal worker groups. The setup also supports local Docker runs through `.cursor/scripts/docker-run.sh` without modifying host dependencies.

## Tests

No automated tests were added because this change is limited to development-environment configuration and shell orchestration. Manually verified the CORS preflight behavior with `front-api` under `NODE_ENV=development` and added startup checks for `front-api`, Temporal, migrations, and the mprocs entrypoint.

## Risk

Low production risk: the changes are scoped to Cursor Cloud Agent and local development tooling. The main risk is bootstrap failure from dependency, secret, or local-service drift; startup scripts fail with logged diagnostics, use idempotent initialization where possible, and the change rolls back cleanly by reverting the commit.

## Deploy Plan

No production deploy or production database migration is required. Merge to `main`; new Cursor Cloud Agents will build `.cursor/Dockerfile` and run the repo-managed environment. Existing local development continues through `tools/start-mprocs.sh`.