### PR TITLE
[front] enh: hide Chrome extension link for current users

### DIFF
--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8970,7 +8970,7 @@
     "/api/w/{wId}/extension/config": {
       "get": {
         "summary": "Get extension configuration",
-        "description": "Returns the extension configuration for the workspace, including blacklisted domains, and records browser extension activity.",
+        "description": "Returns the extension configuration for the workspace, including blacklisted domains.",
         "tags": [
           "Private Extension"
         ],

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8970,7 +8970,7 @@
     "/api/w/{wId}/extension/config": {
       "get": {
         "summary": "Get extension configuration",
-        "description": "Returns the extension configuration for the workspace, including blacklisted domains, and records Chrome extension activity.",
+        "description": "Returns the extension configuration for the workspace, including blacklisted domains, and records browser extension activity.",
         "tags": [
           "Private Extension"
         ],

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -8970,7 +8970,7 @@
     "/api/w/{wId}/extension/config": {
       "get": {
         "summary": "Get extension configuration",
-        "description": "Returns the extension configuration for the workspace, including blacklisted domains.",
+        "description": "Returns the extension configuration for the workspace, including blacklisted domains, and records Chrome extension activity.",
         "tags": [
           "Private Extension"
         ],

--- a/front-api/routes/w/[wId]/extension/config.test.ts
+++ b/front-api/routes/w/[wId]/extension/config.test.ts
@@ -1,5 +1,8 @@
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY } from "@app/types/extension";
+import {
+  CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
+  FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
+} from "@app/types/extension";
 import { honoApp } from "@front-api/app";
 import { describe, expect, it } from "vitest";
 
@@ -29,10 +32,18 @@ describe("GET /api/w/:wId/extension/config", () => {
     const lastUsedAtMs = Date.parse(metadata?.value ?? "");
     expect(lastUsedAtMs).toBeGreaterThanOrEqual(beforeRequestMs);
     expect(lastUsedAtMs).toBeLessThanOrEqual(Date.now());
+    expect(
+      await user.getMetadata(FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY)
+    ).toBeNull();
   });
 
-  it("does not record Firefox extension activity", async () => {
+  it("records the latest Firefox extension use date", async () => {
     const { user, workspace } = await createPrivateApiMockRequest();
+    await user.setMetadata(
+      FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
+      "2026-01-01T00:00:00.000Z"
+    );
+    const beforeRequestMs = Date.now();
 
     const response = await honoApp.request(
       `/api/w/${workspace.sId}/extension/config`,
@@ -40,6 +51,14 @@ describe("GET /api/w/:wId/extension/config", () => {
     );
 
     expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ blacklistedDomains: [] });
+
+    const metadata = await user.getMetadata(
+      FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY
+    );
+    const lastUsedAtMs = Date.parse(metadata?.value ?? "");
+    expect(lastUsedAtMs).toBeGreaterThanOrEqual(beforeRequestMs);
+    expect(lastUsedAtMs).toBeLessThanOrEqual(Date.now());
     expect(
       await user.getMetadata(CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY)
     ).toBeNull();

--- a/front-api/routes/w/[wId]/extension/config.test.ts
+++ b/front-api/routes/w/[wId]/extension/config.test.ts
@@ -1,0 +1,47 @@
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY } from "@app/types/extension";
+import { honoApp } from "@front-api/app";
+import { describe, expect, it } from "vitest";
+
+const CHROME_EXTENSION_ORIGIN =
+  "chrome-extension://fnkfcndbgingjcbdhaofkcnhcjpljhdn";
+
+describe("GET /api/w/:wId/extension/config", () => {
+  it("records the latest Chrome extension use date", async () => {
+    const { user, workspace } = await createPrivateApiMockRequest();
+    await user.setMetadata(
+      CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
+      "2026-01-01T00:00:00.000Z"
+    );
+    const beforeRequestMs = Date.now();
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/extension/config`,
+      { headers: { origin: CHROME_EXTENSION_ORIGIN } }
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ blacklistedDomains: [] });
+
+    const metadata = await user.getMetadata(
+      CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY
+    );
+    const lastUsedAtMs = Date.parse(metadata?.value ?? "");
+    expect(lastUsedAtMs).toBeGreaterThanOrEqual(beforeRequestMs);
+    expect(lastUsedAtMs).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("does not record Firefox extension activity", async () => {
+    const { user, workspace } = await createPrivateApiMockRequest();
+
+    const response = await honoApp.request(
+      `/api/w/${workspace.sId}/extension/config`,
+      { headers: { origin: "moz-extension://dust" } }
+    );
+
+    expect(response.status).toBe(200);
+    expect(
+      await user.getMetadata(CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY)
+    ).toBeNull();
+  });
+});

--- a/front-api/routes/w/[wId]/extension/config.ts
+++ b/front-api/routes/w/[wId]/extension/config.ts
@@ -46,15 +46,15 @@ app.get("/", async (ctx): HandlerResult<GetExtensionConfigResponseBody> => {
   const origin = ctx.req.header("origin");
   if (origin?.startsWith("chrome-extension://")) {
     await auth
-      .getNonNullableUser()
-      .setMetadata(
+      .user()
+      ?.setMetadata(
         CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
         new Date().toISOString()
       );
   } else if (origin?.startsWith("moz-extension://")) {
     await auth
-      .getNonNullableUser()
-      .setMetadata(
+      .user()
+      ?.setMetadata(
         FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
         new Date().toISOString()
       );

--- a/front-api/routes/w/[wId]/extension/config.ts
+++ b/front-api/routes/w/[wId]/extension/config.ts
@@ -1,6 +1,9 @@
 import type { GetExtensionConfigResponseBody } from "@app/lib/resources/extension";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
-import { CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY } from "@app/types/extension";
+import {
+  CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
+  FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
+} from "@app/types/extension";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -12,7 +15,7 @@ const app = workspaceApp();
  * /api/w/{wId}/extension/config:
  *   get:
  *     summary: Get extension configuration
- *     description: Returns the extension configuration for the workspace, including blacklisted domains, and records Chrome extension activity.
+ *     description: Returns the extension configuration for the workspace, including blacklisted domains, and records browser extension activity.
  *     tags:
  *       - Private Extension
  *     parameters:
@@ -40,11 +43,19 @@ app.get("/", async (ctx): HandlerResult<GetExtensionConfigResponseBody> => {
 
   const config = await ExtensionConfigurationResource.fetchForWorkspace(auth);
 
-  if (ctx.req.header("origin")?.startsWith("chrome-extension://")) {
+  const origin = ctx.req.header("origin");
+  if (origin?.startsWith("chrome-extension://")) {
     await auth
       .getNonNullableUser()
       .setMetadata(
         CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
+        new Date().toISOString()
+      );
+  } else if (origin?.startsWith("moz-extension://")) {
+    await auth
+      .getNonNullableUser()
+      .setMetadata(
+        FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
         new Date().toISOString()
       );
   }

--- a/front-api/routes/w/[wId]/extension/config.ts
+++ b/front-api/routes/w/[wId]/extension/config.ts
@@ -15,7 +15,7 @@ const app = workspaceApp();
  * /api/w/{wId}/extension/config:
  *   get:
  *     summary: Get extension configuration
- *     description: Returns the extension configuration for the workspace, including blacklisted domains, and records browser extension activity.
+ *     description: Returns the extension configuration for the workspace, including blacklisted domains.
  *     tags:
  *       - Private Extension
  *     parameters:

--- a/front-api/routes/w/[wId]/extension/config.ts
+++ b/front-api/routes/w/[wId]/extension/config.ts
@@ -1,5 +1,6 @@
 import type { GetExtensionConfigResponseBody } from "@app/lib/resources/extension";
 import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
+import { CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY } from "@app/types/extension";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 
@@ -11,7 +12,7 @@ const app = workspaceApp();
  * /api/w/{wId}/extension/config:
  *   get:
  *     summary: Get extension configuration
- *     description: Returns the extension configuration for the workspace, including blacklisted domains.
+ *     description: Returns the extension configuration for the workspace, including blacklisted domains, and records Chrome extension activity.
  *     tags:
  *       - Private Extension
  *     parameters:
@@ -38,6 +39,15 @@ app.get("/", async (ctx): HandlerResult<GetExtensionConfigResponseBody> => {
   const auth = ctx.get("auth");
 
   const config = await ExtensionConfigurationResource.fetchForWorkspace(auth);
+
+  if (ctx.req.header("origin")?.startsWith("chrome-extension://")) {
+    await auth
+      .getNonNullableUser()
+      .setMetadata(
+        CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
+        new Date().toISOString()
+      );
+  }
 
   return ctx.json({
     blacklistedDomains: config?.blacklistedDomains ?? [],

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -30,7 +30,8 @@ import type { AgentMention, MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
 import {
   CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
-  shouldShowChromeExtensionMenu,
+  FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY,
+  shouldShowExtensionMenu,
 } from "@app/types/extension";
 import type { SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
@@ -107,15 +108,16 @@ export function UserMenu({
 
   const isFirefox =
     typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent);
+  const extensionLastUsedAtMetadataKey = isFirefox
+    ? FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY
+    : CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY;
   const {
-    metadata: chromeExtensionLastUsedAt,
-    isMetadataLoading: isChromeExtensionLastUsedAtLoading,
-  } = useUserMetadata(CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY, {
-    disabled: isFirefox,
-  });
-  const showChromeExtensionMenu =
-    !isChromeExtensionLastUsedAtLoading &&
-    shouldShowChromeExtensionMenu(chromeExtensionLastUsedAt?.value);
+    metadata: extensionLastUsedAt,
+    isMetadataLoading: isExtensionLastUsedAtLoading,
+  } = useUserMetadata(extensionLastUsedAtMetadataKey);
+  const showExtensionMenu =
+    !isExtensionLastUsedAtLoading &&
+    shouldShowExtensionMenu(extensionLastUsedAt?.value);
 
   const sendNotification = useSendNotification();
   const devMode = useDevMode();
@@ -426,23 +428,24 @@ export function UserMenu({
             onClick={() => trackUserMenuEvent("dust_academy")}
           />
 
-          {isFirefox ? (
-            <DropdownMenuItem
-              label="Firefox extension"
-              icon={FirefoxLogo}
-              href="https://addons.mozilla.org/firefox/addon/dust/"
-              target="_blank"
-              onClick={() => trackUserMenuEvent("firefox_extension")}
-            />
-          ) : showChromeExtensionMenu ? (
-            <DropdownMenuItem
-              label="Chrome extension"
-              icon={ChromeLogo}
-              href="https://chromewebstore.google.com/detail/dust/fnkfcndbgingjcbdhaofkcnhcjpljhdn"
-              target="_blank"
-              onClick={() => trackUserMenuEvent("chrome_extension")}
-            />
-          ) : null}
+          {showExtensionMenu &&
+            (isFirefox ? (
+              <DropdownMenuItem
+                label="Firefox extension"
+                icon={FirefoxLogo}
+                href="https://addons.mozilla.org/firefox/addon/dust/"
+                target="_blank"
+                onClick={() => trackUserMenuEvent("firefox_extension")}
+              />
+            ) : (
+              <DropdownMenuItem
+                label="Chrome extension"
+                icon={ChromeLogo}
+                href="https://chromewebstore.google.com/detail/dust/fnkfcndbgingjcbdhaofkcnhcjpljhdn"
+                target="_blank"
+                onClick={() => trackUserMenuEvent("chrome_extension")}
+              />
+            ))}
 
           {subscription?.plan.limits.canUseProduct && (
             <>

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -22,11 +22,16 @@ import {
 import { serializeMention } from "@app/lib/mentions/format";
 import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { useAppRouter } from "@app/lib/platform";
+import { useUserMetadata } from "@app/lib/swr/user";
 import { TRACKING_AREAS, trackEvent } from "@app/lib/tracking";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { AgentMention, MentionType } from "@app/types/assistant/mentions";
 import { isAgentMention } from "@app/types/assistant/mentions";
+import {
+  CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY,
+  shouldShowChromeExtensionMenu,
+} from "@app/types/extension";
 import type { SubscriptionType } from "@app/types/plan";
 import { isDevelopment } from "@app/types/shared/env";
 import type { UserTypeWithWorkspaces, WorkspaceType } from "@app/types/user";
@@ -99,6 +104,18 @@ export function UserMenu({
   const [automationsOpen, setAutomationsOpen] = useState(false);
   const [analyticsOpen, setAnalyticsOpen] = useState(false);
   const [userMenuOpen, setUserMenuOpen] = useState(false);
+
+  const isFirefox =
+    typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent);
+  const {
+    metadata: chromeExtensionLastUsedAt,
+    isMetadataLoading: isChromeExtensionLastUsedAtLoading,
+  } = useUserMetadata(CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY, {
+    disabled: isFirefox,
+  });
+  const showChromeExtensionMenu =
+    !isChromeExtensionLastUsedAtLoading &&
+    shouldShowChromeExtensionMenu(chromeExtensionLastUsedAt?.value);
 
   const sendNotification = useSendNotification();
   const devMode = useDevMode();
@@ -184,9 +201,6 @@ export function UserMenu({
       [createConversationWithMessage, owner, router, sendNotification]
     )
   );
-
-  const isFirefox =
-    typeof navigator !== "undefined" && /firefox/i.test(navigator.userAgent);
 
   const forceRoleUpdate = useMemo(
     () => async (role: "user" | "admin" | "manager") => {
@@ -420,7 +434,7 @@ export function UserMenu({
               target="_blank"
               onClick={() => trackUserMenuEvent("firefox_extension")}
             />
-          ) : (
+          ) : showChromeExtensionMenu ? (
             <DropdownMenuItem
               label="Chrome extension"
               icon={ChromeLogo}
@@ -428,7 +442,7 @@ export function UserMenu({
               target="_blank"
               onClick={() => trackUserMenuEvent("chrome_extension")}
             />
-          )}
+          ) : null}
 
           {subscription?.plan.limits.canUseProduct && (
             <>

--- a/front/types/extension.test.ts
+++ b/front/types/extension.test.ts
@@ -1,23 +1,23 @@
 import {
-  CHROME_EXTENSION_MENU_REDISPLAY_THRESHOLD_MS,
-  shouldShowChromeExtensionMenu,
+  EXTENSION_MENU_REDISPLAY_THRESHOLD_MS,
+  shouldShowExtensionMenu,
 } from "@app/types/extension";
 import { describe, expect, it } from "vitest";
 
 const NOW_MS = Date.UTC(2026, 7, 25);
 
-describe("shouldShowChromeExtensionMenu", () => {
+describe("shouldShowExtensionMenu", () => {
   it.each([
     { lastUsedAt: undefined, expected: true },
     { lastUsedAt: "invalid", expected: true },
     { lastUsedAt: new Date(NOW_MS).toISOString(), expected: false },
     {
       lastUsedAt: new Date(
-        NOW_MS - CHROME_EXTENSION_MENU_REDISPLAY_THRESHOLD_MS
+        NOW_MS - EXTENSION_MENU_REDISPLAY_THRESHOLD_MS
       ).toISOString(),
       expected: true,
     },
   ])("returns $expected for $lastUsedAt", ({ lastUsedAt, expected }) => {
-    expect(shouldShowChromeExtensionMenu(lastUsedAt, NOW_MS)).toBe(expected);
+    expect(shouldShowExtensionMenu(lastUsedAt, NOW_MS)).toBe(expected);
   });
 });

--- a/front/types/extension.test.ts
+++ b/front/types/extension.test.ts
@@ -1,0 +1,23 @@
+import {
+  CHROME_EXTENSION_MENU_REDISPLAY_THRESHOLD_MS,
+  shouldShowChromeExtensionMenu,
+} from "@app/types/extension";
+import { describe, expect, it } from "vitest";
+
+const NOW_MS = Date.UTC(2026, 7, 25);
+
+describe("shouldShowChromeExtensionMenu", () => {
+  it.each([
+    { lastUsedAt: undefined, expected: true },
+    { lastUsedAt: "invalid", expected: true },
+    { lastUsedAt: new Date(NOW_MS).toISOString(), expected: false },
+    {
+      lastUsedAt: new Date(
+        NOW_MS - CHROME_EXTENSION_MENU_REDISPLAY_THRESHOLD_MS
+      ).toISOString(),
+      expected: true,
+    },
+  ])("returns $expected for $lastUsedAt", ({ lastUsedAt, expected }) => {
+    expect(shouldShowChromeExtensionMenu(lastUsedAt, NOW_MS)).toBe(expected);
+  });
+});

--- a/front/types/extension.ts
+++ b/front/types/extension.ts
@@ -2,12 +2,13 @@ import type { ModelId } from "./shared/model_id";
 
 export const CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY =
   "chromeExtensionLastUsedAt";
+export const FIREFOX_EXTENSION_LAST_USED_AT_METADATA_KEY =
+  "firefoxExtensionLastUsedAt";
 
-// Resurface the install link after three months without Chrome extension activity.
-export const CHROME_EXTENSION_MENU_REDISPLAY_THRESHOLD_MS =
-  90 * 24 * 60 * 60 * 1000;
+// Resurface the install link after three months without extension activity.
+export const EXTENSION_MENU_REDISPLAY_THRESHOLD_MS = 90 * 24 * 60 * 60 * 1000;
 
-export function shouldShowChromeExtensionMenu(
+export function shouldShowExtensionMenu(
   lastUsedAt: string | null | undefined,
   nowMs = Date.now()
 ): boolean {
@@ -20,7 +21,7 @@ export function shouldShowChromeExtensionMenu(
     return true;
   }
 
-  return lastUsedAtMs <= nowMs - CHROME_EXTENSION_MENU_REDISPLAY_THRESHOLD_MS;
+  return lastUsedAtMs <= nowMs - EXTENSION_MENU_REDISPLAY_THRESHOLD_MS;
 }
 
 export type ExtensionConfigurationType = {

--- a/front/types/extension.ts
+++ b/front/types/extension.ts
@@ -1,5 +1,28 @@
 import type { ModelId } from "./shared/model_id";
 
+export const CHROME_EXTENSION_LAST_USED_AT_METADATA_KEY =
+  "chromeExtensionLastUsedAt";
+
+// Resurface the install link after three months without Chrome extension activity.
+export const CHROME_EXTENSION_MENU_REDISPLAY_THRESHOLD_MS =
+  90 * 24 * 60 * 60 * 1000;
+
+export function shouldShowChromeExtensionMenu(
+  lastUsedAt: string | null | undefined,
+  nowMs = Date.now()
+): boolean {
+  if (!lastUsedAt) {
+    return true;
+  }
+
+  const lastUsedAtMs = Date.parse(lastUsedAt);
+  if (Number.isNaN(lastUsedAtMs)) {
+    return true;
+  }
+
+  return lastUsedAtMs <= nowMs - CHROME_EXTENSION_MENU_REDISPLAY_THRESHOLD_MS;
+}
+
 export type ExtensionConfigurationType = {
   id: ModelId;
   sId: string;


### PR DESCRIPTION
## Description

We currently dedicate one sub menu of the user menu to the Chrome/Firefox extension, even to users who use it and are already aware of its existence.

This PR hides it for these users. We record the latest usage of the extension and hide the Chrome extension submenu when that the extension was used recently (less than 90 days). We show it again if there's no usage for 90 days because it may have changed a lot since so could be worth checking again.

## Tests

- Added tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
