### PR TITLE
refactor(front): route mention queries through MentionResource

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -7,7 +7,6 @@ import {
   AgentMessageFeedbackModel,
   AgentMessageModel,
   CompactionMessageModel,
-  MentionModel,
   MessageModel,
   MessageReactionModel,
   UserMessageModel,
@@ -25,6 +24,7 @@ import type { ConversationResource } from "@app/lib/resources/conversation_resou
 import { ConversationSandboxAdapter } from "@app/lib/resources/conversation_sandbox_adapter";
 import { ConversationSelectedSpaceResource } from "@app/lib/resources/conversation_selected_space_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { MentionResource } from "@app/lib/resources/mention_resource";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import {
   ProjectTaskConversationModel,
@@ -88,11 +88,8 @@ async function destroyMessageRelatedResources(
       messageId: messageIds,
     },
   });
-  await MentionModel.destroy({
-    where: {
-      workspaceId: owner.id,
-      messageId: messageIds,
-    },
+  await MentionResource.deleteByMessageModelIds(auth, {
+    messageModelIds: messageIds,
   });
   // TODO: We should also destroy the parent message
   await MessageModel.destroy({

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -15,10 +15,10 @@ import { getUserForWorkspace } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
 import { extractFromString } from "@app/lib/mentions/format";
 import type { MentionStatusType } from "@app/lib/models/agent/conversation";
-import { MentionModel } from "@app/lib/models/agent/conversation";
 import { triggerConversationUnreadNotifications } from "@app/lib/notifications/workflows/conversation-unread";
 import { notifyPodMembersAdded } from "@app/lib/notifications/workflows/pod-added-as-member";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MentionResource } from "@app/lib/resources/mention_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -208,13 +208,13 @@ export const createUserMentions = async (
   }
 ): Promise<RichMentionWithStatus[]> => {
   const usersById = new Map<ModelId, UserType>();
-  const mentionModels: MentionModel[] = [];
+  const mentions: MentionResource[] = [];
 
   for (const { user, isParticipant, status } of resolvedMentions) {
     usersById.set(user.id, user);
 
-    mentionModels.push(
-      await MentionModel.create(
+    mentions.push(
+      await MentionResource.makeNew(
         {
           messageId: message.id,
           userId: user.id,
@@ -238,7 +238,7 @@ export const createUserMentions = async (
 
   return getRichMentionsWithStatusForMessage(
     message.id,
-    mentionModels,
+    mentions,
     usersById,
     new Map() // No agent configurations in the users mentions.
   );
@@ -431,17 +431,14 @@ export async function validateUserMention(
         (m) => isPendingStatus(m.status) && m.id === userId
       )
     ) {
-      const mentionModel = await MentionModel.findOne({
-        where: {
-          workspaceId: conversation.owner.id,
-          messageId: latestMessage.id,
-          userId: user.id,
-        },
+      const mention = await MentionResource.findByMessagesAndUser(auth, {
+        messageModelIds: [latestMessage.id],
+        userModelId: user.id,
       });
-      if (!mentionModel) {
+      if (!mention) {
         continue;
       }
-      await mentionModel.update({ status: mentionStatus });
+      await mention.updateStatus(auth, { status: mentionStatus });
       const newRichMentions = latestMessage.richMentions.map((m) =>
         isRichUserMention(m) && m.id === userId
           ? {
@@ -644,29 +641,24 @@ export async function dismissMention(
       !isCompactionMessageType(latestMessage) &&
       latestMessage.richMentions.some(predicate)
     ) {
-      const mentionModels = await MentionModel.findAll({
-        where: {
-          workspaceId: conversation.owner.id,
-          messageId: latestMessage.id,
-          ...(type === "user"
-            ? {
-                userId: userIdForQuery,
-                status: "user_restricted_by_conversation_access",
-              }
-            : {
-                agentConfigurationId: id,
-                status: "agent_restricted_by_space_usage",
-              }),
-        },
+      const mentions = await MentionResource.listByMessageModelIds(auth, {
+        messageModelIds: [latestMessage.id],
+        ...(type === "user"
+          ? {
+              userModelId: userIdForQuery,
+              status: "user_restricted_by_conversation_access",
+            }
+          : {
+              agentConfigurationId: id,
+              status: "agent_restricted_by_space_usage",
+            }),
       });
-      if (mentionModels.length === 0) {
+      if (mentions.length === 0) {
         continue;
       }
       // Instance updates avoid Sequelize bulk-update validation that requires
       // userId/agentConfigurationId on the partial payload.
-      await Promise.all(
-        mentionModels.map((m) => m.update({ dismissed: true }))
-      );
+      await Promise.all(mentions.map((m) => m.dismiss(auth)));
       const newRichMentions = latestMessage.richMentions.map((m) =>
         predicate(m)
           ? {

--- a/front/lib/api/assistant/conversation/messages.ts
+++ b/front/lib/api/assistant/conversation/messages.ts
@@ -8,11 +8,11 @@ import { getFeatureFlags } from "@app/lib/auth";
 import {
   AgentMessageModel,
   CompactionMessageModel,
-  MentionModel,
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { MentionResource } from "@app/lib/resources/mention_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids_server";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { isEmailValid } from "@app/lib/utils";
@@ -361,7 +361,7 @@ export const createAgentMessages = async (
         }
       | {
           type: "approve_existing_mention";
-          mentionRow: MentionModel;
+          mentionRow: MentionResource;
           configuration: LightAgentConfigurationType;
           skipToolsValidation: boolean;
           nextMessageRank: number;
@@ -383,7 +383,7 @@ export const createAgentMessages = async (
     configuration: LightAgentConfigurationType;
     parentMessageId: string;
     parentAgentMessageId: string | null;
-    mentionRow: MentionModel | null;
+    mentionRow: MentionResource | null;
   }[] = [];
 
   switch (metadata.type) {
@@ -493,8 +493,11 @@ export const createAgentMessages = async (
 
     case "approve_existing_mention":
       // Fall through into the shared create path after marking the existing
-      // mention approved (do not insert a duplicate MentionModel row).
-      await metadata.mentionRow.update({ status: "approved" }, { transaction });
+      // mention approved (do not insert a duplicate mention row).
+      await metadata.mentionRow.updateStatus(auth, {
+        status: "approved",
+        transaction,
+      });
     // falls through
     case "create":
       {
@@ -506,14 +509,14 @@ export const createAgentMessages = async (
           break;
         }
 
-        let mentionRow: MentionModel;
+        let mentionRow: MentionResource;
         if (metadata.type === "approve_existing_mention") {
           mentionRow = metadata.mentionRow;
         } else {
           if (metadata.isRestrictedBySpaceUsage) {
             // This create the mentions from the original user message. Not to be mixed with
             // the mentions from the agent message (which will be filled later).
-            const restrictedMentionRow = await MentionModel.create(
+            const restrictedMentionRow = await MentionResource.makeNew(
               {
                 messageId: metadata.userMessage.id,
                 agentConfigurationId: configuration.sId,
@@ -536,7 +539,7 @@ export const createAgentMessages = async (
 
           // This create the mentions from the original user message. Not to be mixed with the
           // mentions from the agent message (which will be filled later).
-          mentionRow = await MentionModel.create(
+          mentionRow = await MentionResource.makeNew(
             {
               messageId: metadata.userMessage.id,
               agentConfigurationId: configuration.sId,

--- a/front/lib/api/assistant/conversation/validate_agent_mention.ts
+++ b/front/lib/api/assistant/conversation/validate_agent_mention.ts
@@ -15,8 +15,8 @@ import {
 import { enforcePremiumModelLimit } from "@app/lib/api/assistant/premium_model_limit";
 import { publishMessageEventsOnMessagePostOrEdit } from "@app/lib/api/assistant/streaming/events";
 import type { Authenticator } from "@app/lib/auth";
-import { MentionModel } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MentionResource } from "@app/lib/resources/mention_resource";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import { auditLog } from "@app/logger/logger";
 import type {
@@ -124,15 +124,12 @@ export async function validateAgentMention(
   }
 
   if (!isApproval) {
-    const mentionModels = await MentionModel.findAll({
-      where: {
-        workspaceId: conversation.owner.id,
-        messageId: message.id,
-        agentConfigurationId,
-        status: "agent_restricted_by_space_usage",
-      },
+    const mentions = await MentionResource.listByMessageModelIds(auth, {
+      messageModelIds: [message.id],
+      agentConfigurationId,
+      status: "agent_restricted_by_space_usage",
     });
-    if (mentionModels.length === 0) {
+    if (mentions.length === 0) {
       return new Err({
         status_code: 404,
         api_error: {
@@ -144,7 +141,7 @@ export async function validateAgentMention(
     // Instance updates avoid Sequelize bulk-update validation that requires
     // userId/agentConfigurationId on the partial payload.
     await Promise.all(
-      mentionModels.map((m) => m.update({ status: "rejected" }))
+      mentions.map((m) => m.updateStatus(auth, { status: "rejected" }))
     );
 
     const newRichMentions = message.richMentions.map((m) =>
@@ -253,21 +250,18 @@ export async function validateAgentMention(
     const created = await withTransaction(async (t) => {
       await getConversationRankVersionLock(auth, conversation, t);
 
-      const mentionModels = await MentionModel.findAll({
-        where: {
-          workspaceId: conversation.owner.id,
-          messageId: message.id,
-          agentConfigurationId,
-          status: "agent_restricted_by_space_usage",
-        },
+      const mentions = await MentionResource.listByMessageModelIds(auth, {
+        messageModelIds: [message.id],
+        agentConfigurationId,
+        status: "agent_restricted_by_space_usage",
         transaction: t,
-        lock: t.LOCK.UPDATE,
+        forUpdate: true,
       });
-      if (mentionModels.length === 0) {
+      if (mentions.length === 0) {
         throw new Error("Restricted agent mention not found");
       }
 
-      const [primaryMention, ...duplicateMentions] = mentionModels;
+      const [primaryMention, ...duplicateMentions] = mentions;
 
       const nextMessageRank = await getNextConversationMessageRank(auth, {
         conversation,
@@ -295,7 +289,7 @@ export async function validateAgentMention(
         // userId/agentConfigurationId on the partial payload.
         await Promise.all(
           duplicateMentions.map((m) =>
-            m.update({ status: "approved" }, { transaction: t })
+            m.updateStatus(auth, { status: "approved", transaction: t })
           )
         );
       }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -8,7 +8,6 @@ import {
 import { getMessagesReactions } from "@app/lib/api/assistant/reaction";
 import type { Authenticator } from "@app/lib/auth";
 import {
-  MentionModel,
   MessageModel,
   UserMessageModel,
 } from "@app/lib/models/agent/conversation";
@@ -16,6 +15,7 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MentionResource } from "@app/lib/resources/mention_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -114,7 +114,7 @@ export function getCompletionDuration(
 
 export function getRichMentionsWithStatusForMessage(
   messageId: ModelId,
-  mentionRows: MentionModel[],
+  mentionRows: MentionResource[],
   usersById: Map<ModelId, UserType>,
   agentConfigurationsById: Map<string, LightAgentConfigurationType>
 ): RichMentionWithStatus[] {
@@ -231,7 +231,7 @@ function renderUserMessage(
 async function batchRenderUserMessages(
   auth: Authenticator,
   messages: MessageModel[],
-  mentionsByMessageId?: Map<ModelId, MentionModel[]>
+  mentionsByMessageId?: Map<ModelId, MentionResource[]>
 ): Promise<UserMessageType[]> {
   const userMessages = messages.filter(
     (m) => m.userMessage !== null && m.userMessage !== undefined
@@ -243,11 +243,8 @@ async function batchRenderUserMessages(
 
   const mentionRows = mentionsByMessageId
     ? userMessages.flatMap((m) => mentionsByMessageId.get(m.id) ?? [])
-    : await MentionModel.findAll({
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          messageId: userMessages.map((message) => message.id),
-        },
+    : await MentionResource.listByMessageModelIds(auth, {
+        messageModelIds: userMessages.map((message) => message.id),
       });
 
   const userIds = [
@@ -356,7 +353,7 @@ export async function batchRenderAgentMessages<V extends RenderMessageVariant>(
   messages: MessageModel[],
   viewType: V,
   messagesWithToolOutputContent: Set<ModelId> | null = null,
-  mentionsByMessageId: Map<ModelId, MentionModel[]>,
+  mentionsByMessageId: Map<ModelId, MentionResource[]>,
   textContentOnly: boolean = false
 ): Promise<
   Result<
@@ -671,7 +668,7 @@ type RenderSingleAgentMessageContext = {
   allMessagesById: Map<ModelId, MessageModel>;
   auth: Authenticator;
   handoverOriginMessagesBySId: Map<string, Pick<MessageModel, "sId">>;
-  mentionsByMessageId: Map<ModelId, MentionModel[]>;
+  mentionsByMessageId: Map<ModelId, MentionResource[]>;
   reactionsByMessageId: Record<ModelId, MessageReactionType[]>;
   stepContentsByMessageId: Record<string, AgentStepContentResource[]>;
   subAgentCostCredits: number | null;
@@ -907,17 +904,14 @@ export async function batchRenderMessages<V extends RenderMessageVariant>(
     ConversationError
   >
 > {
-  const mentionsByMessageId = new Map<ModelId, MentionModel[]>();
+  const mentionsByMessageId = new Map<ModelId, MentionResource[]>();
   const mentionableMessageIds = messages
     .filter((message) => message.userMessage || message.agentMessage)
     .map((message) => message.id);
 
   if (mentionableMessageIds.length > 0) {
-    const mentionRows = await MentionModel.findAll({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        messageId: mentionableMessageIds,
-      },
+    const mentionRows = await MentionResource.listByMessageModelIds(auth, {
+      messageModelIds: mentionableMessageIds,
     });
 
     for (const mentionRow of mentionRows) {

--- a/front/lib/notifications/conversation_fetch.ts
+++ b/front/lib/notifications/conversation_fetch.ts
@@ -2,10 +2,10 @@ import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import type { Authenticator } from "@app/lib/auth";
 import {
   AgentMessageModel,
-  MentionModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MentionResource } from "@app/lib/resources/mention_resource";
 import type {
   ConversationWithoutContentType,
   LightConversationType,
@@ -189,14 +189,10 @@ export async function getUnreadNotificationFlags(
     return { hasUnreadMessages: true, hasUnreadMentions: false };
   }
 
-  const unreadMention = await MentionModel.findOne({
-    attributes: ["id"],
-    where: {
-      workspaceId: auth.getNonNullableWorkspace().id,
-      userId: user.id,
-      status: "approved",
-      messageId: { [Op.in]: unreadMessageIds },
-    },
+  const unreadMention = await MentionResource.findByMessagesAndUser(auth, {
+    messageModelIds: unreadMessageIds,
+    userModelId: user.id,
+    status: "approved",
   });
 
   return {

--- a/front/lib/resources/mention_resource.test.ts
+++ b/front/lib/resources/mention_resource.test.ts
@@ -1,0 +1,300 @@
+import { ONE_DAY_MS } from "@app/lib/api/assistant/inactivity/policy";
+import type { Authenticator } from "@app/lib/auth";
+import { MentionResource } from "@app/lib/resources/mention_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MentionFactory } from "@app/tests/utils/MentionFactory";
+import { describe, expect, it } from "vitest";
+
+async function createMessage(
+  auth: Authenticator,
+  agentConfigurationId: string
+) {
+  const conversation = await ConversationFactory.create(auth, {
+    agentConfigurationId,
+    messagesCreatedAt: [],
+  });
+  const { messageRow } = await ConversationFactory.createUserMessage({
+    auth,
+    workspace: auth.getNonNullableWorkspace(),
+    conversation,
+    content: "@agent hello",
+  });
+
+  return messageRow;
+}
+
+describe("MentionResource", () => {
+  describe("makeNew", () => {
+    it("creates a mention row with the given attributes", async () => {
+      const { authenticator, workspace, user } = await createResourceTest({});
+      const message = await createMessage(authenticator, "test-agent");
+
+      const mention = await MentionResource.makeNew({
+        messageId: message.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "approved",
+      });
+
+      expect(mention.id).toBeTypeOf("number");
+      expect(mention.messageId).toBe(message.id);
+      expect(mention.userId).toBe(user.id);
+      expect(mention.agentConfigurationId).toBeNull();
+      expect(mention.status).toBe("approved");
+      expect(mention.dismissed).toBe(false);
+    });
+  });
+
+  describe("findByMessagesAndUser", () => {
+    it("finds the user's mention across the given messages, optionally narrowed by status", async () => {
+      const { authenticator, workspace, user } = await createResourceTest({});
+      const message = await createMessage(authenticator, "test-agent");
+      const otherMessage = await createMessage(authenticator, "test-agent");
+
+      await MentionResource.makeNew({
+        messageId: message.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "pending_conversation_access",
+      });
+
+      const found = await MentionResource.findByMessagesAndUser(authenticator, {
+        messageModelIds: [otherMessage.id, message.id],
+        userModelId: user.id,
+      });
+      expect(found?.messageId).toBe(message.id);
+
+      const narrowedOut = await MentionResource.findByMessagesAndUser(
+        authenticator,
+        {
+          messageModelIds: [message.id],
+          userModelId: user.id,
+          status: "approved",
+        }
+      );
+      expect(narrowedOut).toBeNull();
+
+      const noMatch = await MentionResource.findByMessagesAndUser(
+        authenticator,
+        { messageModelIds: [otherMessage.id], userModelId: user.id }
+      );
+      expect(noMatch).toBeNull();
+    });
+  });
+
+  describe("listByMessageModelIds", () => {
+    it("lists the mentions of the given messages, optionally narrowed by user, agent, or status", async () => {
+      const { authenticator, workspace, user } = await createResourceTest({});
+      const message = await createMessage(authenticator, "agent-a");
+      const otherMessage = await createMessage(authenticator, "agent-a");
+
+      const userMention = await MentionResource.makeNew({
+        messageId: message.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "approved",
+      });
+      const agentMention = await MentionResource.makeNew({
+        messageId: message.id,
+        agentConfigurationId: "agent-a",
+        workspaceId: workspace.id,
+        status: "agent_restricted_by_space_usage",
+      });
+      await MentionResource.makeNew({
+        messageId: otherMessage.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "approved",
+      });
+
+      const allForMessage = await MentionResource.listByMessageModelIds(
+        authenticator,
+        { messageModelIds: [message.id] }
+      );
+      expect(allForMessage.map((m) => m.id).sort()).toEqual(
+        [userMention.id, agentMention.id].sort()
+      );
+
+      const byAgent = await MentionResource.listByMessageModelIds(
+        authenticator,
+        { messageModelIds: [message.id], agentConfigurationId: "agent-a" }
+      );
+      expect(byAgent.map((m) => m.id)).toEqual([agentMention.id]);
+
+      const byStatus = await MentionResource.listByMessageModelIds(
+        authenticator,
+        {
+          messageModelIds: [message.id],
+          status: "agent_restricted_by_space_usage",
+        }
+      );
+      expect(byStatus.map((m) => m.id)).toEqual([agentMention.id]);
+
+      expect(
+        await MentionResource.listByMessageModelIds(authenticator, {
+          messageModelIds: [],
+        })
+      ).toEqual([]);
+    });
+  });
+
+  describe("listAgentsNotMentionedSince", () => {
+    it("returns active agents whose last mention predates the cutoff", async () => {
+      const { authenticator } = await createResourceTest({});
+      const cutoffAt = new Date("2026-07-19T00:00:00.000Z");
+
+      const staleAgent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Stale agent" }
+      );
+      await AgentConfigurationFactory.backdate(
+        authenticator,
+        staleAgent.sId,
+        new Date(cutoffAt.getTime() - 10 * ONE_DAY_MS)
+      );
+      await MentionFactory.agentMentionedAt(authenticator, {
+        agentId: staleAgent.sId,
+        mentionedAt: new Date(cutoffAt.getTime() - 5 * ONE_DAY_MS),
+      });
+
+      const activeAgent = await AgentConfigurationFactory.createTestAgent(
+        authenticator,
+        { name: "Recently used agent" }
+      );
+      await AgentConfigurationFactory.backdate(
+        authenticator,
+        activeAgent.sId,
+        new Date(cutoffAt.getTime() - 10 * ONE_DAY_MS)
+      );
+      await MentionFactory.agentMentionedAt(authenticator, {
+        agentId: activeAgent.sId,
+        mentionedAt: new Date(cutoffAt.getTime() + 1 * ONE_DAY_MS),
+      });
+
+      const idle = await MentionResource.listAgentsNotMentionedSince(
+        authenticator,
+        { notMentionedSince: cutoffAt }
+      );
+
+      expect(idle.map((a) => a.agentId)).toContain(staleAgent.sId);
+      expect(idle.map((a) => a.agentId)).not.toContain(activeAgent.sId);
+    });
+  });
+
+  describe("updateStatus", () => {
+    it("moves the mention to the new status, live and in the database", async () => {
+      const { authenticator, workspace, user } = await createResourceTest({});
+      const message = await createMessage(authenticator, "test-agent");
+
+      const mention = await MentionResource.makeNew({
+        messageId: message.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "pending_conversation_access",
+      });
+
+      await mention.updateStatus(authenticator, { status: "approved" });
+      expect(mention.status).toBe("approved");
+
+      const refetched = await MentionResource.findByMessagesAndUser(
+        authenticator,
+        { messageModelIds: [message.id], userModelId: user.id }
+      );
+      expect(refetched?.status).toBe("approved");
+    });
+  });
+
+  describe("dismiss", () => {
+    it("marks the mention dismissed, live and in the database", async () => {
+      const { authenticator, workspace, user } = await createResourceTest({});
+      const message = await createMessage(authenticator, "test-agent");
+
+      const mention = await MentionResource.makeNew({
+        messageId: message.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "user_restricted_by_conversation_access",
+      });
+
+      await mention.dismiss(authenticator);
+      expect(mention.dismissed).toBe(true);
+
+      const refetched = await MentionResource.findByMessagesAndUser(
+        authenticator,
+        { messageModelIds: [message.id], userModelId: user.id }
+      );
+      expect(refetched?.dismissed).toBe(true);
+    });
+  });
+
+  describe("deleteByMessageModelIds", () => {
+    it("deletes every mention of the given messages, leaving others untouched", async () => {
+      const { authenticator, workspace, user } = await createResourceTest({});
+      const message = await createMessage(authenticator, "test-agent");
+      const otherMessage = await createMessage(authenticator, "test-agent");
+
+      await MentionResource.makeNew({
+        messageId: message.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "approved",
+      });
+      await MentionResource.makeNew({
+        messageId: otherMessage.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "approved",
+      });
+
+      const deletedCount = await MentionResource.deleteByMessageModelIds(
+        authenticator,
+        { messageModelIds: [message.id] }
+      );
+      expect(deletedCount).toBe(1);
+
+      expect(
+        await MentionResource.listByMessageModelIds(authenticator, {
+          messageModelIds: [message.id],
+        })
+      ).toEqual([]);
+      expect(
+        await MentionResource.listByMessageModelIds(authenticator, {
+          messageModelIds: [otherMessage.id],
+        })
+      ).toHaveLength(1);
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes this mention only", async () => {
+      const { authenticator, workspace, user } = await createResourceTest({});
+      const message = await createMessage(authenticator, "test-agent");
+      const otherMessage = await createMessage(authenticator, "test-agent");
+
+      const mention = await MentionResource.makeNew({
+        messageId: message.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "approved",
+      });
+      await MentionResource.makeNew({
+        messageId: otherMessage.id,
+        userId: user.id,
+        workspaceId: workspace.id,
+        status: "approved",
+      });
+
+      const result = await mention.delete(authenticator);
+      expect(result.isOk()).toBe(true);
+      expect(result.isOk() && result.value).toBe(1);
+
+      expect(
+        await MentionResource.listByMessageModelIds(authenticator, {
+          messageModelIds: [message.id],
+        })
+      ).toEqual([]);
+    });
+  });
+});

--- a/front/lib/resources/mention_resource.ts
+++ b/front/lib/resources/mention_resource.ts
@@ -1,9 +1,11 @@
 import type { Authenticator } from "@app/lib/auth";
+import type { MentionStatusType } from "@app/lib/models/agent/conversation";
 import { MentionModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import logger from "@app/logger/logger";
+import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
 import type {
@@ -13,7 +15,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
-import { QueryTypes } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
 export interface AgentIdleRow {
   agentId: string;
@@ -34,6 +36,33 @@ function isAgentIdleRow(row: unknown): row is AgentIdleRow {
     typeof row.agentId === "string" &&
     (row.lastMentionedAt === null || row.lastMentionedAt instanceof Date)
   );
+}
+
+export interface FindMentionByUserParams {
+  messageModelIds: ModelId[];
+  userModelId: ModelId;
+  status?: MentionStatusType;
+  transaction?: Transaction;
+}
+
+export interface ListMentionsByMessagesParams {
+  messageModelIds: ModelId[];
+  userModelId?: ModelId;
+  agentConfigurationId?: string;
+  status?: MentionStatusType;
+  transaction?: Transaction;
+  // Takes a `FOR UPDATE` lock on the matched rows. Requires a transaction.
+  forUpdate?: boolean;
+}
+
+export interface UpdateMentionStatusParams {
+  status: MentionStatusType;
+  transaction?: Transaction;
+}
+
+export interface DeleteMentionsByMessagesParams {
+  messageModelIds: ModelId[];
+  transaction?: Transaction;
 }
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
@@ -57,6 +86,69 @@ export class MentionResource extends BaseResource<MentionModel> {
     const mention = await this.model.create(blob, { transaction });
 
     return new this(this.model, mention.get());
+  }
+
+  /**
+   * The mention of this user across the given messages, optionally narrowed to one status, or null.
+   */
+  static async findByMessagesAndUser(
+    auth: Authenticator,
+    {
+      messageModelIds,
+      userModelId,
+      status,
+      transaction,
+    }: FindMentionByUserParams
+  ): Promise<MentionResource | null> {
+    if (messageModelIds.length === 0) {
+      return null;
+    }
+
+    const mention = await this.model.findOne({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        messageId: { [Op.in]: messageModelIds },
+        userId: userModelId,
+        ...(status ? { status } : {}),
+      },
+      transaction,
+    });
+
+    return mention ? new this(this.model, mention.get()) : null;
+  }
+
+  /**
+   * The mentions carried by the given messages, optionally narrowed to one user, one agent, and/or
+   * one status.
+   */
+  static async listByMessageModelIds(
+    auth: Authenticator,
+    {
+      messageModelIds,
+      userModelId,
+      agentConfigurationId,
+      status,
+      transaction,
+      forUpdate,
+    }: ListMentionsByMessagesParams
+  ): Promise<MentionResource[]> {
+    if (messageModelIds.length === 0) {
+      return [];
+    }
+
+    const mentions = await this.model.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        messageId: { [Op.in]: messageModelIds },
+        ...(userModelId !== undefined ? { userId: userModelId } : {}),
+        ...(agentConfigurationId !== undefined ? { agentConfigurationId } : {}),
+        ...(status ? { status } : {}),
+      },
+      transaction,
+      ...(transaction && forUpdate ? { lock: transaction.LOCK.UPDATE } : {}),
+    });
+
+    return mentions.map((mention) => new this(this.model, mention.get()));
   }
 
   /**
@@ -112,6 +204,72 @@ export class MentionResource extends BaseResource<MentionModel> {
     }
 
     return agents;
+  }
+
+  /**
+   * Moves this mention to `status`. The payload restates this mention's own `userId` /
+   * `agentConfigurationId`: the model's `beforeValidate` hook requires exactly one of them non-null,
+   * and Sequelize validates against the payload alone, even for a single-row update.
+   */
+  async updateStatus(
+    auth: Authenticator,
+    { status, transaction }: UpdateMentionStatusParams
+  ): Promise<void> {
+    await this.applyUpdate(auth, { status }, transaction);
+
+    // Keep the in-memory attributes in step with the row, as `BaseResource.update` does: callers
+    // render the mention off this instance right after moving its status.
+    Object.assign(this, { status });
+  }
+
+  /**
+   * Hides a restricted mention from the conversation without resolving it either way.
+   */
+  async dismiss(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.applyUpdate(auth, { dismissed: true }, transaction);
+
+    Object.assign(this, { dismissed: true });
+  }
+
+  private async applyUpdate(
+    auth: Authenticator,
+    values: Partial<Attributes<MentionModel>>,
+    transaction: Transaction | undefined
+  ): Promise<void> {
+    await MentionResource.model.update(
+      {
+        ...values,
+        userId: this.userId,
+        agentConfigurationId: this.agentConfigurationId,
+      },
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          id: this.id,
+        },
+        transaction,
+      }
+    );
+  }
+
+  static async deleteByMessageModelIds(
+    auth: Authenticator,
+    { messageModelIds, transaction }: DeleteMentionsByMessagesParams
+  ): Promise<number> {
+    if (messageModelIds.length === 0) {
+      return 0;
+    }
+
+    return this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        messageId: { [Op.in]: messageModelIds },
+      },
+      transaction,
+    });
   }
 
   async delete(


### PR DESCRIPTION
## Description

`MentionModel` was accessed directly from several `lib/api/*` modules, which our
resource-invariant rules disallow — any model access should go through a Resource.
`MentionResource` already existed for the inactive-agent anti-join but had no query
surface for those other call sites. This adds one method per distinct query shape
they need — `findByMessagesAndUser`, `listByMessageModelIds`, `updateStatus`,
`dismiss`, `deleteByMessageModelIds` — and swaps each `MentionModel` call for the
matching Resource method, on the same line, with the same control flow and query
shape as before.

## Tests

- New `mention_resource.test.ts`: one test per public method on `MentionResource`
  (`makeNew`, `findByMessagesAndUser`, `listByMessageModelIds`,
  `listAgentsNotMentionedSince`, `updateStatus`, `dismiss`,
  `deleteByMessageModelIds`, `delete`), including their optional filters.
- Ran the full suite for every touched file plus their neighbors (`mentions`,
  `messages`, `validate_agent_mention`, `validate_actions`, `conversation`,
  `mention_suggestions`, `inactivity`, `notifications`, `conversation_resource`) —
  all pass.

## Risk

Behaviour-preserving, mechanical swap. No query shape, cardinality, or control flow
changed.

## Deploy Plan

Standard deploy, no migration or feature flag needed.