### PR TITLE
[front] expose global agent feedbacks via the Poke MCP

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -1926,6 +1926,10 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool billing info ac
       "freeUsage": true,
       "toolCostCategory": "basic",
     },
+    "list_global_agent_feedbacks": {
+      "freeUsage": true,
+      "toolCostCategory": "basic",
+    },
     "list_workspace_agents": {
       "freeUsage": true,
       "toolCostCategory": "basic",
@@ -3256,6 +3260,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_workspace_skill": "low",
     "get_workspace_spaces": "low",
     "list_data_sources": "low",
+    "list_global_agent_feedbacks": "low",
     "list_workspace_agents": "low",
     "list_workspace_groups": "low",
     "list_workspace_skills": "low",

--- a/front/lib/api/actions/servers/poke/metadata.ts
+++ b/front/lib/api/actions/servers/poke/metadata.ts
@@ -41,6 +41,11 @@ export const GET_WORKSPACE_AGENT_TOOL_NAME = "get_workspace_agent";
 export const LIST_WORKSPACE_SKILLS_TOOL_NAME = "list_workspace_skills";
 export const GET_WORKSPACE_SKILL_TOOL_NAME = "get_workspace_skill";
 
+// ─── Feedback ────────────────────────────────────────────────────────────────
+
+export const LIST_GLOBAL_AGENT_FEEDBACKS_TOOL_NAME =
+  "list_global_agent_feedbacks";
+
 // ─── Shared schema fragments ─────────────────────────────────────────────────
 
 const workspaceIdSchema = {
@@ -397,6 +402,66 @@ export const POKE_TOOLS_METADATA = [
     },
     stake: "low",
     displayLabels: { running: "Fetching skill", done: "Fetched skill" },
+    toolCostCategory: "basic",
+    freeUsage: true,
+  },
+
+  // ── Feedback ─────────────────────────────────────────────────────────────
+
+  {
+    name: LIST_GLOBAL_AGENT_FEEDBACKS_TOOL_NAME,
+    description:
+      "List end-user feedback (thumbs up/down and free-text comments) on Dust global agents " +
+      "across all workspaces. Most recent first.",
+    schema: {
+      since: z
+        .string()
+        .optional()
+        .describe(
+          "Only include feedback created at or after this ISO 8601 date (e.g. '2026-08-01')."
+        ),
+      until: z
+        .string()
+        .optional()
+        .describe(
+          "Only include feedback created strictly before this ISO 8601 date."
+        ),
+      agent_id: z
+        .string()
+        .optional()
+        .describe(
+          "Restrict to a single global agent id (e.g. 'dust'). Omit for all global agents."
+        ),
+      direction: z
+        .enum(["up", "down"])
+        .optional()
+        .describe("Restrict to thumbs up or thumbs down feedback."),
+      include_empty: z
+        .boolean()
+        .optional()
+        .describe(
+          "Include thumbs with no written comment. Defaults to false, which is usually what " +
+            "you want when summarizing what users said."
+        ),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(500)
+        .optional()
+        .describe("Max feedbacks per page (default: 100, max: 500)."),
+      next_page_cursor: z
+        .string()
+        .optional()
+        .describe(
+          "Opaque cursor from the previous response to fetch the next page."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Listing global agent feedback",
+      done: "Listed global agent feedback",
+    },
     toolCostCategory: "basic",
     freeUsage: true,
   },

--- a/front/lib/api/actions/servers/poke/tools/feedbacks.ts
+++ b/front/lib/api/actions/servers/poke/tools/feedbacks.ts
@@ -1,0 +1,117 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { POKE_TOOLS_METADATA } from "@app/lib/api/actions/servers/poke/metadata";
+import { LIST_GLOBAL_AGENT_FEEDBACKS_TOOL_NAME } from "@app/lib/api/actions/servers/poke/metadata";
+import {
+  enforcePokeSecurityGates,
+  jsonResponse,
+} from "@app/lib/api/actions/servers/poke/tools/utils";
+import config from "@app/lib/api/config";
+import { listGlobalAgentFeedbacks } from "@app/lib/api/poke/global_agent_feedbacks";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+type FeedbackHandlers = Pick<
+  ToolHandlers<typeof POKE_TOOLS_METADATA>,
+  typeof LIST_GLOBAL_AGENT_FEEDBACKS_TOOL_NAME
+>;
+
+const DEFAULT_LIMIT = 100;
+
+function parseDate(value: string, field: string): Result<Date, MCPError> {
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    return new Err(
+      new MCPError(
+        `Invalid ${field}: "${value}" is not a valid ISO 8601 date.`,
+        { tracked: false }
+      )
+    );
+  }
+  return new Ok(date);
+}
+
+export const feedbackHandlers: FeedbackHandlers = {
+  [LIST_GLOBAL_AGENT_FEEDBACKS_TOOL_NAME]: async (
+    {
+      since,
+      until,
+      agent_id,
+      direction,
+      include_empty,
+      limit,
+      next_page_cursor,
+    },
+    extra
+  ) => {
+    const gateResult = await enforcePokeSecurityGates(
+      extra,
+      LIST_GLOBAL_AGENT_FEEDBACKS_TOOL_NAME,
+      // No specific target workspace: feedback is aggregated across all of them.
+      "(all workspaces)"
+    );
+    if (gateResult.isErr()) {
+      return gateResult;
+    }
+
+    let sinceDate: Date | undefined;
+    if (since !== undefined) {
+      const parsed = parseDate(since, "since");
+      if (parsed.isErr()) {
+        return parsed;
+      }
+      sinceDate = parsed.value;
+    }
+
+    let untilDate: Date | undefined;
+    if (until !== undefined) {
+      const parsed = parseDate(until, "until");
+      if (parsed.isErr()) {
+        return parsed;
+      }
+      untilDate = parsed.value;
+    }
+
+    // The cursor is the id of the last row of the previous page, kept opaque
+    // to the agent.
+    let lastId: number | undefined;
+    if (next_page_cursor !== undefined) {
+      lastId = parseInt(next_page_cursor, 10);
+      if (isNaN(lastId)) {
+        return new Err(
+          new MCPError("Invalid next_page_cursor.", { tracked: false })
+        );
+      }
+    }
+
+    const { feedbacks, hasMore, totalCount } = await listGlobalAgentFeedbacks({
+      includeEmpty: include_empty ?? false,
+      lastId,
+      since: sinceDate,
+      until: untilDate,
+      agentConfigurationId: agent_id,
+      thumbDirection: direction,
+      limit: limit ?? DEFAULT_LIMIT,
+    });
+
+    const pokeAppUrl = config.getPokeAppUrl();
+    const lastFeedback = feedbacks[feedbacks.length - 1];
+
+    return jsonResponse({
+      totalCount,
+      feedbacks: feedbacks.map((feedback) => ({
+        createdAt: feedback.createdAt,
+        agentId: feedback.agentConfigurationId,
+        direction: feedback.thumbDirection,
+        content: feedback.content,
+        workspaceId: feedback.workspaceId,
+        workspaceName: feedback.workspaceName,
+        conversationId: feedback.conversationId,
+        pokeLink: feedback.conversationId
+          ? `${pokeAppUrl}/${feedback.workspaceId}/conversation/${feedback.conversationId}`
+          : null,
+      })),
+      nextPageCursor: hasMore && lastFeedback ? String(lastFeedback.id) : null,
+    });
+  },
+};

--- a/front/lib/api/actions/servers/poke/tools/index.test.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.test.ts
@@ -214,4 +214,113 @@ describe("poke tools - security gates", () => {
       vi.restoreAllMocks();
     });
   });
