### PR TITLE
[front] enh: add activity metrics in agent info page analytics

### DIFF
--- a/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
+++ b/front-api/routes/w/[wId]/analytics/consumption/overview.test.ts
@@ -23,6 +23,7 @@ const OVERVIEW: GetConsumptionOverviewResponse = {
     endDate: "2026-07-13T00:00:00.000Z",
   },
   members: { active: 121, total: 130 },
+  messageCount: 34243,
   lastRecordAt: "2026-07-12T23:58:00.000Z",
   totalCredits: 7248,
   topAgent: { agentId: "agent1", name: "dust", credits: 2246 },

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.test.tsx
@@ -1,0 +1,82 @@
+import { ConsumptionSummary } from "@app/components/workspace/analytics/consumption/ConsumptionSummary";
+import type { ConsumptionAnalyticsScope } from "@app/lib/analytics/consumption_scope";
+import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/consumption/overview";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockUseConsumptionOverview } = vi.hoisted(() => ({
+  mockUseConsumptionOverview: vi.fn(),
+}));
+
+vi.mock("@app/hooks/useConsumptionOverview", () => ({
+  useConsumptionOverview: mockUseConsumptionOverview,
+}));
+
+const period = { kind: "days", days: 30 } as const;
+const agentAnalyticsScope: ConsumptionAnalyticsScope = {
+  kind: "agent",
+  agentId: "agent-1",
+};
+
+const overview: GetConsumptionOverviewResponse = {
+  period: {
+    startDate: "2026-08-01T00:00:00.000Z",
+    endDate: "2026-08-31T23:59:59.999Z",
+  },
+  members: { active: 2, total: 2 },
+  messageCount: 566,
+  lastRecordAt: "2026-08-25T10:00:00.000Z",
+  totalCredits: 100,
+  topAgent: { agentId: "agent-1", name: "Research agent", credits: 100 },
+  creditUsage: null,
+};
+
+describe("ConsumptionSummary", () => {
+  beforeEach(() => {
+    mockUseConsumptionOverview.mockReturnValue({
+      overview,
+      isOverviewLoading: false,
+      isOverviewError: undefined,
+    });
+  });
+
+  it("shows activity and cost metrics in an agent-scoped summary", () => {
+    render(
+      <ConsumptionSummary
+        workspaceId="workspace-id"
+        period={period}
+        analyticsScope={agentAnalyticsScope}
+      />
+    );
+
+    expect(mockUseConsumptionOverview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "workspace-id",
+        analyticsScope: agentAnalyticsScope,
+      })
+    );
+    expect(screen.getByText("Active Users")).toBeInTheDocument();
+    expect(screen.getByText("Messages / active user")).toBeInTheDocument();
+    expect(screen.getByText("283")).toBeInTheDocument();
+    expect(screen.getByText("Total cost")).toBeInTheDocument();
+    expect(screen.getByText("100 credits")).toBeInTheDocument();
+    expect(screen.getByText("Avg. cost/msg")).toBeInTheDocument();
+    expect(screen.getByText("0.2 credits")).toBeInTheDocument();
+    expect(
+      screen.getByText("Active Users").closest(".bg-panel-background")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Messages / active user").closest(".bg-panel-background")
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Top agent")).not.toBeInTheDocument();
+  });
+
+  it("keeps the top agent in a workspace summary", () => {
+    render(<ConsumptionSummary workspaceId="workspace-id" period={period} />);
+
+    expect(screen.getByText("Top agent")).toBeInTheDocument();
+    expect(screen.getByText("Research agent")).toBeInTheDocument();
+    expect(screen.queryByText("Active Users")).not.toBeInTheDocument();
+    expect(screen.queryByText("Total cost")).not.toBeInTheDocument();
+  });
+});

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -7,7 +7,14 @@ import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/cons
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { formatCredits } from "@app/lib/client/credits";
 import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
-import { ArrowUpRight, Button, Chip, LoadingBlock } from "@dust-tt/sparkle";
+import {
+  ArrowUpRight,
+  Button,
+  CardGrid,
+  Chip,
+  LoadingBlock,
+  ValueCard,
+} from "@dust-tt/sparkle";
 
 const TARGET_CHIP: Record<
   CreditUsageTarget,
