### PR TITLE
[front] fix: send members arg as user IDs from poke members list

### DIFF
--- a/front/components/poke/members/MembersBulkActions.tsx
+++ b/front/components/poke/members/MembersBulkActions.tsx
@@ -64,7 +64,7 @@ export function MembersBulkActions({
     setIsSubmitting(true);
     const res = await runBatchUpdate(
       update,
-      eligible.map((m) => m.email)
+      eligible.map((m) => m.sId)
     );
     setIsSubmitting(false);
 
@@ -80,7 +80,9 @@ export function MembersBulkActions({
       window.alert(
         `${res.value.length - failures.length}/${res.value.length} succeeded.\n\n` +
           `Issues:\n` +
-          failures.map((r) => `${r.email}: ${r.error ?? r.status}`).join("\n")
+          failures
+            .map((r) => `${r.email ?? r.identifier}: ${r.error ?? r.status}`)
+            .join("\n")
       );
     }
 

--- a/front/components/poke/members/table.tsx
+++ b/front/components/poke/members/table.tsx
@@ -55,13 +55,13 @@ export function MembersDataTable({
   const { runBatchUpdate } = useBatchUpdateMembers({ owner });
 
   // Per-row mutations run the same "batch-update-members" plugin as the bulk
-  // toolbar, just with a single email.
+  // toolbar, just with a single user ID.
   const applyToMember = async (
     m: MemberDisplayType,
     update: BatchMemberUpdate,
     context: string
   ) => {
-    const res = await runBatchUpdate(update, [m.email]);
+    const res = await runBatchUpdate(update, [m.sId]);
     if (res.isErr()) {
       window.alert(`An error occurred while ${context}: ${res.error}`);
       return;

--- a/front/components/poke/members/useBatchUpdateMembers.ts
+++ b/front/components/poke/members/useBatchUpdateMembers.ts
@@ -15,14 +15,18 @@ export type BatchMemberUpdate =
   | { action: "revoke" };
 
 interface BatchMemberResultRow {
-  email: string;
+  identifier: string;
+  email?: string;
   status: string;
   error?: string;
 }
 
 function isResultRow(row: unknown): row is BatchMemberResultRow {
   return (
-    typeof row === "object" && row !== null && "email" in row && "status" in row
+    typeof row === "object" &&
+    row !== null &&
+    "identifier" in row &&
+    "status" in row
   );
 }
 
@@ -36,17 +40,18 @@ export function useBatchUpdateMembers({ owner }: { owner: WorkspaceType }) {
     },
   });
 
-  // Runs the plugin for the given emails and returns the per-member outcomes,
-  // or an Err with the plugin-level error message.
+  // Runs the plugin for the given user IDs and returns the per-member outcomes,
+  // or an Err with the plugin-level error message. Passing user IDs (rather than
+  // emails) targets the exact account even when several share an email.
   const runBatchUpdate = async (
     update: BatchMemberUpdate,
-    emails: string[]
+    userIds: string[]
   ): Promise<Result<BatchMemberResultRow[], string>> => {
     const res = await doRunPlugin({
       action: [update.action],
       role: update.action === "update_role" ? [update.role] : [],
       seatType: update.action === "update_seat" ? [update.seatType] : [],
-      emails: emails.join("\n"),
+      members: userIds.join("\n"),
       immediate: true,
     });
     if (res.isErr()) {


### PR DESCRIPTION
## Description

Follow-up to #31159. That PR renamed the `batch-update-members` poke plugin arg from `emails` to `members`, but the poke members-list hook (`useBatchUpdateMembers`) still posted it under `emails`. As a result every per-row and bulk member action (revoke / update role / update seat) failed with:

> The request body is invalid: Validation error: Required at "members"

This PR:

- Sends the arg under `members` (matching the merged plugin schema).
- Passes each member's **user ID** (already available in the members list) instead of the email, so actions target the exact account even when several accounts share an email — the original motivation behind #31159.
- Updates `BatchMemberResultRow` to carry `identifier` (+ optional resolved `email`) to match the plugin's per-row output, and shows `email ?? identifier` in bulk failure messages.

## Tests

Manual (poke members list: per-row revoke/role/seat and bulk toolbar). `tsgo --noEmit` and Biome pass.

## Risk

Low. Internal support-only poke UI; no external API surface.

## Deploy Plan

Standard `front` deploy. #31159 is already merged, so the `members` arg exists in `main`.