### PR TITLE
Admin gov: allow to add members to public spaces (write permissions)

### DIFF
--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -353,31 +353,49 @@ export function CreateOrEditSpaceModal({
                   setSelectedMembers([user, ...selectedMembers]);
                 }
               }}
-              restrictedDescription="Restricted access is active."
-              unrestrictedDescription="Restricted access is disabled. The space is accessible to everyone in
-          the workspace."
+              restrictedDescription={
+                <>
+                  <span>Restricted access is active.</span>
+                  <span>
+                    Members can read the content of the space and write data
+                    into it (upload files, delete documents...).
+                  </span>
+                </>
+              }
+              unrestrictedDescription={
+                <>
+                  <span>Restricted access is disabled. The space is open.</span>
+                  <span>
+                    Anyone in the workspace can read the data from this space.
+                  </span>
+                  <span>
+                    Members of the space can also write data (upload files,
+                    delete documents...).
+                  </span>
+                </>
+              }
             />
 
-            {isRestricted && (
-              <RestrictedAccessBody
-                isManual={isManual}
-                scimEnabled={scimEnabled}
-                managementType={managementType}
-                owner={owner}
-                selectedMembers={selectedMembers}
-                selectedGroups={selectedGroups}
-                onManagementTypeChange={handleManagementTypeChange}
-                onMembersUpdated={(members) => {
-                  setSelectedMembers(members);
-                  setIsDirty(true);
-                }}
-                onGroupsUpdated={(groups) => {
-                  setSelectedGroups(groups);
-                  setIsDirty(true);
-                }}
-                initialMembers={spaceInfo?.members}
-              />
-            )}
+            {/* Shown in both states: an open space still has members, and they are the ones who
+                can write to it. The toggle only controls who can read. */}
+            <RestrictedAccessBody
+              isManual={isManual}
+              scimEnabled={scimEnabled}
+              managementType={managementType}
+              owner={owner}
+              selectedMembers={selectedMembers}
+              selectedGroups={selectedGroups}
+              onManagementTypeChange={handleManagementTypeChange}
+              onMembersUpdated={(members) => {
+                setSelectedMembers(members);
+                setIsDirty(true);
+              }}
+              onGroupsUpdated={(groups) => {
+                setSelectedGroups(groups);
+                setIsDirty(true);
+              }}
+              initialMembers={spaceInfo?.members}
+            />
           </div>
         </SheetContainer>
         <SheetFooter

