### PR TITLE
[front] fix: enforce Dust-only-ness on feature flags flagged as Dust-only

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
@@ -7,7 +7,27 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { PlanFactory } from "@app/tests/utils/PlanFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import {
+  WHITELISTABLE_FEATURES,
+  WHITELISTABLE_FEATURES_CONFIG,
+} from "@app/types/shared/feature_flags";
 import { describe, expect, it } from "vitest";
+
+function findFeatureFlagByDustOnlyStatus(dustOnly: boolean) {
+  const feature = WHITELISTABLE_FEATURES.find(
+    (feature) =>
+      (WHITELISTABLE_FEATURES_CONFIG[feature].stage === "dust_only") ===
+      dustOnly
+  );
+
+  if (!feature) {
+    throw new Error(
+      `Expected at least one ${dustOnly ? "Dust-only" : "non-Dust-only"} feature flag.`
+    );
+  }
+
+  return feature;
+}
 
 describe("toggleFeatureFlagPlugin.execute", () => {
   it("ensures auto MCP server views when enabling a feature flag", async () => {
@@ -93,9 +113,10 @@ describe("toggleFeatureFlagPlugin.execute", () => {
   it("rejects enabling Dust-only feature flags on other plans", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const dustOnlyFeature = findFeatureFlagByDustOnlyStatus(true);
 
     const result = await toggleFeatureFlagPlugin.execute(auth, null, {
-      features: ["sandbox_functions"],
+      features: [dustOnlyFeature],
     });
 
     expect(result.isErr()).toBe(true);
@@ -106,7 +127,7 @@ describe("toggleFeatureFlagPlugin.execute", () => {
       "Dust-only feature flags can only be enabled on Dust or Friends & Family plans."
     );
     await expect(
-      FeatureFlagResource.isEnabledForWorkspace(workspace, "sandbox_functions")
+      FeatureFlagResource.isEnabledForWorkspace(workspace, dustOnlyFeature)
     ).resolves.toBe(false);
   });
 
@@ -114,28 +135,30 @@ describe("toggleFeatureFlagPlugin.execute", () => {
     const plan = await PlanFactory.enterprise("FREE_FRIENDSAMILY");
     const workspace = await WorkspaceFactory.fromPlan(plan);
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const dustOnlyFeature = findFeatureFlagByDustOnlyStatus(true);
 
     const result = await toggleFeatureFlagPlugin.execute(auth, null, {
-      features: ["sandbox_functions"],
+      features: [dustOnlyFeature],
     });
 
     expect(result.isOk()).toBe(true);
     await expect(
-      FeatureFlagResource.isEnabledForWorkspace(workspace, "sandbox_functions")
+      FeatureFlagResource.isEnabledForWorkspace(workspace, dustOnlyFeature)
     ).resolves.toBe(true);
   });
 
   it("allows enabling non-Dust-only feature flags on other plans", async () => {
     const workspace = await WorkspaceFactory.basic();
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    const nonDustOnlyFeature = findFeatureFlagByDustOnlyStatus(false);
 
     const result = await toggleFeatureFlagPlugin.execute(auth, null, {
-      features: ["deepseek_feature"],
+      features: [nonDustOnlyFeature],
     });
 
     expect(result.isOk()).toBe(true);
     await expect(
-      FeatureFlagResource.isEnabledForWorkspace(workspace, "deepseek_feature")
+      FeatureFlagResource.isEnabledForWorkspace(workspace, nonDustOnlyFeature)
     ).resolves.toBe(true);
   });
 });

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.test.ts
@@ -1,14 +1,18 @@
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { toggleFeatureFlagPlugin } from "@app/lib/api/poke/plugins/workspaces/toggle_feature_flag";
 import { Authenticator } from "@app/lib/auth";
+import { DUST_COMPANY_PLAN_CODE } from "@app/lib/plans/plan_codes";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { PlanFactory } from "@app/tests/utils/PlanFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { describe, expect, it } from "vitest";
 
 describe("toggleFeatureFlagPlugin.execute", () => {
   it("ensures auto MCP server views when enabling a feature flag", async () => {
-    const workspace = await WorkspaceFactory.basic();
+    const plan = await PlanFactory.enterprise(DUST_COMPANY_PLAN_CODE);
+    const workspace = await WorkspaceFactory.fromPlan(plan);
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
     await SpaceFactory.defaults(auth);
 
@@ -84,5 +88,54 @@ describe("toggleFeatureFlagPlugin.execute", () => {
       );
     expect(systemViewAfterReenable?.sId).toBe(systemViewAfterEnable?.sId);
     expect(globalViewAfterReenable?.sId).toBe(globalViewAfterEnable?.sId);
+  });
+
+  it("rejects enabling Dust-only feature flags on other plans", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await toggleFeatureFlagPlugin.execute(auth, null, {
+      features: ["sandbox_functions"],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (!result.isErr()) {
+      throw new Error("Expected enabling the feature flag to fail.");
+    }
+    expect(result.error.message).toContain(
+      "Dust-only feature flags can only be enabled on Dust or Friends & Family plans."
+    );
+    await expect(
+      FeatureFlagResource.isEnabledForWorkspace(workspace, "sandbox_functions")
+    ).resolves.toBe(false);
+  });
+
+  it("allows enabling Dust-only feature flags on Friends & Family plans", async () => {
+    const plan = await PlanFactory.enterprise("FREE_FRIENDSAMILY");
+    const workspace = await WorkspaceFactory.fromPlan(plan);
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await toggleFeatureFlagPlugin.execute(auth, null, {
+      features: ["sandbox_functions"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    await expect(
+      FeatureFlagResource.isEnabledForWorkspace(workspace, "sandbox_functions")
+    ).resolves.toBe(true);
+  });
+
+  it("allows enabling non-Dust-only feature flags on other plans", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    const result = await toggleFeatureFlagPlugin.execute(auth, null, {
+      features: ["deepseek_feature"],
+    });
+
+    expect(result.isOk()).toBe(true);
+    await expect(
+      FeatureFlagResource.isEnabledForWorkspace(workspace, "deepseek_feature")
+    ).resolves.toBe(true);
   });
 });

--- a/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
+++ b/front/lib/api/poke/plugins/workspaces/toggle_feature_flag.ts
@@ -1,4 +1,8 @@
 import { createPlugin } from "@app/lib/api/poke/types";
+import {
+  isDustCompanyPlan,
+  isFriendsAndFamilyPlan,
+} from "@app/lib/plans/plan_codes";
 import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
 import { GlobalFeatureFlagResource } from "@app/lib/resources/global_feature_flag_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -10,7 +14,7 @@ import {
   WHITELISTABLE_FEATURES,
   WHITELISTABLE_FEATURES_CONFIG,
 } from "@app/types/shared/feature_flags";
-import { Ok } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 export const toggleFeatureFlagPlugin = createPlugin({
   manifest: {
@@ -81,6 +85,23 @@ export const toggleFeatureFlagPlugin = createPlugin({
     const toRemove = existingFlags
       .filter((flag) => !featureFlags.includes(flag.name))
       .map((flag) => flag.name);
+
+    const planCode = auth.plan()?.code;
+    const dustOnlyFeatures = toAdd.filter(
+      (feature) => WHITELISTABLE_FEATURES_CONFIG[feature].stage === "dust_only"
+    );
+    if (
+      dustOnlyFeatures.length > 0 &&
+      (!planCode ||
+        (!isDustCompanyPlan(planCode) && !isFriendsAndFamilyPlan(planCode)))
+    ) {
+      return new Err(
+        new Error(
+          "Dust-only feature flags can only be enabled on Dust or Friends & Family plans. " +
+            `Invalid flags: ${dustOnlyFeatures.join(", ")}.`
+        )
+      );
+    }
 
     if (toAdd.length > 0) {
       await FeatureFlagResource.enableMany(workspace, toAdd);


### PR DESCRIPTION
## Description

Dust-only feature flags could be enabled on any workspace through Poke. This PR prevents enabling a `dust_only` flags for non-Dust workspaces.

Also allows friends and family workspaces, because, you know.

Doesn't change flags already enabled, because they are already enabled.

This comes with having a better hygiene of the status on our end, will do a pass to review in which stage each FF is (there are probably many of them that were never moved to the next stage).

## Tests

- Added a test.

## Risk

- Low.

## Deploy Plan

- Deploy front.
