### PR TITLE
x(adrsimon): search experimentation harness

### DIFF
--- a/x/adrsimon/agentsearch/.gitignore
+++ b/x/adrsimon/agentsearch/.gitignore
@@ -1,0 +1,10 @@
+# Workspace exports carry every agent's instructions and group-level usage.
+assets/agents_*.json
+!assets/agents_skeleton.json
+
+# Profile snapshots name a real person and their group/space memberships.
+assets/profile_*.json
+!assets/profile_skeleton.json
+
+# Generated eval query sets embed real agent names and descriptions.
+assets/eval_queries_*.json

--- a/x/adrsimon/agentsearch/NOTES.md
+++ b/x/adrsimon/agentsearch/NOTES.md
@@ -1,0 +1,83 @@
+# Working notes
+
+Status of the agent-search harness, what has been measured, and what has not been tried. `README.md` covers how to run things; this file covers where things stand.
+
+## Current state
+
+The harness indexes a workspace export into a local Elasticsearch 8.16.0 (same minor as prod, see `docker-compose.yml`), reproduces the `/manage/agents` permission model at query time, and scores retrieval against a generated query set.
+
+Corpus: 2,566 agents from the Dust workspace, 30-day usage window. For `adrien@dust.tt` the manage view resolves to 389 agents, or 341 with `--exclude-global`.
+
+### Defaults
+
+| Flag | Default | Why |
+|---|---|---|
+| `--match-mode` | `hybrid` | `best_fields` plus a 0.5-weighted `bool_prefix`. Prefix alone drops IDF on the last term. |
+| `--name-fallback` | `fuzzy` | Beats subsequence on transposed characters, 0.913 vs 0.139 MRR, and leaks less. |
+| `--group-boost` | `0.5` | At 2.0 popularity outranks exact names and overall MRR falls to 0.561. |
+| `--min-should-match` | off | Worth +0.024 to +0.045 MRR but turns vocabulary mismatch into zero hits. |
+| `--with-instructions` | off | Instructions are long and drown name and description signal. |
+
+Index: `name` and `description` carry named BM25 similarities (`name_bm25`, `text_bm25`) at Lucene defaults. `name` uses a `word_delimiter_graph` analyzer so `TitleClassifierAI` tokenizes; both text fields use an English stemmer and stopword list.
+
+### Query construction
+
+`scripts/query.ts` builds every query, and both `search.ts` and `eval.ts` call it, so the two cannot drift. Text clauses go in `must`; group adjacency goes in `should`. Keeping them separate matters: when they shared a `should` list under `minimum_should_match: 1`, any agent with group usage matched every query, and `--q invoice` and `--q datadog` returned the same results.
+
+## Tests
+
+There are no unit tests. The eval harness is the regression suite.
+
+```
+npx tsx scripts/generate_queries.ts --agents assets/agents_<id>.json --profile assets/profile_<id>.json
+npx tsx scripts/eval.ts --queries assets/eval_queries_dust.json --profile assets/profile_<id>.json \
+  --exclude-global --compare assets/eval_baseline.json
+npx tsgo --noEmit -p .
+```
+
+`--compare` prints a delta against the saved baseline, which is metrics only and safe to commit. Everything else in `assets/` is gitignored: exports carry agent instructions, group-level usage, and one person's memberships.
+
+### The query set
+
+2,184 queries across seven kinds, generated from the 341 candidates, plus 228 negatives. Ambiguous strings (75) are dropped when they match more than one agent.
+
+| Kind | Queries | MRR@10 | R@1 | Hits | Junk/query |
+|---|---|---|---|---|---|
+| name_exact | 339 | 1.000 | 1.000 | 4.4 | 0.16 |
+| name_words | 301 | 0.977 | 0.967 | 28.4 | 1.38 |
+| name_prefix | 317 | 0.949 | 0.909 | 7.2 | 0.91 |
+| name_typo | 325 | 0.928 | 0.923 | 3.9 | 0.18 |
+| name_transpose | 313 | 0.913 | 0.907 | 3.7 | 0.17 |
+| desc_terms | 294 | 0.924 | 0.864 | 8.7 | 1.98 |
+| desc_phrase | 295 | 0.899 | 0.834 | 35.6 | 1.04 |
+| **overall** | **2,184** | **0.942** | **0.917** | **12.7** | **0.80** |
+
+Negatives: 108 out-of-vocabulary queries return zero hits every time. 120 chimeras, built from terms of two unrelated agents, average 10.7 hits and never return zero. That is the clearest precision failure the harness has found.
+
+### What the metrics do and don't measure
+
+Each query has exactly one labelled target, so precision has no ground truth. The proxies are result-set size, term coverage (how much of the query each non-target result actually contains), and a junk rate derived from it. They catch gross over-matching and miss ranking subtleties. Progression so far: 0.895 baseline, 0.953 after the name analyzer, 0.927 after the English analyzer (a deliberate drop, since generated queries never suffer the vocabulary mismatch stemming exists to fix), 0.961 with hybrid mode, 0.942 on the expanded set with fuzzy fallback.
+
+## Open paths
+
+### Ranking
+
+- Two-tier retrieval. Run lexical with `--min-should-match "2<70%"`, fall back to semantic when it returns too little, fuse client-side. RRF needs a Platinum license and our cluster is on basic, so fusion has to happen in JS. About fifteen lines for `sum 1/(k+rank)`. Vector search itself (`dense_vector`, `knn`, `int8_hnsw`, `bbq_hnsw`) is free on basic and verified working locally. Start with a stub embedder so the fusion behaviour is measurable before adding a model dependency.
+- Coordination. An agent matching only `help` pays nothing for missing `PR` and `review`, because Lucene dropped the `coord` factor under BM25. This is what makes `help for PR review` return `LegalRequestHelper`. `min-should-match` fixes it directly and costs graceful degradation. Nothing else tried so far touches it.
+- Popularity as a feature, not a clause. Group adjacency is an additive `should` on a scale unrelated to BM25, which is why the boost has to stay near 0.5. It belongs in a rescorer over the top N, or in rank fusion.
+- Field weights. `name^4` and `description^2` were picked by hand and never swept. `sweep_bm25.ts` generalizes to this with small changes.
+- Phrase and proximity. `desc_phrase` is the weakest kind at 0.899 and returns 35 hits on average. A `match_phrase` clause on description would help both numbers.
+- Recency. 2,108 of 2,566 agents saw zero messages in the window. Nothing in the query penalizes a well-written agent nobody has used.
+- Tags. Indexed, never queried.
+
+### Correctness
+
+- The manage-list gap. 341 hits against 350 observed in the UI. Attributed to export drift (the corpus is a 15:47 snapshot, the page was live), but never confirmed with a fresh export taken at the same time.
+- `description.subsequence`. Dead weight in the mapping since the clause was dropped. It matched almost anything (`*i*n*v*o*i*c*e*` hits "Incident investigation assistant for Dust using Datadog logs"). Remove it.
+- Programmatic traffic. 25 agents have usage and no group attribution, since API-key runs carry no `user.group_ids`. `CodingRules` has 1,568 messages and 0 users, so adjacency scores it zero however popular it is.
+
+### Evaluation
+
+- One workspace, one profile. Every number here comes from a single corpus, and the queries are generated from the indexed text. That is why the BM25 `b` gain of 0.005 was not baked in. A second workspace would tell us which findings generalize.
+- No human judgments. Adding even fifty hand-labelled queries with graded relevance would let us measure nDCG and score precision properly instead of by proxy.
+- Real query logs. Generated queries are drawn from the corpus, so they systematically understate vocabulary mismatch, which is the failure mode stemming and semantic search exist to address.

