### PR TITLE
[front] enh: track events on new analytics pages

### DIFF
--- a/front/components/UserAnalyticsPopover.tsx
+++ b/front/components/UserAnalyticsPopover.tsx
@@ -18,6 +18,11 @@ import {
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { PERSONAL_CONSUMPTION_ANALYTICS_SCOPE } from "@app/lib/analytics/consumption_scope";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import type { WorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -28,7 +33,7 @@ import {
   XClose,
 } from "@dust-tt/sparkle";
 import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 interface UserAnalyticsPopoverProps {
   open: boolean;
@@ -50,6 +55,17 @@ export function UserAnalyticsPopover({
   const [filter, setFilter] = useState<UsageFilter>({});
   const scopeFilter = useMemo(() => toConsumptionScopeFilter(filter), [filter]);
   const shouldReduceMotion = useReducedMotion();
+
+  useEffect(() => {
+    if (open) {
+      trackEvent({
+        area: TRACKING_AREAS.ANALYTICS,
+        object: "personal_view",
+        action: TRACKING_ACTIONS.VIEW,
+        extra: { workspace_id: owner.sId },
+      });
+    }
+  }, [open, owner.sId]);
 
   return (
     <div className="flex h-full flex-col overflow-hidden">

--- a/front/components/assistant/conversation/CreditCostPopover.test.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.test.tsx
@@ -4,23 +4,28 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockOpenPanel, mockSidePanelContext, mockUseAgentMessageConsumption } =
-  vi.hoisted(() => {
-    const mockOpenPanel = vi.fn();
-    const mockSidePanelContext: {
-      currentPanel: "credits" | undefined;
-      openPanel: typeof mockOpenPanel;
-    } = {
-      currentPanel: undefined,
-      openPanel: mockOpenPanel,
-    };
+const {
+  mockOpenPanel,
+  mockSidePanelContext,
+  mockTrackEvent,
+  mockUseAgentMessageConsumption,
+} = vi.hoisted(() => {
+  const mockOpenPanel = vi.fn();
+  const mockSidePanelContext: {
+    currentPanel: "credits" | undefined;
+    openPanel: typeof mockOpenPanel;
+  } = {
+    currentPanel: undefined,
+    openPanel: mockOpenPanel,
+  };
 
-    return {
-      mockOpenPanel,
-      mockSidePanelContext,
-      mockUseAgentMessageConsumption: vi.fn(),
-    };
-  });
+  return {
+    mockOpenPanel,
+    mockSidePanelContext,
+    mockTrackEvent: vi.fn(),
+    mockUseAgentMessageConsumption: vi.fn(),
+  };
+});
 
 vi.mock(
   "@app/components/assistant/conversation/ConversationSidePanelContext",
@@ -32,6 +37,11 @@ vi.mock(
 vi.mock("@app/hooks/conversations/useAgentMessageConsumption", () => ({
   useAgentMessageConsumption: mockUseAgentMessageConsumption,
 }));
+
+vi.mock("@app/lib/tracking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/tracking")>();
+  return { ...actual, trackEvent: mockTrackEvent };
+});
 
 vi.mock("@app/components/assistant/conversation/actions/inline/utils", () => ({
   getActionStepIcon: () => () => null,
@@ -103,6 +113,7 @@ describe("CreditCostPopover", () => {
   beforeEach(() => {
     mockOpenPanel.mockReset();
     mockSidePanelContext.currentPanel = undefined;
+    mockTrackEvent.mockReset();
     mockUseAgentMessageConsumption.mockReset();
   });
 
@@ -259,15 +270,27 @@ describe("CreditCostPopover", () => {
     const openButton = screen.getByRole("button", {
       name: "Open credit details",
     });
+    expect(mockTrackEvent).not.toHaveBeenCalled();
     fireEvent.click(openButton);
 
     expect(mockUseAgentMessageConsumption).toHaveBeenLastCalledWith(
       expect.objectContaining({ disabled: false })
     );
     expect(mutateConsumption).not.toHaveBeenCalled();
+    expect(mockTrackEvent).toHaveBeenLastCalledWith({
+      area: "analytics",
+      object: "message_breakdown",
+      action: "view",
+      extra: {
+        workspace_id: "workspace_test",
+        conversation_id: "conversation_test",
+        message_id: "message_test",
+      },
+    });
 
     fireEvent.click(openButton);
 
     expect(mutateConsumption).toHaveBeenCalledOnce();
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2);
   });
 });

--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -3,6 +3,11 @@ import { useConversationSidePanelContext } from "@app/components/assistant/conve
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import { useAgentMessageConsumption } from "@app/hooks/conversations/useAgentMessageConsumption";
 import { formatCreditValue, toolUsageLabel } from "@app/lib/client/credits";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import type { AgentMessageConsumptionToolDetails } from "@app/types/assistant/agent_message_consumption";
 import {
   Button,
@@ -130,6 +135,16 @@ export function CreditCostPopover({
         if (!open) {
           return;
         }
+        trackEvent({
+          area: TRACKING_AREAS.ANALYTICS,
+          object: "message_breakdown",
+          action: TRACKING_ACTIONS.VIEW,
+          extra: {
+            workspace_id: workspaceId,
+            conversation_id: conversationId,
+            message_id: messageId,
+          },
+        });
         if (hasOpened) {
           void mutateConsumption();
         } else {

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.test.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.test.tsx
@@ -2,9 +2,10 @@ import { ConversationCreditUsagePanel } from "@app/components/assistant/conversa
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockUseConversationConsumption } = vi.hoisted(() => ({
+const { mockTrackEvent, mockUseConversationConsumption } = vi.hoisted(() => ({
+  mockTrackEvent: vi.fn(),
   mockUseConversationConsumption: vi.fn(),
 }));
 
@@ -18,6 +19,11 @@ vi.mock(
 vi.mock("@app/hooks/conversations/useConversationConsumption", () => ({
   useConversationConsumption: mockUseConversationConsumption,
 }));
+
+vi.mock("@app/lib/tracking", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@app/lib/tracking")>();
+  return { ...actual, trackEvent: mockTrackEvent };
+});
 
 const owner: LightWorkspaceType = {
   id: 1,
@@ -51,6 +57,11 @@ const conversation: ConversationWithoutContentType = {
 };
 
 describe("ConversationCreditUsagePanel", () => {
+  beforeEach(() => {
+    mockTrackEvent.mockReset();
+    mockUseConversationConsumption.mockReset();
+  });
+
   it("shows the empty usage placeholder when no credits have been consumed", () => {
     mockUseConversationConsumption.mockReturnValue({
       consumption: undefined,
@@ -67,5 +78,15 @@ describe("ConversationCreditUsagePanel", () => {
     expect(
       screen.getByText("Updates once a message is fully processed.")
     ).toBeInTheDocument();
+    expect(mockTrackEvent).toHaveBeenCalledOnce();
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      area: "analytics",
+      object: "conversation_breakdown",
+      action: "view",
+      extra: {
+        workspace_id: "workspace_1",
+        conversation_id: "conversation_1",
+      },
+    });
   });
 });

--- a/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.tsx
+++ b/front/components/assistant/conversation/credits_panel/ConversationCreditUsagePanel.tsx
@@ -3,9 +3,15 @@ import { ConversationSidePanelHeader } from "@app/components/assistant/conversat
 import { ConversationCreditUsageBreakdown } from "@app/components/assistant/conversation/credits_panel/ConversationCreditUsageBreakdown";
 import { useConversationConsumption } from "@app/hooks/conversations/useConversationConsumption";
 import { formatCreditValue } from "@app/lib/client/credits";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { CoinsStacked01, Spinner } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 interface ConversationCreditUsagePanelProps {
   conversation: ConversationWithoutContentType;
@@ -23,6 +29,18 @@ export function ConversationCreditUsagePanel({
       workspaceId: owner.sId,
     });
   const hasNoCreditUsage = !consumption || consumption.billedCredits <= 0;
+
+  useEffect(() => {
+    trackEvent({
+      area: TRACKING_AREAS.ANALYTICS,
+      object: "conversation_breakdown",
+      action: TRACKING_ACTIONS.VIEW,
+      extra: {
+        workspace_id: owner.sId,
+        conversation_id: conversation.sId,
+      },
+    });
+  }, [conversation.sId, owner.sId]);
 
   return (
     <div className="flex h-panel flex-col">

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -87,7 +87,7 @@ const ASSISTANTS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
     agentTagsAsString: "",
     canArchive: false,
     canEdit: false,
-  }),
+  })
 );
 
 function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
@@ -108,7 +108,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
                 <LoadingBlock
                   className={classNames(
                     "h-3 max-w-full",
-                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowIndex],
+                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowIndex]
                   )}
                 />
               </div>
@@ -116,7 +116,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
                 <LoadingBlock
                   className={classNames(
                     "h-3 max-w-full",
-                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowIndex],
+                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowIndex]
                   )}
                 />
               </div>
@@ -132,7 +132,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
             <LoadingBlock
               className={classNames(
                 "ml-2 hidden h-3 @xl:block",
-                ["w-20", "w-24", "w-16", "w-28", "w-20"][rowIndex],
+                ["w-20", "w-24", "w-16", "w-28", "w-20"][rowIndex]
               )}
             />
           </div>
@@ -144,7 +144,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-6 rounded-[9px]",
-              ["w-20", "w-24", "w-20", "w-24", "w-20"][rowIndex],
+              ["w-20", "w-24", "w-20", "w-24", "w-20"][rowIndex]
             )}
           />
         </DataTable.CellContent>
@@ -168,7 +168,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3 max-w-full",
-              ["w-14", "w-20", "w-12", "w-24", "w-16"][rowIndex],
+              ["w-14", "w-20", "w-12", "w-24", "w-16"][rowIndex]
             )}
           />
         </DataTable.CellContent>
@@ -180,7 +180,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3",
-              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowIndex],
+              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowIndex]
             )}
           />
         </DataTable.CellContent>
@@ -191,7 +191,7 @@ function renderAssistantsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3",
-              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowIndex],
+              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowIndex]
             )}
           />
         </DataTable.CellContent>
