### PR TITLE
[front] Classify LLM HTTP errors in one place and drop redundant providerId from logs

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -369,7 +369,6 @@ export abstract class LLM<
         const durationMs = Date.now() - startTime;
         const { tokenUsage, ...rest } = buffer.currentOutput;
         const timingLogFields = llmAttemptLogFields({
-          providerId: this.modelConfig.providerId,
           durationMs,
           timeToFirstEventMs,
           timeToFirstTokenMs,
@@ -795,7 +794,6 @@ export abstract class LLM<
               errorType,
               errorSource,
               ...llmAttemptLogFields({
-                providerId: this.modelConfig.providerId,
                 requestedReasoningEffort: this.reasoningEffort,
                 surface: "batch",
               }),

--- a/front/lib/api/llm/run_lifecycle.test.ts
+++ b/front/lib/api/llm/run_lifecycle.test.ts
@@ -607,7 +607,6 @@ describe("LLM stream telemetry", () => {
     expect(info).toHaveBeenCalledWith(
       expect.objectContaining({
         llmEventType: "success",
-        providerId: "noop",
         surface: "stream",
         durationMs: expect.any(Number),
         timeToFirstEventMs: expect.any(Number),
@@ -659,7 +658,6 @@ describe("LLM stream telemetry", () => {
         llmEventType: "error",
         errorType: "overloaded_error",
         errorSource: "provider",
-        providerId: "noop",
         surface: "stream",
         durationMs: expect.any(Number),
       }),
@@ -778,7 +776,6 @@ describe("LLM stream telemetry", () => {
     expect(warn).toHaveBeenCalledWith(
       expect.objectContaining({
         llmEventType: "success_without_usage",
-        providerId: "noop",
         surface: "stream",
         durationMs: expect.any(Number),
       }),
@@ -943,7 +940,6 @@ describe("LLM batch telemetry", () => {
         errorType: "overloaded_error",
         errorSource: "provider",
         surface: "batch",
-        providerId: "noop",
       }),
       "LLM Error"
     );

--- a/front/lib/api/llm/telemetry.ts
+++ b/front/lib/api/llm/telemetry.ts
@@ -5,10 +5,7 @@
 import type { LLMErrorType } from "@app/lib/api/llm/types/errors";
 import type { ErrorSource } from "@app/lib/model_constructors/types/output/events";
 import { statsDMetrics } from "@app/lib/utils/statsd";
-import type {
-  ModelProviderIdType,
-  ReasoningEffort,
-} from "@app/types/assistant/models/types";
+import type { ReasoningEffort } from "@app/types/assistant/models/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type LLMTelemetrySurface = "stream" | "batch";
@@ -88,21 +85,18 @@ export function emitLLMTimeToFirstTokenMs(
 }
 
 export function llmAttemptLogFields({
-  providerId,
   durationMs,
   timeToFirstEventMs,
   timeToFirstTokenMs,
   requestedReasoningEffort,
   surface,
 }: {
-  providerId: ModelProviderIdType;
   durationMs?: number;
   timeToFirstEventMs?: number;
   timeToFirstTokenMs?: number;
   requestedReasoningEffort: ReasoningEffort | null;
   surface: LLMTelemetrySurface;
 }): {
-  providerId: ModelProviderIdType;
   durationMs?: number;
   timeToFirstEventMs?: number;
   timeToFirstTokenMs?: number;
@@ -110,7 +104,6 @@ export function llmAttemptLogFields({
   surface: LLMTelemetrySurface;
 } {
   return {
-    providerId,
     ...(durationMs !== undefined ? { durationMs } : {}),
     ...(timeToFirstEventMs !== undefined ? { timeToFirstEventMs } : {}),
     ...(timeToFirstTokenMs !== undefined ? { timeToFirstTokenMs } : {}),

--- a/front/lib/model_constructors/batch/clients/google_ai_studio.ts
+++ b/front/lib/model_constructors/batch/clients/google_ai_studio.ts
@@ -12,6 +12,7 @@ import { GOOGLE_AI_STUDIO_HOST } from "@app/lib/model_constructors/types/hosts";
 import { GOOGLE_LAB } from "@app/lib/model_constructors/types/labs";
 import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { buildHttpStatusErrorEvent } from "@app/lib/model_constructors/utils/classify_http_status";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   GenerateContentParameters,
@@ -68,11 +69,11 @@ export abstract class GoogleAiStudioBatch extends WithGoogleGenAIInputConverter(
   rawBatchOutputToEvents(result: InlinedResponse): NonDeltaResponseEvent[] {
     if (result.error) {
       return [
-        buildErrorEvent({
-          errorSource: "provider",
+        buildHttpStatusErrorEvent({
           metadata: this.metadata(),
-          type: "server_error",
-          message:
+          status: result.error.code,
+          provider: "Google",
+          detail:
             result.error.message ?? "The batch request failed without details.",
           originalError: result.error,
         }),
@@ -81,7 +82,7 @@ export abstract class GoogleAiStudioBatch extends WithGoogleGenAIInputConverter(
     if (!result.response) {
       return [
         buildErrorEvent({
-          errorSource: "provider",
+          errorSource: "unknown",
           metadata: this.metadata(),
           type: "unknown_error",
           message:

--- a/front/lib/model_constructors/batch/clients/mistral.ts
+++ b/front/lib/model_constructors/batch/clients/mistral.ts
@@ -11,7 +11,7 @@ import type { Credentials } from "@app/lib/model_constructors/types/credentials"
 import { MISTRAL_HOST } from "@app/lib/model_constructors/types/hosts";
 import { MISTRAL_LAB } from "@app/lib/model_constructors/types/labs";
 import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
-import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { buildHttpStatusErrorEvent } from "@app/lib/model_constructors/utils/classify_http_status";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { Mistral } from "@mistralai/mistralai";
 import type {
@@ -145,12 +145,12 @@ export abstract class MistralBatch extends WithMistralAIInputConverter(
       const { custom_id, response, error } = parsed.data;
       if (error || !response) {
         batchResult.set(custom_id, [
-          buildErrorEvent({
-            errorSource: "provider",
+          buildHttpStatusErrorEvent({
             metadata: this.metadata(),
-            type: "server_error",
-            message:
-              error?.message ?? `No response for custom_id ${custom_id}.`,
+            status: response?.status_code,
+            provider: "Mistral",
+            detail: error?.message ?? `No response for custom_id ${custom_id}.`,
+            originalError: error,
           }),
         ]);
         continue;

--- a/front/lib/model_constructors/batch/clients/openai_responses.ts
+++ b/front/lib/model_constructors/batch/clients/openai_responses.ts
@@ -13,7 +13,7 @@ import type { InputConfig } from "@app/lib/model_constructors/types/input/config
 import { OPENAI_LAB } from "@app/lib/model_constructors/types/labs";
 import type { Model } from "@app/lib/model_constructors/types/models";
 import type { NonDeltaResponseEvent } from "@app/lib/model_constructors/types/output/events";
-import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { buildHttpStatusErrorEvent } from "@app/lib/model_constructors/utils/classify_http_status";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 // Do not remove: front-api routes call into this client for the similar skill
 // and similar agent discovery features. Without an explicit version front-api can silently
@@ -175,12 +175,12 @@ export abstract class OpenAIResponsesBatch extends WithOpenAIResponsesInputConve
       const { custom_id, response, error } = parsed.data;
       if (error || !response) {
         batchResult.set(custom_id, [
-          buildErrorEvent({
-            errorSource: "provider",
+          buildHttpStatusErrorEvent({
             metadata: this.metadata(),
-            type: "server_error",
-            message:
-              error?.message ?? `No response for custom_id ${custom_id}.`,
+            status: response?.status_code,
+            provider: "OpenAI",
+            detail: error?.message ?? `No response for custom_id ${custom_id}.`,
+            originalError: error,
           }),
         ]);
         continue;

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.test.ts
@@ -517,7 +517,7 @@ describe("streamErrorToErrorEvent", () => {
     expect(result.content.originalError).toBe(err);
   });
 
-  it("maps file download failures to server_error", () => {
+  it("maps file download failures to a retryable Dust server_error", () => {
     const err = new APIError(
       400,
       {
@@ -535,7 +535,7 @@ describe("streamErrorToErrorEvent", () => {
       "server_error"
     );
     expect(streamErrorToErrorEvent(metadata, err).content.errorSource).toBe(
-      "provider"
+      "dust"
     );
   });
 
@@ -545,6 +545,8 @@ describe("streamErrorToErrorEvent", () => {
     [401, "authentication_error", "dust"],
     [403, "permission_error", "dust"],
     [404, "not_found_error", "dust"],
+    [413, "invalid_request_error", "dust"],
+    [418, "invalid_request_error", "dust"],
     [429, "rate_limit_error", "dust"],
     [503, "overloaded_error", "provider"],
   ] as const)("maps HTTP %i to %s from %s", (status, expectedType, errorSource) => {
@@ -559,13 +561,6 @@ describe("streamErrorToErrorEvent", () => {
     const result = streamErrorToErrorEvent(metadata, err);
     expect(result.content.type).toBe("server_error");
     expect(result.content.errorSource).toBe("provider");
-  });
-
-  it("maps an unrecognized status to unknown_error", () => {
-    const err = new APIError(418, {}, "teapot", undefined, null);
-    expect(streamErrorToErrorEvent(metadata, err).content.type).toBe(
-      "unknown_error"
-    );
   });
 
   // An `APIError` raised mid-stream from an SSE `error` event carries no HTTP
@@ -1643,7 +1638,11 @@ describe("batchResultToEvents", () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       type: "error",
-      content: { type: "server_error", message: "upstream blew up" },
+      content: {
+        type: "server_error",
+        message: "Server error from Anthropic: upstream blew up",
+        errorSource: "provider",
+      },
     });
   });
 

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -41,6 +41,10 @@ import type {
   ToolCallStartedEvent,
 } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import {
+  buildHttpStatusErrorEvent,
+  httpErrorMessage,
+} from "@app/lib/model_constructors/utils/classify_http_status";
 import logger from "@app/logger/logger";
 import {
   assertNever,
@@ -435,94 +439,35 @@ function classifyStreamError(error: unknown): ClassifiedStreamError {
   return { kind: "unknown" };
 }
 
-// HTTP status is a number, not a union, so the 5xx range stays an `if` in the
-// default branch.
 function apiErrorToErrorEvent(
   metadata: EndpointMetadata,
   error: APIError
 ): ErrorEvent {
+  // Anthropic can intermittently fail to download a signed image URL included in a long agent run and returns HTTP 400 with "Unable to download the file".
+  // Classify only this exact Anthropic diagnostic as a retryable server error.
   if (isAnthropicFileDownloadError(error)) {
     return buildErrorEvent({
-      errorSource: "provider",
+      errorSource: "unknown",
       metadata,
       type: "server_error",
-      message: `Server error from Anthropic: ${error.message}`,
+      message: httpErrorMessage({
+        type: "server_error",
+        provider: "Anthropic",
+        detail: error.message,
+      }),
       originalError: error,
     });
   }
 
   // Mid-stream SSE `error` events surface as an `APIError` with no HTTP status;
   // the old router defaulted those to 500, so mirror that here.
-  const status = error.status ?? 500;
-  switch (status) {
-    case 400:
-    case 422:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "invalid_request_error",
-        message: `Invalid request to Anthropic: ${error.message}`,
-        originalError: error,
-      });
-    case 401:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "authentication_error",
-        message: `Authentication failed for Anthropic: ${error.message}`,
-        originalError: error,
-      });
-    case 403:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "permission_error",
-        message: `Permission denied for Anthropic: ${error.message}`,
-        originalError: error,
-      });
-    case 404:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "not_found_error",
-        message: `Resource not found for Anthropic: ${error.message}`,
-        originalError: error,
-      });
-    case 429:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "rate_limit_error",
-        message: `Rate limit exceeded for Anthropic/${metadata.model}: ${error.message}`,
-        originalError: error,
-      });
-    case 503:
-      return buildErrorEvent({
-        errorSource: "provider",
-        metadata,
-        type: "overloaded_error",
-        message: `Anthropic is overloaded: ${error.message}`,
-        originalError: error,
-      });
-    default:
-      if (status !== undefined && status >= 500 && status < 600) {
-        return buildErrorEvent({
-          errorSource: "provider",
-          metadata,
-          type: "server_error",
-          message: `Server error from Anthropic (${status}): ${error.message}`,
-          originalError: error,
-        });
-      }
-
-      return buildErrorEvent({
-        errorSource: "provider",
-        metadata,
-        type: "unknown_error",
-        message: `Error from Anthropic (${status}): ${error.message}`,
-        originalError: error,
-      });
-  }
+  return buildHttpStatusErrorEvent({
+    metadata,
+    status: error.status ?? 500,
+    provider: "Anthropic",
+    detail: error.message,
+    originalError: error,
+  });
 }
 
 // Maps any error thrown by the Anthropic SDK while streaming into a unified
@@ -1256,6 +1201,30 @@ export function messageToEvents(
   return events;
 }
 
+function classifyAnthropicApiErrorType(errorType: string): {
+  errorSource: ErrorSource;
+  type: ErrorType;
+} {
+  switch (errorType) {
+    case "invalid_request_error":
+      return { errorSource: "dust", type: "invalid_request_error" };
+    case "authentication_error":
+      return { errorSource: "dust", type: "authentication_error" };
+    case "permission_error":
+      return { errorSource: "dust", type: "permission_error" };
+    case "not_found_error":
+      return { errorSource: "dust", type: "not_found_error" };
+    case "rate_limit_error":
+      return { errorSource: "dust", type: "rate_limit_error" };
+    case "overloaded_error":
+      return { errorSource: "provider", type: "overloaded_error" };
+    case "api_error":
+      return { errorSource: "provider", type: "server_error" };
+    default:
+      return { errorSource: "unknown", type: "unknown_error" };
+  }
+}
+
 // Converts a single Anthropic batch result into unified events.
 export function batchResultToEvents(
   result: BetaMessageBatchResult,
@@ -1265,16 +1234,25 @@ export function batchResultToEvents(
   switch (result.type) {
     case "succeeded":
       return messageToEvents(result.message, metadata, converters);
-    case "errored":
+    case "errored": {
+      const { errorSource, type } = classifyAnthropicApiErrorType(
+        result.error.error.type
+      );
       return [
         buildErrorEvent({
-          errorSource: "provider",
+          errorSource,
           metadata,
-          type: "server_error",
-          message: result.error.error.message,
+          type,
+          message: httpErrorMessage({
+            type,
+            provider: "Anthropic",
+            detail: result.error.error.message,
+            model: metadata.model,
+          }),
           originalError: result.error,
         }),
       ];
+    }
     case "canceled":
       return [
         buildErrorEvent({

--- a/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/anthropic_ai/converters/output/utils.ts
@@ -447,7 +447,7 @@ function apiErrorToErrorEvent(
   // Classify only this exact Anthropic diagnostic as a retryable server error.
   if (isAnthropicFileDownloadError(error)) {
     return buildErrorEvent({
-      errorSource: "unknown",
+      errorSource: "dust",
       metadata,
       type: "server_error",
       message: httpErrorMessage({

--- a/front/lib/model_constructors/sdk/google_genai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/google_genai/converters/output/utils.ts
@@ -13,6 +13,10 @@ import type {
   ToolCallStartedEvent,
 } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import {
+  buildHttpStatusErrorEvent,
+  httpErrorMessage,
+} from "@app/lib/model_constructors/utils/classify_http_status";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type {
   GenerateContentResponse,
@@ -242,69 +246,22 @@ function apiErrorToErrorEvent(
       errorSource: "dust",
       metadata,
       type: "authentication_error",
-      message: `Authentication failed for Google: ${error.message}`,
+      message: httpErrorMessage({
+        type: "authentication_error",
+        provider: "Google",
+        detail: error.message,
+      }),
       originalError: error,
     });
   }
-  switch (status) {
-    case 400:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "invalid_request_error",
-        message: `Invalid request to Google: ${error.message}`,
-        originalError: error,
-      });
-    case 403:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "permission_error",
-        message: `Permission denied for Google: ${error.message}`,
-        originalError: error,
-      });
-    case 404:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "not_found_error",
-        message: `Resource not found for Google: ${error.message}`,
-        originalError: error,
-      });
-    case 429:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "rate_limit_error",
-        message: `Rate limit exceeded for Google/${metadata.model}: ${error.message}`,
-        originalError: error,
-      });
-    case 503:
-      return buildErrorEvent({
-        errorSource: "provider",
-        metadata,
-        type: "overloaded_error",
-        message: `Google is overloaded: ${error.message}`,
-        originalError: error,
-      });
-    default:
-      if (status >= 500 && status < 600) {
-        return buildErrorEvent({
-          errorSource: "provider",
-          metadata,
-          type: "server_error",
-          message: `Server error from Google (${status}): ${error.message}`,
-          originalError: error,
-        });
-      }
-      return buildErrorEvent({
-        errorSource: "provider",
-        metadata,
-        type: "unknown_error",
-        message: `Error from Google (${status}): ${error.message}`,
-        originalError: error,
-      });
-  }
+
+  return buildHttpStatusErrorEvent({
+    metadata,
+    status: error.status,
+    provider: "Google",
+    detail: error.message,
+    originalError: error,
+  });
 }
 
 // Maps any error thrown by the Google SDK while streaming into a unified

--- a/front/lib/model_constructors/sdk/mistralai/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/mistralai/converters/output/utils.ts
@@ -9,6 +9,7 @@ import type {
   ToolCallEvent,
 } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { buildHttpStatusErrorEvent } from "@app/lib/model_constructors/utils/classify_http_status";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import { isRecord, isString } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
@@ -69,66 +70,13 @@ export function streamErrorToErrorEvent(
   error: unknown
 ): ErrorEvent {
   if (error instanceof MistralError) {
-    const status = error.statusCode;
-    switch (status) {
-      case 400:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "invalid_request_error",
-          message: `Invalid request to Mistral: ${error.message}`,
-          originalError: error,
-        });
-      case 401:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "authentication_error",
-          message: `Authentication failed for Mistral: ${error.message}`,
-          originalError: error,
-        });
-      case 403:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "permission_error",
-          message: `Permission denied for Mistral: ${error.message}`,
-          originalError: error,
-        });
-      case 404:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "not_found_error",
-          message: `Resource not found for Mistral: ${error.message}`,
-          originalError: error,
-        });
-      case 429:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "rate_limit_error",
-          message: `Rate limit exceeded for Mistral/${metadata.model}: ${error.message}`,
-          originalError: error,
-        });
-      default:
-        if (status >= 500 && status < 600) {
-          return buildErrorEvent({
-            errorSource: "provider",
-            metadata,
-            type: "server_error",
-            message: `Server error from Mistral (${status}): ${error.message}`,
-            originalError: error,
-          });
-        }
-        return buildErrorEvent({
-          errorSource: "provider",
-          metadata,
-          type: "unknown_error",
-          message: `Error from Mistral (${status}): ${error.message}`,
-          originalError: error,
-        });
-    }
+    return buildHttpStatusErrorEvent({
+      metadata,
+      status: error.statusCode,
+      provider: "Mistral",
+      detail: error.message,
+      originalError: error,
+    });
   }
   return buildErrorEvent({
     errorSource: "provider",

--- a/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_completions/converters/output/utils.ts
@@ -8,9 +8,10 @@ import type {
   ToolCallEvent,
 } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { buildHttpStatusErrorEvent } from "@app/lib/model_constructors/utils/classify_http_status";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { isNumber, isRecord, isString } from "@app/types/shared/utils/general";
+import { isRecord, isString } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import { APIError } from "openai";
 import type { ChatCompletionChunk } from "openai/resources/chat/completions";
@@ -72,66 +73,13 @@ export function streamErrorToErrorEvent(
   error: unknown
 ): ErrorEvent {
   if (error instanceof APIError) {
-    const status = error.status;
-    switch (status) {
-      case 400:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "invalid_request_error",
-          message: `Invalid request to Fireworks: ${error.message}`,
-          originalError: error,
-        });
-      case 401:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "authentication_error",
-          message: `Authentication failed for Fireworks: ${error.message}`,
-          originalError: error,
-        });
-      case 403:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "permission_error",
-          message: `Permission denied for Fireworks: ${error.message}`,
-          originalError: error,
-        });
-      case 404:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "not_found_error",
-          message: `Resource not found for Fireworks: ${error.message}`,
-          originalError: error,
-        });
-      case 429:
-        return buildErrorEvent({
-          errorSource: "dust",
-          metadata,
-          type: "rate_limit_error",
-          message: `Rate limit exceeded for Fireworks/${metadata.model}: ${error.message}`,
-          originalError: error,
-        });
-      default:
-        if (isNumber(status) && status >= 500 && status < 600) {
-          return buildErrorEvent({
-            errorSource: "provider",
-            metadata,
-            type: "server_error",
-            message: `Server error from Fireworks (${status}): ${error.message}`,
-            originalError: error,
-          });
-        }
-        return buildErrorEvent({
-          errorSource: "provider",
-          metadata,
-          type: "unknown_error",
-          message: `Error from Fireworks (${status}): ${error.message}`,
-          originalError: error,
-        });
-    }
+    return buildHttpStatusErrorEvent({
+      metadata,
+      status: error.status,
+      provider: "Fireworks",
+      detail: error.message,
+      originalError: error,
+    });
   }
   return buildErrorEvent({
     errorSource: "provider",

--- a/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
+++ b/front/lib/model_constructors/sdk/openai_responses/converters/output/utils.ts
@@ -18,6 +18,7 @@ import type {
 } from "@app/lib/model_constructors/types/output/events";
 import type { Phase } from "@app/lib/model_constructors/types/phases";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { buildHttpStatusErrorEvent } from "@app/lib/model_constructors/utils/classify_http_status";
 import { OPENAI_PROVIDER_ID } from "@app/types/assistant/models/providers";
 import {
   assertNever,
@@ -304,76 +305,6 @@ function classifyStreamError(error: unknown): ClassifiedStreamError {
   return { kind: "unknown" };
 }
 
-// HTTP status is a number, not a union, so the 5xx range stays an `if` in the
-// default branch.
-function apiErrorToErrorEvent(
-  metadata: EndpointMetadata,
-  error: APIError,
-  providerName: string
-): ErrorEvent {
-  const status = error.status;
-  switch (status) {
-    case 400:
-    case 422:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "invalid_request_error",
-        message: `Invalid request to ${providerName}: ${error.message}`,
-        originalError: error,
-      });
-    case 401:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "authentication_error",
-        message: `Authentication failed for ${providerName}: ${error.message}`,
-        originalError: error,
-      });
-    case 403:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "permission_error",
-        message: `Permission denied for ${providerName}: ${error.message}`,
-        originalError: error,
-      });
-    case 404:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "not_found_error",
-        message: `Resource not found for ${providerName}: ${error.message}`,
-        originalError: error,
-      });
-    case 429:
-      return buildErrorEvent({
-        errorSource: "dust",
-        metadata,
-        type: "rate_limit_error",
-        message: `Rate limit exceeded for ${providerName}/${metadata.model}: ${error.message}`,
-        originalError: error,
-      });
-    default:
-      if (status !== undefined && status >= 500 && status < 600) {
-        return buildErrorEvent({
-          errorSource: "provider",
-          metadata,
-          type: "server_error",
-          message: `Server error from ${providerName} (${status}): ${error.message}`,
-          originalError: error,
-        });
-      }
-      return buildErrorEvent({
-        errorSource: "provider",
-        metadata,
-        type: "unknown_error",
-        message: `Error from ${providerName} (${status}): ${error.message}`,
-        originalError: error,
-      });
-  }
-}
-
 // Maps any error thrown by the OpenAI SDK while streaming into a unified
 // `ErrorEvent`, so everything leaving the endpoint is an event, not an exception.
 export function makeStreamErrorToErrorEvent(
@@ -391,7 +322,13 @@ export function makeStreamErrorToErrorEvent(
           originalError: error,
         });
       case "api":
-        return apiErrorToErrorEvent(metadata, classified.error, providerName);
+        return buildHttpStatusErrorEvent({
+          metadata,
+          status: classified.error.status,
+          provider: providerName,
+          detail: classified.error.message,
+          originalError: error,
+        });
       case "unknown":
         return buildErrorEvent({
           errorSource: "provider",

--- a/front/lib/model_constructors/utils/classify_http_status.test.ts
+++ b/front/lib/model_constructors/utils/classify_http_status.test.ts
@@ -1,0 +1,86 @@
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import {
+  buildHttpStatusErrorEvent,
+  classifyHttpStatus,
+} from "@app/lib/model_constructors/utils/classify_http_status";
+import { describe, expect, it } from "vitest";
+
+const metadata: EndpointMetadata = {
+  lab: "anthropic",
+  host: "anthropic",
+  region: "us",
+  model: "claude-sonnet-4-6",
+};
+
+describe("classifyHttpStatus", () => {
+  it.each([
+    [400, "invalid_request_error", "dust"],
+    [422, "invalid_request_error", "dust"],
+    [401, "authentication_error", "dust"],
+    [403, "permission_error", "dust"],
+    [404, "not_found_error", "dust"],
+    [413, "invalid_request_error", "dust"],
+    [418, "invalid_request_error", "dust"],
+    [429, "rate_limit_error", "dust"],
+    [500, "server_error", "provider"],
+    [503, "overloaded_error", "provider"],
+    [529, "server_error", "provider"],
+  ] as const)("maps HTTP %i to %s from %s", (status, type, errorSource) => {
+    expect(classifyHttpStatus(status)).toEqual({ type, errorSource });
+  });
+
+  it("maps a missing or non-HTTP status to unknown", () => {
+    expect(classifyHttpStatus(undefined)).toEqual({
+      type: "unknown_error",
+      errorSource: "unknown",
+    });
+    expect(classifyHttpStatus(200)).toEqual({
+      type: "unknown_error",
+      errorSource: "unknown",
+    });
+  });
+});
+
+describe("buildHttpStatusErrorEvent", () => {
+  it("builds the message from type, provider, and status", () => {
+    expect(
+      buildHttpStatusErrorEvent({
+        metadata,
+        status: 400,
+        provider: "Anthropic",
+        detail: "bad payload",
+      }).content
+    ).toMatchObject({
+      type: "invalid_request_error",
+      errorSource: "dust",
+      message: "Invalid request to Anthropic: bad payload",
+    });
+
+    expect(
+      buildHttpStatusErrorEvent({
+        metadata,
+        status: 429,
+        provider: "Anthropic",
+        detail: "slow down",
+      }).content.message
+    ).toBe("Rate limit exceeded for Anthropic/claude-sonnet-4-6: slow down");
+
+    expect(
+      buildHttpStatusErrorEvent({
+        metadata,
+        status: 500,
+        provider: "Anthropic",
+        detail: "kaboom",
+      }).content.message
+    ).toBe("Server error from Anthropic (500): kaboom");
+
+    expect(
+      buildHttpStatusErrorEvent({
+        metadata,
+        status: 503,
+        provider: "Anthropic",
+        detail: "busy",
+      }).content.message
+    ).toBe("Anthropic is overloaded: busy");
+  });
+});

--- a/front/lib/model_constructors/utils/classify_http_status.ts
+++ b/front/lib/model_constructors/utils/classify_http_status.ts
@@ -5,6 +5,7 @@ import type {
   ErrorType,
 } from "@app/lib/model_constructors/types/output/events";
 import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * Maps an HTTP status to fault domain and error type.
@@ -75,10 +76,19 @@ export function httpErrorMessage({
       return status !== undefined
         ? `Server error from ${provider} (${status}): ${detail}`
         : `Server error from ${provider}: ${detail}`;
-    default:
+    case "unknown_error":
+    case "input_configuration_error":
+    case "stop_error":
+    case "refusal_error":
+    case "model_output_error":
+    case "network_error":
+    case "timeout_error":
+    case "stream_error":
       return status !== undefined
         ? `Error from ${provider} (${status}): ${detail}`
         : `Error from ${provider}: ${detail}`;
+    default:
+      assertNever(type);
   }
 }
 

--- a/front/lib/model_constructors/utils/classify_http_status.ts
+++ b/front/lib/model_constructors/utils/classify_http_status.ts
@@ -1,0 +1,112 @@
+import type { EndpointMetadata } from "@app/lib/model_constructors/types/endpoint_metadata";
+import type {
+  ErrorEvent,
+  ErrorSource,
+  ErrorType,
+} from "@app/lib/model_constructors/types/output/events";
+import { buildErrorEvent } from "@app/lib/model_constructors/utils/build_error_event";
+
+/**
+ * Maps an HTTP status to fault domain and error type.
+ * 4xx is Dust's request; 5xx is the provider; anything else is unknown.
+ */
+export function classifyHttpStatus(status: number | undefined): {
+  errorSource: ErrorSource;
+  type: ErrorType;
+} {
+  if (status === undefined) {
+    return { errorSource: "unknown", type: "unknown_error" };
+  }
+
+  switch (status) {
+    case 400:
+    case 422:
+      return { errorSource: "dust", type: "invalid_request_error" };
+    case 401:
+      return { errorSource: "dust", type: "authentication_error" };
+    case 403:
+      return { errorSource: "dust", type: "permission_error" };
+    case 404:
+      return { errorSource: "dust", type: "not_found_error" };
+    case 429:
+      return { errorSource: "dust", type: "rate_limit_error" };
+    case 503:
+      return { errorSource: "provider", type: "overloaded_error" };
+    default:
+      if (status >= 400 && status < 500) {
+        return { errorSource: "dust", type: "invalid_request_error" };
+      }
+      if (status >= 500 && status < 600) {
+        return { errorSource: "provider", type: "server_error" };
+      }
+      return { errorSource: "unknown", type: "unknown_error" };
+  }
+}
+
+export function httpErrorMessage({
+  type,
+  provider,
+  detail,
+  status,
+  model,
+}: {
+  type: ErrorType;
+  provider: string;
+  detail: string;
+  status?: number;
+  model?: string;
+}): string {
+  switch (type) {
+    case "invalid_request_error":
+      return `Invalid request to ${provider}: ${detail}`;
+    case "authentication_error":
+      return `Authentication failed for ${provider}: ${detail}`;
+    case "permission_error":
+      return `Permission denied for ${provider}: ${detail}`;
+    case "not_found_error":
+      return `Resource not found for ${provider}: ${detail}`;
+    case "rate_limit_error":
+      return model
+        ? `Rate limit exceeded for ${provider}/${model}: ${detail}`
+        : `Rate limit exceeded for ${provider}: ${detail}`;
+    case "overloaded_error":
+      return `${provider} is overloaded: ${detail}`;
+    case "server_error":
+      return status !== undefined
+        ? `Server error from ${provider} (${status}): ${detail}`
+        : `Server error from ${provider}: ${detail}`;
+    default:
+      return status !== undefined
+        ? `Error from ${provider} (${status}): ${detail}`
+        : `Error from ${provider}: ${detail}`;
+  }
+}
+
+export function buildHttpStatusErrorEvent({
+  metadata,
+  status,
+  provider,
+  detail,
+  originalError,
+}: {
+  metadata: EndpointMetadata;
+  status: number | undefined;
+  provider: string;
+  detail: string;
+  originalError?: unknown;
+}): ErrorEvent {
+  const { errorSource, type } = classifyHttpStatus(status);
+  return buildErrorEvent({
+    errorSource,
+    metadata,
+    type,
+    message: httpErrorMessage({
+      type,
+      provider,
+      detail,
+      status,
+      model: metadata.model,
+    }),
+    originalError,
+  });
+}


### PR DESCRIPTION
## Description

Follow-up to the LLM attempt Datadog instrumentation. Two log/classification tweaks from looking at production traces:

- Drop `providerId` from structured attempt logs. It duplicated `inferenceProvider` in the common case and is already on metrics as `provider_id` (where it can differ, e.g. Claude on Vertex).
- Collapse the five per-provider HTTP status switches into `classifyHttpStatus` / `buildHttpStatusErrorEvent`. Named statuses keep the same type, source, and message. Generally classify 400 == dust, 500 == provider.

## Tests

Unit tests

## Risk

Low. Streaming happy-path statuses are unchanged. Classification changes are leftover 4xx, some 503s, and batch item errors — telemetry and retryability for those paths only. Safe to rollback by reverting the commit.

## Deploy Plan
1. Deploy front