### PR TITLE
[front] add lastStreamModelResolutions to conversations

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -23,6 +23,7 @@ import type {
   ParticipantActionType,
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
+import type { StreamModelResolutions } from "@app/types/assistant/models/auto";
 import type { ModelResolutionMethodType } from "@app/types/assistant/models/types";
 import { MODEL_RESOLUTION_METHODS } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -40,6 +41,11 @@ export class ConversationModel extends WorkspaceAwareModel<ConversationModel> {
   declare triggerId: ForeignKey<TriggerModel["id"]> | null;
   declare hasError: CreationOptional<boolean>;
   declare metadata: CreationOptional<ConversationMetadata>;
+  // Model each (agent, stream) pair of this conversation last resolved to, so an `auto` stream
+  // stays on one model across messages instead of hopping as availability changes. Denormalized
+  // here rather than read back from the messages: every caller that resolves a model already holds
+  // the conversation row, so the lookup costs no query.
+  declare lastStreamModelResolutions: CreationOptional<StreamModelResolutions>;
 
   declare requestedSpaceIds: number[];
 
@@ -95,6 +101,11 @@ ConversationModel.init(
       defaultValue: false,
     },
     metadata: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+    },
+    lastStreamModelResolutions: {
       type: DataTypes.JSONB,
       allowNull: false,
       defaultValue: {},

--- a/front/migrations/pre-deploy/20260825133857_add_last_stream_model_resolutions_to_conversations.sql
+++ b/front/migrations/pre-deploy/20260825133857_add_last_stream_model_resolutions_to_conversations.sql
@@ -1,0 +1,6 @@
+/*
+Statement 0
+*/
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."conversations" ADD COLUMN "lastStreamModelResolutions" jsonb DEFAULT '{}'::jsonb NOT NULL;

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -18,6 +18,7 @@ import type {
   ModelConfigurationType,
   ModelProviderIdType,
   ReasoningEffort,
+  ResolvedRequestedModel,
 } from "./types";
 import { GROK_3_MINI_MODEL_ID, GROK_4_6_MODEL_ID } from "./xai";
 
@@ -38,6 +39,11 @@ export type ModelStreamIdType = (typeof MODEL_STREAM_IDS)[number];
 export function isModelStreamId(modelId: string): modelId is ModelStreamIdType {
   return MODEL_STREAM_IDS.includes(modelId as ModelStreamIdType);
 }
+
+// Model that each (agent, stream) pair of a conversation last resolved to. Denormalized on the
+// conversation row so reading it costs no query: every caller that resolves a model already holds
+// the conversation. Bounded by the agents used in the conversation times the number of streams.
+export type StreamModelResolutions = Record<string, ResolvedRequestedModel>;
 
 // One candidate of a stream: a concrete model + the reasoning effort to run it
 // at. Ordered by preference — the router picks the first candidate available to


### PR DESCRIPTION
## Description

Adds a `lastStreamModelResolutions` jsonb column to `conversations`, and nothing else. The column is **inert at this commit** — no code reads or writes it. The follow-ups in the stack do.

It will hold, per conversation, the model each `(agent, stream)` pair last resolved to, so an `auto` stream can stay on one model across messages instead of walking its candidate pool from the top on every message.

Denormalised on the conversation row rather than read back from the messages because every caller that resolves a model already holds the conversation, which makes the lookup free. The alternative — a "latest stream-resolved agent message" query joining `messages` to `agent_messages` — costs a round-trip on the message-post path, and on a miss (conversation not on that stream, different agent, or first message, i.e. the common case) walks every message in the conversation before returning null.

Deliberately kept to the migration, the Sequelize column, and the one type its declaration needs, so the PR carrying the schema change is trivial to review and to revert.

## Deploy Plan

Pre-deploy migration — must be applied **before** the code above it in the stack goes out.

`ADD COLUMN` with a non-volatile default does not rewrite the table (PG 11+ stores it as a missing value), so this is safe on `conversations` at its current size. The DB-level `DEFAULT '{}'::jsonb` is what keeps inserts from the currently deployed code valid, which is why the column is `NOT NULL` with a default rather than nullable.

No backfill: an empty map simply means "no hint yet", and the resolver falls back to walking the pool.
