### PR TITLE
[front] feat: keep auto-stream conversations on one model

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -827,6 +827,7 @@ export async function postUserMessage(
   let modelResolution = mentionedAgentConfiguration
     ? await resolveModelForMentionedAgent(auth, {
         configuration: mentionedAgentConfiguration,
+        conversation: conversationResource,
         selection: modelSelection,
       })
     : null;
@@ -1248,6 +1249,7 @@ export async function editUserMessage(
   let modelResolution = mentionedAgentConfiguration
     ? await resolveModelForMentionedAgent(auth, {
         configuration: mentionedAgentConfiguration,
+        conversation: conversationResource,
         selection: message.requestedModel ?? undefined,
       })
     : null;
@@ -1826,6 +1828,7 @@ export async function retryAgentMessage(
       }
     : await resolveModelForMentionedAgent(auth, {
         configuration: message.configuration,
+        conversation: conversationResource,
       });
 
   const user = auth.user();
@@ -3273,6 +3276,7 @@ export async function updateAgentMessageWithFinalStatus(
   const defaultModelResolution = agentMessage.configuration
     ? await resolveModelForMentionedAgent(auth, {
         configuration: agentMessage.configuration,
+        conversation,
       })
     : null;
 
@@ -3441,6 +3445,7 @@ export async function updateAgentMessageWithFinalStatus(
         ? defaultModelResolution
         : await resolveModelForMentionedAgent(promotedAuth, {
             configuration: agentMessage.configuration,
+            conversation,
             selection: promotedUserMessage.requestedModel ?? undefined,
           });
 

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -12,6 +12,7 @@ import {
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -31,11 +32,17 @@ import type {
   UserMessageType,
   UserMessageTypeWithoutMentions,
 } from "@app/types/assistant/conversation";
+import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
+import {
+  isModelStreamId,
+  makeStreamModelResolutionKey,
+} from "@app/types/assistant/models/auto";
 import type {
   ModelResolutionMethodType,
   ModelSelectionType,
   ResolvedRequestedModel,
 } from "@app/types/assistant/models/types";
+import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -294,13 +301,73 @@ export interface AgentMessageModelResolution {
   modelResolutionMethod: ModelResolutionMethodType;
 }
 
+// The stream this resolution will go through, if any: the selection wins over the agent's
+// configured model, mirroring `resolveModel`. Returns null when a concrete model is being resolved.
+function getRequestedStreamId({
+  configuration,
+  selection,
+}: {
+  configuration: LightAgentConfigurationType;
+  selection?: ModelSelectionType;
+}): ModelStreamIdType | null {
+  const requestedModelId = selection
+    ? selection.modelId
+    : configuration.model.modelId;
+
+  return isModelStreamId(requestedModelId) ? requestedModelId : null;
+}
+
+// Model this conversation already resolved this stream to, for this same agent. Returned as a
+// hint: `resolveModel` only honors it while it is still part of the stream and still available to
+// the workspace.
+async function getStickyStreamModel(
+  auth: Authenticator,
+  {
+    conversation,
+    configuration,
+    selection,
+    featureFlags,
+  }: {
+    conversation: ConversationWithoutContentType | ConversationResource;
+    configuration: LightAgentConfigurationType;
+    selection?: ModelSelectionType;
+    featureFlags: WhitelistableFeature[];
+  }
+): Promise<ResolvedRequestedModel | null> {
+  if (!featureFlags.includes("auto_stream_model_routing")) {
+    return null;
+  }
+
+  const streamId = getRequestedStreamId({ configuration, selection });
+  if (!streamId) {
+    return null;
+  }
+
+  const resolutions = await ConversationResource.fetchStreamModelResolutions(
+    auth,
+    conversation
+  );
+
+  // Returned unvalidated on purpose: `resolveStreamModelIfInPool` only honors the hint when the
+  // exact triple is still a candidate of the stream and still enabled, so a stale or malformed
+  // entry resolves to no hint rather than to a bad model.
+  return (
+    resolutions[makeStreamModelResolutionKey(configuration.sId, streamId)] ??
+    null
+  );
+}
+
 export async function resolveModelForMentionedAgent(
   auth: Authenticator,
   {
     configuration,
+    conversation,
     selection,
   }: {
     configuration: LightAgentConfigurationType;
+    // Enables stream stickiness: without it the stream always walks its pool from the top. Pass
+    // the resource where one is at hand — reading the stickiness off it costs no query.
+    conversation?: ConversationWithoutContentType | ConversationResource;
     selection?: ModelSelectionType;
   }
 ): Promise<AgentMessageModelResolution> {
@@ -322,11 +389,58 @@ export async function resolveModelForMentionedAgent(
     effectiveSelection = undefined;
   }
 
+  const stickyModel = conversation
+    ? await getStickyStreamModel(auth, {
+        conversation,
+        configuration,
+        selection: effectiveSelection,
+        featureFlags,
+      })
+    : null;
+
   return resolveModel(auth, {
     selection: effectiveSelection,
     configuration,
     featureFlags,
+    stickyModel,
   });
+}
+
+// Remembers, on the conversation, the model each stream-resolved message just landed on, so the
+// next message of the conversation starts from it instead of walking the pool from the top again.
+// Messages that ran a pinned model carry a `modelResolutionMethod` that is not a stream id and are
+// skipped: there is nothing to stick to.
+async function recordStreamModelResolutions(
+  auth: Authenticator,
+  {
+    agentMessages,
+    conversation,
+    transaction,
+  }: {
+    agentMessages: AgentMessageType[];
+    conversation: ConversationWithoutContentType;
+    transaction?: Transaction;
+  }
+): Promise<void> {
+  for (const agentMessage of agentMessages) {
+    const { modelResolutionMethod, resolvedModel } = agentMessage;
+    if (
+      !resolvedModel ||
+      !modelResolutionMethod ||
+      !isModelStreamId(modelResolutionMethod)
+    ) {
+      continue;
+    }
+
+    // At most one agent message is created per call, so this loop issues at most one statement.
+    await ConversationResource.recordStreamModelResolution(auth, {
+      agentConfigurationId: agentMessage.configuration.sId,
+      conversationModelId: conversation.id,
+      resolvedModel,
+      streamId: modelResolutionMethod,
+      transaction,
+    });
+  }
 }
 
 export const createAgentMessages = async (
@@ -678,6 +792,12 @@ export const createAgentMessages = async (
       }
     })
   );
+
+  await recordStreamModelResolutions(auth, {
+    agentMessages,
+    conversation,
+    transaction,
+  });
 
   await updateConversationRequirements(auth, {
     agents: agentMessages.map((m) => m.configuration),

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -4,6 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   getEnabledModelsForAuth,
   resolveStreamModel,
+  resolveStreamModelIfInPool,
 } from "@app/lib/model_tiers/enabled_models";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
@@ -35,16 +36,25 @@ function toResolvedModel(
 // 2. If the user did not select a model, pick the agent's configured model.
 // 3. If the agent is set on auto mode, pick the auto model.
 // 4. Finally fallback to a supported model by the workspace.
+//
+// `stickyModel` is the model a previous message of the same conversation already resolved this same
+// stream to (see `resolveModelForMentionedAgent`). It is preferred over walking the pool, so a
+// conversation stays on one model instead of hopping as availability changes — including staying on
+// the model a failover moved it to. It is only honored when it is still part of the stream and
+// still available to the workspace, and it never changes the attribution: the message is still an
+// `auto` message.
 export async function resolveModel(
   auth: Authenticator,
   {
     selection,
     configuration,
     featureFlags,
+    stickyModel,
   }: {
     selection?: ModelSelectionType;
     configuration: LightAgentConfigurationType;
     featureFlags: WhitelistableFeature[];
+    stickyModel?: ResolvedRequestedModel | null;
   }
 ): Promise<{
   resolvedModel: ResolvedRequestedModel;
@@ -94,7 +104,10 @@ export async function resolveModel(
   if (enabled && isModelStreamId(enabled.modelId)) {
     const streamId = enabled.modelId;
     const models = await getEnabledModelsForAuth(auth);
-    const resolution = resolveStreamModel(models, streamId);
+    const resolution =
+      (stickyModel &&
+        resolveStreamModelIfInPool(models, streamId, stickyModel)) ||
+      resolveStreamModel(models, streamId);
     enabled = resolution.model;
 
     if (resolution.fromPool) {

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -13,7 +13,10 @@ import type {
   ModelStreamResolutionsType,
   ModelStreamResolutionType,
 } from "@app/types/api/assistant/models";
-import type { ModelStreamIdType } from "@app/types/assistant/models/auto";
+import type {
+  ModelStreamCandidate,
+  ModelStreamIdType,
+} from "@app/types/assistant/models/auto";
 import {
   AUTO_COMPLEX_MODEL_ID,
   AUTO_FAST_MODEL_CONFIG,
@@ -27,6 +30,7 @@ import type {
   ModelConfigurationType,
   ReasoningEffort,
   ReasoningEffortSupport,
+  ResolvedRequestedModel,
 } from "@app/types/assistant/models/types";
 import { getMaximumReasoningEffort } from "@app/types/assistant/models/types";
 
@@ -149,6 +153,17 @@ export interface StreamResolutionType {
   fromPool: boolean;
 }
 
+function isSameCandidate(
+  candidate: ModelStreamCandidate,
+  model: ResolvedRequestedModel
+): boolean {
+  return (
+    candidate.providerId === model.providerId &&
+    candidate.modelId === model.modelId &&
+    candidate.reasoningEffort === model.reasoningEffort
+  );
+}
+
 // Walks a stream's ordered candidate pool and picks the first one available
 // or a fallback large model
 export function resolveStreamModel(
@@ -179,6 +194,40 @@ export function resolveStreamModel(
     model: { ...fallback, isSelectable: true },
     reasoningEffort: fallback.defaultReasoningEffort,
     fromPool: false,
+  };
+}
+
+// Looks up a model in a stream's pool: the sticky hint is only honored when the exact
+// (providerId, modelId, reasoningEffort) triple is still part of the stream and still available to
+// the workspace. A stream that changes the effort it runs a model at therefore invalidates its own
+// sticky hints instead of freezing the old effort.
+export function resolveStreamModelIfInPool(
+  models: EnabledModelConfigurationType[],
+  streamId: ModelStreamIdType,
+  model: ResolvedRequestedModel
+): StreamResolutionType | null {
+  const candidate = MODEL_STREAMS[streamId].find((c) =>
+    isSameCandidate(c, model)
+  );
+  if (!candidate) {
+    return null;
+  }
+
+  const enabled = models.find(
+    (m) =>
+      m.isSelectable &&
+      m.providerId === candidate.providerId &&
+      m.modelId === candidate.modelId &&
+      m.supportedReasoningEfforts[candidate.reasoningEffort]
+  );
+  if (!enabled) {
+    return null;
+  }
+
+  return {
+    model: enabled,
+    reasoningEffort: candidate.reasoningEffort,
+    fromPool: true,
   };
 }
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -53,7 +53,15 @@ import {
   getConversationDisplayTitle,
   getConversationUrlAccessMode,
 } from "@app/types/assistant/conversation";
-import type { ModelResolutionMethodType } from "@app/types/assistant/models/types";
+import type {
+  ModelStreamIdType,
+  StreamModelResolutions,
+} from "@app/types/assistant/models/auto";
+import { makeStreamModelResolutionKey } from "@app/types/assistant/models/auto";
+import type {
+  ModelResolutionMethodType,
+  ResolvedRequestedModel,
+} from "@app/types/assistant/models/types";
 import type { WakeUpScheduleConfig } from "@app/types/assistant/wakeups";
 import { ACTIVE_WAKE_UP_STATUSES } from "@app/types/assistant/wakeups";
 import type { ContentFragmentVersion } from "@app/types/content_fragment";
@@ -888,6 +896,80 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         userId: triggeringUserMessage.user?.sId ?? null,
       },
     };
+  }
+
+  /**
+   * Records the model an (agent, stream) pair of this conversation just resolved to.
+   *
+   * Merged server-side with the jsonb `||` operator rather than read-modify-written: concurrent
+   * writers touching different keys of the same conversation then cannot clobber each other, and
+   * the failover path (which runs outside the post transaction and its conversation lock) needs no
+   * lock of its own.
+   */
+  static async recordStreamModelResolution(
+    auth: Authenticator,
+    {
+      agentConfigurationId,
+      conversationModelId,
+      resolvedModel,
+      streamId,
+      transaction,
+    }: {
+      agentConfigurationId: string;
+      conversationModelId: ModelId;
+      resolvedModel: ResolvedRequestedModel;
+      streamId: ModelStreamIdType;
+      transaction?: Transaction;
+    }
+  ): Promise<void> {
+    const entry: StreamModelResolutions = {
+      [makeStreamModelResolutionKey(agentConfigurationId, streamId)]:
+        resolvedModel,
+    };
+
+    // biome-ignore lint/plugin/noRawSql: jsonb `||` merge has no Sequelize equivalent, and it is what keeps concurrent writers of different keys from clobbering each other.
+    await frontSequelize.query(
+      `UPDATE conversations
+         SET "lastStreamModelResolutions" =
+           COALESCE("lastStreamModelResolutions", '{}'::jsonb) || CAST(:entry AS jsonb)
+       WHERE id = :conversationId
+         AND "workspaceId" = :workspaceId`,
+      {
+        type: QueryTypes.UPDATE,
+        replacements: {
+          entry: JSON.stringify(entry),
+          conversationId: conversationModelId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+        transaction,
+      }
+    );
+  }
+
+  /**
+   * Models the conversation's (agent, stream) pairs last resolved to, used to keep an `auto`
+   * conversation on the model it already ran on.
+   *
+   * Free when the caller holds the resource — posting, editing and retrying a message all do, and
+   * those are the latency-sensitive paths. Everything else pays a single-column primary-key read.
+   */
+  static async fetchStreamModelResolutions(
+    auth: Authenticator,
+    conversation: ConversationWithoutContentType | ConversationResource
+  ): Promise<StreamModelResolutions> {
+    if (conversation instanceof ConversationResource) {
+      return conversation.lastStreamModelResolutions ?? {};
+    }
+
+    const row = await ConversationModel.findOne({
+      attributes: ["lastStreamModelResolutions"],
+      where: {
+        id: conversation.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return row?.lastStreamModelResolutions ?? {};
   }
 
   static async updateAgentMessageCostCredits(

--- a/front/types/assistant/models/auto.ts
+++ b/front/types/assistant/models/auto.ts
@@ -40,10 +40,22 @@ export function isModelStreamId(modelId: string): modelId is ModelStreamIdType {
   return MODEL_STREAM_IDS.includes(modelId as ModelStreamIdType);
 }
 
-// Model that each (agent, stream) pair of a conversation last resolved to. Denormalized on the
-// conversation row so reading it costs no query: every caller that resolves a model already holds
-// the conversation. Bounded by the agents used in the conversation times the number of streams.
+// Model that each (agent, stream) pair of a conversation last resolved to, keyed by
+// `makeStreamModelResolutionKey`. Denormalized on the conversation row so reading it costs no
+// query: every caller that resolves a model already holds the conversation. Entries are hints —
+// the resolver only honors one while it is still part of the stream and still available to the
+// workspace. Bounded by the agents used in the conversation times the number of streams.
 export type StreamModelResolutions = Record<string, ResolvedRequestedModel>;
+
+// Scoped to one agent and one stream: a Premium turn must not inherit what Standard picked, and
+// two agents in the same conversation each keep their own resolution. Agent sIds never contain a
+// colon, so the two parts cannot collide.
+export function makeStreamModelResolutionKey(
+  agentConfigurationId: string,
+  streamId: ModelStreamIdType
+): string {
+  return `${agentConfigurationId}:${streamId}`;
+}
 
 // One candidate of a stream: a concrete model + the reasoning effort to run it
 // at. Ordered by preference — the router picks the first candidate available to

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -28,6 +28,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
   },
+  auto_stream_model_routing: {
+    description:
+      "On auto model streams: fail over to the next model in the stream when a provider-side error survives the retries, and prefer the model a previous message in the same conversation resolved to",
+    stage: "dust_only",
+  },
   anthropic_cache_diagnostics: {
     description:
       "Opt into Anthropic prompt-cache diagnostics to report cache-miss reasons on agent-loop steps",


### PR DESCRIPTION
## Description

Behind the new `auto_stream_model_routing` flag (`dust_only`).

An `auto` stream (Basic / Standard / Premium) resolves at message-send time by walking an ordered candidate pool and taking the first model available to the workspace. That walk started from the top on **every** message, so a conversation could hop models mid-thread as availability shifted.

Each stream-resolved agent message now records what it landed on in the conversation's `lastStreamModelResolutions` (the column added in #31101), and the next message prefers that model.

The hint is scoped to one agent and one stream — a Premium turn must not inherit what Standard picked, and two agents in the same conversation each keep their own resolution. It is only honoured while the exact `(providerId, modelId, reasoningEffort)` triple is still a candidate of the stream *and* still available to the workspace, so a stream that changes the effort it runs a model at invalidates its own hints instead of freezing the old effort. That same check is what makes the stored value safe to use without validating it: anything stale or malformed fails to match a pool candidate and resolves to no hint at all.

Attribution is unchanged — `modelResolutionMethod` still holds the stream id, so the message is still an `auto` message for tiering, pricing and analytics.

Two implementation notes worth a reviewer's attention:

- **Reads cost no query on the paths that matter.** Posting, editing and retrying a message all hold the `ConversationResource`, so the resolutions come off the row already in memory. `fetchStreamModelResolutions` accepts `ConversationWithoutContentType | ConversationResource` (matching the existing convention in that resource) and only falls back to a single-column primary-key read for callers that hold the plain type — currently just message finalisation, which is off the user-facing path.
- **Writes go through a jsonb `||` merge** rather than a read-modify-write, so concurrent writers touching different keys of the same conversation cannot clobber each other. This matters because the failover path stacked on top writes outside the post transaction and its conversation lock.

The resolutions are intentionally **not** added to `ConversationWithoutContentType`: that type is part of API response shapes (conversation search, spaces), and routing state has no business shipping to clients.

## Tests

Flag is off by default, so the behaviour needs the flag enabled on a workspace to observe.

- Send several messages to an agent on an `auto` stream and confirm every message resolves to the same model, where previously each one re-walked the pool.
- Confirm the scoping: switch the same conversation between Standard and Premium and confirm each stream keeps its own resolution rather than inheriting the other's; mention two different agents in one conversation and confirm the same.
- Confirm invalidation: make the previously resolved model unavailable to the workspace (or change the effort the stream runs it at) and confirm the next message falls back to a normal pool walk instead of failing or freezing on the stale entry.

## Risk

Flag-gated, and the hint degrades safely: any path that cannot honour it falls back to today's behaviour of walking the pool from the top. The stored value is never trusted to name a usable model — it only ever selects among candidates the resolver would have considered anyway, so a corrupt or stale entry cannot route a message to a model the workspace should not get.
