### PR TITLE
[marketing] chore: remove unused class-variance-authority dependency

### DIFF
--- a/marketing/package.json
+++ b/marketing/package.json
@@ -27,7 +27,6 @@
     "@radix-ui/react-visually-hidden": "^1.1.2",
     "@tailwindcss/forms": "^0.5.9",
     "@tanstack/react-table": "^8.13.0",
-    "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "contentful": "^11.9.0",
     "date-fns": "^3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1142,7 +1142,6 @@
         "@radix-ui/react-visually-hidden": "^1.1.2",
         "@tailwindcss/forms": "^0.5.9",
         "@tanstack/react-table": "^8.13.0",
-        "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "contentful": "^11.9.0",
         "date-fns": "^3.6.0",


### PR DESCRIPTION
## Description

Remove the unused `class-variance-authority` dependency from `marketing/package.json` and `package-lock.json`.

It was used until PR #28969 ("Rework product page: hero, capabilities, and security sections", merged 2026-08-17), which reworked the product page and dropped the `cva(...)` usage.

## Tests

Verified with `knip --dependencies` and a repo-wide grep (`class-variance-authority`, `\bcva\b`) that it is not referenced anywhere under `marketing/` outside `package.json`/`package-lock.json`. Ran `npm install --package-lock-only -w marketing` to regenerate the lockfile.

## Risk

Low: dependency-only change with no runtime code changes.

## Deploy Plan

None — no runtime behavior change.