### PR TITLE
Remove anthropic_cache_diagnostics feature flag, enable for everyone

### DIFF
--- a/front/lib/api/llm/cache_diagnostics.ts
+++ b/front/lib/api/llm/cache_diagnostics.ts
@@ -9,8 +9,7 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 // and across user turns (each turn is a fresh workflow). The short TTL matches
 // the lifetime of Anthropic's diagnostics fingerprint and the prompt cache
 // itself: once it expires, the previous id is worthless anyway, so we stop
-// sending it and the key cleans itself up. Sunsetting the feature needs no
-// migration: flip the flag off and the keys expire on their own.
+// sending it and the key cleans itself up.
 const CACHE_DIAGNOSTICS_TTL_SECONDS = 600;
 
 export interface CacheDiagnosticsKey {

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -287,7 +287,6 @@ export async function getOutputFromLLMStream(
     conversation,
     toolSearchEnabled,
     disableToolUse,
-    cacheDiagnosticsEnabled,
     specifications,
     flushParserTokens,
     contentParser,
@@ -324,16 +323,14 @@ export async function getOutputFromLLMStream(
   // Prompt-cache diagnostics: thread the previous step's response id so Anthropic
   // can report why the cache prefix diverged. Keyed by conversation and agent in
   // Redis so the chain survives across steps and user turns. `null` (no prior, or
-  // expired) is still a valid opt-in value. `undefined` keeps the feature off.
+  // expired) is still a valid value.
   const cacheDiagnosticsKey: CacheDiagnosticsKey = {
     conversationId: conversation.sId,
     agentConfigurationId: agentConfiguration.sId,
     providerId: model.providerId,
   };
 
-  const previousMessageId = cacheDiagnosticsEnabled
-    ? await getPreviousMessageId(cacheDiagnosticsKey)
-    : undefined;
+  const previousMessageId = await getPreviousMessageId(cacheDiagnosticsKey);
 
   const events = llm.stream(
     {
@@ -565,45 +562,43 @@ export async function getOutputFromLLMStream(
       }
 
       if (event.type === "interaction_id") {
-        if (cacheDiagnosticsEnabled) {
-          const { modelInteractionId, cacheMissReason } = event.content;
+        const { modelInteractionId, cacheMissReason } = event.content;
 
-          // Store this response id so the next step/turn can compare against it.
-          await setPreviousMessageId(cacheDiagnosticsKey, modelInteractionId);
+        // Store this response id so the next step/turn can compare against it.
+        await setPreviousMessageId(cacheDiagnosticsKey, modelInteractionId);
 
-          if (cacheMissReason) {
-            logger.info(
-              {
-                ...logContext,
-                agentConfigurationId: agentConfiguration.sId,
-                modelInteractionId,
-                previousMessageId,
-                cacheMissReasonType: cacheMissReason.type,
-                cacheMissedInputTokens: cacheMissReason.cacheMissedInputTokens,
-              },
-              "[LLM stream] prompt cache miss"
-            );
-            const reasonTags = [
-              `model_id:${model.modelId}`,
-              `reason:${cacheMissReason.type}`,
-              `is_dust_like_agent:${isDustLikeAgent(agentConfiguration.sId)}`,
-            ];
-            // Count: how often each reason occurs.
-            getStatsDClient().increment(
-              "llm.cache_miss_reason.count",
-              1,
+        if (cacheMissReason) {
+          logger.info(
+            {
+              ...logContext,
+              agentConfigurationId: agentConfiguration.sId,
+              modelInteractionId,
+              previousMessageId,
+              cacheMissReasonType: cacheMissReason.type,
+              cacheMissedInputTokens: cacheMissReason.cacheMissedInputTokens,
+            },
+            "[LLM stream] prompt cache miss"
+          );
+          const reasonTags = [
+            `model_id:${model.modelId}`,
+            `reason:${cacheMissReason.type}`,
+            `is_dust_like_agent:${isDustLikeAgent(agentConfiguration.sId)}`,
+          ];
+          // Count: how often each reason occurs.
+          getStatsDClient().increment(
+            "llm.cache_miss_reason.count",
+            1,
+            reasonTags
+          );
+          // Weighted by lost-cache tokens: which reason actually costs the most,
+          // not just which happens most. Only the `*_changed` reasons carry this
+          // (the inconclusive ones have no diverged prefix to measure).
+          if (cacheMissReason.cacheMissedInputTokens !== undefined) {
+            getStatsDClient().distribution(
+              "llm.cache_miss_reason.missed_input_tokens",
+              cacheMissReason.cacheMissedInputTokens,
               reasonTags
             );
-            // Weighted by lost-cache tokens: which reason actually costs the most,
-            // not just which happens most. Only the `*_changed` reasons carry this
-            // (the inconclusive ones have no diverged prefix to measure).
-            if (cacheMissReason.cacheMissedInputTokens !== undefined) {
-              getStatsDClient().distribution(
-                "llm.cache_miss_reason.missed_input_tokens",
-                cacheMissReason.cacheMissedInputTokens,
-                reasonTags
-              );
-            }
           }
         }
         continue;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -903,9 +903,6 @@ export async function runModel(
     conversation,
     toolSearchEnabled,
     disableToolUse,
-    cacheDiagnosticsEnabled: featureFlags.includes(
-      "anthropic_cache_diagnostics"
-    ),
     userMessage,
     specifications,
     flushParserTokens,

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -47,9 +47,6 @@ export type GetOutputRequestParams = {
   // When true, the tools are sent but the model is forbidden from calling them
   // (tool choice "none"). Set on the last step to force the final generation.
   disableToolUse: boolean;
-  // When true, opt this step's Anthropic call into prompt-cache diagnostics and
-  // thread the previous step's response id via Redis (see cache_diagnostics.ts).
-  cacheDiagnosticsEnabled: boolean;
   userMessage: UserMessageType;
   specifications: AgentActionSpecification[];
   flushParserTokens: () => Promise<void>;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -28,11 +28,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",
   },
-  anthropic_cache_diagnostics: {
-    description:
-      "Opt into Anthropic prompt-cache diagnostics to report cache-miss reasons on agent-loop steps",
-    stage: "dust_only",
-  },
   use_vertex_for_supported_models: {
     description:
       "Route LLM calls through Vertex AI when supported instead of the direct provider's API",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -741,7 +741,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "allow_sso"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
-  | "anthropic_cache_diagnostics"
   | "archive_inactive_agents"
   | "audit_logs"
   | "claude_4_5_opus_feature"


### PR DESCRIPTION
## Summary

- Removed the `anthropic_cache_diagnostics` flag from `WHITELISTABLE_FEATURES_CONFIG` and from the SDK's `WhitelistableFeaturesSchema` union — the feature is now unconditionally on instead of `dust_only`.
- Removed the `cacheDiagnosticsEnabled` gating that was threaded through `run_model.ts` → `GetOutputRequestParams` (`types.ts`) → `get_output_from_llm.ts`; the previous-message-id lookup, storage, and cache-miss logging/metrics now always run.
- Updated a stale comment in `cache_diagnostics.ts` that referenced sunsetting the feature by "flipping the flag off."
- Left the tri-state `cacheDiagnosticsEnabled` getter in `anthropic.ts` untouched — that's an unrelated per-request check (`previousMessageId !== undefined`), which now is effectively always true since the caller always fetches it.