--- a/front/components/spaces/RestrictedAccessHeader.tsx
+++ b/front/components/spaces/RestrictedAccessHeader.tsx
@@ -1,10 +1,12 @@
 import { Page, SliderToggle } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 
 interface RestrictedAccessHeaderProps {
   isRestricted: boolean;
   onToggle: () => void;
-  restrictedDescription: string;
-  unrestrictedDescription: string;
+  // Nodes rather than strings: both states describe read and write access on separate lines.
+  restrictedDescription: ReactNode;
+  unrestrictedDescription: ReactNode;
 }
 
 export function RestrictedAccessHeader({
@@ -19,11 +21,9 @@ export function RestrictedAccessHeader({
         <Page.SectionHeader title="Restricted Access" />
         <SliderToggle selected={isRestricted} onClick={onToggle} />
       </div>
-      {isRestricted ? (
-        <span>{restrictedDescription}</span>
-      ) : (
-        <span>{unrestrictedDescription}</span>
-      )}
+      <div className="flex flex-col gap-y-1">
+        {isRestricted ? restrictedDescription : unrestrictedDescription}
+      </div>
     </>
   );
 }

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -434,6 +434,49 @@ describe("createSpaceAndGroup", () => {
       }
     });
 
+    it("gives members of an open space write, and everyone else read only", async () => {
+      const result = await createSpaceAndGroup(adminAuth, {
+        name: "Test Open Space With Members",
+        isRestricted: false,
+        spaceKind: "regular",
+        managementMode: "manual",
+        memberIds: [user1.sId],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        return;
+      }
+
+      // Auths are built after the space exists: they resolve their grants once, at construction.
+      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user1.sId,
+        workspace.sId
+      );
+      const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user2.sId,
+        workspace.sId
+      );
+
+      const asMember = await SpaceResource.fetchById(
+        memberAuth,
+        result.value.sId
+      );
+      const asNonMember = await SpaceResource.fetchById(
+        nonMemberAuth,
+        result.value.sId
+      );
+
+      expect(asMember!.isOpen()).toBe(true);
+
+      // The member group confers write; the global group's `reader` grant only confers read.
+      expect(asMember!.canRead(memberAuth)).toBe(true);
+      expect(asMember!.canWrite(memberAuth)).toBe(true);
+
+      expect(asNonMember!.canRead(nonMemberAuth)).toBe(true);
+      expect(asNonMember!.canWrite(nonMemberAuth)).toBe(false);
+    });
+
     it("should create a restricted space without global group", async () => {
       const result = await createSpaceAndGroup(adminAuth, {
         name: "Test Restricted Space",

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -684,14 +684,6 @@ export async function createSpaceAndGroup(
       );
     }
 
-    // Trim the name to prevent issues with leading/trailing whitespace
-    if (spaceKind === "regular" && !isRestricted) {
-      assert(
-        managementMode === "manual",
-        "Unrestricted regular spaces must use manual management mode."
-      );
-    }
-
     const nameAvailable = await SpaceResource.isNameAvailable(auth, name, t);
     if (!nameAvailable) {
       return new Err(

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -2638,6 +2638,93 @@ describe("SpaceResource group_permissions enforcement", () => {
     expect(space.canWrite(memberAuth)).toBe(true);
   });
 
+  // An open regular space attaches the workspace global group as a `reader` viewer, so everyone can
+  // read it; its own member groups hold `member` and are the only source of write. These mirror the
+  // restricted case above, for both ways a space's members can be managed.
+  it("enforces the table: manual member of an open space can write, non-member can only read", async () => {
+    const space = await SpaceFactory.regular(workspace);
+    const openRes = await space.updatePermissions(adminAuth, {
+      name: space.name,
+      isRestricted: false,
+      managementMode: "manual",
+      memberIds: [memberUser.sId],
+      editorIds: [],
+    });
+    expect(openRes.isOk()).toBe(true);
+
+    const nonMemberUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, nonMemberUser, {
+      role: "user",
+    });
+
+    // Built after the grants exist so their snapshots include them.
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      memberUser.sId,
+      workspace.sId
+    );
+    const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      nonMemberUser.sId,
+      workspace.sId
+    );
+
+    // Refetched, not reused: `space` holds the grant snapshot from before the update.
+    const openSpace = await SpaceResource.fetchById(adminAuth, space.sId);
+    expect(openSpace).not.toBeNull();
+    expect(openSpace!.isOpen()).toBe(true);
+
+    // The member group confers write; the global group's `reader` grant only confers read.
+    expect(openSpace!.canRead(memberAuth)).toBe(true);
+    expect(openSpace!.canWrite(memberAuth)).toBe(true);
+
+    expect(openSpace!.canRead(nonMemberAuth)).toBe(true);
+    expect(openSpace!.canWrite(nonMemberAuth)).toBe(false);
+  });
+
+  it("enforces the table: provisioned group member of an open space can write", async () => {
+    const provisionedGroup = await GroupFactory.provisioned(
+      workspace,
+      "Provisioned Space Members"
+    );
+    await GroupFactory.withMembers(adminAuth, provisionedGroup, [memberUser]);
+
+    const space = await SpaceFactory.regular(workspace);
+    const openRes = await space.updatePermissions(adminAuth, {
+      name: space.name,
+      isRestricted: false,
+      managementMode: "group",
+      groupIds: [provisionedGroup.sId],
+      editorGroupIds: [],
+    });
+    expect(openRes.isOk()).toBe(true);
+
+    const nonMemberUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, nonMemberUser, {
+      role: "user",
+    });
+
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      memberUser.sId,
+      workspace.sId
+    );
+    const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      nonMemberUser.sId,
+      workspace.sId
+    );
+
+    // Refetched, not reused: `space` holds the grant snapshot from before the update.
+    const openSpace = await SpaceResource.fetchById(adminAuth, space.sId);
+    expect(openSpace).not.toBeNull();
+    expect(openSpace!.isOpen()).toBe(true);
+
+    // In group management mode the provisioned group is the space's member group, so it is what
+    // carries write.
+    expect(openSpace!.canRead(memberAuth)).toBe(true);
+    expect(openSpace!.canWrite(memberAuth)).toBe(true);
+
+    expect(openSpace!.canRead(nonMemberAuth)).toBe(true);
+    expect(openSpace!.canWrite(nonMemberAuth)).toBe(false);
+  });
+
   it("enforces the table: member is denied when the space has no grants", async () => {
     // Member is in the space's inline group, but with the table cleared access is served from the
     // (empty) table — denied.

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -87,19 +87,20 @@ class SpaceGroupReference {
     });
   }
 
