### PR TITLE
feat(model-picker): show killed models as temporarily unavailable

### DIFF
--- a/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ModelSelectionSubmenu.tsx
@@ -40,6 +40,21 @@ interface ModelSelectionSubmenuProps {
 const NOT_SELECTABLE_MODEL_DESCRIPTION =
   "Not enabled for you. Choose another model to save.";
 
+const KILLED_MODEL_DESCRIPTION = "Temporarily down. Choose another model.";
+
+function getModelDescription(
+  modelConfig: EnabledModelConfigurationType,
+  isSelected: boolean
+): string | undefined {
+  if (modelConfig.isSelectable || !isSelected) {
+    return modelConfig.shortDescription;
+  }
+
+  return modelConfig.isKilled
+    ? KILLED_MODEL_DESCRIPTION
+    : NOT_SELECTABLE_MODEL_DESCRIPTION;
+}
+
 interface ModelRadioItemProps {
   modelConfig: EnabledModelConfigurationType;
   isDark: boolean;
@@ -59,11 +74,7 @@ function ModelRadioItem({
     <DropdownMenuRadioItem
       value={modelConfig.modelId}
       icon={getModelMakerLogo(getModelMaker(modelConfig), isDark)}
-      description={
-        !modelConfig.isSelectable && isSelected
-          ? NOT_SELECTABLE_MODEL_DESCRIPTION
-          : modelConfig.shortDescription
-      }
+      description={getModelDescription(modelConfig, isSelected)}
       label={modelConfig.displayName}
       disabled={!modelConfig.isSelectable}
       onSelect={(e) => {

--- a/front/components/model_picker/ModelPicker.tsx
+++ b/front/components/model_picker/ModelPicker.tsx
@@ -17,10 +17,10 @@ import {
   buildModelSelection,
   buildTierSelection,
   getInitialEffort,
+  getModelLockReason,
   getModelTier,
   getModelWithReasoningEffortLabel,
   getTierLockReason,
-  isPremiumModel,
   isSameSelection,
   resolveShownSelection,
 } from "@app/components/model_picker/modelPickerUtils";
@@ -29,12 +29,12 @@ import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useAuth, useFeatureFlags } from "@app/lib/auth/AuthContext";
 import { useClientType } from "@app/lib/context/clientType";
 import { useModels } from "@app/lib/swr/models";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import type { AgentModelConfigurationType } from "@app/types/assistant/agent";
 import { isModelStreamId } from "@app/types/assistant/models/auto";
 import { getTierForModel } from "@app/types/assistant/models/model_tiers";
 import { getModelMaker } from "@app/types/assistant/models/providers";
 import type {
-  ModelConfigurationType,
   ModelMakerIdType,
   ModelSelectionType,
   ReasoningEffort,
@@ -158,11 +158,16 @@ export function ModelPicker({
 
   const canRevert = !isSameSelection(shown.display, agentDefault.display);
 
-  // Concrete, selectable models (meta-models are surfaced as tiers instead).
-  const allModels = useMemo<ModelConfigurationType[]>(
+  // Concrete models the picker lists (meta-models are surfaced as tiers
+  // instead). Killed models stay in: they are not selectable, but the picker
+  // shows them disabled rather than hiding them, so a model that is down reads
+  // as temporarily unavailable instead of silently disappearing.
+  const allModels = useMemo<EnabledModelConfigurationType[]>(
     () =>
       models.filter(
-        (model) => !isModelStreamId(model.modelId) && model.isSelectable
+        (model) =>
+          !isModelStreamId(model.modelId) &&
+          (model.isSelectable || model.isKilled)
       ),
     [models]
   );
@@ -177,7 +182,7 @@ export function ModelPicker({
   // Group models by maker, preserving first-seen order of both makers and
   // models within each maker.
   const makerGroups = useMemo<MakerGroup[]>(() => {
-    const groups = new Map<ModelMakerIdType, ModelConfigurationType[]>();
+    const groups = new Map<ModelMakerIdType, EnabledModelConfigurationType[]>();
     for (const model of allModels) {
       const makerId = getModelMaker(model);
       const existing = groups.get(makerId);
@@ -267,8 +272,8 @@ export function ModelPicker({
     );
   };
 
-  const onSelectModel = (model: ModelConfigurationType) => {
-    if (isPremiumModel(model, { lockPremiumEfforts })) {
+  const onSelectModel = (model: EnabledModelConfigurationType) => {
+    if (getModelLockReason(model, { lockPremiumEfforts })) {
       return;
     }
     lastModelInteractionAtMsRef.current = Date.now();

--- a/front/components/model_picker/ModelPickerContent.tsx
+++ b/front/components/model_picker/ModelPickerContent.tsx
@@ -18,7 +18,6 @@ import type {
   ModelStreamResolutionsType,
 } from "@app/types/api/assistant/models";
 import type {
-  ModelConfigurationType,
   ModelMakerIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
@@ -41,7 +40,7 @@ interface ModelPickerContentProps {
   canRevert: boolean;
   lockPremiumEfforts: boolean;
   makerGroups: MakerGroup[];
-  allModels: ModelConfigurationType[];
+  allModels: EnabledModelConfigurationType[];
   streamModels: EnabledModelConfigurationType[];
   streams: ModelStreamResolutionsType | null;
   search: string;
@@ -51,7 +50,7 @@ interface ModelPickerContentProps {
   expandedMaker: ModelMakerIdType | null;
   onToggleMaker: (makerId: ModelMakerIdType) => void;
   onSelectTier: (tierId: ModelTierId) => void;
-  onSelectModel: (model: ModelConfigurationType) => void;
+  onSelectModel: (model: EnabledModelConfigurationType) => void;
   onChangeEffort: (effort: ReasoningEffort) => void;
   onRevert: () => void;
 }

--- a/front/components/model_picker/ModelPickerModelRow.tsx
+++ b/front/components/model_picker/ModelPickerModelRow.tsx
@@ -5,23 +5,25 @@ import type {
 } from "@app/components/model_picker/modelPickerUtils";
 import { getModelLockTooltip } from "@app/components/model_picker/modelPickerUtils";
 import { ReasoningEffortSlider } from "@app/components/model_picker/ReasoningEffortSlider";
-import type {
-  ModelConfigurationType,
-  ReasoningEffort,
-} from "@app/types/assistant/models/types";
-import { DropdownMenuItem, Icon, Lock01 } from "@dust-tt/sparkle";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
+import type { ReasoningEffort } from "@app/types/assistant/models/types";
+import { AlertCircle, DropdownMenuItem, Icon, Lock01 } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 import { useRef } from "react";
 
+function lockIcon(reason: ModelLockReason): ComponentType {
+  return reason === "killed" ? AlertCircle : Lock01;
+}
+
 interface ModelPickerModelRowProps {
-  model: ModelConfigurationType;
+  model: EnabledModelConfigurationType;
   isSelected: boolean;
   isDefault: boolean;
   lockReason: ModelLockReason | null;
   effort: ReasoningEffort;
   effortStops: EffortStop[];
   icon?: ComponentType;
-  onSelectModel: (model: ModelConfigurationType) => void;
+  onSelectModel: (model: EnabledModelConfigurationType) => void;
   onChangeEffort: (effort: ReasoningEffort) => void;
   canRevert: boolean;
   onRevert: () => void;
@@ -52,7 +54,11 @@ export function ModelPickerModelRow({
         disabled
         tooltip={getModelLockTooltip(lockReason)}
         endComponent={
-          <Icon visual={Lock01} size="sm" className="text-muted-foreground" />
+          <Icon
+            visual={lockIcon(lockReason)}
+            size="sm"
+            className="text-muted-foreground"
+          />
         }
         onSelect={(e) => e.preventDefault()}
       />

--- a/front/components/model_picker/ModelPickerMoreModels.tsx
+++ b/front/components/model_picker/ModelPickerMoreModels.tsx
@@ -13,12 +13,12 @@ import {
 import { getModelMakerLogo } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useIsWidthConstrained } from "@app/lib/swr/useIsMobile";
+import type { EnabledModelConfigurationType } from "@app/types/api/assistant/models";
 import {
   getModelMaker,
   getModelMakerDisplayName,
 } from "@app/types/assistant/models/providers";
 import type {
-  ModelConfigurationType,
   ModelMakerIdType,
   ReasoningEffort,
 } from "@app/types/assistant/models/types";
@@ -37,7 +37,7 @@ import { Fragment } from "react";
 
 interface ModelPickerMoreModelsProps {
   makerGroups: MakerGroup[];
-  allModels: ModelConfigurationType[];
+  allModels: EnabledModelConfigurationType[];
   shown: Selection;
   agentDefault: Selection;
   // Whether the active selection differs from the agent default.
@@ -51,7 +51,7 @@ interface ModelPickerMoreModelsProps {
   onToggleExpanded: () => void;
   expandedMaker: ModelMakerIdType | null;
   onToggleMaker: (makerId: ModelMakerIdType) => void;
-  onSelectModel: (model: ModelConfigurationType) => void;
+  onSelectModel: (model: EnabledModelConfigurationType) => void;
   onChangeEffort: (effort: ReasoningEffort) => void;
   onRevert: () => void;
   // Vetoes the interaction-outside dismissal that a model/effort pick triggers
@@ -100,7 +100,7 @@ export function ModelPickerMoreModels({
     shown.display.kind === "model" ? getModelMaker(shown.display.model) : null;
 
   const renderModelRow = (
-    model: ModelConfigurationType,
+    model: EnabledModelConfigurationType,
     showMakerIcon: boolean
   ) => {
     const isSelected = isModelSelection(model, shown.display);

--- a/front/components/model_picker/modelPickerUtils.test.ts
+++ b/front/components/model_picker/modelPickerUtils.test.ts
@@ -2,6 +2,7 @@ import {
   getDefaultTierId,
   getEffortStops,
   getInitialEffort,
+  getModelLockReason,
   getTierLockReason,
   isPremiumModel,
 } from "@app/components/model_picker/modelPickerUtils";
@@ -112,6 +113,44 @@ describe("modelPickerUtils premium gating", () => {
         isPremiumModel(CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG, UNGATED)
       ).toBe(false);
       expect(isPremiumModel(O1_MODEL_CONFIG, UNGATED)).toBe(false);
+    });
+  });
+
+  describe("getModelLockReason", () => {
+    const enabledModel = (
+      model: typeof CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG,
+      isKilled: boolean
+    ): EnabledModelConfigurationType => ({
+      ...model,
+      isSelectable: !isKilled,
+      isKilled,
+    });
+
+    it("locks a killed model, ungated plan included", () => {
+      expect(
+        getModelLockReason(
+          enabledModel(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, true),
+          UNGATED
+        )
+      ).toBe("killed");
+    });
+
+    it("reports the kill rather than the plan for a killed premium model", () => {
+      expect(
+        getModelLockReason(
+          enabledModel(CLAUDE_OPUS_4_8_DEFAULT_MODEL_CONFIG, true),
+          GATED
+        )
+      ).toBe("killed");
+    });
+
+    it("does not lock a model that is not killed", () => {
+      expect(
+        getModelLockReason(
+          enabledModel(CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG, false),
+          UNGATED
+        )
+      ).toBeNull();
     });
   });
 

--- a/front/components/model_picker/modelPickerUtils.ts
+++ b/front/components/model_picker/modelPickerUtils.ts
@@ -40,6 +40,11 @@ const MODEL_TIER_LOCKED_TOOLTIP =
   "You don't have access to this model tier. " +
   "Contact your administrator to get access.";
 
+// Shown when a model row is disabled because the model is killed: its provider
+// is down and we took it out of rotation region-wide.
+const MODEL_KILLED_TOOLTIP =
+  "This model has a temporary outage. Pick another one for now.";
+
 // The three primary picks of the model picker. Each tier is backed by a
 // meta-model that is resolved to a concrete model at message-send time. Tier ids
 // keep the meta-model wording; `name` is what users see:
@@ -173,7 +178,7 @@ export interface Selection {
 
 export interface MakerGroup {
   makerId: ModelMakerIdType;
-  models: ModelConfigurationType[];
+  models: EnabledModelConfigurationType[];
 }
 
 export type EffortLockReason = "unsupported" | "premium" | "model_tier";
@@ -357,12 +362,18 @@ export function isPremiumModel(
   return getTierForModel(enabledModel.modelId, "none") === "premium";
 }
 
-export type ModelLockReason = "premium" | "model_tier";
+export type ModelLockReason = "premium" | "model_tier" | "killed";
 
 export function getModelLockReason(
-  enabledModel: ModelConfigurationType,
+  enabledModel: EnabledModelConfigurationType,
   { lockPremiumEfforts }: { lockPremiumEfforts: boolean }
 ): ModelLockReason | null {
+  // A kill outranks the other reasons: the model cannot run at all, whatever
+  // the workspace plan or tier says.
+  if (enabledModel.isKilled) {
+    return "killed";
+  }
+
   if (!isPremiumModel(enabledModel, { lockPremiumEfforts })) {
     return null;
   }
@@ -375,6 +386,8 @@ export function getModelLockTooltip(reason: ModelLockReason): string {
       return PREMIUM_MODEL_LOCKED_TOOLTIP;
     case "model_tier":
       return MODEL_TIER_LOCKED_TOOLTIP;
+    case "killed":
+      return MODEL_KILLED_TOOLTIP;
     default:
       assertNeverAndIgnore(reason);
       return "";


### PR DESCRIPTION
## Description

Fourth of the per-model kill switch stack (on top of #31138): instead of silently vanishing from the picker, a killed model stays listed and reads as temporarily unavailable.

- `getModelLockReason` gains a `"killed"` reason, which outranks the premium/tier reasons — a killed model cannot run whatever the workspace plan says — plus its tooltip.
- The picker keeps killed models in `allModels` (`isSelectable || isKilled`) and renders them disabled with an `AlertCircle` instead of the padlock used for plan/tier locks.
- The agent builder model submenu shows "Temporarily down. Choose another model." on a selected killed model, rather than the "Not enabled for you" wording meant for plan gating.
- Most of the remaining diff is mechanical: the picker components move from `ModelConfigurationType` to `EnabledModelConfigurationType` so they can read `isKilled`. Skimmable.

Note: the `/model` slash command in the editor still filters on `isSelectable` (`buildPickModelSlashCommandItems.ts:106`), so it keeps hiding killed models rather than showing them disabled. Happy to align it here if we'd rather have one behaviour across both surfaces.

---

Stack:
1. #31136 — poke: kill switch types + write API
2. #31137 — models: take killed models out of rotation
3. #31138 — agent: fail explicitly when the requested model is killed
4. #31139 — model picker: show killed models as temporarily unavailable
5. #31145 — poke: kill individual models from the Kill page


## Tests

New `getModelLockReason` unit tests: a killed model, a killed premium model (kill wins over the plan reason), and a live model. Manual: kill a model from Poke and check the picker row is disabled with the outage tooltip and that clicking it is a no-op.

## Risk

Low, UI only — with no model killed, `isKilled` is always false and every surface behaves as before.
