### PR TITLE
Admin governance: allow regular group in space (group mode)

### DIFF
--- a/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/members.ts
@@ -135,6 +135,15 @@ app.patch(
                 "Some users have insufficient role privilege to be added to the space.",
             },
           });
+        case "invalid_group_kind":
+          return apiError(ctx, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Only provisioned and manual groups can be given access to a space.",
+            },
+          });
         case "system_or_global_group":
           return apiError(ctx, {
             status_code: 400,

--- a/front/components/groups/GroupSelectionTable.tsx
+++ b/front/components/groups/GroupSelectionTable.tsx
@@ -1,7 +1,11 @@
+import { getGroupKindChip } from "@app/components/groups/GroupKinds";
 import { useGroups } from "@app/lib/swr/groups";
-import type { GroupType } from "@app/types/groups";
+import type { GroupKind, GroupType } from "@app/types/groups";
+import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
+import { pluralize } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
+  Chip,
   createSelectionColumn,
   DataTable,
   SearchInput,
@@ -18,6 +22,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 interface GroupRowData {
   sId: string;
   name: string;
+  kind: GroupKind;
   memberCount: number;
   onClick?: () => void;
 }
@@ -26,6 +31,7 @@ function getGroupTableRows(groups: GroupType[]): GroupRowData[] {
   return groups.map((group) => ({
     sId: group.sId,
     name: group.name,
+    kind: group.kind,
     memberCount: group.memberCount,
   }));
 }
@@ -54,7 +60,7 @@ export function GroupSelectionTable({
 
   const { groups, isGroupsLoading } = useGroups({
     owner,
-    kinds: ["provisioned"],
+    kinds: MANAGEABLE_GROUP_KINDS,
   });
 
   const groupMapRef = useRef(new Map<string, GroupType>());
@@ -115,21 +121,30 @@ export function GroupSelectionTable({
         meta: {
           className: "w-full",
         },
-        cell: (info: CellContext<GroupRowData, unknown>) => (
-          <DataTable.CellContent icon={Users01}>
-            {info.row.original.name}
-          </DataTable.CellContent>
-        ),
+        cell: (info: CellContext<GroupRowData, unknown>) => {
+          const { name, memberCount } = info.row.original;
+          return (
+            <DataTable.CellContent
+              icon={Users01}
+              description={`${memberCount} member${pluralize(memberCount)}`}
+            >
+              {name}
+            </DataTable.CellContent>
+          );
+        },
       },
       {
-        accessorKey: "memberCount",
-        header: "Members",
-        id: "memberCount",
-        cell: (info: CellContext<GroupRowData, unknown>) => (
-          <DataTable.CellContent>
-            {info.row.original.memberCount}
-          </DataTable.CellContent>
-        ),
+        id: "kind",
+        header: "",
+        meta: { className: "w-[160px]" },
+        cell: (info: CellContext<GroupRowData, unknown>) => {
+          const { label, color } = getGroupKindChip(info.row.original.kind);
+          return (
+            <DataTable.CellContent>
+              <Chip size="xs" color={color} label={label} />
+            </DataTable.CellContent>
+          );
+        },
       },
     ],
     []

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -15,6 +15,7 @@ import {
 } from "@app/lib/swr/spaces";
 import type { SpaceCategoryInfo } from "@app/types/api/spaces";
 import type { GroupType } from "@app/types/groups";
+import { MANAGEABLE_GROUP_KINDS } from "@app/types/groups";
 import type { PlanType } from "@app/types/plan";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
@@ -93,7 +94,7 @@ export function CreateOrEditSpaceModal({
 
   const { groups } = useGroups({
     owner,
-    kinds: ["provisioned"],
+    kinds: MANAGEABLE_GROUP_KINDS,
     disabled: !scimEnabled,
   });
 

--- a/front/components/spaces/RestrictedAccessBody.tsx
+++ b/front/components/spaces/RestrictedAccessBody.tsx
@@ -126,9 +126,7 @@ export function RestrictedAccessBody({
                 variant="outline"
                 isSelect
                 label={
-                  managementType === "manual"
-                    ? "Manual access"
-                    : "Provisioned group access"
+                  managementType === "manual" ? "Manual access" : "Group access"
                 }
               />
             </DropdownMenuTrigger>
@@ -140,7 +138,7 @@ export function RestrictedAccessBody({
                 }}
               />
               <DropdownMenuItem
-                label="Provisioned group access"
+                label="Group access"
                 onClick={() => {
                   void handleManagementTypeChange("group");
                 }}

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -43,6 +43,7 @@ import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types/api/public/spaces";
 import type { SpaceCategoryInfo } from "@app/types/api/spaces";
 import { SKILL_STATUSES } from "@app/types/assistant/skill_configuration";
 import {
+  isManageableGroupKind,
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
   SPACE_GROUP_PREFIX,
@@ -839,6 +840,17 @@ export async function createSpaceAndGroup(
           }
 
           const selectedGroups = selectedGroupsResult.value;
+          // `fetchByIds` only checks that the caller can read the groups, not what they are. Keep
+          // internal groups (global, system, another space's regular_auto, agent/skill editors) out
+          // of a space's group-managed access.
+          if (selectedGroups.some((g) => !isManageableGroupKind(g.kind))) {
+            return new Err(
+              new DustError(
+                "invalid_request_error",
+                "Only provisioned and manual groups can be given access to a space."
+              )
+            );
+          }
           memberGroups.push(...selectedGroups);
           for (const selectedGroup of selectedGroups) {
             await GroupSpaceMemberResource.makeNew(auth, {

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -38,6 +38,7 @@ export type DustErrorCode =
   | "user_not_member"
   | "group_requirements_not_met"
   | "group_not_found"
+  | "invalid_group_kind"
   // MCP Server errors
   | "remote_server_not_found"
   | "internal_server_not_found"

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -2680,6 +2680,76 @@ describe("SpaceResource group_permissions enforcement", () => {
     expect(openSpace!.canWrite(nonMemberAuth)).toBe(false);
   });
 
+  it("enforces the table: group mode accepts a manual group, and deselecting it revokes access", async () => {
+    const manualGroup = await GroupFactory.regularManual(workspace, "Squad");
+    await GroupFactory.withMembers(adminAuth, manualGroup, [memberUser]);
+    const provisionedGroup = await GroupFactory.provisioned(workspace, "IdP");
+
+    const space = await SpaceFactory.regular(workspace);
+    const setRes = await space.updatePermissions(adminAuth, {
+      name: space.name,
+      isRestricted: true,
+      managementMode: "group",
+      groupIds: [manualGroup.sId, provisionedGroup.sId],
+      editorGroupIds: [],
+    });
+    expect(setRes.isOk()).toBe(true);
+
+    const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      memberUser.sId,
+      workspace.sId
+    );
+    const withGroup = await SpaceResource.fetchById(adminAuth, space.sId);
+    expect(withGroup!.canRead(memberAuth)).toBe(true);
+    expect(withGroup!.canWrite(memberAuth)).toBe(true);
+
+    // Deselecting the manual group must drop its association, not just the provisioned ones.
+    const unsetRes = await space.updatePermissions(adminAuth, {
+      name: space.name,
+      isRestricted: true,
+      managementMode: "group",
+      groupIds: [provisionedGroup.sId],
+      editorGroupIds: [],
+    });
+    expect(unsetRes.isOk()).toBe(true);
+
+    const refreshedMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      memberUser.sId,
+      workspace.sId
+    );
+    const withoutGroup = await SpaceResource.fetchById(adminAuth, space.sId);
+    expect(withoutGroup!.canRead(refreshedMemberAuth)).toBe(false);
+    expect(withoutGroup!.canWrite(refreshedMemberAuth)).toBe(false);
+  });
+
+  it("rejects internal groups in group management mode", async () => {
+    const globalGroupRes =
+      await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+    expect(globalGroupRes.isOk()).toBe(true);
+    if (globalGroupRes.isErr()) {
+      return;
+    }
+
+    const space = await SpaceFactory.regular(workspace);
+    // The space's own auto-created member group is readable by an admin, so only a kind check keeps
+    // it — and the workspace global group — out of a group-managed selection.
+    const [autoGroup] = await space.fetchRegularAutoGroups(adminAuth);
+
+    for (const group of [globalGroupRes.value, autoGroup]) {
+      const res = await space.updatePermissions(adminAuth, {
+        name: space.name,
+        isRestricted: true,
+        managementMode: "group",
+        groupIds: [group.sId],
+        editorGroupIds: [],
+      });
+      expect(res.isErr()).toBe(true);
+      if (res.isErr()) {
+        expect(res.error.code).toBe("invalid_group_kind");
+      }
+    }
+  });
+
   it("enforces the table: provisioned group member of an open space can write", async () => {
     const provisionedGroup = await GroupFactory.provisioned(
       workspace,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -31,6 +31,8 @@ import { SPACE_EDITOR_GRANT_TYPE } from "@app/types/group_permissions";
 import type { GroupType } from "@app/types/groups";
 import {
   GLOBAL_SPACE_NAME,
+  isManageableGroupKind,
+  MANAGEABLE_GROUP_KINDS,
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
   SPACE_GROUP_PREFIX,
@@ -977,6 +979,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         | "user_not_member"
         | "user_already_member"
         | "group_requirements_not_met"
+        | "invalid_group_kind"
         | "system_or_global_group"
         | "invalid_id"
       >
@@ -1174,15 +1177,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         const groupIds = params.groupIds;
         const editorGroupIds = params.editorGroupIds;
 
-        // Remove existing provisioned associations, read straight from group_vaults rather than
-        // `this.groups` (now sourced from group_permissions). Switching to manual mode drops the
-        // provisioned grants but leaves the group_vaults rows, so `this.groups` would not list them
-        // and the re-insert below would hit the (vaultId, groupId) unique constraint.
+        // Remove the associations of every group the user can pick here (provisioned and manual
+        // alike), read straight from group_vaults rather than `this.groups` (now sourced from
+        // group_permissions). Switching to manual mode drops those grants but leaves the
+        // group_vaults rows, so `this.groups` would not list them and the re-insert below would hit
+        // the (vaultId, groupId) unique constraint. Clearing the whole selectable set is also what
+        // makes deselecting a group actually remove its access.
         await GroupSpaceModel.destroy({
           where: {
             vaultId: this.id,
             workspaceId: auth.getNonNullableWorkspace().id,
-            groupKind: "provisioned",
+            groupKind: { [Op.in]: [...MANAGEABLE_GROUP_KINDS] },
           },
           transaction: t,
         });
@@ -1198,6 +1203,23 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           return selectedGroupsResult;
         }
         const selectedGroups = selectedGroupsResult.value;
+        // `fetchByIds` only checks that the caller can read the groups, not what they are. Without
+        // this, any readable group could be attached: the global group (which would silently make
+        // the space open), another space's regular_auto group (two of those on one space breaks
+        // `fetchManualMemberGroup`), or an agent/skill editors group.
+        const unsupportedGroups = selectedGroups.filter(
+          (group) => !isManageableGroupKind(group.kind)
+        );
+        if (unsupportedGroups.length > 0) {
+          // The associations were already dropped above, so re-sync before bailing out.
+          await syncGroupPermissions();
+          return new Err(
+            new DustError(
+              "invalid_group_kind",
+              "Only provisioned and manual groups can be given access to a space."
+            )
+          );
+        }
         for (const selectedGroup of selectedGroups) {
           await GroupSpaceMemberResource.makeNew(auth, {
             group: selectedGroup,
@@ -1225,6 +1247,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             selectedEditorGroups.length > 0,
             "Pods must have at least one editor group."
           );
+          // Same as above: `GroupSpaceEditorResource.makeNew` asserts on the kind, which would be a
+          // 500 rather than a rejected request.
+          const unsupportedEditorGroups = selectedEditorGroups.filter(
+            (group) => !isManageableGroupKind(group.kind)
+          );
+          if (unsupportedEditorGroups.length > 0) {
+            await syncGroupPermissions();
+            return new Err(
+              new DustError(
+                "invalid_group_kind",
+                "Only provisioned and manual groups can be given access to a space."
+              )
+            );
+          }
           for (const selectedEditorGroup of selectedEditorGroups) {
             await GroupSpaceEditorResource.makeNew(auth, {
               group: selectedEditorGroup,


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/10189

Allow to add regular manual group to space
The "provisioned group" mode is now just the "group" mode

Correctly reject invalid group type from both the API and the resource which was not the case before 

<img width="1148" height="1756" alt="image" src="https://github.com/user-attachments/assets/bcd1ff72-f165-4848-833a-4f6bcf808422" />


## Tests

tested locally

## Risk

can be reverted but will need a migration to drop the added group permissions

## Deploy Plan

deploy front
