### PR TITLE
Add conversation window state snapshots

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
@@ -1,5 +1,6 @@
 import {
   CheckpointedConversationWindowState,
+  ConversationWindowStateSnapshotSchema,
   MINIMUM_PRUNING_BATCH_TOKENS,
 } from "@app/lib/api/assistant/conversation_rendering/checkpointed_window_state";
 import type { InteractionWithTokens } from "@app/lib/api/assistant/conversation_rendering/pruning";
@@ -8,7 +9,7 @@ import { describe, expect, it } from "vitest";
 
 function withTokens<T extends ModelMessageTypeMultiActions>(
   message: T,
-  tokenCount: number
+  tokenCount: number,
 ): T & { tokenCount: number } {
   return { ...message, tokenCount };
 }
@@ -20,7 +21,7 @@ function userMessage(name: string, tokenCount: number) {
       name: "user",
       content: [{ type: "text" as const, text: name }],
     },
-    tokenCount
+    tokenCount,
   );
 }
 
@@ -32,7 +33,7 @@ function assistantMessage(name: string, tokenCount = 10) {
       content: name,
       contents: [{ type: "text_content" as const, value: name }],
     },
-    tokenCount
+    tokenCount,
   );
 }
 
@@ -44,12 +45,12 @@ function functionMessage(name: string, tokenCount: number) {
       function_call_id: `${name}_call`,
       content: `${name}_result`,
     },
-    tokenCount
+    tokenCount,
   );
 }
 
 function interaction(
-  messages: InteractionWithTokens["messages"]
+  messages: InteractionWithTokens["messages"],
 ): InteractionWithTokens {
   return { messages };
 }
@@ -112,7 +113,7 @@ describe("CheckpointedConversationWindowState", () => {
         .renderedInteractions()
         .flatMap((item) => item.messages)
         .filter((message) => message.role === "user")
-        .map((message) => message.content[0])
+        .map((message) => message.content[0]),
     ).toEqual([
       { type: "text", text: "first" },
       { type: "text", text: "second" },
@@ -159,7 +160,7 @@ describe("CheckpointedConversationWindowState", () => {
     expect(
       input.messages
         .filter((message) => message.role === "function")
-        .map((message) => message.content)
+        .map((message) => message.content),
     ).toEqual([
       "first_result",
       "second_result",
@@ -187,12 +188,12 @@ describe("CheckpointedConversationWindowState", () => {
         functionMessage("second", 11_000),
         assistantMessage("call_third"),
         functionMessage("third", 11_000),
-      ])
+      ]),
     );
     state.append(interaction([userMessage("follow_up", 10)]));
 
     expect(
-      toolResults(state).some((message) => isPruned(message.content))
+      toolResults(state).some((message) => isPruned(message.content)),
     ).toBe(true);
     const result = state.fit();
     expect(result.isOk()).toBe(true);
@@ -212,18 +213,18 @@ describe("CheckpointedConversationWindowState", () => {
         functionMessage("first", 10_100),
         assistantMessage("call_second"),
         functionMessage("second", 10_100),
-      ])
+      ]),
     );
 
     expect(
-      toolResults(state).every((message) => !isPruned(message.content))
+      toolResults(state).every((message) => !isPruned(message.content)),
     ).toBe(true);
 
     state.append(
       interaction([
         assistantMessage("call_third"),
         functionMessage("third", 1_000),
-      ])
+      ]),
     );
 
     const results = toolResults(state);
@@ -245,7 +246,7 @@ describe("CheckpointedConversationWindowState", () => {
         // Pruning retains a 24-token placeholder, so this yields exactly the minimum savings.
         functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 24),
         assistantMessage("answer"),
-      ])
+      ]),
     );
     state.append(interaction([userMessage("follow_up", 10)]));
 
@@ -264,7 +265,7 @@ describe("CheckpointedConversationWindowState", () => {
         assistantMessage("call_tool"),
         functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 24 - 1),
         assistantMessage("answer"),
-      ])
+      ]),
     );
     state.append(interaction([userMessage("follow_up", 10)]));
 
@@ -283,7 +284,7 @@ describe("CheckpointedConversationWindowState", () => {
         assistantMessage("call_tool"),
         functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 1_000 + 24),
         assistantMessage("answer"),
-      ])
+      ]),
     );
     state.append(interaction([userMessage("follow_up", 10)]));
 
