### PR TITLE
Prepare sandbox schema for Frames v2

### DIFF
--- a/front/lib/resources/sandbox_function_resource.test.ts
+++ b/front/lib/resources/sandbox_function_resource.test.ts
@@ -354,19 +354,34 @@ describe("SandboxFunctionResource", () => {
     ).rejects.toThrow("Invalid JSON schema");
   });
 
-  it("declares unique file and slug indexes", () => {
-    expect(SandboxFunctionModel.options.indexes).toEqual(
+  it("declares legacy and publication-scoped uniqueness indexes", () => {
+    const indexes = SandboxFunctionModel.options.indexes ?? [];
+
+    expect(indexes).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           fields: ["fileId"],
+        }),
+        expect.objectContaining({
+          fields: ["workspaceId", "spaceId", "fileId"],
           unique: true,
         }),
         expect.objectContaining({
           fields: ["workspaceId", "spaceId", "slug"],
           unique: true,
         }),
+        expect.objectContaining({
+          fields: ["workspaceId", "fileId", "publicationId", "slug"],
+          unique: true,
+        }),
       ])
     );
+
+    const fileIndex = indexes.find((index) => {
+      const fields = index.fields ?? [];
+      return fields.length === 1 && fields[0] === "fileId";
+    });
+    expect(fileIndex?.unique).not.toBe(true);
   });
 
   it("overwrites the bundle and contract in place on re-publish", async () => {

--- a/front/lib/resources/sandbox_function_resource.ts
+++ b/front/lib/resources/sandbox_function_resource.ts
@@ -347,9 +347,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
       auth,
       Array.from(
         new Set(
-          sandboxFunctions.map(
-            (sandboxFunction) => sandboxFunction.get().spaceId
-          )
+          sandboxFunctions.flatMap((sandboxFunction) => {
+            const { spaceId } = sandboxFunction.get();
+            return spaceId === null ? [] : [spaceId];
+          })
         )
       ),
       { includeDeleted: includeDeletedSpace }
@@ -380,6 +381,10 @@ export class SandboxFunctionResource extends BaseResource<SandboxFunctionModel> 
 
     return sandboxFunctions.flatMap((sandboxFunction) => {
       const blob = sandboxFunction.get();
+      if (blob.spaceId === null) {
+        return [];
+      }
+
       const space =
         accessibleSpacesById.get(blob.spaceId) ?? spacesById?.get(blob.spaceId);
       const file = filesById.get(blob.fileId);

--- a/front/lib/resources/storage/models/sandbox.ts
+++ b/front/lib/resources/storage/models/sandbox.ts
@@ -1,6 +1,7 @@
 import { ConversationModel } from "@app/lib/models/agent/conversation";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { DataTypes, Op } from "@app/lib/resources/storage/data_types";
+import { FileModel } from "@app/lib/resources/storage/models/files";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
@@ -120,10 +121,12 @@ export class SandboxOwnerModel extends WorkspaceAwareModel<SandboxOwnerModel> {
 
   declare conversationId: ForeignKey<ConversationModel["id"]> | null;
   declare spaceId: ForeignKey<SpaceModel["id"]> | null;
+  declare frameFileModelId: ForeignKey<FileModel["id"]> | null;
   declare sandboxId: ForeignKey<SandboxModel["id"]>;
 
   declare conversation: NonAttribute<ConversationModel>;
   declare space: NonAttribute<SpaceModel>;
+  declare frameFile: NonAttribute<FileModel | null>;
   declare sandbox: NonAttribute<SandboxModel>;
 }
 
@@ -144,6 +147,10 @@ SandboxOwnerModel.init(
       allowNull: true,
     },
     spaceId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
+    frameFileModelId: {
       type: DataTypes.BIGINT,
       allowNull: true,
     },
@@ -177,6 +184,13 @@ SandboxOwnerModel.init(
         concurrently: true,
       },
       {
+        unique: true,
+        fields: ["workspaceId", "frameFileModelId"],
+        name: "sandbox_owners_workspace_frame_file_model_idx",
+        where: { frameFileModelId: { [Op.ne]: null } },
+        concurrently: true,
+      },
+      {
         fields: ["conversationId"],
         name: "sandbox_owners_conversation_id_idx",
         concurrently: true,
@@ -184,6 +198,11 @@ SandboxOwnerModel.init(
       {
         fields: ["spaceId"],
         name: "sandbox_owners_space_id_idx",
+        concurrently: true,
+      },
+      {
+        fields: ["frameFileModelId"],
+        name: "sandbox_owners_frame_file_model_id_idx",
         concurrently: true,
       },
       {
@@ -214,6 +233,17 @@ SandboxOwnerModel.belongsTo(SpaceModel, {
 
 SpaceModel.hasMany(SandboxOwnerModel, {
   foreignKey: { name: "spaceId", allowNull: true },
+  as: "sandboxOwnerLinks",
+});
+
+SandboxOwnerModel.belongsTo(FileModel, {
+  foreignKey: { name: "frameFileModelId", allowNull: true },
+  onDelete: "RESTRICT",
+  as: "frameFile",
+});
+
+FileModel.hasMany(SandboxOwnerModel, {
+  foreignKey: { name: "frameFileModelId", allowNull: true },
   as: "sandboxOwnerLinks",
 });
 

--- a/front/lib/resources/storage/models/sandbox_function.ts
+++ b/front/lib/resources/storage/models/sandbox_function.ts
@@ -51,8 +51,9 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare spaceId: ForeignKey<SpaceModel["id"]>;
+  declare spaceId: ForeignKey<SpaceModel["id"]> | null;
   declare fileId: ForeignKey<FileModel["id"]>;
+  declare publicationId: string | null;
   declare slug: string;
   declare description: string;
   declare userIdentity: SandboxFunctionUserIdentityPolicy | null;
@@ -67,7 +68,7 @@ export class SandboxFunctionModel extends WorkspaceAwareModel<SandboxFunctionMod
   declare inputSchema: JSONSchema;
   declare outputSchema: JSONSchema;
 
-  declare space: NonAttribute<SpaceModel>;
+  declare space: NonAttribute<SpaceModel | null>;
   declare file: NonAttribute<FileModel>;
 }
 
@@ -100,11 +101,15 @@ SandboxFunctionModel.init(
     },
     spaceId: {
       type: DataTypes.BIGINT,
-      allowNull: false,
+      allowNull: true,
     },
     fileId: {
       type: DataTypes.BIGINT,
       allowNull: false,
+    },
+    publicationId: {
+      type: DataTypes.STRING(255),
+      allowNull: true,
     },
     slug: {
       type: DataTypes.STRING(255),
@@ -179,6 +184,10 @@ SandboxFunctionModel.init(
       },
       {
         fields: ["fileId"],
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId", "fileId", "publicationId", "slug"],
         unique: true,
         concurrently: true,
       },
@@ -187,13 +196,13 @@ SandboxFunctionModel.init(
 );
 
 SandboxFunctionModel.belongsTo(SpaceModel, {
-  foreignKey: { name: "spaceId", allowNull: false },
+  foreignKey: { name: "spaceId", allowNull: true },
   onDelete: "RESTRICT",
   as: "space",
 });
 
 SpaceModel.hasMany(SandboxFunctionModel, {
-  foreignKey: { name: "spaceId", allowNull: false },
+  foreignKey: { name: "spaceId", allowNull: true },
   as: "sandboxFunctions",
 });
 

--- a/front/migrations/pre-deploy/20260826122416_prepare_frames_v2_schema.sql
+++ b/front/migrations/pre-deploy/20260826122416_prepare_frames_v2_schema.sql
@@ -1,0 +1,92 @@
+/*
+Expand the sandbox function and sandbox owner schemas for Frames v2 while
+legacy Pod Functions remain supported.
+*/
+
+/* Add the immutable publication identifier used by Frames v2 functions. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions"
+  ADD COLUMN "publicationId" character varying(255) COLLATE "pg_catalog"."default";
+
+/* Frames v2 functions are Frame-owned rather than Space-owned. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions"
+  ALTER COLUMN "spaceId" DROP NOT NULL;
+
+/* Replace the legacy one-function-per-file index with a plain FK index. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER INDEX "public"."sandbox_functions_file_id"
+  RENAME TO "sandbox_functions_file_id_unique_legacy";
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "sandbox_functions_file_id"
+  ON "public"."sandbox_functions" USING btree ("fileId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+DROP INDEX CONCURRENTLY "public"."sandbox_functions_file_id_unique_legacy";
+
+/* A Frame can publish several functions, with one row per name and publication. */
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY
+  "sandbox_functions_workspace_id_file_id_publication_id_slug"
+  ON "public"."sandbox_functions"
+  USING btree ("workspaceId", "fileId", "publicationId", "slug");
+
+/* Add Frame FileResource ownership to sandbox owners. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_owners"
+  ADD COLUMN "frameFileModelId" bigint;
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_owners"
+  ADD CONSTRAINT "sandbox_owners_frameFileModelId_fkey"
+  FOREIGN KEY ("frameFileModelId") REFERENCES "public"."files" ("id")
+  ON UPDATE CASCADE ON DELETE RESTRICT NOT VALID;
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_owners"
+  VALIDATE CONSTRAINT "sandbox_owners_frameFileModelId_fkey";
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE INDEX CONCURRENTLY "sandbox_owners_frame_file_model_id_idx"
+  ON "public"."sandbox_owners" USING btree ("frameFileModelId");
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+CREATE UNIQUE INDEX CONCURRENTLY "sandbox_owners_workspace_frame_file_model_idx"
+  ON "public"."sandbox_owners" USING btree ("workspaceId", "frameFileModelId")
+  WHERE "frameFileModelId" IS NOT NULL;
+
+/* Preserve exactly one owner while adding Frame ownership. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_owners"
+  ADD CONSTRAINT "sandbox_owners_exactly_one_owner_v2_check"
+  CHECK (num_nonnulls("conversationId", "spaceId", "frameFileModelId") = 1)
+  NOT VALID;
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_owners"
+  VALIDATE CONSTRAINT "sandbox_owners_exactly_one_owner_v2_check";
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_owners"
+  DROP CONSTRAINT "sandbox_owners_exactly_one_owner_check";
+
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_owners"
+  RENAME CONSTRAINT "sandbox_owners_exactly_one_owner_v2_check"
+  TO "sandbox_owners_exactly_one_owner_check";

--- a/front/migrations/pre-deploy/20260826122416_prepare_frames_v2_schema.sql
+++ b/front/migrations/pre-deploy/20260826122416_prepare_frames_v2_schema.sql
@@ -15,6 +15,19 @@ SET SESSION lock_timeout = 3000;
 ALTER TABLE "public"."sandbox_functions"
   ALTER COLUMN "spaceId" DROP NOT NULL;
 
+/* Every function is either a legacy Space function or a published Frame function. */
+SET SESSION statement_timeout = 3000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions"
+  ADD CONSTRAINT "sandbox_functions_exactly_one_scope_check"
+  CHECK (num_nonnulls("spaceId", "publicationId") = 1)
+  NOT VALID;
+
+SET SESSION statement_timeout = 1200000;
+SET SESSION lock_timeout = 3000;
+ALTER TABLE "public"."sandbox_functions"
+  VALIDATE CONSTRAINT "sandbox_functions_exactly_one_scope_check";
+
 /* Replace the legacy one-function-per-file index with a plain FK index. */
 SET SESSION statement_timeout = 3000;
 SET SESSION lock_timeout = 3000;


### PR DESCRIPTION
## Description

- Add publication-scoped sandbox function rows while reusing the existing file and slug columns.
- Add Frame FileResource ownership to sandbox owners and extend the exactly-one-owner constraint.
- Keep legacy Pod Function indexes and fetch behavior during the transition.

## Tests

Replayed all migrations on a fresh Hive Postgres database and ran the sandbox function and sandbox resource suites.

## Risk

Low. The migration is an expand step; existing Pod uniqueness remains enforced by the workspace and Space composite indexes.

## Deploy Plan

Apply and verify the pre-deploy migration in both regions before deploying Frames v2 application code. No backfill required.