### PR TITLE
feat(analyst_agent): start migrating to new ES index

### DIFF
--- a/front/lib/api/actions/servers/user_analytics/index.ts
+++ b/front/lib/api/actions/servers/user_analytics/index.ts
@@ -153,8 +153,9 @@ const handlers: ToolHandlers<typeof USER_ANALYTICS_TOOLS_METADATA> = {
       ]);
     }
 
-    const window = resolveTimeWindow(
+    const window = await resolveTimeWindow(
       { period, startDate, endDate, timezone },
+      auth,
       "last_30_days"
     );
     if (window.isErr()) {

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -268,7 +268,7 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
     name: "get_credit_usage",
     description:
       "Return AWU credit consumption over a time window (defaults to the " +
-      "current calendar month), optionally broken down by the top agents, " +
+      "current cycle), optionally broken down by the top agents, " +
       "users or models. Credits combine model compute and tool usage, " +
       "mirroring how billing computes them — these are the same reconciled, " +
       "billed credits the workspace Usage page reports; recent activity can " +

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -267,21 +267,20 @@ export const WORKSPACE_ANALYTICS_TOOLS_METADATA = [
   {
     name: "get_credit_usage",
     description:
-      "Estimate AWU credit consumption over a time window (defaults to the " +
+      "Return AWU credit consumption over a time window (defaults to the " +
       "current calendar month), optionally broken down by the top agents, " +
       "users or models. Credits combine model compute and tool usage, " +
-      "mirroring how billing computes them. IMPORTANT: these figures are " +
-      "ESTIMATES derived from usage logs — always tell the user they are " +
-      "approximate and point them to the workspace Usage page for exact, " +
-      "billed credit amounts. Optionally filter by source (context_origin), " +
-      "agent, user, tag, or model — e.g. filter by tag to attribute credits " +
-      "to all agents with a given tag, or group by model to see which models " +
-      "drive spend. Admin-only.",
+      "mirroring how billing computes them — these are the same reconciled, " +
+      "billed credits the workspace Usage page reports; recent activity can " +
+      "lag by a few minutes. Free platform usage is excluded. Optionally " +
+      "filter by source (context_origin), agent, user, tag, or model — e.g. " +
+      "filter by tag to attribute credits to all agents with a given tag, or " +
+      "group by model to see which models drive spend. Admin-only.",
     schema: getCreditUsageSchema,
     stake: "never_ask",
     displayLabels: {
-      running: "Estimating credit usage",
-      done: "Estimated credit usage",
+      running: "Retrieving credit usage",
+      done: "Retrieved credit usage",
     },
     toolCostCategory: "basic",
     freeUsage: false,

--- a/front/lib/api/actions/servers/workspace_analytics/metadata.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/metadata.ts
@@ -54,7 +54,7 @@ const getCreditUsageSchema = {
     .enum(["agent", "user", "model", "none"])
     .optional()
     .describe(
-      "Break the estimated credits down by top 'agent', 'user' or 'model' " +
+      "Break the billed credits down by top 'agent', 'user' or 'model' " +
         "(the model that answered the message), or 'none' (default) for the " +
         "workspace total only."
     ),

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.test.ts
@@ -2,15 +2,35 @@ import {
   MAX_QUERY_WINDOW_DAYS,
   resolveTimeWindow,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 describe("resolveTimeWindow", () => {
+  let auth: Authenticator;
+
+  beforeAll(async () => {
+    const workspace = await WorkspaceFactory.basic();
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  });
+
   describe("explicit range", () => {
-    it("resolves a valid range to inclusive day bounds", () => {
-      const r = resolveTimeWindow({
-        startDate: "2026-01-01",
-        endDate: "2026-01-31",
-      });
+    it("resolves a valid range to inclusive day bounds", async () => {
+      const r = await resolveTimeWindow(
+        {
+          startDate: "2026-01-01",
+          endDate: "2026-01-31",
+        },
+        auth
+      );
       expect(r.isOk()).toBe(true);
       if (r.isOk()) {
         expect(r.value.startDate).toBe("2026-01-01T00:00:00.000Z");
@@ -20,53 +40,82 @@ describe("resolveTimeWindow", () => {
       }
     });
 
-    it("errors when only one bound is provided", () => {
-      expect(resolveTimeWindow({ startDate: "2026-01-01" }).isErr()).toBe(true);
-      expect(resolveTimeWindow({ endDate: "2026-01-01" }).isErr()).toBe(true);
-    });
-
-    it("errors when endDate is before startDate", () => {
+    it("errors when only one bound is provided", async () => {
       expect(
-        resolveTimeWindow({
-          startDate: "2026-02-01",
-          endDate: "2026-01-01",
-        }).isErr()
+        (await resolveTimeWindow({ startDate: "2026-01-01" }, auth)).isErr()
+      ).toBe(true);
+      expect(
+        (await resolveTimeWindow({ endDate: "2026-01-01" }, auth)).isErr()
       ).toBe(true);
     });
 
-    it(`accepts an inclusive span of exactly ${MAX_QUERY_WINDOW_DAYS} days`, () => {
+    it("errors when endDate is before startDate", async () => {
+      expect(
+        (
+          await resolveTimeWindow(
+            {
+              startDate: "2026-02-01",
+              endDate: "2026-01-01",
+            },
+            auth
+          )
+        ).isErr()
+      ).toBe(true);
+    });
+
+    it(`accepts an inclusive span of exactly ${MAX_QUERY_WINDOW_DAYS} days`, async () => {
       // 2026-01-01 .. 2026-04-10 inclusive = 100 days.
       expect(
-        resolveTimeWindow({
-          startDate: "2026-01-01",
-          endDate: "2026-04-10",
-        }).isOk()
+        (
+          await resolveTimeWindow(
+            {
+              startDate: "2026-01-01",
+              endDate: "2026-04-10",
+            },
+            auth
+          )
+        ).isOk()
       ).toBe(true);
     });
 
-    it(`errors when the inclusive span exceeds ${MAX_QUERY_WINDOW_DAYS} days`, () => {
+    it(`errors when the inclusive span exceeds ${MAX_QUERY_WINDOW_DAYS} days`, async () => {
       // 2026-01-01 .. 2026-04-11 inclusive = 101 days.
       expect(
-        resolveTimeWindow({
-          startDate: "2026-01-01",
-          endDate: "2026-04-11",
-        }).isErr()
+        (
+          await resolveTimeWindow(
+            {
+              startDate: "2026-01-01",
+              endDate: "2026-04-11",
+            },
+            auth
+          )
+        ).isErr()
       ).toBe(true);
     });
 
-    it("errors on an invalid calendar date", () => {
+    it("errors on an invalid calendar date", async () => {
       expect(
-        resolveTimeWindow({
-          startDate: "2026-13-40",
-          endDate: "2026-13-41",
-        }).isErr()
+        (
+          await resolveTimeWindow(
+            {
+              startDate: "2026-13-40",
+              endDate: "2026-13-41",
+            },
+            auth
+          )
+        ).isErr()
       ).toBe(true);
     });
   });
 
-  it("errors on an invalid timezone", () => {
+  it("errors on an invalid timezone", async () => {
     expect(
-      resolveTimeWindow({ period: "this_month", timezone: "Not/AZone" }).isErr()
+      (
+        await resolveTimeWindow(
+          { period: "last_7_days", timezone: "Not/AZone" },
+          auth
+        )
+      ).isErr()
     ).toBe(true);
   });
 
@@ -79,30 +128,39 @@ describe("resolveTimeWindow", () => {
       vi.useRealTimers();
     });
 
-    it("resolves this_month to the calendar month to date (UTC)", () => {
-      const r = resolveTimeWindow({ period: "this_month" });
-      expect(r.isOk()).toBe(true);
-      if (r.isOk()) {
-        expect(r.value.startDate).toBe("2026-06-01T00:00:00.000Z");
-        expect(r.value.endDate).toBe("2026-06-15T12:00:00.000Z");
-        expect(r.value.label).toBe("June 2026");
-      }
-    });
-
-    it("resolves last_7_days to a 7-day window ending now", () => {
-      const r = resolveTimeWindow({ period: "last_7_days" });
+    it("resolves last_7_days to a 7-day window ending now", async () => {
+      const r = await resolveTimeWindow({ period: "last_7_days" }, auth);
       expect(r.isOk()).toBe(true);
       if (r.isOk()) {
         expect(r.value.startDate).toBe("2026-06-09T00:00:00.000Z");
       }
     });
 
-    it("falls back to the provided default period when none is given", () => {
-      const r = resolveTimeWindow({}, "last_30_days");
+    it("falls back to the provided default period when none is given", async () => {
+      const r = await resolveTimeWindow({}, auth, "last_30_days");
       expect(r.isOk()).toBe(true);
       if (r.isOk()) {
         expect(r.value.startDate).toBe("2026-05-17T00:00:00.000Z");
         expect(r.value.label).toBe("the last 30 days");
+      }
+    });
+
+    it("resolves this_cycle to the calendar month for a workspace with no billing cycle", async () => {
+      const r = await resolveTimeWindow({ period: "this_cycle" }, auth);
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) {
+        expect(r.value.startDate).toBe("2026-06-01T00:00:00.000Z");
+        expect(r.value.endDate).toBe("2026-07-01T00:00:00.000Z");
+        expect(r.value.label).toBe("the current billing cycle");
+      }
+    });
+
+    it("defaults to this_cycle when no period is given", async () => {
+      const r = await resolveTimeWindow({}, auth);
+      expect(r.isOk()).toBe(true);
+      if (r.isOk()) {
+        expect(r.value.startDate).toBe("2026-06-01T00:00:00.000Z");
+        expect(r.value.endDate).toBe("2026-07-01T00:00:00.000Z");
       }
     });
   });

--- a/front/lib/api/actions/servers/workspace_analytics/query_input.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/query_input.ts
@@ -1,4 +1,6 @@
+import { resolveConsumptionPeriod } from "@app/lib/api/analytics/consumption/period";
 import { isValidTimezone, timezoneSchema } from "@app/lib/api/timezone";
+import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
@@ -20,12 +22,14 @@ export const MAX_RESULTS = 1000;
 export const DEFAULT_CREDIT_GROUPS = 5;
 export const MAX_CREDIT_GROUPS = 10;
 
+// Mirrors ConsumptionPeriodInput (front/lib/api/analytics/consumption/period.ts)
+// as a flat string enum a model can pick from — the exact periods the
+// Analytics page itself offers.
 const ANALYTICS_PERIODS = [
-  "this_month",
+  "this_cycle",
   "last_7_days",
   "last_30_days",
   "last_90_days",
-  "this_quarter",
 ] as const;
 type AnalyticsPeriod = (typeof ANALYTICS_PERIODS)[number];
 
@@ -36,8 +40,11 @@ export const timeWindowSchemaShape = {
     .enum(ANALYTICS_PERIODS)
     .optional()
     .describe(
-      "Relative time window. Ignored when startDate/endDate are provided. " +
-        "Defaults to the tool's natural window if omitted."
+      "Relative time window. 'this_cycle' is the workspace's current " +
+        "billing cycle — the same period the Analytics page shows by " +
+        "default — and is what to use for an unqualified question like " +
+        "'how many credits have we used'. Ignored when startDate/endDate " +
+        "are provided. Defaults to 'this_cycle' if omitted."
     ),
   startDate: z
     .string()
@@ -107,10 +114,11 @@ export type ResolvedTimeWindow = {
 // Resolves a TimeWindowInput into concrete ISO start/end instants plus a human
 // label. Explicit startDate/endDate take precedence over `period`; when nothing
 // is provided, falls back to `defaultPeriod`.
-export function resolveTimeWindow(
+export async function resolveTimeWindow(
   input: TimeWindowInput,
-  defaultPeriod: AnalyticsPeriod = "this_month"
-): Result<ResolvedTimeWindow, string> {
+  auth: Authenticator,
+  defaultPeriod: AnalyticsPeriod = "this_cycle"
+): Promise<Result<ResolvedTimeWindow, string>> {
   const timezone = input.timezone ?? "UTC";
   if (!isValidTimezone(timezone)) {
     return new Err(`Invalid timezone: ${timezone}`);
@@ -147,13 +155,21 @@ export function resolveTimeWindow(
 
   const period = input.period ?? defaultPeriod;
   const now = moment.tz(timezone);
+  if (period === "this_cycle") {
+    const cyclePeriod = await resolveConsumptionPeriod(auth, {
+      kind: "cycle",
+    });
+    return new Ok({
+      startDate: cyclePeriod.startDate,
+      endDate: cyclePeriod.endDate,
+      label: "the current billing cycle",
+      timezone,
+    });
+  }
+
   let start: moment.Moment;
   let label: string;
   switch (period) {
-    case "this_month":
-      start = now.clone().startOf("month");
-      label = now.format("MMMM YYYY");
-      break;
     case "last_7_days":
       start = now.clone().subtract(6, "days").startOf("day");
       label = "the last 7 days";
@@ -165,10 +181,6 @@ export function resolveTimeWindow(
     case "last_90_days":
       start = now.clone().subtract(89, "days").startOf("day");
       label = "the last 90 days";
-      break;
-    case "this_quarter":
-      start = now.clone().startOf("quarter");
-      label = `Q${now.quarter()} ${now.year()}`;
       break;
     default:
       return assertNever(period);

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.test.ts
@@ -1,10 +1,17 @@
 import { TOOLS } from "@app/lib/api/actions/servers/workspace_analytics/tools";
+import { fetchAnalystCreditUsage } from "@app/lib/api/analytics/analyst/credits";
 import { Authenticator } from "@app/lib/auth";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { describe, expect, it } from "vitest";
+import { Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/analytics/analyst/credits"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, fetchAnalystCreditUsage: vi.fn() };
+});
 
 function getToolByName(name: string) {
   const tool = TOOLS.find((t) => t.name === name);
@@ -54,5 +61,95 @@ describe("workspace_analytics tools", () => {
     if (result.isErr()) {
       expect(result.error.message).toContain("admins");
     }
+  });
+});
+
+describe("get_credit_usage rendering", () => {
+  beforeEach(() => {
+    vi.mocked(fetchAnalystCreditUsage).mockReset();
+  });
+
+  async function managerAuth() {
+    const workspace = await WorkspaceFactory.basic();
+    return Authenticator.internalAdminForWorkspace(workspace.sId);
+  }
+
+  it("reports no data when total credits are zero", async () => {
+    const auth = await managerAuth();
+    vi.mocked(fetchAnalystCreditUsage).mockResolvedValue(
+      new Ok({ totalCredits: 0, rows: [] })
+    );
+
+    const tool = getToolByName("get_credit_usage");
+    const result = await tool.handler(
+      { startDate: "2026-07-01", endDate: "2026-07-31" },
+      createTestExtra(auth)
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value).toEqual([
+      {
+        type: "text",
+        text: "No credit usage recorded for 2026-07-01 to 2026-07-31 (UTC).",
+      },
+    ]);
+  });
+
+  it("renders the total without a breakdown when groupBy is 'none'", async () => {
+    const auth = await managerAuth();
+    vi.mocked(fetchAnalystCreditUsage).mockResolvedValue(
+      new Ok({ totalCredits: 42, rows: [] })
+    );
+
+    const tool = getToolByName("get_credit_usage");
+    const result = await tool.handler(
+      { startDate: "2026-07-01", endDate: "2026-07-31" },
+      createTestExtra(auth)
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value).toEqual([
+      {
+        type: "text",
+        text:
+          "Credit usage for 2026-07-01 to 2026-07-31 (UTC): 42 credits. " +
+          "These are the workspace's reconciled billed credits, the same " +
+          "ones the Usage page shows; very recent activity may still be " +
+          "settling.",
+      },
+    ]);
+  });
+
+  it("renders a ranked breakdown when groupBy is set, with no estimate wording", async () => {
+    const auth = await managerAuth();
+    vi.mocked(fetchAnalystCreditUsage).mockResolvedValue(
+      new Ok({
+        totalCredits: 42,
+        rows: [{ groupKey: "a1", name: "Agent One", totalCredits: 30 }],
+      })
+    );
+
+    const tool = getToolByName("get_credit_usage");
+    const result = await tool.handler(
+      { startDate: "2026-07-01", endDate: "2026-07-31", groupBy: "agent" },
+      createTestExtra(auth)
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    const text = result.value[0]?.type === "text" ? result.value[0].text : "";
+    expect(text).toContain(
+      "Top agents by credits:\n1. Agent One [a1] — 30 credits"
+    );
+    expect(text).not.toContain("estimate");
+    expect(text).not.toContain("ESTIMATE");
   });
 });

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -12,6 +12,8 @@ import {
   DEFAULT_RESULTS,
   resolveTimeWindow,
 } from "@app/lib/api/actions/servers/workspace_analytics/query_input";
+import { fetchAnalystCreditUsage } from "@app/lib/api/analytics/analyst/credits";
+import { buildAnalystScope } from "@app/lib/api/analytics/analyst/scope";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import {
   fetchContextOriginBreakdown,
@@ -20,7 +22,6 @@ import {
 import {
   fetchCreditTimeseries,
   fetchCreditTimeseriesBreakdown,
-  fetchCreditUsage,
 } from "@app/lib/api/assistant/observability/credit_usage";
 import { fetchMessageMetrics } from "@app/lib/api/assistant/observability/messages_metrics";
 import {
@@ -684,21 +685,26 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     }
 
     const selectedGroupBy = groupBy ?? "none";
-    const result = await fetchCreditUsage(auth, {
+    const scope = buildAnalystScope({
       startDate: window.value.startDate,
       endDate: window.value.endDate,
-      limit: limit ?? DEFAULT_RESULTS,
-      groupBy: selectedGroupBy,
-      contextOrigin: source,
+      timezone: window.value.timezone,
+      source,
       agentIds,
       userIds,
       agentTagIds,
       modelIds,
     });
+    const result = await fetchAnalystCreditUsage({
+      auth,
+      scope,
+      groupBy: selectedGroupBy,
+      limit: limit ?? DEFAULT_RESULTS,
+    });
 
     if (result.isErr()) {
       return new Err(
-        new MCPError(`Failed to estimate credit usage: ${result.error.message}`)
+        new MCPError(`Failed to retrieve credit usage: ${result.error.message}`)
       );
     }
 
@@ -715,9 +721,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     }
 
     const header =
-      `Estimated credit usage for ${label} (${tz}): ${totalCredits} credits. ` +
-      "These are estimates — point the user to the workspace Usage page for " +
-      "exact billed credits.";
+      `Credit usage for ${label} (${tz}): ${totalCredits} credits. These ` +
+      "are the workspace's reconciled billed credits, the same ones the " +
+      "Usage page shows; very recent activity may still be settling.";
 
     if (selectedGroupBy === "none" || rows.length === 0) {
       return new Ok([{ type: "text" as const, text: header }]);
@@ -733,8 +739,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       {
         type: "text" as const,
         text:
-          `${header}\nTop ${selectedGroupBy}s by estimated credits:\n` +
-          lines.join("\n"),
+          `${header}\nTop ${selectedGroupBy}s by credits:\n` + lines.join("\n"),
       },
     ]);
   },

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -688,7 +688,6 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
     const scope = buildAnalystScope({
       startDate: window.value.startDate,
       endDate: window.value.endDate,
-      timezone: window.value.timezone,
       source,
       agentIds,
       userIds,

--- a/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
+++ b/front/lib/api/actions/servers/workspace_analytics/tools/index.ts
@@ -132,7 +132,10 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = await resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      auth
+    );
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
@@ -201,7 +204,10 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = await resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      auth
+    );
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
@@ -270,7 +276,10 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = await resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      auth
+    );
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
@@ -339,7 +348,10 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = await resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      auth
+    );
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
@@ -468,7 +480,10 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = await resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      auth
+    );
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
@@ -535,7 +550,10 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = await resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      auth
+    );
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
@@ -609,7 +627,10 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = await resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      auth
+    );
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
@@ -679,7 +700,10 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow({ period, startDate, endDate, timezone });
+    const window = await resolveTimeWindow(
+      { period, startDate, endDate, timezone },
+      auth
+    );
     if (window.isErr()) {
       return new Err(new MCPError(window.error, { tracked: false }));
     }
@@ -721,7 +745,7 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
 
     const header =
       `Credit usage for ${label} (${tz}): ${totalCredits} credits. These ` +
-      "are the workspace's reconciled billed credits, the same ones the " +
+      "are the workspace's billed credits, the same ones the " +
       "Usage page shows; very recent activity may still be settling.";
 
     if (selectedGroupBy === "none" || rows.length === 0) {
@@ -765,8 +789,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow(
+    const window = await resolveTimeWindow(
       { period, startDate, endDate, timezone },
+      auth,
       "last_30_days"
     );
     if (window.isErr()) {
@@ -901,8 +926,9 @@ const handlers: ToolHandlers<typeof WORKSPACE_ANALYTICS_TOOLS_METADATA> = {
       return new Err(denied);
     }
 
-    const window = resolveTimeWindow(
+    const window = await resolveTimeWindow(
       { period, startDate, endDate, timezone },
+      auth,
       "last_30_days"
     );
     if (window.isErr()) {

--- a/front/lib/api/analytics/analyst/credits.test.ts
+++ b/front/lib/api/analytics/analyst/credits.test.ts
@@ -41,7 +41,6 @@ async function setup() {
   const scope = buildAnalystScope({
     startDate: "2026-07-01T00:00:00.000Z",
     endDate: "2026-08-01T00:00:00.000Z",
-    timezone: "UTC",
   });
   return { auth, scope };
 }

--- a/front/lib/api/analytics/analyst/credits.test.ts
+++ b/front/lib/api/analytics/analyst/credits.test.ts
@@ -1,0 +1,208 @@
+import { fetchAnalystCreditUsage } from "@app/lib/api/analytics/analyst/credits";
+import { buildAnalystScope } from "@app/lib/api/analytics/analyst/scope";
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import {
+  ElasticsearchError,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import { Err, Ok } from "@app/types/shared/result";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock(import("@app/lib/api/elasticsearch"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, searchConsumptionAnalytics: vi.fn() };
+});
+
+vi.mock(import("@app/lib/api/analytics/consumption/labels"), async (orig) => {
+  const mod = await orig();
+  return { ...mod, resolveDimensionLabels: vi.fn() };
+});
+
+// A real, fully-populated SearchResponse — only `aggregations` varies per
+// test — so callers never need an `as` cast to satisfy
+// `searchConsumptionAnalytics`'s return type.
+function esResponse(
+  aggregations: unknown
+): Awaited<ReturnType<typeof searchConsumptionAnalytics>> {
+  return new Ok({
+    took: 1,
+    timed_out: false,
+    _shards: { total: 1, successful: 1, skipped: 0, failed: 0 },
+    hits: { total: { value: 0, relation: "eq" }, hits: [] },
+    aggregations,
+  });
+}
+
+async function setup() {
+  const workspace = await WorkspaceFactory.basic();
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const scope = buildAnalystScope({
+    startDate: "2026-07-01T00:00:00.000Z",
+    endDate: "2026-08-01T00:00:00.000Z",
+    timezone: "UTC",
+  });
+  return { auth, scope };
+}
+
+describe("fetchAnalystCreditUsage", () => {
+  beforeEach(() => {
+    vi.mocked(searchConsumptionAnalytics).mockReset();
+    vi.mocked(resolveDimensionLabels).mockReset();
+  });
+
+  it("groupBy 'none' requests only the total, no by_group aggregation", async () => {
+    const { auth, scope } = await setup();
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({ metric: { value: 5_000_000 } })
+    );
+
+    const result = await fetchAnalystCreditUsage({
+      auth,
+      scope,
+      groupBy: "none",
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value).toEqual({ totalCredits: 5, rows: [] });
+
+    const [, options] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(options?.aggregations).toEqual({
+      metric: { sum: { field: "credit_micro" } },
+    });
+  });
+
+  it("groupBy 'agent' ranks within a filter sub-agg on agent.attributed_id", async () => {
+    const { auth, scope } = await setup();
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({
+        metric: { value: 10_000_000 },
+        by_group: {
+          ranked: {
+            buckets: [
+              { key: "a1", doc_count: 3, metric: { value: 4_000_000 } },
+            ],
+          },
+        },
+      })
+    );
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(
+      new Map([
+        ["a1", { name: "Agent One", pictureUrl: null, description: null }],
+      ])
+    );
+
+    const result = await fetchAnalystCreditUsage({
+      auth,
+      scope,
+      groupBy: "agent",
+      limit: 5,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    // The root total, not the sum of the ranked buckets — the whole point of
+    // wrapping the ranking in a `filter` sub-agg instead of the root query.
+    expect(result.value.totalCredits).toBe(10);
+    expect(result.value.rows).toEqual([
+      { groupKey: "a1", name: "Agent One", totalCredits: 4 },
+    ]);
+
+    const [, options] = vi.mocked(searchConsumptionAnalytics).mock.calls[0];
+    expect(options?.aggregations).toEqual({
+      metric: { sum: { field: "credit_micro" } },
+      by_group: {
+        filter: { exists: { field: "agent.attributed_id" } },
+        aggs: {
+          ranked: {
+            terms: {
+              field: "agent.attributed_id",
+              size: 5,
+              order: { metric: "desc" },
+            },
+            aggs: { metric: { sum: { field: "credit_micro" } } },
+          },
+        },
+      },
+    });
+  });
+
+  it("falls back to the raw key when a group's label does not resolve", async () => {
+    const { auth, scope } = await setup();
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({
+        metric: { value: 1_000_000 },
+        by_group: {
+          ranked: {
+            buckets: [
+              {
+                key: "deleted-model",
+                doc_count: 1,
+                metric: { value: 1_000_000 },
+              },
+            ],
+          },
+        },
+      })
+    );
+    vi.mocked(resolveDimensionLabels).mockResolvedValue(new Map());
+
+    const result = await fetchAnalystCreditUsage({
+      auth,
+      scope,
+      groupBy: "model",
+      limit: 5,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.rows).toEqual([
+      { groupKey: "deleted-model", name: "deleted-model", totalCredits: 1 },
+    ]);
+  });
+
+  it("rounds micro-credits to whole credits", async () => {
+    const { auth, scope } = await setup();
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      esResponse({ metric: { value: 1_500_000 } })
+    );
+
+    const result = await fetchAnalystCreditUsage({
+      auth,
+      scope,
+      groupBy: "none",
+      limit: 10,
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (!result.isOk()) {
+      return;
+    }
+    expect(result.value.totalCredits).toBe(2);
+  });
+
+  it("propagates an Elasticsearch error", async () => {
+    const { auth, scope } = await setup();
+    vi.mocked(searchConsumptionAnalytics).mockResolvedValue(
+      new Err(new ElasticsearchError("query_error", "boom"))
+    );
+
+    const result = await fetchAnalystCreditUsage({
+      auth,
+      scope,
+      groupBy: "none",
+      limit: 10,
+    });
+
+    expect(result.isErr()).toBe(true);
+  });
+});

--- a/front/lib/api/analytics/analyst/credits.ts
+++ b/front/lib/api/analytics/analyst/credits.ts
@@ -74,12 +74,9 @@ export async function fetchAnalystCreditUsage({
   Result<AnalystCreditUsage, ElasticsearchError>
 > {
   const dimension = dimensionForGroupBy(groupBy);
-  const metric = DEFAULT_CONSUMPTION_METRIC;
-
+  const metricAgg = metricSubAgg(DEFAULT_CONSUMPTION_METRIC);
   const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
-    {
-      ...metricSubAgg(metric),
-    };
+    metricAgg;
 
   if (dimension) {
     const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
@@ -92,7 +89,7 @@ export async function fetchAnalystCreditUsage({
             size: limit,
             order: { metric: "desc" },
           },
-          aggs: metricSubAgg(metric),
+          aggs: metricAgg,
         },
       },
     };
@@ -108,7 +105,7 @@ export async function fetchAnalystCreditUsage({
   }
 
   const totalCredits = Math.round(
-    metricValue(metric, result.value.aggregations?.metric)
+    metricValue(DEFAULT_CONSUMPTION_METRIC, result.value.aggregations?.metric)
   );
 
   if (!dimension) {
@@ -126,7 +123,9 @@ export async function fetchAnalystCreditUsage({
     return {
       groupKey: key,
       name: labels.get(key)?.name ?? key,
-      totalCredits: Math.round(metricValue(metric, bucket.metric)),
+      totalCredits: Math.round(
+        metricValue(DEFAULT_CONSUMPTION_METRIC, bucket.metric)
+      ),
     };
   });
 

--- a/front/lib/api/analytics/analyst/credits.ts
+++ b/front/lib/api/analytics/analyst/credits.ts
@@ -1,0 +1,134 @@
+import type { AnalystScope } from "@app/lib/api/analytics/analyst/scope";
+import { analystQuery } from "@app/lib/api/analytics/analyst/scope";
+import { resolveDimensionLabels } from "@app/lib/api/analytics/consumption/labels";
+import type { ConsumptionGroupBucket } from "@app/lib/api/analytics/consumption/scope";
+import {
+  CONSUMPTION_DIMENSION_FIELDS,
+  DEFAULT_CONSUMPTION_METRIC,
+  metricSubAgg,
+  metricValue,
+} from "@app/lib/api/analytics/consumption/scope";
+import type { ElasticsearchError } from "@app/lib/api/elasticsearch";
+import {
+  bucketsToArray,
+  searchConsumptionAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { ConsumptionScopeDimension } from "@app/types/api/analytics/consumption";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import type { WithAuth } from "@app/types/shared/typescipt_utils";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type AnalystCreditGroupBy = "agent" | "user" | "model" | "none";
+
+export type AnalystCreditRow = {
+  groupKey: string;
+  name: string;
+  totalCredits: number;
+};
+
+export type AnalystCreditUsage = {
+  totalCredits: number;
+  rows: AnalystCreditRow[];
+};
+
+function dimensionForGroupBy(
+  groupBy: AnalystCreditGroupBy
+): ConsumptionScopeDimension | null {
+  switch (groupBy) {
+    case "agent":
+    case "user":
+    case "model":
+      return groupBy;
+    case "none":
+      return null;
+    default:
+      return assertNever(groupBy);
+  }
+}
+
+type ByGroupAgg = estypes.AggregationsSingleBucketAggregateBase & {
+  ranked?: estypes.AggregationsMultiBucketAggregateBase<ConsumptionGroupBucket>;
+};
+
+type CreditUsageAggs = {
+  metric?: estypes.AggregationsSumAggregate;
+  by_group?: ByGroupAgg;
+};
+
+export interface FetchAnalystCreditUsageParams {
+  scope: AnalystScope;
+  groupBy: AnalystCreditGroupBy;
+  limit: number;
+}
+
+// Ranks by credits within a `filter` sub-agg rather than filtering the root
+// query, so `totalCredits` always reflects the whole period.
+export async function fetchAnalystCreditUsage({
+  auth,
+  scope,
+  groupBy,
+  limit,
+}: WithAuth<FetchAnalystCreditUsageParams>): Promise<
+  Result<AnalystCreditUsage, ElasticsearchError>
+> {
+  const dimension = dimensionForGroupBy(groupBy);
+  const metric = DEFAULT_CONSUMPTION_METRIC;
+
+  const aggregations: Record<string, estypes.AggregationsAggregationContainer> =
+    {
+      ...metricSubAgg(metric),
+    };
+
+  if (dimension) {
+    const dimensionField = CONSUMPTION_DIMENSION_FIELDS[dimension];
+    aggregations.by_group = {
+      filter: { exists: { field: dimensionField } },
+      aggs: {
+        ranked: {
+          terms: {
+            field: dimensionField,
+            size: limit,
+            order: { metric: "desc" },
+          },
+          aggs: metricSubAgg(metric),
+        },
+      },
+    };
+  }
+
+  const result = await searchConsumptionAnalytics<never, CreditUsageAggs>(
+    analystQuery({ auth, scope }),
+    { aggregations, size: 0 }
+  );
+
+  if (result.isErr()) {
+    return result;
+  }
+
+  const totalCredits = Math.round(
+    metricValue(metric, result.value.aggregations?.metric)
+  );
+
+  if (!dimension) {
+    return new Ok({ totalCredits, rows: [] });
+  }
+
+  const buckets = bucketsToArray<ConsumptionGroupBucket>(
+    result.value.aggregations?.by_group?.ranked?.buckets
+  );
+  const keys = buckets.map((bucket) => String(bucket.key));
+  const labels = await resolveDimensionLabels(auth, dimension, keys);
+
+  const rows = buckets.map((bucket) => {
+    const key = String(bucket.key);
+    return {
+      groupKey: key,
+      name: labels.get(key)?.name ?? key,
+      totalCredits: Math.round(metricValue(metric, bucket.metric)),
+    };
+  });
+
+  return new Ok({ totalCredits, rows });
+}

--- a/front/lib/api/analytics/analyst/scope.test.ts
+++ b/front/lib/api/analytics/analyst/scope.test.ts
@@ -1,0 +1,140 @@
+import {
+  analystQuery,
+  buildAnalystScope,
+} from "@app/lib/api/analytics/analyst/scope";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { describe, expect, it } from "vitest";
+
+describe("buildAnalystScope", () => {
+  it("converts an inclusive endOf('day') endDate to a half-open range", () => {
+    // resolveTimeWindow's explicit-range branch returns endOf("day"), i.e.
+    // 23:59:59.999 — bumping by 1ms must land exactly on the next midnight.
+    const scope = buildAnalystScope({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-13T23:59:59.999Z",
+      timezone: "UTC",
+    });
+    expect(scope.startDate).toBe("2026-07-01T00:00:00.000Z");
+    expect(scope.endDate).toBe("2026-07-14T00:00:00.000Z");
+  });
+
+  it("converts a 'now' endDate (no endOf-day rounding) the same way", () => {
+    // resolveTimeWindow's relative-period branch returns `now.toISOString()`
+    // verbatim, with no endOf("day") — the +1ms conversion must be uniform
+    // across both branches, not conditioned on the input looking rounded.
+    const scope = buildAnalystScope({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-13T14:32:07.123Z",
+      timezone: "UTC",
+    });
+    expect(scope.endDate).toBe("2026-07-13T14:32:07.124Z");
+  });
+
+  it("puts agentIds, userIds and modelIds in the scope filter", () => {
+    const scope = buildAnalystScope({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-13T00:00:00.000Z",
+      timezone: "UTC",
+      agentIds: ["a1"],
+      userIds: ["u1", "u2"],
+      modelIds: ["gpt-5.6-luna"],
+    });
+    expect(scope.filter).toEqual({
+      agents: ["a1"],
+      users: ["u1", "u2"],
+      models: ["gpt-5.6-luna"],
+    });
+    expect(scope.extraFilters).toEqual([]);
+  });
+
+  it("puts a single agentTagIds value in extraFilters as a term, never in filter", () => {
+    const scope = buildAnalystScope({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-13T00:00:00.000Z",
+      timezone: "UTC",
+      agentTagIds: ["tag1"],
+    });
+    expect(scope.filter).toEqual({});
+    expect(scope.extraFilters).toEqual([{ term: { "agent.tag_ids": "tag1" } }]);
+  });
+
+  it("puts multiple agentTagIds values in extraFilters as a terms clause", () => {
+    const scope = buildAnalystScope({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-13T00:00:00.000Z",
+      timezone: "UTC",
+      agentTagIds: ["tag1", "tag2"],
+    });
+    expect(scope.extraFilters).toEqual([
+      { terms: { "agent.tag_ids": ["tag1", "tag2"] } },
+    ]);
+  });
+
+  it("filters 'unknown' source as a missing-context_origin clause", () => {
+    const scope = buildAnalystScope({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-13T00:00:00.000Z",
+      timezone: "UTC",
+      source: "unknown",
+    });
+    expect(scope.extraFilters).toEqual([
+      {
+        bool: {
+          should: [
+            { term: { context_origin: "unknown" } },
+            { bool: { must_not: { exists: { field: "context_origin" } } } },
+          ],
+          minimum_should_match: 1,
+        },
+      },
+    ]);
+  });
+
+  it("filters a regular source as a context_origin term", () => {
+    const scope = buildAnalystScope({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-13T00:00:00.000Z",
+      timezone: "UTC",
+      source: "web",
+    });
+    expect(scope.extraFilters).toEqual([{ term: { context_origin: "web" } }]);
+  });
+});
+
+describe("analystQuery", () => {
+  it("scopes to the workspace and merges the scope's extraFilters with the caller's extra", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const scope = buildAnalystScope({
+      startDate: "2026-07-01T00:00:00.000Z",
+      endDate: "2026-07-13T00:00:00.000Z",
+      timezone: "UTC",
+      agentTagIds: ["tag1"],
+    });
+
+    const query = analystQuery({
+      auth: authenticator,
+      scope,
+      extra: [{ exists: { field: "user.id" } }],
+    });
+
+    expect(query).toEqual({
+      bool: {
+        filter: [
+          {
+            term: { workspace_id: authenticator.getNonNullableWorkspace().sId },
+          },
+          {
+            range: {
+              completed_at: {
+                gte: "2026-07-01T00:00:00.000Z",
+                lt: "2026-07-13T00:00:00.001Z",
+              },
+            },
+          },
+          { term: { "agent.tag_ids": "tag1" } },
+          { exists: { field: "user.id" } },
+        ],
+      },
+    });
+  });
+});

--- a/front/lib/api/analytics/analyst/scope.test.ts
+++ b/front/lib/api/analytics/analyst/scope.test.ts
@@ -6,35 +6,19 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { describe, expect, it } from "vitest";
 
 describe("buildAnalystScope", () => {
-  it("converts an inclusive endOf('day') endDate to a half-open range", () => {
-    // resolveTimeWindow's explicit-range branch returns endOf("day"), i.e.
-    // 23:59:59.999 — bumping by 1ms must land exactly on the next midnight.
-    const scope = buildAnalystScope({
-      startDate: "2026-07-01T00:00:00.000Z",
-      endDate: "2026-07-13T23:59:59.999Z",
-      timezone: "UTC",
-    });
-    expect(scope.startDate).toBe("2026-07-01T00:00:00.000Z");
-    expect(scope.endDate).toBe("2026-07-14T00:00:00.000Z");
-  });
-
-  it("converts a 'now' endDate (no endOf-day rounding) the same way", () => {
-    // resolveTimeWindow's relative-period branch returns `now.toISOString()`
-    // verbatim, with no endOf("day") — the +1ms conversion must be uniform
-    // across both branches, not conditioned on the input looking rounded.
+  it("rounds endDate up to the start of the following calendar day", () => {
     const scope = buildAnalystScope({
       startDate: "2026-07-01T00:00:00.000Z",
       endDate: "2026-07-13T14:32:07.123Z",
-      timezone: "UTC",
     });
-    expect(scope.endDate).toBe("2026-07-13T14:32:07.124Z");
+    expect(scope.startDate).toBe("2026-07-01T00:00:00.000Z");
+    expect(scope.endDate).toBe("2026-07-14");
   });
 
   it("puts agentIds, userIds and modelIds in the scope filter", () => {
     const scope = buildAnalystScope({
       startDate: "2026-07-01T00:00:00.000Z",
       endDate: "2026-07-13T00:00:00.000Z",
-      timezone: "UTC",
       agentIds: ["a1"],
       userIds: ["u1", "u2"],
       modelIds: ["gpt-5.6-luna"],
@@ -51,7 +35,6 @@ describe("buildAnalystScope", () => {
     const scope = buildAnalystScope({
       startDate: "2026-07-01T00:00:00.000Z",
       endDate: "2026-07-13T00:00:00.000Z",
-      timezone: "UTC",
       agentTagIds: ["tag1"],
     });
     expect(scope.filter).toEqual({});
@@ -62,7 +45,6 @@ describe("buildAnalystScope", () => {
     const scope = buildAnalystScope({
       startDate: "2026-07-01T00:00:00.000Z",
       endDate: "2026-07-13T00:00:00.000Z",
-      timezone: "UTC",
       agentTagIds: ["tag1", "tag2"],
     });
     expect(scope.extraFilters).toEqual([
@@ -74,7 +56,6 @@ describe("buildAnalystScope", () => {
     const scope = buildAnalystScope({
       startDate: "2026-07-01T00:00:00.000Z",
       endDate: "2026-07-13T00:00:00.000Z",
-      timezone: "UTC",
       source: "unknown",
     });
     expect(scope.extraFilters).toEqual([
@@ -94,7 +75,6 @@ describe("buildAnalystScope", () => {
     const scope = buildAnalystScope({
       startDate: "2026-07-01T00:00:00.000Z",
       endDate: "2026-07-13T00:00:00.000Z",
-      timezone: "UTC",
       source: "web",
     });
     expect(scope.extraFilters).toEqual([{ term: { context_origin: "web" } }]);
@@ -107,7 +87,6 @@ describe("analystQuery", () => {
     const scope = buildAnalystScope({
       startDate: "2026-07-01T00:00:00.000Z",
       endDate: "2026-07-13T00:00:00.000Z",
-      timezone: "UTC",
       agentTagIds: ["tag1"],
     });
 
@@ -127,7 +106,7 @@ describe("analystQuery", () => {
             range: {
               completed_at: {
                 gte: "2026-07-01T00:00:00.000Z",
-                lt: "2026-07-13T00:00:00.001Z",
+                lt: "2026-07-14",
               },
             },
           },

--- a/front/lib/api/analytics/analyst/scope.ts
+++ b/front/lib/api/analytics/analyst/scope.ts
@@ -1,0 +1,98 @@
+import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
+import { contextOriginFilter } from "@app/lib/api/assistant/observability/context_origin";
+import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
+import type { WithAuth } from "@app/types/shared/typescipt_utils";
+import type { estypes } from "@elastic/elasticsearch";
+
+export type AnalystFilterInput = {
+  source?: string;
+  agentIds?: string[];
+  userIds?: string[];
+  agentTagIds?: string[];
+  modelIds?: string[];
+};
+
+export type AnalystScope = {
+  startDate: string;
+  endDate: string;
+  timezone: string;
+  filter: ConsumptionScopeFilter;
+  extraFilters: estypes.QueryDslQueryContainer[];
+};
+
+// Expects an end-of-day timestamp (e.g. moment's `endOf("day")`, ending in
+// `.999Z`), as produced by the tool's time window resolution. Adding 1ms
+// rounds it up to the start of the next day, the half-open upper bound
+// `buildConsumptionScopeQuery` expects.
+function toExclusiveEndDate(inclusiveEndDate: string): string {
+  return new Date(Date.parse(inclusiveEndDate) + 1).toISOString();
+}
+
+export interface BuildAnalystScopeParams extends AnalystFilterInput {
+  startDate: string;
+  endDate: string;
+  timezone: string;
+}
+
+export function buildAnalystScope({
+  startDate,
+  endDate,
+  timezone,
+  source,
+  agentIds,
+  userIds,
+  agentTagIds,
+  modelIds,
+}: BuildAnalystScopeParams): AnalystScope {
+  const filter: ConsumptionScopeFilter = {};
+  if (agentIds && agentIds.length > 0) {
+    filter.agents = agentIds;
+  }
+  if (userIds && userIds.length > 0) {
+    filter.users = userIds;
+  }
+  if (modelIds && modelIds.length > 0) {
+    filter.models = modelIds;
+  }
+
+  const extraFilters: estypes.QueryDslQueryContainer[] = [];
+  if (agentTagIds && agentTagIds.length > 0) {
+    // There is no scope dimension for tags, so this is not expressible via
+    // `filter` above.
+    extraFilters.push(
+      agentTagIds.length === 1
+        ? { term: { "agent.tag_ids": agentTagIds[0] } }
+        : { terms: { "agent.tag_ids": agentTagIds } }
+    );
+  }
+  if (source !== undefined) {
+    extraFilters.push(...contextOriginFilter(source));
+  }
+
+  return {
+    startDate,
+    endDate: toExclusiveEndDate(endDate),
+    timezone,
+    filter,
+    extraFilters,
+  };
+}
+
+export interface AnalystQueryParams {
+  scope: AnalystScope;
+  extra?: estypes.QueryDslQueryContainer[];
+}
+
+export function analystQuery({
+  auth,
+  scope,
+  extra = [],
+}: WithAuth<AnalystQueryParams>): estypes.QueryDslQueryContainer {
+  return buildConsumptionScopeQuery({
+    auth,
+    startDate: scope.startDate,
+    endDate: scope.endDate,
+    filter: scope.filter,
+    extraFilters: [...scope.extraFilters, ...extra],
+  });
+}

--- a/front/lib/api/analytics/analyst/scope.ts
+++ b/front/lib/api/analytics/analyst/scope.ts
@@ -1,4 +1,7 @@
-import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
+import {
+  buildConsumptionScopeQuery,
+  exclusiveEndDate,
+} from "@app/lib/api/analytics/consumption/scope";
 import { contextOriginFilter } from "@app/lib/api/assistant/observability/context_origin";
 import type { ConsumptionScopeFilter } from "@app/types/api/analytics/consumption";
 import type { WithAuth } from "@app/types/shared/typescipt_utils";
@@ -15,29 +18,18 @@ export type AnalystFilterInput = {
 export type AnalystScope = {
   startDate: string;
   endDate: string;
-  timezone: string;
   filter: ConsumptionScopeFilter;
   extraFilters: estypes.QueryDslQueryContainer[];
 };
 
-// Expects an end-of-day timestamp (e.g. moment's `endOf("day")`, ending in
-// `.999Z`), as produced by the tool's time window resolution. Adding 1ms
-// rounds it up to the start of the next day, the half-open upper bound
-// `buildConsumptionScopeQuery` expects.
-function toExclusiveEndDate(inclusiveEndDate: string): string {
-  return new Date(Date.parse(inclusiveEndDate) + 1).toISOString();
-}
-
 export interface BuildAnalystScopeParams extends AnalystFilterInput {
   startDate: string;
   endDate: string;
-  timezone: string;
 }
 
 export function buildAnalystScope({
   startDate,
   endDate,
-  timezone,
   source,
   agentIds,
   userIds,
@@ -57,8 +49,6 @@ export function buildAnalystScope({
 
   const extraFilters: estypes.QueryDslQueryContainer[] = [];
   if (agentTagIds && agentTagIds.length > 0) {
-    // There is no scope dimension for tags, so this is not expressible via
-    // `filter` above.
     extraFilters.push(
       agentTagIds.length === 1
         ? { term: { "agent.tag_ids": agentTagIds[0] } }
@@ -71,8 +61,7 @@ export function buildAnalystScope({
 
   return {
     startDate,
-    endDate: toExclusiveEndDate(endDate),
-    timezone,
+    endDate: exclusiveEndDate(endDate),
     filter,
     extraFilters,
   };

--- a/front/lib/api/analytics/consumption/scope.ts
+++ b/front/lib/api/analytics/consumption/scope.ts
@@ -9,6 +9,7 @@ import {
   CONSUMPTION_SCOPE_DIMENSIONS,
 } from "@app/types/api/analytics/consumption";
 import type { estypes } from "@elastic/elasticsearch";
+import moment from "moment-timezone";
 
 export type {
   ConsumptionFacetScope,
@@ -35,6 +36,12 @@ export const CONVERSATION_ID_FIELD = "conversation_id";
 export const TRIGGER_ID_FIELD = "trigger_id";
 
 export const CARDINALITY_PRECISION_THRESHOLD = 40_000;
+
+// Input: the last day to include ("YYYY-MM-DD"). Output: the start of the
+// next day, i.e. the exclusive upper bound for a `lt` range query.
+export function exclusiveEndDate(inclusiveEndDate: string): string {
+  return moment.utc(inclusiveEndDate).add(1, "day").format("YYYY-MM-DD");
+}
 
 // Upper bound on the number of buckets a terms aggregation over an export's
 // full dimension (every agent, every user, ...) can return. Large enough that

--- a/front/lib/api/analytics/export_tables.ts
+++ b/front/lib/api/analytics/export_tables.ts
@@ -4,7 +4,10 @@ import {
   fetchAgentExportRows,
   toAgentExportCsvRow,
 } from "@app/lib/api/analytics/agents_export";
-import { buildConsumptionScopeQuery } from "@app/lib/api/analytics/consumption/scope";
+import {
+  buildConsumptionScopeQuery,
+  exclusiveEndDate,
+} from "@app/lib/api/analytics/consumption/scope";
 import { rowsToCsv } from "@app/lib/api/analytics/csv_utils";
 import type { FeedbackExportRow } from "@app/lib/api/analytics/feedback_export";
 import {
@@ -263,15 +266,10 @@ function buildExportConsumptionScopeQuery(
   auth: Authenticator,
   { startDate, endDate }: { startDate: string; endDate: string }
 ): estypes.QueryDslQueryContainer {
-  const exclusiveEndDate = moment
-    .utc(endDate)
-    .add(1, "day")
-    .format("YYYY-MM-DD");
-
   return buildConsumptionScopeQuery({
     auth,
     startDate,
-    endDate: exclusiveEndDate,
+    endDate: exclusiveEndDate(endDate),
   });
 }
 

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -55,7 +55,7 @@ export const workspaceAnalyticsSkill = {
     `- Listing the agents other members have not published is admin-only, so ` +
     `fall back to the default view if it reports an authorization error.\n` +
     "- Chart timeseries results so the admin can see the trend.\n" +
-    "- get_credit_usage returns the workspace's reconciled billed credits, " +
+    "- get_credit_usage returns the workspace's billed credits, " +
     "the same ones the Usage page shows — do not describe them as " +
     "estimates. Free platform usage is never counted.",
   mcpServers: [

--- a/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
+++ b/front/lib/resources/skill/code_defined/global/workspace_analytics.ts
@@ -55,14 +55,14 @@ export const workspaceAnalyticsSkill = {
     `- Listing the agents other members have not published is admin-only, so ` +
     `fall back to the default view if it reports an authorization error.\n` +
     "- Chart timeseries results so the admin can see the trend.\n" +
-    "- Credit figures are estimates; when reporting them, tell the admin they " +
-    "are approximate and point to the workspace Usage page for exact billed " +
-    "amounts.",
+    "- get_credit_usage returns the workspace's reconciled billed credits, " +
+    "the same ones the Usage page shows — do not describe them as " +
+    "estimates. Free platform usage is never counted.",
   mcpServers: [
     { name: "workspace_analytics" },
     { name: WORKSPACE_MANAGEMENT_SERVER_NAME },
   ],
-  version: 5,
+  version: 6,
   icon: "ActionPieChartIcon",
   isRestricted: async (auth: Authenticator) => {
     if (!auth.isManager()) {

--- a/front/types/shared/typescipt_utils.ts
+++ b/front/types/shared/typescipt_utils.ts
@@ -1,3 +1,7 @@
+import type { Authenticator } from "@app/lib/auth";
+
+export type WithAuth<T> = T & { auth: Authenticator };
+
 export type ExtractSpecificKeys<T, K extends keyof T> = T extends any
   ? {
       [P in K]: T[P];


### PR DESCRIPTION
## Description

Start migrating the @analyst agent to the new ES index. 
Starting with the get_credit_usage tool. 

## Tests

New unit tests + tested locally.

## Risk

Low. 

## Deploy Plan

Standard deploy. No migrations