### PR TITLE
[front] automations dialog: richer empty state

### DIFF
--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -2,7 +2,6 @@ import { UserAutomationsTable } from "@app/components/me/UserAutomationsTable";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Dialog,
-  DialogContainer,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -27,9 +26,12 @@ export function UserAutomationsDialog({
         <DialogHeader>
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>
-        <DialogContainer>
+        {/* Plain flex body instead of DialogContainer so the empty state can
+         * fill the fixed-height dialog (percentage heights don't chain through
+         * DialogContainer's ScrollArea). */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
           <UserAutomationsTable owner={owner} />
-        </DialogContainer>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -27,9 +27,9 @@ export function UserAutomationsDialog({
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>
         {/* Plain flex body instead of DialogContainer so the empty state can
-         * fill the fixed-height dialog (percentage heights don't chain through
-         * DialogContainer's ScrollArea). */}
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+         * fill the dialog height. Flex growth, not percentage heights: with
+         * `grow` the dialog only has a min-height, which percentages ignore. */}
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4">
           <UserAutomationsTable owner={owner} />
         </div>
       </DialogContent>

--- a/front/components/me/UserAutomationsDialog.tsx
+++ b/front/components/me/UserAutomationsDialog.tsx
@@ -26,9 +26,7 @@ export function UserAutomationsDialog({
         <DialogHeader>
           <DialogTitle>Automations</DialogTitle>
         </DialogHeader>
-        {/* Plain flex body instead of DialogContainer so the empty state can
-         * fill the dialog height. Flex growth, not percentage heights: with
-         * `grow` the dialog only has a min-height, which percentages ignore. */}
+        {/* Not DialogContainer: the empty state must stretch to the dialog height, which doesn't chain through its ScrollArea. */}
         <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-5 py-4">
           <UserAutomationsTable owner={owner} />
         </div>

--- a/front/components/me/UserAutomationsTable.tsx
+++ b/front/components/me/UserAutomationsTable.tsx
@@ -397,7 +397,7 @@ export function UserAutomationsTable({ owner }: UserAutomationsTableProps) {
     !hasActiveQuery;
 
   return (
-    <div className="flex min-h-full flex-col gap-2">
+    <div className="flex flex-1 flex-col gap-2">
       {!showEmptyState && (
         <>
           <div className="flex items-center gap-2">

--- a/front/components/me/UserAutomationsTable.tsx
+++ b/front/components/me/UserAutomationsTable.tsx
@@ -455,13 +455,13 @@ export function UserAutomationsTable({ owner }: UserAutomationsTableProps) {
                 <div className="flex items-center gap-2">
                   <Button
                     label="Learn about triggers"
-                    variant="outline"
+                    variant="ghost-secondary"
                     href={TRIGGERS_DOC_URL}
                     target="_blank"
                   />
                   <Button
                     label="Learn about wakeups"
-                    variant="outline"
+                    variant="ghost-secondary"
                     href={WAKEUPS_DOC_URL}
                     target="_blank"
                   />

--- a/front/components/me/UserAutomationsTable.tsx
+++ b/front/components/me/UserAutomationsTable.tsx
@@ -56,10 +56,12 @@ import { useCallback, useMemo, useState } from "react";
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
 const TRIGGERS_PAGE_SIZE = 10;
 
-// TODO(2026-08-25 AUTOMATIONS): links to be provided.
+// TODO(2026-08-25 AUTOMATIONS): link to be provided.
 const SETUP_TRIGGER_URL = "#";
-const TRIGGERS_DOC_URL = "#";
-const WAKEUPS_DOC_URL = "#";
+const TRIGGERS_DOC_URL =
+  "https://docs.dust.tt/docs/user-documentation/agents/triggers/schedules";
+const WAKEUPS_DOC_URL =
+  "https://docs.dust.tt/docs/user-documentation/agents/tools/wake-ups";
 
 interface TriggerRowData extends BaseTriggerRowData, PoolRowFields {
   isStatusPending: boolean;

--- a/front/components/me/UserAutomationsTable.tsx
+++ b/front/components/me/UserAutomationsTable.tsx
@@ -42,6 +42,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  EmptyCTA,
   Pagination,
   SearchInput,
   SliderToggle,
@@ -54,6 +55,11 @@ import { useCallback, useMemo, useState } from "react";
 
 const SEARCH_DEBOUNCE_DELAY_MS = 300;
 const TRIGGERS_PAGE_SIZE = 10;
+
+// TODO(2026-08-25 AUTOMATIONS): links to be provided.
+const SETUP_TRIGGER_URL = "#";
+const TRIGGERS_DOC_URL = "#";
+const WAKEUPS_DOC_URL = "#";
 
 interface TriggerRowData extends BaseTriggerRowData, PoolRowFields {
   isStatusPending: boolean;
@@ -380,30 +386,44 @@ export function UserAutomationsTable({ owner }: UserAutomationsTableProps) {
       ? Math.min(pagination.pageSize, totalCount - firstRowIndex)
       : pagination.pageSize;
 
+  const hasActiveQuery =
+    debouncedValue.trim().length > 0 || Object.keys(triggersFilter).length > 0;
+  // No automations at all (as opposed to a search/filter matching nothing):
+  // the empty state replaces the search and filter controls.
+  const showEmptyState =
+    !isTriggersError &&
+    !isTriggersLoading &&
+    rows.length === 0 &&
+    !hasActiveQuery;
+
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-center gap-2">
-        <SearchInput
-          name="user-automations-search"
-          placeholder="Search automations"
-          value={inputValue}
-          onChange={setValue}
-          className="flex-1"
-        />
-        <AutomationsFilterPanel
-          owner={owner}
-          period={period}
-          filter={filter}
-          onFilterChange={setFilter}
-          categories={USER_AUTOMATIONS_FILTER_CATEGORIES}
-          agentOptions={agents}
-        />
-      </div>
-      <AutomationsFilterSummary
-        filter={filter}
-        onFilterChange={setFilter}
-        categories={USER_AUTOMATIONS_FILTER_CATEGORIES}
-      />
+    <div className="flex min-h-full flex-col gap-2">
+      {!showEmptyState && (
+        <>
+          <div className="flex items-center gap-2">
+            <SearchInput
+              name="user-automations-search"
+              placeholder="Search automations"
+              value={inputValue}
+              onChange={setValue}
+              className="flex-1"
+            />
+            <AutomationsFilterPanel
+              owner={owner}
+              period={period}
+              filter={filter}
+              onFilterChange={setFilter}
+              categories={USER_AUTOMATIONS_FILTER_CATEGORIES}
+              agentOptions={agents}
+            />
+          </div>
+          <AutomationsFilterSummary
+            filter={filter}
+            onFilterChange={setFilter}
+            categories={USER_AUTOMATIONS_FILTER_CATEGORIES}
+          />
+        </>
+      )}
 
       {!isConsumptionAvailable && (
         <div className="text-sm text-muted-foreground">
@@ -416,11 +436,40 @@ export function UserAutomationsTable({ owner }: UserAutomationsTableProps) {
           Failed to load your automations.
         </div>
       ) : !isTriggersLoading && rows.length === 0 ? (
-        <div className="py-10 text-center text-sm text-muted-foreground">
-          {debouncedValue.trim() || Object.keys(triggersFilter).length > 0
-            ? "No automation matches your search criteria."
-            : "You haven't created any automation yet."}
-        </div>
+        hasActiveQuery ? (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            No automation matches your search criteria.
+          </div>
+        ) : (
+          <EmptyCTA
+            className="flex-1"
+            title="Create your first automation"
+            message="Triggers start automations when something happens. Agents can also start them with wakeups."
+            action={
+              <div className="mt-4 flex flex-col items-center gap-3">
+                <Button
+                  label="Set up a trigger"
+                  variant="highlight"
+                  href={SETUP_TRIGGER_URL}
+                />
+                <div className="flex items-center gap-2">
+                  <Button
+                    label="Learn about triggers"
+                    variant="outline"
+                    href={TRIGGERS_DOC_URL}
+                    target="_blank"
+                  />
+                  <Button
+                    label="Learn about wakeups"
+                    variant="outline"
+                    href={WAKEUPS_DOC_URL}
+                    target="_blank"
+                  />
+                </div>
+              </div>
+            }
+          />
+        )
       ) : (
         <div aria-busy={isTriggersLoading || undefined}>
           <div className="overflow-x-auto">


### PR DESCRIPTION
The automations dialog empty state was a single line of muted text ("You haven't created any automation yet.").

- Replace it with an EmptyCTA filling the dialog: "Create your first automation", a short explanation of triggers and wakeups, a primary "Set up a trigger" button and two "Learn about" buttons.
- Hide the search bar and filter button when there are no automations at all (they stay when a search/filter matches nothing).
- Button links are placeholder constants for now, to be filled in.