### PR TITLE
feat(agent): fail explicitly when the requested model is killed

### DIFF
--- a/front-api/lib/api/assistant/conversation/model_selection.ts
+++ b/front-api/lib/api/assistant/conversation/model_selection.ts
@@ -45,7 +45,9 @@ export async function validatePublicModelSelection(
   const enabledModels = await getEnabledModelsForAuth(auth);
   const isAuthorized = enabledModels.some(
     (model) =>
-      model.isSelectable &&
+      // Let it through so the message is created and the agent message carries
+      // the "model unavailable" error instead.
+      (model.isSelectable || model.isKilled) &&
       model.providerId === modelSelection.providerId &&
       model.modelId === modelSelection.modelId
   );

--- a/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
+++ b/front/components/editor/extensions/shared/slash_suggestion/buildPickModelSlashCommandItems.test.ts
@@ -11,7 +11,7 @@ const Icon = () => null;
 function asSelectable(
   model: ModelConfigurationType
 ): EnabledModelConfigurationType {
-  return { ...model, isSelectable: true };
+  return { ...model, isSelectable: true, isKilled: false };
 }
 
 describe("buildPickModelSlashCommandItems", () => {
@@ -84,7 +84,7 @@ describe("buildPickModelSlashCommandItems", () => {
       lockPremiumEfforts: false,
       models: [
         asSelectable(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG),
-        { ...AUTO_COMPLEX_MODEL_CONFIG, isSelectable: false },
+        { ...AUTO_COMPLEX_MODEL_CONFIG, isSelectable: false, isKilled: false },
       ],
       query: "",
       streams: null,

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -124,6 +124,7 @@ describe("modelPickerUtils premium gating", () => {
       modelId,
       providerId: modelId,
       isSelectable,
+      isKilled: false,
     });
 
     it("locks a tier whose stream is above the member's cap", () => {
@@ -166,6 +167,7 @@ describe("modelPickerUtils premium gating", () => {
       modelId,
       providerId: modelId,
       isSelectable,
+      isKilled: false,
     });
 
     it("falls back to Basic when Standard is above the member's cap", () => {

--- a/front/lib/api/assistant/killed_models.ts
+++ b/front/lib/api/assistant/killed_models.ts
@@ -1,0 +1,42 @@
+import { killedModelIdsFromKillSwitches } from "@app/lib/poke/types";
+import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+// How long a pod may serve a stale set of killed models.
+const REFRESH_INTERVAL_MS = 60 * 1000;
+
+let cachedKilledModelIds: ReadonlySet<string> = new Set();
+let lastRefreshStartedAt = 0;
+let refreshing = false;
+
+export function getKilledModelIds(): ReadonlySet<string> {
+  const now = Date.now();
+  if (!refreshing && now - lastRefreshStartedAt > REFRESH_INTERVAL_MS) {
+    refreshing = true;
+    lastRefreshStartedAt = now;
+
+    void KillSwitchResource.listEnabledKillSwitches()
+      .then((killSwitches) => {
+        cachedKilledModelIds = new Set(
+          killedModelIdsFromKillSwitches(killSwitches)
+        );
+      })
+      .catch((err) => {
+        // Keep the last known set: a Redis blip must not silently un-kill a model.
+        logger.error(
+          { err: normalizeError(err) },
+          "Failed to refresh the killed models"
+        );
+      })
+      .finally(() => {
+        refreshing = false;
+      });
+  }
+
+  return cachedKilledModelIds;
+}
+
+export function isModelKilled(modelId: string): boolean {
+  return getKilledModelIds().has(modelId);
+}

--- a/front/lib/api/assistant/models.ts
+++ b/front/lib/api/assistant/models.ts
@@ -1,3 +1,4 @@
+import { getKilledModelIds } from "@app/lib/api/assistant/killed_models";
 import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
 import { isProviderWhitelisted } from "@app/lib/api/assistant/provider_whitelist";
 import { config as regionConfig } from "@app/lib/api/regions/config";
@@ -93,6 +94,7 @@ function getModelEnablementContext(
     region: regionConfig.getCurrentRegion(),
     whitelistedProviders:
       getWhitelistedProviders(auth).difference(excludeProviders),
+    killedModelIds: getKilledModelIds(),
   };
 }
 

--- a/front/lib/api/assistant/resolve_model.ts
+++ b/front/lib/api/assistant/resolve_model.ts
@@ -1,3 +1,4 @@
+import { isModelKilled } from "@app/lib/api/assistant/killed_models";
 import { PREFERRED_LARGE_MODEL_CONFIGS } from "@app/lib/api/assistant/model_preferences";
 import { selectEnabledModel } from "@app/lib/api/assistant/models";
 import type { Authenticator } from "@app/lib/auth";
@@ -69,8 +70,15 @@ export async function resolveModel(
 
   const requestedConfig = userConfig ?? agentConfig;
 
+  // Two cases keep the requested model instead of running the fallback list:
+  // a stream, which resolves through its own candidate pool below, and a killed
+  // model, which is kept so the run fails on the model that was actually asked
+  // for. Falling through on a kill would answer as a different model than the
+  // agent or the user picked, silently.
   let enabled =
-    requestedConfig && isModelStreamId(requestedConfig.modelId)
+    requestedConfig &&
+    (isModelStreamId(requestedConfig.modelId) ||
+      isModelKilled(requestedConfig.modelId))
       ? requestedConfig
       : selectEnabledModel(
           auth,

--- a/front/lib/api/assistant/workspace_capabilities.ts
+++ b/front/lib/api/assistant/workspace_capabilities.ts
@@ -4,10 +4,11 @@ import {
   getMcpServerViewDisplayName,
   isToolWithKnowledge,
 } from "@app/lib/actions/mcp_helper";
+import { getKilledModelIds } from "@app/lib/api/assistant/killed_models";
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import type { MCPServerType, MCPServerViewType } from "@app/lib/api/mcp";
 import { config as regionConfig } from "@app/lib/api/regions/config";
-import { filterEnabledModels } from "@app/lib/assistant";
+import { filterAvailableModels } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -50,12 +51,13 @@ export async function getAvailableModelsForWorkspace(
   const whitelistedProviders = getWhitelistedProviders(auth);
 
   const allUsedModels = [...USED_MODEL_CONFIGS, ...CUSTOM_MODEL_CONFIGS];
-  return filterEnabledModels(allUsedModels, {
+  return filterAvailableModels(allUsedModels, {
     featureFlags,
     plan,
     regionalModelsOnly: owner.regionalModelsOnly,
     region,
     whitelistedProviders,
+    killedModelIds: getKilledModelIds(),
   });
 }
 

--- a/front/lib/assistant.test.ts
+++ b/front/lib/assistant.test.ts
@@ -1,6 +1,6 @@
 import { getWhitelistedProviders } from "@app/lib/api/assistant/models";
 import {
-  filterEnabledModels,
+  filterAvailableModels,
   isModelAvailable,
   isModelReleased,
 } from "@app/lib/assistant";
@@ -391,7 +391,7 @@ describe("isModelReleased", () => {
   });
 });
 
-describe("filterEnabledModels", () => {
+describe("filterAvailableModels", () => {
   it("excludes advanced models when models_picker is enabled without plan access", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
@@ -401,12 +401,13 @@ describe("filterEnabledModels", () => {
       providerId: "anthropic",
     });
 
-    const result = filterEnabledModels([model], {
+    const result = filterAvailableModels([model], {
       featureFlags: ["models_picker"],
       plan: { ...auth.plan()!, hasAdvancedModelAccess: false },
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
+      killedModelIds: new Set<string>(),
     });
 
     expect(result).toEqual([]);
@@ -417,12 +418,13 @@ describe("filterEnabledModels", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     const model = createMockModel({ providerId: "openai", largeModel: false });
 
-    const result = filterEnabledModels([model], {
+    const result = filterAvailableModels([model], {
       featureFlags: [],
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
+      killedModelIds: new Set<string>(),
     });
     expect(result).toContain(model);
   });
@@ -437,12 +439,13 @@ describe("filterEnabledModels", () => {
       largeModel: false,
     });
 
-    const result = filterEnabledModels([model], {
+    const result = filterAvailableModels([model], {
       featureFlags: [],
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
+      killedModelIds: new Set<string>(),
     });
     expect(result).toHaveLength(0);
   });
@@ -456,12 +459,13 @@ describe("filterEnabledModels", () => {
       largeModel: false,
     });
 
-    const result = filterEnabledModels([model], {
+    const result = filterAvailableModels([model], {
       featureFlags: [],
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
+      killedModelIds: new Set<string>(),
     });
     expect(result).toHaveLength(0);
   });
@@ -475,12 +479,13 @@ describe("filterEnabledModels", () => {
       largeModel: false,
     });
 
-    const result = filterEnabledModels([model], {
+    const result = filterAvailableModels([model], {
       featureFlags: ["deepseek_feature"],
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
+      killedModelIds: new Set<string>(),
     });
     expect(result).toContain(model);
   });
@@ -499,12 +504,13 @@ describe("filterEnabledModels", () => {
       largeModel: false,
     });
 
-    const result = filterEnabledModels([openaiModel, xaiModel], {
+    const result = filterAvailableModels([openaiModel, xaiModel], {
       featureFlags: [],
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
+      killedModelIds: new Set<string>(),
     });
     expect(result).toEqual([openaiModel]);
   });
@@ -517,12 +523,13 @@ describe("filterEnabledModels", () => {
       largeModel: false,
     });
 
-    const result = filterEnabledModels([model], {
+    const result = filterAvailableModels([model], {
       featureFlags: [],
       plan: auth.plan(),
       regionalModelsOnly: auth.getNonNullableWorkspace().regionalModelsOnly,
       region: TEST_REGION,
       whitelistedProviders: getWhitelistedProviders(auth),
+      killedModelIds: new Set<string>(),
     });
     expect(result).toContain(model);
   });

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -96,8 +96,23 @@ export function isModelAvailable(
   return true;
 }
 
-// Returns true if the model is enabled for the workspace.
-export function isModelEnabled(
+// killed means the model has an incident
+export type ModelEnablementStatus =
+  | { status: "enabled" }
+  | { status: "killed" }
+  | { status: "provider_not_whitelisted" }
+  | { status: "not_available" };
+
+export type ModelEnablementContext = {
+  featureFlags: WhitelistableFeature[];
+  plan: PlanType | null;
+  regionalModelsOnly: boolean;
+  region: RegionType;
+  whitelistedProviders: Set<ModelProviderIdType>;
+  killedModelIds: ReadonlySet<string>;
+};
+
+export function getModelEnablementStatus(
   m: ModelConfigurationType,
   {
     featureFlags,
@@ -105,43 +120,50 @@ export function isModelEnabled(
     regionalModelsOnly,
     region,
     whitelistedProviders,
-  }: {
-    featureFlags: WhitelistableFeature[];
-    plan: PlanType | null;
-    regionalModelsOnly: boolean;
-    region: RegionType;
-    whitelistedProviders: Set<ModelProviderIdType>;
+    killedModelIds,
+  }: ModelEnablementContext
+): ModelEnablementStatus {
+  if (
+    !isModelAvailable(m, { featureFlags, plan, regionalModelsOnly, region })
+  ) {
+    return { status: "not_available" };
   }
-) {
-  return (
-    isModelAvailable(m, { featureFlags, plan, regionalModelsOnly, region }) &&
-    isProviderWhitelisted(whitelistedProviders, m.providerId)
-  );
+
+  if (!isProviderWhitelisted(whitelistedProviders, m.providerId)) {
+    return { status: "provider_not_whitelisted" };
+  }
+
+  if (killedModelIds.has(m.modelId)) {
+    return { status: "killed" };
+  }
+
+  return { status: "enabled" };
 }
 
-export function filterEnabledModels(
+/**
+ * Returns true if the model can run for the workspace right now.
+ *
+ * A killed model is not enabled: kills take it out of every path, so nothing
+ * ever routes onto one automatically. Use `filterAvailableModels` for the
+ * surfaces that must still show it as unavailable rather than hide it.
+ */
+export function isModelEnabled(
+  m: ModelConfigurationType,
+  context: ModelEnablementContext
+) {
+  return getModelEnablementStatus(m, context).status === "enabled";
+}
+
+/**
+ * The models a workspace may see: the ones it can run, plus the killed ones.
+ */
+export function filterAvailableModels(
   models: ModelConfigurationType[],
-  {
-    featureFlags,
-    plan,
-    regionalModelsOnly,
-    region,
-    whitelistedProviders,
-  }: {
-    featureFlags: WhitelistableFeature[];
-    plan: PlanType | null;
-    regionalModelsOnly: boolean;
-    region: RegionType;
-    whitelistedProviders: Set<ModelProviderIdType>;
-  }
+  context: ModelEnablementContext
 ): ModelConfigurationType[] {
-  return models.filter((m) =>
-    isModelEnabled(m, {
-      featureFlags,
-      plan,
-      regionalModelsOnly,
-      region,
-      whitelistedProviders,
-    })
-  );
+  return models.filter((m) => {
+    const { status } = getModelEnablementStatus(m, context);
+
+    return status === "enabled" || status === "killed";
+  });
 }

--- a/front/lib/model_tiers/enabled_models.ts
+++ b/front/lib/model_tiers/enabled_models.ts
@@ -1,3 +1,4 @@
+import { getKilledModelIds } from "@app/lib/api/assistant/killed_models";
 import { pickPreferredLargeModel } from "@app/lib/api/assistant/model_preferences";
 import { getAvailableModelsForWorkspace } from "@app/lib/api/assistant/workspace_capabilities";
 import type { Authenticator } from "@app/lib/auth";
@@ -38,14 +39,16 @@ function isStaticModel(
 
 function restrictModelConfigToAllowedTiers(
   model: ModelConfigurationType,
-  allowedTierNamesSet: Set<ModelsTierName>
+  allowedTierNamesSet: Set<ModelsTierName>,
+  isKilled: boolean
 ): EnabledModelConfigurationType {
   if (!isStaticModel(model.modelId)) {
     // Models outside the tier table are models added dynamically (as we
     // have a type guard for all models), so it is expected that we allow them.
     return {
       ...model,
-      isSelectable: true,
+      isSelectable: !isKilled,
+      isKilled,
     };
   }
 
@@ -77,9 +80,12 @@ function restrictModelConfigToAllowedTiers(
     ...model,
     supportedReasoningEfforts,
     defaultReasoningEffort,
-    isSelectable: ORDERED_REASONING_EFFORTS.some(
-      (effort) => supportedReasoningEfforts[effort]
-    ),
+    isSelectable:
+      !isKilled &&
+      ORDERED_REASONING_EFFORTS.some(
+        (effort) => supportedReasoningEfforts[effort]
+      ),
+    isKilled,
   };
 }
 
@@ -88,19 +94,25 @@ export async function withModelSelectability(
   { models }: { models: ModelConfigurationType[] }
 ): Promise<EnabledModelConfigurationType[]> {
   const featureFlags = await getFeatureFlags(auth);
+  const killedModelIds = getKilledModelIds();
 
   if (!featureFlags.includes("models_picker")) {
-    return models.map((model) => ({
-      ...model,
-      isSelectable: true,
-    }));
+    return models.map((model) => {
+      const isKilled = killedModelIds.has(model.modelId);
+
+      return { ...model, isSelectable: !isKilled, isKilled };
+    });
   }
 
   const { tiers: allowedTierNames } = await resolveAllowedTierNames(auth);
   const allowedTierNamesSet = new Set(allowedTierNames);
 
   return models.map((model) =>
-    restrictModelConfigToAllowedTiers(model, allowedTierNamesSet)
+    restrictModelConfigToAllowedTiers(
+      model,
+      allowedTierNamesSet,
+      killedModelIds.has(model.modelId)
+    )
   );
 }
 
@@ -139,6 +151,7 @@ export function getDefaultModelFromEnabledModels(
   return {
     ...pickPreferredLargeModel(selectableModels),
     isSelectable: true,
+    isKilled: false,
   };
 }
 
@@ -176,7 +189,7 @@ export function resolveStreamModel(
     models.filter((m) => m.isSelectable)
   );
   return {
-    model: { ...fallback, isSelectable: true },
+    model: { ...fallback, isSelectable: true, isKilled: false },
     reasoningEffort: fallback.defaultReasoningEffort,
     fromPool: false,
   };

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -1,4 +1,5 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
+import { isModelKilled } from "@app/lib/api/assistant/killed_models";
 import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -144,6 +145,38 @@ async function _runModelAndCreateActionsActivity({
   }
 
   const { auth, ...runAgentData } = runAgentDataRes.value;
+
+  const runModelConfig = runAgentData.modelInfo.endpoint.modelConfig;
+  if (isModelKilled(runModelConfig.modelId)) {
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        agentMessageId: runAgentArgs.agentMessageId,
+        conversationId: runAgentArgs.conversationId,
+        modelId: runModelConfig.modelId,
+        step,
+      },
+      "Agent loop stopped: the requested model is killed"
+    );
+
+    await publishAgentLoopGuardrailExceededError(auth, {
+      runAgentData,
+      runIds,
+      step,
+      errorCode: "model_disabled",
+      errorMessage:
+        `${runModelConfig.displayName}'s provider is temporarily down. ` +
+        "Pick another model for this conversation, or retry once it is back.",
+      errorMetadata: {
+        category: "model_disabled",
+        errorTitle: "Model unavailable",
+        modelId: runModelConfig.modelId,
+      },
+    });
+
+    return null;
+  }
+
   const isRootAgentMessage = !runAgentData.userMessage.agenticMessageData;
 
   // Intentionally check at step start (not step end) to early exit if dollar amount too high.
@@ -340,12 +373,14 @@ async function publishAgentLoopGuardrailExceededError(
     runIds,
     step,
     errorCode,
+    errorMessage = AGENT_LOOP_RESOURCE_CAP_ERROR_MESSAGE,
     errorMetadata,
   }: {
     runAgentData: AgentLoopExecutionData;
     runIds: string[];
     step: number;
     errorCode: string;
+    errorMessage?: string;
     errorMetadata: Record<string, string | number | boolean>;
   }
 ): Promise<void> {
@@ -357,7 +392,7 @@ async function publishAgentLoopGuardrailExceededError(
       messageId: runAgentData.agentMessage.sId,
       error: {
         code: errorCode,
-        message: AGENT_LOOP_RESOURCE_CAP_ERROR_MESSAGE,
+        message: errorMessage,
         metadata: errorMetadata,
       },
       runIds,

--- a/front/types/api/assistant/models.ts
+++ b/front/types/api/assistant/models.ts
@@ -7,6 +7,7 @@ import type {
 
 export type EnabledModelConfigurationType = ModelConfigurationType & {
   isSelectable: boolean;
+  isKilled: boolean;
 };
 
 export type ModelStreamResolutionType = {


### PR DESCRIPTION
## Description

Third of the per-model kill switch stack (on top of #31137): what happens when a conversation is pinned to a model that has just been killed.

The choice here is to **fail loudly on the model that was actually requested** rather than quietly answer as a different one:

- `resolve_model.ts`: a killed requested model is kept instead of running the fallback list. Falling through on a kill would answer as a model neither the agent nor the user picked, without saying so.
- `run_model_and_create_actions_wrapper.ts`: the agent loop stops before running and publishes a `model_disabled` guardrail error with a "Model unavailable" title and a message naming the model. `publishAgentLoopGuardrailExceededError` gains an optional `errorMessage` so it is not tied to the resource-cap wording.
- `front-api` public model selection: a killed model is let through validation so the message is created and the error surfaces on the agent message, instead of the send being rejected with an opaque authorization error.

---

Stack:
1. #31136 — poke: kill switch types + write API
2. #31137 — models: take killed models out of rotation
3. #31138 — agent: fail explicitly when the requested model is killed
4. #31139 — model picker: show killed models as temporarily unavailable
5. #31145 — poke: kill individual models from the Kill page


## Tests

Manual: kill a model from Poke, then send a message on an agent pinned to it — the user message is created and the agent message carries the "Model unavailable" error. Same check for a model picked explicitly from the picker.

## Risk

Medium — this deliberately turns a silent fallback into a user-visible error, so killing a model during an incident produces failed agent messages for anyone pinned to it rather than answers from another model. That is the intent (an operator killing a model wants the blast radius visible), but it is the behavioural decision to review in this stack.