+  describe("list_global_agent_feedbacks", () => {
+    it("denies access to non-super-user", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      const tool = getToolByName("list_global_agent_feedbacks");
+      const result = await tool.handler({}, createTestExtra(auth));
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("super user privileges");
+      }
+    });
+
+    it("rejects an invalid since date", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+
+      const superUser = await UserFactory.superUser();
+      await MembershipFactory.associate(workspace, superUser, {
+        role: "admin",
+      });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        superUser.sId,
+        workspace.sId
+      );
+
+      vi.stubEnv("PRODUCTION_DUST_WORKSPACE_ID", workspace.sId);
+      const authModule = await import("@app/lib/auth");
+      vi.spyOn(authModule, "getFeatureFlags").mockResolvedValueOnce([
+        "poke_mcp",
+      ]);
+
+      const tool = getToolByName("list_global_agent_feedbacks");
+      const result = await tool.handler(
+        { since: "not-a-date" },
+        createTestExtra(auth)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Invalid since");
+      }
+
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+    });
+
+    it("returns an empty page when all security gates pass", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+
+      const superUser = await UserFactory.superUser();
+      await MembershipFactory.associate(workspace, superUser, {
+        role: "admin",
+      });
+
+      const auth = await Authenticator.fromUserIdAndWorkspaceId(
+        superUser.sId,
+        workspace.sId
+      );
+
+      vi.stubEnv("PRODUCTION_DUST_WORKSPACE_ID", workspace.sId);
+      vi.stubEnv("POKE_APP_URL", "http://localhost:3000");
+      const authModule = await import("@app/lib/auth");
+      vi.spyOn(authModule, "getFeatureFlags").mockResolvedValueOnce([
+        "poke_mcp",
+      ]);
+
+      const tool = getToolByName("list_global_agent_feedbacks");
+      const result = await tool.handler(
+        { since: "2026-08-01", limit: 10 },
+        createTestExtra(auth)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const parsed = JSON.parse(content.text);
+          expect(parsed.feedbacks).toEqual([]);
+          expect(parsed.totalCount).toBe(0);
+          expect(parsed.nextPageCursor).toBeNull();
+        }
+      }
+
+      vi.unstubAllEnvs();
+      vi.restoreAllMocks();
+    });
+  });
 });

