### PR TITLE
[front] fix: compact agent analytics summary cards

### DIFF
--- a/front/components/workspace/analytics/SummaryCard.tsx
+++ b/front/components/workspace/analytics/SummaryCard.tsx
@@ -1,17 +1,24 @@
 import { cn } from "@dust-tt/sparkle";
 
 interface SummaryCardProps {
+  className?: string;
   label: string;
   value: string;
   hint: string | null;
 }
 
-export function SummaryCard({ label, value, hint }: SummaryCardProps) {
+export function SummaryCard({
+  className,
+  label,
+  value,
+  hint,
+}: SummaryCardProps) {
   return (
     <div
       className={cn(
         "flex flex-1 flex-col justify-center h-24 gap-1 rounded-xl",
-        "border border-border bg-panel-background p-4"
+        "border border-border bg-panel-background p-4",
+        className
       )}
     >
       <span className="text-xs font-semibold text-muted-foreground">

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.test.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.test.tsx
@@ -41,7 +41,7 @@ describe("ConsumptionSummary", () => {
   });
 
   it("shows activity and cost metrics in an agent-scoped summary", () => {
-    render(
+    const { container } = render(
       <ConsumptionSummary
         workspaceId="workspace-id"
         period={period}
@@ -62,20 +62,49 @@ describe("ConsumptionSummary", () => {
     expect(screen.getByText("100 credits")).toBeInTheDocument();
     expect(screen.getByText("Avg. cost/msg")).toBeInTheDocument();
     expect(screen.getByText("0.2 credits")).toBeInTheDocument();
-    expect(
-      screen.getByText("Active Users").closest(".bg-panel-background")
-    ).toBeInTheDocument();
+    const activeUsersCard = screen
+      .getByText("Active Users")
+      .closest(".bg-panel-background");
+    expect(activeUsersCard).toHaveClass("h-20");
+    expect(activeUsersCard).not.toHaveClass("h-24");
     expect(
       screen.getByText("Messages / active user").closest(".bg-panel-background")
     ).toBeInTheDocument();
+    expect(container.firstElementChild).toHaveClass("gap-6");
     expect(screen.queryByText("Top agent")).not.toBeInTheDocument();
   });
 
+  it("matches the agent card geometry while loading", () => {
+    mockUseConsumptionOverview.mockReturnValue({
+      overview: null,
+      isOverviewLoading: true,
+      isOverviewError: undefined,
+    });
+
+    const { container } = render(
+      <ConsumptionSummary
+        workspaceId="workspace-id"
+        period={period}
+        analyticsScope={agentAnalyticsScope}
+      />
+    );
+
+    expect(container.firstElementChild).toHaveClass("gap-6");
+    expect(container.querySelectorAll(".h-20.flex-1")).toHaveLength(4);
+    expect(container.querySelectorAll(".h-24")).toHaveLength(0);
+  });
+
   it("keeps the top agent in a workspace summary", () => {
-    render(<ConsumptionSummary workspaceId="workspace-id" period={period} />);
+    const { container } = render(
+      <ConsumptionSummary workspaceId="workspace-id" period={period} />
+    );
 
     expect(screen.getByText("Top agent")).toBeInTheDocument();
     expect(screen.getByText("Research agent")).toBeInTheDocument();
+    expect(
+      screen.getByText("Top agent").closest(".bg-panel-background")
+    ).toHaveClass("h-24");
+    expect(container.firstElementChild).toHaveClass("gap-4");
     expect(screen.queryByText("Active Users")).not.toBeInTheDocument();
     expect(screen.queryByText("Total cost")).not.toBeInTheDocument();
   });

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -66,10 +66,13 @@ export function ConsumptionSummary({
   );
 }
 
-interface ConsumptionSummaryViewProps {
+interface ConsumptionSummaryData {
   overview: GetConsumptionOverviewResponse | null;
   isOverviewLoading: boolean;
   isOverviewError: boolean;
+}
+
+interface ConsumptionSummaryViewProps extends ConsumptionSummaryData {
   usageHref: string;
   usageLinkLabel: string;
   responsiveLayout?: boolean;
@@ -85,31 +88,24 @@ export function ConsumptionSummaryView({
   responsiveLayout = false,
   analyticsScope = WORKSPACE_CONSUMPTION_ANALYTICS_SCOPE,
 }: ConsumptionSummaryViewProps) {
-  const isAgentScoped = analyticsScope.kind === "agent";
-  const cardHeightClassName = isAgentScoped ? "h-20" : "h-24";
+  if (analyticsScope.kind === "agent") {
+    return (
+      <AgentConsumptionSummaryView
+        overview={overview}
+        isOverviewLoading={isOverviewLoading}
+        isOverviewError={isOverviewError}
+        responsiveLayout={responsiveLayout}
+      />
+    );
+  }
+
   const loadingCardClassName = responsiveLayout
-    ? `${cardHeightClassName} rounded-xl`
-    : `${cardHeightClassName} flex-1 rounded-xl`;
+    ? "h-24 rounded-xl"
+    : "h-24 flex-1 rounded-xl";
 
   if (isOverviewLoading) {
     return (
-      <div
-        className={
-          isAgentScoped ? "flex flex-col gap-6" : "flex flex-col gap-4"
-        }
-      >
-        {isAgentScoped && (
-          <div
-            className={
-              responsiveLayout
-                ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
-                : "flex items-stretch gap-6"
-            }
-          >
-            <LoadingBlock className={loadingCardClassName} />
-            <LoadingBlock className={loadingCardClassName} />
-          </div>
-        )}
+      <div className="flex flex-col gap-4">
         <div
           className={
             responsiveLayout
@@ -131,21 +127,9 @@ export function ConsumptionSummaryView({
   const { topAgent, totalCredits } = overview;
   const creditUsage =
     analyticsScope.kind === "workspace" ? overview.creditUsage : null;
-  const messagesPerActiveUser =
-    overview.messageCount === undefined
-      ? null
-      : overview.members.active > 0
-        ? Math.round(overview.messageCount / overview.members.active)
-        : 0;
-  const averageCostPerMessage =
-    overview.messageCount !== undefined && overview.messageCount > 0
-      ? totalCredits / overview.messageCount
-      : null;
 
   return (
-    <div
-      className={isAgentScoped ? "flex flex-col gap-6" : "flex flex-col gap-4"}
-    >
+    <div className="flex flex-col gap-4">
       {creditUsage && (
         <div
           className={
@@ -174,28 +158,6 @@ export function ConsumptionSummaryView({
           />
         </div>
       )}
-      {isAgentScoped && (
-        <div
-          className={
-            responsiveLayout
-              ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
-              : "flex items-stretch gap-6"
-          }
-        >
-          <SummaryCard
-            className="h-20"
-            label="Active Users"
-            value={overview.members.active.toLocaleString()}
-            hint={null}
-          />
-          <SummaryCard
-            className="h-20"
-            label="Messages / active user"
-            value={messagesPerActiveUser?.toLocaleString() ?? "—"}
-            hint={null}
-          />
-        </div>
-      )}
       <div
         className={
           responsiveLayout
@@ -203,47 +165,130 @@ export function ConsumptionSummaryView({
             : "flex items-stretch gap-6"
         }
       >
-        {isAgentScoped ? (
-          <>
-            <SummaryCard
-              className="h-20"
-              label="Total cost"
-              value={`${formatCredits(totalCredits)} credits`}
-              hint={null}
-            />
-            <SummaryCard
-              className="h-20"
-              label="Avg. cost/msg"
-              value={
-                averageCostPerMessage === null
-                  ? "—"
-                  : `${formatCredits(averageCostPerMessage)} credits`
-              }
-              hint={null}
-            />
-          </>
-        ) : (
-          <>
-            <SummaryCard
-              label="Used this period"
-              value={formatCredits(totalCredits)}
-              hint={
-                creditUsage
-                  ? `${creditUsage.status.usedPercentage}% of ${formatCredits(creditUsage.capCredits)} cap`
-                  : null
-              }
-            />
-            <SummaryCard
-              label="Top agent"
-              value={topAgent?.name ?? "—"}
-              hint={
-                topAgent && totalCredits > 0
-                  ? `${Math.round((topAgent.credits / totalCredits) * 100)}% of total consumption`
-                  : null
-              }
-            />
-          </>
-        )}
+        <SummaryCard
+          label="Used this period"
+          value={formatCredits(totalCredits)}
+          hint={
+            creditUsage
+              ? `${creditUsage.status.usedPercentage}% of ${formatCredits(creditUsage.capCredits)} cap`
+              : null
+          }
+        />
+        <SummaryCard
+          label="Top agent"
+          value={topAgent?.name ?? "—"}
+          hint={
+            topAgent && totalCredits > 0
+              ? `${Math.round((topAgent.credits / totalCredits) * 100)}% of total consumption`
+              : null
+          }
+        />
+      </div>
+    </div>
+  );
+}
+
+interface AgentConsumptionSummaryViewProps extends ConsumptionSummaryData {
+  responsiveLayout: boolean;
+}
+
+function AgentConsumptionSummaryView({
+  overview,
+  isOverviewLoading,
+  isOverviewError,
+  responsiveLayout,
+}: AgentConsumptionSummaryViewProps) {
+  const loadingCardClassName = responsiveLayout
+    ? "h-20 rounded-xl"
+    : "h-20 flex-1 rounded-xl";
+
+  if (isOverviewLoading) {
+    return (
+      <div className="flex flex-col gap-6">
+        <div
+          className={
+            responsiveLayout
+              ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+              : "flex items-stretch gap-6"
+          }
+        >
+          <LoadingBlock className={loadingCardClassName} />
+          <LoadingBlock className={loadingCardClassName} />
+        </div>
+        <div
+          className={
+            responsiveLayout
+              ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+              : "flex items-stretch gap-6"
+          }
+        >
+          <LoadingBlock className={loadingCardClassName} />
+          <LoadingBlock className={loadingCardClassName} />
+        </div>
+      </div>
+    );
+  }
+
+  if (isOverviewError || !overview) {
+    return null;
+  }
+
+  const messagesPerActiveUser =
+    overview.messageCount === undefined
+      ? null
+      : overview.members.active > 0
+        ? Math.round(overview.messageCount / overview.members.active)
+        : 0;
+  const averageCostPerMessage =
+    overview.messageCount !== undefined && overview.messageCount > 0
+      ? overview.totalCredits / overview.messageCount
+      : null;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div
+        className={
+          responsiveLayout
+            ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+            : "flex items-stretch gap-6"
+        }
+      >
+        <SummaryCard
+          className="h-20"
+          label="Active Users"
+          value={overview.members.active.toLocaleString()}
+          hint={null}
+        />
+        <SummaryCard
+          className="h-20"
+          label="Messages / active user"
+          value={messagesPerActiveUser?.toLocaleString() ?? "—"}
+          hint={null}
+        />
+      </div>
+      <div
+        className={
+          responsiveLayout
+            ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+            : "flex items-stretch gap-6"
+        }
+      >
+        <SummaryCard
+          className="h-20"
+          label="Total cost"
+          value={`${formatCredits(overview.totalCredits)} credits`}
+          hint={null}
+        />
+        <SummaryCard
+          className="h-20"
+          label="Avg. cost/msg"
+          value={
+            averageCostPerMessage === null
+              ? "—"
+              : `${formatCredits(averageCostPerMessage)} credits`
+          }
+          hint={null}
+        />
       </div>
     </div>
   );

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -89,13 +89,17 @@ export function ConsumptionSummaryView({
   const cardRowClassName = responsiveLayout
     ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
     : "flex items-stretch gap-6";
+  const summaryClassName = isAgentScoped
+    ? "flex flex-col gap-6"
+    : "flex flex-col gap-4";
+  const cardHeightClassName = isAgentScoped ? "h-20" : "h-24";
   const loadingCardClassName = responsiveLayout
-    ? "h-24 rounded-xl"
-    : "h-24 flex-1 rounded-xl";
+    ? `${cardHeightClassName} rounded-xl`
+    : `${cardHeightClassName} flex-1 rounded-xl`;
 
   if (isOverviewLoading) {
     return (
-      <div className="flex flex-col gap-4">
+      <div className={summaryClassName}>
         {isAgentScoped && (
           <div className={cardRowClassName}>
             <LoadingBlock className={loadingCardClassName} />
@@ -129,7 +133,7 @@ export function ConsumptionSummaryView({
       : null;
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className={summaryClassName}>
       {creditUsage && (
         <div
           className={
@@ -161,11 +165,13 @@ export function ConsumptionSummaryView({
       {isAgentScoped && (
         <div className={cardRowClassName}>
           <SummaryCard
+            className="h-20"
             label="Active Users"
             value={overview.members.active.toLocaleString()}
             hint={null}
           />
           <SummaryCard
+            className="h-20"
             label="Messages / active user"
             value={messagesPerActiveUser?.toLocaleString() ?? "—"}
             hint={null}
@@ -176,11 +182,13 @@ export function ConsumptionSummaryView({
         {isAgentScoped ? (
           <>
             <SummaryCard
+              className="h-20"
               label="Total cost"
               value={`${formatCredits(totalCredits)} credits`}
               hint={null}
             />
             <SummaryCard
+              className="h-20"
               label="Avg. cost/msg"
               value={
                 averageCostPerMessage === null

--- a/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
+++ b/front/components/workspace/analytics/consumption/ConsumptionSummary.tsx
@@ -86,12 +86,6 @@ export function ConsumptionSummaryView({
   analyticsScope = WORKSPACE_CONSUMPTION_ANALYTICS_SCOPE,
 }: ConsumptionSummaryViewProps) {
   const isAgentScoped = analyticsScope.kind === "agent";
-  const cardRowClassName = responsiveLayout
-    ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
-    : "flex items-stretch gap-6";
-  const summaryClassName = isAgentScoped
-    ? "flex flex-col gap-6"
-    : "flex flex-col gap-4";
   const cardHeightClassName = isAgentScoped ? "h-20" : "h-24";
   const loadingCardClassName = responsiveLayout
     ? `${cardHeightClassName} rounded-xl`
@@ -99,14 +93,30 @@ export function ConsumptionSummaryView({
 
   if (isOverviewLoading) {
     return (
-      <div className={summaryClassName}>
+      <div
+        className={
+          isAgentScoped ? "flex flex-col gap-6" : "flex flex-col gap-4"
+        }
+      >
         {isAgentScoped && (
-          <div className={cardRowClassName}>
+          <div
+            className={
+              responsiveLayout
+                ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+                : "flex items-stretch gap-6"
+            }
+          >
             <LoadingBlock className={loadingCardClassName} />
             <LoadingBlock className={loadingCardClassName} />
           </div>
         )}
-        <div className={cardRowClassName}>
+        <div
+          className={
+            responsiveLayout
+              ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+              : "flex items-stretch gap-6"
+          }
+        >
           <LoadingBlock className={loadingCardClassName} />
           <LoadingBlock className={loadingCardClassName} />
         </div>
@@ -133,7 +143,9 @@ export function ConsumptionSummaryView({
       : null;
 
   return (
-    <div className={summaryClassName}>
+    <div
+      className={isAgentScoped ? "flex flex-col gap-6" : "flex flex-col gap-4"}
+    >
       {creditUsage && (
         <div
           className={
@@ -163,7 +175,13 @@ export function ConsumptionSummaryView({
         </div>
       )}
       {isAgentScoped && (
-        <div className={cardRowClassName}>
+        <div
+          className={
+            responsiveLayout
+              ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+              : "flex items-stretch gap-6"
+          }
+        >
           <SummaryCard
             className="h-20"
             label="Active Users"
@@ -178,7 +196,13 @@ export function ConsumptionSummaryView({
           />
         </div>
       )}
-      <div className={cardRowClassName}>
+      <div
+        className={
+          responsiveLayout
+            ? "grid grid-cols-1 gap-4 sm:grid-cols-2"
+            : "flex items-stretch gap-6"
+        }
+      >
         {isAgentScoped ? (
           <>
             <SummaryCard


### PR DESCRIPTION
## Description

This PR fixes the card layout for the agent analytics. Reduces their height and increases the vertical spacing to match the horizontal one.

Other consumption summary views keep their existing `h-24` cards and `gap-4` spacing.

Current live version

<img width="684" height="640" alt="Screenshot 2026-08-26 at 11 25 50 AM" src="https://github.com/user-attachments/assets/8a9c81cb-6a0a-4034-a984-59ca12dfedeb" />

Proposal

<img width="683" height="616" alt="Screenshot 2026-08-26 at 11 27 18 AM" src="https://github.com/user-attachments/assets/f45b662d-a366-4fbd-9e03-f2fa62a02aff" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
