### PR TITLE
[front] Raise agent version history limit to 50, with a localStorage override

### DIFF
--- a/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
+++ b/front-api/routes/w/[wId]/assistant/agent_configurations/[aId]/history/index.ts
@@ -45,7 +45,7 @@ app.get(
     }
 
     // The schema expects `limit` as a number; query params arrive as strings,
-    // so we parseInt before validation (matches the Next-side handler).
+    // so we parseInt before validation.
     const queryRaw = ctx.req.query();
     const queryValidation = GetAgentConfigurationsHistoryQuerySchema.safeParse({
       ...queryRaw,

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsBlock.tsx
@@ -18,6 +18,31 @@ import { format } from "date-fns/format";
 import React, { useState } from "react";
 import { useFormContext } from "react-hook-form";
 
+const DEFAULT_INSTRUCTIONS_HISTORY_LIMIT = 50;
+const INSTRUCTIONS_HISTORY_LIMIT_STORAGE_KEY =
+  "dust_instructions_history_limit";
+
+function readInstructionsHistoryLimit(): number {
+  if (typeof window === "undefined") {
+    return DEFAULT_INSTRUCTIONS_HISTORY_LIMIT;
+  }
+  try {
+    const raw = localStorage.getItem(INSTRUCTIONS_HISTORY_LIMIT_STORAGE_KEY);
+    const parsed = Number.parseInt(raw ?? "", 10);
+
+    return parsed > 0 ? parsed : DEFAULT_INSTRUCTIONS_HISTORY_LIMIT;
+  } catch {
+    // localStorage unavailable.
+    return DEFAULT_INSTRUCTIONS_HISTORY_LIMIT;
+  }
+}
+
+// Escape hatch for users who want a higher limit They can run e.g.
+// localStorage.setItem("dust_instructions_history_limit", "100")
+// And to go back to default:
+// localStorage.removeItem("dust_instructions_history_limit")
+const INSTRUCTIONS_HISTORY_LIMIT = readInstructionsHistoryLimit();
+
 interface AgentBuilderInstructionsBlockProps {
   agentConfigurationId: string | null;
 }
@@ -35,7 +60,7 @@ export function AgentBuilderInstructionsBlock({
     workspaceId: owner.sId,
     agentConfigurationId,
     disabled: !agentConfigurationId,
-    limit: 30,
+    limit: INSTRUCTIONS_HISTORY_LIMIT,
   });
 
   const restoreVersion = () => {

--- a/front/types/api/agent_configuration.ts
+++ b/front/types/api/agent_configuration.ts
@@ -37,7 +37,7 @@ export const GetAgentConfigurationsQuerySchema = z.object({
 });
 
 export const GetAgentConfigurationsHistoryQuerySchema = z.object({
-  limit: LimitSchema.optional(),
+  limit: z.number().int().min(1).optional(),
 });
 
 // Data sources


### PR DESCRIPTION
## Description

The version history dropdown in the agent builder fetched 30 versions. This bumps the default to 50, and adds an escape hatch for users who need to go further back: set `dust_instructions_history_limit` in localStorage and reload.

```js
localStorage.setItem("dust_instructions_history_limit", "100")  // override
localStorage.removeItem("dust_instructions_history_limit")      // back to default
```

This is a bit unusual, but it lets us make a few customers who ask for this happy at low cost, without affecting everyone else.

Leaving it uncapped costs nothing server-side: `listsAgentConfigurationVersions` does a `findAll` with no limit and runs `enrichAgentConfigurations` over every version, and the handler only slices the result afterwards. The database and enrichment work is already paid in full at the default, so a higher value only means a larger response, paid for by the caller who asked for it.

Note that the dropdown collapses consecutive versions with identical instructions and drops the current version, so the number of visible rows is still lower than the number of versions fetched.

Also removes a stale comment in the route referring to a "Next-side handler" — that handler no longer exists, this Hono route is the only one.

## Risk

Low. Default behaviour changes only in fetching 50 versions instead of 30. The override is opt-in per browser, and the endpoint still authorizes per config via `canRead`, so nothing here lets a user reach an agent they can't already see.

## Deploy Plan

Deploy front and front-api.