--- a/front/lib/api/actions/servers/poke/tools/index.ts
+++ b/front/lib/api/actions/servers/poke/tools/index.ts
@@ -7,6 +7,7 @@ import {
 import { agentHandlers } from "@app/lib/api/actions/servers/poke/tools/agents";
 import { connectorHandlers } from "@app/lib/api/actions/servers/poke/tools/connectors";
 import { conversationHandlers } from "@app/lib/api/actions/servers/poke/tools/conversations";
+import { feedbackHandlers } from "@app/lib/api/actions/servers/poke/tools/feedbacks";
 import { skillHandlers } from "@app/lib/api/actions/servers/poke/tools/skills";
 import { userHandlers } from "@app/lib/api/actions/servers/poke/tools/users";
 import {
@@ -76,6 +77,7 @@ const handlers: ToolHandlers<typeof POKE_TOOLS_METADATA> = {
   ...userHandlers,
   ...agentHandlers,
   ...skillHandlers,
+  ...feedbackHandlers,
 };
 
 export const TOOLS = buildTools(POKE_TOOLS_METADATA, handlers);

--- a/front/lib/api/poke/global_agent_feedbacks.ts
+++ b/front/lib/api/poke/global_agent_feedbacks.ts
@@ -10,7 +10,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import { Op } from "sequelize";
 
-const PAGE_SIZE = 500;
+const MAX_PAGE_SIZE = 500;
 
 const GLOBAL_AGENT_IDS = Object.values(GLOBAL_AGENTS_SID);
 
@@ -42,34 +42,80 @@ interface ListGlobalAgentFeedbacksParams {
   includeEmpty: boolean;
   /** Cursor for pagination — return rows with id less than this value. */
   lastId?: number;
+  /** Only return feedbacks created at or after this date. */
+  since?: Date;
+  /** Only return feedbacks created strictly before this date. */
+  until?: Date;
+  /** Restrict to a single global agent (e.g. "dust"). */
+  agentConfigurationId?: string;
+  /** Restrict to thumbs up or thumbs down. */
+  thumbDirection?: AgentMessageFeedbackDirection;
+  /** Max rows to return. Defaults to (and is capped at) `MAX_PAGE_SIZE`. */
+  limit?: number;
 }
 
 interface ListGlobalAgentFeedbacksResult {
   feedbacks: GlobalAgentFeedbackItem[];
   hasMore: boolean;
+  /** Total rows matching the filters, ignoring the `lastId` cursor. */
+  totalCount: number;
 }
 
 export interface GetGlobalAgentFeedbacksResponseBody {
   feedbacks: GlobalAgentFeedbackItem[];
   hasMore: boolean;
+  totalCount: number;
 }
 
 /**
  * Aggregate global-agent feedback rows across all workspaces for the poke
- * super-admin review tool. Returns up to `PAGE_SIZE` rows, enriched with the
+ * super-admin review tool. Returns up to `limit` rows, enriched with the
  * workspace name, conversation sId, and message sId via batched lookups.
  */
 export async function listGlobalAgentFeedbacks({
   includeEmpty,
   lastId,
+  since,
+  until,
+  agentConfigurationId,
+  thumbDirection,
+  limit,
 }: ListGlobalAgentFeedbacksParams): Promise<ListGlobalAgentFeedbacksResult> {
+  const pageSize = Math.min(limit ?? MAX_PAGE_SIZE, MAX_PAGE_SIZE);
+
+  if (
+    agentConfigurationId !== undefined &&
+    !GLOBAL_AGENT_IDS.some((id) => id === agentConfigurationId)
+  ) {
+    return { feedbacks: [], hasMore: false, totalCount: 0 };
+  }
+
   const where: Record<string, unknown> = {
-    agentConfigurationId: { [Op.in]: GLOBAL_AGENT_IDS },
+    agentConfigurationId:
+      agentConfigurationId !== undefined
+        ? agentConfigurationId
+        : { [Op.in]: GLOBAL_AGENT_IDS },
   };
 
   if (!includeEmpty) {
     where.content = { [Op.and]: [{ [Op.ne]: null }, { [Op.ne]: "" }] };
   }
+
+  if (thumbDirection !== undefined) {
+    where.thumbDirection = thumbDirection;
+  }
+
+  if (since !== undefined || until !== undefined) {
+    where.createdAt = {
+      ...(since !== undefined ? { [Op.gte]: since } : {}),
+      ...(until !== undefined ? { [Op.lt]: until } : {}),
+    };
+  }
+
+  // Counted across all workspaces for the poke super-admin review tool. The
+  // workspace isolation hook only guards find queries, so `count` takes no
+  // bypass flag.
+  const totalCount = await AgentMessageFeedbackModel.count({ where });
 
   if (lastId !== undefined && !isNaN(lastId)) {
     where.id = { [Op.lt]: lastId };
@@ -89,14 +135,14 @@ export async function listGlobalAgentFeedbacks({
       },
     ],
     order: [["id", "DESC"]],
-    limit: PAGE_SIZE + 1,
+    limit: pageSize + 1,
   });
 
-  const hasMore = feedbackRows.length > PAGE_SIZE;
-  const rows = feedbackRows.slice(0, PAGE_SIZE);
+  const hasMore = feedbackRows.length > pageSize;
+  const rows = feedbackRows.slice(0, pageSize);
 
   if (rows.length === 0) {
-    return { feedbacks: [], hasMore: false };
+    return { feedbacks: [], hasMore: false, totalCount };
   }
 
   // Batch-fetch workspace info.
@@ -147,5 +193,5 @@ export async function listGlobalAgentFeedbacks({
     };
   });
 
-  return { feedbacks, hasMore };
+  return { feedbacks, hasMore, totalCount };
 }