@@ -235,7 +235,7 @@ const getTableColumns = ({
       header: (info: HeaderContext<RowData, boolean>) => {
         const areAllPageRowsSelected = info.table.getIsAllPageRowsSelected();
         const hasSelection = Object.values(
-          info.table.getState().rowSelection,
+          info.table.getState().rowSelection
         ).some((isSelected) => isSelected);
 
         return (
@@ -528,7 +528,7 @@ type AssistantsTableProps = {
   agents: LightAgentConfigurationType[];
   setDetailedAgentId: (sId: string) => void;
   handleToggleAgentStatus: (
-    agent: LightAgentConfigurationType,
+    agent: LightAgentConfigurationType
   ) => Promise<void>;
   showDisabledFreeWorkspacePopup: string | null;
   setShowDisabledFreeWorkspacePopup: (s: string | null) => void;
@@ -560,7 +560,7 @@ export function AssistantsTable({
         tags: sortedTags,
         mutateAgentConfigurations,
       }),
-    [owner, sortedTags],
+    [owner, sortedTags]
   );
   const skeletonColumns = useMemo(
     () =>
@@ -569,7 +569,7 @@ export function AssistantsTable({
         cell: (info: CellContext<RowData, unknown>) =>
           renderAssistantsTableSkeletonCell(info.column.id, info.row.index),
       })),
-    [columns],
+    [columns]
   );
 
   const { isDark } = useTheme();
@@ -594,7 +594,7 @@ export function AssistantsTable({
   // selecting an agent does not change the rows, which would reset pagination.
   const rowSelection = useMemo(
     () => Object.fromEntries(selection.map((agentId) => [agentId, true])),
-    [selection],
+    [selection]
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -665,7 +665,7 @@ export function AssistantsTable({
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       void router.push(
-                        getAgentBuilderRoute(owner.sId, agentConfiguration.sId),
+                        getAgentBuilderRoute(owner.sId, agentConfiguration.sId)
                       );
                     },
                     kind: "item" as const,
@@ -678,7 +678,7 @@ export function AssistantsTable({
                     onClick: (e: React.MouseEvent) => {
                       e.stopPropagation();
                       void navigator.clipboard.writeText(
-                        agentConfiguration.sId,
+                        agentConfiguration.sId
                       );
                     },
                     kind: "item" as const,
@@ -705,8 +705,8 @@ export function AssistantsTable({
                         getAgentBuilderRoute(
                           owner.sId,
                           "new",
-                          `duplicate=${agentConfiguration.sId}`,
-                        ),
+                          `duplicate=${agentConfiguration.sId}`
+                        )
                       );
                     },
                     kind: "item" as const,
@@ -738,14 +738,14 @@ export function AssistantsTable({
       showDisabledFreeWorkspacePopup,
       isDark,
       canCreateAgent,
-    ],
+    ]
   );
 
   const selectionSet = useMemo(() => new Set(selection), [selection]);
 
   const selectableRowIds = useMemo(
     () => rows.filter((row) => row.canArchive).map((row) => row.sId),
-    [rows],
+    [rows]
   );
   const totalSelectableCount = selectableRowIds.length;
 
@@ -753,7 +753,7 @@ export function AssistantsTable({
   // checkbox), so no extra filtering is needed here.
   const selectedAgents = useMemo(
     () => agents.filter((a) => selectionSet.has(a.sId)),
-    [agents, selectionSet],
+    [agents, selectionSet]
   );
 
   return (
@@ -806,8 +806,8 @@ export function AssistantsTable({
               setRowSelection={(newRowSelection) => {
                 setSelection(
                   Object.keys(newRowSelection).filter(
-                    (agentId) => newRowSelection[agentId],
-                  ),
+                    (agentId) => newRowSelection[agentId]
+                  )
                 );
               }}
             />

--- a/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsAutomationsPage.tsx
@@ -5,8 +5,13 @@ import { ConsumptionPeriodSelector } from "@app/components/workspace/analytics/c
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import { Page } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function AnalyticsAutomationsPage() {
   const owner = useWorkspace();
@@ -14,6 +19,15 @@ export function AnalyticsAutomationsPage() {
     DEFAULT_CONSUMPTION_PERIOD
   );
   const [filter, setFilter] = useState<AutomationsFilter>({});
+
+  useEffect(() => {
+    trackEvent({
+      area: TRACKING_AREAS.ANALYTICS,
+      object: "automations_page",
+      action: TRACKING_ACTIONS.VIEW,
+      extra: { workspace_id: owner.sId },
+    });
+  }, [owner.sId]);
 
   return (
     <Page.Vertical align="stretch" gap="xl">

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -27,6 +27,11 @@ import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
+import {
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  trackEvent,
+} from "@app/lib/tracking";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   cn,
@@ -37,7 +42,7 @@ import {
 } from "@dust-tt/sparkle";
 import { domMax, LazyMotion, m, useReducedMotion } from "framer-motion";
 import type { ComponentType } from "react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const canReload = () => !isNavigationLocked();
 
@@ -120,6 +125,15 @@ export function AnalyticsConsumptionPage() {
     period: state.period,
     filter: state.filter,
   });
+
+  useEffect(() => {
+    trackEvent({
+      area: TRACKING_AREAS.ANALYTICS,
+      object: "consumption_page",
+      action: TRACKING_ACTIONS.VIEW,
+      extra: { workspace_id: owner.sId },
+    });
+  }, [owner.sId]);
 
   return (
     <AnalyticsConsumptionContent owner={owner} state={{ ...state, filter }} />

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -130,19 +130,6 @@ export function AnalyticsConsumptionPage() {
     filter: state.filter,
   });
 
-  const trackClick = (clickTarget: string, extra?: TrackingExtra) => {
-    trackEvent({
-      area: TRACKING_AREAS.ANALYTICS,
-      object: "analytics_page",
-      action: TRACKING_ACTIONS.CLICK,
-      extra: {
-        ...extra,
-        workspace_id: owner.sId,
-        click_target: clickTarget,
-      },
-    });
-  };
-
   useEffect(() => {
     trackEvent({
       area: TRACKING_AREAS.ANALYTICS,
@@ -153,11 +140,7 @@ export function AnalyticsConsumptionPage() {
   }, [owner.sId]);
 
   return (
-    <AnalyticsConsumptionContent
-      owner={owner}
-      state={{ ...state, filter }}
-      onTrackClick={trackClick}
-    />
+    <AnalyticsConsumptionContent owner={owner} state={{ ...state, filter }} />
   );
 }
 
@@ -165,7 +148,6 @@ interface AnalyticsConsumptionContentProps {
   components?: AnalyticsConsumptionComponents;
   embedded?: boolean;
   owner: LightWorkspaceType;
-  onTrackClick?: (clickTarget: string, extra?: TrackingExtra) => void;
   showExport?: boolean;
   showMemberGroupFilter?: boolean;
   showOverviewError?: boolean;
@@ -179,7 +161,6 @@ export function AnalyticsConsumptionContent({
   components = WORKSPACE_CONSUMPTION_COMPONENTS,
   embedded = false,
   owner,
-  onTrackClick,
   showExport = true,
   showMemberGroupFilter = true,
   showOverviewError = false,
@@ -206,15 +187,32 @@ export function AnalyticsConsumptionContent({
     UsageFilterPanel: UsageFilterPanelComponent,
   } = components;
 
+  function trackAnalyticsClick(clickTarget: string, extra?: TrackingExtra) {
+    if (embedded) {
+      return;
+    }
+
+    trackEvent({
+      area: TRACKING_AREAS.ANALYTICS,
+      object: "analytics_page",
+      action: TRACKING_ACTIONS.CLICK,
+      extra: {
+        ...extra,
+        workspace_id: owner.sId,
+        click_target: clickTarget,
+      },
+    });
+  }
+
   const handlePeriodChange = (nextPeriod: ConsumptionPeriodSelection) => {
-    onTrackClick?.("period_selector", {
+    trackAnalyticsClick("period_selector", {
       period: consumptionPeriodKey(nextPeriod),
     });
     setPeriod(nextPeriod);
   };
 
   const handleFilterChange = (nextFilter: UsageFilter) => {
-    onTrackClick?.("filter", { filter_action: "apply" });
+    trackAnalyticsClick("filter", { filter_action: "apply" });
     setFilter(nextFilter);
   };
 
@@ -269,7 +267,7 @@ export function AnalyticsConsumptionContent({
               onFilterChange={handleFilterChange}
               onOpenChange={(open) => {
                 if (open) {
-                  onTrackClick?.("filter", { filter_action: "open" });
+                  trackAnalyticsClick("filter", { filter_action: "open" });
                 }
               }}
               showMemberGroupFilter={showMemberGroupFilter}
@@ -278,7 +276,7 @@ export function AnalyticsConsumptionContent({
           <UsageFilterSummary
             filter={filter}
             onFilterChange={(nextFilter) => {
-              onTrackClick?.("filter", { filter_action: "clear" });
+              trackAnalyticsClick("filter", { filter_action: "clear" });
               setFilter(nextFilter);
             }}
           />
@@ -298,7 +296,7 @@ export function AnalyticsConsumptionContent({
                 dimension={dimension}
                 filter={scopeFilter}
                 onModeChange={(mode) => {
-                  onTrackClick?.("chart_mode", { mode });
+                  trackAnalyticsClick("chart_mode", { mode });
                 }}
               />
             </SafeSuspense>
@@ -311,7 +309,7 @@ export function AnalyticsConsumptionContent({
         period={period}
         filter={scopeFilter}
         onAddFilter={(selectedRow) => {
-          onTrackClick?.("attribution_filter", {
+          trackAnalyticsClick("attribution_filter", {
             dimension,
             filter_action: "add",
           });
@@ -320,7 +318,7 @@ export function AnalyticsConsumptionContent({
           );
         }}
         onRemoveFilter={(selectedRow) => {
-          onTrackClick?.("attribution_filter", {
+          trackAnalyticsClick("attribution_filter", {
             dimension,
             filter_action: "remove",
           });
@@ -330,11 +328,11 @@ export function AnalyticsConsumptionContent({
         }}
         dimension={dimension}
         onDimensionChange={(nextDimension) => {
-          onTrackClick?.("attribution_tab", { dimension: nextDimension });
+          trackAnalyticsClick("attribution_tab", { dimension: nextDimension });
           handleDimensionChange(nextDimension);
         }}
         onViewAll={(nextDimension, selectedRow) => {
-          onTrackClick?.("attribution_view_all", {
+          trackAnalyticsClick("attribution_view_all", {
             dimension: nextDimension,
           });
           setFilter((current) =>

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -74,6 +74,27 @@ const WORKSPACE_CONSUMPTION_COMPONENTS: AnalyticsConsumptionComponents = {
   UsageFilterPanel,
 };
 
+function trackAnalyticsClick(
+  workspaceId: string | null,
+  clickTarget: string,
+  extra?: TrackingExtra
+) {
+  if (!workspaceId) {
+    return;
+  }
+
+  trackEvent({
+    area: TRACKING_AREAS.ANALYTICS,
+    object: "analytics_page",
+    action: TRACKING_ACTIONS.CLICK,
+    extra: {
+      ...extra,
+      workspace_id: workspaceId,
+      click_target: clickTarget,
+    },
+  });
+}
+
 interface ChartFallbackProps {
   controlsInCard?: boolean;
 }
@@ -186,33 +207,19 @@ export function AnalyticsConsumptionContent({
     Summary: SummaryComponent,
     UsageFilterPanel: UsageFilterPanelComponent,
   } = components;
-
-  function trackAnalyticsClick(clickTarget: string, extra?: TrackingExtra) {
-    if (embedded) {
-      return;
-    }
-
-    trackEvent({
-      area: TRACKING_AREAS.ANALYTICS,
-      object: "analytics_page",
-      action: TRACKING_ACTIONS.CLICK,
-      extra: {
-        ...extra,
-        workspace_id: owner.sId,
-        click_target: clickTarget,
-      },
-    });
-  }
+  const trackingWorkspaceId = embedded ? null : owner.sId;
 
   const handlePeriodChange = (nextPeriod: ConsumptionPeriodSelection) => {
-    trackAnalyticsClick("period_selector", {
+    trackAnalyticsClick(trackingWorkspaceId, "period_selector", {
       period: consumptionPeriodKey(nextPeriod),
     });
     setPeriod(nextPeriod);
   };
 
   const handleFilterChange = (nextFilter: UsageFilter) => {
-    trackAnalyticsClick("filter", { filter_action: "apply" });
+    trackAnalyticsClick(trackingWorkspaceId, "filter", {
+      filter_action: "apply",
+    });
     setFilter(nextFilter);
   };
 
@@ -267,7 +274,9 @@ export function AnalyticsConsumptionContent({
               onFilterChange={handleFilterChange}
               onOpenChange={(open) => {
                 if (open) {
-                  trackAnalyticsClick("filter", { filter_action: "open" });
+                  trackAnalyticsClick(trackingWorkspaceId, "filter", {
+                    filter_action: "open",
+                  });
                 }
               }}
               showMemberGroupFilter={showMemberGroupFilter}
@@ -276,7 +285,9 @@ export function AnalyticsConsumptionContent({
           <UsageFilterSummary
             filter={filter}
             onFilterChange={(nextFilter) => {
-              trackAnalyticsClick("filter", { filter_action: "clear" });
+              trackAnalyticsClick(trackingWorkspaceId, "filter", {
+                filter_action: "clear",
+              });
               setFilter(nextFilter);
             }}
           />
@@ -296,7 +307,9 @@ export function AnalyticsConsumptionContent({
                 dimension={dimension}
                 filter={scopeFilter}
                 onModeChange={(mode) => {
-                  trackAnalyticsClick("chart_mode", { mode });
+                  trackAnalyticsClick(trackingWorkspaceId, "chart_mode", {
+                    mode,
+                  });
                 }}
               />
             </SafeSuspense>
@@ -309,7 +322,7 @@ export function AnalyticsConsumptionContent({
         period={period}
         filter={scopeFilter}
         onAddFilter={(selectedRow) => {
-          trackAnalyticsClick("attribution_filter", {
+          trackAnalyticsClick(trackingWorkspaceId, "attribution_filter", {
             dimension,
             filter_action: "add",
           });
@@ -318,7 +331,7 @@ export function AnalyticsConsumptionContent({
           );
         }}
         onRemoveFilter={(selectedRow) => {
-          trackAnalyticsClick("attribution_filter", {
+          trackAnalyticsClick(trackingWorkspaceId, "attribution_filter", {
             dimension,
             filter_action: "remove",
           });
@@ -328,11 +341,13 @@ export function AnalyticsConsumptionContent({
         }}
         dimension={dimension}
         onDimensionChange={(nextDimension) => {
-          trackAnalyticsClick("attribution_tab", { dimension: nextDimension });
+          trackAnalyticsClick(trackingWorkspaceId, "attribution_tab", {
+            dimension: nextDimension,
+          });
           handleDimensionChange(nextDimension);
         }}
         onViewAll={(nextDimension, selectedRow) => {
-          trackAnalyticsClick("attribution_view_all", {
+          trackAnalyticsClick(trackingWorkspaceId, "attribution_view_all", {
             dimension: nextDimension,
           });
           setFilter((current) =>

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -24,9 +24,13 @@ import { useAnalyticsViewState } from "@app/hooks/useAnalyticsViewState";
 import { useQueryParams } from "@app/hooks/useQueryParams";
 import { useResolvedUsageFilter } from "@app/hooks/useResolvedUsageFilter";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
-import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
+import {
+  consumptionPeriodKey,
+  DEFAULT_CONSUMPTION_PERIOD,
+} from "@app/lib/analytics/consumption_period";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { isNavigationLocked } from "@app/lib/navigation-lock";
+import type { TrackingExtra } from "@app/lib/tracking";
 import {
   TRACKING_ACTIONS,
   TRACKING_AREAS,
@@ -126,6 +130,19 @@ export function AnalyticsConsumptionPage() {
     filter: state.filter,
   });
 
+  const trackClick = (clickTarget: string, extra?: TrackingExtra) => {
+    trackEvent({
+      area: TRACKING_AREAS.ANALYTICS,
+      object: "analytics_page",
+      action: TRACKING_ACTIONS.CLICK,
+      extra: {
+        ...extra,
+        workspace_id: owner.sId,
+        click_target: clickTarget,
+      },
+    });
+  };
+
   useEffect(() => {
     trackEvent({
       area: TRACKING_AREAS.ANALYTICS,
@@ -136,7 +153,11 @@ export function AnalyticsConsumptionPage() {
   }, [owner.sId]);
 
   return (
-    <AnalyticsConsumptionContent owner={owner} state={{ ...state, filter }} />
+    <AnalyticsConsumptionContent
+      owner={owner}
+      state={{ ...state, filter }}
+      onTrackClick={trackClick}
+    />
   );
 }
 
@@ -144,6 +165,7 @@ interface AnalyticsConsumptionContentProps {
   components?: AnalyticsConsumptionComponents;
   embedded?: boolean;
   owner: LightWorkspaceType;
+  onTrackClick?: (clickTarget: string, extra?: TrackingExtra) => void;
   showExport?: boolean;
   showMemberGroupFilter?: boolean;
   showOverviewError?: boolean;
@@ -157,6 +179,7 @@ export function AnalyticsConsumptionContent({
   components = WORKSPACE_CONSUMPTION_COMPONENTS,
   embedded = false,
   owner,
+  onTrackClick,
   showExport = true,
   showMemberGroupFilter = true,
   showOverviewError = false,
@@ -183,6 +206,18 @@ export function AnalyticsConsumptionContent({
     UsageFilterPanel: UsageFilterPanelComponent,
   } = components;
 
+  const handlePeriodChange = (nextPeriod: ConsumptionPeriodSelection) => {
+    onTrackClick?.("period_selector", {
+      period: consumptionPeriodKey(nextPeriod),
+    });
+    setPeriod(nextPeriod);
+  };
+
+  const handleFilterChange = (nextFilter: UsageFilter) => {
+    onTrackClick?.("filter", { filter_action: "apply" });
+    setFilter(nextFilter);
+  };
+
   const header = embedded ? (
     <div className="flex w-full flex-col gap-4 sm:flex-row sm:justify-between">
       <div className="flex flex-row flex-wrap items-center gap-2">
@@ -192,7 +227,10 @@ export function AnalyticsConsumptionContent({
           showError={showOverviewError}
         />
       </div>
-      <ConsumptionPeriodSelector period={period} onPeriodChange={setPeriod} />
+      <ConsumptionPeriodSelector
+        period={period}
+        onPeriodChange={handlePeriodChange}
+      />
     </div>
   ) : (
     <div className="flex w-full flex-row justify-between">
@@ -200,7 +238,10 @@ export function AnalyticsConsumptionContent({
         <Page.H variant="h3">{title}</Page.H>
         <OverviewComponent workspaceId={owner.sId} period={period} />
       </div>
-      <ConsumptionPeriodSelector period={period} onPeriodChange={setPeriod} />
+      <ConsumptionPeriodSelector
+        period={period}
+        onPeriodChange={handlePeriodChange}
+      />
     </div>
   );
 
@@ -225,11 +266,22 @@ export function AnalyticsConsumptionContent({
               owner={owner}
               period={period}
               filter={filter}
-              onFilterChange={setFilter}
+              onFilterChange={handleFilterChange}
+              onOpenChange={(open) => {
+                if (open) {
+                  onTrackClick?.("filter", { filter_action: "open" });
+                }
+              }}
               showMemberGroupFilter={showMemberGroupFilter}
             />
           </div>
-          <UsageFilterSummary filter={filter} onFilterChange={setFilter} />
+          <UsageFilterSummary
+            filter={filter}
+            onFilterChange={(nextFilter) => {
+              onTrackClick?.("filter", { filter_action: "clear" });
+              setFilter(nextFilter);
+            }}
+          />
         </div>
         <LazyMotion features={domMax}>
           <m.div
@@ -245,6 +297,9 @@ export function AnalyticsConsumptionContent({
                 period={period}
                 dimension={dimension}
                 filter={scopeFilter}
+                onModeChange={(mode) => {
+                  onTrackClick?.("chart_mode", { mode });
+                }}
               />
             </SafeSuspense>
           </m.div>
@@ -256,18 +311,32 @@ export function AnalyticsConsumptionContent({
         period={period}
         filter={scopeFilter}
         onAddFilter={(selectedRow) => {
+          onTrackClick?.("attribution_filter", {
+            dimension,
+            filter_action: "add",
+          });
           setFilter((current) =>
             addUsageFilterFromAttributionRow(current, dimension, selectedRow)
           );
         }}
         onRemoveFilter={(selectedRow) => {
+          onTrackClick?.("attribution_filter", {
+            dimension,
+            filter_action: "remove",
+          });
           setFilter((current) =>
             removeUsageFilterFromAttributionRow(current, dimension, selectedRow)
           );
         }}
         dimension={dimension}
-        onDimensionChange={handleDimensionChange}
+        onDimensionChange={(nextDimension) => {
+          onTrackClick?.("attribution_tab", { dimension: nextDimension });
+          handleDimensionChange(nextDimension);
+        }}
         onViewAll={(nextDimension, selectedRow) => {
+          onTrackClick?.("attribution_view_all", {
+            dimension: nextDimension,
+          });
           setFilter((current) =>
             setUsageFilterFromAttributionRow(current, dimension, selectedRow)
           );

--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -129,7 +129,7 @@ export function AnalyticsConsumptionPage() {
   useEffect(() => {
     trackEvent({
       area: TRACKING_AREAS.ANALYTICS,
-      object: "consumption_page",
+      object: "analytics_page",
       action: TRACKING_ACTIONS.VIEW,
       extra: { workspace_id: owner.sId },
     });

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -37,7 +37,7 @@ import { useMemo, useState } from "react";
 // skill can only be batch-edited by someone who can make skills auto-discoverable.
 export function isSkillSelectable(
   skill: { editedBy: number | null; availability: SkillAvailability },
-  canMakeSkillAutoDiscoverable: boolean,
+  canMakeSkillAutoDiscoverable: boolean
 ): boolean {
   return (
     !isDustProvidedSkill(skill) &&
@@ -77,7 +77,7 @@ const SKILLS_TABLE_SKELETON_ROWS: RowData[] = Array.from(
     createdAt: null,
     onClick: () => undefined,
     menuItems: [],
-  }),
+  })
 );
 
 function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
@@ -98,7 +98,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
                 <LoadingBlock
                   className={classNames(
                     "h-3 max-w-full",
-                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowIndex],
+                    ["w-32", "w-40", "w-28", "w-36", "w-44"][rowIndex]
                   )}
                 />
               </div>
@@ -106,7 +106,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
                 <LoadingBlock
                   className={classNames(
                     "h-3 max-w-full",
-                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowIndex],
+                    ["w-56", "w-64", "w-48", "w-60", "w-52"][rowIndex]
                   )}
                 />
               </div>
@@ -120,7 +120,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-6 rounded-[9px]",
-              ["w-20", "w-28", "w-24", "w-28", "w-20"][rowIndex],
+              ["w-20", "w-28", "w-24", "w-28", "w-20"][rowIndex]
             )}
           />
         </DataTable.CellContent>
@@ -131,7 +131,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-5 rounded-md",
-              ["w-14", "w-16", "w-12", "w-20", "w-14"][rowIndex],
+              ["w-14", "w-16", "w-12", "w-20", "w-14"][rowIndex]
             )}
           />
         </div>
@@ -142,7 +142,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3",
-              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowIndex],
+              ["w-7", "w-9", "w-6", "w-8", "w-10"][rowIndex]
             )}
           />
         </DataTable.CellContent>
@@ -166,7 +166,7 @@ function renderSkillsTableSkeletonCell(columnId: string, rowIndex: number) {
           <LoadingBlock
             className={classNames(
               "h-3",
-              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowIndex],
+              ["w-14", "w-16", "w-20", "w-16", "w-14"][rowIndex]
             )}
           />
         </DataTable.CellContent>
@@ -281,7 +281,7 @@ const editorsColumn = {
 
 const usedByColumn = (
   onAgentClick: (agentId: string) => void,
-  onUsedBySkillClick: (skillId: string) => void,
+  onUsedBySkillClick: (skillId: string) => void
 ): ColumnDef<RowData, number> => ({
   id: "usedBy",
   header: () => <div className="flex w-full justify-center">Used by</div>,
@@ -354,7 +354,7 @@ const selectionColumn = {
   header: (info: HeaderContext<RowData, boolean>) => {
     const areAllPageRowsSelected = info.table.getIsAllPageRowsSelected();
     const hasSelection = Object.values(info.table.getState().rowSelection).some(
-      (isSelected) => isSelected,
+      (isSelected) => isSelected
     );
 
     return (
@@ -454,7 +454,7 @@ type SkillsTableProps = {
   skills: GetSkillsWithRelationsResponseBody["skills"];
   owner: LightWorkspaceType;
   onSkillClick: (
-    skill: GetSkillsWithRelationsResponseBody["skills"][number],
+    skill: GetSkillsWithRelationsResponseBody["skills"][number]
   ) => void;
   onAgentClick: (agentId: string) => void;
   onUsedBySkillClick: (skillId: string) => void;
@@ -496,7 +496,7 @@ export function SkillsTable({
         onUsedBySkillClick,
         enableSelection,
       }),
-    [onAgentClick, onUsedBySkillClick, enableSelection],
+    [onAgentClick, onUsedBySkillClick, enableSelection]
   );
   const skeletonColumns = useMemo(
     () =>
@@ -505,7 +505,7 @@ export function SkillsTable({
         cell: (info: CellContext<RowData, unknown>) =>
           renderSkillsTableSkeletonCell(info.column.id, info.row.index),
       })),
-    [columns],
+    [columns]
   );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: ignored using `--suppress`
@@ -536,7 +536,7 @@ export function SkillsTable({
                   onClick: (e: React.MouseEvent) => {
                     e.stopPropagation();
                     void router.push(
-                      getSkillBuilderRoute(owner.sId, skill.sId),
+                      getSkillBuilderRoute(owner.sId, skill.sId)
                     );
                   },
                   kind: "item" as const,
@@ -565,12 +565,12 @@ export function SkillsTable({
             : [],
       })),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- router is not stable, mutating the skills list which prevent pagination to work
-    [skills, onSkillClick, owner.sId],
+    [skills, onSkillClick, owner.sId]
   );
 
   const selectionSet = useMemo(
     () => new Set(Object.keys(rowSelection)),
-    [rowSelection],
+    [rowSelection]
   );
 
   const selectableRowIds = useMemo(
@@ -578,13 +578,13 @@ export function SkillsTable({
       rows
         .filter((row) => isSkillSelectable(row, canMakeSkillAutoDiscoverable))
         .map((row) => row.sId),
-    [rows, canMakeSkillAutoDiscoverable],
+    [rows, canMakeSkillAutoDiscoverable]
   );
   const totalSelectableCount = selectableRowIds.length;
 
   const skillsBySId = useMemo(
     () => new Map(skills.map((skill) => [skill.sId, skill])),
-    [skills],
+    [skills]
   );
 
   const selectedSkills = useMemo(
@@ -593,9 +593,9 @@ export function SkillsTable({
         .filter((sId) => selectionSet.has(sId))
         .map((sId) => skillsBySId.get(sId))
         .filter(
-          (s): s is GetSkillsWithRelationsResponseBody["skills"][number] => !!s,
+          (s): s is GetSkillsWithRelationsResponseBody["skills"][number] => !!s
         ),
-    [selectableRowIds, selectionSet, skillsBySId],
+    [selectableRowIds, selectionSet, skillsBySId]
   );
 
   if (!isLoading && rows.length === 0) {
@@ -651,7 +651,7 @@ export function SkillsTable({
                   enableRowSelection: (row: Row<RowData>) =>
                     isSkillSelectable(
                       row.original,
-                      canMakeSkillAutoDiscoverable,
+                      canMakeSkillAutoDiscoverable
                     ),
                   getRowId: (row: RowData) => row.sId,
                 }
@@ -669,7 +669,7 @@ export function SkillsTable({
           onClear={() => setRowSelection({})}
           onSelectAll={() =>
             setRowSelection(
-              Object.fromEntries(selectableRowIds.map((sId) => [sId, true])),
+              Object.fromEntries(selectableRowIds.map((sId) => [sId, true]))
             )
           }
           onSelectAction={onSelectAvailabilityAction}

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -50,6 +50,7 @@ export interface UsageFilterPanelProps {
   filter: UsageFilter;
   analyticsScope?: ConsumptionAnalyticsScope;
   onFilterChange: (next: UsageFilter) => void;
+  onOpenChange?: (open: boolean) => void;
   showMemberGroupFilter?: boolean;
 }
 
@@ -59,6 +60,7 @@ export function UsageFilterPanel({
   filter,
   analyticsScope = WORKSPACE_CONSUMPTION_ANALYTICS_SCOPE,
   onFilterChange,
+  onOpenChange,
   showMemberGroupFilter = true,
 }: UsageFilterPanelProps) {
   const categories = getUsageFilterCategories(analyticsScope);
@@ -87,6 +89,7 @@ export function UsageFilterPanel({
     <UsageFilterPanelView
       filter={filter}
       onFilterChange={onFilterChange}
+      onOpenChange={onOpenChange}
       showMemberGroupFilter={shouldShowMemberGroupFilter}
       categories={categories}
       state={state}
@@ -185,6 +188,7 @@ export function useUsageFilterPanelState({
 interface UsageFilterPanelViewProps {
   filter: UsageFilter;
   onFilterChange: (next: UsageFilter) => void;
+  onOpenChange?: (open: boolean) => void;
   showMemberGroupFilter: boolean;
   categories?: readonly UsageFilterCategory[];
   state: ReturnType<typeof useUsageFilterPanelState>;
@@ -197,6 +201,7 @@ interface UsageFilterPanelViewProps {
 export function UsageFilterPanelView({
   filter,
   onFilterChange,
+  onOpenChange,
   showMemberGroupFilter,
   categories = USAGE_FILTER_CATEGORIES,
   state,
@@ -298,6 +303,7 @@ export function UsageFilterPanelView({
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
+    onOpenChange?.(open);
     if (open) {
       setDraftFilter(filter);
       setSearchText("");

--- a/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionChart.tsx
@@ -354,6 +354,7 @@ export interface ConsumptionChartProps {
   filter?: ConsumptionScopeFilter;
   analyticsScope?: ConsumptionAnalyticsScope;
   disabled?: boolean;
+  onModeChange?: (mode: ConsumptionTimeseriesMode) => void;
 }
 
 function WorkspaceConsumptionDailyChart({
@@ -443,8 +444,14 @@ export function ConsumptionChart({
   filter,
   analyticsScope,
   disabled,
+  onModeChange,
 }: ConsumptionChartProps) {
   const [mode, setMode] = useState<ConsumptionTimeseriesMode>("daily");
+
+  const handleModeChange = (nextMode: ConsumptionTimeseriesMode) => {
+    onModeChange?.(nextMode);
+    setMode(nextMode);
+  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -454,12 +461,12 @@ export function ConsumptionChart({
           <ButtonsSwitch
             value="daily"
             label="Daily"
-            onClick={() => setMode("daily")}
+            onClick={() => handleModeChange("daily")}
           />
           <ButtonsSwitch
             value="cumulative"
             label="Cumulative"
-            onClick={() => setMode("cumulative")}
+            onClick={() => handleModeChange("cumulative")}
           />
         </ButtonsSwitchList>
       </div>

--- a/front/lib/tracking.ts
+++ b/front/lib/tracking.ts
@@ -43,6 +43,7 @@ export const TRACKING_AREAS = {
   SETTINGS: "settings",
 
   // Features
+  ANALYTICS: "analytics",
   ACADEMY: "academy",
   BUILDER: "builder",
   SPACES: "spaces",
@@ -72,6 +73,7 @@ export const TRACKING_ACTIONS = {
   SELECT: "select",
   OPEN: "open",
   CLOSE: "close",
+  VIEW: "view",
 } as const;
 
 export type TrackingAction =


### PR DESCRIPTION
## Description

Add PostHog view tracking across the analytics surfaces.
Starting with a broad pass, we can iterate later to deep dive on specific UX flows.

The workspace consumption and automations pages, personal analytics view, conversation credit breakdown, and message credit breakdown now emit analytics view events when they become visible. Events include the workspace ID, the convo and message ID when relevant.

## Tests

- Updated existing tests.

## Risk

- Low. Adds client-side analytics events only.

## Deploy Plan

- Deploy front.