### PR TITLE
[front] Stop fetching all admin spaces to invalidate MCP views

### DIFF
--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -34,7 +34,6 @@ import type {
   PostConnectionResponseBody,
 } from "@app/lib/resources/mcp_server_connection_resource";
 import type { GetMCPServerViewsResponseBody } from "@app/lib/resources/mcp_server_view_resource";
-import { useSpacesAsAdmin } from "@app/lib/swr/spaces";
 import { emptyArray, useFetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { DiscoverOAuthMetadataResponseBody } from "@app/types/api/oauth/providers/mcp";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -51,9 +50,9 @@ import { Err, Ok } from "@app/types/shared/result";
 import { removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
-import { isAdmin } from "@app/types/user";
 import { useCallback, useMemo, useState } from "react";
 import type { Fetcher, SWRConfiguration } from "swr";
+import { useSWRConfig } from "swr";
 
 export type MCPConnectionType = {
   useCase: MCPOAuthUseCase;
@@ -61,15 +60,7 @@ export type MCPConnectionType = {
 };
 
 export function useMutateMCPServersViewsForAdmin(owner: LightWorkspaceType) {
-  const { spaces } = useSpacesAsAdmin({
-    workspaceId: owner.sId,
-    disabled: !isAdmin(owner),
-  });
-  const { mutateMCPServerViews } = useMCPServerViews({
-    owner,
-    space: spaces.find((s) => s.kind === "system"),
-    disabled: true,
-  });
+  const { mutate: globalMutate } = useSWRConfig();
   const { mutateMCPServers } = useMCPServers({
     disabled: true,
     owner,
@@ -77,9 +68,14 @@ export function useMutateMCPServersViewsForAdmin(owner: LightWorkspaceType) {
 
   return {
     mutate: useCallback(async () => {
-      await mutateMCPServerViews();
+      await globalMutate(
+        (key) =>
+          typeof key === "string" &&
+          key.startsWith(`/api/w/${owner.sId}/spaces/`) &&
+          key.includes("/mcp_views")
+      );
       await mutateMCPServers();
-    }, [mutateMCPServerViews, mutateMCPServers]),
+    }, [owner.sId, globalMutate, mutateMCPServers]),
   };
 }
 


### PR DESCRIPTION
## What

`useMutateMCPServersViewsForAdmin` (used by ~8 MCP mutation hooks — `useDeleteMCPServer`, `useCreate*`, `useSync*`, `useUpdateMCPServerView`, connect, and `MCPServerDetails`) called `useSpacesAsAdmin` on mount, fetching **every** workspace space (enriched with `groupIds`/`isRestricted`) solely to `spaces.find(s => s.kind === "system")` and rebuild one SWR key to invalidate after a server mutation. The spaces were never rendered or read.

Now it invalidates the space-scoped `mcp_views` keys by pattern via `useSWRConfig().mutate(predicate)` — no spaces fetched, no enrichment:

```ts
await globalMutate(
  (key) =>
    typeof key === "string" &&
    key.startsWith(`/api/w/${owner.sId}/spaces/`) &&
    key.includes("/mcp_views")
);
```

`mutate` is only called *after* a create/delete/update/sync succeeds, so pattern invalidation is sufficient (nothing needs to be pre-fetched at render time).

## Why

This eager fetch was the source of the `GET /spaces?role=admin` call on the new-conversation page (via `MCPServerDetails`, mounted closed) — and on every other admin page mounting these hooks. Removing it kills that query everywhere, along with the now-pointless space enrichment.

## Trade-off

Invalidates all spaces' `mcp_views` keys rather than only the system space's. This is safe (revalidation, not mutation), and MCP server views for admin config live in the system space anyway — the effective set is the same.

## Test plan

- `tsgo --noEmit` clean (front).
- No behavior change for callers — `useMutateMCPServersViewsForAdmin` still returns `{ mutate }`; the returned `mutate` still invalidates the MCP views + servers caches after a mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)