### PR TITLE
fix: resolve analytics filter names hydrated from the URL

### DIFF
--- a/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
+++ b/front/components/pages/workspace/AnalyticsConsumptionPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "@app/components/workspace/analytics/usageFilter";
 import { useAnalyticsViewState } from "@app/hooks/useAnalyticsViewState";
 import { useQueryParams } from "@app/hooks/useQueryParams";
+import { useResolvedUsageFilter } from "@app/hooks/useResolvedUsageFilter";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
 import { DEFAULT_CONSUMPTION_PERIOD } from "@app/lib/analytics/consumption_period";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -114,8 +115,15 @@ function ChartFallback({ controlsInCard = false }: ChartFallbackProps) {
 export function AnalyticsConsumptionPage() {
   const owner = useWorkspace();
   const state = useAnalyticsConsumptionState(useAnalyticsViewState());
+  const filter = useResolvedUsageFilter({
+    workspaceId: owner.sId,
+    period: state.period,
+    filter: state.filter,
+  });
 
-  return <AnalyticsConsumptionContent owner={owner} state={state} />;
+  return (
+    <AnalyticsConsumptionContent owner={owner} state={{ ...state, filter }} />
+  );
 }
 
 interface AnalyticsConsumptionContentProps {

--- a/front/components/workspace/analytics/UsageFilterPanel.tsx
+++ b/front/components/workspace/analytics/UsageFilterPanel.tsx
@@ -3,6 +3,7 @@ import { FilterFooter } from "@app/components/workspace/analytics/filterPanel/Fi
 import { FilterOptionCheckboxList } from "@app/components/workspace/analytics/filterPanel/FilterOptionCheckboxList";
 import { FilterSelectionSummary } from "@app/components/workspace/analytics/filterPanel/FilterSelectionSummary";
 import type {
+  ConsumptionFacetOptions,
   UsageFilter,
   UsageFilterAgentScope,
   UsageFilterCategory,
@@ -22,7 +23,6 @@ import { UsageFilterModelComplexityControls } from "@app/components/workspace/an
 import { UsageFilterOptionIcon } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterOptionIcon";
 import { UsageFilterSection } from "@app/components/workspace/analytics/usageFilterPanel/UsageFilterSection";
 import { useUsageFilter } from "@app/components/workspace/analytics/useUsageFilter";
-import type { ConsumptionFacetOptions } from "@app/hooks/useConsumptionFacets";
 import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
 import { useToggleSelectionList } from "@app/hooks/useToggleSelectionList";
 import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";

--- a/front/components/workspace/analytics/usageFilter.test.ts
+++ b/front/components/workspace/analytics/usageFilter.test.ts
@@ -1,8 +1,11 @@
+import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
 import {
   addUsageFilterFromAttributionRow,
+  EMPTY_FACET_OPTIONS,
   getUsageFilterCategories,
   getUsageFilterSummaries,
   removeUsageFilterFromAttributionRow,
+  resolveUsageFilter,
   setUsageFilterFromAttributionRow,
   toConsumptionScopeFilter,
 } from "@app/components/workspace/analytics/usageFilter";
@@ -353,5 +356,64 @@ describe("removeUsageFilterFromAttributionRow", () => {
     const removed = removeUsageFilterFromAttributionRow(filter, "user", row);
 
     expect(removed).toEqual(filter);
+  });
+});
+
+describe("resolveUsageFilter", () => {
+  it("replaces url-hydrated options with their facet counterpart", () => {
+    const filter: UsageFilter = {
+      group: [
+        { id: "group-1", name: "group-1", disabled: false, kind: "group" },
+      ],
+    };
+
+    expect(
+      resolveUsageFilter(filter, {
+        ...EMPTY_FACET_OPTIONS,
+        group: [
+          {
+            id: "group-1",
+            name: "Engineering",
+            disabled: false,
+            kind: "group",
+          },
+        ],
+      })
+    ).toEqual({
+      group: [
+        { id: "group-1", name: "Engineering", disabled: false, kind: "group" },
+      ],
+    });
+  });
+
+  it("keeps options the facets do not cover", () => {
+    const filter: UsageFilter = {
+      member: [
+        {
+          id: "user-1",
+          name: "user-1",
+          disabled: false,
+          kind: "member",
+          image: null,
+        },
+      ],
+    };
+
+    expect(resolveUsageFilter(filter, EMPTY_FACET_OPTIONS)).toBe(filter);
+  });
+
+  it("returns the same filter when every option is already resolved", () => {
+    const filter: UsageFilter = {
+      group: [
+        { id: "group-1", name: "Engineering", disabled: false, kind: "group" },
+      ],
+    };
+
+    expect(
+      resolveUsageFilter(filter, {
+        ...EMPTY_FACET_OPTIONS,
+        group: filter.group ?? [],
+      })
+    ).toBe(filter);
   });
 });

--- a/front/components/workspace/analytics/usageFilter.ts
+++ b/front/components/workspace/analytics/usageFilter.ts
@@ -168,6 +168,21 @@ export type UsageFilterIds = Partial<
   Record<ConsumptionScopeDimension, string[]>
 >;
 
+export type ConsumptionFacetOptions = {
+  [C in UsageFilterCategory]: UsageFilterOptionForCategory<C>[];
+};
+
+export const EMPTY_FACET_OPTIONS: ConsumptionFacetOptions = {
+  agent: [],
+  member: [],
+  group: [],
+  model: [],
+  tool: [],
+  skill: [],
+  source: [],
+  api_key: [],
+};
+
 // URL filters only carry ids. Keep that transport shape at the boundary and
 // use minimal options until the user replaces them from the filter panel.
 export function usageFilterFromIds(ids: UsageFilterIds): UsageFilter {
@@ -186,6 +201,54 @@ export function usageFilterFromIds(ids: UsageFilterIds): UsageFilter {
   }
 
   return filter;
+}
+
+function resolveCategory<C extends UsageFilterCategory>(
+  selected: UsageFilterOptionForCategory<C>[] | undefined,
+  facetOptions: UsageFilterOptionForCategory<C>[]
+): UsageFilterOptionForCategory<C>[] | undefined {
+  if (!selected?.length || facetOptions.length === 0) {
+    return selected;
+  }
+
+  const facetOptionById = new Map(
+    facetOptions.map((option) => [option.id, option])
+  );
+  const resolved = selected.map(
+    (option) => facetOptionById.get(option.id) ?? option
+  );
+
+  return resolved.every((option, index) => option === selected[index])
+    ? selected
+    : resolved;
+}
+
+export function hasUnresolvedUsageFilterNames(filter: UsageFilter): boolean {
+  return USAGE_FILTER_CATEGORIES.flatMap(
+    (category): UsageFilterOption[] => filter[category] ?? []
+  ).some((option) => option.name === option.id);
+}
+
+export function resolveUsageFilter(
+  filter: UsageFilter,
+  facetOptions: ConsumptionFacetOptions
+): UsageFilter {
+  const resolved: UsageFilter = {
+    agent: resolveCategory(filter.agent, facetOptions.agent),
+    member: resolveCategory(filter.member, facetOptions.member),
+    group: resolveCategory(filter.group, facetOptions.group),
+    model: resolveCategory(filter.model, facetOptions.model),
+    tool: resolveCategory(filter.tool, facetOptions.tool),
+    skill: resolveCategory(filter.skill, facetOptions.skill),
+    source: resolveCategory(filter.source, facetOptions.source),
+    api_key: resolveCategory(filter.api_key, facetOptions.api_key),
+  };
+
+  return USAGE_FILTER_CATEGORIES.every(
+    (category) => resolved[category] === filter[category]
+  )
+    ? filter
+    : resolved;
 }
 
 export function usageFilterToIds(filter: UsageFilter): UsageFilterIds {

--- a/front/hooks/useConsumptionFacets.ts
+++ b/front/hooks/useConsumptionFacets.ts
@@ -1,15 +1,15 @@
 import type {
+  ConsumptionFacetOptions,
   UsageFilterAgentOption,
   UsageFilterApiKeyOption,
-  UsageFilterCategory,
   UsageFilterGroupOption,
   UsageFilterMemberOption,
   UsageFilterModelOption,
-  UsageFilterOptionForCategory,
   UsageFilterSkillOption,
   UsageFilterSourceOption,
   UsageFilterToolOption,
 } from "@app/components/workspace/analytics/usageFilter";
+import { EMPTY_FACET_OPTIONS } from "@app/components/workspace/analytics/usageFilter";
 import {
   getConsumptionAnalyticsUrl,
   useConsumptionQuery,
@@ -29,21 +29,6 @@ import type {
 } from "@app/types/api/analytics/consumption";
 import { isConnectorProvider } from "@app/types/data_source";
 import { useMemo } from "react";
-
-export type ConsumptionFacetOptions = {
-  [C in UsageFilterCategory]: UsageFilterOptionForCategory<C>[];
-};
-
-const EMPTY_FACET_OPTIONS: ConsumptionFacetOptions = {
-  agent: [],
-  member: [],
-  group: [],
-  model: [],
-  tool: [],
-  skill: [],
-  source: [],
-  api_key: [],
-};
 
 export interface UseConsumptionFacetsParams {
   workspaceId: string;

--- a/front/hooks/useResolvedUsageFilter.ts
+++ b/front/hooks/useResolvedUsageFilter.ts
@@ -1,0 +1,40 @@
+import type { UsageFilter } from "@app/components/workspace/analytics/usageFilter";
+import {
+  hasUnresolvedUsageFilterNames,
+  resolveUsageFilter,
+  toConsumptionScopeFilter,
+} from "@app/components/workspace/analytics/usageFilter";
+import { useConsumptionFacets } from "@app/hooks/useConsumptionFacets";
+import type { ConsumptionPeriodSelection } from "@app/lib/analytics/consumption_period";
+import type { ConsumptionAnalyticsScope } from "@app/lib/analytics/consumption_scope";
+import { useMemo } from "react";
+
+interface UseResolvedUsageFilterParams {
+  workspaceId: string;
+  period: ConsumptionPeriodSelection;
+  filter: UsageFilter;
+  analyticsScope?: ConsumptionAnalyticsScope;
+}
+
+// A filter hydrated from the query string only carries ids, so its options
+// start with the id as display name and without a picture. The facets already
+// fetched by the filter panel carry the real labels.
+export function useResolvedUsageFilter({
+  workspaceId,
+  period,
+  filter,
+  analyticsScope,
+}: UseResolvedUsageFilterParams): UsageFilter {
+  const { options: facetOptions } = useConsumptionFacets({
+    workspaceId,
+    period,
+    filter: toConsumptionScopeFilter(filter),
+    analyticsScope,
+    disabled: !hasUnresolvedUsageFilterNames(filter),
+  });
+
+  return useMemo(
+    () => resolveUsageFilter(filter, facetOptions),
+    [filter, facetOptions]
+  );
+}

--- a/front/poke/swr/consumption.ts
+++ b/front/poke/swr/consumption.ts
@@ -1,8 +1,6 @@
 import type { ConsumptionDimension } from "@app/components/workspace/analytics/consumption/consumptionDimensions";
-import type {
-  ConsumptionFacetOptions,
-  UseConsumptionFacetsParams,
-} from "@app/hooks/useConsumptionFacets";
+import { EMPTY_FACET_OPTIONS } from "@app/components/workspace/analytics/usageFilter";
+import type { UseConsumptionFacetsParams } from "@app/hooks/useConsumptionFacets";
 import { toConsumptionFacetOptions } from "@app/hooks/useConsumptionFacets";
 import type { UseConsumptionOverviewParams } from "@app/hooks/useConsumptionOverview";
 import { useConsumptionQuery } from "@app/hooks/useConsumptionQuery";
@@ -30,17 +28,6 @@ import type {
 } from "@app/lib/api/analytics/consumption/timeseries";
 import { emptyArray } from "@app/lib/swr/swr";
 import { useMemo } from "react";
-
-const EMPTY_FACET_OPTIONS: ConsumptionFacetOptions = {
-  agent: [],
-  member: [],
-  group: [],
-  model: [],
-  tool: [],
-  skill: [],
-  source: [],
-  api_key: [],
-};
 
 const CONSUMPTION_TOP_ENDPOINTS = {
   agent: "top-agents",


### PR DESCRIPTION
## Description

The analytics consumption view keeps its filter in the query string, which only carries ids. On refresh `usageFilterFromIds` built each option with the id as its display name, so the filter chips and the panel's "filters selected" list showed raw sIds (and lost avatars/icons) for every category until the user reselected the option by hand.

`useResolvedUsageFilter` now swaps those placeholders for their facet counterpart, taking the whole option so names, pictures, agent scope and tool icons all come back.

`ConsumptionFacetOptions` and `EMPTY_FACET_OPTIONS` moved to `usageFilter.ts` so the new transform sits with the other per-category filter helpers. That also removes the two existing copies of the empty-options constant.

## Tests

Unit tests on `resolveUsageFilter` in `usageFilter.test.ts`.

## Risk

Low.

## Deploy Plan

Deploy front.