### PR TITLE
[front] Move isRestricted off SpaceType onto EnrichedSpaceType

### DIFF
--- a/front-api/middlewares/with_space.ts
+++ b/front-api/middlewares/with_space.ts
@@ -89,8 +89,7 @@ export function withSpace(options: WithSpaceOptions) {
       });
     }
 
-    const spaceJSON = space.toJSON();
-    if (spaceJSON.isRestricted) {
+    if (space.isRestricted()) {
       void emitAuditLogEvent({
         auth,
         action: "space.accessed",
@@ -101,7 +100,7 @@ export function withSpace(options: WithSpaceOptions) {
         context: getAuditLogContext(auth),
         metadata: {
           space_name: space.name,
-          space_kind: spaceJSON.kind,
+          space_kind: space.kind,
           is_restricted: "true",
           access_method: deriveAccessMethod(auth),
         },

--- a/front-api/public/swagger.json
+++ b/front-api/public/swagger.json
@@ -9847,6 +9847,9 @@
                                 "type": "string"
                               }
                             },
+                            "isRestricted": {
+                              "type": "boolean"
+                            },
                             "categories": {
                               "type": "object",
                               "additionalProperties": {
@@ -12270,7 +12273,6 @@
           "sId",
           "name",
           "kind",
-          "isRestricted",
           "managementMode"
         ],
         "properties": {
@@ -12289,9 +12291,6 @@
               "regular",
               "project"
             ]
-          },
-          "isRestricted": {
-            "type": "boolean"
           },
           "managementMode": {
             "type": "string",
@@ -12323,6 +12322,9 @@
                 "items": {
                   "type": "string"
                 }
+              },
+              "isRestricted": {
+                "type": "boolean"
               },
               "description": {
                 "type": "string",
@@ -14850,6 +14852,10 @@
               "type": "string"
             },
             "description": "List of group IDs that have access to the space"
+          },
+          "isRestricted": {
+            "type": "boolean",
+            "description": "Whether the space is restricted to specific groups"
           }
         }
       },

--- a/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -77,7 +77,7 @@ app.get(
       agentConfigurations,
       authors,
       lastVersionEditors,
-      spaces: spaces.map((s) => s.toJSON()),
+      spaces: await SpaceResource.batchToJSONEnriched(auth, spaces),
       skillsByVersion,
     });
   }

--- a/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front-api/routes/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -48,7 +48,7 @@ app.get(
     return ctx.json({
       skill: serializedSkill,
       editedByUser: editedByUser ? editedByUser.toJSON() : null,
-      spaces: spaces.map((s) => s.toJSON()),
+      spaces: await SpaceResource.batchToJSONEnriched(auth, spaces),
       agentsUsage,
       usedBySkills,
     });

--- a/front-api/routes/poke/workspaces/[wId]/spaces/index.ts
+++ b/front-api/routes/poke/workspaces/[wId]/spaces/index.ts
@@ -14,7 +14,9 @@ app.get("/", async (ctx): HandlerResult<PokeListSpaces> => {
 
   const spaces = await SpaceResource.listWorkspaceSpaces(auth);
 
-  return ctx.json({ spaces: spaces.map((s) => s.toJSON()) });
+  return ctx.json({
+    spaces: await SpaceResource.batchToJSONEnriched(auth, spaces),
+  });
 });
 
 app.route("/:spaceId", spaceId);

--- a/front-api/routes/swagger_private_schemas.ts
+++ b/front-api/routes/swagger_private_schemas.ts
@@ -1084,7 +1084,6 @@
  *         - sId
  *         - name
  *         - kind
- *         - isRestricted
  *         - managementMode
  *       properties:
  *         sId:
@@ -1094,8 +1093,6 @@
  *         kind:
  *           type: string
  *           enum: [global, system, conversations, regular, project]
- *         isRestricted:
- *           type: boolean
  *         managementMode:
  *           type: string
  *           enum: [manual, group]
@@ -1114,6 +1111,8 @@
  *               type: array
  *               items:
  *                 type: string
+ *             isRestricted:
+ *               type: boolean
  *             description:
  *               type: string
  *               nullable: true

--- a/front-api/routes/v1/w/[wId]/apps/index.ts
+++ b/front-api/routes/v1/w/[wId]/apps/index.ts
@@ -30,17 +30,14 @@ app.get(
 
     // All apps belong to `space`; load its group sIds once so the public app response keeps the
     // space's `groupIds` without relying on the eagerly-loaded grants.
-    const spaceGroupIds =
-      (
-        await SpaceResource.listGroupIdsBySpaceModelId(auth, {
-          spaces: [space],
-        })
-      ).get(space.id) ?? [];
+    const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+      space,
+    ]);
 
     return ctx.json({
       apps: apps
         .filter((a) => a.canRead(auth))
-        .map((a) => a.toJSONWithSpaceGroupIds(spaceGroupIds)),
+        .map((a) => a.toJSONEnriched(enrichedSpace)),
     });
   }
 );

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/apps/index.ts
@@ -93,17 +93,14 @@ app.get(
 
     // All apps belong to `space`; load its group sIds once so the public app response keeps the
     // space's `groupIds` without relying on the eagerly-loaded grants.
-    const spaceGroupIds =
-      (
-        await SpaceResource.listGroupIdsBySpaceModelId(auth, {
-          spaces: [space],
-        })
-      ).get(space.id) ?? [];
+    const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+      space,
+    ]);
 
     return ctx.json({
       apps: apps
         .filter((a) => a.canRead(auth))
-        .map((a) => a.toJSONWithSpaceGroupIds(spaceGroupIds)),
+        .map((a) => a.toJSONEnriched(enrichedSpace)),
     });
   }
 );

--- a/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -193,15 +193,12 @@ app.post(
       });
     }
 