@@ -309,7 +310,7 @@ describe("CheckpointedConversationWindowState", () => {
       interaction([
         assistantMessage("call_fourth"),
         functionMessage("fourth", 1_000),
-      ])
+      ]),
     );
 
     const prefixResults = toolResults(prefixState);
@@ -320,7 +321,83 @@ describe("CheckpointedConversationWindowState", () => {
       false,
     ]);
     expect(
-      extendedResults.slice(0, 3).map((message) => isPruned(message.content))
+      extendedResults.slice(0, 3).map((message) => isPruned(message.content)),
     ).toEqual([true, true, false]);
+  });
+
+  it("restores and continues an interaction like uninterrupted rendering", () => {
+    const prefix = [
+      userMessage("question", 10),
+      assistantMessage("call_first"),
+      functionMessage("first", 10_100),
+    ];
+    const continuation = [
+      assistantMessage("call_second"),
+      functionMessage("second", 10_100),
+      assistantMessage("call_third"),
+      functionMessage("third", 1_000),
+    ];
+
+    const uninterrupted = makeState({ pruningBudget: 15_000 });
+    uninterrupted.append(interaction([...prefix, ...continuation]));
+
+    const checkpointed = makeState({ pruningBudget: 15_000 });
+    checkpointed.append(interaction(prefix));
+    const serializedSnapshot: unknown = JSON.parse(
+      JSON.stringify(checkpointed.snapshot()),
+    );
+    const parsedSnapshot =
+      ConversationWindowStateSnapshotSchema.safeParse(serializedSnapshot);
+    expect(parsedSnapshot.success).toBe(true);
+    if (!parsedSnapshot.success) {
+      return;
+    }
+
+    const restored = CheckpointedConversationWindowState.restore(
+      parsedSnapshot.data,
+      {
+        pruningBudget: 15_000,
+        budgetForInteractions: 100_000,
+        logDetails: {},
+      },
+    );
+    restored.appendToLatestInteraction(interaction(continuation));
+
+    expect(restored.snapshot()).toEqual(uninterrupted.snapshot());
+    expect(restored.fit()).toEqual(uninterrupted.fit());
+    expect(checkpointed.renderedInteractions()).toHaveLength(1);
+    expect(isPruned(toolResults(checkpointed)[0].content)).toBe(false);
+  });
+
+  it("rejects an inconsistent persisted tool-result phase", () => {
+    const snapshot = {
+      version: 1,
+      interactions: [
+        {
+          messages: [
+            {
+              kind: "tool_result",
+              message: {
+                role: "function",
+                name: "tool",
+                function_call_id: "call_1",
+                content: "result",
+                tokenCount: 100,
+              },
+              tokenSavings: 50,
+              pruned: true,
+              phase: "eligible",
+            },
+          ],
+        },
+      ],
+      retainedTokens: 100,
+      totalTokensBefore: 150,
+      prunedTokens: 50,
+    };
+
+    expect(
+      ConversationWindowStateSnapshotSchema.safeParse(snapshot).success,
+    ).toBe(false);
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it } from "vitest";
 
 function withTokens<T extends ModelMessageTypeMultiActions>(
   message: T,
-  tokenCount: number,
+  tokenCount: number
 ): T & { tokenCount: number } {
   return { ...message, tokenCount };
 }
@@ -21,7 +21,7 @@ function userMessage(name: string, tokenCount: number) {
       name: "user",
       content: [{ type: "text" as const, text: name }],
     },
-    tokenCount,
+    tokenCount
   );
 }
 
@@ -33,7 +33,28 @@ function assistantMessage(name: string, tokenCount = 10) {
       content: name,
       contents: [{ type: "text_content" as const, value: name }],
     },
-    tokenCount,
+    tokenCount
+  );
+}
+
+function reasoningMessage(reasoningTokens: number, tokenCount = 10) {
+  return withTokens(
+    {
+      role: "assistant" as const,
+      name: "assistant",
+      contents: [
+        {
+          type: "reasoning" as const,
+          value: {
+            reasoning: "reasoning",
+            metadata: "{}",
+            tokens: reasoningTokens,
+            provider: "openai" as const,
+          },
+        },
+      ],
+    },
+    tokenCount
   );
 }
 
@@ -45,12 +66,12 @@ function functionMessage(name: string, tokenCount: number) {
       function_call_id: `${name}_call`,
       content: `${name}_result`,
     },