--- a/x/adrsimon/agentsearch/README.md
+++ b/x/adrsimon/agentsearch/README.md
@@ -1,0 +1,284 @@
+# agentsearch
+
+A local Elasticsearch harness for **agent discovery**: given a user, which agents in their workspace are worth suggesting to them?
+
+The idea is to combine two signals that neither the current agent search nor the analytics pages combine today:
+
+- **BM25** over an agent's name, description and instructions — what the agent is *about*.
+- **Usage in the groups the user belongs to** — what people *like them* actually use.
+
+Everything here is a scratch harness for trying that out against a real workspace. It is not wired into `front` and does not serve traffic.
+
+## Layout
+
+```
+agentsearch/
+├── assets/
+│   ├── agents_skeleton.json          shape of an agent export   (committed, no real data)
+│   ├── profile_skeleton.json         shape of a user profile    (committed, no real data)
+│   ├── agents_<wId>.json             a real export   (gitignored, you produce it)
+│   ├── profile_<userSId>.json        a real profile  (gitignored, you produce it)
+│   ├── eval_queries_<name>.json      a generated eval set (gitignored)
+│   └── eval_baseline.json            metrics only, safe to commit
+├── index/
+│   └── agent_search.mappings.json    ES mapping for the discovery index
+├── scripts/
+│   ├── export_workspace_agents.ts    dumps a workspace's agents  — RUNS IN front/, not here
+│   ├── export_user_profile.ts        dumps a user's Authenticator — RUNS IN front/, not here
+│   ├── ingest.ts                     export JSON -> local ES
+│   ├── query.ts                      the query builder, shared by search and eval
+│   ├── search.ts                     query CLI
+│   ├── generate_queries.ts           builds a known-item eval set from the corpus
+│   ├── eval.ts                       scores the ranker against an eval set
+│   ├── es.ts                         tiny fetch wrapper
+│   └── types.ts                      export + document types
+└── docker-compose.yml                ES 8.16.0 on 127.0.0.1:9250
+```
+
+Port 9250 stays clear of the dev container (9200) and of dust-hive, which allocates `1X2XX` per environment.
+
+Both export scripts live here as the single source of truth, but neither can run from here: they import `@app/...`, which only resolves under `front/`. Copy them into `front/scripts/` to run or typecheck them. The flip side is that `front`'s CI never sees them, so re-check after touching anything they call into.
+
+## Quickstart
+
+```bash
+npm run es:up
+npm run ingest                                   # defaults to assets/agents_0ec9852c2f.json
+npm run search -- --q sales --spaces vlt_ZqMdUAzI0OTf --groups grp_gXHmJEbOCeCy
+```
+
+`npm run es:reset` wipes the volume and starts clean. Nothing here needs credentials: security is off, the cluster is single-node, and it binds to localhost only.
+
+## Producing an export
+
+**Nothing real is committed.** An agent export carries every agent's full instructions and group-level usage; a profile names a real person and their memberships. Both are gitignored, and only the skeletons are tracked. Two scripts produce them.
+
+Neither runs from this directory — they import `@app/...`. On prodbox:
+
+```bash
+kclpush prodbox scripts/export_workspace_agents.ts /dust/front/scripts/export_workspace_agents.ts
+kclpush prodbox scripts/export_user_profile.ts     /dust/front/scripts/export_user_profile.ts
+kclssh prodbox
+  cd /dust/front
+  npx tsx scripts/export_workspace_agents.ts --wId <wId> --days 30 --execute
+  npx tsx scripts/export_user_profile.ts --wId <wId> --email <someone@dust.tt> --execute
+kclpull prodbox /dust/front/agents_<wId>.json        ./assets/agents_<wId>.json
+kclpull prodbox /dust/front/profile_<userSId>.json   ./assets/profile_<userSId>.json
+```
+
+Then `rm` both files on the pod, and point ingest at the export: `npm run ingest -- --file assets/agents_<wId>.json`.
+
+### Searching as a user
+
+A profile is the slice of an `Authenticator` a search needs: role, `auth.groupIds()`, and the workspace spaces where `space.canRead(auth)` holds, split into pods and non-pods. Pass it instead of spelling out ids:
+
+```bash
+npm run search -- --profile assets/profile_<userSId>.json --q "pull request"
+```
+
+`--profile` overrides `--spaces` and `--groups`. It does not make the search permission-correct — see below — it just stops you hand-assembling ids that drift.
+
+### What the export contains
+
+Agent configuration comes from `getAgentConfigurationsForView` with `dangerouslySkipPermissionFiltering`, so unpublished agents and spaces the caller cannot read are included — this is an admin-side corpus.
+
+Usage comes from **Elasticsearch, not Postgres**: `fetchAgentExportRows` (`front/lib/api/analytics/agents_export.ts`) over `front.agent_message_consumption_analytics`, the same path as `GET /api/w/:wId/analytics/agents-export`. Messages are a cardinality aggregation on `agent_message_id`, because consumption documents are split per LLM step and per tool call. The per-group breakdown is a nested terms aggregation on `user.group_ids`, and feedbacks come from `front.agent_message_analytics`, where they live as a nested field.
+
+See `assets/agents_skeleton.json` for the exact shape.
+
+## The permission model
+
+The harness reproduces what `/manage/agents` (and the `@` mention picker) show, which is `getAgentConfigurationsForView` with the `manage` / `list` view. Two filters:
+
+**Spaces** — `filterAgentsByRequestedSpaces` (`front/lib/api/assistant/configuration/agent.ts`) keeps an agent only when *every* space it requests is readable by the caller. Pods included; there is no carve-out. That is a `terms_set` with the required count stored on the document:
+
+```json
+{ "terms_set": { "requested_space_ids": {
+    "terms": ["<every space the caller can read, pods included>"],
+    "minimum_should_match_field": "requested_space_count" } } }
+```
+
+A second `should` branch matches `requested_space_count: 0` for agents that require nothing.
+
+**Visibility** — `scope` in `visible` / `global`, plus `hidden` agents where the caller is an editor (`editors` holds emails, and the profile carries the caller's). `--exclude-global` drops the globals, which is what the default *All custom* tab of `/manage/agents` displays. Passing `--scope` explicitly bypasses the visibility filter entirely.
+
+The index also carries `non_pod_space_ids` / `non_pod_space_count`, the projection skill search uses (PRs #30452 / #30450). Skill search excludes pods from the query because a user's project memberships are potentially unbounded: it over-fetches a bounded candidate window and authorizes pods afterwards against Postgres. Those fields are indexed here for comparison but are not what the default filter uses.
+
+A profile is also a **snapshot**. Memberships change; a stale profile answers as the user was on `generatedAt`, not as they are now.
+
+## Ranking
+
+Matching and ranking are structurally separate. Text clauses go in a `must`, so they decide *which* agents come back; group adjacency goes in a `should`, which — with a `must` present — defaults to `minimum_should_match: 0` and therefore only contributes score. Collapsing the two into one `should` list means any agent with group usage matches every query, text match or not.
+
+Text matching runs two `multi_match` clauses over `name^4` and `description^2`: a `best_fields` clause carrying full BM25 term weighting, and a `bool_prefix` clause at boost 0.5 for as-you-type prefix tolerance (`--match-mode`, default `hybrid`). `instructions` is **off by default** and enabled with `--with-instructions`; see below. Typo tolerance on `name` comes from a `fuzziness: AUTO` match (`--name-fallback`, default `fuzzy`). The alternative, a wildcard subsequence clause, is available as `--name-fallback subsequence` but is strictly worse — see below. Neither is applied to `description`: a subsequence only requires the letters in order *anywhere*, so on a field of a few hundred characters almost any short query matches — `*i*n*v*o*i*c*e*` happily matches "**In**cident in**v**estigat**i**on assistant for Dust using Datad**o**g logs".
+
+`description` and `instructions` use an English analyzer — possessive stripping, lowercase, stopwords, light stemming — so `reviews` matches `review` and `for`/`the` stop being full-weight terms that match nearly every document. `name` uses a `word_delimiter_graph` analyzer so compound names split into their parts: `TitleClassifierAI` indexes as `titleclassifierai`, `title`, `classifier`, `ai`, and `agenda_cleaner` as `agenda_cleaner`, `agendacleaner`, `agenda`, `cleaner`. Without it the standard analyzer emits one opaque token and "industry radar" cannot find `IndustryRadar`. The same filter runs at search time, minus `flatten_graph`.
+
+Adjacency is a `nested` query over `usage.by_group` matching the caller's groups, scoring `log1p(messages)` per matching group with `score_mode: "sum"` — so an agent used across several of your groups outranks one concentrated in a single group.
+
+One trap worth remembering: **`boost` on a `nested` query is silently discarded** when the inner `function_score` uses `boost_mode: "replace"`. Scores came back byte-identical at boost 1 and boost 15. The weight has to go inside `functions[].weight`.
+
+### Why instructions are off by default
+
+The eval says including them is a small *gain* (+0.006 MRR). Ignore that number: known-item retrieval only asks whether the true target ranks well, and an agent's own prompt usually restates its purpose, so the target gets reinforced. What the eval cannot see is precision — there are no relevance labels for non-targets, so nothing penalizes irrelevant agents crowding the list.
+
+That cost is easy to see by hand. `--q datadog` returns 1 agent by default (`IncidentQ`, which is genuinely about Datadog) and 7 with instructions on, the extra six being agents whose prompts happen to mention Datadog in passing — a cold-email writer, two Slack digests. Matching on instructions surfaces agents whose *prompt* mentions your term rather than agents that *do* your task. The flag is there for when you want that reach.
+
+### Why `bool_prefix` alone is the wrong matcher
+
+`match_bool_prefix` turns the **last** query term into a prefix query, and Lucene prefix queries are constant-scored — so whichever word you type last silently loses its IDF weighting. `help hiring` and `hiring help` therefore returned different agents: the first ranked Helper agents, the second ranked Hiring agents, each driven by whichever term was *not* last.
+
+That behaviour is correct for an as-you-type picker, where the last token really is incomplete, and wrong for a submitted query. `hybrid` keeps both: a `best_fields` clause so every term keeps its weighting, plus the prefix clause at boost 0.5 so partial typing still works. It beats either alone on the eval — 0.981 against 0.972 for `bool_prefix` and 0.968 for `best_fields` at `msm 2<70%` — and both orderings now rank `Hiring` first.
+
+### Coordination: why one matched term can win
+
+BM25 sums over the terms a document *matches* and never penalizes the ones it misses — Lucene dropped the old `coord` factor when it moved to BM25. So for `help for PR review`, `HelpDeskStatusDemo` matched `help` alone and ranked first over an actual PR agent. IDF was not the problem: `help` in a name has df 20 (IDF 4.83) against `review` at df 14 (IDF 5.18), and `pr` in a description is the rarest term of the three. What beat them was `name^4` plus short-field length normalization — one term in a three-word name scores ~19, two rarer terms in a twenty-word description ~12.
+
+`--min-should-match "2<70%"` restores coordination and is worth +0.045 MRR on the eval (0.927 to 0.972). It is **not** on by default, because it makes vocabulary mismatch fatal rather than merely bad: `review pull requests` correctly returns `CodingRules` first, while `PR review` returns nothing at all, since `pr` and `pull request` are unrelated strings and both terms are now required. Before turning it on, pick one of:
+
+- **Graceful degradation** — run strict, and re-run looser when the result set is too small.
+- **Synonyms** — an analyzer synonym list for domain acronyms (`pr` ⇒ `pull request`). Effective and precise, but a hand-maintained list that rots.
+- **A semantic layer** — the only one of the three that generalizes to paraphrase.
+
+### Flags
+
+| flag | meaning |
+| --- | --- |
+| `--q` | search term; omit for pure usage-based discovery |
+| `--profile` | a profile snapshot; fills in spaces and groups |
+| `--spaces` | comma-separated space sIds the caller can read |
+| `--groups` | comma-separated group sIds the caller belongs to |
+| `--group-boost` | weight on the adjacency signal (default 0.5) |
+| `--with-instructions` | also match against agent instructions (default off) |
+| `--min-should-match` | ES `minimum_should_match` on the text query, e.g. `2<70%` (default off) |
+| `--match-mode` | `hybrid` (default), `best_fields`, or `bool_prefix` |
+| `--name-fallback` | typo tolerance on `name`: `fuzzy` (default), `subsequence`, `both`, `off` |
+| `--exclude-global` | drop global agents, matching the *All custom* tab |
+| `--scope` | restrict to `visible`, `hidden`, `global`; bypasses the visibility filter |
+| `--limit` | number of hits (default 10) |
+| `--explain` | dump the ES explanation for the top hit |
+| `--es`, `--index` | point elsewhere |
+
+## Evaluation
+
+Tuning without measurement is guessing, so every ranking change should be scored. The harness does **known-item retrieval**: for each agent, synthesize queries someone might plausibly type to find *that* agent, then measure where it actually lands.
+
+```bash
+npm run gen:queries -- --profile assets/profile_pQwo5uKyt6.json --exclude-global \
+  --out assets/eval_queries_dust.json
+npm run eval -- --queries assets/eval_queries_dust.json \
+  --profile assets/profile_pQwo5uKyt6.json --exclude-global
+```
+
+Candidates come from ES through the same filters the search uses, so the eval targets are exactly the agents the ranker is allowed to return — recall is never capped by permissions. Five query kinds, reported separately because they fail for different reasons:
+
+| kind | example, for `TitleClassifierAI` | probes |
+| --- | --- | --- |
+| `name_exact` | `titleclassifierai` | the analyzer; should be ~1.0 |
+| `name_words` | `title classifier ai` | tokenization of compound names |
+| `name_prefix` | `titleclassi` | prefix matching, the `@` picker case |
+| `name_typo` | `titleclassfierai` | a deleted character |
+| `name_transpose` | `titleclasisfierai` | two swapped characters |
+| `desc_terms` | high-IDF terms from the description | the description field |
+| `desc_phrase` | a window around the top-IDF term | phrase-ish natural queries |
+
+Description terms are picked by IDF computed over the candidate set, so a query is made of what actually distinguishes that agent from its neighbours. Query strings that two agents both produce are dropped as ambiguous rather than scored against an arbitrary winner.
+
+`eval.ts` batches through `_msearch`, so a full 1,546-query run is about a second. Useful flags: `--group-boost` to sweep, `--misses N` to print what fell out of the top 10, and `--save` / `--compare` to diff two configurations:
+
+```bash
+npm run eval -- --group-boost 2 --compare assets/eval_baseline.json
+```
+
+Metrics are MRR@10 and recall@1/5/10. Queries that error in ES are counted as misses and reported — an eval that dies on one bad query is useless.
+
+### Precision
+
+Known-item retrieval alone is blind to precision: with one labelled document per query, nothing scores the *other* results, so junk crowding the list is free. Every relevance bug found so far — the ranking clause that satisfied matching on its own, the `description.subsequence` wildcard — was invisible to MRR and caught by hand. Three label-free proxies close that gap, all computed over the **non-target** results in the top 10:
+
+| metric | meaning |
+| --- | --- |
+| `hits` | mean result-set size; gross over-matching shows up here first |
+| `coverage` | mean fraction of the query's content terms that a result actually contains |
+| `junk` | fraction of results containing *none* of them |
+| `junk/query` | the same as an absolute count |
+
+Read `junk` and `junk/query` together: the rate is a ratio, so it can rise while absolute noise falls, simply because the denominator shrank. Term comparison happens in JS against a plural-stripping normalizer (`scripts/text.ts`) rather than a round trip to `_analyze` per term, so it approximates the index-time stemmer.
+
+### Negative queries
+
+The set also carries queries that should return **nothing**, which needs no labels at all:
+
+- `oov` — words verified absent from the corpus (checked at generation time, `df` 0 across `name` and `description`). Any hit is definitionally a false positive.
+- `chimera` — the two highest-IDF terms from each of two unrelated agents. No single agent should satisfy all four.
+
+Reported as mean hits and the share returning zero.
+
+**What this does not measure.** These are lexical robustness tests, not intent paraphrase: the queries are derived from the very text being searched, so they cannot tell you whether someone asking for "help me write customer emails" finds the right agent. That needs either LLM-generated queries or real query logs; the file format is just `{query, kind, targetId, targetName}`, so either drops straight in. The other missing half is a **discovery** metric — hold out a user's own usage and check whether group adjacency alone surfaces the agents they actually use. That needs a per-user usage export, which the current export does not produce.
+
+## What the precision metrics showed
+
+- **A quarter of results were junk.** At the default config, `junk` is 0.245 and mean result-set size is 16.5 — for queries built from a single agent's own distinctive terms, against a 341-agent corpus.
+- **Every chimera query returns something.** Mean 10.7 hits, and `zeroHit` 0.00 — not one of the 120 four-term chimeras came back empty, though by construction no agent matches all four. `--min-should-match "2<70%"` cuts that to 2.2 mean hits, still only 2% empty.
+- **`msm` is a precision fix, not a recall trade.** It was worth +0.024 MRR, which looked marginal. On precision it moves mean hits 16.5 to 2.2, coverage 0.293 to 0.452, and junk/query 1.09 to 0.19 — better on every kind. The known-item metrics had been systematically understating it.
+- **The subsequence wildcard was the dominant junk source, and replacing it was free.** It leaked an out-of-vocabulary word — `pelican` matched `PartnerApplicationAnalyzer`, **p**artn**e**rapp**lica**tio**n** — because it matches letters in order anywhere, and long names contain a great many subsequences. Swapping it for `fuzziness: AUTO` fixed that and won on every axis; see below.
+
+## Typo tolerance: fuzzy beats subsequence outright
+
+Comparing the two on `name`, once the eval gained typo queries:
+
+| variant | `name_typo` | `name_transpose` | OVERALL MRR | junk/query | `oov` clean |
+| --- | --- | --- | --- | --- | --- |
+| `off` | 0.085 | 0.139 | 0.706 | 0.75 | 1.00 |
+| `subsequence` | 0.893 | **0.139** | 0.828 | 0.83 | 0.99 |
+| `fuzzy` | 0.928 | 0.913 | **0.942** | 0.80 | 1.00 |
+| `both` | 0.933 | 0.913 | 0.945 | 0.87 | 0.99 |
+
+The decisive column is `name_transpose`: a subsequence match **requires the letters in order**, so swapping two adjacent characters — the most common real typo — defeats it completely. It scores 0.139, exactly the same as having no fallback at all. Fuzzy handles it at 0.913, costs less junk, and closes the `pelican` leak. `both` buys +0.003 MRR for +0.07 junk/query and reopens that leak, so `fuzzy` is the default.
+
+This only became measurable after adding the typo kinds. The earlier comparison used `name_prefix`, which contains no typos — it is a clean prefix, already handled by `bool_prefix`, so it made the two fallbacks look nearly equivalent and both look nearly redundant.
+
+## What the first runs showed
+
+Against the Dust workspace (2,566 agents, 30-day window):
+
+- **The space filter behaves.** `--q sales` with nothing readable returns 574 hits; adding Company Data takes it to 1,734.
+- **Discovery mode works well.** With no query at all, a user in the `Dev` group gets `AVTDustPRReviewPro`, `at_pr`, `AVTGitHubPRDocGen`, `DD` — the agents their colleagues actually use.
+- **The two signals are on incompatible scales, and it is expensive.** The eval put a number on it: at `--group-boost 2`, overall MRR@10 is 0.561; at 0, it is 0.904. Exact-name lookup collapses from 0.992 to 0.229 — popular agents outscore the agent you literally named. The default is now 0.5, which costs ~0.01 MRR, but the additive `should` clause is the wrong shape regardless. It wants rank fusion or a normalized popularity feature in a rescorer over the top-N.
+- **Compound names did not tokenize — the single biggest win so far.** `name` analyzed `TitleClassifierAI` to one opaque token, so "industry radar" could not find `IndustryRadar`. Adding a `word_delimiter_graph` analyzer took `name_words` from 0.570 to 0.924 MRR and overall from 0.895 to 0.953. Description kinds gave back a little (name tokens now compete for the same queries), a clearly worthwhile trade.
+- **Stopwords and stemming were missing entirely.** `reviews` did not match `review`, and `for`/`the` were scored like content words. Adding an English analyzer moved the eval slightly *down* (0.950 to 0.927 without coordination) — expected, since eval queries are drawn from the indexed text and so never suffer the vocabulary mismatch stemming exists to fix. Qualitatively it is what makes `review pull requests` find `CodingRules`.
+- **Two precision bugs the eval could not see.** Group adjacency shared a `should` list with the text clauses under `minimum_should_match: 1`, so it satisfied the match by itself and every agent with group usage matched every query. And the `description.subsequence` wildcard matched nearly anything. Together they made `--q invoice` and `--q datadog` return the same agents. Fixing both moved the eval by +0.003 — it measures whether the target ranks, not whether junk ranks with it. `--q invoice` now returns 0 hits.
+- **Subsequence wildcards blow up past ~24 characters.** Lucene refuses to determinize the automaton (`would require more than 10000 effort`), and the whole query errors — not just that clause. The clause is also pointless for multi-word input, since the field holds the full name and a space in the pattern demands a literal space in the name. Now gated on both length and token count.
+- **Global agents swamp anything usage-weighted.** `dust` alone accounts for 42k of the workspace's messages. `--exclude-global` filters them out.
+- **The manage list reproduces.** With no query, `adrien@dust.tt` gets 389 hits, or 341 with `--exclude-global` — against 350 observed in `/manage/agents`. The residual is export drift: the corpus is a snapshot, the page is live.
+- **82% of the corpus is dead.** 2,108 of 2,566 agents saw zero messages in the window, and 2,141 are `hidden`. BM25 will happily surface a well-written agent nobody has ever used.
+- **Programmatic traffic has no groups.** 25 agents have usage but no group attribution at all (`CodingRules`: 1,568 messages, 0 users) — API-key runs carry no `user.group_ids`, so adjacency scores them zero no matter how popular.
+- **Group sums exceed agent totals** by 2-4x, since `user.group_ids` is multi-valued. Good as a per-group signal, wrong as a denominator.
+
+## BM25 parameters: `b` is worth ~0.005 MRR, `k1` is inert
+
+`name`, `description` and `instructions` each carry a named similarity (`name_bm25`, `text_bm25`) so they can be tuned independently. Similarity is a query-time parameter, so changing it needs a close / `PUT _settings` / open cycle — no reindex. `scripts/sweep_bm25.ts` does that and runs the full eval per value:
+
+```
+npx tsx scripts/sweep_bm25.ts --similarity name_bm25 --param b --values 0,0.25,0.5,0.75,1 \
+  --queries assets/eval_queries_dust.json --profile assets/profile_<id>.json --exclude-global
+```
+
+Results over the 2,184-query set:
+
+| | 0 | 0.25 | 0.5 | 0.75 | 1 |
+|---|---|---|---|---|---|
+| `name_bm25.b` | 0.9443 | **0.9467** | 0.9451 | 0.9425 | 0.9394 |
+| `text_bm25.b` | 0.9409 | 0.9427 | **0.9441** | 0.9425 | 0.9422 |
+
+| | 0.5 | 0.9 | 1.2 | 1.6 | 2.0 |
+|---|---|---|---|---|---|
+| `name_bm25.k1` (b=0.25) | 0.9473 | **0.9475** | 0.9471 | 0.9469 | 0.9464 |
+| `text_bm25.k1` (b=0.5) | 0.9474 | 0.9473 | 0.9471 | 0.9471 | 0.9473 |
+
+- **`k1` does nothing here, and that is expected.** `k1` controls term-frequency saturation. Names and descriptions are short enough that a query term appears once, so there is no term frequency to saturate.
+- **`b` is real but small.** The `name` curve is monotone in the predicted direction — less length normalization means less advantage for a very short name — but the whole sweep spans 0.007 MRR, and both fields together buy 0.9425 → 0.9475.
+- **It does not fix the `help` bug.** Under tuned values `help for PR review` still returns `LegalRequestHelper` first: it matches `help` through the stemmed `helps` in its *description*, so `name` length normalization never enters into it. It does flip `help hiring`, where `Hiring` (30.27) now edges past `LegalRequestHelper` (30.02).
+- `hits`, `coverage` and `junk/query` were flat across every sweep, as they must be — BM25 parameters change scoring, not matching.
+
+The index ships at the Lucene defaults (`k1 1.2`, `b 0.75`). A 0.005 gain measured on one workspace, one profile, and queries generated from the indexed text is not enough evidence to bake in; the named similarities and the sweep script are there to redo this against a second corpus.

--- a/x/adrsimon/agentsearch/assets/agents_skeleton.json
+++ b/x/adrsimon/agentsearch/assets/agents_skeleton.json
@@ -1,0 +1,65 @@
+{
+  "__": [
+    "This is a SKELETON, not data. It documents the shape of a workspace export.",
+    "No export is committed: the real file holds every agent's full instructions",
+    "plus group-level usage, so assets/agents_*.json is gitignored.",
+    "",
+    "To produce one, run scripts/export_workspace_agents.ts against a workspace",
+    "(see README.md, 'Producing an export'). It writes agents_<wId>.json; drop it",
+    "in this directory and point scripts/ingest.mjs at it."
+  ],
+  "workspaceId": "0000000000",
+  "workspaceName": "Example Workspace",
+  "generatedAt": "2026-08-25T15:47:51.665Z",
+  "usagePeriodDays": 30,
+  "agentCount": 1,
+  "agents": [
+    {
+      "sId": "abcdef0123",
+      "name": "SupportTriage",
+      "description": "Triages incoming support tickets and drafts a first reply.",
+      "instructions": "You are a support triage agent. Classify the ticket, then draft a reply...",
+      "scope": "visible",
+      "status": "active",
+      "tags": ["support"],
+      "templateId": null,
+      "author": "someone@example.com",
+      "editors": ["someone@example.com", "someone-else@example.com"],
+      "requestedSpaceIds": ["vlt_AAAAAAAAAAAA", "vlt_BBBBBBBBBBBB"],
+      "spaces": [
+        { "sId": "vlt_AAAAAAAAAAAA", "name": "Company Data", "kind": "global" },
+        {
+          "sId": "vlt_BBBBBBBBBBBB",
+          "name": "Support Knowledge",
+          "kind": "project"
+        }
+      ],
+      "nonPodSpaceIds": ["vlt_AAAAAAAAAAAA"],
+      "nonPodSpaceCount": 1,
+      "podSpaceIds": ["vlt_BBBBBBBBBBBB"],
+      "usage": {
+        "periodDays": 30,
+        "messages": 43,
+        "conversations": 21,
+        "users": 7,
+        "credits": 1204,
+        "feedbacksUp": 2,
+        "feedbacksDown": 0,
+        "byGroup": [
+          {
+            "groupId": "grp_AAAAAAAAAAAA",
+            "groupName": "support",
+            "messages": 31,
+            "users": 5
+          },
+          {
+            "groupId": "grp_BBBBBBBBBBBB",
+            "groupName": "team-eu",
+            "messages": 12,
+            "users": 2
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/x/adrsimon/agentsearch/assets/eval_baseline.json
+++ b/x/adrsimon/agentsearch/assets/eval_baseline.json
@@ -1,0 +1,112 @@
+{
+  "ranAt": "2026-08-25T18:02:18.571Z",
+  "querySet": "eval_queries_dust.json",
+  "groupBoost": 0.5,
+  "excludeGlobal": true,
+  "includeInstructions": false,
+  "minShouldMatch": "",
+  "matchMode": "hybrid",
+  "nameFallback": "fuzzy",
+  "overall": {
+    "queries": 2184,
+    "mrr": 0.9424768518518519,
+    "recallAt1": 0.9166666666666666,
+    "recallAt5": 0.9748168498168498,
+    "recallAt10": 0.978021978021978,
+    "hits": 12.74587912087912,
+    "coverage": 0.29330561991730975,
+    "junk": 0.23960746899277635,
+    "junkHits": 0.804945054945055
+  },
+  "byKind": {
+    "desc_phrase": {
+      "queries": 295,
+      "mrr": 0.8988229755178906,
+      "recallAt1": 0.8338983050847457,
+      "recallAt5": 0.9796610169491525,
+      "recallAt10": 0.9966101694915255,
+      "hits": 35.637288135593224,
+      "coverage": 0.26290011037527594,
+      "junk": 0.12665562913907286,
+      "junkHits": 1.0372881355932204
+    },
+    "desc_terms": {
+      "queries": 294,
+      "mrr": 0.9244047619047621,
+      "recallAt1": 0.8639455782312925,
+      "recallAt5": 0.9965986394557823,
+      "recallAt10": 1,
+      "hits": 8.741496598639456,
+      "coverage": 0.191047471620229,
+      "junk": 0.45123839009287925,
+      "junkHits": 1.9829931972789117
+    },
+    "name_exact": {
+      "queries": 339,
+      "mrr": 1,
+      "recallAt1": 1,
+      "recallAt5": 1,
+      "recallAt10": 1,
+      "hits": 4.398230088495575,
+      "coverage": 0.41292134831460636,
+      "junk": 0.15168539325842698,
+      "junkHits": 0.1592920353982301
+    },
+    "name_prefix": {
+      "queries": 317,
+      "mrr": 0.9492639327024184,
+      "recallAt1": 0.9085173501577287,
+      "recallAt5": 0.9936908517350158,
+      "recallAt10": 0.9936908517350158,
+      "hits": 7.220820189274448,
+      "coverage": 0.30464216634429425,
+      "junk": 0.5589941972920697,
+      "junkHits": 0.9116719242902208
+    },
+    "name_transpose": {
+      "queries": 313,
+      "mrr": 0.9127795527156549,
+      "recallAt1": 0.9073482428115016,
+      "recallAt5": 0.9233226837060703,
+      "recallAt10": 0.9233226837060703,
+      "hits": 3.6613418530351436,
+      "coverage": 0.23898678414096944,
+      "junk": 0.23348017621145375,
+      "junkHits": 0.16932907348242812
+    },
+    "name_typo": {
+      "queries": 325,
+      "mrr": 0.9283076923076923,
+      "recallAt1": 0.9230769230769231,
+      "recallAt5": 0.9384615384615385,
+      "recallAt10": 0.9384615384615385,
+      "hits": 3.8923076923076922,
+      "coverage": 0.2576666666666669,
+      "junk": 0.232,
+      "junkHits": 0.17846153846153845
+    },
+    "name_words": {
+      "queries": 301,
+      "mrr": 0.9771594684385381,
+      "recallAt1": 0.9667774086378738,
+      "recallAt5": 0.9933554817275747,
+      "recallAt10": 0.9966777408637874,
+      "hits": 28.448504983388705,
+      "coverage": 0.3715737896738379,
+      "junk": 0.18209741114523914,
+      "junkHits": 1.3787375415282392
+    }
+  },
+  "negatives": {
+    "chimera": {
+      "queries": 120,
+      "meanHits": 10.675,
+      "zeroHitRate": 0
+    },
+    "oov": {
+      "queries": 108,
+      "meanHits": 0,
+      "zeroHitRate": 1
+    }
+  }
+}

--- a/x/adrsimon/agentsearch/assets/profile_skeleton.json
+++ b/x/adrsimon/agentsearch/assets/profile_skeleton.json
@@ -1,0 +1,38 @@
+{
+  "__": [
+    "This is a SKELETON, not data. It documents the shape of a user profile snapshot:",
+    "the parts of an Authenticator a search needs in order to answer as that user.",
+    "",
+    "No profile is committed — a snapshot names a real person and their group and space",
+    "memberships — so assets/profile_*.json is gitignored.",
+    "",
+    "To produce one, run scripts/export_user_profile.ts against a workspace member",
+    "(see README.md, 'Producing an export'). It writes profile_<userSId>.json; drop it",
+    "in this directory and pass it to search with --profile.",
+    "",
+    "readableNonPodSpaces feeds the terms_set space filter. readablePodSpaces is",
+    "recorded but not filtered on, mirroring skill search, which authorizes pods",
+    "against Postgres after the query rather than inside it."
+  ],
+  "workspaceId": "0000000000",
+  "workspaceName": "Example Workspace",
+  "generatedAt": "2026-08-25T16:20:00.000Z",
+  "user": {
+    "sId": "aaaaaaaaaaaaaaaaaaaa",
+    "email": "someone@example.com",
+    "fullName": "Some One"
+  },
+  "role": "user",
+  "groupIds": ["grp_AAAAAAAAAAAA", "grp_BBBBBBBBBBBB"],
+  "groups": [
+    { "sId": "grp_AAAAAAAAAAAA", "name": "Workspace", "kind": "global" },
+    { "sId": "grp_BBBBBBBBBBBB", "name": "support", "kind": "provisioned" }
+  ],
+  "readableNonPodSpaces": [
+    { "sId": "vlt_AAAAAAAAAAAA", "name": "Company Data", "kind": "global" },
+    { "sId": "vlt_CCCCCCCCCCCC", "name": "Support", "kind": "regular" }
+  ],
+  "readablePodSpaces": [
+    { "sId": "vlt_BBBBBBBBBBBB", "name": "Support Knowledge", "kind": "project" }
+  ]
+}

--- a/x/adrsimon/agentsearch/docker-compose.yml
+++ b/x/adrsimon/agentsearch/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.16.0
+    container_name: dust-agentsearch-es
+    ports:
+      - "127.0.0.1:9250:9200"
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.license.self_generated.type=basic
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - agentsearch-es:/usr/share/elasticsearch/data
+    healthcheck:
+      test:
+        ["CMD-SHELL", "curl -s --fail http://localhost:9200/_cluster/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  agentsearch-es:

--- a/x/adrsimon/agentsearch/index/agent_search.mappings.json
+++ b/x/adrsimon/agentsearch/index/agent_search.mappings.json
@@ -1,0 +1,185 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "agent_id": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "agent_name_index",
+        "search_analyzer": "agent_name_search",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "subsequence": {
+            "type": "wildcard"
+          }
+        },
+        "similarity": "name_bm25"
+      },
+      "description": {
+        "type": "text",
+        "analyzer": "agent_text",
+        "fields": {
+          "subsequence": {
+            "type": "wildcard"
+          }
+        },
+        "similarity": "text_bm25"
+      },
+      "instructions": {
+        "type": "text",
+        "analyzer": "agent_text",
+        "similarity": "text_bm25"
+      },
+      "tags": {
+        "type": "keyword"
+      },
+      "scope": {
+        "type": "keyword"
+      },
+      "status": {
+        "type": "keyword"
+      },
+      "author": {
+        "type": "keyword"
+      },
+      "editors": {
+        "type": "keyword"
+      },
+      "requested_space_ids": {
+        "type": "keyword"
+      },
+      "requested_space_count": {
+        "type": "integer"
+      },
+      "non_pod_space_ids": {
+        "type": "keyword"
+      },
+      "non_pod_space_count": {
+        "type": "integer"
+      },
+      "pod_space_ids": {
+        "type": "keyword"
+      },
+      "usage": {
+        "properties": {
+          "messages": {
+            "type": "integer"
+          },
+          "conversations": {
+            "type": "integer"
+          },
+          "users": {
+            "type": "integer"
+          },
+          "credits": {
+            "type": "long"
+          },
+          "feedbacks_up": {
+            "type": "integer"
+          },
+          "feedbacks_down": {
+            "type": "integer"
+          },
+          "by_group": {
+            "type": "nested",
+            "properties": {
+              "group_id": {
+                "type": "keyword"
+              },
+              "group_name": {
+                "type": "keyword"
+              },
+              "messages": {
+                "type": "integer"
+              },
+              "users": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0,
+    "analysis": {
+      "filter": {
+        "agent_name_delimiter": {
+          "type": "word_delimiter_graph",
+          "generate_word_parts": true,
+          "generate_number_parts": true,
+          "catenate_words": true,
+          "catenate_numbers": true,
+          "split_on_case_change": true,
+          "split_on_numerics": true,
+          "preserve_original": true,
+          "stem_english_possessive": true
+        },
+        "english_stop": {
+          "type": "stop",
+          "stopwords": "_english_"
+        },
+        "english_stemmer": {
+          "type": "stemmer",
+          "language": "light_english"
+        },
+        "english_possessive": {
+          "type": "stemmer",
+          "language": "possessive_english"
+        }
+      },
+      "analyzer": {
+        "agent_name_index": {
+          "type": "custom",
+          "tokenizer": "whitespace",
+          "filter": [
+            "agent_name_delimiter",
+            "flatten_graph",
+            "lowercase",
+            "english_stop",
+            "english_stemmer"
+          ]
+        },
+        "agent_name_search": {
+          "type": "custom",
+          "tokenizer": "whitespace",
+          "filter": [
+            "agent_name_delimiter",
+            "lowercase",
+            "english_stop",
+            "english_stemmer"
+          ]
+        },
+        "agent_text": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "english_possessive",
+            "lowercase",
+            "english_stop",
+            "english_stemmer"
+          ]
+        }
+      }
+    },
+    "similarity": {
+      "name_bm25": {
+        "type": "BM25",
+        "k1": 1.2,
+        "b": 0.75
+      },
+      "text_bm25": {
+        "type": "BM25",
+        "k1": 1.2,
+        "b": 0.75
+      }
+    }
+  }
+}

--- a/x/adrsimon/agentsearch/package.json
+++ b/x/adrsimon/agentsearch/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "agentsearch",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "es:up": "docker compose up -d",
+    "es:down": "docker compose down",
+    "es:reset": "docker compose down -v && docker compose up -d",
+    "ingest": "tsx scripts/ingest.ts",
+    "search": "tsx scripts/search.ts",
+    "typecheck": "tsgo --noEmit -p .",
+    "gen:queries": "tsx scripts/generate_queries.ts",
+    "eval": "tsx scripts/eval.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/x/adrsimon/agentsearch/scripts/es.ts
+++ b/x/adrsimon/agentsearch/scripts/es.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_ES_URL = "http://localhost:9250";
+export const DEFAULT_INDEX = "agent_search";
+
+export async function esRequest<T>(
+  esUrl: string,
+  method: string,
+  path: string,
+  body?: string,
+  contentType = "application/json"
+): Promise<T> {
+  const res = await fetch(`${esUrl}${path}`, {
+    method,
+    headers: body ? { "Content-Type": contentType } : {},
+    body,
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`${method} ${path} -> ${res.status}: ${text.slice(0, 500)}`);
+  }
+  return text ? (JSON.parse(text) as T) : (null as T);
+}

--- a/x/adrsimon/agentsearch/scripts/eval.ts
+++ b/x/adrsimon/agentsearch/scripts/eval.ts
@@ -1,0 +1,379 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
+import type { MatchMode, NameFallback } from "./query.ts";
+import { buildAgentSearchQuery, contextFromProfile } from "./query.ts";
+import { contentTerms, documentTerms } from "./text.ts";
+import type {
+  EvalMetrics,
+  NegativeMetrics,
+  EvalQuery,
+  EvalQuerySet,
+  EvalReport,
+  UserProfile,
+} from "./types.ts";
+
+const BATCH_SIZE = 100;
+const CUTOFF = 10;
+
+const { values } = parseArgs({
+  options: {
+    queries: { type: "string", default: "assets/eval_queries_dust.json" },
+    profile: { type: "string" },
+    spaces: { type: "string", default: "" },
+    groups: { type: "string", default: "" },
+    "exclude-global": { type: "boolean", default: false },
+    "with-instructions": { type: "boolean", default: false },
+    "min-should-match": { type: "string", default: "" },
+    "match-mode": { type: "string", default: "hybrid" },
+    "name-fallback": { type: "string", default: "fuzzy" },
+    "group-boost": { type: "string", default: "0.5" },
+    "max-queries": { type: "string", default: "0" },
+    save: { type: "string" },
+    compare: { type: "string" },
+    misses: { type: "string", default: "0" },
+    es: { type: "string", default: DEFAULT_ES_URL },
+    index: { type: "string", default: DEFAULT_INDEX },
+  },
+});
+
+const querySet: EvalQuerySet = JSON.parse(
+  await readFile(resolve(values.queries), "utf-8")
+);
+const profile: UserProfile | null = values.profile
+  ? JSON.parse(await readFile(resolve(values.profile), "utf-8"))
+  : null;
+
+const context = contextFromProfile(profile, {
+  spaces: values.spaces,
+  groups: values.groups,
+});
+const groupBoost = Number(values["group-boost"]);
+const excludeGlobal = values["exclude-global"];
+const includeInstructions = values["with-instructions"];
+const minShouldMatch = values["min-should-match"];
+const matchMode = values["match-mode"] as MatchMode;
+const nameFallback = values["name-fallback"] as NameFallback;
+const maxQueries = Number(values["max-queries"]);
+const queries =
+  maxQueries > 0 ? querySet.queries.slice(0, maxQueries) : querySet.queries;
+
+interface Hit {
+  _id: string;
+  _source: { name: string; description: string };
+}
+
+interface MsearchResponse {
+  responses: {
+    hits?: { total: { value: number }; hits: Hit[] };
+    error?: { reason?: string };
+  }[];
+}
+
+interface QueryOutcome {
+  rank: number | null;
+  totalHits: number;
+  coverage: number[];
+}
+
+const errors: { query: string; reason: string }[] = [];
+
+function rankOf(hits: Hit[], targetId: string): number | null {
+  const index = hits.findIndex((hit) => hit._id === targetId);
+  return index === -1 ? null : index + 1;
+}
+
+// Precision proxy: with only one labelled document per query there is nothing to score the
+// other results against, so measure how much of what was asked for each non-target result
+// actually contains.
+function coverageOfNonTargets(
+  hits: Hit[],
+  query: string,
+  targetId: string | null
+): number[] {
+  const queryTerms = [...contentTerms(query)];
+  if (queryTerms.length === 0) {
+    return [];
+  }
+  return hits
+    .filter((hit) => hit._id !== targetId)
+    .map((hit) => {
+      const terms = documentTerms(hit._source.name, hit._source.description);
+      return (
+        queryTerms.filter((term) => terms.has(term)).length / queryTerms.length
+      );
+    });
+}
+
+async function runBatch(
+  batch: { query: string; targetId: string | null }[]
+): Promise<QueryOutcome[]> {
+  const lines: string[] = [];
+  for (const query of batch) {
+    lines.push(JSON.stringify({ index: values.index }));
+    lines.push(
+      JSON.stringify({
+        query: buildAgentSearchQuery({
+          ...context,
+          searchTerm: query.query,
+          scopes: [],
+          excludeGlobal,
+          includeInstructions,
+          minShouldMatch,
+          matchMode,
+          nameFallback,
+          groupBoost,
+        }),
+        size: CUTOFF,
+        _source: ["name", "description"],
+        track_total_hits: true,
+        sort: [{ _score: "desc" }, { "name.keyword": "asc" }],
+      })
+    );
+  }
+  const result = await esRequest<MsearchResponse>(
+    values.es,
+    "POST",
+    "/_msearch",
+    `${lines.join("\n")}\n`,
+    "application/x-ndjson"
+  );
+  return result.responses.map((response, index) => {
+    const { query, targetId } = batch[index];
+    if (!response.hits) {
+      errors.push({ query, reason: response.error?.reason ?? "unknown" });
+      return { rank: null, totalHits: 0, coverage: [] };
+    }
+    return {
+      rank: targetId ? rankOf(response.hits.hits, targetId) : null,
+      totalHits: response.hits.total.value,
+      coverage: coverageOfNonTargets(response.hits.hits, query, targetId),
+    };
+  });
+}
+
+async function runAll(
+  items: { query: string; targetId: string | null }[],
+  label: string
+): Promise<QueryOutcome[]> {
+  const outcomes: QueryOutcome[] = [];
+  for (let offset = 0; offset < items.length; offset += BATCH_SIZE) {
+    outcomes.push(...(await runBatch(items.slice(offset, offset + BATCH_SIZE))));
+    process.stdout.write(
+      `\r${label} ${Math.min(offset + BATCH_SIZE, items.length)}/${items.length}`
+    );
+  }
+  process.stdout.write("\r\x1b[K");
+  return outcomes;
+}
+
+const outcomes = await runAll(queries, "scored");
+const ranks = outcomes.map((outcome) => outcome.rank);
+const negatives = querySet.negatives ?? [];
+const negativeOutcomes = await runAll(
+  negatives.map((negative) => ({ query: negative.query, targetId: null })),
+  "negatives"
+);
+
+function mean(values: number[]): number {
+  return values.length === 0
+    ? 0
+    : values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function metricsFor(indices: number[]): EvalMetrics {
+  const coverage = indices.flatMap((index) => outcomes[index].coverage);
+  const hit = (cutoff: number) =>
+    indices.filter((index) => {
+      const rank = ranks[index];
+      return rank !== null && rank <= cutoff;
+    }).length / indices.length;
+  return {
+    queries: indices.length,
+    mrr:
+      indices.reduce((sum, index) => {
+        const rank = ranks[index];
+        return sum + (rank === null ? 0 : 1 / rank);
+      }, 0) / indices.length,
+    recallAt1: hit(1),
+    recallAt5: hit(5),
+    recallAt10: hit(10),
+    hits: mean(indices.map((index) => outcomes[index].totalHits)),
+    coverage: mean(coverage),
+    junk: coverage.length === 0 ? 0 : mean(coverage.map((value) => (value === 0 ? 1 : 0))),
+    junkHits: mean(
+      indices.map(
+        (index) => outcomes[index].coverage.filter((value) => value === 0).length
+      )
+    ),
+  };
+}
+
+const indicesByKind = new Map<string, number[]>();
+for (const [index, query] of queries.entries()) {
+  const existing = indicesByKind.get(query.kind) ?? [];
+  existing.push(index);
+  indicesByKind.set(query.kind, existing);
+}
+
+const negativeIndicesByKind = new Map<string, number[]>();
+for (const [index, negative] of negatives.entries()) {
+  const existing = negativeIndicesByKind.get(negative.kind) ?? [];
+  existing.push(index);
+  negativeIndicesByKind.set(negative.kind, existing);
+}
+
+function negativeMetricsFor(indices: number[]): NegativeMetrics {
+  return {
+    queries: indices.length,
+    meanHits: mean(indices.map((index) => negativeOutcomes[index].totalHits)),
+    zeroHitRate: mean(
+      indices.map((index) => (negativeOutcomes[index].totalHits === 0 ? 1 : 0))
+    ),
+  };
+}
+
+const report: EvalReport = {
+  ranAt: new Date().toISOString(),
+  querySet: basename(values.queries),
+  groupBoost,
+  excludeGlobal,
+  includeInstructions,
+  minShouldMatch,
+  matchMode,
+  nameFallback,
+  overall: metricsFor(queries.map((_, index) => index)),
+  byKind: Object.fromEntries(
+    [...indicesByKind]
+      .sort()
+      .map(([kind, indices]) => [kind, metricsFor(indices)])
+  ),
+  negatives: Object.fromEntries(
+    [...negativeIndicesByKind]
+      .sort()
+      .map(([kind, indices]) => [kind, negativeMetricsFor(indices)])
+  ),
+};
+
+const baseline: EvalReport | null = values.compare
+  ? JSON.parse(await readFile(resolve(values.compare), "utf-8"))
+  : null;
+
+function formatRow(label: string, metrics: EvalMetrics, previous?: EvalMetrics) {
+  const cell = (value: number, before?: number) => {
+    const rendered = value.toFixed(3).padStart(6);
+    if (before === undefined) {
+      return rendered;
+    }
+    const delta = value - before;
+    const sign = delta >= 0 ? "+" : "";
+    return `${rendered} (${sign}${delta.toFixed(3)})`.padStart(20);
+  };
+  console.log(
+    [
+      label.padEnd(13),
+      String(metrics.queries).padStart(5),
+      cell(metrics.mrr, previous?.mrr),
+      cell(metrics.recallAt1, previous?.recallAt1),
+      cell(metrics.recallAt5, previous?.recallAt5),
+      cell(metrics.recallAt10, previous?.recallAt10),
+    ].join("  ")
+  );
+}
+
+console.log(
+  `${querySet.candidateCount} candidates, ${queries.length} queries, `
+    + `group-boost=${groupBoost}${excludeGlobal ? ", no globals" : ""}`
+    + `${includeInstructions ? ", +instructions" : ""}`
+    + `${minShouldMatch ? `, msm=${minShouldMatch}` : ""}`
+    + `, ${matchMode}, name-fallback=${nameFallback}`
+    + `${baseline ? ` — vs ${basename(values.compare!)}` : ""}\n`
+);
+const header = baseline
+  ? "kind             n     MRR@10                 R@1                   R@5                  R@10"
+  : "kind             n     MRR@10     R@1     R@5    R@10";
+console.log(header);
+for (const [kind, metrics] of Object.entries(report.byKind)) {
+  formatRow(kind, metrics, baseline?.byKind[kind]);
+}
+formatRow("OVERALL", report.overall, baseline?.overall);
+
+function formatPrecisionRow(
+  label: string,
+  metrics: EvalMetrics,
+  previous?: EvalMetrics
+) {
+  const cell = (value: number, before: number | undefined, digits = 3) => {
+    const rendered = value.toFixed(digits).padStart(7);
+    if (before === undefined) {
+      return rendered;
+    }
+    const delta = value - before;
+    return `${rendered} (${delta >= 0 ? "+" : ""}${delta.toFixed(digits)})`.padStart(20);
+  };
+  console.log(
+    [
+      label.padEnd(13),
+      cell(metrics.hits, previous?.hits, 1),
+      cell(metrics.coverage, previous?.coverage),
+      cell(metrics.junk, previous?.junk),
+      cell(metrics.junkHits, previous?.junkHits, 2),
+    ].join("  ")
+  );
+}
+
+console.log(
+  `\nprecision (non-target results in the top ${CUTOFF})\n`
+    + `kind             hits  coverage     junk  junk/query`
+);
+for (const [kind, metrics] of Object.entries(report.byKind)) {
+  formatPrecisionRow(kind, metrics, baseline?.byKind[kind]);
+}
+formatPrecisionRow("OVERALL", report.overall, baseline?.overall);
+
+if (negatives.length > 0) {
+  console.log(`\nnegative queries (should return nothing)\nkind             n   meanHits  zeroHit`);
+  for (const [kind, metrics] of Object.entries(report.negatives)) {
+    const previous = baseline?.negatives?.[kind];
+    const cell = (value: number, before: number | undefined, digits = 2) => {
+      const rendered = value.toFixed(digits).padStart(8);
+      if (before === undefined) {
+        return rendered;
+      }
+      const delta = value - before;
+      return `${rendered} (${delta >= 0 ? "+" : ""}${delta.toFixed(digits)})`.padStart(20);
+    };
+    console.log(
+      [
+        kind.padEnd(13),
+        String(metrics.queries).padStart(4),
+        cell(metrics.meanHits, previous?.meanHits, 1),
+        cell(metrics.zeroHitRate, previous?.zeroHitRate),
+      ].join("  ")
+    );
+  }
+}
+
+const missCount = Number(values.misses);
+if (missCount > 0) {
+  console.log(`\nworst misses (target outside top ${CUTOFF}):`);
+  const missed = queries
+    .map((query, index) => ({ query, rank: ranks[index] }))
+    .filter((entry) => entry.rank === null)
+    .slice(0, missCount);
+  for (const entry of missed) {
+    console.log(
+      `  ${entry.query.kind.padEnd(13)} "${entry.query.query.slice(0, 46).padEnd(46)}" -> ${entry.query.targetName}`
+    );
+  }
+}
+
+if (values.save) {
+  await writeFile(
+    resolve(values.save),
+    `${JSON.stringify(report, null, 2)}\n`
+  );
+  console.log(`\nsaved ${values.save}`);
+}

--- a/x/adrsimon/agentsearch/scripts/export_user_profile.ts
+++ b/x/adrsimon/agentsearch/scripts/export_user_profile.ts
@@ -1,0 +1,98 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+import * as fs from "fs";
+
+makeScript(
+  {
+    wId: {
+      type: "string",
+      demandOption: true,
+      description: "Workspace sId",
+    },
+    email: {
+      type: "string",
+      demandOption: true,
+      description: "Email of the user to snapshot",
+    },
+    outputFile: {
+      type: "string",
+      description: "Output path (defaults to ./profile_<userSId>.json)",
+    },
+  },
+  async ({ wId, email, outputFile }, logger) => {
+    const workspace = await WorkspaceResource.fetchById(wId);
+    if (!workspace) {
+      throw new Error(`Workspace ${wId} not found.`);
+    }
+
+    const user = await UserResource.fetchByEmail(email);
+    if (!user) {
+      throw new Error(`User ${email} not found.`);
+    }
+
+    const auth = await Authenticator.fromUserIdAndWorkspaceId(user.sId, wId);
+    if (auth.role() === "none") {
+      throw new Error(`User ${email} is not a member of workspace ${wId}.`);
+    }
+
+    const groups = await GroupResource.listUserGroupsInWorkspace({
+      user,
+      workspace: auth.getNonNullableWorkspace(),
+    });
+
+    const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
+      includeConversationsSpace: true,
+    });
+    const readableSpaces = spaces.filter((space) => space.canRead(auth));
+
+    const toSpace = (space: (typeof readableSpaces)[number]) => ({
+      sId: space.sId,
+      name: space.name,
+      kind: space.kind,
+    });
+
+    const profile = {
+      workspaceId: workspace.sId,
+      workspaceName: workspace.name,
+      generatedAt: new Date().toISOString(),
+      user: {
+        sId: user.sId,
+        email: user.email,
+        fullName: user.fullName(),
+      },
+      role: auth.role(),
+      groupIds: auth.groupIds(),
+      groups: groups.map((group) => ({
+        sId: group.sId,
+        name: group.name,
+        kind: group.kind,
+      })),
+      readableNonPodSpaces: readableSpaces
+        .filter((space) => !space.isProject())
+        .map(toSpace),
+      readablePodSpaces: readableSpaces
+        .filter((space) => space.isProject())
+        .map(toSpace),
+    };
+
+    const path = outputFile ?? `./profile_${user.sId}.json`;
+    await fs.promises.writeFile(
+      path,
+      JSON.stringify(profile, null, 2),
+      "utf-8"
+    );
+
+    logger.info(
+      {
+        path,
+        groupCount: profile.groups.length,
+        readableSpaceCount: readableSpaces.length,
+      },
+      "Profile exported"
+    );
+  }
+);

--- a/x/adrsimon/agentsearch/scripts/export_workspace_agents.ts
+++ b/x/adrsimon/agentsearch/scripts/export_workspace_agents.ts
@@ -1,0 +1,327 @@
+import { fetchAgentExportRows } from "@app/lib/api/analytics/agents_export";
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import { buildDaysConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/period";
+import {
+  CARDINALITY_PRECISION_THRESHOLD,
+  CONSUMPTION_DIMENSION_FIELDS,
+  CREDIT_MICRO_FIELD,
+  MAX_EXPORT_TERMS_SIZE,
+  uniqueMessagesCardinalityAgg,
+} from "@app/lib/api/analytics/consumption/scope";
+import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
+import { getAgentsEditors, getAuthors } from "@app/lib/api/assistant/editors";
+import {
+  bucketsToArray,
+  searchAnalytics,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { microCreditsToCredits } from "@app/lib/credits/units";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { makeScript } from "@app/scripts/helpers";
+import type { estypes } from "@elastic/elasticsearch";
+import * as fs from "fs";
+
+type GroupBucket = {
+  key: string;
+  unique_messages?: estypes.AggregationsCardinalityAggregate;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+  credit_micro?: estypes.AggregationsSumAggregate;
+};
+
+type AgentGroupBucket = {
+  key: string;
+  by_group?: estypes.AggregationsMultiBucketAggregateBase<GroupBucket>;
+};
+
+type AgentGroupAggs = {
+  by_agent?: estypes.AggregationsMultiBucketAggregateBase<AgentGroupBucket>;
+};
+
+type ThumbBucket = {
+  key: string;
+  doc_count: number;
+};
+
+type AgentFeedbackBucket = {
+  key: string;
+  feedbacks?: {
+    by_direction?: estypes.AggregationsMultiBucketAggregateBase<ThumbBucket>;
+  };
+};
+
+type AgentFeedbackAggs = {
+  by_agent?: estypes.AggregationsMultiBucketAggregateBase<AgentFeedbackBucket>;
+};
+
+type GroupUsage = {
+  groupId: string;
+  groupName: string;
+  messages: number;
+  users: number;
+  credits: number;
+};
+
+async function fetchGroupUsageByAgent(
+  auth: Authenticator,
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Map<string, GroupUsage[]>> {
+  const esResult = await searchConsumptionAnalytics<never, AgentGroupAggs>(
+    baseQuery,
+    {
+      aggregations: {
+        by_agent: {
+          terms: {
+            field: CONSUMPTION_DIMENSION_FIELDS.agent,
+            size: MAX_EXPORT_TERMS_SIZE,
+          },
+          aggs: {
+            by_group: {
+              terms: {
+                field: CONSUMPTION_DIMENSION_FIELDS.group,
+                size: MAX_EXPORT_TERMS_SIZE,
+              },
+              aggs: {
+                unique_messages: uniqueMessagesCardinalityAgg(),
+                unique_users: {
+                  cardinality: {
+                    field: CONSUMPTION_DIMENSION_FIELDS.user,
+                    precision_threshold: CARDINALITY_PRECISION_THRESHOLD,
+                  },
+                },
+                credit_micro: { sum: { field: CREDIT_MICRO_FIELD } },
+              },
+            },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (esResult.isErr()) {
+    throw new Error(
+      `Failed to aggregate group usage: ${esResult.error.message}`
+    );
+  }
+
+  const agentBuckets = bucketsToArray<AgentGroupBucket>(
+    esResult.value.aggregations?.by_agent?.buckets
+  );
+
+  const groupIds = new Set(
+    agentBuckets.flatMap((agentBucket) =>
+      bucketsToArray<GroupBucket>(agentBucket.by_group?.buckets).map((g) =>
+        String(g.key)
+      )
+    )
+  );
+  const groupLabels = await resolveDimensionLabels(auth, "group", [
+    ...groupIds,
+  ]);
+
+  return new Map(
+    agentBuckets.map((agentBucket) => [
+      String(agentBucket.key),
+      bucketsToArray<GroupBucket>(agentBucket.by_group?.buckets)
+        .map((groupBucket) => ({
+          groupId: String(groupBucket.key),
+          groupName:
+            groupLabels.get(String(groupBucket.key))?.name ??
+            String(groupBucket.key),
+          messages: Math.round(groupBucket.unique_messages?.value ?? 0),
+          users: Math.round(groupBucket.unique_users?.value ?? 0),
+          credits: Math.round(
+            microCreditsToCredits(groupBucket.credit_micro?.value ?? 0)
+          ),
+        }))
+        .sort((a, b) => b.messages - a.messages),
+    ])
+  );
+}
+
+async function fetchFeedbacksByAgent(
+  workspaceId: string,
+  days: number
+): Promise<Map<string, { up: number; down: number }>> {
+  const esResult = await searchAnalytics<never, AgentFeedbackAggs>(
+    {
+      bool: {
+        filter: [
+          { term: { workspace_id: workspaceId } },
+          { range: { timestamp: { gte: `now-${days}d/d` } } },
+        ],
+      },
+    },
+    {
+      aggregations: {
+        by_agent: {
+          terms: { field: "agent_id", size: MAX_EXPORT_TERMS_SIZE },
+          aggs: {
+            feedbacks: {
+              nested: { path: "feedbacks" },
+              aggs: {
+                by_direction: {
+                  terms: { field: "feedbacks.thumb_direction", size: 5 },
+                },
+              },
+            },
+          },
+        },
+      },
+      size: 0,
+    }
+  );
+
+  if (esResult.isErr()) {
+    throw new Error(`Failed to aggregate feedbacks: ${esResult.error.message}`);
+  }
+
+  return new Map(
+    bucketsToArray<AgentFeedbackBucket>(
+      esResult.value.aggregations?.by_agent?.buckets
+    ).map((agentBucket) => {
+      const directions = bucketsToArray<ThumbBucket>(
+        agentBucket.feedbacks?.by_direction?.buckets
+      );
+      const countFor = (direction: string) =>
+        directions.find((d) => String(d.key) === direction)?.doc_count ?? 0;
+      return [
+        String(agentBucket.key),
+        { up: countFor("up"), down: countFor("down") },
+      ];
+    })
+  );
+}
+
+makeScript(
+  {
+    wId: {
+      type: "string",
+      demandOption: true,
+      description: "Workspace sId",
+    },
+    days: {
+      type: "number",
+      default: 30,
+      description: "Usage window, in days",
+    },
+    outputFile: {
+      type: "string",
+      description: "Output path (defaults to ./agents_<wId>.json)",
+    },
+  },
+  async ({ wId, days, outputFile }, logger) => {
+    const workspace = await WorkspaceResource.fetchById(wId);
+    if (!workspace) {
+      throw new Error(`Workspace ${wId} not found.`);
+    }
+    const auth = await Authenticator.internalAdminForWorkspace(wId);
+
+    const agentConfigurations = await getAgentConfigurationsForView({
+      auth,
+      agentsGetView: "admin_internal",
+      variant: "light",
+      dangerouslySkipPermissionFiltering: true,
+    });
+
+    const baseQuery = await buildDaysConsumptionScopeQuery(auth, days);
+
+    const usageRowsRes = await fetchAgentExportRows(baseQuery, auth, true);
+    if (usageRowsRes.isErr()) {
+      throw usageRowsRes.error;
+    }
+    const usageByAgent = new Map(
+      usageRowsRes.value.map((row) => [row.agentId, row])
+    );
+
+    const [groupUsageByAgent, feedbacksByAgent, editorsByAgent] =
+      await Promise.all([
+        fetchGroupUsageByAgent(auth, baseQuery),
+        fetchFeedbacksByAgent(wId, days),
+        getAgentsEditors(auth, agentConfigurations),
+      ]);
+
+    const authors = await getAuthors(agentConfigurations);
+    const authorById = new Map(authors.map((a) => [a.id, a]));
+
+    const spaces = await SpaceResource.fetchByIds(auth, [
+      ...new Set(agentConfigurations.flatMap((a) => a.requestedSpaceIds)),
+    ]);
+    const spaceById = new Map(spaces.map((s) => [s.sId, s]));
+
+    const isPod = (sId: string) => spaceById.get(sId)?.isProject() ?? false;
+    const nonPodSpaceIdsFor = (spaceIds: string[]) =>
+      spaceIds.filter((sId) => spaceById.has(sId) && !isPod(sId));
+    const podSpaceIdsFor = (spaceIds: string[]) => spaceIds.filter(isPod);
+
+    const unresolvedSpaceAgents = agentConfigurations.filter((agent) =>
+      agent.requestedSpaceIds.some((sId) => !spaceById.has(sId))
+    );
+    if (unresolvedSpaceAgents.length > 0) {
+      logger.warn(
+        {
+          agentCount: unresolvedSpaceAgents.length,
+          agentIds: unresolvedSpaceAgents.map((a) => a.sId).slice(0, 20),
+        },
+        "Agents reference spaces that could not be resolved"
+      );
+    }
+
+    const agents = agentConfigurations.map((agent) => {
+      const usage = usageByAgent.get(agent.sId);
+      const feedbacks = feedbacksByAgent.get(agent.sId);
+
+      return {
+        sId: agent.sId,
+        name: agent.name,
+        description: agent.description,
+        instructions: agent.instructions,
+        scope: agent.scope,
+        status: agent.status,
+        tags: agent.tags.map((t) => t.name),
+        templateId: agent.templateId,
+        author: agent.versionAuthorId
+          ? (authorById.get(agent.versionAuthorId)?.email ?? null)
+          : null,
+        editors: (editorsByAgent[agent.sId] ?? []).map((u) => u.email),
+        requestedSpaceIds: agent.requestedSpaceIds,
+        spaces: agent.requestedSpaceIds.map((sId) => ({
+          sId,
+          name: spaceById.get(sId)?.name ?? null,
+          kind: spaceById.get(sId)?.kind ?? null,
+        })),
+        nonPodSpaceIds: nonPodSpaceIdsFor(agent.requestedSpaceIds),
+        nonPodSpaceCount: nonPodSpaceIdsFor(agent.requestedSpaceIds).length,
+        podSpaceIds: podSpaceIdsFor(agent.requestedSpaceIds),
+        usage: {
+          periodDays: days,
+          messages: usage?.messages ?? 0,
+          conversations: usage?.distinctConversations ?? 0,
+          users: usage?.distinctUsersReached ?? 0,
+          credits: usage?.credits ?? 0,
+          feedbacksUp: feedbacks?.up ?? 0,
+          feedbacksDown: feedbacks?.down ?? 0,
+          byGroup: groupUsageByAgent.get(agent.sId) ?? [],
+        },
+      };
+    });
+
+    agents.sort((a, b) => b.usage.messages - a.usage.messages);
+
+    const output = {
+      workspaceId: wId,
+      workspaceName: workspace.name,
+      generatedAt: new Date().toISOString(),
+      usagePeriodDays: days,
+      agentCount: agents.length,
+      agents,
+    };
+
+    const path = outputFile ?? `./agents_${wId}.json`;
+    await fs.promises.writeFile(path, JSON.stringify(output, null, 2), "utf-8");
+
+    logger.info({ path, agentCount: agents.length }, "Agents exported");
+  }
+);

--- a/x/adrsimon/agentsearch/scripts/generate_queries.ts
+++ b/x/adrsimon/agentsearch/scripts/generate_queries.ts
@@ -1,0 +1,337 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { basename, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
+import { buildFilters, contextFromProfile } from "./query.ts";
+import { splitName, tokenize } from "./text.ts";
+import type {
+  EvalNegative,
+  EvalQuery,
+  EvalQuerySet,
+  QueryKind,
+  UserProfile,
+} from "./types.ts";
+
+const PAGE_SIZE = 1000;
+const MIN_TERM_LENGTH = 3;
+const NAME_PREFIX_RATIO = 0.6;
+const MIN_NAME_PREFIX = 4;
+const DESC_TERM_COUNT = 3;
+const DESC_PHRASE_LENGTH = 4;
+const CHIMERA_COUNT = 120;
+const CHIMERA_TERMS_PER_SOURCE = 2;
+
+const OOV_WORDBANK =
+  ("aardvark accordion avalanche bassoon bicycle blizzard cathedral cinnamon compass "
+   + "coriander dandelion driftwood eyebrow flamingo glacier granite harmonica hedgehog "
+   + "igloo jellyfish kayak lagoon lantern marmalade meteorite molasses narwhal obsidian "
+   + "octopus paprika parchment pelican quartz raccoon rhubarb saffron seashell sequoia "
+   + "sledgehammer stalactite tambourine tangerine thimble tornado trombone tulip "
+   + "umbrella vanilla volcano walrus wheelbarrow windmill xylophone yacht zeppelin").split(" ");
+
+const { values } = parseArgs({
+  options: {
+    profile: { type: "string" },
+    spaces: { type: "string", default: "" },
+    groups: { type: "string", default: "" },
+    "exclude-global": { type: "boolean", default: false },
+    out: { type: "string" },
+    es: { type: "string", default: DEFAULT_ES_URL },
+    index: { type: "string", default: DEFAULT_INDEX },
+  },
+});
+
+const profile: UserProfile | null = values.profile
+  ? JSON.parse(await readFile(resolve(values.profile), "utf-8"))
+  : null;
+
+const context = contextFromProfile(profile, {
+  spaces: values.spaces,
+  groups: values.groups,
+});
+
+interface Candidate {
+  agentId: string;
+  name: string;
+  description: string;
+}
+
+interface PageResponse {
+  hits: {
+    hits: {
+      _id: string;
+      sort: unknown[];
+      _source: { name: string; description: string };
+    }[];
+  };
+}
+
+async function fetchCandidates(): Promise<Candidate[]> {
+  const query = {
+    bool: {
+      filter: buildFilters({
+        ...context,
+        searchTerm: "",
+        scopes: [],
+        excludeGlobal: values["exclude-global"],
+        includeInstructions: false,
+        minShouldMatch: "",
+        matchMode: "bool_prefix",
+        nameFallback: "off",
+        groupBoost: 0,
+      }),
+    },
+  };
+
+  const candidates: Candidate[] = [];
+  let searchAfter: unknown[] | undefined;
+  for (;;) {
+    const page = await esRequest<PageResponse>(
+      values.es,
+      "POST",
+      `/${values.index}/_search`,
+      JSON.stringify({
+        query,
+        size: PAGE_SIZE,
+        _source: ["name", "description"],
+        sort: [{ _doc: "asc" }],
+        ...(searchAfter ? { search_after: searchAfter } : {}),
+      })
+    );
+    if (page.hits.hits.length === 0) {
+      return candidates;
+    }
+    for (const hit of page.hits.hits) {
+      candidates.push({
+        agentId: hit._id,
+        name: hit._source.name,
+        description: hit._source.description ?? "",
+      });
+    }
+    searchAfter = page.hits.hits[page.hits.hits.length - 1].sort;
+  }
+}
+
+function buildIdf(candidates: Candidate[]): Map<string, number> {
+  const documentFrequency = new Map<string, number>();
+  for (const candidate of candidates) {
+    for (const token of new Set(tokenize(candidate.description))) {
+      documentFrequency.set(token, (documentFrequency.get(token) ?? 0) + 1);
+    }
+  }
+  const idf = new Map<string, number>();
+  for (const [token, frequency] of documentFrequency) {
+    idf.set(token, Math.log(candidates.length / frequency));
+  }
+  return idf;
+}
+
+function descriptionQueries(
+  candidate: Candidate,
+  idf: Map<string, number>
+): { kind: QueryKind; query: string }[] {
+  const tokens = tokenize(candidate.description);
+  if (tokens.length < DESC_TERM_COUNT) {
+    return [];
+  }
+
+  const ranked = [...new Set(tokens)].sort(
+    (a, b) => (idf.get(b) ?? 0) - (idf.get(a) ?? 0)
+  );
+  const salientTerms = ranked.slice(0, DESC_TERM_COUNT);
+
+  const anchor = tokens.indexOf(ranked[0]);
+  const start = Math.max(0, anchor - 1);
+  const phrase = tokens.slice(start, start + DESC_PHRASE_LENGTH);
+
+  return [
+    { kind: "desc_terms", query: salientTerms.join(" ") },
+    { kind: "desc_phrase", query: phrase.join(" ") },
+  ];
+}
+
+function deleteMiddleCharacter(name: string): string {
+  const at = Math.floor(name.length / 2);
+  return name.slice(0, at) + name.slice(at + 1);
+}
+
+function transposeMiddleCharacters(name: string): string {
+  const at = Math.floor(name.length / 2);
+  return (
+    name.slice(0, at) + name[at + 1] + name[at] + name.slice(at + 2)
+  );
+}
+
+function typoQueries(name: string): { kind: QueryKind; query: string }[] {
+  if (name.length < MIN_NAME_PREFIX + 2) {
+    return [];
+  }
+  return [
+    { kind: "name_typo", query: deleteMiddleCharacter(name).toLowerCase() },
+    {
+      kind: "name_transpose",
+      query: transposeMiddleCharacters(name).toLowerCase(),
+    },
+  ];
+}
+
+function queriesFor(
+  candidate: Candidate,
+  idf: Map<string, number>
+): { kind: QueryKind; query: string }[] {
+  const prefixLength = Math.max(
+    MIN_NAME_PREFIX,
+    Math.ceil(candidate.name.length * NAME_PREFIX_RATIO)
+  );
+  return [
+    { kind: "name_exact", query: candidate.name.toLowerCase() },
+    { kind: "name_words", query: splitName(candidate.name) },
+    {
+      kind: "name_prefix",
+      query: candidate.name.slice(0, prefixLength).toLowerCase(),
+    },
+    ...typoQueries(candidate.name),
+    ...descriptionQueries(candidate, idf),
+  ];
+}
+
+interface CountResponse {
+  responses: { hits: { total: { value: number } } }[];
+}
+
+async function absentFromCorpus(words: string[]): Promise<string[]> {
+  const lines: string[] = [];
+  for (const word of words) {
+    lines.push(JSON.stringify({ index: values.index }));
+    lines.push(
+      JSON.stringify({
+        query: { multi_match: { query: word, fields: ["name", "description"] } },
+        size: 0,
+        track_total_hits: true,
+      })
+    );
+  }
+  const result = await esRequest<CountResponse>(
+    values.es,
+    "POST",
+    "/_msearch",
+    `${lines.join("\n")}\n`,
+    "application/x-ndjson"
+  );
+  return words.filter(
+    (_, index) => result.responses[index].hits.total.value === 0
+  );
+}
+
+function buildNegatives(
+  candidates: Candidate[],
+  idf: Map<string, number>,
+  oovWords: string[]
+): EvalNegative[] {
+  const negatives: EvalNegative[] = [];
+
+  for (const [index, word] of oovWords.entries()) {
+    negatives.push({
+      query: word,
+      kind: "oov",
+      sources: [],
+    });
+    const partner = oovWords[(index + 1) % oovWords.length];
+    if (partner !== word) {
+      negatives.push({ query: `${word} ${partner}`, kind: "oov", sources: [] });
+    }
+  }
+
+  const salient = (candidate: Candidate) =>
+    [...new Set(tokenize(candidate.description))]
+      .sort((a, b) => (idf.get(b) ?? 0) - (idf.get(a) ?? 0))
+      .slice(0, CHIMERA_TERMS_PER_SOURCE);
+
+  const usable = candidates.filter(
+    (candidate) => salient(candidate).length === CHIMERA_TERMS_PER_SOURCE
+  );
+  const stride = Math.floor(usable.length / 2);
+  for (let index = 0; index < Math.min(CHIMERA_COUNT, stride); index++) {
+    const left = usable[index];
+    const right = usable[index + stride];
+    const terms = [...salient(left), ...salient(right)];
+    if (new Set(terms).size !== terms.length) {
+      continue;
+    }
+    negatives.push({
+      query: terms.join(" "),
+      kind: "chimera",
+      sources: [left.agentId, right.agentId],
+    });
+  }
+
+  return negatives;
+}
+
+const candidates = await fetchCandidates();
+const idf = buildIdf(candidates);
+
+const byQuery = new Map<string, EvalQuery[]>();
+for (const candidate of candidates) {
+  for (const { kind, query } of queriesFor(candidate, idf)) {
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_TERM_LENGTH) {
+      continue;
+    }
+    const existing = byQuery.get(trimmed) ?? [];
+    existing.push({
+      query: trimmed,
+      kind,
+      targetId: candidate.agentId,
+      targetName: candidate.name,
+    });
+    byQuery.set(trimmed, existing);
+  }
+}
+
+const queries: EvalQuery[] = [];
+let ambiguousDropped = 0;
+for (const entries of byQuery.values()) {
+  const targets = new Set(entries.map((entry) => entry.targetId));
+  if (targets.size > 1) {
+    ambiguousDropped += entries.length;
+    continue;
+  }
+  queries.push(entries[0]);
+}
+
+const oovWords = await absentFromCorpus(OOV_WORDBANK);
+const negatives = buildNegatives(candidates, idf, oovWords);
+
+const querySet: EvalQuerySet = {
+  generatedAt: new Date().toISOString(),
+  index: values.index,
+  profile: values.profile ? basename(values.profile) : null,
+  excludeGlobal: values["exclude-global"],
+  candidateCount: candidates.length,
+  queries,
+  negatives,
+};
+
+const outputPath = resolve(
+  values.out ?? `assets/eval_queries_${values.index}.json`
+);
+await writeFile(outputPath, `${JSON.stringify(querySet, null, 2)}\n`);
+
+const byKind = new Map<string, number>();
+for (const query of queries) {
+  byKind.set(query.kind, (byKind.get(query.kind) ?? 0) + 1);
+}
+console.log(
+  `${candidates.length} candidates -> ${queries.length} queries `
+    + `(${ambiguousDropped} dropped as ambiguous)`
+);
+for (const [kind, count] of [...byKind].sort()) {
+  console.log(`  ${kind.padEnd(13)} ${String(count).padStart(5)}`);
+}
+console.log(
+  `  ${"negatives".padEnd(13)} ${String(negatives.length).padStart(5)} `
+    + `(${oovWords.length}/${OOV_WORDBANK.length} wordbank terms absent from corpus)`
+);
+console.log(`wrote ${outputPath}`);

--- a/x/adrsimon/agentsearch/scripts/ingest.ts
+++ b/x/adrsimon/agentsearch/scripts/ingest.ts
@@ -1,0 +1,114 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
+import type {
+  AgentSearchDocument,
+  ExportedAgent,
+  WorkspaceAgentExport,
+} from "./types.ts";
+
+const PROJECT_ROOT = resolve(dirname(new URL(import.meta.url).pathname), "..");
+const BATCH_SIZE = 200;
+
+const { values } = parseArgs({
+  options: {
+    file: { type: "string" },
+    es: { type: "string", default: DEFAULT_ES_URL },
+    index: { type: "string", default: DEFAULT_INDEX },
+  },
+});
+
+interface BulkResponse {
+  errors: boolean;
+  items: { index: { error?: unknown } }[];
+}
+
+function toDocument(agent: ExportedAgent): AgentSearchDocument {
+  return {
+    agent_id: agent.sId,
+    name: agent.name,
+    description: agent.description,
+    instructions: agent.instructions,
+    tags: agent.tags,
+    scope: agent.scope,
+    status: agent.status,
+    author: agent.author,
+    editors: agent.editors,
+    requested_space_ids: agent.requestedSpaceIds,
+    requested_space_count: agent.requestedSpaceIds.length,
+    non_pod_space_ids: agent.nonPodSpaceIds,
+    non_pod_space_count: agent.nonPodSpaceCount,
+    pod_space_ids: agent.podSpaceIds,
+    usage: {
+      messages: agent.usage.messages,
+      conversations: agent.usage.conversations,
+      users: agent.usage.users,
+      credits: agent.usage.credits,
+      feedbacks_up: agent.usage.feedbacksUp,
+      feedbacks_down: agent.usage.feedbacksDown,
+      by_group: agent.usage.byGroup.map((group) => ({
+        group_id: group.groupId,
+        group_name: group.groupName,
+        messages: group.messages,
+        users: group.users,
+      })),
+    },
+  };
+}
+
+const exportPath = values.file
+  ? resolve(values.file)
+  : join(PROJECT_ROOT, "assets", "agents_0ec9852c2f.json");
+
+const workspaceExport: WorkspaceAgentExport = JSON.parse(
+  await readFile(exportPath, "utf-8")
+);
+
+if (workspaceExport.agents.length === 0) {
+  throw new Error(
+    `${exportPath} holds no agents. Run scripts/export_workspace_agents.ts first (see README).`
+  );
+}
+
+console.log(
+  `loaded ${workspaceExport.agents.length} agents from ${workspaceExport.workspaceName} (${workspaceExport.workspaceId}), generated ${workspaceExport.generatedAt}`
+);
+
+await esRequest(values.es, "DELETE", `/${values.index}`).catch(() => {});
+await esRequest(
+  values.es,
+  "PUT",
+  `/${values.index}`,
+  await readFile(join(PROJECT_ROOT, "index", "agent_search.mappings.json"), "utf-8")
+);
+
+for (let i = 0; i < workspaceExport.agents.length; i += BATCH_SIZE) {
+  const batch = workspaceExport.agents.slice(i, i + BATCH_SIZE);
+  const lines = batch.flatMap((agent) => [
+    JSON.stringify({ index: { _index: values.index, _id: agent.sId } }),
+    JSON.stringify(toDocument(agent)),
+  ]);
+  const result = await esRequest<BulkResponse>(
+    values.es,
+    "POST",
+    "/_bulk",
+    `${lines.join("\n")}\n`,
+    "application/x-ndjson"
+  );
+  if (result.errors) {
+    const failed = result.items.find((item) => item.index.error);
+    throw new Error(`bulk error: ${JSON.stringify(failed?.index.error)}`);
+  }
+  const done = Math.min(i + BATCH_SIZE, workspaceExport.agents.length);
+  process.stdout.write(`\rindexed ${done}/${workspaceExport.agents.length}`);
+}
+
+await esRequest(values.es, "POST", `/${values.index}/_refresh`);
+const { count } = await esRequest<{ count: number }>(
+  values.es,
+  "GET",
+  `/${values.index}/_count`
+);
+console.log(`\ndone: ${count} documents in ${values.index}`);

--- a/x/adrsimon/agentsearch/scripts/query.ts
+++ b/x/adrsimon/agentsearch/scripts/query.ts
@@ -1,0 +1,251 @@
+import type { UserProfile } from "./types.ts";
+
+export type EsQuery = Record<string, unknown>;
+
+export type MatchMode = "bool_prefix" | "best_fields" | "hybrid";
+
+export type NameFallback = "subsequence" | "fuzzy" | "both" | "off";
+
+const NAME_FALLBACK_BOOST = 4;
+
+const PREFIX_CLAUSE_BOOST = 0.5;
+
+// Lucene refuses to determinize a subsequence automaton much past this; the pattern is
+// only meaningful for a single token anyway, since the field holds the whole name. It is
+// applied to `name` only: on a description-length field a short subsequence matches nearly
+// everything.
+const MAX_SUBSEQUENCE_LENGTH = 24;
+
+export interface SearchContext {
+  readableSpaceIds: string[];
+  userGroupIds: string[];
+  userEmail: string | null;
+}
+
+export interface SearchParams extends SearchContext {
+  searchTerm: string;
+  scopes: string[];
+  includeInstructions: boolean;
+  minShouldMatch: string;
+  matchMode: MatchMode;
+  nameFallback: NameFallback;
+  excludeGlobal: boolean;
+  groupBoost: number;
+}
+
+export function contextFromProfile(
+  profile: UserProfile | null,
+  fallback: { spaces: string; groups: string }
+): SearchContext {
+  if (profile) {
+    return {
+      readableSpaceIds: [
+        ...profile.readableNonPodSpaces,
+        ...profile.readablePodSpaces,
+      ].map((space) => space.sId),
+      userGroupIds: profile.groupIds,
+      userEmail: profile.user.email,
+    };
+  }
+  return {
+    readableSpaceIds: fallback.spaces.split(",").filter(Boolean),
+    userGroupIds: fallback.groups.split(",").filter(Boolean),
+    userEmail: null,
+  };
+}
+
+function buildSpaceAccessFilter(readableSpaceIds: string[]): EsQuery {
+  if (readableSpaceIds.length === 0) {
+    return { term: { requested_space_count: 0 } };
+  }
+  return {
+    bool: {
+      should: [
+        { term: { requested_space_count: 0 } },
+        {
+          terms_set: {
+            requested_space_ids: {
+              terms: readableSpaceIds,
+              minimum_should_match_field: "requested_space_count",
+            },
+          },
+        },
+      ],
+      minimum_should_match: 1,
+    },
+  };
+}
+
+function buildVisibilityFilter(
+  userEmail: string | null,
+  excludeGlobal: boolean
+): EsQuery {
+  const visibleScopes = excludeGlobal ? ["visible"] : ["visible", "global"];
+  const should: EsQuery[] = [{ terms: { scope: visibleScopes } }];
+  if (userEmail) {
+    should.push({
+      bool: {
+        filter: [
+          { term: { scope: "hidden" } },
+          { term: { editors: userEmail } },
+        ],
+      },
+    });
+  }
+  return { bool: { should, minimum_should_match: 1 } };
+}
+
+function buildSubsequencePattern(term: string): string {
+  const escaped = Array.from(term, (character) =>
+    "\\*?".includes(character) ? `\\${character}` : character
+  );
+  return `*${escaped.join("*")}*`;
+}
+
+function supportsSubsequence(searchTerm: string): boolean {
+  return (
+    searchTerm.length <= MAX_SUBSEQUENCE_LENGTH && !/\s/.test(searchTerm)
+  );
+}
+
+function buildTextClauses(
+  searchTerm: string,
+  includeInstructions: boolean,
+  minShouldMatch: string,
+  matchMode: MatchMode,
+  nameFallback: NameFallback
+): EsQuery[] {
+  if (!searchTerm) {
+    return [];
+  }
+
+  const fields = [
+    "name^4",
+    "description^2",
+    ...(includeInstructions ? ["instructions"] : []),
+  ];
+  const shared = {
+    query: searchTerm,
+    fields,
+    ...(minShouldMatch ? { minimum_should_match: minShouldMatch } : {}),
+  };
+
+  const weightedClause = { multi_match: { ...shared, type: "best_fields" } };
+  const prefixClause = { multi_match: { ...shared, type: "bool_prefix" } };
+
+  const matchClauses: EsQuery[] = {
+    bool_prefix: [prefixClause],
+    best_fields: [weightedClause],
+    hybrid: [
+      weightedClause,
+      { multi_match: { ...shared, type: "bool_prefix", boost: PREFIX_CLAUSE_BOOST } },
+    ],
+  }[matchMode];
+
+  if (!supportsSubsequence(searchTerm)) {
+    return matchClauses;
+  }
+
+  const subsequenceClause = {
+    wildcard: {
+      "name.subsequence": {
+        value: buildSubsequencePattern(searchTerm),
+        case_insensitive: true,
+        boost: NAME_FALLBACK_BOOST,
+      },
+    },
+  };
+  const fuzzyClause = {
+    match: {
+      name: {
+        query: searchTerm,
+        fuzziness: "AUTO",
+        prefix_length: 1,
+        boost: NAME_FALLBACK_BOOST,
+      },
+    },
+  };
+
+  return [
+    ...matchClauses,
+    ...{
+      subsequence: [subsequenceClause],
+      fuzzy: [fuzzyClause],
+      both: [subsequenceClause, fuzzyClause],
+      off: [],
+    }[nameFallback],
+  ];
+}
+
+// The weight has to live inside functions[]: a boost on the nested query is
+// discarded when the inner function_score uses boost_mode "replace".
+function buildGroupAdjacencyClause(
+  userGroupIds: string[],
+  groupBoost: number
+): EsQuery[] {
+  if (userGroupIds.length === 0) {
+    return [];
+  }
+  return [
+    {
+      nested: {
+        path: "usage.by_group",
+        score_mode: "sum",
+        query: {
+          function_score: {
+            query: { terms: { "usage.by_group.group_id": userGroupIds } },
+            functions: [
+              {
+                field_value_factor: {
+                  field: "usage.by_group.messages",
+                  modifier: "log1p",
+                  missing: 0,
+                },
+                weight: groupBoost,
+              },
+            ],
+            score_mode: "multiply",
+            boost_mode: "replace",
+          },
+        },
+      },
+    },
+  ];
+}
+
+export function buildFilters(params: SearchParams): EsQuery[] {
+  return [
+    { term: { status: "active" } },
+    buildSpaceAccessFilter(params.readableSpaceIds),
+    ...(params.scopes.length > 0
+      ? [{ terms: { scope: params.scopes } }]
+      : [buildVisibilityFilter(params.userEmail, params.excludeGlobal)]),
+  ];
+}
+
+export function buildAgentSearchQuery(params: SearchParams): EsQuery {
+  const textClauses = buildTextClauses(
+    params.searchTerm,
+    params.includeInstructions,
+    params.minShouldMatch,
+    params.matchMode,
+    params.nameFallback
+  );
+  const rankingClauses = buildGroupAdjacencyClause(
+    params.userGroupIds,
+    params.groupBoost
+  );
+
+  // Ranking clauses must never gate matching: with a `must` present, `should` defaults to
+  // minimum_should_match 0 and only contributes score. Without that split, an agent with
+  // any group usage matches every query, text match or not.
+  return {
+    bool: {
+      filter: buildFilters(params),
+      ...(textClauses.length > 0
+        ? { must: [{ bool: { should: textClauses, minimum_should_match: 1 } }] }
+        : {}),
+      ...(rankingClauses.length > 0 ? { should: rankingClauses } : {}),
+    },
+  };
+}

--- a/x/adrsimon/agentsearch/scripts/search.ts
+++ b/x/adrsimon/agentsearch/scripts/search.ts
@@ -1,0 +1,109 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { parseArgs } from "node:util";
+
+import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
+import type { MatchMode, NameFallback } from "./query.ts";
+import { buildAgentSearchQuery, contextFromProfile } from "./query.ts";
+import type { AgentSearchDocument, UserProfile } from "./types.ts";
+
+const { values } = parseArgs({
+  options: {
+    q: { type: "string", default: "" },
+    profile: { type: "string" },
+    spaces: { type: "string", default: "" },
+    groups: { type: "string", default: "" },
+    scope: { type: "string", default: "" },
+    "exclude-global": { type: "boolean", default: false },
+    "with-instructions": { type: "boolean", default: false },
+    "min-should-match": { type: "string", default: "" },
+    "match-mode": { type: "string", default: "hybrid" },
+    "name-fallback": { type: "string", default: "fuzzy" },
+    limit: { type: "string", default: "10" },
+    "group-boost": { type: "string", default: "0.5" },
+    explain: { type: "boolean", default: false },
+    es: { type: "string", default: DEFAULT_ES_URL },
+    index: { type: "string", default: DEFAULT_INDEX },
+  },
+});
+
+const profile: UserProfile | null = values.profile
+  ? JSON.parse(await readFile(resolve(values.profile), "utf-8"))
+  : null;
+
+const context = contextFromProfile(profile, {
+  spaces: values.spaces,
+  groups: values.groups,
+});
+const searchTerm = values.q.trim();
+const limit = Number(values.limit);
+
+interface SearchResponse {
+  hits: {
+    total: { value: number };
+    hits: {
+      _id: string;
+      _score: number;
+      _source: Pick<
+        AgentSearchDocument,
+        "name" | "description" | "scope" | "usage"
+      >;
+    }[];
+  };
+}
+
+const query = buildAgentSearchQuery({
+  ...context,
+  searchTerm,
+  scopes: values.scope.split(",").filter(Boolean),
+  excludeGlobal: values["exclude-global"],
+  includeInstructions: values["with-instructions"],
+  minShouldMatch: values["min-should-match"],
+  matchMode: values["match-mode"] as MatchMode,
+  nameFallback: values["name-fallback"] as NameFallback,
+  groupBoost: Number(values["group-boost"]),
+});
+
+const result = await esRequest<SearchResponse>(
+  values.es,
+  "POST",
+  `/${values.index}/_search`,
+  JSON.stringify({
+    query,
+    size: limit,
+    _source: ["name", "description", "scope", "usage.messages"],
+    sort: [{ _score: "desc" }, { "name.keyword": "asc" }],
+  })
+);
+
+const asWhom = profile
+  ? `as ${profile.user.email} (${profile.role})`
+  : "as an anonymous caller";
+console.log(
+  `q="${searchTerm}" ${asWhom} spaces=${context.readableSpaceIds.length} groups=${context.userGroupIds.length} -> ${result.hits.total.value} hits\n`
+);
+for (const [rank, hit] of result.hits.hits.entries()) {
+  const source = hit._source;
+  console.log(
+    [
+      String(rank + 1).padStart(2),
+      source.name.slice(0, 34).padEnd(34),
+      hit._score.toFixed(2).padStart(8),
+      `${String(source.usage.messages).padStart(6)} msg`,
+      source.scope.padEnd(7),
+      source.description.slice(0, 58).replace(/\n/g, " "),
+    ].join("  ")
+  );
+}
+
+if (values.explain && result.hits.hits.length > 0) {
+  const top = result.hits.hits[0];
+  const explanation = await esRequest<{ explanation: unknown }>(
+    values.es,
+    "POST",
+    `/${values.index}/_explain/${top._id}`,
+    JSON.stringify({ query })
+  );
+  console.log(`\nexplain for "${top._source.name}":`);
+  console.log(JSON.stringify(explanation.explanation, null, 2).slice(0, 3000));
+}

--- a/x/adrsimon/agentsearch/scripts/sweep_bm25.ts
+++ b/x/adrsimon/agentsearch/scripts/sweep_bm25.ts
@@ -1,0 +1,113 @@
+import { execFile } from "node:child_process";
+import { readFile, rm } from "node:fs/promises";
+import { parseArgs } from "node:util";
+import { promisify } from "node:util";
+
+import { DEFAULT_ES_URL, DEFAULT_INDEX, esRequest } from "./es.ts";
+import type { EvalReport } from "./types.ts";
+
+const run = promisify(execFile);
+const REPORT_PATH = "/tmp/agentsearch_sweep_report.json";
+
+const { values } = parseArgs({
+  options: {
+    similarity: { type: "string", default: "name_bm25" },
+    param: { type: "string", default: "b" },
+    values: { type: "string", default: "0,0.25,0.5,0.75,1" },
+    queries: { type: "string", default: "assets/eval_queries_dust.json" },
+    profile: { type: "string" },
+    "exclude-global": { type: "boolean", default: false },
+    "eval-args": { type: "string", default: "" },
+    es: { type: "string", default: DEFAULT_ES_URL },
+    index: { type: "string", default: DEFAULT_INDEX },
+  },
+});
+
+interface SettingsResponse {
+  [index: string]: {
+    settings: {
+      index: { similarity: Record<string, { k1: string; b: string }> };
+    };
+  };
+}
+
+async function currentSimilarity() {
+  const settings = await esRequest<SettingsResponse>(
+    values.es,
+    "GET",
+    `/${values.index}/_settings`
+  );
+  return settings[values.index].settings.index.similarity;
+}
+
+async function setParam(value: number) {
+  const current = await currentSimilarity();
+  const target = current[values.similarity];
+  await esRequest(values.es, "POST", `/${values.index}/_close`);
+  await esRequest(
+    values.es,
+    "PUT",
+    `/${values.index}/_settings`,
+    JSON.stringify({
+      index: {
+        similarity: {
+          [values.similarity]: {
+            type: "BM25",
+            k1: Number(target.k1),
+            b: Number(target.b),
+            [values.param]: value,
+          },
+        },
+      },
+    })
+  );
+  await esRequest(values.es, "POST", `/${values.index}/_open`);
+  await esRequest(
+    values.es,
+    "GET",
+    "/_cluster/health?wait_for_status=green&timeout=30s"
+  );
+}
+
+async function runEval(): Promise<EvalReport> {
+  await rm(REPORT_PATH, { force: true });
+  await run("npx", [
+    "tsx",
+    "scripts/eval.ts",
+    "--queries",
+    values.queries,
+    ...(values.profile ? ["--profile", values.profile] : []),
+    ...(values["exclude-global"] ? ["--exclude-global"] : []),
+    ...values["eval-args"].split(" ").filter(Boolean),
+    "--save",
+    REPORT_PATH,
+  ]);
+  return JSON.parse(await readFile(REPORT_PATH, "utf-8"));
+}
+
+const before = await currentSimilarity();
+console.log(
+  `sweeping ${values.similarity}.${values.param} over [${values.values}]`
+    + ` (starting: ${JSON.stringify(before[values.similarity])})\n`
+);
+console.log(`${values.param.padEnd(6)}  MRR@10     R@1    hits  coverage  junk/query`);
+
+for (const raw of values.values.split(",")) {
+  const value = Number(raw);
+  await setParam(value);
+  const report = await runEval();
+  const { overall } = report;
+  console.log(
+    [
+      raw.padEnd(6),
+      overall.mrr.toFixed(4).padStart(6),
+      overall.recallAt1.toFixed(3).padStart(6),
+      overall.hits.toFixed(1).padStart(6),
+      overall.coverage.toFixed(3).padStart(8),
+      overall.junkHits.toFixed(2).padStart(10),
+    ].join("  ")
+  );
+}
+
+await setParam(Number(before[values.similarity][values.param as "k1" | "b"]));
+console.log(`\nrestored ${values.similarity}.${values.param}`);

--- a/x/adrsimon/agentsearch/scripts/text.ts
+++ b/x/adrsimon/agentsearch/scripts/text.ts
@@ -1,0 +1,38 @@
+const MIN_TERM_LENGTH = 3;
+
+export const STOPWORDS = new Set(
+  ("a an and are as at be but by can for from has have help helps how i if in into is it its "
+   + "me my of on or our so that the their them then there these they this to use used user "
+   + "users using was what when which who will with without you your agent assistant").split(" ")
+);
+
+export function splitName(name: string): string {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/[_\-.]+/g, " ")
+    .toLowerCase()
+    .trim();
+}
+
+// Approximates the index-time light_english stemmer well enough to compare a query term
+// against document text in JS, without a round trip to _analyze per term.
+export function normalize(token: string): string {
+  return token.replace(/(ies)$/, "y").replace(/(sses|ses|es|s)$/, "");
+}
+
+export function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length >= MIN_TERM_LENGTH && !STOPWORDS.has(token))
+    .map(normalize);
+}
+
+export function contentTerms(text: string): Set<string> {
+  return new Set(tokenize(text));
+}
+
+export function documentTerms(name: string, description: string): Set<string> {
+  return contentTerms(`${splitName(name)} ${description}`);
+}

--- a/x/adrsimon/agentsearch/scripts/types.ts
+++ b/x/adrsimon/agentsearch/scripts/types.ts
@@ -1,0 +1,165 @@
+export type SpaceKind =
+  | "global"
+  | "system"
+  | "conversations"
+  | "regular"
+  | "project";
+
+export interface AgentGroupUsage {
+  groupId: string;
+  groupName: string;
+  messages: number;
+  users: number;
+}
+
+export interface AgentUsage {
+  periodDays: number;
+  messages: number;
+  conversations: number;
+  users: number;
+  credits: number;
+  feedbacksUp: number;
+  feedbacksDown: number;
+  byGroup: AgentGroupUsage[];
+}
+
+export interface ExportedAgent {
+  sId: string;
+  name: string;
+  description: string;
+  instructions: string | null;
+  scope: "global" | "visible" | "hidden";
+  status: string;
+  tags: string[];
+  templateId: string | null;
+  author: string | null;
+  editors: string[];
+  requestedSpaceIds: string[];
+  spaces: { sId: string; name: string | null; kind: SpaceKind | null }[];
+  nonPodSpaceIds: string[];
+  nonPodSpaceCount: number;
+  podSpaceIds: string[];
+  usage: AgentUsage;
+}
+
+export interface WorkspaceAgentExport {
+  workspaceId: string;
+  workspaceName: string;
+  generatedAt: string;
+  usagePeriodDays: number;
+  agentCount: number;
+  agents: ExportedAgent[];
+}
+
+export interface AgentSearchDocument {
+  agent_id: string;
+  name: string;
+  description: string;
+  instructions: string | null;
+  tags: string[];
+  scope: string;
+  status: string;
+  author: string | null;
+  editors: string[];
+  requested_space_ids: string[];
+  requested_space_count: number;
+  non_pod_space_ids: string[];
+  non_pod_space_count: number;
+  pod_space_ids: string[];
+  usage: {
+    messages: number;
+    conversations: number;
+    users: number;
+    credits: number;
+    feedbacks_up: number;
+    feedbacks_down: number;
+    by_group: {
+      group_id: string;
+      group_name: string;
+      messages: number;
+      users: number;
+    }[];
+  };
+}
+
+export interface ProfileSpace {
+  sId: string;
+  name: string;
+  kind: SpaceKind;
+}
+
+export interface UserProfile {
+  workspaceId: string;
+  workspaceName: string;
+  generatedAt: string;
+  user: { sId: string; email: string; fullName: string };
+  role: string;
+  groupIds: string[];
+  groups: { sId: string; name: string; kind: string }[];
+  readableNonPodSpaces: ProfileSpace[];
+  readablePodSpaces: ProfileSpace[];
+}
+
+export type QueryKind =
+  | "name_exact"
+  | "name_words"
+  | "name_prefix"
+  | "name_typo"
+  | "name_transpose"
+  | "desc_terms"
+  | "desc_phrase";
+
+export interface EvalQuery {
+  query: string;
+  kind: QueryKind;
+  targetId: string;
+  targetName: string;
+}
+
+export interface EvalNegative {
+  query: string;
+  kind: "oov" | "chimera";
+  sources: string[];
+}
+
+export interface EvalQuerySet {
+  generatedAt: string;
+  index: string;
+  profile: string | null;
+  excludeGlobal: boolean;
+  candidateCount: number;
+  queries: EvalQuery[];
+  negatives: EvalNegative[];
+}
+
+export interface EvalMetrics {
+  queries: number;
+  mrr: number;
+  recallAt1: number;
+  recallAt5: number;
+  recallAt10: number;
+  hits: number;
+  coverage: number;
+  junk: number;
+  junkHits: number;
+}
+
+export interface NegativeMetrics {
+  queries: number;
+  meanHits: number;
+  zeroHitRate: number;
+}
+
+export interface EvalReport {
+  ranAt: string;
+  querySet: string;
+  groupBoost: number;
+  excludeGlobal: boolean;
+  includeInstructions: boolean;
+  minShouldMatch: string;
+  matchMode: string;
+  nameFallback: string;
+  overall: EvalMetrics;
+  byKind: Record<string, EvalMetrics>;
+  negatives: Record<string, NegativeMetrics>;
+}

--- a/x/adrsimon/agentsearch/tsconfig.json
+++ b/x/adrsimon/agentsearch/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "skipLibCheck": true
+  },
+  "include": ["scripts/ingest.ts", "scripts/search.ts"]
+}


### PR DESCRIPTION
## Description

Offline harness under `x/` to experiment with lexical retrieval over workspace agents, ahead of a proper agent discovery feature. It indexes a workspace export into a local Elasticsearch, rebuilds the `/manage/agents` permission model at query time so results match what a given user can actually see, and scores ranking changes against a generated query set. 

Exists so the retrieval design can be argued with numbers. 
`NOTES.md` records where things stand and which paths are still open.

## Tests

No tests, vibe coded eval harness to be refined in later PRs.

## Risk

None.

## Deploy Plan

Nothing to deploy.