### PR TITLE
fix: empty screen after adding favorite skill

### DIFF
--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -2,6 +2,7 @@ import type { ImportFormValues } from "@app/components/skills/import/formSchema"
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import type { ImportSkillsResponseBody } from "@app/lib/api/skills/detection/github/import_skills";
+import { useAppRouter } from "@app/lib/platform";
 import type {
   DetectedSkillSummary,
   DetectSkillsResponseBody,
@@ -410,6 +411,7 @@ export function useUpdateSkillFavorite({
 }) {
   const { fetcher } = useFetcher();
   const sendNotification = useSendNotification();
+  const router = useAppRouter();
 
   const { mutateSkills: mutateActiveSkills } = useSkills({
     owner,
@@ -443,7 +445,15 @@ export function useUpdateSkillFavorite({
             description: skill.name,
             action: {
               label: "View",
-              href: `${getManageSkillsRoute(owner.sId)}#?selectedTab=favorites`,
+              onClick: () => {
+                void router
+                  .push(
+                    `${getManageSkillsRoute(owner.sId)}#?selectedTab=favorites`
+                  )
+                  .then(() =>
+                    window.dispatchEvent(new HashChangeEvent("hashchange"))
+                  );
+              },
             },
           });
         }
@@ -464,6 +474,7 @@ export function useUpdateSkillFavorite({
       mutateActiveSkills,
       mutateActiveSkillsWithRelations,
       owner.sId,
+      router,
       sendNotification,
     ]
   );

--- a/sparkle/src/components/Notification.tsx
+++ b/sparkle/src/components/Notification.tsx
@@ -19,9 +19,8 @@ const NOTIFICATION_DELAY_MS = 5000;
 export type NotificationType = {
   /** Optional action button shown under the message; clicking it also dismisses the toast. */
   action?: {
-    href?: string;
     label: string;
-    onClick?: () => void;
+    onClick: () => void;
   };
   title?: string;
   description?: string;
@@ -136,9 +135,8 @@ export function NotificationContent({
             size="xs"
             variant="ghost"
             label={action.label}
-            href={action.href}
             onClick={() => {
-              action.onClick?.();
+              action.onClick();
               onDismiss?.();
             }}
           />

--- a/sparkle/src/stories/Notification.stories.tsx
+++ b/sparkle/src/stories/Notification.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
+import { fn } from "storybook/test";
 
 import {
   NotificationContent,
@@ -32,7 +33,7 @@ export default meta;
 /**
  * Notification shown inline (no toast) for design iteration: every `type`
  * variant of the underlying NotificationContent card, plus one with an
- * `action` link.
+ * `action` button.
  * @summary All notification types rendered inline.
  */
 export const Inline: StoryObj = {
@@ -67,7 +68,7 @@ export const Inline: StoryObj = {
         type="success"
         title="Added to favorites"
         description="Research assistant"
-        action={{ label: "View", href: "#favorites" }}
+        action={{ label: "View", onClick: fn() }}
       />
     </div>
   ),


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/10173 

When adding a skill to favorites, clicking on the "view" button showed an empty page.

The toast's **View** action used `action.href`. Sparkle renders that as a link built from `SparkleContext.components.link`, which the SPA sets to a React Router `<Link>`. But the toaster is mounted by `Notification.Area` in `RootLayout`, which sits **above** `<RouterProvider>` in `front-spa/src/app/App.tsx` — so toast content renders with no Router context, `<Link>` throws and because the toaster is outside the `ErrorBoundary` the error reached the React root and unmounted everything.

Replaced the `href` with an `onClick` that pushes through `useAppRouter()`.

## Tests

Manually.

## Risks

Low. Single call site behind the `skill_favorites` flag.

## Deploy Plan

Standard deployment.