-    tokenCount,
+    tokenCount
   );
 }
 
 function interaction(
-  messages: InteractionWithTokens["messages"],
+  messages: InteractionWithTokens["messages"]
 ): InteractionWithTokens {
   return { messages };
 }
@@ -113,7 +134,7 @@ describe("CheckpointedConversationWindowState", () => {
         .renderedInteractions()
         .flatMap((item) => item.messages)
         .filter((message) => message.role === "user")
-        .map((message) => message.content[0]),
+        .map((message) => message.content[0])
     ).toEqual([
       { type: "text", text: "first" },
       { type: "text", text: "second" },
@@ -160,7 +181,7 @@ describe("CheckpointedConversationWindowState", () => {
     expect(
       input.messages
         .filter((message) => message.role === "function")
-        .map((message) => message.content),
+        .map((message) => message.content)
     ).toEqual([
       "first_result",
       "second_result",
@@ -188,12 +209,12 @@ describe("CheckpointedConversationWindowState", () => {
         functionMessage("second", 11_000),
         assistantMessage("call_third"),
         functionMessage("third", 11_000),
-      ]),
+      ])
     );
     state.append(interaction([userMessage("follow_up", 10)]));
 
     expect(
-      toolResults(state).some((message) => isPruned(message.content)),
+      toolResults(state).some((message) => isPruned(message.content))
     ).toBe(true);
     const result = state.fit();
     expect(result.isOk()).toBe(true);
@@ -213,18 +234,18 @@ describe("CheckpointedConversationWindowState", () => {
         functionMessage("first", 10_100),
         assistantMessage("call_second"),
         functionMessage("second", 10_100),
-      ]),
+      ])
     );
 
     expect(
-      toolResults(state).every((message) => !isPruned(message.content)),
+      toolResults(state).every((message) => !isPruned(message.content))
     ).toBe(true);
 
     state.append(
       interaction([
         assistantMessage("call_third"),
         functionMessage("third", 1_000),
-      ]),
+      ])
     );
 
     const results = toolResults(state);
@@ -246,7 +267,7 @@ describe("CheckpointedConversationWindowState", () => {
         // Pruning retains a 24-token placeholder, so this yields exactly the minimum savings.
         functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 24),
         assistantMessage("answer"),
-      ]),
+      ])
     );
     state.append(interaction([userMessage("follow_up", 10)]));
 
@@ -265,7 +286,7 @@ describe("CheckpointedConversationWindowState", () => {
         assistantMessage("call_tool"),
         functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 24 - 1),
         assistantMessage("answer"),
-      ]),
+      ])
     );
     state.append(interaction([userMessage("follow_up", 10)]));
 
@@ -284,7 +305,7 @@ describe("CheckpointedConversationWindowState", () => {
         assistantMessage("call_tool"),
         functionMessage("result", MINIMUM_PRUNING_BATCH_TOKENS + 1_000 + 24),
         assistantMessage("answer"),
-      ]),
+      ])
     );
     state.append(interaction([userMessage("follow_up", 10)]));
 
@@ -310,7 +331,7 @@ describe("CheckpointedConversationWindowState", () => {
       interaction([
         assistantMessage("call_fourth"),
         functionMessage("fourth", 1_000),
-      ]),
+      ])
     );
 
     const prefixResults = toolResults(prefixState);
@@ -321,7 +342,7 @@ describe("CheckpointedConversationWindowState", () => {
       false,
     ]);
     expect(
-      extendedResults.slice(0, 3).map((message) => isPruned(message.content)),
+      extendedResults.slice(0, 3).map((message) => isPruned(message.content))
     ).toEqual([true, true, false]);
   });
 