@@ -85,25 +92,35 @@ export function ConsumptionSummaryView({
   responsiveLayout = false,
   analyticsScope = WORKSPACE_CONSUMPTION_ANALYTICS_SCOPE,
 }: ConsumptionSummaryViewProps) {
+  const isAgentScoped = analyticsScope.kind === "agent";
+
   if (isOverviewLoading) {
     return (
-      <div
-        className={
-          responsiveLayout
-            ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
-            : "flex items-stretch gap-6"
-        }
-      >
-        <LoadingBlock
+      <div className="flex flex-col gap-4">
+        {isAgentScoped && (
+          <CardGrid adaptColumns>
+            <LoadingBlock className="h-24 rounded-xl" />
+            <LoadingBlock className="h-24 rounded-xl" />
+          </CardGrid>
+        )}
+        <div
           className={
-            responsiveLayout ? "h-24 rounded-xl" : "h-24 flex-1 rounded-xl"
+            responsiveLayout
+              ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+              : "flex items-stretch gap-6"
           }
-        />
-        <LoadingBlock
-          className={
-            responsiveLayout ? "h-24 rounded-xl" : "h-24 flex-1 rounded-xl"
-          }
-        />
+        >
+          <LoadingBlock
+            className={
+              responsiveLayout ? "h-24 rounded-xl" : "h-24 flex-1 rounded-xl"
+            }
+          />
+          <LoadingBlock
+            className={
+              responsiveLayout ? "h-24 rounded-xl" : "h-24 flex-1 rounded-xl"
+            }
+          />
+        </div>
       </div>
     );
   }
@@ -115,6 +132,16 @@ export function ConsumptionSummaryView({
   const { topAgent, totalCredits } = overview;
   const creditUsage =
     analyticsScope.kind === "workspace" ? overview.creditUsage : null;
+  const messagesPerActiveUser =
+    overview.messageCount === undefined
+      ? null
+      : overview.members.active > 0
+        ? Math.round(overview.messageCount / overview.members.active)
+        : 0;
+  const averageCostPerMessage =
+    overview.messageCount !== undefined && overview.messageCount > 0
+      ? totalCredits / overview.messageCount
+      : null;
 
   return (
     <div className="flex flex-col gap-4">
@@ -146,6 +173,28 @@ export function ConsumptionSummaryView({
           />
         </div>
       )}
+      {isAgentScoped && (
+        <CardGrid adaptColumns>
+          <ValueCard
+            title="Active Users"
+            className="h-24 bg-panel-background"
+            content={
+              <div className="truncate text-2xl tabular-nums text-foreground">
+                {overview.members.active.toLocaleString()}
+              </div>
+            }
+          />
+          <ValueCard
+            title="Messages / active user"
+            className="h-24 bg-panel-background"
+            content={
+              <div className="truncate text-2xl tabular-nums text-foreground">
+                {messagesPerActiveUser?.toLocaleString() ?? "—"}
+              </div>
+            }
+          />
+        </CardGrid>
+      )}
       <div
         className={
           responsiveLayout
@@ -153,24 +202,45 @@ export function ConsumptionSummaryView({
             : "flex items-stretch gap-6"
         }
       >
-        <SummaryCard
-          label="Used this period"
-          value={formatCredits(totalCredits)}
-          hint={
-            creditUsage
-              ? `${creditUsage.status.usedPercentage}% of ${formatCredits(creditUsage.capCredits)} cap`
-              : null
-          }
-        />
-        <SummaryCard
-          label="Top agent"
-          value={topAgent?.name ?? "—"}
-          hint={
-            topAgent && totalCredits > 0
-              ? `${Math.round((topAgent.credits / totalCredits) * 100)}% of total consumption`
-              : null
-          }
-        />
+        {isAgentScoped ? (
+          <>
+            <SummaryCard
+              label="Total cost"
+              value={`${formatCredits(totalCredits)} credits`}
+              hint={null}
+            />
+            <SummaryCard
+              label="Avg. cost/msg"
+              value={
+                averageCostPerMessage === null
+                  ? "—"
+                  : `${formatCredits(averageCostPerMessage)} credits`
+              }
+              hint={null}
+            />
+          </>
+        ) : (
+          <>
+            <SummaryCard
+              label="Used this period"
+              value={formatCredits(totalCredits)}
+              hint={
+                creditUsage
+                  ? `${creditUsage.status.usedPercentage}% of ${formatCredits(creditUsage.capCredits)} cap`
+                  : null
+              }
+            />
+            <SummaryCard
+              label="Top agent"
+              value={topAgent?.name ?? "—"}
+              hint={
+                topAgent && totalCredits > 0
+                  ? `${Math.round((topAgent.credits / totalCredits) * 100)}% of total consumption`
+                  : null
+              }
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -7,14 +7,7 @@ import type { GetConsumptionOverviewResponse } from "@app/lib/api/analytics/cons
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { formatCredits } from "@app/lib/client/credits";
 import type { CreditUsageTarget } from "@app/types/api/credits/usage_status";
-import {
-  ArrowUpRight,
-  Button,
-  CardGrid,
-  Chip,
-  LoadingBlock,
-  ValueCard,
-} from "@dust-tt/sparkle";
+import { ArrowUpRight, Button, Chip, LoadingBlock } from "@dust-tt/sparkle";
 
 const TARGET_CHIP: Record<
   CreditUsageTarget,
@@ -93,33 +86,25 @@ export function ConsumptionSummaryView({
   analyticsScope = WORKSPACE_CONSUMPTION_ANALYTICS_SCOPE,
 }: ConsumptionSummaryViewProps) {
   const isAgentScoped = analyticsScope.kind === "agent";
+  const cardRowClassName = responsiveLayout
+    ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+    : "flex items-stretch gap-6";
+  const loadingCardClassName = responsiveLayout
+    ? "h-24 rounded-xl"
+    : "h-24 flex-1 rounded-xl";
 
   if (isOverviewLoading) {
     return (
       <div className="flex flex-col gap-4">
         {isAgentScoped && (
-          <CardGrid adaptColumns>
-            <LoadingBlock className="h-24 rounded-xl" />
-            <LoadingBlock className="h-24 rounded-xl" />
-          </CardGrid>
+          <div className={cardRowClassName}>
+            <LoadingBlock className={loadingCardClassName} />
+            <LoadingBlock className={loadingCardClassName} />
+          </div>
         )}
-        <div
-          className={
-            responsiveLayout
-              ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
-              : "flex items-stretch gap-6"
-          }
-        >
-          <LoadingBlock
-            className={
-              responsiveLayout ? "h-24 rounded-xl" : "h-24 flex-1 rounded-xl"
-            }
-          />
-          <LoadingBlock
-            className={
-              responsiveLayout ? "h-24 rounded-xl" : "h-24 flex-1 rounded-xl"
-            }
-          />
+        <div className={cardRowClassName}>
+          <LoadingBlock className={loadingCardClassName} />
+          <LoadingBlock className={loadingCardClassName} />
         </div>
       </div>
     );
@@ -174,34 +159,20 @@ export function ConsumptionSummaryView({
         </div>
       )}
       {isAgentScoped && (
-        <CardGrid adaptColumns>
-          <ValueCard
-            title="Active Users"
-            className="h-24 bg-panel-background"
-            content={
-              <div className="truncate text-2xl tabular-nums text-foreground">
-                {overview.members.active.toLocaleString()}
-              </div>
-            }
+        <div className={cardRowClassName}>
+          <SummaryCard
+            label="Active Users"
+            value={overview.members.active.toLocaleString()}
+            hint={null}
           />
-          <ValueCard
-            title="Messages / active user"
-            className="h-24 bg-panel-background"
-            content={
-              <div className="truncate text-2xl tabular-nums text-foreground">
-                {messagesPerActiveUser?.toLocaleString() ?? "—"}
-              </div>
-            }
+          <SummaryCard
+            label="Messages / active user"
+            value={messagesPerActiveUser?.toLocaleString() ?? "—"}
+            hint={null}
           />
-        </CardGrid>
+        </div>
       )}
-      <div
-        className={
-          responsiveLayout
-            ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
-            : "flex items-stretch gap-6"
-        }
-      >
+      <div className={cardRowClassName}>
         {isAgentScoped ? (
           <>
             <SummaryCard

--- a/front/lib/api/analytics/consumption/overview.test.ts
+++ b/front/lib/api/analytics/consumption/overview.test.ts
@@ -1,0 +1,55 @@
+import { fetchConsumptionOverview } from "@app/lib/api/analytics/consumption/overview";
+import { searchConsumptionAnalytics } from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Ok } from "@app/types/shared/result";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+
+function esResponse(aggregations: unknown) {
+  return new Ok({ aggregations }) as Awaited<
+    ReturnType<typeof searchConsumptionAnalytics>
+  >;
+}
+
+describe("fetchConsumptionOverview", () => {
+  afterEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+  });
+
+  it("counts distinct messages in the scoped period", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({
+        active_members: { value: 2 },
+        message_count: { value: 7 },
+        total_credit_micro: { value: 0 },
+      })
+    );
+
+    const result = await fetchConsumptionOverview(auth, {
+      periodInput: { kind: "days", days: 7 },
+      filter: { agents: ["agent-1"] },
+      includeWorkspaceContext: false,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.members).toEqual({ active: 2, total: 2 });
+    expect(result.value.messageCount).toBe(7);
+    expect(
+      vi.mocked(searchConsumptionAnalytics).mock.calls[0]?.[1]?.aggregations
+        ?.message_count?.cardinality
+    ).toEqual({
+      field: "agent_message_id",
+      precision_threshold: 40_000,
+    });
+  });
+});

--- a/front/lib/api/analytics/consumption/overview.ts
+++ b/front/lib/api/analytics/consumption/overview.ts
@@ -6,7 +6,9 @@ import type {
 import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import type { ConsumptionScopeFilter } from "@app/lib/api/analytics/consumption/scope";
 import {
+  AGENT_MESSAGE_ID_FIELD,
   buildConsumptionScopeQuery,
+  CARDINALITY_PRECISION_THRESHOLD,
   COMPLETED_AT_FIELD,
   CONSUMPTION_DIMENSION_FIELDS,
   CREDIT_MICRO_FIELD,
@@ -43,6 +45,7 @@ export type ConsumptionOverview = {
     active: number;
     total: number;
   };
+  messageCount?: number;
   lastRecordAt: string | null;
   totalCredits: number;
   topAgent: ConsumptionOverviewTopAgent | null;
@@ -60,6 +63,7 @@ type TopAgentBucket = {
 
 type OverviewAggs = {
   active_members?: estypes.AggregationsCardinalityAggregate;
+  message_count?: estypes.AggregationsCardinalityAggregate;
   last_completed_at?: estypes.AggregationsMaxAggregate;
   total_credit_micro?: estypes.AggregationsSumAggregate;
   top_agent?: estypes.AggregationsMultiBucketAggregateBase<TopAgentBucket>;
@@ -163,6 +167,12 @@ export async function fetchConsumptionOverview(
     searchConsumptionAnalytics<never, OverviewAggs>(query, {
       aggregations: {
         active_members: { cardinality: { field: "user.id" } },
+        message_count: {
+          cardinality: {
+            field: AGENT_MESSAGE_ID_FIELD,
+            precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+          },
+        },
         last_completed_at: { max: { field: COMPLETED_AT_FIELD } },
         total_credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
         top_agent: {
@@ -202,6 +212,7 @@ export async function fetchConsumptionOverview(
       active: activeMembers,
       total: includeWorkspaceContext ? totalMembers : activeMembers,
     },
+    messageCount: Math.round(aggregations?.message_count?.value ?? 0),
     lastRecordAt: lastRecordAtFromAgg(aggregations?.last_completed_at),
     totalCredits,
     topAgent: await topAgentFromAgg(auth, aggregations?.top_agent),


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/10167.

Follow up on https://github.com/dust-tt/dust/pull/31070, which replaced the observability charts in the Insights tab of the agent info page with a view of the new analytics page scoped to the agent.

This PR ports two cards that were present in the observability view: the number of active users and the avg number of messages per user.

<img width="677" height="656" alt="image" src="https://github.com/user-attachments/assets/96e9bb1a-8a54-4020-87d9-dd06e35b73ba" />

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
