### PR TITLE
[front] fix: use Sparkle LoadingBlock for hand-rolled skeleton placeholders

### DIFF
--- a/front/components/assistant/conversation/CreditCostPopover.tsx
+++ b/front/components/assistant/conversation/CreditCostPopover.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Chip,
   Icon,
+  LoadingBlock,
   Plus,
   PopoverContent,
   PopoverRoot,
@@ -180,7 +181,7 @@ export function CreditCostPopover({
               className="flex min-h-9 items-center text-sm text-muted-foreground"
             >
               <span className="flex-1">Loading details</span>
-              <span className="h-3 w-8 animate-pulse rounded bg-muted-foreground/20" />
+              <LoadingBlock className="h-3 w-8" />
             </div>
           ) : details ? (
             <dl>

--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -19,6 +19,7 @@ import {
   Button,
   ContentMessage,
   Hoverable,
+  LoadingBlock,
   Page,
 } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
@@ -136,8 +137,8 @@ function UsageSection({
   if (isLoading) {
     return (
       <div className="flex flex-col gap-6 rounded-lg border border-border p-6">
-        <div className="h-8 w-32 animate-pulse rounded bg-muted-foreground/20" />
-        <div className="h-24 w-full animate-pulse rounded bg-muted-foreground/20" />
+        <LoadingBlock className="h-8 w-32" />
+        <LoadingBlock className="h-24 w-full" />
       </div>
     );
   }
@@ -452,7 +453,7 @@ export function CreditsUsagePage() {
 
         {/* Usage Graph */}
         {isCreditPurchaseInfoLoading ? (
-          <div className="h-64 animate-pulse rounded bg-muted-foreground/20" />
+          <LoadingBlock className="h-64" />
         ) : (
           <ProgrammaticCostChart
             workspaceId={owner.sId}


### PR DESCRIPTION
## Description

Some skeleton/loading placeholders were still hand-rolled `animate-pulse rounded bg-muted-foreground/20` divs instead of Sparkle's `LoadingBlock`. This swaps them over in `CreditCostPopover` and `CreditsUsagePage`. Same motivation as #30951: as more code gets AI-generated, uniform use of existing Sparkle primitives is what keeps patterns from silently drifting apart again. Part of a broader pass on this (see also #31174, #31175).

## Tests

Manual: loading states render the same skeleton visuals as before.

## Risk

Low. Purely a visual/markup swap to an existing Sparkle primitive, no behavior or data changes.

## Deploy Plan

- Deploy front
