### PR TITLE
[front] Agent loop: log the tool identity at tool activity start

### DIFF
--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -169,6 +169,23 @@ export async function runToolActivity(
   // Heartbeating here as retrieving the agent loop data takes some time.
   heartbeat();
 
+  // Identify the tool as early as possible: activities that die past this point (worker killed,
+  // stall in the pre-execution phases) leave no tool-level log otherwise, making heartbeat
+  // timeout failures unattributable to a tool.
+  logger.info(
+    {
+      actionId,
+      attempt: Context.current().info.attempt,
+      conversationId: runAgentArgs.conversationId,
+      agentMessageId: runAgentArgs.agentMessageId,
+      step,
+      workspaceId: authType.workspaceId,
+      toolName: action.toolConfiguration.name,
+      mcpServerName: action.toolConfiguration.mcpServerName,
+    },
+    "Tool activity starting execution"
+  );
+
   const {
     agentConfiguration,
     modelInfo: model,


### PR DESCRIPTION
## Description

Adding a temporary log to debug which tool fails activities 🙏🏻 

Heartbeat-timeout failures on `runToolActivity` are mostly unattributable to a tool today: in a 20-workflow sample of last week's failures, 17 died before any tool-level log fired (the first log naming the tool is `Starting MCP tool notification loop`, deep inside the MCP call path). 

This logs `toolName` / `mcpServerName` (plus actionId, attempt, conversation, step) right after the action fetch, before the pre-execution phases where those activities die, so future failures can be attributed by joining on conversationId.

## Tests

Log-only change. `tsgo --noEmit` clean.

## Risk

None: one info log per tool activity, comparable volume to the existing per-call MCP logs.

## Deploy Plan

Deploy front.