### PR TITLE
[front] user menu: single analytics entry point

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -436,11 +436,13 @@ export function UserMenu({
                 icon={Clock}
                 onSelect={() => setAutomationsOpen(true)}
               />
-              <DropdownMenuItem
-                label="Analytics"
-                icon={BarChart01}
-                onSelect={() => setAnalyticsOpen(true)}
-              />
+              {!creditUsageState && (
+                <DropdownMenuItem
+                  label="Analytics"
+                  icon={BarChart01}
+                  onSelect={() => setAnalyticsOpen(true)}
+                />
+              )}
             </>
           )}
 

--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -312,7 +312,7 @@ export function UserMenu({
           sideOffset={8}
           className="w-64"
         >
-          {creditUsageState && (
+          {subscription?.plan.limits.canUseProduct && creditUsageState && (
             <>
               <CreditUsage
                 state={creditUsageState}
@@ -436,6 +436,7 @@ export function UserMenu({
                 icon={Clock}
                 onSelect={() => setAutomationsOpen(true)}
               />
+              {/* The credit usage card is the analytics entry point when shown; keep exactly one. */}
               {!creditUsageState && (
                 <DropdownMenuItem
                   label="Analytics"

--- a/front/components/app/CreditUsage.test.tsx
+++ b/front/components/app/CreditUsage.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { CreditUsageState } from "./CreditUsage";
-import { CreditUsage } from "./CreditUsage";
+import { CREDIT_USAGE_LEARN_MORE_LABEL, CreditUsage } from "./CreditUsage";
 
 const ON_TARGET_STATE = {
   usedPercentage: 80,
@@ -34,7 +34,7 @@ describe("CreditUsage", () => {
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: "Understand your usage" })
+      screen.getByRole("button", { name: CREDIT_USAGE_LEARN_MORE_LABEL })
     );
 
     expect(onLearnMore).toHaveBeenCalledOnce();

--- a/front/components/app/CreditUsage.test.tsx
+++ b/front/components/app/CreditUsage.test.tsx
@@ -33,7 +33,9 @@ describe("CreditUsage", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Learn more" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Understand your usage" })
+    );
 
     expect(onLearnMore).toHaveBeenCalledOnce();
   });

--- a/front/components/app/CreditUsage.tsx
+++ b/front/components/app/CreditUsage.tsx
@@ -9,6 +9,8 @@ export interface CreditUsageState {
   target: CreditUsageTarget;
 }
 
+export const CREDIT_USAGE_LEARN_MORE_LABEL = "See your usage";
+
 const RESET_LABEL_PREFIX: Record<CreditUsageCardVariant, string> = {
   profile_menu: "Reset",
   companion: "Credit reset",
@@ -48,7 +50,7 @@ export function CreditUsage({ state, variant, onLearnMore }: CreditUsageProps) {
         <div className="flex flex-col gap-2">
           <span>{resetLabel}</span>
           <Button
-            label="Understand your usage"
+            label={CREDIT_USAGE_LEARN_MORE_LABEL}
             variant="outline"
             size="sm"
             className="w-full"

--- a/front/components/app/CreditUsage.tsx
+++ b/front/components/app/CreditUsage.tsx
@@ -48,7 +48,7 @@ export function CreditUsage({ state, variant, onLearnMore }: CreditUsageProps) {
         <div className="flex flex-col gap-2">
           <span>{resetLabel}</span>
           <Button
-            label="Learn more"
+            label="Understand your usage"
             variant="outline"
             size="sm"
             className="w-full"


### PR DESCRIPTION
In the user menu, the credit usage card's "Learn more" button and the Analytics item both opened the analytics dialog.

- Rename "Learn more" to "See your usage".
- Show the Analytics item only when the usage card is not in the menu (non-credit plan, or above-target usage where the card moves to the sidebar), so exactly one entry point is visible.