### PR TITLE
[front] feat: show consumption analytics in Agent Builder

### DIFF
--- a/front/components/agent_builder/AgentBuilderInsights.tsx
+++ b/front/components/agent_builder/AgentBuilderInsights.tsx
@@ -1,5 +1,5 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import { CombinedInsightsContent } from "@app/components/observability/CombinedInsightsContent";
+import { AgentInsightsTab } from "@app/components/assistant/details/tabs/AgentInsightsTab";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { cn, LoadingBlock } from "@dust-tt/sparkle";
 
@@ -28,14 +28,11 @@ export function AgentBuilderInsights({
     );
   }
 
-  const isCustomAgent = agentConfiguration.scope !== "global";
-
   return (
     <section className="flex h-full flex-col overflow-y-auto p-4">
-      <CombinedInsightsContent
+      <AgentInsightsTab
         owner={owner}
-        agentConfigurationId={agentConfiguration.sId}
-        isCustomAgent={isCustomAgent}
+        agentConfiguration={agentConfiguration}
       />
     </section>
   );

--- a/front/components/agent_builder/AgentBuilderInsights.tsx
+++ b/front/components/agent_builder/AgentBuilderInsights.tsx
@@ -30,10 +30,7 @@ export function AgentBuilderInsights({
 
   return (
     <section className="flex h-full flex-col overflow-y-auto p-4">
-      <AgentInsightsTab
-        owner={owner}
-        agentConfiguration={agentConfiguration}
-      />
+      <AgentInsightsTab owner={owner} agentConfiguration={agentConfiguration} />
     </section>
   );
 }

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -1,7 +1,6 @@
 import { AgentBuilderInsights } from "@app/components/agent_builder/AgentBuilderInsights";
 import { AgentBuilderPreview } from "@app/components/agent_builder/AgentBuilderPreview";
 import { AgentBuilderSidekick } from "@app/components/agent_builder/AgentBuilderSidekick";
-import { ObservabilityProvider } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
 import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
@@ -156,20 +155,18 @@ function ExpandedContent({
           <AgentBuilderPreview />
         </div>
       )}
-      <ObservabilityProvider>
-        {selectedTab === "insights" &&
-          (agentConfigurationId ? (
-            <AgentBuilderInsights agentConfigurationId={agentConfigurationId} />
-          ) : (
-            <TabContentLayout title="Insights">
-              <EmptyPlaceholder
-                icon={BarChart01}
-                title="Waiting for data"
-                description="Use your agent or share it with your team to see insights data."
-              />
-            </TabContentLayout>
-          ))}
-      </ObservabilityProvider>
+      {selectedTab === "insights" &&
+        (agentConfigurationId ? (
+          <AgentBuilderInsights agentConfigurationId={agentConfigurationId} />
+        ) : (
+          <TabContentLayout title="Insights">
+            <EmptyPlaceholder
+              icon={BarChart01}
+              title="Waiting for data"
+              description="Use your agent or share it with your team to see insights data."
+            />
+          </TabContentLayout>
+        ))}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Part of https://github.com/dust-tt/tasks/issues/10167.

The Agent Builder Insights tab currently uses the legacy observability view. The agent info page was moved to the new analytics consumption view in https://github.com/dust-tt/dust/pull/31070.

This PR migrates the AgentInsightsTab.

<img width="1250" height="1186" alt="image" src="https://github.com/user-attachments/assets/1b5a8799-7413-4a48-ab57-9a0d52c0f506" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
