### PR TITLE
[front] fix: three retry-boundary bugs in the agent loop

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -379,8 +379,11 @@ export function useAgentMessageStream({
   // thinking (chain_of_thought) and writing (tokens), flushing completed
   // segments as activity steps on each switch.
   const lastClassification = useRef<"tokens" | "chain_of_thought" | null>(null);
-  // Tracks the traceId of the last CoT event to detect Temporal retry boundaries.
-  const lastCoTTraceId = useRef<string | null>(null);
+  // Tracks the traceId of the last generation event to detect Temporal retry
+  // boundaries. Any classification counts: a retry that emits no chain of thought
+  // (a `none`-effort model, e.g. after an auto-stream failover) must reset the
+  // accumulators too, otherwise its answer is appended to the dead call's text.
+  const lastTraceId = useRef<string | null>(null);
   // Tracks the agent-loop step of the last generation event. Combined with a
   // traceId change, an unchanged step number means the SAME step was re-run
   // (Temporal activity retry) rather than the loop advancing to a new step. It is
@@ -448,7 +451,7 @@ export function useAgentMessageStream({
           ) {
             content.current = "";
             chainOfThought.current = "";
-            lastCoTTraceId.current = null;
+            lastTraceId.current = null;
             retryCoTBuffer.current = null;
             currentStep.current = null;
             mapMessagesWithAutoScroll((m) => {
@@ -473,45 +476,56 @@ export function useAgentMessageStream({
             classification === "tokens" ||
             classification === "chain_of_thought"
           ) {
-            // When a CoT event arrives with a new traceId, the Temporal activity
-            // was retried. Reset content.current (prevents stale tokens from
-            // being flushed at the transition boundary) and enter shadow-buffer
-            // mode: new CoT tokens are compared against what's already shown
-            // rather than appended, so an identical retry is invisible to the
-            // user.
-            if (classification === "chain_of_thought") {
-              const newTraceId = generationTokens.traceId;
-              if (
-                newTraceId &&
-                lastCoTTraceId.current !== null &&
-                newTraceId !== lastCoTTraceId.current
-              ) {
-                content.current = "";
+            // A new traceId means these tokens come from a different LLM call than
+            // the previous ones: the Temporal activity was retried, possibly on
+            // another model (auto-stream failover). Reset the accumulators so the
+            // new call's output replaces the dead call's partial output instead of
+            // being appended to it, and drop the inline steps already committed for
+            // this step.
+            const newTraceId = generationTokens.traceId;
+            if (
+              newTraceId &&
+              lastTraceId.current !== null &&
+              newTraceId !== lastTraceId.current
+            ) {
+              content.current = "";
+
+              if (classification === "chain_of_thought") {
+                // Enter shadow-buffer mode: new CoT tokens are compared against
+                // what's already shown rather than appended, so a same-model retry
+                // re-emitting the same CoT prefix stays invisible to the user.
                 retryCoTBuffer.current = "";
-                if (
-                  currentStep.current !== null &&
-                  eventStep === currentStep.current
-                ) {
-                  mapMessagesWithAutoScroll((m) => {
-                    if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
-                      return m;
-                    }
-                    return {
-                      ...m,
-                      streaming: {
-                        ...m.streaming,
-                        inlineActivitySteps:
-                          m.streaming.inlineActivitySteps.filter(
-                            (s) => s.step !== eventStep
-                          ),
-                      },
-                    };
-                  });
-                }
+              } else {
+                // Plain text with nothing to diff against: drop the dead call's
+                // unflushed CoT so the classification transition below does not
+                // commit it as a thinking step.
+                chainOfThought.current = "";
+                retryCoTBuffer.current = null;
               }
-              if (newTraceId) {
-                lastCoTTraceId.current = newTraceId;
+
+              if (
+                currentStep.current !== null &&
+                eventStep === currentStep.current
+              ) {
+                mapMessagesWithAutoScroll((m) => {
+                  if (!isAgentMessageWithStreaming(m) || m.sId !== sId) {
+                    return m;
+                  }
+                  return {
+                    ...m,
+                    streaming: {
+                      ...m.streaming,
+                      inlineActivitySteps:
+                        m.streaming.inlineActivitySteps.filter(
+                          (s) => s.step !== eventStep
+                        ),
+                    },
+                  };
+                });
               }
+            }
+            if (newTraceId) {
+              lastTraceId.current = newTraceId;
             }
 
             currentStep.current = eventStep;

--- a/front/lib/api/llm/transitionLLM.test.ts
+++ b/front/lib/api/llm/transitionLLM.test.ts
@@ -119,7 +119,7 @@ describe("toBaseMessages", () => {
       ],
     };
 
-    expect(toBaseMessages(message)).toEqual([
+    expect(toBaseMessages(message, { targetProviderId: "anthropic" })).toEqual([
       { role: "assistant", type: "text", content: { value: "hi" } },
       {
         role: "assistant",
@@ -146,7 +146,7 @@ describe("toBaseMessages", () => {
       ],
     };
 
-    expect(toBaseMessages(message)).toEqual([
+    expect(toBaseMessages(message, { targetProviderId: "openai" })).toEqual([
       {
         role: "assistant",
         type: "tool_call_request",
@@ -241,7 +241,9 @@ describe("withMessageCacheBreakpoints", () => {
     ];
 
     const result = withMessageCacheBreakpoints(
-      conversation.flatMap(toBaseMessages),
+      conversation.flatMap((message) =>
+        toBaseMessages(message, { targetProviderId: "anthropic" })
+      ),
       conversation[0],
       { explicitTailBreakpoint: true }
     );
@@ -308,7 +310,8 @@ describe("toBaseMessages — reasoning signatures", () => {
       reasoningMessage({
         provider: "anthropic",
         metadata: JSON.stringify({ encrypted_content: "anthropic-sig" }),
-      })
+      }),
+      { targetProviderId: "anthropic" }
     );
     expect(result).toEqual([
       {
@@ -325,7 +328,8 @@ describe("toBaseMessages — reasoning signatures", () => {
       reasoningMessage({
         provider: "google_ai_studio",
         metadata: JSON.stringify({ encrypted_content: "gemini-thought-sig" }),
-      })
+      }),
+      { targetProviderId: "google_ai_studio" }
     );
     expect(result).toEqual([
       {
@@ -345,7 +349,8 @@ describe("toBaseMessages — reasoning signatures", () => {
           id: "rs_123",
           encrypted_content: "gAAAA-encrypted-blob",
         }),
-      })
+      }),
+      { targetProviderId: "openai" }
     );
     expect(result).toEqual([
       {
@@ -363,7 +368,8 @@ describe("toBaseMessages — reasoning signatures", () => {
       reasoningMessage({
         provider: "fireworks",
         metadata: JSON.stringify({ id: "rs_fireworks_123" }),
-      })
+      }),
+      { targetProviderId: "fireworks" }
     );
     expect(result).toEqual([
       {
@@ -385,7 +391,8 @@ describe("OpenAI reasoning round-trip — persisted metadata to Responses input"
           id: "rs_123",
           encrypted_content: "gAAAA-encrypted-blob",
         }),
-      })
+      }),
+      { targetProviderId: "openai" }
     );
     if (baseMessage.type !== "reasoning") {
       throw new Error("Expected a reasoning BaseMessage.");
@@ -408,7 +415,8 @@ describe("Fireworks reasoning round-trip — persisted metadata to Responses inp
         provider: "fireworks",
         metadata: JSON.stringify({ id: "rs_fireworks_empty" }),
         reasoning: "",
-      })
+      }),
+      { targetProviderId: "fireworks" }
     );
     if (baseMessage.type !== "reasoning") {
       throw new Error("Expected a reasoning BaseMessage.");
@@ -465,7 +473,7 @@ describe("Fireworks reasoning round-trip — persisted metadata to Responses inp
       ],
     };
 
-    expect(toBaseMessages(message)).toEqual([
+    expect(toBaseMessages(message, { targetProviderId: "fireworks" })).toEqual([
       {
         role: "assistant",
         type: "reasoning",

--- a/front/lib/api/llm/transitionLLM.ts
+++ b/front/lib/api/llm/transitionLLM.ts
@@ -176,9 +176,17 @@ function labToPassthroughProvider(
 
 /**
  * Converts an old-system message to new BaseMessage(s).
+ *
+ * `targetProviderId` is the provider the payload is about to be sent to. Reasoning is
+ * provider-scoped replay state — an Anthropic thinking signature or an OpenAI reasoning item id —
+ * so reasoning produced by another provider is dropped rather than replayed under a signature the
+ * target provider will reject. This matters whenever the provider changes mid-message, which is
+ * what an auto-stream model failover does. Text and tool calls are provider-agnostic and always
+ * kept. Passthrough blocks carry their own provider and are dropped by each provider's converter.
  */
 export function toBaseMessages(
-  message: ModelMessageTypeMultiActionsWithoutContentFragment
+  message: ModelMessageTypeMultiActionsWithoutContentFragment,
+  { targetProviderId }: { targetProviderId: ModelProviderIdType }
 ): BaseMessage[] {
   switch (message.role) {
     case "user":
@@ -238,6 +246,11 @@ export function toBaseMessages(
                 },
               ];
             case "reasoning": {
+              // Reasoning from another provider cannot be replayed: its signature is only valid
+              // for the provider that produced it.
+              if (c.value.provider && c.value.provider !== targetProviderId) {
+                return [];
+              }
               const reasoning = c.value.reasoning ?? "";
               const { id, encryptedContent } = parseReasoningMetadata(
                 c.value.metadata
@@ -714,7 +727,11 @@ abstract class BaseTransition extends LLM {
     const { conversation, prompt } = streamParameters;
 
     const baseMessages = withMessageCacheBreakpoints(
-      conversation.messages.flatMap(toBaseMessages),
+      conversation.messages.flatMap((message) =>
+        toBaseMessages(message, {
+          targetProviderId: this.metadata.clientId,
+        })
+      ),
       conversation.messages[0],
       { explicitTailBreakpoint }
     );

--- a/front/lib/resources/agent_step_content/cache.ts
+++ b/front/lib/resources/agent_step_content/cache.ts
@@ -142,6 +142,45 @@ export async function warmAgentStepContentCacheMany(
   }
 }
 
+/**
+ * Evicts specific `(step, index)` fields of an agent message's cache hash. Used when step contents
+ * are dropped rather than superseded (see `createNewVersions` step truncation). Best-effort:
+ * failures are logged and ignored, a stale field is re-read from PG on the next miss anyway.
+ */
+export async function evictAgentStepContentCacheFields({
+  workspaceId,
+  agentMessageId,
+  fields,
+}: {
+  workspaceId: ModelId;
+  agentMessageId: ModelId;
+  fields: { step: number; index: number }[];
+}): Promise<void> {
+  if (fields.length === 0) {
+    return;
+  }
+
+  try {
+    const redis = await getRedisCacheClient({
+      origin: "agent_step_content_cache",
+    });
+
+    await redis.hDel(
+      agentStepContentCacheKey({ workspaceId, agentMessageId }),
+      fields.map((field) => agentStepContentHashField(field))
+    );
+  } catch (err) {
+    logger.warn(
+      {
+        err: normalizeError(err),
+        agentMessageId,
+        count: fields.length,
+      },
+      "Failed to evict agent step content cache fields"
+    );
+  }
+}
+
 function isCachedAgentStepContent(
   value: unknown
 ): value is CachedAgentStepContent {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -1,10 +1,12 @@
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
+import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import type { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import type { CachedAgentStepContent } from "@app/lib/resources/agent_step_content/cache";
 import {
+  evictAgentStepContentCacheFields,
   tryHydrateAgentStepContentsFromCache,
   warmAgentStepContentCacheMany,
 } from "@app/lib/resources/agent_step_content/cache";
@@ -513,9 +515,16 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
    * Bulk-insert step contents with correct per-(step, index) versioning
    * (one version lookup + one INSERT). Prefer this over looping
    * `createNewVersion` when persisting multiple contents for a step.
+   *
+   * `replacesStep` marks a write that carries the *whole* output of a step (as opposed to appending
+   * a single content to it, like the error content published on failure). Versioning is per
+   * `(step, index)`, so a re-run of a step that emits fewer contents than the previous attempt
+   * would leave the previous attempt's trailing indexes behind as the latest version of their own
+   * index, mixing two runs into one message. Passing `replacesStep` drops those trailing rows.
    */
   static async createNewVersions(
-    blobs: Omit<CreationAttributes<AgentStepContentModel>, "version">[]
+    blobs: Omit<CreationAttributes<AgentStepContentModel>, "version">[],
+    { replacesStep = false }: { replacesStep?: boolean } = {}
   ): Promise<AgentStepContentResource[]> {
     if (blobs.length === 0) {
       return [];
@@ -532,15 +541,16 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       "createNewVersions requires all blobs to share the same workspaceId, agentMessageId, and step"
     );
 
-    const indexes = [...new Set(blobs.map((blob) => blob.index))];
+    // Scoped to the whole step rather than to the indexes being written: the unique
+    // (workspaceId, agentMessageId, step, index, version) index covers this prefix, so it costs the
+    // same and it is what lets us detect trailing rows from a previous attempt below.
     const existingContent = await this.model.findAll({
       where: {
         workspaceId,
         agentMessageId,
         step,
-        index: { [Op.in]: indexes },
       },
-      attributes: ["index", "version"],
+      attributes: ["id", "index", "version"],
     });
 
     const maxVersionByIndex = new Map<number, number>();
@@ -570,7 +580,93 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
 
     await warmAgentStepContentCacheMany(resources.map((r) => r.toCachedJSON()));
 
+    if (replacesStep) {
+      // Read the ids off a persisted row: on the creation blobs they are creation attributes and
+      // therefore optional, while `bulkCreate` guarantees them here.
+      const [created] = resources;
+      await this.dropTrailingStepContents({
+        workspaceId: created.workspaceId,
+        agentMessageId: created.agentMessageId,
+        step: created.step,
+        existingContent,
+        lastWrittenIndex: Math.max(...blobs.map((blob) => blob.index)),
+      });
+    }
+
     return resources;
+  }
+
+  /**
+   * Drops the rows of a step sitting past `lastWrittenIndex`, i.e. contents of a previous attempt
+   * that the attempt we just persisted did not supersede. Rows referenced by a tool execution are
+   * left alone: the FK is `RESTRICT` and a referenced content means that attempt's tools actually
+   * ran, which is not ours to unwind.
+   */
+  private static async dropTrailingStepContents({
+    workspaceId,
+    agentMessageId,
+    step,
+    existingContent,
+    lastWrittenIndex,
+  }: {
+    workspaceId: ModelId;
+    agentMessageId: ModelId;
+    step: number;
+    existingContent:
+      | Attributes<AgentStepContentModel>[]
+      | AgentStepContentModel[];
+    lastWrittenIndex: number;
+  }): Promise<void> {
+    const trailing = existingContent.filter(
+      (row) => row.index > lastWrittenIndex
+    );
+    if (trailing.length === 0) {
+      return;
+    }
+
+    const trailingIds = trailing.map((row) => row.id);
+    const toolExecutions = await AgentStepContentToolExecutionModel.findAll({
+      where: {
+        workspaceId,
+        stepContentId: { [Op.in]: trailingIds },
+      },
+      attributes: ["stepContentId"],
+    });
+    const referencedIds = new Set(
+      toolExecutions.map((execution) => execution.stepContentId)
+    );
+
+    const droppable = trailing.filter((row) => !referencedIds.has(row.id));
+    if (droppable.length === 0) {
+      logger.warn(
+        { agentMessageId, step, trailingCount: trailing.length },
+        "Trailing step contents are all referenced by a tool execution, keeping them"
+      );
+      return;
+    }
+
+    await this.model.destroy({
+      where: {
+        workspaceId,
+        id: { [Op.in]: droppable.map((row) => row.id) },
+      },
+    });
+
+    await evictAgentStepContentCacheFields({
+      workspaceId,
+      agentMessageId,
+      fields: droppable.map((row) => ({ step, index: row.index })),
+    });
+
+    logger.info(
+      {
+        agentMessageId,
+        step,
+        droppedCount: droppable.length,
+        keptReferencedCount: trailing.length - droppable.length,
+      },
+      "Dropped trailing step contents from a superseded step attempt"
+    );
   }
 
   get sId(): string {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -1049,7 +1049,10 @@ export async function runModel(
       // Same run id appended to AgentMessage.runIds below. Lets consumption attribution join a
       // RunUsage (RunModel.dustRunId) to the contents this run emitted.
       dustRunId,
-    }))
+    })),
+    // Carries the whole output of this step: any trailing content left by a previous attempt of the
+    // same step (a Temporal retry) must not survive alongside it.
+    { replacesStep: true }
   );
 
   for (const [i, content] of output.contents.entries()) {


### PR DESCRIPTION
## Description

Three independent bug fixes in the agent loop, all pre-existing on `main`, all sharing a root cause: something re-runs a model step and the previous attempt's leftovers are not cleaned up. Grouped because they are prerequisites for the auto-stream failover work stacked on top of this PR, which turns each of them from rare into routine.

**1. Step contents of a superseded attempt survived a re-run.** Versioning is per `(step, index)`, so a re-run that emits *fewer* contents than the previous attempt left that attempt's trailing indexes behind as the latest version of their own index — two runs mixed into one message. `AgentStepContentResource.createNewVersions` now accepts `replacesStep` for writes that carry a step's whole output (as opposed to appending a single content, like the error content published on failure) and drops the trailing rows. Rows referenced by a tool execution are deliberately left alone: the FK is `RESTRICT`, and a referenced content means that attempt's tools actually ran, which is not ours to unwind. The existing-content query widens from specific indexes to the whole step — same index prefix, same cost — which is what makes the trailing rows visible.

**2. The streaming hook only detected a retry boundary on a chain-of-thought event.** A retry that emitted no CoT (a `none`-effort model) never tripped the boundary, so the new call's answer was appended to the dead call's partial text. `lastCoTTraceId` becomes `lastTraceId`, tracked on any generation classification. On a plain-token boundary the unflushed chain of thought is also cleared, so the classification transition does not commit the dead call's thinking as an activity step. CoT shadow-buffer behaviour is unchanged.

**3. Reasoning was replayed to whichever provider the payload was headed to.** A thinking signature or reasoning-item id is only valid for the provider that produced it. `toBaseMessages` now takes the target provider and drops reasoning that came from another one; text and tool calls are provider-agnostic and always kept.

## Tests

Fix 3 is a **no-op on current behaviour** — the provider cannot change mid-message today — so it is covered by the updated `transitionLLM.test.ts` assertions alone.

Fixes 1 and 2 are worth exercising manually, since both need a step to actually re-run:

- **Trailing step contents**: get an agent step to retry after emitting contents (e.g. kill the worker mid-stream) and confirm the message ends up with only the final attempt's contents, no interleaving. Then confirm the guard: if a tool execution references a trailing content, the row must survive and the `"Trailing step contents are all referenced by a tool execution, keeping them"` warning must fire.
- **Stream boundary**: force a Temporal retry on a step and confirm the answer *replaces* the dead call's partial text rather than appending to it, and that inline activity steps for that step are dropped. Worth checking on a `none`-effort model, which is the case the old code missed entirely.

## Risk

Fix 1 deletes rows, which is the only real risk here. It is scoped to a single `(workspaceId, agentMessageId, step)` and only to indexes past the one just written, it skips anything a tool execution references, and it runs only on the `replacesStep: true` call site. The blast radius of a bug is a message losing trailing contents of a step that was being rewritten anyway. Cache eviction alongside it is best-effort — a stale Redis field is re-read from PG on the next miss.

Fixes 2 and 3 are safe to roll back independently; nothing else depends on them at this point in the stack.
