### PR TITLE
[front] fix: remove user requirement on toolsets enable

### DIFF
--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -76,15 +76,9 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
   enable: async ({ toolsetId }, { auth, runContext }) => {
     assert(isAgentLoopRunContext(runContext), "AgentLoopRunContext expected");
 
-    const conversationId = runContext.conversation.sId;
-
-    if (!auth.user()) {
-      return new Err(new MCPError("User not found", { tracked: false }));
-    }
-
     const conversation = await ConversationResource.fetchById(
       auth,
-      conversationId
+      runContext.conversation.sId
     );
     const mcpServerView = await MCPServerViewResource.fetchById(
       auth,


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/31132

This PR removes the requirement of having a user in the toolsets enable tool.
It seems that this requirement is a leftover from relying on the public API, but keep me honest.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
