### PR TITLE
[front] use consumption ES index for users export

### DIFF
--- a/front-api/routes/w/[wId]/analytics/agents-export.ts
+++ b/front-api/routes/w/[wId]/analytics/agents-export.ts
@@ -4,8 +4,7 @@ import {
   fetchAgentExportRows,
   toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
-import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
-import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
+import { buildDaysConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/period";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
@@ -26,12 +25,7 @@ app.get("/", ensureIsManager(), validate("query", QuerySchema), async (ctx) => {
 
   const { days } = ctx.req.valid("query");
 
-  const period = await resolveConsumptionPeriod(auth, { kind: "days", days });
-  const baseQuery = buildConsumptionScopeQuery({
-    auth,
-    startDate: period.startDate,
-    endDate: period.endDate,
-  });
+  const baseQuery = await buildDaysConsumptionScopeQuery(auth, days);
 
   const result = await fetchAgentExportRows(baseQuery, auth, true);
 

--- a/front-api/routes/w/[wId]/analytics/users-export.ts
+++ b/front-api/routes/w/[wId]/analytics/users-export.ts
@@ -1,12 +1,10 @@
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { buildDaysConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/period";
 import {
   fetchUserExportRows,
   USER_EXPORT_HEADERS,
 } from "@app/lib/api/analytics/users_export";
-import {
-  buildAgentAnalyticsBaseQuery,
-  daysToDateRange,
-} from "@app/lib/api/assistant/observability/utils";
+import { daysToDateRange } from "@app/lib/api/assistant/observability/utils";
 import { timezoneSchema } from "@app/lib/api/timezone";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import { ensureIsManager } from "@front-api/middlewares/ensure_role";
@@ -30,10 +28,7 @@ app.get("/", ensureIsManager(), validate("query", QuerySchema), async (ctx) => {
   const { days, timezone } = ctx.req.valid("query");
   const owner = auth.getNonNullableWorkspace();
 
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
-    days,
-  });
+  const baseQuery = await buildDaysConsumptionScopeQuery(auth, days);
 
   const { startDate, endDate } = daysToDateRange(days, timezone);
 

--- a/front/lib/api/analytics/agents_export.ts
+++ b/front/lib/api/analytics/agents_export.ts
@@ -1,9 +1,10 @@
 import {
-  AGENT_MESSAGE_ID_FIELD,
   CARDINALITY_PRECISION_THRESHOLD,
   CONSUMPTION_DIMENSION_FIELDS,
   CONVERSATION_ID_FIELD,
   CREDIT_MICRO_FIELD,
+  MAX_EXPORT_TERMS_SIZE,
+  uniqueMessagesCardinalityAgg,
 } from "@app/lib/api/analytics/consumption/scope";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
@@ -105,17 +106,12 @@ export async function fetchAgentExportRows(
     {
       aggregations: {
         by_agent: {
-          terms: { field: CONSUMPTION_DIMENSION_FIELDS.agent, size: 10000 },
+          terms: {
+            field: CONSUMPTION_DIMENSION_FIELDS.agent,
+            size: MAX_EXPORT_TERMS_SIZE,
+          },
           aggs: {
-            // Consumption documents are split per LLM step and per tool call,
-            // so a message contributes several documents to the same agent
-            // bucket: dedupe by agent_message_id to count distinct messages.
-            unique_messages: {
-              cardinality: {
-                field: AGENT_MESSAGE_ID_FIELD,
-                precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
-              },
-            },
+            unique_messages: uniqueMessagesCardinalityAgg(),
             unique_users: {
               cardinality: {
                 field: CONSUMPTION_DIMENSION_FIELDS.user,

--- a/front/lib/api/analytics/consumption/period.ts
+++ b/front/lib/api/analytics/consumption/period.ts
@@ -1,8 +1,10 @@
+import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
 import type { Authenticator } from "@app/lib/auth";
 import { getCachedMetronomeCurrentBillingPeriod } from "@app/lib/metronome/contracts";
 import logger from "@app/logger/logger";
 import { isCreditPricedPlan } from "@app/types/plan";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
 /**
@@ -118,4 +120,19 @@ export async function resolveConsumptionPeriod(
     default:
       assertNever(input);
   }
+}
+
+// Shared by the "last N days" export endpoints (agents, users, source, ...):
+// resolves the trailing window and scopes a consumption-index query to it in
+// one call, so each caller doesn't redo the same two-step wiring.
+export async function buildDaysConsumptionScopeQuery(
+  auth: Authenticator,
+  days: number
+): Promise<estypes.QueryDslQueryContainer> {
+  const period = await resolveConsumptionPeriod(auth, { kind: "days", days });
+  return buildConsumptionScopeQuery({
+    auth,
+    startDate: period.startDate,
+    endDate: period.endDate,
+  });
 }

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -36,6 +36,24 @@ export const TRIGGER_ID_FIELD = "trigger_id";
 
 export const CARDINALITY_PRECISION_THRESHOLD = 40_000;
 
+// Upper bound on the number of buckets a terms aggregation over an export's
+// full dimension (every agent, every user, ...) can return. Large enough that
+// no real workspace hits it, so every value comes back in one page.
+export const MAX_EXPORT_TERMS_SIZE = 10_000;
+
+// Consumption documents are split per LLM step and per tool call, so a
+// message contributes several documents to the same bucket: dedupe by
+// agent_message_id to count distinct messages, at the same precision as the
+// rest of the consumption module's cardinality aggregations.
+export function uniqueMessagesCardinalityAgg(): estypes.AggregationsAggregationContainer {
+  return {
+    cardinality: {
+      field: AGENT_MESSAGE_ID_FIELD,
+      precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+    },
+  };
+}
+
 export type ConsumptionTopDimension =
   | ConsumptionScopeDimension
   | "conversation";

--- a/front/lib/api/analytics/export_tables.test.ts
+++ b/front/lib/api/analytics/export_tables.test.ts
@@ -3,6 +3,7 @@ import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { Ok } from "@app/types/shared/result";
+import moment from "moment-timezone";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Keep `bucketsToArray` (and everything else) real; only stub the
@@ -113,5 +114,101 @@ describe("exportTable agents", () => {
     expect(row!.distinctUsersReached).toBe(2);
     expect(row!.distinctConversations).toBe(1);
     expect(row!.credits).toBe(2);
+  });
+});
+
+describe("exportTable users", () => {
+  beforeEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("queries the consumption index with a half-open completed_at range and returns its aggregated metrics", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+
+    // The user's membership is created "now" by createResourceTest, so the
+    // window has to cover the present rather than a fixed historical range
+    // (unlike the agents test, this one hits the real memberships table).
+    const today = moment.utc();
+    const startDate = today.clone().subtract(30, "days").format("YYYY-MM-DD");
+    const endDate = today.format("YYYY-MM-DD");
+    const exclusiveEndDate = today.clone().add(1, "day").format("YYYY-MM-DD");
+    const lastMessageAt = today.clone().subtract(1, "day");
+
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Ok({
+        took: 1,
+        timed_out: false,
+        _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+        hits: { total: { value: 0, relation: "eq" }, hits: [] },
+        aggregations: {
+          by_user: {
+            buckets: [
+              {
+                key: user.sId,
+                doc_count: 5,
+                unique_messages: { value: 4 },
+                last_message: { value: lastMessageAt.valueOf() },
+                active_days: { buckets: [{ doc_count: 1 }, { doc_count: 1 }] },
+                credit_micro: { value: 3_000_000 },
+              },
+            ],
+          },
+        },
+      })
+    );
+
+    const result = await exportTable({
+      auth: authenticator,
+      table: "users",
+      startDate,
+      endDate,
+      timezone: "UTC",
+      owner: workspace,
+      includeHiddenAgents: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    if (result.value.table !== "users") {
+      throw new Error(`Expected "users" table, got "${result.value.table}"`);
+    }
+
+    // Regression: exportUsers used to build its query with the legacy,
+    // timestamp-based buildAgentAnalyticsBaseQuery, which the consumption
+    // index does not have a `timestamp` field for — every user row silently
+    // came back with zero metrics. It must now query the consumption index
+    // with a half-open [startDate, endDate) `completed_at` range, bumping the
+    // inclusive `endDate` calendar day up by one day.
+    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(1);
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          {
+            bool: {
+              filter: [
+                { term: { workspace_id: workspace.sId } },
+                {
+                  range: {
+                    completed_at: { gte: startDate, lt: exclusiveEndDate },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    const row = result.value.rows.find((r) => r.userId === user.sId);
+    expect(row).toBeDefined();
+    expect(row!.messageCount).toBe(4);
+    expect(row!.activeDaysCount).toBe(2);
+    expect(row!.credits).toBe(3);
+    expect(row!.lastMessageSent).toBe(lastMessageAt.format("YYYY-MM-DD"));
   });
 });

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -45,6 +45,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WorkspaceType } from "@app/types/user";
+import type { estypes } from "@elastic/elasticsearch";
 import moment from "moment-timezone";
 
 type AnalyticsExportTable =
@@ -211,7 +212,7 @@ export async function exportTable({
         includeHiddenAgents,
       });
     case "users":
-      return exportUsers({ startDate, endDate, timezone, owner });
+      return exportUsers({ auth, startDate, endDate, timezone, owner });
     case "skills":
       return exportSkills({ auth, startDate, endDate, timezone, owner });
     case "skill_usage":
@@ -252,6 +253,26 @@ export function stringifyExportTableAsCsv(data: ExportTableData): string {
     default:
       assertNever(data);
   }
+}
+
+// exportTable's startDate/endDate are inclusive calendar days ("YYYY-MM-DD"),
+// while the consumption index's completed_at range is half-open ([startDate,
+// endDate)); bump the upper bound to the start of the following day so the
+// whole endDate day is included.
+function buildExportConsumptionScopeQuery(
+  auth: Authenticator,
+  { startDate, endDate }: { startDate: string; endDate: string }
+): estypes.QueryDslQueryContainer {
+  const exclusiveEndDate = moment
+    .utc(endDate)
+    .add(1, "day")
+    .format("YYYY-MM-DD");
+
+  return buildConsumptionScopeQuery({
+    auth,
+    startDate,
+    endDate: exclusiveEndDate,
+  });
 }
 
 async function exportUsageMetrics({
@@ -391,19 +412,9 @@ async function exportAgents({
   endDate: string;
   includeHiddenAgents: boolean;
 }): Promise<Result<ExportTableData, Error>> {
-  // The consumption index's completed_at range is half-open ([startDate,
-  // endDate)), while startDate/endDate here are inclusive calendar days
-  // ("YYYY-MM-DD"); bump the upper bound to the start of the following day so
-  // the whole endDate day is included.
-  const exclusiveEndDate = moment
-    .utc(endDate)
-    .add(1, "day")
-    .format("YYYY-MM-DD");
-
-  const baseQuery = buildConsumptionScopeQuery({
-    auth,
+  const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
-    endDate: exclusiveEndDate,
+    endDate,
   });
 
   const result = await fetchAgentExportRows(
@@ -426,18 +437,19 @@ async function exportAgents({
 }
 
 async function exportUsers({
+  auth,
   startDate,
   endDate,
   timezone,
   owner,
 }: {
+  auth: Authenticator;
   startDate: string;
   endDate: string;
   timezone: string;
   owner: WorkspaceType;
 }): Promise<Result<ExportTableData, Error>> {
-  const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId: owner.sId,
+  const baseQuery = buildExportConsumptionScopeQuery(auth, {
     startDate,
     endDate,
   });

--- a/front/lib/api/analytics/users_export.test.ts
+++ b/front/lib/api/analytics/users_export.test.ts
@@ -1,5 +1,5 @@
 import { fetchUserExportRows } from "@app/lib/api/analytics/users_export";
-import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -13,7 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("@app/lib/api/elasticsearch", async (importActual) => {
   const actual =
     await importActual<typeof import("@app/lib/api/elasticsearch")>();
-  return { ...actual, searchAnalytics: vi.fn() };
+  return { ...actual, searchConsumptionAnalytics: vi.fn() };
 });
 
 // The group memberships are read from the read replica; in tests there is no
@@ -28,7 +28,7 @@ vi.mock("@app/lib/resources/storage", async (importActual) => {
 });
 
 function mockEsMetrics(buckets: unknown[] = []) {
-  vi.mocked(searchAnalytics).mockResolvedValue(
+  vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
     new Ok({
       took: 1,
       timed_out: false,
@@ -60,9 +60,10 @@ describe("fetchUserExportRows", () => {
       {
         key: member.sId,
         doc_count: 2,
+        unique_messages: { value: 2 },
         last_message: { value: Date.UTC(2025, 0, 12, 8, 0, 0) },
         active_days: { buckets: [{ doc_count: 1 }, { doc_count: 1 }] },
-        credits: { value: 41.6 },
+        credit_micro: { value: 41_600_000 },
       },
     ]);
 

--- a/front/lib/api/analytics/users_export.ts
+++ b/front/lib/api/analytics/users_export.ts
@@ -1,4 +1,15 @@
-import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import {
+  COMPLETED_AT_FIELD,
+  CONSUMPTION_DIMENSION_FIELDS,
+  CREDIT_MICRO_FIELD,
+  MAX_EXPORT_TERMS_SIZE,
+  uniqueMessagesCardinalityAgg,
+} from "@app/lib/api/analytics/consumption/scope";
+import {
+  bucketsToArray,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { microCreditsToCredits } from "@app/lib/credits/units";
 import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { getUserGroupMemberships } from "@app/lib/workspace_usage";
@@ -12,9 +23,10 @@ import { Op } from "sequelize";
 type TopUserExportBucket = {
   key: string;
   doc_count: number;
+  unique_messages?: estypes.AggregationsCardinalityAggregate;
   last_message?: estypes.AggregationsMaxAggregate;
   active_days?: estypes.AggregationsDateHistogramAggregate;
-  credits?: estypes.AggregationsSumAggregate;
+  credit_micro?: estypes.AggregationsSumAggregate;
 };
 
 type TopUsersExportAggs = {
@@ -64,7 +76,7 @@ export async function fetchUserExportRows({
   endDate: Date;
   timezone: string;
 }): Promise<Result<UserExportRow[], Error>> {
-  const esResult = await searchAnalytics<never, TopUsersExportAggs>(
+  const esResult = await searchConsumptionAnalytics<never, TopUsersExportAggs>(
     {
       bool: {
         filter: [baseQuery],
@@ -73,21 +85,22 @@ export async function fetchUserExportRows({
     {
       aggregations: {
         by_user: {
-          terms: { field: "user_id", size: 10000 },
+          terms: {
+            field: CONSUMPTION_DIMENSION_FIELDS.user,
+            size: MAX_EXPORT_TERMS_SIZE,
+          },
           aggs: {
-            last_message: { max: { field: "timestamp" } },
+            unique_messages: uniqueMessagesCardinalityAgg(),
+            last_message: { max: { field: COMPLETED_AT_FIELD } },
             active_days: {
               date_histogram: {
-                field: "timestamp",
+                field: COMPLETED_AT_FIELD,
                 calendar_interval: "day",
                 min_doc_count: 1,
                 time_zone: timezone,
               },
             },
-            // Billed credits per execution via `cost.billable_awu` (0 for the
-            // non-billable errored-terminal part), so no status filter is needed;
-            // the count metrics above stay inclusive of all activity.
-            credits: { sum: { field: "cost.billable_awu" } },
+            credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
           },
         },
       },
@@ -110,7 +123,7 @@ export async function fetchUserExportRows({
       return [
         String(b.key),
         {
-          messageCount: b.doc_count,
+          messageCount: Math.round(b.unique_messages?.value ?? 0),
           lastMessageSent:
             typeof lastMessageMs === "number"
               ? moment(lastMessageMs).tz(timezone).format("YYYY-MM-DD")
@@ -118,7 +131,9 @@ export async function fetchUserExportRows({
           activeDaysCount: Array.isArray(activeDaysBuckets)
             ? activeDaysBuckets.filter((d) => d.doc_count > 0).length
             : 0,
-          credits: Math.round(b.credits?.value ?? 0),
+          credits: Math.round(
+            microCreditsToCredits(b.credit_micro?.value ?? 0)
+          ),
         },
       ] as const;
     })


### PR DESCRIPTION
## Description

Same move as the agents export ([#31087](https://github.com/dust-tt/dust/pull/31087)), applied to the users table: it read from the old, message-level Elasticsearch index while the rest of the consumption dashboard already reads from the newer consumption index. This switches the users export over too, for both places it's produced: the dedicated users-export endpoint and the `users` table of the combined export endpoint.

Same reasoning as before: the consumption index stores data at a finer grain, so metrics are computed with distinct-count aggregations rather than raw document counts.

The CSV output and what the user sees is unchanged — only the underlying data source and computation method changed.

## Tests

- Updated the existing users-export test to the new data source.
- Added a regression test for the combined export endpoint's `users` table, covering the same date-range bug class caught in the agents PR.
- Confirmed the neighboring export-endpoint test suites (100 tests across `front-api/routes/.../analytics`) still pass.

## Risk

- Same as the agents PR: other tables in the export panel still read from the old index, so the panel now sources different tables from different indices.

## Deploy Plan

Standard deploy, no migration or feature flag needed. Stacked on top of #31087.
