### PR TITLE
Remove dust_agent_gpt_5_6_luna_default feature flag, enable for everyone

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -87,13 +87,10 @@ interface DustLikeGlobalAgentArgs {
   // same model availability check that is enforced when a message is posted.
   featureFlags: WhitelistableFeature[];
   // When set, the @dust agent defaults to this stream meta-model (the highest
-  // one the member's model-tier cap allows) instead of Claude Sonnet 4.6.
+  // one the member's model-tier cap allows) instead of GPT 5.6 Luna.
   autoDefaultModelConfig?: ModelConfigurationType | null;
-  // When set, the @dust agent defaults to GPT 5.6 Luna (high reasoning) instead
-  // of Claude Sonnet 4.6. Gated by the `dust_agent_gpt_5_6_luna_default` flag.
-  preferGpt56LunaDefaultModel?: boolean;
-  // When set, the @dust agent defaults to Claude Sonnet 5 instead of Claude
-  // Sonnet 4.6. Gated by the `dust_agent_sonnet_5_default` feature flag.
+  // When set, the @dust agent defaults to Claude Sonnet 5 instead of GPT 5.6
+  // Luna. Gated by the `dust_agent_sonnet_5_default` feature flag.
   preferSonnet5DefaultModel?: boolean;
 }
 
@@ -480,8 +477,8 @@ export function _getDustGlobalAgent(
   args: DustLikeGlobalAgentArgs
 ): AgentConfigurationType | null {
   let preferredModelConfiguration: ModelConfigurationType =
-    CLAUDE_SONNET_4_6_DEFAULT_MODEL_CONFIG;
-  let preferredReasoningEffort: ReasoningEffort = "medium";
+    GPT_5_6_LUNA_MODEL_CONFIG;
+  let preferredReasoningEffort: ReasoningEffort = "high";
 
   if (args.autoDefaultModelConfig) {
     preferredModelConfiguration = args.autoDefaultModelConfig;
@@ -489,9 +486,6 @@ export function _getDustGlobalAgent(
   } else if (args.preferSonnet5DefaultModel) {
     preferredModelConfiguration = CLAUDE_SONNET_5_DEFAULT_MODEL_CONFIG;
     preferredReasoningEffort = "medium";
-  } else if (args.preferGpt56LunaDefaultModel) {
-    preferredModelConfiguration = GPT_5_6_LUNA_MODEL_CONFIG;
-    preferredReasoningEffort = "high";
   }
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/api/assistant/global_agents/global_agents.test.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.test.ts
@@ -277,10 +277,8 @@ describe("getGlobalAgents custom model agents", () => {
 });
 
 describe("getGlobalAgents OpenAI Dust agents", () => {
-  it("uses GPT 5.6 Luna with high reasoning as the flagged Dust default", async () => {
-    const auth = await createAuthenticatorWithFlags([
-      "dust_agent_gpt_5_6_luna_default",
-    ]);
+  it("uses GPT 5.6 Luna with high reasoning as the Dust default", async () => {
+    const auth = await createAuthenticatorWithFlags([]);
 
     const agents = await getGlobalAgents(
       auth,
@@ -296,9 +294,8 @@ describe("getGlobalAgents OpenAI Dust agents", () => {
     });
   });
 
-  it("keeps Sonnet 5 at medium reasoning when both default flags are set", async () => {
+  it("keeps Sonnet 5 at medium reasoning when the Sonnet 5 default flag is set", async () => {
     const auth = await createAuthenticatorWithFlags([
-      "dust_agent_gpt_5_6_luna_default",
       "dust_agent_sonnet_5_default",
     ]);
 

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -151,7 +151,6 @@ function getGlobalAgent({
   globalAgentContext,
   excludeProviders,
   autoDefaultModelConfig,
-  preferGpt56LunaDefaultModel,
   preferSonnet5DefaultModel,
   featureFlags,
 }: {
@@ -166,7 +165,6 @@ function getGlobalAgent({
   globalAgentContext?: GlobalAgentContext;
   excludeProviders: ReadonlySet<ModelProviderIdType>;
   autoDefaultModelConfig: ModelConfigurationType | null;
-  preferGpt56LunaDefaultModel: boolean;
   preferSonnet5DefaultModel: boolean;
   featureFlags: WhitelistableFeature[];
 }): AgentConfigurationType | null {
@@ -388,7 +386,6 @@ function getGlobalAgent({
         globalAgentContext,
         excludeProviders,
         autoDefaultModelConfig,
-        preferGpt56LunaDefaultModel,
         preferSonnet5DefaultModel,
       });
       break;
@@ -1223,9 +1220,6 @@ export async function getGlobalAgents(
       globalAgentContext: options?.globalAgentContext,
       excludeProviders,
       autoDefaultModelConfig,
-      preferGpt56LunaDefaultModel: flags.includes(
-        "dust_agent_gpt_5_6_luna_default"
-      ),
       preferSonnet5DefaultModel: flags.includes("dust_agent_sonnet_5_default"),
       featureFlags: flags,
     })

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -51,11 +51,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Access to internal global agents (dust-edge, dust-quick, dust-oai, dust-goog, custom model agents and their variants)",
     stage: "dust_only",
   },
-  dust_agent_gpt_5_6_luna_default: {
-    description:
-      "Use GPT 5.6 Luna (high reasoning) as the default model for the @dust agent",
-    stage: "on_demand",
-  },
   gpt_5_6_terra_long_context: {
     description: "Access to GPT 5.6 Terra with its full context window",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -756,7 +756,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "disable_run_logs"
   | "discord_bot"
   | "dummy_feature_for_flag_testing"
-  | "dust_agent_gpt_5_6_luna_default"
   | "dust_agent_sonnet_5_default"
   | "dust_filesystem"
   | "dust_internal_dangerous_in_cluster_mcp_servers"


### PR DESCRIPTION
## Summary

Getting rid of `dust_agent_gpt_5_6_luna_default` flag, since it's been at 100% rollout for a month.