### PR TITLE
[front] Merge tool usage into a single llm_usage_v3 event

### DIFF
--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -230,6 +230,32 @@ describe("Metronome usage event adapter", () => {
     expect(events[0]?.properties).toMatchObject({ cost_awu: 21 });
   });
 
+  it("applies the free_mcp_server_cap per server, not globally", () => {
+    // Two different servers, 8 "advanced" (3 AWU) calls each. The 20-credit cap
+    // is applied independently per server, so each server bills 7 calls (21) and
+    // waives its own 8th. A global cap would waive far more and undercount.
+    const serverActions = (mcpServerId: string) =>
+      Array.from({ length: 8 }, () => ({
+        toolName: "custom_tool",
+        mcpServerId,
+        internalMCPServerName: null,
+        status: "succeeded" as const,
+        shouldEmit: true,
+      }));
+
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      actions: [
+        ...serverActions("mcp_server_a"),
+        ...serverActions("mcp_server_b"),
+      ],
+    });
+
+    // 21 (server A) + 21 (server B) = 42.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({ cost_awu: 42 });
+  });
+
   it("does not re-bill prior-execution actions", () => {
     const events = buildUsageEvents({
       ...commonEventInput,

--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -5,6 +5,7 @@ import {
   buildToolUseEvents,
   buildUsageEvents,
 } from "@app/lib/metronome/events";
+import type { MetronomeEvent } from "@app/lib/metronome/types";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { describe, expect, it } from "vitest";
 
@@ -311,5 +312,46 @@ describe("Aggregated usage event (shadow) and legacy cost parity", () => {
     );
     expect(newCostAwu).toBe(0);
     expect(billedCostAwuFromEvents(legacyEvents)).toBe(0);
+  });
+
+  it("counts only user/programmatic usage types, skipping any other value", () => {
+    const events: MetronomeEvent[] = [
+      {
+        transaction_id: "a",
+        customer_id: "c",
+        event_type: "llm_usage_v3",
+        timestamp: "2026-08-05T12:00:00.000Z",
+        properties: { cost_awu: 5, usage_type: "user" },
+      },
+      {
+        transaction_id: "b",
+        customer_id: "c",
+        event_type: "llm_usage_v3",
+        timestamp: "2026-08-05T12:00:00.000Z",
+        properties: { cost_awu: 7, usage_type: "programmatic" },
+      },
+      {
+        transaction_id: "c",
+        customer_id: "c",
+        event_type: "llm_usage_v3",
+        timestamp: "2026-08-05T12:00:00.000Z",
+        properties: { cost_awu: 11, usage_type: "free" },
+      },
+      // An unknown usage_type is entitled at 0 in the rate card — skip it.
+      {
+        transaction_id: "d",
+        customer_id: "c",
+        event_type: "tool_use_v3",
+        timestamp: "2026-08-05T12:00:00.000Z",
+        properties: {
+          count: 4,
+          tool_category: "advanced",
+          usage_type: "other",
+        },
+      },
+    ];
+
+    // Only the "user" (5) and "programmatic" (7) events count.
+    expect(billedCostAwuFromEvents(events)).toBe(12);
   });
 });

--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -1,3 +1,4 @@
+import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constants";
 import { buildUsageEvents } from "@app/lib/metronome/events";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { describe, expect, it } from "vitest";
@@ -113,6 +114,63 @@ describe("Metronome usage event adapter", () => {
     expect(props["usage_type"]).toBe("user");
     expect(props["model_id"]).toBe("aggregate");
     expect(props["origin"]).toBe("web");
+  });
+
+  it("matches the pre-merge cost: per-model LLM rounding, then flat tool addition excluding free/capped", () => {
+    const perAwu = MODEL_COST_MICRO_USD_PER_AWU_CREDIT;
+
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      runUsages: [
+        // openai/gpt-4o group: two usages summed (1 + 1 = 2 µUSD) THEN rounded.
+        usage({ costMicroUsd: 1 }),
+        usage({ costMicroUsd: 1 }),
+        // anthropic group: a separate model, rounded on its own.
+        usage({
+          costMicroUsd: perAwu + 1,
+          modelId: "claude-opus-4-8",
+          providerId: "anthropic",
+        }),
+      ],
+      // 8 external "advanced" (3 AWU) calls on one server: the 20-credit
+      // per-server cap is reached after 7 (21 credits), so the 8th is waived.
+      actions: [
+        ...Array.from({ length: 8 }, () => ({
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "succeeded" as const,
+          shouldEmit: true,
+        })),
+        // A denied call is unbillable and must not contribute either.
+        {
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "denied" as const,
+          shouldEmit: true,
+        },
+      ],
+    });
+
+    // Reference computed exactly as billing did before the merge:
+    // LLM cost is the SUM of per-(provider, model) ceilings — never a single
+    // ceiling over the combined micro-USD.
+    const expectedLlmCredits =
+      Math.ceil(2 / perAwu) + Math.ceil((perAwu + 1) / perAwu); // 1 + 2 = 3
+    // Tool cost is the flat sum of the rated weights of the BILLED calls only
+    // (7 × 3); the capped 8th call and the denied call add nothing.
+    const expectedToolCredits = 21;
+    const expectedCostAwu = expectedLlmCredits + expectedToolCredits; // 24
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties["cost_awu"]).toBe(expectedCostAwu);
+
+    // Guard against a regression to "round once at the end": collapsing the
+    // per-model ceilings into a single ceiling over the combined micro-USD would
+    // undercount here (ceil((2 + perAwu + 1) / perAwu) = 2, not 3).
+    const roundOnceLlmCredits = Math.ceil((2 + perAwu + 1) / perAwu);
+    expect(roundOnceLlmCredits).not.toBe(expectedLlmCredits);
   });
 
   it("emits an LLM-only event when there are no tool actions", () => {

--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -1,7 +1,4 @@
-import {
-  buildLlmUsageEvents,
-  buildToolUseEvents,
-} from "@app/lib/metronome/events";
+import { buildUsageEvents } from "@app/lib/metronome/events";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { describe, expect, it } from "vitest";
 
@@ -22,6 +19,7 @@ function usage(overrides: Partial<RunUsageType>): RunUsageType {
 
 const commonEventInput = {
   workspaceId: "workspace",
+  isByok: false,
   conversationId: "conversation",
   userId: "user",
   isFreeSeatedUser: false,
@@ -30,6 +28,8 @@ const commonEventInput = {
   subAgentId: null,
   parentAgentMessageId: null,
   runKey: "execution",
+  runUsages: [],
+  actions: [],
   origin: "web" as const,
   usageType: "user" as const,
   authMethod: "session",
@@ -39,11 +39,10 @@ const commonEventInput = {
   timestamp: "2026-08-05T12:00:00.000Z",
 };
 
-describe("Metronome billing event adapters", () => {
-  it("emits the canonical LLM billing groups and credit amounts", () => {
-    const events = buildLlmUsageEvents({
+describe("Metronome usage event adapter", () => {
+  it("emits a single event summing LLM and tool cost", () => {
+    const events = buildUsageEvents({
       ...commonEventInput,
-      isByok: false,
       runUsages: [
         usage({ costMicroUsd: 1, promptTokens: 2 }),
         usage({ costMicroUsd: 2, promptTokens: 3 }),
@@ -53,61 +52,90 @@ describe("Metronome billing event adapters", () => {
           providerId: "anthropic",
         }),
       ],
-    });
-
-    expect(events).toHaveLength(2);
-    expect(events.map(({ properties }) => properties)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          provider_id: "openai",
-          model_id: "gpt-4o",
-          prompt_tokens: 5,
-          cost_micro_usd: 3,
-          cost_awu: 1,
-        }),
-        expect.objectContaining({
-          provider_id: "anthropic",
-          model_id: "claude-opus-4-8",
-          cost_awu: 1,
-        }),
-      ])
-    );
-  });
-
-  it("emits canonical tool categories and free-usage overrides", () => {
-    const events = buildToolUseEvents({
-      ...commonEventInput,
       actions: [
         {
           toolName: "websearch",
           mcpServerId: null,
           internalMCPServerName: "web_search_&_browse",
           status: "succeeded",
-          executionDurationMs: 10,
-          shouldEmit: true,
-        },
-        {
-          toolName: "websearch",
-          mcpServerId: null,
-          internalMCPServerName: "web_search_&_browse",
-          status: "succeeded",
-          executionDurationMs: 20,
           shouldEmit: true,
         },
       ],
     });
 
     expect(events).toHaveLength(1);
+    expect(events[0]?.event_type).toBe("llm_usage_v3");
+    expect(events[0]?.transaction_id).toBe(
+      "usage3-workspace-conversation-message-execution"
+    );
     expect(events[0]?.properties).toMatchObject({
-      tool_category: "basic",
-      count: 2,
-      total_execution_duration_ms: 30,
+      provider_id: "aggregate",
+      model_id: "aggregate",
+      // LLM: ceil(3/µ)=1 + ceil(1/µ)=1 = 2. Tool: one "basic" (1 AWU) call = 1.
+      cost_awu: 3,
+      prompt_tokens: 5,
       usage_type: "user",
     });
   });
 
-  it("does not emit events for unbillable tool statuses", () => {
-    const events = buildToolUseEvents({
+  it("always emits the required billable shape with valid values", () => {
+    // Even with no user / api key / agent, the required properties fall back to
+    // valid, non-empty values so the billable metric's `exists` filters match.
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      userId: null,
+      apiKeyName: null,
+      agentId: null,
+      runUsages: [usage({ costMicroUsd: 1 })],
+    });
+
+    expect(events).toHaveLength(1);
+    const event = events[0];
+    expect(event?.event_type).toBe("llm_usage_v3");
+
+    const props = event?.properties ?? {};
+    for (const key of [
+      "agent_id",
+      "api_key_name",
+      "cost_awu",
+      "model_id",
+      "origin",
+      "usage_type",
+      "user_id",
+    ]) {
+      expect(props[key]).toBeDefined();
+    }
+
+    // The attribution keys must carry valid, non-empty values.
+    expect(props["user_id"]).toBe("unknown");
+    expect(props["api_key_name"]).toBe("unknown");
+    expect(props["agent_id"]).toBe("unknown");
+    expect(props["usage_type"]).toBe("user");
+    expect(props["model_id"]).toBe("aggregate");
+    expect(props["origin"]).toBe("web");
+  });
+
+  it("emits an LLM-only event when there are no tool actions", () => {
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      runUsages: [usage({ costMicroUsd: 1 })],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({
+      cost_awu: 1,
+      usage_type: "user",
+    });
+  });
+
+  it("emits no event when there is nothing to attribute", () => {
+    const events = buildUsageEvents({ ...commonEventInput });
+
+    expect(events).toEqual([]);
+  });
+
+  it("does not bill unbillable tool statuses", () => {
+    const events = buildUsageEvents({
       ...commonEventInput,
       actions: [
         {
@@ -115,42 +143,37 @@ describe("Metronome billing event adapters", () => {
           mcpServerId: null,
           internalMCPServerName: null,
           status: "denied",
-          executionDurationMs: null,
           shouldEmit: true,
         },
       ],
     });
 
-    expect(events).toEqual([]);
+    // The action is emitted for observability but denied statuses are never
+    // billed, so cost is 0.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({ cost_awu: 0 });
   });
 
-  it("splits paid and post-cap calls to the same tool", () => {
-    const events = buildToolUseEvents({
+  it("waives per-server-capped tool calls in the net cost", () => {
+    const events = buildUsageEvents({
       ...commonEventInput,
       actions: Array.from({ length: 8 }, () => ({
         toolName: "custom_tool",
         mcpServerId: "mcp_server",
         internalMCPServerName: null,
         status: "succeeded" as const,
-        executionDurationMs: 10,
         shouldEmit: true,
       })),
     });
 
-    expect(events).toHaveLength(2);
-    expect(events.map(({ properties }) => properties)).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ count: 7, usage_type: "user" }),
-        expect.objectContaining({ count: 1, usage_type: "free" }),
-      ])
-    );
-    expect(
-      new Set(events.map(({ transaction_id }) => transaction_id)).size
-    ).toBe(2);
+    // External tools are "advanced" (3 AWU). The 20-credit per-server cap is
+    // reached after 7 calls (21 credits); the 8th is waived. Net billed = 21.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({ cost_awu: 21 });
   });
 
-  it("applies prior execution spend without re-emitting prior actions", () => {
-    const events = buildToolUseEvents({
+  it("does not re-bill prior-execution actions", () => {
+    const events = buildUsageEvents({
       ...commonEventInput,
       actions: [
         ...Array.from({ length: 7 }, () => ({
@@ -158,7 +181,6 @@ describe("Metronome billing event adapters", () => {
           mcpServerId: "mcp_server",
           internalMCPServerName: null,
           status: "succeeded" as const,
-          executionDurationMs: 10,
           shouldEmit: false,
         })),
         {
@@ -166,7 +188,29 @@ describe("Metronome billing event adapters", () => {
           mcpServerId: "mcp_server",
           internalMCPServerName: null,
           status: "succeeded",
-          executionDurationMs: 10,
+          shouldEmit: true,
+        },
+      ],
+    });
+
+    // Prior actions already reached the cap, so this execution's only action is
+    // waived: it is emitted but bills 0.
+    expect(events).toHaveLength(1);
+    expect(events[0]?.properties).toMatchObject({ cost_awu: 0 });
+  });
+
+  it("bills nothing for free origins", () => {
+    const events = buildUsageEvents({
+      ...commonEventInput,
+      usageType: "free",
+      origin: "agent_sidekick",
+      runUsages: [usage({ costMicroUsd: 1_000_000 })],
+      actions: [
+        {
+          toolName: "custom_tool",
+          mcpServerId: "mcp_server",
+          internalMCPServerName: null,
+          status: "succeeded",
           shouldEmit: true,
         },
       ],
@@ -174,7 +218,7 @@ describe("Metronome billing event adapters", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]?.properties).toMatchObject({
-      count: 1,
+      cost_awu: 0,
       usage_type: "free",
     });
   });

--- a/front/lib/metronome/events.test.ts
+++ b/front/lib/metronome/events.test.ts
@@ -1,5 +1,10 @@
 import { MODEL_COST_MICRO_USD_PER_AWU_CREDIT } from "@app/lib/metronome/constants";
-import { buildUsageEvents } from "@app/lib/metronome/events";
+import {
+  billedCostAwuFromEvents,
+  buildLlmUsageEvents,
+  buildToolUseEvents,
+  buildUsageEvents,
+} from "@app/lib/metronome/events";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import { describe, expect, it } from "vitest";
 
@@ -20,7 +25,6 @@ function usage(overrides: Partial<RunUsageType>): RunUsageType {
 
 const commonEventInput = {
   workspaceId: "workspace",
-  isByok: false,
   conversationId: "conversation",
   userId: "user",
   isFreeSeatedUser: false,
@@ -29,8 +33,6 @@ const commonEventInput = {
   subAgentId: null,
   parentAgentMessageId: null,
   runKey: "execution",
-  runUsages: [],
-  actions: [],
   origin: "web" as const,
   usageType: "user" as const,
   authMethod: "session",
@@ -40,10 +42,11 @@ const commonEventInput = {
   timestamp: "2026-08-05T12:00:00.000Z",
 };
 
-describe("Metronome usage event adapter", () => {
-  it("emits a single event summing LLM and tool cost", () => {
-    const events = buildUsageEvents({
+describe("Metronome billing event adapters", () => {
+  it("emits the canonical LLM billing groups and credit amounts", () => {
+    const events = buildLlmUsageEvents({
       ...commonEventInput,
+      isByok: false,
       runUsages: [
         usage({ costMicroUsd: 1, promptTokens: 2 }),
         usage({ costMicroUsd: 2, promptTokens: 3 }),
@@ -53,147 +56,61 @@ describe("Metronome usage event adapter", () => {
           providerId: "anthropic",
         }),
       ],
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events.map(({ properties }) => properties)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider_id: "openai",
+          model_id: "gpt-4o",
+          prompt_tokens: 5,
+          cost_micro_usd: 3,
+          cost_awu: 1,
+        }),
+        expect.objectContaining({
+          provider_id: "anthropic",
+          model_id: "claude-opus-4-8",
+          cost_awu: 1,
+        }),
+      ])
+    );
+  });
+
+  it("emits canonical tool categories and free-usage overrides", () => {
+    const events = buildToolUseEvents({
+      ...commonEventInput,
       actions: [
         {
           toolName: "websearch",
           mcpServerId: null,
           internalMCPServerName: "web_search_&_browse",
           status: "succeeded",
+          executionDurationMs: 10,
           shouldEmit: true,
         },
-      ],
-    });
-
-    expect(events).toHaveLength(1);
-    expect(events[0]?.event_type).toBe("llm_usage_v3");
-    expect(events[0]?.transaction_id).toBe(
-      "usage3-workspace-conversation-message-execution"
-    );
-    expect(events[0]?.properties).toMatchObject({
-      provider_id: "aggregate",
-      model_id: "aggregate",
-      // LLM: ceil(3/µ)=1 + ceil(1/µ)=1 = 2. Tool: one "basic" (1 AWU) call = 1.
-      cost_awu: 3,
-      prompt_tokens: 5,
-      usage_type: "user",
-    });
-  });
-
-  it("always emits the required billable shape with valid values", () => {
-    // Even with no user / api key / agent, the required properties fall back to
-    // valid, non-empty values so the billable metric's `exists` filters match.
-    const events = buildUsageEvents({
-      ...commonEventInput,
-      userId: null,
-      apiKeyName: null,
-      agentId: null,
-      runUsages: [usage({ costMicroUsd: 1 })],
-    });
-
-    expect(events).toHaveLength(1);
-    const event = events[0];
-    expect(event?.event_type).toBe("llm_usage_v3");
-
-    const props = event?.properties ?? {};
-    for (const key of [
-      "agent_id",
-      "api_key_name",
-      "cost_awu",
-      "model_id",
-      "origin",
-      "usage_type",
-      "user_id",
-    ]) {
-      expect(props[key]).toBeDefined();
-    }
-
-    // The attribution keys must carry valid, non-empty values.
-    expect(props["user_id"]).toBe("unknown");
-    expect(props["api_key_name"]).toBe("unknown");
-    expect(props["agent_id"]).toBe("unknown");
-    expect(props["usage_type"]).toBe("user");
-    expect(props["model_id"]).toBe("aggregate");
-    expect(props["origin"]).toBe("web");
-  });
-
-  it("matches the pre-merge cost: per-model LLM rounding, then flat tool addition excluding free/capped", () => {
-    const perAwu = MODEL_COST_MICRO_USD_PER_AWU_CREDIT;
-
-    const events = buildUsageEvents({
-      ...commonEventInput,
-      runUsages: [
-        // openai/gpt-4o group: two usages summed (1 + 1 = 2 µUSD) THEN rounded.
-        usage({ costMicroUsd: 1 }),
-        usage({ costMicroUsd: 1 }),
-        // anthropic group: a separate model, rounded on its own.
-        usage({
-          costMicroUsd: perAwu + 1,
-          modelId: "claude-opus-4-8",
-          providerId: "anthropic",
-        }),
-      ],
-      // 8 external "advanced" (3 AWU) calls on one server: the 20-credit
-      // per-server cap is reached after 7 (21 credits), so the 8th is waived.
-      actions: [
-        ...Array.from({ length: 8 }, () => ({
-          toolName: "custom_tool",
-          mcpServerId: "mcp_server",
-          internalMCPServerName: null,
-          status: "succeeded" as const,
-          shouldEmit: true,
-        })),
-        // A denied call is unbillable and must not contribute either.
         {
-          toolName: "custom_tool",
-          mcpServerId: "mcp_server",
-          internalMCPServerName: null,
-          status: "denied" as const,
+          toolName: "websearch",
+          mcpServerId: null,
+          internalMCPServerName: "web_search_&_browse",
+          status: "succeeded",
+          executionDurationMs: 20,
           shouldEmit: true,
         },
       ],
     });
 
-    // Reference computed exactly as billing did before the merge:
-    // LLM cost is the SUM of per-(provider, model) ceilings — never a single
-    // ceiling over the combined micro-USD.
-    const expectedLlmCredits =
-      Math.ceil(2 / perAwu) + Math.ceil((perAwu + 1) / perAwu); // 1 + 2 = 3
-    // Tool cost is the flat sum of the rated weights of the BILLED calls only
-    // (7 × 3); the capped 8th call and the denied call add nothing.
-    const expectedToolCredits = 21;
-    const expectedCostAwu = expectedLlmCredits + expectedToolCredits; // 24
-
-    expect(events).toHaveLength(1);
-    expect(events[0]?.properties["cost_awu"]).toBe(expectedCostAwu);
-
-    // Guard against a regression to "round once at the end": collapsing the
-    // per-model ceilings into a single ceiling over the combined micro-USD would
-    // undercount here (ceil((2 + perAwu + 1) / perAwu) = 2, not 3).
-    const roundOnceLlmCredits = Math.ceil((2 + perAwu + 1) / perAwu);
-    expect(roundOnceLlmCredits).not.toBe(expectedLlmCredits);
-  });
-
-  it("emits an LLM-only event when there are no tool actions", () => {
-    const events = buildUsageEvents({
-      ...commonEventInput,
-      runUsages: [usage({ costMicroUsd: 1 })],
-    });
-
     expect(events).toHaveLength(1);
     expect(events[0]?.properties).toMatchObject({
-      cost_awu: 1,
+      tool_category: "basic",
+      count: 2,
+      total_execution_duration_ms: 30,
       usage_type: "user",
     });
   });
 
-  it("emits no event when there is nothing to attribute", () => {
-    const events = buildUsageEvents({ ...commonEventInput });
-
-    expect(events).toEqual([]);
-  });
-
-  it("does not bill unbillable tool statuses", () => {
-    const events = buildUsageEvents({
+  it("does not emit events for unbillable tool statuses", () => {
+    const events = buildToolUseEvents({
       ...commonEventInput,
       actions: [
         {
@@ -201,63 +118,42 @@ describe("Metronome usage event adapter", () => {
           mcpServerId: null,
           internalMCPServerName: null,
           status: "denied",
+          executionDurationMs: null,
           shouldEmit: true,
         },
       ],
     });
 
-    // The action is emitted for observability but denied statuses are never
-    // billed, so cost is 0.
-    expect(events).toHaveLength(1);
-    expect(events[0]?.properties).toMatchObject({ cost_awu: 0 });
+    expect(events).toEqual([]);
   });
 
-  it("waives per-server-capped tool calls in the net cost", () => {
-    const events = buildUsageEvents({
+  it("splits paid and post-cap calls to the same tool", () => {
+    const events = buildToolUseEvents({
       ...commonEventInput,
       actions: Array.from({ length: 8 }, () => ({
         toolName: "custom_tool",
         mcpServerId: "mcp_server",
         internalMCPServerName: null,
         status: "succeeded" as const,
+        executionDurationMs: 10,
         shouldEmit: true,
       })),
     });
 
-    // External tools are "advanced" (3 AWU). The 20-credit per-server cap is
-    // reached after 7 calls (21 credits); the 8th is waived. Net billed = 21.
-    expect(events).toHaveLength(1);
-    expect(events[0]?.properties).toMatchObject({ cost_awu: 21 });
+    expect(events).toHaveLength(2);
+    expect(events.map(({ properties }) => properties)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ count: 7, usage_type: "user" }),
+        expect.objectContaining({ count: 1, usage_type: "free" }),
+      ])
+    );
+    expect(
+      new Set(events.map(({ transaction_id }) => transaction_id)).size
+    ).toBe(2);
   });
 
-  it("applies the free_mcp_server_cap per server, not globally", () => {
-    // Two different servers, 8 "advanced" (3 AWU) calls each. The 20-credit cap
-    // is applied independently per server, so each server bills 7 calls (21) and
-    // waives its own 8th. A global cap would waive far more and undercount.
-    const serverActions = (mcpServerId: string) =>
-      Array.from({ length: 8 }, () => ({
-        toolName: "custom_tool",
-        mcpServerId,
-        internalMCPServerName: null,
-        status: "succeeded" as const,
-        shouldEmit: true,
-      }));
-
-    const events = buildUsageEvents({
-      ...commonEventInput,
-      actions: [
-        ...serverActions("mcp_server_a"),
-        ...serverActions("mcp_server_b"),
-      ],
-    });
-
-    // 21 (server A) + 21 (server B) = 42.
-    expect(events).toHaveLength(1);
-    expect(events[0]?.properties).toMatchObject({ cost_awu: 42 });
-  });
-
-  it("does not re-bill prior-execution actions", () => {
-    const events = buildUsageEvents({
+  it("applies prior execution spend without re-emitting prior actions", () => {
+    const events = buildToolUseEvents({
       ...commonEventInput,
       actions: [
         ...Array.from({ length: 7 }, () => ({
@@ -265,6 +161,7 @@ describe("Metronome usage event adapter", () => {
           mcpServerId: "mcp_server",
           internalMCPServerName: null,
           status: "succeeded" as const,
+          executionDurationMs: 10,
           shouldEmit: false,
         })),
         {
@@ -272,29 +169,7 @@ describe("Metronome usage event adapter", () => {
           mcpServerId: "mcp_server",
           internalMCPServerName: null,
           status: "succeeded",
-          shouldEmit: true,
-        },
-      ],
-    });
-
-    // Prior actions already reached the cap, so this execution's only action is
-    // waived: it is emitted but bills 0.
-    expect(events).toHaveLength(1);
-    expect(events[0]?.properties).toMatchObject({ cost_awu: 0 });
-  });
-
-  it("bills nothing for free origins", () => {
-    const events = buildUsageEvents({
-      ...commonEventInput,
-      usageType: "free",
-      origin: "agent_sidekick",
-      runUsages: [usage({ costMicroUsd: 1_000_000 })],
-      actions: [
-        {
-          toolName: "custom_tool",
-          mcpServerId: "mcp_server",
-          internalMCPServerName: null,
-          status: "succeeded",
+          executionDurationMs: 10,
           shouldEmit: true,
         },
       ],
@@ -302,8 +177,139 @@ describe("Metronome usage event adapter", () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]?.properties).toMatchObject({
-      cost_awu: 0,
+      count: 1,
       usage_type: "free",
     });
+  });
+});
+
+describe("Aggregated usage event (shadow) and legacy cost parity", () => {
+  const aggregatedInput = { ...commonEventInput, isByok: false };
+
+  it("aggregates LLM and tool cost into a single llm_usage_v3 event", () => {
+    const events = buildUsageEvents({
+      ...aggregatedInput,
+      runUsages: [usage({ costMicroUsd: 1 })],
+      actions: [
+        {
+          toolName: "websearch",
+          mcpServerId: null,
+          internalMCPServerName: "web_search_&_browse",
+          status: "succeeded",
+          executionDurationMs: 10,
+          shouldEmit: true,
+        },
+      ],
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.event_type).toBe("llm_usage_v3");
+    expect(events[0]?.properties).toMatchObject({
+      model_id: "aggregate",
+      // LLM ceil(1/µ) = 1 + one "basic" (1 AWU) tool = 2.
+      cost_awu: 2,
+      usage_type: "user",
+    });
+  });
+
+  it("matches the legacy events' billed cost on a mixed message", () => {
+    const perAwu = MODEL_COST_MICRO_USD_PER_AWU_CREDIT;
+
+    const runUsages = [
+      // openai group: two usages summed (1 + 1 µUSD) THEN rounded → 1 credit.
+      usage({ costMicroUsd: 1 }),
+      usage({ costMicroUsd: 1 }),
+      // anthropic group: rounded on its own → 2 credits.
+      usage({
+        costMicroUsd: perAwu + 1,
+        modelId: "claude-opus-4-8",
+        providerId: "anthropic",
+      }),
+    ];
+    const actions = [
+      // 8 external "advanced" (3 AWU) calls: 7 billed (21) + 1 capped (free).
+      ...Array.from({ length: 8 }, () => ({
+        toolName: "custom_tool",
+        mcpServerId: "mcp_server",
+        internalMCPServerName: null,
+        status: "succeeded" as const,
+        executionDurationMs: 10,
+        shouldEmit: true,
+      })),
+      // One internal "basic" (1 AWU) billed call.
+      {
+        toolName: "websearch",
+        mcpServerId: null,
+        internalMCPServerName: "web_search_&_browse" as const,
+        status: "succeeded" as const,
+        executionDurationMs: 5,
+        shouldEmit: true,
+      },
+      // A denied call: unbillable, must not contribute on either side.
+      {
+        toolName: "custom_tool",
+        mcpServerId: null,
+        internalMCPServerName: null,
+        status: "denied" as const,
+        executionDurationMs: null,
+        shouldEmit: true,
+      },
+    ];
+
+    const legacyEvents = [
+      ...buildLlmUsageEvents({ ...aggregatedInput, runUsages }),
+      ...buildToolUseEvents({ ...commonEventInput, actions }),
+    ];
+    const aggregatedEvents = buildUsageEvents({
+      ...aggregatedInput,
+      runUsages,
+      actions,
+    });
+
+    // LLM 3 (1 + 2, per-model rounding) + tools 22 (7×3 capped + 1 basic) = 25.
+    const newCostAwu = Number(aggregatedEvents[0]?.properties["cost_awu"]);
+    expect(newCostAwu).toBe(25);
+    expect(billedCostAwuFromEvents(legacyEvents)).toBe(newCostAwu);
+  });
+
+  it("matches (both zero) for free-origin messages", () => {
+    const runUsages = [usage({ costMicroUsd: 1_000_000 })];
+    const actions = [
+      {
+        toolName: "custom_tool",
+        mcpServerId: "mcp_server",
+        internalMCPServerName: null,
+        status: "succeeded" as const,
+        executionDurationMs: 10,
+        shouldEmit: true,
+      },
+    ];
+    const freeInput = {
+      ...aggregatedInput,
+      usageType: "free" as const,
+      origin: "agent_sidekick" as const,
+    };
+
+    const legacyEvents = [
+      ...buildLlmUsageEvents({ ...freeInput, runUsages }),
+      ...buildToolUseEvents({
+        ...commonEventInput,
+        usageType: "free" as const,
+        origin: "agent_sidekick" as const,
+        actions,
+      }),
+    ];
+    const aggregatedEvents = buildUsageEvents({
+      ...freeInput,
+      runUsages,
+      actions,
+    });
+
+    const newCostAwu = aggregatedEvents.reduce(
+      (total, event) => total + Number(event.properties["cost_awu"] ?? 0),
+      0
+    );
+    expect(newCostAwu).toBe(0);
+    expect(billedCostAwuFromEvents(legacyEvents)).toBe(0);
   });
 });

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -575,7 +575,13 @@ export function buildUsageEvents({
  */
 export function billedCostAwuFromEvents(events: MetronomeEvent[]): number {
   return events.reduce((total, event) => {
-    if (event.properties[USAGE_TYPE_GROUP_KEY] === USAGE_TYPE_FREE) {
+    // The rate card only prices the paid usage types; "free" and any other
+    // value are entitled at 0, so only count "user" and "programmatic".
+    const usageType = event.properties[USAGE_TYPE_GROUP_KEY];
+    if (
+      usageType !== USAGE_TYPE_USER &&
+      usageType !== USAGE_TYPE_PROGRAMMATIC
+    ) {
       return total;
     }
     if (event.event_type === "tool_use_v3") {

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -595,8 +595,10 @@ export function billedCostAwuFromEvents(events: MetronomeEvent[]): number {
         return total + count * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
       }
       return total;
+    } else if (event.event_type === "llm_usage_v3") {
+      const costAwu = event.properties["cost_awu"];
+      return total + (typeof costAwu === "number" ? costAwu : 0);
     }
-    const costAwu = event.properties["cost_awu"];
-    return total + (typeof costAwu === "number" ? costAwu : 0);
+    return total;
   }, 0);
 }

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -3,6 +3,8 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   buildAgentMessageBillingPlan,
   isFreeOrigin,
+  isToolCostCategory,
+  TOOL_COST_CATEGORY_AWU_WEIGHTS,
 } from "@app/lib/credits/agent_message_billing";
 import type { RunUsageType } from "@app/lib/resources/run_resource";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
@@ -30,6 +32,7 @@ export {
 } from "@app/lib/credits/agent_message_billing";
 
 const MAX_TRANSACTION_ID_LENGTH = 128;
+const MAX_PROPERTY_VALUE_BYTES = 128;
 
 /**
  * If a transaction_id exceeds Metronome's 128-char limit, keep the first
@@ -44,6 +47,21 @@ function truncateTransactionId(id: string): string {
   return `${id.slice(0, MAX_TRANSACTION_ID_LENGTH - 13)}-${hash}`;
 }
 
+/**
+ * Truncate a string property value to fit Metronome's 256-byte limit.
+ */
+function truncatePropertyValue(value: string): string {
+  if (Buffer.byteLength(value, "utf8") <= MAX_PROPERTY_VALUE_BYTES) {
+    return value;
+  }
+  // Truncate conservatively — slice characters until within byte limit.
+  let truncated = value;
+  while (Buffer.byteLength(truncated, "utf8") > MAX_PROPERTY_VALUE_BYTES - 3) {
+    truncated = truncated.slice(0, truncated.length - 1);
+  }
+  return truncated + "...";
+}
+
 // ---------------------------------------------------------------------------
 // Usage type helpers
 // ---------------------------------------------------------------------------
@@ -56,6 +74,16 @@ export function getUsageType(
     return USAGE_TYPE_FREE;
   }
   return isProgrammaticUsage ? USAGE_TYPE_PROGRAMMATIC : USAGE_TYPE_USER;
+}
+
+function getToolUsageType({
+  baseUsageType,
+  isFreeUsage,
+}: {
+  baseUsageType: UsageType;
+  isFreeUsage: boolean;
+}): UsageType {
+  return isFreeUsage ? USAGE_TYPE_FREE : baseUsageType;
 }
 
 // Intelligence (AI compute) credits for a *single execution's* run usages.
@@ -127,7 +155,105 @@ export function toolAwuFromAction(
 }
 
 // ---------------------------------------------------------------------------
-// Usage events
+// LLM usage events
+// ---------------------------------------------------------------------------
+
+/**
+ * Build aggregated Metronome llm_usage events for an agent message.
+ * Usages are grouped by (providerId, modelId) — one event per model used
+ * with aggregated token counts and cost.
+ *
+ * transaction_id pattern: llm-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{providerId}-{modelId}
+ */
+export function buildLlmUsageEvents({
+  workspaceId,
+  isByok,
+  conversationId,
+  userId,
+  isFreeSeatedUser,
+  agentMessageId,
+  agentId,
+  subAgentId,
+  parentAgentMessageId,
+  runKey,
+  runUsages,
+  origin,
+  usageType,
+  authMethod,
+  apiKeyName,
+  messageStatus,
+  isSubAgentMessage,
+  timestamp,
+}: {
+  workspaceId: string;
+  isByok: boolean;
+  conversationId: string;
+  userId: string | null;
+  isFreeSeatedUser: boolean;
+  agentMessageId: string;
+  agentId: string | null;
+  subAgentId: string | null;
+  parentAgentMessageId: string | null;
+  runKey: string;
+  runUsages: RunUsageType[];
+  origin: UserMessageOrigin;
+  usageType: UsageType;
+  authMethod: string | null;
+  apiKeyName: string | null;
+  messageStatus: string;
+  isSubAgentMessage: boolean;
+  timestamp: string;
+}): MetronomeEvent[] {
+  const billingPlan = buildAgentMessageBillingPlan({
+    actions: [],
+    contextOrigin: origin,
+    runUsages: runUsages.map((usage) => ({ ...usage, runKey })),
+  });
+
+  return billingPlan.llm.map((group) => ({
+    transaction_id: `llm3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${group.providerId}-${group.modelId}`,
+    customer_id: getMetronomeIngestAlias(workspaceId),
+    event_type: "llm_usage_v3",
+    timestamp,
+    properties: {
+      workspace_id: workspaceId,
+      user_id: userId
+        ? isFreeSeatedUser
+          ? toFreeMetronomeUserId(userId)
+          : userId
+        : "unknown",
+      is_byok: isByok ? "true" : "false",
+      agent_message_id: agentMessageId,
+      conversation_id: conversationId,
+      agent_id: agentId ?? "unknown",
+      sub_agent_id: subAgentId ?? "none",
+      parent_agent_message_id: parentAgentMessageId ?? "none",
+      provider_id: group.providerId,
+      model_id: group.modelId,
+      prompt_tokens: group.promptTokensCount,
+      completion_tokens: group.completionTokensCount,
+      cached_tokens: group.cachedTokensCount,
+      cache_creation_tokens: group.cacheCreationTokensCount,
+      // Provider cost without markup — markup is applied in Metronome rate card. Only used for legacy rates.
+      cost_micro_usd: group.providerCostMicroUsd,
+      // 1 AWU credit = $0.0085
+      cost_awu: group.ratedCredits,
+      // TODO: Remove is_programmatic_usage & is_free_usage, this is replaced by single property "usage type"
+      is_programmatic_usage:
+        usageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
+      is_free_usage: usageType === USAGE_TYPE_FREE ? "true" : "false",
+      [USAGE_TYPE_GROUP_KEY]: usageType,
+      auth_method: authMethod ?? "unknown",
+      api_key_name: apiKeyName ?? "unknown",
+      message_status: messageStatus,
+      is_sub_agent_message: isSubAgentMessage ? "true" : "false",
+      origin,
+    },
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tool use events
 // ---------------------------------------------------------------------------
 
 interface ToolAction {
@@ -135,26 +261,173 @@ interface ToolAction {
   mcpServerId: string | null;
   internalMCPServerName: InternalMCPServerNameType | null;
   status: ToolExecutionStatus;
+  executionDurationMs: number | null;
   // The billing plan needs every chronological action in the message to apply
   // the per-server cap, while each execution emits only its own actions.
   shouldEmit: boolean;
 }
 
 /**
- * Build the single Metronome llm_usage_v3 event for one agent-message execution.
+ * Build aggregated Metronome tool_use events for an agent message.
+ * Actions are grouped by (toolName, internalMCPServerName, mcpServerId, status,
+ * billingDisposition). Each group produces one event with `count` and
+ * `total_execution_duration_ms`.
  *
- * LLM (intelligence) and tool (platform action) costs are computed on our side
- * and summed into one `cost_awu`, so an execution emits exactly one billing
- * event instead of one per model and one per MCP server. We no longer emit
- * `tool_use_v3` events, and we no longer report per-model / per-tool
- * granularity here — `model_id` is required by the billable metric but carries a
- * constant placeholder.
+ * transaction_id pattern: tool-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{toolHash}
+ * toolHash is a 12-char SHA-256 of toolName|mcpServerId|status to keep under 128 chars.
+ */
+export function buildToolUseEvents({
+  workspaceId,
+  conversationId,
+  userId,
+  isFreeSeatedUser,
+  agentMessageId,
+  agentId,
+  subAgentId,
+  parentAgentMessageId,
+  runKey,
+  actions,
+  origin,
+  usageType,
+  authMethod,
+  apiKeyName,
+  messageStatus,
+  isSubAgentMessage,
+  timestamp,
+}: {
+  workspaceId: string;
+  conversationId: string;
+  userId: string | null;
+  isFreeSeatedUser: boolean;
+  agentMessageId: string;
+  agentId: string | null;
+  subAgentId: string | null;
+  parentAgentMessageId: string | null;
+  runKey: string;
+  actions: ToolAction[];
+  origin: UserMessageOrigin;
+  usageType: UsageType;
+  authMethod: string | null;
+  apiKeyName: string | null;
+  messageStatus: string;
+  isSubAgentMessage: boolean;
+  timestamp: string;
+}): MetronomeEvent[] {
+  const billingPlan = buildAgentMessageBillingPlan({
+    actions,
+    contextOrigin: origin,
+    runUsages: [],
+  });
+
+  // Group actions by (toolName, internalMCPServerName, mcpServerId, status,
+  // billingDisposition). The disposition split is required when one execution
+  // contains both paid and post-cap calls to the same tool.
+  const groups = new Map<
+    string,
+    {
+      billingLine: (typeof billingPlan.tools)[number];
+      count: number;
+      totalDurationMs: number;
+    }
+  >();
+  for (const billingLine of billingPlan.tools) {
+    if (!billingLine.action.shouldEmit) {
+      continue;
+    }
+    // Metronome prices every emitted tool event. Actions that never reached the
+    // tool must therefore be omitted rather than represented as zero-cost.
+    if (billingLine.billingDisposition === "unbillable_status") {
+      continue;
+    }
+    const { action } = billingLine;
+    const key = `${action.toolName}|${action.internalMCPServerName ?? ""}|${action.mcpServerId ?? ""}|${action.status}|${billingLine.billingDisposition}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.count++;
+      existing.totalDurationMs += action.executionDurationMs ?? 0;
+    } else {
+      groups.set(key, {
+        billingLine,
+        count: 1,
+        totalDurationMs: action.executionDurationMs ?? 0,
+      });
+    }
+  }
+
+  return [...groups.values()].map(({ billingLine, count, totalDurationMs }) => {
+    const { action, billingDisposition, toolCostCategory } = billingLine;
+    const effectiveUsageType = getToolUsageType({
+      baseUsageType: usageType,
+      isFreeUsage: billingDisposition !== "billed",
+    });
+    const transactionIdDispositionSuffix =
+      billingDisposition === "free_mcp_server_cap"
+        ? `-${billingDisposition}`
+        : "";
+    return {
+      transaction_id: truncateTransactionId(
+        `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}${transactionIdDispositionSuffix}`
+      ),
+      customer_id: getMetronomeIngestAlias(workspaceId),
+      event_type: "tool_use_v3",
+      timestamp,
+      properties: {
+        workspace_id: workspaceId,
+        user_id: userId
+          ? isFreeSeatedUser
+            ? toFreeMetronomeUserId(userId)
+            : userId
+          : "unknown",
+        agent_message_id: agentMessageId,
+        conversation_id: conversationId,
+        agent_id: agentId ?? "unknown",
+        sub_agent_id: subAgentId ?? "none",
+        parent_agent_message_id: parentAgentMessageId ?? "none",
+        auth_method: authMethod ?? "unknown",
+        api_key_name: apiKeyName ?? "unknown",
+        tool_name: truncatePropertyValue(action.toolName),
+        mcp_server_id: truncatePropertyValue(action.mcpServerId ?? ""),
+        internal_mcp_server_name: truncatePropertyValue(
+          action.internalMCPServerName ?? ""
+        ),
+        tool_category: toolCostCategory,
+        // Constant grouping key — used as presentation_group_key in Metronome to
+        // aggregate all tool categories into a single "Tool Usage" invoice line.
+        tool_group: "tools",
+        status: action.status,
+        count,
+        total_execution_duration_ms: totalDurationMs,
+        // TODO: Remove is_programmatic_usage, this is replaced by single property "usage type"
+        is_programmatic_usage:
+          effectiveUsageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
+        [USAGE_TYPE_GROUP_KEY]: effectiveUsageType,
+        message_status: messageStatus,
+        is_sub_agent_message: isSubAgentMessage ? "true" : "false",
+        origin,
+      },
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Aggregated usage event (shadow — not yet ingested)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the single aggregated Metronome llm_usage_v3 event for one agent-message
+ * execution: LLM (intelligence) and tool (platform action) costs are computed on
+ * our side and summed into one `cost_awu`.
+ *
+ * This is the target shape that will eventually replace the per-model
+ * `buildLlmUsageEvents` + per-tool `buildToolUseEvents` events. For now it is
+ * only used to shadow-compute the aggregated amount for a parity log, so its
+ * result is NOT ingested.
  *
  * `cost_awu` is the net billed credits: free origins, the per-server tool cap
- * and free tools are already waived in the number, so Metronome prices it as a
- * flat multiply on the shared AWU rate. Only actions belonging to this execution
- * (`shouldEmit`) contribute; prior-execution actions are still fed to the
- * billing plan so the per-server cap is applied across the whole message.
+ * and free tools are already waived in the number, so Metronome would price it
+ * as a flat multiply on the shared AWU rate. Only actions belonging to this
+ * execution (`shouldEmit`) contribute; prior-execution actions are still fed to
+ * the billing plan so the per-server cap is applied across the whole message.
  *
  * transaction_id pattern: usage3-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}
  */
@@ -291,4 +564,33 @@ export function buildUsageEvents({
       },
     },
   ];
+}
+
+/**
+ * Sum the AWU that Metronome will bill from a set of legacy usage events:
+ * `llm_usage_v3` → `cost_awu`; `tool_use_v3` → `count` × the tool category
+ * weight. Events tagged `usage_type: free` are priced at 0 and contribute
+ * nothing. Used to shadow-compare the legacy per-model/per-tool events against
+ * the aggregated `buildUsageEvents` cost before switching over.
+ */
+export function billedCostAwuFromEvents(events: MetronomeEvent[]): number {
+  return events.reduce((total, event) => {
+    if (event.properties[USAGE_TYPE_GROUP_KEY] === USAGE_TYPE_FREE) {
+      return total;
+    }
+    if (event.event_type === "tool_use_v3") {
+      const category = event.properties["tool_category"];
+      const count = event.properties["count"];
+      if (
+        typeof category === "string" &&
+        isToolCostCategory(category) &&
+        typeof count === "number"
+      ) {
+        return total + count * TOOL_COST_CATEGORY_AWU_WEIGHTS[category];
+      }
+      return total;
+    }
+    const costAwu = event.properties["cost_awu"];
+    return total + (typeof costAwu === "number" ? costAwu : 0);
+  }, 0);
 }

--- a/front/lib/metronome/events.ts
+++ b/front/lib/metronome/events.ts
@@ -30,7 +30,6 @@ export {
 } from "@app/lib/credits/agent_message_billing";
 
 const MAX_TRANSACTION_ID_LENGTH = 128;
-const MAX_PROPERTY_VALUE_BYTES = 128;
 
 /**
  * If a transaction_id exceeds Metronome's 128-char limit, keep the first
@@ -45,21 +44,6 @@ function truncateTransactionId(id: string): string {
   return `${id.slice(0, MAX_TRANSACTION_ID_LENGTH - 13)}-${hash}`;
 }
 
-/**
- * Truncate a string property value to fit Metronome's 256-byte limit.
- */
-function truncatePropertyValue(value: string): string {
-  if (Buffer.byteLength(value, "utf8") <= MAX_PROPERTY_VALUE_BYTES) {
-    return value;
-  }
-  // Truncate conservatively — slice characters until within byte limit.
-  let truncated = value;
-  while (Buffer.byteLength(truncated, "utf8") > MAX_PROPERTY_VALUE_BYTES - 3) {
-    truncated = truncated.slice(0, truncated.length - 1);
-  }
-  return truncated + "...";
-}
-
 // ---------------------------------------------------------------------------
 // Usage type helpers
 // ---------------------------------------------------------------------------
@@ -72,16 +56,6 @@ export function getUsageType(
     return USAGE_TYPE_FREE;
   }
   return isProgrammaticUsage ? USAGE_TYPE_PROGRAMMATIC : USAGE_TYPE_USER;
-}
-
-function getToolUsageType({
-  baseUsageType,
-  isFreeUsage,
-}: {
-  baseUsageType: UsageType;
-  isFreeUsage: boolean;
-}): UsageType {
-  return isFreeUsage ? USAGE_TYPE_FREE : baseUsageType;
 }
 
 // Intelligence (AI compute) credits for a *single execution's* run usages.
@@ -153,17 +127,38 @@ export function toolAwuFromAction(
 }
 
 // ---------------------------------------------------------------------------
-// LLM usage events
+// Usage events
 // ---------------------------------------------------------------------------
 
+interface ToolAction {
+  toolName: string;
+  mcpServerId: string | null;
+  internalMCPServerName: InternalMCPServerNameType | null;
+  status: ToolExecutionStatus;
+  // The billing plan needs every chronological action in the message to apply
+  // the per-server cap, while each execution emits only its own actions.
+  shouldEmit: boolean;
+}
+
 /**
- * Build aggregated Metronome llm_usage events for an agent message.
- * Usages are grouped by (providerId, modelId) — one event per model used
- * with aggregated token counts and cost.
+ * Build the single Metronome llm_usage_v3 event for one agent-message execution.
  *
- * transaction_id pattern: llm-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{providerId}-{modelId}
+ * LLM (intelligence) and tool (platform action) costs are computed on our side
+ * and summed into one `cost_awu`, so an execution emits exactly one billing
+ * event instead of one per model and one per MCP server. We no longer emit
+ * `tool_use_v3` events, and we no longer report per-model / per-tool
+ * granularity here — `model_id` is required by the billable metric but carries a
+ * constant placeholder.
+ *
+ * `cost_awu` is the net billed credits: free origins, the per-server tool cap
+ * and free tools are already waived in the number, so Metronome prices it as a
+ * flat multiply on the shared AWU rate. Only actions belonging to this execution
+ * (`shouldEmit`) contribute; prior-execution actions are still fed to the
+ * billing plan so the per-server cap is applied across the whole message.
+ *
+ * transaction_id pattern: usage3-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}
  */
-export function buildLlmUsageEvents({
+export function buildUsageEvents({
   workspaceId,
   isByok,
   conversationId,
@@ -175,6 +170,7 @@ export function buildLlmUsageEvents({
   parentAgentMessageId,
   runKey,
   runUsages,
+  actions,
   origin,
   usageType,
   authMethod,
@@ -194,114 +190,6 @@ export function buildLlmUsageEvents({
   parentAgentMessageId: string | null;
   runKey: string;
   runUsages: RunUsageType[];
-  origin: UserMessageOrigin;
-  usageType: UsageType;
-  authMethod: string | null;
-  apiKeyName: string | null;
-  messageStatus: string;
-  isSubAgentMessage: boolean;
-  timestamp: string;
-}): MetronomeEvent[] {
-  const billingPlan = buildAgentMessageBillingPlan({
-    actions: [],
-    contextOrigin: origin,
-    runUsages: runUsages.map((usage) => ({ ...usage, runKey })),
-  });
-
-  return billingPlan.llm.map((group) => ({
-    transaction_id: `llm3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${group.providerId}-${group.modelId}`,
-    customer_id: getMetronomeIngestAlias(workspaceId),
-    event_type: "llm_usage_v3",
-    timestamp,
-    properties: {
-      workspace_id: workspaceId,
-      user_id: userId
-        ? isFreeSeatedUser
-          ? toFreeMetronomeUserId(userId)
-          : userId
-        : "unknown",
-      is_byok: isByok ? "true" : "false",
-      agent_message_id: agentMessageId,
-      conversation_id: conversationId,
-      agent_id: agentId ?? "unknown",
-      sub_agent_id: subAgentId ?? "none",
-      parent_agent_message_id: parentAgentMessageId ?? "none",
-      provider_id: group.providerId,
-      model_id: group.modelId,
-      prompt_tokens: group.promptTokensCount,
-      completion_tokens: group.completionTokensCount,
-      cached_tokens: group.cachedTokensCount,
-      cache_creation_tokens: group.cacheCreationTokensCount,
-      // Provider cost without markup — markup is applied in Metronome rate card. Only used for legacy rates.
-      cost_micro_usd: group.providerCostMicroUsd,
-      // 1 AWU credit = $0.0085
-      cost_awu: group.ratedCredits,
-      // TODO: Remove is_programmatic_usage & is_free_usage, this is replaced by single property "usage type"
-      is_programmatic_usage:
-        usageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
-      is_free_usage: usageType === USAGE_TYPE_FREE ? "true" : "false",
-      [USAGE_TYPE_GROUP_KEY]: usageType,
-      auth_method: authMethod ?? "unknown",
-      api_key_name: apiKeyName ?? "unknown",
-      message_status: messageStatus,
-      is_sub_agent_message: isSubAgentMessage ? "true" : "false",
-      origin,
-    },
-  }));
-}
-
-// ---------------------------------------------------------------------------
-// Tool use events
-// ---------------------------------------------------------------------------
-
-interface ToolAction {
-  toolName: string;
-  mcpServerId: string | null;
-  internalMCPServerName: InternalMCPServerNameType | null;
-  status: ToolExecutionStatus;
-  executionDurationMs: number | null;
-  // The billing plan needs every chronological action in the message to apply
-  // the per-server cap, while each execution emits only its own actions.
-  shouldEmit: boolean;
-}
-
-/**
- * Build aggregated Metronome tool_use events for an agent message.
- * Actions are grouped by (toolName, internalMCPServerName, mcpServerId, status,
- * billingDisposition). Each group produces one event with `count` and
- * `total_execution_duration_ms`.
- *
- * transaction_id pattern: tool-{workspaceId}-{conversationId}-{agentMessageId}-{runKey}-{toolHash}
- * toolHash is a 12-char SHA-256 of toolName|mcpServerId|status to keep under 128 chars.
- */
-export function buildToolUseEvents({
-  workspaceId,
-  conversationId,
-  userId,
-  isFreeSeatedUser,
-  agentMessageId,
-  agentId,
-  subAgentId,
-  parentAgentMessageId,
-  runKey,
-  actions,
-  origin,
-  usageType,
-  authMethod,
-  apiKeyName,
-  messageStatus,
-  isSubAgentMessage,
-  timestamp,
-}: {
-  workspaceId: string;
-  conversationId: string;
-  userId: string | null;
-  isFreeSeatedUser: boolean;
-  agentMessageId: string;
-  agentId: string | null;
-  subAgentId: string | null;
-  parentAgentMessageId: string | null;
-  runKey: string;
   actions: ToolAction[];
   origin: UserMessageOrigin;
   usageType: UsageType;
@@ -314,60 +202,55 @@ export function buildToolUseEvents({
   const billingPlan = buildAgentMessageBillingPlan({
     actions,
     contextOrigin: origin,
-    runUsages: [],
+    runUsages: runUsages.map((usage) => ({ ...usage, runKey })),
   });
 
-  // Group actions by (toolName, internalMCPServerName, mcpServerId, status,
-  // billingDisposition). The disposition split is required when one execution
-  // contains both paid and post-cap calls to the same tool.
-  const groups = new Map<
-    string,
-    {
-      billingLine: (typeof billingPlan.tools)[number];
-      count: number;
-      totalDurationMs: number;
-    }
-  >();
-  for (const billingLine of billingPlan.tools) {
-    if (!billingLine.action.shouldEmit) {
-      continue;
-    }
-    // Metronome prices every emitted tool event. Actions that never reached the
-    // tool must therefore be omitted rather than represented as zero-cost.
-    if (billingLine.billingDisposition === "unbillable_status") {
-      continue;
-    }
-    const { action } = billingLine;
-    const key = `${action.toolName}|${action.internalMCPServerName ?? ""}|${action.mcpServerId ?? ""}|${action.status}|${billingLine.billingDisposition}`;
-    const existing = groups.get(key);
-    if (existing) {
-      existing.count++;
-      existing.totalDurationMs += action.executionDurationMs ?? 0;
-    } else {
-      groups.set(key, {
-        billingLine,
-        count: 1,
-        totalDurationMs: action.executionDurationMs ?? 0,
-      });
-    }
+  // Only actions belonging to this execution are billed here — prior-execution
+  // actions were billed by their own event but are kept in the plan so the
+  // per-server cap sees the whole message.
+  const emittedToolLines = billingPlan.tools.filter(
+    (line) => line.action.shouldEmit
+  );
+  const toolBilledCredits = emittedToolLines.reduce(
+    (total, line) => total + line.billedCredits,
+    0
+  );
+
+  // Nothing to attribute for this execution (e.g. a resume that only replays
+  // prior actions): emit no event.
+  if (billingPlan.llm.length === 0 && emittedToolLines.length === 0) {
+    return [];
   }
 
-  return [...groups.values()].map(({ billingLine, count, totalDurationMs }) => {
-    const { action, billingDisposition, toolCostCategory } = billingLine;
-    const effectiveUsageType = getToolUsageType({
-      baseUsageType: usageType,
-      isFreeUsage: billingDisposition !== "billed",
-    });
-    const transactionIdDispositionSuffix =
-      billingDisposition === "free_mcp_server_cap"
-        ? `-${billingDisposition}`
-        : "";
-    return {
+  const costAwu = billingPlan.totals.llmBilledCredits + toolBilledCredits;
+
+  // Aggregate token counts across models for observability only — the billable
+  // metric sums `cost_awu` and ignores these.
+  const tokenTotals = billingPlan.llm.reduce(
+    (totals, group) => ({
+      promptTokens: totals.promptTokens + group.promptTokensCount,
+      completionTokens: totals.completionTokens + group.completionTokensCount,
+      cachedTokens: totals.cachedTokens + group.cachedTokensCount,
+      cacheCreationTokens:
+        totals.cacheCreationTokens + group.cacheCreationTokensCount,
+      costMicroUsd: totals.costMicroUsd + group.providerCostMicroUsd,
+    }),
+    {
+      promptTokens: 0,
+      completionTokens: 0,
+      cachedTokens: 0,
+      cacheCreationTokens: 0,
+      costMicroUsd: 0,
+    }
+  );
+
+  return [
+    {
       transaction_id: truncateTransactionId(
-        `tool3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}-${action.toolName}-${action.mcpServerId ?? ""}-${action.status}${transactionIdDispositionSuffix}`
+        `usage3-${workspaceId}-${conversationId}-${agentMessageId}-${runKey}`
       ),
       customer_id: getMetronomeIngestAlias(workspaceId),
-      event_type: "tool_use_v3",
+      event_type: "llm_usage_v3",
       timestamp,
       properties: {
         workspace_id: workspaceId,
@@ -376,33 +259,36 @@ export function buildToolUseEvents({
             ? toFreeMetronomeUserId(userId)
             : userId
           : "unknown",
+        is_byok: isByok ? "true" : "false",
         agent_message_id: agentMessageId,
         conversation_id: conversationId,
         agent_id: agentId ?? "unknown",
         sub_agent_id: subAgentId ?? "none",
         parent_agent_message_id: parentAgentMessageId ?? "none",
+        // Required by the billable metric but intentionally not granular: LLM and
+        // tool cost are aggregated into this single event.
+        provider_id: "aggregate",
+        model_id: "aggregate",
+        prompt_tokens: tokenTotals.promptTokens,
+        completion_tokens: tokenTotals.completionTokens,
+        cached_tokens: tokenTotals.cachedTokens,
+        cache_creation_tokens: tokenTotals.cacheCreationTokens,
+        // Provider cost without markup — observability only. 1 AWU = $0.0085.
+        cost_micro_usd: tokenTotals.costMicroUsd,
+        // Net billed credits (LLM + tools) computed on our side; waivers already
+        // applied, so Metronome prices this as a flat multiply on the AWU rate.
+        cost_awu: costAwu,
+        // TODO: Remove is_programmatic_usage & is_free_usage, this is replaced by single property "usage type"
+        is_programmatic_usage:
+          usageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
+        is_free_usage: usageType === USAGE_TYPE_FREE ? "true" : "false",
+        [USAGE_TYPE_GROUP_KEY]: usageType,
         auth_method: authMethod ?? "unknown",
         api_key_name: apiKeyName ?? "unknown",
-        tool_name: truncatePropertyValue(action.toolName),
-        mcp_server_id: truncatePropertyValue(action.mcpServerId ?? ""),
-        internal_mcp_server_name: truncatePropertyValue(
-          action.internalMCPServerName ?? ""
-        ),
-        tool_category: toolCostCategory,
-        // Constant grouping key — used as presentation_group_key in Metronome to
-        // aggregate all tool categories into a single "Tool Usage" invoice line.
-        tool_group: "tools",
-        status: action.status,
-        count,
-        total_execution_duration_ms: totalDurationMs,
-        // TODO: Remove is_programmatic_usage, this is replaced by single property "usage type"
-        is_programmatic_usage:
-          effectiveUsageType === USAGE_TYPE_PROGRAMMATIC ? "true" : "false",
-        [USAGE_TYPE_GROUP_KEY]: effectiveUsageType,
         message_status: messageStatus,
         is_sub_agent_message: isSubAgentMessage ? "true" : "false",
         origin,
       },
-    };
-  });
+    },
+  ];
 }

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -8,6 +8,9 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ingestMetronomeEvents } from "@app/lib/metronome/client";
 import {
+  billedCostAwuFromEvents,
+  buildLlmUsageEvents,
+  buildToolUseEvents,
   buildUsageEvents,
   computeRunKey,
   getUsageType,
@@ -372,6 +375,7 @@ export async function emitMetronomeUsageEventsActivity(
       mcpServerId: json.mcpServerId,
       internalMCPServerName: json.internalMCPServerName,
       status: json.status,
+      executionDurationMs: json.executionDurationMs,
       shouldEmit:
         agentLoopArgs.startStep === undefined ||
         json.step >= agentLoopArgs.startStep,
@@ -385,8 +389,54 @@ export async function emitMetronomeUsageEventsActivity(
   // ceils per the exact same execution partition that is billed here.
   const runKey = computeRunKey(effectiveRunIds);
 
-  // Build and ingest the single aggregated usage event (LLM + tool cost).
-  const usageEvents = buildUsageEvents({
+  // Build and ingest events.
+  const llmEvents = buildLlmUsageEvents({
+    workspaceId: workspace.sId,
+    isByok,
+    conversationId,
+    userId,
+    isFreeSeatedUser,
+    agentMessageId,
+    agentId,
+    subAgentId,
+    parentAgentMessageId,
+    runKey,
+    runUsages,
+    origin: userMessageOrigin,
+    usageType,
+    authMethod,
+    apiKeyName,
+    messageStatus,
+    isSubAgentMessage,
+    timestamp,
+  });
+
+  const toolEvents = buildToolUseEvents({
+    workspaceId: workspace.sId,
+    conversationId,
+    userId,
+    isFreeSeatedUser,
+    agentMessageId,
+    agentId,
+    subAgentId,
+    parentAgentMessageId,
+    runKey,
+    actions: toolActions,
+    origin: userMessageOrigin,
+    usageType,
+    authMethod,
+    apiKeyName,
+    messageStatus,
+    isSubAgentMessage,
+    timestamp,
+  });
+
+  await ingestMetronomeEvents([...llmEvents, ...toolEvents]);
+
+  // Shadow the upcoming single aggregated event and log its cost against the
+  // legacy events' cost, so we can confirm parity on real traffic before
+  // switching over. The aggregated event is NOT ingested yet.
+  const aggregatedUsageEvents = buildUsageEvents({
     workspaceId: workspace.sId,
     isByok,
     conversationId,
@@ -407,8 +457,23 @@ export async function emitMetronomeUsageEventsActivity(
     isSubAgentMessage,
     timestamp,
   });
-
-  await ingestMetronomeEvents(usageEvents);
+  const newCostAwu = aggregatedUsageEvents.reduce((total, event) => {
+    const costAwu = event.properties["cost_awu"];
+    return total + (typeof costAwu === "number" ? costAwu : 0);
+  }, 0);
+  const oldCostAwu = billedCostAwuFromEvents([...llmEvents, ...toolEvents]);
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      conversationId,
+      agentMessageId,
+      runKey,
+      newCostAwu,
+      oldCostAwu,
+      costMatches: newCostAwu === oldCostAwu,
+    },
+    "[UsageQueue] Metronome usage event cost parity check."
+  );
 
   // Per-key cap enforcement is pull-based: Metronome spend alerts can't
   // attribute spend by `api_key_name` (it's not the products' presentation

--- a/front/temporal/usage_queue/activities.ts
+++ b/front/temporal/usage_queue/activities.ts
@@ -8,8 +8,7 @@ import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ingestMetronomeEvents } from "@app/lib/metronome/client";
 import {
-  buildLlmUsageEvents,
-  buildToolUseEvents,
+  buildUsageEvents,
   computeRunKey,
   getUsageType,
 } from "@app/lib/metronome/events";
@@ -373,7 +372,6 @@ export async function emitMetronomeUsageEventsActivity(
       mcpServerId: json.mcpServerId,
       internalMCPServerName: json.internalMCPServerName,
       status: json.status,
-      executionDurationMs: json.executionDurationMs,
       shouldEmit:
         agentLoopArgs.startStep === undefined ||
         json.step >= agentLoopArgs.startStep,
@@ -387,8 +385,8 @@ export async function emitMetronomeUsageEventsActivity(
   // ceils per the exact same execution partition that is billed here.
   const runKey = computeRunKey(effectiveRunIds);
 
-  // Build and ingest events.
-  const llmEvents = buildLlmUsageEvents({
+  // Build and ingest the single aggregated usage event (LLM + tool cost).
+  const usageEvents = buildUsageEvents({
     workspaceId: workspace.sId,
     isByok,
     conversationId,
@@ -400,25 +398,6 @@ export async function emitMetronomeUsageEventsActivity(
     parentAgentMessageId,
     runKey,
     runUsages,
-    origin: userMessageOrigin,
-    usageType,
-    authMethod,
-    apiKeyName,
-    messageStatus,
-    isSubAgentMessage,
-    timestamp,
-  });
-
-  const toolEvents = buildToolUseEvents({
-    workspaceId: workspace.sId,
-    conversationId,
-    userId,
-    isFreeSeatedUser,
-    agentMessageId,
-    agentId,
-    subAgentId,
-    parentAgentMessageId,
-    runKey,
     actions: toolActions,
     origin: userMessageOrigin,
     usageType,
@@ -429,7 +408,7 @@ export async function emitMetronomeUsageEventsActivity(
     timestamp,
   });
 
-  await ingestMetronomeEvents([...llmEvents, ...toolEvents]);
+  await ingestMetronomeEvents(usageEvents);
 
   // Per-key cap enforcement is pull-based: Metronome spend alerts can't
   // attribute spend by `api_key_name` (it's not the products' presentation


### PR DESCRIPTION
## Description

Groundwork for merging tool usage into a single `llm_usage_v3` event, rolled out safely behind a shadow log.

We **keep generating and ingesting the legacy events unchanged** (per-model `llm_usage_v3` + per-tool `tool_use_v3`) and add a **parity log** that computes — without ingesting — what the future aggregated event's cost would be, so we can confirm it matches the current billing on real traffic before flipping the switch. The net diff against `main` is **purely additive**; legacy emission is untouched.

- `buildUsageEvents` (new, not ingested): builds the target single aggregated `llm_usage_v3` event. Its `cost_awu` is the net billed credits (LLM + tools): per-`(provider, model)` LLM rounding first, then flat integer tool weights added, excluding free/capped/unbillable tool calls. `model_id`/`provider_id` are constant `"aggregate"` placeholders.
- `billedCostAwuFromEvents` (new): derives, from the legacy event payloads, the AWU Metronome will actually bill — `cost_awu` for `llm_usage_v3`, `count` × tool-category weight for `tool_use_v3`, zeroing any `usage_type: free` event.
- Activity `emitMetronomeUsageEventsActivity`: after ingesting the legacy events as before, logs `{ workspaceId, conversationId, agentMessageId, runKey, newCostAwu, oldCostAwu, costMatches }`.

The two amounts come from **independent code paths** (aggregated builder vs. parsing the legacy payloads), so any real divergence in rounding, waivers, or emission filtering shows up in the log.

## Tests

Added/updated in `front/lib/metronome/events.test.ts` (8 tests, all passing):
- The 5 original legacy-builder tests are kept unchanged.
- `buildUsageEvents` aggregates LLM + tool cost into one event.
- Parity on a mixed paid message (per-model rounding = 3; tools 7×3 capped + 1 basic = 22; total **25**), asserting `billedCostAwuFromEvents(legacy) === buildUsageEvents(...).cost_awu`.
- Parity on free-origin messages (both **0**).

Run: `npm run test -- lib/metronome/events.test.ts`. Also `npx tsgo --noEmit` and biome are clean.

## Risk

Low. No change to what is emitted or billed — the legacy events are generated and ingested exactly as on `main`. The only additions are a non-ingested shadow computation and one `logger.info` line, both inside the always-on, fire-and-forget usage activity where Metronome failures already don't affect the agent loop. Fully rollback-safe (revert the single commit); no schema, migration, or Metronome-config change.

## Deploy Plan

1. Deploy this PR. No coordination needed — additive only.
2. Watch the `[UsageQueue] Metronome usage event cost parity check.` logs and alert/dashboard on `costMatches: false` across real traffic.
3. Once parity holds, follow up: flip the activity to ingest `buildUsageEvents` and stop sending `tool_use_v3`, then prune the now-dead Metronome `tool_use_v3` metric/`Tool Usage` product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)