### PR TITLE
[sparkle] chore: remove unused @headlessui/react dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5950,23 +5950,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@headlessui/react": {
-      "version": "1.7.19",
-      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
-      "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/react-virtual": "^3.0.0-beta.60",
-        "client-only": "^0.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "react": "^16 || ^17 || ^18",
-        "react-dom": "^16 || ^17 || ^18"
-      }
-    },
     "node_modules/@heroicons/react": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
@@ -56606,7 +56589,6 @@
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",
-        "@headlessui/react": "^1.7.19",
         "@radix-ui/react-aspect-ratio": "^1.1.0",
         "@radix-ui/react-checkbox": "^1.1.2",
         "@radix-ui/react-collapsible": "^1.1.3",

--- a/sparkle/package.json
+++ b/sparkle/package.json
@@ -106,7 +106,6 @@
   "dependencies": {
     "@emoji-mart/data": "^1.1.2",
     "@emoji-mart/react": "^1.1.1",
-    "@headlessui/react": "^1.7.19",
     "@radix-ui/react-aspect-ratio": "^1.1.0",
     "@radix-ui/react-checkbox": "^1.1.2",
     "@radix-ui/react-collapsible": "^1.1.3",


### PR DESCRIPTION
## Description

Remove the unused `@headlessui/react` dependency from `sparkle/package.json` and `package-lock.json`.

It has been unused since PR #12330 ("Deleting pop up component", merged 2025-04-29), which removed the last component that imported it. Prior cleanups (#10784, #9342) had already removed most other usages before that.

## Tests

Verified with `knip --dependencies` and a repo-wide grep (`@headlessui`, `Headless`) that it is not referenced anywhere under `sparkle/src` or re-exported from the package's public entry point (`src/index.ts`). It is also not declared as a peer dependency. Ran `npm install --package-lock-only -w sparkle` to regenerate the lockfile.

## Risk

Low: dependency-only change with no runtime code changes. Since `sparkle` is a published package (`@dust-tt/sparkle`), this also slightly reduces its install footprint for consumers.

## Deploy Plan

None — no runtime behavior change.