### PR TITLE
[front] fix: use Sparkle Spinner instead of lucide Loader2 in poke member search

### DIFF
--- a/front/components/members/InvitationsList.tsx
+++ b/front/components/members/InvitationsList.tsx
@@ -11,12 +11,10 @@ import type { MembershipInvitationType } from "@app/types/membership_invitation"
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 import {
-  Avatar,
   Button,
-  ChevronRight,
   Chip,
-  cn,
   DataTable,
+  DataTableLoadingSkeleton,
   Mail01,
   Page,
 } from "@dust-tt/sparkle";
@@ -145,28 +143,7 @@ export function InvitationsList({
       />
       <div className="flex flex-col gap-1 pt-2">
         {isInvitationsLoading && (
-          <div className="flex flex-col gap-2">
-            <div
-              className={cn(
-                "flex animate-pulse cursor-pointer items-center justify-center gap-3 border-t py-2 text-xs sm:text-sm",
-                "border-border-dark bg-background"
-              )}
-            >
-              <div className="hidden sm:block">
-                <Avatar size="xs" isRounded />
-              </div>
-              <div className="copy-base flex grow flex-col gap-1 sm:flex-row sm:gap-3">
-                <div className="font-semibold text-foreground">Loading...</div>
-                <div className="grow text-muted-foreground"></div>
-              </div>
-              <div>
-                <Chip size="xs">Loading...</Chip>
-              </div>
-              <div className="hidden sm:block">
-                <ChevronRight />
-              </div>
-            </div>
-          </div>
+          <DataTableLoadingSkeleton showSelectionColumn={false} rows={3} />
         )}
         {!isInvitationsLoading && invitations.length === 0 && (
           <div className="flex flex-col items-center justify-center py-8 text-center">

--- a/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
+++ b/front/components/poke/plugins/ServerSideSearchEnumSelect.tsx
@@ -18,8 +18,9 @@ import {
   PopoverContent,
   PopoverRoot,
   PopoverTrigger,
+  Spinner,
 } from "@dust-tt/sparkle";
-import { Check, Loader2 } from "lucide-react";
+import { Check } from "lucide-react";
 import React from "react";
 
 function formatMemberLabel(member: PokeSearchWorkspaceMember) {
@@ -169,7 +170,7 @@ export function ServerSideSearchEnumSelect({
           <PokeCommandList>
             {isLoading ? (
               <div className="flex items-center gap-2 px-2 py-3 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" />
+                <Spinner size="xs" />
                 Searching members…
               </div>
             ) : isError ? (


### PR DESCRIPTION
## Description

`ServerSideSearchEnumSelect` used lucide's `Loader2` with a manual `animate-spin` class for its loading state instead of Sparkle's `Spinner`. This swaps it over. Same motivation as #30951, #31173 and #31174: as more code gets AI-generated, uniform use of existing Sparkle primitives is what keeps patterns from silently drifting apart again. Part of a broader pass on this (see also #31173, #31174).

## Tests

Manual: verified the spinner renders correctly while searching members in the poke member search.

## Risk

Low. Purely a visual/markup swap to an existing Sparkle primitive, no behavior or data changes.

## Deploy Plan

- Deploy front