-  // A `reader` grant is read-only (viewer) access. It is held by the workspace global group on open
-  // spaces (attached as a viewer), and additionally by the member group on open *regular* spaces
-  // (where every group only reads — write comes from the role grants). Presence of any reader grant
-  // therefore means the space is open; such groups never confer membership by themselves.
+  // A `reader` grant is read-only (viewer) access. It is held by the workspace global group, and
+  // only by it, on open spaces — regular and project alike — where it is attached as a viewer.
+  // Presence of any reader grant therefore means the space is open; such groups never confer
+  // membership by themselves.
   isReader(): boolean {
     return this.grantType === "reader";
   }
 }
 
 // Space membership resolved from the caller's governance grants (see `SpaceResource.isMember`). The
-// membership verb differs by space kind because the grants `spaceGroupRoles` writes differ:
-// - Regular spaces grant `read` to every member — open spaces via the global group's `reader`,
-//   restricted spaces via their own groups' `member` — so holding `read` marks membership.
+// membership verb differs by space kind:
+// - Regular spaces treat everyone who can read as a member: on an open space that is the whole
+//   workspace, through the global group's `reader`. Membership there is about visibility, and the
+//   member group's `write` is a capability on top of it.
 // - Project (pod) spaces attach the workspace global group as a `reader` viewer on unrestricted
 //   projects, so `read` would count every workspace member as a member. `write` is held only by a
 //   project's editor (`admin`) and member (`member`) groups, so it is what marks an actual member.
@@ -1748,9 +1749,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   // The groups that make up this space's membership: its member group and, for projects, its editor
   // group (regular_auto in manual mode, provisioned in group mode). Groups holding only a read-only