@@ -344,7 +365,7 @@ describe("CheckpointedConversationWindowState", () => {
     const checkpointed = makeState({ pruningBudget: 15_000 });
     checkpointed.append(interaction(prefix));
     const serializedSnapshot: unknown = JSON.parse(
-      JSON.stringify(checkpointed.snapshot()),
+      JSON.stringify(checkpointed.snapshot())
     );
     const parsedSnapshot =
       ConversationWindowStateSnapshotSchema.safeParse(serializedSnapshot);
@@ -359,7 +380,7 @@ describe("CheckpointedConversationWindowState", () => {
         pruningBudget: 15_000,
         budgetForInteractions: 100_000,
         logDetails: {},
-      },
+      }
     );
     restored.appendToLatestInteraction(interaction(continuation));
 
@@ -397,7 +418,27 @@ describe("CheckpointedConversationWindowState", () => {
     };
 
     expect(
-      ConversationWindowStateSnapshotSchema.safeParse(snapshot).success,
+      ConversationWindowStateSnapshotSchema.safeParse(snapshot).success
+    ).toBe(false);
+  });
+
+  it("rejects fractional reasoning token counts", () => {
+    const state = makeState();
+    state.append(interaction([reasoningMessage(1.5)]));
+
+    expect(
+      ConversationWindowStateSnapshotSchema.safeParse(state.snapshot()).success
+    ).toBe(false);
+  });
+
+  it("rejects fractional message token counts even when their total is an integer", () => {
+    const state = makeState();
+    state.append(
+      interaction([userMessage("first", 0.5), userMessage("second", 0.5)])
+    );
+
+    expect(
+      ConversationWindowStateSnapshotSchema.safeParse(state.snapshot()).success
     ).toBe(false);
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -91,7 +91,7 @@ const assistantContentSchema = z.discriminatedUnion("type", [
         .object({
           reasoning: z.string().optional(),
           metadata: z.string(),
-          tokens: z.number().finite().nonnegative(),
+          tokens: z.number().int().nonnegative(),
           provider: z.string(),
           region: z.string().nullable().optional(),
         })
@@ -109,7 +109,7 @@ const assistantContentSchema = z.discriminatedUnion("type", [
     .strict(),
 ]);
 
-const tokenCountSchema = z.number().finite().nonnegative();
+const tokenCountSchema = z.number().int().nonnegative();
 const persistedMessageBaseSchema = z.discriminatedUnion("role", [
   z
     .object({

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -14,6 +14,7 @@ import type {
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { z } from "zod";
 
 type RegularMessageNode = {
   kind: "message";
@@ -25,6 +26,7 @@ type ToolResultNode = {
   message: Extract<MessageWithTokens, { role: "function" }>;
   tokenSavings: number;
   pruned: boolean;
+  phase: "pending" | "eligible" | "consumed";
 };
 
 type PendingToolResult = {
@@ -45,6 +47,236 @@ type WindowInteraction = {
   messages: WindowMessageNode[];
 };
 
+export const CONVERSATION_WINDOW_STATE_SNAPSHOT_VERSION = 1;
+
+const modelContentSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("text"), text: z.string() }).strict(),
+  z
+    .object({
+      type: z.literal("image_url"),
+      image_url: z.object({ url: z.string() }).strict(),
+    })
+    .strict(),
+]);
+
+const functionCallSchema = z
+  .object({
+    id: z.string(),
+    name: z.string(),
+    arguments: z.string(),
+    namespace: z.string().optional(),
+    metadata: z
+      .object({ thoughtSignature: z.string().optional() })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+const assistantContentSchema = z.discriminatedUnion("type", [
+  z
+    .object({
+      type: z.literal("text_content"),
+      value: z.string(),
+      metadata: z
+        .object({ phase: z.enum(["commentary", "final_answer"]).optional() })
+        .strict()
+        .optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal("reasoning"),
+      value: z
+        .object({
+          reasoning: z.string().optional(),
+          metadata: z.string(),
+          tokens: z.number().finite().nonnegative(),
+          provider: z.string(),
+          region: z.string().nullable().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({ type: z.literal("function_call"), value: functionCallSchema })
+    .strict(),
+  z
+    .object({
+      type: z.literal("provider_passthrough"),
+      value: z.object({ provider: z.string(), block: z.unknown() }).strict(),
+    })
+    .strict(),
+]);
+
+const tokenCountSchema = z.number().finite().nonnegative();
+const persistedMessageBaseSchema = z.discriminatedUnion("role", [
+  z
+    .object({
+      role: z.literal("user"),
+      name: z.string(),
+      content: z.array(modelContentSchema),
+      tokenCount: tokenCountSchema,
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal("content_fragment"),
+      name: z.string(),
+      content: z.array(modelContentSchema),
+      tokenCount: tokenCountSchema,
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal("assistant"),
+      name: z.string().optional(),
+      content: z.string().optional(),
+      function_calls: z.array(functionCallSchema).optional(),
+      contents: z.array(assistantContentSchema),
+      tokenCount: tokenCountSchema,
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal("function"),
+      name: z.string(),
+      function_call_id: z.string(),
+      content: z.union([z.string(), z.array(modelContentSchema)]),
+      tokenCount: tokenCountSchema,
+    })
+    .strict(),
+  z
+    .object({
+      role: z.literal("compaction"),
+      content: z.string(),
+      tokenCount: tokenCountSchema,
+    })
+    .strict(),
+]);
+
+const persistedMessageSchema = persistedMessageBaseSchema.superRefine(
+  (message, context) => {
+    if (
+      message.role === "assistant" &&
+      message.name === undefined &&
+      message.function_calls === undefined
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Assistant message requires a name or function calls",
+      });
+    }
+  },
+);
+
+const messageWithTokensSchema = z.custom<MessageWithTokens>(
+  (value) => persistedMessageSchema.safeParse(value).success,
+  "Invalid checkpointed model message",
+);
+const windowMessageNodeSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("message"),
+      message: messageWithTokensSchema,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("tool_result"),
+      message: z.custom<Extract<MessageWithTokens, { role: "function" }>>(
+        (value) => {
+          const result = persistedMessageSchema.safeParse(value);
+          return result.success && result.data.role === "function";
+        },
+        "Invalid checkpointed tool result",
+      ),
+      tokenSavings: z.number().int().nonnegative(),
+      pruned: z.boolean(),
+      phase: z.enum(["pending", "eligible", "consumed"]),
+    })
+    .strict(),
+]);
+
+export const ConversationWindowStateSnapshotSchema = z
+  .object({
+    version: z.literal(CONVERSATION_WINDOW_STATE_SNAPSHOT_VERSION),
+    interactions: z.array(
+      z.object({ messages: z.array(windowMessageNodeSchema) }).strict(),
+    ),
+    retainedTokens: z.number().int().nonnegative(),
+    totalTokensBefore: z.number().int().nonnegative(),
+    prunedTokens: z.number().int().nonnegative(),
+  })
+  .strict()
+  .superRefine((snapshot, context) => {
+    let retainedTokens = 0;
+    let prunedTokens = 0;
+
+    for (const [
+      interactionIndex,
+      interaction,
+    ] of snapshot.interactions.entries()) {
+      for (const [messageIndex, node] of interaction.messages.entries()) {
+        retainedTokens += node.message.tokenCount;
+        if (node.kind !== "tool_result") {
+          continue;
+        }
+
+        const path = [
+          "interactions",
+          interactionIndex,
+          "messages",
+          messageIndex,
+        ];
+        if (node.pruned) {
+          prunedTokens += node.tokenSavings;
+          if (node.phase !== "consumed" || node.tokenSavings === 0) {
+            context.addIssue({
+              code: "custom",
+              path,
+              message: "Pruned tool result has an inconsistent phase",
+            });
+          }
+        } else if (
+          (node.phase === "eligible" && node.tokenSavings === 0) ||
+          (node.phase === "consumed" && node.tokenSavings !== 0)
+        ) {
+          context.addIssue({
+            code: "custom",
+            path,
+            message: "Unpruned tool result has an inconsistent phase",
+          });
+        }
+      }
+    }
+
+    if (retainedTokens !== snapshot.retainedTokens) {
+      context.addIssue({
+        code: "custom",
+        message: "Checkpoint retained token count is inconsistent",
+      });
+    }
+    if (
+      snapshot.retainedTokens + snapshot.prunedTokens !==
+      snapshot.totalTokensBefore
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "Checkpoint total token count is inconsistent",
+      });
+    }
+    if (prunedTokens !== snapshot.prunedTokens) {
+      context.addIssue({
+        code: "custom",
+        message: "Checkpoint pruned token count is inconsistent",
+      });
+    }
+  });
+
+export type ConversationWindowStateSnapshot = z.infer<
+  typeof ConversationWindowStateSnapshotSchema
+>;
+
 export const MINIMUM_PRUNING_BATCH_TOKENS = 5_000;
 
 function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
@@ -54,6 +286,7 @@ function makeWindowMessageNode(message: MessageWithTokens): WindowMessageNode {
       message,
       tokenSavings: getToolResultTokenSavings(message),
       pruned: false,
+      phase: "pending",
     };
   }
 
@@ -90,7 +323,7 @@ export class CheckpointedConversationWindowState {
       pruningBudget: number;
       budgetForInteractions: number;
       logDetails: Record<string, unknown>;
-    }
+    },
   ) {}
 
   static empty(options: {
@@ -101,28 +334,89 @@ export class CheckpointedConversationWindowState {
     return new CheckpointedConversationWindowState(options);
   }
 
+  static restore(
+    snapshot: ConversationWindowStateSnapshot,
+    options: {
+      pruningBudget: number;
+      budgetForInteractions: number;
+      logDetails: Record<string, unknown>;
+    },
+  ): CheckpointedConversationWindowState {
+    const state = new CheckpointedConversationWindowState(options);
+    state.interactions = structuredClone(snapshot.interactions);
+    state.retainedTokens = snapshot.retainedTokens;
+    state.totalTokensBefore = snapshot.totalTokensBefore;
+    state.prunedTokens = snapshot.prunedTokens;
+
+    for (const interaction of state.interactions) {
+      for (const node of interaction.messages) {
+        if (node.kind !== "tool_result") {
+          continue;
+        }
+
+        if (node.phase === "pending") {
+          state.pendingToolResults.push({ phase: "pending", node });
+        } else if (node.phase === "eligible") {
+          state.eligibleToolResults.push({ phase: "eligible", node });
+          state.eligibleToolResultTokenSavings += node.tokenSavings;
+        }
+      }
+    }
+
+    return state;
+  }
+
+  snapshot(): ConversationWindowStateSnapshot {
+    return {
+      version: CONVERSATION_WINDOW_STATE_SNAPSHOT_VERSION,
+      interactions: structuredClone(this.interactions),
+      retainedTokens: this.retainedTokens,
+      totalTokensBefore: this.totalTokensBefore,
+      prunedTokens: this.prunedTokens,
+    };
+  }
+
   append(interaction: InteractionWithTokens): void {
     if (interaction.messages.length === 0) {
       return;
     }
 
-    const windowInteraction: WindowInteraction = { messages: [] };
-    this.interactions.push(windowInteraction);
+    const messages = this.appendMessages(interaction.messages);
+    this.interactions.push({ messages });
+  }
 
-    for (
-      let messageIndex = 0;
-      messageIndex < interaction.messages.length;
-      messageIndex++
-    ) {
-      const message = interaction.messages[messageIndex];
-      const nextMessage = interaction.messages[messageIndex + 1];
+  appendToLatestInteraction(interaction: InteractionWithTokens): void {
+    if (interaction.messages.length === 0) {
+      return;
+    }
+
+    const latestInteractionIndex = this.interactions.length - 1;
+    const latestInteraction = this.interactions[latestInteractionIndex];
+    if (!latestInteraction) {
+      this.append(interaction);
+      return;
+    }
+
+    const messages = this.appendMessages(interaction.messages);
+    this.interactions[latestInteractionIndex] = {
+      messages: [...latestInteraction.messages, ...messages],
+    };
+  }
+
+  private appendMessages(
+    messages: InteractionWithTokens["messages"],
+  ): WindowMessageNode[] {
+    const nodes: WindowMessageNode[] = [];
+    for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+      const message = messages[messageIndex];
+      const nextMessage = messages[messageIndex + 1];
 
       if (message.role === "assistant") {
         this.makePendingToolResultsEligible();
       }
 
       const node = makeWindowMessageNode(message);
-      windowInteraction.messages.push(node);
+      nodes.push(node);
       this.retainedTokens += message.tokenCount;
       this.totalTokensBefore += message.tokenCount;
 
@@ -134,6 +428,8 @@ export class CheckpointedConversationWindowState {
         this.applyBufferedPruning();
       }
     }
+
+    return nodes;
   }
 
   renderedInteractions(): InteractionWithTokens[] {
@@ -162,7 +458,7 @@ export class CheckpointedConversationWindowState {
           budgetForInteractions,
           tokensOverBudget: this.retainedTokens - budgetForInteractions,
         },
-        "Render Conversation V2: complete interaction history exceeds the nominal budget."
+        "Render Conversation V2: complete interaction history exceeds the nominal budget.",
       );
     }
 
@@ -180,13 +476,13 @@ export class CheckpointedConversationWindowState {
     const latestInteraction = this.interactions[this.interactions.length - 1];
 
     return latestInteraction.messages.some(
-      (node) => node.kind === "tool_result" && node.pruned
+      (node) => node.kind === "tool_result" && node.pruned,
     );
   }
 
   private isModelInputCheckpoint(
     message: MessageWithTokens,
-    nextMessage: MessageWithTokens | undefined
+    nextMessage: MessageWithTokens | undefined,
   ): boolean {
     const endsUserInput =
       message.role === "user" &&
@@ -201,8 +497,11 @@ export class CheckpointedConversationWindowState {
   private makePendingToolResultsEligible(): void {
     for (const { node } of this.pendingToolResults) {
       if (node.tokenSavings > 0) {
+        node.phase = "eligible";
         this.eligibleToolResults.push({ phase: "eligible", node });
         this.eligibleToolResultTokenSavings += node.tokenSavings;
+      } else {
+        node.phase = "consumed";
       }
     }
 
@@ -239,6 +538,7 @@ export class CheckpointedConversationWindowState {
 
       node.message = pruneToolResultMessage(node.message);
       node.pruned = true;
+      node.phase = "consumed";
       this.retainedTokens -= node.tokenSavings;
       this.prunedTokens += node.tokenSavings;
       this.eligibleToolResultTokenSavings -= node.tokenSavings;

--- a/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
+++ b/front/lib/api/assistant/conversation_rendering/checkpointed_window_state.ts
@@ -14,6 +14,7 @@ import type {
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types/shared/result";
 import { Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { z } from "zod";
 
 type RegularMessageNode = {
@@ -166,12 +167,12 @@ const persistedMessageSchema = persistedMessageBaseSchema.superRefine(
         message: "Assistant message requires a name or function calls",
       });
     }
-  },
+  }
 );
 
 const messageWithTokensSchema = z.custom<MessageWithTokens>(
   (value) => persistedMessageSchema.safeParse(value).success,
-  "Invalid checkpointed model message",
+  "Invalid checkpointed model message"
 );
 const windowMessageNodeSchema = z.discriminatedUnion("kind", [
   z
@@ -188,7 +189,7 @@ const windowMessageNodeSchema = z.discriminatedUnion("kind", [
           const result = persistedMessageSchema.safeParse(value);
           return result.success && result.data.role === "function";
         },
-        "Invalid checkpointed tool result",
+        "Invalid checkpointed tool result"
       ),
       tokenSavings: z.number().int().nonnegative(),
       pruned: z.boolean(),
@@ -201,7 +202,7 @@ export const ConversationWindowStateSnapshotSchema = z
   .object({
     version: z.literal(CONVERSATION_WINDOW_STATE_SNAPSHOT_VERSION),
     interactions: z.array(
-      z.object({ messages: z.array(windowMessageNodeSchema) }).strict(),
+      z.object({ messages: z.array(windowMessageNodeSchema) }).strict()
     ),
     retainedTokens: z.number().int().nonnegative(),
     totalTokensBefore: z.number().int().nonnegative(),
@@ -218,34 +219,39 @@ export const ConversationWindowStateSnapshotSchema = z
     ] of snapshot.interactions.entries()) {
       for (const [messageIndex, node] of interaction.messages.entries()) {
         retainedTokens += node.message.tokenCount;
-        if (node.kind !== "tool_result") {
-          continue;
-        }
-
-        const path = [
-          "interactions",
-          interactionIndex,
-          "messages",
-          messageIndex,
-        ];
-        if (node.pruned) {
-          prunedTokens += node.tokenSavings;
-          if (node.phase !== "consumed" || node.tokenSavings === 0) {
-            context.addIssue({
-              code: "custom",
-              path,
-              message: "Pruned tool result has an inconsistent phase",
-            });
+        switch (node.kind) {
+          case "message":
+            break;
+          case "tool_result": {
+            const path = [
+              "interactions",
+              interactionIndex,
+              "messages",
+              messageIndex,
+            ];
+            if (node.pruned) {
+              prunedTokens += node.tokenSavings;
+              if (node.phase !== "consumed" || node.tokenSavings === 0) {
+                context.addIssue({
+                  code: "custom",
+                  path,
+                  message: "Pruned tool result has an inconsistent phase",
+                });
+              }
+            } else if (
+              (node.phase === "eligible" && node.tokenSavings === 0) ||
+              (node.phase === "consumed" && node.tokenSavings !== 0)
+            ) {
+              context.addIssue({
+                code: "custom",
+                path,
+                message: "Unpruned tool result has an inconsistent phase",
+              });
+            }
+            break;
           }
-        } else if (
-          (node.phase === "eligible" && node.tokenSavings === 0) ||
-          (node.phase === "consumed" && node.tokenSavings !== 0)
-        ) {
-          context.addIssue({
-            code: "custom",
-            path,
-            message: "Unpruned tool result has an inconsistent phase",
-          });
+          default:
+            assertNever(node);
         }
       }
     }
@@ -323,7 +329,7 @@ export class CheckpointedConversationWindowState {
       pruningBudget: number;
       budgetForInteractions: number;
       logDetails: Record<string, unknown>;
-    },
+    }
   ) {}
 
   static empty(options: {
@@ -340,7 +346,7 @@ export class CheckpointedConversationWindowState {
       pruningBudget: number;
       budgetForInteractions: number;
       logDetails: Record<string, unknown>;
-    },
+    }
   ): CheckpointedConversationWindowState {
     const state = new CheckpointedConversationWindowState(options);
     state.interactions = structuredClone(snapshot.interactions);
@@ -350,15 +356,30 @@ export class CheckpointedConversationWindowState {
 
     for (const interaction of state.interactions) {
       for (const node of interaction.messages) {
-        if (node.kind !== "tool_result") {
-          continue;
-        }
+        switch (node.kind) {
+          case "message":
+            break;
 
-        if (node.phase === "pending") {
-          state.pendingToolResults.push({ phase: "pending", node });
-        } else if (node.phase === "eligible") {
-          state.eligibleToolResults.push({ phase: "eligible", node });
-          state.eligibleToolResultTokenSavings += node.tokenSavings;
+          case "tool_result":
+            switch (node.phase) {
+              case "pending":
+                state.pendingToolResults.push({ phase: "pending", node });
+                break;
+
+              case "eligible":
+                state.eligibleToolResults.push({ phase: "eligible", node });
+                state.eligibleToolResultTokenSavings += node.tokenSavings;
+                break;
+
+              case "consumed":
+                break;
+
+              default:
+                assertNever(node.phase);
+            }
+            break;
+          default:
+            assertNever(node);
         }
       }
     }
@@ -404,7 +425,7 @@ export class CheckpointedConversationWindowState {
   }
 
   private appendMessages(
-    messages: InteractionWithTokens["messages"],
+    messages: InteractionWithTokens["messages"]
   ): WindowMessageNode[] {
     const nodes: WindowMessageNode[] = [];
     for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
@@ -458,7 +479,7 @@ export class CheckpointedConversationWindowState {
           budgetForInteractions,
           tokensOverBudget: this.retainedTokens - budgetForInteractions,
         },
-        "Render Conversation V2: complete interaction history exceeds the nominal budget.",
+        "Render Conversation V2: complete interaction history exceeds the nominal budget."
       );
     }
 
@@ -476,13 +497,13 @@ export class CheckpointedConversationWindowState {
     const latestInteraction = this.interactions[this.interactions.length - 1];
 
     return latestInteraction.messages.some(
-      (node) => node.kind === "tool_result" && node.pruned,
+      (node) => node.kind === "tool_result" && node.pruned
     );
   }
 
   private isModelInputCheckpoint(
     message: MessageWithTokens,
-    nextMessage: MessageWithTokens | undefined,
+    nextMessage: MessageWithTokens | undefined
   ): boolean {
     const endsUserInput =
       message.role === "user" &&


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See context in https://github.com/dust-tt/dust/pull/31128.

This PR is the second preparatory step toward stateful conversation windows across agent-loop steps.

Today, each model step reconstructs the full context window from conversation history. The target design persists the fitted window after step N, then restores it for step N+1 and processes only the newly added content.

Before introducing GCS or agent-loop wiring, we need a reliable persistence contract for the in-memory pruning state.

Persisting only the rendered messages is insufficient. The window must also remember which tool results are:
- Pending consumption by a later assistant message
- Eligible for pruning
- Already consumed or pruned

Losing this frontier could make resumed rendering prune differently from uninterrupted rendering. Which is the exact previous bug that this class is addresssing.

## This PR

This PR makes `CheckpointedConversationWindowState` serializable and restorable.

It adds:
- A Zod-validated snapshot schema
- An explicit snapshot format version
- `snapshot()` to produce a persistence-safe representation
- `restore()` to reconstruct the complete pruning state
- `appendToLatestInteraction()` to continue an agent interaction across model steps
- Validation of token-accounting and tool-result-phase invariants (be ready for some super zod schema!)

The snapshot contains the model-facing messages, their token counts, the pruning frontier, and the accumulated token accounting.

Runtime options such as the current pruning budget and logging details are supplied when restoring rather than persisted. Compatibility decisions such as model, prompt, tools, and step continuity will remain the responsibility of the future checkpoint-loading path.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
