### PR TITLE
[front] enh: allow deleting all legacy feature flags at once

### DIFF
--- a/front/scripts/delete_legacy_feature_flag.ts
+++ b/front/scripts/delete_legacy_feature_flag.ts
@@ -2,49 +2,86 @@ import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { makeScript } from "@app/scripts/helpers";
 import { isWhitelistableFeature } from "@app/types/shared/feature_flags";
 
-// Deletes all rows for a given feature flag name from the feature_flags table.
+// Deletes all rows for legacy feature flag names from the feature_flags table.
 // Use this to clean up feature flags that have been removed from the codebase
 // (for flags still in WHITELISTABLE_FEATURES, use disable_feature_flag_all_workspaces.ts instead).
+//
+//   npx tsx scripts/delete_legacy_feature_flag.ts --featureFlag <name>
+//   npx tsx scripts/delete_legacy_feature_flag.ts --all
 makeScript(
   {
     featureFlag: {
       type: "string" as const,
-      demandOption: true,
+      demandOption: false,
       description:
         "Name of the legacy feature flag to delete (must no longer exist in WHITELISTABLE_FEATURES).",
     },
+    all: {
+      type: "boolean" as const,
+      default: false,
+      description:
+        "Delete every legacy feature flag found in the database instead of a single name.",
+    },
   },
-  async ({ featureFlag, execute }, logger) => {
-    if (isWhitelistableFeature(featureFlag)) {
-      throw new Error(
-        `"${featureFlag}" is still in WHITELISTABLE_FEATURES. Use disable_feature_flag_all_workspaces.ts instead.`
-      );
+  async ({ featureFlag, all, execute }, logger) => {
+    if (featureFlag && all) {
+      throw new Error("Pass either --featureFlag or --all, not both.");
+    }
+    if (!featureFlag && !all) {
+      throw new Error("Pass --featureFlag <name> or --all.");
     }
 
-    const count = await FeatureFlagResource.countLegacyByName(featureFlag);
+    const countByName = new Map<string, number>();
+
+    if (featureFlag) {
+      if (isWhitelistableFeature(featureFlag)) {
+        throw new Error(
+          `"${featureFlag}" is still in WHITELISTABLE_FEATURES. Use disable_feature_flag_all_workspaces.ts instead.`
+        );
+      }
+
+      countByName.set(
+        featureFlag,
+        await FeatureFlagResource.countLegacyByName(featureFlag)
+      );
+    } else {
+      const countByAllNames =
+        await FeatureFlagResource.countByFlagNameForAllWorkspaces();
+
+      for (const [name, count] of countByAllNames) {
+        if (!isWhitelistableFeature(name)) {
+          countByName.set(name, count);
+        }
+      }
+    }
+
+    const targets = [...countByName].filter(([, count]) => count > 0);
+
+    if (targets.length === 0) {
+      logger.info("No legacy feature flag rows found.");
+      return;
+    }
 
     logger.info(
-      { featureFlag, workspaceCount: count },
+      { featureFlags: targets.map(([name]) => name) },
       "Found legacy feature flag rows."
     );
 
-    if (count === 0) {
-      return;
-    }
+    for (const [name, workspaceCount] of targets) {
+      if (!execute) {
+        logger.info(
+          { featureFlag: name, workspaceCount },
+          "Would delete legacy feature flag rows."
+        );
+        continue;
+      }
 
-    if (!execute) {
+      await FeatureFlagResource.deleteLegacyByName(name);
+
       logger.info(
-        { featureFlag, workspaceCount: count },
-        "Would delete legacy feature flag rows."
+        { featureFlag: name, workspaceCount },
+        "Deleted legacy feature flag rows."
       );
-      return;
     }
-
-    await FeatureFlagResource.deleteLegacyByName(featureFlag);
-
-    logger.info(
-      { featureFlag, workspaceCount: count },
-      "Deleted legacy feature flag rows."
-    );
   }
 );


### PR DESCRIPTION
`scripts/delete_legacy_feature_flag.ts` could only delete one legacy flag name at a time. This adds an `--all` mode so the whole leftover set can be cleaned up in one pass.

`--all` discovers the targets with `FeatureFlagResource.countByFlagNameForAllWorkspaces()` (which already returns names no longer declared in `WHITELISTABLE_FEATURES_CONFIG`) and keeps only those failing `isWhitelistableFeature`. Both modes then converge on a single name → row-count map and a shared dry-run/delete loop, reusing the existing `deleteLegacyByName` which handles the workspace-isolation bypass and cache invalidation.

`--featureFlag` and `--all` are mutually exclusive and exactly one is required, so a bare invocation can't wipe every legacy flag by accident. The single-name path keeps its existing guard pointing at `disable_feature_flag_all_workspaces.ts` for flags that are still declared.

Verified locally, all read-only (no `--execute`):

- `--all` dry run listed the 15 legacy flags in my local DB, one "Would delete" line each with its workspace count.
- `--featureFlag projects` behaves as before.
- `--featureFlag projects --all` and no args both error out.
- `--featureFlag labs_transcripts` (still live) still errors with the `WHITELISTABLE_FEATURES` message.