-  // (`reader`) grant are excluded — the workspace global group attached to open spaces as a viewer,
-  // and on open regular spaces the member group too, since an open space confers access to everyone
-  // rather than through a member group. Use this to list who actually belongs to the space.
+  // (`reader`) grant are excluded — that is the workspace global group attached to an open space as
+  // a viewer, which makes the space visible without making anyone a member. Use this to list who
+  // actually belongs to the space.
   async fetchMembershipGroups(
     auth: Authenticator,
     transaction?: Transaction
@@ -1967,11 +1968,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // A space is open when the workspace global group is one of its groups.
     const isOpen = associatedGroups.some((group) => group.isGlobal());
 
-    // Open regular space: every group only reads; write comes from the role grants.
+    // Open regular space: the workspace global group is attached as a viewer, so it must only read
+    // — conferring write would hand write on every open space to every workspace member. Every
+    // other group is a member group and reads and writes, exactly as on a restricted space; that is
+    // what makes a space's member list meaningful even when the space is open.
     if (this.isRegular() && isOpen) {
       return groups.map((group) => ({
         groupId: group.id,
-        grantType: "reader",
+        grantType: group.isGlobal() ? "reader" : "member",
       }));
     }
 

--- a/front/migrations/20260825_reset_open_space_members.ts
+++ b/front/migrations/20260825_reset_open_space_members.ts
@@ -1,7 +1,7 @@
 import { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
@@ -10,6 +10,7 @@ import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { LightWorkspaceType } from "@app/types/user";
+import { Op } from "sequelize";
 
 // Empties the member group of every open regular space, so open spaces start from a clean slate now
 // that their members confer write (see `spaceGroupRoles`).
@@ -32,7 +33,23 @@ async function resetWorkspaceOpenSpaceMembers(
   // workspace global group as a `reader` viewer. Soft-deleted spaces are left out (default scope).
   const spaces = await SpaceResource.listWorkspaceSpaces(auth);
   const openRegularSpaces = spaces.filter((space) => space.isRegularAndOpen());
+  // Counts for every stage, logged once at the end: a run that removes nothing has to say which
+  // stage came up empty, or a no-op is indistinguishable from a bug.
+  const counts = {
+    spaces: spaces.length,
+    openRegularSpaces: openRegularSpaces.length,
+    memberGroups: 0,
+    groupMembers: 0,
+    removed: 0,
+  };
+  const report = () =>
+    logger.info(
+      { workspaceId: workspace.sId, execute, ...counts },
+      "Open regular space member reset"
+    );
+
   if (openRegularSpaces.length === 0) {
+    report();
     return;
   }
 
@@ -51,7 +68,9 @@ async function resetWorkspaceOpenSpaceMembers(
       groupKinds: ["regular_auto"],
     }
   );
+  counts.memberGroups = memberGroups.length;
   if (memberGroups.length === 0) {
+    report();
     return;
   }
 
@@ -66,34 +85,21 @@ async function resetWorkspaceOpenSpaceMembers(
   const allUserModelIds = [
     ...new Set(Object.values(userModelIdsByGroupModelId).flat()),
   ];
+  counts.groupMembers = allUserModelIds.length;
   if (allUserModelIds.length === 0) {
+    report();
     return;
   }
+  // Resolved for the audit log only. Membership is deliberately not a precondition: a group
+  // membership outlives the workspace membership it came with, and those rows are exactly the ones
+  // worth clearing — the user regains the group, and with it write on the space, if they rejoin.
   const users = await UserResource.fetchByModelIds(allUserModelIds);
+  const usersByModelId = new Map(users.map((user) => [user.id, user]));
 
-  // `dangerouslyRemoveMembers` rejects the whole batch if any user is no longer an active member of
-  // the workspace, and a group membership outlives the workspace membership it came with. Drop
-  // those users here: without an active workspace membership their groups do not resolve, so they
-  // hold no access to strip anyway.
-  const { memberships } = await MembershipResource.getActiveMemberships({
-    users,
-    workspace,
-  });
-  const activeUserModelIds = new Set(memberships.map((m) => m.userId));
-  const usersByModelId = new Map(
-    users
-      .filter((user) => activeUserModelIds.has(user.id))
-      .map((user) => [user.id, user])
-  );
-
-  let removed = 0;
+  const now = new Date();
   for (const group of memberGroups) {
-    const members = removeNulls(
-      (userModelIdsByGroupModelId[group.id] ?? []).map(
-        (userModelId) => usersByModelId.get(userModelId) ?? null
-      )
-    );
-    if (members.length === 0) {
+    const userModelIds = userModelIdsByGroupModelId[group.id] ?? [];
+    if (userModelIds.length === 0) {
       continue;
     }
 
@@ -102,41 +108,45 @@ async function resetWorkspaceOpenSpaceMembers(
       workspaceId: workspace.sId,
       spaceId: space?.sId,
       groupId: group.sId,
-      userIds: members.map((user) => user.sId),
+      userIds: removeNulls(
+        userModelIds.map((id) => usersByModelId.get(id)?.sId ?? null)
+      ),
     };
 
     if (!execute) {
       logger.info(context, "Dry run: would remove members of an open space");
-      removed += members.length;
+      counts.removed += userModelIds.length;
       continue;
     }
 
-    const res = await group.dangerouslyRemoveMembers(auth, {
-      users: members.map((user) => user.toJSON()),
-    });
-    if (res.isErr()) {
-      logger.error(
-        { ...context, error: res.error },
-        "Failed to remove members of an open space"
-      );
-      continue;
+    // `GroupResource.dangerouslyRemoveMembers` would refuse the whole batch as soon as one user has
+    // left the workspace, so the rows are ended here the same way it ends them, followed by the
+    // per-user group cache invalidation it would have done.
+    await GroupMembershipModel.update(
+      { endAt: now },
+      {
+        where: {
+          groupId: group.id,
+          userId: userModelIds,
+          workspaceId: workspace.id,
+          status: "active",
+          startAt: { [Op.lte]: now },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+        },
+      }
+    );
+    for (const userModelId of userModelIds) {
+      await GroupResource.invalidateGroupIdsCacheForUser({
+        user: { id: userModelId },
+        workspace: { id: workspace.id },
+      });
     }
 
     logger.info(context, "Removed members of an open space");
-    removed += members.length;
+    counts.removed += userModelIds.length;
   }
 
-  if (removed > 0) {
-    logger.info(
-      {
-        workspaceId: workspace.sId,
-        openRegularSpaces: openRegularSpaces.length,
-        removed,
-        execute,
-      },
-      "Reset open regular space members"
-    );
-  }
+  report();
 }
 
 makeScript(

--- a/front/migrations/20260825_reset_open_space_members.ts
+++ b/front/migrations/20260825_reset_open_space_members.ts
@@ -1,0 +1,170 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import { removeNulls } from "@app/types/shared/utils/general";
+import type { LightWorkspaceType } from "@app/types/user";
+
+// Empties the member group of every open regular space, so open spaces start from a clean slate now
+// that their members confer write (see `spaceGroupRoles`).
+//
+// Members conferred nothing on an open space before, and the settings panel did not show them, but
+// a space that was restricted and later opened kept its list. Left alone, those leftovers would
+// silently gain write on the next save.
+//
+// Only the space's own `regular_auto` group is emptied: provisioned groups are IdP-owned and shared
+// across spaces. Grants are untouched — with no members they confer nothing either way, and the
+// next `writeGroupPermissions` converges them. Idempotent.
+async function resetWorkspaceOpenSpaceMembers(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // `isRegularAndOpen` is the predicate this targets: a regular space whose groups include the
+  // workspace global group as a `reader` viewer. Soft-deleted spaces are left out (default scope).
+  const spaces = await SpaceResource.listWorkspaceSpaces(auth);
+  const openRegularSpaces = spaces.filter((space) => space.isRegularAndOpen());
+  if (openRegularSpaces.length === 0) {
+    return;
+  }
+
+  // Resolved in bulk rather than per space: one query for the groups, one for their memberships.
+  const groupModelIds = [
+    ...new Set(
+      openRegularSpaces.flatMap((space) =>
+        space.groups.map((ref) => ref.groupId)
+      )
+    ),
+  ];
+  const memberGroups = await GroupResource.fetchByModelIds(
+    auth,
+    groupModelIds,
+    {
+      groupKinds: ["regular_auto"],
+    }
+  );
+  if (memberGroups.length === 0) {
+    return;
+  }
+
+  const spaceByGroupModelId = new Map(
+    openRegularSpaces.flatMap((space) =>
+      space.groups.map((ref) => [ref.groupId, space] as const)
+    )
+  );
+
+  const userModelIdsByGroupModelId =
+    await GroupResource.getActiveMembershipsForGroups(auth, memberGroups);
+  const allUserModelIds = [
+    ...new Set(Object.values(userModelIdsByGroupModelId).flat()),
+  ];
+  if (allUserModelIds.length === 0) {
+    return;
+  }
+  const users = await UserResource.fetchByModelIds(allUserModelIds);
+
+  // `dangerouslyRemoveMembers` rejects the whole batch if any user is no longer an active member of
+  // the workspace, and a group membership outlives the workspace membership it came with. Drop
+  // those users here: without an active workspace membership their groups do not resolve, so they
+  // hold no access to strip anyway.
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    users,
+    workspace,
+  });
+  const activeUserModelIds = new Set(memberships.map((m) => m.userId));
+  const usersByModelId = new Map(
+    users
+      .filter((user) => activeUserModelIds.has(user.id))
+      .map((user) => [user.id, user])
+  );
+
+  let removed = 0;
+  for (const group of memberGroups) {
+    const members = removeNulls(
+      (userModelIdsByGroupModelId[group.id] ?? []).map(
+        (userModelId) => usersByModelId.get(userModelId) ?? null
+      )
+    );
+    if (members.length === 0) {
+      continue;
+    }
+
+    const space = spaceByGroupModelId.get(group.id);
+    const context = {
+      workspaceId: workspace.sId,
+      spaceId: space?.sId,
+      groupId: group.sId,
+      userIds: members.map((user) => user.sId),
+    };
+
+    if (!execute) {
+      logger.info(context, "Dry run: would remove members of an open space");
+      removed += members.length;
+      continue;
+    }
+
+    const res = await group.dangerouslyRemoveMembers(auth, {
+      users: members.map((user) => user.toJSON()),
+    });
+    if (res.isErr()) {
+      logger.error(
+        { ...context, error: res.error },
+        "Failed to remove members of an open space"
+      );
+      continue;
+    }
+
+    logger.info(context, "Removed members of an open space");
+    removed += members.length;
+  }
+
+  if (removed > 0) {
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        openRegularSpaces: openRegularSpaces.length,
+        removed,
+        execute,
+      },
+      "Reset open regular space members"
+    );
+  }
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting open regular space member reset");
+
+    if (wId) {
+      const workspace = await WorkspaceResource.fetchById(wId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      await resetWorkspaceOpenSpaceMembers(
+        execute,
+        logger,
+        renderLightWorkspaceType({ workspace })
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await resetWorkspaceOpenSpaceMembers(execute, logger, workspace);
+        },
+        { concurrency: 4 }
+      );
+    }
+
+    logger.info("Open regular space member reset completed");
+  }
+);


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/10189

Allow to add member to public spaces which will be the writers of the space

<img width="550" height="550" alt="image" src="https://github.com/user-attachments/assets/f7404a58-6b14-4960-8f09-2963e8f6f49b" />

<img width="550" height="550" alt="image" src="https://github.com/user-attachments/assets/aba4c351-7632-4763-8df2-230c285242a1" />


## Tests

tested locally 

## Risk

can be reverted

## Deploy Plan

run script to remove membership on regular_open spaces so we start from clean state
deploy front 