-    const groupIdsBySpaceModelId =
-      await SpaceResource.listGroupIdsBySpaceModelId(auth, {
-        spaces: [space],
-      });
+    const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+      space,
+    ]);
 
     return ctx.json({
-      space: space.toJSONWithGroupIds(
-        groupIdsBySpaceModelId.get(space.id) ?? []
-      ),
+      space: enrichedSpace,
       users: usersJson.map((userJson) => ({
         sId: userJson.sId,
         id: userJson.id,

--- a/front-api/routes/v1/w/[wId]/spaces/index.ts
+++ b/front-api/routes/v1/w/[wId]/spaces/index.ts
@@ -1,5 +1,5 @@
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { SpaceTypeWithGroupIds } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import { publicApiApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
 import { validate } from "@front-api/middlewares/validator";
@@ -8,7 +8,7 @@ import { z } from "zod";
 import spaceId from "./[spaceId]";
 
 export type GetPublicSpacesResponseBody = {
-  spaces: SpaceTypeWithGroupIds[];
+  spaces: EnrichedSpaceType[];
 };
 
 // The kinds this endpoint returns when `kinds` is omitted.
@@ -88,13 +88,8 @@ app.get(
       kinds: kinds ?? [...DEFAULT_SPACE_KINDS],
     });
 
-    const groupIdsBySpaceModelId =
-      await SpaceResource.listGroupIdsBySpaceModelId(auth, { spaces });
-
     return ctx.json({
-      spaces: spaces.map((space) =>
-        space.toJSONWithGroupIds(groupIdsBySpaceModelId.get(space.id) ?? [])
-      ),
+      spaces: await SpaceResource.batchToJSONEnriched(auth, spaces),
     });
   }
 );

--- a/front-api/routes/v1/w/[wId]/swagger_schemas.ts
+++ b/front-api/routes/v1/w/[wId]/swagger_schemas.ts
@@ -504,6 +504,9 @@
  *           items:
  *             type: string
  *           description: List of group IDs that have access to the space
+ *         isRestricted:
+ *           type: boolean
+ *           description: Whether the space is restricted to specific groups
  *     Datasource:
  *       type: object
  *       properties:

--- a/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front-api/routes/w/[wId]/assistant/conversations/spaces/index.ts
@@ -98,20 +98,16 @@ app.get("/", async (ctx): HandlerResult<GetBySpacesSummaryResponseBody> => {
   const filteredSpaces = nonArchivedSpaces.filter(
     (space) => space.kind === "project" || conversationsBySpace.has(space.id)
   );
-  const groupIdsBySpaceModelId = await SpaceResource.listGroupIdsBySpaceModelId(
-    auth,
-    {
-      spaces: filteredSpaces,
-    }
+  const sortedSpaces = sortSpacesSummary(
+    filteredSpaces,
+    conversationsBySpace,
+    lastUserActivityBySpace
   );
+  const enriched = await SpaceResource.batchToJSONEnriched(auth, sortedSpaces);
   return ctx.json({
-    summary: sortSpacesSummary(
-      filteredSpaces,
-      conversationsBySpace,
-      lastUserActivityBySpace
-    ).map((space) => ({
+    summary: sortedSpaces.map((space, i) => ({
       space: {
-        ...space.toJSONWithGroupIds(groupIdsBySpaceModelId.get(space.id) ?? []),
+        ...enriched[i],
         description: metadataMap.get(space.id)?.description ?? null,
         // We excluded archived projects and we only list projects where the user is a member.
         archivedAt: null,

--- a/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front-api/routes/w/[wId]/spaces/[spaceId]/index.ts
@@ -100,6 +100,8 @@ const app = workspaceApp();
  *                           type: array
  *                           items:
  *                             type: string
+ *                         isRestricted:
+ *                           type: boolean
  *                         categories:
  *                           type: object
  *                           additionalProperties:
@@ -312,14 +314,13 @@ app.get(
       ? await ProjectMetadataResource.fetchBySpace(auth, space)
       : undefined;
 
-    const groupIdsBySpaceModelId =
-      await SpaceResource.listGroupIdsBySpaceModelId(auth, {
-        spaces: [space],
-      });
+    const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+      space,
+    ]);
 
     return ctx.json({
       space: {
-        ...space.toJSONWithGroupIds(groupIdsBySpaceModelId.get(space.id) ?? []),
+        ...enrichedSpace,
         categories,
         canWrite: space.canWrite(auth),
         canRead: space.canRead(auth),

--- a/front-api/routes/w/[wId]/spaces/index.ts
+++ b/front-api/routes/w/[wId]/spaces/index.ts
@@ -15,9 +15,9 @@ import type {
 import { PostSpaceRequestBodySchema } from "@app/types/api/spaces";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import {
+  type EnrichedSpaceType,
   type PodType,
   SPACE_KINDS,
-  type SpaceTypeWithGroupIds,
 } from "@app/types/space";
 import { workspaceApp } from "@front-api/middlewares/ctx";
 import type { HandlerResult } from "@front-api/middlewares/utils";
@@ -185,13 +185,8 @@ app.get(
     const nonProjectSpaces = spaces.filter((s) => s.kind !== "project");
     const projectSpaces = spaces.filter((s) => s.kind === "project");
 
-    const groupIdsBySpaceModelId =
-      await SpaceResource.listGroupIdsBySpaceModelId(auth, {
-        spaces: nonProjectSpaces,
-      });
-    const nonProjectsJson: SpaceTypeWithGroupIds[] = nonProjectSpaces.map((s) =>
-      s.toJSONWithGroupIds(groupIdsBySpaceModelId.get(s.id) ?? [])
-    );
+    const nonProjectsJson: EnrichedSpaceType[] =
+      await SpaceResource.batchToJSONEnriched(auth, nonProjectSpaces);
     const projectsJson: PodType[] =
       projectSpaces.length > 0
         ? await enrichProjectsWithMetadata(auth, projectSpaces)

--- a/front/components/agent_builder/SpacesContext.tsx
+++ b/front/components/agent_builder/SpacesContext.tsx
@@ -1,6 +1,6 @@
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSpaces } from "@app/lib/swr/spaces";
-import type { PodType, SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, PodType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { ReactNode } from "react";
 // biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
@@ -8,7 +8,7 @@ import React, { createContext, useContext, useEffect, useMemo } from "react";
 
 interface SpacesContextType {
   owner: LightWorkspaceType;
-  spaces: (SpaceType | PodType)[];
+  spaces: (EnrichedSpaceType | PodType)[];
   isSpacesLoading: boolean;
   isSpacesError: boolean;
 }

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -1,7 +1,7 @@
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
-import type { PodType, SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, PodType, SpaceType } from "@app/types/space";
 import { isProjectType } from "@app/types/space";
 import {
   Checkbox,
@@ -26,7 +26,7 @@ type SpaceRowData = {
   sId: string;
   name: string;
   description?: string;
-  space: SpaceType | PodType;
+  space: EnrichedSpaceType | PodType;
   isSelected: boolean;
   isAlreadyRequested: boolean;
   onToggle: () => void;

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
@@ -3,12 +3,12 @@ import { DataSourceList } from "@app/components/agent_builder/capabilities/knowl
 import { ConfirmContext } from "@app/components/Confirm";
 import { useDataSourceBuilderContext } from "@app/components/data_source_view/context/DataSourceBuilderContext";
 import { getSpaceIcon } from "@app/lib/spaces";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import { SPACE_KINDS } from "@app/types/space";
 import { useCallback, useContext, useMemo } from "react";
 
 interface DataSourceSpaceSelectorProps {
-  spaces: SpaceType[];
+  spaces: EnrichedSpaceType[];
 }
 
 export function DataSourceSpaceSelector({

--- a/front/components/agent_builder/hooks/useAgentRequestedSpaces.ts
+++ b/front/components/agent_builder/hooks/useAgentRequestedSpaces.ts
@@ -4,7 +4,7 @@ import { getSpaceIdToActionsMap } from "@app/components/shared/getSpaceIdToActio
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useSpaceProjectsLookup } from "@app/lib/swr/spaces";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import { useMemo } from "react";
 import { useWatch } from "react-hook-form";
 
@@ -14,11 +14,11 @@ interface UseAgentRequestedSpacesProps {
 
 interface UseAgentRequestedSpacesResult {
   actionsAndSkillsRequestedSpaceIds: Set<string>;
-  allSpaces: SpaceType[];
-  globalSpace: SpaceType | undefined;
+  allSpaces: EnrichedSpaceType[];
+  globalSpace: EnrichedSpaceType | undefined;
   missingSpaceIds: string[];
-  nonGlobalSpacesUsedByAgent: SpaceType[];
-  nonGlobalSpacesWithRestrictions: SpaceType[];
+  nonGlobalSpacesUsedByAgent: EnrichedSpaceType[];
+  nonGlobalSpacesWithRestrictions: EnrichedSpaceType[];
   spaceIdToActions: ReturnType<typeof getSpaceIdToActionsMap>;
 }
 

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -53,7 +53,7 @@ import type {
   TagsFilterMode,
 } from "@app/types/data_source_view";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import {
   createContext,
   useCallback,
@@ -116,7 +116,7 @@ type DataSourceBuilderState = StateType & {
   /**
    * Add the current selected space
    */
-  setSpaceEntry: (space: SpaceType) => void;
+  setSpaceEntry: (space: EnrichedSpaceType) => void;
 
   /**
    * Set the current selected category in the navigation
@@ -149,7 +149,7 @@ type DataSourceBuilderState = StateType & {
 type ActionType =
   | {
       type: "NAVIGATION_SET_SPACE";
-      payload: { space: SpaceType };
+      payload: { space: EnrichedSpaceType };
     }
   | {
       type: "NAVIGATION_SET_CATEGORY";

--- a/front/components/data_source_view/context/types.ts
+++ b/front/components/data_source_view/context/types.ts
@@ -3,7 +3,7 @@ import type {
   DataSourceViewContentNode,
   DataSourceViewType,
 } from "@app/types/data_source_view";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import { z } from "zod";
 
 const tagsFilter = z.object({
@@ -14,7 +14,10 @@ const tagsFilter = z.object({
 
 const navigationHistoryEntry = z.discriminatedUnion("type", [
   z.object({ type: z.literal("root") }),
-  z.object({ type: z.literal("space"), space: z.custom<SpaceType>() }),
+  z.object({
+    type: z.literal("space"),
+    space: z.custom<EnrichedSpaceType>(),
+  }),
   z.object({
     type: z.literal("category"),
     category: z.custom<DataSourceViewCategoryWithoutApps>(),

--- a/front/components/poke/assistants/AgentOverviewTable.tsx
+++ b/front/components/poke/assistants/AgentOverviewTable.tsx
@@ -6,7 +6,7 @@ import {
   PokeTableRow,
 } from "@app/components/poke/shadcn/ui/table";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 import { ContentMessage, InfoCircle } from "@dust-tt/sparkle";
 
@@ -14,7 +14,7 @@ interface AgentOverviewTableProps {
   agentConfiguration: AgentConfigurationType;
   authors: UserType[];
   owner: LightWorkspaceType;
-  spacesById: Map<string, SpaceType>;
+  spacesById: Map<string, EnrichedSpaceType>;
 }
 
 export function AgentOverviewTable({
@@ -30,7 +30,8 @@ export function AgentOverviewTable({
   const restrictedSpaces = agentConfiguration.requestedSpaceIds
     .map((spaceId) => spacesById.get(spaceId))
     .filter(
-      (space): space is SpaceType => space !== undefined && space.isRestricted
+      (space): space is EnrichedSpaceType =>
+        space !== undefined && space.isRestricted
     );
 
   return (

--- a/front/components/poke/assistants/RequestedSpacesList.tsx
+++ b/front/components/poke/assistants/RequestedSpacesList.tsx
@@ -1,12 +1,12 @@
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import { Icon, LinkWrapper } from "@dust-tt/sparkle";
 
 interface RequestedSpacesListProps {
   owner?: LightWorkspaceType;
   requestedSpaceIds: string[];
-  spacesById: Map<string, SpaceType>;
+  spacesById: Map<string, EnrichedSpaceType>;
 }
 
 export function RequestedSpacesList({

--- a/front/components/poke/skills/SkillOverviewTable.tsx
+++ b/front/components/poke/skills/SkillOverviewTable.tsx
@@ -6,14 +6,14 @@ import {
 } from "@app/components/poke/shadcn/ui/table";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { UserType } from "@app/types/user";
 import { Chip } from "@dust-tt/sparkle";
 
 interface SkillOverviewTableProps {
   skill: SkillType;
   editedByUser: UserType | null;
-  spaces: SpaceType[];
+  spaces: EnrichedSpaceType[];
 }
 
 export function SkillOverviewTable({

--- a/front/components/poke/spaces/columns.tsx
+++ b/front/components/poke/spaces/columns.tsx
@@ -1,13 +1,13 @@
 import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
 export function makeColumnsForSpaces(
   owner: WorkspaceType
-): ColumnDef<SpaceType>[] {
+): ColumnDef<EnrichedSpaceType>[] {
   return [
     {
       accessorKey: "sId",

--- a/front/components/shared/SpaceChips.tsx
+++ b/front/components/shared/SpaceChips.tsx
@@ -1,9 +1,9 @@
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, SpaceType } from "@app/types/space";
 import { Chip } from "@dust-tt/sparkle";
 
 interface SpaceChipsProps {
-  spaces: SpaceType[];
+  spaces: EnrichedSpaceType[];
   onRemoveSpace?: (space: SpaceType) => void;
 }
 

--- a/front/components/skill_builder/SkillSpaceRestrictionsContext.tsx
+++ b/front/components/skill_builder/SkillSpaceRestrictionsContext.tsx
@@ -10,7 +10,7 @@ import {
   useSpaceProjectsLookup,
   useSpacesAccessCheck,
 } from "@app/lib/swr/spaces";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, SpaceType } from "@app/types/space";
 import type { ReactNode } from "react";
 import { createContext, useContext, useMemo } from "react";
 import { useWatch } from "react-hook-form";
@@ -23,16 +23,16 @@ export interface EditorWithoutSpaceAccess {
 
 interface SkillSpaceRestrictionsContextType {
   actionsBySpaceId: ReturnType<typeof getSpaceIdToActionsMap>;
-  allSpaces: SpaceType[];
+  allSpaces: EnrichedSpaceType[];
   areSpaceRequirementsReady: boolean;
   editorsWithoutSpaceAccess: EditorWithoutSpaceAccess[];
-  globalSpace: SpaceType | undefined;
+  globalSpace: EnrichedSpaceType | undefined;
   initialAdditionalSpaces: string[];
   initialRequestedSpaceIds?: string[];
   knowledgeBySpaceId: Record<string, AttachedKnowledgeFormData[]>;
   missingSpaceIds: string[];
-  nonGlobalSpacesUsedBySkill: SpaceType[];
-  nonGlobalSpacesWithRestrictions: SpaceType[];
+  nonGlobalSpacesUsedBySkill: EnrichedSpaceType[];
+  nonGlobalSpacesWithRestrictions: EnrichedSpaceType[];
   skillsBySpaceId: Record<string, ReferencedSkillFormData[]>;
   spaceIdsUsedBySkill: Set<string>;
 }

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -18,7 +18,7 @@ import type {
   SkillRelations,
   SkillType,
 } from "@app/types/assistant/skill_configuration";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   AttachmentChip,
@@ -34,7 +34,7 @@ import { useCallback, useMemo, useState } from "react";
 interface SkillInfoTabProps {
   skill: SkillType & { relations?: Pick<SkillRelations, "childSkills"> };
   owner: LightWorkspaceType;
-  spaces?: SpaceType[];
+  spaces?: EnrichedSpaceType[];
   showDescription?: boolean;
 }
 

--- a/front/components/spaces/SpaceBreadcrumb.tsx
+++ b/front/components/spaces/SpaceBreadcrumb.tsx
@@ -3,7 +3,7 @@ import { CATEGORY_DETAILS, getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type { DataSourceViewType } from "@app/types/data_source_view";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { BreadcrumbsItem } from "@dust-tt/sparkle";
 import {
@@ -16,7 +16,7 @@ import React from "react";
 
 interface SpaceBreadcrumbProps {
   owner: LightWorkspaceType;
-  space: SpaceType;
+  space: EnrichedSpaceType;
   category?: DataSourceViewCategory;
   dataSourceView?: DataSourceViewType;
   parentId?: string;

--- a/front/components/spaces/SpacePageHeaders.tsx
+++ b/front/components/spaces/SpacePageHeaders.tsx
@@ -2,7 +2,7 @@ import { SpaceBreadCrumbs } from "@app/components/spaces/SpaceBreadcrumb";
 import { LinkWrapper } from "@app/lib/platform";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type { DataSourceViewType } from "@app/types/data_source_view";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import React from "react";
 
@@ -14,7 +14,7 @@ interface SpacePageToolsProps {
   dataSourceView: DataSourceViewType | undefined;
   owner: LightWorkspaceType;
   parentId: string | undefined;
-  space: SpaceType;
+  space: EnrichedSpaceType;
 }
 
 export function SpacePageHeader({

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -46,7 +46,7 @@ import type {
   DataSourceViewType,
 } from "@app/types/data_source_view";
 import type { APIError } from "@app/types/error";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 // biome-ignore lint/plugin/enforceClientTypesInPublicApi: existing usage
 import { DATA_SOURCE_MIME_TYPE } from "@dust-tt/client";
@@ -63,7 +63,7 @@ interface BaseSpaceSearchInputProps {
   children: React.ReactNode;
   owner: LightWorkspaceType;
   dataSourceView: DataSourceViewType | undefined;
-  space: SpaceType;
+  space: EnrichedSpaceType;
   parentId: string | undefined;
   category: DataSourceViewCategory | undefined;
   /**
@@ -182,7 +182,7 @@ interface FullBackendSearchProps extends BackendSearchProps {
   searchContextValue: SpaceSearchContextType;
   targetDataSourceViews: DataSourceViewType[];
   viewType: ContentNodesViewType;
-  space: SpaceType;
+  space: EnrichedSpaceType;
 }
 
 const PAGE_SIZE = 25;

--- a/front/components/spaces/SpaceSelector.tsx
+++ b/front/components/spaces/SpaceSelector.tsx
@@ -3,7 +3,7 @@ import {
   getSpaceName,
   groupSpacesForDisplay,
 } from "@app/lib/spaces";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, SpaceType } from "@app/types/space";
 import {
   cn,
   Dialog,
@@ -23,7 +23,7 @@ import React, { useState } from "react";
 interface SpaceSelectorProps {
   allowedSpaces?: SpaceType[];
   defaultSpace: string | undefined;
-  spaces: SpaceType[];
+  spaces: EnrichedSpaceType[];
   renderChildren: (space?: SpaceType) => React.ReactNode;
 }
 export function SpaceSelector({

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -46,7 +46,7 @@ import type {
 } from "@app/types/data_source_view";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import { assertNeverAndIgnore } from "@app/types/shared/utils/assert_never";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -127,7 +127,7 @@ export default function SpaceSideBarMenu({
 
   // Function to render space items.
   const renderSpaceItems = (
-    spaces: SpaceType[],
+    spaces: EnrichedSpaceType[],
     spacesAsUser: SpaceType[],
     owner: LightWorkspaceType
   ) => {
@@ -386,7 +386,7 @@ const SpaceMenu = ({
   hasFeature,
 }: {
   owner: LightWorkspaceType;
-  space: SpaceType;
+  space: EnrichedSpaceType;
   isMember: boolean;
   hasFeature: ReturnType<typeof useFeatureFlags>["hasFeature"];
 }) => {
@@ -409,7 +409,7 @@ const SpaceMenuItem = ({
   hasFeature,
 }: {
   owner: LightWorkspaceType;
-  space: SpaceType;
+  space: EnrichedSpaceType;
   isMember: boolean;
   hasFeature: ReturnType<typeof useFeatureFlags>["hasFeature"];
 }) => {

--- a/front/lib/api/assistant/conversation/selected_spaces.ts
+++ b/front/lib/api/assistant/conversation/selected_spaces.ts
@@ -77,13 +77,19 @@ export async function listSelectableSpaces(
     selectedSpaces.map((selectedSpace) => selectedSpace.sId)
   );
 
-  const selectableSpaces = spaces
+  const selectableSpaceResources = spaces
     .filter((space) => space.isRegular())
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .map((space) => ({
-      ...space.toJSON(),
-      selected: selectedSpaceIds.has(space.sId),
-    }));
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const enriched = await SpaceResource.batchToJSONEnriched(
+    auth,
+    selectableSpaceResources
+  );
+
+  const selectableSpaces = selectableSpaceResources.map((space, i) => ({
+    ...enriched[i],
+    selected: selectedSpaceIds.has(space.sId),
+  }));
 
   return new Ok(selectableSpaces);
 }
@@ -200,9 +206,14 @@ export async function addSelectedConversationSpaces(
         }
       );
 
+    const enriched = await SpaceResource.batchToJSONEnriched(
+      auth,
+      selectedSpaces
+    );
+
     return new Ok({
-      selectedSpaces: selectedSpaces.map((space) => ({
-        ...space.toJSON(),
+      selectedSpaces: selectedSpaces.map((_space, i) => ({
+        ...enriched[i],
         selected: true,
       })),
       effectiveAcl: {
@@ -306,9 +317,14 @@ export async function addSelectedConversationSpaces(
         }
       );
 
+    const enriched = await SpaceResource.batchToJSONEnriched(
+      auth,
+      allSelectedSpaces
+    );
+
     return new Ok({
-      selectedSpaces: allSelectedSpaces.map((space) => ({
-        ...space.toJSON(),
+      selectedSpaces: allSelectedSpaces.map((_space, i) => ({
+        ...enriched[i],
         selected: true,
       })),
       effectiveAcl: {

--- a/front/lib/api/poke/spaces.ts
+++ b/front/lib/api/poke/spaces.ts
@@ -1,10 +1,10 @@
 import type { PokeSandboxType, PokeSpaceType } from "@app/types/poke";
 import type { PodMetadataType } from "@app/types/project_metadata";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { UserTypeWithWorkspaces } from "@app/types/user";
 
 export type PokeListSpaces = {
-  spaces: SpaceType[];
+  spaces: EnrichedSpaceType[];
 };
 
 export type PokeGetSpaceDetails = {

--- a/front/lib/api/projects/list.ts
+++ b/front/lib/api/projects/list.ts
@@ -4,7 +4,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { removeDiacritics } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import type { SearchProjectsResponseBody } from "@app/types/api/projects/list";
-import type { PodType, SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, PodType } from "@app/types/space";
 
 type ListPodsAccess = "member" | "open";
 
@@ -208,13 +208,10 @@ export async function enrichProjectsWithMetadata(
     metadatas.map((m) => [m.spaceId, m])
   );
 
-  const groupIdsBySpaceModelId = await SpaceResource.listGroupIdsBySpaceModelId(
-    auth,
-    { spaces }
-  );
+  const enrichedSpaces = await SpaceResource.batchToJSONEnriched(auth, spaces);
 
-  return spaces.map((space) => ({
-    ...space.toJSONWithGroupIds(groupIdsBySpaceModelId.get(space.id) ?? []),
+  return spaces.map((space, i) => ({
+    ...enrichedSpaces[i],
     description: metadataMap.get(space.id)?.description ?? null,
     isMember: space.isMember(auth),
     isEditor: space.canAdministrate(auth),
@@ -222,7 +219,7 @@ export async function enrichProjectsWithMetadata(
   }));
 }
 
-export type ProjectWithAdminMetadata = SpaceType & {
+export type ProjectWithAdminMetadata = EnrichedSpaceType & {
   description: string | null;
   archivedAt: number | null;
   todoGenerationEnabled: boolean;
@@ -244,10 +241,15 @@ export async function listAllProjectsWithAdminMetadata(
   );
   const metadataMap = new Map(metadatas.map((m) => [m.spaceId, m]));
 
-  return projectSpaces.map((space) => {
+  const enrichedSpaces = await SpaceResource.batchToJSONEnriched(
+    auth,
+    projectSpaces
+  );
+
+  return projectSpaces.map((space, i) => {
     const metadata = metadataMap.get(space.id);
     return {
-      ...space.toJSON(),
+      ...enrichedSpaces[i],
       description: metadata?.description ?? null,
       archivedAt: metadata?.archivedAt?.getTime() ?? null,
       todoGenerationEnabled: metadata?.todoGenerationEnabled ?? false,

--- a/front/lib/api/skills/space_requirements.ts
+++ b/front/lib/api/skills/space_requirements.ts
@@ -72,8 +72,8 @@ export async function findSkillEditorsWithoutSpaceAccess(
     return null;
   }
 
-  const restrictedSpaces = requestedSpaces.filter(
-    (space) => space.isRegularAndRestricted() || space.isProjectAndRestricted()
+  const restrictedSpaces = requestedSpaces.filter((space) =>
+    space.isRestricted()
   );
 
   const editorsWithoutAccess = await listUsersWithoutAccessToSpaceResources(

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -5,7 +5,7 @@ import type { DataSourceResource } from "@app/lib/resources/data_source_resource
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type {
   PokeDataSourceType,
@@ -20,10 +20,12 @@ export async function spaceToPokeJSON(
   space: SpaceResource
 ): Promise<PokeSpaceType> {
   const groups = await space.fetchGroupResources(auth);
+  const [enriched] = await SpaceResource.batchToJSONEnriched(auth, [space]);
   return {
     id: space.id,
     ...space.toJSON(),
     groups: groups.map((group) => group.toJSON()),
+    isRestricted: enriched.isRestricted,
   };
 }
 

--- a/front/lib/resources/app_resource.ts
+++ b/front/lib/resources/app_resource.ts
@@ -12,11 +12,12 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
   AppType,
-  AppTypeWithSpaceGroupIds,
+  EnrichedAppType,
   SpecificationType,
 } from "@app/types/app";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
 import assert from "assert";
 import sortBy from "lodash/sortBy";
@@ -317,13 +318,14 @@ export class AppResource extends ResourceWithSpace<AppModel> {
     };
   }
 
-  // The app serialized with its space's `groupIds` (part of the public app contract). The public API
-  // loads them on demand via `SpaceResource.listGroupIdsBySpaceModelId` and passes them here, so app
-  // serialization does not depend on the space's eagerly-loaded grants.
-  toJSONWithSpaceGroupIds(spaceGroupIds: string[]): AppTypeWithSpaceGroupIds {
+  // The app serialized with its space in enriched form (`groupIds`, `isRestricted` — part of the
+  // public app contract). The caller obtains the `EnrichedSpaceType` on demand via
+  // `SpaceResource.batchToJSONEnriched`, so app serialization does not depend on the space's
+  // eagerly-loaded grants.
+  toJSONEnriched(space: EnrichedSpaceType): EnrichedAppType {
     return {
       ...this.toJSON(),
-      space: this.space.toJSONWithGroupIds(spaceGroupIds),
+      space,
     };
   }
 

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1766,14 +1766,14 @@ describe("SpaceResource", () => {
           workspaceId: workspace.id,
         }),
       ]);
-      // groupIds are no longer on `toJSON`; they are loaded on demand from group_permissions.
-      const groupIdsBySpaceModelId =
-        await SpaceResource.listGroupIdsBySpaceModelId(adminAuth, {
-          spaces: [regularSpace],
-        });
-      expect(groupIdsBySpaceModelId.get(regularSpace.id)).toEqual([
-        groupReference.groupSId,
-      ]);
+      // groupIds/isRestricted are no longer on `toJSON`; they are loaded on demand from
+      // group_permissions via `batchToJSONEnriched`.
+      const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(
+        adminAuth,
+        [regularSpace]
+      );
+      expect(enrichedSpace.groupIds).toEqual([groupReference.groupSId]);
+      expect(enrichedSpace.isRestricted).toBe(true);
 
       findAllSpy.mockRestore();
     });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -47,11 +47,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { removeNulls } from "@app/types/shared/utils/general";
-import type {
-  SpaceKind,
-  SpaceType,
-  SpaceTypeWithGroupIds,
-} from "@app/types/space";
+import type { EnrichedSpaceType, SpaceKind, SpaceType } from "@app/types/space";
 import assert from "assert";
 import type {
   Attributes,
@@ -127,6 +123,19 @@ const POD_MEMBERSHIP_GRANT_TYPES: ReadonlySet<GrantType> = new Set(
 
 // The "no memberships" fallback used by batch membership resolution.
 const EMPTY_GROUP_MODEL_IDS: ReadonlySet<ModelId> = new Set();
+
+// A space's grant-derived serialization fields, loaded on demand from `group_permissions` (see
+// `listSpaceEnrichmentBySpaceModelId`) and passed to `toJSONEnriched`.
+type SpaceGrantEnrichment = {
+  groupIds: string[];
+  isRestricted: boolean;
+};
+
+// The enrichment for a space with no grants loaded (used as the fallback when serializing).
+const EMPTY_SPACE_GRANT_ENRICHMENT: SpaceGrantEnrichment = {
+  groupIds: [],
+  isRestricted: false,
+};
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SpaceResource extends BaseResource<SpaceModel> {
@@ -2314,6 +2323,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return this.isRegular() && this.isOpen();
   }
 
+  // Whether the space is restricted (its data is visible only to its members). Only regular and
+  // project spaces can be restricted; the unique kinds (`global`/`conversations` are workspace-wide,
+  // `system` is admin-only and not a membership space) are never "restricted" in this sense. Note
+  // this is NOT `!isOpen()`: a `system` space is not open but is not restricted either.
+  isRestricted() {
+    return this.isRegularAndRestricted() || this.isProjectAndRestricted();
+  }
+
   isOpen() {
     // A space is open when it has a reader (viewer) grant: the workspace global group is attached as
     // a viewer on open spaces (restricted spaces have no reader grant). See
@@ -2526,9 +2543,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   toJSON(): SpaceType {
     return {
       createdAt: this.createdAt.getTime(),
-      isRestricted:
-        this.isRegularAndRestricted() || this.isProjectAndRestricted(),
-
       kind: this.kind,
       managementMode: this.managementMode,
       name: this.name,
@@ -2537,32 +2551,55 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     };
   }
 
-  // Serialize with the sIds of the groups holding a grant on this space. `groupIds` is not carried
-  // on `toJSON` (it would force the eager `group_permissions` include on every space load); the
-  // endpoints that expose it — the public API for backward compatibility, and the space-management
-  // UI — load it on demand via `listGroupIdsBySpaceModelId` and pass it here.
-  toJSONWithGroupIds(groupIds: string[]): SpaceTypeWithGroupIds {
+  // Serialize with the space's grant-derived fields (`groupIds` and `isRestricted`). Private: these
+  // are not carried on `toJSON` (that would force the eager `group_permissions` include on every
+  // space load), so callers go through the batched `batchToJSONEnriched` rather than pairing this
+  // with the loader themselves.
+  private toJSONEnriched({
+    groupIds,
+    isRestricted,
+  }: SpaceGrantEnrichment): EnrichedSpaceType {
     return {
       ...this.toJSON(),
       groupIds,
+      isRestricted,
     };
   }
 
-  // The sIds of the groups holding a grant on each of `spaces`, keyed by space model id. One query
-  // against `group_permissions` (the source of truth), so serializers can include `groupIds`
-  // without relying on the eagerly-loaded `this.groups`. Mirrors `toJSON`'s former output: every
-  // grant group (members, editors, provisioned, and the open-space global reader).
-  static async listGroupIdsBySpaceModelId(
+  // Serialize each of `spaces` to `EnrichedSpaceType` (base fields + grant-derived `groupIds` and
+  // `isRestricted`), loading the grants in a single `group_permissions` query. This keeps the whole
+  // enrichment flow inside the resource: the public API, the space-management UI and poke go through
+  // here instead of wiring the loader + per-space fallback at each call site. The result preserves
+  // the order of `spaces`.
+  static async batchToJSONEnriched(
     auth: Authenticator,
-    { spaces }: { spaces: SpaceResource[] }
-  ): Promise<Map<ModelId, string[]>> {
-    const groupIdsBySpaceModelId = new Map<ModelId, string[]>();
+    spaces: SpaceResource[]
+  ): Promise<EnrichedSpaceType[]> {
+    const enrichmentBySpaceModelId =
+      await this.listSpaceEnrichmentBySpaceModelId(auth, spaces);
+    return spaces.map((space) =>
+      space.toJSONEnriched(
+        enrichmentBySpaceModelId.get(space.id) ?? EMPTY_SPACE_GRANT_ENRICHMENT
+      )
+    );
+  }
+
+  // The grant-derived enrichment (`groupIds` + `isRestricted`) for each of `spaces`, keyed by space
+  // model id. One query against `group_permissions` (the source of truth), so `batchToJSONEnriched`
+  // can serialize without relying on the eagerly-loaded `this.groups`. `groupIds` mirrors `toJSON`'s
+  // former output (every grant group: members, editors, provisioned, and the open-space global
+  // reader); `isRestricted` mirrors `isRestricted()` (grant-based, without `this.groups`).
+  private static async listSpaceEnrichmentBySpaceModelId(
+    auth: Authenticator,
+    spaces: SpaceResource[]
+  ): Promise<Map<ModelId, SpaceGrantEnrichment>> {
+    const enrichmentBySpaceModelId = new Map<ModelId, SpaceGrantEnrichment>();
     if (spaces.length === 0) {
-      return groupIdsBySpaceModelId;
+      return enrichmentBySpaceModelId;
     }
 
     const grants = await GroupPermissionModel.findAll({
-      attributes: ["resourceId", "workspaceId", "groupId"],
+      attributes: ["resourceId", "workspaceId", "groupId", "grantType"],
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         resourceType: "space",
@@ -2570,6 +2607,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       },
     });
 
+    const groupIdsBySpaceModelId = new Map<ModelId, string[]>();
+    const hasReaderGrantBySpaceModelId = new Map<ModelId, boolean>();
     for (const grant of grants) {
       const groupId = GroupResource.modelIdToSId({
         id: grant.groupId,
@@ -2581,8 +2620,22 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       } else {
         groupIdsBySpaceModelId.set(grant.resourceId, [groupId]);
       }
+      if (grant.grantType === "reader") {
+        hasReaderGrantBySpaceModelId.set(grant.resourceId, true);
+      }
     }
 
-    return groupIdsBySpaceModelId;
+    for (const space of spaces) {
+      // A reader (viewer) grant means the workspace global group is attached: the space is open.
+      // Only regular and project spaces can be restricted (the unique kinds never are), matching
+      // `isRestricted()`.
+      const isOpen = hasReaderGrantBySpaceModelId.get(space.id) ?? false;
+      enrichmentBySpaceModelId.set(space.id, {
+        groupIds: groupIdsBySpaceModelId.get(space.id) ?? [],
+        isRestricted: (space.isRegular() || space.isProject()) && !isOpen,
+      });
+    }
+
+    return enrichmentBySpaceModelId;
   }
 }

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -1,7 +1,7 @@
 import { MCP_SPECIFICATION } from "@app/lib/actions/utils_ui";
 import type { DataSourceViewCategory } from "@app/types/api/public/spaces";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import {
   Building04,
   CloudArrowLeftRight,
@@ -26,7 +26,7 @@ export {
 } from "@app/lib/spaces_utils";
 
 export function getSpaceIcon(
-  space: SpaceType
+  space: EnrichedSpaceType
 ): (props: React.SVGProps<SVGSVGElement>) => React.ReactElement {
   if (space.kind === "project") {
     return space.isRestricted ? CubeOutline : Cube01;

--- a/front/lib/spaces_utils.ts
+++ b/front/lib/spaces_utils.ts
@@ -1,7 +1,7 @@
 import { GLOBAL_SPACE_NAME } from "@app/types/groups";
 import type { PlanType } from "@app/types/plan";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType, SpaceType } from "@app/types/space";
 import type { WorkspaceType } from "@app/types/user";
 import groupBy from "lodash/groupBy";
 
@@ -20,7 +20,7 @@ export const dustAppsListUrl = (
   return `/w/${owner.sId}/spaces/${space.sId}/categories/apps`;
 };
 
-export const groupSpacesForDisplay = (spaces: SpaceType[]) => {
+export const groupSpacesForDisplay = (spaces: EnrichedSpaceType[]) => {
   // Conversations space should never be displayed
   const spacesWithoutConversations = spaces.filter(
     (space) => space.kind !== "conversations"

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -38,10 +38,10 @@ import type { SearchWarningCode } from "@app/types/core/core_api";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types/core/utils";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type {
+  EnrichedSpaceType,
   PodType,
   SpaceKind,
   SpaceType,
-  SpaceTypeWithGroupIds,
 } from "@app/types/space";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 import { useMemo } from "react";
@@ -78,7 +78,7 @@ export function useSpaces({
   const spaces = useMemo(() => {
     return (
       data?.spaces?.filter((s) => kinds === "all" || kinds.includes(s.kind)) ??
-      emptyArray<SpaceTypeWithGroupIds | PodType>()
+      emptyArray<EnrichedSpaceType | PodType>()
     );
     // Serialize the kinds array to a string to avoid unnecessary re-renders
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -119,7 +119,7 @@ export function useSpaceProjectsLookup({
 
   const spaces = useMemo(() => {
     if (!data?.spaces) {
-      return emptyArray<SpaceType>();
+      return emptyArray<PodType>();
     }
     return data.spaces;
   }, [data?.spaces]);

--- a/front/lib/utils/apps.ts
+++ b/front/lib/utils/apps.ts
@@ -396,12 +396,12 @@ export async function exportApps(
 ): Promise<Result<ApiAppType[], Error>> {
   const apps = await AppResource.listBySpace(auth, space);
 
-  // All apps belong to `space`; load its group sIds once so the exported app keeps the space's
-  // `groupIds` (part of the public app contract) without relying on the eagerly-loaded grants.
-  const spaceGroupIds =
-    (
-      await SpaceResource.listGroupIdsBySpaceModelId(auth, { spaces: [space] })
-    ).get(space.id) ?? [];
+  // All apps belong to `space`; load its grant-derived enrichment once so the exported app keeps the
+  // space's `groupIds`/`isRestricted` (part of the public app contract) without relying on the
+  // eagerly-loaded grants.
+  const [enrichedSpace] = await SpaceResource.batchToJSONEnriched(auth, [
+    space,
+  ]);
 
   const enhancedApps = await concurrentExecutor(
     apps.filter((app) => app.canRead(auth)),
@@ -448,7 +448,7 @@ export async function exportApps(
       }
 
       return {
-        ...app.toJSONWithSpaceGroupIds(spaceGroupIds),
+        ...app.toJSONEnriched(enrichedSpace),
         datasets,
         coreSpecifications,
       };

--- a/front/types/api/poke/agent_configurations.ts
+++ b/front/types/api/poke/agent_configurations.ts
@@ -3,7 +3,7 @@ import type {
   LightAgentConfigurationType,
 } from "@app/types/assistant/agent";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
 import type { UserType } from "@app/types/user";
 
@@ -19,7 +19,7 @@ export type PokeGetAgentDetails = {
   agentConfigurations: AgentConfigurationType[];
   authors: UserType[];
   lastVersionEditors: UserType[];
-  spaces: SpaceType[];
+  spaces: EnrichedSpaceType[];
   skillsByVersion: Record<number, SkillType[]>;
 };
 

--- a/front/types/api/poke/skills.ts
+++ b/front/types/api/poke/skills.ts
@@ -4,7 +4,7 @@ import type {
   UsedBySkillType,
 } from "@app/types/assistant/skill_configuration";
 import type { AgentsUsageType } from "@app/types/data_source";
-import type { SpaceType } from "@app/types/space";
+import type { EnrichedSpaceType } from "@app/types/space";
 import type { SkillSuggestionType } from "@app/types/suggestions/skill_suggestion";
 import type { UserType } from "@app/types/user";
 
@@ -27,7 +27,7 @@ export type PostSkillSuggestionBodyType = {
 export type PokeGetSkillDetails = {
   skill: SkillType;
   editedByUser: UserType | null;
-  spaces: SpaceType[];
+  spaces: EnrichedSpaceType[];
   // Agents that use this skill.
   agentsUsage: AgentsUsageType;
   // Parent skills that reference this skill.

--- a/front/types/api/spaces.ts
+++ b/front/types/api/spaces.ts
@@ -4,11 +4,7 @@ import {
   PodFrameTabsSchema,
   PodTabsOrderSchema,
 } from "@app/types/pod_frame_tab";
-import type {
-  PodType,
-  SpaceType,
-  SpaceTypeWithGroupIds,
-} from "@app/types/space";
+import type { EnrichedSpaceType, PodType, SpaceType } from "@app/types/space";
 import type { SpaceUserType } from "@app/types/user";
 import { z } from "zod";
 
@@ -83,7 +79,7 @@ export type PostSpaceRequestBodyType = z.infer<
 >;
 
 export type GetSpacesResponseBody = {
-  spaces: (SpaceTypeWithGroupIds | PodType)[];
+  spaces: (EnrichedSpaceType | PodType)[];
 };
 
 export type PostSpacesResponseBody = {
@@ -95,7 +91,7 @@ export type SpaceCategoryInfo = {
   count: number;
 };
 
-export type RichSpaceType = SpaceTypeWithGroupIds & {
+export type RichSpaceType = EnrichedSpaceType & {
   categories: { [key: string]: SpaceCategoryInfo };
   canWrite: boolean;
   canRead: boolean;

--- a/front/types/app.ts
+++ b/front/types/app.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import type { BlockType } from "./run";
 import type { ModelId } from "./shared/model_id";
 import { DbModelIdSchema } from "./shared/model_id";
-import type { SpaceType, SpaceTypeWithGroupIds } from "./space";
+import type { EnrichedSpaceType, SpaceType } from "./space";
 
 export type AppVisibility = "private" | "deleted";
 
@@ -25,10 +25,10 @@ export type AppType = {
 };
 
 // An app serialized with its space's `groupIds` (part of the public app contract). Produced by
-// `AppResource.toJSONWithSpaceGroupIds` for the public API; the internal `AppType` omits them so app
+// `AppResource.toJSONEnriched` for the public API; the internal `AppType` omits them so app
 // serialization does not depend on the space's eagerly-loaded grants.
-export type AppTypeWithSpaceGroupIds = Omit<AppType, "space"> & {
-  space: SpaceTypeWithGroupIds;
+export type EnrichedAppType = Omit<AppType, "space"> & {
+  space: EnrichedSpaceType;
 };
 
 export type SpecificationBlockType = {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -8,7 +8,7 @@ import type { ContentFragmentType } from "../content_fragment";
 import type { AllSupportedWithDustSpecificFileContentType } from "../files";
 import type { ModelId } from "../shared/model_id";
 import { assertNeverAndIgnore } from "../shared/utils/assert_never";
-import type { SpaceType } from "../space";
+import type { EnrichedSpaceType } from "../space";
 import type { UserType, WorkspaceType } from "../user";
 import type {
   AgentConfigurationStatus,
@@ -624,7 +624,7 @@ export type ConversationWithoutContentType = ConversationListItemType & {
   forkingData?: ConversationForkingDataType;
 };
 
-export type SelectableConversationSpaceType = SpaceType & {
+export type SelectableConversationSpaceType = EnrichedSpaceType & {
   selected: boolean;
 };
 

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -41,6 +41,7 @@ export interface PokeItemBase {
 export type PokeSpaceType = SpaceType & {
   id: ModelId;
   groups: GroupType[];
+  isRestricted: boolean;
 };
 
 export type PokeSandboxType = {

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -20,7 +20,6 @@ type UniqueSpaceKind = (typeof UNIQUE_SPACE_KINDS)[number];
  */
 export type SpaceType = {
   createdAt: number;
-  isRestricted: boolean;
   kind: SpaceKind;
   managementMode: "manual" | "group";
   name: string;
@@ -29,20 +28,23 @@ export type SpaceType = {
 };
 
 /**
- * A space serialized together with the sIds of the groups holding a grant on it. `groupIds` is
- * loaded from `group_permissions` on demand by the endpoints that expose it (the public API for
- * backward compatibility, and the space-management UI) rather than carried on every `SpaceType`.
+ * A space serialized together with its grant-derived fields — the sIds of the groups holding a
+ * grant on it, and whether it is restricted. Both come from `group_permissions`, so they are loaded
+ * on demand by the endpoints that expose them (the public API for backward compatibility, and the
+ * space-management UI) rather than carried on every `SpaceType` (which would force the eager grant
+ * include on every space load).
  *
  * @swaggerschema Space (swagger_schemas.ts)
  */
-export type SpaceTypeWithGroupIds = SpaceType & {
+export type EnrichedSpaceType = SpaceType & {
   groupIds: string[];
+  isRestricted: boolean;
 };
 
 /**
  * @swaggerschema PrivateProject (swagger_private_schemas.ts)
  */
-export type PodType = SpaceTypeWithGroupIds & {
+export type PodType = EnrichedSpaceType & {
   description: string | null;
   isMember: boolean;
   isEditor: boolean;


### PR DESCRIPTION
## What

`isRestricted` is grant-derived (a space is restricted unless the workspace global group holds a `reader` grant), so — like `groupIds` — it shouldn't force the eager `group_permissions` include on every space load. This moves it off the base `SpaceType`.

- `SpaceTypeWithGroupIds` → **`EnrichedSpaceType`** = `SpaceType & { groupIds; isRestricted }`; `AppTypeWithSpaceGroupIds` → `EnrichedAppType`.
- The on-demand loader is now `SpaceResource.listSpaceEnrichmentBySpaceModelId` → `Map<modelId, { groupIds, isRestricted }>` (one `group_permissions` query). Serializers use `SpaceResource.toJSONEnriched` / `AppResource.toJSONEnriched`. **`toJSON()` no longer reads `this.groups` at all.**
- FE consumers of `space.isRestricted` already receive enriched spaces from `useSpaces`/`useSpaceInfo`/`useSpacesAsAdmin`, so this is annotation-widening (`SpaceType` → `EnrichedSpaceType`) up to those hooks — no runtime change.
- `with_space` middleware reads restriction from the resource (`isRegularAndRestricted() || isProjectAndRestricted()`), not `toJSON()`. Poke (spaces list/detail, agent/skill details) and app serializers load the enrichment on demand.

## Why

With this, base `SpaceType`/`toJSON()` is fully independent of the eagerly-loaded grants. Combined with the async `isOpen()` work and moving the 3 remaining group-management helpers to on-demand loads, the eager `spaceGrants` include can then be dropped — no schema/DB column needed.

## Swagger

`PrivateSpace` drops `isRestricted`; public `Space`, `PrivateProject`, and the space-detail response add it. `swagger.json` regenerated.

## Test plan

- `tsgo --noEmit` clean in both `front` and `front-api` (2 pre-existing unrelated errors remain).
- `lint:swagger-annotations` OK; swagger regenerates with no errors.
- 154 tests passing: `space_resource` (77), `spaces` api (41), v1 spaces (5), private spaces list (5) + detail (2), access-check (8), pods apps export (4) / index (9), project_tasks (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)