### PR TITLE
[front] Agent loop: log stuck tools when finalizing an errored run

### DIFF
--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -1,4 +1,4 @@
-const TOOL_EXECUTION_FINAL_STATUSES = [
+export const TOOL_EXECUTION_FINAL_STATUSES = [
   "succeeded",
   "errored",
   "denied",

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -507,7 +507,7 @@ describe("listNonFinalActionsForAgentMessage", () => {
 
     const actions =
       await AgentMCPActionResource.listNonFinalActionsForAgentMessage(auth, {
-        agentMessageId: agentMessage.agentMessageId,
+        agentMessageModelId: agentMessage.agentMessageId,
       });
 
     expect(actions.map((a) => a.id).sort()).toEqual(
@@ -523,7 +523,7 @@ describe("listNonFinalActionsForAgentMessage", () => {
 
     const actions =
       await AgentMCPActionResource.listNonFinalActionsForAgentMessage(auth, {
-        agentMessageId: agentMessage.agentMessageId,
+        agentMessageModelId: agentMessage.agentMessageId,
       });
 
     expect(actions).toEqual([]);

--- a/front/lib/resources/agent_mcp_action_resource.test.ts
+++ b/front/lib/resources/agent_mcp_action_resource.test.ts
@@ -449,6 +449,87 @@ describe("listBlockedActionsForConversation", () => {
   });
 });
 
+describe("listNonFinalActionsForAgentMessage", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+  });
+
+  it("should return only the message's non-final actions", async () => {
+    const { agentMessage } = await AgentMCPActionFactory.createWithAgentMessage(
+      auth,
+      { workspace, conversation, status: "succeeded" }
+    );
+
+    const { action: runningAction } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      status: "running",
+    });
+    const { action: blockedAction } = await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: agentMessage.agentMessageId,
+      status: "blocked_validation_required",
+    });
+
+    // Non-final action on another agent message: must not be returned.
+    const otherAgentConfig = await AgentConfigurationFactory.createTestAgent(
+      auth,
+      { name: "Other Agent" }
+    );
+    const { agentMessage: otherAgentMessage } =
+      await ConversationFactory.createAgentMessage(auth, {
+        workspace,
+        conversation,
+        agentConfig: otherAgentConfig,
+        // The first agent message of the test occupies rank 0.
+        rank: 1,
+      });
+    await AgentMCPActionFactory.create(auth, {
+      workspace,
+      conversationModelId: conversation.id,
+      agentMessageModelId: otherAgentMessage.agentMessageId,
+      status: "running",
+    });
+
+    const actions =
+      await AgentMCPActionResource.listNonFinalActionsForAgentMessage(auth, {
+        agentMessageId: agentMessage.agentMessageId,
+      });
+
+    expect(actions.map((a) => a.id).sort()).toEqual(
+      [runningAction.id, blockedAction.id].sort()
+    );
+  });
+
+  it("should return an empty array when every action is final", async () => {
+    const { agentMessage } = await AgentMCPActionFactory.createWithAgentMessage(
+      auth,
+      { workspace, conversation, status: "errored" }
+    );
+
+    const actions =
+      await AgentMCPActionResource.listNonFinalActionsForAgentMessage(auth, {
+        agentMessageId: agentMessage.agentMessageId,
+      });
+
+    expect(actions).toEqual([]);
+  });
+});
+
 describe("Output items with GCS storage", () => {
   let workspace: WorkspaceType;
   let auth: Authenticator;

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -7,6 +7,7 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   isToolExecutionStatusBlocked,
   TOOL_EXECUTION_BLOCKED_STATUSES,
+  TOOL_EXECUTION_FINAL_STATUSES,
 } from "@app/lib/actions/statuses";
 import { getApprovalArgsLabel } from "@app/lib/actions/tool_approval_labels";
 import {
@@ -982,6 +983,23 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     }
 
     return actions;
+  }
+
+  // Actions the agent message left in a non-final status: still running when a workflow errors
+  // (the worker that ran them may have died before finalizing the row), or parked on a user
+  // interaction (blocked_*). Callers discriminate on `status`.
+  static async listNonFinalActionsForAgentMessage(
+    auth: Authenticator,
+    { agentMessageId }: { agentMessageId: ModelId }
+  ): Promise<AgentMCPActionResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        agentMessageId,
+        status: {
+          [Op.notIn]: TOOL_EXECUTION_FINAL_STATUSES,
+        },
+      },
+    });
   }
 
   /**

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -990,11 +990,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
   // interaction (blocked_*). Callers discriminate on `status`.
   static async listNonFinalActionsForAgentMessage(
     auth: Authenticator,
-    { agentMessageId }: { agentMessageId: ModelId }
+    { agentMessageModelId }: { agentMessageModelId: ModelId }
   ): Promise<AgentMCPActionResource[]> {
     return this.baseFetch(auth, {
       where: {
-        agentMessageId,
+        agentMessageId: agentMessageModelId,
         status: {
           [Op.notIn]: TOOL_EXECUTION_FINAL_STATUSES,
         },

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -33,6 +33,7 @@ import type {
   AgentMessageType,
   ConversationWithoutContentType,
 } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import maxBy from "lodash/maxBy";
 import type { InferAttributes, WhereOptions } from "sequelize";
@@ -525,11 +526,14 @@ function toUserFriendlyMessage(error: {
   return error.message;
 }
 
+// Returns the errored agent message's model id (already resolved here) so the caller can
+// attribute the failure without refetching the conversation, or null when the conversation is
+// gone.
 export async function notifyWorkflowError(
   authType: AuthenticatorType,
   { conversationId, agentMessageId, agentMessageVersion }: AgentLoopArgs,
   error: { message: string; name: string }
-): Promise<void> {
+): Promise<ModelId | null> {
   const auth = await AuthenticatorClass.fromJsonWithRefrehedGroups(authType);
 
   const conversation = await ConversationResource.fetchById(
@@ -537,7 +541,7 @@ export async function notifyWorkflowError(
     conversationId
   );
   if (!conversation) {
-    return;
+    return null;
   }
 
   // Fetch the agent message using the proper API function
@@ -620,6 +624,8 @@ export async function notifyWorkflowError(
     conversation: conversation.toJSON(),
     step: 0, // Workflow-level error, not tied to a specific step
   });
+
+  return messageRow.agentMessage.id;
 }
 
 /**

--- a/front/temporal/agent_loop/activities/finalize.test.ts
+++ b/front/temporal/agent_loop/activities/finalize.test.ts
@@ -1,6 +1,10 @@
 import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import logger from "@app/logger/logger";
 import { creditsExhaustedMessage } from "@app/temporal/agent_loop/activities/common";
-import { describe, expect, it } from "vitest";
+import { logStuckToolsForErroredAgentMessage } from "@app/temporal/agent_loop/activities/finalize";
+import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("creditsExhaustedMessage", () => {
   it("tells admins to purchase more credits", () => {
@@ -14,6 +18,80 @@ describe("creditsExhaustedMessage", () => {
     const auth = { isAdmin: () => false } as unknown as Authenticator;
     expect(creditsExhaustedMessage(auth)).toBe(
       "Your workspace has run out of credits. Please contact your administrator to purchase more credits."
+    );
+  });
+});
+
+describe("logStuckToolsForErroredAgentMessage", () => {
+  const auth = {
+    getNonNullableWorkspace: () => ({ sId: "workspace-1" }),
+  } as unknown as Authenticator;
+  const agentLoopArgs = {
+    conversationId: "conversation-1",
+    agentMessageId: "message-1",
+    agentMessageVersion: 0,
+  } as AgentLoopArgs;
+  const error = { message: "Activity task timed out", name: "ActivityFailure" };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs the non-final actions as stuck tools", async () => {
+    vi.spyOn(
+      AgentMCPActionResource,
+      "listNonFinalActionsForAgentMessage"
+    ).mockResolvedValue([
+      {
+        id: 42,
+        status: "running",
+        toolConfiguration: { name: "notion-search", mcpServerName: "notion" },
+      },
+    ] as unknown as AgentMCPActionResource[]);
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => true);
+
+    await logStuckToolsForErroredAgentMessage(auth, {
+      agentLoopArgs,
+      agentMessageModelId: 1,
+      error,
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowErrorName: "ActivityFailure",
+        stuckTools: [
+          {
+            actionModelId: 42,
+            status: "running",
+            toolName: "notion-search",
+            mcpServerName: "notion",
+          },
+        ],
+      }),
+      "Agent loop finalized as errored"
+    );
+  });
+
+  it("does not throw when the actions query fails, and still logs the failure cause", async () => {
+    vi.spyOn(
+      AgentMCPActionResource,
+      "listNonFinalActionsForAgentMessage"
+    ).mockRejectedValue(new Error("db down"));
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => true);
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => true);
+
+    await expect(
+      logStuckToolsForErroredAgentMessage(auth, {
+        agentLoopArgs,
+        agentMessageModelId: 1,
+        error,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ stuckTools: [] }),
+      "Agent loop finalized as errored"
     );
   });
 });

--- a/front/temporal/agent_loop/activities/finalize.test.ts
+++ b/front/temporal/agent_loop/activities/finalize.test.ts
@@ -3,7 +3,9 @@ import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_reso
 import logger from "@app/logger/logger";
 import { creditsExhaustedMessage } from "@app/temporal/agent_loop/activities/common";
 import { logStuckToolsForErroredAgentMessage } from "@app/temporal/agent_loop/activities/finalize";
-import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import { AgentMCPActionFactory } from "@app/tests/utils/AgentMCPActionFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 describe("creditsExhaustedMessage", () => {
@@ -23,36 +25,44 @@ describe("creditsExhaustedMessage", () => {
 });
 
 describe("logStuckToolsForErroredAgentMessage", () => {
-  const auth = {
-    getNonNullableWorkspace: () => ({ sId: "workspace-1" }),
-  } as unknown as Authenticator;
-  const agentLoopArgs = {
-    conversationId: "conversation-1",
-    agentMessageId: "message-1",
-    agentMessageVersion: 0,
-  } as AgentLoopArgs;
   const error = { message: "Activity task timed out", name: "ActivityFailure" };
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("logs the non-final actions as stuck tools", async () => {
-    vi.spyOn(
-      AgentMCPActionResource,
-      "listNonFinalActionsForAgentMessage"
-    ).mockResolvedValue([
-      {
-        id: 42,
+  async function setup() {
+    const { workspace, authenticator: auth } = await createResourceTest({});
+    const conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+    const { agentMessage, action } =
+      await AgentMCPActionFactory.createWithAgentMessage(auth, {
+        workspace,
+        conversation,
         status: "running",
-        toolConfiguration: { name: "notion-search", mcpServerName: "notion" },
+      });
+
+    return {
+      auth,
+      action,
+      agentLoopArgs: {
+        conversationId: conversation.sId,
+        agentMessageId: agentMessage.sId,
       },
-    ] as unknown as AgentMCPActionResource[]);
+      agentMessageModelId: agentMessage.agentMessageId,
+    };
+  }
+
+  it("logs the non-final actions as stuck tools", async () => {
+    const { auth, action, agentLoopArgs, agentMessageModelId } = await setup();
     const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => true);
 
     await logStuckToolsForErroredAgentMessage(auth, {
       agentLoopArgs,
-      agentMessageModelId: 1,
+      agentMessageModelId,
       error,
     });
 
@@ -61,10 +71,10 @@ describe("logStuckToolsForErroredAgentMessage", () => {
         workflowErrorName: "ActivityFailure",
         stuckTools: [
           {
-            actionModelId: 42,
+            actionModelId: action.id,
             status: "running",
-            toolName: "notion-search",
-            mcpServerName: "notion",
+            toolName: action.toolConfiguration.name,
+            mcpServerName: action.toolConfiguration.mcpServerName,
           },
         ],
       }),
@@ -73,6 +83,7 @@ describe("logStuckToolsForErroredAgentMessage", () => {
   });
 
   it("does not throw when the actions query fails, and still logs the failure cause", async () => {
+    const { auth, agentLoopArgs, agentMessageModelId } = await setup();
     vi.spyOn(
       AgentMCPActionResource,
       "listNonFinalActionsForAgentMessage"
@@ -83,7 +94,7 @@ describe("logStuckToolsForErroredAgentMessage", () => {
     await expect(
       logStuckToolsForErroredAgentMessage(auth, {
         agentLoopArgs,
-        agentMessageModelId: 1,
+        agentMessageModelId,
         error,
       })
     ).resolves.toBeUndefined();

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -1,4 +1,3 @@
-import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { computeAndStoreAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
 import {
   sendEmailReplyOnCompletion,
@@ -190,17 +189,16 @@ export async function finalizeErroredAgentLoopActivity(
   // died without logging anything (heartbeat timeouts), but the action rows it left behind in a
   // non-final status carry the tool identity.
   if (agentMessageModelId !== null) {
-    const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
-      agentMessageModelId,
-    ]);
-    const stuckTools = actions
-      .filter((action) => !isToolExecutionStatusFinal(action.status))
-      .map((action) => ({
-        actionModelId: action.id,
-        status: action.status,
-        toolName: action.toolConfiguration.name,
-        mcpServerName: action.toolConfiguration.mcpServerName,
-      }));
+    const actions =
+      await AgentMCPActionResource.listNonFinalActionsForAgentMessage(auth, {
+        agentMessageId: agentMessageModelId,
+      });
+    const stuckTools = actions.map((action) => ({
+      actionModelId: action.id,
+      status: action.status,
+      toolName: action.toolConfiguration.name,
+      mcpServerName: action.toolConfiguration.mcpServerName,
+    }));
 
     logger.warn(
       {

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -186,7 +186,7 @@ export async function logStuckToolsForErroredAgentMessage(
     agentMessageModelId,
     error,
   }: {
-    agentLoopArgs: AgentLoopArgs;
+    agentLoopArgs: Pick<AgentLoopArgs, "conversationId" | "agentMessageId">;
     agentMessageModelId: ModelId;
     error: { message: string; name: string };
   }
@@ -200,7 +200,7 @@ export async function logStuckToolsForErroredAgentMessage(
   try {
     const actions =
       await AgentMCPActionResource.listNonFinalActionsForAgentMessage(auth, {
-        agentMessageId: agentMessageModelId,
+        agentMessageModelId,
       });
     stuckTools = actions.map((action) => ({
       actionModelId: action.id,

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -1,3 +1,4 @@
+import { isToolExecutionStatusFinal } from "@app/lib/actions/statuses";
 import { computeAndStoreAgentMessageCredits } from "@app/lib/api/assistant/credit_cost";
 import {
   sendEmailReplyOnCompletion,
@@ -5,6 +6,8 @@ import {
 } from "@app/lib/api/assistant/email/email_reply";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import logger from "@app/logger/logger";
 import {
   launchAgentMessageAnalytics,
   launchAgentMessageConsumptionAttribution,
@@ -175,9 +178,42 @@ export async function finalizeErroredAgentLoopActivity(
   agentLoopArgs: AgentLoopArgs,
   error: { message: string; name: string }
 ): Promise<void> {
-  await notifyWorkflowError(authType, agentLoopArgs, error);
+  const agentMessageModelId = await notifyWorkflowError(
+    authType,
+    agentLoopArgs,
+    error
+  );
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
+
+  // Attribute the failure to the tools that never finished. The worker that ran them may have
+  // died without logging anything (heartbeat timeouts), but the action rows it left behind in a
+  // non-final status carry the tool identity.
+  if (agentMessageModelId !== null) {
+    const actions = await AgentMCPActionResource.listByAgentMessageIds(auth, [
+      agentMessageModelId,
+    ]);
+    const stuckTools = actions
+      .filter((action) => !isToolExecutionStatusFinal(action.status))
+      .map((action) => ({
+        actionModelId: action.id,
+        status: action.status,
+        toolName: action.toolConfiguration.name,
+        mcpServerName: action.toolConfiguration.mcpServerName,
+      }));
+
+    logger.warn(
+      {
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+        workspaceId: authType.workspaceId,
+        workflowErrorName: error.name,
+        workflowErrorMessage: error.message,
+        stuckTools,
+      },
+      "Agent loop finalized as errored"
+    );
+  }
 
   await Promise.all([
     launchAgentMessageAnalytics(auth, agentLoopArgs),

--- a/front/temporal/agent_loop/activities/finalize.ts
+++ b/front/temporal/agent_loop/activities/finalize.ts
@@ -30,6 +30,8 @@ import {
   launchTrackProgrammaticUsage,
 } from "@app/temporal/agent_loop/activities/usage_tracking";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
+import type { ModelId } from "@app/types/shared/model_id";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 async function launchAgentMessageConsumptionAttributionAfterPersistingInputs(
   auth: Authenticator,
@@ -172,6 +174,64 @@ export async function finalizeCreditStoppedAgentLoopActivity(
   ]);
 }
 
+// Attribute the failure to the tools that never finished. The worker that ran them may have died
+// without logging anything (heartbeat timeouts), but the action rows it left behind in a
+// non-final status carry the tool identity. Diagnostic only: it must never fail the finalize
+// activity, which carries billing, analytics and email side effects, so the DB read is
+// best-effort. Exported for tests.
+export async function logStuckToolsForErroredAgentMessage(
+  auth: Authenticator,
+  {
+    agentLoopArgs,
+    agentMessageModelId,
+    error,
+  }: {
+    agentLoopArgs: AgentLoopArgs;
+    agentMessageModelId: ModelId;
+    error: { message: string; name: string };
+  }
+): Promise<void> {
+  let stuckTools: {
+    actionModelId: ModelId;
+    status: string;
+    toolName: string;
+    mcpServerName: string;
+  }[] = [];
+  try {
+    const actions =
+      await AgentMCPActionResource.listNonFinalActionsForAgentMessage(auth, {
+        agentMessageId: agentMessageModelId,
+      });
+    stuckTools = actions.map((action) => ({
+      actionModelId: action.id,
+      status: action.status,
+      toolName: action.toolConfiguration.name,
+      mcpServerName: action.toolConfiguration.mcpServerName,
+    }));
+  } catch (err) {
+    logger.error(
+      {
+        err: normalizeError(err),
+        conversationId: agentLoopArgs.conversationId,
+        agentMessageId: agentLoopArgs.agentMessageId,
+      },
+      "Failed to list stuck tools for errored agent message"
+    );
+  }
+
+  logger.warn(
+    {
+      conversationId: agentLoopArgs.conversationId,
+      agentMessageId: agentLoopArgs.agentMessageId,
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      workflowErrorName: error.name,
+      workflowErrorMessage: error.message,
+      stuckTools,
+    },
+    "Agent loop finalized as errored"
+  );
+}
+
 export async function finalizeErroredAgentLoopActivity(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs,
@@ -185,32 +245,12 @@ export async function finalizeErroredAgentLoopActivity(
 
   const auth = await Authenticator.fromJsonWithRefrehedGroups(authType);
 
-  // Attribute the failure to the tools that never finished. The worker that ran them may have
-  // died without logging anything (heartbeat timeouts), but the action rows it left behind in a
-  // non-final status carry the tool identity.
   if (agentMessageModelId !== null) {
-    const actions =
-      await AgentMCPActionResource.listNonFinalActionsForAgentMessage(auth, {
-        agentMessageId: agentMessageModelId,
-      });
-    const stuckTools = actions.map((action) => ({
-      actionModelId: action.id,
-      status: action.status,
-      toolName: action.toolConfiguration.name,
-      mcpServerName: action.toolConfiguration.mcpServerName,
-    }));
-
-    logger.warn(
-      {
-        conversationId: agentLoopArgs.conversationId,
-        agentMessageId: agentLoopArgs.agentMessageId,
-        workspaceId: authType.workspaceId,
-        workflowErrorName: error.name,
-        workflowErrorMessage: error.message,
-        stuckTools,
-      },
-      "Agent loop finalized as errored"
-    );
+    await logStuckToolsForErroredAgentMessage(auth, {
+      agentLoopArgs,
+      agentMessageModelId,
+      error,
+    });
   }
 
   await Promise.all([


### PR DESCRIPTION
## Description

We're trying to understand and fix the heartbeat-timeout workflow failures (87% of agentLoopWorkflow failures, see #31054). To pick the right fix we need to know which tools are involved. Worker-side logging can't tell us: in 16 of 20 failures since #31106 deployed, the worker died before emitting a single log line.

The database can. The action rows are persisted (by the model step) before the tool runs, and a dead worker can't finalize them. So when `finalizeErroredAgentLoopActivity` runs, the actions still in a non-final status are exactly the tools that never finished. This PR logs them (`stuckTools`: tool name, MCP server, status) alongside the workflow error, giving attribution for every failure, including silent worker deaths.

The attribution is best-effort: a failing actions read is logged and never blocks the billing/analytics/email finalizers.

## Tests

Resource test for `listNonFinalActionsForAgentMessage`, unit tests for the log shape and the non-blocking behavior.

## Risk

Low: one best-effort DB read and one warn log per errored finalize (~1k/week).

## Deploy Plan

- [ ] Deploy front.
- [ ] Attribution query: `service:front-agent-loop-worker "Agent loop finalized as errored"`, `stuckTools` names the tools.