### PR TITLE
[front] enh: add skeletons in manage agents/skills tables

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -40,6 +40,7 @@ import {
   Edit04,
   Eye,
   Label,
+  LoadingBlock,
   Tooltip,
   Trash01,
 } from "@dust-tt/sparkle";
@@ -67,6 +68,144 @@ type RowData = {
   canArchive: boolean;
   canEdit: boolean;
 };
+
+const ASSISTANTS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
+  { length: 5 },
+  (_, index) => ({
+    sId: `assistant-skeleton-${index}`,
+    name: "",
+    description: "",
+    pictureUrl: "",
+    editors: [],
+    usage: undefined,
+    feedbacks: undefined,
+    lastUpdate: null,
+    scope: "hidden",
+    model: "",
+    modelIcon: undefined,
+    agentTags: [],
+    agentTagsAsString: "",
+    canArchive: false,
+    canEdit: false,
+  })
+);
+
+function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
+  switch (columnId) {
+    case "select":
+      return (
+        <DataTable.CellContent className="size-full items-center justify-center">
+          <LoadingBlock className="h-4 w-4 rounded-sm" />
+        </DataTable.CellContent>
+      );
+    case "name":
+      return (
+        <DataTable.CellContent>
+          <div className="flex flex-row items-center gap-2 py-3">
+            <LoadingBlock className="h-9 w-9 shrink-0 rounded-lg" />
+            <div className="flex min-w-0 grow flex-col">
+              <div className="flex h-5 items-center">
+                <LoadingBlock
+                  className={classNames(
+                    "h-3 max-w-full",
+                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowIndex]
+                  )}
+                />
+              </div>
+              <div className="flex h-5 items-center">
+                <LoadingBlock
+                  className={classNames(
+                    "h-3 max-w-full",
+                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowIndex]
+                  )}
+                />
+              </div>
+            </div>
+          </div>
+        </DataTable.CellContent>
+      );
+    case "model":
+      return (
+        <DataTable.CellContent>
+          <div className="flex items-center">
+            <LoadingBlock className="h-5 w-5 shrink-0 rounded-sm" />
+            <LoadingBlock
+              className={classNames(
+                "ml-2 hidden h-3 @xl:block",
+                ["w-20", "w-24", "w-16", "w-28", "w-20"][rowIndex]
+              )}
+            />
+          </div>
+        </DataTable.CellContent>
+      );
+    case "scope":
+      return (
+        <DataTable.CellContent>
+          <LoadingBlock
+            className={classNames(
+              "h-6 rounded-[9px]",
+              ["w-20", "w-24", "w-20", "w-24", "w-20"][rowIndex]
+            )}
+          />
+        </DataTable.CellContent>
+      );
+    case "editors":
+      return (
+        <DataTable.CellContent>
+          <div className="flex -space-x-2">
+            {Array.from({ length: (rowIndex % 3) + 1 }, (_, index) => (
+              <LoadingBlock
+                key={index}
+                className="h-7 w-7 rounded-full ring-2 ring-background"
+              />
+            ))}
+          </div>
+        </DataTable.CellContent>
+      );
+    case "agentTagsAsString":
+      return (
+        <DataTable.CellContent grow>
+          <LoadingBlock
+            className={classNames(
+              "h-3 max-w-full",
+              ["w-14", "w-20", "w-12", "w-24", "w-16"][rowIndex]
+            )}
+          />
+        </DataTable.CellContent>
+      );
+    case "Usage":
+    case "Feedback":
+      return (
+        <DataTable.CellContent>
+          <LoadingBlock
+            className={classNames(
+              "h-3",
+              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowIndex]
+            )}
+          />
+        </DataTable.CellContent>
+      );
+    case "lastUpdate":
+      return (
+        <DataTable.CellContent>
+          <LoadingBlock
+            className={classNames(
+              "h-3",
+              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowIndex]
+            )}
+          />
+        </DataTable.CellContent>
+      );
+    case "actions":
+      return (
+        <DataTable.CellContent>
+          <LoadingBlock className="h-8 w-8 rounded-xl" />
+        </DataTable.CellContent>
+      );
+    default:
+      return null;
+  }
+}
 
 const getTableColumns = ({
   owner,
@@ -396,6 +535,7 @@ type AssistantsTableProps = {
   selection: string[];
   setSelection: (selection: string[]) => void;
   mutateAgentConfigurations: () => Promise<any>;
+  isLoading?: boolean;
 };
 
 export function AssistantsTable({
@@ -408,6 +548,7 @@ export function AssistantsTable({
   selection,
   setSelection,
   mutateAgentConfigurations,
+  isLoading = false,
 }: AssistantsTableProps) {
   const { tags } = useTags({ owner });
   const sortedTags = useMemo(() => [...tags].sort(tagsSorter), [tags]);
@@ -420,6 +561,15 @@ export function AssistantsTable({
         mutateAgentConfigurations,
       }),
     [owner, sortedTags]
+  );
+  const skeletonColumns = useMemo(
+    () =>
+      columns.map((column) => ({
+        ...column,
+        cell: (info: CellContext<RowData, unknown>) =>
+          renderAssistantsTableSkeletonCell(info.column.id, info.row.index),
+      })),
+    [columns]
   );
 
   const { isDark } = useTheme();
@@ -619,47 +769,74 @@ export function AssistantsTable({
 
   return (
     <>
-      <DeleteAgentDialog
-        owner={owner}
-        isOpen={showDeleteDialog.open}
-        agentConfiguration={showDeleteDialog.agentConfiguration}
-        onClose={() => {
-          setShowDeleteDialog(({ agentConfiguration }) => ({
-            open: false,
-            agentConfiguration,
-          }));
-        }}
-      />
-      <AgentEditBar
-        owner={owner}
-        selectedAgents={selectedAgents}
-        tags={sortedTags}
-        mutateAgentConfigurations={mutateAgentConfigurations}
-        pageSelectedCount={pageSelectedCount}
-        totalCount={totalSelectableCount}
-        onClear={() => setSelection([])}
-        onSelectAll={() => setSelection(selectableRowIds)}
-      />
-      <div>
-        {rows.length > 0 && (
-          <DataTable
-            className="relative"
-            data={rows}
-            columns={columns}
-            pagination={pagination}
-            setPagination={setPagination}
-            getRowId={(row) => row.sId}
-            enableRowSelection={(row) => row.original.canArchive}
-            disableRowClickSelection
-            rowSelection={rowSelection}
-            setRowSelection={(newRowSelection) => {
-              setSelection(
-                Object.keys(newRowSelection).filter(
-                  (agentId) => newRowSelection[agentId]
-                )
-              );
+      {!isLoading && (
+        <>
+          <DeleteAgentDialog
+            owner={owner}
+            isOpen={showDeleteDialog.open}
+            agentConfiguration={showDeleteDialog.agentConfiguration}
+            onClose={() => {
+              setShowDeleteDialog(({ agentConfiguration }) => ({
+                open: false,
+                agentConfiguration,
+              }));
             }}
           />
+          <AgentEditBar
+            owner={owner}
+            selectedAgents={selectedAgents}
+            tags={sortedTags}
+            mutateAgentConfigurations={mutateAgentConfigurations}
+            pageSelectedCount={pageSelectedCount}
+            totalCount={totalSelectableCount}
+            onClear={() => setSelection([])}
+            onSelectAll={() => setSelection(selectableRowIds)}
+          />
+        </>
+      )}
+      <div
+        role={isLoading ? "status" : undefined}
+        aria-label={isLoading ? "Loading agents" : undefined}
+        aria-busy={isLoading || undefined}
+      >
+        {isLoading ? (
+          <div aria-hidden="true" className="flex flex-col gap-2">
+            <DataTable
+              className="relative"
+              data={ASSISTANTS_TABLE_SKELETON_ROWS}
+              columns={skeletonColumns}
+              enableRowSelection={() => false}
+              disableRowClickSelection
+              rowSelection={{}}
+              setRowSelection={() => undefined}
+            />
+            <div className="p-1">
+              <div className="flex h-8 items-center justify-end">
+                <LoadingBlock className="h-3 w-14" />
+              </div>
+            </div>
+          </div>
+        ) : (
+          rows.length > 0 && (
+            <DataTable
+              className="relative"
+              data={rows}
+              columns={columns}
+              pagination={pagination}
+              setPagination={setPagination}
+              getRowId={(row) => row.sId}
+              enableRowSelection={(row) => row.original.canArchive}
+              disableRowClickSelection
+              rowSelection={rowSelection}
+              setRowSelection={(newRowSelection) => {
+                setSelection(
+                  Object.keys(newRowSelection).filter(
+                    (agentId) => newRowSelection[agentId]
+                  )
+                );
+              }}
+            />
+          )
         )}
       </div>
     </>

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -769,31 +769,27 @@ export function AssistantsTable({
 
   return (
     <>
-      {!isLoading && (
-        <>
-          <DeleteAgentDialog
-            owner={owner}
-            isOpen={showDeleteDialog.open}
-            agentConfiguration={showDeleteDialog.agentConfiguration}
-            onClose={() => {
-              setShowDeleteDialog(({ agentConfiguration }) => ({
-                open: false,
-                agentConfiguration,
-              }));
-            }}
-          />
-          <AgentEditBar
-            owner={owner}
-            selectedAgents={selectedAgents}
-            tags={sortedTags}
-            mutateAgentConfigurations={mutateAgentConfigurations}
-            pageSelectedCount={pageSelectedCount}
-            totalCount={totalSelectableCount}
-            onClear={() => setSelection([])}
-            onSelectAll={() => setSelection(selectableRowIds)}
-          />
-        </>
-      )}
+      <DeleteAgentDialog
+        owner={owner}
+        isOpen={showDeleteDialog.open}
+        agentConfiguration={showDeleteDialog.agentConfiguration}
+        onClose={() => {
+          setShowDeleteDialog(({ agentConfiguration }) => ({
+            open: false,
+            agentConfiguration,
+          }));
+        }}
+      />
+      <AgentEditBar
+        owner={owner}
+        selectedAgents={selectedAgents}
+        tags={sortedTags}
+        mutateAgentConfigurations={mutateAgentConfigurations}
+        pageSelectedCount={pageSelectedCount}
+        totalCount={totalSelectableCount}
+        onClear={() => setSelection([])}
+        onSelectAll={() => setSelection(selectableRowIds)}
+      />
       <div
         role={isLoading ? "status" : undefined}
         aria-label={isLoading ? "Loading agents" : undefined}

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -35,7 +35,6 @@ import {
   Page,
   Plus,
   SearchInput,
-  Spinner,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -296,6 +295,9 @@ export function ManageAgentsPage() {
   useSetContentWidth("wide");
   useSetNavChildren(navChildren);
 
+  const isLoading =
+    isAgentConfigurationsLoading || isArchivedAgentConfigurationsLoading;
+
   return (
     <>
       <AgentDetailsSheet
@@ -410,19 +412,7 @@ export function ManageAgentsPage() {
                 )}
               </TabsList>
             </Tabs>
-            {isAgentConfigurationsLoading ||
-            isArchivedAgentConfigurationsLoading ? (
-              <div className="mt-8 flex justify-center">
-                <Spinner size="lg" />
-              </div>
-            ) : isFilterActive && agentsByTab[activeTab].length === 0 ? (
-              <div className="pt-2">
-                <EmptyCTA
-                  message="No agent matches your search or filters."
-                  action={null}
-                />
-              </div>
-            ) : agentsByTab[activeTab].length > 0 ? (
+            {isLoading || agentsByTab[activeTab].length > 0 ? (
               <AssistantsTable
                 selection={selection}
                 setSelection={setSelection}
@@ -435,7 +425,15 @@ export function ManageAgentsPage() {
                   setShowDisabledFreeWorkspacePopup
                 }
                 mutateAgentConfigurations={mutateAgentConfigurations}
+                isLoading={isLoading}
               />
+            ) : isFilterActive ? (
+              <div className="pt-2">
+                <EmptyCTA
+                  message="No agent matches your search or filters."
+                  action={null}
+                />
+              </div>
             ) : activeTab === "archived" ? (
               <div className="pt-2">
                 <NoArchivedAgentsCTA

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -61,7 +61,6 @@ import {
   Page,
   Plus,
   SearchInput,
-  Spinner,
   Tabs,
   TabsList,
   TabsTrigger,
@@ -536,40 +535,34 @@ export function ManageSkillsPage() {
                 </div>
               </TabsList>
             </Tabs>
-            {isLoading ? (
-              <div className="mt-8 flex justify-center">
-                <Spinner size="lg" />
-              </div>
+            {!isLoading &&
+              activeTab === "active" &&
+              availabilityFilter === "all" &&
+              suggestedSkills.length > 0 && (
+                <SuggestedSkillsSection
+                  skills={sortSkillsByName(suggestedSkills)}
+                  onSkillClick={handleSkillSelect}
+                  owner={owner}
+                  user={user}
+                />
+              )}
+            {isLoading || !isActiveTabEmpty ? (
+              <SkillsTable
+                owner={owner}
+                skills={skillsByTab[activeTab]}
+                onSkillClick={handleSkillSelect}
+                onAgentClick={setAgentId}
+                onUsedBySkillClick={handleUsedBySkillSelect}
+                canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
+                enableSelection={isBatchEditionAvailable}
+                rowSelection={rowSelection}
+                setRowSelection={setRowSelection}
+                isBatchUpdating={isBatchUpdating}
+                onSelectAvailabilityAction={setPendingBatchAction}
+                isLoading={isLoading}
+              />
             ) : (
-              <>
-                {activeTab === "active" &&
-                  availabilityFilter === "all" &&
-                  suggestedSkills.length > 0 && (
-                    <SuggestedSkillsSection
-                      skills={sortSkillsByName(suggestedSkills)}
-                      onSkillClick={handleSkillSelect}
-                      owner={owner}
-                      user={user}
-                    />
-                  )}
-                {isActiveTabEmpty ? (
-                  <div className="pt-2">{renderEmptyTabState()}</div>
-                ) : (
-                  <SkillsTable
-                    owner={owner}
-                    skills={skillsByTab[activeTab]}
-                    onSkillClick={handleSkillSelect}
-                    onAgentClick={setAgentId}
-                    onUsedBySkillClick={handleUsedBySkillSelect}
-                    canMakeSkillAutoDiscoverable={canMakeSkillAutoDiscoverable}
-                    enableSelection={isBatchEditionAvailable}
-                    rowSelection={rowSelection}
-                    setRowSelection={setRowSelection}
-                    isBatchUpdating={isBatchUpdating}
-                    onSelectAvailabilityAction={setPendingBatchAction}
-                  />
-                )}
-              </>
+              <div className="pt-2">{renderEmptyTabState()}</div>
             )}
           </div>
         </Page.Vertical>

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -57,7 +57,7 @@ type RowData = {
   messageCount: number | null;
   updatedAt: number | null;
   createdAt: number | null;
-  onClick?: () => void;
+  onClick: () => void;
   menuItems: MenuItem[];
 };
 
@@ -75,6 +75,7 @@ const SKILLS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
     messageCount: null,
     updatedAt: null,
     createdAt: null,
+    onClick: () => undefined,
     menuItems: [],
   })
 );
@@ -617,7 +618,7 @@ export function SkillsTable({
 
   return (
     <>
-      {!isLoading && skillToArchive && (
+      {skillToArchive && (
         <ArchiveSkillDialog
           owner={owner}
           isOpen={true}
@@ -627,7 +628,7 @@ export function SkillsTable({
           }}
         />
       )}
-      {!isLoading && enableSelection && (
+      {enableSelection && (
         <SkillsBatchEditBar
           owner={owner}
           selectedSkills={selectedSkills}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -5,7 +5,7 @@ import { UsedByButton } from "@app/components/spaces/UsedByButton";
 import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useAppRouter } from "@app/lib/platform";
 import { getSkillAvatarIcon, isDustProvidedSkill } from "@app/lib/skill";
-import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { GetSkillsWithRelationsResponseBody } from "@app/types/api/skills";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
@@ -20,6 +20,7 @@ import {
   Edit04,
   Eye,
   Label,
+  LoadingBlock,
   Tooltip,
   Trash01,
 } from "@dust-tt/sparkle";
@@ -56,9 +57,129 @@ type RowData = {
   messageCount: number | null;
   updatedAt: number | null;
   createdAt: number | null;
-  onClick: () => void;
+  onClick?: () => void;
   menuItems: MenuItem[];
 };
+
+const SKILLS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
+  { length: 5 },
+  (_, index) => ({
+    sId: `skill-skeleton-${index}`,
+    name: "",
+    icon: null,
+    editedBy: null,
+    description: "",
+    availability: "editors",
+    editors: [],
+    usage: { count: 0, agents: [], skills: [] },
+    messageCount: null,
+    updatedAt: null,
+    createdAt: null,
+    menuItems: [],
+  })
+);
+
+function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
+  switch (columnId) {
+    case "select":
+      return (
+        <DataTable.CellContent className="size-full items-center justify-center">
+          <LoadingBlock className="h-4 w-4 rounded-sm" />
+        </DataTable.CellContent>
+      );
+    case "name":
+      return (
+        <DataTable.CellContent>
+          <div className="flex flex-row items-center gap-2 py-3">
+            <LoadingBlock className="h-9 w-9 shrink-0 rounded-lg" />
+            <div className="flex min-w-0 grow flex-col">
+              <div className="flex h-5 items-center">
+                <LoadingBlock
+                  className={classNames(
+                    "h-3 max-w-full",
+                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowIndex]
+                  )}
+                />
+              </div>
+              <div className="flex h-5 items-center">
+                <LoadingBlock
+                  className={classNames(
+                    "h-3 max-w-full",
+                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowIndex]
+                  )}
+                />
+              </div>
+            </div>
+          </div>
+        </DataTable.CellContent>
+      );
+    case "availability":
+      return (
+        <DataTable.CellContent>
+          <LoadingBlock
+            className={classNames(
+              "h-6 rounded-[9px]",
+              ["w-20", "w-28", "w-24", "w-28", "w-20"][rowIndex]
+            )}
+          />
+        </DataTable.CellContent>
+      );
+    case "usedBy":
+      return (
+        <div className="flex h-12 w-full items-center justify-center">
+          <LoadingBlock
+            className={classNames(
+              "h-5 rounded-md",
+              ["w-14", "w-16", "w-12", "w-20", "w-14"][rowIndex]
+            )}
+          />
+        </div>
+      );
+    case "messageCount":
+      return (
+        <DataTable.CellContent>
+          <LoadingBlock
+            className={classNames(
+              "h-3",
+              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowIndex]
+            )}
+          />
+        </DataTable.CellContent>
+      );
+    case "editors":
+      return (
+        <DataTable.CellContent>
+          <div className="flex -space-x-2">
+            {Array.from({ length: (rowIndex % 3) + 1 }, (_, index) => (
+              <LoadingBlock
+                key={index}
+                className="h-7 w-7 rounded-full ring-2 ring-background"
+              />
+            ))}
+          </div>
+        </DataTable.CellContent>
+      );
+    case "updatedAt":
+      return (
+        <DataTable.CellContent>
+          <LoadingBlock
+            className={classNames(
+              "h-3",
+              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowIndex]
+            )}
+          />
+        </DataTable.CellContent>
+      );
+    case "menuItems":
+      return (
+        <DataTable.CellContent>
+          <LoadingBlock className="h-8 w-8 rounded-xl" />
+        </DataTable.CellContent>
+      );
+    default:
+      return null;
+  }
+}
 
 export const SKILL_AVAILABILITY_DISPLAY: Record<
   SkillAvailability,
@@ -342,6 +463,7 @@ type SkillsTableProps = {
   setRowSelection: (selection: RowSelectionState) => void;
   isBatchUpdating: boolean;
   onSelectAvailabilityAction: (action: BatchAvailabilityAction) => void;
+  isLoading?: boolean;
 };
 
 export function SkillsTable({
@@ -356,6 +478,7 @@ export function SkillsTable({
   setRowSelection,
   isBatchUpdating,
   onSelectAvailabilityAction,
+  isLoading = false,
 }: SkillsTableProps) {
   const router = useAppRouter();
   const { pagination, setPagination } = usePaginationFromUrl({});
@@ -373,6 +496,15 @@ export function SkillsTable({
         enableSelection,
       }),
     [onAgentClick, onUsedBySkillClick, enableSelection]
+  );
+  const skeletonColumns = useMemo(
+    () =>
+      columns.map((column) => ({
+        ...column,
+        cell: (info: CellContext<RowData, unknown>) =>
+          renderSkillsTableSkeletonCell(info.column.id, info.row.index),
+      })),
+    [columns]
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -479,13 +611,13 @@ export function SkillsTable({
     [pageRows, canMakeSkillAutoDiscoverable, selectionSet]
   );
 
-  if (rows.length === 0) {
+  if (!isLoading && rows.length === 0) {
     return null;
   }
 
   return (
     <>
-      {skillToArchive && (
+      {!isLoading && skillToArchive && (
         <ArchiveSkillDialog
           owner={owner}
           isOpen={true}
@@ -495,7 +627,7 @@ export function SkillsTable({
           }}
         />
       )}
-      {enableSelection && (
+      {!isLoading && enableSelection && (
         <SkillsBatchEditBar
           owner={owner}
           selectedSkills={selectedSkills}
@@ -512,23 +644,51 @@ export function SkillsTable({
           onSelectAction={onSelectAvailabilityAction}
         />
       )}
-      <DataTable
-        className="relative"
-        data={rows}
-        columns={columns}
-        pagination={pagination}
-        setPagination={setPagination}
-        disableRowClickSelection
-        {...(enableSelection
-          ? {
-              rowSelection,
-              setRowSelection,
-              enableRowSelection: (row: Row<RowData>) =>
-                isSkillSelectable(row.original, canMakeSkillAutoDiscoverable),
-              getRowId: (row: RowData) => row.sId,
-            }
-          : {})}
-      />
+      <div
+        role={isLoading ? "status" : undefined}
+        aria-label={isLoading ? "Loading skills" : undefined}
+        aria-busy={isLoading || undefined}
+      >
+        {isLoading ? (
+          <div aria-hidden="true" className="flex flex-col gap-2">
+            <DataTable
+              className="relative"
+              data={SKILLS_TABLE_SKELETON_ROWS}
+              columns={skeletonColumns}
+              enableRowSelection={() => false}
+              disableRowClickSelection
+              rowSelection={{}}
+              setRowSelection={() => undefined}
+            />
+            <div className="p-1">
+              <div className="flex h-8 items-center justify-end">
+                <LoadingBlock className="h-3 w-14" />
+              </div>
+            </div>
+          </div>
+        ) : (
+          <DataTable
+            className="relative"
+            data={rows}
+            columns={columns}
+            pagination={pagination}
+            setPagination={setPagination}
+            disableRowClickSelection
+            {...(enableSelection
+              ? {
+                  rowSelection,
+                  setRowSelection,
+                  enableRowSelection: (row: Row<RowData>) =>
+                    isSkillSelectable(
+                      row.original,
+                      canMakeSkillAutoDiscoverable
+                    ),
+                  getRowId: (row: RowData) => row.sId,
+                }
+              : {})}
+          />
+        )}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Description

Manage Agents and Manage Skills currently show a centered spinner while their tables load, so the final structure appears all at once. This replaces those spinners with table-shaped loading states built with `LoadingBlock`.

The skeletons reuse each table definition and mirror its row content, responsive visibility, selection layout, and pagination height so loaded content lands in the same structure.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
