### PR TITLE
[front] enh: tweak ask user question prompt

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -176,9 +176,7 @@ function constructToolsSection({
       "target or scope before a consequential action, collecting missing " +
       "inputs, or letting the user pick preferences such as topic, " +
       "difficulty, format, audience, length, or direction for creative and " +
-      "interactive tasks. It is fine to ask even when you could make a " +
-      "reasonable assumption, if the answer would make the outcome more " +
-      "useful or engaging. Ask one precise question at a time, and prefer " +
+      "interactive tasks. Ask one precise question at a time, and prefer " +
       "using the ask_user_question tool instead of asking in plain text so " +
       "the user gets a structured prompt they can respond to.\n";
   }


### PR DESCRIPTION
## Description

This PR tweaks the prompt for the ask user question tool to use it less eagerly.

The existing prompt was fine tuned heavily on a category of models that had a tendency to use tools (in general) less eagerly. This PR optimizes the behavior for the Standard model (luna high).

## Tests

- Tested locally with the following example: "do some research on Chatel". used the tool 3/5 times without this PR, 1/5 with.

## Risk

- Low.

## Deploy Plan

- Deploy front.