### PR TITLE
feat(connectors): list and remove endpoints for the Slack summoning whitelist

### DIFF
--- a/connectors/src/api/slack_bot_summoning_whitelist.ts
+++ b/connectors/src/api/slack_bot_summoning_whitelist.ts
@@ -1,0 +1,186 @@
+import { apiError, withLogging } from "@connectors/logger/withlogging";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+import type { WhitelistedBotType } from "@connectors/resources/slack_configuration_resource";
+import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
+import type { WithConnectorsAPIErrorReponse } from "@connectors/types";
+import { zodParsePayload } from "@connectors/types";
+import type { Request, Response } from "express";
+import { z } from "zod";
+
+const WHITELIST_TYPE = "summon_agent" as const;
+
+const ConnectorIdQuerySchema = z.object({
+  connector_id: z.string(),
+});
+
+const PostBodySchema = z.object({
+  connector_id: z.string(),
+  bot_name: z.string().trim().min(1),
+  group_ids: z.array(z.string()).min(1),
+});
+
+const DeleteBodySchema = z.object({
+  connector_id: z.string(),
+  bot_name: z.string().trim().min(1),
+});
+
+type GetSlackBotSummoningWhitelistResBody = WithConnectorsAPIErrorReponse<{
+  bots: WhitelistedBotType[];
+}>;
+
+type MutateSlackBotSummoningWhitelistResBody = WithConnectorsAPIErrorReponse<{
+  success: true;
+}>;
+
+async function fetchSlackConfiguration(connectorId: string) {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector || connector.type !== "slack_bot") {
+    return null;
+  }
+
+  const { configuration } = connector;
+
+  return configuration instanceof SlackConfigurationResource
+    ? configuration
+    : null;
+}
+
+const _getSlackBotSummoningWhitelistHandler = async (
+  req: Request<Record<string, string>>,
+  res: Response<GetSlackBotSummoningWhitelistResBody>
+) => {
+  const queryValidation = zodParsePayload(req.query, ConnectorIdQuerySchema);
+  if (queryValidation.isErr()) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid query: ${queryValidation.error}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const slackConfig = await fetchSlackConfiguration(
+    queryValidation.value.connector_id
+  );
+  if (!slackConfig) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Slack bot connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const bots = await slackConfig.listWhitelistedBots(WHITELIST_TYPE);
+
+  res.status(200).json({ bots });
+};
+
+export const getSlackBotSummoningWhitelistHandler = withLogging(
+  _getSlackBotSummoningWhitelistHandler
+);
+
+const _postSlackBotSummoningWhitelistHandler = async (
+  req: Request<Record<string, string>, MutateSlackBotSummoningWhitelistResBody>,
+  res: Response<MutateSlackBotSummoningWhitelistResBody>
+) => {
+  const bodyValidation = zodParsePayload(req.body, PostBodySchema);
+  if (bodyValidation.isErr()) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${bodyValidation.error}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const {
+    connector_id: connectorId,
+    bot_name: botName,
+    group_ids: groupIds,
+  } = bodyValidation.value;
+
+  const slackConfig = await fetchSlackConfiguration(connectorId);
+  if (!slackConfig) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Slack bot connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const whitelistRes = await slackConfig.whitelistBot(
+    botName,
+    groupIds,
+    WHITELIST_TYPE
+  );
+  if (whitelistRes.isErr()) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_update_error",
+        message: whitelistRes.error.message,
+      },
+      status_code: 500,
+    });
+  }
+
+  res.status(200).json({ success: true });
+};
+
+export const postSlackBotSummoningWhitelistHandler = withLogging(
+  _postSlackBotSummoningWhitelistHandler
+);
+
+const _deleteSlackBotSummoningWhitelistHandler = async (
+  req: Request<Record<string, string>, MutateSlackBotSummoningWhitelistResBody>,
+  res: Response<MutateSlackBotSummoningWhitelistResBody>
+) => {
+  const bodyValidation = zodParsePayload(req.body, DeleteBodySchema);
+  if (bodyValidation.isErr()) {
+    return apiError(req, res, {
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid request body: ${bodyValidation.error}`,
+      },
+      status_code: 400,
+    });
+  }
+
+  const { connector_id: connectorId, bot_name: botName } = bodyValidation.value;
+
+  const slackConfig = await fetchSlackConfiguration(connectorId);
+  if (!slackConfig) {
+    return apiError(req, res, {
+      api_error: {
+        type: "connector_not_found",
+        message: "Slack bot connector not found",
+      },
+      status_code: 404,
+    });
+  }
+
+  const destroyedCount = await slackConfig.removeWhitelistedBot(
+    botName,
+    WHITELIST_TYPE
+  );
+  if (destroyedCount === 0) {
+    return apiError(req, res, {
+      api_error: {
+        type: "not_found",
+        message: `No whitelisted bot named "${botName}"`,
+      },
+      status_code: 404,
+    });
+  }
+
+  res.status(200).json({ success: true });
+};
+
+export const deleteSlackBotSummoningWhitelistHandler = withLogging(
+  _deleteSlackBotSummoningWhitelistHandler
+);

--- a/connectors/src/api_server.ts
+++ b/connectors/src/api_server.ts
@@ -11,6 +11,11 @@ import { getNotionUrlStatusHandler } from "@connectors/api/notion_url_status";
 import { pauseConnectorAPIHandler } from "@connectors/api/pause_connector";
 import { setConnectorPermissionsAPIHandler } from "@connectors/api/set_connector_permissions";
 import {
+  deleteSlackBotSummoningWhitelistHandler,
+  getSlackBotSummoningWhitelistHandler,
+  postSlackBotSummoningWhitelistHandler,
+} from "@connectors/api/slack_bot_summoning_whitelist";
+import {
   getSlackChannelsLinkedWithAgentHandler,
   patchSlackChannelsLinkedWithAgentHandler,
 } from "@connectors/api/slack_channels_linked_with_agent";
@@ -133,6 +138,19 @@ export function startServer(port: number) {
   app.get(
     "/slack/channels/linked_with_agent",
     getSlackChannelsLinkedWithAgentHandler
+  );
+
+  app.get(
+    "/slack/bots/summoning_whitelist",
+    getSlackBotSummoningWhitelistHandler
+  );
+  app.post(
+    "/slack/bots/summoning_whitelist",
+    postSlackBotSummoningWhitelistHandler
+  );
+  app.delete(
+    "/slack/bots/summoning_whitelist",
+    deleteSlackBotSummoningWhitelistHandler
   );
 
   app.get("/notion/url/status", getNotionUrlStatusHandler);

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -20,6 +20,12 @@ import type { ConnectorProvider, Result } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
 import type { Attributes, ModelStatic, Transaction } from "sequelize";
 
+export type WhitelistedBotType = {
+  botName: string;
+  groupIds: string[];
+  createdAt: number;
+};
+
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
@@ -203,6 +209,39 @@ export class SlackConfigurationResource extends BaseResource<SlackConfigurationM
     }
 
     return new Ok(undefined);
+  }
+
+  async listWhitelistedBots(
+    whitelistType: SlackbotWhitelistType
+  ): Promise<WhitelistedBotType[]> {
+    const bots = await SlackBotWhitelistModel.findAll({
+      where: {
+        connectorId: this.connectorId,
+        slackConfigurationId: this.id,
+        whitelistType,
+      },
+      order: [["botName", "ASC"]],
+    });
+
+    return bots.map((bot) => ({
+      botName: bot.botName,
+      groupIds: bot.groupIds ?? [],
+      createdAt: bot.createdAt.getTime(),
+    }));
+  }
+
+  async removeWhitelistedBot(
+    botName: string,
+    whitelistType: SlackbotWhitelistType
+  ): Promise<number> {
+    return SlackBotWhitelistModel.destroy({
+      where: {
+        connectorId: this.connectorId,
+        slackConfigurationId: this.id,
+        botName,
+        whitelistType,
+      },
+    });
   }
 
   // Get the Dust group IDs that the bot is whitelisted for.


### PR DESCRIPTION
## Description

A Slack workflow that mentions @/Dust is refused unless its sender name is whitelisted for `summon_agent`. Today that only happens through poke and is handled by support team. There's no built-in way for users, nor support, to see in product which workflow is allowed and to remove any of them. 

The goal of this stack is to make the whole thing self-served by workspace admins.

Connectors only exposed a write path. This adds GET, POST and DELETE on `/slack/bots/summoning_whitelist`, plus the matching `listWhitelistedBots` / `removeWhitelistedBot` on `SlackConfigurationResource`, so front can read and mutate the allowlist without going through `admin`.

The stack:

1. This PR: connectors endpoints.
2. `front` business layer in `lib/api/slack/summoning_whitelist.ts` (allow, list, revoke, group validation, audit events), poke plugin moved onto it.
3. Poke lists and revokes allowed workflows on the Slack bot data source page. Drops the Metabase link.
4. Admin UI on the automations page, and the Slack denial message points there.

## Tests

UI tested on a local dev setup. I didn't test the actual workflow sending a message.

## Risk

Low. Three new endpoints, no change to any existing read or write path.

## Deploy Plan

Deploy connectors first, it gates the rest of the stack.