### PR TITLE
[front] fix: add filter metadata for agent analytics

### DIFF
--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -436,7 +436,7 @@ describe("fetchConsumptionFacets", () => {
     }
   });
 
-  it("keeps personal facets bucket-scoped and preserves their metadata", async () => {
+  it("preserves metadata on personal bucket facets", async () => {
     const { authenticator, user } = await createResourceTest({ role: "user" });
     const valuesByField: Record<string, string> = {
       "agent.attributed_id": "used-agent",
@@ -462,7 +462,7 @@ describe("fetchConsumptionFacets", () => {
     const labels: Partial<Record<ConsumptionScopeDimension, DimensionLabel>> = {
       agent: {
         name: "Used agent",
-        pictureUrl: null,
+        pictureUrl: "https://example.com/agent.png",
         description: null,
         scope: "visible",
       },
@@ -505,7 +505,11 @@ describe("fetchConsumptionFacets", () => {
     }
     expect(listConsumptionFacetCatalog).not.toHaveBeenCalled();
     expect(result.value.facets.agent).toEqual([
-      expect.objectContaining({ value: "used-agent", scope: "visible" }),
+      expect.objectContaining({
+        value: "used-agent",
+        pictureUrl: "https://example.com/agent.png",
+        scope: "visible",
+      }),
     ]);
     expect(result.value.facets.model).toEqual([
       expect.objectContaining({
@@ -528,24 +532,8 @@ describe("fetchConsumptionFacets", () => {
     }
   });
 
-  it("keeps agent facets bucket-scoped and preserves their metadata", async () => {
+  it("returns model metadata for agent-scoped bucket facets", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
-    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
-      agent: [],
-      user: [],
-      api_key: [],
-      group: [],
-      model: [
-        {
-          value: "unrelated-model",
-          label: "Unrelated model",
-          pictureUrl: null,
-        },
-      ],
-      tool: [],
-      skill: [],
-      source: [],
-    });
     vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
       esResponse({
         values: {

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -1,7 +1,9 @@
 import { listConsumptionFacetCatalog } from "@app/lib/api/analytics/consumption/facet_catalog";
 import { fetchConsumptionFacets } from "@app/lib/api/analytics/consumption/facets";
+import type { DimensionLabel } from "@app/lib/api/analytics/consumption/labels";
 import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
 import type { ConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
+import type { ConsumptionScopeDimension } from "@app/lib/api/analytics/consumption/scope";
 import {
   ElasticsearchError,
   searchConsumptionAnalytics,
@@ -434,42 +436,99 @@ describe("fetchConsumptionFacets", () => {
     }
   });
 
-  it("keeps the user scope on every personal facet query and skips the workspace catalog", async () => {
+  it("keeps personal facets bucket-scoped and preserves their metadata", async () => {
     const { authenticator, user } = await createResourceTest({ role: "user" });
-    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
-      esResponse({ values: { buckets: [] } })
+    const valuesByField: Record<string, string> = {
+      "agent.attributed_id": "used-agent",
+      "model.model_id": "used-model",
+      "tool.server_name": "used-tool",
+      "tool.attributed_skill_ids": "used-skill",
+    };
+    vi.mocked(searchConsumptionAnalytics).mockImplementation(
+      async (_query, options) => {
+        const field =
+          options?.aggregations?.values?.composite?.sources?.[0]?.value?.terms
+            ?.field;
+        const value = field ? valuesByField[field] : undefined;
+        return esResponse({
+          values: {
+            buckets: value
+              ? [{ key: { value }, contextual: { doc_count: 1 } }]
+              : [],
+          },
+        });
+      }
+    );
+    const labels: Partial<Record<ConsumptionScopeDimension, DimensionLabel>> = {
+      agent: {
+        name: "Used agent",
+        pictureUrl: null,
+        description: null,
+        scope: "visible",
+      },
+      model: {
+        name: "Used model",
+        pictureUrl: null,
+        description: null,
+        maker: "openai",
+        tier: "balanced",
+      },
+      tool: {
+        name: "Used tool",
+        pictureUrl: null,
+        description: null,
+        icon: "tool-icon",
+      },
+      skill: {
+        name: "Used skill",
+        pictureUrl: null,
+        description: null,
+        icon: "skill-icon",
+      },
+    };
+    vi.mocked(resolveDimensionLabels).mockImplementation(
+      async (_auth, dimension, values) => {
+        const label = labels[dimension];
+        return new Map(label ? values.map((value) => [value, label]) : []);
+      }
     );
 
     const result = await fetchConsumptionFacets(authenticator, {
       period: PERIOD,
-      filter: { users: [user.sId], agents: ["agent_1"] },
       userId: user.sId,
+      dimensions: ["agent", "model", "tool", "skill"],
     });
 
     expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
     expect(listConsumptionFacetCatalog).not.toHaveBeenCalled();
-    expect(searchConsumptionAnalytics).toHaveBeenCalledTimes(8);
+    expect(result.value.facets.agent).toEqual([
+      expect.objectContaining({ value: "used-agent", scope: "visible" }),
+    ]);
+    expect(result.value.facets.model).toEqual([
+      expect.objectContaining({
+        value: "used-model",
+        maker: "openai",
+        tier: "balanced",
+      }),
+    ]);
+    expect(result.value.facets.tool).toEqual([
+      expect.objectContaining({ value: "used-tool", icon: "tool-icon" }),
+    ]);
+    expect(result.value.facets.skill).toEqual([
+      expect.objectContaining({ value: "used-skill", icon: "skill-icon" }),
+    ]);
 
     for (const [query] of vi.mocked(searchConsumptionAnalytics).mock.calls) {
       expect(query.bool?.filter).toContainEqual({
         term: { "user.id": user.sId },
       });
     }
-
-    const userCall = vi
-      .mocked(searchConsumptionAnalytics)
-      .mock.calls.find(
-        ([, options]) =>
-          options?.aggregations?.values?.composite?.sources?.[0]?.value?.terms
-            ?.field === "user.id"
-      );
-    expect(
-      userCall?.[1]?.aggregations?.values?.aggs?.contextual?.filter?.bool
-        ?.filter
-    ).toContainEqual({ term: { "user.id": user.sId } });
   });
 
-  it("merges the current catalog into agent-scoped facets", async () => {
+  it("keeps agent facets bucket-scoped and preserves their metadata", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
     vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
       agent: [],
@@ -478,11 +537,9 @@ describe("fetchConsumptionFacets", () => {
       group: [],
       model: [
         {
-          value: "current-model",
-          label: "Current model",
+          value: "unrelated-model",
+          label: "Unrelated model",
           pictureUrl: null,
-          maker: "openai",
-          tier: "balanced",
         },
       ],
       tool: [],
@@ -490,7 +547,30 @@ describe("fetchConsumptionFacets", () => {
       source: [],
     });
     vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
-      esResponse({ values: { buckets: [] } })
+      esResponse({
+        values: {
+          buckets: [
+            {
+              key: { value: "used-model" },
+              contextual: { doc_count: 1 },
+            },
+          ],
+        },
+      })
+    );
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(
+      new Map([
+        [
+          "used-model",
+          {
+            name: "Used model",
+            pictureUrl: null,
+            description: null,
+            maker: "anthropic",
+            tier: "premium",
+          },
+        ],
+      ])
     );
 
     const result = await fetchConsumptionFacets(authenticator, {
@@ -504,16 +584,13 @@ describe("fetchConsumptionFacets", () => {
       return;
     }
     expect(result.value.facets.model).toEqual([
-      {
-        value: "current-model",
-        label: "Current model",
-        pictureUrl: null,
-        maker: "openai",
-        tier: "balanced",
-        documentCount: 0,
-        disabled: true,
-      },
+      expect.objectContaining({
+        value: "used-model",
+        maker: "anthropic",
+        tier: "premium",
+      }),
     ]);
+    expect(listConsumptionFacetCatalog).not.toHaveBeenCalled();
 
     const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
     expect(query.bool?.filter).toContainEqual({

--- a/front/lib/api/analytics/consumption/facets.test.ts
+++ b/front/lib/api/analytics/consumption/facets.test.ts
@@ -469,6 +469,58 @@ describe("fetchConsumptionFacets", () => {
     ).toContainEqual({ term: { "user.id": user.sId } });
   });
 
+  it("merges the current catalog into agent-scoped facets", async () => {
+    const { authenticator } = await createResourceTest({ role: "manager" });
+    vi.mocked(listConsumptionFacetCatalog).mockResolvedValue({
+      agent: [],
+      user: [],
+      api_key: [],
+      group: [],
+      model: [
+        {
+          value: "current-model",
+          label: "Current model",
+          pictureUrl: null,
+          maker: "openai",
+          tier: "balanced",
+        },
+      ],
+      tool: [],
+      skill: [],
+      source: [],
+    });
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({ values: { buckets: [] } })
+    );
+
+    const result = await fetchConsumptionFacets(authenticator, {
+      period: PERIOD,
+      agentId: "agent_1",
+      dimensions: ["model"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.facets.model).toEqual([
+      {
+        value: "current-model",
+        label: "Current model",
+        pictureUrl: null,
+        maker: "openai",
+        tier: "balanced",
+        documentCount: 0,
+        disabled: true,
+      },
+    ]);
+
+    const [query] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(query.bool?.filter).toContainEqual({
+      term: { "agent.attributed_id": "agent_1" },
+    });
+  });
+
   it("returns the Elasticsearch failure before resolving historical labels", async () => {
     const { authenticator } = await createResourceTest({ role: "manager" });
     const error = new ElasticsearchError("query_error", "query failed");

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -254,7 +254,7 @@ async function resolveFacets(
   const missingCatalogValues = historicalValues.filter(
     (value) => !catalogByValue.has(value)
   );
-  const historicalLabels = await tracer.trace(
+  const resolvedLabels = await tracer.trace(
     "analytics.consumption.facets.resolve_labels",
     { resource: dimension },
     async (span) => {
@@ -268,11 +268,18 @@ async function resolveFacets(
   );
   const entries = [
     ...catalogEntries,
-    ...missingCatalogValues.map((value) => ({
-      value,
-      label: historicalLabels.get(value)?.name ?? value,
-      pictureUrl: historicalLabels.get(value)?.pictureUrl ?? null,
-    })),
+    ...missingCatalogValues.map((value) => {
+      const resolved = resolvedLabels.get(value);
+      return {
+        value,
+        label: resolved?.name ?? value,
+        pictureUrl: resolved?.pictureUrl ?? null,
+        ...(resolved?.icon !== undefined ? { icon: resolved.icon } : {}),
+        ...(resolved?.scope ? { scope: resolved.scope } : {}),
+        ...(resolved?.maker ? { maker: resolved.maker } : {}),
+        ...(resolved?.tier ? { tier: resolved.tier } : {}),
+      };
+    }),
   ];
 
   return entries
@@ -359,9 +366,13 @@ async function fetchConsumptionFacetsWithoutTracing(
     bucketsByDimension.set(dimension, result.value);
   }
 
-  const catalog = userId
-    ? EMPTY_FACET_CATALOG
-    : await listConsumptionFacetCatalog(auth, requestedDimensions);
+  // Scoped views are available to non-managers. Keep their option universe to
+  // values found in their Elasticsearch buckets instead of appending unrelated
+  // current workspace entities from the catalog.
+  const catalog =
+    userId || agentId
+      ? EMPTY_FACET_CATALOG
+      : await listConsumptionFacetCatalog(auth, requestedDimensions);
   // TODO(2026-08-11 OBSERVABILITY): Historical label resolution still reads
   // from several database-backed resources. Store the relevant labels in the
   // consumption index so these lookups can stay within Elasticsearch.

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -359,10 +359,9 @@ async function fetchConsumptionFacetsWithoutTracing(
     bucketsByDimension.set(dimension, result.value);
   }
 
-  const catalog =
-    userId || agentId
-      ? EMPTY_FACET_CATALOG
-      : await listConsumptionFacetCatalog(auth, requestedDimensions);
+  const catalog = userId
+    ? EMPTY_FACET_CATALOG
+    : await listConsumptionFacetCatalog(auth, requestedDimensions);
   // TODO(2026-08-11 OBSERVABILITY): Historical label resolution still reads
   // from several database-backed resources. Store the relevant labels in the
   // consumption index so these lookups can stay within Elasticsearch.

--- a/front/lib/api/analytics/consumption/facets.ts
+++ b/front/lib/api/analytics/consumption/facets.ts
@@ -366,9 +366,6 @@ async function fetchConsumptionFacetsWithoutTracing(
     bucketsByDimension.set(dimension, result.value);
   }
 
-  // Scoped views are available to non-managers. Keep their option universe to
-  // values found in their Elasticsearch buckets instead of appending unrelated
-  // current workspace entities from the catalog.
   const catalog =
     userId || agentId
       ? EMPTY_FACET_CATALOG

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -13,6 +13,8 @@ import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory"
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
+import { getModelMaker } from "@app/types/assistant/models/providers";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("resolveDimensionDisplayNames", () => {
@@ -126,6 +128,36 @@ describe("resolveDimensionLabels", () => {
       description: "Answers analytics questions",
       modelId: agent.model.modelId,
       modelDisplayName: getAgentModelDisplayName(agent.model),
+      scope: agent.scope,
+    });
+  });
+
+  it("labels models with their maker and tier", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const model = getSupportedModelConfigs().find(
+      (config) =>
+        getTierForModel(config.modelId, config.defaultReasoningEffort) !== null
+    );
+    expect(model).toBeDefined();
+    if (!model) {
+      return;
+    }
+    const tier = getTierForModel(model.modelId, model.defaultReasoningEffort);
+    expect(tier).not.toBeNull();
+    if (!tier) {
+      return;
+    }
+
+    const labels = await resolveDimensionLabels(authenticator, "model", [
+      model.modelId,
+    ]);
+
+    expect(labels.get(model.modelId)).toEqual({
+      name: model.displayName,
+      pictureUrl: null,
+      description: null,
+      maker: getModelMaker(model),
+      tier,
     });
   });
 

--- a/front/lib/api/analytics/consumption/labels.test.ts
+++ b/front/lib/api/analytics/consumption/labels.test.ts
@@ -9,8 +9,10 @@ import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { getTierForModel } from "@app/types/assistant/models/model_tiers";
@@ -130,6 +132,35 @@ describe("resolveDimensionLabels", () => {
       modelDisplayName: getAgentModelDisplayName(agent.model),
       scope: agent.scope,
     });
+  });
+
+  it("preserves scope for fallback agent labels", async () => {
+    const { authenticator: editorAuth, workspace } = await createResourceTest({
+      role: "user",
+    });
+    const space = await SpaceFactory.regular(workspace);
+    const agent = await AgentConfigurationFactory.createTestAgent(editorAuth, {
+      name: "Restricted agent",
+      scope: "hidden",
+      requestedSpaceIds: [space.id],
+    });
+    const manager = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, manager, { role: "manager" });
+    const managerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      manager.sId,
+      workspace.sId
+    );
+
+    const labels = await resolveDimensionLabels(managerAuth, "agent", [
+      agent.sId,
+    ]);
+
+    expect(labels.get(agent.sId)).toEqual(
+      expect.objectContaining({
+        name: "Restricted agent",
+        scope: "hidden",
+      })
+    );
   });
 
   it("labels models with their maker and tier", async () => {

--- a/front/lib/api/analytics/consumption/labels.ts
+++ b/front/lib/api/analytics/consumption/labels.ts
@@ -8,6 +8,11 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import type { AgentConfigurationScope } from "@app/types/assistant/agent";
+import type { ModelsTierName } from "@app/types/assistant/models/model_tiers";
+import { getTierForModel } from "@app/types/assistant/models/model_tiers";
+import { getModelMaker } from "@app/types/assistant/models/providers";
+import type { ModelMakerIdType } from "@app/types/assistant/models/types";
 import { CAP_ELIGIBLE_GROUP_KINDS } from "@app/types/groups";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
@@ -38,6 +43,10 @@ export type DimensionLabel = {
   modelDisplayName?: string;
   // Only tools and skills have an icon.
   icon?: string | null;
+  // Facet metadata used to classify agents and models in filter controls.
+  scope?: AgentConfigurationScope;
+  maker?: ModelMakerIdType;
+  tier?: ModelsTierName;
 };
 
 function labelsFromNames(
@@ -74,6 +83,7 @@ export async function resolveDimensionLabels(
               description: label?.description || null,
               modelId: label?.modelId,
               modelDisplayName: label?.modelDisplayName,
+              ...(label?.scope ? { scope: label.scope } : {}),
             },
           ];
         })
@@ -112,13 +122,23 @@ export async function resolveDimensionLabels(
     }
 
     case "model":
-      return labelsFromNames(
-        new Map(
-          keys.map((key) => [
+      return new Map(
+        keys.map((key) => {
+          const model = getModelConfigByModelId(key);
+          const tier = model
+            ? getTierForModel(model.modelId, model.defaultReasoningEffort)
+            : null;
+          return [
             key,
-            getModelConfigByModelId(key)?.displayName ?? key,
-          ])
-        )
+            {
+              name: model?.displayName ?? key,
+              pictureUrl: null,
+              description: null,
+              ...(model ? { maker: getModelMaker(model) } : {}),
+              ...(tier ? { tier } : {}),
+            },
+          ];
+        })
       );
 
     case "tool": {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -434,6 +434,7 @@ type AgentLabel = {
   name: string;
   pictureUrl: string | null;
   model: AgentModelConfigurationType;
+  scope: Exclude<AgentConfigurationScope, "global">;
 };
 
 export async function getAgentLabelsByIds(
@@ -456,6 +457,7 @@ export async function getAgentLabelsByIds(
     authorModelId: agent.authorId,
     pictureUrl: agent.pictureUrl,
     model: getModelForAgentConfiguration(agent),
+    scope: agent.scope,
   }));
 }
 

--- a/front/lib/api/assistant/observability/agent_labels.ts
+++ b/front/lib/api/assistant/observability/agent_labels.ts
@@ -14,7 +14,7 @@ export type AnalyticsAgentLabel = {
   modelId: string;
   modelDisplayName: string;
   description: string;
-  scope?: AgentConfigurationScope;
+  scope: AgentConfigurationScope;
 };
 
 const PRIVATE_AGENT_DESCRIPTION = "Private agent: description unavailable";
@@ -96,6 +96,7 @@ export async function resolveAnalyticsAgentLabels(
         description: privateAgentDescription(
           authorEmailByModelId.get(fallback.authorModelId)
         ),
+        scope: fallback.scope,
       });
     }
   }

--- a/front/lib/api/assistant/observability/agent_labels.ts
+++ b/front/lib/api/assistant/observability/agent_labels.ts
@@ -5,6 +5,7 @@ import {
 import { getAgentModelDisplayName } from "@app/lib/api/assistant/observability/credit_labels";
 import type { Authenticator } from "@app/lib/auth";
 import { UserResource } from "@app/lib/resources/user_resource";
+import type { AgentConfigurationScope } from "@app/types/assistant/agent";
 import { removeNulls } from "@app/types/shared/utils/general";
 
 export type AnalyticsAgentLabel = {
@@ -13,6 +14,7 @@ export type AnalyticsAgentLabel = {
   modelId: string;
   modelDisplayName: string;
   description: string;
+  scope?: AgentConfigurationScope;
 };
 
 const PRIVATE_AGENT_DESCRIPTION = "Private agent: description unavailable";
@@ -79,6 +81,7 @@ export async function resolveAnalyticsAgentLabels(
         description: agent.canRead
           ? agent.description
           : privateAgentDescription(authorEmail),
+        scope: agent.scope,
       });
       continue;
     }


### PR DESCRIPTION
## Description

The filter panel in an agent's Insights tab could doesn't populate the metadata correctly for agents.
We're missing the icon, the category, the provider.
Missing the category causes the filter to be empty, since we filter by category at all times.

This PR adds the missing metadata.

## Tests

- Added a tests.

## Risk

- Low.

## Deploy Plan

- Deploy front.
