### PR TITLE
feat(front): business layer for the Slack workflow allowlist

### DIFF
--- a/front/admin/audit_log_schemas/slack_workflow.allowed.json
+++ b/front/admin/audit_log_schemas/slack_workflow.allowed.json
@@ -1,0 +1,16 @@
+{
+  "action": "slack_workflow.allowed",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "data_source"
+    }
+  ],
+  "metadata": {
+    "bot_name": "string",
+    "group_names": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/admin/audit_log_schemas/slack_workflow.revoked.json
+++ b/front/admin/audit_log_schemas/slack_workflow.revoked.json
@@ -1,0 +1,15 @@
+{
+  "action": "slack_workflow.revoked",
+  "targets": [
+    {
+      "type": "workspace"
+    },
+    {
+      "type": "data_source"
+    }
+  ],
+  "metadata": {
+    "bot_name": "string",
+    "actor_type": "string"
+  }
+}

--- a/front/lib/api/audit/schema_versions.json
+++ b/front/lib/api/audit/schema_versions.json
@@ -82,6 +82,8 @@
   "skill.self_improvement_updated": 1,
   "skill_import_github_connection.created": 1,
   "skill_import_github_connection.deleted": 1,
+  "slack_workflow.allowed": 1,
+  "slack_workflow.revoked": 1,
   "space.accessed": 2,
   "space.created": 4,
   "space.deleted": 4,

--- a/front/lib/api/audit/workos_audit.ts
+++ b/front/lib/api/audit/workos_audit.ts
@@ -170,6 +170,9 @@ export const AUDIT_ACTIONS = [
   "datasource.deleted",
   "datasource.deleted_admin",
   "datasource.reauthorized",
+  // Slack workflows.
+  "slack_workflow.allowed",
+  "slack_workflow.revoked",
   // Files.
   "file.moved",
   "frame.authorized_files_updated",

--- a/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
+++ b/front/lib/api/poke/plugins/data_sources/slack_whitelist_bot.ts
@@ -1,6 +1,7 @@
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import { config as regionsConfig } from "@app/lib/api/regions/config";
+import { allowSlackWorkflow } from "@app/lib/api/slack/summoning_whitelist";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import logger from "@app/logger/logger";
 import type { AdminCommandType } from "@app/types/connectors/admin/cli";
@@ -126,7 +127,6 @@ export const slackWhitelistBotPlugin = createPlugin({
     });
   },
   execute: async (auth, resource, args) => {
-    const owner = auth.getNonNullableWorkspace();
     const { botName, groupIds } = args;
 
     if (!resource) {
@@ -141,38 +141,13 @@ export const slackWhitelistBotPlugin = createPlugin({
       return new Err(new Error("Groups selection is required"));
     }
 
-    // Always include the Workspace (global) group.
-    const workspaceGroupRes =
-      await GroupResource.fetchWorkspaceGlobalGroup(auth);
-    if (workspaceGroupRes.isErr()) {
-      return new Err(new Error("Failed to fetch workspace global group"));
-    }
-
-    const allGroupIds = groupIds.includes(workspaceGroupRes.value.sId)
-      ? groupIds
-      : [...groupIds, workspaceGroupRes.value.sId];
-
-    const connectorsAPI = new ConnectorsAPI(
-      config.getConnectorsAPIConfig(),
-      logger
-    );
-
-    const whitelistBotCmd: AdminCommandType = {
-      majorCommand: "slack",
-      command: "whitelist-bot",
-      args: {
-        botName,
-        wId: owner.sId,
-        groupId: allGroupIds.join(","),
-        whitelistType: "summon_agent",
-        providerType: "slack_bot",
-      },
-    };
-
-    const adminCommandRes = await connectorsAPI.admin(whitelistBotCmd);
-    if (adminCommandRes.isErr()) {
+    const allowRes = await allowSlackWorkflow(auth, {
+      botName: botName.trim(),
+      groupIds,
+    });
+    if (allowRes.isErr()) {
       return new Err(
-        new Error(`Failed to whitelist bot: ${adminCommandRes.error.message}`)
+        new Error(`Failed to whitelist bot: ${allowRes.error.message}`)
       );
     }
 

--- a/front/lib/api/slack/summoning_whitelist.ts
+++ b/front/lib/api/slack/summoning_whitelist.ts
@@ -1,0 +1,221 @@
+import {
+  buildAuditLogTarget,
+  emitAuditLogEvent,
+  getAuditLogContext,
+} from "@app/lib/api/audit/workos_audit";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import logger from "@app/logger/logger";
+import type {
+  GetSlackWorkflowsResponseBody,
+  SlackWorkflowType,
+} from "@app/types/api/slack/workflows";
+import { SLACK_WORKFLOW_GROUP_KINDS } from "@app/types/api/slack/workflows";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+type SlackWorkflowErrorType =
+  | "slack_bot_not_connected"
+  | "invalid_groups"
+  | "not_found"
+  | "connectors_error";
+
+export class SlackWorkflowError extends Error {
+  constructor(
+    readonly type: SlackWorkflowErrorType,
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+async function fetchSlackBotDataSource(
+  auth: Authenticator
+): Promise<
+  Result<
+    { dataSource: DataSourceResource; connectorId: string },
+    SlackWorkflowError
+  >
+> {
+  const [dataSource] = await DataSourceResource.listByConnectorProvider(
+    auth,
+    "slack_bot"
+  );
+
+  if (!dataSource?.connectorId) {
+    return new Err(
+      new SlackWorkflowError(
+        "slack_bot_not_connected",
+        "The Dust Slack bot is not connected to this workspace."
+      )
+    );
+  }
+
+  return new Ok({ dataSource, connectorId: dataSource.connectorId });
+}
+
+export async function listSlackWorkflows(
+  auth: Authenticator
+): Promise<Result<GetSlackWorkflowsResponseBody, SlackWorkflowError>> {
+  const dataSourceRes = await fetchSlackBotDataSource(auth);
+  if (dataSourceRes.isErr()) {
+    if (dataSourceRes.error.type === "slack_bot_not_connected") {
+      return new Ok({ isSlackBotConnected: false, workflows: [] });
+    }
+    return dataSourceRes;
+  }
+
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  const [whitelistRes, groups] = await Promise.all([
+    connectorsAPI.getSlackBotSummoningWhitelist({
+      connectorId: dataSourceRes.value.connectorId,
+    }),
+    GroupResource.listAllWorkspaceGroups(auth, {
+      groupKinds: SLACK_WORKFLOW_GROUP_KINDS,
+    }),
+  ]);
+
+  if (whitelistRes.isErr()) {
+    return new Err(
+      new SlackWorkflowError("connectors_error", whitelistRes.error.message)
+    );
+  }
+
+  const groupNameById = new Map(groups.map((g) => [g.sId, g.name]));
+
+  const workflows: SlackWorkflowType[] = whitelistRes.value.bots.map((bot) => ({
+    botName: bot.botName,
+    groups: bot.groupIds.map((sId) => ({
+      sId,
+      name: groupNameById.get(sId) ?? sId,
+    })),
+    createdAt: bot.createdAt,
+  }));
+
+  return new Ok({ isSlackBotConnected: true, workflows });
+}
+
+export async function allowSlackWorkflow(
+  auth: Authenticator,
+  { botName, groupIds }: { botName: string; groupIds: string[] }
+): Promise<Result<undefined, SlackWorkflowError>> {
+  const dataSourceRes = await fetchSlackBotDataSource(auth);
+  if (dataSourceRes.isErr()) {
+    return dataSourceRes;
+  }
+  const { dataSource, connectorId } = dataSourceRes.value;
+
+  const groups = await GroupResource.listAllWorkspaceGroups(auth, {
+    groupKinds: SLACK_WORKFLOW_GROUP_KINDS,
+  });
+  const groupById = new Map(groups.map((g) => [g.sId, g]));
+
+  const unknownGroupIds = groupIds.filter((sId) => !groupById.has(sId));
+  if (unknownGroupIds.length > 0) {
+    return new Err(
+      new SlackWorkflowError(
+        "invalid_groups",
+        `Unknown groups: ${unknownGroupIds.join(", ")}.`
+      )
+    );
+  }
+
+  const globalGroupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
+  if (globalGroupRes.isErr()) {
+    return new Err(
+      new SlackWorkflowError(
+        "invalid_groups",
+        "Failed to fetch the workspace group."
+      )
+    );
+  }
+
+  const allGroupIds = groupIds.includes(globalGroupRes.value.sId)
+    ? groupIds
+    : [...groupIds, globalGroupRes.value.sId];
+
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  const whitelistRes = await connectorsAPI.whitelistSlackBotToSummon({
+    connectorId,
+    botName,
+    groupIds: allGroupIds,
+  });
+  if (whitelistRes.isErr()) {
+    return new Err(
+      new SlackWorkflowError("connectors_error", whitelistRes.error.message)
+    );
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "slack_workflow.allowed",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("data_source", dataSource),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      bot_name: botName,
+      group_names: allGroupIds
+        .map((sId) => groupById.get(sId)?.name ?? globalGroupRes.value.name)
+        .join(", "),
+    },
+  });
+
+  return new Ok(undefined);
+}
+
+export async function revokeSlackWorkflow(
+  auth: Authenticator,
+  { botName }: { botName: string }
+): Promise<Result<undefined, SlackWorkflowError>> {
+  const dataSourceRes = await fetchSlackBotDataSource(auth);
+  if (dataSourceRes.isErr()) {
+    return dataSourceRes;
+  }
+  const { dataSource, connectorId } = dataSourceRes.value;
+
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  const revokeRes = await connectorsAPI.unwhitelistSlackBotToSummon({
+    connectorId,
+    botName,
+  });
+  if (revokeRes.isErr()) {
+    return new Err(
+      new SlackWorkflowError(
+        revokeRes.error.type === "not_found" ? "not_found" : "connectors_error",
+        revokeRes.error.message
+      )
+    );
+  }
+
+  void emitAuditLogEvent({
+    auth,
+    action: "slack_workflow.revoked",
+    targets: [
+      buildAuditLogTarget("workspace", auth.getNonNullableWorkspace()),
+      buildAuditLogTarget("data_source", dataSource),
+    ],
+    context: getAuditLogContext(auth),
+    metadata: {
+      bot_name: botName,
+    },
+  });
+
+  return new Ok(undefined);
+}

--- a/front/types/api/slack/workflows.ts
+++ b/front/types/api/slack/workflows.ts
@@ -1,0 +1,19 @@
+import type { GroupKind } from "@app/types/groups";
+
+export const SLACK_WORKFLOW_GROUP_KINDS: GroupKind[] = [
+  "global",
+  "provisioned",
+  "regular_auto",
+  "regular_manual",
+];
+
+export type SlackWorkflowType = {
+  botName: string;
+  groups: { sId: string; name: string }[];
+  createdAt: number;
+};
+
+export type GetSlackWorkflowsResponseBody = {
+  isSlackBotConnected: boolean;
+  workflows: SlackWorkflowType[];
+};

--- a/front/types/connectors/connectors_api.ts
+++ b/front/types/connectors/connectors_api.ts
@@ -149,6 +149,12 @@ export interface ContentNodeWithParent extends ContentNode {
   parentTitle: string | null;
 }
 
+export type WhitelistedSlackBotType = {
+  botName: string;
+  groupIds: string[];
+  createdAt: number;
+};
+
 export class ConnectorsAPI {
   _url: string;
   _secret: string;
@@ -553,6 +559,73 @@ export class ConnectorsAPI {
       {
         method: "GET",
         headers: this.getDefaultHeaders(),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
+  async getSlackBotSummoningWhitelist({
+    connectorId,
+  }: {
+    connectorId: string;
+  }): Promise<ConnectorsAPIResponse<{ bots: WhitelistedSlackBotType[] }>> {
+    const res = await this._fetchWithError(
+      `${
+        this._url
+      }/slack/bots/summoning_whitelist?connector_id=${encodeURIComponent(
+        connectorId
+      )}`,
+      {
+        method: "GET",
+        headers: this.getDefaultHeaders(),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
+  async whitelistSlackBotToSummon({
+    connectorId,
+    botName,
+    groupIds,
+  }: {
+    connectorId: string;
+    botName: string;
+    groupIds: string[];
+  }): Promise<ConnectorsAPIResponse<{ success: true }>> {
+    const res = await this._fetchWithError(
+      `${this._url}/slack/bots/summoning_whitelist`,
+      {
+        method: "POST",
+        headers: this.getDefaultHeaders(),
+        body: JSON.stringify({
+          connector_id: connectorId,
+          bot_name: botName,
+          group_ids: groupIds,
+        }),
+      }
+    );
+
+    return this._resultFromResponse(res);
+  }
+
+  async unwhitelistSlackBotToSummon({
+    connectorId,
+    botName,
+  }: {
+    connectorId: string;
+    botName: string;
+  }): Promise<ConnectorsAPIResponse<{ success: true }>> {
+    const res = await this._fetchWithError(
+      `${this._url}/slack/bots/summoning_whitelist`,
+      {
+        method: "DELETE",
+        headers: this.getDefaultHeaders(),
+        body: JSON.stringify({
+          connector_id: connectorId,
+          bot_name: botName,
+        }),
       }
     );
 


### PR DESCRIPTION
## Description

Stacked on #31177.

`allowSlackWorkflow`, `listSlackWorkflows` and `revokeSlackWorkflow` in `lib/api/slack/summoning_whitelist.ts` wrap the connectors endpoints so callers get one function per operation: group sIds validated against the workspace, the global group always appended so the workflow can at least reach workspace-wide agents, and a `slack_workflow.allowed` / `slack_workflow.revoked` audit event on success. Failures come back as a `SlackWorkflowError` with a domain type, no HTTP shapes.

Listing returns `isSlackBotConnected: false` rather than an error when the workspace has no Slack bot, so callers can hide the feature instead of surfacing a failure.

The poke plugin now calls `allowSlackWorkflow` instead of the `slack whitelist-bot` admin command. Same group kinds in the picker, same "groups are required" guard, so nothing changes for support.

## Tests

Covered end to end by the endpoint tests in the next two PRs. Ran the poke plugin against a local hive to confirm the audit event and the appended global group.

## Risk

The poke plugin changes path while keeping its behaviour, so the risk is limited to the new code path itself.

## Deploy Plan

Register the new audit schemas after merge, before deploying front: `npx tsx front/admin/register_audit_log_schemas.ts --execute --changed`.