### PR TITLE
Introduce agent loop context provider

### DIFF
--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -8,7 +8,10 @@ import type { SandboxFunctionInvocationResource } from "@app/lib/resources/sandb
 import type { SandboxFunctionMCPActionResource } from "@app/lib/resources/sandbox_function_mcp_action_resource";
 import type { FileModel } from "@app/lib/resources/storage/models/files";
 import type { AgentConfigurationWithoutModelType } from "@app/types/assistant/agent";
-import type { StreamModelInfo } from "@app/types/assistant/agent_run";
+import type {
+  AgentLoopRuntimeData,
+  StreamModelInfo,
+} from "@app/types/assistant/agent_run";
 import type {
   AgentMessageType,
   ConversationType,
@@ -180,7 +183,7 @@ export type AgentLoopListToolsContext = {
   agentConfiguration: AgentConfigurationWithoutModelType;
   agentActionConfiguration: MCPServerConfigurationType;
   clientSideActionConfigurations?: ClientSideMCPServerConfigurationType[];
-  conversation: ConversationType;
+  conversation: AgentLoopRuntimeData["conversation"];
   agentMessage: AgentMessageType;
   // Needed at listing time to know whether a person wrote the message this run
   // answers: servers an admin scoped to personal credentials are not listed for

--- a/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
+++ b/front/lib/api/actions/servers/pod_manager/tools/index.test.ts
@@ -10,7 +10,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { getTestStreamEndpoint } from "@app/tests/utils/models";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
-import { getAgentLoopData } from "@app/types/assistant/agent_run";
+import { getAgentLoopRuntimeData } from "@app/types/assistant/agent_run";
 import {
   isAgentMessageType,
   isUserMessageType,
@@ -214,7 +214,10 @@ describe("pod_manager move_conversation", () => {
       userMessageVersion: runContext.userMessage.version,
       userMessageOrigin: runContext.userMessage.context.origin,
     };
-    const agentLoopData = await getAgentLoopData(auth.toJSON(), agentLoopArgs);
+    const agentLoopData = await getAgentLoopRuntimeData(
+      auth.toJSON(),
+      agentLoopArgs
+    );
     assert(agentLoopData.isOk());
     expect(agentLoopData.value.conversation.spaceId).toBe(targetPod.sId);
 

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -11,7 +11,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import {
-  getAgentLoopData,
+  getAgentLoopRuntimeData,
   isAgentLoopDataSoftDeleteError,
 } from "@app/types/assistant/agent_run";
 import type {
@@ -66,7 +66,10 @@ export async function ensureConversationTitleFromAgentLoop(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<string | null> {
-  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  const runAgentDataRes = await getAgentLoopRuntimeData(
+    authType,
+    agentLoopArgs
+  );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(

--- a/front/lib/api/assistant/conversation_rendering/conversation_window_core.ts
+++ b/front/lib/api/assistant/conversation_rendering/conversation_window_core.ts
@@ -18,7 +18,7 @@ import { getLlmCredentials } from "@app/lib/api/provider_credentials";
 import type { Authenticator } from "@app/lib/auth";
 import { tokenCountForTexts } from "@app/lib/tokenization";
 import logger from "@app/logger/logger";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { AgentConfigurationWithoutModelType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type {
   ModelConversationTypeMultiActions,
@@ -50,6 +50,29 @@ export const PREVIOUS_INTERACTIONS_TO_PRESERVE = 3;
 // otherwise leave pruning inactive until compaction has already fired. Applies to the whole
 // conversation, current interaction included. No separate, looser budget for it.
 export const PRUNING_TARGET_CONTEXT_UTILIZATION = 0.6;
+
+export type ConversationRenderingInput = {
+  leadingMessages?: ModelMessageTypeMultiActionsWithoutContentFragment[];
+  model: ModelConfigurationType;
+  prompt: string;
+  tools: string;
+  allowedTokenCount: number;
+  excludeActions?: boolean;
+  excludeImages?: boolean;
+  onMissingAction?: "inject-placeholder" | "skip";
+  enablePreviousInteractionsPruning?: boolean;
+  agentConfiguration?: AgentConfigurationWithoutModelType;
+  enabledSkills: EnabledSkill[];
+  // Opt-in StatsD emission. Callers have different budgets, so unnamed renders would skew the
+  // pruning dashboards.
+  metricsCaller?: ConversationRenderingMetricsCaller;
+};
+
+export type RenderConversationForModelResult = {
+  modelConversation: ModelConversationTypeMultiActions;
+  tokensUsed: number;
+  prunedContext: boolean;
+};
 
 /**
  * Replays the conversation chronologically so consumed tool results are pruned at stable
@@ -95,34 +118,10 @@ export async function renderConversationForModel(
     agentConfiguration,
     enabledSkills,
     metricsCaller,
-  }: {
-    leadingMessages?: ModelMessageTypeMultiActionsWithoutContentFragment[];
+  }: ConversationRenderingInput & {
     conversation: ConversationType;
-    model: ModelConfigurationType;
-    prompt: string;
-    tools: string;
-    allowedTokenCount: number;
-    excludeActions?: boolean;
-    excludeImages?: boolean;
-    onMissingAction?: "inject-placeholder" | "skip";
-    enablePreviousInteractionsPruning?: boolean;
-    agentConfiguration?: AgentLoopExecutionData["agentConfiguration"];
-    enabledSkills: EnabledSkill[];
-    // Opt-in StatsD emission. This function has callers with very different budgets (Dust app
-    // history injection, reinforcement batches, scripts) whose renders would skew the pruning
-    // dashboards, so only callers that name themselves are measured.
-    metricsCaller?: ConversationRenderingMetricsCaller;
   }
-): Promise<
-  Result<
-    {
-      modelConversation: ModelConversationTypeMultiActions;
-      tokensUsed: number;
-      prunedContext: boolean;
-    },
-    Error
-  >
-> {
+): Promise<Result<RenderConversationForModelResult, Error>> {
   const now = Date.now();
   let stepStart = now;
 

--- a/front/lib/api/assistant/email/email_reply.test.ts
+++ b/front/lib/api/assistant/email/email_reply.test.ts
@@ -11,7 +11,7 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { getAgentLoopDataWithAuth } from "@app/types/assistant/agent_run";
+import { getAgentLoopRuntimeDataWithAuth } from "@app/types/assistant/agent_run";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@app/lib/api/assistant/configuration/agent", () => ({
@@ -49,7 +49,7 @@ vi.mock("@app/lib/utils/router", () => ({
 }));
 
 vi.mock("@app/types/assistant/agent_run", () => ({
-  getAgentLoopDataWithAuth: vi.fn(),
+  getAgentLoopRuntimeDataWithAuth: vi.fn(),
 }));
 
 import { sendEmailReplyOnCompletion } from "@app/lib/api/assistant/email/email_reply";
@@ -91,7 +91,7 @@ describe("sendEmailReplyOnCompletion", () => {
       replyCc: ["security@dust.tt"],
     } as never);
 
-    vi.mocked(getAgentLoopDataWithAuth).mockResolvedValue({
+    vi.mocked(getAgentLoopRuntimeDataWithAuth).mockResolvedValue({
       isErr: () => false,
       value: {
         agentMessage: {
@@ -138,7 +138,7 @@ describe("sendEmailReplyOnCompletion", () => {
       workspaceId: "workspace-1",
       conversationId: "conversation-1",
     } as never);
-    vi.mocked(getAgentLoopDataWithAuth).mockResolvedValue({
+    vi.mocked(getAgentLoopRuntimeDataWithAuth).mockResolvedValue({
       isErr: () => false,
       value: {
         agentMessage: {

--- a/front/lib/api/assistant/email/email_reply.ts
+++ b/front/lib/api/assistant/email/email_reply.ts
@@ -17,7 +17,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
-import { getAgentLoopDataWithAuth } from "@app/types/assistant/agent_run";
+import { getAgentLoopRuntimeDataWithAuth } from "@app/types/assistant/agent_run";
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
 
@@ -177,7 +177,7 @@ export async function sendEmailReplyOnCompletion(
   }
 
   // Get the completed agent message data.
-  const dataRes = await getAgentLoopDataWithAuth(auth, agentLoopArgs);
+  const dataRes = await getAgentLoopRuntimeDataWithAuth(auth, agentLoopArgs);
   if (dataRes.isErr()) {
     logger.warn(
       {

--- a/front/lib/api/assistant/static_reply.ts
+++ b/front/lib/api/assistant/static_reply.ts
@@ -1,5 +1,5 @@
 import type {
-  ConversationType,
+  ConversationWithoutContentType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
 import { isReinforcedSkillNotificationMetadata } from "@app/types/assistant/conversation";
@@ -19,7 +19,7 @@ export function getStaticReplyForUserMessage({
   conversation,
   userMessage,
 }: {
-  conversation: ConversationType;
+  conversation: ConversationWithoutContentType;
   userMessage: UserMessageType;
 }): string | undefined {
   if (

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -25,7 +25,7 @@ import type {
 } from "@app/types/assistant/agent";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
 import {
-  getAgentLoopData,
+  getAgentLoopRuntimeData,
   isAgentLoopDataSoftDeleteError,
 } from "@app/types/assistant/agent_run";
 import type {
@@ -629,7 +629,10 @@ export async function finalizeCancellation(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  const runAgentDataRes = await getAgentLoopRuntimeData(
+    authType,
+    agentLoopArgs
+  );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
@@ -696,7 +699,10 @@ export async function finalizeInterruption(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  const runAgentDataRes = await getAgentLoopRuntimeData(
+    authType,
+    agentLoopArgs
+  );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
@@ -780,7 +786,10 @@ export async function finalizeGracefulStop(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  const runAgentDataRes = await getAgentLoopRuntimeData(
+    authType,
+    agentLoopArgs
+  );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(
@@ -841,7 +850,10 @@ export async function finalizeCreditStop(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
 ): Promise<void> {
-  const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
+  const runAgentDataRes = await getAgentLoopRuntimeData(
+    authType,
+    agentLoopArgs
+  );
   if (runAgentDataRes.isErr()) {
     if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
       logger.info(

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -1,7 +1,7 @@
 import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
-import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
+import type { AuthenticatorType } from "@app/lib/auth";
+import { Authenticator, getFeatureFlags } from "@app/lib/auth";
 import { DurationRecorder } from "@app/lib/duration_recorder";
 import { AgentStepContentToolExecutionModel } from "@app/lib/models/agent/actions/agent_step_content_tool_execution";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
@@ -20,6 +20,7 @@ import {
   MODEL_ACTIVITY_HEARTBEAT_INTERVAL_MS,
   RUN_MODEL_ACTIVITY_TIMEOUT_SAFETY_MARGIN_MS,
 } from "@app/temporal/agent_loop/config";
+import { prepareFullContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/full";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { handlePromptCommand } from "@app/temporal/agent_loop/lib/prompt_commands";
@@ -27,12 +28,9 @@ import { runModel } from "@app/temporal/agent_loop/lib/run_model";
 import { getMaxActionsPerStep } from "@app/types/assistant/agent";
 import type {
   AgentLoopArgsWithTiming,
-  AgentLoopExecutionData,
+  AgentLoopRuntimeData,
 } from "@app/types/assistant/agent_run";
-import {
-  getAgentLoopData,
-  isAgentLoopDataSoftDeleteError,
-} from "@app/types/assistant/agent_run";
+import { isAgentLoopDataSoftDeleteError } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
 import { startActiveObservation } from "@langfuse/tracing";
 import { Context, heartbeat } from "@temporalio/activity";
@@ -125,12 +123,13 @@ async function _runModelAndCreateActionsActivity({
   const activityTimeoutDeadlineMs = getActivityTimeoutDeadlineMs();
   const durationRecorder = DurationRecorder.create([]);
 
-  const runAgentDataRes = await startActiveObservation(
+  const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+  const contextProviderRes = await startActiveObservation(
     "get-agent-loop-data",
-    () => getAgentLoopData(authType, runAgentArgs)
+    () => prepareFullContextProvider(auth, runAgentArgs, step)
   );
-  if (runAgentDataRes.isErr()) {
-    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+  if (contextProviderRes.isErr()) {
+    if (isAgentLoopDataSoftDeleteError(contextProviderRes.error)) {
       logger.info(
         {
           conversationId: runAgentArgs.conversationId,
@@ -140,10 +139,11 @@ async function _runModelAndCreateActionsActivity({
       );
       return null;
     }
-    throw runAgentDataRes.error;
+    throw contextProviderRes.error;
   }
 
-  const { auth, ...runAgentData } = runAgentDataRes.value;
+  const contextProvider = contextProviderRes.value;
+  const runAgentData = contextProvider.runtimeData;
   const isRootAgentMessage = !runAgentData.userMessage.agenticMessageData;
 
   // Intentionally check at step start (not step end) to early exit if dollar amount too high.
@@ -266,7 +266,7 @@ async function _runModelAndCreateActionsActivity({
 
   // 1. Run model.
   const modelResult = await runModel(auth, {
-    runAgentData,
+    contextProvider,
     runIds,
     step,
     functionCallStepContentIds,
@@ -342,7 +342,7 @@ async function publishAgentLoopGuardrailExceededError(
     errorCode,
     errorMetadata,
   }: {
-    runAgentData: AgentLoopExecutionData;
+    runAgentData: AgentLoopRuntimeData;
     runIds: string[];
     step: number;
     errorCode: string;
@@ -374,7 +374,7 @@ async function publishAgentLoopGuardrailExceededError(
  */
 async function getExistingActionsAndBlobs(
   auth: Authenticator,
-  runAgentArgs: AgentLoopExecutionData,
+  runAgentArgs: AgentLoopRuntimeData,
   step: number
 ): Promise<{
   actionBlobs: ActionBlob[];

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -25,7 +25,7 @@ import type {
   AgentLoopExecutionData,
 } from "@app/types/assistant/agent_run";
 import {
-  getAgentLoopDataWithAuth,
+  getFullAgentLoopDataWithAuth,
   isAgentLoopDataSoftDeleteError,
 } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -120,7 +120,7 @@ export async function runToolActivity(
           Promise.all([
             // Cache conversation fetches to reduce DB load when multiple tool activities run in parallel
             // during the same step. Each tool would otherwise fetch the same conversation independently.
-            getAgentLoopDataWithAuth(auth, {
+            getFullAgentLoopDataWithAuth(auth, {
               ...runAgentArgs,
               caching: {
                 useCachedGetConversation: true,

--- a/front/temporal/agent_loop/lib/agent_loop_context_provider/full.test.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_context_provider/full.test.ts
@@ -1,0 +1,71 @@
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { prepareFullContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/full";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+describe("prepareFullContextProvider", () => {
+  it("exposes metadata-only runtime data sliced at the requested step", async () => {
+    const { authenticator: auth, workspace } = await createResourceTest({});
+    const agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(auth);
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfiguration.sId,
+      messagesCreatedAt: [],
+    });
+    const { messageRow: userMessageRow, userMessage } =
+      await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Hello",
+      });
+    const { agentMessage } = await ConversationFactory.createAgentMessage(
+      auth,
+      {
+        workspace,
+        conversation,
+        agentConfig: agentConfiguration,
+        parentMessageModelId: userMessageRow.id,
+        rank: 1,
+      }
+    );
+
+    for (const step of [0, 1]) {
+      await AgentStepContentResource.createNewVersion({
+        workspaceId: workspace.id,
+        agentMessageId: agentMessage.agentMessageId,
+        step,
+        index: 0,
+        type: "text_content",
+        value: {
+          type: "text_content",
+          value: `step ${step}`,
+        },
+      });
+    }
+
+    const result = await prepareFullContextProvider(
+      auth,
+      {
+        agentMessageId: agentMessage.sId,
+        agentMessageVersion: agentMessage.version,
+        conversationId: conversation.sId,
+        conversationTitle: conversation.title,
+        userMessageId: userMessage.sId,
+        userMessageVersion: userMessage.version,
+        userMessageOrigin: userMessage.context.origin,
+      },
+      1
+    );
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    expect("content" in result.value.runtimeData.conversation).toBe(false);
+    expect(
+      result.value.runtimeData.agentMessage.contents.map(({ step }) => step)
+    ).toEqual([0]);
+  });
+});

--- a/front/temporal/agent_loop/lib/agent_loop_context_provider/full.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_context_provider/full.ts
@@ -1,0 +1,44 @@
+import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import type { Authenticator } from "@app/lib/auth";
+import {
+  getMissingActionCatcherFunctionCallIds,
+  prepareRuntimeData,
+} from "@app/temporal/agent_loop/lib/agent_loop_context_provider/shared";
+import type { AgentLoopContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/types";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { getFullAgentLoopDataWithAuth } from "@app/types/assistant/agent_run";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+
+export async function prepareFullContextProvider(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs,
+  step: number
+): Promise<Result<AgentLoopContextProvider, Error>> {
+  const data = await getFullAgentLoopDataWithAuth(auth, agentLoopArgs);
+  if (data.isErr()) {
+    return data;
+  }
+
+  const { conversation, runtimeData } = prepareRuntimeData(data.value, step);
+  const missingActionCatcherFunctionCallIds =
+    getMissingActionCatcherFunctionCallIds(conversation);
+
+  return new Ok({
+    runtimeData,
+    render: async (input) => {
+      const result = await renderConversationForModel(auth, {
+        ...input,
+        conversation,
+      });
+      if (result.isErr()) {
+        return result;
+      }
+
+      return new Ok({
+        ...result.value,
+        missingActionCatcherFunctionCallIds,
+      });
+    },
+  });
+}

--- a/front/temporal/agent_loop/lib/agent_loop_context_provider/shared.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_context_provider/shared.ts
@@ -1,0 +1,62 @@
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
+import type {
+  AgentLoopExecutionData,
+  AgentLoopRuntimeData,
+} from "@app/types/assistant/agent_run";
+import type { ConversationType } from "@app/types/assistant/conversation";
+import { isAgentMessageType } from "@app/types/assistant/conversation";
+
+export function getMissingActionCatcherFunctionCallIds(
+  conversation: ConversationType
+): string[] {
+  const functionCallIds = new Set<string>();
+  const missingActionCatcherMCPServerId = autoInternalMCPServerNameToSId({
+    name: "missing_action_catcher",
+    workspaceId: conversation.owner.id,
+  });
+
+  for (const messageVersions of conversation.content) {
+    for (const message of messageVersions) {
+      if (!isAgentMessageType(message)) {
+        continue;
+      }
+
+      for (const action of message.actions) {
+        if (action.mcpServerId === missingActionCatcherMCPServerId) {
+          functionCallIds.add(action.functionCallId);
+        }
+      }
+    }
+  }
+
+  return [...functionCallIds];
+}
+
+export function prepareRuntimeData(
+  data: AgentLoopExecutionData,
+  step: number
+): {
+  conversation: ConversationType;
+  runtimeData: AgentLoopRuntimeData;
+} {
+  const fullConversation = structuredClone(data.conversation);
+  const { slicedConversation, slicedAgentMessage } =
+    sliceConversationForAgentMessage(fullConversation, {
+      agentMessageId: data.agentMessage.sId,
+      agentMessageVersion: data.agentMessage.version,
+      step,
+    });
+  const { content: _content, ...conversation } = slicedConversation;
+
+  return {
+    conversation: slicedConversation,
+    runtimeData: {
+      agentConfiguration: data.agentConfiguration,
+      modelInfo: data.modelInfo,
+      agentMessage: structuredClone(slicedAgentMessage),
+      conversation,
+      userMessage: data.userMessage,
+    },
+  };
+}

--- a/front/temporal/agent_loop/lib/agent_loop_context_provider/types.ts
+++ b/front/temporal/agent_loop/lib/agent_loop_context_provider/types.ts
@@ -1,0 +1,17 @@
+import type {
+  ConversationRenderingInput,
+  RenderConversationForModelResult,
+} from "@app/lib/api/assistant/conversation_rendering/conversation_window_core";
+import type { AgentLoopRuntimeData } from "@app/types/assistant/agent_run";
+import type { Result } from "@app/types/shared/result";
+
+export type AgentLoopModelContext = RenderConversationForModelResult & {
+  missingActionCatcherFunctionCallIds: string[];
+};
+
+export type AgentLoopContextProvider = {
+  runtimeData: AgentLoopRuntimeData;
+  render: (
+    input: ConversationRenderingInput
+  ) => Promise<Result<AgentLoopModelContext, Error>>;
+};

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -19,7 +19,7 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import type { AgentActionsEvent } from "@app/types/assistant/agent";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { AgentLoopRuntimeData } from "@app/types/assistant/agent_run";
 import type { ModelId } from "@app/types/shared/model_id";
 import assert from "assert";
 
@@ -52,7 +52,7 @@ export async function createToolActionsActivity(
     step,
     runIds,
   }: {
-    runAgentData: AgentLoopExecutionData;
+    runAgentData: AgentLoopRuntimeData;
     actions: AgentActionsEvent["actions"];
     stepContexts: StepContext[];
     functionCallStepContentIds: Record<string, ModelId>;
@@ -163,7 +163,7 @@ async function createActionForTool(
     runIds,
   }: {
     preparedAction: PreparedToolAction;
-    runAgentData: AgentLoopExecutionData;
+    runAgentData: AgentLoopRuntimeData;
     stepRequiresApproval: boolean;
     step: number;
     runIds: string[];

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -16,9 +16,8 @@ import logger from "@app/logger/logger";
 import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activities/common";
 import type { RunModelAndCreateActionsResult } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
-import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type { AgentActionsEvent } from "@app/types/assistant/agent";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { AgentLoopRuntimeData } from "@app/types/assistant/agent_run";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 
@@ -138,22 +137,10 @@ function parseToolCalls(body: string): ParsedToolCall[] | { error: string } {
  */
 async function listAvailableTools(
   auth: Authenticator,
-  runAgentData: AgentLoopExecutionData,
-  step: number
+  runAgentData: AgentLoopRuntimeData
 ): Promise<MCPToolConfigurationType[]> {
-  const {
-    agentConfiguration,
-    conversation: originalConversation,
-    userMessage,
-    agentMessage: originalAgentMessage,
-  } = runAgentData;
-
-  const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
-    sliceConversationForAgentMessage(originalConversation, {
-      agentMessageId: originalAgentMessage.sId,
-      agentMessageVersion: originalAgentMessage.version,
-      step,
-    });
+  const { agentConfiguration, conversation, userMessage, agentMessage } =
+    runAgentData;
 
   const attachments = await listAttachments(auth, { conversation });
   const jitServers = await getJITServers(auth, {
@@ -201,22 +188,11 @@ async function listAvailableTools(
  */
 async function publishSuccessAndFinish(
   auth: Authenticator,
-  runAgentData: AgentLoopExecutionData,
+  runAgentData: AgentLoopRuntimeData,
   step: number,
   content: string
 ): Promise<null> {
-  const {
-    agentConfiguration,
-    conversation: originalConversation,
-    agentMessage: originalAgentMessage,
-  } = runAgentData;
-
-  const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
-    sliceConversationForAgentMessage(originalConversation, {
-      agentMessageId: originalAgentMessage.sId,
-      agentMessageVersion: originalAgentMessage.version,
-      step,
-    });
+  const { agentConfiguration, conversation, agentMessage } = runAgentData;
 
   await AgentStepContentResource.createNewVersion({
     workspaceId: conversation.owner.id,
@@ -270,7 +246,7 @@ async function publishSuccessAndFinish(
  */
 export async function handlePromptCommand(
   auth: Authenticator,
-  runAgentData: AgentLoopExecutionData,
+  runAgentData: AgentLoopRuntimeData,
   step: number,
   runIds: string[]
 ): Promise<RunModelAndCreateActionsResult | null | "not_a_command"> {
@@ -331,10 +307,10 @@ function formatToolListWithButtons(tools: MCPToolConfigurationType[]): string {
  */
 async function handleToolListCommand(
   auth: Authenticator,
-  runAgentData: AgentLoopExecutionData,
+  runAgentData: AgentLoopRuntimeData,
   step: number
 ): Promise<null> {
-  const availableTools = await listAvailableTools(auth, runAgentData, step);
+  const availableTools = await listAvailableTools(auth, runAgentData);
   const body = getBodyAfterCommand(runAgentData.userMessage.content);
 
   if (body) {
@@ -396,7 +372,7 @@ async function handleToolListCommand(
  */
 async function handleToolRunFirstStep(
   auth: Authenticator,
-  runAgentData: AgentLoopExecutionData,
+  runAgentData: AgentLoopRuntimeData,
   step: number,
   runIds: string[]
 ): Promise<{
@@ -408,17 +384,10 @@ async function handleToolRunFirstStep(
   const {
     agentConfiguration,
     modelInfo,
-    conversation: originalConversation,
+    conversation,
     userMessage,
-    agentMessage: originalAgentMessage,
+    agentMessage,
   } = runAgentData;
-
-  const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
-    sliceConversationForAgentMessage(originalConversation, {
-      agentMessageId: originalAgentMessage.sId,
-      agentMessageVersion: originalAgentMessage.version,
-      step,
-    });
 
   const localLogger = logger.child({
     workspaceId: conversation.owner.sId,
@@ -460,7 +429,7 @@ async function handleToolRunFirstStep(
     return null;
   }
 
-  const availableTools = await listAvailableTools(auth, runAgentData, step);
+  const availableTools = await listAvailableTools(auth, runAgentData);
 
   // Match each parsed tool call to an available tool.
   const actions: AgentActionsEvent["actions"] = [];
@@ -508,7 +477,7 @@ async function handleToolRunFirstStep(
   }
 
   // Compute the citations offset.
-  const citationsRefsOffset = originalAgentMessage.actions.reduce(
+  const citationsRefsOffset = agentMessage.actions.reduce(
     (total, action) => total + (action.citationsAllocated || 0),
     0
   );
@@ -533,7 +502,7 @@ async function handleToolRunFirstStep(
  */
 async function handleToolRunFinalStep(
   auth: Authenticator,
-  runAgentData: AgentLoopExecutionData,
+  runAgentData: AgentLoopRuntimeData,
   step: number
 ): Promise<null> {
   // Build the output from the actions that ran in step 0.

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -2,7 +2,6 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { buildToolSpecification } from "@app/lib/actions/mcp";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
-import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { isJITMCPServerView } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { StepContext } from "@app/lib/actions/types";
@@ -14,7 +13,6 @@ import {
 } from "@app/lib/actions/types/guards";
 import { computeStepContexts } from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
-import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
 import {
   constructPromptMultiActions,
@@ -85,21 +83,18 @@ import {
 } from "@app/temporal/agent_loop/activities/common";
 import { METRICS } from "@app/temporal/agent_loop/activities/instrumentation";
 import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
+import type { AgentLoopContextProvider } from "@app/temporal/agent_loop/lib/agent_loop_context_provider/types";
 import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
-import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import { makeRunModelLLMError } from "@app/temporal/agent_loop/lib/run_model_errors";
 import type {
   AgentActionsEvent,
   AgentConfigurationType,
 } from "@app/types/assistant/agent";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { isGlobalAgentId } from "@app/types/assistant/assistant";
 import type {
   AgentMessageType,
-  ConversationType,
   UserMessageOrigin,
 } from "@app/types/assistant/conversation";
-import { isAgentMessageType } from "@app/types/assistant/conversation";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import { isTextContent } from "@app/types/assistant/generation";
 import { isByokProviderId } from "@app/types/assistant/models/providers";
@@ -251,34 +246,6 @@ function getReplayedToolNames(
   return [...toolNames];
 }
 
-function getMissingActionCatcherFunctionCallIds(
-  conversation: ConversationType
-): Set<string> {
-  const functionCallIds = new Set<string>();
-  const missingActionCatcherMCPServerId = autoInternalMCPServerNameToSId({
-    name: "missing_action_catcher",
-    workspaceId: conversation.owner.id,
-  });
-
-  for (const messageVersions of conversation.content) {
-    for (const message of messageVersions) {
-      if (!isAgentMessageType(message)) {
-        continue;
-      }
-
-      for (const action of message.actions) {
-        // mcpServerId is serialized from the action's
-        // toolConfiguration.toolServerId.
-        if (action.mcpServerId === missingActionCatcherMCPServerId) {
-          functionCallIds.add(action.functionCallId);
-        }
-      }
-    }
-  }
-
-  return functionCallIds;
-}
-
 function buildReplayOnlyToolSpecification(
   name: string
 ): AgentActionSpecification {
@@ -379,7 +346,7 @@ export function buildSpecificationsWithReplayPlaceholders(
 export async function runModel(
   auth: Authenticator,
   {
-    runAgentData,
+    contextProvider,
     runIds,
     step,
     functionCallStepContentIds,
@@ -387,7 +354,7 @@ export async function runModel(
     activityTimeoutDeadlineMs,
     forceDisableToolUse = false,
   }: {
-    runAgentData: AgentLoopExecutionData;
+    contextProvider: AgentLoopContextProvider;
     runIds: string[];
     step: number;
     functionCallStepContentIds: Record<string, ModelId>;
@@ -405,22 +372,12 @@ export async function runModel(
   // tool use disabled to force a final answer.
   retryWithoutTools?: boolean;
 } | null> {
-  const {
-    agentConfiguration,
-    conversation: originalConversation,
-    userMessage,
-    agentMessage: originalAgentMessage,
-  } = runAgentData;
-
-  const { slicedConversation: conversation, slicedAgentMessage: agentMessage } =
-    sliceConversationForAgentMessage(originalConversation, {
-      agentMessageId: originalAgentMessage.sId,
-      agentMessageVersion: originalAgentMessage.version,
-      step,
-    });
+  const runAgentData = contextProvider.runtimeData;
+  const { agentConfiguration, conversation, userMessage, agentMessage } =
+    runAgentData;
 
   // Compute the citations offset by summing citations allocated to all past actions for this message.
-  const citationsRefsOffset = originalAgentMessage.actions.reduce(
+  const citationsRefsOffset = agentMessage.actions.reduce(
     (total, action) => total + (action.citationsAllocated || 0),
     0
   );
@@ -689,8 +646,7 @@ export async function runModel(
     "render-conversation",
     () =>
       tracer.trace("renderConversationForModel", async () =>
-        renderConversationForModel(auth, {
-          conversation,
+        contextProvider.render({
           model: modelConfig,
           prompt: promptText,
           tools,
@@ -740,8 +696,9 @@ export async function runModel(
   const { specifications, missingReplayedToolNames } =
     buildSpecificationsWithReplayPlaceholders(baseSpecifications, {
       modelConversation: modelConversationRes.value.modelConversation,
-      missingActionCatcherFunctionCallIds:
-        getMissingActionCatcherFunctionCallIds(conversation),
+      missingActionCatcherFunctionCallIds: new Set(
+        modelConversationRes.value.missingActionCatcherFunctionCallIds
+      ),
     });
 
   if (missingReplayedToolNames.length > 0) {

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -10,10 +10,9 @@ import type {
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import type { AgentLoopRuntimeData } from "@app/types/assistant/agent_run";
 import type {
   AgentMessageType,
-  ConversationType,
   ConversationWithoutContentType,
   UserMessageType,
 } from "@app/types/assistant/conversation";
@@ -40,7 +39,7 @@ export type GetOutputRequestParams = {
     modelConversation: ModelConversationTypeMultiActions;
     tokensUsed: number;
   }>;
-  conversation: ConversationType;
+  conversation: AgentLoopRuntimeData["conversation"];
   // When true, the Anthropic client defers non-eager tools behind tool search.
   // Provider-agnostic signal: clients without tool-search support ignore it.
   toolSearchEnabled: boolean;
@@ -55,8 +54,8 @@ export type GetOutputRequestParams = {
   flushParserTokens: () => Promise<void>;
   contentParser: AgentMessageContentParser;
   step: number;
-  agentConfiguration: AgentLoopExecutionData["agentConfiguration"];
-  agentMessage: AgentLoopExecutionData["agentMessage"];
+  agentConfiguration: AgentLoopRuntimeData["agentConfiguration"];
+  agentMessage: AgentLoopRuntimeData["agentMessage"];
   model: ModelConfigurationType;
   activityTimeoutDeadlineMs: number;
   publishAgentError: (error: {

--- a/front/types/assistant/agent_run.test.ts
+++ b/front/types/assistant/agent_run.test.ts
@@ -53,6 +53,7 @@ describe("getAgentLoopDataWithAuth", () => {
     }
 
     expect(result.value.agentMessage.resolvedModel).toBeNull();
+    expect("content" in result.value.conversation).toBe(false);
     expect(result.value.modelInfo.endpoint.modelConfig.modelId).not.toBe(
       AUTO_MODEL_ID
     );

--- a/front/types/assistant/agent_run.test.ts
+++ b/front/types/assistant/agent_run.test.ts
@@ -1,11 +1,11 @@
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { getAgentLoopDataWithAuth } from "@app/types/assistant/agent_run";
+import { getAgentLoopRuntimeDataWithAuth } from "@app/types/assistant/agent_run";
 import { AUTO_MODEL_ID } from "@app/types/assistant/models/auto";
 import { describe, expect, it } from "vitest";
 
-describe("getAgentLoopDataWithAuth", () => {
+describe("getAgentLoopRuntimeDataWithAuth", () => {
   it("resolves an auto stream for a legacy message without a stored model", async () => {
     const { authenticator: auth, workspace } = await createResourceTest({});
     const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
@@ -38,7 +38,7 @@ describe("getAgentLoopDataWithAuth", () => {
 
     expect(agentMessage.resolvedModel).toBeNull();
 
-    const result = await getAgentLoopDataWithAuth(auth, {
+    const result = await getAgentLoopRuntimeDataWithAuth(auth, {
       agentMessageId: agentMessage.sId,
       agentMessageVersion: agentMessage.version,
       conversationId: conversation.sId,

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -40,7 +40,7 @@ import { isGlobalAgentId } from "./assistant";
 import { ConversationError } from "./conversation";
 
 /**
- * Error types for getAgentLoopData that indicate deleted or unavailable resources.
+ * Error types for getAgentLoopRuntimeData that indicate deleted or unavailable resources.
  * These are safe to ignore in callers since retrying won't make the data available.
  */
 const AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES = [
@@ -166,7 +166,7 @@ export type AgentLoopRuntimeData = Omit<
   conversation: Omit<ConversationType, "content">;
 };
 
-export type AgentLoopDataWithAuth = AgentLoopRuntimeData & {
+export type AgentLoopRuntimeDataWithAuth = AgentLoopRuntimeData & {
   auth: Authenticator;
 };
 
@@ -178,23 +178,23 @@ export type AgentLoopArgsWithTiming = AgentLoopArgs & {
   initialStartTime: number;
 };
 
-export async function getAgentLoopData(
+export async function getAgentLoopRuntimeData(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
-): Promise<Result<AgentLoopDataWithAuth, AgentLoopDataError | Error>> {
+): Promise<Result<AgentLoopRuntimeDataWithAuth, AgentLoopDataError | Error>> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
-  return getAgentLoopDataWithAuth(auth, agentLoopArgs);
+  return getAgentLoopRuntimeDataWithAuth(auth, agentLoopArgs);
 }
 
 /**
- * Same as getAgentLoopData but accepts a pre-built Authenticator, avoiding redundant
+ * Same as getAgentLoopRuntimeData but accepts a pre-built Authenticator, avoiding redundant
  * Authenticator.fromJSON calls when the caller already has a valid auth.
  */
-export async function getAgentLoopDataWithAuth(
+export async function getAgentLoopRuntimeDataWithAuth(
   auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
-): Promise<Result<AgentLoopDataWithAuth, AgentLoopDataError | Error>> {
+): Promise<Result<AgentLoopRuntimeDataWithAuth, AgentLoopDataError | Error>> {
   const conversation = await ConversationResource.fetchById(
     auth,
     agentLoopArgs.conversationId,
@@ -420,7 +420,7 @@ async function buildAgentLoopRuntimeData(
     conversation: Omit<ConversationType, "content">;
     userMessage: UserMessageType;
   }
-): Promise<Result<AgentLoopDataWithAuth, Error>> {
+): Promise<Result<AgentLoopRuntimeDataWithAuth, Error>> {
   const { agentMessageId, agentMessageVersion } = agentLoopArgs;
 
   const agentId = agentMessage.configuration.sId;

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -4,6 +4,7 @@
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { PREVIOUS_INTERACTIONS_TO_PRESERVE } from "@app/lib/api/assistant/conversation_rendering";
+import { batchRenderMessages } from "@app/lib/api/assistant/messages";
 import { resolveModel } from "@app/lib/api/assistant/resolve_model";
 import { getStaticReplyForUserMessage } from "@app/lib/api/assistant/static_reply";
 import { legacyModelIdToModel } from "@app/lib/api/llm";
@@ -77,7 +78,7 @@ export type ConversationCaching =
   | { useCachedGetConversation: true; unicitySuffix: string; ttlMs: number };
 
 // Throws on error because cacheWithRedis expects functions that throw (not Result types).
-// Errors are caught and converted back to Result in getAgentLoopData.
+// Errors are caught and converted back to Result in getFullAgentLoopDataWithAuth.
 async function getConversationForAgentLoop(
   auth: Authenticator,
   conversationId: string,
@@ -158,6 +159,21 @@ export type AgentLoopExecutionData = {
   userMessage: UserMessageType;
 };
 
+export type AgentLoopRuntimeData = Omit<
+  AgentLoopExecutionData,
+  "conversation"
+> & {
+  conversation: Omit<ConversationType, "content">;
+};
+
+export type AgentLoopDataWithAuth = AgentLoopRuntimeData & {
+  auth: Authenticator;
+};
+
+export type FullAgentLoopDataWithAuth = AgentLoopExecutionData & {
+  auth: Authenticator;
+};
+
 export type AgentLoopArgsWithTiming = AgentLoopArgs & {
   initialStartTime: number;
 };
@@ -165,12 +181,7 @@ export type AgentLoopArgsWithTiming = AgentLoopArgs & {
 export async function getAgentLoopData(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
-): Promise<
-  Result<
-    AgentLoopExecutionData & { auth: Authenticator },
-    AgentLoopDataError | Error
-  >
-> {
+): Promise<Result<AgentLoopDataWithAuth, AgentLoopDataError | Error>> {
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
   return getAgentLoopDataWithAuth(auth, agentLoopArgs);
@@ -183,12 +194,92 @@ export async function getAgentLoopData(
 export async function getAgentLoopDataWithAuth(
   auth: Authenticator,
   agentLoopArgs: AgentLoopArgs
-): Promise<
-  Result<
-    AgentLoopExecutionData & { auth: Authenticator },
-    AgentLoopDataError | Error
-  >
-> {
+): Promise<Result<AgentLoopDataWithAuth, AgentLoopDataError | Error>> {
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    agentLoopArgs.conversationId,
+    { includeDeleted: true, includeForkingData: true }
+  );
+  if (!conversation || conversation.visibility === "deleted") {
+    return new Err(new AgentLoopDataError("conversation_deleted"));
+  }
+
+  const messageRows = await ConversationResource.getMessageByIds(
+    auth,
+    conversation,
+    [agentLoopArgs.agentMessageId, agentLoopArgs.userMessageId]
+  );
+  const agentMessageRow = messageRows.find(
+    (message) =>
+      message.sId === agentLoopArgs.agentMessageId &&
+      message.version === agentLoopArgs.agentMessageVersion &&
+      message.agentMessage
+  );
+  if (!agentMessageRow) {
+    return new Err(new Error("Agent message not found"));
+  }
+  if (agentMessageRow.visibility === "deleted") {
+    return new Err(new AgentLoopDataError("agent_message_deleted"));
+  }
+
+  const userMessageRow = messageRows.find(
+    (message) =>
+      message.sId === agentLoopArgs.userMessageId &&
+      message.version === agentLoopArgs.userMessageVersion &&
+      message.userMessage
+  );
+  if (!userMessageRow) {
+    return new Err(new Error("Unexpected: User message not found"));
+  }
+  if (userMessageRow.visibility === "deleted") {
+    return new Err(new AgentLoopDataError("user_message_deleted"));
+  }
+
+  const renderedMessages = await batchRenderMessages(
+    auth,
+    conversation,
+    [userMessageRow, agentMessageRow],
+    "full"
+  );
+  if (renderedMessages.isErr()) {
+    return renderedMessages;
+  }
+
+  const agentMessage = renderedMessages.value.find(
+    (message) =>
+      isAgentMessageType(message) &&
+      message.sId === agentLoopArgs.agentMessageId &&
+      message.version === agentLoopArgs.agentMessageVersion
+  );
+  if (!agentMessage || !isAgentMessageType(agentMessage)) {
+    return new Err(new Error("Agent message not found after rendering"));
+  }
+
+  const userMessage = renderedMessages.value.find(
+    (message) =>
+      isUserMessageType(message) &&
+      message.sId === agentLoopArgs.userMessageId &&
+      message.version === agentLoopArgs.userMessageVersion
+  );
+  if (!userMessage || !isUserMessageType(userMessage)) {
+    return new Err(new Error("User message not found after rendering"));
+  }
+
+  return buildAgentLoopRuntimeData(auth, agentLoopArgs, {
+    agentMessage,
+    conversation: {
+      ...conversation.toJSON(),
+      owner: auth.getNonNullableWorkspace(),
+      visibility: conversation.visibility,
+    },
+    userMessage,
+  });
+}
+
+export async function getFullAgentLoopDataWithAuth(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs
+): Promise<Result<FullAgentLoopDataWithAuth, AgentLoopDataError | Error>> {
   const {
     agentMessageId,
     agentMessageVersion,
@@ -301,6 +392,36 @@ export async function getAgentLoopDataWithAuth(
   if (userMessage.visibility === "deleted") {
     return new Err(new AgentLoopDataError("user_message_deleted"));
   }
+
+  const runtimeData = await buildAgentLoopRuntimeData(auth, agentLoopArgs, {
+    agentMessage,
+    conversation,
+    userMessage,
+  });
+  if (runtimeData.isErr()) {
+    return runtimeData;
+  }
+
+  return new Ok({
+    ...runtimeData.value,
+    conversation,
+  });
+}
+
+async function buildAgentLoopRuntimeData(
+  auth: Authenticator,
+  agentLoopArgs: AgentLoopArgs,
+  {
+    agentMessage,
+    conversation,
+    userMessage,
+  }: {
+    agentMessage: AgentMessageType;
+    conversation: Omit<ConversationType, "content">;
+    userMessage: UserMessageType;
+  }
+): Promise<Result<AgentLoopDataWithAuth, Error>> {
+  const { agentMessageId, agentMessageVersion } = agentLoopArgs;
 
   const agentId = agentMessage.configuration.sId;
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR introduces an explicit context provider boundary between the agent loop and conversation rendering.

This prepares the model activity for stateful checkpoint hydration while preserving the current rendering behavior.

Today, agent-loop data loading and model-context hydration are coupled. Fetching agent-loop metadata can therefore hydrate and render conversation history even when the caller only needs the current messages or conversation metadata.

Stateful context windows need a clear boundary where we can later choose between:
- Loading a valid checkpoint plus the current-step delta
- Falling back to the existing full bounded rendering path

In this PR we:
- introduce `AgentLoopContextProvider` with the current rendering logic, flagged as "full" which will be the default one if no checkpoint context can be found.
- separate metadata-only `AgentLoopRuntimeData` from full `AgentLoopExecutionData`.
- make the generic agent-loop loader fetch only:
    - Conversation metadata
    - The current user message
    - The current agent message
- (sadly) keeps `runTool` explicitly on full conversation hydration because some tools inspect conversation history. There are 5 tools relying on conversation content, will clean them up in follow up PRs.
- Moves conversation slicing and missing-action-catcher discovery behind the provider

## Behavior

No model-visible, tool-visible, or client-visible behavior change is intended.

The model activity still uses the same bounded full conversation, step slicing, and renderer. The provider currently wraps that existing behavior.

The immediate improvement applies to auxiliary activities that no longer need to hydrate conversation history through the generic agent-loop loader.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