### PR DESCRIPTION
### Description

`agent_message_feedbacks` for global agents is aggregated by `listGlobalAgentFeedbacks`, but the only way to see it is the poke `global-agent-feedbacks` page — which nobody reads. This exposes the same data through the Poke MCP server so an agent can go over it and produce a summary (and a frame) instead.

Adds a `list_global_agent_feedbacks` tool that returns the raw feedback rows, tightly filtered:

```
list_global_agent_feedbacks({
  since?, until?,          // ISO 8601 date range
  agent_id?,               // a single global agent, e.g. "dust"
  direction?,              // "up" | "down"
  include_empty?,          // defaults to false — thumbs with no comment are noise when summarizing
  limit?,                  // default 100, max 500
  next_page_cursor?
})
```

The free text is the value here, so the tool hands back rows rather than pre-aggregated stats and lets the agent synthesize. It does return `totalCount` alongside the page so a summary can quote real totals rather than numbers derived from one sampled page.

### Changes

- `front/lib/api/poke/global_agent_feedbacks.ts`: `listGlobalAgentFeedbacks` gains optional `since`, `until`, `agentConfigurationId`, `thumbDirection` and `limit`, and returns `totalCount` (over the filters, ignoring the pagination cursor). An `agentConfigurationId` that is not a global agent short-circuits to an empty result rather than silently widening to all global agents.
- `front/lib/api/actions/servers/poke/metadata.ts`: new tool metadata under a `── Feedback ──` section.
- `front/lib/api/actions/servers/poke/tools/feedbacks.ts`: the handler. Gates with `enforcePokeSecurityGates(..., "(all workspaces)")`, following the `search_workspaces` precedent for a tool with no single target workspace. Rows are mapped to a compact shape with a `pokeLink` pointing at the same `/poke/{wsId}/conversation/{convId}` path the page links to.
- `front/lib/api/actions/servers/poke/tools/index.ts`: wired in as `...feedbackHandlers`.

The existing `/api/poke/global-agent-feedbacks` route and its page are unchanged — `totalCount` is additive on the response body, and the default limit is still 500.

### Tests

Three cases added to the existing poke tools suite: non-super-user is denied, an invalid `since` is rejected, and a gates-pass call returns a well-formed empty page. There is no feedback factory in `front/tests/utils`, so this stops short of a fixture-backed happy path over real rows.

`npm run test -- lib/api/actions/servers/poke/tools/index.test.ts` → 8/8 pass. `npx tsgo --noEmit` and biome are clean.

### Risk

Low. New read-only tool behind the existing poke super-user + Dust-workspace + `poke_mcp` flag gates; the only change to existing behaviour is one extra indexed `COUNT` per load of a page nobody reads.
