### PR TITLE
[front] feat: fail over to the next model of an auto stream

### DIFF
--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -165,12 +165,23 @@ function isSameCandidate(
 }
 
 // Walks a stream's ordered candidate pool and picks the first one available
-// or a fallback large model
+// or a fallback large model. `afterModel` restricts the walk to the candidates after.
 export function resolveStreamModel(
   models: EnabledModelConfigurationType[],
-  streamId: ModelStreamIdType
+  streamId: ModelStreamIdType,
+  { afterModel }: { afterModel?: ResolvedRequestedModel } = {}
 ): StreamResolutionType {
-  for (const candidate of MODEL_STREAMS[streamId]) {
+  const pool = MODEL_STREAMS[streamId];
+
+  let candidates = pool;
+  if (afterModel) {
+    const currentIndex = pool.findIndex((candidate) =>
+      isSameCandidate(candidate, afterModel)
+    );
+    candidates = currentIndex === -1 ? [] : pool.slice(currentIndex + 1);
+  }
+
+  for (const candidate of candidates) {
     const model = models.find(
       (m) =>
         m.isSelectable &&

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -898,6 +898,49 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     };
   }
 
+  static async updateAgentMessageResolvedModel(
+    auth: Authenticator,
+    {
+      agentMessageModelId,
+      agentConfigurationId,
+      conversationModelId,
+      resolvedModel,
+      streamId,
+    }: {
+      agentMessageModelId: ModelId;
+      agentConfigurationId: string;
+      conversationModelId: ModelId;
+      resolvedModel: ResolvedRequestedModel;
+      streamId: ModelStreamIdType;
+    }
+  ): Promise<void> {
+    // `modelResolutionMethod` is intentionally left untouched: a stream message that fails over to
+    // another model is still an `auto` message, and tiering, pricing and analytics all read the
+    // resolution method.
+    await AgentMessageModel.update(
+      {
+        resolvedProviderId: resolvedModel.providerId,
+        resolvedModelId: resolvedModel.modelId,
+        resolvedReasoningEffort: resolvedModel.reasoningEffort,
+      },
+      {
+        where: {
+          id: agentMessageModelId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+        },
+      }
+    );
+
+    // Keep the conversation pointing at the model the message actually ends up on, so the next
+    // message starts where this one recovered to rather than back at the candidate that failed.
+    await this.recordStreamModelResolution(auth, {
+      agentConfigurationId,
+      conversationModelId,
+      resolvedModel,
+      streamId,
+    });
+  }
+
   /**
    * Records the model an (agent, stream) pair of this conversation just resolved to.
    *

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -75,6 +75,7 @@ export async function runModelAndCreateActionsActivity({
   runIds,
   step,
   forceDisableToolUse = false,
+  modelFailoverCount = 0,
 }: {
   authType: AuthenticatorType;
   checkForResume?: boolean;
@@ -82,6 +83,8 @@ export async function runModelAndCreateActionsActivity({
   runIds: string[];
   step: number;
   forceDisableToolUse?: boolean;
+  // How many times the workflow already restarted this step on the next model of its stream.
+  modelFailoverCount?: number;
 }): Promise<RunModelAndCreateActionsResult | null> {
   // The pre-stream setup (agent data loading, MCP tools listing, conversation rendering) can
   // stall past the heartbeat timeout, e.g. on a hung MCP server's tools/list call: heartbeat
@@ -98,6 +101,7 @@ export async function runModelAndCreateActionsActivity({
           runIds,
           step,
           forceDisableToolUse,
+          modelFailoverCount,
         })
       ),
     {
@@ -114,6 +118,7 @@ async function _runModelAndCreateActionsActivity({
   runIds,
   step,
   forceDisableToolUse,
+  modelFailoverCount,
 }: {
   authType: AuthenticatorType;
   checkForResume: boolean;
@@ -121,6 +126,7 @@ async function _runModelAndCreateActionsActivity({
   runIds: string[];
   step: number;
   forceDisableToolUse: boolean;
+  modelFailoverCount: number;
 }): Promise<RunModelAndCreateActionsResult | null> {
   const activityTimeoutDeadlineMs = getActivityTimeoutDeadlineMs();
   const durationRecorder = DurationRecorder.create([]);
@@ -273,6 +279,7 @@ async function _runModelAndCreateActionsActivity({
     durationRecorder,
     activityTimeoutDeadlineMs,
     forceDisableToolUse,
+    modelFailoverCount,
   });
 
   if (!modelResult) {

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -92,6 +92,19 @@ export function getQueueForUserMessageOrigin(
 // for a Temporal retry (see shouldSurfaceModelError).
 export const RUN_MODEL_MAX_RETRIES = 5;
 
+// Attempts a single model of an auto stream gets before the message is moved to the next model of
+// that stream (see shouldFailOverModel). Deliberately lower than `RUN_MODEL_MAX_RETRIES`: spending
+// a full budget on a provider that is already failing costs the user latency for nothing when
+// another provider of the same tier is one activity restart away.
+export const RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER = 2;
+
+// How many times a single model step may be moved to the next model of its stream. Each failover
+// restarts the activity, and no model of a stream ever gets more than
+// `RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER` attempts — including the last one, which surfaces the error
+// rather than falling back to the larger `RUN_MODEL_MAX_RETRIES` budget — so this bounds an auto
+// stream at RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER * (1 + MAX_MODEL_FAILOVERS) attempts in total.
+export const MAX_MODEL_FAILOVERS = 2;
+
 // Leave room for our code to surface a retryable agent error before Temporal enforces StartToClose.
 export const RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS = 1 * 60 * 1000;
 

--- a/front/temporal/agent_loop/lib/run_model.test.ts
+++ b/front/temporal/agent_loop/lib/run_model.test.ts
@@ -2,11 +2,16 @@ import { RETRY_ON_INTERRUPT_MAX_ATTEMPTS } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp_schemas";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
+import {
+  MAX_MODEL_FAILOVERS,
+  RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER,
+  RUN_MODEL_MAX_RETRIES,
+} from "@app/temporal/agent_loop/config";
 import {
   buildBaseSpecifications,
   buildSpecificationsWithReplayPlaceholders,
   buildToolDefinitionsForTokenCount,
+  shouldFailOverModel,
   shouldSurfaceModelError,
 } from "@app/temporal/agent_loop/lib/run_model";
 import type {
@@ -652,5 +657,53 @@ describe("shouldSurfaceModelError", () => {
     expect(shouldSurfaceModelError({ isRetryable: false, attempt: 1 })).toBe(
       true
     );
+  });
+});
+
+describe("shouldFailOverModel", () => {
+  it("gives the model another attempt below the failover threshold", () => {
+    expect(
+      shouldFailOverModel({
+        isRetryable: true,
+        attempt: RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER - 1,
+      })
+    ).toBe(false);
+  });
+
+  it("fails over once the model has had its attempts", () => {
+    expect(
+      shouldFailOverModel({
+        isRetryable: true,
+        attempt: RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER,
+      })
+    ).toBe(true);
+  });
+
+  it("fails over on a non-retryable error immediately", () => {
+    expect(shouldFailOverModel({ isRetryable: false, attempt: 1 })).toBe(true);
+  });
+
+  it("fails over well before the retry budget the pinned-model path uses", () => {
+    // The whole point of the threshold: a stream moves on while `shouldSurfaceModelError` would
+    // still be handing the same failing provider more attempts.
+    expect(RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER).toBeLessThan(
+      RUN_MODEL_MAX_RETRIES
+    );
+    expect(
+      shouldSurfaceModelError({
+        isRetryable: true,
+        attempt: RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER,
+      })
+    ).toBe(false);
+  });
+
+  it("bounds an auto stream well below the pinned-model budget", () => {
+    // Every model of the stream is capped at the same threshold, including the last one, which
+    // surfaces the error rather than falling back to `RUN_MODEL_MAX_RETRIES`.
+    const streamAttempts =
+      RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER * (1 + MAX_MODEL_FAILOVERS);
+
+    expect(streamAttempts).toBe(6);
+    expect(streamAttempts).toBeLessThan(RETRY_ON_INTERRUPT_MAX_ATTEMPTS);
   });
 });

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -45,6 +45,7 @@ import {
 import { getStreamLLM } from "@app/lib/api/llm";
 import { isFreeUsageBlocked } from "@app/lib/api/llm/free_usage";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
+import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
 import {
   getByokUserFacingLLMErrorMessage,
   getUserFacingLLMErrorMessage,
@@ -65,11 +66,16 @@ import {
   parseAnthropicToolSearchBlock,
   TOOL_SEARCH_SERVER_TOOL_NAMES,
 } from "@app/lib/model_constructors/sdk/anthropic_ai/converters/input/tool_search_passthrough";
+import type { ErrorSource } from "@app/lib/model_constructors/types/output/events";
 import {
   isToolDeferred,
   isToolSearchEnabledForModel,
 } from "@app/lib/model_constructors/types/tool_search";
 import { getModelTierAccessErrorForAgentConfiguration } from "@app/lib/model_tiers/access";
+import {
+  getEnabledModelsForAuth,
+  resolveStreamModel,
+} from "@app/lib/model_tiers/enabled_models";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -77,6 +83,7 @@ import { ProviderCredentialResource } from "@app/lib/resources/provider_credenti
 import { constructProjectContext } from "@app/lib/resources/skill/code_defined/global/projects";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
+import type { Logger } from "@app/logger/logger";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";
 import {
@@ -84,10 +91,17 @@ import {
   updateResourceAndPublishEvent,
 } from "@app/temporal/agent_loop/activities/common";
 import { METRICS } from "@app/temporal/agent_loop/activities/instrumentation";
-import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
+import {
+  MAX_MODEL_FAILOVERS,
+  RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER,
+  RUN_MODEL_MAX_RETRIES,
+} from "@app/temporal/agent_loop/config";
 import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
-import { makeRunModelLLMError } from "@app/temporal/agent_loop/lib/run_model_errors";
+import {
+  makeModelFailoverError,
+  makeRunModelLLMError,
+} from "@app/temporal/agent_loop/lib/run_model_errors";
 import type {
   AgentActionsEvent,
   AgentConfigurationType,
@@ -102,7 +116,13 @@ import type {
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { isTextContent } from "@app/types/assistant/generation";
+import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
+import type {
+  ModelConfigurationType,
+  ReasoningEffort,
+  ResolvedRequestedModel,
+} from "@app/types/assistant/models/types";
 import { isComputerFeatureEnabled } from "@app/types/shared/feature_flags";
 import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -143,6 +163,20 @@ export function shouldSurfaceModelError({
   attempt: number;
 }): boolean {
   return !isRetryable || attempt >= RUN_MODEL_MAX_RETRIES;
+}
+
+// A provider-side error on an auto stream does not spend the whole `RUN_MODEL_MAX_RETRIES` budget
+// on one model: after `RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER` attempts the message moves to the next
+// model of the stream instead. An error that is not retryable at all has no attempts to spend, so
+// it moves on the first one. Exported for tests.
+export function shouldFailOverModel({
+  isRetryable,
+  attempt,
+}: {
+  isRetryable: boolean;
+  attempt: number;
+}): boolean {
+  return !isRetryable || attempt >= RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER;
 }
 
 // Builds the JSON blob whose token count estimates how many tokens the tool
@@ -374,6 +408,149 @@ export function buildSpecificationsWithReplayPlaceholders(
   };
 }
 
+// Why a model step did — or did not — move to the next model of its stream.
+type ModelFailoverOutcome =
+  // The message now points at the next model of its stream: the step must be restarted on it.
+  | "failed_over"
+  // Eligible to fail over, but the stream has nowhere left to go. The error must be surfaced now:
+  // every attempt left would go back to the provider that just failed.
+  | "exhausted"
+  // Not an auto-stream provider-attributed failure. The normal retry budget applies, untouched.
+  | "not_eligible";
+
+// Moves an auto-stream agent message to the next model of its stream once the current model has had
+// its `RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER` attempts.
+//
+// The new model is persisted on the agent message: the model activity re-reads it from the database
+// on every run (the run-model path does not use `ConversationCaching`, only the tool path does), so
+// restarting the activity is all it takes for the step to run on it. The resolution method stays
+// the stream id — the message is still an `auto` message, and tiering, pricing and analytics all
+// read that.
+async function failOverToNextStreamModel(
+  auth: Authenticator,
+  {
+    agentMessage,
+    conversation,
+    errorSource,
+    errorType,
+    localLogger,
+    modelConfig,
+    modelFailoverCount,
+    reasoningEffort,
+  }: {
+    agentMessage: AgentMessageType;
+    conversation: ConversationType;
+    errorSource: ErrorSource;
+    // Reported only: eligibility is decided on `errorSource`, not on the error type.
+    errorType: LLMErrorType;
+    localLogger: Logger;
+    modelConfig: ModelConfigurationType;
+    modelFailoverCount: number;
+    reasoningEffort: ReasoningEffort | undefined;
+  }
+): Promise<ModelFailoverOutcome> {
+  const { modelResolutionMethod } = agentMessage;
+
+  // The three `not_eligible` guards below decide whether this message plays by the stream rules at
+  // all. They must stay distinct from `exhausted`: an ineligible message keeps the full
+  // `RUN_MODEL_MAX_RETRIES` budget, while an exhausted stream gives up right away.
+  //
+  // Only auto streams fail over: a user- or agent-pinned model is a choice we must not silently
+  // swap. `modelResolutionMethod` holds the stream id exactly when the model came from a stream.
+  if (!modelResolutionMethod || !isModelStreamId(modelResolutionMethod)) {
+    return "not_eligible";
+  }
+
+  // Only failures whose fault domain is the provider: the request was well-formed, so another
+  // provider has a real chance of answering it. Errors attributed to us (a malformed request, an
+  // oversized context, bad credentials, a refusal, our own stream time budget) are excluded —
+  // spending another model on those just burns it too.
+  if (errorSource !== "provider") {
+    return "not_eligible";
+  }
+
+  const featureFlags = await getFeatureFlags(auth);
+  if (!featureFlags.includes("auto_stream_model_routing")) {
+    return "not_eligible";
+  }
+
+  if (modelFailoverCount >= MAX_MODEL_FAILOVERS) {
+    localLogger.warn(
+      {
+        errorSource,
+        errorType,
+        modelFailoverCount,
+        streamId: modelResolutionMethod,
+      },
+      "Model failover budget exhausted, surfacing the provider error."
+    );
+    return "exhausted";
+  }
+
+  // The model that just failed, as resolved for this run: the walk resumes after it, so a message
+  // that already failed over (or started on a sticky model) keeps moving forward in the pool
+  // instead of re-picking candidates that were already ruled out.
+  const failedModel: ResolvedRequestedModel = {
+    providerId: modelConfig.providerId,
+    modelId: modelConfig.modelId,
+    reasoningEffort: reasoningEffort ?? modelConfig.defaultReasoningEffort,
+  };
+
+  const models = await getEnabledModelsForAuth(auth);
+  const resolution = resolveStreamModel(models, modelResolutionMethod, {
+    afterModel: failedModel,
+  });
+
+  // `fromPool: false` means the walk found no candidate after the failed one: the stream is
+  // exhausted, and falling back to a generic large model here would leave the requested tier.
+  if (!resolution.fromPool) {
+    localLogger.warn(
+      {
+        errorSource,
+        errorType,
+        modelFailoverCount,
+        streamId: modelResolutionMethod,
+      },
+      "No model left in the stream to fail over to, surfacing the provider error."
+    );
+    return "exhausted";
+  }
+
+  const nextModel: ResolvedRequestedModel = {
+    providerId: resolution.model.providerId,
+    modelId: resolution.model.modelId,
+    reasoningEffort: resolution.reasoningEffort,
+  };
+
+  await ConversationResource.updateAgentMessageResolvedModel(auth, {
+    agentConfigurationId: agentMessage.configuration.sId,
+    agentMessageModelId: agentMessage.agentMessageId,
+    conversationModelId: conversation.id,
+    resolvedModel: nextModel,
+    streamId: modelResolutionMethod,
+  });
+
+  localLogger.warn(
+    {
+      conversationId: conversation.sId,
+      agentMessageId: agentMessage.sId,
+      errorSource,
+      errorType,
+      streamId: modelResolutionMethod,
+      modelFailoverCount: modelFailoverCount + 1,
+      fromProviderId: failedModel.providerId,
+      fromModelId: failedModel.modelId,
+      fromReasoningEffort: failedModel.reasoningEffort,
+      toProviderId: nextModel.providerId,
+      toModelId: nextModel.modelId,
+      toReasoningEffort: nextModel.reasoningEffort,
+    },
+    "Provider-attributed error survived this model's attempts, failing over to the next model of the stream."
+  );
+
+  return "failed_over";
+}
+
 // This method is used by the multi-actions execution loop to pick the next action to execute and
 // generate its inputs.
 export async function runModel(
@@ -386,6 +563,7 @@ export async function runModel(
     durationRecorder,
     activityTimeoutDeadlineMs,
     forceDisableToolUse = false,
+    modelFailoverCount = 0,
   }: {
     runAgentData: AgentLoopExecutionData;
     runIds: string[];
@@ -395,6 +573,9 @@ export async function runModel(
     activityTimeoutDeadlineMs: number;
     // Set when the previous step came back empty: force the final generation.
     forceDisableToolUse?: boolean;
+    // How many times this step already moved to the next model of its stream. Carried by the
+    // workflow across activity restarts, since Temporal resets the attempt counter for each.
+    modelFailoverCount?: number;
   }
 ): Promise<{
   actions: AgentActionsEvent["actions"];
@@ -928,7 +1109,7 @@ export async function runModel(
 
     switch (error.type) {
       case "shouldRetryMessage": {
-        const { type, isRetryable } = error.content;
+        const { type, isRetryable, errorSource } = error.content;
         const errorDustRunId = llm?.getTraceId();
         const currentAttempt = Context.current().info.attempt;
         const plan = auth.getNonNullablePlan();
@@ -976,8 +1157,8 @@ export async function runModel(
             ? getByokUserFacingLLMErrorMessage(type, metadata)
             : getUserFacingLLMErrorMessage(type, metadata);
 
-        if (shouldSurfaceModelError({ isRetryable, attempt: currentAttempt })) {
-          await publishAgentError(
+        const publishModelError = () =>
+          publishAgentError(
             {
               code: "multi_actions_error",
               message: errorMessage,
@@ -987,14 +1168,62 @@ export async function runModel(
             },
             errorDustRunId
           );
-          return null;
-        }
 
-        // Throw to let Temporal handle the retry via its retry policy.
-        throw makeRunModelLLMError({
-          type,
-          message: errorMessage,
-        });
+        // On an auto stream a provider-attributed failure is not the user's problem: once this
+        // model has had its attempts, move the message to the next model of the stream rather than
+        // spending more of them on the provider that is failing.
+        const failover = shouldFailOverModel({
+          isRetryable,
+          attempt: currentAttempt,
+        })
+          ? await failOverToNextStreamModel(auth, {
+              agentMessage,
+              conversation,
+              errorSource,
+              errorType: type,
+              localLogger,
+              modelConfig,
+              modelFailoverCount,
+              reasoningEffort: modelInfo.reasoningEffort,
+            })
+          : "not_eligible";
+
+        switch (failover) {
+          case "failed_over":
+            // The next model is already persisted on the message: fail the activity with the
+            // failover marker so the workflow restarts the step on it, with an attempt counter of
+            // its own.
+            throw makeModelFailoverError(
+              `Failing over to the next model of the ${agentMessage.modelResolutionMethod} stream after: ${errorMessage}`
+            );
+
+          case "exhausted":
+            // The stream has nowhere left to go. Surface the error instead of falling back to the
+            // larger `RUN_MODEL_MAX_RETRIES` budget: those attempts would go back to a provider
+            // that has already failed `RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER` times, so they buy the
+            // user latency rather than an answer.
+            await publishModelError();
+            return null;
+
+          case "not_eligible":
+            // A pinned model, an error attributed to us, or the flag off: unchanged
+            // behavior, the error surfaces only once the full retry budget is spent.
+            if (
+              shouldSurfaceModelError({ isRetryable, attempt: currentAttempt })
+            ) {
+              await publishModelError();
+              return null;
+            }
+
+            // Throw to let Temporal handle the retry via its retry policy.
+            throw makeRunModelLLMError({
+              type,
+              message: errorMessage,
+            });
+
+          default:
+            assertNever(failover);
+        }
       }
       case "shouldReturnNull":
         return null;
@@ -1051,7 +1280,7 @@ export async function runModel(
       dustRunId,
     })),
     // Carries the whole output of this step: any trailing content left by a previous attempt of the
-    // same step (a Temporal retry) must not survive alongside it.
+    // same step (a Temporal retry, or a model failover) must not survive alongside it.
     { replacesStep: true }
   );
 

--- a/front/temporal/agent_loop/lib/run_model_errors.ts
+++ b/front/temporal/agent_loop/lib/run_model_errors.ts
@@ -12,6 +12,8 @@ const RUN_MODEL_LLM_UNRESPONSIVE_ERROR_TYPES = new Set<LLMErrorType>([
 
 const MODEL_INTERRUPTION_ERROR_TYPE = "ModelInterruption";
 
+const MODEL_FAILOVER_ERROR_TYPE = "ModelFailover";
+
 // Same pattern as makeToolInterruptionError: a retryable failure so Temporal reruns the step on
 // another worker when the current one is shutting down.
 export function makeModelInterruptionError(): ApplicationFailure {
@@ -54,4 +56,20 @@ export function isRunModelLLMUnresponsiveFailureType(
   return RUN_MODEL_LLM_UNRESPONSIVE_ERROR_TYPES.has(
     llmErrorType as LLMErrorType
   );
+}
+
+/**
+ * Signals that an auto-stream message exhausted its retries on a provider-side error and has been
+ * moved to the next model of its stream (already persisted on the agent message). Non-retryable on
+ * purpose: the current activity has no attempts left, so the workflow catches this and starts a
+ * fresh activity, which reads the new model and gets a full retry budget for it.
+ */
+export function makeModelFailoverError(message: string): ApplicationFailure {
+  return ApplicationFailure.nonRetryable(message, MODEL_FAILOVER_ERROR_TYPE);
+}
+
+export function isModelFailoverFailureType(
+  failureType: string | null | undefined
+): boolean {
+  return failureType === MODEL_FAILOVER_ERROR_TYPE;
 }

--- a/front/temporal/agent_loop/lib/workflow_failures.ts
+++ b/front/temporal/agent_loop/lib/workflow_failures.ts
@@ -8,7 +8,10 @@ import {
   TimeoutType,
 } from "@temporalio/common";
 
-import { isRunModelLLMUnresponsiveFailureType } from "./run_model_errors";
+import {
+  isModelFailoverFailureType,
+  isRunModelLLMUnresponsiveFailureType,
+} from "./run_model_errors";
 
 export const RUN_MODEL_ACTIVITY_NAME = "runModelAndCreateActionsActivity";
 
@@ -84,6 +87,49 @@ function isLLMUnresponsiveProtoFailure(failure: ProtoFailure): boolean {
 
   if (failure.cause) {
     return isLLMUnresponsiveProtoFailure(failure.cause);
+  }
+
+  return false;
+}
+
+// The model activity moved an auto-stream message to the next model of its stream and wants the
+// workflow to restart the step on it. Walks the cause chain like
+// `isRunModelLLMUnresponsiveError`: the activity failure the workflow sees wraps the application
+// failure the activity threw.
+export function isModelFailoverError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  if (
+    error instanceof ApplicationFailure &&
+    isModelFailoverFailureType(error.type)
+  ) {
+    return true;
+  }
+
+  if (
+    error instanceof TemporalFailure &&
+    error.failure &&
+    isModelFailoverProtoFailure(error.failure)
+  ) {
+    return true;
+  }
+
+  if (error.cause instanceof Error) {
+    return isModelFailoverError(error.cause);
+  }
+
+  return false;
+}
+
+function isModelFailoverProtoFailure(failure: ProtoFailure): boolean {
+  if (isModelFailoverFailureType(failure.applicationFailureInfo?.type)) {
+    return true;
+  }
+
+  if (failure.cause) {
+    return isModelFailoverProtoFailure(failure.cause);
   }
 
   return false;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -12,14 +12,17 @@ import type * as finalizeActivities from "@app/temporal/agent_loop/activities/fi
 import type * as finalizeSandboxChildToolActivities from "@app/temporal/agent_loop/activities/finalize_sandbox_child_tool";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
+import type { RunModelAndCreateActionsResult } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
 import {
+  MAX_MODEL_FAILOVERS,
   MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
   TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS,
 } from "@app/temporal/agent_loop/config";
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { waitForAllPromises } from "@app/temporal/agent_loop/lib/wait_for_all_promises";
 import {
+  isModelFailoverError,
   isRunModelLLMUnresponsiveError,
   isTerminalRunModelTimeout,
 } from "@app/temporal/agent_loop/lib/workflow_failures";
@@ -473,14 +476,39 @@ async function executeStepIteration({
 }> {
   deprecatePatch("wait-for-model-activity-before-finalization");
 
-  const result = await runModelAndCreateActionsActivity({
-    authType,
-    checkForResume: currentStep === startStep, // Only run resume the first time.
-    runAgentArgs: agentLoopArgs,
-    runIds,
-    step: currentStep,
-    forceDisableToolUse,
-  });
+  // On an auto stream, a provider-side error that survives the activity's retries moves the
+  // message to the next model of its stream and fails the activity with a failover marker. Temporal
+  // resets the attempt counter per activity, so restarting the activity here is what gives the new
+  // model a full retry budget of its own. The activity enforces `MAX_MODEL_FAILOVERS` (it owns the
+  // error published to the user once the budget is spent); the same bound is applied here so a
+  // misbehaving activity cannot loop the workflow.
+  let result: RunModelAndCreateActionsResult | null = null;
+  for (
+    let modelFailoverCount = 0;
+    modelFailoverCount <= MAX_MODEL_FAILOVERS;
+    modelFailoverCount++
+  ) {
+    try {
+      result = await runModelAndCreateActionsActivity({
+        authType,
+        checkForResume: currentStep === startStep, // Only run resume the first time.
+        runAgentArgs: agentLoopArgs,
+        runIds,
+        step: currentStep,
+        forceDisableToolUse,
+        modelFailoverCount,
+      });
+      break;
+    } catch (err) {
+      if (
+        !patched("auto-stream-model-failover") ||
+        !isModelFailoverError(err) ||
+        modelFailoverCount === MAX_MODEL_FAILOVERS
+      ) {
+        throw err;
+      }
+    }
+  }
 
   if (!result) {
     // Error occurred — no runId to capture.


### PR DESCRIPTION
## Description

Behind the `auto_stream_model_routing` flag and the `auto-stream-model-failover` patch.

Today, when a provider fails on an `auto` stream, the message spends its whole retry budget on that one provider and then surfaces an error the user cannot act on. This makes the message move to the next candidate of its stream instead.

**What decides eligibility.** The error's fault domain (`errorSource`), which the provider adapters already set — not a hand-maintained list of error types. Only failures attributed to the provider fail over; a malformed request, an oversized context, bad credentials, a refusal or our own stream time budget are attributed to us, and retrying those on another model just burns it too. A user- or agent-pinned model never fails over: that is a choice we must not silently swap, and `modelResolutionMethod` holds a stream id exactly when the model came from a stream.

**How far it moves.** The pool walk resumes *after* the model that failed, matched on the full `(providerId, modelId, reasoningEffort)` triple since the same model can appear twice in a pool at different efforts. A model no longer in the pool is treated as exhausted rather than restarting from the top, which would re-pick the candidates already ruled out — including the one that just failed. If the stream has nothing left, the error surfaces rather than falling back to a generic large model, which would leave the requested tier.

**How the step restarts.** The new model is persisted on the agent message and on the conversation (so the next message starts where this one recovered to, rather than back at the candidate that failed), then the activity fails with a non-retryable `ModelFailover` marker. Temporal resets the attempt counter per activity, so restarting the activity is precisely what gives the new model a full retry budget of its own; the run-model path re-reads the model from the database on every run, so no state needs threading through. `MAX_MODEL_FAILOVERS` bounds it, enforced in the activity (which owns the error published to the user once the budget is spent) and again in the workflow so a misbehaving activity cannot loop it.

Also splits the retry budget: a provider-attributed error on an auto stream now moves on after `RUN_MODEL_ATTEMPTS_BEFORE_FAILOVER` rather than spending all of `RUN_MODEL_MAX_RETRIES` on one model. Ineligible messages keep the full budget, unchanged.

## Tests

`shouldFailOverModel` is unit-tested (budget boundary, non-retryable errors moving on the first attempt, and that the failover threshold stays below the surface threshold).

The rest needs the flag and patch enabled and a forced provider failure:

- Force a 5xx / overloaded response from the first candidate of a stream and confirm the message completes on the next candidate, that the step's contents are the new model's only (not interleaved with the dead attempt's — this is what #31100 fixes), and that the UI shows the new answer replacing the partial one rather than appended.
- Confirm a **cross-provider** failover specifically, since that is the case that exercises reasoning being dropped rather than replayed under a signature the new provider would reject.
- Confirm the negative cases: a 400 / context-length / auth error must **not** fail over; a pinned (user- or agent-selected) model must not fail over; an exhausted stream must surface the provider error rather than silently leaving the tier.
- Confirm the budget: after `MAX_MODEL_FAILOVERS` the error surfaces, with the `"Model failover budget exhausted"` warning.

## Risk

Highest-risk PR in the stack — it changes agent-loop control flow — and correspondingly the most gated: both the feature flag and the `auto-stream-model-failover` patch must be on, and with either off the workflow takes exactly today's path.

The two failure modes worth watching: a message failing over when it should not (bounded — it retries on a different model and the user still gets an answer, just later), and the workflow looping on repeated failovers (bounded twice over, in the activity and in the workflow). Rollback is flipping the patch or the flag; no schema or data change is introduced here.

Note the deliberate behaviour change in what fails over versus a naive "retryable error" reading: `rate_limit_error` is attributed to us (it is our shared quota, not the provider being down) and so does **not** fail over, while `unknown_error` from a provider does. Happy to widen the 429 case if we would rather move to a different provider that does not share the quota.
